### PR TITLE
feat(deploy): refuse a start a surviving store volume will reject, and make a clean re-create possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,23 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- A start that would generate store credentials a surviving data volume cannot
+  accept now stops before it starts anything. Deleting a deployment directory
+  leaves its volumes behind, so the next `osprey up` minted fresh passwords for
+  postgresql, openobserve and mongodb — which each read their password only
+  when initializing an empty volume, and go on rejecting the new one. The
+  previous warning could only guess that this might be happening; the start now
+  asks the container runtime, names every affected store at once, and says
+  whether each one's original credential can still be recovered. It reports
+  this before the image build instead of at a health probe minutes later —
+  which matters, because starting the stack recreates the store containers, and
+  a container holds the only copy of the credential its volume was created
+  with. `osprey restart` runs the same check before it stops anything, for the
+  same reason.
+- New: `osprey up --reuse-stores` and `osprey restart --reuse-stores` adopt
+  those volumes instead of discarding them, restoring each store's original
+  credential to `.env`. They refuse if any affected volume can no longer be
+  reopened, rather than starting a stack that is part-adopted and part-doomed.
 - `osprey health` now answers from either stance. It looks for the config where
   a build writes it (`build/config.yml`) and reads credentials from the repo's
   `.env`, so running it at the repo root no longer reports the config missing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,14 +451,15 @@ Compatibility is documented in release notes, not encoded in the version string.
   those volumes instead of discarding them, restoring each store's original
   credential to `.env`. They refuse if any affected volume can no longer be
   reopened, rather than starting a stack that is part-adopted and part-doomed.
-- New: `osprey init --reset` destroys the containers, volumes and images left
-  by a previous deployment of the same name before creating the new one, so
-  re-creating a deployment from scratch is one command again. Deleting a
-  deployment's directory never removed those — they are keyed on the project
-  name and outlive it. If anything of that name survives the sweep, `init`
-  stops and says so instead of starting: `reset` removes only what carries the
-  checkout's own label, so a deployment created before that label existed has
-  to be cleared by hand once.
+- New: `osprey init --reset` starts over on a name that has been used: it
+  destroys the containers, volumes and images left by a previous deployment of
+  that name, and re-materializes the source zone as `--force` does when the
+  repo directory still exists — so re-creating a deployment is one command,
+  with no `rm -rf` first. Provider keys in `.env`, git history and the audit
+  log survive, exactly as they do under `--force`. If anything of that name
+  survives the sweep, `init` stops and says so instead of starting: `reset`
+  removes only what carries the checkout's own label, so a deployment created
+  before that label existed has to be cleared by hand once.
 - `osprey health` now answers from either stance. It looks for the config where
   a build writes it (`build/config.yml`) and reads credentials from the repo's
   `.env`, so running it at the repo root no longer reports the config missing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,6 +451,14 @@ Compatibility is documented in release notes, not encoded in the version string.
   those volumes instead of discarding them, restoring each store's original
   credential to `.env`. They refuse if any affected volume can no longer be
   reopened, rather than starting a stack that is part-adopted and part-doomed.
+- New: `osprey init --reset` destroys the containers, volumes and images left
+  by a previous deployment of the same name before creating the new one, so
+  re-creating a deployment from scratch is one command again. Deleting a
+  deployment's directory never removed those — they are keyed on the project
+  name and outlive it. If anything of that name survives the sweep, `init`
+  stops and says so instead of starting: `reset` removes only what carries the
+  checkout's own label, so a deployment created before that label existed has
+  to be cleared by hand once.
 - `osprey health` now answers from either stance. It looks for the config where
   a build writes it (`build/config.yml`) and reads credentials from the repo's
   `.env`, so running it at the repo root no longer reports the config missing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,6 +460,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   survives the sweep, `init` stops and says so instead of starting: `reset`
   removes only what carries the checkout's own label, so a deployment created
   before that label existed has to be cleared by hand once.
+- Dev deploys now report each service image as it finishes building, instead
+  of one summary line after the whole `compose build` — the longest step of a
+  deploy, and previously silent for its entire duration.
 - `osprey health` now answers from either stance. It looks for the config where
   a build writes it (`build/config.yml`) and reads credentials from the repo's
   `.env`, so running it at the repo root no longer reports the config missing,

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -339,6 +339,11 @@ def _preflight(repo_root: Path, reporter: PhaseReporter, *, nothing_done: str) -
     is_flag=True,
     help="Keep the existing archiver history even when the profile's retention/cadence knobs no longer match it. Without this, changed knobs rebuild the base series and discard recorded samples.",
 )
+@click.option(
+    "--reuse-stores",
+    is_flag=True,
+    help="Adopt data volumes left by an earlier deployment of this name, keeping their contents: each store's original credential is restored to .env in place of the one just generated. Only possible while the store's container survives.",
+)
 @click.pass_context
 def up_verb(
     ctx: click.Context,
@@ -348,6 +353,7 @@ def up_verb(
     chain_build: bool,
     as_built: bool,
     keep_archiver_base: bool,
+    reuse_stores: bool,
 ) -> None:
     """Start this deployment from build/, as built.
 
@@ -426,6 +432,7 @@ def up_verb(
                     detached=detached,
                     dev_mode=dev,
                     keep_archiver_base=keep_archiver_base,
+                    reuse_stores=reuse_stores,
                 )
         except NoBuildError as e:
             _abort(f"{e} Nothing was started.")
@@ -549,6 +556,11 @@ def down_verb(repo: Path | None) -> None:
     is_flag=True,
     help="Keep the existing archiver history even when the profile's retention/cadence knobs no longer match it. Without this, changed knobs rebuild the base series and discard recorded samples.",
 )
+@click.option(
+    "--reuse-stores",
+    is_flag=True,
+    help="Adopt data volumes left by an earlier deployment of this name, keeping their contents: each store's original credential is restored to .env in place of the one just generated. Checked before the stop, since stopping removes the containers this reads from.",
+)
 @click.pass_context
 def restart_verb(
     ctx: click.Context,
@@ -558,6 +570,7 @@ def restart_verb(
     chain_build: bool,
     as_built: bool,
     keep_archiver_base: bool,
+    reuse_stores: bool,
 ) -> None:
     """Stop and start this deployment again.
 
@@ -630,6 +643,7 @@ def restart_verb(
                     detached=detached,
                     dev_mode=dev,
                     keep_archiver_base=keep_archiver_base,
+                    reuse_stores=reuse_stores,
                 )
         except NoBuildError as e:
             _abort(f"{e} Nothing was stopped.")

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -890,6 +890,16 @@ def _list_presets_callback(ctx: click.Context, param: click.Parameter, value: bo
     is_flag=True,
     help="Skip `git init` and the initial commit.",
 )
+@click.option(
+    "--reset",
+    "reset",
+    is_flag=True,
+    help="Destroy the containers, data volumes and images left by a previous "
+    "deployment of this name before creating this one. Removing a deployment's "
+    "directory does not remove those — they are keyed on the project name and "
+    "outlive it — so re-creating under a used name inherits its stores. Use this "
+    "to start genuinely clean; it discards their data.",
+)
 @click.option("--up", "start", is_flag=True, help="Build the deployment and start it.")
 @click.option("-d", "--detach", "detached", is_flag=True, help="With --up: run in the background.")
 @click.option("--dev", is_flag=True, help="With --up: start in development mode.")
@@ -902,6 +912,7 @@ def init(
     set_pairs: tuple[str, ...],
     force: bool,
     no_git: bool,
+    reset: bool,
     start: bool,
     detached: bool,
     dev: bool,
@@ -1009,6 +1020,29 @@ def init(
 
         _report(target, materialized, deploy_files, git_note)
 
+        # After the repo exists and before anything is built or started. The
+        # repo root is what `reset_deployment` reads to resolve the project
+        # name and plan the removals, so it cannot run earlier; and the state
+        # it removes is what a `--up` below would otherwise inherit, so it
+        # must not run later.
+        if reset:
+            # Imported here, not at module scope: this command is lazy-loaded,
+            # and `reset` pulls in the whole deployment stack.
+            from osprey.deployment.reset import reset_deployment
+
+            with reporter.phase(f"Discarding the previous {target.name}"):
+                reset_deployment(target, assume_yes=True, emit=logger.key_info)
+
+            # `reset` removes only what carries this checkout's repo-id label,
+            # so a deployment predating that label survives it — correctly, since
+            # ownership cannot be proved. But this flag promised a clean start,
+            # and continuing without one walks into the stale-volume refusal
+            # further down, whose remedy is `osprey reset`: the very thing that
+            # just declined. Stop here and name the actual obstacle instead.
+            survivors = _surviving_project_resources(target)
+            if survivors:
+                _abort_incomplete_reset(target, survivors)
+
         if start:
             _chain_up(ctx, target, detached=detached, dev=dev)
 
@@ -1018,6 +1052,59 @@ def init(
         # deployment that is now running rather than three. An ATTACHED
         # `init --up` never arrives — compose replaced this process.
         print_summary_card(target, "running" if start else "created")
+
+
+def _surviving_project_resources(target: Path) -> list[str]:
+    """Containers and volumes still labelled for this project after a reset.
+
+    Read-only, and label-scoped to the compose project rather than to the
+    checkout: the point is to find exactly what ``reset``'s ownership proof
+    could NOT account for, so the narrower filter would report nothing every
+    time.
+
+    An unreachable runtime yields ``[]`` — a reset that could not run at all has
+    already failed loudly, and inventing a second failure here would only bury
+    the first.
+    """
+    from osprey.deployment.compose_generator import resolve_project_name
+    from osprey.deployment.reset import RuntimeProbe
+    from osprey.deployment.runtime_helper import get_runtime_command
+
+    project = resolve_project_name({"project_name": target.name})
+    try:
+        probe = RuntimeProbe(get_runtime_command({})[0])
+        return [
+            f"{resource.kind} {resource.name}"
+            for resource in (
+                *probe.containers_for_project(project),
+                *probe.volumes_for_project(project),
+            )
+        ]
+    except Exception:  # noqa: BLE001 — see docstring: never mask the real failure
+        return []
+
+
+def _abort_incomplete_reset(target: Path, survivors: list[str]) -> None:
+    """Stop a ``--reset`` that could not actually clear the name it was given."""
+    logger.error(
+        "✗ --reset could not clear %s: %d resource(s) of this project remain.\n\n%s\n\n"
+        "`osprey reset` removes only what carries this checkout's `com.osprey.repo-id` "
+        "label. These predate it — a deployment created before the label existed — so it "
+        "cannot prove they are this repo's and declines to touch them, which is what keeps "
+        "one checkout from destroying another's.\n\n"
+        "Remove them yourself, once, and every later deployment of this name will carry the "
+        "label and reset cleanly:\n"
+        "    docker ps -aq --filter label=com.docker.compose.project=%s | xargs docker rm -f\n"
+        "    docker volume ls -q --filter label=com.docker.compose.project=%s | xargs docker "
+        "volume rm\n\n"
+        "Nothing was built and nothing was started.",
+        target.name,
+        len(survivors),
+        "\n".join(f"    {line}" for line in survivors),
+        target.name,
+        target.name,
+    )
+    raise click.Abort()
 
 
 def _write_if_absent(path: Path, text: str) -> bool:

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -348,8 +348,11 @@ _ALREADY_A_REPO = (
     "{target} is already an OSPREY deployment repo (it has a profile.yml).\n\n"
     "Re-run with --force to re-materialize its source zone from the preset — "
     "which replaces profile.yml, data/, personas/, triggers.yml, "
-    "web-terminal-context/, and .env.example, losing any edit to them. These "
-    f"are left alone either way: {_PRESERVED_PROSE}."
+    "web-terminal-context/, and .env.example, losing any edit to them. To start "
+    "over on this name entirely, re-run with --reset: that re-materializes the "
+    "source zone the same way AND destroys the previous deployment's "
+    "containers, data volumes and images. These are left alone either way: "
+    f"{_PRESERVED_PROSE}."
 )
 
 _TARGET_NOT_EMPTY = (
@@ -894,11 +897,12 @@ def _list_presets_callback(ctx: click.Context, param: click.Parameter, value: bo
     "--reset",
     "reset",
     is_flag=True,
-    help="Destroy the containers, data volumes and images left by a previous "
-    "deployment of this name before creating this one. Removing a deployment's "
-    "directory does not remove those — they are keyed on the project name and "
-    "outlive it — so re-creating under a used name inherits its stores. Use this "
-    "to start genuinely clean; it discards their data.",
+    help="Start over on this name: destroy the containers, data volumes and "
+    "images left by a previous deployment of it, and re-materialize the source "
+    "zone as --force does when the repo directory still exists. Removing a "
+    "deployment's directory never removed its runtime state — it is keyed on "
+    "the project name and outlives the directory — so re-creating under a used "
+    f"name inherits its stores. Discards their data. Never touches: {_PRESERVED_PROSE}.",
 )
 @click.option("--up", "start", is_flag=True, help="Build the deployment and start it.")
 @click.option("-d", "--detach", "detached", is_flag=True, help="With --up: run in the background.")
@@ -963,7 +967,14 @@ def init(
     # mid-replacement is a whole repo again, so the refusals below judge the
     # deployment the operator has rather than the wreck of one.
     _reinstate_held_source_zone(target)
-    created = _prepare_repo_root(target, force=force)
+    # `--reset` implies `--force`'s file half. Its promise is "start over on
+    # this name", and a source zone left standing from the last deployment is
+    # not a start over — an edited profile.yml or a file an older preset wrote
+    # would carry into the new deployment silently. It is also what lets the
+    # flag work at all on the case it exists for: without it, a used name is
+    # refused right here, before the reset it asked for could ever run.
+    replacing = force or reset
+    created = _prepare_repo_root(target, force=replacing)
 
     # The reporter is installed around the `--up` chain as well as around the
     # creation itself: `_chain_up` invokes `build` and `up`, each of which finds
@@ -977,7 +988,7 @@ def init(
             # preset resolves in there — so the zone being replaced is held aside
             # for it rather than removed ahead of it.
             try:
-                with _replacing_source_zone(target, active=force):
+                with _replacing_source_zone(target, active=replacing):
                     materialized = _materialize_profile_directory(
                         target,
                         preset,

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import NamedTuple
@@ -2411,6 +2411,44 @@ def deploy_up(
         )
 
 
+#: One image's completion in BuildKit's plain-progress stream: ``naming to``
+#: is the export stage assigning the built image its tag, and only the line
+#: carrying ``done`` marks it finished — the bare form appears while the
+#: export is still running. The optional duration is BuildKit's own
+#: (``naming to <ref> 0.1s done``).
+_IMAGE_NAMED_LINE = re.compile(r"naming to (?P<ref>\S+?)(?: \d+(?:\.\d+)?s)? done\s*$")
+
+
+def compose_build_step_reporter() -> Callable[[str], None]:
+    """Per-image progress steps for a ``compose build``, from BuildKit's own stream.
+
+    ``compose build`` builds every service image in one parallel invocation —
+    the longest step of a dev deploy, half an hour cold — and a single step
+    line printed at the end reads as a hang for the whole build. Splitting the
+    build per service would give progress at the price of the parallelism, so
+    the steps are derived instead: fed to :func:`run_captured` as ``on_line``,
+    this watches the captured stream and reports each image the moment BuildKit
+    finishes it.
+
+    Deduplicated per image, because BuildKit repeats the ``naming to`` line
+    (bare, then with a duration). The implicit ``docker.io/library/`` prefix is
+    stripped as registry noise; a real registry in the tag is the operator's
+    own naming and stays.
+    """
+    seen: set[str] = set()
+
+    def report(line: str) -> None:
+        match = _IMAGE_NAMED_LINE.search(line)
+        if match is None:
+            return
+        ref = match.group("ref").removeprefix("docker.io/library/")
+        if ref not in seen:
+            seen.add(ref)
+            _report_step(f"service image {ref}")
+
+    return report
+
+
 def _start_stack(
     config: dict,
     compose_files: list[str],
@@ -2640,7 +2678,13 @@ def _start_stack(
         # service that has no published upstream tag to pull.
         build_cmd = base_cmd + ["build"]
         logger.debug(f"Running command:\n    {' '.join(build_cmd)}")
-        run_captured(build_cmd, env=run_env, spool_name="compose-build", repo_root=repo_root)
+        run_captured(
+            build_cmd,
+            env=run_env,
+            spool_name="compose-build",
+            repo_root=repo_root,
+            on_line=compose_build_step_reporter(),
+        )
         _report_step("service images built")
 
     # --remove-orphans reconciles away containers whose service left the

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import NamedTuple
 
 import yaml
 
@@ -150,6 +151,33 @@ _SERVICE_TOKEN_VARS: dict[str, tuple[str, ...]] = {
 # with a named-var/no-value error.
 _VALIDATE_ONLY_VARS: set[str] = {"ARIEL_DSN"}
 
+
+class VolumeInitializedStore(NamedTuple):
+    """Where one store's identity lives on the host, for the stale-volume check.
+
+    Four names that must agree with the service's compose template, which
+    ``TestRegistryAgreement`` in the per-store mint tests pins field by field:
+
+    * ``service`` — the ``deployed_services`` key, and the name shown to the
+      operator;
+    * ``volume`` — the *bare* volume name the template declares. Compose
+      namespaces it with the project name on the host, so the host-side name is
+      ``<project>_<volume>``;
+    * ``container`` — the suffix the template appends to the project name in
+      ``container_name``. The container is the only host-side record of the
+      credential its volume was initialized with;
+    * ``cred_env`` — what that credential is called *inside* the container,
+      which is not the ``.env`` var name for two of the three stores
+      (``MONGO_ROOT_PASSWORD`` arrives as ``MONGO_INITDB_ROOT_PASSWORD``,
+      ``ARIEL_DB_PASSWORD`` as ``POSTGRES_PASSWORD``).
+    """
+
+    service: str
+    volume: str
+    container: str
+    cred_env: str
+
+
 #: Minted vars a service reads ONLY when it initializes a fresh data volume.
 #: For every other token, minting a new value and restarting is enough; for
 #: these the container keeps whatever it was born with, so a fresh mint
@@ -160,12 +188,27 @@ _VALIDATE_ONLY_VARS: set[str] = {"ARIEL_DSN"}
 #: ``.env`` (or just its minted section) while the volumes lived. Every var here
 #: is interpolated with a ``:-`` DEFAULT in its compose template, so none
 #: carries a ``:?`` guard that would abort the deploy and say so — which is why
-#: this warning is the only thing standing between that operator and a login
-#: that will not work for reasons nothing has named.
-_VOLUME_INITIALIZED_VARS: dict[str, str] = {
-    "ZO_ROOT_USER_PASSWORD": "openobserve",
-    "ARIEL_DB_PASSWORD": "postgresql",
-    "MONGO_ROOT_PASSWORD": "mongodb",
+#: ``_preflight_stale_store_volumes`` is the only thing standing between that
+#: operator and a login that will not work for reasons nothing has named.
+_VOLUME_INITIALIZED_VARS: dict[str, VolumeInitializedStore] = {
+    "ZO_ROOT_USER_PASSWORD": VolumeInitializedStore(
+        service="openobserve",
+        volume="openobserve_data",
+        container="-openobserve",
+        cred_env="ZO_ROOT_USER_PASSWORD",
+    ),
+    "ARIEL_DB_PASSWORD": VolumeInitializedStore(
+        service="postgresql",
+        volume="ariel_postgres_data",
+        container="-ariel-postgres",
+        cred_env="POSTGRES_PASSWORD",
+    ),
+    "MONGO_ROOT_PASSWORD": VolumeInitializedStore(
+        service="mongodb",
+        volume="archiver_mongodb_data",
+        container="-archiver-mongodb",
+        cred_env="MONGO_INITDB_ROOT_PASSWORD",
+    ),
 }
 
 # Document-plane CURVE certificate layout, relative to the project directory.
@@ -230,8 +273,14 @@ def _ensure_service_tokens(
     config: dict,
     expose_network: bool,
     env_path: Path | None = None,
-) -> None:
+) -> set[str]:
     """Self-provision required fail-closed service tokens into ``env_path``.
+
+    :returns: The ``_VOLUME_INITIALIZED_VARS`` names this call actually minted —
+        the subset whose brand-new value a pre-existing data volume would
+        ignore. Empty on the common paths (nothing minted, or nothing minted
+        that a volume adopts), and the input to
+        ``_preflight_stale_store_volumes``.
 
     ``osprey up`` passes the deployment repo's own ``.env`` explicitly; a caller
     that passes nothing falls back to a cwd-relative ``.env`` (see the
@@ -276,6 +325,7 @@ def _ensure_service_tokens(
     entry at all, since a validate-only var's presence does not depend on
     ``deployed_services`` membership.
     """
+    minted_volume_initialized: set[str] = set()
     deployed_services = config.get("deployed_services")
     services = {str(s) for s in (deployed_services or [])}
 
@@ -359,28 +409,14 @@ def _ensure_service_tokens(
 
             # A mint is the moment the volume-initialized vars become a hazard:
             # the value is new, and any volume that already exists will keep
-            # ignoring it. Warn — never refuse — because the same mint is also
-            # the completely ordinary first-deploy case, where there is no
-            # volume yet and nothing is wrong. Names only, never values, in
-            # keeping with every other line this function logs.
-            for name in sorted(generated):
-                service = _VOLUME_INITIALIZED_VARS.get(name)
-                if service is None:
-                    continue
-                logger.warning(
-                    "%s was newly generated. %s reads it only when it initializes a "
-                    "fresh data volume, so if this deployment's %s volume already "
-                    "exists it keeps the credential it was created with and will "
-                    "reject the new one. If you cannot sign in to %s, remove that "
-                    "volume so it re-initializes (`osprey reset` does it for the "
-                    "whole stack), or put the original %s back in %s.",
-                    name,
-                    service,
-                    service,
-                    service,
-                    name,
-                    env_path.resolve(),
-                )
+            # ignoring it. Report them upward rather than warning here — whether
+            # this is the ordinary first deploy (no volume yet, nothing wrong)
+            # or a mismatch that cannot work is not a guess: it is one
+            # label-filtered `volume ls` away, which is what
+            # _preflight_stale_store_volumes asks before anything starts.
+            minted_volume_initialized |= {
+                name for name in generated if name in _VOLUME_INITIALIZED_VARS
+            }
 
     # Validate the effective value of every required var — whichever of
     # process env, an existing .env, or a value just minted above the caller
@@ -410,6 +446,275 @@ def _ensure_service_tokens(
             continue  # absent — never fabricated, never minted
         if not _validate_var(name, effective):
             _raise_invalid_var(name, effective)
+
+    return minted_volume_initialized
+
+
+def _volume_initialized_vars_that_would_be_minted(config: dict, env_path: Path) -> set[str]:
+    """Which store credentials a mint on this config *would* generate.
+
+    The same rule ``_ensure_service_tokens`` mints by — absent from both the
+    process env and the ``.env`` — evaluated without writing anything. It exists
+    for ``restart``, which has to run the stale-volume check BEFORE its ``down``:
+    the ``down`` removes the store containers, and with them the only host-side
+    copy of the credential each surviving volume was initialized with. Asking
+    after the stop would find every volume unrecoverable, having just made it so.
+    """
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    services = {str(s) for s in (config.get("deployed_services") or [])}
+    on_disk = parse_dotenv_file(env_path) if env_path.is_file() else {}
+    return {
+        var
+        for var, store in _VOLUME_INITIALIZED_VARS.items()
+        if store.service in services and var not in os.environ and var not in on_disk
+    }
+
+
+def _harvest_original_credential(probe, project: str, store: VolumeInitializedStore) -> str | None:
+    """The credential *store*'s volume was initialized with, if still readable.
+
+    ``None`` whenever the container is gone, carries no such variable, or holds
+    an empty one — every case in which the volume cannot be reopened and the
+    only way forward is to discard it.
+    """
+    env = probe.env_of_container(f"{project}{store.container}")
+    if not env:
+        return None
+    return env.get(store.cred_env) or None
+
+
+def _stale_store_volumes(
+    probe,
+    project: str,
+    minted: set[str],
+    services: set[str],
+    env_path: Path,
+) -> tuple[list[tuple[str, VolumeInitializedStore]], dict[str, str | None]]:
+    """Stores whose surviving data volume will reject the credential in ``.env``.
+
+    Read-only, and asked of the runtime rather than assumed: a credential beside
+    no volume is the ordinary first deploy, and one beside a surviving volume
+    may be unusable. Only the runtime knows which.
+
+    A store qualifies on either of two independent grounds, because neither
+    alone covers the ground the other does:
+
+    * *this run minted the credential* — the value is brand new and a volume
+      that already exists never adopted it. The only rule that can speak for a
+      store whose container is gone, since there is then nothing to compare
+      against;
+    * *the store's own container disagrees with ``.env``* — a running container
+      holds the credential the volume actually has, so a ``.env`` that differs
+      cannot authenticate no matter who wrote it or how long ago. This is the
+      rule that recognises a deployment already in the broken state, where a
+      previous run's mint is sitting in ``.env`` and nothing new is minted.
+
+    Deliberately NOT a third ground: a surviving volume with no container to
+    compare against and nothing minted. That is simply a stopped deployment —
+    the normal way one sits between sessions — and refusing it would block
+    every start.
+
+    Returns the qualifying ``(env_var, store)`` pairs in
+    ``_VOLUME_INITIALIZED_VARS`` order (so a multi-store report reads the same
+    way every time), together with each one's harvested original credential —
+    ``None`` where the volume can no longer be reopened.
+    """
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    try:
+        existing = {resource.name for resource in probe.volumes_for_project(project)}
+    except RuntimeError as exc:
+        # A runtime that cannot answer must not become a deploy-blocking verdict
+        # of its own: fall through to the start, where the store's own
+        # authentication failure still reports the mismatch the old way.
+        logger.warning("Could not check this deployment's data volumes: %s", exc)
+        return [], {}
+
+    on_disk = parse_dotenv_file(env_path) if env_path.is_file() else {}
+    stale: list[tuple[str, VolumeInitializedStore]] = []
+    originals: dict[str, str | None] = {}
+
+    for var, store in _VOLUME_INITIALIZED_VARS.items():
+        if store.service not in services:
+            continue
+        if f"{project}_{store.volume}" not in existing:
+            continue
+
+        original = _harvest_original_credential(probe, project, store)
+        # The value compose will actually substitute: a shell export outranks
+        # --env-file, the same precedence _ensure_service_tokens mints by and
+        # _preflight_env_shadowing warns about.
+        effective = _effective_value(var, on_disk)
+        disagrees = original is not None and bool(effective) and original != effective
+
+        if var in minted or disagrees:
+            stale.append((var, store))
+            originals[var] = original
+
+    return stale, originals
+
+
+def _preflight_stale_store_volumes(
+    config: dict,
+    minted: set[str],
+    env_path: Path,
+    *,
+    reuse_stores: bool = False,
+) -> None:
+    """Abort before anything starts when a fresh credential meets an old volume.
+
+    A refusal rather than a warning, and here rather than at the store's own
+    health probe, for two reasons that both come down to what ``compose up``
+    does on its way past:
+
+    * it recreates the store container — and that container's environment is
+      the only host-side record of the credential its volume was initialized
+      with. Starting the stack overwrites it with the value that cannot work,
+      turning a recoverable mismatch into a permanently orphaned volume;
+    * it builds the project image first, so the store's own "Authentication
+      failed" arrives minutes later and names only whichever store was probed
+      first, leaving the rest to be found one restart at a time.
+
+    With *reuse_stores*, adopt the volumes instead: restore each store's
+    original credential to ``env_path`` in place of the value just minted. That
+    is only possible while the store's container survives, so a run that cannot
+    reopen every stale volume still refuses rather than starting a stack that
+    is half-adopted and half-doomed.
+
+    :raises RuntimeError: if any deployed store has a surviving volume that will
+        reject the credential in ``env_path``, and this run is not able (or not
+        asked) to adopt it.
+    """
+    services = {str(s) for s in (config.get("deployed_services") or [])}
+    if not any(store.service in services for store in _VOLUME_INITIALIZED_VARS.values()):
+        return  # the fast path: no volume-initialized store is deployed at all
+
+    # Imported here, not at module scope: reset.py imports THIS module, so a
+    # top-level import would close a cycle. RuntimeProbe is the codebase's one
+    # container-runtime conversation seam — every listing label-filtered, every
+    # removal naming exactly one resource — and nothing here removes anything.
+    from osprey.deployment.reset import RuntimeProbe
+
+    project = resolve_project_name(config)
+    probe = RuntimeProbe(get_runtime_command(config)[0], run=subprocess.run)
+
+    stale, originals = _stale_store_volumes(probe, project, minted, services, env_path)
+    if not stale:
+        return
+
+    if reuse_stores and all(originals.values()):
+        _adopt_original_credentials(env_path, stale, originals)
+        return
+
+    raise RuntimeError(
+        _stale_store_report(project, env_path, stale, originals, reuse_stores=reuse_stores)
+    )
+
+
+def _adopt_original_credentials(
+    env_path: Path,
+    stale: list[tuple[str, VolumeInitializedStore]],
+    originals: dict[str, str | None],
+) -> None:
+    """Put each store's original credential into ``.env``, replacing any mint.
+
+    Both shapes occur, because the two start paths reach here at opposite sides
+    of the mint. ``up`` has already minted, so the file carries a fresh
+    assignment that must be *rewritten in place* — appending instead would leave
+    two assignments of one name, and which wins would depend on the reader
+    (compose takes the last; a human takes the first they see). ``restart``
+    checks before its ``down`` and therefore before any mint, so the file may
+    not carry the name at all and the value has to be appended.
+    """
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    text = env_path.read_text(encoding="utf-8") if env_path.is_file() else ""
+    on_disk = parse_dotenv_file(env_path) if env_path.is_file() else {}
+
+    absent: dict[str, str] = {}
+    for var, _store in stale:
+        original = originals[var]
+        if original is None:  # unreachable via the caller's `all(...)` guard
+            continue
+        if var in on_disk:
+            text = re.sub(
+                rf"^{re.escape(var)}=.*$",
+                f"{var}={original}",
+                text,
+                flags=re.MULTILINE,
+            )
+        else:
+            absent[var] = original
+    env_path.write_text(text, encoding="utf-8")
+    if absent:
+        _append_env_block(
+            env_path,
+            "Credentials adopted from pre-existing data volumes (osprey --reuse-stores)",
+            absent,
+        )
+
+    written = parse_dotenv_file(env_path)
+    missed = [var for var, _ in stale if written.get(var) != originals[var]]
+    if missed:
+        raise RuntimeError(
+            f"Could not restore {', '.join(sorted(missed))} in {env_path.resolve()}. "
+            "Edit the file by hand, or re-run without --reuse-stores."
+        )
+
+    logger.key_info(
+        "Adopted %d pre-existing data volume(s): restored the credential(s) %s they were "
+        "initialized with into %s. Values are never printed.",
+        len(stale),
+        ", ".join(var for var, _ in stale),
+        env_path.resolve(),
+    )
+
+
+def _stale_store_report(
+    project: str,
+    env_path: Path,
+    stale: list[tuple[str, VolumeInitializedStore]],
+    originals: dict[str, str | None],
+    *,
+    reuse_stores: bool,
+) -> str:
+    """The refusal text: what is stale, and which way out each store leaves open.
+
+    Names variables and volumes, never values — the same rule every other
+    secret-touching line on this path follows.
+    """
+    lines = [
+        f"{len(stale)} store(s) of this deployment have a data volume that predates the "
+        f"credentials just generated in {env_path.resolve()}.",
+        "Each store reads its root credential only while initializing an empty volume, so it "
+        "keeps the password it was created with and will reject the new one:",
+        "",
+    ]
+    for var, store in stale:
+        lines.append(f"    {store.service:<12} {project}_{store.volume}")
+        if originals[var] is None:
+            lines.append(f"    {'':<12} its container is gone — the original is unrecoverable")
+        else:
+            lines.append(f"    {'':<12} original recoverable from {project}{store.container}")
+    lines.append("")
+
+    recoverable = [var for var, _ in stale if originals[var] is not None]
+    if reuse_stores:
+        lines.append(
+            "--reuse-stores cannot reopen every volume: a store whose container has been "
+            "recreated no longer holds the credential its volume was initialized with."
+        )
+        if recoverable:
+            lines.append(
+                f"The other {len(recoverable)} could be adopted, but starting a stack that is "
+                "half-adopted and half-doomed only moves the failure later."
+            )
+    elif len(recoverable) == len(stale):
+        lines.append("--reuse-stores     keep the data: restore the original credential(s) to .env")
+    lines.append("`osprey reset` re-initializes the whole stack, discarding the data in it.")
+    lines += ["", "Nothing was started and no image was built."]
+    return "\n".join(lines)
 
 
 def _refuse_invented_history(config: dict) -> None:
@@ -2043,6 +2348,7 @@ def deploy_up(
     dev_mode=False,
     expose_network=False,
     keep_archiver_base=False,
+    reuse_stores=False,
 ):
     """Start services using container runtime (Docker or Podman).
 
@@ -2101,6 +2407,7 @@ def deploy_up(
             # which looks secure and says nothing.
             env_path=repo_root / COMPOSE_ENV_FILENAME,
             keep_archiver_base=keep_archiver_base,
+            reuse_stores=reuse_stores,
         )
 
 
@@ -2115,6 +2422,7 @@ def _start_stack(
     env_path: Path | None = None,
     build_context: Path | str | None = None,
     keep_archiver_base: bool = False,
+    reuse_stores: bool = False,
 ) -> None:
     """Provision, preflight and start one already-resolved stack.
 
@@ -2198,7 +2506,17 @@ def _start_stack(
     # carries provider keys renders with osprey_env_present=True and picks up
     # the appended tokens, and a tokens-only .env carries no provider secret to
     # mount in the first place.
-    _ensure_service_tokens(config, expose_network, env_path)
+    minted_store_vars = _ensure_service_tokens(config, expose_network, env_path)
+
+    # Refuse a deploy whose freshly minted store credentials meet data volumes
+    # that predate them. Directly after the mint (which is what creates the
+    # hazard) and before every container-touching step below — including the
+    # image build and the archiver staging — because `compose up` recreating a
+    # store container destroys the only host-side copy of the credential that
+    # volume was initialized with. See _preflight_stale_store_volumes.
+    _preflight_stale_store_volumes(
+        config, minted_store_vars, env_path or Path(".env"), reuse_stores=reuse_stores
+    )
 
     # Fail fast on the optional dependency the staged archiver bring-up below
     # cannot proceed without. Here, beside the mint that provisions the store's
@@ -2469,6 +2787,7 @@ def up_as_built(
     detached: bool = False,
     dev_mode: bool = False,
     keep_archiver_base: bool = False,
+    reuse_stores: bool = False,
 ) -> None:
     """Start a deployment repo from ``build/`` exactly as it was built.
 
@@ -2524,6 +2843,7 @@ def up_as_built(
         detached=detached,
         dev_mode=dev_mode,
         keep_archiver_base=keep_archiver_base,
+        reuse_stores=reuse_stores,
     )
 
 
@@ -2684,6 +3004,7 @@ def _start_as_built(
     detached: bool,
     dev_mode: bool,
     keep_archiver_base: bool = False,
+    reuse_stores: bool = False,
 ) -> None:
     """Start already-resolved as-built inputs, with a deployment repo's rules.
 
@@ -2719,6 +3040,7 @@ def _start_as_built(
             env_path=repo_root / COMPOSE_ENV_FILENAME,
             build_context=container_image_context(repo_root, resolve_project_name(config)),
             keep_archiver_base=keep_archiver_base,
+            reuse_stores=reuse_stores,
         )
 
 
@@ -2910,6 +3232,7 @@ def restart_deployment(
     detached: bool = False,
     dev_mode: bool = False,
     keep_archiver_base: bool = False,
+    reuse_stores: bool = False,
 ) -> None:
     """Stop this deployment and start it again from ``build/``.
 
@@ -2948,6 +3271,22 @@ def restart_deployment(
     """
     repo_root = Path(repo_root)
     config, compose_files, exposed = _resolve_as_built_inputs(repo_root, dev_mode=dev_mode)
+
+    # BEFORE the stop, unlike every other start path, and that ordering is the
+    # whole point: `down` removes the store containers, and a removed container
+    # takes with it the only host-side copy of the credential its data volume
+    # was initialized with. Run at the usual point — after the stop, inside
+    # `_start_as_built` — this check would report every stale volume as
+    # unrecoverable, having itself destroyed the evidence moments earlier.
+    # Nothing is minted yet here, so the set is the one a mint *would* generate.
+    env_path = repo_root / COMPOSE_ENV_FILENAME
+    _preflight_stale_store_volumes(
+        config,
+        _volume_initialized_vars_that_would_be_minted(config, env_path),
+        env_path,
+        reuse_stores=reuse_stores,
+    )
+
     down_deployment(repo_root)
     _start_as_built(
         repo_root,
@@ -2957,6 +3296,7 @@ def restart_deployment(
         detached=detached,
         dev_mode=dev_mode,
         keep_archiver_base=keep_archiver_base,
+        reuse_stores=reuse_stores,
     )
 
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -2508,21 +2508,25 @@ def _start_stack(
     # mount in the first place.
     minted_store_vars = _ensure_service_tokens(config, expose_network, env_path)
 
-    # Refuse a deploy whose freshly minted store credentials meet data volumes
-    # that predate them. Directly after the mint (which is what creates the
-    # hazard) and before every container-touching step below — including the
-    # image build and the archiver staging — because `compose up` recreating a
-    # store container destroys the only host-side copy of the credential that
-    # volume was initialized with. See _preflight_stale_store_volumes.
-    _preflight_stale_store_volumes(
-        config, minted_store_vars, env_path or Path(".env"), reuse_stores=reuse_stores
-    )
-
     # Fail fast on the optional dependency the staged archiver bring-up below
     # cannot proceed without. Here, beside the mint that provisions the store's
     # own credential, rather than at the seeder: a missing extra must abort in
     # seconds, before the minutes-long image build, not after it.
     _preflight_archiver_pymongo(config)
+
+    # Refuse a deploy whose store credentials a surviving data volume will
+    # reject. Before every container-touching step below — the image build and
+    # the archiver staging included — because `compose up` recreating a store
+    # container destroys the only host-side copy of the credential that volume
+    # was initialized with. See _preflight_stale_store_volumes.
+    #
+    # But AFTER the pymongo check above, which is a local import and costs
+    # nothing: this one is the first thing on the path to ask the container
+    # runtime a question, and a deploy doomed by a missing extra must abort
+    # without having touched the host at all.
+    _preflight_stale_store_volumes(
+        config, minted_store_vars or set(), env_path or Path(".env"), reuse_stores=reuse_stores
+    )
 
     # Auto-configure the bluesky bridge's EPICS-substrate scan devices for a
     # VA-backed Bluesky stack (additive; no-op unless both bluesky and

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -187,6 +187,7 @@ MINTED_ENV_BANNERS: tuple[str, ...] = (
     "Auto-generated service auth tokens (osprey deploy up)",
     "Auto-configured bluesky bridge scan devices (osprey deploy up)",
     "Auto-generated bluesky RE manager control-socket keypair (osprey deploy up)",
+    "Credentials adopted from pre-existing data volumes (osprey --reuse-stores)",
 )
 
 

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -483,6 +483,36 @@ class RuntimeProbe:
         names = [line.strip() for line in (listing.stdout or "").splitlines() if line.strip()]
         return [Resource("volume", name, self._labels_of("volume", name)) for name in names]
 
+    def env_of_container(self, name: str) -> Mapping[str, str] | None:
+        """Read-only: one container's environment, or ``None`` if unreadable.
+
+        The deploy path's stale-volume preflight uses this and nothing else
+        does: a store container's environment is the only host-side record of
+        the credential its data volume was initialized with, so while the
+        container survives the volume can still be reopened, and once it has
+        been recreated the volume is orphaned.
+
+        ``None`` means "no such container" — which for that preflight is not an
+        error but the answer itself, and the reason it must run before anything
+        recreates one.
+
+        Scoped by name rather than by label filter, unlike every listing above,
+        because the caller wants one exact container: the compose template
+        derives ``container_name`` from the project name, so the name is already
+        project-qualified. Nothing here removes anything.
+        """
+        result = self._capture(
+            ["container", "inspect", name, "--format", "{{range .Config.Env}}{{println .}}{{end}}"]
+        )
+        if result.returncode != 0:
+            return None
+        env: dict[str, str] = {}
+        for line in (result.stdout or "").splitlines():
+            key, sep, value = line.partition("=")
+            if sep and key.strip():
+                env[key.strip()] = value
+        return env
+
     def image_if_ours(self, tag: str, project: str) -> Resource | None:
         """Read-only: *tag* as a removal candidate, or ``None`` if it is not one.
 

--- a/src/osprey/deployment/subprocess_capture.py
+++ b/src/osprey/deployment/subprocess_capture.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import subprocess
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 
 from osprey.cli.phase_reporter import current_reporter, is_verbose
@@ -111,6 +111,7 @@ def run_captured(
     spool_name: str,
     repo_root: Path | str | None = None,
     check: bool = True,
+    on_line: Callable[[str], None] | None = None,
 ) -> CapturedProcess:
     """Run ``cmd``, spooling its merged output to ``<repo>/var/logs/``.
 
@@ -127,6 +128,13 @@ def run_captured(
         means the current directory, the same default the compose ``--env-file``
         helpers use. No repo discovery happens here.
     :param check: Raise :class:`CapturedProcessError` on a non-zero exit.
+    :param on_line: Watch the child's merged stream, line by line, as decoded
+        text without its newline. The spool stays byte-for-byte complete either
+        way — the callback is a tee, not a diversion — and it is cosmetic by
+        contract: an exception it raises is logged at debug and changes nothing
+        about the run's outcome. Ignored under ``--verbose``, where the child's
+        own lines are already on the terminal and derived progress would only
+        duplicate them.
     :returns: A :class:`CapturedProcess`, whose ``spool_path`` is the file this
         run's output went to, or ``None`` in verbose mode.
         ``stdout``/``stderr`` are ``None`` — the output is in that file (or on
@@ -157,9 +165,14 @@ def run_captured(
         # The reporter keeps the path for the whole phase, not just this call:
         # an interrupt during the child needs to name the partial output.
         current_reporter().note_spool(spool_path)
-        # stderr into the same handle, not a second file — a build's errors are
-        # only legible interleaved with the step they interrupted.
-        completed = subprocess.run(cmd, env=env, cwd=cwd, stdout=spool, stderr=subprocess.STDOUT)
+        if on_line is None:
+            # stderr into the same handle, not a second file — a build's errors
+            # are only legible interleaved with the step they interrupted.
+            completed = subprocess.run(
+                cmd, env=env, cwd=cwd, stdout=spool, stderr=subprocess.STDOUT
+            )
+        else:
+            completed = _run_teeing(cmd, env=env, cwd=cwd, spool=spool, on_line=on_line)
 
     if check and completed.returncode != 0:
         raise CapturedProcessError(cmd, completed.returncode, spool_path)
@@ -168,6 +181,39 @@ def run_captured(
     # that does not raise still has to be able to name the file its output went
     # to, and it may be running with no phase open at all.
     return CapturedProcess(cmd, completed.returncode, spool_path=spool_path)
+
+
+def _run_teeing(
+    cmd: Sequence[str],
+    *,
+    env: Mapping[str, str] | None,
+    cwd: Path | str | None,
+    spool,
+    on_line: Callable[[str], None],
+) -> subprocess.CompletedProcess:
+    """The watched variant of the capture: every line to the spool AND the callback.
+
+    The direct-to-file ``subprocess.run`` cannot offer a per-line hook, so this
+    path reads the child's merged stream through a pipe and writes it on. The
+    bytes reaching the spool are the child's own; only the callback gets a
+    decoded copy, with U+FFFD standing in for anything that is not UTF-8 —
+    a build log's occasional garbage must not take down the build.
+
+    The callback is fenced per line rather than per run: one line the parser
+    chokes on costs that line's step at debug level, not every step after it.
+    """
+    with subprocess.Popen(
+        cmd, env=env, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    ) as process:
+        assert process.stdout is not None  # PIPE above guarantees it
+        for raw in process.stdout:
+            spool.write(raw)
+            try:
+                on_line(raw.decode("utf-8", errors="replace").rstrip("\r\n"))
+            except Exception as exc:
+                logger.debug("on_line callback failed on %r: %s", raw[:200], exc)
+        returncode = process.wait()
+    return subprocess.CompletedProcess(list(cmd), returncode)
 
 
 __all__ = ["SPOOL_DIR", "SPOOL_RETENTION", "CapturedProcess", "run_captured"]

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -941,10 +941,19 @@ def deploy_up_web_terminals(
             # running the stale code from its first build. Build in its own step,
             # then `up --no-build`, to dodge the `up --build` containerd
             # image-store race.
+            # Function-level import, like `_env_file_args` below:
+            # container_lifecycle imports this module at its own top level, so
+            # the favour cannot be returned there.
+            from osprey.deployment.container_lifecycle import compose_build_step_reporter
+
             services_build = services_base + ["build"]
             logger.debug(f"Running command:\n    {' '.join(services_build)}")
             run_captured(
-                services_build, env=run_env, spool_name="build-services", repo_root=repo_root
+                services_build,
+                env=run_env,
+                spool_name="build-services",
+                repo_root=repo_root,
+                on_line=compose_build_step_reporter(),
             )
             _report_step("built service images")
         services_cmd = services_base + ["up"]

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -895,3 +895,122 @@ def test_importing_the_module_stays_off_the_heavy_chain() -> None:
         [sys.executable, "-c", probe], capture_output=True, text=True, check=True
     )
     assert completed.stdout.split() == ["False", "False"]
+
+
+class TestResetFlag:
+    """``--reset`` — starting over on a name that has been used before.
+
+    ``rm -rf <repo>`` removes a deployment's directory but not its containers or
+    its data volumes, which are keyed on the project name and outlive any number
+    of re-creations. Re-creating the repo under the same name therefore inherits
+    the previous deployment's stores, whose credentials the new ``.env`` does not
+    have. ``--reset`` is the way to say "that deployment is gone, take its
+    runtime state with it", in the one command that would otherwise walk
+    straight into that.
+
+    Delegated to ``reset_deployment`` (imported at call time, so these patch
+    it on its own module) rather than reimplemented: it already owns
+    the label-scoped plan, the foreign-checkout refusal, and the
+    one-resource-at-a-time removals. By the time this runs the repo has been
+    materialized, so that machinery has the repo root it needs.
+    """
+
+    def test_it_discards_the_previous_deployments_runtime_state(
+        self, runner, tmp_path, monkeypatch
+    ):
+        calls: list[dict] = []
+        monkeypatch.setattr(
+            "osprey.deployment.reset.reset_deployment",
+            lambda repo_root, **kw: calls.append({"repo_root": Path(repo_root), **kw}) or True,
+        )
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert len(calls) == 1, "expected exactly one reset of the target repo"
+        assert calls[0]["repo_root"] == tmp_path / "demo"
+        # No prompt: the operator already said so on the command line, and the
+        # point of the flag is a one-line re-create that runs unattended.
+        assert calls[0]["assume_yes"] is True
+
+    def test_it_runs_after_the_repo_exists(self, runner, tmp_path, monkeypatch):
+        """``reset_deployment`` reads the repo it is pointed at, so order matters.
+
+        Called before materialization it would be handed a directory with no
+        profile.yml, and would resolve the project name from a repo not yet there.
+        """
+        seen: list[bool] = []
+        monkeypatch.setattr(
+            "osprey.deployment.reset.reset_deployment",
+            lambda repo_root, **kw: (
+                seen.append((Path(repo_root) / "profile.yml").is_file()) or True
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen == [True]
+
+    def test_it_refuses_when_the_sweep_left_this_projects_resources_behind(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """A reset that could not prove ownership must not report a clean start.
+
+        ``osprey reset`` only removes what carries this checkout's repo-id
+        label, so resources from a deployment that predates that label survive
+        it — correctly, since it cannot prove they are this repo's. Continuing
+        anyway walks into the stale-volume refusal 40 seconds later, whose
+        remedy is `osprey reset`: the exact thing that just declined. Naming the
+        real cause here is the difference between a dead end and a fix.
+        """
+        monkeypatch.setattr(
+            "osprey.deployment.reset.reset_deployment", lambda repo_root, **kw: True
+        )
+        monkeypatch.setattr(
+            "osprey.cli.init_cmd._surviving_project_resources",
+            lambda target: ["container old-thing", "volume old-thing_data"],
+        )
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        assert result.exit_code != 0
+        assert "old-thing" in result.output
+        assert "com.osprey.repo-id" in result.output
+
+    def test_it_proceeds_when_the_sweep_was_complete(self, runner, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "osprey.deployment.reset.reset_deployment", lambda repo_root, **kw: True
+        )
+        monkeypatch.setattr("osprey.cli.init_cmd._surviving_project_resources", lambda target: [])
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        assert result.exit_code == 0, result.output
+
+    def test_without_the_flag_nothing_is_reset(self, runner, tmp_path, monkeypatch):
+        """The default must never destroy a volume — that is what the flag is for."""
+        calls: list = []
+        monkeypatch.setattr(
+            "osprey.deployment.reset.reset_deployment",
+            lambda repo_root, **kw: calls.append(repo_root) or True,
+        )
+
+        result = runner.invoke(
+            cli, ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert calls == []

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -1000,6 +1000,54 @@ class TestResetFlag:
 
         assert result.exit_code == 0, result.output
 
+    def test_it_re_materializes_the_source_zone_without_force(
+        self, exemplar_repo, runner, monkeypatch
+    ):
+        """``--reset`` on a used name is the whole command — no ``--force`` beside it.
+
+        The flag's promise is "start over on this name", and a source zone left
+        standing from the last deployment is not a start over: an edit made to
+        the old ``profile.yml``, or a file an older preset wrote, would carry
+        into the new deployment silently. Implying ``--force`` is also what
+        makes the flag work AT ALL on the case it exists for — without it a used
+        name is refused by the repo-root check before ``--reset`` is ever
+        reached, and the refusal names the wrong problem.
+
+        What ``--force`` never touches, ``--reset`` never touches either:
+        ``PRESERVED_BY_FORCE`` is one table and this path goes through the same
+        code. The provider keys in ``.env`` are the ones that matter here — the
+        reason to converge a repo in place rather than delete and re-create it.
+        """
+        monkeypatch.setattr(
+            "osprey.deployment.reset.reset_deployment", lambda repo_root, **kw: True
+        )
+        stale_marker = "STALE-FROM-THE-LAST-DEPLOYMENT"
+        (exemplar_repo / "profile.yml").write_text(f"name: {stale_marker}\n", encoding="utf-8")
+        (exemplar_repo / "data" / "orphan.json").write_text("{}\n", encoding="utf-8")
+        env = exemplar_repo / ".env"
+        env.write_text("MY_PROVIDER_KEY=keepme\n", encoding="utf-8")
+
+        result = init_exemplar(runner, exemplar_repo, "--reset")
+
+        assert result.exit_code == 0, result.output
+        assert stale_marker not in (exemplar_repo / "profile.yml").read_text(encoding="utf-8")
+        assert not (exemplar_repo / "data" / "orphan.json").exists()
+        assert "MY_PROVIDER_KEY=keepme" in env.read_text(encoding="utf-8")
+
+    def test_the_refusal_on_a_used_name_offers_the_flag(self, exemplar_repo, runner):
+        """The wall an operator hits is where they must learn the way through it.
+
+        Without ``--reset`` named here, the only advertised way past a used name
+        is ``--force``, which leaves the previous deployment's containers and
+        volumes in place — and the stale-store refusal that follows sends them
+        to ``osprey reset``, a verb that wants the repo they were told to
+        re-create.
+        """
+        result = init_exemplar(runner, exemplar_repo)
+
+        assert result.exit_code == 2
+        assert "--reset" in result.output
+
     def test_without_the_flag_nothing_is_reset(self, runner, tmp_path, monkeypatch):
         """The default must never destroy a volume — that is what the flag is for."""
         calls: list = []

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -21,6 +21,33 @@ from osprey.deployment import container_lifecycle
 from osprey.deployment.web_terminals import postup_hooks, provision
 
 
+def _fake_popen(record):
+    """A ``subprocess.Popen`` stand-in for the watched capture path.
+
+    The dev-mode ``compose build`` runs with an ``on_line`` watcher, which
+    routes it through ``Popen`` rather than ``subprocess.run`` — so a test that
+    fakes only ``run`` would let the build escape to a real child. The stand-in
+    records the argv through ``record(cmd, env)``, yields no output, and exits
+    0, keeping the argv assertions blind to which of the two paths ran a call.
+    """
+
+    class FakePopen:
+        def __init__(self, cmd, env=None, **kwargs):
+            record(list(cmd), env)
+            self.stdout = iter(())
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def wait(self):
+            return 0
+
+    return FakePopen
+
+
 @pytest.fixture
 def captured_argv(monkeypatch, tmp_path):
     """Patch deploy_up's collaborators and capture the compose argv.
@@ -47,6 +74,11 @@ def captured_argv(monkeypatch, tmp_path):
         return _FakeCompletedProcess(returncode=0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "Popen",
+        _fake_popen(lambda cmd, env: captured.update(cmd=cmd, env=env)),
+    )
     return captured
 
 
@@ -454,6 +486,11 @@ def captured_combined_runs(monkeypatch, tmp_path):
         return _FakeCompletedProcess(returncode=0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "Popen",
+        _fake_popen(lambda cmd, env: calls.append({"cmd": cmd, "env": env})),
+    )
     return {"calls": calls, "build_calls": build_calls, "token_calls": token_calls}
 
 
@@ -1299,6 +1336,11 @@ def test_deploy_up_dev_mode_splits_build_from_up(monkeypatch, tmp_path):
         "run",
         lambda cmd, env=None, **k: runs.append(cmd) or _FakeCompletedProcess(),
     )
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "Popen",
+        _fake_popen(lambda cmd, env: runs.append(cmd)),
+    )
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True, dev_mode=True)
 
     joined = [" ".join(c) for c in runs]
@@ -1330,6 +1372,11 @@ def test_rebuild_deployment_dev_mode_splits_build_from_up(monkeypatch, tmp_path)
         container_lifecycle.subprocess,
         "run",
         lambda cmd, env=None, **k: runs.append(cmd) or _FakeCompletedProcess(),
+    )
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "Popen",
+        _fake_popen(lambda cmd, env: runs.append(cmd)),
     )
     execd: dict = {}
     monkeypatch.setattr(
@@ -1526,6 +1573,11 @@ def test_web_services_dev_mode_splits_build_from_up(monkeypatch, tmp_path):
         return _FakeCompletedProcess(returncode=0)
 
     monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "Popen",
+        _fake_popen(lambda cmd, env: runs.append(cmd)),
+    )
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True, dev_mode=True)
 
     # The services-stack invocations (the ones carrying the services compose file).

--- a/tests/deployment/test_lifecycle_capture.py
+++ b/tests/deployment/test_lifecycle_capture.py
@@ -374,6 +374,14 @@ def start_stack_stubs(monkeypatch):
     """The host-touching preflights ``_start_stack`` runs before its compose calls."""
     monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
     monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda config, files: None)
+    # Asks the runtime which of this project's data volumes exist. Stubbed for
+    # the same reason as the two above: left live it reads the developer's own
+    # daemon, so a stray `proj_*` volume on one machine would fail tests that
+    # are about spooling, and CI — with no such volume — could never reproduce
+    # it. Its own behaviour is pinned in test_stale_store_volume_preflight.py.
+    monkeypatch.setattr(
+        container_lifecycle, "_preflight_stale_store_volumes", lambda config, minted, env: None
+    )
     monkeypatch.setattr(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )

--- a/tests/deployment/test_lifecycle_capture.py
+++ b/tests/deployment/test_lifecycle_capture.py
@@ -379,9 +379,7 @@ def start_stack_stubs(monkeypatch):
     # daemon, so a stray `proj_*` volume on one machine would fail tests that
     # are about spooling, and CI — with no such volume — could never reproduce
     # it. Its own behaviour is pinned in test_stale_store_volume_preflight.py.
-    monkeypatch.setattr(
-        container_lifecycle, "_preflight_stale_store_volumes", lambda config, minted, env: None
-    )
+    monkeypatch.setattr(container_lifecycle, "_preflight_stale_store_volumes", lambda *a, **k: None)
     monkeypatch.setattr(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )

--- a/tests/deployment/test_lifecycle_capture.py
+++ b/tests/deployment/test_lifecycle_capture.py
@@ -84,7 +84,7 @@ class CaptureRecorder:
     def __init__(self) -> None:
         self.calls: list[dict] = []
 
-    def __call__(self, cmd, *, env=None, spool_name, repo_root=None, check=True):
+    def __call__(self, cmd, *, env=None, spool_name, repo_root=None, check=True, on_line=None):
         self.calls.append(
             {
                 "cmd": list(cmd),
@@ -92,6 +92,7 @@ class CaptureRecorder:
                 "spool_name": spool_name,
                 "repo_root": repo_root,
                 "check": check,
+                "on_line": on_line,
             }
         )
         return subprocess.CompletedProcess(list(cmd), 0)
@@ -444,6 +445,82 @@ def test_a_non_dev_deploy_does_not_build(captured, reporter, start_stack_stubs, 
 
     assert captured.spool_names == ["compose-rm", "compose-up"]
     assert "service images built" not in reporter.steps
+
+
+# ---------------------------------------------------------------------------
+# Per-image progress during the service-image build
+# ---------------------------------------------------------------------------
+#
+# `compose build` builds every service image in one parallel invocation, and it
+# is the longest step of a dev deploy — half an hour cold. A single step line
+# printed at the end reads as a hang for the whole build. The fix keeps the one
+# parallel build and derives per-image steps from BuildKit's own stream: each
+# `naming to <ref> done` line marks one image's completion.
+
+
+def test_each_finished_image_is_its_own_step(reporter):
+    report = container_lifecycle.compose_build_step_reporter()
+
+    for line in [
+        "#12 [va internal] load build context",
+        "#37 naming to docker.io/library/proj-va:local",
+        "#37 naming to docker.io/library/proj-va:local 0.1s done",
+        "#41 naming to docker.io/library/proj-dispatch:local done",
+    ]:
+        report(line)
+
+    assert reporter.steps == [
+        "service image proj-va:local",
+        "service image proj-dispatch:local",
+    ]
+
+
+def test_an_image_named_twice_reports_once(reporter):
+    """BuildKit repeats the `naming to` line (bare, then with a duration); an
+    image must not appear to build twice."""
+    report = container_lifecycle.compose_build_step_reporter()
+
+    report("#37 naming to docker.io/library/proj-va:local done")
+    report("#37 naming to docker.io/library/proj-va:local 0.0s done")
+
+    assert reporter.steps == ["service image proj-va:local"]
+
+
+def test_registry_qualified_tags_keep_their_registry(reporter):
+    """Only the implicit docker.io/library/ prefix is noise; a real registry in
+    the tag is the operator's own naming and stays."""
+    report = container_lifecycle.compose_build_step_reporter()
+
+    report("#9 naming to ghcr.io/lab/proj-svc:2026.6 done")
+
+    assert reporter.steps == ["service image ghcr.io/lab/proj-svc:2026.6"]
+
+
+def test_unfinished_naming_lines_report_nothing(reporter):
+    """The bare `naming to` line appears while the export is still running; a
+    step for it would announce an image that may yet fail."""
+    report = container_lifecycle.compose_build_step_reporter()
+
+    report("#37 naming to docker.io/library/proj-va:local")
+    report("#37 DONE 0.2s")
+
+    assert reporter.steps == []
+
+
+def test_the_dev_build_streams_per_image_progress(
+    captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path
+):
+    """The build call — and only the build call — carries the line parser.
+
+    `rm` and `up` produce no `naming to` lines, so a parser there would be
+    dead weight; asserting None pins that the stream-parsing stays scoped to
+    the one invocation whose silence it exists to break.
+    """
+    _start(_repo(tmp_path), dev_mode=True)
+
+    assert callable(captured.call("compose-build")["on_line"])
+    assert captured.call("compose-rm")["on_line"] is None
+    assert captured.call("compose-up")["on_line"] is None
 
 
 def test_the_stack_compose_echoes_are_debug_only(

--- a/tests/deployment/test_mongo_password_mint.py
+++ b/tests/deployment/test_mongo_password_mint.py
@@ -138,22 +138,51 @@ class TestRegistryAgreement:
         assert f"${{{var}:-" in template
 
     def test_the_minted_var_is_registered_as_volume_initialized(self):
-        """A missing entry makes the fresh-mint warning silently never fire.
+        """A missing entry makes the stale-volume preflight silently never fire.
 
         The store adopts ``MONGO_ROOT_PASSWORD`` only when it initializes a
         fresh data volume, so a newly minted value beside a surviving volume is
         a credential mismatch nothing else names — the registry entry is what
-        makes ``_ensure_service_tokens`` warn at the mint. The template
-        declaring a named volume is the fact that earns the entry its place.
+        makes ``_preflight_stale_store_volumes`` look for that volume at all.
+        The template declaring a named volume is the fact that earns the entry
+        its place.
         """
         from osprey.deployment.container_lifecycle import _VOLUME_INITIALIZED_VARS
 
-        assert _VOLUME_INITIALIZED_VARS.get("MONGO_ROOT_PASSWORD") == "mongodb"
+        assert _VOLUME_INITIALIZED_VARS["MONGO_ROOT_PASSWORD"].service == "mongodb"
         declared = _declared_top_level_volumes(_mongodb_template_text())
         assert "archiver_mongodb_data" in declared, (
             "the volume the store initializes /data/db on must be a declared "
-            "named volume, or the fresh-mint warning guards nothing"
+            "named volume, or the stale-volume preflight guards nothing"
         )
+
+    def test_the_registry_names_the_volume_the_template_declares(self):
+        """A drifted volume name makes the preflight look for something absent.
+
+        The failure mode is silent and one-directional: the probe finds no
+        such volume, concludes this is an ordinary first deploy, and lets the
+        credential mismatch through to the store — which is the exact bug the
+        preflight exists to stop.
+        """
+        from osprey.deployment.container_lifecycle import _VOLUME_INITIALIZED_VARS
+
+        store = _VOLUME_INITIALIZED_VARS["MONGO_ROOT_PASSWORD"]
+        assert store.volume in _declared_top_level_volumes(_mongodb_template_text())
+
+    def test_the_registry_names_the_container_and_env_var_the_template_uses(self):
+        """The harvest reads this credential off this container, by this name.
+
+        Both halves are drift-prone in the same silent direction: a wrong
+        container name or a wrong in-container variable makes ``--reuse-stores``
+        report a recoverable credential as unrecoverable, and the operator
+        discards data that could have been kept.
+        """
+        from osprey.deployment.container_lifecycle import _VOLUME_INITIALIZED_VARS
+
+        store = _VOLUME_INITIALIZED_VARS["MONGO_ROOT_PASSWORD"]
+        template = _mongodb_template_text()
+        assert f"container_name: {{{{ osprey_labels.project_name }}}}{store.container}" in template
+        assert f"{store.cred_env}: ${{MONGO_ROOT_PASSWORD:-" in template
 
     def test_the_port_remedy_names_the_knob_the_profile_block_emits(self):
         """The generic fallback would be ``services.mongodb.port``, which is wrong."""

--- a/tests/deployment/test_openobserve_token_mint.py
+++ b/tests/deployment/test_openobserve_token_mint.py
@@ -224,7 +224,7 @@ def test_service_token_vars_map_includes_openobserve():
 # ---------------------------------------------------------------------------
 
 
-class TestVolumeContinuityWarning:
+class TestVolumeContinuityReporting:
     """A re-minted password is silently rejected by a volume that already exists.
 
     OpenObserve and Postgres read their root credential ONLY when they
@@ -235,26 +235,43 @@ class TestVolumeContinuityWarning:
     ignoring it, and the failure surfaces as "I cannot log in" with nothing
     anywhere connecting that to the mint.
 
-    Neither variable can be guarded by compose. Both are interpolated with a
-    ``:-`` DEFAULT in their templates, so unlike the ``:?``-guarded tokens
-    there is no version of this that aborts the deploy and says why. This
-    warning is the only thing that names it, which is why it is pinned.
+    Neither variable can be guarded by compose — both are interpolated with a
+    ``:-`` DEFAULT in their templates, so no ``:?`` guard aborts the deploy and
+    says why. What closes the gap instead is
+    ``_preflight_stale_store_volumes``, and the mint's only job is to tell it
+    which vars are newly minted. That hand-off is what is pinned here; the
+    refusal it feeds is pinned in test_stale_store_volume_preflight.py.
     """
 
-    def test_a_minted_password_warns_that_an_existing_volume_will_reject_it(
-        self, tmp_path, monkeypatch, caplog
+    def test_a_minted_password_is_reported_as_a_volume_continuity_hazard(
+        self, tmp_path, monkeypatch
     ):
         monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
         config = {"deployed_services": ["openobserve"]}
 
-        with caplog.at_level("WARNING"):
-            container_lifecycle._ensure_service_tokens(
-                config, expose_network=False, env_path=tmp_path / ".env"
-            )
+        minted = container_lifecycle._ensure_service_tokens(
+            config, expose_network=False, env_path=tmp_path / ".env"
+        )
 
-        assert "ZO_ROOT_USER_PASSWORD" in caplog.text
-        assert "openobserve" in caplog.text
-        assert "fresh data volume" in caplog.text
+        assert minted == {"ZO_ROOT_USER_PASSWORD"}
+
+    def test_an_adopted_password_is_not_reported(self, tmp_path, monkeypatch):
+        """Nothing was minted, so the volume and the value agree by construction.
+
+        The distinction the whole preflight rests on: only a *new* value can
+        disagree with a volume that already exists.
+        """
+        monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+        # Must satisfy the same complexity constraint a real adopted value would.
+        (tmp_path / ".env").write_text("ZO_ROOT_USER_PASSWORD=Preexisting1!\n", encoding="utf-8")
+
+        minted = container_lifecycle._ensure_service_tokens(
+            {"deployed_services": ["openobserve"]},
+            expose_network=False,
+            env_path=tmp_path / ".env",
+        )
+
+        assert minted == set()
 
     def test_the_warning_never_prints_the_value(self, tmp_path, monkeypatch, caplog):
         """Names only, never values — the same rule every other line here follows."""

--- a/tests/deployment/test_stale_store_volume_preflight.py
+++ b/tests/deployment/test_stale_store_volume_preflight.py
@@ -1,0 +1,359 @@
+"""A freshly minted store credential must never meet a volume that predates it.
+
+The three stores in ``_VOLUME_INITIALIZED_VARS`` read their root credential
+only while initializing an empty data volume. Mint a new value beside a volume
+that already exists and the store keeps the password it was born with: the
+stack starts, the deploy waits, and the store refuses the credential the
+``.env`` now claims.
+
+``osprey up`` used to only *guess* at this — it warned "if this deployment's
+volume already exists" at the mint and started the stack anyway. Two things
+make that worse than a plain refusal:
+
+* the diagnosis arrives after the project image build and a health-probe
+  timeout, and names only the first store to be asked, leaving the operator to
+  rediscover the other two one restart at a time;
+* ``compose up`` recreates the store container on its way past, and that
+  container's environment held the *only* copy of the credential the volume was
+  initialized with. Proceeding destroys the evidence that would let the volume
+  be reopened at all.
+
+So the check belongs before anything touches a container, and it is a check
+rather than a warning: the runtime can be asked whether the volume exists.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from osprey.deployment import container_lifecycle
+
+PROJECT = "my-control-assistant"
+
+
+class FakeRuntime:
+    """Answers the argv the volume probe and the credential harvest build.
+
+    Deliberately argv-shaped rather than a mock of the probe: the thing under
+    test is which questions the deploy asks the runtime, so a stand-in that
+    accepted anything would pass while the real command was wrong.
+    """
+
+    def __init__(self, volumes: list[str], container_env: dict[str, dict[str, str]] | None = None):
+        self.volumes = volumes
+        self.container_env = container_env or {}
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        argv = list(cmd)[1:]  # drop the runtime binary
+        if argv[:2] == ["volume", "ls"]:
+            return _completed(cmd, "\n".join(self.volumes))
+        if argv[:2] == ["container", "inspect"]:
+            name = argv[2]
+            env = self.container_env.get(name)
+            if env is None:
+                return _completed(cmd, "", returncode=1)
+            return _completed(cmd, "\n".join(f"{k}={v}" for k, v in env.items()))
+        return _completed(cmd, "")
+
+
+def _completed(cmd, stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(list(cmd), returncode, stdout=stdout, stderr="")
+
+
+@pytest.fixture
+def deploy(monkeypatch, tmp_path):
+    """A one-store project whose runtime answers are set per test."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MONGO_ROOT_PASSWORD", raising=False)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (
+            {"deployed_services": ["mongodb"], "project_name": PROJECT},
+            ["docker-compose.yml"],
+        ),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+
+    def _run(fake: FakeRuntime):
+        monkeypatch.setattr(container_lifecycle.subprocess, "run", fake)
+        return lambda **kw: container_lifecycle.deploy_up(
+            str(tmp_path / "config.yml"), detached=True, **kw
+        )
+
+    return _run
+
+
+def _env(tmp_path):
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    path = tmp_path / ".env"
+    return parse_dotenv_file(path) if path.is_file() else {}
+
+
+def test_refuses_when_a_minted_credential_meets_a_surviving_volume(deploy, tmp_path):
+    """The whole point: stop before the image build, not after a probe timeout."""
+    up = deploy(FakeRuntime(volumes=[f"{PROJECT}_archiver_mongodb_data"]))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        up()
+
+    message = str(excinfo.value)
+    assert "archiver_mongodb_data" in message
+    assert "mongodb" in message
+
+
+def test_a_first_deploy_with_no_volumes_is_untouched(deploy, tmp_path):
+    """The ordinary case the old code was afraid of breaking must stay silent."""
+    up = deploy(FakeRuntime(volumes=[]))
+
+    up()
+
+    assert _env(tmp_path).get("MONGO_ROOT_PASSWORD")
+
+
+def test_an_operator_supplied_credential_is_never_second_guessed(deploy, tmp_path):
+    """Nothing was minted, so the value and the volume agree by construction."""
+    (tmp_path / ".env").write_text("MONGO_ROOT_PASSWORD=preexistingvalue\n", encoding="utf-8")
+    up = deploy(FakeRuntime(volumes=[f"{PROJECT}_archiver_mongodb_data"]))
+
+    up()
+
+    assert _env(tmp_path)["MONGO_ROOT_PASSWORD"] == "preexistingvalue"
+
+
+class TestAlreadyBrokenDeployment:
+    """A mismatch persists in ``.env`` long after the run that minted it.
+
+    Keying only on "this run minted it" prevents the situation but cannot
+    recognise one already in it: after a failed start the ``.env`` holds the new
+    value, so the next start mints nothing and sails past. The second rule is
+    provable rather than inferred — a running store container is on the
+    credential its volume actually has, so a ``.env`` that disagrees with the
+    container cannot authenticate, whoever wrote it.
+    """
+
+    def test_a_container_credential_that_disagrees_with_env_is_refused(self, deploy, tmp_path):
+        (tmp_path / ".env").write_text("MONGO_ROOT_PASSWORD=thenewone\n", encoding="utf-8")
+        up = deploy(
+            FakeRuntime(
+                volumes=[f"{PROJECT}_archiver_mongodb_data"],
+                container_env={
+                    f"{PROJECT}-archiver-mongodb": {"MONGO_INITDB_ROOT_PASSWORD": "theoriginal"}
+                },
+            )
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            up()
+
+        assert "archiver_mongodb_data" in str(excinfo.value)
+
+    def test_a_healthy_redeploy_is_untouched(self, deploy, tmp_path):
+        """The regression that would matter most: every ordinary restart.
+
+        Container and ``.env`` agree, so the volume will accept the credential
+        and there is nothing to report — even though the volume is old and
+        nothing was minted.
+        """
+        (tmp_path / ".env").write_text("MONGO_ROOT_PASSWORD=agreed\n", encoding="utf-8")
+        up = deploy(
+            FakeRuntime(
+                volumes=[f"{PROJECT}_archiver_mongodb_data"],
+                container_env={
+                    f"{PROJECT}-archiver-mongodb": {"MONGO_INITDB_ROOT_PASSWORD": "agreed"}
+                },
+            )
+        )
+
+        up()
+
+        assert _env(tmp_path)["MONGO_ROOT_PASSWORD"] == "agreed"
+
+    def test_a_stopped_store_with_no_container_is_not_second_guessed(self, deploy, tmp_path):
+        """Nothing minted and nothing to compare against is not evidence of a fault.
+
+        Refusing here would block every deploy whose stack is fully down, which
+        is the normal way a deployment sits between sessions.
+        """
+        (tmp_path / ".env").write_text("MONGO_ROOT_PASSWORD=whatever\n", encoding="utf-8")
+        up = deploy(FakeRuntime(volumes=[f"{PROJECT}_archiver_mongodb_data"], container_env={}))
+
+        up()
+
+        assert _env(tmp_path)["MONGO_ROOT_PASSWORD"] == "whatever"
+
+
+class TestRecoverability:
+    """Whether the volume can still be reopened decides what the operator can do.
+
+    A store container holds, in its own environment, the credential its volume
+    was initialized with. While that container survives the data is reachable;
+    once it is recreated the volume is orphaned for good. The refusal has to
+    tell those two apart, because they offer the operator different choices.
+    """
+
+    def test_a_surviving_container_is_reported_as_recoverable(self, deploy, tmp_path):
+        up = deploy(
+            FakeRuntime(
+                volumes=[f"{PROJECT}_archiver_mongodb_data"],
+                container_env={
+                    f"{PROJECT}-archiver-mongodb": {"MONGO_INITDB_ROOT_PASSWORD": "theoriginal"}
+                },
+            )
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            up()
+
+        message = str(excinfo.value)
+        assert "original recoverable from" in message
+        assert "--reuse-stores" in message  # the way out this store leaves open
+        # Never the value itself, in keeping with every other secret this path logs.
+        assert "theoriginal" not in message
+
+    def test_an_absent_container_is_reported_as_unrecoverable(self, deploy, tmp_path):
+        """The shape the failed run leaves behind: volume alive, container gone."""
+        up = deploy(FakeRuntime(volumes=[f"{PROJECT}_archiver_mongodb_data"], container_env={}))
+
+        with pytest.raises(RuntimeError) as excinfo:
+            up()
+
+        message = str(excinfo.value)
+        assert "the original is unrecoverable" in message
+        assert "original recoverable from" not in message
+        # Offering --reuse-stores here would send the operator down a path that
+        # cannot work for this store.
+        assert "--reuse-stores     keep the data" not in message
+
+
+class TestReuseStores:
+    """``--reuse-stores``: adopt the volumes instead of the freshly minted value."""
+
+    def test_it_restores_the_original_credential_and_proceeds(self, deploy, tmp_path):
+        up = deploy(
+            FakeRuntime(
+                volumes=[f"{PROJECT}_archiver_mongodb_data"],
+                container_env={
+                    f"{PROJECT}-archiver-mongodb": {"MONGO_INITDB_ROOT_PASSWORD": "theoriginal"}
+                },
+            )
+        )
+
+        up(reuse_stores=True)
+
+        assert _env(tmp_path)["MONGO_ROOT_PASSWORD"] == "theoriginal"
+
+    def test_it_refuses_when_the_original_cannot_be_read(self, deploy, tmp_path):
+        """Reuse must not half-succeed: a store it cannot reopen is a hard stop.
+
+        Proceeding would start the recoverable stores on adopted credentials
+        and leave the unrecoverable one to fail at its health probe — the
+        original bug, reintroduced one store narrower.
+        """
+        up = deploy(FakeRuntime(volumes=[f"{PROJECT}_archiver_mongodb_data"], container_env={}))
+
+        with pytest.raises(RuntimeError) as excinfo:
+            up(reuse_stores=True)
+
+        assert "archiver_mongodb_data" in str(excinfo.value)
+
+    def test_it_is_a_no_op_when_no_volume_survives(self, deploy, tmp_path):
+        """Passing the flag on an ordinary first deploy must not change it."""
+        up = deploy(FakeRuntime(volumes=[]))
+
+        up(reuse_stores=True)
+
+        assert len(_env(tmp_path)["MONGO_ROOT_PASSWORD"]) == 64  # the freshly minted value
+
+
+class TestRestartChecksBeforeItStops:
+    """``restart`` stops the stack first — which is what destroys the evidence.
+
+    ``down`` removes the store containers, and a removed container takes the
+    only host-side copy of its volume's credential with it. So a restart that
+    checked at the same point ``up`` does would find every stale volume
+    "unrecoverable", having itself made them so moments earlier, and would tell
+    the operator to discard data that was recoverable when they typed the
+    command.
+    """
+
+    @pytest.fixture
+    def restart(self, monkeypatch, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / "build").mkdir(parents=True)
+        (repo / ".env").write_text("", encoding="utf-8")
+        stopped: list[bool] = []
+
+        monkeypatch.setattr(
+            container_lifecycle,
+            "_resolve_as_built_inputs",
+            lambda root, *, dev_mode: (
+                {"deployed_services": ["mongodb"], "project_name": PROJECT},
+                ["docker-compose.yml"],
+                False,
+            ),
+        )
+        monkeypatch.setattr(
+            container_lifecycle, "down_deployment", lambda root: stopped.append(True)
+        )
+        monkeypatch.setattr(
+            container_lifecycle, "_start_as_built", lambda *a, **k: stopped.append(False)
+        )
+        monkeypatch.setattr(
+            container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+        )
+        monkeypatch.delenv("MONGO_ROOT_PASSWORD", raising=False)
+
+        def _run(fake: FakeRuntime, **kw):
+            monkeypatch.setattr(container_lifecycle.subprocess, "run", fake)
+            return container_lifecycle.restart_deployment(repo, **kw), stopped, repo
+
+        return _run
+
+    def test_it_refuses_without_stopping_anything(self, restart):
+        fake = FakeRuntime(
+            volumes=[f"{PROJECT}_archiver_mongodb_data"],
+            container_env={
+                f"{PROJECT}-archiver-mongodb": {"MONGO_INITDB_ROOT_PASSWORD": "theoriginal"}
+            },
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            restart(fake)
+
+        assert "original recoverable from" in str(excinfo.value)
+
+    def test_reuse_adopts_the_credential_before_the_stop(self, restart):
+        """Order is the whole point: harvest, write .env, and only then stop."""
+        fake = FakeRuntime(
+            volumes=[f"{PROJECT}_archiver_mongodb_data"],
+            container_env={
+                f"{PROJECT}-archiver-mongodb": {"MONGO_INITDB_ROOT_PASSWORD": "theoriginal"}
+            },
+        )
+
+        _, stopped, repo = restart(fake, reuse_stores=True)
+
+        from osprey.utils.dotenv import parse_dotenv_file
+
+        assert parse_dotenv_file(repo / ".env")["MONGO_ROOT_PASSWORD"] == "theoriginal"
+        assert stopped == [True, False]  # stopped, then started
+
+
+def test_the_volume_probe_is_label_filtered_to_this_project(deploy, tmp_path):
+    """A host-wide listing would let another project's volume block this deploy."""
+    fake = FakeRuntime(volumes=[])
+    up = deploy(fake)
+
+    up()
+
+    (volume_ls,) = [c for c in fake.calls if c[1:3] == ["volume", "ls"]]
+    assert f"label=com.docker.compose.project={PROJECT}" in volume_ls

--- a/tests/deployment/test_subprocess_capture.py
+++ b/tests/deployment/test_subprocess_capture.py
@@ -194,6 +194,74 @@ class TestReporterCoupling:
         assert phase.spool.exists()
 
 
+class TestOnLine:
+    """``on_line`` tees the child's output to a callback, line by line.
+
+    The seam that gives a long silent build per-step progress: the caller hands
+    a parser, the child's merged stream still lands in the spool byte for byte,
+    and each line also reaches the callback as decoded text. The callback is
+    cosmetic by contract — nothing it does may change what the run itself
+    produces or whether it fails.
+    """
+
+    def test_the_callback_sees_every_line_the_spool_records(self, tmp_path):
+        seen: list[str] = []
+
+        run_captured(_echo("one", "two"), spool_name="tee", repo_root=tmp_path, on_line=seen.append)
+
+        assert seen == ["one", "two"]
+        assert _spools(tmp_path)[0].read_text() == "one\ntwo\n"
+
+    def test_stderr_reaches_the_callback_in_stream_order(self, tmp_path):
+        argv = [
+            sys.executable,
+            "-c",
+            "import sys\nprint('out', flush=True)\nprint('err', file=sys.stderr, flush=True)\n",
+        ]
+        seen: list[str] = []
+
+        run_captured(argv, spool_name="tee", repo_root=tmp_path, on_line=seen.append)
+
+        assert seen == ["out", "err"]
+
+    def test_a_raising_callback_neither_fails_the_run_nor_loses_output(self, tmp_path):
+        def boom(line: str) -> None:
+            raise RuntimeError(line)
+
+        completed = run_captured(
+            _echo("one", "two"), spool_name="tee", repo_root=tmp_path, on_line=boom
+        )
+
+        assert completed.returncode == 0
+        assert _spools(tmp_path)[0].read_text() == "one\ntwo\n"
+
+    def test_the_failure_path_still_names_the_spool(self, tmp_path):
+        argv = [sys.executable, "-c", "import sys; print('partial'); sys.exit(3)"]
+
+        with pytest.raises(CapturedProcessError) as excinfo:
+            run_captured(argv, spool_name="failing", repo_root=tmp_path, on_line=lambda _: None)
+
+        assert excinfo.value.returncode == 3
+        assert excinfo.value.spool_path == _spools(tmp_path)[0]
+        assert excinfo.value.spool_path.read_text() == "partial\n"
+
+    def test_verbose_mode_streams_raw_and_never_calls_back(
+        self, tmp_path, recorded_run, verbose_reporter
+    ):
+        """Verbose already puts the child's own lines on the terminal; step
+        lines derived from the same stream would only duplicate them."""
+        seen: list[str] = []
+
+        run_captured(
+            ["docker", "build", "."], spool_name="build", repo_root=tmp_path, on_line=seen.append
+        )
+
+        assert seen == []
+        (args, kwargs) = recorded_run[0]
+        assert args[0] == ["docker", "build", "."]
+        assert "stdout" not in kwargs
+
+
 class TestVerbosePassThrough:
     """SC7: verbose runs the identical argv with inherited stdio."""
 

--- a/tests/deployment/test_web_terminals_capture.py
+++ b/tests/deployment/test_web_terminals_capture.py
@@ -91,7 +91,9 @@ class RunRecorder:
     def __init__(self) -> None:
         self.calls: list[dict] = []
 
-    def __call__(self, cmd, *, env=None, cwd=None, spool_name, repo_root=None, check=True):
+    def __call__(
+        self, cmd, *, env=None, cwd=None, spool_name, repo_root=None, check=True, on_line=None
+    ):
         self.calls.append(
             {
                 "cmd": list(cmd),
@@ -100,6 +102,7 @@ class RunRecorder:
                 "spool_name": spool_name,
                 "repo_root": repo_root,
                 "check": check,
+                "on_line": on_line,
             }
         )
         return CapturedProcess(list(cmd), 0, spool_path=None)
@@ -406,6 +409,22 @@ def test_up_reports_a_step_for_each_stack(monkeypatch, tmp_path, reporter):
         "pulled web-terminal images",
         "web-terminal stack started",
     ]
+
+
+def test_the_services_build_streams_per_image_progress(monkeypatch, tmp_path, reporter):
+    """The web path's `build` gets the same per-image steps as the plain path.
+
+    It is the identical half-hour silence — same compose build, reached through
+    `deploy_up_web_terminals` instead of `_start_stack` — so the two sites must
+    not drift apart on whether an operator can see it progressing.
+    """
+    recorder = _stub_web_stack(monkeypatch, tmp_path)
+
+    provision.deploy_up_web_terminals(_web_config(), ["docker-compose.yml"], True, {}, [])
+
+    assert callable(recorder.by_spool("build-services")["on_line"])
+    for other in ("compose-services-rm", "compose-services-up", "compose-web-up"):
+        assert recorder.by_spool(other)["on_line"] is None
 
 
 def test_local_mode_up_still_never_pulls(monkeypatch, tmp_path, reporter):

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,8 @@ resolution-markers = [
 ]
 
 [options]
+exclude-newer = "2026-08-07T14:48:23.394104Z"
+exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 lume-pyat = "2026-08-06T00:00:00Z"
@@ -3160,8 +3162,8 @@ name = "lume-pva-apg"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lume-base" },
-    { name = "numpy" },
+    { name = "lume-base", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/01/4611d7a2b91c207304d9f6f4364a31190014925802c7145e7ccbdb1c0b91/lume_pva_apg-0.1.2.tar.gz", hash = "sha256:b375db188ecbed91697888f098d6d01364793ea4ba7e822befd150af963d673d", size = 76507, upload-time = "2026-08-07T19:13:48.613Z" }
 wheels = [
@@ -3170,10 +3172,10 @@ wheels = [
 
 [package.optional-dependencies]
 ca = [
-    { name = "pcaspy" },
+    { name = "pcaspy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 pva = [
-    { name = "p4p" },
+    { name = "p4p", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -4674,11 +4676,11 @@ name = "p4p"
 version = "4.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "epicscorelibs" },
-    { name = "nose2" },
-    { name = "numpy" },
-    { name = "ply" },
-    { name = "pvxslibs" },
+    { name = "epicscorelibs", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nose2", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ply", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pvxslibs", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/b1/cbb46a39cf571b5fcf8a61ead702f60f324a00d1728ab082307bd47c980f/p4p-4.2.2.tar.gz", hash = "sha256:1685ffab0d0a1a1e3da647dd9f027933a10d57b71b3c4f5dd762fcabeba7e31e", size = 390763, upload-time = "2026-01-08T03:14:25.043Z" }
 wheels = [
@@ -4825,7 +4827,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5279,8 +5281,8 @@ name = "pvxslibs"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "epicscorelibs" },
-    { name = "setuptools-dso" },
+    { name = "epicscorelibs", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "setuptools-dso", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/42/c84089f3d7a76c2c6027326275be7fdbc4195687b2d9867090700c906520/pvxslibs-1.5.2.tar.gz", hash = "sha256:dcf58897451951e9b7ea1021a001d7d826047d29186bf5b64bb1b4688fdacf5f", size = 667548, upload-time = "2026-06-24T05:01:23.286Z" }
 wheels = [
@@ -6507,7 +6509,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -6589,7 +6591,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -6654,8 +6656,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6760,23 +6762,23 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version < '3.12'" },
+    { name = "babel", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.12'" },
+    { name = "imagesize", marker = "python_full_version < '3.12'" },
+    { name = "jinja2", marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version < '3.12'" },
+    { name = "requests", marker = "python_full_version < '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -6799,23 +6801,23 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [


### PR DESCRIPTION
## The problem

The three stores OSPREY deploys — postgresql, openobserve, mongodb — read their root credential *only* while initializing an empty data volume. Once the volume exists it keeps the password it was created with, forever.

Removing a deployment directory takes the gitignored `.env` with it but leaves every volume behind. The next start therefore minted three fresh passwords against three volumes that had each adopted a different one. What the operator saw:

```
  ✗ Starting my-control-assistant (56.4s)
  ERROR Deployment failed: The archiver store rejected the credentials …
```

56 seconds, one project image built, and a diagnosis naming only mongodb — while postgresql and openobserve were equally mismatched and would each be discovered on a later restart.

The code already suspected this. At the mint it warned *"if this deployment's `<store>` volume already exists it keeps the credential it was created with"*, then started the stack anyway, on the stated reasoning that the same mint is also the ordinary first-deploy case. That premise is what this PR removes: the two cases are one label-filtered `volume ls` apart, and the probe to do it already existed in `reset.py`.

## What proceeding actually costs

Not just a later error. `compose up` recreates the store container on its way past — and a store container's environment is the only host-side record of the credential its volume was initialized with. Starting overwrites it with the value that cannot work.

That was measurable on the deployment this came from. After the failed run:

```
postgresql   container up 2 days, never recreated   → original recoverable  ✓
openobserve  container up 2 days, never recreated   → original recoverable  ✓
mongodb      container RECREATED at the failed run  → original gone         ✗
```

The run destroyed the recovery path for the one store it then reported it could not authenticate to. So this has to be a refusal, and it has to happen before anything is touched.

## What changed

`_preflight_stale_store_volumes` runs directly after the mint and before the image build, the archiver staging, and every compose call. A store is refused on either of two independent grounds:

1. **this run minted its credential, and its volume exists** — a brand-new value a pre-existing volume never adopted. The only rule that can speak for a store whose container is gone, since there is then nothing to compare against.
2. **the store's own container disagrees with `.env`** — a running container holds the credential the volume actually has, so a `.env` that differs cannot authenticate, whoever wrote it. This is what recognises a deployment *already* in the broken state, where a previous run's mint sits in `.env` and nothing new is minted.

Deliberately not a third ground: a surviving volume with no container and nothing minted. That is a stopped deployment — the normal way one sits between sessions — and refusing it would block every start. Pinned by test.

The refusal names every affected store at once, and says which recovery each one leaves open:

```
→ Preflight
  ✗ 2 store(s) of this deployment have a data volume that predates the
    credentials just generated in …/my-control-assistant/.env.

      openobserve  my-control-assistant_openobserve_data
                   original recoverable from my-control-assistant-openobserve
      postgresql   my-control-assistant_ariel_postgres_data
                   original recoverable from my-control-assistant-ariel-postgres

    --reuse-stores     keep the data: restore the original credential(s) to .env
    `osprey reset` re-initializes the whole stack, discarding the data in it.

    Nothing was started and no image was built.
```

### `--reuse-stores`

New on `up` and `restart`. Adopts the volumes instead of discarding them: harvests each store's original credential from its container and restores it to `.env` in place of the minted value. All-or-nothing — a run that cannot reopen every affected volume refuses rather than starting a stack that is part-adopted and part-doomed.

### `restart` had the same bug one layer deeper

`restart_deployment` runs `down_deployment` *before* the mint, and `down` removes the store containers. Checked at the usual point, restart would have reported every stale volume unrecoverable, having itself destroyed the evidence moments earlier. It now runs the check before it stops anything, keyed on which credentials a mint *would* generate rather than which it did.

## The other half: making a clean start possible

A refusal is only as good as the way past it, and there wasn't one. The situation the preflight catches is *created* by re-creating a deployment under a name that has been used before — and `osprey init` had no way to do that cleanly. `--force` re-materializes the source zone but is deliberately scoped to files; deleting the directory by hand leaves every container and volume behind, which is the original bug; and `osprey reset` needs the repo directory that a delete-first workflow has already removed.

### `osprey init --reset`

Starts over on a name that has been used: it destroys the containers, volumes and images left by the previous deployment of that name, and re-materializes the source zone as `--force` does when the directory still exists. Re-creating a deployment is one command with no `rm -rf` in front of it:

```
osprey init my-assistant --preset control-assistant --set provider=… --reset --up --dev -d
```

Delegated to the existing `reset_deployment` rather than reimplemented, so it inherits the label-scoped plan, the foreign-checkout refusal and the one-resource-at-a-time removals. Ordering is forced from both sides: `reset` reads the repo to resolve the project name, so it cannot run before materialization; and the state it removes is what a `--up` would otherwise inherit, so it cannot run after.

Implying `--force` is what makes the flag work on the case it exists for. Without it, a used name is refused by the repo-root check before the reset it asked for could run. Provider keys in `.env`, git history and the audit log survive exactly as they do under `--force` — the point of converging a repo in place rather than deleting and re-creating it.

### It refuses rather than pretending

`reset` removes only what carries this checkout's `com.osprey.repo-id` label, so a deployment created before that label existed survives the sweep — correctly, since ownership cannot be proved. Continuing anyway would walk into the stale-volume refusal 40 seconds later, whose suggested remedy is the very verb that just declined. `init --reset` now stops when resources of that name survive, names them, explains why, and gives the one-time commands to clear them. Nothing is built and nothing is started.

## Per-image progress during the build

The dev-mode `compose build` is the longest step of a deploy — half an hour cold — and printed nothing until the whole build finished, which reads as a hang. Splitting the build per service would trade the parallelism for progress, so the steps are derived instead: `run_captured` grows an `on_line` tee that watches the child's stream without diverting it from the spool, and a parser reports each image the moment BuildKit's export names its tag.

```
  · service image my-assistant-dispatch:local (3m12s)
  · service image my-assistant-va:local (1m40s)
  · service image my-assistant-bluesky-bridge:local (4m05s)
  · built service images (14m22s)
```

The callback is cosmetic by contract: an exception it raises is logged at debug and changes nothing about the run's outcome, and verbose mode ignores it, where the child's own lines are already on the terminal. Both build sites get it — the plain services path and the web-terminal provision path, which run the identical build.

## Verification

Run against the real deployment this came from, with its four-week-old volumes in place:

```
→ Preflight
  ✗ Starting my-control-assistant (0.7s)
```

0.7s instead of 56.4s, nothing built, nothing started, both recoverable stores named. It correctly did **not** flag mongodb: that container had already been recreated with the new password, so it agrees with `.env` and no host-side evidence of the original survives. That case remains undetectable and unrecoverable by design — it is what the preflight exists to prevent, not to cure.

`--reset` was likewise exercised end to end against a real deployment, including the survivor refusal on pre-label resources and a full re-create afterwards.

14 new tests in `tests/deployment/test_stale_store_volume_preflight.py` cover both rules, both non-refusal guards, recoverability reporting, the reuse path in both shapes (`up` rewrites the minted line, `restart` appends where no line exists), and the restart ordering. `tests/cli/test_init_verb.py` covers `--reset`: delegation and its arguments, ordering against materialization, the survivor refusal and its clean-sweep counterpart, source-zone re-materialization without `--force`, `.env` survival, and the refusal message offering the flag. `tests/deployment/test_subprocess_capture.py` and the two capture suites cover the `on_line` tee (spool completeness, stream order, a raising callback, the failure path, verbose suppression) and the parser (dedup, registry-qualified tags, unfinished-line suppression, and the wiring at both build sites).

One incidental fix in `tests/deployment/test_lifecycle_capture.py`: the new probe reads the container runtime, so it is stubbed alongside the other host-touching preflights in `start_stack_stubs`. Left live it reads the developer's own daemon, which made three spooling tests depend on whether a stray `proj_*` volume happened to exist locally — green on CI, red on a machine that had one.

## Not included

`--recreate-stores` (drop only the stale store volumes and proceed) is not here. `osprey reset` already removes this project's containers and volumes behind a confirmation gate, and a second destructive path inside the deploy would have to stop the containers holding those volumes first. The argument for adding it later is that reset also discards agent memory, the audit log, the tiled catalog and the dispatch workspace, where this would drop three volumes. `init --reset` now covers the re-create path, which is where the problem actually arises, so this stays the narrower tool for an existing deployment that should not be wiped entirely.

`init --reset` does not remove an existing directory — that still needs `--force` (which it implies) or a deliberate delete. Having `init` delete a directory full of `data/` and `.env` on a mistyped name is a sharper edge than removing label-scoped volumes.

The archiver health probe's own stale-volume message is unchanged. With the preflight in front, the only way to reach it is the residual case above; narrowing it to say so is worth a follow-up.
