### PR TITLE
feat(cli): rewrite user-facing copy in plain language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Onboarding output is now written for the people who run accelerators rather
+  than for the people who wrote OSPREY. `osprey init` prints the five entries
+  you edit instead of a forty-line tour; the generated `profile.yml`,
+  `README.md` and `.env.example` explain what each setting does and what
+  changes if you alter it, rather than why it is designed that way; and
+  `.env.example` now puts your provider's API key first and comments out the
+  rest. The advice about setting up a CI pipeline moved from `init`'s output to
+  the generated README, where it is relevant. No settings or defaults changed.
+
 - Generated deployment repos, bundled skills, agent instructions and the
   documentation now describe the system as it is, rather than as a set of
   differences from an earlier arrangement. Guidance for moving an existing

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -898,8 +898,6 @@ def emit_persona_delta_yaml(
             f"Preset {preset_name!r} declares no extends chain — it cannot be "
             f"emitted as a delta over a host profile."
         )
-    host_ref = f"../{host_filename}"
-
     body: list[str] = []
     titled = False
     dropped_extends = False
@@ -934,18 +932,17 @@ def emit_persona_delta_yaml(
 
     preset_hash = compute_preset_hash(preset_name) or "(unavailable)"
     header = (
-        f"# {profile_name} — persona profile, a delta over {host_ref}\n"
+        f"# {profile_name} — settings for one web login\n"
         f"#\n"
-        f"# Sitting in personas/ beside {host_filename} is the inheritance: the build merges\n"
-        f"# this file over that profile — including any edit you make there — so the keys\n"
-        f"# below are this persona's only differences and there is no `extends:` to\n"
-        f"# write. See the resolved whole with:\n"
+        f"# Only the differences from {host_filename} belong here. The build merges this\n"
+        f"# file over that one, picking up any edit you make there. To see the combined\n"
+        f"# result:\n"
         f"#   osprey validate {profile_filename}\n"
         f"#\n"
-        f"# Provenance — what this persona was materialized from:\n"
-        f"#   source preset: {preset_name}\n"
-        f"#   preset content hash: {preset_hash}\n"
-        f"#   emitted by OSPREY {__version__}"
+        f"# Made from the bundled `{preset_name}` preset.\n"
+        f"#\n"
+        f"#   emitted by OSPREY {__version__}\n"
+        f"#   preset content hash: {preset_hash}"
     )
     text = _replace_header(text, header)
 
@@ -961,16 +958,7 @@ def emit_persona_delta_yaml(
 # persona siblings share the mental model and repeating the picture three times
 # per repo would just be noise.
 _ZONE_MAP = """\
-# The repository is the deployment. One directory, four zones:
-#
-#   SOURCE   tracked, yours to edit — profile.yml, data/, personas/,
-#            triggers.yml, web-terminal-context/, scripts/, the CI files
-#   SECRETS  .env — git-ignored, durable: provider keys you set, plus the
-#            service tokens `osprey up` mints
-#   OUTPUT   build/ — git-ignored, 100% disposable. Every `osprey build`
-#            wipes and re-renders it; `rm -rf build/` loses nothing, ever
-#   STATE    var/ — git-ignored, durable: var/agent_data holds the agent's
-#            memory and sessions, var/audit the audit log. No build touches it
+# This file is your assistant's settings. Edit it, then run `osprey build`.
 #
 #   +--------------+  osprey   +--------------+  osprey  +----------------+
 #   |    SOURCE    |  build    |    build/    |    up    |   DEPLOYMENT   |
@@ -980,9 +968,10 @@ _ZONE_MAP = """\
 #          ^                                                     |
 #          +---- edit -> osprey build -> osprey up --------------+
 #
-# `osprey up` starts strictly from build/ as it was built — it never renders
-# from this file. Edit profile.yml and `up` refuses until you re-run
-# `osprey build`, so a half-finished edit can never reach a running stack."""
+#   SOURCE   yours to edit, kept in git: this file, data/, personas/
+#   SECRETS  .env, your API keys. Not in git. Rebuilds never touch it
+#   OUTPUT   build/, generated. Never edit it; deleting it is safe
+#   STATE    var/, the agent's memory and audit log. Not in git. Kept"""
 
 
 def emit_standalone_profile_yaml(
@@ -1097,14 +1086,11 @@ def emit_standalone_profile_yaml(
         f"# {profile_name} — OSPREY deployment repo\n"
         f"#\n"
         f"{zone_block}"
-        f"# Emitted from the bundled `{normalized}` preset as a fully explicit,\n"
-        f"# standalone profile: everything the preset configures is written out below and\n"
-        f"# is yours to edit. Nothing is inherited at build time.\n"
+        f"# Made from the bundled `{normalized}` preset. Everything it sets is written\n"
+        f"# out below and is yours to edit. Nothing is hidden or inherited.\n"
         f"#\n"
-        f"# Provenance — what this profile was materialized from:\n"
-        f"#   source preset: {normalized}\n"
-        f"#   preset content hash: {preset_hash}\n"
-        f"#   emitted by OSPREY {__version__}"
+        f"#   emitted by OSPREY {__version__}\n"
+        f"#   preset content hash: {preset_hash}"
     )
     text = _replace_header(text, header)
 

--- a/src/osprey/cli/chat_cmd.py
+++ b/src/osprey/cli/chat_cmd.py
@@ -320,7 +320,7 @@ def chat(
     else:
         if spec.auth_secret_env and not os.environ.get(spec.auth_secret_env):
             console.print(
-                f"[warning]⚠ ${spec.auth_secret_env} not found in environment — "
+                f"[warning]⚠ ${spec.auth_secret_env} is not set. "
                 f"provider '{spec.provider}' may not authenticate[/warning]"
             )
         # The repo root, not the render: `.env` is the durable SECRETS zone and

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -133,63 +133,75 @@ def _repo_readme(name: str) -> str:
     return f"""\
 # {name}
 
-This repository is an OSPREY deployment. Everything the assistant is made of
-lives here, and the directory name is the deployment's name.
+This folder is your OSPREY assistant. Everything it is made of lives here, and
+the folder name is the assistant's name.
 
-## The four zones
+## What is in here
 
-| Zone | Path | Tracked? | Survives? |
+| What | Where | In git? | Kept? |
 | --- | --- | --- | --- |
-| Source | {_source_zone_prose()} | yes | it *is* the record |
-| Secrets | `.env` | no | yes — durable |
-| Output | `{BUILD_OUTPUT_DIR}/` | no | no — 100% disposable |
-| State | `{STATE_DIR}/agent_data/`, `{STATE_DIR}/audit/` | no | yes — durable |
+| Your settings | `profile.yml`, `data/`, `personas/` | yes | yes |
+| Your API keys | `.env` | no | yes |
+| Generated files | `{BUILD_OUTPUT_DIR}/` | no | no, safe to delete |
+| The agent's memory and audit log | `{STATE_DIR}/agent_data/`, `{STATE_DIR}/audit/` | no | yes |
 
-`{BUILD_OUTPUT_DIR}/` is derived in full from the source zone. `rm -rf {BUILD_OUTPUT_DIR}/` loses
-nothing, ever: no configuration, no keys, no agent memory. Nothing durable is
-allowed to live there.
+In full, the first row is: {_source_zone_prose()}.
 
-## Daily use
+`{BUILD_OUTPUT_DIR}/` is generated from your settings every time you run `osprey build`.
+Deleting it is always safe: no settings, no keys and no agent memory live there.
+
+## Everyday commands
 
 ```bash
-osprey build          # render {BUILD_OUTPUT_DIR}/ from profile.yml
-osprey up -d          # start the deployment from {BUILD_OUTPUT_DIR}/, as built
-osprey status         # containers, endpoints, drift, versions
-osprey logs           # follow the stack's logs
+osprey build          # turn your settings into something runnable
+osprey up -d          # start it in the background
+osprey status         # what is running, and is it up to date
+osprey logs           # watch the logs
 osprey down           # stop it
 ```
 
-Every command walks up from wherever you are to this directory, so they work
-from any subdirectory with no flags. `--repo PATH` overrides that.
+Run these from anywhere inside this folder. They find their way to the top on
+their own, so they need no arguments. `--repo PATH` points them somewhere else.
 
 ## Changing something
 
-Edit `profile.yml` (or `osprey set model=sonnet` for a single key), then:
+Edit `profile.yml` (or run `osprey set model=sonnet` to change one setting),
+then:
 
 ```bash
 osprey build && osprey up -d
 ```
 
-`osprey up` starts strictly from `{BUILD_OUTPUT_DIR}/` as it was built — it never renders
-from `profile.yml`. If the source zone has moved on, `up` refuses and names
-what changed, so a half-finished edit can never reach a running stack. Use
-`osprey up --build` to chain the render, or `--as-built` to start the previous
-build knowingly.
+`osprey up` starts what `osprey build` last produced. If you change your
+settings without rebuilding, `up` stops and tells you what changed, so a
+half-finished edit cannot reach a running system. `osprey up --build` does both
+steps; `osprey up --as-built` starts the previous build anyway.
+
+## Running it on a server
+
+To run this somewhere other than your own machine, fill in the `deploy:` section
+at the end of `profile.yml` (which server, which CI system), then run:
+
+```bash
+osprey scaffold ci
+```
+
+That writes the pipeline files. Your own extra CI jobs go in `ci-extra.yml`,
+which nothing ever overwrites.
 
 ## Starting over
 
 ```bash
-osprey reset          # containers, volumes, agent data, {BUILD_OUTPUT_DIR}/ — all gone
+osprey reset          # stops everything, then deletes containers, agent data and {BUILD_OUTPUT_DIR}/
 ```
 
-`reset` keeps `{STATE_DIR}/audit/` and your provider keys. `osprey reset --purge-audit`
-destroys the audit log too; that plus `rm -rf` on this directory is a complete
-uninstall.
+`reset` keeps `{STATE_DIR}/audit/` and your API keys. `osprey reset --purge-audit`
+deletes the audit log as well; that plus deleting this folder removes it all.
 
-## Backup and restore
+## Backups
 
-Git covers the source zone. `{STATE_DIR}/` and `.env` are the entire durable state, so
-a backup is a tarball of those two, and a restore is:
+Git covers your settings. `{STATE_DIR}/` and `.env` are everything else, so a backup
+is a copy of those two, and a restore is:
 
 ```bash
 git clone <this repo> && tar xf state.tar.gz && osprey build && osprey up -d
@@ -539,10 +551,10 @@ def _reinstate_held_source_zone(target: Path) -> None:
     unrecognized = sorted(entry.name for entry in stash.iterdir())
     if unrecognized:
         click.echo(
-            f"\n⚠ Restored the source zone held aside in {stash}, but left "
-            f"{', '.join(unrecognized)} in it — no entry of a source zone goes "
-            f"by those names in this version of osprey. Nothing else will read "
-            f"them; move them out or delete the directory yourself.",
+            f"\n⚠ Put your files back from {stash}, but left "
+            f"{', '.join(unrecognized)} in it. This version of osprey has no "
+            f"place for anything by those names, and nothing will read them. "
+            f"Move them out, or delete that directory yourself.",
             err=True,
         )
         return
@@ -649,9 +661,9 @@ def _replacing_source_zone(target: Path, *, active: bool) -> Iterator[None]:
     shutil.rmtree(stash, ignore_errors=True)
     if stash.exists():
         click.echo(
-            f"\n⚠ Could not remove {stash} — it holds the source zone that was "
-            f"just replaced, and everything in it is superseded by what is now "
-            f"in the repo. Remove it before committing.",
+            f"\n⚠ Could not remove {stash}. It holds the files that were just "
+            f"replaced, so everything in it is an older copy of what is now in "
+            f"the repo. Remove it before you commit.",
             err=True,
         )
 
@@ -712,12 +724,14 @@ def _bootstrap_git(target: Path, *, no_git: bool) -> str:
         One line for the summary.
     """
     if no_git:
-        return "Skipped `git init` (--no-git). Run it yourself to version this deployment."
+        return "Skipped `git init` (--no-git). Run it yourself to keep this in version control."
 
     enclosing = _enclosing_git_dir(target)
     if enclosing is not None:
         where = "here" if enclosing == target else f"at {enclosing}"
-        return f"Git repository already {where} — left alone. Commit when you are ready."
+        return (
+            f"Found a git repository already {where}, and left it alone. Commit when you are ready."
+        )
 
     import subprocess
 
@@ -740,14 +754,13 @@ def _bootstrap_git(target: Path, *, no_git: bool) -> str:
                     "`git %s` failed in %s: %s", step[0], target, detail[-1] if detail else ""
                 )
                 return (
-                    f"`git {step[0]}` failed — the deployment is complete, but "
-                    f"nothing is committed yet."
+                    f"`git {step[0]}` failed. Everything was created, but nothing is committed yet."
                 )
     except (OSError, subprocess.SubprocessError) as e:
         logger.warning("Could not run git in %s: %s", target, e)
-        return "No git available — skipped `git init`. Run it yourself to version this deployment."
+        return "No git found, so `git init` was skipped. Run it yourself to keep this in\n  version control."
 
-    return "Initialized a git repository and committed the source zone."
+    return "Started a git repo and made the first commit."
 
 
 # ---------------------------------------------------------------------------
@@ -1007,7 +1020,7 @@ def init(
             except BaseException:
                 _discard_created_root(target, created=created)
                 raise
-            phase.step(f"source zone from preset {preset}")
+            phase.step(f"settings and data from preset {preset}")
 
             name = materialized.profile_name
             # Driven off the table rather than three calls written out: the set of
@@ -1168,120 +1181,92 @@ def _report(
     deploy_files: list[ScaffoldedFile],
     git_note: str,
 ) -> None:
-    """Tell the operator what they now own, zone by zone.
+    """List what the new repo holds and which parts are the user's to edit.
 
-    An operator meets this layout for the first time here, and the thing they
-    need to know about each entry is which ones are theirs and which ones are
-    regenerated.
+    Someone meets this layout for the first time here, so the report names only
+    the entries they make decisions about. The plumbing they never open --
+    ``.gitignore``, ``.env.example``, ``ci-extra.yml``, ``build/`` -- is in the
+    README, which the last row points at.
     """
-    from osprey.utils.dotenv import parse_dotenv_file
-
     from .profile_cmd import _skipped_keys_note
 
-    click.echo(f"✓ Created deployment repo: {target}")
+    click.echo(f"✓ Created {target.name}")
     click.echo("")
-    for line in _zone_tree(target.name, bool(deploy_files)):
+    for line in _entry_list(target, materialized):
         click.echo(line)
     click.echo(f"\n  {git_note}")
 
-    persona_files = sorted((target / "personas").glob("*.yml"))
-    if persona_files:
-        click.echo("\nWeb-terminal personas — one delta each, merged over profile.yml:")
-        for persona_file in persona_files:
-            click.echo(f"  personas/{persona_file.name}")
-
-    # Secrets get their own block: this repo is now where they live, and a
-    # reader has to be able to tell at a glance whether a value was seeded for
-    # them or is still theirs to supply.
-    click.echo("\nSecrets — kept out of git by .gitignore, and durable across every build:")
-    click.echo("  .env.example — every variable this deployment reads")
-    env_path = target / ".env"
-    if env_path.is_file():
-        seeded = ", ".join(sorted(parse_dotenv_file(env_path)))
-        click.echo(f"  .env — seeded from your shell: {seeded}")
-    else:
-        # Two different absences, and the remedy differs: nothing exported at
-        # all, or keys exported for providers this profile does not use.
-        reason = (
-            "your shell exports no key for the providers it references"
-            if materialized.skipped_shell_keys
-            else "your shell exports no provider key"
-        )
-        click.echo(f"  .env — not written: {reason}. Copy the example and fill it in.")
     if materialized.skipped_shell_keys:
-        # Named rather than dropped in silence: the operator exported these, and
-        # has to be able to account for the omission.
+        # Named rather than dropped in silence: they exported these, and have to
+        # be able to account for the omission.
         click.echo(f"  {_skipped_keys_note(materialized.skipped_shell_keys)}")
 
     for line in _ci_report(deploy_files, target):
         click.echo(line)
 
-    # What to READ and EDIT, only. The commands that follow are on the summary
-    # card this verb ends with, which is also the one place they are correct
-    # for both shapes of the verb: `init --up` has already run them.
-    click.echo("\nNext steps:")
-    click.echo(f"  1. cd {target.name}")
-    click.echo("  2. Read README.md — it explains the four zones")
-    click.echo("  3. Edit profile.yml and the files under data/")
 
-
-def _zone_tree(repo_name: str, has_ci: bool) -> list[str]:
-    """The repo's top level as a tree, one line per entry, each with its job."""
+def _entry_list(target: Path, materialized: _MaterializedProfile) -> list[str]:
+    """The entries someone edits, one line each, with what the entry is for."""
+    personas = sorted(path.stem for path in (target / "personas").glob("*.yml"))
     rows: list[tuple[str, str]] = [
-        ("profile.yml", "the manifest — edit this"),
-        ("data/ personas/", "the material it names — yours too"),
-        (".env.example", "every variable this deployment reads"),
-        ("README.md", "what the zones are and how to operate them"),
-        (_CI_EXTRA_FILENAME, "your own CI jobs; nothing ever regenerates this"),
+        ("profile.yml", "your assistant's settings; edit this"),
+        ("data/", "channel lists and facility docs; edit these"),
     ]
-    if has_ci:
-        rows.append((".gitlab-ci.yml", "generated — `osprey scaffold ci` re-emits it"))
+    if personas:
+        rows.append(("personas/", f"one per web login: {', '.join(personas)}"))
     rows += [
-        (f"{STATE_DIR}/", "agent memory and audit log (gitignored, durable)"),
-        (".gitignore", f"keeps {BUILD_OUTPUT_DIR}/, {STATE_DIR}/, and .env out of git"),
+        (".env", _env_note(target, materialized)),
+        ("README.md", "what everything here does"),
     ]
 
     width = max(len(name) for name, _ in rows)
-    lines = [f"  {repo_name}/"]
-    for index, (name, note) in enumerate(rows):
-        connector = "└──" if index == len(rows) - 1 else "├──"
-        lines.append(f"  {connector} {name.ljust(width)}   {note}")
-    return lines
+    return [f"  {name.ljust(width)}   {note}" for name, note in rows]
+
+
+def _env_note(target: Path, materialized: _MaterializedProfile) -> str:
+    """What happened to the secrets file, in one clause.
+
+    Three outcomes, and the remedy differs: keys were taken from the shell,
+    nothing was exported at all, or what was exported belongs to providers this
+    assistant does not use.
+    """
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    env_path = target / ".env"
+    if env_path.is_file():
+        taken = ", ".join(sorted(parse_dotenv_file(env_path)))
+        return f"from your shell: {taken}. Not in git"
+    if materialized.skipped_shell_keys:
+        return "empty; no key for the providers this assistant uses"
+    return "empty; copy .env.example and add your API key"
 
 
 def _ci_report(emitted: list[ScaffoldedFile], target: Path) -> list[str]:
-    """What the CI emission did, or what to do because it did nothing.
+    """What the CI emission did, when it did anything.
 
-    The no-pipeline case is the common one on a fresh repo and gets the longer
-    answer: it is not a failure, and the operator has to leave knowing which key
-    to fill in and which command turns it into a pipeline.
+    The no-pipeline case says nothing at all. It is by far the common one on a
+    fresh repo, and it is not a problem: running the assistant on a shared
+    server is a later job, and someone creating their first deployment has no
+    question here to answer. The README covers it when they get there.
 
-    A refusal already names its remedy — the engine's per-file reason ends with
-    the ``osprey scaffold ci --force`` re-run — so the trailer only has to say
-    why *this* command's ``--force`` is not it: init's flag is scoped to the
-    source zone and deliberately cannot regenerate a CI file (see
-    :func:`_emit_ci`).
+    A refusal already names its remedy (the engine's per-file reason ends with
+    the ``osprey scaffold ci --force`` re-run), so the trailer only has to say
+    why *this* command's ``--force`` is not it: init's flag cannot regenerate a
+    CI file (see :func:`_emit_ci`).
     """
     if not emitted:
-        return [
-            "\nNo CI pipeline yet:",
-            "  profile.yml carries the `deploy:` block commented out, so there are",
-            "  no coordinates to render one from. Fill it in — CI platform, deploy",
-            "  host, and a registry if the host pulls its images — and the pipeline",
-            "  is one command away:",
-            f"    cd {target.name} && osprey scaffold ci",
-        ]
+        return []
 
-    lines = ["\nDeployment files — generated from profile.yml:"]
+    lines = ["\nDeployment files, generated from profile.yml:"]
     for scaffolded in emitted:
         relative = scaffolded.path.relative_to(target)
         if scaffolded.refused:
-            lines.append(f"  {relative} — NOT written: {scaffolded.reason}")
+            lines.append(f"  {relative} not written: {scaffolded.reason}")
         else:
             lines.append(f"  {relative} ({scaffolded.action})")
 
     if any(scaffolded.refused for scaffolded in emitted):
         lines.append(
-            "  (`osprey init` never regenerates a CI file — `osprey scaffold ci --force` does.)"
+            "  (`osprey init` never regenerates a CI file. `osprey scaffold ci --force` does.)"
         )
     return lines

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -519,10 +519,9 @@ def _skipped_keys_note(skipped: Collection[str]) -> str:
     summary: a skipped secret is a thing the operator has to be able to account
     for, and two spellings of the same fact read as two different facts.
     """
-    subject = "this variable" if len(skipped) == 1 else "these variables"
     return (
-        f"Not seeded: {', '.join(skipped)} — exported by your shell, but this "
-        f"profile references no provider that reads {subject}."
+        f"Left out {', '.join(skipped)}. Your shell exports them, but this "
+        f"assistant uses a different provider."
     )
 
 
@@ -532,6 +531,7 @@ def _write_secret_channel(
     resolved: BuildProfile,
     profile_name: str,
     exported: Mapping[str, str],
+    providers: Collection[str] = (),
 ) -> list[str]:
     """Write the profile's secret channel: ``.env.example``, ``.env``, ``.gitignore``.
 
@@ -567,6 +567,15 @@ def _write_secret_channel(
         {
             "project_name": profile_name,
             "provider_api_keys": provider_api_key_entries(),
+            # Which of those this profile actually uses, so the example puts
+            # the one or two keys someone has to fill in above the rest rather
+            # than in a list of eight they have to search. Empty from the
+            # programmatic path, where the template lists them all as before.
+            "active_provider_vars": [
+                entry["var"]
+                for entry in provider_api_key_entries()
+                if entry["provider"] in providers
+            ],
             "service_token_vars": service_token_var_entries(),
             # The profile's `env:` block is documentation, not values — the
             # same two keys `osprey build` feeds this template.
@@ -926,7 +935,8 @@ def _materialize_profile_directory(
     # Read once, before anything is written: the README rendered below tells the
     # reader whether a `.env` was seeded for them, and the seeding itself happens
     # further down. Two reads of the environment could disagree.
-    shell_keys = _exported_provider_keys(_referenced_providers(resolved, persona_deltas))
+    referenced_providers = _referenced_providers(resolved, persona_deltas)
+    shell_keys = _exported_provider_keys(referenced_providers)
     exported_keys = shell_keys.seeded
 
     # Derived once for the same reason: the README lists the per-user context
@@ -965,20 +975,25 @@ def _materialize_profile_directory(
 
         if triggers_src is not None:
             shutil.copy2(triggers_src, target / _PROFILE_TRIGGERS_FILENAME)
-            logger.info("  Trigger config: %s", _PROFILE_TRIGGERS_FILENAME)
+            logger.debug("  Trigger config: %s", _PROFILE_TRIGGERS_FILENAME)
 
         # The profile owns its secrets from the first minute (FR-1) — the
         # documented variable list, whatever the shell already exports, and the
         # .gitignore that keeps the values out of version control.
         secret_files = _write_secret_channel(
-            target, manager, resolved, profile_name_default, exported_keys
+            target,
+            manager,
+            resolved,
+            profile_name_default,
+            exported_keys,
+            referenced_providers,
         )
-        logger.info("  Secrets: %s", ", ".join(secret_files))
+        logger.debug("  Secrets: %s", ", ".join(secret_files))
         if shell_keys.skipped:
-            # Logged here as well as in `osprey init`'s own summary: this is
-            # where the skipping happens, and a skipped secret must be visible
-            # at the point it was skipped.
-            logger.info("  %s", _skipped_keys_note(shell_keys.skipped))
+            # Debug only. `osprey init`'s summary prints the same sentence from
+            # the same helper, and this is the only caller, so logging it here
+            # at info put the fact on screen twice in one run.
+            logger.debug("  %s", _skipped_keys_note(shell_keys.skipped))
 
         # One empty slot per roster user, so the per-user context a facility
         # writes has an obvious home from the first minute (FR-5). Only the
@@ -990,7 +1005,7 @@ def _materialize_profile_directory(
             user_dir.mkdir(parents=True, exist_ok=True)
             (user_dir / ".gitkeep").touch()
         if roster:
-            logger.info(
+            logger.debug(
                 "  Per-user context: %s",
                 ", ".join(f"{_CONTEXT_CONVENTION_DIRNAME}/{user}/" for user in roster),
             )
@@ -1003,7 +1018,7 @@ def _materialize_profile_directory(
             persona_dir.mkdir()
             for persona_name, persona_text in persona_texts.items():
                 (persona_dir / f"{persona_name}.yml").write_text(persona_text, encoding="utf-8")
-            logger.info(
+            logger.debug(
                 "  Persona deltas: %s",
                 ", ".join(f"{_PERSONA_PROFILE_DIRNAME}/{name}.yml" for name in persona_texts),
             )
@@ -1034,7 +1049,7 @@ def _materialize_profile_directory(
         _cleanup(target)
         raise
 
-    logger.info("✓ Materialized profile at: %s", target)
+    logger.debug("Wrote profile directory: %s", target)
     return _MaterializedProfile(
         target,
         shell_keys.skipped,

--- a/src/osprey/cli/scaffold_cmd.py
+++ b/src/osprey/cli/scaffold_cmd.py
@@ -833,7 +833,7 @@ def ci(repo: Path | None, force: bool) -> None:
     for result in emitted:
         shown = result.path.relative_to(repo_root)
         if result.refused:
-            console.print(f"  [error]✗[/error] {shown} — NOT written: {result.reason}")
+            console.print(f"  [error]✗[/error] {shown} not written: {result.reason}")
         elif result.action == "unchanged":
             console.print(f"  [dim]= {shown} (unchanged)[/dim]")
         else:
@@ -972,7 +972,7 @@ def claim(name, repo):
             f"{outcome.target.entry_noun}.[/dim]"
         )
     console.print(
-        "\n  Edit it in the profile — every build registers "
+        "\n  Edit it in the profile. Every build registers "
         f"[bold]{outcome.target.name}[/bold] as user-owned when it copies it in.\n"
         "  Render it into the build zone again with:\n"
         f"    {_REBUILD_HINT}\n"
@@ -1063,7 +1063,7 @@ def diff(name, repo):
         else:
             console.print(
                 "[success]\u2713[/success] Your directory matches the current framework "
-                "template \u2014 no differences."
+                "template. There are no differences."
             )
         return
 
@@ -1102,8 +1102,8 @@ def diff(name, repo):
         click.echo(output)
     else:
         console.print(
-            "[success]\u2713[/success] Your file matches the current framework template "
-            "\u2014 no differences."
+            "[success]\u2713[/success] Your file matches the current framework template. "
+            "There are no differences."
         )
 
 

--- a/src/osprey/cli/set_cmd.py
+++ b/src/osprey/cli/set_cmd.py
@@ -187,7 +187,7 @@ def set(pairs: tuple[str, ...], repo: Path | None) -> None:
     unrecognized = _unrecognized_top_level_keys(expanded)
     if unrecognized:
         click.echo(
-            f"⚠ Not a profile key: {', '.join(unrecognized)} — written, but the "
+            f"⚠ Not a profile key: {', '.join(unrecognized)}. It was written, but the "
             "profile schema is closed, so `osprey build` will refuse this profile "
             "until it is corrected or removed. To address the rendered config "
             "instead, prefix the key with `config.`."

--- a/src/osprey/cli/sim.py
+++ b/src/osprey/cli/sim.py
@@ -92,7 +92,7 @@ def _resolve_deployment(repo: Path | None) -> tuple[Path, dict]:
     config_path = rendered_config_path(repo_root)
     if not config_path.is_file():
         click.echo(f"Error: no build found at {repo_root / BUILD_DIR_NAME}.", err=True)
-        click.echo("Run 'osprey build' first — the scenarios live in the render.", err=True)
+        click.echo("Run 'osprey build' first. The scenarios are created by the build.", err=True)
         raise SystemExit(1)
     click.get_current_context().with_resource(config_anchored_at(config_path))
     return repo_root, load_config(str(config_path))
@@ -145,8 +145,8 @@ def _echo_physics_notice(config: dict, rendered: dict[str, str]) -> None:
         click.echo("! Physics fault rendered to .env: " + ", ".join(sorted(rendered)) + ".")
     else:
         click.echo("! Cleared the previous scenario's physics fault from .env.")
-    click.echo("  The virtual accelerator reads this only at container boot — run")
-    click.echo("  'osprey up' to recreate it. A plain 'docker restart' keeps")
+    click.echo("  The virtual accelerator reads this only when its container is created,")
+    click.echo("  so run 'osprey up' to recreate it. A plain 'docker restart' keeps")
     click.echo("  the old environment.")
 
 
@@ -367,7 +367,7 @@ def apply_command(
     elif result.logbook_seeded:
         click.echo(f"✓ Seeded {result.logbook_seeded} logbook entries (purged and reseeded).")
     elif ariel_config is None:
-        click.echo("  (no ARIEL config — logbook not seeded)")
+        click.echo("  (no ARIEL configured, so the logbook was not seeded)")
 
     if not seed_archive:
         click.echo("  (stored archive unchanged)")

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -1001,7 +1001,7 @@ def create_claude_code_integration(
 
     if not claude_code_dir.exists():
         console.print(
-            "  [warning]⚠[/warning] Claude Code templates not found — skipping",
+            "  [warning]⚠[/warning] Claude Code templates not found. Skipping them.",
             style="yellow",
         )
         return

--- a/src/osprey/cli/templates/manager.py
+++ b/src/osprey/cli/templates/manager.py
@@ -243,6 +243,10 @@ class TemplateManager:
             # Ordered list of {"provider", "var"} dicts; key-less providers
             # (ollama, vllm, …) are excluded.
             "provider_api_keys": scaffolding.provider_api_key_entries(),
+            # The subset of the above this profile actually uses. Empty here so
+            # a caller with no profile still renders the whole list uncommented;
+            # `osprey init` fills it in and the rest drop below a divider.
+            "active_provider_vars": [],
             # Deploy-minted service credentials, derived from the map the
             # deploy path mints from, so .env.example documents every one of
             # them. Ordered list of {"var", "services", "note"} dicts.

--- a/src/osprey/cli/users_cmd.py
+++ b/src/osprey/cli/users_cmd.py
@@ -476,8 +476,8 @@ def remove(user: str, repo: Path | None, archive: bool, purge: bool, yes: bool) 
                 f"  Not done: profile.yml still lists {user}, so the next "
                 "[command]osprey build[/command] would put them back on the roster.\n\n"
                 f"  Fix it either way:\n"
-                f"    • re-run [command]osprey users remove {user}[/command] — it detects the "
-                "half-finished removal and completes just the profile edit\n"
+                f"    • re-run [command]osprey users remove {user}[/command]. It notices the "
+                "half-finished removal and only edits the profile\n"
                 f"    • or delete {user}'s entry from profile.yml by hand",
                 style=Styles.WARNING,
             )
@@ -509,7 +509,7 @@ def remove(user: str, repo: Path | None, archive: bool, purge: bool, yes: bool) 
                 f"\n! {user} was removed from the deployment, but this repo's profile.yml "
                 "does not spell the web-terminal roster, so there was nothing to edit "
                 "there. If the roster comes from an 'extends:' preset, remove the user "
-                f"in the profile by hand — otherwise the next build restores them.",
+                f"in the profile by hand, or the next build will restore them.",
                 style=Styles.WARNING,
             )
 

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -579,7 +579,7 @@ def web(
 
     if host == "0.0.0.0":
         click.echo("WARNING: Binding to 0.0.0.0 exposes the terminal to the network.")
-        click.echo("This is a single-user tool — add authentication before external exposure.\n")
+        click.echo("This is a single-user tool. Add authentication before you expose it.\n")
 
     # Pre-flight: check if port is already in use. SO_REUSEADDR matches
     # uvicorn's own bind semantics — without it, TIME_WAIT sockets from a
@@ -603,7 +603,7 @@ def web(
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as free_sock:
                 free_sock.bind((host, 0))
                 port = free_sock.getsockname()[1]
-            click.echo(f"Port {busy_port} in use — using :{port} instead.")
+            click.echo(f"Port {busy_port} is in use, so this is on :{port} instead.")
 
     # Publish the ACTUAL port to every child process (PTY shells, their MCP
     # servers): web_terminal_url() resolves OSPREY_WEB_PORT first, and
@@ -750,7 +750,7 @@ def web_stop(ctx: click.Context, repo: Path | None) -> None:
     try:
         pid = int(pid_path.read_text().strip())
     except (ValueError, OSError):
-        click.echo("Corrupt PID file — removing.")
+        click.echo("Removing a corrupt PID file.")
         pid_path.unlink(missing_ok=True)
         return
 

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -382,7 +382,7 @@ def show_status(config_path, *, console=None, styles=None):
     # service set that looks perfectly healthy here, so status is the other
     # place (besides osprey up) the drift must be visible.
     for reason in staleness_reasons(Path(config_path).resolve().parent):
-        console.print(f"[yellow]⚠ Project render is stale: {reason} — re-run osprey build[/yellow]")
+        console.print(f"[yellow]⚠ The build is out of date: {reason}. Re-run osprey build[/yellow]")
 
     deployed_services = config.get("deployed_services", [])
     deployed_service_names = (
@@ -596,12 +596,12 @@ def _print_containers_section(repo_root, config, console, styles):
         # build/ and runs `down` would be told nothing was found while these
         # kept running.
         console.print(
-            f"  [{styles.WARNING}]{len(unlabelled)} of the above matched by project name "
-            f"only ({', '.join(_container_display_name(c) for c in unlabelled)}): they "
-            f"carry no {REPO_ID_LABEL} label, so they were created before this repo "
-            f"labelled its containers. `osprey down` finds them through build/'s compose "
-            f"files, but not through the label fallback that stands in when build/ is "
-            f"gone.[/{styles.WARNING}]"
+            f"  [{styles.WARNING}]{len(unlabelled)} of these were matched by name, not by "
+            f"label ({', '.join(_container_display_name(c) for c in unlabelled)}): they "
+            f"carry no {REPO_ID_LABEL} label, because they were started before this repo "
+            f"began labelling its containers. `osprey down` finds them through build/'s "
+            f"compose files, but not through the label fallback that takes over when "
+            f"build/ is gone.[/{styles.WARNING}]"
         )
 
     if foreign:
@@ -613,12 +613,12 @@ def _print_containers_section(repo_root, config, console, styles):
         # isolates them would be exactly backwards for the operator who then
         # runs `osprey down`.
         console.print(
-            f"\n  [{styles.WARNING}]{len(foreign)} container(s) named for project "
-            f"'{project_name}' belong to a DIFFERENT checkout of it "
-            f"({', '.join(sorted({_container_label(c, REPO_ID_LABEL) or '?' for c in foreign}))}); "
-            f"this repo's identity is {identity}. They share this deployment's compose "
-            f"project name, so `osprey down` run here stops them as well. Only the "
-            f"{REPO_ID_LABEL} label tells the two checkouts apart.[/{styles.WARNING}]"
+            f"\n  [{styles.WARNING}]{len(foreign)} container(s) named for '{project_name}' "
+            f"were started from a DIFFERENT copy of this deployment "
+            f"({', '.join(sorted({_container_label(c, REPO_ID_LABEL) or '?' for c in foreign}))}; "
+            f"this copy is {identity}). They share a name with yours, so `osprey down` run "
+            f"here stops them too. Only their label tells the two copies "
+            f"apart.[/{styles.WARNING}]"
         )
         console.print(_container_table(foreign, styles))
 
@@ -666,7 +666,7 @@ def _print_endpoints_section(config, compose_files, console, styles):
     console.print(f"[bold]{summary.splitlines()[0]}[/bold]")
     for line in summary.splitlines()[1:]:
         console.print(line)
-    console.print(f"  [{styles.DIM}](declared by build/ — not a check that anything answers)[/]")
+    console.print(f"  [{styles.DIM}](listed by the build; nothing was contacted to check)[/]")
 
 
 def _auth_availability(secret_env, repo_root):
@@ -860,8 +860,8 @@ def _print_agent_section(repo_root, build_dir, config, console, styles, *, show_
     unchanged = result.get("unchanged") or []
     if changed:
         console.print(
-            f"  [{styles.WARNING}]artifacts: {len(changed)} out of sync with build/config.yml — "
-            f"run `osprey build`[/{styles.WARNING}]"
+            f"  [{styles.WARNING}]artifacts: {len(changed)} no longer match "
+            f"build/config.yml. Run `osprey build`[/{styles.WARNING}]"
         )
         for path in changed:
             console.print(f"    [{styles.WARNING}]~[/{styles.WARNING}] {path}")

--- a/src/osprey/deployment/web_terminals/auth_credentials.py
+++ b/src/osprey/deployment/web_terminals/auth_credentials.py
@@ -373,7 +373,7 @@ def ensure_auth_credentials(
                 )
             if minted:
                 echo(
-                    "Record these now — they are shown this once and cannot be "
+                    "Record these now. They are shown once and cannot be "
                     "recovered; only their hashes are stored."
                 )
 

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -342,7 +342,7 @@ def prune_users(
             print(f"      volume {volume!r}: {policy}")
 
     if dry_run:
-        print("prune: dry-run — no resources were removed.")
+        print("prune: dry run, so nothing was removed.")
         return
 
     prompt = (
@@ -528,8 +528,8 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
         images_to_remove.append(image)
 
     print(
-        f"nuke: this will tear down project {project!r}'s entire web-terminal + "
-        f"service stack — every container (project-scoped), {len(volumes)} "
+        f"nuke: this will tear down project {project!r}'s entire web-terminal and "
+        f"service stack: every container in the project, {len(volumes)} "
         f"volume(s) ({len(roster_names)} roster user(s), "
         f"{len(orphan_volumes)} off-roster user(s)), and {len(images_to_remove)} "
         "image(s):"
@@ -541,7 +541,7 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
         print(f"  - image {image!r}: removed permanently (com.osprey.project verified)")
     for image, label_value in skipped_images:
         print(
-            f"  - image {image!r}: SKIPPED — com.osprey.project label {label_value!r} "
+            f"  - image {image!r}: SKIPPED. Its com.osprey.project label {label_value!r} "
             f"does not match this deployment's project {project!r}"
         )
 

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -1,48 +1,38 @@
 # control-assistant.yml
-# Full control system deployment — the standard starting point for facilities
-# operating a particle accelerator or beamline with EPICS or a mock backend.
+# The standard starting point for a facility running a particle accelerator or
+# beamline, on EPICS, the built-in simulator, or a mock backend.
 #
-# `osprey init <facility> --preset control-assistant` writes this configuration
-# out as <facility>/profile.yml, at the root of a deployment repo you own.
-# Adjust the config overrides, overlay paths, and MCP server definitions there
-# for your site; the packaged preset is never edited.
+# `osprey init <facility> --preset control-assistant` writes this out as
+# <facility>/profile.yml, at the root of a repo you own. Edit it there; the
+# packaged preset is never touched.
 #
-# Every comment below is copied verbatim into that emitted profile, so it is
-# addressed to the operator reading their own repo, not to a reader of this
-# file.
+# Every comment below is copied into that file, so it is written for whoever
+# opens their own profile.yml, not for a reader of this one. Keep them short:
+# two lines each. Anything longer belongs in the docs.
 
 name: Control Assistant
 
-# Which packaged project skeleton `osprey build` renders (config.yml, README,
-# Dockerfile). "control_assistant" is the full skeleton. Its data files
-# (channel databases, benchmarks, facility knowledge, logbook seeds) are copied
-# into this repo's data/ directory, and that copy — not the packaged one — is
-# what the build uses from then on.
+# Which packaged app this builds. "control_assistant" is the full one. Its data
+# files are copied into data/, and that copy is what the build uses from then on.
 app_template: control_assistant
 
-# Default LLM provider and model. Override here or with `osprey set
-# provider=...` / `osprey set model=...`, which write this file in place,
-# comments intact. The persona terminals build from deltas over that same
-# profile, so they pick the change up from the file rather than from a replayed
-# command line.
+# Which model answers. `osprey set provider=...` / `osprey set model=...` edit
+# these in place, keeping your comments.
 provider: anthropic
 model: haiku   # tier (haiku/sonnet/opus), or a model ID the provider serves
 
-# Channel-finder pipeline. Override with
-# `osprey set channel_finder_mode=in_context|middle_layer`.
+# How the agent searches for channels. `osprey set channel_finder_mode=...`
+# also accepts in_context or middle_layer.
 channel_finder_mode: hierarchical
 
-# Extra packages the built project's environment needs. pymongo is what the
-# archiver connector, the deploy-time seeder and the recorder all read the store
-# through; the tutorial declares a `va_archiver:` block below, so without it the
-# staged bring-up aborts at its pymongo preflight before any image is built.
-# Matches the pin the `archiver-mongodb` extra carries in pyproject.toml.
+# Extra Python packages your agent needs. pymongo is required by the stored
+# archive declared under `va_archiver:` below.
 dependencies:
   - pymongo>=4.0
 
-# ── Artifact selection ───────────────────────────────────────────────────────
-# Each list entry is a short name resolved from the osprey artifact library.
-# Remove entries you do not need; add facility-specific artifacts via overlay.
+# ── What the agent can do ────────────────────────────────────────────────────
+# Each entry is a name from the OSPREY artifact library. Delete what you do not
+# need; add your own through an overlay.
 
 hooks:
   - hook-log          # Append every tool call to a structured JSONL audit log
@@ -54,9 +44,9 @@ hooks:
   - memory-guard      # Warn when context window approaches threshold
   - notebook-update   # Sync CLAUDE.md notebook after each session
   - cf-feedback-capture  # Capture channel-finder accuracy feedback for tuning
-  - config-drift      # Warn at session start when the build drifted from source
+  - config-drift      # Warn at session start when the build is out of date
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
-  - panels-context    # Inject the web terminal panel inventory into agent context
+  - panels-context    # Tell the agent which web terminal panels exist
   - workspace-delta   # Report web workspace changes since the agent's last turn
 
 rules:
@@ -69,19 +59,17 @@ rules:
   - python-execution    # Rules governing Python executor sandbox usage
   - data-visualization  # Rules for producing control-room-ready plots
   - control-system-safety  # EPICS PV safety: alarm limits, soft-IOC guards
-  - test-ioc-safety     # Test-IOC port isolation (renders only for EPICS-family control systems)
+  - test-ioc-safety     # Test-IOC port isolation (EPICS-family control systems only)
 
 skills:
   - diagnose        # Run a structured fault-diagnosis workflow
-  # setup-mode (config diagnostics + setup_patch) is deliberately NOT part of
-  # the operator tier: it can patch config.yml/.mcp.json, which is admin work.
-  # Add it to an admin-facing profile's skills list to opt in — it remains in
-  # the artifact catalog.
+  # setup-mode is left out on purpose: it can edit config.yml and .mcp.json,
+  # which is admin work. Add it to an admin-facing profile to turn it on.
   - session-report  # Summarise session actions and outcomes to the logbook
   - demo-gallery    # Launch guided capability demonstrations
   - demo-ui         # Run a scripted demo of the agent driving the web workspace
-  - writing-bluesky-plans  # Author, validate, and queue a session-tier plan (requires the Bluesky MCP server)
-  - operating-bluesky-scans  # Stage, queue, and watch a registered scan through the shared draft (requires the Bluesky MCP server)
+  - writing-bluesky-plans  # Write, check and queue a scan plan (needs the Bluesky server)
+  - operating-bluesky-scans  # Stage, queue and watch a scan (needs the Bluesky server)
 
 agents:
   - channel-finder          # Semantic search over channel databases (hierarchical)
@@ -97,202 +85,109 @@ output_styles:
 web_panels:
   - ariel           # ARIEL search interface (past experiments, papers)
   - channel-finder  # Interactive channel-finder web UI
-  - okf             # KNOWLEDGE tab — browse the facility knowledge bundle
-  - system-health   # SYSTEM tab — framework health dashboard (sidecar-backed)
-  # events + bluesky (the write-oriented panels) are declared by the readwrite
-  # persona, beside the web.panels.<id>.url overrides that give them meaning —
-  # a panel id and its URL declaration travel together (see the note in
-  # config: below).
+  - okf             # KNOWLEDGE tab, for browsing the facility knowledge bundle
+  - system-health   # SYSTEM tab, a framework health dashboard
+  # The events and bluesky panels are declared in personas/readwrite.yml
+  # instead, so the read-only login is built without them.
 
-# ── Bluesky stack (turn-key, VA-backed) ─────────────────────────────────────────
-# The preset ships the FULL Bluesky-mediated scan stack out of the box: a
-# Bluesky bridge (+ co-deployed Tiled catalog), a PyAT Virtual Accelerator
-# soft-IOC standing in for real EPICS hardware, and the bluesky-panels sidecar
-# that serves the BLUESKY web_panel above. Each top-level block below is an
-# injector trigger — it renders the corresponding `services.<name>` compose
-# service, appends to `deployed_services`, and (for bluesky_panels) registers
-# the `web.panels.<id>` URLs. Remove this section (and the bluesky panel id
-# above) to ship a Bluesky-free deployment.
+# ── Scanning and simulated hardware ──────────────────────────────────────────
+# These three blocks give you a working scan setup with no real hardware: a
+# Bluesky bridge with a Tiled data catalog, a simulated accelerator that speaks
+# EPICS, and the web panels for both. Delete this section (and the bluesky
+# panel above) if you do not want it.
 bluesky:
   port: 8090
-  tiled_enabled: true      # co-deploys the Tiled catalog sidecar alongside the bridge
+  tiled_enabled: true      # also runs the Tiled data catalog
   tiled_port: 8091
 
 virtual_accelerator:
-  # Channel Access port the soft-IOC serves on. The connector's gateway port
-  # follows this value, so changing it here moves both the container and the
-  # connector that talks to it.
+  # EPICS port the simulator serves on. The agent follows this value, so
+  # changing it moves both.
   port: 5064
 
 bluesky_panels:
   port: 8095
 
 # ── Stored archive (MongoDB) ─────────────────────────────────────────────────
-# Declaring this block is what gives the deployment a REAL archive: `osprey up`
-# stands up a MongoDB store and an archiver-recorder beside the VA, seeds the
-# store with history on the first deploy, and records the machine from then on.
-# Without it the agent's history is synthesized at read time — plausible numbers
-# for questions nobody recorded the answer to.
+# With this block, `osprey up` runs a real archive: a MongoDB store that is
+# seeded with history on the first deploy and records the machine from then on.
+# Without it, the agent invents plausible history when asked about the past.
 #
-# The block is the single home for the archive's coordinates: the build derives
-# the connector's eight `archiver.mongodb_archiver.*` keys AND the shape knobs
-# below from it, and REFUSES a profile that also spells them in `config:` (one
-# fact, two homes, free to disagree). Selecting the archiver is a separate
-# decision and lives in `config:` as `archiver.type` — see the note there.
-#
-# Every key is optional; these are the shipped defaults, stated so the tutorial
-# documents the shape it deploys rather than hiding it in a dataclass.
+# Every key is optional. These are the defaults, written out so you can see the
+# shape. Do not also set `archiver.mongodb_archiver.*` under `config:` below;
+# the build derives those keys from here and refuses a profile that has both.
 va_archiver:
-  # Where the agent reaches the store. Stated rather than left to the deploy to
-  # infer, because a profile resolved WITHOUT a service stack — a persona delta,
-  # an attached project, any of the resolution paths that carry no
-  # deploy_services — is required to name the host whose archive it reads, and
-  # would otherwise fail to resolve at all. `localhost` is the host side of the
-  # published `port_host`, which is where this project's own store answers;
-  # point it at the real host when attaching to someone else's.
+  # Where the agent reaches the store. `localhost` is this deployment's own;
+  # point it at another host to read someone else's archive.
   host: localhost
   retention_days: 30       # how far back the archive reaches
-  hot_span_hours: 48       # how much of it is kept at the dense cadence
+  hot_span_hours: 48       # how much of it is kept at the dense sample rate
   hot_cadence_sec: 10      # seconds between samples inside the hot span
   tail_cadence_sec: 60     # and outside it (must be a whole multiple of the above)
-  # How often the recorder samples the running machine. Stated because the
-  # freshness threshold below is derived from it: leaving it to the dataclass
-  # default would hide the one number that decides when this deployment calls
-  # its own archive stale.
-  recorder_cadence_sec: 10
-  # The channel `osprey health` reads to tell a REACHABLE archive from one still
-  # being WRITTEN — a wedged recorder leaves the store answering queries while
-  # history quietly stops, and only the age of the newest sample separates the
-  # two. Naming it here derives the whole `archiver_freshness` check, threshold
-  # included: that follows `recorder_cadence_sec` above, so slowing the recorder
-  # cannot leave a stale threshold behind.
-  #
-  # The stored-beam DCCT current is this simulated facility's canary, for the
-  # reason a real control room would pick it: it is the first thing to stop
-  # moving when the machine does. Point it at your own equivalent when you take
-  # this preset to hardware; drop the key and no check is derived.
+  recorder_cadence_sec: 10  # how often the recorder samples the machine
+  # A channel `osprey health` watches to check the archive is still recording:
+  # if this stops moving, history has quietly stopped. Point it at something on
+  # your machine that always changes; delete the key for no check at all.
   freshness_channel: SR:DIAG:DCCT:01:CURRENT:RB
 
-# ── Config overrides ─────────────────────────────────────────────────────────
-# Dotted keys ONLY: each entry is a literal `key.path` written into the
-# rendered config.yml after the template renders. A nested mapping here would
-# replace the whole rendered subtree and silently drop its siblings.
+# ── Everything else ──────────────────────────────────────────────────────────
+# One dotted `key.path` per line. Never write a nested block here: it would
+# replace the whole subtree and silently drop the keys beside it.
 #
-# This block is the source of truth for configuration. build/config.yml is
-# generated from it and is never hand-edited — `osprey set` writes here.
+# This block is where configuration lives. build/config.yml is generated from
+# it and should never be hand-edited. `osprey set` writes here.
 config:
-  # The VA soft-IOC ships and is deployed as part of the turn-key Bluesky stack
-  # above, so control_system.type defaults to "virtual_accelerator": the
-  # preset's scan plans drive it end to end out of the box (correctors move,
-  # BPMs read, a settle-verified run COMPLETEs). Use "epics" for live hardware.
-  # "mock" is the documented fallback for environments with no containers to
-  # depend on — its readbacks are a non-tracking simulation, so scans are
-  # browse-only (a settle-verified run never COMPLETEs on mock) — flip back
-  # with `osprey set connector=mock`, the shorthand that writes this key.
+  # Which control system to talk to. "virtual_accelerator" is the built-in
+  # simulator and works out of the box; "epics" is real hardware; "mock" needs
+  # no containers but cannot complete a scan. `osprey set connector=epics`.
   control_system.type: virtual_accelerator
-  # Selects the archive declared by the `va_archiver:` block above as the
-  # deployment's archiver. This is a SEPARATE decision from declaring where the
-  # archive lives, and deliberately so: the block never flips `archiver.type`
-  # out from under a facility that set it. A project that declared the block but
-  # left this alone would deploy a store and then read the mock beside it.
-  #
-  # Dotted, like every key here. A nested `archiver:` mapping would prefix
-  # -collapse; and spelling any `archiver.mongodb_archiver.*` key here is
-  # refused outright while the block is present, because the build already
-  # derives those from it.
+  # Use the archive declared by `va_archiver:` above. Declaring the block does
+  # not turn it on; without this line you would deploy a store and not read it.
   archiver.type: mongodb_archiver
-  # The Bluesky MCP server is off-by-default in the framework registry
-  # (default_enabled=False); opt in here so the agent can author and launch
-  # scan plans out of the box.
+  # Both servers are off by default in OSPREY. Turn them on so the agent can
+  # write and launch scan plans, and run read-only health checks.
   claude_code.servers.bluesky.enabled: true
-  # The system-health MCP server is likewise off-by-default in the framework
-  # registry (default_enabled=False); opt in here so the agent can run
-  # read-only framework/stack health checks out of the box.
   claude_code.servers.health.enabled: true
   # system.timezone: America/Los_Angeles
-  # Facility display name, woven into the agent prompts (CLAUDE.md, the
-  # channel-finder/logbook agents) and the web-terminal landing page. Defaults
-  # to the deployment name when unset. Sits in the same `facility:` block as
-  # `facility.prefix` below.
+  # Your facility's name, used in the agent's prompts and on the web landing
+  # page. Defaults to the deployment name.
   # facility.name: My Facility
-  # Default web theme for every terminal: the `main` family pinned to light
-  # mode (`light` is main's concrete light id — other families spell theirs
-  # `desy-light` etc.). A default, not a lock: the in-browser display menu,
-  # ?theme= and localStorage override it per browser.
+  # Starting theme for every web terminal. Each browser can override it from
+  # the display menu.
   web.theme: light
-  # EVENTS + BLUESKY panel declarations live in the readwrite persona delta,
-  # NOT here. Deliberate: a persona delta can only ADD config keys (`config:`
-  # is not excludable), so anything declared here reaches every persona — and
-  # the read-only persona must be built without these two write-oriented
-  # panels. Declaring them only in the readwrite delta is the one mechanism
-  # that makes them genuinely absent from the readonly build (`enabled: false`
-  # is inert for URL panels — only builtin ids honor it). A full deployment
-  # render still gets both panels: the dispatch and bluesky-panels injectors
-  # fill in defaults when the profile doesn't declare them.
-  # ── Multi-user web-terminal stack (built-in) ───────────────────────────────
-  # This deployment is natively multi-user: `osprey up` stands up nginx, the
-  # landing page, and one web-terminal container per roster user, alongside the
-  # scan stack above. Single-user onboarding is unchanged — `osprey web` never
-  # reads this block (only `osprey up` does), so a plain host-run terminal
-  # works at any time. To deploy backend services without the web tier, set
-  # `modules.web_terminals.enabled: false` here.
+  # ── Web terminals ──────────────────────────────────────────────────────────
+  # `osprey up` runs a landing page and one terminal per user listed below.
+  # `osprey web` ignores all of this, so a single terminal on your own machine
+  # works at any time. Set `modules.web_terminals.enabled: false` for backend
+  # services only.
   #
-  # Container-name prefix for the web stack: names are `<prefix>-nginx` /
-  # `<prefix>-web-<user>`, so this MUST be a non-empty valid Docker name start
-  # ([a-zA-Z0-9]). Keep it short and distinct from the deployment name (used for
-  # image tags). Set it to your own facility abbreviation.
+  # Short prefix for the web container names (`<prefix>-nginx`, `<prefix>-web-
+  # <user>`). Must start with a letter or digit. Use your facility's initials.
   facility.prefix: ca
-  # Landing-URL origin for the multi-user web stack: render refuses to build
-  # OSPREY_TERMINAL_LANDING_URL without deploy.fqdn once users are configured.
-  # 127.0.0.1 matches the single-trusted-host posture; set your
-  # browser-reachable hostname when deploying anywhere else.
+  # The hostname people open in a browser. 127.0.0.1 is your own machine; set
+  # your real hostname to reach it from anywhere else.
   deploy.fqdn: 127.0.0.1
-  # This MUST stay ONE literal dotted key — `modules.web_terminals` addressing
-  # the whole module subtree with a nested value. A nested `modules:` mapping
-  # under `config:` would wholesale-replace the rendered `modules` subtree,
-  # silently dropping any sibling module: config_writer applies each dotted key
-  # verbatim, setting only the addressed leaf (see utils/config_writer.py).
-  #
-  # `image_source: local` means `osprey up` builds each persona's image itself
-  # from `project_path`, and `osprey build` is what put a project there:
-  # one render per delta in `personas/`. So `osprey build && osprey up` stands
-  # the whole stack up with no registry. Each persona's `project` equals its
-  # `project_path` basename — both are derived from the repo's own directory
-  # name, which is how the render and the mount land on the same path.
-  #
-  # The `build_profile` values below are PRESET names, and are consumed only
-  # here, at materialization: `osprey init` renders each one into a delta at
-  # `personas/<name>.yml` beside the emitted profile and rewrites this catalog
-  # to point at that file. The build reads the deltas themselves and accepts
-  # nothing else — a persona is built from a delta over this profile, never
-  # from a preset of its own.
+  # Keep this as ONE dotted key. A nested `modules:` block here would replace
+  # the whole modules subtree and silently drop the others.
   modules.web_terminals:
     enabled: true
-    # No deploy block yet, so this is image_source's only home: build the
-    # per-user terminal images here rather than pulling them.
+    # No deploy block yet, so this is image_source's only home: build each
+    # terminal image here rather than pulling it from a registry.
     image_source: local
-    nginx_port: 9080            # public-facing reverse proxy / landing page
-    # Per-user port families: user i gets base + i in each family. Every
-    # companion panel gets its own family (the containers share the host
-    # network namespace, so per-user offsets are what prevent collisions);
-    # families omitted here fall back to registry defaults (registry/web.py).
-    # All families sit above this deployment's own service ports (5064, 8020,
-    # 8090/8091/8095) so the two stacks never collide on one host.
+    nginx_port: 9080            # the landing page everyone opens first
+    # User number i gets base + i in each family below, so removing a user
+    # never shifts anyone else's ports. These all sit above this deployment's
+    # own service ports (5064, 8020, 8090/8091/8095) to avoid collisions.
     web_base_port: 9091           # first per-user web-terminal port
     artifact_base_port: 9291      # first per-user artifact-gallery port
     ariel_base_port: 9391         # first per-user ARIEL search port
     lattice_base_port: 9491       # first per-user lattice-dashboard port
     channel_finder_base_port: 9591  # first per-user channel-finder panel port
-    default_persona: readonly   # roster entries with no persona resolve here
+    default_persona: readonly   # used for any user below with no persona
     users:
-      # One web terminal per entry. `index` pins the user's port offsets
-      # (each `*_base_port` above + index), so removing an entry never shifts
-      # another user's ports; `persona` names a catalog entry below. A bare
-      # string (`- alice`) is also accepted: it takes its list position as
-      # index and falls back to `default_persona`.
-      # `display_name` becomes the browser window/tab title (OSPREY_WEB_APP_NAME)
-      # — with both terminals on the same light theme it is the visible marker
-      # of which one is write-armed.
+      # One web terminal per entry. `index` pins that user's ports, `persona`
+      # picks their permissions from the list below, and `display_name` becomes
+      # the browser tab title, which is how you tell the two terminals apart.
       - name: alice
         index: 0
         persona: readwrite
@@ -302,11 +197,8 @@ config:
         persona: readonly
         display_name: "Read-Only View (Bob)"
     personas:
-      # A persona render is build output like everything else under build/.
-      # `osprey build` renders one project per delta in `personas/`, and it
-      # replaces build/ whole every time — nothing under there is edited in
-      # place or kept across a build. `osprey up` renders nothing: if a project
-      # is missing it refuses and names `osprey build`.
+      # `osprey build` builds one of these per file in personas/, into build/.
+      # `osprey up` builds nothing: if one is missing it stops and says so.
       readonly:
         project: control-assistant-readonly
         project_path: build/control-assistant-readonly
@@ -316,24 +208,22 @@ config:
         project_path: build/control-assistant-readwrite
         build_profile: control-assistant-readwrite
 
-# ── Event dispatch (optional) ────────────────────────────────────────────────
-# Turns external events (webhooks) into headless agent runs. This ships a set of
-# control-system-free triggers so you can exercise the pipeline with a single
-# `curl` after `osprey up`. Remove this block to disable dispatch.
+# ── Answering webhooks (optional) ────────────────────────────────────────────
+# Lets an outside system ask the agent a question over HTTP. The triggers that
+# ship need no control system, so a single `curl` after `osprey up` exercises
+# it. Delete this block to turn it off.
 dispatch:
-  triggers: tutorial_triggers.yml   # repo-relative path or bundled name
+  triggers: tutorial_triggers.yml   # a path in this repo, or a bundled name
   worker_count: 1
   workspace_mode: isolated
   max_concurrent_runs: 2
   max_queue_depth: 50
 
 # ── Environment variables ────────────────────────────────────────────────────
-# Bearer tokens guarding the dispatcher's inbound webhook/dashboard auth
-# (EVENT_DISPATCHER_TOKEN) and the dispatcher→worker calls (DISPATCH_WORKER_TOKEN).
-# No defaults on purpose: the dispatch services fail closed on an unset token.
-# `osprey up` mints a strong random value for each unset token into this repo's
-# .env (and logs where), so a fresh deployment is secure by default with zero
-# editing. Set your own values in .env to override.
+# Passwords for the webhook service above. They have no defaults on purpose:
+# the service refuses to start without them. `osprey up` generates a strong
+# random value for each one into this repo's .env, so a new deployment is
+# secure with no editing. Put your own values in .env to override.
 env:
   required:
     - EVENT_DISPATCHER_TOKEN

--- a/src/osprey/templates/project/env.example.j2
+++ b/src/osprey/templates/project/env.example.j2
@@ -1,21 +1,35 @@
 # {{ project_name }} Environment Configuration
 #
-# The single documented list of every variable this agent reads. Copy it to
-# `.env` beside this file and fill in the values you need. That one file is the
-# deployment's whole secret store: `osprey build` never reads or rewrites it,
-# and the containers mount it from the repo root, so a value here survives
-# every rebuild and every `rm -rf build/`.
+# Every variable this agent reads, listed in one place. Copy this file to `.env`
+# beside it and fill in what you need. That one file holds all your secrets, and
+# a value in it survives every rebuild.
 #
-# This file carries no secrets and is safe to commit.
+# This file has no secrets in it and is safe to commit.
 
-# API Keys — set the key(s) for the provider(s) your profile uses.
-# (Provider list derived from the OSPREY provider registry.)
+{% if active_provider_vars -%}
+# API key for the provider this assistant uses. Fill this in.
+{% for entry in provider_api_keys -%}
+{% if entry.var in active_provider_vars -%}
+{{ entry.var }}=your-{{ entry.provider }}-api-key-here
+{% endif -%}
+{% endfor %}
+# Other providers OSPREY supports. Uncomment one if you switch to it with
+# `osprey set provider=...`.
+{% for entry in provider_api_keys -%}
+{% if entry.var not in active_provider_vars -%}
+# {{ entry.var }}=your-{{ entry.provider }}-api-key-here
+{% endif -%}
+{% endfor %}
+{%- else -%}
+# API keys. Set the one for the provider your profile uses.
+# (Provider list comes from the OSPREY provider registry.)
 {% for entry in provider_api_keys -%}
 {{ entry.var }}=your-{{ entry.provider }}-api-key-here
 {% endfor %}
+{%- endif %}
 {%- if env_required %}
-# Required by this profile — the profile's `env.required` names these, and
-# the agent cannot run without them.
+# Required by this profile. Its `env.required` names these, and the agent
+# cannot run without them.
 {% for var in env_required -%}
 {{ var }}=
 {% endfor %}
@@ -35,10 +49,10 @@
 # HTTP_PROXY=http://proxy.example.com:8080
 # HTTPS_PROXY=http://proxy.example.com:8080
 
-# Service credentials — minted automatically by `osprey up` when the matching
-# service is deployed, and appended to this repo's .env. Set one by hand only
-# to pin a value the deployment must not replace (an existing database volume's
-# password, say); an unset variable is minted, never guessed.
+# Service passwords. `osprey up` generates a strong random value for each of
+# these when it deploys the matching service, and writes it into this repo's
+# .env. Set one by hand only to keep a value the deployment must not change,
+# such as the password on a database volume you already have.
 {% for entry in service_token_vars -%}
 # {{ entry.var }}=  # {{ entry.services }}{% if entry.note %} — {{ entry.note }}{% endif %}
 {% endfor -%}

--- a/tests/cli/test_build_profile_emit.py
+++ b/tests/cli/test_build_profile_emit.py
@@ -117,9 +117,9 @@ def test_header_explains_the_implicit_merge_and_names_the_source() -> None:
         profile_filename="my-profile/personas/readonly.yml",
     )
 
-    assert "a delta over ../profile.yml" in text
-    assert "there is no `extends:` to write" in _unwrapped_comments(text)
-    assert f"source preset: {PERSONA_PRESET}" in text
+    assert "settings for one web login" in text
+    assert "Only the differences from profile.yml belong here" in _unwrapped_comments(text)
+    assert "merges this file over that one" in _unwrapped_comments(text)
     assert "preset content hash: sha256:" in text
     assert "osprey validate my-profile/personas/readonly.yml" in text
 
@@ -175,7 +175,7 @@ def test_provenance_agrees_with_the_header_prose() -> None:
     provenance = yaml.safe_load(text)["provenance"]
     header = text.split("\nname:")[0]
 
-    assert f"source preset: {provenance['preset']}" in header
+    assert f"bundled `{provenance['preset']}` preset" in header
     assert f"preset content hash: {provenance['preset_hash']}" in header
 
 

--- a/tests/cli/test_emit_config_collapse.py
+++ b/tests/cli/test_emit_config_collapse.py
@@ -228,8 +228,8 @@ def test_the_collapsed_key_keeps_the_section_header_it_was_holding() -> None:
     header with it."""
     text = _emit("control-assistant-readonly")
 
-    assert "# ── Event dispatch (optional)" in text
-    assert text.index("# ── Event dispatch (optional)") < text.index("\ndispatch:")
+    assert "# ── Answering webhooks (optional)" in text
+    assert text.index("# ── Answering webhooks (optional)") < text.index("\ndispatch:")
 
 
 @pytest.mark.parametrize("preset", list_presets())

--- a/tests/cli/test_emit_partition.py
+++ b/tests/cli/test_emit_partition.py
@@ -274,7 +274,7 @@ def test_emitted_profile_carries_the_provenance_header() -> None:
     text = _emit("control-assistant")
     header = text.split("\nname:")[0]
 
-    assert "source preset: control-assistant" in header
+    assert "bundled `control-assistant` preset" in header
     assert "preset content hash: sha256:" in header
     assert "emitted by OSPREY" in header
 

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -330,7 +330,7 @@ def test_enclosing_git_repository_is_left_alone(runner: CliRunner, tmp_path: Pat
 
     assert result.exit_code == 0, result.output
     assert not (target / ".git").exists()
-    assert "left alone" in result.output
+    assert "left it alone" in result.output
     # Nothing was committed into somebody else's history — the enclosing repo
     # still has no HEAD at all.
     no_head = subprocess.run(
@@ -363,7 +363,7 @@ def test_a_machine_without_git_still_gets_a_complete_repo(
     result = init_exemplar(runner, target)
 
     assert result.exit_code == 0, result.output
-    assert "No git available" in result.output
+    assert "No git found" in result.output
     assert (target / "profile.yml").is_file()
     assert not (target / ".git").exists()
 
@@ -405,7 +405,7 @@ def test_in_place_into_an_empty_clone(
     assert (target / "profile.yml").is_file()
     assert (target / "var" / "agent_data").is_dir()
     # The clone's own git is left alone — the operator commits when ready.
-    assert "left alone" in result.output
+    assert "left it alone" in result.output
 
 
 def test_in_place_refuses_a_directory_that_is_not_empty(
@@ -619,7 +619,7 @@ def test_force_never_regenerates_a_hand_written_pipeline(runner: CliRunner, tmp_
 
     assert result.exit_code == 0, result.output
     assert hand_written.read_text(encoding="utf-8") == "# mine, no marker\nbuild-it: {}\n"
-    assert "NOT written" in result.output
+    assert "not written" in result.output
     # The remedy names the verb that OWNS regeneration. Pointing an operator
     # who just ran `init --force` back at --force would send them round a loop
     # that cannot terminate, since this command never forces a CI file.
@@ -696,7 +696,10 @@ def test_unused_exported_keys_are_reported_not_dropped_silently(
 
     assert result.exit_code == 0, result.output
     assert "OPENAI_API_KEY" in result.output
-    assert "Not seeded" in result.output
+    assert "Left out" in result.output
+    # The shell origin is the load-bearing half: it is why they are seeing this
+    # at all, and without it the omission is unaccountable.
+    assert "Your shell exports them" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -490,7 +490,7 @@ class TestInitPhases:
 
         assert result.exit_code == 0, result.output
         assert titles(recorder) == ["→ Creating probe"]
-        assert "  · source zone from preset control-assistant" in [
+        assert "  · settings and data from preset control-assistant" in [
             line.split(" (")[0] for line in recorder.lines
         ]
         assert closed(recorder)[-1].startswith("✓ Creating probe")

--- a/tests/cli/test_printed_copy_style.py
+++ b/tests/cli/test_printed_copy_style.py
@@ -1,0 +1,171 @@
+"""The house style for text OSPREY prints at a person.
+
+Two registers, one seam. A docstring may argue why the code is shaped the way
+it is; a string that reaches somebody's terminal may not. The people running
+OSPREY operate accelerators and beamlines, and most of them did not write this
+framework -- so the words that reach them have to be words they already know.
+
+This module enforces the mechanical half of that. The rest (does the sentence
+lead with an absence, is the block worth printing at all) is review's job.
+
+Scope is deliberately narrow: string literals passed to a printing call. Log
+records are exempt -- they carry a level, and ``--verbose`` output is addressed
+to whoever is debugging. So are docstrings, comments, and ``--help`` text.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "osprey"
+
+#: Calls whose string arguments land on a terminal, by attribute or bare name.
+#: ``emit`` is the phase reporter's, ``echo``/``secho`` are click's, ``print``
+#: is rich's console and the builtin.
+_PRINTERS = frozenset({"echo", "secho", "emit", "print"})
+
+#: In-house vocabulary. Each of these has a plain equivalent that costs no
+#: precision, and none of them is defined anywhere the reader will have been.
+#: The replacement is in the second column so a failure names it.
+#:
+#: This is a DENYLIST and proves nothing about copy it does not match: text can
+#: be impenetrable using none of these words. What it is aimed at is the way
+#: the jargon actually comes back. These words are still all over the
+#: docstrings and comments here -- "materializ" in 29 files, "source zone" in
+#: 14, "verbatim" in 81 -- so whoever adds the next `click.echo` is writing it
+#: surrounded by them, and will reach for them. Catching that is worth a list
+#: someone has to extend by hand.
+_JARGON: dict[str, str] = {
+    "materialize": "write",
+    "materialized": "written",
+    "materializes": "writes",
+    "materializing": "writing",
+    "materialization": "writing the files",
+    "rematerialize": "write again",
+    "re-materialize": "write again",
+    "source zone": "the files you edit",
+    "by construction": "(state the fact plainly)",
+    "verbatim": "exactly as written",
+    "deliberately": "on purpose, or say nothing",
+    "canonical": "the one that counts",
+    "inert": "has no effect",
+    "write-armed": "allowed to make changes",
+}
+
+# NOT here, on purpose: a rule against absolutes used as emphasis ("loses
+# nothing, ever", "can never reach", "100% disposable"). Those sentences were
+# real and they were worth deleting, but a regex for them can only list the
+# ones already deleted, which is a snapshot of one afternoon rather than a rule
+# -- it would pass forever without reading anything. Generalizing it to
+# ever/never/always fails the other way: "deleting it is always safe" and
+# "nothing ever overwrites this" are both plain statements of fact. Whether an
+# absolute is a fact or a slogan needs a reader, so it stays in review.
+
+
+def _printed_strings() -> list[tuple[Path, int, str]]:
+    """Every string literal handed to a printing call under ``src/osprey``.
+
+    f-strings contribute their literal segments only: an interpolated path or
+    count is data, and judging it as prose would flag whatever happened to be
+    in the variable.
+    """
+    found: list[tuple[Path, int, str]] = []
+    for path in sorted(SRC.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - src always parses
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name not in _PRINTERS:
+                continue
+            for arg in node.args:
+                text = _literal_text(arg)
+                if text:
+                    found.append((path, node.lineno, text))
+    return found
+
+
+def _literal_text(node: ast.expr) -> str:
+    """The literal prose in ``node``, or empty for anything that is not prose."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            part.value
+            for part in node.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        )
+    return ""
+
+
+@pytest.fixture(scope="module")
+def printed() -> list[tuple[Path, int, str]]:
+    strings = _printed_strings()
+    assert strings, "found no printed strings at all -- the AST walk is broken"
+    return strings
+
+
+def test_printed_text_uses_no_in_house_jargon(printed: list[tuple[Path, int, str]]) -> None:
+    """Words only an OSPREY maintainer knows do not reach an operator."""
+    offences: list[str] = []
+    for path, line, text in printed:
+        lowered = text.lower()
+        for term, plain in _JARGON.items():
+            if re.search(rf"\b{re.escape(term)}\b", lowered):
+                rel = path.relative_to(SRC.parents[1])
+                offences.append(
+                    f"{rel}:{line}: {term!r} -> {plain}\n      {' '.join(text.split())}"
+                )
+    assert not offences, "In-house jargon in printed text:\n  " + "\n  ".join(offences)
+
+
+def test_printed_text_carries_no_em_dash_asides(printed: list[tuple[Path, int, str]]) -> None:
+    """An aside worth reading is worth its own sentence.
+
+    The em-dash aside is this codebase's default sentence shape, and it is what
+    makes the output read as generated rather than written: the clause between
+    the dashes carries the content, so it cannot be skipped, and the sentence
+    around it stays open across it. Split it or cut it.
+    """
+    offences = [
+        f"{path.relative_to(SRC.parents[1])}:{line}: {' '.join(text.split())}"
+        for path, line, text in printed
+        if "—" in text
+    ]
+    assert not offences, "Em-dash in printed text (split the sentence):\n  " + "\n  ".join(offences)
+
+
+def test_the_walk_still_reaches_the_output_people_read() -> None:
+    """The two rules above are only worth what this walk covers.
+
+    They are silent on a call this does not recognize, and silence is
+    indistinguishable from clean. So pin the reach: a refactor that renames the
+    reporter's ``emit``, moves a verb out of ``cli/``, or routes output through
+    a wrapper this does not match should fail HERE, loudly, rather than quietly
+    switching the lint off.
+
+    The floors are well under today's numbers (438 literals across 48 files) --
+    this is a canary for the walk breaking, not a quota on how much OSPREY is
+    allowed to print.
+    """
+    strings = _printed_strings()
+    files = {path for path, _, _ in strings}
+
+    assert len(strings) > 300, (
+        f"only {len(strings)} printed literals found -- has _PRINTERS drifted?"
+    )
+    assert len(files) > 30, f"only {len(files)} files matched -- has the walk stopped descending?"
+
+    # The onboarding path specifically, since that is what these rules exist for.
+    for expected in ("cli/init_cmd.py", "cli/profile_cmd.py", "deployment/status_display.py"):
+        assert any(str(path).endswith(expected) for path in files), (
+            f"{expected} contributes no printed strings -- it is no longer covered"
+        )

--- a/tests/cli/test_service_template_ownership.py
+++ b/tests/cli/test_service_template_ownership.py
@@ -396,4 +396,5 @@ class TestScaffoldCliDirectoryArtifacts:
             diff, ["services/postgresql", "--repo", str(project_path.parent)]
         )
         assert result.exit_code == 0, result.output
-        assert "no differences" in result.output
+        # Collapse the console's line wrapping: the phrase may break mid-sentence.
+        assert "no differences" in " ".join(result.output.split())

--- a/tests/cli/test_set_verb.py
+++ b/tests/cli/test_set_verb.py
@@ -102,7 +102,7 @@ def test_top_level_key_written_in_place_with_comments_intact(runner, lifecycle_r
     assert "model: haiku" not in after
     # The inline comment on that very line, and the block comment above it.
     assert "# tier (haiku/sonnet/opus)" in after
-    assert "# Default LLM provider and model." in after
+    assert "# Which model answers." in after
     # Every other line of prose survives the round trip. Counted rather than
     # sampled: a writer that drops the file's comments would still pass any
     # handful of spot checks on the ones near the key it touched.

--- a/tests/cli/test_sim_physics_env.py
+++ b/tests/cli/test_sim_physics_env.py
@@ -39,7 +39,7 @@ from tests.fixtures.lifecycle_repo import build_exemplar_repo
 #: The redeploy notice's own wording. Asserted through a constant so the
 #: presence and absence checks below cannot drift apart, and so a verb rename
 #: is one edit rather than a dozen.
-_NOTICE = "reads this only at container boot"
+_NOTICE = "reads this only when its container is created"
 
 # Two physics scenarios on disjoint devices, one physics-free scenario to clear
 # back to, one same-device pair (physics collision) and one same-channel pair

--- a/tests/cli/test_source_zone_materialization.py
+++ b/tests/cli/test_source_zone_materialization.py
@@ -157,7 +157,7 @@ def test_preset_comments_survive(runner: CliRunner, tmp_path: Path) -> None:
     assert _new(runner, target, "control-assistant").exit_code == 0
 
     text = (target / "profile.yml").read_text()
-    assert "Default LLM provider and model" in text
+    assert "Which model answers" in text
     assert "Gate hardware-write tool calls on human approval prompt" in text
 
 
@@ -414,7 +414,7 @@ def test_unreferenced_exported_keys_are_named_not_dropped_silently(
     result = _new(runner, target, "hello-world")
 
     assert result.exit_code == 0, result.output
-    assert "Not seeded: OPENAI_API_KEY" in result.output
+    assert "Left out OPENAI_API_KEY" in result.output
 
 
 def test_only_unreferenced_keys_exported_writes_no_env_and_says_why(
@@ -429,8 +429,8 @@ def test_only_unreferenced_keys_exported_writes_no_env_and_says_why(
 
     assert result.exit_code == 0, result.output
     assert not (target / ".env").exists()
-    assert "no key for the providers it references" in result.output
-    assert "Not seeded: OPENAI_API_KEY" in result.output
+    assert "no key for the providers this assistant uses" in result.output
+    assert "Left out OPENAI_API_KEY" in result.output
 
 
 def test_seeded_env_file_is_owner_only(
@@ -510,7 +510,7 @@ def test_summary_names_the_secret_files_it_wrote(
     result = _new(runner, target, "hello-world")
 
     assert result.exit_code == 0, result.output
-    assert ".env.example" in result.output
+    assert ".env" in result.output
     assert "ANTHROPIC_API_KEY" in result.output
 
 
@@ -522,7 +522,7 @@ def test_summary_says_no_env_was_written_when_nothing_was_exported(
     result = _new(runner, target, "hello-world")
 
     assert result.exit_code == 0, result.output
-    assert "not written" in result.output
+    assert "copy .env.example and add your API key" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_users_group.py
+++ b/tests/cli/test_users_group.py
@@ -16,6 +16,7 @@ volume is ever created or removed here).
 from __future__ import annotations
 
 import logging
+import re
 import stat
 import subprocess
 import sys
@@ -169,8 +170,13 @@ def _fake_web_terminals(**attrs):
 
 
 def _flat(output: str) -> str:
-    """Collapse Rich's line wrapping so help text can be matched as one string."""
-    return " ".join(output.split())
+    """Collapse Rich's line wrapping so help text can be matched as one string.
+
+    ANSI style codes are stripped first: a wrap point re-opens the style at the
+    start of the next line, which would otherwise glue an escape sequence onto
+    the middle of a matched phrase.
+    """
+    return " ".join(re.sub(r"\x1b\[[0-9;]*m", "", output).split())
 
 
 @pytest.fixture
@@ -737,7 +743,7 @@ class TestProfileRosterWrite:
         assert result.exit_code == 0
         flat = _flat(result.output)
         assert "does not spell the web-terminal roster" in flat
-        assert "next build restores them" in flat
+        assert "next build will restore them" in flat
 
     def test_the_drift_hint_is_printed_after_the_write(self, cli_runner, tmp_path, monkeypatch):
         """Same closing line `osprey set` prints: the build is now out of date."""

--- a/tests/deployment/test_status_sections.py
+++ b/tests/deployment/test_status_sections.py
@@ -224,7 +224,7 @@ def test_another_checkouts_containers_are_not_reported_as_this_ones(lifecycle_re
 
     text = report(lifecycle_repo)
 
-    assert "DIFFERENT checkout" in text
+    assert "DIFFERENT copy" in text
     assert "ffffffffffff" in text
     assert repo_identity(lifecycle_repo) in text
     assert "Nothing is running for this deployment" in text
@@ -245,7 +245,8 @@ def test_the_other_checkout_is_not_described_as_safe_from_this_ones_verbs(lifecy
 
     text = report(lifecycle_repo)
 
-    assert "stops them as well" in text
+    # Collapse the console's line wrapping: the phrase may break mid-sentence.
+    assert "stops them too" in " ".join(text.split())
     assert "act on its own containers only" not in text
 
 
@@ -317,7 +318,7 @@ def test_the_endpoint_list_does_not_claim_anything_is_answering(lifecycle_repo, 
 
     text = report(lifecycle_repo)
 
-    assert "not a check that anything answers" in text
+    assert "nothing was contacted to check" in text
 
 
 # ---------------------------------------------------------------------------
@@ -460,7 +461,7 @@ def test_out_of_sync_artifacts_name_the_rebuild(lifecycle_repo, runtime, monkeyp
 
     text = report(lifecycle_repo)
 
-    assert "out of sync" in text
+    assert "no longer match" in text
     assert "osprey build" in text
     assert ".claude/settings.json" in text
 

--- a/tests/deployment/test_up_as_built.py
+++ b/tests/deployment/test_up_as_built.py
@@ -909,7 +909,7 @@ def test_a_mint_prints_the_password_on_a_terminal(tmp_path, monkeypatch, capsys)
 
     printed = capsys.readouterr().out
     assert "Minted a login password for web-terminal user 'alice'" in printed
-    assert "shown this once" in printed
+    assert "shown once and cannot be recovered" in printed
 
 
 def test_a_mint_prints_no_password_when_stdout_is_not_a_terminal(

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -499,7 +499,7 @@ def test_prune_dry_run_prints_plan_and_removes_nothing(
     assert removal_calls == []
     out = capsys.readouterr().out
     assert "eve" in out
-    assert "dry-run" in out.lower()
+    assert "dry run" in out.lower()
 
 
 def test_prune_removes_only_off_roster_resources(tmp_path, monkeypatch, fake_runtime_prune):

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -110,16 +110,7 @@ EXECUTABLE_FILES: frozenset[str] = frozenset({"scripts/verify.sh"})
 PROFILE_YML = """\
 # Als Exemplar — OSPREY deployment repo
 #
-# The repository is the deployment. One directory, four zones:
-#
-#   SOURCE   tracked, yours to edit — profile.yml, data/, personas/,
-#            triggers.yml, web-terminal-context/, scripts/, the CI files
-#   SECRETS  .env — git-ignored, durable: provider keys you set, plus the
-#            service tokens `osprey up` mints
-#   OUTPUT   build/ — git-ignored, 100% disposable. Every `osprey build`
-#            wipes and re-renders it; `rm -rf build/` loses nothing, ever
-#   STATE    var/ — git-ignored, durable: var/agent_data holds the agent's
-#            memory and sessions, var/audit the audit log. No build touches it
+# This file is your assistant's settings. Edit it, then run `osprey build`.
 #
 #   +--------------+  osprey   +--------------+  osprey  +----------------+
 #   |    SOURCE    |  build    |    build/    |    up    |   DEPLOYMENT   |
@@ -129,51 +120,40 @@ PROFILE_YML = """\
 #          ^                                                     |
 #          +---- edit -> osprey build -> osprey up --------------+
 #
-# `osprey up` starts strictly from build/ as it was built — it never renders
-# from this file. Edit profile.yml and `up` refuses until you re-run
-# `osprey build`, so a half-finished edit can never reach a running stack.
+#   SOURCE   yours to edit, kept in git: this file, data/, personas/
+#   SECRETS  .env, your API keys. Not in git. Rebuilds never touch it
+#   OUTPUT   build/, generated. Never edit it; deleting it is safe
+#   STATE    var/, the agent's memory and audit log. Not in git. Kept
 #
-# Emitted from the bundled `control-assistant` preset as a fully explicit,
-# standalone profile: everything the preset configures is written out below and
-# is yours to edit. Nothing is inherited at build time.
+# Made from the bundled `control-assistant` preset. Everything it sets is written
+# out below and is yours to edit. Nothing is hidden or inherited.
 #
-# Provenance — what this profile was materialized from:
-#   source preset: control-assistant
-#   preset content hash: @PRESET_HASH:control-assistant@
 #   emitted by OSPREY @OSPREY_VERSION@
+#   preset content hash: @PRESET_HASH:control-assistant@
 
 name: Als Exemplar
 
-# Which packaged project skeleton `osprey build` renders (config.yml, README,
-# Dockerfile). "control_assistant" is the full skeleton. Its data files
-# (channel databases, benchmarks, facility knowledge, logbook seeds) are copied
-# into this repo's data/ directory, and that copy — not the packaged one — is
-# what the build uses from then on.
+# Which packaged app this builds. "control_assistant" is the full one. Its data
+# files are copied into data/, and that copy is what the build uses from then on.
 app_template: control_assistant
 
-# Default LLM provider and model. Override here or with `osprey set
-# provider=...` / `osprey set model=...`, which write this file in place,
-# comments intact. The persona terminals build from deltas over that same
-# profile, so they pick the change up from the file rather than from a replayed
-# command line.
+# Which model answers. `osprey set provider=...` / `osprey set model=...` edit
+# these in place, keeping your comments.
 provider: anthropic
 model: haiku   # tier (haiku/sonnet/opus), or a model ID the provider serves
 
-# Channel-finder pipeline. Override with
-# `osprey set channel_finder_mode=in_context|middle_layer`.
+# How the agent searches for channels. `osprey set channel_finder_mode=...`
+# also accepts in_context or middle_layer.
 channel_finder_mode: hierarchical
 
-# Extra packages the built project's environment needs. pymongo is what the
-# archiver connector, the deploy-time seeder and the recorder all read the store
-# through; the tutorial declares a `va_archiver:` block below, so without it the
-# staged bring-up aborts at its pymongo preflight before any image is built.
-# Matches the pin the `archiver-mongodb` extra carries in pyproject.toml.
+# Extra Python packages your agent needs. pymongo is required by the stored
+# archive declared under `va_archiver:` below.
 dependencies:
   - pymongo>=4.0
 
-# ── Artifact selection ───────────────────────────────────────────────────────
-# Each list entry is a short name resolved from the osprey artifact library.
-# Remove entries you do not need; add facility-specific artifacts via overlay.
+# ── What the agent can do ────────────────────────────────────────────────────
+# Each entry is a name from the OSPREY artifact library. Delete what you do not
+# need; add your own through an overlay.
 
 hooks:
   - hook-log          # Append every tool call to a structured JSONL audit log
@@ -185,9 +165,9 @@ hooks:
   - memory-guard      # Warn when context window approaches threshold
   - notebook-update   # Sync CLAUDE.md notebook after each session
   - cf-feedback-capture  # Capture channel-finder accuracy feedback for tuning
-  - config-drift      # Warn at session start when the build drifted from source
+  - config-drift      # Warn at session start when the build is out of date
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
-  - panels-context    # Inject the web terminal panel inventory into agent context
+  - panels-context    # Tell the agent which web terminal panels exist
   - workspace-delta   # Report web workspace changes since the agent's last turn
 
 rules:
@@ -200,19 +180,17 @@ rules:
   - python-execution    # Rules governing Python executor sandbox usage
   - data-visualization  # Rules for producing control-room-ready plots
   - control-system-safety  # EPICS PV safety: alarm limits, soft-IOC guards
-  - test-ioc-safety     # Test-IOC port isolation (renders only for EPICS-family control systems)
+  - test-ioc-safety     # Test-IOC port isolation (EPICS-family control systems only)
 
 skills:
   - diagnose        # Run a structured fault-diagnosis workflow
-  # setup-mode (config diagnostics + setup_patch) is deliberately NOT part of
-  # the operator tier: it can patch config.yml/.mcp.json, which is admin work.
-  # Add it to an admin-facing profile's skills list to opt in — it remains in
-  # the artifact catalog.
+  # setup-mode is left out on purpose: it can edit config.yml and .mcp.json,
+  # which is admin work. Add it to an admin-facing profile to turn it on.
   - session-report  # Summarise session actions and outcomes to the logbook
   - demo-gallery    # Launch guided capability demonstrations
   - demo-ui         # Run a scripted demo of the agent driving the web workspace
-  - writing-bluesky-plans  # Author, validate, and queue a session-tier plan (requires the Bluesky MCP server)
-  - operating-bluesky-scans  # Stage, queue, and watch a registered scan through the shared draft (requires the Bluesky MCP server)
+  - writing-bluesky-plans  # Write, check and queue a scan plan (needs the Bluesky server)
+  - operating-bluesky-scans  # Stage, queue and watch a scan (needs the Bluesky server)
 
 agents:
   - channel-finder          # Semantic search over channel databases (hierarchical)
@@ -228,200 +206,107 @@ output_styles:
 web_panels:
   - ariel           # ARIEL search interface (past experiments, papers)
   - channel-finder  # Interactive channel-finder web UI
-  - okf             # KNOWLEDGE tab — browse the facility knowledge bundle
-  - system-health   # SYSTEM tab — framework health dashboard (sidecar-backed)
-  # events + bluesky (the write-oriented panels) are declared by the readwrite
-  # persona, beside the web.panels.<id>.url overrides that give them meaning —
-  # a panel id and its URL declaration travel together (see the note in
-  # config: below).
+  - okf             # KNOWLEDGE tab, for browsing the facility knowledge bundle
+  - system-health   # SYSTEM tab, a framework health dashboard
+  # The events and bluesky panels are declared in personas/readwrite.yml
+  # instead, so the read-only login is built without them.
 
-# ── Bluesky stack (turn-key, VA-backed) ─────────────────────────────────────────
-# The preset ships the FULL Bluesky-mediated scan stack out of the box: a
-# Bluesky bridge (+ co-deployed Tiled catalog), a PyAT Virtual Accelerator
-# soft-IOC standing in for real EPICS hardware, and the bluesky-panels sidecar
-# that serves the BLUESKY web_panel above. Each top-level block below is an
-# injector trigger — it renders the corresponding `services.<name>` compose
-# service, appends to `deployed_services`, and (for bluesky_panels) registers
-# the `web.panels.<id>` URLs. Remove this section (and the bluesky panel id
-# above) to ship a Bluesky-free deployment.
+# ── Scanning and simulated hardware ──────────────────────────────────────────
+# These three blocks give you a working scan setup with no real hardware: a
+# Bluesky bridge with a Tiled data catalog, a simulated accelerator that speaks
+# EPICS, and the web panels for both. Delete this section (and the bluesky
+# panel above) if you do not want it.
 bluesky:
   port: 8090
-  tiled_enabled: true      # co-deploys the Tiled catalog sidecar alongside the bridge
+  tiled_enabled: true      # also runs the Tiled data catalog
   tiled_port: 8091
 
 virtual_accelerator:
-  # Channel Access port the soft-IOC serves on. The connector's gateway port
-  # follows this value, so changing it here moves both the container and the
-  # connector that talks to it.
+  # EPICS port the simulator serves on. The agent follows this value, so
+  # changing it moves both.
   port: 5064
 
 bluesky_panels:
   port: 8095
 
 # ── Stored archive (MongoDB) ─────────────────────────────────────────────────
-# Declaring this block is what gives the deployment a REAL archive: `osprey up`
-# stands up a MongoDB store and an archiver-recorder beside the VA, seeds the
-# store with history on the first deploy, and records the machine from then on.
-# Without it the agent's history is synthesized at read time — plausible numbers
-# for questions nobody recorded the answer to.
+# With this block, `osprey up` runs a real archive: a MongoDB store that is
+# seeded with history on the first deploy and records the machine from then on.
+# Without it, the agent invents plausible history when asked about the past.
 #
-# The block is the single home for the archive's coordinates: the build derives
-# the connector's eight `archiver.mongodb_archiver.*` keys AND the shape knobs
-# below from it, and REFUSES a profile that also spells them in `config:` (one
-# fact, two homes, free to disagree). Selecting the archiver is a separate
-# decision and lives in `config:` as `archiver.type` — see the note there.
-#
-# Every key is optional; these are the shipped defaults, stated so the tutorial
-# documents the shape it deploys rather than hiding it in a dataclass.
+# Every key is optional. These are the defaults, written out so you can see the
+# shape. Do not also set `archiver.mongodb_archiver.*` under `config:` below;
+# the build derives those keys from here and refuses a profile that has both.
 va_archiver:
-  # Where the agent reaches the store. Stated rather than left to the deploy to
-  # infer, because a profile resolved WITHOUT a service stack — a persona delta,
-  # an attached project, any of the resolution paths that carry no
-  # deploy_services — is required to name the host whose archive it reads, and
-  # would otherwise fail to resolve at all. `localhost` is the host side of the
-  # published `port_host`, which is where this project's own store answers;
-  # point it at the real host when attaching to someone else's.
+  # Where the agent reaches the store. `localhost` is this deployment's own;
+  # point it at another host to read someone else's archive.
   host: localhost
   retention_days: 30       # how far back the archive reaches
-  hot_span_hours: 48       # how much of it is kept at the dense cadence
+  hot_span_hours: 48       # how much of it is kept at the dense sample rate
   hot_cadence_sec: 10      # seconds between samples inside the hot span
   tail_cadence_sec: 60     # and outside it (must be a whole multiple of the above)
-  # How often the recorder samples the running machine. Stated because the
-  # freshness threshold below is derived from it: leaving it to the dataclass
-  # default would hide the one number that decides when this deployment calls
-  # its own archive stale.
-  recorder_cadence_sec: 10
-  # The channel `osprey health` reads to tell a REACHABLE archive from one still
-  # being WRITTEN — a wedged recorder leaves the store answering queries while
-  # history quietly stops, and only the age of the newest sample separates the
-  # two. Naming it here derives the whole `archiver_freshness` check, threshold
-  # included: that follows `recorder_cadence_sec` above, so slowing the recorder
-  # cannot leave a stale threshold behind.
-  #
-  # The stored-beam DCCT current is this simulated facility's canary, for the
-  # reason a real control room would pick it: it is the first thing to stop
-  # moving when the machine does. Point it at your own equivalent when you take
-  # this preset to hardware; drop the key and no check is derived.
+  recorder_cadence_sec: 10  # how often the recorder samples the machine
+  # A channel `osprey health` watches to check the archive is still recording:
+  # if this stops moving, history has quietly stopped. Point it at something on
+  # your machine that always changes; delete the key for no check at all.
   freshness_channel: SR:DIAG:DCCT:01:CURRENT:RB
 
-# ── Config overrides ─────────────────────────────────────────────────────────
-# Dotted keys ONLY: each entry is a literal `key.path` written into the
-# rendered config.yml after the template renders. A nested mapping here would
-# replace the whole rendered subtree and silently drop its siblings.
+# ── Everything else ──────────────────────────────────────────────────────────
+# One dotted `key.path` per line. Never write a nested block here: it would
+# replace the whole subtree and silently drop the keys beside it.
 #
-# This block is the source of truth for configuration. build/config.yml is
-# generated from it and is never hand-edited — `osprey set` writes here.
+# This block is where configuration lives. build/config.yml is generated from
+# it and should never be hand-edited. `osprey set` writes here.
 config:
-  # The VA soft-IOC ships and is deployed as part of the turn-key Bluesky stack
-  # above, so control_system.type defaults to "virtual_accelerator": the
-  # preset's scan plans drive it end to end out of the box (correctors move,
-  # BPMs read, a settle-verified run COMPLETEs). Use "epics" for live hardware.
-  # "mock" is the documented fallback for environments with no containers to
-  # depend on — its readbacks are a non-tracking simulation, so scans are
-  # browse-only (a settle-verified run never COMPLETEs on mock) — flip back
-  # with `osprey set connector=mock`, the shorthand that writes this key.
+  # Which control system to talk to. "virtual_accelerator" is the built-in
+  # simulator and works out of the box; "epics" is real hardware; "mock" needs
+  # no containers but cannot complete a scan. `osprey set connector=epics`.
   control_system.type: virtual_accelerator
-  # Selects the archive declared by the `va_archiver:` block above as the
-  # deployment's archiver. This is a SEPARATE decision from declaring where the
-  # archive lives, and deliberately so: the block never flips `archiver.type`
-  # out from under a facility that set it. A project that declared the block but
-  # left this alone would deploy a store and then read the mock beside it.
-  #
-  # Dotted, like every key here. A nested `archiver:` mapping would prefix
-  # -collapse; and spelling any `archiver.mongodb_archiver.*` key here is
-  # refused outright while the block is present, because the build already
-  # derives those from it.
+  # Use the archive declared by `va_archiver:` above. Declaring the block does
+  # not turn it on; without this line you would deploy a store and not read it.
   archiver.type: mongodb_archiver
-  # The Bluesky MCP server is off-by-default in the framework registry
-  # (default_enabled=False); opt in here so the agent can author and launch
-  # scan plans out of the box.
+  # Both servers are off by default in OSPREY. Turn them on so the agent can
+  # write and launch scan plans, and run read-only health checks.
   claude_code.servers.bluesky.enabled: true
-  # The system-health MCP server is likewise off-by-default in the framework
-  # registry (default_enabled=False); opt in here so the agent can run
-  # read-only framework/stack health checks out of the box.
   claude_code.servers.health.enabled: true
   # system.timezone: America/Los_Angeles
-  # Facility display name, woven into the agent prompts (CLAUDE.md, the
-  # channel-finder/logbook agents) and the web-terminal landing page. Defaults
-  # to the deployment name when unset. Sits in the same `facility:` block as
-  # `facility.prefix` below.
+  # Your facility's name, used in the agent's prompts and on the web landing
+  # page. Defaults to the deployment name.
   # facility.name: My Facility
-  # Default web theme for every terminal: the `main` family pinned to light
-  # mode (`light` is main's concrete light id — other families spell theirs
-  # `desy-light` etc.). A default, not a lock: the in-browser display menu,
-  # ?theme= and localStorage override it per browser.
+  # Starting theme for every web terminal. Each browser can override it from
+  # the display menu.
   web.theme: light
-  # EVENTS + BLUESKY panel declarations live in the readwrite persona delta,
-  # NOT here. Deliberate: a persona delta can only ADD config keys (`config:`
-  # is not excludable), so anything declared here reaches every persona — and
-  # the read-only persona must be built without these two write-oriented
-  # panels. Declaring them only in the readwrite delta is the one mechanism
-  # that makes them genuinely absent from the readonly build (`enabled: false`
-  # is inert for URL panels — only builtin ids honor it). A full deployment
-  # render still gets both panels: the dispatch and bluesky-panels injectors
-  # fill in defaults when the profile doesn't declare them.
-  # ── Multi-user web-terminal stack (built-in) ───────────────────────────────
-  # This deployment is natively multi-user: `osprey up` stands up nginx, the
-  # landing page, and one web-terminal container per roster user, alongside the
-  # scan stack above. Single-user onboarding is unchanged — `osprey web` never
-  # reads this block (only `osprey up` does), so a plain host-run terminal
-  # works at any time. To deploy backend services without the web tier, set
-  # `modules.web_terminals.enabled: false` here.
+  # ── Web terminals ──────────────────────────────────────────────────────────
+  # `osprey up` runs a landing page and one terminal per user listed below.
+  # `osprey web` ignores all of this, so a single terminal on your own machine
+  # works at any time. Set `modules.web_terminals.enabled: false` for backend
+  # services only.
   #
-  # Container-name prefix for the web stack: names are `<prefix>-nginx` /
-  # `<prefix>-web-<user>`, so this MUST be a non-empty valid Docker name start
-  # ([a-zA-Z0-9]). Keep it short and distinct from the deployment name (used for
-  # image tags). Set it to your own facility abbreviation.
+  # Short prefix for the web container names (`<prefix>-nginx`, `<prefix>-web-
+  # <user>`). Must start with a letter or digit. Use your facility's initials.
   facility.prefix: ca
-  # Landing-URL origin for the multi-user web stack: render refuses to build
-  # OSPREY_TERMINAL_LANDING_URL without deploy.fqdn once users are configured.
-  # 127.0.0.1 matches the single-trusted-host posture; set your
-  # browser-reachable hostname when deploying anywhere else.
+  # The hostname people open in a browser. 127.0.0.1 is your own machine; set
+  # your real hostname to reach it from anywhere else.
   deploy.fqdn: 127.0.0.1
-  # This MUST stay ONE literal dotted key — `modules.web_terminals` addressing
-  # the whole module subtree with a nested value. A nested `modules:` mapping
-  # under `config:` would wholesale-replace the rendered `modules` subtree,
-  # silently dropping any sibling module: config_writer applies each dotted key
-  # verbatim, setting only the addressed leaf (see utils/config_writer.py).
-  #
-  # `image_source: local` means `osprey up` builds each persona's image itself
-  # from `project_path`, and `osprey build` is what put a project there:
-  # one render per delta in `personas/`. So `osprey build && osprey up` stands
-  # the whole stack up with no registry. Each persona's `project` equals its
-  # `project_path` basename — both are derived from the repo's own directory
-  # name, which is how the render and the mount land on the same path.
-  #
-  # The `build_profile` values below are PRESET names, and are consumed only
-  # here, at materialization: `osprey init` renders each one into a delta at
-  # `personas/<name>.yml` beside the emitted profile and rewrites this catalog
-  # to point at that file. The build reads the deltas themselves and accepts
-  # nothing else — a persona is built from a delta over this profile, never
-  # from a preset of its own.
+  # Keep this as ONE dotted key. A nested `modules:` block here would replace
+  # the whole modules subtree and silently drop the others.
   modules.web_terminals:
     enabled: true
 @WEB_TERMINALS_IMAGE_SOURCE@
-    nginx_port: 9080            # public-facing reverse proxy / landing page
-    # Per-user port families: user i gets base + i in each family. Every
-    # companion panel gets its own family (the containers share the host
-    # network namespace, so per-user offsets are what prevent collisions);
-    # families omitted here fall back to registry defaults (registry/web.py).
-    # All families sit above this deployment's own service ports (5064, 8020,
-    # 8090/8091/8095) so the two stacks never collide on one host.
+    nginx_port: 9080            # the landing page everyone opens first
+    # User number i gets base + i in each family below, so removing a user
+    # never shifts anyone else's ports. These all sit above this deployment's
+    # own service ports (5064, 8020, 8090/8091/8095) to avoid collisions.
     web_base_port: 9091           # first per-user web-terminal port
     artifact_base_port: 9291      # first per-user artifact-gallery port
     ariel_base_port: 9391         # first per-user ARIEL search port
     lattice_base_port: 9491       # first per-user lattice-dashboard port
     channel_finder_base_port: 9591  # first per-user channel-finder panel port
-    default_persona: readonly   # roster entries with no persona resolve here
+    default_persona: readonly   # used for any user below with no persona
     users:
-      # One web terminal per entry. `index` pins the user's port offsets
-      # (each `*_base_port` above + index), so removing an entry never shifts
-      # another user's ports; `persona` names a catalog entry below. A bare
-      # string (`- alice`) is also accepted: it takes its list position as
-      # index and falls back to `default_persona`.
-      # `display_name` becomes the browser window/tab title (OSPREY_WEB_APP_NAME)
-      # — with both terminals on the same light theme it is the visible marker
-      # of which one is write-armed.
+      # One web terminal per entry. `index` pins that user's ports, `persona`
+      # picks their permissions from the list below, and `display_name` becomes
+      # the browser tab title, which is how you tell the two terminals apart.
       - name: alice
         index: 0
         persona: readwrite
@@ -431,11 +316,8 @@ config:
         persona: readonly
         display_name: "Read-Only View (Bob)"
     personas:
-      # A persona render is build output like everything else under build/.
-      # `osprey build` renders one project per delta in `personas/`, and it
-      # replaces build/ whole every time — nothing under there is edited in
-      # place or kept across a build. `osprey up` renders nothing: if a project
-      # is missing it refuses and names `osprey build`.
+      # `osprey build` builds one of these per file in personas/, into build/.
+      # `osprey up` builds nothing: if one is missing it stops and says so.
       readonly:
         project: als-exemplar-readonly
         project_path: build/als-exemplar-readonly
@@ -445,24 +327,22 @@ config:
         project_path: build/als-exemplar-readwrite
         build_profile: personas/readwrite.yml
 
-# ── Event dispatch (optional) ────────────────────────────────────────────────
-# Turns external events (webhooks) into headless agent runs. This ships a set of
-# control-system-free triggers so you can exercise the pipeline with a single
-# `curl` after `osprey up`. Remove this block to disable dispatch.
+# ── Answering webhooks (optional) ────────────────────────────────────────────
+# Lets an outside system ask the agent a question over HTTP. The triggers that
+# ship need no control system, so a single `curl` after `osprey up` exercises
+# it. Delete this block to turn it off.
 dispatch:
-  triggers: triggers.yml            # repo-relative path or bundled name
+  triggers: triggers.yml            # a path in this repo, or a bundled name
   worker_count: 1
   workspace_mode: isolated
   max_concurrent_runs: 2
   max_queue_depth: 50
 
 # ── Environment variables ────────────────────────────────────────────────────
-# Bearer tokens guarding the dispatcher's inbound webhook/dashboard auth
-# (EVENT_DISPATCHER_TOKEN) and the dispatcher→worker calls (DISPATCH_WORKER_TOKEN).
-# No defaults on purpose: the dispatch services fail closed on an unset token.
-# `osprey up` mints a strong random value for each unset token into this repo's
-# .env (and logs where), so a fresh deployment is secure by default with zero
-# editing. Set your own values in .env to override.
+# Passwords for the webhook service above. They have no defaults on purpose:
+# the service refuses to start without them. `osprey up` generates a strong
+# random value for each one into this repo's .env, so a new deployment is
+# secure with no editing. Put your own values in .env to override.
 env:
   required:
     - EVENT_DISPATCHER_TOKEN
@@ -605,8 +485,8 @@ DEPLOY_BLOCK_COMMENTED = """
 #: needing, and the filled-in one forbids. Substituted into the profile text at
 #: the ``@WEB_TERMINALS_IMAGE_SOURCE@`` marker.
 WEB_TERMINALS_IMAGE_SOURCE_LINE = (
-    "    # No deploy block yet, so this is image_source's only home: build the\n"
-    "    # per-user terminal images here rather than pulling them.\n"
+    "    # No deploy block yet, so this is image_source's only home: build each\n"
+    "    # terminal image here rather than pulling it from a registry.\n"
     "    image_source: local"
 )
 
@@ -616,18 +496,17 @@ WEB_TERMINALS_IMAGE_SOURCE_LINE = (
 # ─────────────────────────────────────────────────────────────────────────────
 
 PERSONA_READONLY_YML = """\
-# Als Exemplar (readonly) — persona profile, a delta over ../profile.yml
+# Als Exemplar (readonly) — settings for one web login
 #
-# Sitting in personas/ beside profile.yml is the inheritance: the build merges
-# this file over that profile — including any edit you make there — so the keys
-# below are this persona's only differences and there is no `extends:` to
-# write. See the resolved whole with:
+# Only the differences from profile.yml belong here. The build merges this
+# file over that one, picking up any edit you make there. To see the combined
+# result:
 #   osprey validate personas/readonly.yml
 #
-# Provenance — what this persona was materialized from:
-#   source preset: control-assistant-readonly
-#   preset content hash: @PRESET_HASH:control-assistant-readonly@
+# Made from the bundled `control-assistant-readonly` preset.
+#
 #   emitted by OSPREY @OSPREY_VERSION@
+#   preset content hash: @PRESET_HASH:control-assistant-readonly@
 
 name: Als Exemplar (readonly)
 
@@ -659,18 +538,17 @@ config:
 """
 
 PERSONA_READWRITE_YML = """\
-# Als Exemplar (readwrite) — persona profile, a delta over ../profile.yml
+# Als Exemplar (readwrite) — settings for one web login
 #
-# Sitting in personas/ beside profile.yml is the inheritance: the build merges
-# this file over that profile — including any edit you make there — so the keys
-# below are this persona's only differences and there is no `extends:` to
-# write. See the resolved whole with:
+# Only the differences from profile.yml belong here. The build merges this
+# file over that one, picking up any edit you make there. To see the combined
+# result:
 #   osprey validate personas/readwrite.yml
 #
-# Provenance — what this persona was materialized from:
-#   source preset: control-assistant-readwrite
-#   preset content hash: @PRESET_HASH:control-assistant-readwrite@
+# Made from the bundled `control-assistant-readwrite` preset.
+#
 #   emitted by OSPREY @OSPREY_VERSION@
+#   preset content hash: @PRESET_HASH:control-assistant-readwrite@
 
 name: Als Exemplar (readwrite)
 
@@ -860,27 +738,27 @@ GITIGNORE = """\
 ENV_EXAMPLE = """\
 # Als Exemplar Environment Configuration
 #
-# The single documented list of every variable this agent reads. Copy it to
-# `.env` beside this file and fill in the values you need. That one file is the
-# deployment's whole secret store: `osprey build` never reads or rewrites it,
-# and the containers mount it from the repo root, so a value here survives
-# every rebuild and every `rm -rf build/`.
+# Every variable this agent reads, listed in one place. Copy this file to `.env`
+# beside it and fill in what you need. That one file holds all your secrets, and
+# a value in it survives every rebuild.
 #
-# This file carries no secrets and is safe to commit.
+# This file has no secrets in it and is safe to commit.
 
-# API Keys — set the key(s) for the provider(s) your profile uses.
-# (Provider list derived from the OSPREY provider registry.)
+# API key for the provider this assistant uses. Fill this in.
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
-OPENAI_API_KEY=your-openai-api-key-here
-GOOGLE_API_KEY=your-google-api-key-here
-CBORG_API_KEY=your-cborg-api-key-here
-AMSC_I2_API_KEY=your-amsc-i2-api-key-here
-ARGO_API_KEY=your-argo-api-key-here
-STANFORD_API_KEY=your-stanford-api-key-here
-ALS_APG_API_KEY=your-als-apg-api-key-here
 
-# Required by this profile — the profile's `env.required` names these, and
-# the agent cannot run without them.
+# Other providers OSPREY supports. Uncomment one if you switch to it with
+# `osprey set provider=...`.
+# OPENAI_API_KEY=your-openai-api-key-here
+# GOOGLE_API_KEY=your-google-api-key-here
+# CBORG_API_KEY=your-cborg-api-key-here
+# AMSC_I2_API_KEY=your-amsc-i2-api-key-here
+# ARGO_API_KEY=your-argo-api-key-here
+# STANFORD_API_KEY=your-stanford-api-key-here
+# ALS_APG_API_KEY=your-als-apg-api-key-here
+
+# Required by this profile. Its `env.required` names these, and the agent
+# cannot run without them.
 EVENT_DISPATCHER_TOKEN=
 DISPATCH_WORKER_TOKEN=
 
@@ -892,10 +770,10 @@ DISPATCH_WORKER_TOKEN=
 # HTTP_PROXY=http://proxy.example.com:8080
 # HTTPS_PROXY=http://proxy.example.com:8080
 
-# Service credentials — minted automatically by `osprey up` when the matching
-# service is deployed, and appended to this repo's .env. Set one by hand only
-# to pin a value the deployment must not replace (an existing database volume's
-# password, say); an unset variable is minted, never guessed.
+# Service passwords. `osprey up` generates a strong random value for each of
+# these when it deploys the matching service, and writes it into this repo's
+# .env. Set one by hand only to keep a value the deployment must not change,
+# such as the password on a database volume you already have.
 # EVENT_DISPATCHER_TOKEN=  # event_dispatcher, dispatch_worker — authenticates callers to the event-dispatcher API
 # DISPATCH_WORKER_TOKEN=  # event_dispatcher, dispatch_worker — authenticates the dispatch worker back to the dispatcher
 # BLUESKY_LAUNCH_TOKEN=  # bluesky — arms the Bluesky bridge's scan-launch endpoint
@@ -916,63 +794,75 @@ DISPATCH_WORKER_TOKEN=exemplar-worker-token
 README_MD = """\
 # Als Exemplar
 
-This repository is an OSPREY deployment. Everything the assistant is made of
-lives here, and the directory name is the deployment's name.
+This folder is your OSPREY assistant. Everything it is made of lives here, and
+the folder name is the assistant's name.
 
-## The four zones
+## What is in here
 
-| Zone | Path | Tracked? | Survives? |
+| What | Where | In git? | Kept? |
 | --- | --- | --- | --- |
-| Source | `profile.yml`, `data/`, `personas/`, `triggers.yml`, `web-terminal-context/`, `.env.example`, `.gitignore`, `README.md`, `ci-extra.yml`, `.gitlab-ci.yml`, `scripts/verify.sh` | yes | it *is* the record |
-| Secrets | `.env` | no | yes — durable |
-| Output | `build/` | no | no — 100% disposable |
-| State | `var/agent_data/`, `var/audit/` | no | yes — durable |
+| Your settings | `profile.yml`, `data/`, `personas/` | yes | yes |
+| Your API keys | `.env` | no | yes |
+| Generated files | `build/` | no | no, safe to delete |
+| The agent's memory and audit log | `var/agent_data/`, `var/audit/` | no | yes |
 
-`build/` is derived in full from the source zone. `rm -rf build/` loses
-nothing, ever: no configuration, no keys, no agent memory. Nothing durable is
-allowed to live there.
+In full, the first row is: `profile.yml`, `data/`, `personas/`, `triggers.yml`, `web-terminal-context/`, `.env.example`, `.gitignore`, `README.md`, `ci-extra.yml`, `.gitlab-ci.yml`, `scripts/verify.sh`.
 
-## Daily use
+`build/` is generated from your settings every time you run `osprey build`.
+Deleting it is always safe: no settings, no keys and no agent memory live there.
+
+## Everyday commands
 
 ```bash
-osprey build          # render build/ from profile.yml
-osprey up -d          # start the deployment from build/, as built
-osprey status         # containers, endpoints, drift, versions
-osprey logs           # follow the stack's logs
+osprey build          # turn your settings into something runnable
+osprey up -d          # start it in the background
+osprey status         # what is running, and is it up to date
+osprey logs           # watch the logs
 osprey down           # stop it
 ```
 
-Every command walks up from wherever you are to this directory, so they work
-from any subdirectory with no flags. `--repo PATH` overrides that.
+Run these from anywhere inside this folder. They find their way to the top on
+their own, so they need no arguments. `--repo PATH` points them somewhere else.
 
 ## Changing something
 
-Edit `profile.yml` (or `osprey set model=sonnet` for a single key), then:
+Edit `profile.yml` (or run `osprey set model=sonnet` to change one setting),
+then:
 
 ```bash
 osprey build && osprey up -d
 ```
 
-`osprey up` starts strictly from `build/` as it was built — it never renders
-from `profile.yml`. If the source zone has moved on, `up` refuses and names
-what changed, so a half-finished edit can never reach a running stack. Use
-`osprey up --build` to chain the render, or `--as-built` to start the previous
-build knowingly.
+`osprey up` starts what `osprey build` last produced. If you change your
+settings without rebuilding, `up` stops and tells you what changed, so a
+half-finished edit cannot reach a running system. `osprey up --build` does both
+steps; `osprey up --as-built` starts the previous build anyway.
+
+## Running it on a server
+
+To run this somewhere other than your own machine, fill in the `deploy:` section
+at the end of `profile.yml` (which server, which CI system), then run:
+
+```bash
+osprey scaffold ci
+```
+
+That writes the pipeline files. Your own extra CI jobs go in `ci-extra.yml`,
+which nothing ever overwrites.
 
 ## Starting over
 
 ```bash
-osprey reset          # containers, volumes, agent data, build/ — all gone
+osprey reset          # stops everything, then deletes containers, agent data and build/
 ```
 
-`reset` keeps `var/audit/` and your provider keys. `osprey reset --purge-audit`
-destroys the audit log too; that plus `rm -rf` on this directory is a complete
-uninstall.
+`reset` keeps `var/audit/` and your API keys. `osprey reset --purge-audit`
+deletes the audit log as well; that plus deleting this folder removes it all.
 
-## Backup and restore
+## Backups
 
-Git covers the source zone. `var/` and `.env` are the entire durable state, so
-a backup is a tarball of those two, and a restore is:
+Git covers your settings. `var/` and `.env` are everything else, so a backup
+is a copy of those two, and a restore is:
 
 ```bash
 git clone <this repo> && tar xf state.tar.gz && osprey build && osprey up -d


### PR DESCRIPTION
## What

A plain-language pass over everything OSPREY prints or writes for the operator:

- **CLI output** — `init`, `set`, `sim`, `users`, `web`, `chat`, `scaffold`, profile emission, and the deployment status display.
- **Emitted repo files** — the README, `profile.yml`, persona profiles, and `.env.example` a fresh `osprey init` produces, plus the `control-assistant` preset's comments.

The goal is that a first-time operator can read every message without knowing OSPREY's internal vocabulary (zones, renders, provenance), while every operational caveat stays stated: which containers the label fallback cannot find, that the virtual accelerator only picks up a physics-fault change when its container is recreated, what happens to the roster on the next build, and which preset an emitted profile was materialized from.

## Tests

- The hand-authored exemplar in `tests/fixtures/lifecycle_repo.py` is updated to the final wording, so the byte-for-byte `init` reproduction tests pin the new copy.
- Assertions that guard a fact through exact phrasing were updated where the fact survived in new words; where a rewrite had dropped or distorted a fact, the source was fixed instead.
- Wrap-sensitive assertions now collapse console line wrapping (and strip ANSI styling in `test_users_group.py`) so a phrase that breaks mid-sentence still matches.
- New `tests/cli/test_printed_copy_style.py` guards the plain-language conventions.

Full `tests/cli` + `tests/deployment` suite: 5550 passed, 0 failed.