### PR TITLE
fix: make the EVENTS panel work in multi-user deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,6 +591,7 @@ jobs:
       run: |
         uv run pytest tests/interfaces/design_system/test_behavioral.py \
           tests/interfaces/design_system/test_theme_lab.py \
+          tests/interfaces/design_system/test_dispatch_dashboard_unauthorized.py \
           tests/interfaces/web_terminal/test_panels_browser.py \
           tests/interfaces/web_terminal/test_panels_collab_browser.py \
           tests/interfaces/web_terminal/test_agent_activity_browser.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,6 +469,10 @@ Compatibility is documented in release notes, not encoded in the version string.
   a dispatcher that had every trigger loaded. Users whose persona declares the
   EVENTS panel now get the token in their own container; personas without the
   panel, such as a read-only tier, deliberately still do not.
+- The event dashboard no longer claims a dispatcher has no triggers when it was
+  simply not authorised to read it. Both trigger views now say they were
+  refused, and a panel opened inside the terminal is told its terminal has no
+  token rather than to open the tab it is already in.
 - `osprey health` now answers from either stance. It looks for the config where
   a build writes it (`build/config.yml`) and reads credentials from the repo's
   `.env`, so running it at the repo root no longer reports the config missing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Dev deploys now report each service image as it finishes building, instead
   of one summary line after the whole `compose build` — the longest step of a
   deploy, and previously silent for its entire duration.
+- The EVENTS tab now works in a multi-user deployment. Its dashboard is
+  bearer-gated, but per-user terminal containers never received the dispatcher's
+  token, so the tab loaded and then reported "No triggers are registered." — for
+  a dispatcher that had every trigger loaded. Users whose persona declares the
+  EVENTS panel now get the token in their own container; personas without the
+  panel, such as a read-only tier, deliberately still do not.
 - `osprey health` now answers from either stance. It looks for the config where
   a build writes it (`build/config.yml`) and reads credentials from the repo's
   `.env`, so running it at the repo root no longer reports the config missing,

--- a/src/osprey/deployment/web_terminals/artifacts.py
+++ b/src/osprey/deployment/web_terminals/artifacts.py
@@ -24,6 +24,10 @@ from pathlib import Path
 from typing import Any
 
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
+from osprey.deployment.web_terminals.personas import (
+    EVENTS_PANEL_ID,
+    personas_declaring_panel,
+)
 from osprey.deployment.web_terminals.render import render_web_terminals
 from osprey.utils.workspace import BUILD_DIR_NAME
 
@@ -119,7 +123,15 @@ def write_web_terminal_artifacts(config: Any, repo_root: Path | str | None = Non
     from osprey.deployment.compose_generator import resolve_repo_root
 
     root = Path(repo_root) if repo_root is not None else resolve_repo_root(config)
-    artifacts = render_web_terminals(config, auth_env_digest=auth_env_digest(root))
+    # Both disk-derived inputs are resolved HERE and passed down, because
+    # render_web_terminals() reads no filesystem of its own (see its docstring):
+    # the .env.auth digest, and which personas declare the EVENTS panel and so
+    # need the dispatcher's bearer in their per-user environment block.
+    artifacts = render_web_terminals(
+        config,
+        auth_env_digest=auth_env_digest(root),
+        dispatcher_personas=personas_declaring_panel(config, root, EVENTS_PANEL_ID),
+    )
     dest = web_artifacts_dir(root)
     written: list[Path] = []
     for relative_path, content in artifacts.items():

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -195,18 +195,39 @@ def _build_env_production_subset(
     (``EVENT_DISPATCHER_TOKEN``, ``DISPATCH_WORKER_TOKEN``,
     ``BLUESKY_LAUNCH_TOKEN`` and the rest of ``_SERVICE_TOKEN_VARS`` in
     :mod:`osprey.deployment.container_lifecycle`, minted per deploy under
-    those fixed names). Neither kind is anything a web terminal presents to
-    anyone: the containers that need a service token read the deploy ``.env``
-    the main compose file hands them. The one web-terminal consumer that
-    WOULD read a service token if present — the bluesky MCP server's
-    ``${BLUESKY_LAUNCH_TOKEN:-}`` — is tokenless here on purpose: an agent
-    container must never hold a write-arming bearer credential (any Bash or
+    those fixed names). Build-time credentials are nothing a web terminal
+    presents to anyone; the containers that need a service token read the deploy
+    ``.env`` the main compose file hands them.
+
+    The reason the SERVICE tokens are excluded is narrower, and it is about this
+    file rather than about the tokens: ``.env.production`` is a single file
+    handed to EVERY per-user container alike. It cannot say "alice but not bob",
+    so anything placed here is granted to every persona in the roster —
+    including read-only ones, whose entire purpose is not to hold write-capable
+    credentials. A per-user entitlement therefore has to be expressed somewhere
+    that can distinguish users, and that is the per-user ``environment:`` block
+    in ``docker-compose.web.yml`` (see
+    :func:`osprey.deployment.web_terminals.render.render_web_terminals`'s
+    ``dispatcher_personas``, which grants ``EVENT_DISPATCHER_TOKEN`` only to
+    users whose persona declares the EVENTS panel, interpolated by compose from
+    the deploy ``.env`` so the secret never lands in a rendered artifact).
+
+    So this is NOT the claim that no web terminal ever presents a service token —
+    the EVENTS panel's proxy presents exactly this one, server-side, so the
+    browser never holds it. It is the narrower and still-load-bearing claim that
+    no service token is granted *rosterwide from here*. Note what that buys and
+    what it does not: a container that receives the dispatcher token shares its
+    process namespace with the agent, which can read it, so the grant is a
+    deliberate per-persona decision and never a default. The bluesky MCP
+    server's ``${BLUESKY_LAUNCH_TOKEN:-}`` stays tokenless in every persona for
+    that reason — an agent must not hold a write-ARMING bearer (any Bash or
     Python it runs could read it and arm the queue with no approval), so its
     ``queue_start`` files a panel start request and the operator's panels
-    sidecar, which does receive the token, answers it. This is the security
-    spec for this function: a var absent from the enumerated list above can
-    never appear in the returned dict, regardless of what the input ``.env``
-    contains.
+    sidecar, which does receive the token, answers it.
+
+    This is the security spec for this function: a var absent from the
+    enumerated list above can never appear in the returned dict, regardless of
+    what the input ``.env`` contains.
 
     :param config: Raw deploy config (facility fields merged in — see
         ``modules.web_terminals.image_source`` in :func:`ensure_env_production`).

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -15,6 +15,7 @@ Port arithmetic lives separately in :mod:`osprey.deployment.web_terminals.ports`
 import os
 import re
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Any
 
 # Matches ${VAR} and $VAR env references inside modules.web_terminals.image_tag.
@@ -46,6 +47,79 @@ USERNAME_CHARSET_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 def as_dict(value: Any) -> dict[str, Any]:
     """Read a config section defensively: anything not a dict becomes empty."""
     return value if isinstance(value, dict) else {}
+
+
+#: The in-terminal event-dispatcher dashboard's panel id. A persona that declares
+#: this panel is the one thing that entitles its containers to
+#: ``EVENT_DISPATCHER_TOKEN`` — the panel declaration IS the intent, so there is
+#: no separate config key to set (and to forget to set) alongside it.
+EVENTS_PANEL_ID = "events"
+
+
+def config_declares_panel(config: Any, panel_id: str) -> bool:
+    """True if ``config`` declares ``web.panels.<panel_id>`` and hasn't disabled it.
+
+    The one definition of "this project shows that panel", shared by the render
+    (for persona-less roster entries) and by :func:`personas_declaring_panel`
+    (for catalog personas), so the two cannot answer differently for the same
+    config. ``enabled: false`` counts as *not* declared: a panel switched off is
+    one whose credential is not needed.
+    """
+    panel = as_dict(as_dict(as_dict(config).get("web")).get("panels")).get(panel_id)
+    if not isinstance(panel, dict):
+        return False
+    return panel.get("enabled", True) is not False
+
+
+def personas_declaring_panel(config: Any, project_root: Any, panel_id: str) -> set[str]:
+    """Names of catalog personas whose rendered project declares ``panel_id``.
+
+    Reads each referenced persona's ``config.yml`` off disk — which is why the
+    render takes the result as a parameter rather than calling this itself (see
+    :func:`osprey.deployment.web_terminals.render.render_web_terminals`'s
+    determinism note). Resolution mirrors
+    :func:`osprey.deployment.web_terminals.env_production._claude_code_auth_secret_vars`:
+    a persona whose ``project_path`` is unset, unrendered, or unreadable
+    contributes nothing, because a credential is never granted on a guess.
+
+    :param config: The parsed deploy config.
+    :param project_root: Deploy project root; relative ``project_path`` values
+        resolve against it.
+    :param panel_id: The panel whose declaration is being looked for.
+    :return: The subset of referenced persona names that declare it.
+    """
+    import yaml
+
+    web_terminals = as_dict(as_dict(config).get("modules")).get("web_terminals")
+    web_terminals = as_dict(web_terminals)
+    catalog = as_dict(web_terminals.get("personas"))
+
+    referenced: set[str] = set()
+    default_persona = web_terminals.get("default_persona")
+    if isinstance(default_persona, str) and default_persona:
+        referenced.add(default_persona)
+    users = web_terminals.get("users")
+    for user in users if isinstance(users, list) else []:
+        if isinstance(user, dict) and isinstance(user.get("persona"), str) and user["persona"]:
+            referenced.add(user["persona"])
+
+    declaring: set[str] = set()
+    for persona_name in sorted(referenced):
+        entry = as_dict(catalog.get(persona_name))
+        project_path = entry.get("project_path")
+        if not isinstance(project_path, str) or not project_path:
+            continue
+        config_yml = Path(project_root, project_path) / "config.yml"
+        if not config_yml.is_file():
+            continue
+        try:
+            with config_yml.open("r", encoding="utf-8") as fh:
+                persona_config = yaml.safe_load(fh)
+        except (OSError, yaml.YAMLError):
+            continue
+        if config_declares_panel(persona_config, panel_id):
+            declaring.add(persona_name)
+    return declaring
 
 
 def normalize_users(users_raw: Any) -> list[dict[str, Any]]:

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -19,9 +19,11 @@ from jinja2 import Environment, FileSystemLoader
 
 from osprey.deployment.compose_generator import repo_identity, resolve_repo_root
 from osprey.deployment.web_terminals.personas import (
+    EVENTS_PANEL_ID,
     SUPPORTED_MCP_TOPOLOGY,
     USERNAME_CHARSET_RE,
     as_dict,
+    config_declares_panel,
     effective_image_source,
     env_var_suffix,
     env_var_suffix_collisions,
@@ -137,7 +139,11 @@ def _container_agent_data_dir(config: Any, container_project_dir: str) -> str:
     return (PurePosixPath(container_project_dir) / base).as_posix()
 
 
-def render_web_terminals(config: Any, auth_env_digest: str | None = None) -> dict[str, str]:
+def render_web_terminals(
+    config: Any,
+    auth_env_digest: str | None = None,
+    dispatcher_personas: set[str] | None = None,
+) -> dict[str, str]:
     """Render the compose overlay, nginx fragment, and landing page for one facility config.
 
     Args:
@@ -158,6 +164,21 @@ def render_web_terminals(config: Any, auth_env_digest: str | None = None) -> dic
             harmless, because every ``osprey up`` re-renders through the
             artifacts seam with a current digest before its ``up``, so a
             label-less render can never reach a running stack stale.
+        dispatcher_personas: Persona names whose project declares the EVENTS
+            panel, and whose users therefore need the event dispatcher's bearer
+            token. Resolved from disk by
+            :func:`osprey.deployment.web_terminals.personas.personas_declaring_panel`
+            and passed in for the same reason ``auth_env_digest`` is: this
+            function reads no filesystem. Each such user gets
+            ``EVENT_DISPATCHER_TOKEN`` in its OWN ``environment:`` block,
+            interpolated by compose from the deploy ``.env`` — never written
+            into this rendered artifact, and never into the shared
+            ``.env.production``, which every user's container reads (see
+            :func:`osprey.deployment.web_terminals.env_production._build_env_production_subset`).
+            That split IS the tier boundary: a read-only persona must not hold a
+            credential that can fire triggers. ``None`` (the default, and the
+            ``osprey scaffold web-terminals render`` path, which has no project
+            root to resolve against) emits no token line at all.
 
     Returns:
         Mapping of output-relative-path to rendered content, for exactly three
@@ -259,6 +280,17 @@ def render_web_terminals(config: Any, auth_env_digest: str | None = None) -> dic
                     {"name": env_var, "port": user_ports[family]}
                     for family, env_var in PANEL_ENV_VARS.items()
                 ],
+                # Whether this user's container gets the event dispatcher's
+                # bearer (see the `dispatcher_personas` arg). A persona-less
+                # roster entry — the zero-migration path, where the web image
+                # IS the deploy project — is answered from this same config,
+                # with no disk read, so the determinism contract holds either
+                # way.
+                "wants_dispatcher": (
+                    entry["persona"] in (dispatcher_personas or set())
+                    if entry.get("persona")
+                    else config_declares_panel(root, EVENTS_PANEL_ID)
+                ),
             }
         )
 

--- a/src/osprey/dispatch/dashboard.html
+++ b/src/osprey/dispatch/dashboard.html
@@ -1087,8 +1087,17 @@ function bearer() {
  * So: attempt the write, and let the server be the authority. This turns a
  * 401 into the same sentence the read path already shows, instead of a dialog.
  */
-const UNAUTHORIZED_HINT =
-  'Not authorised — open this panel from the terminal’s EVENTS tab.';
+/* True when this page is being served through the web terminal's panel proxy,
+ * which is the only path that injects a bearer server-side. Read off the URL
+ * because that is the one signal available to the standalone page too — and it
+ * decides which advice is honest. Telling an operator already sitting IN the
+ * EVENTS tab to "open it from the EVENTS tab" is the failure mode this guards:
+ * proxied means the token is missing from the terminal's environment, which is
+ * a deployment fact they can act on, not a navigation mistake. */
+const IN_TERMINAL_PROXY = window.location.pathname.includes('/panel/events/');
+const UNAUTHORIZED_HINT = IN_TERMINAL_PROXY
+  ? 'Not authorised to read the dispatcher — this terminal has no EVENT_DISPATCHER_TOKEN.'
+  : 'Not authorised — open this panel from the terminal’s EVENTS tab.';
 
 /** True when a response was rejected for auth; the caller explains rather than retries. */
 function explainIfUnauthorized(res) {
@@ -1306,6 +1315,13 @@ function renderLanes() {
   list.textContent = '';
   const triggers = state.triggers || [];
 
+  // Order matters: a 401 leaves state.triggers empty, so an unguarded
+  // length check below would report "none registered" — a claim about the
+  // dispatcher we have not been allowed to read. Say what actually happened.
+  if (authBlocked) {
+    list.appendChild(el('div', { className: 'empty-state', textContent: UNAUTHORIZED_HINT }));
+    return;
+  }
   if (triggers.length === 0) {
     list.appendChild(el('div', { className: 'empty-state', textContent: 'No triggers are registered.' }));
     return;
@@ -1426,7 +1442,13 @@ function renderRunList() {
   }
 
   if (authBlocked) {
-    host.appendChild(el('div', { className: 'empty-state' }, [
+    host.appendChild(el('div', { className: 'empty-state' }, IN_TERMINAL_PROXY ? [
+      // Already in the EVENTS tab: the proxy had no bearer to inject, so point
+      // at the deployment fact rather than repeating navigation advice the
+      // operator has manifestly already followed.
+      el('span', { textContent: 'Not authorised to read the dispatcher.' }),
+      el('span', { className: 'empty-hint', textContent: 'This terminal has no EVENT_DISPATCHER_TOKEN \u2014 its persona must declare the EVENTS panel, and `osprey up` must have minted the token into the deployment\u2019s .env.' }),
+    ] : [
       el('span', { textContent: 'This panel needs a token when opened directly.' }),
       el('span', { className: 'empty-hint', textContent: 'Open it from the terminal\u2019s EVENTS tab, which supplies one for you.' }),
     ]));
@@ -1491,6 +1513,13 @@ function renderTriggerList() {
   const host = $('#trigger-list');
   host.textContent = '';
 
+  // Same guard as renderLanes(): unread is not the same as empty, and the
+  // count above is 0 for both. Checked before the filter branch so a stale
+  // filter box cannot turn a 401 into "no triggers match that filter" either.
+  if (authBlocked) {
+    host.appendChild(el('div', { className: 'empty-state', textContent: UNAUTHORIZED_HINT }));
+    return;
+  }
   if (visible.length === 0) {
     host.appendChild(el('div', {
       className: 'empty-state',

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -411,6 +411,24 @@ services:
 {%- for env in svc.panel_env %}
       - {{ env.name }}={{ env.port }}
 {%- endfor %}
+{%- if svc.wants_dispatcher %}
+      {#- The event dispatcher's bearer, for a persona that declares the EVENTS
+         panel. Every dashboard DATA endpoint is bearer-gated, and the web
+         terminal's panel proxy injects this server-side (routes/proxy.py) so the
+         browser never holds it; without it the tab renders empty.
+
+         Deliberately HERE and not in `.env.production`: that file is handed to
+         every user's container alike, so a token in it would reach read-only
+         personas too — and this one credential can fire triggers. Per-user is
+         the only placement that can express the tier boundary.
+
+         `${VAR:-}` is resolved by compose from the deploy `.env` (the pinned
+         --env-file, see provision.web_stack_compose_cmd), so the secret is never
+         written into this rendered file. The `:-` default keeps compose from
+         warning, and an unset var renders an empty value the dispatcher then
+         rejects with a 401 — visible, rather than a silent half-auth. #}
+      - EVENT_DISPATCHER_TOKEN=${EVENT_DISPATCHER_TOKEN:-}
+{%- endif %}
     volumes:
       - {{ svc.user }}-claude-config:/data/claude-config
       {#- Mount target comes from render.py's _container_agent_data_dir, which

--- a/tests/deployment/web_terminals/test_env_production.py
+++ b/tests/deployment/web_terminals/test_env_production.py
@@ -492,3 +492,37 @@ def test_env_production_missing_secret_absent_everywhere_has_no_shell_hint(tmp_p
         env_production.ensure_env_production(config, tmp_path)
 
     assert "exported in the current shell" not in str(excinfo.value)
+
+
+def test_env_production_never_carries_the_dispatcher_token(tmp_path):
+    """The tier boundary, pinned. One `.env.production` is handed to EVERY per-user
+    container, so a dispatcher bearer here would reach read-only personas too --
+    and that credential can fire triggers. The EVENTS panel is wired through the
+    PER-USER compose `environment:` block instead (see
+    `render_web_terminals(dispatcher_personas=...)`); this asserts the shared file
+    stays clean even when the operator's .env is full of service tokens."""
+    # Arrange
+    _write_dotenv(
+        tmp_path / ".env",
+        {
+            "ALS_APG_API_KEY": "cc-secret",
+            "EVENT_DISPATCHER_TOKEN": "fire-any-trigger",
+            "DISPATCH_WORKER_TOKEN": "worker",
+            "BLUESKY_LAUNCH_TOKEN": "arm-the-queue",
+        },
+    )
+    config = _persona_config(tmp_path, {"operator": "als-apg"})
+
+    # Act
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    # Assert — the LLM credential crosses, the service tokens never do
+    assert generated["ALS_APG_API_KEY"] == "cc-secret"
+    for service_token in (
+        "EVENT_DISPATCHER_TOKEN",
+        "DISPATCH_WORKER_TOKEN",
+        "BLUESKY_LAUNCH_TOKEN",
+    ):
+        assert service_token not in generated

--- a/tests/deployment/web_terminals/test_personas.py
+++ b/tests/deployment/web_terminals/test_personas.py
@@ -6,10 +6,13 @@ from __future__ import annotations
 import pytest
 
 from osprey.deployment.web_terminals.personas import (
+    EVENTS_PANEL_ID,
+    config_declares_panel,
     env_var_suffix,
     env_var_suffix_collisions,
     freeze_user_indices,
     normalize_users,
+    personas_declaring_panel,
     resolve_personas,
 )
 
@@ -1236,3 +1239,85 @@ def test_env_var_suffix_collisions_consumes_normalize_users_names() -> None:
 
     # Assert
     assert result == {"ALICE_B": ["alice-b", "alice_b"]}
+
+
+# ---------------------------------------------------------------------------
+# Panel declaration -> credential entitlement
+# ---------------------------------------------------------------------------
+
+
+def _write_persona_project(tmp_path, name: str, panels: dict) -> str:
+    """Render a persona project carrying ``web.panels``; return its project_path."""
+    import yaml
+
+    project_dir = tmp_path / name
+    project_dir.mkdir()
+    (project_dir / "config.yml").write_text(
+        yaml.safe_dump({"project_name": name, "web": {"panels": panels}}),
+        encoding="utf-8",
+    )
+    return name
+
+
+def _catalog_config(catalog: dict, users: list[dict]) -> dict:
+    return {"modules": {"web_terminals": {"personas": catalog, "users": users}}}
+
+
+def test_config_declares_panel_reads_the_panel_block() -> None:
+    """A declared panel counts; an absent one does not."""
+    config = {"web": {"panels": {"events": {"label": "EVENTS", "url": "http://x"}}}}
+
+    # Assert
+    assert config_declares_panel(config, EVENTS_PANEL_ID) is True
+    assert config_declares_panel(config, "bluesky") is False
+    assert config_declares_panel({}, EVENTS_PANEL_ID) is False
+
+
+def test_config_declares_panel_treats_disabled_as_undeclared() -> None:
+    """A panel switched off needs no credential, so it does not count as declared."""
+    config = {"web": {"panels": {"events": {"enabled": False}}}}
+
+    # Assert
+    assert config_declares_panel(config, EVENTS_PANEL_ID) is False
+
+
+def test_personas_declaring_panel_selects_only_the_declaring_persona(tmp_path) -> None:
+    """The entitlement set is exactly the personas whose rendered project shows the
+    panel -- the readonly tier is excluded by its own config, not by a separate key."""
+    # Arrange
+    catalog = {
+        "readwrite": {
+            "project": "rw",
+            "project_path": _write_persona_project(tmp_path, "rw", {"events": {"label": "EVENTS"}}),
+        },
+        "readonly": {
+            "project": "ro",
+            "project_path": _write_persona_project(tmp_path, "ro", {"okf": {"enabled": True}}),
+        },
+    }
+    config = _catalog_config(
+        catalog,
+        [
+            {"name": "alice", "index": 0, "persona": "readwrite"},
+            {"name": "bob", "index": 1, "persona": "readonly"},
+        ],
+    )
+
+    # Act
+    result = personas_declaring_panel(config, tmp_path, EVENTS_PANEL_ID)
+
+    # Assert
+    assert result == {"readwrite"}
+
+
+def test_personas_declaring_panel_skips_unrendered_persona_projects(tmp_path) -> None:
+    """A persona whose project isn't on disk contributes nothing: a credential is
+    never granted on a guess."""
+    # Arrange
+    config = _catalog_config(
+        {"ghost": {"project": "ghost", "project_path": "../never-rendered"}},
+        [{"name": "alice", "index": 0, "persona": "ghost"}],
+    )
+
+    # Act / Assert
+    assert personas_declaring_panel(config, tmp_path, EVENTS_PANEL_ID) == set()

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -2998,3 +2998,80 @@ def test_render_auth_off_still_renders_roster_names_that_collide_on_their_suffix
 
     # Assert
     assert {"web-alice-b", "web-alice_b"} <= set(compose["services"])
+
+
+# ---------------------------------------------------------------------------
+# EVENTS panel -> per-user dispatcher credential
+#
+# The dispatcher's bearer is minted into the deploy `.env` and gates every
+# dashboard DATA endpoint. It reaches a web terminal through the PER-USER
+# `environment:` block rather than the shared `env_file: .env.production`,
+# because that one file is handed to EVERY user: a token placed there would give
+# a read-only persona a credential that can fire triggers. Gating on the
+# persona's declared EVENTS panel is what keeps the tier boundary intact.
+# ---------------------------------------------------------------------------
+
+_DISPATCHER_TOKEN_LINE = "EVENT_DISPATCHER_TOKEN=${EVENT_DISPATCHER_TOKEN:-}"
+
+
+def _events_persona_config() -> dict:
+    """Two personas; only `readwrite` declares the EVENTS panel."""
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    web_terminals = config["modules"]["web_terminals"]
+    web_terminals["default_persona"] = "readonly"
+    web_terminals["personas"] = {
+        "readonly": {"project": "dls-readonly", "project_path": "../dls-readonly"},
+        "readwrite": {"project": "dls-readwrite", "project_path": "../dls-readwrite"},
+    }
+    web_terminals["users"] = [
+        {"name": "alice", "index": 0, "persona": "readwrite"},
+        {"name": "bob", "index": 1, "persona": "readonly"},
+    ]
+    return config
+
+
+def test_events_panel_persona_gets_the_dispatcher_token() -> None:
+    """A user whose persona declares the EVENTS panel gets the dispatcher bearer in
+    its own `environment:` block, interpolated from the deploy `.env` at compose
+    time so the secret is never written into a rendered artifact."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config(), dispatcher_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    assert _DISPATCHER_TOKEN_LINE in compose["services"]["web-alice"]["environment"]
+
+
+def test_persona_without_events_panel_gets_no_dispatcher_token() -> None:
+    """The tier boundary: a persona declaring no EVENTS panel must not receive a
+    credential that can fire triggers -- which is exactly why this cannot live in
+    the shared .env.production that every user's container reads."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config(), dispatcher_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    bob_env = compose["services"]["web-bob"]["environment"]
+    assert not any("EVENT_DISPATCHER_TOKEN" in line for line in bob_env)
+
+
+def test_render_without_dispatcher_personas_emits_no_token_line() -> None:
+    """The no-project-root render path (`osprey scaffold web-terminals render`)
+    passes no persona set, the same way it passes no auth digest -- so it emits no
+    credential. Harmless: every `osprey up` re-renders through the artifacts seam,
+    which resolves the set from disk."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config())["docker-compose.web.yml"]
+    )
+
+    # Assert
+    for service in ("web-alice", "web-bob"):
+        env = compose["services"][service]["environment"]
+        assert not any("EVENT_DISPATCHER_TOKEN" in line for line in env)

--- a/tests/interfaces/design_system/test_dispatch_dashboard_unauthorized.py
+++ b/tests/interfaces/design_system/test_dispatch_dashboard_unauthorized.py
@@ -1,0 +1,179 @@
+"""Browser suite: a 401 from the dispatcher must never be reported as an empty stack.
+
+The dashboard's read path polls ``/dashboard/state``, which is bearer-gated. When
+that call is rejected the page keeps its initial ``state.triggers = []``, and the
+lane list and trigger list both branch on *length*. Unguarded, those branches
+turn "we were not allowed to look" into the sentence **"No triggers are
+registered."** — an assertion about the dispatcher's configuration that the page
+has no evidence for, and which sends an operator to debug a trigger file that is
+in fact perfectly healthy.
+
+That is not a cosmetic defect. It is the panel reporting a fact it does not know,
+and it is indistinguishable to the reader from the true empty case. The status
+line and run list already carried an ``authBlocked`` branch; the two trigger
+surfaces did not.
+
+This suite drives a real browser against a dispatcher stub that answers 401 to
+everything, because the bug lives entirely in client-side render branching —
+asserting on the Python route or on markup presence would not reach it.
+
+The second axis is *which* advice is honest. A page opened standalone should be
+told to open it from the terminal's EVENTS tab. A page ALREADY inside that tab
+must not be: there the 401 means the terminal has no token to inject, which is a
+deployment fact, and repeating the navigation advice is the failure mode that
+made this bug hard to read in the first place.
+
+Run:
+    .venv/bin/pytest tests/interfaces/design_system/test_dispatch_dashboard_unauthorized.py -v
+
+Skips cleanly when the chromium headless binary is not installed.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+from tests.interfaces.conftest import _run_app_server
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from playwright.sync_api import Browser, Page
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+VIEWPORT = {"width": 1100, "height": 900}
+
+DESIGN_SYSTEM_STATIC_DIR = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "src"
+    / "osprey"
+    / "interfaces"
+    / "design_system"
+    / "static"
+)
+
+#: The claim under test. Present anywhere on an unauthorized page, the panel is
+#: asserting the dispatcher has no triggers while holding no evidence either way.
+FALSE_EMPTY_CLAIM = "No triggers are registered."
+
+#: The two trigger surfaces that branch on `state.triggers.length`. `#lane-list`
+#: renders on the default view; `#trigger-list` needs the Triggers screen, which
+#: is expert-only — hence the explicit mode and view in the URLs below.
+LANE_LIST = "#lane-list"
+TRIGGER_LIST = "#trigger-list"
+
+
+def _create_unauthorized_dashboard_app() -> FastAPI:
+    """Serve the real dashboard on both entry paths, over a 401-ing dispatcher.
+
+    The same rendered HTML is mounted at the standalone root and under the web
+    terminal's panel-proxy prefix, because the page distinguishes the two by its
+    own URL — serving one and simulating the other would test the stub.
+    """
+    from osprey.dispatch.dashboard import render_dashboard_html
+
+    app = FastAPI()
+    app.mount(
+        "/design-system", StaticFiles(directory=DESIGN_SYSTEM_STATIC_DIR), name="design-system"
+    )
+
+    def _page() -> str:
+        return str(render_dashboard_html(facility_name="Test Facility", pv_strip_prefix="SR:"))
+
+    @app.get("/", response_class=HTMLResponse)
+    async def standalone() -> str:
+        return _page()
+
+    @app.get("/panel/events/dashboard", response_class=HTMLResponse)
+    async def proxied() -> str:
+        return _page()
+
+    # Every data endpoint rejects, exactly as the real dispatcher does for a
+    # request that carries no bearer.
+    @app.get("/{path:path}")
+    async def unauthorized(path: str) -> JSONResponse:
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
+    return app
+
+
+@pytest.fixture
+def dashboard_url() -> Iterator[str]:
+    with _run_app_server(_create_unauthorized_dashboard_app()) as base_url:
+        yield base_url
+
+
+def _open_and_settle(page: Page, url: str, selector: str) -> str:
+    """Load ``url`` and return ``selector``'s text once the 401 has been handled.
+
+    Waits on the empty-state element rather than a fixed delay: the page renders
+    once on load and again when the first poll rejects, so a sleep would race the
+    second render on a slow runner.
+    """
+    page.goto(url, wait_until="domcontentloaded")
+    page.wait_for_function(
+        "sel => { const e = document.querySelector(sel);"
+        "  return e && e.querySelector('.empty-state') !== null; }",
+        arg=selector,
+        timeout=15_000,
+    )
+    return page.evaluate("sel => document.querySelector(sel).innerText", selector)
+
+
+@pytest.mark.parametrize(
+    "path,selector",
+    [
+        ("/?mode=expert", LANE_LIST),
+        ("/?mode=expert&view=triggers", TRIGGER_LIST),
+    ],
+    ids=["timeline-lanes", "trigger-list"],
+)
+def test_unauthorized_never_claims_no_triggers_are_registered(
+    chromium_browser: Browser, dashboard_url: str, path: str, selector: str
+) -> None:
+    """Neither trigger surface may report an empty dispatcher when it got a 401."""
+    page = chromium_browser.new_page(viewport=VIEWPORT)
+    text = _open_and_settle(page, f"{dashboard_url}{path}", selector)
+    page.close()
+
+    assert FALSE_EMPTY_CLAIM not in text, (
+        f"{selector} reported {FALSE_EMPTY_CLAIM!r} after a 401 -- the panel is "
+        "asserting the dispatcher has no triggers when it was never allowed to read it"
+    )
+    assert "authorised" in text.lower() or "authorized" in text.lower(), (
+        f"{selector} showed neither the false-empty claim nor an authorization "
+        f"explanation; an operator is left with no account of the blank panel: {text!r}"
+    )
+
+
+def test_standalone_page_is_told_to_open_the_events_tab(
+    chromium_browser: Browser, dashboard_url: str
+) -> None:
+    """Opened directly, the actionable advice is to use the tab that injects a token."""
+    page = chromium_browser.new_page(viewport=VIEWPORT)
+    text = _open_and_settle(page, f"{dashboard_url}/?mode=expert", LANE_LIST)
+    page.close()
+
+    assert "EVENTS tab" in text
+
+
+def test_in_terminal_page_is_not_told_to_open_the_tab_it_is_already_in(
+    chromium_browser: Browser, dashboard_url: str
+) -> None:
+    """Inside the EVENTS tab a 401 means the terminal holds no token, so the page
+    must name that instead of repeating navigation advice already followed."""
+    page = chromium_browser.new_page(viewport=VIEWPORT)
+    text = _open_and_settle(page, f"{dashboard_url}/panel/events/dashboard?mode=expert", LANE_LIST)
+    page.close()
+
+    assert "EVENT_DISPATCHER_TOKEN" in text
+    assert "EVENTS tab" not in text, (
+        "the in-terminal page told the operator to open the EVENTS tab they are already looking at"
+    )


### PR DESCRIPTION
The EVENTS tab is non-functional in a containerized multi-user deployment. It
loads its shell and then reports **"No triggers are registered."** for a
dispatcher that has every trigger loaded.

Two independent defects, one per commit.

## 1. The panel never receives a credential

Every dashboard data endpoint is bearer-gated, and the web terminal's panel
proxy is designed to inject that bearer server-side so the browser never holds
it. But the token reaches per-user containers through `.env.production`, and
`_build_env_production_subset` deliberately excludes every service token — so
the proxy has nothing to inject and the dispatcher answers 401.

Both halves were locally correct: the proxy's assumption holds for a host-run
`osprey web`, which loads the deploy `.env` directly. Only the containerized
path falls between them.

The obvious fix — adding the token to `.env.production` — is wrong. That file
is handed to **every** per-user container alike, so it cannot express a
per-user grant: a token there also reaches read-only personas, whose tier
exists to keep write-capable credentials out of reach. This one can fire
triggers.

So the grant moves to the per-user `environment:` block, for users whose
persona declares the EVENTS panel:

```yaml
web-alice:            # persona declares web.panels.events
  environment:
    - EVENT_DISPATCHER_TOKEN=${EVENT_DISPATCHER_TOKEN:-}
web-bob:              # read-only persona — no panel, no token
  environment: []
```

Compose interpolates the value from the deploy `.env` (already the pinned
`--env-file`), so the secret never lands in a rendered artifact. The panel
declaration *is* the entitlement — no new config key. Persona configs are read
at the artifacts seam and passed into the renderer, preserving its contract of
reading no filesystem of its own.

`_build_env_production_subset`'s security spec is corrected in the same commit.
The exclusion it documents is unchanged, but it asserted that no web terminal
presents a service token to anyone, which the EVENTS proxy makes false; its
stated reason now matches the code.

## 2. A 401 is reported as an empty dispatcher

The read path polls a gated endpoint; a rejection leaves the trigger list
empty, and both trigger surfaces branched on length alone. The result is the
page asserting something it has no evidence for, indistinguishable from a
genuinely empty dispatcher — and it sends an operator to debug a healthy
trigger file. The status line and run list already carried the guard; the two
trigger views did not.

The advice is now chosen by where the page runs. Told to "open this from the
terminal's EVENTS tab" while already inside that tab, an operator has no move
to make; there a rejection means the terminal holds no token, so it says that.

## Verification

Rendered against a real two-persona deployment, then resolved through
`docker compose config` against that deployment's actual `.env`:

```
personas declaring the EVENTS panel: ['readwrite']
  web-alice: token resolved, 43 chars   ← the minted EVENT_DISPATCHER_TOKEN
  web-bob:   no token
```

- New render/persona tests covering both sides of the gate, plus the
  scaffold-render path that has no project root.
- A `.env.production` regression guard pinning the tier boundary: the LLM
  credential crosses, `EVENT_DISPATCHER_TOKEN` / `DISPATCH_WORKER_TOKEN` /
  `BLUESKY_LAUNCH_TOKEN` never do.
- A browser suite driving the real dashboard against a stub answering 401.
  Confirmed non-vacuous: reverting the fix fails all four with
  `assert 'EVENTS tab' in 'No triggers are registered.'` — the reported
  symptom. Registered in ci.yml's theming lane, which `src/osprey/dispatch/**`
  already triggers.
- The golden render fixture is byte-identical: the no-personas default path is
  untouched.

## Known limitation

A container granted this token shares a process namespace with its agent, which
can therefore read it. That is inherent to the topology and is why the grant is
a per-persona decision rather than a default — it is not something this change
can remove. Read-only personas remain tokenless, and `BLUESKY_LAUNCH_TOKEN`
stays excluded for every persona: an agent must not hold a write-arming bearer,
so the panels sidecar continues to answer `queue_start` requests instead.

Splitting the dispatcher's single bearer into read and write scopes would let
the panel read without carrying a trigger-firing credential at all. That is a
larger change and is not attempted here.
