### PR TITLE
fix: make the ARIEL panel work on a freshly deployed project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -450,6 +450,13 @@ Compatibility is documented in release notes, not encoded in the version string.
   `osprey up` mints never reached the containers, so both authenticated with the
   shipped default instead. Each user whose persona configures ARIEL is now given
   it, and a persona that configures none is not.
+- A start now creates ARIEL's schema for a database it brought up itself, and
+  writes the active scenarios' logbook entries when the logbook is empty. Until
+  now nothing on the deploy path created the tables — that lived only behind
+  `osprey ariel migrate`/`quickstart` — so a first start left a database with no
+  tables behind a panel that could not say so usefully. An existing logbook is
+  left untouched, and a database that cannot be reached warns and names the
+  command that finishes the job rather than failing the deploy.
 - A start that would generate store credentials a surviving data volume cannot
   accept now stops before it starts anything. Deleting a deployment directory
   leaves its volumes behind, so the next `osprey up` minted fresh passwords for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Per-user web terminals now receive ARIEL's database password. Without it, the
+  ARIEL tab reported the database as unavailable and the agent's logbook tools
+  failed, on a deployment whose database was running and healthy: the password
+  `osprey up` mints never reached the containers, so both authenticated with the
+  shipped default instead. Each user whose persona configures ARIEL is now given
+  it, and a persona that configures none is not.
 - A start that would generate store credentials a surviving data volume cannot
   accept now stops before it starts anything. Deleting a deployment directory
   leaves its volumes behind, so the next `osprey up` minted fresh passwords for

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -2342,6 +2342,186 @@ def _stage_archiver_store(config, compose_files, env, project_dir, *, keep_base=
     _reapply_active_scenarios(config, project_dir, engine)
 
 
+# ---------------------------------------------------------------------------
+# Staged ARIEL bring-up
+# ---------------------------------------------------------------------------
+
+# ARIEL's store, under both names it goes by: the compose service key and the
+# ``deployed_services`` entry are the same word here (unlike the archiver's
+# recorder), but naming it once keeps the two uses from drifting apart.
+_ARIEL_STORE_SERVICE = "postgresql"
+
+# How long the staged store gets to accept a connection. Shorter than the
+# archiver's budget because postgres does not open its port until the cluster is
+# initialized and ready — a first start of a fresh volume runs initdb behind a
+# closed socket, so what this waits out is a refusal, not a slow answer.
+_ARIEL_HEALTH_TIMEOUT_S = 90.0
+_ARIEL_HEALTH_POLL_S = 2.0
+
+# The one command that finishes the job by hand, named in every warning below.
+# `quickstart` rather than `migrate`: it runs the migration AND reports what it
+# found, so an operator following the message once ends up where this staging
+# would have left them.
+_ARIEL_RECOVERY_HINT = "osprey ariel quickstart"
+
+
+def _ariel_store_deployed(config: dict) -> bool:
+    """True when this deploy runs ARIEL's store itself, for a project that uses it.
+
+    Both halves matter. Membership in ``deployed_services`` keeps a project
+    pointed at a Postgres someone *else* runs from having its schema created or
+    its logbook written by a local deploy. An ``ariel:`` section is what makes a
+    deployed Postgres ARIEL's at all — the same store can be deployed for
+    something else entirely, and a deploy has no business migrating a database
+    whose schema it cannot claim to own.
+    """
+    return _ARIEL_STORE_SERVICE in (config.get("deployed_services") or []) and bool(
+        config.get("ariel")
+    )
+
+
+def _ariel_store_config(config: dict, project_dir: Path) -> dict:
+    """The project's ``ariel:`` section with its DSN resolved for THIS project.
+
+    The password is read from ``<project_dir>/.env`` by name, never from the
+    ambient environment — the same rule the archiver seeder follows, and for the
+    same reason: a deploy is routinely driven from another directory, where an
+    exported ``ARIEL_DB_PASSWORD`` belongs to somebody else's deployment.
+
+    Resolving it here (rather than letting each consumer derive its own) also
+    means the migration and the seed that follows are pinned to one DSN, so they
+    cannot disagree about which database this deploy is talking to.
+    """
+    from osprey.services.ariel_search.config import resolve_ariel_dsn
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    env_path = Path(project_dir) / ".env"
+    env = parse_dotenv_file(env_path) if env_path.is_file() else {}
+
+    ariel = dict(config.get("ariel") or {})
+    services = (config.get("services") or {}).get(_ARIEL_STORE_SERVICE) or {}
+    dsn = resolve_ariel_dsn(ariel, services, env=env)
+    ariel["database"] = {**(ariel.get("database") or {}), "uri": dsn}
+    return ariel
+
+
+def _wait_for_ariel_store(ariel_config: dict, deadline: float) -> None:
+    """Block until the staged store accepts these credentials, or give up.
+
+    Probes with the DSN the migration is about to use, so a wrong password
+    surfaces here — named, and beside the deploy step that owns it — rather than
+    as a migration error that reads like a schema problem.
+
+    :param ariel_config: ARIEL config with its DSN already resolved.
+    :param deadline: :func:`time.monotonic` instant to give up at.
+    :raises RuntimeError: if the store is still unreachable at ``deadline``.
+    """
+    import psycopg
+
+    dsn = str((ariel_config.get("database") or {}).get("uri"))
+    last: Exception | None = None
+    while True:
+        try:
+            with psycopg.connect(dsn, connect_timeout=5):
+                return
+        except Exception as exc:  # noqa: BLE001 — every failure here is "not yet"
+            last = exc
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"ARIEL's database did not accept a connection within "
+                    f"{_ARIEL_HEALTH_TIMEOUT_S:.0f}s: {last}"
+                ) from last
+            time.sleep(_ARIEL_HEALTH_POLL_S)
+
+
+def _migrate_ariel_store(ariel_config: dict) -> None:
+    """Create ARIEL's schema, idempotently.
+
+    Wrapped rather than called inline so the deploy has one seam for "the schema
+    now exists", and so the async boundary lives in exactly one place.
+    """
+    import asyncio
+
+    from osprey.services.ariel_search.cli_operations import run_migrate
+
+    asyncio.run(run_migrate(ariel_config))
+
+
+def _stage_ariel_store(config, compose_files, env, project_dir) -> None:
+    """Start ARIEL's store, create its schema, and seed a first narrative.
+
+    The logbook counterpart of :func:`_stage_archiver_store`, and staged ahead of
+    the full bring-up for the same kind of reason: everything that reads ARIEL —
+    the panel's own server and the ``ariel`` MCP server inside every web terminal
+    — connects at start-up and reports a database with no tables as no database
+    at all. Creating the schema after those consumers are running would leave a
+    stack that is only correct once somebody restarts it.
+
+    Three steps, each conditional on the one before:
+
+    * **migrate** — always, and idempotent: this is what a store this deploy
+      brought up owes the consumers it is about to start.
+    * **seed** — only into an EMPTY logbook, and only what the active scenarios
+      already narrate (see
+      :func:`osprey.simulation.apply.seed_active_logbook`). A deploy may fill a
+      blank; it may not rewrite history.
+
+    Failure here warns and returns rather than aborting the deploy. The logbook is
+    one panel among many, and a control room whose channels, scans and archive are
+    all up should not be denied them because its search tab could not be
+    provisioned — but the warning names the command that finishes the job, so the
+    gap is never silent.
+
+    :param config: Raw deploy config.
+    :param compose_files: Rendered compose file paths for this deploy.
+    :param env: The environment the deploy hands compose.
+    :param project_dir: Root of the built project (holds ``.env``).
+    """
+    if not _ariel_store_deployed(config):
+        return
+
+    from osprey.simulation import apply as simulation_apply
+
+    run_env = runtime_env(config, env)
+    base_cmd = compose_base_cmd(
+        get_runtime_command(config),
+        compose_files,
+        project_dir,
+        _env_file_args(project_dir),
+    )
+
+    up_cmd = base_cmd + ["up", "-d", _ARIEL_STORE_SERVICE]
+    logger.debug(f"Running command:\n    {' '.join(up_cmd)}")
+    run_captured(up_cmd, env=run_env, spool_name="ariel-store-up", repo_root=project_dir)
+    _report_step("ARIEL store started")
+
+    ariel_config = _ariel_store_config(config, project_dir)
+    try:
+        _wait_for_ariel_store(ariel_config, time.monotonic() + _ARIEL_HEALTH_TIMEOUT_S)
+        _migrate_ariel_store(ariel_config)
+    except Exception as exc:  # noqa: BLE001 — reported, never fatal (see docstring)
+        logger.warning(
+            f"ARIEL's schema could not be created, so its panel and MCP tools will "
+            f"report the database as unavailable. Everything else in this deploy is "
+            f"unaffected. Run `{_ARIEL_RECOVERY_HINT}` from {project_dir} once the "
+            f"database is reachable. Cause: {exc}"
+        )
+        return
+    _report_step("ARIEL schema ready")
+
+    try:
+        seeded = simulation_apply.seed_active_logbook(config, project_dir, ariel_config)
+    except Exception as exc:  # noqa: BLE001 — reported, never fatal (see docstring)
+        logger.warning(
+            f"ARIEL's schema is in place but its logbook could not be seeded, so the "
+            f"panel will come up empty. Run `osprey sim apply` from {project_dir} to "
+            f"write the active scenarios' entries. Cause: {exc}"
+        )
+        return
+    if seeded:
+        logger.key_info(f"Seeded {seeded} logbook entries from the active scenarios")
+
+
 def deploy_up(
     config_path,
     detached=False,
@@ -2634,6 +2814,13 @@ def _start_stack(
         _stage_archiver_store(
             config, compose_files, env, Path(repo_root), keep_base=keep_archiver_base
         )
+
+    # Same placement and the same reason for ARIEL's store: the schema has to
+    # exist before the consumers that read it start, and both deploy paths need
+    # it. Ordered AFTER the archiver so the logbook is seeded against a machine
+    # whose history is already in place — the two halves of one narrative, in the
+    # order they document each other.
+    _stage_ariel_store(config, compose_files, env, Path(repo_root))
 
     if web_terminals_enabled:
         deploy_up_web_terminals(config, compose_files, dev_mode, env, _env_file_args(repo_root))

--- a/src/osprey/deployment/web_terminals/artifacts.py
+++ b/src/osprey/deployment/web_terminals/artifacts.py
@@ -27,6 +27,7 @@ from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
 from osprey.deployment.web_terminals.personas import (
     EVENTS_PANEL_ID,
     personas_declaring_panel,
+    personas_using_ariel,
 )
 from osprey.deployment.web_terminals.render import render_web_terminals
 from osprey.utils.workspace import BUILD_DIR_NAME
@@ -123,14 +124,16 @@ def write_web_terminal_artifacts(config: Any, repo_root: Path | str | None = Non
     from osprey.deployment.compose_generator import resolve_repo_root
 
     root = Path(repo_root) if repo_root is not None else resolve_repo_root(config)
-    # Both disk-derived inputs are resolved HERE and passed down, because
+    # Every disk-derived input is resolved HERE and passed down, because
     # render_web_terminals() reads no filesystem of its own (see its docstring):
-    # the .env.auth digest, and which personas declare the EVENTS panel and so
-    # need the dispatcher's bearer in their per-user environment block.
+    # the .env.auth digest, which personas declare the EVENTS panel and so need
+    # the dispatcher's bearer, and which configure ARIEL and so need its Postgres
+    # password — each in their own per-user environment block.
     artifacts = render_web_terminals(
         config,
         auth_env_digest=auth_env_digest(root),
         dispatcher_personas=personas_declaring_panel(config, root, EVENTS_PANEL_ID),
+        ariel_personas=personas_using_ariel(config, root),
     )
     dest = web_artifacts_dir(root)
     written: list[Path] = []

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -71,27 +71,33 @@ def config_declares_panel(config: Any, panel_id: str) -> bool:
     return panel.get("enabled", True) is not False
 
 
-def personas_declaring_panel(config: Any, project_root: Any, panel_id: str) -> set[str]:
-    """Names of catalog personas whose rendered project declares ``panel_id``.
+def config_uses_ariel(config: Any) -> bool:
+    """True if ``config`` carries a non-empty ``ariel:`` section.
 
-    Reads each referenced persona's ``config.yml`` off disk — which is why the
-    render takes the result as a parameter rather than calling this itself (see
-    :func:`osprey.deployment.web_terminals.render.render_web_terminals`'s
-    determinism note). Resolution mirrors
-    :func:`osprey.deployment.web_terminals.env_production._claude_code_auth_secret_vars`:
-    a persona whose ``project_path`` is unset, unrendered, or unreadable
-    contributes nothing, because a credential is never granted on a guess.
+    The ARIEL counterpart of :func:`config_declares_panel`, and deliberately not
+    expressed as one: a web terminal has TWO ARIEL consumers that authenticate
+    against the same Postgres — the panel's own server (``web.panels.ariel``)
+    and the ``ariel`` MCP server the agent calls, which is selected during the
+    build and appears nowhere in ``web.panels``. Gating the credential on the
+    panel would leave the agent's logbook tools broken in exactly the projects
+    that switched the tab off.
 
-    :param config: The parsed deploy config.
-    :param project_root: Deploy project root; relative ``project_path`` values
-        resolve against it.
-    :param panel_id: The panel whose declaration is being looked for.
-    :return: The subset of referenced persona names that declare it.
+    What both consumers do read is the ``ariel:`` section — it is the input to
+    :func:`osprey.services.ariel_search.config.resolve_ariel_dsn` — so its
+    presence is the entitlement. An absent or empty section configures no
+    logbook, and so entitles nothing.
     """
-    import yaml
+    return bool(as_dict(as_dict(config).get("ariel")))
 
-    web_terminals = as_dict(as_dict(config).get("modules")).get("web_terminals")
-    web_terminals = as_dict(web_terminals)
+
+def _referenced_personas(config: Any) -> tuple[dict[str, Any], set[str]]:
+    """The persona catalog and the names some roster entry actually resolves to.
+
+    ``default_persona`` counts alongside every entry's explicit ``persona``: a
+    roster entry that names none runs the default, so the default's project is
+    as deployed as any other.
+    """
+    web_terminals = as_dict(as_dict(as_dict(config).get("modules")).get("web_terminals"))
     catalog = as_dict(web_terminals.get("personas"))
 
     referenced: set[str] = set()
@@ -102,8 +108,27 @@ def personas_declaring_panel(config: Any, project_root: Any, panel_id: str) -> s
     for user in users if isinstance(users, list) else []:
         if isinstance(user, dict) and isinstance(user.get("persona"), str) and user["persona"]:
             referenced.add(user["persona"])
+    return catalog, referenced
 
-    declaring: set[str] = set()
+
+def _personas_whose_config(config: Any, project_root: Any, predicate) -> set[str]:
+    """Referenced personas whose rendered ``config.yml`` satisfies ``predicate``.
+
+    The one walk behind every per-persona credential grant, so two credentials
+    cannot disagree about which personas a roster deploys. Reads each persona's
+    ``config.yml`` off disk — which is why the render takes the result as a
+    parameter rather than calling this itself (see
+    :func:`osprey.deployment.web_terminals.render.render_web_terminals`'s
+    determinism note). Resolution mirrors
+    :func:`osprey.deployment.web_terminals.env_production._claude_code_auth_secret_vars`:
+    a persona whose ``project_path`` is unset, unrendered, or unreadable
+    contributes nothing, because a credential is never granted on a guess.
+    """
+    import yaml
+
+    catalog, referenced = _referenced_personas(config)
+
+    matching: set[str] = set()
     for persona_name in sorted(referenced):
         entry = as_dict(catalog.get(persona_name))
         project_path = entry.get("project_path")
@@ -117,9 +142,35 @@ def personas_declaring_panel(config: Any, project_root: Any, panel_id: str) -> s
                 persona_config = yaml.safe_load(fh)
         except (OSError, yaml.YAMLError):
             continue
-        if config_declares_panel(persona_config, panel_id):
-            declaring.add(persona_name)
-    return declaring
+        if predicate(persona_config):
+            matching.add(persona_name)
+    return matching
+
+
+def personas_declaring_panel(config: Any, project_root: Any, panel_id: str) -> set[str]:
+    """Names of catalog personas whose rendered project declares ``panel_id``.
+
+    :param config: The parsed deploy config.
+    :param project_root: Deploy project root; relative ``project_path`` values
+        resolve against it.
+    :param panel_id: The panel whose declaration is being looked for.
+    :return: The subset of referenced persona names that declare it.
+    """
+    return _personas_whose_config(
+        config, project_root, lambda persona: config_declares_panel(persona, panel_id)
+    )
+
+
+def personas_using_ariel(config: Any, project_root: Any) -> set[str]:
+    """Names of catalog personas whose rendered project configures ARIEL.
+
+    :param config: The parsed deploy config.
+    :param project_root: Deploy project root; relative ``project_path`` values
+        resolve against it.
+    :return: The subset of referenced persona names entitled to
+        ``ARIEL_DB_PASSWORD`` (see :func:`config_uses_ariel`).
+    """
+    return _personas_whose_config(config, project_root, config_uses_ariel)
 
 
 def normalize_users(users_raw: Any) -> list[dict[str, Any]]:

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -24,6 +24,7 @@ from osprey.deployment.web_terminals.personas import (
     USERNAME_CHARSET_RE,
     as_dict,
     config_declares_panel,
+    config_uses_ariel,
     effective_image_source,
     env_var_suffix,
     env_var_suffix_collisions,
@@ -143,6 +144,7 @@ def render_web_terminals(
     config: Any,
     auth_env_digest: str | None = None,
     dispatcher_personas: set[str] | None = None,
+    ariel_personas: set[str] | None = None,
 ) -> dict[str, str]:
     """Render the compose overlay, nginx fragment, and landing page for one facility config.
 
@@ -179,6 +181,18 @@ def render_web_terminals(
             credential that can fire triggers. ``None`` (the default, and the
             ``osprey scaffold web-terminals render`` path, which has no project
             root to resolve against) emits no token line at all.
+        ariel_personas: Persona names whose project configures ARIEL, and whose
+            users therefore need the Postgres password ``osprey up`` minted into
+            the deploy ``.env`` (see
+            :func:`osprey.deployment.web_terminals.personas.personas_using_ariel`).
+            Same placement and same reason as ``dispatcher_personas``: both ARIEL
+            consumers inside the container — the panel's server and the ``ariel``
+            MCP server — resolve their DSN through
+            :func:`osprey.services.ariel_search.config.resolve_ariel_dsn`, which
+            reads ``ARIEL_DB_PASSWORD`` from the environment and otherwise falls
+            back to the shipped default, so a container that never receives it
+            authenticates with the wrong password against a Postgres initialized
+            with the minted one. ``None`` emits no line.
 
     Returns:
         Mapping of output-relative-path to rendered content, for exactly three
@@ -290,6 +304,15 @@ def render_web_terminals(
                     entry["persona"] in (dispatcher_personas or set())
                     if entry.get("persona")
                     else config_declares_panel(root, EVENTS_PANEL_ID)
+                ),
+                # Whether this user's container gets the ARIEL Postgres password
+                # (see the `ariel_personas` arg). Persona-less entries are
+                # answered from this same config, with no disk read, exactly as
+                # above.
+                "wants_ariel_db": (
+                    entry["persona"] in (ariel_personas or set())
+                    if entry.get("persona")
+                    else config_uses_ariel(root)
                 ),
             }
         )

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -972,6 +972,29 @@ async def execute_purge(config_dict: dict, embeddings_only: bool, progress: _Pro
         await pool.close()
 
 
+async def logbook_entry_count(config_dict: dict) -> int:
+    """How many entries the logbook currently holds.
+
+    The question a caller has to answer before writing anything it did not
+    author: an empty logbook is one nothing is lost by seeding, and a non-empty
+    one is history — an operator's own entries, or a narrative already seeded and
+    since edited — that no automated step may overwrite. Migrations must already
+    have run (call :func:`run_migrate` first).
+
+    Args:
+        config_dict: ARIEL config dict (``ARIELConfig.from_dict`` shape).
+
+    Returns:
+        The total number of entries.
+    """
+    from osprey.services.ariel_search import create_ariel_service
+
+    config = _ariel_config(config_dict)
+    service = await create_ariel_service(config)
+    async with service:
+        return await service.repository.count_entries()
+
+
 async def seed_logbook_entries(
     config_dict: dict,
     entries: list[EnhancedLogbookEntry],

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -7,6 +7,7 @@ Configuration is loaded from the `ariel:` section of config.yml.
 
 import logging
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -37,6 +38,7 @@ _connection_string_warned = False
 def resolve_ariel_dsn(
     ariel_section: dict[str, Any],
     services: dict[str, Any] | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> str:
     """Resolve the effective ARIEL database DSN.
 
@@ -62,6 +64,13 @@ def resolve_ariel_dsn(
         services: The ``services.postgresql`` mapping from config.yml, or None
             when the caller has no services block — the derived DSN then falls
             back to the shipped Postgres defaults.
+        env: Where to read ``ARIEL_DB_PASSWORD`` from. Defaults to the process
+            environment, which is what every in-container consumer wants. A
+            caller acting ON a project rather than IN it — the deploy, which
+            migrates a store it is bringing up — passes that project's own
+            ``.env`` instead: run from another directory, the ambient value
+            belongs to some other deployment, and using it would either fail
+            confusingly or reach a database this call was never pointed at.
 
     Returns:
         The DSN to connect with.
@@ -81,7 +90,9 @@ def resolve_ariel_dsn(
     username = postgresql.get("username", _DEFAULT_DB_USERNAME)
     database_name = postgresql.get("database_name", _DEFAULT_DB_NAME)
     port = postgresql.get("port_host", _DEFAULT_DB_PORT)
-    password = os.environ.get("ARIEL_DB_PASSWORD", _DEFAULT_DB_PASSWORD)
+    password = (env if env is not None else os.environ).get(
+        "ARIEL_DB_PASSWORD", _DEFAULT_DB_PASSWORD
+    )
 
     return f"postgresql://{username}:{password}@localhost:{port}/{database_name}"
 

--- a/src/osprey/simulation/apply.py
+++ b/src/osprey/simulation/apply.py
@@ -318,6 +318,73 @@ _WRITE_CHUNK = 1000
 _SPIKE_WINDOW_SIGMAS = 4.0
 
 
+def active_logbook_entries(config: dict, project_dir: Path) -> list[EnhancedLogbookEntry]:
+    """The logbook entries the project's ALREADY-active scenarios narrate.
+
+    Read back from the project's own state rather than composed from an argument:
+    the caller here (a deploy) is not activating anything, it is writing down what
+    the running world already says it is. The anchor comes from the same state, so
+    the entries land where the telemetry that accompanies them already is — a
+    fresh anchor would slide the narrative to a T0 nobody asked for.
+
+    Args:
+        config: The project's loaded ``config.yml``.
+        project_dir: Root of the built project.
+
+    Returns:
+        The entries, or ``[]`` when the project is not simulation-backed — a
+        project with no machine model narrates nothing, which is a normal
+        configuration and not a fault.
+    """
+    machine_path, _, _, _ = resolve_simulation_file(config, project_dir)
+    if machine_path is None or not machine_path.is_file():
+        return []
+
+    engine = SimulationEngine.from_file(
+        machine_path, state_dir=resolve_state_dir(config, project_dir)
+    )
+    anchor = persisted_scenario_anchor(config, project_dir) or datetime.now(get_facility_timezone())
+    return [_to_enhanced_entry(entry, anchor) for entry in engine.active_logbook()]
+
+
+def seed_active_logbook(config: dict, project_dir: Path, ariel_config: dict) -> int:
+    """Write the active narrative into a logbook that has none. Returns entries seeded.
+
+    The counterpart of :func:`seed_archiver` for the other half of a simulated
+    world: a deployment whose archive is full while its logbook is empty documents
+    a machine nobody can read about. Called by the deploy, which is why it is
+    strictly additive where :func:`apply_scenarios`' own seeding purges first — an
+    operator asking for a scenario is asking for that narrative and no other, but
+    a deploy is asking for the stack to come up and has no licence to delete
+    entries anyone wrote.
+
+    So it writes only into an EMPTY logbook. A logbook with anything in it is left
+    exactly as it is; the operator's route to a clean reseed remains
+    ``osprey sim apply``.
+
+    Args:
+        config: The project's loaded ``config.yml``.
+        project_dir: Root of the built project.
+        ariel_config: ARIEL config section with its DSN already resolved.
+
+    Returns:
+        The number of entries seeded; ``0`` when the project narrates none, or
+        when the logbook already holds entries.
+    """
+    entries = active_logbook_entries(config, project_dir)
+    if not entries:
+        return 0
+
+    async def _seed_if_empty() -> int:
+        from osprey.services.ariel_search import cli_operations
+
+        if await cli_operations.logbook_entry_count(ariel_config) > 0:
+            return 0
+        return await cli_operations.seed_logbook_entries(ariel_config, entries)
+
+    return _run_coro(_seed_if_empty)
+
+
 def archiver_store_config(config: dict, project_dir: Path) -> dict | None:
     """Connection parameters for the project's stored archive, if it has one.
 

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -429,6 +429,24 @@ services:
          rejects with a 401 — visible, rather than a silent half-auth. #}
       - EVENT_DISPATCHER_TOKEN=${EVENT_DISPATCHER_TOKEN:-}
 {%- endif %}
+{%- if svc.wants_ariel_db %}
+      {#- The ARIEL Postgres password, for a persona that configures ARIEL. Two
+         consumers in this container authenticate with it — the ARIEL panel's own
+         server and the `ariel` MCP server the agent calls — and both derive the
+         DSN the same way (services.ariel_search.config.resolve_ariel_dsn), from
+         `services.postgresql` plus this variable. Without it they fall back to
+         the shipped default while Postgres holds the password `osprey up` minted,
+         and the ARIEL tab reports the database as unavailable.
+
+         Per-user for the same reason as the dispatcher token above: a shared
+         `.env.production` cannot say "the personas that configure ARIEL".
+
+         `:-ariel` mirrors the postgresql service template's own default, so a
+         project deploying no minted password behaves here exactly as it does on
+         the host — an empty value would NOT, since `resolve_ariel_dsn` falls
+         back only on an unset variable, never on an empty one. #}
+      - ARIEL_DB_PASSWORD=${ARIEL_DB_PASSWORD:-ariel}
+{%- endif %}
     volumes:
       - {{ svc.user }}-claude-config:/data/claude-config
       {#- Mount target comes from render.py's _container_agent_data_dir, which

--- a/tests/deployment/test_ariel_store_stage.py
+++ b/tests/deployment/test_ariel_store_stage.py
@@ -1,0 +1,168 @@
+"""A deploy that runs ARIEL's Postgres also makes it usable.
+
+Before this, ``osprey up`` started the ARIEL store and stopped there: nothing on
+the deploy path ever created the schema, so a first bring-up left a database with
+no tables, an ARIEL panel that reported the database unavailable, and an `ariel`
+MCP server whose every tool failed on a missing relation. Migrations existed only
+behind commands an operator had to know to run (``osprey ariel migrate`` /
+``quickstart``), which is knowledge a turn-key preset cannot assume.
+
+Staging ARIEL is therefore the logbook counterpart of ``_stage_archiver_store``:
+start the store, wait for it, create the schema, and — on a first bring-up only —
+write the narrative the active scenarios document.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment import container_lifecycle
+
+ARIEL_CONFIG: dict = {
+    "project_name": "demo",
+    "deployed_services": ["postgresql"],
+    "services": {"postgresql": {"username": "ariel", "database_name": "ariel", "port_host": 5432}},
+    "ariel": {"search_modules": {"keyword": {"enabled": True}}},
+}
+
+
+@pytest.fixture
+def ariel_stubs(monkeypatch, tmp_path):
+    """Reduce ``_stage_ariel_store`` to its compose call and its two ARIEL calls."""
+    state: dict = {"cmds": [], "migrated": [], "seeded": [], "waited": []}
+
+    (tmp_path / ".env").write_text("ARIEL_DB_PASSWORD=s3cret\n", encoding="utf-8")
+
+    monkeypatch.setattr(container_lifecycle, "runtime_env", lambda config, env: dict(env))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "compose_base_cmd", lambda *a, **k: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle, "_env_file_args", lambda root=None: [])
+    monkeypatch.setattr(
+        container_lifecycle,
+        "run_captured",
+        lambda cmd, **kwargs: state["cmds"].append(list(cmd)),
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_wait_for_ariel_store",
+        lambda ariel_config, deadline: state["waited"].append(ariel_config),
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_migrate_ariel_store",
+        lambda ariel_config: state["migrated"].append(ariel_config),
+    )
+
+    from osprey.simulation import apply as apply_mod
+
+    monkeypatch.setattr(
+        apply_mod,
+        "seed_active_logbook",
+        lambda config, project_dir, ariel_config: state["seeded"].append(ariel_config) or 3,
+    )
+    return state
+
+
+def _stage(config: dict, project_dir: Path) -> None:
+    container_lifecycle._stage_ariel_store(config, ["compose.yml"], {}, project_dir)
+
+
+def test_the_store_is_started_on_its_own(ariel_stubs, tmp_path):
+    """Started ahead of the stack, like the archiver store: the schema has to
+    exist before anything that reads it comes up."""
+    # Act
+    _stage(ARIEL_CONFIG, tmp_path)
+
+    # Assert
+    assert ariel_stubs["cmds"] == [["docker", "compose", "up", "-d", "postgresql"]]
+
+
+def test_the_schema_is_created_before_anything_reads_it(ariel_stubs, tmp_path):
+    """The defect this staging exists for: a store with no tables."""
+    # Act
+    _stage(ARIEL_CONFIG, tmp_path)
+
+    # Assert
+    assert len(ariel_stubs["migrated"]) == 1
+
+
+def test_migrations_authenticate_with_the_project_dotenv_password(
+    ariel_stubs, tmp_path, monkeypatch
+):
+    """Read from the project's own `.env` by name -- never from whatever the
+    ambient environment happens to export for another deployment's database."""
+    # Arrange
+    monkeypatch.setenv("ARIEL_DB_PASSWORD", "someone-elses-database")
+
+    # Act
+    _stage(ARIEL_CONFIG, tmp_path)
+
+    # Assert
+    dsn = ariel_stubs["migrated"][0]["database"]["uri"]
+    assert "s3cret" in dsn
+    assert "someone-elses-database" not in dsn
+
+
+def test_the_active_narrative_is_seeded_after_the_schema(ariel_stubs, tmp_path):
+    """Order matters: seeding writes into tables the migration creates."""
+    # Act
+    _stage(ARIEL_CONFIG, tmp_path)
+
+    # Assert
+    assert len(ariel_stubs["seeded"]) == 1
+    assert ariel_stubs["seeded"][0] == ariel_stubs["migrated"][0]
+
+
+def test_a_store_the_project_does_not_run_is_left_alone(ariel_stubs, tmp_path):
+    """A project pointed at a Postgres someone else runs must never have its
+    schema or its contents rewritten by a local deploy."""
+    # Arrange
+    config = {**ARIEL_CONFIG, "deployed_services": []}
+
+    # Act
+    _stage(config, tmp_path)
+
+    # Assert
+    assert ariel_stubs["cmds"] == []
+    assert ariel_stubs["migrated"] == []
+
+
+def test_a_project_without_ariel_stages_nothing(ariel_stubs, tmp_path):
+    """The store can be deployed for something else entirely; with no `ariel:`
+    section there is no schema this deploy knows how to create."""
+    # Arrange
+    config = {key: value for key, value in ARIEL_CONFIG.items() if key != "ariel"}
+
+    # Act
+    _stage(config, tmp_path)
+
+    # Assert
+    assert ariel_stubs["migrated"] == []
+
+
+def test_an_unreachable_store_warns_and_leaves_the_deploy_standing(
+    ariel_stubs, tmp_path, monkeypatch, caplog
+):
+    """The logbook is one panel of many. A database that will not answer must be
+    said out loud, naming the command that finishes the job -- but a control-room
+    deploy whose scans and channels are fine is not aborted over its search tab."""
+
+    # Arrange
+    def _boom(ariel_config, deadline):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(container_lifecycle, "_wait_for_ariel_store", _boom)
+
+    # Act
+    with caplog.at_level("WARNING"):
+        _stage(ARIEL_CONFIG, tmp_path)
+
+    # Assert
+    assert "osprey ariel quickstart" in caplog.text
+    assert ariel_stubs["migrated"] == []

--- a/tests/deployment/web_terminals/test_personas.py
+++ b/tests/deployment/web_terminals/test_personas.py
@@ -8,11 +8,13 @@ import pytest
 from osprey.deployment.web_terminals.personas import (
     EVENTS_PANEL_ID,
     config_declares_panel,
+    config_uses_ariel,
     env_var_suffix,
     env_var_suffix_collisions,
     freeze_user_indices,
     normalize_users,
     personas_declaring_panel,
+    personas_using_ariel,
     resolve_personas,
 )
 
@@ -1321,3 +1323,86 @@ def test_personas_declaring_panel_skips_unrendered_persona_projects(tmp_path) ->
 
     # Act / Assert
     assert personas_declaring_panel(config, tmp_path, EVENTS_PANEL_ID) == set()
+
+
+# ---------------------------------------------------------------------------
+# ARIEL config -> per-user database credential
+#
+# ARIEL's Postgres password is not panel-gated the way the dispatcher token is:
+# two consumers inside a web terminal need it -- the ARIEL panel's own server
+# and the `ariel` MCP server the agent calls -- and only one of them is visible
+# in `web.panels`. The `ariel:` section is what BOTH read to resolve their DSN,
+# so its presence is the entitlement.
+# ---------------------------------------------------------------------------
+
+
+def _write_persona_project_config(tmp_path, name: str, config: dict) -> str:
+    """Render a persona project carrying an arbitrary config; return its project_path."""
+    import yaml
+
+    project_dir = tmp_path / name
+    project_dir.mkdir()
+    (project_dir / "config.yml").write_text(
+        yaml.safe_dump({"project_name": name, **config}), encoding="utf-8"
+    )
+    return name
+
+
+def test_config_uses_ariel_reads_the_ariel_section() -> None:
+    """A project carrying an `ariel:` section resolves a DSN and needs the password."""
+    # Assert
+    assert config_uses_ariel({"ariel": {"search_modules": {"keyword": {"enabled": True}}}}) is True
+    assert config_uses_ariel({}) is False
+
+
+def test_config_uses_ariel_ignores_an_empty_section() -> None:
+    """A key present but empty configures nothing, so it entitles nothing."""
+    # Assert
+    assert config_uses_ariel({"ariel": None}) is False
+    assert config_uses_ariel({"ariel": {}}) is False
+
+
+def test_personas_using_ariel_selects_only_the_ariel_persona(tmp_path) -> None:
+    """The entitlement set is exactly the personas whose rendered project configures
+    ARIEL -- a persona with no logbook gets no logbook credential."""
+    # Arrange
+    catalog = {
+        "readwrite": {
+            "project": "rw",
+            "project_path": _write_persona_project_config(
+                tmp_path, "rw", {"ariel": {"search_modules": {"keyword": {"enabled": True}}}}
+            ),
+        },
+        "readonly": {
+            "project": "ro",
+            "project_path": _write_persona_project_config(
+                tmp_path, "ro", {"web": {"panels": {"okf": {"enabled": True}}}}
+            ),
+        },
+    }
+    config = _catalog_config(
+        catalog,
+        [
+            {"name": "alice", "index": 0, "persona": "readwrite"},
+            {"name": "bob", "index": 1, "persona": "readonly"},
+        ],
+    )
+
+    # Act
+    result = personas_using_ariel(config, tmp_path)
+
+    # Assert
+    assert result == {"readwrite"}
+
+
+def test_personas_using_ariel_skips_unrendered_persona_projects(tmp_path) -> None:
+    """A persona whose project isn't on disk contributes nothing: a credential is
+    never granted on a guess."""
+    # Arrange
+    config = _catalog_config(
+        {"ghost": {"project": "ghost", "project_path": "../never-rendered"}},
+        [{"name": "alice", "index": 0, "persona": "ghost"}],
+    )
+
+    # Act / Assert
+    assert personas_using_ariel(config, tmp_path) == set()

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -3075,3 +3075,65 @@ def test_render_without_dispatcher_personas_emits_no_token_line() -> None:
     for service in ("web-alice", "web-bob"):
         env = compose["services"][service]["environment"]
         assert not any("EVENT_DISPATCHER_TOKEN" in line for line in env)
+
+
+# ---------------------------------------------------------------------------
+# ARIEL config -> per-user database password
+#
+# `osprey up` mints a strong ARIEL_DB_PASSWORD into the deploy `.env`, and
+# Postgres initializes its volume with it. Inside a web terminal, BOTH ARIEL
+# consumers -- the panel's own server and the `ariel` MCP server -- derive their
+# DSN through `resolve_ariel_dsn`, which reads that variable from the
+# environment and otherwise falls back to the shipped default. A container that
+# never receives it therefore authenticates with the wrong password and the
+# ARIEL tab reports the database as unavailable.
+#
+# Per-user, not `.env.production`, for the same reason as the dispatcher token:
+# that file is handed to every user alike and cannot express "the personas that
+# configure ARIEL".
+# ---------------------------------------------------------------------------
+
+_ARIEL_PASSWORD_LINE = "ARIEL_DB_PASSWORD=${ARIEL_DB_PASSWORD:-ariel}"
+
+
+def test_ariel_persona_gets_the_database_password() -> None:
+    """A user whose persona configures ARIEL gets the minted Postgres password in
+    its own `environment:` block, interpolated from the deploy `.env` at compose
+    time so the secret is never written into a rendered artifact."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config(), ariel_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    assert _ARIEL_PASSWORD_LINE in compose["services"]["web-alice"]["environment"]
+
+
+def test_persona_without_ariel_gets_no_database_password() -> None:
+    """A persona that configures no logbook needs no logbook credential."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config(), ariel_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    bob_env = compose["services"]["web-bob"]["environment"]
+    assert not any("ARIEL_DB_PASSWORD" in line for line in bob_env)
+
+
+def test_render_without_ariel_personas_emits_no_password_line() -> None:
+    """The no-project-root render path passes no persona set and so emits no
+    credential, exactly as it does for the dispatcher token."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config())["docker-compose.web.yml"]
+    )
+
+    # Assert
+    for service in ("web-alice", "web-bob"):
+        env = compose["services"][service]["environment"]
+        assert not any("ARIEL_DB_PASSWORD" in line for line in env)

--- a/tests/simulation/test_active_logbook_seed.py
+++ b/tests/simulation/test_active_logbook_seed.py
@@ -1,0 +1,146 @@
+"""The narrative half of a simulated world reaches ARIEL on its own.
+
+``osprey up`` composes a machine out of two halves: the archiver's stored history
+(seeded by the deploy) and the logbook that documents it (until now seeded only
+by an explicit ``osprey sim apply``). A deployment that shipped one without the
+other came up with an ARIEL panel whose "Browse Entries" tab was empty for a
+machine whose archive was full.
+
+:func:`seed_active_logbook` closes that: it writes the entries the ALREADY-active
+scenarios narrate, at the anchor the running world is already on, and only into a
+logbook that has none — an operator's own entries are never overwritten by a
+deploy.
+
+DB-free: the two ARIEL calls are stubbed, so the contract is pinned without a
+Postgres dependency and runs in the fast suite.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import yaml
+
+from osprey.simulation.apply import (
+    active_logbook_entries,
+    apply_scenarios,
+    seed_active_logbook,
+)
+
+TEMPLATE_SIM = (
+    Path(__file__).resolve().parents[2]
+    / "src/osprey/templates/apps/control_assistant/data/simulation"
+)
+
+ARIEL_CONFIG = {"database": {"uri": "postgresql://unused-mocked/none"}}
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Stage a sim-backed project with `rf-thermal` already active."""
+    sim_dst = tmp_path / "data" / "simulation"
+    sim_dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(TEMPLATE_SIM, sim_dst)
+    config = {
+        "control_system": {
+            "connector": {"mock": {"simulation_file": "data/simulation/machine.json"}}
+        },
+        "ariel": ARIEL_CONFIG,
+    }
+    (tmp_path / "config.yml").write_text(yaml.safe_dump(config))
+    return tmp_path
+
+
+def _activate(project: Path, monkeypatch, names: list[str]) -> None:
+    """Activate scenarios the way an operator would, without touching a database."""
+
+    async def _no_seed(ariel_config, entries):
+        return 0, False
+
+    monkeypatch.setattr("osprey.simulation.apply._seed_logbook", _no_seed)
+    apply_scenarios(project, names, seed_archive=False)
+
+
+def _stub_ariel(monkeypatch, *, existing: int) -> dict:
+    """Stub ARIEL's two database calls; return what the seeder was asked to write."""
+    seen: dict = {"seeded": None, "counted": 0}
+
+    async def _count(config_dict):
+        seen["counted"] += 1
+        return existing
+
+    async def _seed(config_dict, entries, progress=None):
+        seen["seeded"] = entries
+        return len(entries)
+
+    import osprey.services.ariel_search.cli_operations as ops
+
+    monkeypatch.setattr(ops, "logbook_entry_count", _count, raising=False)
+    monkeypatch.setattr(ops, "seed_logbook_entries", _seed)
+    return seen
+
+
+def test_active_logbook_entries_follow_the_active_scenarios(tmp_path, monkeypatch):
+    """The entries are the ones the currently-active set narrates -- read back from
+    the project's own state, not re-activated from an argument."""
+    # Arrange
+    project = _make_project(tmp_path)
+    _activate(project, monkeypatch, ["rf-thermal"])
+    config = yaml.safe_load((project / "config.yml").read_text())
+
+    # Act
+    entries = active_logbook_entries(config, project)
+
+    # Assert
+    assert entries, "the active scenario narrates entries, so some must be built"
+    assert all(entry["timestamp"].tzinfo is not None for entry in entries)
+
+
+def test_seed_active_logbook_writes_into_an_empty_logbook(tmp_path, monkeypatch):
+    """The deploy's own seed: a first bring-up finds no entries and writes the
+    narrative that matches the archive it just seeded."""
+    # Arrange
+    project = _make_project(tmp_path)
+    _activate(project, monkeypatch, ["rf-thermal"])
+    config = yaml.safe_load((project / "config.yml").read_text())
+    seen = _stub_ariel(monkeypatch, existing=0)
+
+    # Act
+    seeded = seed_active_logbook(config, project, ARIEL_CONFIG)
+
+    # Assert
+    assert seeded == len(seen["seeded"])
+    assert seeded > 0
+
+
+def test_seed_active_logbook_never_overwrites_an_existing_logbook(tmp_path, monkeypatch):
+    """A logbook with entries in it is history this deploy was not asked to touch --
+    an operator's own entries, or a narrative already seeded and since edited."""
+    # Arrange
+    project = _make_project(tmp_path)
+    _activate(project, monkeypatch, ["rf-thermal"])
+    config = yaml.safe_load((project / "config.yml").read_text())
+    seen = _stub_ariel(monkeypatch, existing=7)
+
+    # Act
+    seeded = seed_active_logbook(config, project, ARIEL_CONFIG)
+
+    # Assert
+    assert seeded == 0
+    assert seen["seeded"] is None
+
+
+def test_seed_active_logbook_is_a_no_op_without_a_machine_model(tmp_path, monkeypatch):
+    """A project with no simulation has no narrative to seed, which is a normal
+    configuration and not a fault."""
+    # Arrange
+    (tmp_path / "config.yml").write_text(yaml.safe_dump({"ariel": ARIEL_CONFIG}))
+    config = yaml.safe_load((tmp_path / "config.yml").read_text())
+    seen = _stub_ariel(monkeypatch, existing=0)
+
+    # Act
+    seeded = seed_active_logbook(config, tmp_path, ARIEL_CONFIG)
+
+    # Assert
+    assert seeded == 0
+    assert seen["seeded"] is None


### PR DESCRIPTION
## Problem

On a project deployed from the `control-assistant` preset, the ARIEL tab reports:

> Database unavailable — search, browse, and entry creation require a database connection.

The database is running and healthy. Two independent defects both break the panel, and either one alone is enough to.

**The credential never reaches the container.** Both ARIEL consumers inside a web terminal — the panel's own server and the `ariel` MCP server the agent calls — derive their DSN from `services.postgresql` plus `ARIEL_DB_PASSWORD`. Per-user containers were never given that variable, so both authenticated with the shipped default against a store initialized with the password `osprey up` minted:

```
FATAL: password authentication failed for user "ariel"
```

The service then fails to start and every `/api/*` route answers 503. This is a multi-user/single-user parity break: the same project run on the host loads `.env` directly and works.

**Nothing creates the schema.** Migrations are reachable only through `osprey ariel migrate`, `sync` and `quickstart`; no deploy path runs any of them. A first bring-up therefore leaves a database with no tables at all — `osprey ariel status` reports `relation "enhanced_entries" does not exist` — so even with correct credentials the panel would fail, just with a less useful message.

## Fix

**Per-persona credential.** Each user whose persona configures ARIEL gets `ARIEL_DB_PASSWORD` in its own compose `environment:` block, interpolated from the deploy `.env` so the secret never lands in a rendered artifact. Same placement and reasoning as the EVENTS panel's dispatcher token: `.env.production` is handed to every per-user container alike and cannot express which personas run a logbook.

The entitlement is the `ariel:` section rather than the panel declaration, because the MCP server is selected during the build and appears nowhere in `web.panels` — gating on the panel would leave the agent's logbook tools broken in exactly the projects that switched the tab off.

**Staged store.** `_stage_ariel_store` is the logbook counterpart of `_stage_archiver_store`: start the store alone, wait for it, migrate, then seed the entries the active scenarios narrate — but only into an empty logbook. An existing logbook is never touched; `osprey sim apply` remains the route to a clean reseed. The DSN is read from the project's own `.env` by name, so a deploy driven from another directory cannot reach a different deployment's database.

Failure warns and names the recovery command rather than aborting the deploy — a control room whose channels, scans and archive are up should not lose them to its search tab.

## Tests

- `tests/deployment/test_ariel_store_stage.py` — staging order, the `.env` password, the two gates (store not deployed / no `ariel:` section), and warn-don't-abort.
- `tests/simulation/test_active_logbook_seed.py` — seeds an empty logbook, never overwrites a populated one, no-ops without a machine model.
- `tests/deployment/web_terminals/test_{personas,render}.py` — the persona that configures ARIEL gets the password, the one that does not gets nothing.

All written failing first. `tests/deployment`, `tests/simulation`, `tests/services/ariel_search` and `tests/mcp_server` pass locally; one unrelated `tests/cli` test failed on a full local run with `No space left on device`.

Rendering the fixed compose against a real deployed project gives `alice` and `bob` the ARIEL password and only `alice` the dispatcher token — the tier split holds.
