### PR TITLE
fix(web): panel and terminal UI defects, and a signed ORM figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -796,6 +796,41 @@ Compatibility is documented in release notes, not encoded in the version string.
   outright. Embedded panels also no longer lose the last 28px of every view to
   padding the frame already supplies.
 
+- The axes table in a scan's parameter form no longer truncates device names —
+  its columns are sized to the names they hold.
+
+- The web terminal header names the product once. The page title repeating it
+  alongside is gone.
+
+- An embedded status strip now keeps its own inset. The queue badge sat against
+  the tile frame and the halt buttons touched its corner, while the content
+  below them was comfortably inset.
+
+- The session picker's dropdown opens in front of the terminal rather than
+  behind it. The tab strip it is adopted into clipped the menu and pinned it
+  under the content pane whatever its stacking order; it now mounts at body
+  level and closes on scroll, resize, Escape, or a click outside.
+
+- The ORM figure reads as a signed response matrix. A corrector kicks the beam
+  and a BPM downstream reads positive or negative by phase advance, but the
+  matrix was painted on a single-hue ramp anchored to the raw extent: zero
+  landed mid-ramp, so an unresponsive BPM looked like a real response, and the
+  strongest negative response painted faintest. It is now diverging about zero
+  and scaled against a symmetric max|value|, so equal and opposite responses
+  read as equally strong and two runs stay comparable. Cells with no reading
+  are hatched rather than left blank, and the legend became a colorbar carrying
+  the numbers.
+
+- New: an ORM result carries the two views that conventionally accompany a
+  response matrix. **Response by BPM** reads the matrix column-wise, where the
+  sign oscillation is legible and a dead corrector shows as a flat line against
+  a dead BPM's shared spike; you pick which correctors are drawn without
+  refetching. **Singular values** plots the spectrum on a log axis, with modes
+  at or below the numerical-rank tolerance drawn as gaps rather than as the
+  ~1e-16 residue a rank-deficient matrix leaves behind. The raw per-corrector
+  sweeps move below the fit into a collapsed section that shows one corrector
+  at a time; when the fit is skipped they stay inline.
+
 ## [2026.8.0]
 
 ### Removed

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-controls.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-controls.js
@@ -1,0 +1,265 @@
+/**
+ * Reader-owned controls for a figure: what it groups, what it shows, and the
+ * chips that change either.
+ *
+ * Split out of `figure-renderer.js`, which draws a figure the bridge sent. This
+ * module owns the other half of the screen — the reader's own choices about
+ * that figure, which the bridge knows nothing about and which must survive the
+ * renderer replacing its whole subtree on every poll tick.
+ *
+ * Everything here is pure or builds one detached element. No fetching, no
+ * drawing, no theme.
+ */
+
+/** @typedef {import('./figure-renderer.js').FigurePanel} FigurePanel */
+
+/**
+ * Reader-owned view state, held by the CALLER across renders.
+ *
+ * `renderFigure` empties and refills its container on every call, so any
+ * selection parked in that DOM would reset itself roughly once a second on a
+ * live run. Keying by panel title and section name — both stable tick to tick —
+ * is what lets a choice survive a redraw, a theme flip, and a figure that grew
+ * new panels since the choice was made.
+ *
+ * @typedef {{
+ *   series?: Record<string, string[]>,
+ *   section?: Record<string, string>,
+ *   open?: Record<string, boolean>,
+ * }} FigureSelection
+ */
+
+/** How many series a picker-bearing panel draws before the reader chooses. */
+export const DEFAULT_PICKED_SERIES = 3;
+
+/**
+ * Split panels into the inline ones and the sectioned ones, preserving order.
+ *
+ * A section is a demotion: its panels render inside one collapsed disclosure
+ * below everything inline, and a section holding more than one panel shows one
+ * at a time behind a picker. Sections appear in the order their first panel
+ * does, so a figure that grows a section keeps the ones it had where they were.
+ *
+ * @param {FigurePanel[]} panels
+ * @returns {{inline: FigurePanel[], sections: Array<{name: string, panels: FigurePanel[]}>}}
+ */
+export function groupPanels(panels) {
+  /** @type {FigurePanel[]} */
+  const inline = [];
+  /** @type {Map<string, FigurePanel[]>} */
+  const sections = new Map();
+
+  for (const panel of panels) {
+    const name = panel.section;
+    if (!name) {
+      inline.push(panel);
+      continue;
+    }
+    const existing = sections.get(name);
+    if (existing) existing.push(panel);
+    else sections.set(name, [panel]);
+  }
+
+  return {
+    inline,
+    sections: Array.from(sections, ([name, grouped]) => ({ name, panels: grouped })),
+  };
+}
+
+/**
+ * Reconcile a stored multi-selection against the labels actually present.
+ *
+ * Selections outlive the figure that produced them: a live run gains fitted
+ * correctors tick by tick, and a capped one can drop them. Anything no longer
+ * present is dropped rather than drawn as an empty line, and a selection left
+ * with nothing falls back to the default rather than to a blank panel — an
+ * empty plot reads as "no data", which would be a lie about a run that has
+ * plenty.
+ *
+ * @param {string[]|undefined} stored
+ * @param {string[]} available
+ * @param {number} [fallbackCount]
+ * @returns {string[]}
+ */
+export function resolveSeriesSelection(stored, available, fallbackCount = DEFAULT_PICKED_SERIES) {
+  if (available.length === 0) return [];
+  if (stored) {
+    const kept = stored.filter((label) => available.includes(label));
+    if (kept.length > 0) return kept;
+  }
+  return available.slice(0, Math.max(1, fallbackCount));
+}
+
+/**
+ * Reconcile a stored single-selection against the titles actually present.
+ *
+ * @param {string|undefined} stored
+ * @param {string[]} available
+ * @returns {string}
+ */
+export function resolveSectionSelection(stored, available) {
+  if (stored && available.includes(stored)) return stored;
+  return available[0] ?? '';
+}
+
+/**
+ * One collapsed disclosure holding a section's panels, one at a time.
+ *
+ * Closed by default and closed on arrival: a section is detail the reader
+ * consults, not content they scroll past. The summary carries the count so the
+ * section stays legible without opening it — a disclosure that hides *state* is
+ * a bad one; hiding *detail* while summarising is the point.
+ *
+ * `drawPanel` is injected rather than imported so this module never depends on
+ * the renderer that depends on it.
+ *
+ * @param {{name: string, panels: FigurePanel[]}} group
+ * @param {{selection: Required<FigureSelection>, redraw: () => void}} view
+ * @param {(panel: FigurePanel) => HTMLElement} drawPanel
+ * @returns {HTMLElement}
+ */
+export function sectionElement(group, view, drawPanel) {
+  const details = document.createElement('details');
+  details.className = 'figure-section';
+  details.dataset.section = group.name;
+  // `<details open>` is DOM state, and this subtree is replaced on every poll
+  // tick — without carrying it in the selection, a section would slam shut
+  // under the reader roughly once a second on a live run.
+  details.open = view.selection.open[group.name] === true;
+  details.addEventListener('toggle', () => {
+    view.selection.open[group.name] = details.open;
+  });
+
+  const summary = document.createElement('summary');
+  summary.className = 'figure-section-summary';
+  const name = document.createElement('span');
+  name.className = 'figure-section-name';
+  name.textContent = group.name;
+  const count = document.createElement('span');
+  count.className = 'figure-section-count';
+  count.textContent = group.panels.length === 1 ? '1 panel' : `${group.panels.length} panels`;
+  summary.append(name, count);
+  details.appendChild(summary);
+
+  const titles = group.panels.map((panel) => panel.title);
+  const picked = resolveSectionSelection(view.selection.section[group.name], titles);
+
+  if (group.panels.length > 1) {
+    details.appendChild(
+      chipPicker({
+        label: 'Show',
+        options: titles,
+        selected: [picked],
+        multi: false,
+        onPick: (value) => {
+          view.selection.section[group.name] = value;
+          view.redraw();
+        },
+      })
+    );
+  }
+
+  const shown = group.panels.find((panel) => panel.title === picked) ?? group.panels[0];
+  if (shown) details.appendChild(drawPanel(shown));
+  return details;
+}
+
+/**
+ * The heatmap's value scale, as a gradient strip with its numbers.
+ *
+ * A heatmap without one is unreadable: the reader can see which cells differ,
+ * but not by how much, nor which side of zero they fall on. The gradient is
+ * built from the two palette strings straight out of CSS — negative hue,
+ * transparent at the midpoint, positive hue — which is the same "fade toward
+ * the background at zero" the cells are painted with, and needs no colour
+ * parsing to stay theme-correct.
+ *
+ * The endpoint numbers arrive already formatted: the caller owns tick
+ * formatting, and taking strings here is what keeps this module free of a
+ * circular import back into the renderer.
+ *
+ * @param {{label: string, low: string, high: string, negative: string, positive: string}} bar
+ * @returns {HTMLElement}
+ */
+export function colorbarElement(bar) {
+  const wrap = document.createElement('div');
+  wrap.className = 'figure-colorbar';
+
+  if (bar.label) {
+    const label = document.createElement('span');
+    label.className = 'figure-colorbar-label';
+    label.textContent = bar.label;
+    wrap.appendChild(label);
+  }
+
+  const scale = document.createElement('div');
+  scale.className = 'figure-colorbar-scale';
+
+  const low = document.createElement('span');
+  low.className = 'figure-colorbar-tick';
+  low.textContent = bar.low;
+
+  const strip = document.createElement('div');
+  strip.className = 'figure-colorbar-strip';
+  strip.style.backgroundImage = `linear-gradient(to right, ${bar.negative} 0%, transparent 50%, ${bar.positive} 100%)`;
+
+  const high = document.createElement('span');
+  high.className = 'figure-colorbar-tick';
+  high.textContent = bar.high;
+
+  const zero = document.createElement('span');
+  zero.className = 'figure-colorbar-tick figure-colorbar-zero';
+  zero.textContent = '0';
+
+  scale.append(low, strip, high);
+  wrap.append(scale, zero);
+  return wrap;
+}
+
+/**
+ * A row of toggle chips.
+ *
+ * Chips rather than a `<select>` because the current choice has to be readable
+ * at a glance: a closed select hides exactly the thing the reader is comparing.
+ * `onPick` receives the chosen value and the caller decides what that means
+ * (one OF, or one MORE OF) and re-renders.
+ *
+ * @param {{label: string, options: string[], selected: string[], multi: boolean, onPick: (value: string) => void, note?: string}} spec
+ * @returns {HTMLElement}
+ */
+export function chipPicker(spec) {
+  const wrap = document.createElement('div');
+  wrap.className = 'figure-picker';
+
+  const label = document.createElement('span');
+  label.className = 'figure-picker-label';
+  label.textContent = spec.label;
+  wrap.appendChild(label);
+
+  const chips = document.createElement('div');
+  chips.className = 'figure-picker-chips';
+  chips.setAttribute('role', spec.multi ? 'group' : 'radiogroup');
+  chips.setAttribute('aria-label', spec.label);
+
+  for (const option of spec.options) {
+    const on = spec.selected.includes(option);
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = `figure-chip${on ? ' selected' : ''}`;
+    chip.textContent = option;
+    chip.dataset.value = option;
+    chip.setAttribute('role', spec.multi ? 'switch' : 'radio');
+    chip.setAttribute('aria-checked', on ? 'true' : 'false');
+    chip.addEventListener('click', () => spec.onPick(option));
+    chips.appendChild(chip);
+  }
+  wrap.appendChild(chips);
+
+  if (spec.note) {
+    const note = document.createElement('span');
+    note.className = 'figure-picker-note';
+    note.textContent = spec.note;
+    wrap.appendChild(note);
+  }
+  return wrap;
+}

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js
@@ -9,10 +9,16 @@
  *    `splitSegments`, `heatmapCells`, `barGeometry`, …). No DOM, no theme, no
  *    globals; given plain figure objects they return numbers and strings, and
  *    they are what the unit tests exercise directly.
- *  - **Drawing** — `renderFigure(elements, figure)`, which turns that geometry
- *    into nodes. Every node is built with `createElement`/`createElementNS` and
- *    every string lands via `textContent` or `setAttribute`; nothing in this
- *    file assigns `innerHTML`.
+ *  - **Drawing** — `renderFigure(elements, figure, options)`, which turns that
+ *    geometry into nodes. Every node is built with
+ *    `createElement`/`createElementNS` and every string lands via `textContent`
+ *    or `setAttribute`; nothing in this file assigns `innerHTML`.
+ *
+ * The reader's own choices about a figure — which series a panel draws, which
+ * panel a section shows, whether a section is open — live in
+ * `figure-controls.js`, along with the chrome that changes them. This file
+ * draws what the bridge sent; that one owns what the reader did with it. Pass
+ * `options.selection` to give those choices memory across a redraw.
  *
  * Colors are read from the theme-manager computed-style bridges *inside*
  * `renderFigure`, never at module or closure scope, so a caller that re-renders
@@ -32,14 +38,25 @@
 
 import { chartSeries, chartTheme } from '/design-system/js/theme-manager.js';
 
+import {
+  chipPicker,
+  colorbarElement,
+  groupPanels,
+  resolveSeriesSelection,
+  sectionElement,
+} from './figure-controls.js';
+
+/** @typedef {import('./figure-controls.js').FigureSelection} FigureSelection */
+
 /** @typedef {{x: number, y: number|null}} FigurePoint */
 /** @typedef {{label: string, points: FigurePoint[], decimated: boolean, source_points: number}} FigureSeries */
 /** @typedef {{kind: 'lines', series: FigureSeries[], decimated: boolean, source_points: number}} LinesMark */
 /** @typedef {{kind: 'heatmap', x_labels: string[], y_labels: string[], values: Array<Array<number|null>>, value_label: string, value_units: string|null, decimated: boolean, source_points: number}} HeatmapMark */
 /** @typedef {{kind: 'bars', label: string, categories: string[], values: Array<number|null>, decimated: boolean, source_points: number}} BarsMark */
 /** @typedef {LinesMark|HeatmapMark|BarsMark} FigureMark */
-/** @typedef {{title: string, x_label: string, y_label: string, x_units: string|null, y_units: string|null, annotations: string[], mark: FigureMark}} FigurePanel */
+/** @typedef {{title: string, x_label: string, y_label: string, x_units: string|null, y_units: string|null, annotations: string[], mark: FigureMark, section?: string|null, series_picker?: boolean}} FigurePanel */
 /** @typedef {{panels: FigurePanel[], partial: boolean, source: 'live'|'tiled', reason: string|null}} Figure */
+
 
 /** @typedef {{left: number, top: number, width: number, height: number, right: number, bottom: number}} PlotBox */
 /** @typedef {(value: number) => number} Scale */
@@ -323,6 +340,41 @@ export function heatmapExtent(values) {
 }
 
 /**
+ * The signed colour scale for a heatmap, anchored at zero.
+ *
+ * A response matrix is signed and roughly zero-centred: a corrector kicks the
+ * beam and a BPM downstream reads positive or negative by phase advance. On a
+ * sequential ramp anchored to `[min, max]` that structure is destroyed twice
+ * over -- zero lands mid-ramp, so an unresponsive BPM paints like a real
+ * response, and the most negative cell paints faintest, so the strongest
+ * negative response is indistinguishable from no measurement at all.
+ *
+ * So: one hue each side of zero, and a magnitude scaled against a SYMMETRIC
+ * `limit` of `max|value|` rather than the raw extent. Zero maps to opacity 0 --
+ * the plot background, painted by nothing -- which is what makes a dead row
+ * read as dead. The symmetric limit is also what makes two runs comparable: a
+ * ramp fitted to each run's own extent means a different thing every time.
+ *
+ * `null` when no cell holds a reading.
+ *
+ * @param {Array<Array<number|null>>} values
+ * @returns {{limit: number, opacityFor: (value: number) => number, isNegative: (value: number) => boolean}|null}
+ */
+export function divergingScale(values) {
+  const extent = heatmapExtent(values);
+  if (extent === null) return null;
+
+  const limit = Math.max(Math.abs(extent.min), Math.abs(extent.max));
+  return {
+    limit,
+    // A flat matrix (limit 0) is all zero, and all zero is all background:
+    // inventing contrast for it would draw structure that is not there.
+    opacityFor: (value) => (limit > 0 ? Math.min(1, Math.abs(value) / limit) : 0),
+    isNegative: (value) => value < 0,
+  };
+}
+
+/**
  * One rectangle per heatmap cell, row 0 at the top so the drawn grid reads in
  * the same order as `values` and `y_labels`. Cells with no reading are
  * returned with `value: null` — the caller leaves them unpainted rather than
@@ -538,7 +590,49 @@ export function seriesColor(palette, index, fallback) {
 
 /** @typedef {{text: string, grid: string, plotBg: string, palette: string[]}} RenderColors */
 /** @typedef {{label: string, color: string}} LegendEntry */
-/** @typedef {{plotted: boolean, legend: LegendEntry[]}} MarkResult */
+/** @typedef {{label: string, limit: number, negative: string, positive: string}} Colorbar */
+/** @typedef {{plotted: boolean, legend: LegendEntry[], colorbar?: Colorbar}} MarkResult */
+
+/** Distinguishes one render's `<pattern>` ids from another's on the same page. */
+let patternSequence = 0;
+
+/**
+ * Define a diagonal hatch in `svg` and return the `fill` value referencing it.
+ *
+ * Ids must be unique per document, not per SVG: several figures share a page,
+ * and a duplicate id would silently hand every one of them the first figure's
+ * pattern -- drawn in the first figure's palette, which a theme flip would then
+ * fail to update.
+ *
+ * @param {SVGElement} svg
+ * @param {string} color
+ * @returns {string}
+ */
+function hatchFill(svg, color) {
+  const id = `figure-hatch-${(patternSequence += 1)}`;
+  const pattern = svgNode('pattern', {
+    id,
+    width: 5,
+    height: 5,
+    patternUnits: 'userSpaceOnUse',
+    patternTransform: 'rotate(45)',
+  });
+  pattern.appendChild(
+    svgNode('line', {
+      x1: 0,
+      y1: 0,
+      x2: 0,
+      y2: 5,
+      stroke: color,
+      'stroke-width': 1.5,
+      'stroke-opacity': 0.4,
+    })
+  );
+  const defs = svgNode('defs', {});
+  defs.appendChild(pattern);
+  svg.appendChild(defs);
+  return `url(#${id})`;
+}
 
 /**
  * @param {string} name
@@ -739,24 +833,37 @@ function drawLines(svg, mark, panel, box, colors) {
  * @returns {MarkResult}
  */
 function drawHeatmap(svg, mark, panel, box, colors) {
-  const extent = heatmapExtent(mark.values);
-  if (extent === null) return { plotted: false, legend: [] };
+  const scale = divergingScale(mark.values);
+  if (scale === null) return { plotted: false, legend: [] };
 
-  const color = seriesColor(colors.palette, 0, colors.text);
-  const toOpacity = linearScale(extent.min, extent.max, 0.12, 1);
+  const positive = seriesColor(colors.palette, 0, colors.text);
+  // The second palette slot, not a parsed complement: the tokens are arbitrary
+  // CSS colour strings and any ramp built by taking them apart would break on
+  // the first theme shipping a colour space this file cannot parse.
+  const negative = seriesColor(colors.palette, 1, colors.text);
+  const missingFill = hatchFill(svg, colors.text);
+
   for (const cell of heatmapCells(mark, box)) {
-    if (cell.value === null) continue;
-    const rect = svgNode('rect', {
-      class: 'figure-cell',
+    const attributes = {
       x: cell.x.toFixed(1),
       y: cell.y.toFixed(1),
       width: Math.max(0, cell.width).toFixed(1),
       height: Math.max(0, cell.height).toFixed(1),
-      fill: color,
-      'fill-opacity': toOpacity(cell.value).toFixed(3),
-    });
+    };
+    // A missing cell is HATCHED, not skipped. Left unpainted it would be plot
+    // background -- which is exactly what a zero reading now looks like, so
+    // "never measured" and "measured, no response" would be the same picture.
+    const rect =
+      cell.value === null
+        ? svgNode('rect', { ...attributes, class: 'figure-cell figure-cell-missing', fill: missingFill })
+        : svgNode('rect', {
+            ...attributes,
+            class: 'figure-cell',
+            fill: scale.isNegative(cell.value) ? negative : positive,
+            'fill-opacity': scale.opacityFor(cell.value).toFixed(3),
+          });
     const hover = svgNode('title', {});
-    hover.textContent = formatTickValue(cell.value);
+    hover.textContent = cell.value === null ? 'No reading' : formatTickValue(cell.value);
     rect.appendChild(hover);
     svg.appendChild(rect);
   }
@@ -780,9 +887,19 @@ function drawHeatmap(svg, mark, panel, box, colors) {
     colors
   );
 
-  const valueTitle = axisTitle(mark.value_label, mark.value_units);
-  const legend = valueTitle ? [{ label: valueTitle, color }] : [];
-  return { plotted: true, legend };
+  // A colorbar, not a legend swatch: a single flat chip labelled "Response
+  // slope" says which quantity is painted but leaves every shade in the grid
+  // unreadable as a number.
+  return {
+    plotted: true,
+    legend: [],
+    colorbar: {
+      label: axisTitle(mark.value_label, mark.value_units),
+      limit: scale.limit,
+      negative,
+      positive,
+    },
+  };
 }
 
 /**
@@ -875,9 +992,10 @@ function annotationList(notes) {
 /**
  * @param {FigurePanel} panel
  * @param {RenderColors} colors
+ * @param {{selection: Required<FigureSelection>, redraw: () => void}} [view]
  * @returns {HTMLElement}
  */
-function renderPanel(panel, colors) {
+function renderPanel(panel, colors, view) {
   const section = document.createElement('section');
   section.className = 'figure-panel';
   section.dataset.mark = panel.mark.kind;
@@ -887,6 +1005,35 @@ function renderPanel(panel, colors) {
     heading.className = 'figure-panel-title';
     heading.textContent = panel.title;
     section.appendChild(heading);
+  }
+
+  // A series picker filters what is DRAWN from series already on the wire, so
+  // changing the comparison costs no fetch. The panel keeps every series in
+  // `mark` either way -- narrowing that here would make the choice one-way.
+  let mark = panel.mark;
+  if (view && panel.series_picker && mark.kind === 'lines') {
+    const available = mark.series.map((line) => line.label);
+    const stored = view.selection.series[panel.title];
+    const picked = resolveSeriesSelection(stored, available);
+    section.appendChild(
+      chipPicker({
+        label: 'Show',
+        options: available,
+        selected: picked,
+        multi: true,
+        note: `${picked.length} of ${available.length}`,
+        onPick: (value) => {
+          const next = picked.includes(value)
+            ? picked.filter((label) => label !== value)
+            : [...picked, value];
+          // Never let the last chip off: an empty plot reads as "no data",
+          // which would be a lie about a run that has plenty.
+          if (next.length > 0) view.selection.series[panel.title] = next;
+          view.redraw();
+        },
+      })
+    );
+    mark = { ...mark, series: mark.series.filter((line) => picked.includes(line.label)) };
   }
 
   const box = plotBox();
@@ -908,7 +1055,6 @@ function renderPanel(panel, colors) {
     })
   );
 
-  const mark = panel.mark;
   let result;
   if (mark.kind === 'lines') result = drawLines(svg, mark, panel, box, colors);
   else if (mark.kind === 'heatmap') result = drawHeatmap(svg, mark, panel, box, colors);
@@ -916,6 +1062,17 @@ function renderPanel(panel, colors) {
 
   if (result.plotted) {
     section.appendChild(svg);
+    if (result.colorbar) {
+      section.appendChild(
+        colorbarElement({
+          label: result.colorbar.label,
+          low: formatTickValue(-result.colorbar.limit),
+          high: formatTickValue(result.colorbar.limit),
+          negative: result.colorbar.negative,
+          positive: result.colorbar.positive,
+        })
+      );
+    }
     if (result.legend.length > 0) section.appendChild(legendList(result.legend));
   } else {
     const empty = document.createElement('p');
@@ -945,10 +1102,17 @@ function renderPanel(panel, colors) {
  * Theme colors are read here, once per render, so a caller re-rendering from a
  * theme change gets the new palette.
  *
+ * Pass a stable `options.selection` object to give the figure's pickers and
+ * disclosures memory: this function replaces its container's children on every
+ * call, so any state left in that DOM dies with it. The object is the caller's
+ * -- reset it when the RUN changes, or one run's choices would be re-applied to
+ * the next run's panels.
+ *
  * @param {FigureElements} elements
  * @param {Figure} figure
+ * @param {{selection?: FigureSelection}} [options]
  */
-export function renderFigure(elements, figure) {
+export function renderFigure(elements, figure, options = {}) {
   const theme = chartTheme();
   /** @type {RenderColors} */
   const colors = {
@@ -980,5 +1144,18 @@ export function renderFigure(elements, figure) {
     return;
   }
 
-  for (const panel of figure.panels) root.appendChild(renderPanel(panel, colors));
+  const store = options.selection ?? {};
+  store.series ??= {};
+  store.section ??= {};
+  store.open ??= {};
+  const view = {
+    selection: /** @type {Required<FigureSelection>} */ (store),
+    redraw: () => renderFigure(elements, figure, { ...options, selection: store }),
+  };
+
+  const { inline, sections } = groupPanels(figure.panels);
+  for (const panel of inline) root.appendChild(renderPanel(panel, colors, view));
+  for (const group of sections) {
+    root.appendChild(sectionElement(group, view, (panel) => renderPanel(panel, colors, view)));
+  }
 }

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.css
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.css
@@ -145,6 +145,20 @@ html:not([data-ui-mode="simple"]) body.embedded .panel-tabs { display: none; }
 }
 .status-strip-spacer { flex: 1 1 auto; }
 
+/* `body.embedded` zeroes the body padding so the scrolling views can meet the
+   tile edges — but this strip is a fixed header band, not scrolling content,
+   and it had no inset of its own: standalone, the body padding was quietly
+   providing one. Embedded, that left the badge against the frame's left edge
+   and the emergency halt touching the top-right corner, while the card content
+   below it sat at a comfortable inset — the mismatch that made the strip look
+   misplaced and the halts look oversized. Restoring the inset here (rather
+   than un-zeroing the body) keeps the views themselves edge-to-edge. */
+body.embedded .status-strip {
+  padding-top: 10px;
+  padding-left: 14px;
+  padding-right: 14px;
+}
+
 /* ---- View containers ---- */
 
 .view {
@@ -920,6 +934,54 @@ select.field-input { cursor: pointer; }
   border-color: var(--color-accent-light);
   background: var(--bg-primary);
 }
+/* Column widths follow the schema type (`columnKind` in schema-form.js), because
+   the DOM cannot tell the columns apart on its own: every cell holds an
+   <input>, and an input's intrinsic width is the same ~20-character UA default
+   whatever its type, so `table-layout: auto` alone hands all four columns an
+   equal share — a PV name truncating beside a two-digit point count.
+
+   `width: 1%` is the shrink-to-fit idiom: under auto layout a percentage below
+   a column's min-content width resolves back *up* to min-content, so these
+   columns end up exactly as wide as their contents need and every remaining
+   pixel falls to the untouched free-text column. */
+.obj-table th.col-num, .obj-table td.col-num,
+.obj-table th.col-bool, .obj-table td.col-bool,
+.obj-table th.col-enum, .obj-table td.col-enum {
+  width: 1%;
+}
+
+/* Room for a signed four-decimal setpoint (-0.0125) plus the input's own
+   padding and border — the value decides the column, not the header above it,
+   which is free to wrap onto a second line. */
+.obj-table td.col-num .field-input {
+  width: calc(7ch + 16px);
+  min-width: 0;
+}
+
+/* Wrapped headers ("NUM / POINTS") sit on the same baseline as their unwrapped
+   neighbours instead of floating above them. */
+.obj-table th { vertical-align: bottom; }
+
+/* Spin buttons are ~15px of the input's own width and appear on hover/focus —
+   in a column sized to the value they would clip the digits at exactly the
+   moment you reach for the field. Keyboard up/down still step the value, so no
+   way of entering a number is lost. Scoped to the table: full-width number
+   fields elsewhere in the form keep their spinners. */
+.obj-table td.col-num .field-input {
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+.obj-table td.col-num .field-input::-webkit-outer-spin-button,
+.obj-table td.col-num .field-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* A floor under the flexing column so a narrow panel squeezes it to a still-
+   readable width and then scrolls, rather than crushing it to nothing. */
+.obj-table td.col-text .field-input { min-width: 12ch; }
+.table-field { overflow-x: auto; }
+
 .th-x, .td-x { width: 30px; }
 .td-x { text-align: center; }
 

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.css
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.css
@@ -1680,6 +1680,115 @@ button.queue-label:focus-visible {
   margin-top: 2px;
 }
 
+/* Colorbar: the heatmap's value scale, with its numbers. A heatmap without one
+   is unreadable — the reader can see which cells differ but not by how much,
+   nor which side of zero they are on. The strip's gradient is written inline by
+   the renderer from the live palette (negative hue → transparent → positive
+   hue), so it tracks the theme without this file naming a colour. */
+.figure-colorbar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  margin-top: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.figure-colorbar-label {
+  font-family: var(--font-display);
+  color: var(--text-muted);
+}
+.figure-colorbar-scale {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.figure-colorbar-strip {
+  width: 180px;
+  height: 10px;
+  border-radius: 2px;
+  border: 1px solid var(--border-default);
+}
+.figure-colorbar-zero {
+  color: var(--text-muted);
+}
+
+/* A cell with no reading. Hatched rather than left as background, because
+   background is now what a genuine ZERO looks like. */
+.figure-cell-missing {
+  pointer-events: all;
+}
+
+/* Section: detail demoted below the figure's findings, one panel at a time. */
+.figure-section {
+  margin-top: 14px;
+  border-top: 1px solid var(--border-default);
+  padding-top: 10px;
+}
+.figure-section-summary {
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--font-display);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.figure-section-summary:hover {
+  color: var(--text-primary);
+}
+.figure-section-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Picker: which series a panel draws, or which panel a section shows. Chips
+   rather than a <select> because the current choice has to be visible at a
+   glance — a closed select hides exactly the thing the reader is comparing. */
+.figure-picker {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 8px 0 4px;
+}
+.figure-picker-label,
+.figure-picker-note {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.figure-picker-note {
+  font-family: var(--font-mono);
+}
+.figure-picker-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.figure-chip {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.figure-chip:hover,
+.figure-chip:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+}
+.figure-chip.selected {
+  color: var(--text-primary);
+  border-color: var(--color-accent-light);
+  background: var(--accent-tint-08);
+}
+
 /* Stands in for the plot when a panel has nothing plottable yet. Styled as an
    ordinary quiet line, NOT as an error: a run still filling in, and a default
    view that declined to render, are both normal states. */

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/results-view.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/results-view.js
@@ -228,6 +228,9 @@ export function createResultsView({ api, elements, onPollingChange, saveFile = s
     exporting: false,
   };
 
+  /** @type {import('./figure-renderer.js').FigureSelection} */
+  const figureSelection = { series: {}, section: {}, open: {} };
+
   /**
    * Announce a change in whether the view is polling. Derived from the timer
    * alone — the single fact that decides it — so there is no second flag that
@@ -674,7 +677,11 @@ export function createResultsView({ api, elements, onPollingChange, saveFile = s
    */
   function drawFigure(figure) {
     try {
-      renderFigure({ panels: elements.figurePanels, note: elements.figureNote }, figure);
+      renderFigure(
+        { panels: elements.figurePanels, note: elements.figureNote },
+        figure,
+        { selection: figureSelection }
+      );
     } catch (error) {
       console.error('osprey bluesky results: the figure renderer threw', error);
       return false;
@@ -708,6 +715,14 @@ export function createResultsView({ api, elements, onPollingChange, saveFile = s
       // `tableDetails.open` is deliberately NOT reset here — see the module
       // docstring. The operator's choice to have the table open outlives any
       // one run.
+      //
+      // The figure's pickers follow the same split. `series`/`section` name
+      // devices and panels belonging to ONE run — re-applying "show hcm3" to
+      // the next run would silently pick a different magnet, or nothing — so
+      // they are cleared. `open` is a disclosure preference exactly like
+      // `tableDetails.open`, so it survives.
+      figureSelection.series = {};
+      figureSelection.section = {};
       setExportNote(null);
       if (!runId) {
         setEmptyState('Select a queued or completed run to see its results.');

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/schema-form.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/schema-form.js
@@ -240,6 +240,31 @@ function isScalar(node) {
 }
 
 /**
+ * The width class one scalar gets as a `buildTable` column.
+ *
+ * Numbers, booleans and enums all render controls whose useful width is
+ * bounded and small — a point count, a checkbox, a fixed set of options — so
+ * their columns shrink to fit. Free text is unbounded (a PV name runs to
+ * ``SR:C01:CORR:HORIZ:X:SP``) and absorbs whatever width is left.
+ *
+ * This has to come from the schema because the DOM cannot tell the difference:
+ * every cell holds an ``<input>`` whose *intrinsic* width is the same ~20
+ * character UA default whatever its ``type`` is, so ``table-layout: auto`` on
+ * its own hands each column an equal share and truncates the one field that
+ * actually needed the room.
+ *
+ * @param {JsonSchemaNode} node A resolved scalar node.
+ * @returns {string}
+ */
+function columnKind(node) {
+  if (Array.isArray(node.enum)) return 'col-enum';
+  const type = effectiveType(node);
+  if (type === 'boolean') return 'col-bool';
+  if (type === 'integer' || type === 'number') return 'col-num';
+  return 'col-text';
+}
+
+/**
  * True when a resolved node is an object whose every property is scalar —
  * i.e. it can render as one table row.
  *
@@ -764,15 +789,19 @@ function buildTable(root, node, itemSchema, seed) {
   const properties = itemSchema.properties || {};
   const columnNames = Object.keys(properties);
   const required = new Set(itemSchema.required || []);
+  // Per-column width class, from the schema type (see `columnKind`). Computed
+  // once here rather than per row so every row's cells stay in step with the
+  // header they sit under.
+  const columnKinds = columnNames.map((name) => columnKind(resolveNode(root, properties[name])));
 
   const headRow = h(
     'tr',
     undefined,
-    ...columnNames.map((name) => {
+    ...columnNames.map((name, index) => {
       const prop = resolveNode(root, properties[name]);
       return h(
         'th',
-        { scope: 'col' },
+        { scope: 'col', class: columnKinds[index] },
         h('span', { text: prop.title || name }),
         required.has(name) ? h('span', { class: 'field-required', text: '*' }) : null
       );
@@ -789,14 +818,14 @@ function buildTable(root, node, itemSchema, seed) {
   function addRow(itemValue) {
     /** @type {Array<{name: string, collect: () => unknown}>} */
     const cells = [];
-    const tds = columnNames.map((name) => {
+    const tds = columnNames.map((name, index) => {
       const control = buildControl(
         root,
         properties[name],
         itemValue && typeof itemValue === 'object' ? itemValue[name] : undefined
       );
       cells.push({ name, collect: control.collect });
-      return h('td', undefined, control.el);
+      return h('td', { class: columnKinds[index] }, control.el);
     });
     const removeBtn = h('button', {
       type: 'button',

--- a/src/osprey/interfaces/web_terminal/static/css/sessions.css
+++ b/src/osprey/interfaces/web_terminal/static/css/sessions.css
@@ -24,18 +24,22 @@
   border-color: var(--border-accent);
 }
 
+/* Body-level and fixed. The picker button is adopted into dockview's tab strip
+ * (dock-tab.js), which is overflow:hidden and one bar tall AND carries a
+ * transform — that opens a stacking context, so an absolutely-positioned
+ * dropdown is both clipped away and pinned below the terminal content pane no
+ * matter how high its z-index. sessions.js appends this to <body> and sets
+ * left/top from the button's rect; everything here is appearance only. */
 .session-dropdown {
   display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
+  position: fixed;
+  z-index: var(--z-dropdown);
   min-width: 280px;
   max-height: 360px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-dropdown);
-  z-index: var(--z-dropdown);
   overflow: hidden;
 }
 

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -194,21 +194,6 @@
   color: var(--text-muted);
 }
 
-/* Rides the secondary accent: the shell's three always-visible orientation
-   marks — what this is (here), which session (.terminal-label), which panel
-   (.panel-rail-button.active) — share one color, distinct from the primary
-   accent that means "you can act here". --color-accent-secondary-light is the
-   text-safe slot of the pair (the base is decorative-only and is not gated
-   for body text). */
-.header-title {
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  font-weight: var(--weight-regular);
-  color: var(--color-accent-secondary-light);
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-}
-
 /* ---- Header action cluster (bordered chips, frame 2a) ---- */
 
 /* Any `.header-icon-btn` (base style in drawer.css) that lands in the header
@@ -1276,8 +1261,11 @@ html[data-rail-position="top"] .rail-hint {
   background: var(--color-success);
 }
 
-/* "SESSION <hex>" — the second of the shell's orientation marks (see
-   .header-title). */
+/* "SESSION <hex>" — one of the shell's two always-visible orientation marks;
+   the other is which panel is open (.panel-rail-button.active). Both ride the
+   secondary accent, distinct from the primary accent that means "you can act
+   here". --color-accent-secondary-light is the text-safe slot of the pair (the
+   base is decorative-only and is not gated for body text). */
 .terminal-label {
   font-family: var(--font-mono);
   font-size: var(--text-sm);

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -92,10 +92,9 @@
   <header class="header">
     <div class="header-left">
       <span class="header-logo">OSPREY</span>
-      <span class="header-title">Web Terminal</span>
       <!-- Deployment identity (web.app_name / OSPREY_WEB_APP_NAME) sits with the
            product name it qualifies, not in the action cluster: it says WHICH
-           deployment this is, which is the same kind of fact as "Web Terminal",
+           deployment this is, the same kind of fact as the product name itself,
            whereas everything on the right is something you can DO. It used to
            render as a second grey chip beside the user name, where the two read
            as a pair of unrelated badges. -->

--- a/src/osprey/interfaces/web_terminal/static/js/sessions.js
+++ b/src/osprey/interfaces/web_terminal/static/js/sessions.js
@@ -17,6 +17,13 @@ import { escapeHtml } from '/design-system/js/dom.js';
 let sessionsData = [];
 
 /**
+ * The one open dropdown, or null. Tracked at module scope because the node is
+ * body-level (see `openDropdown`) rather than a child of the picker container.
+ * @type {{ dropdown: HTMLElement, btn: HTMLElement, off: () => void } | null}
+ */
+let openPicker = null;
+
+/**
  * Initialize the session selector dropdown.
  * @param {string} containerId
  */
@@ -24,38 +31,114 @@ export function initSessionSelector(containerId) {
   const container = document.getElementById(containerId);
   if (!container) return;
 
-  // Build dropdown structure
+  // A re-init would orphan a body-level dropdown from the button it anchors to.
+  closeDropdown();
+
   container.innerHTML = `
-    <button class="session-picker-btn" id="session-picker-btn" title="Browse sessions">
+    <button class="session-picker-btn" id="session-picker-btn" title="Browse sessions"
+            aria-haspopup="menu" aria-expanded="false">
       <span class="session-picker-icon">&#9662;</span>
     </button>
-    <div class="session-dropdown" id="session-dropdown">
-      <div class="session-dropdown-header">Recent Sessions</div>
-      <div class="session-dropdown-list" id="session-dropdown-list"></div>
-    </div>
   `;
 
   const btn = /** @type {HTMLElement} */ (document.getElementById('session-picker-btn'));
-  const dropdown = /** @type {HTMLElement} */ (document.getElementById('session-dropdown'));
 
   btn.addEventListener('click', async (e) => {
     e.stopPropagation();
-    const isOpen = dropdown.classList.contains('open');
-    if (isOpen) {
-      dropdown.classList.remove('open');
-    } else {
-      await fetchSessions();
-      renderSessionList();
-      dropdown.classList.add('open');
+    if (openPicker) {
+      closeDropdown();
+      return;
     }
+    await fetchSessions();
+    openDropdown(btn);
   });
+}
 
-  // Close on outside click
-  document.addEventListener('click', (e) => {
-    if (!container.contains(/** @type {Node} */ (e.target))) {
-      dropdown.classList.remove('open');
-    }
-  });
+/* ---- dropdown popover ----
+ * Appended to document.body rather than inside the picker: dock-tab.js adopts
+ * the live `.terminal-header` into dockview's tab strip, and that strip is both
+ * `overflow: hidden` (one bar tall) and `transform: translate3d(...)`. The
+ * transform opens a stacking context, so an in-place dropdown is clipped away
+ * AND its z-index is trapped below the sibling content pane -- it rendered
+ * behind the terminal. Body-level + `position: fixed` + JS placement escapes
+ * both, matching `.contrib-menu-popover` in tile-header-items.js. */
+
+/**
+ * Build, mount, fill and pin the dropdown, and register it as THE open picker.
+ * @param {HTMLElement} btn
+ */
+function openDropdown(btn) {
+  closeDropdown();
+
+  const dropdown = document.createElement('div');
+  dropdown.className = 'session-dropdown';
+  dropdown.id = 'session-dropdown';
+  dropdown.setAttribute('role', 'menu');
+  dropdown.innerHTML = `
+    <div class="session-dropdown-header">Recent Sessions</div>
+    <div class="session-dropdown-list" id="session-dropdown-list"></div>
+  `;
+  document.body.appendChild(dropdown);
+
+  const onDown = (/** @type {Event} */ e) => {
+    const t = e.target;
+    if (t instanceof Node && (dropdown.contains(t) || btn.contains(t))) return;
+    closeDropdown();
+  };
+  const onKey = (/** @type {KeyboardEvent} */ e) => {
+    if (e.key === 'Escape') closeDropdown();
+  };
+  // Close on reflow rather than running a reposition loop: the anchor lives in
+  // a scrollable tab strip, so a stale popover would drift off its button.
+  const onReflow = () => closeDropdown();
+  document.addEventListener('pointerdown', onDown, true);
+  document.addEventListener('keydown', onKey, true);
+  window.addEventListener('resize', onReflow);
+  window.addEventListener('scroll', onReflow, true);
+
+  openPicker = {
+    dropdown,
+    btn,
+    off: () => {
+      document.removeEventListener('pointerdown', onDown, true);
+      document.removeEventListener('keydown', onKey, true);
+      window.removeEventListener('resize', onReflow);
+      window.removeEventListener('scroll', onReflow, true);
+    },
+  };
+
+  renderSessionList();
+  // `.open` before placing: the node must be laid out for offsetWidth/Height.
+  dropdown.classList.add('open');
+  place(dropdown, btn);
+  btn.setAttribute('aria-expanded', 'true');
+}
+
+/** Tear down the open dropdown, if any. */
+function closeDropdown() {
+  if (!openPicker) return;
+  openPicker.off();
+  openPicker.dropdown.remove();
+  openPicker.btn.setAttribute('aria-expanded', 'false');
+  openPicker = null;
+}
+
+/**
+ * Pin the dropdown under the button, left edges aligned, clamped to the
+ * viewport so a picker near the right or bottom edge still shows a full list.
+ * @param {HTMLElement} dropdown
+ * @param {HTMLElement} btn
+ */
+function place(dropdown, btn) {
+  const r = btn.getBoundingClientRect();
+  const w = dropdown.offsetWidth;
+  const h = dropdown.offsetHeight;
+  const margin = 6;
+  const left = Math.max(margin, Math.min(r.left, window.innerWidth - w - margin));
+  let top = r.bottom + margin;
+  if (top + h > window.innerHeight - margin) top = Math.max(margin, r.top - h - margin);
+  dropdown.style.left = `${Math.round(left)}px`;
+  dropdown.style.top = `${Math.round(top)}px`;
 }
 
 /**
@@ -111,7 +194,7 @@ function renderSessionList() {
   items.forEach(el => {
     el.addEventListener('click', () => {
       const id = /** @type {string} */ (el.dataset.sessionId);
-      /** @type {HTMLElement} */ (document.getElementById('session-dropdown')).classList.remove('open');
+      closeDropdown();
       resumeSession(id);
     });
   });

--- a/src/osprey/services/bluesky_bridge/figure.py
+++ b/src/osprey/services/bluesky_bridge/figure.py
@@ -227,6 +227,22 @@ class Panel(_FigureNode):
     mark: Mark
     """Exactly one mark. A panel showing two things is two panels."""
 
+    section: str | None = None
+    """Groups this panel with every other panel carrying the same string into
+    one collapsed disclosure below the unsectioned panels, in first-appearance
+    order. ``None`` -- the default, and what every other plan emits -- renders
+    the panel inline, exactly as before this field existed.
+
+    A section holding more than one panel shows *one at a time*, behind a
+    picker: sections exist for detail a reader consults about a chosen device,
+    not for a wall of plots to scroll past."""
+
+    series_picker: bool = False
+    """Whether the reader may choose which of this panel's series are drawn.
+    Only meaningful for a `LinesMark` with labelled series. The panel ships
+    every series either way -- the picker filters what is *drawn*, so toggling
+    it costs no fetch."""
+
 
 class Figure(_FigureNode):
     """A complete plan view: the payload of `GET /runs/{run_id}/figure`.

--- a/src/osprey/services/bluesky_bridge/orm_analysis.py
+++ b/src/osprey/services/bluesky_bridge/orm_analysis.py
@@ -478,6 +478,29 @@ def row_anomaly(matrix: np.ndarray) -> np.ndarray:
     return scores
 
 
+def singular_values(matrix: np.ndarray) -> np.ndarray:
+    """The response matrix's singular value spectrum, largest first.
+
+    The conventional companion to the matrix itself: how fast the spectrum
+    falls says how many independent correction modes the measured machine
+    actually supports, and where the tail flattens is the noise floor an
+    orbit correction would truncate at. A separable (rank-1) matrix collapses
+    to a single significant value; genuine independent structure lifts the
+    ones behind it.
+
+    Returns an empty array rather than raising when there is nothing to
+    decompose -- no correctors or BPMs yet, or a matrix still carrying
+    non-finite cells from a partly-fitted live run. `numpy.linalg.svd` raises
+    on both, and a figure is a view: a spectrum that cannot be computed must
+    cost its own panel, not the whole figure.
+    """
+    matrix = np.asarray(matrix, dtype=float)
+    if matrix.ndim != 2 or matrix.size == 0 or not np.all(np.isfinite(matrix)):
+        return np.zeros(0)
+
+    return np.linalg.svd(matrix, compute_uv=False)
+
+
 def _peer_score(vector: np.ndarray, reference: np.ndarray) -> float:
     """Combined norm-ratio + anti-correlation score of *vector* vs *reference*."""
     vector_norm = float(np.linalg.norm(vector))

--- a/src/osprey/services/bluesky_bridge/plans_core/orm.py
+++ b/src/osprey/services/bluesky_bridge/plans_core/orm.py
@@ -39,6 +39,7 @@ from osprey.services.bluesky_bridge.orm_analysis import (
     SlicedResponseFit,
     column_anomaly,
     row_anomaly,
+    singular_values,
     sliced_response_matrix,
 )
 
@@ -197,6 +198,15 @@ _MAX_TRACE_SERIES = 12
 N largest: series identity has to stay stable from tick to tick, and a
 "largest" selection would swap lines in and out as the sweep fills in."""
 
+_SWEEPS_SECTION = "Per-corrector sweeps"
+"""Section holding the raw sweep traces. They are the run's evidence rather
+than its finding, so once there is a finding to lead with they move below it
+and the reader picks the corrector they want."""
+
+_SPECTRUM_SECTION = "Singular values"
+"""Section holding the singular value spectrum -- a second opinion on the
+matrix above, consulted rather than scanned."""
+
 
 def _sweep_series(fit: SlicedResponseFit, index: int) -> tuple[list[Series], bool, int, int]:
     """Corrector *index*'s BPM traces: series, decimated, points, samples drawn.
@@ -223,7 +233,13 @@ def _sweep_series(fit: SlicedResponseFit, index: int) -> tuple[list[Series], boo
     return series, decimated, source_points, len(kept)
 
 
-def _trace_panels(fit: SlicedResponseFit, num: int, lead_annotations: list[str]) -> list[Panel]:
+def _trace_panels(
+    fit: SlicedResponseFit,
+    num: int,
+    lead_annotations: list[str],
+    *,
+    section: str | None,
+) -> list[Panel]:
     """One panel per traced corrector: BPM readings against that corrector's current.
 
     A corrector that has recorded no current yet -- the sweep has not reached
@@ -274,10 +290,111 @@ def _trace_panels(fit: SlicedResponseFit, num: int, lead_annotations: list[str])
                 x_units="A",
                 y_label="BPM reading",
                 annotations=annotations,
+                section=section,
                 mark=LinesMark(series=series, decimated=decimated, source_points=source_points),
             )
         )
     return panels
+
+
+def _response_by_bpm_panel(fit: SlicedResponseFit) -> Panel:
+    """The matrix read column-wise: each corrector's response across the BPMs.
+
+    The same numbers as the heatmap in the encoding that makes a *shape*
+    legible -- the sign oscillation of betatron phase advance, a flat line for
+    a dead corrector, a spike every trace shares for a dead BPM. Every fitted
+    corrector ships as its own series and the reader picks which are drawn, so
+    changing the comparison costs no fetch.
+
+    The BPM axis is the requested detector order, which is not `s` order: the
+    plan is device-agnostic and carries no lattice positions, so the panel says
+    so rather than implying a geometry it cannot know.
+    """
+    series = [
+        Series(
+            label=corrector,
+            points=[
+                Point(
+                    x=float(i + 1),
+                    y=(float(cell) if math.isfinite(float(cell)) else None),
+                )
+                for i, cell in enumerate(row[j] for row in fit.matrix)
+            ],
+            source_points=len(fit.detectors),
+        )
+        for j, corrector in enumerate(fit.fitted_correctors)
+    ]
+
+    return Panel(
+        title="Response by BPM",
+        x_label="BPM index",
+        y_label="Response slope",
+        y_units="BPM units / A",
+        annotations=[
+            "Each line is one corrector's column of the matrix above. The "
+            "oscillation in sign is betatron phase advance; a flat line is a "
+            "corrector with no measured response.",
+            "BPMs are in the order they were requested, which is not their "
+            "order around the ring -- this plan carries no lattice positions.",
+        ],
+        series_picker=True,
+        mark=LinesMark(series=series, source_points=len(fit.detectors) * len(series)),
+    )
+
+
+def _spectrum_panel(fit: SlicedResponseFit) -> Panel | None:
+    """The singular value spectrum, or `None` when there is nothing to decompose.
+
+    Plotted as log10 because a spectrum's whole shape is its decades of
+    fall-off, and the renderer draws linear axes only -- taking the log here is
+    honest about the transform in the axis label, where a linear plot of the
+    same values would simply hide every mode below the first.
+
+    Values at or below the numerical-rank tolerance become gaps rather than
+    points. A rank-deficient matrix does not decompose to exact zeros: it
+    leaves floating-point residue around 1e-16 of the largest value, and
+    `log10` of *that* is a -16 that stretches the axis over sixteen decades and
+    squashes every real mode into a sliver. The threshold is the standard
+    numerical-rank one (`numpy.linalg.matrix_rank`'s): below it a value is an
+    artefact of the decomposition, not a measured mode.
+    """
+    values = singular_values(fit.matrix)
+    if values.size == 0:
+        return None
+
+    # `math.ulp(1.0)` IS the machine epsilon `sys.float_info.epsilon` reports,
+    # reached through the one module the plan validator's import allowlist
+    # permits here -- a plan file may not import `sys`.
+    rows, columns = fit.matrix.shape
+    tolerance = float(values[0]) * max(rows, columns) * math.ulp(1.0)
+
+    return Panel(
+        title="Singular values",
+        x_label="Singular value index",
+        y_label="log10 singular value",
+        annotations=[
+            "How many independent correction modes the measured machine "
+            "supports: where this curve flattens is the noise floor an orbit "
+            "correction would truncate at.",
+        ],
+        section=_SPECTRUM_SECTION,
+        mark=LinesMark(
+            series=[
+                Series(
+                    label="Singular value",
+                    points=[
+                        Point(
+                            x=float(index + 1),
+                            y=(math.log10(value) if value > tolerance else None),
+                        )
+                        for index, value in enumerate(float(v) for v in values)
+                    ],
+                    source_points=int(values.size),
+                )
+            ],
+            source_points=int(values.size),
+        ),
+    )
 
 
 def _fit_panels(fit: SlicedResponseFit) -> list[Panel]:
@@ -302,7 +419,12 @@ def _fit_panels(fit: SlicedResponseFit) -> list[Panel]:
             title="Response matrix",
             x_label="Corrector",
             y_label="BPM",
-            annotations=matrix_note,
+            annotations=[
+                *matrix_note,
+                "Colour is signed: one hue each side of zero, scaled "
+                "symmetrically, so an unresponsive BPM reads as background "
+                "rather than as a mid-scale response.",
+            ],
             mark=HeatmapMark(
                 x_labels=list(fit.fitted_correctors),
                 y_labels=list(fit.detectors),
@@ -312,6 +434,7 @@ def _fit_panels(fit: SlicedResponseFit) -> list[Panel]:
                 source_points=int(fit.matrix.size),
             ),
         ),
+        _response_by_bpm_panel(fit),
         Panel(
             title="Corrector anomaly score",
             x_label="Corrector",
@@ -362,9 +485,30 @@ def _build(rows: list[dict[str, Any]], params: PARAMS, *, with_fit: bool) -> Fig
             "an anomaly score compares each corrector against its peers."
         )
 
-    panels = _trace_panels(fit, params.num, lead_annotations)
+    # The finding leads and the evidence follows, collapsed. But a section is a
+    # demotion, and there is nothing to demote beneath when the fit was skipped:
+    # with no fitted panels the sweeps ARE the figure, so they stay inline --
+    # which is also what keeps the capped-run warning above the fold, on the
+    # first panel the reader actually sees.
+    #
+    # `lead_annotations` is only ever non-empty when `capped`, and a capped run
+    # has no fitted panels -- so the cap warning always lands on an inline sweep
+    # panel, never inside a collapsed section.
+    fitted: list[Panel] = []
     if with_fit and not capped and fit.fitted_correctors:
-        panels.extend(_fit_panels(fit))
+        fitted.extend(_fit_panels(fit))
+        spectrum = _spectrum_panel(fit)
+        if spectrum is not None:
+            fitted.append(spectrum)
+
+    sweeps = _trace_panels(
+        fit,
+        params.num,
+        lead_annotations,
+        section=_SWEEPS_SECTION if fitted else None,
+    )
+
+    panels = [*fitted, *sweeps]
 
     # Placeholders: the figure route stamps the truth onto both on every path.
     # A render sees rows, never their provenance, so `partial=True` is the

--- a/tests/e2e/test_orm_roundtrip.py
+++ b/tests/e2e/test_orm_roundtrip.py
@@ -596,13 +596,15 @@ def test_orm_roundtrip_matches_model_with_no_corrector_hang(
     )
 
     # Panel order is part of the wire contract the JS renderer and the MCP
-    # projection both read: every swept corrector's traces, in sweep order,
-    # then the fit.
+    # projection both read: the fit leads, then every swept corrector's traces
+    # in sweep order, demoted below it into their own section.
     assert [panel["title"] for panel in settled["panels"]] == [
-        *sweep_titles,
         "Response matrix",
+        "Response by BPM",
         "Corrector anomaly score",
         "BPM anomaly score",
+        "Singular values",
+        *sweep_titles,
     ], f"unexpected panels on the settled figure: {_figure_summary(settled)}"
 
     # THE point of the oversized run: a full sweep on every panel. Read through

--- a/tests/e2e/test_orm_roundtrip.py
+++ b/tests/e2e/test_orm_roundtrip.py
@@ -390,8 +390,19 @@ def _panel(figure: dict[str, Any], title: str) -> dict[str, Any]:
 
 
 def _sweep_panels(figure: dict[str, Any]) -> list[dict[str, Any]]:
-    """The corrector-sweep trace panels -- every panel drawn as lines."""
-    return [panel for panel in figure["panels"] if panel["mark"]["kind"] == "lines"]
+    """The corrector-sweep trace panels.
+
+    Keyed on the per-corrector title the plan builds (``f"{name} sweep"``) and
+    not on the lines mark alone: the fit draws its own lines panel, "Response
+    by BPM", whose series are correctors rather than BPMs. Matching every lines
+    panel would sweep that one into the per-sweep assertions below, where it
+    fails on a contract it was never meant to satisfy.
+    """
+    return [
+        panel
+        for panel in figure["panels"]
+        if panel["mark"]["kind"] == "lines" and panel["title"].endswith(" sweep")
+    ]
 
 
 def _is_number(value: Any) -> bool:

--- a/tests/interfaces/bluesky_panels/figure-renderer.test.mjs
+++ b/tests/interfaces/bluesky_panels/figure-renderer.test.mjs
@@ -27,6 +27,7 @@ import {
   barGeometry,
   categoryTicks,
   decimationAnnotations,
+  divergingScale,
   figureNoteText,
   formatTickValue,
   gapAnnotations,
@@ -46,6 +47,11 @@ import {
   shownPointCount,
   splitSegments,
 } from '../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js';
+import {
+  groupPanels,
+  resolveSectionSelection,
+  resolveSeriesSelection,
+} from '../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-controls.js';
 
 /** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').FigurePoint} FigurePoint */
 /** @typedef {import('../../../src/osprey/interfaces/bluesky_panels/panels/bluesky/figure-renderer.js').FigureSeries} FigureSeries */
@@ -138,7 +144,7 @@ function barsMark(categories, values, extra = {}) {
 
 /**
  * @param {FigureMark} mark
- * @param {{title?: string, x_label?: string, y_label?: string, x_units?: string|null, y_units?: string|null, annotations?: string[]}} [extra]
+ * @param {{title?: string, x_label?: string, y_label?: string, x_units?: string|null, y_units?: string|null, annotations?: string[], section?: string|null, series_picker?: boolean}} [extra]
  * @returns {FigurePanel}
  */
 function panel(mark, extra = {}) {
@@ -150,6 +156,8 @@ function panel(mark, extra = {}) {
     y_units: extra.y_units ?? null,
     annotations: extra.annotations ?? [],
     mark,
+    section: extra.section ?? null,
+    series_picker: extra.series_picker ?? false,
   };
 }
 
@@ -375,6 +383,71 @@ describe('tick formatting and placement', () => {
   });
 });
 
+describe('panel grouping and selection', () => {
+  /**
+   * @param {string} title
+   * @param {string|null} [section]
+   */
+  const p = (title, section = null) =>
+    panel(linesMark([series('a', [[0, 1]])]), { title, section });
+
+  test('sections gather in first-appearance order, inline panels keep theirs', () => {
+    const grouped = groupPanels([
+      p('Matrix'),
+      p('Response by BPM'),
+      p('Spectrum', 'Singular values'),
+      p('c1 sweep', 'Sweeps'),
+      p('c2 sweep', 'Sweeps'),
+    ]);
+
+    expect(grouped.inline.map((panel) => panel.title)).toEqual(['Matrix', 'Response by BPM']);
+    expect(grouped.sections.map((group) => group.name)).toEqual(['Singular values', 'Sweeps']);
+    expect(grouped.sections[1].panels.map((panel) => panel.title)).toEqual([
+      'c1 sweep',
+      'c2 sweep',
+    ]);
+  });
+
+  test('a figure with no sections groups exactly as it always did', () => {
+    const grouped = groupPanels([p('one'), p('two')]);
+    expect(grouped.inline).toHaveLength(2);
+    expect(grouped.sections).toEqual([]);
+  });
+
+  test('a stored series selection is kept, minus anything no longer present', () => {
+    // A live run drops correctors past the payload cap; the selection must
+    // survive with what remains rather than resetting wholesale.
+    expect(resolveSeriesSelection(['c1', 'c9'], ['c1', 'c2', 'c3'])).toEqual(['c1']);
+  });
+
+  test('a selection with nothing left falls back to the default, never to empty', () => {
+    // An empty plot reads as "no data", which would be a lie about the run.
+    expect(resolveSeriesSelection(['gone'], ['c1', 'c2', 'c3', 'c4'])).toEqual([
+      'c1',
+      'c2',
+      'c3',
+    ]);
+    expect(resolveSeriesSelection(undefined, ['c1', 'c2'])).toEqual(['c1', 'c2']);
+    expect(resolveSeriesSelection(undefined, [])).toEqual([]);
+  });
+
+  test('a stored section choice survives only while its panel does', () => {
+    expect(resolveSectionSelection('c2 sweep', ['c1 sweep', 'c2 sweep'])).toBe('c2 sweep');
+    expect(resolveSectionSelection('gone', ['c1 sweep', 'c2 sweep'])).toBe('c1 sweep');
+    expect(resolveSectionSelection(undefined, [])).toBe('');
+  });
+});
+
+/**
+ * `divergingScale` for values known to hold a reading, typed as non-null.
+ * @param {Array<Array<number|null>>} values
+ */
+function scaleOf(values) {
+  const scale = divergingScale(values);
+  if (scale === null) throw new Error('expected a scale');
+  return scale;
+}
+
 describe('heatmap geometry', () => {
   const mark = heatmapMark(
     ['x0', 'x1', 'x2'],
@@ -394,6 +467,42 @@ describe('heatmap geometry', () => {
       rows: 3,
       cols: 2,
     });
+  });
+
+  test('the diverging scale anchors zero and takes a symmetric limit', () => {
+    // A signed matrix: an ORM's cells are responses either side of zero.
+    const scale = scaleOf([
+      [-4, 2],
+      [1, 3],
+    ]);
+
+    // The limit is max|value|, NOT the raw extent — so equal magnitudes of
+    // opposite sign are equally salient, and two runs stay comparable.
+    expect(scale.limit).toBe(4);
+
+    // Zero is the plot background, so an unresponsive BPM reads as dead
+    // rather than as the mid-tone a min→max ramp would give it.
+    expect(scale.opacityFor(0)).toBe(0);
+
+    // Equal magnitudes, opposite signs: same weight, different hue.
+    expect(scale.opacityFor(-4)).toBe(scale.opacityFor(4));
+    expect(scale.isNegative(-4)).toBe(true);
+    expect(scale.isNegative(4)).toBe(false);
+
+    // Magnitude scales linearly against the limit.
+    expect(scale.opacityFor(2)).toBeCloseTo(0.5, 10);
+    expect(scale.opacityFor(-2)).toBeCloseTo(0.5, 10);
+  });
+
+  test('an all-zero matrix paints nothing rather than inventing contrast', () => {
+    const scale = scaleOf([[0, 0]]);
+    expect(scale.limit).toBe(0);
+    expect(scale.opacityFor(0)).toBe(0);
+  });
+
+  test('the diverging scale is null when no cell holds a reading', () => {
+    expect(divergingScale([[null, null]])).toBeNull();
+    expect(divergingScale([])).toBeNull();
   });
 
   test('the extent ignores cells with no reading', () => {
@@ -634,6 +743,23 @@ function mount() {
 const textsOf = (root, selector) =>
   Array.from(root.querySelectorAll(selector)).map((node) => node.textContent ?? '');
 
+/**
+ * The figure's one section disclosure, typed as one.
+ * @param {Element} root
+ * @returns {HTMLDetailsElement}
+ */
+function disclosure(root) {
+  const found = root.querySelector('details.figure-section');
+  if (found === null) throw new Error('no section disclosure rendered');
+  return /** @type {HTMLDetailsElement} */ (found);
+}
+
+/** @param {Element|undefined} target */
+function click(target) {
+  if (!target) throw new Error('nothing to click');
+  target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
 describe('renderFigure', () => {
   beforeEach(() => {
     applyTheme(LIGHT);
@@ -730,27 +856,191 @@ describe('renderFigure', () => {
         ])
       );
 
+      // Six slots, six rects: five readings plus the one with no reading,
+      // which is HATCHED rather than skipped — left unpainted it would be
+      // plot background, and background is what a zero reading now looks like.
       const cells = elements.panels.querySelectorAll('rect.figure-cell');
-      expect(cells, name).toHaveLength(5); // six slots, one with no reading
+      expect(cells, name).toHaveLength(6);
+      const missing = elements.panels.querySelectorAll('rect.figure-cell-missing');
+      expect(missing, name).toHaveLength(1);
+      expect(missing[0].getAttribute('fill'), name).toMatch(/^url\(#figure-hatch-/);
+
+      // All readings here are positive, so all take the positive hue.
       expect(cells[0].getAttribute('fill'), name).toBe(tokens['--chart-series-1']);
 
-      // Opacity carries the value: the smallest reading is the faintest.
-      const opacities = Array.from(cells).map((cell) =>
-        Number(cell.getAttribute('fill-opacity'))
-      );
+      // Opacity carries the magnitude: the smallest reading is the faintest.
+      const opacities = Array.from(cells)
+        .filter((cell) => cell.hasAttribute('fill-opacity'))
+        .map((cell) => Number(cell.getAttribute('fill-opacity')));
       expect(opacities[0], name).toBeLessThan(opacities[opacities.length - 1]);
 
       // Both label lists are rendered, and only from the mark's own labels.
       const ticks = textsOf(elements.panels, 'text.figure-tick');
       expect(ticks, name).toEqual(expect.arrayContaining(['ch1', 'ch2', 'ch3', 'bpm1', 'bpm2']));
-      expect(textsOf(elements.panels, 'ul.figure-legend li'), name).toEqual([
-        'response (mm/A)',
-      ]);
+
+      // A heatmap gets a colorbar carrying its numbers, not a flat legend chip.
+      expect(elements.panels.querySelectorAll('ul.figure-legend'), name).toHaveLength(0);
+      expect(
+        elements.panels.querySelector('.figure-colorbar-label')?.textContent,
+        name
+      ).toBe('response (mm/A)');
+      expect(textsOf(elements.panels, '.figure-colorbar-tick'), name).toEqual(['-6', '6', '0']);
       expect(
         elements.panels.querySelector('section.figure-panel')?.getAttribute('data-mark'),
         name
       ).toBe('heatmap');
     }
+  });
+
+  test('a negative reading takes the other hue, and zero is left as background', () => {
+    applyTheme(LIGHT);
+    const elements = mount();
+    renderFigure(
+      elements,
+      figure([
+        panel(
+          heatmapMark(
+            ['c1', 'c2'],
+            ['b1'],
+            [[-5, 0]],
+            { value_label: 'slope', value_units: 'mm/A' }
+          )
+        ),
+      ])
+    );
+
+    const cells = elements.panels.querySelectorAll('rect.figure-cell');
+    // Negative → the second palette slot, at full weight (it IS the limit).
+    expect(cells[0].getAttribute('fill')).toBe(LIGHT['--chart-series-2']);
+    expect(Number(cells[0].getAttribute('fill-opacity'))).toBe(1);
+    // Zero → painted at opacity 0, which is the plot background.
+    expect(Number(cells[1].getAttribute('fill-opacity'))).toBe(0);
+  });
+
+  test('a cell with no reading says so on hover, rather than reading as a zero', () => {
+    const elements = mount();
+    renderFigure(elements, figure([panel(heatmapMark(['x0'], ['y0'], [[null]]))]));
+    // Nothing is plottable, so the panel says that rather than drawing a grid.
+    expect(elements.panels.querySelector('.figure-empty')).not.toBeNull();
+
+    const mixed = mount();
+    renderFigure(mixed, figure([panel(heatmapMark(['x0', 'x1'], ['y0'], [[1, null]]))]));
+    expect(
+      mixed.panels.querySelector('rect.figure-cell-missing title')?.textContent
+    ).toBe('No reading');
+  });
+
+  test('a series picker filters what is drawn and remembers the choice across a redraw', () => {
+    const elements = mount();
+    const selection = {};
+    const fig = figure([
+      panel(
+        linesMark([
+          series('c1', [[0, 1]]),
+          series('c2', [[0, 2]]),
+          series('c3', [[0, 3]]),
+          series('c4', [[0, 4]]),
+        ]),
+        { title: 'Response by BPM', series_picker: true }
+      ),
+    ]);
+
+    renderFigure(elements, fig, { selection });
+
+    // Default: the first three of four, so the panel opens on something.
+    const chips = elements.panels.querySelectorAll('button.figure-chip');
+    expect(Array.from(chips).map((chip) => chip.textContent)).toEqual(['c1', 'c2', 'c3', 'c4']);
+    expect(textsOf(elements.panels, 'ul.figure-legend li')).toEqual(['c1', 'c2', 'c3']);
+
+    // Turning c4 on redraws with four lines...
+    chips[3].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(textsOf(elements.panels, 'ul.figure-legend li')).toEqual(['c1', 'c2', 'c3', 'c4']);
+
+    // ...and the choice survives the ~1s poll redrawing the whole subtree,
+    // which is the bug this state exists to prevent.
+    renderFigure(elements, fig, { selection });
+    expect(textsOf(elements.panels, 'ul.figure-legend li')).toEqual(['c1', 'c2', 'c3', 'c4']);
+  });
+
+  test('a series picker refuses to empty the plot', () => {
+    const elements = mount();
+    const selection = { series: { P: ['c1'] } };
+    const fig = figure([
+      panel(linesMark([series('c1', [[0, 1]]), series('c2', [[0, 2]])]), {
+        title: 'P',
+        series_picker: true,
+      }),
+    ]);
+    renderFigure(elements, fig, { selection });
+    expect(textsOf(elements.panels, 'ul.figure-legend li')).toEqual(['c1']);
+
+    // Clicking the only selected chip would leave nothing drawn.
+    click(elements.panels.querySelectorAll('button.figure-chip')[0]);
+    expect(textsOf(elements.panels, 'ul.figure-legend li')).toEqual(['c1']);
+  });
+
+  test('sectioned panels render closed, below the inline ones, one at a time', () => {
+    const elements = mount();
+    const selection = {};
+    const fig = figure([
+      panel(heatmapMark(['c1'], ['b1'], [[1]]), { title: 'Response matrix' }),
+      panel(linesMark([series('b1', [[0, 1]])]), { title: 'c1 sweep', section: 'Sweeps' }),
+      panel(linesMark([series('b1', [[0, 2]])]), { title: 'c2 sweep', section: 'Sweeps' }),
+    ]);
+
+    renderFigure(elements, fig, { selection });
+
+    // The inline finding comes first; the evidence is a closed disclosure.
+    const details = disclosure(elements.panels);
+    expect(details.open).toBe(false);
+    const inline = /** @type {Element} */ (
+      elements.panels.querySelector('section.figure-panel')
+    );
+    expect(details.compareDocumentPosition(inline)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
+    expect(elements.panels.querySelector('.figure-section-count')?.textContent).toBe('2 panels');
+
+    // One panel at a time, chosen by the picker.
+    expect(textsOf(details, 'h4.figure-panel-title')).toEqual(['c1 sweep']);
+
+    click(details.querySelectorAll('button.figure-chip')[1]);
+    expect(textsOf(elements.panels, 'h4.figure-panel-title')).toContain('c2 sweep');
+    expect(textsOf(elements.panels, 'h4.figure-panel-title')).not.toContain('c1 sweep');
+  });
+
+  test('an opened section stays open across a redraw', () => {
+    const elements = mount();
+    const selection = {};
+    const fig = figure([
+      panel(heatmapMark(['c1'], ['b1'], [[1]]), { title: 'Response matrix' }),
+      panel(linesMark([series('b1', [[0, 1]])]), { title: 'c1 sweep', section: 'Sweeps' }),
+    ]);
+
+    renderFigure(elements, fig, { selection });
+    const details = disclosure(elements.panels);
+    expect(details.open).toBe(false);
+
+    // happy-dom does not fire `toggle` for a property set, so drive the event
+    // the way a real disclosure click does.
+    details.open = true;
+    details.dispatchEvent(new Event('toggle'));
+
+    renderFigure(elements, fig, { selection });
+    expect(disclosure(elements.panels).open).toBe(true);
+  });
+
+  test('a figure with no sections renders exactly as it did before sections existed', () => {
+    const elements = mount();
+    renderFigure(
+      elements,
+      figure([
+        panel(linesMark([series('a', [[0, 1]])]), { title: 'one' }),
+        panel(linesMark([series('b', [[0, 2]])]), { title: 'two' }),
+      ])
+    );
+
+    expect(elements.panels.querySelectorAll('details.figure-section')).toHaveLength(0);
+    expect(elements.panels.querySelectorAll('.figure-picker')).toHaveLength(0);
+    expect(textsOf(elements.panels, 'h4.figure-panel-title')).toEqual(['one', 'two']);
   });
 
   test('heatmap cells carry their value as hover text', () => {

--- a/tests/interfaces/bluesky_panels/schema-form.test.mjs
+++ b/tests/interfaces/bluesky_panels/schema-form.test.mjs
@@ -338,6 +338,50 @@ describe('grid_scan schema (axes table + toggle)', () => {
     expect(check.checked).toBe(false);
   });
 
+  test('classes each column by its schema type so widths are not shared evenly', () => {
+    renderSchemaForm(form, GRID_SCAN_SCHEMA);
+    const table = $(form, '.obj-table');
+
+    // Every cell holds an <input>, and an input's intrinsic width is the same
+    // ~20-character UA default whatever its type — so `table-layout: auto`
+    // alone splits the table evenly and truncates the PV name next to a
+    // two-digit point count. The schema already knows which columns are
+    // bounded (numbers) and which are free text, so the renderer tags them
+    // and the stylesheet sizes them accordingly.
+    const headCols = $$(table, 'thead th:not(.th-x)').map((th) => th.className);
+    expect(headCols).toEqual(['col-text', 'col-num', 'col-num', 'col-num']);
+
+    const bodyCols = $$(table, 'tbody tr:first-child td:not(.td-x)').map((td) => td.className);
+    expect(bodyCols).toEqual(['col-text', 'col-num', 'col-num', 'col-num']);
+  });
+
+  test('bounded non-numeric columns (boolean, enum) shrink too', () => {
+    // buildTable is generic over any array-of-flat-objects, so the rule is
+    // "bounded content shrinks, free text absorbs" — not "numbers shrink".
+    renderSchemaForm(form, {
+      type: 'object',
+      properties: {
+        rows: {
+          type: 'array',
+          minItems: 1,
+          title: 'Rows',
+          items: {
+            type: 'object',
+            properties: {
+              label: { type: 'string', title: 'Label' },
+              mode: { type: 'string', enum: ['fast', 'slow'], title: 'Mode' },
+              active: { type: 'boolean', title: 'Active' },
+            },
+          },
+        },
+      },
+    });
+
+    const table = $(form, '.obj-table');
+    const headCols = $$(table, 'thead th:not(.th-x)').map((th) => th.className);
+    expect(headCols).toEqual(['col-text', 'col-enum', 'col-bool']);
+  });
+
   test('collects detectors + nested axes rows + toggled snake_axes', () => {
     const collect = renderSchemaForm(form, GRID_SCAN_SCHEMA);
 

--- a/tests/interfaces/web_terminal/sessions.test.mjs
+++ b/tests/interfaces/web_terminal/sessions.test.mjs
@@ -86,16 +86,107 @@ afterEach(() => {
 });
 
 describe('initSessionSelector: dropdown shell', () => {
-  test('builds the picker button and dropdown structure inside the container', () => {
+  test('builds the picker button in the container, with no dropdown until it is opened', () => {
     sessions.initSessionSelector('session-selector');
 
     const container = /** @type {HTMLElement} */ (document.getElementById('session-selector'));
     expect(container.querySelector('#session-picker-btn')).not.toBeNull();
-    const dropdown = container.querySelector('#session-dropdown');
+    // The dropdown is built on demand, so nothing exists while closed.
+    expect(document.getElementById('session-dropdown')).toBeNull();
+    expect(container.getAttribute('aria-expanded')).toBeNull();
+    expect(
+      /** @type {HTMLElement} */ (container.querySelector('#session-picker-btn')).getAttribute(
+        'aria-expanded'
+      )
+    ).toBe('false');
+  });
+});
+
+/**
+ * The picker button is adopted into dockview's tab strip (dock-tab.js relocates
+ * the live `.terminal-header` there). That strip is `overflow: hidden` AND
+ * `transform: translate3d(...)`, which both clips an in-place dropdown and traps
+ * its `z-index` in a stacking context that paints under the terminal content
+ * pane -- the dropdown rendered *behind* the terminal. The dropdown therefore
+ * mounts at body level and is positioned from JS, matching `.contrib-menu-popover`.
+ */
+describe('dropdown portal: escaping the dockview tab strip', () => {
+  test('mounts the dropdown as a direct child of <body>, not inside the picker container', async () => {
+    stubSessions(RECORDS);
+    sessions.initSessionSelector('session-selector');
+    await openPicker();
+
+    const dropdown = /** @type {HTMLElement} */ (document.getElementById('session-dropdown'));
     expect(dropdown).not.toBeNull();
-    expect(container.querySelector('#session-dropdown-list')).not.toBeNull();
-    // Closed until the picker is opened.
-    expect(/** @type {Element} */ (dropdown).classList.contains('open')).toBe(false);
+    expect(dropdown.parentElement).toBe(document.body);
+
+    // Nothing of the dropdown is left inside the (clipped, transformed) container.
+    const container = /** @type {HTMLElement} */ (document.getElementById('session-selector'));
+    expect(container.querySelector('#session-dropdown')).toBeNull();
+    expect(container.querySelector('.session-dropdown')).toBeNull();
+    // The list still resolves globally, so rendering is unaffected.
+    expect(document.getElementById('session-dropdown-list')).not.toBeNull();
+  });
+
+  test('pins the dropdown with JS-computed viewport coordinates', async () => {
+    stubSessions(RECORDS);
+    sessions.initSessionSelector('session-selector');
+    await openPicker();
+
+    const dropdown = /** @type {HTMLElement} */ (document.getElementById('session-dropdown'));
+    // `position: fixed` placement is meaningless without both coordinates set.
+    expect(dropdown.style.left).not.toBe('');
+    expect(dropdown.style.top).not.toBe('');
+  });
+
+  test('closing removes the dropdown from the document entirely', async () => {
+    stubSessions(RECORDS);
+    sessions.initSessionSelector('session-selector');
+    await openPicker();
+    expect(document.getElementById('session-dropdown')).not.toBeNull();
+
+    // Second click on the picker toggles it shut.
+    await openPicker();
+    expect(document.getElementById('session-dropdown')).toBeNull();
+    const btn = /** @type {HTMLElement} */ (document.getElementById('session-picker-btn'));
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('Escape closes the dropdown', async () => {
+    stubSessions(RECORDS);
+    sessions.initSessionSelector('session-selector');
+    await openPicker();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.getElementById('session-dropdown')).toBeNull();
+  });
+
+  test('a scroll closes the dropdown rather than leaving it stranded off its anchor', async () => {
+    stubSessions(RECORDS);
+    sessions.initSessionSelector('session-selector');
+    await openPicker();
+
+    window.dispatchEvent(new Event('scroll'));
+    expect(document.getElementById('session-dropdown')).toBeNull();
+  });
+
+  test('a pointerdown outside the picker closes the dropdown', async () => {
+    stubSessions(RECORDS);
+    sessions.initSessionSelector('session-selector');
+    await openPicker();
+
+    document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(document.getElementById('session-dropdown')).toBeNull();
+  });
+
+  test('re-initializing the selector tears down a dropdown left open', async () => {
+    stubSessions(RECORDS);
+    sessions.initSessionSelector('session-selector');
+    await openPicker();
+    expect(document.getElementById('session-dropdown')).not.toBeNull();
+
+    sessions.initSessionSelector('session-selector');
+    expect(document.getElementById('session-dropdown')).toBeNull();
   });
 });
 
@@ -155,13 +246,12 @@ describe('session selection', () => {
     sessions.initSessionSelector('session-selector');
     await openPicker();
 
-    const dropdown = /** @type {HTMLElement} */ (document.getElementById('session-dropdown'));
-    expect(dropdown.classList.contains('open')).toBe(true);
+    expect(document.getElementById('session-dropdown')).not.toBeNull();
 
     const item = /** @type {HTMLElement} */ (document.querySelector('.session-item[data-session-id]'));
     item.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 
-    expect(dropdown.classList.contains('open')).toBe(false);
+    expect(document.getElementById('session-dropdown')).toBeNull();
   });
 });
 

--- a/tests/services/bluesky_bridge/test_figure_models.py
+++ b/tests/services/bluesky_bridge/test_figure_models.py
@@ -128,6 +128,8 @@ def test_dumped_field_names_are_the_wire_contract() -> None:
         "y_units",
         "annotations",
         "mark",
+        "section",
+        "series_picker",
     }
     assert set(dumped["panels"][0]["mark"]["series"][0]) == {
         "label",

--- a/tests/services/bluesky_bridge/test_orm_analysis.py
+++ b/tests/services/bluesky_bridge/test_orm_analysis.py
@@ -15,6 +15,7 @@ from osprey.services.bluesky_bridge.orm_analysis import (
     column_anomaly,
     localize_kick,
     row_anomaly,
+    singular_values,
 )
 
 CORRECTORS = ["corr1", "corr2", "corr3"]
@@ -266,3 +267,54 @@ def test_row_anomaly_detector_is_all_zero_with_fewer_than_two_bpms() -> None:
     scores = row_anomaly(np.ones((1, 4)))
 
     assert np.all(scores == 0.0)
+
+
+# =========================================================================
+# 3.7 singular_values
+# =========================================================================
+
+
+def test_singular_values_are_returned_largest_first() -> None:
+    values = singular_values(_clean_matrix())
+
+    assert values.size > 0
+    assert np.all(np.diff(values) <= 0.0)
+
+
+def test_a_separable_matrix_has_exactly_one_significant_mode() -> None:
+    """`_clean_matrix` is a rank-1 outer product, so all the response lives in
+    the first singular value -- the spectrum a perfectly-correlated (and so
+    uninformative-beyond-one-mode) machine would show."""
+    values = singular_values(_clean_matrix())
+
+    assert values[0] > 0.0
+    assert np.all(values[1:] < values[0] * 1e-10)
+
+
+def test_added_independent_structure_raises_the_second_mode() -> None:
+    matrix = _clean_matrix()
+    matrix[:, 1] += np.array([0.4, -0.4, 0.4, -0.4, 0.4])  # a second direction
+
+    values = singular_values(matrix)
+
+    assert values[1] > values[0] * 1e-3
+
+
+def test_singular_values_count_is_the_smaller_dimension() -> None:
+    assert singular_values(np.ones((7, 3))).size == 3
+    assert singular_values(np.ones((3, 7))).size == 3
+
+
+def test_singular_values_of_an_empty_matrix_is_empty() -> None:
+    assert singular_values(np.zeros((0, 0))).size == 0
+    assert singular_values(np.zeros((5, 0))).size == 0
+
+
+def test_singular_values_of_a_non_finite_matrix_is_empty() -> None:
+    """`numpy.linalg.svd` raises on NaN rather than returning one, and a
+    figure is a view: a partly-fitted matrix must degrade to no spectrum, not
+    to an exception that costs the whole figure."""
+    matrix = _clean_matrix()
+    matrix[1, 1] = np.nan
+
+    assert singular_values(matrix).size == 0

--- a/tests/services/bluesky_bridge/test_orm_render.py
+++ b/tests/services/bluesky_bridge/test_orm_render.py
@@ -138,8 +138,12 @@ def test_bidirectional_run_renders_the_same_matrix() -> None:
 # =========================================================================
 
 
-def test_panel_order_is_traces_then_matrix_then_anomaly_bars() -> None:
-    """Stable order, so a live figure grows instead of rearranging."""
+def test_panel_order_leads_with_the_fit_and_demotes_the_sweeps() -> None:
+    """The finding leads; the raw evidence follows in collapsed sections.
+
+    Order is stable, so a live figure grows instead of rearranging: the fitted
+    panels appear above the sweep section as sweeps complete.
+    """
     correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
     truth = _truth(len(detectors), len(correctors))
     rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
@@ -147,13 +151,26 @@ def test_panel_order_is_traces_then_matrix_then_anomaly_bars() -> None:
     figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
 
     assert [panel.title for panel in figure.panels] == [
-        "hcm1 sweep",
-        "hcm2 sweep",
         "Response matrix",
+        "Response by BPM",
         "Corrector anomaly score",
         "BPM anomaly score",
+        "Singular values",
+        "hcm1 sweep",
+        "hcm2 sweep",
     ]
-    traces = figure.panels[0].mark
+    # The fitted headline is inline; the sweeps and the spectrum are demoted.
+    assert [panel.section for panel in figure.panels] == [
+        None,
+        None,
+        None,
+        None,
+        "Singular values",
+        "Per-corrector sweeps",
+        "Per-corrector sweeps",
+    ]
+
+    traces = _panel(figure, "hcm1 sweep").mark
     assert isinstance(traces, LinesMark)
     assert [series.label for series in traces.series] == detectors
     assert traces.source_points == len(detectors) * 7
@@ -167,6 +184,103 @@ def test_panel_order_is_traces_then_matrix_then_anomaly_bars() -> None:
     assert bpm_bar.categories == detectors
 
 
+def test_response_by_bpm_is_the_matrix_read_column_wise() -> None:
+    """One line per fitted corrector, carrying that corrector's matrix column.
+
+    The panel ships EVERY fitted corrector and marks itself selectable: the
+    reader's choice of which lines to draw is a filter over data already on the
+    wire, never a refetch.
+    """
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+    panel = _panel(figure, "Response by BPM")
+
+    assert panel.series_picker is True
+    assert panel.section is None  # a headline panel, not demoted
+
+    mark = panel.mark
+    assert isinstance(mark, LinesMark)
+    assert [series.label for series in mark.series] == correctors
+
+    # Series j is column j of the matrix, against a 1-based BPM index.
+    for j, series in enumerate(mark.series):
+        assert [point.x for point in series.points] == [1.0, 2.0, 3.0]
+        assert [point.y for point in series.points] == pytest.approx(truth[:, j], abs=1e-9)
+
+
+def test_response_by_bpm_carries_only_fitted_correctors() -> None:
+    """An in-flight corrector has no column, so it has no line -- the same
+    subsequence the heatmap's x axis uses, never a flat zero line that would
+    read as a dead corrector."""
+    correctors = ["hcm1", "hcm2", "hcm3"]
+    detectors = ["bpm1", "bpm2"]
+    num = 7
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(
+        correctors,
+        detectors,
+        truth,
+        _currents(1.0, num, sweep="bidirectional"),
+        stop_after=num + 3,  # hcm1 complete, hcm2 in flight, hcm3 untouched
+    )
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors, num=num))
+    mark = _panel(figure, "Response by BPM").mark
+
+    assert isinstance(mark, LinesMark)
+    assert [series.label for series in mark.series] == ["hcm1"]
+
+
+def test_singular_values_panel_is_log10_and_sectioned() -> None:
+    """The spectrum is a second opinion, so it is demoted into its own section.
+
+    Values are log10 because the renderer draws linear axes only and a
+    spectrum's meaning is its decades of fall-off; the axis label says so.
+    """
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
+    truth = _truth(len(detectors), len(correctors))
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+    panel = _panel(figure, "Singular values")
+
+    assert panel.section == "Singular values"
+    assert panel.y_label == "log10 singular value"
+
+    mark = panel.mark
+    assert isinstance(mark, LinesMark)
+    points = mark.series[0].points
+    assert [point.x for point in points] == [1.0, 2.0]  # min(n_bpm, n_corr)
+
+    expected = np.log10(np.linalg.svd(truth, compute_uv=False))
+    assert [point.y for point in points] == pytest.approx(expected, abs=1e-9)
+
+
+def test_a_numerically_zero_singular_value_is_a_gap_not_a_minus_sixteen() -> None:
+    """A rank-deficient matrix leaves ~1e-16 residue, not an exact zero.
+
+    Plotting log10 of that residue would stretch the axis over sixteen decades
+    and squash every real mode flat, so anything at or below the numerical-rank
+    tolerance is a gap.
+    """
+    correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2"]
+    # Both correctors drive an identical BPM shape: a rank-1 matrix, so the
+    # second singular value is zero.
+    truth = np.array([[1.0, 1.0], [2.0, 2.0]])
+    rows = _rows(correctors, detectors, truth, _currents(1.0, 7, sweep="bidirectional"))
+
+    figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
+    mark = _panel(figure, "Singular values").mark
+
+    assert isinstance(mark, LinesMark)
+    points = mark.series[0].points
+    assert points[0].y is not None
+    assert points[1].y is None
+
+
 def test_trace_points_are_the_recorded_current_and_reading() -> None:
     """A trace point is a claim about one row, not a smoothed curve."""
     correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
@@ -175,7 +289,7 @@ def test_trace_points_are_the_recorded_current_and_reading() -> None:
     rows = _rows(correctors, detectors, truth, currents)
 
     figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
-    traces = figure.panels[1].mark
+    traces = _panel(figure, "hcm2 sweep").mark
     assert isinstance(traces, LinesMark)
 
     series = traces.series[0]
@@ -246,7 +360,8 @@ def test_mid_sweep_fits_completed_correctors_and_traces_the_in_flight_one() -> N
     figure = orm.render(rows, _params(correctors=correctors, detectors=detectors, num=num))
 
     titles = [panel.title for panel in figure.panels]
-    assert titles[:4] == ["hcm1 sweep", "hcm2 sweep", "hcm3 sweep", "hcm4 sweep"]
+    sweeps = [title for title in titles if title.endswith(" sweep")]
+    assert sweeps == ["hcm1 sweep", "hcm2 sweep", "hcm3 sweep", "hcm4 sweep"]
     assert "hcm5 sweep" not in titles  # not started: no panel, not an empty one
 
     heatmap = _panel(figure, "Response matrix").mark
@@ -304,7 +419,7 @@ def test_a_bpm_that_missed_a_reading_draws_a_gap_not_a_zero() -> None:
     rows[3]["bpm1"] = None  # type: ignore[assignment]
 
     figure = orm.render(rows, _params(correctors=correctors, detectors=detectors))
-    traces = figure.panels[0].mark
+    traces = _panel(figure, "hcm1 sweep").mark
     assert isinstance(traces, LinesMark)
     assert traces.series[0].points[3].y is None
     assert traces.series[1].points[3].y is not None
@@ -386,7 +501,7 @@ def test_panels_and_series_are_capped_with_annotations_naming_the_excess() -> No
     assert len(trace_titles) == orm._MAX_TRACE_PANELS
     assert trace_titles[-1] == "hcm20 sweep"  # the tail, where a live sweep is
 
-    first = figure.panels[0]
+    first = _panel(figure, trace_titles[0])
     assert any("8 most recently swept of 20 correctors" in n for n in first.annotations)
     assert any("first 12 of 30 BPMs" in n for n in first.annotations)
 


### PR DESCRIPTION
Two unrelated concerns, kept as separate commits: four UI defects in the web
terminal and its docked panels, and the ORM result figure.

## UI defects

- **Axes table columns.** A scan's parameter form truncated device names. The
  columns are now sized to the names they hold.
- **Doubled title.** The web terminal header carried the product name and a page
  title repeating it. Only the product name remains.
- **Embedded status strip.** `body.embedded` zeroes the body padding so scrolling
  views can meet the tile edge, which left the queue badge against the frame and
  the halt buttons on the corner while the content below sat comfortably inset.
  The strip now supplies its own inset.
- **Session picker dropdown.** Its button is adopted into the dockview tab strip,
  which is `overflow: hidden` and carries a transform. The transform opens a
  stacking context, so an absolutely-positioned menu was both clipped and pinned
  below the content pane no matter how high its `z-index`. It now mounts at body
  level with fixed positioning, is placed from JS, and closes on scroll, resize,
  Escape, or an outside click.

## ORM figure

The response matrix holds signed slopes — a corrector kicks the beam and a BPM
downstream reads positive or negative by betatron phase advance. It was painted
on a single-hue ramp anchored to the raw extent, which destroyed that twice
over: zero landed mid-ramp, so an unresponsive BPM looked like a real response,
and the most negative cell painted faintest, so the strongest negative response
was indistinguishable from no measurement.

It is now diverging — one hue each side of zero, magnitude scaled against a
symmetric `max|value|` so equal and opposite responses are equally salient and
two runs stay comparable. Zero is left as background, cells with no reading are
hatched rather than skipped, and the flat legend chip became a colorbar carrying
the numbers.

Two views that conventionally accompany a matrix are added:

- **Response by BPM** — the matrix read column-wise, where the sign oscillation,
  a flat line for a dead corrector, and a shared spike for a dead BPM are all
  legible. Every fitted corrector ships with the figure and the reader picks
  which are drawn, so changing the comparison costs no fetch.
- **Singular values** — the spectrum, on a log axis because a linear one hides
  every mode below the first. Values at or below the numerical-rank tolerance
  are drawn as gaps: a rank-deficient matrix leaves ~1e-16 residue, and plotting
  its logarithm would stretch the axis over sixteen decades.

The finding leads and the raw sweeps follow, demoted into a collapsed section
showing one corrector at a time. A section is a demotion, so when the fit is
skipped the sweeps stay inline — which also keeps the capped-run warning above
the fold.

Panels gain optional `section` and `series_picker` fields. Every other plan
emits neither and renders exactly as before. Picker selection lives in a
caller-held object, because the panel replaces the figure's DOM on each poll
tick, and is cleared per run since it names that run's devices.

## Verification

`tsc --noEmit`, eslint, ruff and `ruff format --check` clean; the JS suite and
the bridge + panel Python suites pass locally. Checked in a browser against a
24 BPM × 10 corrector ring with a seeded phase advance, one dead BPM and one
stuck corrector, driven through the real `orm.render()` and the real renderer:
the dead BPM reads as a dark stripe, the stuck corrector as a blank column, and
the spectrum's last mode as a gap.
