### PR TITLE
feat: start a Bluesky queue on a single approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,15 +77,19 @@ Compatibility is documented in release notes, not encoded in the version string.
   time budget now cap their test step below it, so a hang fails that step and
   the capture still runs, rather than the whole job being cancelled mid-teardown.
 
-- A tokenless `queue_start` now files a **start request** the operator confirms
-  in the BLUESKY queue panel, instead of dead-ending in a refusal. Deployed
-  web terminals never hold the scan launch token by design; the agent stages
-  and queues, the request appears in the queue panel beside the queue it would
-  drain, and the human's *Confirm start* click — the panel's own token-gated
-  start — is what arms it. Dismissing the request is always available and
-  starts nothing. Skill and error-message guidance across the scan stack now
-  explains this posture so agents hand the start to the human instead of
-  chasing the token in configuration.
+- The OSPREY agent can start a Bluesky queue on a single approval: approving
+  its `queue_start` call in chat arms and runs the queue, with no separate
+  confirmation step elsewhere. The token that arms a start is granted only to a
+  persona configured for control-system writes that also runs the bluesky MCP
+  server, so a read-only persona still cannot start anything. The BLUESKY
+  panel's own **Start queue** control is unchanged.
+
+  A deploy refuses to grant that token to a persona that is also permitted to
+  run a shell: the approval gates the `queue_start` tool, not a shell, so such
+  an agent could read the token out of its own environment and arm a queue with
+  no approval at all. Restore `Bash` to that persona's `permissions.deny` and
+  rebuild its image — or republish and re-pull it, if you deploy from a
+  registry — or move the persona off the bluesky server or off writes.
 
 - An archiver read that comes back empty now says why: the response carries a
   coverage verdict — the window predates or postdates the archive, the channel

--- a/docs/source/how-to/bluesky/queue.rst
+++ b/docs/source/how-to/bluesky/queue.rst
@@ -70,7 +70,6 @@ One queue, three ways to drive it
 
          POST /queue/items          add the current draft revision
          POST /queue/start          start draining (needs the launch token)
-         POST /queue/start-request  ask a token holder to start — arms nothing
          POST /queue/stop           stop after the running item
          POST /queue/abort          abort the running plan — never gated
          GET  /queue                what is queued and running
@@ -119,9 +118,6 @@ quirks worth knowing:
         - The launch token — this hands work straight to a moving machine.
       * - Start the queue
         - The launch token.
-      * - Ask for a start (file a start request)
-        - Nothing — the request arms nothing. Confirming it *is* the
-          token-gated start, done from the queue panel.
       * - Stop the queue / abort the running plan
         - Nothing. Ever. Anywhere.
       * - Withdraw a pending stop
@@ -133,13 +129,13 @@ quirks worth knowing:
    anything, even on an idle queue. Its halts and its read tools are never
    taken away.
 
-   In a deployed control room the agent's environment never holds the launch
-   token at all — the token lives with the operator panels. The agent's
-   ``queue_start`` then files a **start request**: it appears in the BLUESKY
-   queue panel beside the queue it would drain, with *Confirm start* and
-   *Dismiss* controls. Confirming fires the panel's own token-carrying start;
-   dismissing starts nothing. Either way, the human's click is the arming
-   decision.
+   In a deployed control room the agent holds the launch token only where the
+   deployment grants it — to a persona configured for control-system writes
+   that also runs the bluesky MCP server. Where it is granted, the agent's
+   ``queue_start`` arms the queue itself, and your approval of that tool call
+   is the arming decision. Where it is not, ``queue_start`` is refused with
+   ``launch_token_required`` and the start stays with you, from the BLUESKY
+   queue panel's own **Start queue** button.
 
 .. dropdown:: When something is refused
    :color: info
@@ -154,12 +150,9 @@ quirks worth knowing:
 
    ``launch_token_required``
       The operation was armed and the caller held no valid token. Nothing was
-      started. (An agent asking for a plain start never hits this — it files a
-      start request for the panel instead.)
-
-   ``queue_empty``
-      A start was requested with nothing queued, so there was nothing a
-      confirmation could run. Stage and add a plan first.
+      started. An agent meets this where the deployment did not grant it a
+      token, where the token it holds does not match the bridge's, or where
+      no launch token is configured at all — hand the start to the operator.
 
    ``browse_only_connector``
       This deployment cannot execute scans at all — it is pointed at the

--- a/docs/source/how-to/bluesky/run-first-scan.rst
+++ b/docs/source/how-to/bluesky/run-first-scan.rst
@@ -137,10 +137,12 @@ token, no switch can disable them:
      process with its own copy of the devices. That is why the queue survives
      restarts of everything around it.
    - **Start queue** is checked against a **launch token** the deployment
-     holds. In deployed control rooms the agent never holds it — asking the
-     agent to start a scan gets you a **start request** to confirm in the
-     queue panel. For the agent, starting is additionally switched off
-     entirely whenever the project's control-system writes are disabled.
+     holds. Whether the agent holds one too is the deployment's choice: where
+     it grants the token, asking the agent to start a scan starts the scan —
+     your approval of that one tool call is the decision. Where it does not,
+     the agent's start is refused and it tells you so; you start it from the
+     queue panel yourself. For the agent, starting is additionally switched
+     off entirely whenever the project's control-system writes are disabled.
 
 .. dropdown:: First-run hiccups
    :color: info

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -519,8 +519,8 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
     logger.debug(
         "    Token:      `osprey up` writes BLUESKY_LAUNCH_TOKEN to .env; "
         "a host-run agent's queue tools read it automatically. Deployed web "
-        "terminals never receive it — their agents file a start request the "
-        "operator confirms in the BLUESKY queue panel."
+        "terminals receive it only for personas entitled to it; the rest are "
+        "refused with launch_token_required and hand arming to the operator."
     )
     logger.debug(
         "    Images:     `osprey up` builds the bluesky-bridge image locally "

--- a/src/osprey/deployment/web_terminals/artifacts.py
+++ b/src/osprey/deployment/web_terminals/artifacts.py
@@ -20,14 +20,17 @@ one helper makes that class of drift impossible.
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from osprey.deployment.errors import DeploymentError
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
 from osprey.deployment.web_terminals.personas import (
-    EVENTS_PANEL_ID,
-    personas_declaring_panel,
-    personas_using_ariel,
+    personas_needing_ariel_password,
+    personas_needing_dispatcher_token,
+    personas_needing_launch_token,
+    personas_not_denying_bash,
 )
 from osprey.deployment.web_terminals.render import render_web_terminals
 from osprey.utils.workspace import BUILD_DIR_NAME
@@ -35,6 +38,141 @@ from osprey.utils.workspace import BUILD_DIR_NAME
 #: Filename of the rendered web-stack compose file, as
 #: :func:`~osprey.deployment.web_terminals.render.render_web_terminals` keys it.
 WEB_COMPOSE_FILENAME = "docker-compose.web.yml"
+
+
+class BashLaunchTokenConflictError(DeploymentError):
+    """A persona would hold ``BLUESKY_LAUNCH_TOKEN`` while its agent may run a shell.
+
+    ``BLUESKY_LAUNCH_TOKEN`` exists so a single chat approval is enough to arm a
+    Bluesky queue start, which is physical accelerator hardware motion. That
+    approval gates the ``queue_start`` MCP tool — and only that tool. An agent
+    that may also run ``Bash`` can read the token straight out of its own
+    environment and arm the queue with a plain HTTP call, reaching the same
+    hardware with no approval prompt at any point. The chat gate is then
+    decoration.
+
+    So the two are refused *together* rather than shipped and documented: the
+    deploy stops before a single web-terminal artifact is written, while the
+    operator still has the context to fix it. Fail-closed, like
+    :class:`~osprey.deployment.errors.ComposeInterpolationError` and for the same
+    reason — a warning about this would scroll past and leave a stack running.
+
+    Deliberately not a ``ValueError``. ``force_recreate_auth_sidecar`` catches
+    ``(ValueError, OSError)`` around its best-effort re-render and downgrades it
+    to a warning; a safety refusal that a credential rotation could swallow is
+    not a refusal.
+
+    Three boundaries this guard does **not** cover, none of them accidental:
+
+    * **Persona-less roster entries are out of reach.** Both sides of the
+      intersection are keyed on persona names, so a roster entry naming no
+      persona — the zero-migration path, where the web image *is* the deploy
+      project — appears in neither set and is not bound by this check.
+      :func:`~osprey.deployment.web_terminals.render.render_web_terminals`
+      answers that entry's entitlement independently, via
+      :func:`~osprey.deployment.web_terminals.personas.config_needs_launch_token`
+      on the deploy config itself. This is consistent with the feature's scope:
+      the single-user path already resolves this token today, so it is not new
+      exposure — but a reader who assumes the guard covers every entitled
+      container will be wrong.
+    * **The check is render-scoped, not image-scoped.** It reads the rendered
+      project directory, which equals the image's ``.claude/settings.json`` only
+      as of that image's last build: ``COPY . /app/<project>/`` bakes the
+      directory in, and the per-user compose services declare only ``image:``,
+      with no ``build:`` stanza to rebuild one at start. A render that *adds* a
+      ``Bash`` deny without an image rebuild therefore passes this guard while
+      the running image is still permissive. That is why the remedy below says
+      rebuild, not merely "restore the deny".
+    * **It assumes the agent does not run in bypass-permissions mode.** An agent
+      launched with permissions bypassed ignores its deny list wholesale, and a
+      ``Bash`` deny then proves nothing. No such flag appears anywhere on the
+      web-terminal launch path today, so the assumption holds — but nothing here
+      would fail if a future change broke it.
+
+    Args:
+        personas: The offending persona names — every persona that is both
+            entitled to the launch token and shipping a settings artifact that
+            does not deny ``Bash``. All of them are named in the message; an
+            operator fixing one at a time would otherwise redeploy once per
+            offender to discover the next.
+    """
+
+    def __init__(self, personas: Iterable[str]) -> None:
+        self.personas = sorted(personas)
+        named = ", ".join(repr(name) for name in self.personas)
+        super().__init__(
+            f"Refusing to deploy: {named} would be granted BLUESKY_LAUNCH_TOKEN "
+            f"while also permitted to run a shell. Each named persona is entitled to "
+            f"the token — its rendered config.yml sets control_system.writes_enabled: "
+            f"true AND leaves the bluesky MCP server enabled — and its shipped "
+            f'.claude/settings.json does not list "Bash" in permissions.deny (a '
+            f"missing or unparseable settings.json counts the same — it is not "
+            f"evidence of a deny). The token arms a queue start, which moves "
+            f"accelerator hardware; the chat approval gates only the queue_start "
+            f"tool, so an agent with a shell can read the token out of its own "
+            f"environment and arm a queue with no approval at all. Fix either half "
+            f'of the conflict: restore "Bash" to permissions.deny for that persona '
+            f"and REBUILD its image (or republish and re-pull it in registry mode) "
+            f"— a re-render alone is not enough, because the settings.json read here "
+            f"is the one baked into the image, and the per-user services declare only "
+            f"`image:`, so nothing rebuilds at start. Or withdraw the entitlement by "
+            f"moving that persona off the bluesky server "
+            f"(claude_code.servers.bluesky.enabled: false) or off writes "
+            f"(control_system.writes_enabled: false)."
+        )
+
+
+def check_bash_launch_token_conflict(config: Any, project_root: Path | str) -> set[str]:
+    """Refuse the deploy if any launch-token persona's shipped settings permit ``Bash``.
+
+    The whole guard in one callable, because it runs at **three** points and the
+    three must never be able to disagree about what a conflict is:
+
+    * :func:`preflight_web_terminals` — the fail-fast gate. Refusing there is what
+      keeps a conflicted deploy from paying for the minutes-long project-image
+      build, the archiver/ARIEL store staging, and the minting *and printing* of
+      ``.env.production`` and auth credentials for a stack that will never come up.
+      That last part is the property ``preflight_web_terminals``' own docstring
+      commits to, so the check belongs ahead of :func:`ensure_env_production`.
+    * :func:`~osprey.deployment.web_terminals.lifecycle.decommission_user` — ahead
+      of its ``config_replace_list`` roster edit. The seam below would refuse this
+      path anyway, but only *after* the roster edit had been written, leaving
+      ``config.yml`` updated, the artifacts stale, and the container and volume
+      removal never run. It is handed the **post-removal** roster, and that is
+      load-bearing rather than incidental: decommissioning the offending persona's
+      own last user drops that persona from the referenced set and so must still
+      succeed — it is the one remediation that needs no image rebuild. A future
+      change that probes the pre-removal roster silently takes that away.
+    * :func:`write_web_terminal_artifacts` — belt and braces, and the only cover
+      for :func:`~osprey.deployment.web_terminals.provision.force_recreate_auth_sidecar`,
+      whose pre-recreate re-render reaches the render seam through neither of the
+      call sites above. The seam has to answer for itself.
+
+    No call site is redundant; removing any one of them leaves a real path
+    uncovered. The decommission check is the easiest to mistake for duplication,
+    because the seam behind it means deleting it breaks no test about *safety* —
+    only the one about ordering
+    (``test_decommission_refuses_before_touching_the_roster_when_a_survivor_is_conflicted``).
+
+    Args:
+        config: The parsed deploy config.
+        project_root: Deploy project root; relative ``project_path`` values resolve
+            against it.
+
+    Returns:
+        The personas entitled to ``BLUESKY_LAUNCH_TOKEN`` — returned rather than
+        recomputed so the caller that goes on to render hands the *same* set down,
+        and the set the guard cleared cannot drift from the set the render grants.
+
+    Raises:
+        BashLaunchTokenConflictError: One or more entitled personas ship a
+            ``.claude/settings.json`` that does not deny ``Bash``.
+    """
+    launch_token_personas = personas_needing_launch_token(config, project_root)
+    offenders = launch_token_personas & personas_not_denying_bash(config, project_root)
+    if offenders:
+        raise BashLaunchTokenConflictError(offenders)
+    return launch_token_personas
 
 
 def web_artifacts_dir(repo_root: Path | str) -> Path:
@@ -120,6 +258,17 @@ def write_web_terminal_artifacts(config: Any, repo_root: Path | str | None = Non
 
     Returns:
         The list of files written, in the render mapping's iteration order.
+
+    Raises:
+        BashLaunchTokenConflictError: A persona is entitled to
+            ``BLUESKY_LAUNCH_TOKEN`` and its shipped ``.claude/settings.json``
+            does not deny ``Bash``. Raised before the render, so a refused
+            deploy writes nothing. Every writer routes through here, so every
+            path that could put such a stack on disk — bring-up, the roster
+            verbs' re-render, the pre-recreate re-render — refuses it. Two of
+            those refuse earlier still (see
+            :func:`check_bash_launch_token_conflict`); this is the backstop that
+            makes the property hold for all of them.
     """
     from osprey.deployment.compose_generator import resolve_repo_root
 
@@ -127,13 +276,26 @@ def write_web_terminal_artifacts(config: Any, repo_root: Path | str | None = Non
     # Every disk-derived input is resolved HERE and passed down, because
     # render_web_terminals() reads no filesystem of its own (see its docstring):
     # the .env.auth digest, which personas declare the EVENTS panel and so need
-    # the dispatcher's bearer, and which configure ARIEL and so need its Postgres
-    # password — each in their own per-user environment block.
+    # the dispatcher's bearer, which configure ARIEL and so need its Postgres
+    # password, and which both allow writes and run the bluesky server and so may
+    # arm a queue start — each in their own per-user environment block.
+    # Fail closed BEFORE the render, so a refused deploy leaves no half-written
+    # artifacts behind: a persona holding BLUESKY_LAUNCH_TOKEN whose shipped
+    # settings still permit `Bash` can arm a queue start from a shell, with none
+    # of the chat approval the token exists to make sufficient. `osprey up` and
+    # `decommission_user` each already refused this earlier, where refusing is
+    # cheaper and cannot half-apply; force_recreate_auth_sidecar's pre-recreate
+    # re-render reaches here having passed neither, which is why the seam checks
+    # for itself. The entitled set comes back from the guard so the render is
+    # handed exactly the set that was cleared.
+    launch_token_personas = check_bash_launch_token_conflict(config, root)
+
     artifacts = render_web_terminals(
         config,
         auth_env_digest=auth_env_digest(root),
-        dispatcher_personas=personas_declaring_panel(config, root, EVENTS_PANEL_ID),
-        ariel_personas=personas_using_ariel(config, root),
+        dispatcher_personas=personas_needing_dispatcher_token(config, root),
+        ariel_personas=personas_needing_ariel_password(config, root),
+        launch_token_personas=launch_token_personas,
     )
     dest = web_artifacts_dir(root)
     written: list[Path] = []

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -206,24 +206,43 @@ def _build_env_production_subset(
     including read-only ones, whose entire purpose is not to hold write-capable
     credentials. A per-user entitlement therefore has to be expressed somewhere
     that can distinguish users, and that is the per-user ``environment:`` block
-    in ``docker-compose.web.yml`` (see
-    :func:`osprey.deployment.web_terminals.render.render_web_terminals`'s
-    ``dispatcher_personas``, which grants ``EVENT_DISPATCHER_TOKEN`` only to
-    users whose persona declares the EVENTS panel, interpolated by compose from
-    the deploy ``.env`` so the secret never lands in a rendered artifact).
+    in ``docker-compose.web.yml``. See
+    :func:`osprey.deployment.web_terminals.render.render_web_terminals`, whose
+    ``dispatcher_personas``, ``ariel_personas`` and ``launch_token_personas``
+    arguments each carry the subset of the roster entitled to one credential —
+    ``EVENT_DISPATCHER_TOKEN``, ``ARIEL_DB_PASSWORD`` and
+    ``BLUESKY_LAUNCH_TOKEN`` respectively — emitted into that user's own
+    ``environment:`` block and interpolated by compose from the deploy ``.env``,
+    so the secret never lands in a rendered artifact either.
 
     So this is NOT the claim that no web terminal ever presents a service token —
-    the EVENTS panel's proxy presents exactly this one, server-side, so the
-    browser never holds it. It is the narrower and still-load-bearing claim that
-    no service token is granted *rosterwide from here*. Note what that buys and
-    what it does not: a container that receives the dispatcher token shares its
-    process namespace with the agent, which can read it, so the grant is a
-    deliberate per-persona decision and never a default. The bluesky MCP
-    server's ``${BLUESKY_LAUNCH_TOKEN:-}`` stays tokenless in every persona for
-    that reason — an agent must not hold a write-ARMING bearer (any Bash or
-    Python it runs could read it and arm the queue with no approval), so its
-    ``queue_start`` files a panel start request and the operator's panels
-    sidecar, which does receive the token, answers it.
+    the EVENTS panel's proxy presents the dispatcher token server-side, so the
+    browser never holds it, and the ``bluesky`` MCP server presents the launch
+    token to the bridge from inside the terminal container. It is the narrower
+    and still-load-bearing claim that no
+    service token is granted *rosterwide from here*. Note what that buys and
+    what it does not: a container that receives one of these tokens shares its
+    process namespace with the agent, which can read it, so every grant is a
+    deliberate per-persona decision and never a default.
+
+    ``BLUESKY_LAUNCH_TOKEN`` is the sharpest case, because it arms a queue start
+    — an agent that holds it can put hardware in motion. Its entitlement
+    predicate,
+    :func:`osprey.deployment.web_terminals.personas.config_needs_launch_token`,
+    requires BOTH ``control_system.writes_enabled: true`` AND an enabled
+    ``bluesky`` MCP server in that persona's own rendered config. A read-only
+    persona is spelled ``writes_enabled: false``, so it cannot satisfy that pair
+    and can never be handed the token. That guarantee exists only because the
+    grant is per-persona; a copy of the token in this file would hand it to
+    exactly the personas the predicate is there to exclude.
+
+    One nuance applies to all three credentials alike. A roster entry that names
+    no persona — the zero-migration path, where the web image IS the deploy
+    project — consults no persona set at all; the render answers it straight
+    from the deploy config, via ``config_needs_launch_token``,
+    ``config_needs_dispatcher_token`` or ``config_needs_ariel_password``. An
+    empty persona set therefore does NOT mean "this credential is granted
+    nowhere": persona-less entries are decided independently of it.
 
     This is the security spec for this function: a var absent from the
     enumerated list above can never appear in the returned dict, regardless of

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -90,7 +90,10 @@ from osprey.deployment.runtime_helper import (
     runtime_env,
     verify_runtime_is_running,
 )
-from osprey.deployment.web_terminals.artifacts import write_web_terminal_artifacts
+from osprey.deployment.web_terminals.artifacts import (
+    check_bash_launch_token_conflict,
+    write_web_terminal_artifacts,
+)
 from osprey.deployment.web_terminals.auth_credentials import (
     AUTH_ENV_FILENAME,
     PW_PLAINTEXT_VAR_PREFIX,
@@ -192,6 +195,11 @@ def decommission_user(
         ValueError: If ``user`` is not present in ``modules.web_terminals.users``.
         RuntimeError: If the container runtime daemon is not running, or volume
             destruction was requested but not confirmed.
+        BashLaunchTokenConflictError: If a persona that survives this removal
+            would hold ``BLUESKY_LAUNCH_TOKEN`` while its shipped settings still
+            permit ``Bash``. Raised before ``config.yml`` is touched, so nothing
+            is half-applied; removing the offending persona's own last user is
+            unaffected, because the check reads the post-removal roster.
     """
     config_path = Path(config_path)
     config = ConfigBuilder(str(config_path)).raw_config
@@ -222,6 +230,24 @@ def decommission_user(
         )
         if not confirm_destroy(prompt, assume_yes, expected=user):
             raise RuntimeError(f"Decommission of {user!r} aborted: confirmation did not match.")
+
+    # Refuse a conflicted deployment BEFORE touching config.yml, not at the
+    # re-render below. The re-render would catch it either way, but only after
+    # `config_replace_list` had already written the roster edit — leaving the file
+    # updated, the artifacts stale, and the container/volume removal never run.
+    # The probe roster is the POST-removal one, which is what preserves the
+    # escape hatch: decommissioning the offending persona's last user drops it
+    # from the referenced set, so that removal still succeeds.
+    check_bash_launch_token_conflict(
+        {
+            **config,
+            "modules": {
+                **as_dict(config.get("modules")),
+                "web_terminals": {**web_terminals, "users": remaining},
+            },
+        },
+        repo_root,
+    )
 
     # Roster edit + artifact re-render happen before container/volume removal:
     # they are recoverable by re-running `osprey up`, unlike volume removal.

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -12,6 +12,7 @@ sidecar and lint share so a user's credentials are keyed identically everywhere.
 Port arithmetic lives separately in :mod:`osprey.deployment.web_terminals.ports`.
 """
 
+import json
 import os
 import re
 from collections.abc import Iterable
@@ -60,7 +61,7 @@ def config_declares_panel(config: Any, panel_id: str) -> bool:
     """True if ``config`` declares ``web.panels.<panel_id>`` and hasn't disabled it.
 
     The one definition of "this project shows that panel", shared by the render
-    (for persona-less roster entries) and by :func:`personas_declaring_panel`
+    (for persona-less roster entries) and by :func:`personas_needing_dispatcher_token`
     (for catalog personas), so the two cannot answer differently for the same
     config. ``enabled: false`` counts as *not* declared: a panel switched off is
     one whose credential is not needed.
@@ -71,7 +72,20 @@ def config_declares_panel(config: Any, panel_id: str) -> bool:
     return panel.get("enabled", True) is not False
 
 
-def config_uses_ariel(config: Any) -> bool:
+def config_needs_dispatcher_token(config: Any) -> bool:
+    """True if ``config`` declares the EVENTS panel and so needs the dispatcher bearer.
+
+    A thin, named wrapper around :func:`config_declares_panel` for
+    :data:`EVENTS_PANEL_ID` specifically: the panel declaration IS the
+    entitlement (see that constant's docstring — there is no separate config
+    key to set, or to forget to set, alongside it), so this is the one
+    predicate every dispatcher-token call site should read rather than each
+    re-supplying the panel id itself.
+    """
+    return config_declares_panel(config, EVENTS_PANEL_ID)
+
+
+def config_needs_ariel_password(config: Any) -> bool:
     """True if ``config`` carries a non-empty ``ariel:`` section.
 
     The ARIEL counterpart of :func:`config_declares_panel`, and deliberately not
@@ -88,6 +102,43 @@ def config_uses_ariel(config: Any) -> bool:
     logbook, and so entitles nothing.
     """
     return bool(as_dict(as_dict(config).get("ariel")))
+
+
+def config_needs_launch_token(config: Any) -> bool:
+    """True if ``config`` both allows writes and runs the bluesky MCP server.
+
+    ``BLUESKY_LAUNCH_TOKEN`` arms a queue start — it is what turns an agent's
+    ``queue_start`` call into physical hardware motion — so it is granted only
+    where both halves of that capability are actually configured. The consumer
+    is the ``bluesky`` MCP server, not the BLUESKY panel, which is the same
+    reasoning :func:`config_needs_ariel_password` applies to its own credential:
+    a credential is gated on what its consumer reads, never on which panel tab
+    happens to be visible. A project that switched the panel off still runs the
+    agent's queue tools, and a project that shows the panel but runs no bluesky
+    server has nothing to arm.
+
+    The two conditions are deliberately asymmetric, because their defaults are:
+
+    * ``control_system.writes_enabled`` must be **explicitly** ``True``. This is
+      the read-only tier's whole boundary — a read-only persona expresses itself
+      as ``writes_enabled: false``, and an absent or null key means writes were
+      never granted. Anything other than a literal ``True`` therefore entitles
+      nothing.
+    * ``claude_code.servers.bluesky.enabled`` must merely be **not** ``False``.
+      That key is an *override* over the server's built-in default (see
+      :func:`osprey.registry.mcp.resolve_servers`, which likewise disables only
+      on a literal ``enabled: false``), so an absent key leaves the server
+      enabled. Reading absence as "disabled" here would deny the token to
+      correctly-configured projects that simply never wrote the override.
+
+    Neither condition entitles on its own: writes without the server have no
+    caller, and the server without writes has nothing it may arm.
+    """
+    root = as_dict(config)
+    if as_dict(root.get("control_system")).get("writes_enabled") is not True:
+        return False
+    servers = as_dict(as_dict(root.get("claude_code")).get("servers"))
+    return as_dict(servers.get("bluesky")).get("enabled", True) is not False
 
 
 def _referenced_personas(config: Any) -> tuple[dict[str, Any], set[str]]:
@@ -147,30 +198,54 @@ def _personas_whose_config(config: Any, project_root: Any, predicate) -> set[str
     return matching
 
 
-def personas_declaring_panel(config: Any, project_root: Any, panel_id: str) -> set[str]:
-    """Names of catalog personas whose rendered project declares ``panel_id``.
+def personas_needing_dispatcher_token(config: Any, project_root: Any) -> set[str]:
+    """Names of catalog personas whose rendered project needs the dispatcher token.
 
     :param config: The parsed deploy config.
     :param project_root: Deploy project root; relative ``project_path`` values
         resolve against it.
-    :param panel_id: The panel whose declaration is being looked for.
-    :return: The subset of referenced persona names that declare it.
+    :return: The subset of referenced persona names entitled to
+        ``EVENT_DISPATCHER_TOKEN`` (see :func:`config_needs_dispatcher_token`).
     """
-    return _personas_whose_config(
-        config, project_root, lambda persona: config_declares_panel(persona, panel_id)
-    )
+    return _personas_whose_config(config, project_root, config_needs_dispatcher_token)
 
 
-def personas_using_ariel(config: Any, project_root: Any) -> set[str]:
+def personas_needing_ariel_password(config: Any, project_root: Any) -> set[str]:
     """Names of catalog personas whose rendered project configures ARIEL.
 
     :param config: The parsed deploy config.
     :param project_root: Deploy project root; relative ``project_path`` values
         resolve against it.
     :return: The subset of referenced persona names entitled to
-        ``ARIEL_DB_PASSWORD`` (see :func:`config_uses_ariel`).
+        ``ARIEL_DB_PASSWORD`` (see :func:`config_needs_ariel_password`).
     """
-    return _personas_whose_config(config, project_root, config_uses_ariel)
+    return _personas_whose_config(config, project_root, config_needs_ariel_password)
+
+
+def personas_needing_launch_token(config: Any, project_root: Any) -> set[str]:
+    """Names of catalog personas whose rendered project may arm a queue start.
+
+    This is the tier boundary in roster form. :func:`config_needs_launch_token`
+    decides the question per project; this wrapper is where that decision
+    becomes a *set* a caller can hand a bearer token to, one persona at a
+    time -- and it is therefore also where the security property the whole
+    feature rests on actually holds: a read-only persona's rendered
+    ``config.yml`` carries ``control_system.writes_enabled: false``, which can
+    never satisfy the predicate, so a read-only persona can never appear in
+    this set and can never be handed ``BLUESKY_LAUNCH_TOKEN``. That guarantee
+    falls out of walking the same per-persona ``config.yml`` files
+    :func:`personas_needing_dispatcher_token` and
+    :func:`personas_needing_ariel_password` already walk -- there is no
+    separate roster-level flag to keep in sync with the tier, and so nothing
+    that a future persona addition could forget to set.
+
+    :param config: The parsed deploy config.
+    :param project_root: Deploy project root; relative ``project_path`` values
+        resolve against it.
+    :return: The subset of referenced persona names entitled to
+        ``BLUESKY_LAUNCH_TOKEN`` (see :func:`config_needs_launch_token`).
+    """
+    return _personas_whose_config(config, project_root, config_needs_launch_token)
 
 
 def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
@@ -689,3 +764,119 @@ def resolve_personas(
         )
 
     return resolved
+
+
+# ---------------------------------------------------------------------------
+# Shipped-artifact reads
+#
+# Everything above answers a question about a persona's *config* — its authored
+# intent. The two functions below deliberately do not: they read the built
+# `.claude/settings.json` artifact instead, and so are kept out of the
+# entitlement-predicate cluster above rather than joining it.
+# ---------------------------------------------------------------------------
+
+
+#: The exact ``permissions.deny`` entry that blocks the agent's shell wholesale.
+#: A *scoped* deny (``Bash(rm:*)``) constrains one command family and leaves the
+#: shell otherwise usable, so only this literal counts as "Bash is denied".
+_BASH_DENY_ENTRY = "Bash"
+
+
+def settings_json_denies_bash(project_dir: Any) -> bool:
+    """True if ``<project_dir>/.claude/settings.json`` denies ``Bash`` outright.
+
+    Reads the **shipped build artifact**, not the ``config.yml`` that produced
+    it, and that distinction is the whole point of this function. ``osprey up``
+    does not rebuild (rebuilding is a separate operator step), so a persona's
+    config edited after its last build does not change what its image actually
+    ships. A caller that asked the config instead would see a permission set
+    that has never been rendered: an operator who removed ``Bash`` from
+    ``remove_deny`` would read as safe while the running image still permits the
+    shell.
+
+    The scope of that claim is the rendered project directory, which is what
+    ``COPY . /app/<project>/`` bakes into the persona image — so what this reads
+    equals the image's own ``.claude/settings.json`` **as of that image's last
+    build**, and the per-user compose services declare only ``image:``, with no
+    ``build:`` stanza to rebuild one at start. A guard built on this is
+    therefore sound *provided persona images are rebuilt after a render*, and
+    deliberately claims nothing beyond that: a render newer than its image can
+    report a deny the running image does not yet carry. Reading ``config.yml``
+    would not close that window either — it is one step further from the image,
+    not one step closer.
+
+    Only the exact ``"Bash"`` entry counts (see :data:`_BASH_DENY_ENTRY`).
+
+    Fails **closed**: an artifact that cannot be read and parsed into a
+    ``permissions.deny`` list is not evidence that anything is denied, so every
+    such case answers ``False`` rather than raising or defaulting to "safe".
+    That covers an absent file, unreadable or invalid JSON, a top-level value
+    that is not an object, and a missing or non-list ``permissions`` /
+    ``permissions.deny``.
+
+    Args:
+        project_dir: The rendered persona project directory (the one holding
+            ``config.yml`` and ``.claude/``).
+
+    Returns:
+        ``True`` only when the artifact was read, parsed, and lists ``"Bash"``
+        in ``permissions.deny``; ``False`` in every other case.
+    """
+    settings_json = Path(project_dir) / ".claude" / "settings.json"
+    try:
+        # utf-8-sig, not utf-8: `json.load` does not strip a BOM, so a hand-edited
+        # artifact saved with one would fail to parse and a genuinely Bash-denying
+        # persona would read as permissive — an opaque deploy refusal. The codec is
+        # a strict superset for BOM-less files, which is everything OSPREY renders.
+        with settings_json.open("r", encoding="utf-8-sig") as fh:
+            settings = json.load(fh)
+    except (OSError, ValueError):
+        return False
+    deny = as_dict(as_dict(settings).get("permissions")).get("deny")
+    if not isinstance(deny, list):
+        return False
+    return _BASH_DENY_ENTRY in [entry for entry in deny if isinstance(entry, str)]
+
+
+def personas_not_denying_bash(config: Any, project_root: Any) -> set[str]:
+    """Names of referenced personas whose shipped settings do **not** deny ``Bash``.
+
+    The roster-shaped form of :func:`settings_json_denies_bash`, phrased as the
+    *unsafe* set so its caller can name every offending persona in one error
+    rather than re-deriving them. A persona granted ``BLUESKY_LAUNCH_TOKEN``
+    while its agent may also run a shell can read that token out of its own
+    environment and arm a queue with a plain HTTP call, bypassing the chat
+    approval entirely — the approval gates the ``queue_start`` tool, not a
+    shell. Intersecting this set with :func:`personas_needing_launch_token`
+    therefore names exactly the personas a deploy must refuse.
+
+    Walks the roster itself rather than routing through the shared
+    ``config.yml`` engine the entitlement predicates use, because the question
+    is about the built artifact and not about intent — see
+    :func:`settings_json_denies_bash`. Membership is inclusive for the same
+    fail-closed reason: a persona with no ``project_path``, or one whose project
+    is not rendered, is reported here as not denying ``Bash``. That never
+    over-blocks a deploy, since a persona whose project is missing cannot
+    satisfy :func:`config_needs_launch_token` either and so drops out of the
+    intersection anyway.
+
+    Args:
+        config: The parsed deploy config.
+        project_root: Deploy project root; relative ``project_path`` values
+            resolve against it.
+
+    Returns:
+        The subset of referenced persona names whose rendered
+        ``.claude/settings.json`` does not deny the shell.
+    """
+    catalog, referenced = _referenced_personas(config)
+
+    permitting: set[str] = set()
+    for persona_name in sorted(referenced):
+        project_path = as_dict(catalog.get(persona_name)).get("project_path")
+        if not isinstance(project_path, str) or not project_path:
+            permitting.add(persona_name)
+            continue
+        if not settings_json_denies_bash(Path(project_root, project_path)):
+            permitting.add(persona_name)
+    return permitting

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -38,6 +38,7 @@ from osprey.deployment.runtime_helper import (
 )
 from osprey.deployment.subprocess_capture import run_captured
 from osprey.deployment.web_terminals.artifacts import (
+    check_bash_launch_token_conflict,
     web_compose_file,
     write_web_terminal_artifacts,
 )
@@ -77,7 +78,10 @@ def preflight_web_terminals(config: dict) -> None:
 
     ``deploy_up`` invokes this ahead of its (minutes-long) project-image
     build so the deploy aborts that need no image at all — an
-    unresolvable persona catalog, a missing provider auth secret
+    unresolvable persona catalog, a persona that would hold
+    ``BLUESKY_LAUNCH_TOKEN`` while its agent may also run a shell
+    (:func:`~osprey.deployment.web_terminals.artifacts.check_bash_launch_token_conflict`),
+    a missing provider auth secret
     (:func:`ensure_env_production`'s fail-closed gate), a registry-mode
     deployment with no ``auth.image`` (:func:`_require_auth_sidecar_image`) and
     an auth credential that could not be established
@@ -114,6 +118,14 @@ def preflight_web_terminals(config: dict) -> None:
         registry_cfg = config.get("registry") or {}
         resolved_users = resolve_personas(web_terminals, registry_cfg, facility_prefix, strict=True)
         verify_persona_renders(config, resolved_users, repo_root=Path(repo_root))
+    # BEFORE ensure_env_production, for the same reason auth provisioning runs
+    # last: a persona that would hold BLUESKY_LAUNCH_TOKEN while its shipped
+    # settings still permit `Bash` is a deploy that must not come up, and
+    # discovering that after the image build would have already minted (and
+    # printed) credentials for it. The render seam and `decommission_user` check
+    # again — see check_bash_launch_token_conflict for why all three call sites
+    # are load-bearing.
+    check_bash_launch_token_conflict(config, repo_root)
     ensure_env_production(config, repo_root)
     # BEFORE the mint, deliberately: a registry-mode deploy that forgot
     # auth.image is already doomed, and minting here first would write (and

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -19,12 +19,12 @@ from jinja2 import Environment, FileSystemLoader
 
 from osprey.deployment.compose_generator import repo_identity, resolve_repo_root
 from osprey.deployment.web_terminals.personas import (
-    EVENTS_PANEL_ID,
     SUPPORTED_MCP_TOPOLOGY,
     USERNAME_CHARSET_RE,
     as_dict,
-    config_declares_panel,
-    config_uses_ariel,
+    config_needs_ariel_password,
+    config_needs_dispatcher_token,
+    config_needs_launch_token,
     effective_image_source,
     env_var_suffix,
     env_var_suffix_collisions,
@@ -145,6 +145,7 @@ def render_web_terminals(
     auth_env_digest: str | None = None,
     dispatcher_personas: set[str] | None = None,
     ariel_personas: set[str] | None = None,
+    launch_token_personas: set[str] | None = None,
 ) -> dict[str, str]:
     """Render the compose overlay, nginx fragment, and landing page for one facility config.
 
@@ -169,7 +170,7 @@ def render_web_terminals(
         dispatcher_personas: Persona names whose project declares the EVENTS
             panel, and whose users therefore need the event dispatcher's bearer
             token. Resolved from disk by
-            :func:`osprey.deployment.web_terminals.personas.personas_declaring_panel`
+            :func:`osprey.deployment.web_terminals.personas.personas_needing_dispatcher_token`
             and passed in for the same reason ``auth_env_digest`` is: this
             function reads no filesystem. Each such user gets
             ``EVENT_DISPATCHER_TOKEN`` in its OWN ``environment:`` block,
@@ -184,7 +185,7 @@ def render_web_terminals(
         ariel_personas: Persona names whose project configures ARIEL, and whose
             users therefore need the Postgres password ``osprey up`` minted into
             the deploy ``.env`` (see
-            :func:`osprey.deployment.web_terminals.personas.personas_using_ariel`).
+            :func:`osprey.deployment.web_terminals.personas.personas_needing_ariel_password`).
             Same placement and same reason as ``dispatcher_personas``: both ARIEL
             consumers inside the container — the panel's server and the ``ariel``
             MCP server — resolve their DSN through
@@ -193,6 +194,16 @@ def render_web_terminals(
             back to the shipped default, so a container that never receives it
             authenticates with the wrong password against a Postgres initialized
             with the minted one. ``None`` emits no line.
+        launch_token_personas: Persona names entitled to arm a Bluesky queue
+            start, resolved from disk by
+            :func:`osprey.deployment.web_terminals.personas.personas_needing_launch_token`.
+            Same placement and same reason as ``dispatcher_personas`` — see that
+            argument for why a per-persona credential belongs in the per-user
+            ``environment:`` block and never in the shared ``.env.production``.
+            The tier boundary bites hardest here: ``BLUESKY_LAUNCH_TOKEN`` is
+            what lets the ``bluesky`` MCP server arm a queue start without a
+            second confirmation, so a read-only persona holding it would be able
+            to move hardware. ``None`` emits no line.
 
     Returns:
         Mapping of output-relative-path to rendered content, for exactly three
@@ -303,7 +314,7 @@ def render_web_terminals(
                 "wants_dispatcher": (
                     entry["persona"] in (dispatcher_personas or set())
                     if entry.get("persona")
-                    else config_declares_panel(root, EVENTS_PANEL_ID)
+                    else config_needs_dispatcher_token(root)
                 ),
                 # Whether this user's container gets the ARIEL Postgres password
                 # (see the `ariel_personas` arg). Persona-less entries are
@@ -312,7 +323,16 @@ def render_web_terminals(
                 "wants_ariel_db": (
                     entry["persona"] in (ariel_personas or set())
                     if entry.get("persona")
-                    else config_uses_ariel(root)
+                    else config_needs_ariel_password(root)
+                ),
+                # Whether this user's container gets the Bluesky queue's launch
+                # token (see the `launch_token_personas` arg). Persona-less
+                # entries are answered from this same config, with no disk read,
+                # exactly as above.
+                "wants_launch_token": (
+                    entry["persona"] in (launch_token_personas or set())
+                    if entry.get("persona")
+                    else config_needs_launch_token(root)
                 ),
             }
         )

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/index.html
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/index.html
@@ -241,22 +241,6 @@
         <button type="button" id="start-btn" class="btn" disabled>Start queue</button>
       </div>
 
-      <!-- A pending start request: the agent (which never holds the launch
-           token in a deployed terminal) asked for a start, and THIS panel is
-           where a human answers. Confirm fires the same token-carrying
-           POST /queue/start as the Start button above; Dismiss withdraws the
-           request and starts nothing. Hidden unless the status summary
-           carries a `start_request` record (queue-view.js renders it). -->
-      <div id="start-request-card" class="start-request" hidden>
-        <p id="start-request-text" class="start-request-text"></p>
-        <div class="start-request-actions">
-          <button type="button" id="confirm-start-btn" class="btn confirm" disabled>
-            Confirm start &mdash; queue drains toward hardware
-          </button>
-          <button type="button" id="dismiss-request-btn" class="btn">Dismiss request</button>
-        </div>
-      </div>
-
       <div id="running-card" class="running" hidden>
         <div class="running-head">
           <span class="running-kicker">running</span>

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.css
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/panel.css
@@ -1244,26 +1244,6 @@ code {
   background: var(--accent-tint-06);
 }
 
-/* A pending start request: the one card on this panel that asks the operator
-   for a decision, so it wears the caution tint (same vocabulary as
-   .btn.confirm — armed-and-consequential), never the accent or success one. */
-.start-request {
-  border: 1px solid var(--color-accent-secondary);
-  border-radius: 6px;
-  padding: 10px 12px;
-  margin-bottom: 12px;
-  background: var(--accent-secondary-tint-08);
-}
-.start-request-text {
-  margin: 0 0 8px;
-  font-size: 12.5px;
-  color: var(--text-primary);
-}
-.start-request-actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
 .running.selected { border-color: var(--color-accent-light); }
 
 .running-head {

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/queue-client.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/queue-client.js
@@ -18,9 +18,6 @@
  *   items_in_queue, items_in_history, running_item_uid, plan_queue_uid,
  *   plan_history_uid, queue_stop_pending, queue_autostart_enabled, ...}`, or
  *   `{available: false, reason}` when the manager could not be read at all.
- *   Either shape may carry `start_request` — the bridge-local record of a
- *   tokenless caller (the agent) asking a token holder (this panel) to start
- *   the queue; see `startRequest` / `describeStartRequest`.
  * - `items` are the manager's own item documents (`item_uid`, `name`,
  *   `kwargs`, `meta.osprey_run_id`); the running item may carry `progress`.
  *
@@ -239,65 +236,6 @@ export function queueControls(state) {
       };
 
   return { start, stop };
-}
-
-// The confirm control on a pending start request. This button IS the arming
-// action — the sidecar attaches the launch token the agent never holds — so
-// its label says what confirming does, not who asked.
-export const CONFIRM_START_LABEL = 'Confirm start — queue drains toward hardware';
-export const DISMISS_START_REQUEST_LABEL = 'Dismiss request';
-
-/**
- * The pending start request riding the status summary, or null.
- *
- * The record is bridge-local state (`queue.py`'s `_start_request`): an agent
- * without the launch token filed it, and the ONLY thing that honours it is a
- * human clicking the token-holding confirm — this accessor never decides
- * anything, it only says whether there is something to render.
- *
- * @param {QueueState} state
- * @returns {Record<string, any>|null}
- */
-export function startRequest(state) {
-  const record = state.status && state.status.start_request;
-  return record && typeof record === 'object' ? /** @type {Record<string, any>} */ (record) : null;
-}
-
-/**
- * The pending start request's operator-facing sentence.
- *
- * Names who asked, how much would run, and when — the three things an
- * operator weighs before confirming. The item count is the count AT FILING
- * time; the queue list right next to this card is the live truth, which is
- * why the sentence points at it rather than restating it.
- *
- * @param {Record<string, any>} record
- * @returns {string}
- */
-export function describeStartRequest(record) {
-  const by = typeof record.requested_by === 'string' && record.requested_by ? record.requested_by : 'agent';
-  const count = Number.isInteger(record.items_in_queue)
-    ? `${record.items_in_queue} item${record.items_in_queue === 1 ? '' : 's'} at the time`
-    : 'the queued items';
-  const at = formatRequestedAt(record.requested_at);
-  return (
-    `The ${by} asks to start the queue (${count}${at ? `, requested ${at}` : ''}). ` +
-    'Confirming runs the queue exactly as listed below.'
-  );
-}
-
-/**
- * `requested_at` as a short local time, or null when unparseable — the
- * sentence simply omits what it cannot state truthfully.
- *
- * @param {unknown} iso
- * @returns {string|null}
- */
-function formatRequestedAt(iso) {
-  if (typeof iso !== 'string' || !iso) return null;
-  const parsed = new Date(iso);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
 /**

--- a/src/osprey/interfaces/bluesky_panels/panels/bluesky/queue-view.js
+++ b/src/osprey/interfaces/bluesky_panels/panels/bluesky/queue-view.js
@@ -47,7 +47,6 @@ import {
   createQueueStream,
   describeProgress,
   describeQueueStatus,
-  describeStartRequest,
   historyChanged,
   historyEmptyState,
   historyRecords,
@@ -59,7 +58,6 @@ import {
   queueEmptyState,
   reduceQueueFrame,
   refusalTone,
-  startRequest,
   stopButtonClass,
   stopButtonLabel,
   writeOutcomeTone,
@@ -106,10 +104,6 @@ export function createQueueView({ root, api, onSelectRun }) {
   const queueNote = byId('queue-note');
   const queueBanner = byId('queue-banner');
   const startBtn = /** @type {HTMLButtonElement} */ (byId('start-btn'));
-  const startRequestCard = byId('start-request-card');
-  const startRequestText = byId('start-request-text');
-  const confirmStartBtn = /** @type {HTMLButtonElement} */ (byId('confirm-start-btn'));
-  const dismissRequestBtn = /** @type {HTMLButtonElement} */ (byId('dismiss-request-btn'));
   const stopBtn = /** @type {HTMLButtonElement} */ (byId('stop-btn'));
   const stopNote = byId('stop-note');
   const abortBtn = /** @type {HTMLButtonElement} */ (byId('abort-btn'));
@@ -276,18 +270,6 @@ export function createQueueView({ root, api, onSelectRun }) {
     const controls = queueControls(queue);
     startBtn.disabled = controls.start.disabled;
     startBtn.title = controls.start.reason || '';
-
-    // The pending start request, when the summary carries one. Confirm is the
-    // SAME arming action as the Start button — the sidecar attaches the launch
-    // token the requester never held — so it shares Start's usability gate and
-    // its reason tooltip. Dismiss is never gated: declining is always safe.
-    const request = startRequest(queue);
-    startRequestCard.hidden = request === null;
-    if (request !== null) {
-      startRequestText.textContent = describeStartRequest(request);
-      confirmStartBtn.disabled = controls.start.disabled;
-      confirmStartBtn.title = controls.start.reason || '';
-    }
 
     // The stop button is never disabled — see `queueControls`. Whatever this
     // panel believes about the manager is a tooltip, not a gate.
@@ -575,31 +557,6 @@ export function createQueueView({ root, api, onSelectRun }) {
       {},
       'Queue started — it is now draining toward hardware.',
       writeOutcomeTone(true)
-    );
-  });
-
-  // Confirming a start request fires the same token-carrying start as the
-  // Start button — the bridge clears the request record on a successful
-  // start, and the next SSE frame hides this card. One click, like Start:
-  // the human reading this card IS the deliberation the flow exists for.
-  confirmStartBtn.addEventListener('click', () => {
-    if (confirmStartBtn.disabled) return;
-    void queueWrite(
-      'POST',
-      '/queue/start',
-      {},
-      'Start confirmed — the queue is now draining toward hardware.',
-      writeOutcomeTone(true)
-    );
-  });
-
-  dismissRequestBtn.addEventListener('click', () => {
-    void queueWrite(
-      'DELETE',
-      '/queue/start-request',
-      undefined,
-      'Start request dismissed — nothing was started.',
-      writeOutcomeTone(false)
     );
   });
 

--- a/src/osprey/interfaces/bluesky_panels/queue_relay.py
+++ b/src/osprey/interfaces/bluesky_panels/queue_relay.py
@@ -13,8 +13,6 @@ The relayed surface mirrors the bridge's queue contract one-for-one:
 - ``POST /queue/items/{uid}/move`` -> reorder one queued item
 - ``DELETE /queue/items/{uid}`` -> drop one queued item
 - ``POST /queue/start`` -> start draining the queue
-- ``POST /queue/start-request`` -> file the tokenless "please start" record
-- ``DELETE /queue/start-request`` -> dismiss a pending start request
 - ``POST /queue/stop`` -> stop after the running item (``cancel: true`` withdraws)
 - ``POST /queue/abort`` -> abort the plan already in motion
 - ``GET /queue/events`` -> the queue's Server-Sent-Events stream
@@ -247,30 +245,6 @@ async def start_queue(request: Request) -> JSONResponse:
     with its body intact.
     """
     return await _forward_write(request, "POST", "/queue/start")
-
-
-@router.post("/queue/start-request")
-async def request_queue_start(request: Request) -> JSONResponse:
-    """Relay the filing of a start request — the tokenless "please start" record.
-
-    Exists on the panel surface for symmetry and testing; the usual FILER is
-    the agent's MCP server talking to the bridge directly, and the usual
-    CONFIRMER is this sidecar's own ``POST /queue/start``, whose launch token
-    is the entire point of the flow. The resolved token rides along like every
-    other queue write (module docstring) and the bridge ignores it — the
-    request route arms nothing for anyone.
-    """
-    return await _forward_write(request, "POST", "/queue/start-request")
-
-
-@router.delete("/queue/start-request")
-async def dismiss_queue_start_request(request: Request) -> JSONResponse:
-    """Relay the dismissal of a pending start request — the panel's Dismiss control.
-
-    Ungated at the bridge (declining to start is the safe direction), so the
-    dismissal always answers, token or no token.
-    """
-    return await _forward_write(request, "DELETE", "/queue/start-request")
 
 
 @router.post("/queue/stop")

--- a/src/osprey/mcp_server/bluesky/tools/queue.py
+++ b/src/osprey/mcp_server/bluesky/tools/queue.py
@@ -22,8 +22,9 @@ queue_stop                  POST   /queue/stop
 lives in its own module but shares this one's refusal relay and hint table, so
 the two answer the same bridge code the same way.
 
-**Arming.** Two operations can put hardware in motion, and each carries two
-local safety layers, both enforced BEFORE any HTTP call:
+**Arming.** Two operations can put hardware in motion. Two local safety layers
+guard them, both enforced BEFORE any HTTP call — but only the first is carried
+everywhere:
 
 1. A ``control_system.writes_enabled`` re-read straight from config, mirroring
    ``ControlSystemConnector._writes_enabled``
@@ -34,17 +35,23 @@ local safety layers, both enforced BEFORE any HTTP call:
 2. A client-side launch-token presence check, so an unarmed server refuses
    locally with no network call.
 
-``queue_start`` carries both unconditionally. ``queue_add`` is armed only
-*sometimes* — enqueuing onto an idle queue moves nothing, while enqueuing onto
-a queue that is already draining hands the item straight to hardware — so it
-carries them conditionally: the launch token is attached to the request only
-when writes are enabled, and the bridge (which alone knows the manager's live
-state, under a lock, with a post-add re-check) decides whether this particular
-enqueue needed it. A writes-disabled deployment therefore keeps composing
-queues and is refused exactly at the point where composing would become
-executing. ``queue_stop`` inverts the asymmetry: a plain stop is ungated in
-every layer because halting is always allowed, while ``cancel=True`` withdraws
-a human's pending halt and is gated like a start.
+``queue_start`` carries layer 1 unconditionally, then delegates the token
+decision to the bridge: it posts with its launch token when it holds one and
+with no token header when it does not, and the bridge answers
+``launch_token_required`` for absence and mismatch alike. Keeping that one
+verdict in one place is deliberate — a local presence check would let the agent
+hear a different answer from the tool than the bridge would have given.
+``queue_add`` is armed only *sometimes* — enqueuing onto an idle queue moves
+nothing, while enqueuing onto a queue that is already draining hands the item
+straight to hardware — so it too carries layer 1 and then attaches the launch
+token to the request only when writes are enabled, leaving the bridge (which
+alone knows the manager's live state, under a lock, with a post-add re-check)
+to decide whether this particular enqueue needed it. A writes-disabled
+deployment therefore keeps composing queues and is refused exactly at the point
+where composing would become executing. ``queue_stop`` inverts the asymmetry: a
+plain stop is ungated in every layer because halting is always allowed, while
+``cancel=True`` withdraws a human's pending halt and is gated like a start — it
+is the one operation that carries layer 2.
 
 **Refusals are relayed, never rewritten.** Every refusal the bridge issues is
 an HTTP 4xx/5xx whose ``detail`` is ``{"code", "detail", ...extras}``, where
@@ -93,17 +100,12 @@ from osprey.mcp_server.http import notify_agent_activity_async
 _REFUSAL_HINTS: dict[str, list[str]] = {
     "launch_token_required": [
         "This operation arms hardware motion and needs the bridge's launch token, "
-        "which this agent does not hold — in deployed control rooms the token stays "
-        "with the operator's BLUESKY queue panel, by design.",
-        "Hand the action to the operator: arming is done from the queue panel by a "
-        "human. Never edit config.yml, .env, or settings to obtain a token.",
+        "which this agent does not hold here — this deployment either withholds it "
+        "or the token this agent holds does not match the bridge's.",
+        "Hand the action to the operator: they can arm the queue from the BLUESKY "
+        "queue panel. Never edit config.yml, .env, or settings to obtain a token.",
         "Only if this deployment has no token configured ANYWHERE (details say so) "
         "does an operator need to set one — that is operator work, not yours.",
-    ],
-    "queue_empty": [
-        "The queue holds no items, so there is nothing a start could run.",
-        "Stage the plan with set_draft and add it with queue_add first, then ask "
-        "for the start again.",
     ],
     "stale_draft_revision": [
         "The draft changed after you pinned this revision; re-read it with get_draft "
@@ -233,25 +235,25 @@ def _refuse_unarmed(tool: str) -> NoReturn:
     Uses the bridge's own ``launch_token_required`` code so the agent branches
     on one name whether the missing token is caught here or at the bridge.
 
-    The wording is posture-aware, not accusatory: in deployed control rooms
-    the agent's environment holds no launch token BY DESIGN — the token lives
-    with the operator's queue panel, and only a human arms from there. So the
-    suggestion sends the agent to the human, never to config surgery
-    (``queue_start`` itself never comes here — tokenless, it files a start
-    request for the panel instead).
+    ``queue_stop(cancel=True)`` is the sole caller. ``queue_start`` no longer
+    refuses here: it posts to the bridge with no token header and relays the
+    bridge's own ``launch_token_required``.
+
+    The wording states the situation without settling it. A missing token means
+    this deployment did not grant one to this agent — which may be deliberate,
+    or may be a misconfiguration — so the refusal points at the operator and
+    never at config surgery, without telling the agent which of the two it is.
     """
     return make_error(
         "launch_token_required",
         f"This Bluesky MCP server holds no launch token, so {tool} is refused "
-        f"client-side before contacting the bridge. In deployed control rooms this "
-        f"is the intended posture, not a misconfiguration: the launch token stays "
-        f"with the operator's BLUESKY queue panel, and arming decisions are made "
-        f"there by a human.",
+        f"client-side before contacting the bridge. This deployment either withheld "
+        f"the token from this agent or has none configured; only the operator can "
+        f"say which, and only they can change it.",
         [
             f"Ask the operator to perform this from the BLUESKY queue panel — "
             f"{tool} is an arming action reserved for the launch-token holder.",
-            "Do not edit config.yml or environment files to obtain a token; the "
-            "agent's environment is tokenless by design in deployed terminals.",
+            "Do not edit config.yml or environment files to obtain a token.",
         ],
         details={"code": "launch_token_required"},
     )
@@ -367,11 +369,8 @@ async def queue_list() -> str:
         ``status`` carries ``available`` (false when the manager could not be
         read at all, with ``reason``), ``manager_state``,
         ``worker_environment_exists``, ``items_in_queue``, ``items_in_history``,
-        ``running_item_uid``, ``queue_stop_pending``,
-        ``queue_autostart_enabled`` and ``start_request`` (the pending
-        panel start request a tokenless queue_start filed, or null — non-null
-        means the operator has not confirmed or dismissed it yet). A
-        ``manager_state`` of ``executing_queue``,
+        ``running_item_uid``, ``queue_stop_pending`` and
+        ``queue_autostart_enabled``. A ``manager_state`` of ``executing_queue``,
         ``starting_queue``, ``executing_task`` or ``paused`` means the queue is
         already draining toward hardware — adding to it then is an armed
         operation.
@@ -437,9 +436,9 @@ async def queue_add(draft_revision: int) -> str:
     Refusals (nothing is queued, and the pinned revision stays usable):
         - launch_token_required: the queue is already draining and this add
           needed the launch token. ``details.manager_state`` names the state
-          that made it armed. Either this server holds no token (in deployed
-          terminals that is the intended posture — the token lives with the
-          operator's queue panel, so hand the add to the human there), or this
+          that made it armed. Either this server was not granted a token in
+          this deployment, or the token it holds does not match the bridge's —
+          hand the add to the operator either way — or this
           server withheld it because writes are disabled (then enabling
           writes, an operator action, is what unblocks it) — the suggestions
           say which. Neither is agent-recoverable, and neither is a config
@@ -520,43 +519,27 @@ async def queue_start() -> str:
     every pending item, in order, not just the one you added — so read
     queue_list first and be sure the whole queue is what should run.
 
-    This tool behaves differently depending on where the launch token lives,
-    and BOTH outcomes are success paths — know which deployment you are in:
-
-    - **This server holds the launch token** (typically a host-run dev
-      session): the start goes to the bridge directly, behind your approval
-      prompt. ``control_system.writes_enabled`` is re-read fresh first — never
-      cached — so a hook-bypassed invocation holding a valid token is still
-      refused while writes are off. The bridge re-verifies the token,
-      re-checks every queued session plan's validation, and opens the worker
-      environment if needed. Returns ``{"started": true, "msg"}``.
-    - **This server holds no token** (every deployed web terminal — the token
-      stays with the operator's BLUESKY queue panel, by design, and no config
-      change from here can obtain it): the call files a START REQUEST instead.
-      The request shows up in the human's queue panel, right next to the queue
-      it would drain, with a Confirm control only the panel (the token holder)
-      can honour. Returns ``{"started": false, "start_request": {...},
-      "message"}`` — tell the human their confirmation is waiting in the
-      queue panel, then watch queue_status/queue_list for the start. Refiling
-      replaces the pending request; the human can also dismiss it.
+    The start goes to the bridge behind your approval prompt, carrying this
+    server's launch token. ``control_system.writes_enabled`` is re-read fresh
+    first — never cached — so a hook-bypassed invocation holding a valid token
+    is still refused while writes are off. The bridge then re-verifies the
+    token, re-checks every queued session plan's validation, and opens the
+    worker environment if needed.
 
     Returns:
-        JSON ``{"started": true, "msg"}`` when this server holds the token and
-        the bridge accepted the start — the queue then drains asynchronously
-        (poll queue_list for progress and get_run_data for the running item's
-        data). JSON ``{"started": false, "start_request", "message"}`` when
-        the start was handed to the operator's queue panel to confirm.
+        JSON ``{"started": true, "msg"}`` once the bridge has accepted the
+        start — the queue then drains asynchronously (poll queue_list for
+        progress and get_run_data for the running item's data). There is no
+        other success shape: this tool either arms the queue or refuses.
 
-    Refusals (nothing started, no request filed):
+    Refusals (nothing started):
         - writes_disabled: writes are off in this deployment. Refused before
-          a direct start AND before filing a request — a confirmable request
-          must not exist while the kill switch is off. Not agent-recoverable;
-          the operator must enable writes.
-        - launch_token_required: the bridge rejected this server's token (the
-          two do not match), or the bridge itself has no token configured.
-          Not agent-recoverable; contact the operator.
-        - queue_empty (tokenless path): the queue holds no items, so there is
-          nothing a confirmation could run. Stage a draft and queue_add first.
+          the bridge is called at all. Not agent-recoverable; the operator
+          must enable writes.
+        - launch_token_required: this deployment did not grant the agent a
+          launch token, the token it holds does not match the bridge's, or the
+          bridge itself has none configured. Not agent-recoverable; contact
+          the operator.
         - session_plan_unvalidated / session_plan_not_in_namespace: a plan
           somewhere in the queue is a session plan without a current passing
           validation. One stale plan refuses the whole start, all-or-nothing;
@@ -584,18 +567,16 @@ async def queue_start() -> str:
     if not _writes_enabled():
         return _refuse_writes_disabled("queue_start")
 
+    # A server without a token still goes to the bridge, sending no header:
+    # the bridge is the one authority on arming, and it answers
+    # launch_token_required either way.
     token = get_server_context().launch_token
-    if not token:
-        # The tokenless deployment posture: this server cannot arm — the
-        # launch token lives with the operator's queue panel — so hand the
-        # human the decision instead of dead-ending. The request route is
-        # ungated and arms nothing (no token header exists to send).
-        return await _request_panel_start()
+    headers = {"X-Launch-Token": token} if token else None
 
     # anyio's run_sync only forwards positional args, and `headers` is
     # keyword-only on `_http_post_json`, hence the lambda.
     status, body = await anyio.to_thread.run_sync(
-        lambda: _http_post_json("/queue/start", {}, headers={"X-Launch-Token": token})
+        lambda: _http_post_json("/queue/start", {}, headers=headers)
     )
     if status != 200:
         return _relay_refusal(
@@ -606,45 +587,6 @@ async def queue_start() -> str:
 
     await notify_agent_activity_async("queue_start", "run", detail="queue")
     return json.dumps(body)
-
-
-async def _request_panel_start() -> str:
-    """File a start request for the operator's queue panel to confirm.
-
-    ``queue_start``'s tokenless half. The bridge parks the request on the
-    queue summary, every open queue panel renders it as a Confirm control
-    within a poll tick, and the confirmation itself is the panel's own
-    token-gated start — nothing here acquired any arming capability. The
-    kill-switch re-read has already passed in ``queue_start``; it is the one
-    local gate this path shares with the direct start.
-    """
-    status, body = await anyio.to_thread.run_sync(
-        lambda: _http_post_json("/queue/start-request", {"requested_by": "agent"}, headers=None)
-    )
-    if status != 200:
-        return _relay_refusal(
-            body,
-            status,
-            fallback_hints=["Check queue_list for the queue's current state."],
-        )
-
-    record = body.get("start_request") if isinstance(body, dict) else None
-    await notify_agent_activity_async("queue_start", "run", detail="start-request")
-    return json.dumps(
-        {
-            "started": False,
-            "start_request": record,
-            "message": (
-                "This deployment keeps the launch token with the operator's BLUESKY "
-                "queue panel, so the agent cannot start the queue directly — that is "
-                "the intended arming posture, not an error. A start request has been "
-                "filed and is now visible in the queue panel: tell the operator their "
-                "confirmation is waiting there, then watch queue_status/queue_list "
-                "for the start. Do not attempt to obtain a token or edit "
-                "configuration; only the panel's Confirm control arms the queue."
-            ),
-        }
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -669,10 +611,13 @@ async def queue_stop(cancel: bool = False) -> str:
 
     ``cancel=True`` is the opposite operation: it WITHDRAWS a stop that a human
     (or you) already requested and lets the queue keep draining toward
-    hardware. Reversing someone's halt is an arming action, so it carries the
-    same gates as queue_start — ``control_system.writes_enabled`` re-read fresh,
-    plus the launch token — at this tool and again at the bridge. Only withdraw
-    a stop when you know why it was requested.
+    hardware. Reversing someone's halt is an arming action, so it is gated
+    twice over locally: ``control_system.writes_enabled`` is re-read fresh, and
+    a missing launch token is refused here as well, both before any HTTP call —
+    then the bridge checks both again. That local token check is MORE than
+    ``queue_start`` does: a tokenless start goes to the bridge and relays the
+    bridge's refusal, while a tokenless withdrawal never leaves this process.
+    Only withdraw a stop when you know why it was requested.
 
     Args:
         cancel: False (default) requests the stop. True withdraws a pending
@@ -686,8 +631,8 @@ async def queue_stop(cancel: bool = False) -> str:
         - writes_disabled (cancel=True only): writes are off, so a pending stop
           cannot be withdrawn. A plain stop is never refused for this reason.
         - launch_token_required (cancel=True only): no launch token here or at
-          the bridge, or the two do not match. In deployed terminals the agent
-          holds no token by design — ask the operator to withdraw the stop
+          the bridge, or the two do not match. This deployment did not grant
+          this agent a usable token — ask the operator to withdraw the stop
           from their queue panel instead; never chase the token in config.
         - manager_not_configured / manager_unreachable: the manager could not
           be reached. The queue was NOT stopped — say so plainly; do not report

--- a/src/osprey/services/bluesky_bridge/queue.py
+++ b/src/osprey/services/bluesky_bridge/queue.py
@@ -32,14 +32,6 @@ a failure mode. It is also deliberately not capability-gated: a deployment that
 somehow has a plan running is a deployment that must be able to stop it,
 whatever its capability record says.
 
-``POST /queue/start-request`` / ``DELETE /queue/start-request`` — the bridge's
-one concession to callers WITHOUT the token (deployed web terminals, where the
-token lives with the operator panels sidecar and never enters the agent's
-environment): filing publishes a "please start" record on the queue summary
-for a token holder to confirm in the queue panel. Both routes are ungated and
-declare no token header — a request arms nothing, and the only confirmation
-path is the existing token-gated ``POST /queue/start``.
-
 The gate is race-free by construction, twice over. First, ``_arming_lock``
 serializes the enqueue critical section {status-check + add + re-check} and
 the start critical section {idle-check + interruption-gate + session-gate +
@@ -77,12 +69,11 @@ import asyncio
 import json
 import logging
 import uuid
-from datetime import UTC, datetime
 from typing import Any, NoReturn
 
 from fastapi import APIRouter, Header, HTTPException
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from . import document_plane, draft, runs
 from .queue_backend import (
@@ -155,15 +146,6 @@ _poller_task: asyncio.Task[None] | None = None
 _change_event = asyncio.Event()
 _last_summary: dict[str, Any] | None = None
 
-# The one OTHER bridge-local record this module holds: the pending start
-# request an untokened caller (the agent, in deployments where the launch
-# token lives with the operator panel and never enters the agent's
-# environment) has filed for a token holder to confirm. Not queue state — the
-# manager knows nothing of it — and deliberately ephemeral: losing it on a
-# restart loses a UI affordance, never a safety property, because the ONLY
-# thing that ever starts the queue remains the token-gated POST /queue/start.
-_start_request: dict[str, Any] | None = None
-
 
 def _get_backend() -> QueueBackend:
     """The process's single `QueueBackend`, via `app.py`'s shared accessor.
@@ -184,10 +166,9 @@ def _clear() -> None:
     it, and the next test may run on a fresh loop. The backend singleton
     lives in `app.py` (`set_queue_backend(None)` resets it) — not here.
     """
-    global _last_summary, _arming_lock, _change_event, _start_request
+    global _last_summary, _arming_lock, _change_event
     _stop_poller()
     _last_summary = None
-    _start_request = None
     _subscribers.clear()
     _arming_lock = asyncio.Lock()
     _change_event = asyncio.Event()
@@ -593,30 +574,18 @@ async def _check_devices_exist(backend: QueueBackend, plan_name: str, plan_args:
 
 
 def _status_summary(status: dict[str, Any]) -> dict[str, Any]:
-    """The bounded, diffable projection of a manager status document.
-
-    ``start_request`` is the one summary entry that is bridge-local rather
-    than read from the status document; carrying it here is what makes a
-    filed or dismissed request reach SSE subscribers through the same
-    summary-diff the manager-side keys use.
-    """
+    """The bounded, diffable projection of a manager status document."""
     summary: dict[str, Any] = {"available": True}
     for key in _SUMMARY_KEYS:
         summary[key] = status.get(key)
-    summary["start_request"] = _start_request
     return summary
 
 
 def _unavailable_summary(reason: str) -> dict[str, Any]:
-    """The summary published when the manager (or backend) cannot be read.
-
-    A pending start request survives a manager outage — it is bridge-local
-    state, and the confirm path re-answers for itself when the human clicks.
-    """
+    """The summary published when the manager (or backend) cannot be read."""
     summary: dict[str, Any] = {"available": False, "reason": reason}
     for key in _SUMMARY_KEYS:
         summary[key] = None
-    summary["start_request"] = _start_request
     return summary
 
 
@@ -807,17 +776,6 @@ class QueueStopRequest(BaseModel):
     """Body for `POST /queue/stop`. ``cancel: true`` withdraws a pending stop."""
 
     cancel: bool = False
-
-
-class StartRequestBody(BaseModel):
-    """Body for `POST /queue/start-request` (optional in its entirety).
-
-    ``requested_by`` is a display label for the confirm affordance ("the
-    agent requests…"), never an identity the bridge trusts for anything —
-    the request arms nothing regardless of who filed it.
-    """
-
-    requested_by: str = Field(default="agent", min_length=1, max_length=80)
 
 
 # ---------------------------------------------------------------------------
@@ -1115,102 +1073,8 @@ async def start_queue(x_launch_token: str = Header(default="")) -> dict[str, Any
             result = await backend.start()
     except QueueBackendError as exc:
         raise _http_error(exc) from exc
-    # An armed start consumes any pending start request — whether it WAS the
-    # confirmation (a token holder answering the agent) or simply overtook it,
-    # the queue is now doing the thing the request asked for.
-    global _start_request
-    _start_request = None
     _notify_change()
     return {"started": True, "msg": str(result.get("msg") or "")}
-
-
-@router.post("/queue/start-request")
-async def request_queue_start(body: StartRequestBody | None = None) -> dict[str, Any]:
-    """File a request for a launch-token holder to start the queue. Ungated.
-
-    The deployed posture this exists for: the launch token is minted into the
-    operator panels sidecar and never into the agent's environment, so the
-    agent can compose, stage, and enqueue — but only a human, in the queue
-    panel, can arm. This route is how the agent hands the human that decision
-    without acquiring any arming capability itself: filing publishes a record
-    on the queue summary (and its SSE stream), where the panel renders it as a
-    confirm affordance next to the very queue items it would drain. The
-    confirmation is the EXISTING token-gated ``POST /queue/start`` — this
-    route adds no second way to start anything, and like ``POST /queue/abort``
-    it declares no token header at all, so no later edit can quietly promote
-    it into one.
-
-    Refusals mirror the checks a real start would fail, so the requester
-    hears them immediately instead of parking a request no click could ever
-    honour: a deployment that cannot execute refuses with its capability
-    record (same as enqueue), an already-moving queue refuses
-    ``manager_not_idle`` (the drain is already happening), and an empty queue
-    refuses ``queue_empty`` (there is nothing to confirm). The authoritative
-    versions of these checks still run inside the confirm's arming lock —
-    these are a courtesy, not the gate.
-
-    One request at a time: refiling replaces the pending record (fresh
-    ``request_id``), and a successful armed start or an explicit
-    ``DELETE /queue/start-request`` clears it.
-    """
-    backend = _get_backend()
-    try:
-        capability = await backend.capability()
-    except QueueBackendError as exc:
-        raise _http_error(exc) from exc
-    if not capability.can_execute:
-        raise _http_error(ExecutionUnavailableError(capability))
-
-    try:
-        status = await backend.status(reload=True)
-        queue_state = await backend.items()
-    except QueueBackendError as exc:
-        raise _http_error(exc) from exc
-
-    running_item = queue_state.get("running_item")
-    if _requires_arming(status):
-        _refuse_manager_not_idle(running_item if isinstance(running_item, dict) else {})
-
-    items_in_queue = int(status.get("items_in_queue") or 0)
-    if items_in_queue == 0:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "code": "queue_empty",
-                "detail": (
-                    "the queue holds no items, so there is nothing a start could run — "
-                    "stage a draft and enqueue it (POST /queue/items) before requesting "
-                    "a start."
-                ),
-            },
-        )
-
-    record = {
-        "request_id": uuid.uuid4().hex[:12],
-        "requested_by": (body or StartRequestBody()).requested_by,
-        "requested_at": datetime.now(UTC).isoformat(timespec="seconds"),
-        "items_in_queue": items_in_queue,
-    }
-    global _start_request
-    _start_request = record
-    _notify_change()
-    return {"start_request": record}
-
-
-@router.delete("/queue/start-request")
-async def dismiss_queue_start_request() -> dict[str, Any]:
-    """Withdraw the pending start request. Ungated and idempotent.
-
-    Declining to start is the safe direction — like the plain stop, it must
-    never have a failure mode, so no token, no capability check, and a dismiss
-    with nothing pending is a 200 ``{"dismissed": false}``, not an error.
-    """
-    global _start_request
-    dismissed = _start_request is not None
-    _start_request = None
-    if dismissed:
-        _notify_change()
-    return {"dismissed": dismissed}
 
 
 @router.post("/queue/stop")

--- a/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
+++ b/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
@@ -91,3 +91,28 @@ Direct {{ protocol_name }} calls skip all of these protections.
 For scripts that write to the control system, use the `execute` MCP tool directly
 with `execution_mode: "write"` —
 the `execute` tool defaults to readonly mode, which blocks write operations.
+{% if "bluesky" in enabled_servers | default([]) %}
+
+## Starting a Bluesky Queue
+
+Starting a queue moves accelerator hardware. Arming a start needs
+`BLUESKY_LAUNCH_TOKEN`, which a persona is granted only when its config sets
+`control_system.writes_enabled: true` **and** runs the `bluesky` MCP server.
+A read-only persona never holds it.
+
+Where it is granted, one approval is the whole gate: approving `queue_start` in
+chat starts the queue. There is no second confirmation step anywhere else.
+
+A deploy refuses to grant this token to a persona whose settings permit `Bash`.
+The approval gates the `queue_start` tool, not a shell — an agent with a shell
+could read the token out of its own environment and arm a queue with no approval
+at all.
+
+If `queue_start` is refused with `launch_token_required`, this agent cannot arm
+the queue here — it was not granted a token, the token it holds does not match
+the bridge's, or this deployment has no launch token configured at all. Do not
+go looking for the token in the environment, in config, or through a shell. Tell
+the operator what you have staged and that the
+start was refused for a missing or mismatched token, and let them start the
+queue from the BLUESKY panel.
+{% endif -%}

--- a/src/osprey/templates/claude_code/claude/skills/operating-bluesky-scans/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/operating-bluesky-scans/SKILL.md
@@ -137,37 +137,24 @@ control. It runs **the queue as it stands — every pending item, in order**,
 not just the one you added. Read `queue_list()` first and be sure the whole
 queue is what should run.
 
-`queue_start` has **two success shapes**, decided by where this deployment
-keeps the launch token, and you must recognize both:
+`queue_start` has **one success shape**: `{"started": true, "msg": ...}`, once
+the bridge has accepted the start behind your approval prompt. The queue is
+draining from that moment. There is no other shape — this call either arms the
+queue or refuses, and every refusal carries a code you branch on (see below).
 
-- **`{"started": true, ...}`** — this MCP server holds the token (typical for
-  a host-run dev session). The start went to the bridge directly, behind your
-  approval prompt, and the queue is now draining.
-- **`{"started": false, "start_request": {...}, "message": ...}`** — this
-  server holds **no** token, which in a deployed control room is the intended
-  posture, not a misconfiguration: the token lives with the operator's
-  BLUESKY queue panel, and no environment variable, config edit, or retry
-  from your side can obtain it. Your call filed a **start request** that is
-  now showing in the human's queue panel, beside the very queue it would
-  drain, with a *Confirm start* control only the panel can honour. Tell the
-  operator their confirmation is waiting in the queue panel, then watch
-  `queue_status`/`queue_list` for the start. Calling `queue_start` again
-  replaces the pending request (it does not stack); the human can also
-  dismiss it, which starts nothing.
-
-Never respond to the second shape by hunting for the token, editing
-configuration, or entering a setup mode — the tokenless environment is the
-deployment working as designed, and the human's panel click is the missing
-step, not a missing setting.
+The approval prompt is the whole gate. One human sees one start, says yes, and
+the queue runs; there is no second confirmation anywhere. If the start is
+refused with `launch_token_required`, that is not a step you can complete —
+never hunt for a token, edit configuration, or enter a setup mode. Hand the
+action to the operator, who can start the queue from the BLUESKY panel's own
+*Start queue* control.
 
 **`queue_list()`** is the read surface for all of this, and is the same view
 the human's queue panel shows. It returns `{status, items, running_item}`:
 `status` carries `available`, `manager_state`, `items_in_queue`,
-`queue_stop_pending`, `queue_autostart_enabled` and `start_request` (the
-pending panel start request, or `null` — non-null means the operator has not
-confirmed or dismissed it yet); `items` are the pending items in execution
-order with their `item_uid`, plan `name` and `kwargs`; and `running_item` is
-the item under way (`null` when idle).
+`queue_stop_pending` and `queue_autostart_enabled`; `items` are the pending
+items in execution order with their `item_uid`, plan `name` and `kwargs`; and
+`running_item` is the item under way (`null` when idle).
 
 ---
 
@@ -198,9 +185,11 @@ stopping at "I can't".
 so `queue_stop` and `stop_run` are never denied by it — halting must not depend
 on the same switch that disables motion.
 
-(These tools *also* withhold the launch token whenever `writes_enabled` re-reads
-false. That is a backstop for a consumer running without the hooks above, not
-the layer doing the work here.)
+(The tools re-read `writes_enabled` themselves too — a backstop for a consumer
+running without the hooks above, not the layer doing the work here. It is not
+uniform: `queue_start` and `queue_stop(cancel=True)` refuse outright with
+`writes_disabled` before the bridge is contacted at all, while `queue_add`
+withholds the launch token and lets the bridge decide.)
 
 ### Layer 2: the bridge, on the calls that do reach it
 
@@ -208,10 +197,10 @@ The bridge alone knows the queue server's live state, under a lock, so it is
 what decides whether a particular call was armed:
 
 - **`queue_start`** is always armed: starting needs the launch token, and it
-  is approval-gated so a human sees the start. When this server holds a token
-  the start goes to the bridge directly; when it holds none, the same call
-  files a panel start request instead (see Step 2) — the token requirement is
-  never waived, it is answered by the human's confirm click.
+  is approval-gated so a human sees the start. The requirement is never
+  waived. A server holding a valid token starts the queue; one holding none,
+  or one whose token the bridge rejects, is refused with
+  `launch_token_required` and the operator starts the queue themselves.
 - **`queue_add`** is armed only *sometimes*. Adding to an idle queue moves
   nothing; adding to a queue that is already draining (`manager_state` of
   `executing_queue`, `starting_queue`, `executing_task` or `paused`, or
@@ -232,23 +221,21 @@ whole detail object comes through as `details`. Nothing is reworded, so branch
 on the code and relay the bridge's sentence to the operator as written.
 
 - **`launch_token_required`** — this operation is armed and the token was
-  missing or rejected. You will see it from `queue_add` onto an
-  already-draining queue, from `queue_stop(cancel=True)`, or from the bridge
-  rejecting a mismatched token — never from a tokenless `queue_start`, which
-  files a panel start request instead. Not agent-recoverable, and NOT a
-  configuration task for you: in deployed control rooms the token lives with
-  the operator's queue panel by design, so hand the action to the human —
-  the panel performs these operations with its own token. Never edit
-  config.yml, `.env`, or settings to obtain a token. For a `queue_add`,
-  `details.manager_state` names the state that made it armed, and the
-  suggestions say whether this server withheld the token because writes are
-  disabled (then enabling writes, an operator action, is what unblocks it).
-  If `details.item_left_behind` is true, an item could not be withdrawn and is
-  sitting in an armed queue — `details.item_uid` names it, and a human must
-  deal with it. Say so.
-- **`queue_empty`** — a tokenless `queue_start` found nothing queued, so there
-  was nothing a confirmation could run and no request was filed. Stage the
-  plan with `set_draft` and add it with `queue_add` first.
+  missing or rejected. You will see it from `queue_start`, from `queue_add`
+  onto an already-draining queue, and from `queue_stop(cancel=True)` — whether
+  this server holds no token at all, holds one the bridge rejects, or the
+  bridge itself was never given one. The code is the same in every case: it
+  tells you the operation was refused for want of a token, not which of those
+  is true. Not agent-recoverable, and NOT a configuration task for you: which
+  agents may arm this deployment is an operator's decision, so hand the action
+  to the human — the BLUESKY queue panel performs these operations with its
+  own token. Never edit config.yml, `.env`, or settings to obtain a token. For
+  a `queue_add`, `details.manager_state` names the state that made it armed,
+  and the suggestions say whether this server withheld the token because
+  writes are disabled (then enabling writes, an operator action, is what
+  unblocks it). If `details.item_left_behind` is true, an item could not be
+  withdrawn and is sitting in an armed queue — `details.item_uid` names it,
+  and a human must deal with it. Say so.
 - **`stale_draft_revision`** — the draft changed or was cleared since you
   pinned it. Re-read it with `get_draft` (or re-stage the full configuration
   with `set_draft`), then add the **current** revision.

--- a/src/osprey/templates/claude_code/claude/skills/writing-bluesky-plans/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/writing-bluesky-plans/SKILL.md
@@ -236,11 +236,7 @@ failure downgrades the figure instead of losing it.
    `queue_start()` begins draining it. Both consult the validation record:
    the plan's content hash is re-checked at enqueue **and** again at queue
    start, `queue_start` requires `control_system.writes_enabled` plus the
-   launch token, and a human sees an approval prompt. In deployments where
-   this server holds no launch token (the deployed-terminal norm — the token
-   lives with the operator's queue panel), `queue_start` instead files a
-   start request the human confirms in that panel; see
-   `operating-bluesky-scans` for the two success shapes. A refusal whose
+   launch token, and a human sees an approval prompt. A refusal whose
    `detail.code` starts with `session_plan_` (`session_plan_unvalidated`,
    `session_plan_not_in_namespace`) means exactly one thing: re-validate the
    plan and try again. Use `get_run(run_id)` / `get_run_data(run_id, ...)` to

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -447,6 +447,27 @@ services:
          back only on an unset variable, never on an empty one. #}
       - ARIEL_DB_PASSWORD=${ARIEL_DB_PASSWORD:-ariel}
 {%- endif %}
+{%- if svc.wants_launch_token %}
+      {#- The Bluesky queue's launch token, for a persona entitled to arm a queue
+         start. The consumer is the `bluesky` MCP server inside this container:
+         holding this token is what lets the agent start the queue on the
+         operator's approval of that one tool call, with no second confirmation
+         step anywhere else. A persona without it is refused by the bridge, and
+         the operator starts the queue from the BLUESKY panel themselves.
+
+         Per-user for the same reason as the two credentials above, and more
+         sharply: this one arms physical hardware motion. A read-only persona
+         reads the same `.env.production` as everyone else, so a token placed
+         there would hand queue-start capability to exactly the personas that
+         must never have it.
+
+         `${VAR:-}` is resolved by compose from the deploy `.env`, so the secret
+         is never written into this rendered file. The `:-` default keeps compose
+         from warning, and an empty value is falsy to `resolve_launch_token`,
+         which then resolves no token and refuses the launch client-side — the
+         same fail-closed outcome as never emitting this line at all. #}
+      - BLUESKY_LAUNCH_TOKEN=${BLUESKY_LAUNCH_TOKEN:-}
+{%- endif %}
     volumes:
       - {{ svc.user }}-claude-config:/data/claude-config
       {#- Mount target comes from render.py's _container_agent_data_dir, which

--- a/tests/deployment/web_terminals/test_artifacts.py
+++ b/tests/deployment/web_terminals/test_artifacts.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import hashlib
+import json
 
 import pytest
 import yaml
 
-from osprey.deployment.web_terminals.artifacts import auth_env_digest, write_web_terminal_artifacts
+from osprey.deployment.web_terminals.artifacts import (
+    BashLaunchTokenConflictError,
+    auth_env_digest,
+    write_web_terminal_artifacts,
+)
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
 from osprey.deployment.web_terminals.render import AUTH_ENV_DIGEST_LABEL
 
@@ -169,3 +174,251 @@ def test_auth_env_digest_reads_the_file_under_the_given_root(tmp_path):
 
     (tmp_path / AUTH_ENV_FILENAME).write_bytes(b"A=1\n")
     assert auth_env_digest(tmp_path) == hashlib.sha256(b"A=1\n").hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Per-persona credentials: this seam resolves them, the render only formats them
+#
+# `render_web_terminals` reads no filesystem, so every persona entitlement is
+# decided HERE, where the deploy root is in scope, and handed down as a set. The
+# proof below is therefore end-to-end in a way no render-level test can be: it
+# starts from persona projects actually on disk and ends at the rendered compose.
+# `BLUESKY_LAUNCH_TOKEN` is the credential worth pinning this way, because it
+# arms physical hardware motion — the one grant where handing the set to the
+# wrong persona has consequences that a redeploy cannot take back.
+# ---------------------------------------------------------------------------
+
+_LAUNCH_TOKEN_LINE = "BLUESKY_LAUNCH_TOKEN=${BLUESKY_LAUNCH_TOKEN:-}"
+
+
+#: The shell-relevant subset of `settings.json.j2`'s `deny_defaults` (the template also
+#: ships the playwright and context7 MCP wildcards, which no guard here reads). Every
+#: OSPREY project denies the shell unless its config removed the entry, so a persona
+#: project fixture that shipped no `.claude/settings.json` at all would be modelling a
+#: deployment that cannot exist — and would trip the Bash/launch-token conflict guard.
+_SHIPPED_DENY = ["Bash", "Edit", "WebFetch", "WebSearch"]
+
+
+def _write_persona_project(
+    tmp_path, name: str, project_config: dict, *, denies_bash: bool = True
+) -> str:
+    """Render a persona project under *tmp_path*; return its relative project_path.
+
+    Writes both halves of what the guard reads: the `config.yml` the entitlement
+    predicates walk, and the built `.claude/settings.json` artifact the Bash check
+    reads. `denies_bash=False` renders the artifact a project whose config carried
+    `claude_code.permissions.remove_deny: ["Bash"]` would produce.
+    """
+    project_dir = tmp_path / "profiles" / name
+    project_dir.mkdir(parents=True)
+    (project_dir / "config.yml").write_text(
+        yaml.safe_dump({"project_name": name, **project_config}), encoding="utf-8"
+    )
+    deny = [entry for entry in _SHIPPED_DENY if denies_bash or entry != "Bash"]
+    (project_dir / ".claude").mkdir()
+    (project_dir / ".claude" / "settings.json").write_text(
+        json.dumps({"permissions": {"allow": [], "deny": deny, "ask": []}}), encoding="utf-8"
+    )
+    return f"profiles/{name}"
+
+
+def _tiered_roster_config(tmp_path, *, rw_denies_bash: bool = True, ro_denies_bash: bool = True):
+    """A two-tier roster whose persona projects are really on disk.
+
+    `alice` runs a read-write persona that also runs the bluesky server, so its
+    project satisfies both halves of the launch-token predicate. `bob` runs a
+    read-only persona — `writes_enabled: false` — which can never satisfy it.
+    Both ship the shell deny by default; the `*_denies_bash` switches drop it to
+    construct the conflict the deploy guard refuses.
+    """
+    config = _config(
+        [
+            {"name": "alice", "index": 0, "persona": "readwrite"},
+            {"name": "bob", "index": 1, "persona": "readonly"},
+        ]
+    )
+    config["modules"]["web_terminals"]["personas"] = {
+        "readwrite": {
+            "project": "rw",
+            "project_path": _write_persona_project(
+                tmp_path,
+                "rw",
+                {"control_system": {"writes_enabled": True}},
+                denies_bash=rw_denies_bash,
+            ),
+        },
+        "readonly": {
+            "project": "ro",
+            "project_path": _write_persona_project(
+                tmp_path,
+                "ro",
+                {"control_system": {"writes_enabled": False}},
+                denies_bash=ro_denies_bash,
+            ),
+        },
+    }
+    return config
+
+
+def _rendered_services(dest) -> dict:
+    return yaml.safe_load((dest / "docker-compose.web.yml").read_text(encoding="utf-8"))["services"]
+
+
+def test_write_grants_the_launch_token_to_the_entitled_persona(tmp_path):
+    """The wiring, proven from disk: a persona project that enables writes and runs
+    the bluesky server gets the launch token in its OWN `environment:` block,
+    interpolated from the deploy .env at compose time so no secret is ever written
+    into a rendered artifact."""
+    write_web_terminal_artifacts(_tiered_roster_config(tmp_path), tmp_path)
+
+    services = _rendered_services(tmp_path / "build")
+    assert _LAUNCH_TOKEN_LINE in services["web-alice"]["environment"]
+
+
+def test_write_never_grants_the_launch_token_to_a_read_only_persona(tmp_path):
+    """The tier boundary, asserted POSITIVELY on the persona that must not have it.
+    A test that only checks the entitled persona passes just as happily when the
+    token leaks to the whole roster — which is the failure mode this seam exists
+    to prevent, since this token arms hardware motion."""
+    write_web_terminal_artifacts(_tiered_roster_config(tmp_path), tmp_path)
+
+    bob_env = _rendered_services(tmp_path / "build")["web-bob"]["environment"]
+    assert _LAUNCH_TOKEN_LINE not in bob_env
+    assert not any("BLUESKY_LAUNCH_TOKEN" in value for value in bob_env)
+
+
+def test_launch_token_is_granted_per_user_and_never_through_the_shared_env_file(tmp_path):
+    """`.env.production` is ROSTERWIDE — every persona's container reads it, read-only
+    ones included — so the grant must reach exactly one `environment:` block and
+    nothing else. Rendering the artifacts must also not create or touch that file:
+    it is a durable secret store this seam never writes.
+    """
+    config = _tiered_roster_config(tmp_path)
+
+    write_web_terminal_artifacts(config, tmp_path)
+
+    compose_text = (tmp_path / "build" / "docker-compose.web.yml").read_text(encoding="utf-8")
+    assert compose_text.count(_LAUNCH_TOKEN_LINE) == 1
+    services = _rendered_services(tmp_path / "build")
+    assert services["web-alice"]["env_file"] == ".env.production"
+    assert services["web-bob"]["env_file"] == services["web-alice"]["env_file"]
+    assert not (tmp_path / ".env.production").exists()
+
+
+# ---------------------------------------------------------------------------
+# The Bash/launch-token conflict guard
+#
+# The one accepted cost of granting BLUESKY_LAUNCH_TOKEN is that the chat
+# approval gates the `queue_start` tool and nothing else: a persona holding the
+# token whose agent may also run a shell reads it out of its own environment and
+# arms hardware with no approval at any point. The deploy refuses that pairing
+# rather than shipping it, which is what makes the grant defensible — so these
+# tests pin the refusal, and pin that it names every offender.
+# ---------------------------------------------------------------------------
+
+
+def test_entitled_persona_permitting_bash_refuses_the_deploy_and_is_named(tmp_path):
+    """THE conflict: alice's persona is entitled to the token and its shipped
+    settings.json omits the shell deny. The deploy must stop, and the message must
+    name the persona — an operator hitting this at `osprey up` has no other context."""
+    config = _tiered_roster_config(tmp_path, rw_denies_bash=False)
+
+    with pytest.raises(BashLaunchTokenConflictError) as excinfo:
+        write_web_terminal_artifacts(config, tmp_path)
+
+    assert "readwrite" in str(excinfo.value)
+    assert excinfo.value.personas == ["readwrite"]
+
+
+def test_refusing_the_deploy_writes_no_artifacts(tmp_path):
+    """The guard runs BEFORE the render, so a refusal leaves nothing half-written.
+    A build/ directory carrying a compose file from a refused deploy is worse than
+    no deploy: the next `compose up -f build/...` would start the stack the guard
+    rejected."""
+    with pytest.raises(BashLaunchTokenConflictError):
+        write_web_terminal_artifacts(
+            _tiered_roster_config(tmp_path, rw_denies_bash=False), tmp_path
+        )
+
+    assert not (tmp_path / "build").exists()
+
+
+def test_the_refusal_states_both_conditions_and_the_remedy(tmp_path):
+    """The message IS the deliverable. It has to say what made the persona
+    entitled, what made it unsafe, and — because the settings.json read here is
+    the one baked into the image at build time — that restoring the deny requires
+    a REBUILD, not just a re-render."""
+    with pytest.raises(BashLaunchTokenConflictError) as excinfo:
+        write_web_terminal_artifacts(
+            _tiered_roster_config(tmp_path, rw_denies_bash=False), tmp_path
+        )
+
+    message = str(excinfo.value)
+    assert "writes_enabled" in message
+    assert "bluesky" in message
+    assert "permissions.deny" in message
+    assert "REBUILD" in message
+
+
+def test_a_correctly_configured_deployment_renders_without_the_guard_firing(tmp_path):
+    """The negative control. Every persona ships the shell deny — the state every
+    OSPREY build produces unless its config removed the entry — so the entitled
+    persona still gets its token and the artifacts are written normally."""
+    written = write_web_terminal_artifacts(_tiered_roster_config(tmp_path), tmp_path)
+
+    assert written
+    assert _LAUNCH_TOKEN_LINE in _rendered_services(tmp_path / "build")["web-alice"]["environment"]
+
+
+def test_a_read_only_persona_permitting_bash_is_not_a_conflict(tmp_path):
+    """Permitting the shell is only a conflict for a persona that HOLDS the token.
+    A read-only persona is never handed one, so there is nothing for a shell to
+    read — refusing here would block deployments that are not exposed."""
+    config = _tiered_roster_config(tmp_path, ro_denies_bash=False)
+
+    write_web_terminal_artifacts(config, tmp_path)
+
+    bob_env = _rendered_services(tmp_path / "build")["web-bob"]["environment"]
+    assert not any("BLUESKY_LAUNCH_TOKEN" in value for value in bob_env)
+
+
+def test_every_offending_persona_is_named_not_just_the_first(tmp_path):
+    """An operator fixing one offender at a time would redeploy once per persona to
+    discover the next. The guard intersects SETS precisely so one refusal reports
+    the whole conflict."""
+    config = _tiered_roster_config(tmp_path, rw_denies_bash=False)
+    config["modules"]["web_terminals"]["users"].append(
+        {"name": "carol", "index": 2, "persona": "alsobad"}
+    )
+    config["modules"]["web_terminals"]["personas"]["alsobad"] = {
+        "project": "bad2",
+        "project_path": _write_persona_project(
+            tmp_path, "bad2", {"control_system": {"writes_enabled": True}}, denies_bash=False
+        ),
+    }
+
+    with pytest.raises(BashLaunchTokenConflictError) as excinfo:
+        write_web_terminal_artifacts(config, tmp_path)
+
+    assert excinfo.value.personas == ["alsobad", "readwrite"]
+    message = str(excinfo.value)
+    assert "alsobad" in message
+    assert "readwrite" in message
+
+
+def test_the_guard_follows_the_shipped_artifact_not_the_config_intent(tmp_path):
+    """`osprey up` does not rebuild. A persona whose config.yml was edited to drop
+    the shell deny AFTER its last build still ships an image that denies it — the
+    edit reaches nothing until someone rebuilds. Reading intent here would refuse a
+    deployment that is not actually exposed, and (in the mirror case) would clear
+    one that is."""
+    config = _tiered_roster_config(tmp_path)
+    rw_config = tmp_path / "profiles" / "rw" / "config.yml"
+    parsed = yaml.safe_load(rw_config.read_text(encoding="utf-8"))
+    parsed["claude_code"] = {"permissions": {"remove_deny": ["Bash"]}}
+    rw_config.write_text(yaml.safe_dump(parsed), encoding="utf-8")
+
+    # The built artifact — what the image actually carries — still denies Bash.
+    write_web_terminal_artifacts(config, tmp_path)
+
+    assert _LAUNCH_TOKEN_LINE in _rendered_services(tmp_path / "build")["web-alice"]["environment"]

--- a/tests/deployment/web_terminals/test_env_production.py
+++ b/tests/deployment/web_terminals/test_env_production.py
@@ -65,13 +65,18 @@ _FULL_CONFIG = {
 # Every secret .env.production must NEVER contain -- the build-time
 # credentials (CI, registry, external-project pulls) and the fixed-name tokens
 # OSPREY's own deployed services authenticate to each other with. This
-# exclusion list is the security spec for the generator.
+# exclusion list is the security spec for the generator, so a service token
+# that is granted per-persona elsewhere belongs here too: BLUESKY_LAUNCH_TOKEN
+# reaches its entitled containers through the per-user compose `environment:`
+# block, and the whole point of that placement is that this rosterwide file
+# never carries it.
 _EXCLUDED_ENV = {
     "TEST_CI_TOKEN": "ci-secret",
     "TEST_REGISTRY_TOKEN": "registry-secret",
     "BEAM_VIEWER_DEPLOY_TOKEN": "external-project-secret",
     "EVENT_DISPATCHER_TOKEN": "dispatcher-secret",
     "DISPATCH_WORKER_TOKEN": "worker-secret",
+    "BLUESKY_LAUNCH_TOKEN": "launch-token-secret",
 }
 
 # Credentials the agent inside a web terminal presents to systems outside the

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -18,6 +18,7 @@ from ruamel.yaml import YAML
 
 from osprey.deployment.compose_generator import resolve_user_volume_names
 from osprey.deployment.web_terminals import lifecycle
+from osprey.deployment.web_terminals.artifacts import BashLaunchTokenConflictError
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME, PW_HASH_VAR_PREFIX
 from osprey.deployment.web_terminals.personas import resolve_personas
 from osprey.deployment.web_terminals.provision import AUTH_SERVICE_NAME
@@ -2226,3 +2227,83 @@ def test_passwd_recreate_argv_addresses_the_repos_web_stack_from_any_directory(
     # `.env.auth` — and a byte-exact revert would then be skipped as unchanged.
     assert (repo / "build" / "nginx" / "nginx.conf").is_file()
     assert not (tmp_path / "build").exists()
+
+
+# =============================================================================
+# decommission_user + the Bash/launch-token conflict guard
+#
+# The guard also runs at the render seam this verb calls, so a conflicted
+# deployment was always refused. What these pin is WHERE: refusing at the
+# re-render would leave config.yml already rewritten, the artifacts stale, and
+# the container/volume removal below never run. The verb must refuse before it
+# touches the roster — and must NOT lose the escape hatch that lets an operator
+# decommission the offending persona's own user.
+# =============================================================================
+
+
+def _conflicted_persona_config(tmp_path, users, *, personas):
+    """A roster whose persona projects are really on disk under *tmp_path*.
+
+    `personas` maps a persona name to `(writes_enabled, denies_bash)`, so a case
+    can pair the launch-token entitlement with either shipped permission state.
+    """
+    import json as _json
+
+    catalog = {}
+    for name, (writes, denies_bash) in personas.items():
+        project_dir = tmp_path / "profiles" / name
+        (project_dir / ".claude").mkdir(parents=True)
+        (project_dir / "config.yml").write_text(
+            yaml.safe_dump({"project_name": name, "control_system": {"writes_enabled": writes}}),
+            encoding="utf-8",
+        )
+        (project_dir / ".claude" / "settings.json").write_text(
+            _json.dumps({"permissions": {"deny": ["Bash"] if denies_bash else []}}),
+            encoding="utf-8",
+        )
+        catalog[name] = {"project": name, "project_path": f"profiles/{name}"}
+    return _config(users, personas=catalog)
+
+
+_TIERED_PERSONAS = {"armed": (True, False), "safe": (False, True)}
+_TIERED_USERS = [
+    {"name": "alice", "index": 0, "persona": "armed"},
+    {"name": "bob", "index": 1, "persona": "safe"},
+]
+
+
+def test_decommission_refuses_before_touching_the_roster_when_a_survivor_is_conflicted(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """Removing bob while alice's persona is conflicted must abort cleanly. The
+    roster edit is precisely what makes a failed decommission half-applied, so
+    the refusal has to land before it — not at the re-render that follows."""
+    monkeypatch.chdir(tmp_path)
+    config = _conflicted_persona_config(tmp_path, _TIERED_USERS, personas=_TIERED_PERSONAS)
+    config_path = _write_config(tmp_path, config)
+
+    with pytest.raises(BashLaunchTokenConflictError) as excinfo:
+        lifecycle.decommission_user(str(config_path), "bob", assume_yes=True)
+
+    assert "armed" in str(excinfo.value)
+    # config.yml untouched: both users still on the roster.
+    assert [entry["name"] for entry in _reload_users(config_path)] == ["alice", "bob"]
+    # And nothing downstream ran.
+    assert [c for c in fake_runtime if c[1] == "rm"] == []
+
+
+def test_decommission_of_the_conflicted_personas_own_user_still_succeeds(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """THE ESCAPE HATCH. Moving the check earlier must not cost the operator the
+    one remediation that needs no image rebuild: removing the conflicted
+    persona's last user. The probed roster is the POST-removal one, so that
+    persona stops being referenced and the conflict dissolves."""
+    monkeypatch.chdir(tmp_path)
+    config = _conflicted_persona_config(tmp_path, _TIERED_USERS, personas=_TIERED_PERSONAS)
+    config_path = _write_config(tmp_path, config)
+
+    lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
+
+    assert [entry["name"] for entry in _reload_users(config_path)] == ["bob"]
+    assert [c for c in fake_runtime if c[1] == "rm"] == [["docker", "rm", "-f", "dls-web-alice"]]

--- a/tests/deployment/web_terminals/test_personas.py
+++ b/tests/deployment/web_terminals/test_personas.py
@@ -3,19 +3,26 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from osprey.deployment.web_terminals.personas import (
     EVENTS_PANEL_ID,
     config_declares_panel,
-    config_uses_ariel,
+    config_needs_ariel_password,
+    config_needs_dispatcher_token,
+    config_needs_launch_token,
     env_var_suffix,
     env_var_suffix_collisions,
     freeze_user_indices,
     normalize_users,
-    personas_declaring_panel,
-    personas_using_ariel,
+    personas_needing_ariel_password,
+    personas_needing_dispatcher_token,
+    personas_needing_launch_token,
+    personas_not_denying_bash,
     resolve_personas,
+    settings_json_denies_bash,
 )
 
 
@@ -1283,7 +1290,17 @@ def test_config_declares_panel_treats_disabled_as_undeclared() -> None:
     assert config_declares_panel(config, EVENTS_PANEL_ID) is False
 
 
-def test_personas_declaring_panel_selects_only_the_declaring_persona(tmp_path) -> None:
+def test_config_needs_dispatcher_token_reads_the_events_panel_declaration() -> None:
+    """A thin wrapper: it reads exactly what `config_declares_panel(config,
+    EVENTS_PANEL_ID)` reads, with no separate config key of its own."""
+    config = {"web": {"panels": {"events": {"label": "EVENTS"}}}}
+
+    # Assert
+    assert config_needs_dispatcher_token(config) is True
+    assert config_needs_dispatcher_token({}) is False
+
+
+def test_personas_needing_dispatcher_token_selects_only_the_declaring_persona(tmp_path) -> None:
     """The entitlement set is exactly the personas whose rendered project shows the
     panel -- the readonly tier is excluded by its own config, not by a separate key."""
     # Arrange
@@ -1306,13 +1323,13 @@ def test_personas_declaring_panel_selects_only_the_declaring_persona(tmp_path) -
     )
 
     # Act
-    result = personas_declaring_panel(config, tmp_path, EVENTS_PANEL_ID)
+    result = personas_needing_dispatcher_token(config, tmp_path)
 
     # Assert
     assert result == {"readwrite"}
 
 
-def test_personas_declaring_panel_skips_unrendered_persona_projects(tmp_path) -> None:
+def test_personas_needing_dispatcher_token_skips_unrendered_persona_projects(tmp_path) -> None:
     """A persona whose project isn't on disk contributes nothing: a credential is
     never granted on a guess."""
     # Arrange
@@ -1322,7 +1339,7 @@ def test_personas_declaring_panel_skips_unrendered_persona_projects(tmp_path) ->
     )
 
     # Act / Assert
-    assert personas_declaring_panel(config, tmp_path, EVENTS_PANEL_ID) == set()
+    assert personas_needing_dispatcher_token(config, tmp_path) == set()
 
 
 # ---------------------------------------------------------------------------
@@ -1348,21 +1365,24 @@ def _write_persona_project_config(tmp_path, name: str, config: dict) -> str:
     return name
 
 
-def test_config_uses_ariel_reads_the_ariel_section() -> None:
+def test_config_needs_ariel_password_reads_the_ariel_section() -> None:
     """A project carrying an `ariel:` section resolves a DSN and needs the password."""
     # Assert
-    assert config_uses_ariel({"ariel": {"search_modules": {"keyword": {"enabled": True}}}}) is True
-    assert config_uses_ariel({}) is False
+    assert (
+        config_needs_ariel_password({"ariel": {"search_modules": {"keyword": {"enabled": True}}}})
+        is True
+    )
+    assert config_needs_ariel_password({}) is False
 
 
-def test_config_uses_ariel_ignores_an_empty_section() -> None:
+def test_config_needs_ariel_password_ignores_an_empty_section() -> None:
     """A key present but empty configures nothing, so it entitles nothing."""
     # Assert
-    assert config_uses_ariel({"ariel": None}) is False
-    assert config_uses_ariel({"ariel": {}}) is False
+    assert config_needs_ariel_password({"ariel": None}) is False
+    assert config_needs_ariel_password({"ariel": {}}) is False
 
 
-def test_personas_using_ariel_selects_only_the_ariel_persona(tmp_path) -> None:
+def test_personas_needing_ariel_password_selects_only_the_ariel_persona(tmp_path) -> None:
     """The entitlement set is exactly the personas whose rendered project configures
     ARIEL -- a persona with no logbook gets no logbook credential."""
     # Arrange
@@ -1389,13 +1409,13 @@ def test_personas_using_ariel_selects_only_the_ariel_persona(tmp_path) -> None:
     )
 
     # Act
-    result = personas_using_ariel(config, tmp_path)
+    result = personas_needing_ariel_password(config, tmp_path)
 
     # Assert
     assert result == {"readwrite"}
 
 
-def test_personas_using_ariel_skips_unrendered_persona_projects(tmp_path) -> None:
+def test_personas_needing_ariel_password_skips_unrendered_persona_projects(tmp_path) -> None:
     """A persona whose project isn't on disk contributes nothing: a credential is
     never granted on a guess."""
     # Arrange
@@ -1405,4 +1425,396 @@ def test_personas_using_ariel_skips_unrendered_persona_projects(tmp_path) -> Non
     )
 
     # Act / Assert
-    assert personas_using_ariel(config, tmp_path) == set()
+    assert personas_needing_ariel_password(config, tmp_path) == set()
+
+
+# ---------------------------------------------------------------------------
+# writes + bluesky server -> per-user queue launch token
+#
+# `BLUESKY_LAUNCH_TOKEN` arms a queue start, so it is gated on the intersection
+# of the two things that make arming meaningful: writes actually enabled, and
+# the bluesky MCP server (the token's consumer -- not the panel) actually run.
+# The two reads are asymmetric on purpose: `writes_enabled` must be explicitly
+# true, while the server's `enabled` override defaults to on when absent.
+# ---------------------------------------------------------------------------
+
+
+def _launch_config(writes_enabled: Any = "absent", bluesky_enabled: Any = "absent") -> dict:
+    """A project config with either read spelled out, or omitted via the sentinel."""
+    config: dict = {}
+    if writes_enabled != "absent":
+        config["control_system"] = {"writes_enabled": writes_enabled}
+    if bluesky_enabled != "absent":
+        config["claude_code"] = {"servers": {"bluesky": {"enabled": bluesky_enabled}}}
+    return config
+
+
+def test_config_needs_launch_token_requires_writes_and_the_bluesky_server() -> None:
+    """Both halves of the capability present -- the readwrite tier."""
+    # Assert
+    assert config_needs_launch_token(_launch_config(True, True)) is True
+
+
+def test_config_needs_launch_token_defaults_the_bluesky_server_to_enabled() -> None:
+    """`claude_code.servers.bluesky.enabled` is an override over an already-enabled
+    default, so its absence must not deny the token."""
+    # Assert
+    assert config_needs_launch_token(_launch_config(writes_enabled=True)) is True
+
+
+def test_config_needs_launch_token_denies_when_the_bluesky_server_is_off() -> None:
+    """Writes alone entitle nothing: with no bluesky server there is no consumer."""
+    # Assert
+    assert config_needs_launch_token(_launch_config(True, False)) is False
+
+
+def test_config_needs_launch_token_denies_the_readonly_tier() -> None:
+    """The read-only tier is `writes_enabled: false` and still runs the bluesky
+    server for browsing -- the server alone must never arm a queue start."""
+    # Assert
+    assert config_needs_launch_token(_launch_config(False, True)) is False
+
+
+def test_config_needs_launch_token_requires_writes_enabled_explicitly() -> None:
+    """Anything short of a literal `True` -- absent, null, or a truthy non-bool --
+    means writes were never granted."""
+    # Assert
+    assert config_needs_launch_token(_launch_config(bluesky_enabled=True)) is False
+    assert config_needs_launch_token(_launch_config(None, True)) is False
+    assert config_needs_launch_token(_launch_config("true", True)) is False
+    assert config_needs_launch_token(_launch_config(1, True)) is False
+
+
+def test_config_needs_launch_token_denies_an_empty_config() -> None:
+    """A config configuring neither half entitles nothing, and non-dict sections
+    are read defensively rather than raising."""
+    # Assert
+    assert config_needs_launch_token({}) is False
+    assert config_needs_launch_token(None) is False
+    assert config_needs_launch_token({"control_system": "on"}) is False
+
+
+def test_personas_needing_launch_token_selects_only_the_readwrite_persona(tmp_path) -> None:
+    """The entitlement set is exactly the personas whose rendered project both allows
+    writes and runs the bluesky server -- the read-only tier runs the same server (for
+    browsing) and must still be excluded, because it is `writes_enabled` that decides,
+    not whether the server is present. This is the tier boundary the whole feature
+    rests on: a read-only persona can never end up in this set."""
+    # Arrange
+    catalog = {
+        "readwrite": {
+            "project": "rw",
+            "project_path": _write_persona_project_config(
+                tmp_path,
+                "rw",
+                {
+                    "control_system": {"writes_enabled": True},
+                    "claude_code": {"servers": {"bluesky": {"enabled": True}}},
+                },
+            ),
+        },
+        "readonly": {
+            "project": "ro",
+            "project_path": _write_persona_project_config(
+                tmp_path,
+                "ro",
+                {
+                    "control_system": {"writes_enabled": False},
+                    "claude_code": {"servers": {"bluesky": {"enabled": True}}},
+                },
+            ),
+        },
+    }
+    config = _catalog_config(
+        catalog,
+        [
+            {"name": "alice", "index": 0, "persona": "readwrite"},
+            {"name": "bob", "index": 1, "persona": "readonly"},
+        ],
+    )
+
+    # Act
+    result = personas_needing_launch_token(config, tmp_path)
+
+    # Assert
+    assert result == {"readwrite"}
+
+
+def test_personas_needing_launch_token_skips_unrendered_persona_projects(tmp_path) -> None:
+    """A persona whose project isn't on disk contributes nothing: a credential is
+    never granted on a guess."""
+    # Arrange
+    config = _catalog_config(
+        {"ghost": {"project": "ghost", "project_path": "../never-rendered"}},
+        [{"name": "alice", "index": 0, "persona": "ghost"}],
+    )
+
+    # Act / Assert
+    assert personas_needing_launch_token(config, tmp_path) == set()
+
+
+# ---------------------------------------------------------------------------
+# Shipped-artifact reads: .claude/settings.json Bash deny
+# ---------------------------------------------------------------------------
+
+
+def _write_settings_json(tmp_path, name: str, body: Any) -> str:
+    """Render a persona project carrying a ``.claude/settings.json``.
+
+    ``body`` is written verbatim when it is a string (so a test can ship
+    unparseable bytes) and JSON-encoded otherwise. Returns the project_path.
+    """
+    import json as _json
+
+    claude_dir = tmp_path / name / ".claude"
+    claude_dir.mkdir(parents=True)
+    text = body if isinstance(body, str) else _json.dumps(body)
+    (claude_dir / "settings.json").write_text(text, encoding="utf-8")
+    return name
+
+
+def test_settings_json_denies_bash_reads_the_shipped_deny_list(tmp_path) -> None:
+    """The happy path: `Bash` listed in permissions.deny is a deny."""
+    # Arrange
+    _write_settings_json(
+        tmp_path, "locked", {"permissions": {"allow": ["Read(/x/**)"], "deny": ["Bash", "Edit"]}}
+    )
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "locked") is True
+
+
+def test_settings_json_denies_bash_false_when_bash_absent_from_a_well_formed_deny(
+    tmp_path,
+) -> None:
+    """A readable artifact that simply doesn't deny the shell -- the `remove_deny`
+    case this whole guard exists to catch."""
+    # Arrange
+    _write_settings_json(
+        tmp_path, "open", {"permissions": {"deny": ["Edit", "WebFetch"], "ask": ["Bash"]}}
+    )
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "open") is False
+
+
+def test_settings_json_denies_bash_ignores_a_scoped_bash_deny(tmp_path) -> None:
+    """`Bash(rm:*)` constrains one command family and leaves the shell usable, so it
+    is not a wholesale deny -- only the exact literal counts."""
+    # Arrange
+    _write_settings_json(tmp_path, "scoped", {"permissions": {"deny": ["Bash(rm:*)"]}})
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "scoped") is False
+
+
+def test_settings_json_denies_bash_fails_closed_on_a_missing_file(tmp_path) -> None:
+    """An unrendered project proves nothing about its permissions."""
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "never-rendered") is False
+
+
+def test_settings_json_denies_bash_fails_closed_on_invalid_json(tmp_path) -> None:
+    """A truncated or hand-mangled artifact is unreadable, not safe."""
+    # Arrange
+    _write_settings_json(tmp_path, "broken", '{"permissions": {"deny": ["Bash"')
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "broken") is False
+
+
+def test_settings_json_denies_bash_fails_closed_on_a_non_object_document(tmp_path) -> None:
+    """Valid JSON that isn't an object carries no permissions at all."""
+    # Arrange
+    _write_settings_json(tmp_path, "listy", ["Bash"])
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "listy") is False
+
+
+def test_settings_json_denies_bash_fails_closed_when_permissions_is_missing(tmp_path) -> None:
+    """No permissions block means nothing has been denied."""
+    # Arrange
+    _write_settings_json(tmp_path, "bare", {"hooks": {}})
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "bare") is False
+
+
+def test_settings_json_denies_bash_fails_closed_when_deny_is_missing(tmp_path) -> None:
+    """A permissions block with an allow list but no deny list denies nothing."""
+    # Arrange
+    _write_settings_json(tmp_path, "allow-only", {"permissions": {"allow": ["Read(/x/**)"]}})
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "allow-only") is False
+
+
+def test_settings_json_denies_bash_fails_closed_when_deny_is_not_a_list(tmp_path) -> None:
+    """A malformed deny value is unreadable, so it proves no deny -- including the
+    string "Bash", which must not be read as a one-element list."""
+    # Arrange
+    _write_settings_json(tmp_path, "stringly", {"permissions": {"deny": "Bash"}})
+    _write_settings_json(tmp_path, "nully", {"permissions": {"deny": None}})
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "stringly") is False
+    assert settings_json_denies_bash(tmp_path / "nully") is False
+
+
+def test_settings_json_denies_bash_ignores_non_string_deny_entries(tmp_path) -> None:
+    """Junk entries alongside a real deny neither raise nor suppress the deny."""
+    # Arrange
+    _write_settings_json(tmp_path, "mixed", {"permissions": {"deny": [None, 7, {}, "Bash"]}})
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "mixed") is True
+
+
+def test_personas_not_denying_bash_reports_only_the_permissive_persona(tmp_path) -> None:
+    """The roster form: the persona whose shipped settings dropped the Bash deny is
+    named; the locked-down one is not."""
+    # Arrange
+    catalog = {
+        "locked": {
+            "project": "locked",
+            "project_path": _write_settings_json(
+                tmp_path, "locked", {"permissions": {"deny": ["Bash", "Edit"]}}
+            ),
+        },
+        "shelly": {
+            "project": "shelly",
+            "project_path": _write_settings_json(
+                tmp_path, "shelly", {"permissions": {"deny": ["Edit"]}}
+            ),
+        },
+    }
+    config = _catalog_config(
+        catalog,
+        [
+            {"name": "alice", "index": 0, "persona": "locked"},
+            {"name": "bob", "index": 1, "persona": "shelly"},
+        ],
+    )
+
+    # Act
+    result = personas_not_denying_bash(config, tmp_path)
+
+    # Assert
+    assert result == {"shelly"}
+
+
+def test_personas_not_denying_bash_includes_unrendered_and_pathless_personas(tmp_path) -> None:
+    """Fail-closed at roster level too: a persona whose artifact cannot be located
+    is reported as permissive rather than silently skipped."""
+    # Arrange
+    config = _catalog_config(
+        {
+            "ghost": {"project": "ghost", "project_path": "../never-rendered"},
+            "pathless": {"project": "pathless"},
+        },
+        [
+            {"name": "alice", "index": 0, "persona": "ghost"},
+            {"name": "bob", "index": 1, "persona": "pathless"},
+        ],
+    )
+
+    # Act / Assert
+    assert personas_not_denying_bash(config, tmp_path) == {"ghost", "pathless"}
+
+
+def test_personas_not_denying_bash_covers_the_default_persona(tmp_path) -> None:
+    """`default_persona` is deployed by every roster entry that names none, so it is
+    walked alongside the explicitly referenced ones."""
+    # Arrange
+    catalog = {
+        "fallback": {
+            "project": "fallback",
+            "project_path": _write_settings_json(
+                tmp_path, "fallback", {"permissions": {"deny": ["Edit"]}}
+            ),
+        },
+    }
+    config = _catalog_config(catalog, [{"name": "alice", "index": 0}])
+    config["modules"]["web_terminals"]["default_persona"] = "fallback"
+
+    # Act / Assert
+    assert personas_not_denying_bash(config, tmp_path) == {"fallback"}
+
+
+def test_personas_not_denying_bash_ignores_unreferenced_catalog_entries(tmp_path) -> None:
+    """A persona nobody deploys cannot leak a token, so it is not reported."""
+    # Arrange
+    catalog = {
+        "unused": {
+            "project": "unused",
+            "project_path": _write_settings_json(tmp_path, "unused", {"permissions": {"deny": []}}),
+        },
+    }
+    config = _catalog_config(catalog, [])
+
+    # Act / Assert
+    assert personas_not_denying_bash(config, tmp_path) == set()
+
+
+def test_personas_not_denying_bash_reads_the_artifact_not_the_config(tmp_path) -> None:
+    """`osprey up` does not rebuild, so a config edited after the last build does not
+    change what ships. Both directions of that divergence are asserted here, because
+    the function must follow the artifact whichever way the two disagree.
+
+    `intent-permissive` has a config.yml that unblocks the shell while its rendered
+    settings.json still denies it -- it must NOT be reported.
+
+    `intent-safe` is the security-relevant inverse and the entire reason this function
+    reads the artifact at all: its config.yml looks safe (it removes nothing), while the
+    shipped settings.json is stale-permissive and omits the Bash deny. A config-reading
+    implementation would clear this persona for a launch token while the running image
+    still hands its agent a shell. It must be reported UNSAFE.
+    """
+    # Arrange
+    import yaml
+
+    def _write_config_yml(name: str, claude_code: dict) -> None:
+        (tmp_path / name / "config.yml").write_text(
+            yaml.safe_dump({"claude_code": claude_code}),
+            encoding="utf-8",
+        )
+
+    # Intent says the shell was unblocked; the built artifact still blocks it.
+    _write_settings_json(tmp_path, "intent-permissive", {"permissions": {"deny": ["Bash"]}})
+    _write_config_yml("intent-permissive", {"permissions": {"remove_deny": ["Bash"]}})
+
+    # Intent says the shell is blocked; the built artifact does not block it.
+    _write_settings_json(tmp_path, "intent-safe", {"permissions": {"deny": ["Edit"]}})
+    _write_config_yml("intent-safe", {"permissions": {"remove_deny": []}})
+
+    config = _catalog_config(
+        {
+            "intent-permissive": {
+                "project": "intent-permissive",
+                "project_path": "intent-permissive",
+            },
+            "intent-safe": {"project": "intent-safe", "project_path": "intent-safe"},
+        },
+        [
+            {"name": "alice", "index": 0, "persona": "intent-permissive"},
+            {"name": "bob", "index": 1, "persona": "intent-safe"},
+        ],
+    )
+
+    # Act
+    result = personas_not_denying_bash(config, tmp_path)
+
+    # Assert -- the verdict tracks the artifact, opposite to the intent, both ways
+    assert result == {"intent-safe"}
+
+
+def test_settings_json_denies_bash_reads_an_artifact_written_with_a_bom(tmp_path) -> None:
+    """`json.load` does not strip a UTF-8 BOM, so a hand-edited artifact saved with one
+    would fail to parse and a genuinely Bash-denying persona would read as permissive --
+    an opaque deploy refusal. The file is opened as utf-8-sig so the deny is seen."""
+    # Arrange
+    _write_settings_json(tmp_path, "bommed", '﻿{"permissions": {"deny": ["Bash", "Edit"]}}')
+
+    # Act / Assert
+    assert settings_json_denies_bash(tmp_path / "bommed") is True

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 from osprey.deployment.web_terminals import provision
+from osprey.deployment.web_terminals.artifacts import BashLaunchTokenConflictError
 from osprey.deployment.web_terminals.auth_credentials import (
     AUTH_ENV_FILENAME,
     PW_HASH_VAR_PREFIX,
@@ -903,3 +904,103 @@ def test_force_recreate_auth_sidecar_is_a_warning_not_a_failure_without_a_stack(
         provision.force_recreate_auth_sidecar({"project_name": "myproj"}, [])
 
     assert "docker-compose.web.yml" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# preflight_web_terminals -- the Bash/launch-token conflict gate
+#
+# The guard also lives at the render seam (tests/.../test_artifacts.py), which is
+# what covers the lifecycle re-render paths that never reach a preflight. What
+# only THIS placement can give is timing: the refusal has to land before
+# `ensure_env_production`, or a doomed deploy has already paid for the project
+# image build and minted -- and printed -- credentials for a stack that will
+# never come up. A regression that dropped this call would leave the render-seam
+# tests green, so it needs its own assertion.
+# ---------------------------------------------------------------------------
+
+
+def _persona_project(root: Path, name: str, *, writes: bool, denies_bash: bool) -> str:
+    """Write a persona project under *root*; return its relative project_path."""
+    import json
+
+    import yaml
+
+    project_dir = root / "profiles" / name
+    (project_dir / ".claude").mkdir(parents=True)
+    (project_dir / "config.yml").write_text(
+        yaml.safe_dump({"project_name": name, "control_system": {"writes_enabled": writes}}),
+        encoding="utf-8",
+    )
+    deny = ["Bash", "Edit"] if denies_bash else ["Edit"]
+    (project_dir / ".claude" / "settings.json").write_text(
+        json.dumps({"permissions": {"deny": deny}}), encoding="utf-8"
+    )
+    return f"profiles/{name}"
+
+
+def _persona_roster_config(root: Path, *, denies_bash: bool) -> dict:
+    """A registry-mode roster whose single persona both enables writes and runs bluesky."""
+    return {
+        "facility": {"prefix": "als"},
+        "modules": {
+            "web_terminals": {
+                "users": [{"name": "alice", "index": 0, "persona": "readwrite"}],
+                "auth": {"method": "none"},
+                "personas": {
+                    "readwrite": {
+                        "project": "rw",
+                        "project_path": _persona_project(
+                            root, "rw", writes=True, denies_bash=denies_bash
+                        ),
+                    }
+                },
+            }
+        },
+    }
+
+
+def test_preflight_refuses_a_bash_permitting_launch_token_persona(monkeypatch, tmp_path):
+    """The fail-fast gate: an entitled persona shipping no shell deny stops the
+    deploy in seconds, naming the persona.
+
+    `ensure_env_production` is deliberately NOT stubbed here. It raises on this
+    root too, so demanding specifically a `BashLaunchTokenConflictError` proves
+    the conflict is what the operator is told about — a guard moved below it
+    would surface the wrong error and fail this test.
+    """
+    monkeypatch.chdir(tmp_path)
+    config = _persona_roster_config(tmp_path, denies_bash=False)
+
+    with pytest.raises(BashLaunchTokenConflictError) as excinfo:
+        provision.preflight_web_terminals(config)
+
+    assert "readwrite" in str(excinfo.value)
+
+
+def test_preflight_refuses_before_any_credential_is_minted(monkeypatch, tmp_path):
+    """THE reason this placement exists. `preflight_web_terminals`' docstring
+    commits to not writing (and printing) passwords for a stack that never comes
+    up; the conflict refusal has to sit ahead of `ensure_env_production` to honour
+    that, not merely somewhere in the function."""
+    monkeypatch.chdir(tmp_path)
+    reached: list[str] = []
+    monkeypatch.setattr(
+        provision, "ensure_env_production", lambda config, root: reached.append("env_production")
+    )
+    monkeypatch.setattr(
+        provision, "_provision_auth_secrets", lambda wt, root: reached.append("auth_secrets")
+    )
+
+    with pytest.raises(BashLaunchTokenConflictError):
+        provision.preflight_web_terminals(_persona_roster_config(tmp_path, denies_bash=False))
+
+    assert reached == []
+
+
+def test_preflight_passes_a_persona_that_denies_bash(monkeypatch, tmp_path):
+    """The negative control: the same entitled persona shipping the shell deny
+    clears the gate, so the guard cannot be passing by refusing everything."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(provision, "ensure_env_production", lambda config, root: None)
+
+    provision.preflight_web_terminals(_persona_roster_config(tmp_path, denies_bash=True))

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -3137,3 +3137,91 @@ def test_render_without_ariel_personas_emits_no_password_line() -> None:
     for service in ("web-alice", "web-bob"):
         env = compose["services"][service]["environment"]
         assert not any("ARIEL_DB_PASSWORD" in line for line in env)
+
+
+# ---------------------------------------------------------------------------
+# Write entitlement -> per-user Bluesky launch token
+#
+# `BLUESKY_LAUNCH_TOKEN` is what lets the `bluesky` MCP server arm a queue start
+# on the operator's chat approval alone. Per-user for the same reason as the two
+# credentials above, and more sharply: the shared `.env.production` is handed to
+# every user's container alike, so a launch token placed there would hand
+# queue-start capability -- physical hardware motion -- to the read-only
+# personas that must never hold it.
+# ---------------------------------------------------------------------------
+
+_LAUNCH_TOKEN_LINE = "BLUESKY_LAUNCH_TOKEN=${BLUESKY_LAUNCH_TOKEN:-}"
+
+
+def test_entitled_persona_gets_the_launch_token() -> None:
+    """A user whose persona is entitled to arm a queue start gets the launch token
+    in its own `environment:` block, interpolated from the deploy `.env` at compose
+    time so the secret is never written into a rendered artifact."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config(), launch_token_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    assert _LAUNCH_TOKEN_LINE in compose["services"]["web-alice"]["environment"]
+
+
+def test_unentitled_persona_gets_no_launch_token() -> None:
+    """The tier boundary: a persona outside the entitled set must not receive the
+    credential that arms hardware motion -- which is exactly why this cannot live
+    in the shared .env.production that every user's container reads."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config(), launch_token_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    bob_env = compose["services"]["web-bob"]["environment"]
+    assert not any("BLUESKY_LAUNCH_TOKEN" in line for line in bob_env)
+
+
+def test_render_without_launch_token_personas_emits_no_token_line() -> None:
+    """The no-project-root render path (`osprey scaffold web-terminals render`)
+    passes no persona set, so no user is armed. Harmless: every `osprey up`
+    re-renders through the artifacts seam, which resolves the set from disk."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config())["docker-compose.web.yml"]
+    )
+
+    # Assert
+    for service in ("web-alice", "web-bob"):
+        env = compose["services"][service]["environment"]
+        assert not any("BLUESKY_LAUNCH_TOKEN" in line for line in env)
+
+
+def test_persona_less_roster_is_armed_from_the_config_itself() -> None:
+    """The zero-migration path -- roster entries that name no persona, where the web
+    image IS the deploy project -- has no persona to look up, so entitlement is read
+    from this same config with no disk read. That keeps the determinism contract
+    while still arming a deployment that never adopted personas.
+    """
+    # Arrange
+    config = copy.deepcopy(_config(["alice"]))
+    config["control_system"] = {"writes_enabled": True}
+
+    # Act
+    compose = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+
+    # Assert
+    assert _LAUNCH_TOKEN_LINE in compose["services"]["web-alice"]["environment"]
+
+
+def test_persona_less_roster_without_writes_is_not_armed() -> None:
+    """The same path, read-only: writes were never granted, so there is nothing to
+    arm and no token is emitted."""
+    # Act
+    compose = yaml.safe_load(render_web_terminals(_config(["alice"]))["docker-compose.web.yml"])
+
+    # Assert
+    env = compose["services"]["web-alice"]["environment"]
+    assert not any("BLUESKY_LAUNCH_TOKEN" in line for line in env)

--- a/tests/e2e/_queue_drive.py
+++ b/tests/e2e/_queue_drive.py
@@ -227,6 +227,35 @@ def wait_for_terminal_status(
     return last
 
 
+def assert_start_request_route_is_gone(base_url: str) -> None:
+    """Assert the deployed bridge exposes NO ``POST /queue/start-request``.
+
+    ``POST /queue/start`` is the only route that starts a queue. The route this
+    probes used to be the second half of a two-action arming flow: an agent
+    without the launch token filed a start REQUEST here, and an operator then
+    confirmed it from the queue panel. Both halves are gone -- the agent either
+    holds the token and starts the queue outright, or is refused.
+
+    Worth probing over HTTP rather than by grepping the source, because this is
+    the only assertion in the suite that can see the DEPLOYED bridge. Every
+    other test of this path mocks the MCP server's HTTP client, so an MCP
+    server posting to a route the bridge no longer serves stays green
+    everywhere else -- which is exactly the two-party break the deletion could
+    have left behind, in either direction.
+
+    A 404 is the pass. Anything else means a route answers there: 405 would say
+    the path exists under another method, and a 2xx/4xx from the app itself
+    would say the mechanism is still deployed.
+    """
+    status, body = request(base_url, "/queue/start-request", "POST", {})
+    assert status == 404, (
+        f"POST /queue/start-request answered {status} ({body!r}) -- the bridge "
+        "still serves a start-request route. Starting a queue is one action "
+        "through POST /queue/start; a second route that files a request for an "
+        "operator to confirm is the flow that was removed"
+    )
+
+
 def run_scan(
     base_url: str,
     plan_name: str,

--- a/tests/e2e/test_scan_stack_agentic.py
+++ b/tests/e2e/test_scan_stack_agentic.py
@@ -57,10 +57,30 @@ draft in the queue and moves nothing; only ``queue_start`` drains it. A floor
 satisfied by the add alone would pass a run in which no measurement was ever
 taken, which is the one thing this module exists to detect. ``get_run_data``
 closes it, and closes it on the RIGHT run: the add's own result names the run id
-the bridge assigned, and the read is required to ask for that id. Both live
-tests share one deploy, so an earlier test's run stays readable — without that
+the bridge assigned, and the read is required to ask for that id. Every live
+test shares one deploy, so an earlier test's run stays readable — without that
 binding, a run that read the PREVIOUS measurement back would look identical to
 one that took its own.
+
+The third live test grades the ARMING GATE, not a measurement
+-------------------------------------------------------------
+
+Starting a queued scan is the moment hardware moves, and it costs the operator
+exactly ONE action: they approve the agent's ``queue_start``, and the queue
+drains. The measurement tests above cannot see that — they run headless with
+the approval gate deliberately disarmed, because a headless session has no
+responder and an unanswered prompt is a hard denial. So they prove the flow
+WORKS while saying nothing about how many human actions it took, which is the
+one property this feature changed.
+
+:func:`test_starting_a_queued_scan_costs_one_operator_approval` re-arms the
+shipped approval hook for ``queue_start`` alone, answers the prompt from the
+test, and asserts the transcript: one prompt, for the arming step, allowed
+once — followed by a scan that really ran. It also probes the deployed bridge
+for the route that used to carry the second action. That probe is the only
+place in the suite where the MCP server's expectations meet the bridge's real
+routing table; everywhere else the HTTP client is mocked, so a server posting
+to a route the bridge no longer serves stays green.
 
 Both halves are dry-verified offline, against the SAME contracts the live
 tests use. The floor runs against hand-built ``ToolTrace`` fixtures — no
@@ -85,15 +105,18 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
 from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
 from osprey import bluesky_tool_names
 from osprey.agent_runner import SDKWorkflowResult, ToolTrace
@@ -105,10 +128,13 @@ from tests.e2e.judge import LLMJudge, WorkflowResult
 from tests.e2e.sdk_helpers import (
     HAS_SDK,
     SCENARIO_INTEGRITY_DISALLOWED_TOOLS,
+    HookEvent,
     _default_opus_model,
     is_claude_code_available,
     promote_ask_to_allow,
+    render_dir,
     run_sdk_query,
+    run_sdk_query_with_hooks,
 )
 from tests.e2e.test_preset_agentic import _to_workflow_result
 
@@ -127,6 +153,18 @@ SET_DRAFT = bluesky_tool_names.matcher(bluesky_tool_names.SET_DRAFT)
 QUEUE_ADD = bluesky_tool_names.matcher(bluesky_tool_names.QUEUE_ADD)
 QUEUE_START = bluesky_tool_names.matcher(bluesky_tool_names.QUEUE_START)
 GET_RUN_DATA = bluesky_tool_names.matcher(bluesky_tool_names.GET_RUN_DATA)
+
+#: Every tool that moves the queue itself — add, start, stop. The approval
+#: transcript is read over exactly this set (see
+#: :func:`assert_one_arming_approval`): these are the operations an operator
+#: consents to on the way to hardware motion, and the whole claim under test is
+#: how many of those consents starting a queued scan costs. Plan AUTHORING
+#: (``write_plan``/``validate_plan``) is ask-gated too but is a different
+#: activity — an agent that stops to author a plan body has not thereby taken a
+#: second step toward arming.
+QUEUE_CONTROL = frozenset(
+    bluesky_tool_names.matcher(tool) for tool in bluesky_tool_names.QUEUE_CONTROL_TOOLS
+)
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +192,13 @@ GET_RUN_DATA = bluesky_tool_names.matcher(bluesky_tool_names.GET_RUN_DATA)
 #               25434 test_bluesky_panels_deploy
 #   openobserve 25080 test_bluesky_queue_e2e · 25081 test_bluesky_deploy
 #               25082 test_tiled_roundtrip · 25083 test_bluesky_panels_deploy
+#   mongodb     no sibling pins one — the archiver's Mongo published the
+#               service default, and a tutorial stack deployed on this host
+#               holds it. The preflight refuses to touch any container when a
+#               published port is taken, so this one blocked the whole module
+#               (every service above was already free) over a service none of
+#               these tests read. Moved via the ``va_archiver`` PROFILE block,
+#               not a ``config:`` key — see ``_EXTRA_CONFIG``.
 # ---------------------------------------------------------------------------
 BRIDGE_PORT = 18109
 BRIDGE_URL = f"http://localhost:{BRIDGE_PORT}"
@@ -162,6 +207,7 @@ TILED_PORT = 18193
 VA_CA_PORT = 15066
 POSTGRES_PORT = 25435
 OPENOBSERVE_PORT = 25084
+MONGODB_PORT = 27117
 
 #: Compose project this module deploys under. Container names and locally-built
 #: image tags both follow ``<project>-<service>``, so every exact-named docker
@@ -295,19 +341,49 @@ def _launched_run_id(add_trace: ToolTrace) -> str | None:
 
     ``queue_add`` answers with ``json.dumps({"run_id", "revision", "item"})``,
     and ``run_id`` is OSPREY's handle for the run that add will produce — the
-    same value ``get_run_data`` takes as its required argument. Returns
-    ``None`` when the result is not parseable JSON or carries no usable id,
-    which is what makes the binding in :func:`find_satisfying_chain` degrade
-    instead of hard-failing.
+    same value ``get_run_data`` takes as its required argument.
+
+    That body does not reach the transcript bare. FastMCP surfaces a
+    ``str``-returning tool as structured content under a single ``result``
+    key, so what the SDK records for a real run is ``{"result": "<that JSON
+    string>"}`` — the id one layer down, inside a re-encoded string. A direct
+    call yields the bare body instead, so both forms are read: the sole-key
+    ``result`` envelope is peeled (bounded, and only when ``result`` is the
+    ONLY key, so a real body carrying its own ``result`` field is never
+    mistaken for transport), and a bare body is taken as-is.
+
+    Returns ``None`` when the result is not parseable JSON or carries no
+    usable id, which is what makes the binding in :func:`find_satisfying_chain`
+    degrade instead of hard-failing.
     """
-    try:
-        body = json.loads(add_trace.result or "")
-    except (TypeError, ValueError):
+    body: Any = add_trace.result
+    # Bounded so a pathological body cannot spin. The ceiling is derived, not
+    # padded: every iteration consumes exactly ONE step — parse a string, peel
+    # one envelope, or read the id and return — so N envelope layers cost
+    # 2N + 2. A bare body is 2 (parse, read); the live single-envelope shape is
+    # 4 (parse outer, peel, parse inner, read). 8 is therefore "tolerate up to
+    # THREE nested envelopes", which is the real boundary this number encodes.
+    # Raising it buys deeper nesting and nothing else; lowering it below 4
+    # silently reverts to the bug this helper exists to fix — an earlier draft
+    # used 3 and returned None on the real payload while passing hand-written
+    # tests, because 3 lands one step short of reading the id it just parsed.
+    for _ in range(8):
+        if isinstance(body, str):
+            try:
+                body = json.loads(body)
+            except (TypeError, ValueError):
+                return None
+            continue
+        if not isinstance(body, dict):
+            return None
+        run_id = body.get("run_id")
+        if isinstance(run_id, str) and run_id:
+            return run_id
+        if set(body) == {"result"}:  # FastMCP str-return transport envelope
+            body = body["result"]
+            continue
         return None
-    if not isinstance(body, dict):
-        return None
-    run_id = body.get("run_id")
-    return run_id if isinstance(run_id, str) and run_id else None
+    return None
 
 
 def _reads_run(run_id: str) -> Callable[[ToolTrace], bool]:
@@ -423,6 +499,30 @@ def assert_orbit_response_scan_executed(result: SDKWorkflowResult) -> None:
 def assert_grid_scan_executed(result: SDKWorkflowResult) -> None:
     """The grid-scan-class floor — see :func:`assert_scan_executed`."""
     assert_scan_executed(result, is_grid_scan_state, plan_class="grid-scan-class")
+
+
+def is_any_staged_plan_state(state: dict[str, Any]) -> bool:
+    """Accept any accumulated draft state that actually staged something.
+
+    Deliberately class-AGNOSTIC, and the only predicate here that is. The two
+    predicates above exist because their tests grade a MEASUREMENT, and a
+    measurement of the wrong class is the wrong measurement. The arming-gate
+    test below grades neither the class nor the physics: its subject is how
+    many human actions it takes to start a queued scan, and pinning a plan
+    class there would make the test fail for reasons that have nothing to do
+    with the gate — while costing a longer scan to sit through.
+
+    Empty state is still rejected, so this is not "accept anything": the chain
+    it anchors still needs a SUCCESSFUL ``queue_add`` that saw a staged plan,
+    a successful ``queue_start``, and a read of the run that add launched.
+    Pinned by :func:`test_any_class_floor_still_requires_the_whole_chain`.
+    """
+    return bool(state)
+
+
+def assert_a_scan_executed(result: SDKWorkflowResult) -> None:
+    """The class-agnostic floor — see :func:`is_any_staged_plan_state`."""
+    assert_scan_executed(result, is_any_staged_plan_state, plan_class="any-class")
 
 
 # ---------------------------------------------------------------------------
@@ -551,15 +651,23 @@ def _draft(
 
 def _add(*, is_error: bool = False, revision: int = 1, run_id: str = "run-1") -> ToolTrace:
     """A ``queue_add`` trace. The success body carries ``run_id`` because the
-    real tool's does, and the floor binds the later data read to it."""
+    real tool's does, and the floor binds the later data read to it.
+
+    Wrapped in the ``{"result": "<json>"}`` transport envelope that FastMCP
+    puts around a ``str``-returning tool, because that is the form the SDK
+    actually records for a live run — a fixture that emitted the bare body
+    would let the floor tests pass while the binding they exercise silently
+    degraded on every real run.
+    """
+    body = (
+        '{"code": "stale_revision"}'
+        if is_error
+        else f'{{"run_id": "{run_id}", "revision": 1, "item": {{"item_uid": "item-1"}}}}'
+    )
     return ToolTrace(
         name=QUEUE_ADD,
         input={"draft_revision": revision},
-        result=(
-            '{"code": "stale_revision"}'
-            if is_error
-            else f'{{"run_id": "{run_id}", "revision": 1, "item": {{"item_uid": "item-1"}}}}'
-        ),
+        result=json.dumps({"result": body}),
         is_error=is_error,
     )
 
@@ -781,13 +889,159 @@ def test_floor_binds_the_data_read_to_the_run_the_add_launched() -> None:
     ]
     assert not _floor_passes(read_an_older_run)
 
+    # Enveloped, because that is how a real result arrives — the same
+    # correction ``_add()`` needed. A bare string here would behave
+    # identically (both yield no id, so both degrade), which is exactly why
+    # the mismatch could sit unnoticed: a fixture that disagrees with reality
+    # and passes anyway is the shape this whole module just got wrong.
     unparseable_add_result = [
         _draft(patch=_ORM_ARGS),
-        ToolTrace(name=QUEUE_ADD, input={"draft_revision": 1}, result="queued at revision 1"),
+        ToolTrace(
+            name=QUEUE_ADD,
+            input={"draft_revision": 1},
+            result=json.dumps({"result": "queued at revision 1"}),
+        ),
         _start(),
         _read(run_id="run-1"),
     ]
     assert _floor_passes(unparseable_add_result)
+
+
+# A ``queue_add`` result captured verbatim off a live deployed stack. FastMCP
+# surfaces a ``str``-returning tool as structured content under a single
+# ``result`` key whose value is the tool's own JSON string, so what the SDK
+# records is double-encoded. This is the form every real run produces; the
+# bare form below is what a direct (non-MCP) call produces. Both are pinned
+# because :func:`_launched_run_id` has to read either.
+_LIVE_ENVELOPED_ADD_RESULT = (
+    r'{"result":"{\"run_id\": \"5f2d23d785c042dfa3eeeaeddc898ee3\", \"revision\": 5, \"item\":'
+    r" {\"item_type\": \"plan\", \"name\": \"orm\", \"kwargs\": {\"correctors\": "
+    r"[\"SR:MAG:HCM:01:CURRENT:SP\"], \"detectors\": [\"SR:DIAG:BPM:01:POSITION:X\"], "
+    r"\"span_a\": 2.0, \"num\": 5, \"sweep\": \"bidirectional\"}, \"meta\": "
+    r"{\"osprey_run_id\": \"5f2d23d785c042dfa3eeeaeddc898ee3\", \"osprey_plan\": {\"name\": "
+    r"\"orm\", \"kwargs\": {\"correctors\": [\"SR:MAG:HCM:01:CURRENT:SP\"], \"detectors\": "
+    r"[\"SR:DIAG:BPM:01:POSITION:X\"], \"span_a\": 2.0, \"num\": 5, \"sweep\": "
+    r"\"bidirectional\"}}}, \"user\": \"Queue Server API User\", \"user_group\": \"primary\", "
+    r'\"item_uid\": \"c575be41-db28-4047-a667-2b434408be8d\"}}"}'
+)
+_LIVE_RUN_ID = "5f2d23d785c042dfa3eeeaeddc898ee3"
+
+
+@pytest.mark.harness_benchmark
+def test_launched_run_id_reads_the_transport_envelope_a_live_run_produces() -> None:
+    """The id must come back out of the shape live runs actually carry.
+
+    Read against the captured payload above, not a hand-written one: the whole
+    point is that the form the offline fixtures assumed (a bare JSON object)
+    is one layer shallower than the form the MCP transport delivers, so a
+    helper checked only against hand-written bodies reports ``None`` on every
+    real run while every offline test stays green.
+
+    The structural assertions below are not redundant with the id check. They
+    exist to keep the capture a CAPTURE. Extracting the id exercises the outer
+    envelope and one key, leaving the whole ``item``/``meta`` subtree — the
+    part that makes this payload an independent referee rather than one more
+    fixture written from the same assumptions as the code — unasserted, and so
+    free to decay. A "this literal is huge, let me trim it" edit, or a reflow
+    of the multi-fragment concatenation that drops a byte, would otherwise
+    stay green. Pinning the shape turns "captured verbatim off a live run"
+    from a docstring claim into something a hand-written replacement has to
+    reproduce the real bridge's response to satisfy.
+    """
+    trace = ToolTrace(
+        name=QUEUE_ADD, input={"draft_revision": 5}, result=_LIVE_ENVELOPED_ADD_RESULT
+    )
+    assert _launched_run_id(trace) == _LIVE_RUN_ID
+
+    outer = json.loads(_LIVE_ENVELOPED_ADD_RESULT)
+    assert set(outer) == {"result"}, "the FastMCP envelope carries exactly one key"
+    body = json.loads(outer["result"])
+    assert set(body) == {"run_id", "revision", "item"}, (
+        "queue_add's documented response keys — see the tool's own docstring"
+    )
+    assert body["run_id"] == _LIVE_RUN_ID
+    item = body["item"]
+    assert {"item_uid", "user", "user_group"} <= set(item), (
+        "the queueserver item the bridge echoes back"
+    )
+    assert item["meta"]["osprey_run_id"] == _LIVE_RUN_ID, (
+        "the bridge stamps its run id into plan meta; a capture whose meta no "
+        "longer agrees with its own run_id is not a real response"
+    )
+
+
+@pytest.mark.harness_benchmark
+def test_launched_run_id_reads_every_nesting_depth_and_rejects_junk() -> None:
+    """Bare, singly- and doubly-enveloped bodies all resolve; nothing that
+    fails to yield a usable id is invented into one — that last part is what
+    keeps :func:`find_satisfying_chain`'s degrade path reachable.
+
+    Named for nesting depth rather than "bare bodies and junk" because the
+    doubly-enveloped case below is neither, and it is the case that makes this
+    test red under the regression it guards.
+    """
+
+    def _add_result(raw: str) -> ToolTrace:
+        return ToolTrace(name=QUEUE_ADD, input={"draft_revision": 1}, result=raw)
+
+    assert _launched_run_id(_add_result('{"run_id": "run-7", "revision": 1}')) == "run-7"
+    # A DOUBLY-enveloped body. Nothing produces this shape today, and that is
+    # the point: this assertion is aimed at a WRONG REFACTOR, not at current
+    # behaviour. The refactor is the live one — unifying this helper with
+    # ``_unwrap_health_payload`` in test_health_mcp_smoke.py, which peels the
+    # same envelope with a different loop strategy (a shorter bound plus a
+    # trailing re-check). Copy one strategy's bound without the other's
+    # fallthrough and you get a helper that peels exactly one layer.
+    #
+    # Such a helper passes EIGHT of the nine cases these two tests assert —
+    # the live capture resolves, the bare body resolves, every junk shape
+    # still returns None. This line is the only discriminator. Deleting it as
+    # an assertion for an impossible input removes the guard at precisely the
+    # moment it is needed. If the two readers are ever genuinely unified, this
+    # is the acceptance test for that work, not an obstacle to it.
+    doubly = json.dumps({"result": json.dumps({"result": '{"run_id": "run-8"}'})})
+    assert _launched_run_id(_add_result(doubly)) == "run-8"
+    # Envelope around a body that carries no id, and an envelope whose payload
+    # is not JSON at all: neither may be mistaken for a run id.
+    assert _launched_run_id(_add_result('{"result":"{\\"revision\\": 1}"}')) is None
+    assert _launched_run_id(_add_result('{"result":"queued at revision 1"}')) is None
+    assert _launched_run_id(_add_result("queued at revision 1")) is None
+    assert _launched_run_id(_add_result('{"run_id": ""}')) is None
+    assert _launched_run_id(_add_result('{"run_id": 5}')) is None
+    assert _launched_run_id(_add_result("[1, 2, 3]")) is None
+    assert _launched_run_id(ToolTrace(name=QUEUE_ADD, input={}, result=None)) is None
+
+
+@pytest.mark.harness_benchmark
+def test_start_request_assertion_catches_the_old_shape_in_both_encodings() -> None:
+    """The retired ``start_request`` shape must be caught however it is encoded.
+
+    Both halves of :func:`assert_no_start_request_was_filed` are exercised in
+    both the bare and MCP-enveloped encodings. The ``started`` false half is
+    the one that matters here: it is quoted, so escaping hides it from a plain
+    substring test, and it was dead on every live run for exactly that reason.
+    A dead clause is worse than an absent one — it reads as coverage.
+    """
+
+    def _start_result(raw: str) -> list[ToolTrace]:
+        return [ToolTrace(name=QUEUE_START, input={}, result=raw)]
+
+    def _enveloped(body: str) -> str:
+        return json.dumps({"result": body})
+
+    full_old_shape = '{"started": false, "start_request": {"id": "sr-1"}}'
+    started_false_only = '{"started": false, "msg": "queued for confirmation"}'
+
+    for body in (full_old_shape, started_false_only):
+        for raw in (body, _enveloped(body)):
+            with pytest.raises(AssertionError, match="start request"):
+                assert_no_start_request_was_filed(_start_result(raw))
+
+    # The shape the tool actually returns today passes in both encodings —
+    # the guard must not fire on a healthy run.
+    healthy = '{"started": true, "msg": ""}'
+    assert_no_start_request_was_filed(_start_result(healthy))
+    assert_no_start_request_was_filed(_start_result(_enveloped(healthy)))
 
 
 @pytest.mark.harness_benchmark
@@ -878,6 +1132,38 @@ def test_grid_and_orbit_response_floors_do_not_accept_each_other() -> None:
     graded as having done the right measurement."""
     assert not _grid_floor_passes(_orm_run_trace())
     assert not _floor_passes(_grid_run_trace())
+
+
+def _any_class_floor_passes(traces: list[ToolTrace]) -> bool:
+    return find_satisfying_chain(traces, is_any_staged_plan_state) is not None
+
+
+@pytest.mark.harness_benchmark
+def test_any_class_floor_still_requires_the_whole_chain() -> None:
+    """Dropping the plan class must not drop the chain.
+
+    :func:`is_any_staged_plan_state` accepts any measurement, which is the one
+    way a floor turns vacuous: a predicate that answers True unconditionally
+    would let the arming-gate test pass on a run where nothing was ever staged
+    or started, and that test's whole claim is that ONE approval starts a scan
+    that then really runs. So the class-agnostic floor is checked here against
+    the same negatives the class floors are: it takes both runs of either
+    class, and it still refuses a trace with no staged plan, a trace missing
+    either queue step, and a chain built from refused calls.
+    """
+    assert _any_class_floor_passes(_orm_run_trace())
+    assert _any_class_floor_passes(_grid_run_trace())
+
+    # Nothing staged: the add saw an empty draft state, so there is no plan the
+    # start could have drained.
+    assert not _any_class_floor_passes([_add(), _start(), _read()])
+    # Each queue step, dropped in turn.
+    assert not _any_class_floor_passes([*_orm_run_trace()[:2], _read()])
+    assert not _any_class_floor_passes(_orm_run_trace()[:-1])
+    # A chain of refusals changed nothing on the bridge.
+    assert not _any_class_floor_passes(
+        [_draft(patch=_ORM_ARGS), _add(is_error=True), _start(is_error=True), _read(is_error=True)]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1087,13 +1373,22 @@ PANELS_IMAGE = _orm_stack.panels_image(PROJECT_NAME)
 #: - ``services.postgresql.port_host`` / ``services.openobserve.port`` are
 #:   CONFIG keys — those services are in the preset's config template, so a
 #:   dotted key under ``config:`` edits them in place.
-#: - ``bluesky.tiled_port`` / ``bluesky_panels.port`` are BUILD-PROFILE keys
+#: - ``bluesky.tiled_port`` / ``bluesky_panels.port`` / ``va_archiver.port_host``
+#:   are BUILD-PROFILE keys
 #:   (see ``profiles/presets/control-assistant.yml``). Their ``services.*``
 #:   entries are synthesized by the build injectors AFTER the config overlay
 #:   runs, so a dotted ``config:`` key for either is silently discarded — no
 #:   error, no stray key, just the default port. They must be set at profile
 #:   altitude, as top-level blocks, which is where the override file already
 #:   speaks.
+#:
+#: ``va_archiver.port_host`` moves the archiver store's Mongo off 27017, and
+#: it is the altitude trap above in its most expensive form: ``osprey up``
+#: refuses to touch ANY container when one published port is taken, so a
+#: tutorial stack holding 27017 blocks this whole module — and the ``config:``
+#: spelling of the same key is accepted in silence and changes nothing. The
+#: ``va_archiver`` block deep-merges into the one ``_orm_stack.override_yaml()``
+#: already declares, so the CI-sized retention knobs there stay put.
 #:
 #: The ``bluesky`` block here carries ONLY ``tiled_port``: ``bluesky.port`` and
 #: ``bluesky.tiled_enabled`` come from ``init_args``' own ``--set`` flags, so
@@ -1128,6 +1423,7 @@ _EXTRA_CONFIG: dict[str, Any] = {
     },
     "bluesky": {"tiled_port": TILED_PORT},
     "bluesky_panels": {"port": PANELS_PORT},
+    "va_archiver": {"port_host": MONGODB_PORT},
 }
 
 #: Tools promoted from ``permissions.ask`` to ``permissions.allow`` on the
@@ -1583,3 +1879,286 @@ async def test_agent_maps_a_two_axis_grid_on_a_healthy_stack(
         expectations=GRID_JUDGE_EXPECTATIONS,
     )
     assert eval.passed, eval.reasoning
+
+
+# ---------------------------------------------------------------------------
+# The arming gate. Same stack, same deploy, different subject: not what the
+# agent measured, but how many times it had to stop and ask a human before the
+# hardware moved. See the module docstring's third section.
+# ---------------------------------------------------------------------------
+
+ONE_ACTION_OPERATOR_REQUEST = (
+    "Please take a quick beam-position measurement on the machine for me: step "
+    "one of the steering correctors across a few settings inside the range it "
+    "is allowed and record where the beam sits at each step. Tell me what you "
+    "measured once it has run."
+)
+
+#: How long to wait for the run the agent started to reach a terminal status.
+#: Short on purpose — by the time the agent has read its data back the run is
+#: already terminal, so this only covers a read that raced the last point.
+ONE_ACTION_TERMINAL_TIMEOUT_SEC = 180.0
+
+#: Tools this test refuses whatever asks for them, via its approval policy.
+#:
+#: The measurement tests above get this for free: both sit in the render's
+#: ``permissions.ask`` list, which a headless session with no responder turns
+#: into a hard denial. This test HAS a responder, so an "approve everything"
+#: policy would hand the agent both — and either one is a hand-stepped
+#: substitute for the scan whose start is the whole subject here. An agent that
+#: drove the correctors by hand would satisfy nothing this test asserts, but it
+#: would waste a live run finding that out.
+#:
+#: ``mcp__python__execute`` is the sanctioned compute path and is NOT blocked
+#: wholesale: the approval hook's shipped ``selective`` policy allows a readonly
+#: execute outright, so an analysis call never reaches this callback at all.
+#: Only a WRITE-mode or write-patterned execute is asked about — which is
+#: exactly the ``caput``-shaped case to refuse.
+_HAND_STEPPING_TOOLS = frozenset(
+    {
+        "mcp__controls__channel_write",
+        "mcp__python__execute",
+    }
+)
+
+
+def _one_action_approval_policy(tool_name: str, tool_input: dict[str, Any]) -> bool:
+    """Approve what an operator would; refuse a hand-stepped scan.
+
+    The operator this test plays says yes to the arming prompt — that is the
+    single action under test — and no to anything that would move the
+    correctors outside the queue. See :data:`_HAND_STEPPING_TOOLS`.
+    """
+    return tool_name not in _HAND_STEPPING_TOOLS
+
+
+@contextmanager
+def approval_hook_armed_for_queue_start(repo: Path) -> Iterator[None]:
+    """Restore the SHIPPED approval gate on ``queue_start`` for one test.
+
+    ``_EXTRA_CONFIG`` pins ``approval.tools.queue_start: skip`` on this
+    deployment so the two headless measurement tests can run at all (an "ask"
+    they cannot answer is a hard denial). This test needs the opposite: the
+    prompt has to fire so there is a transcript to count. Dropping the key
+    puts the tool back on ``approval.default_policy``, which ships ``always``
+    — the same gate a real deployment has, reached the same way, rather than a
+    gate this test invented.
+
+    Edits the RENDER's ``config.yml``, which is what the host-side
+    ``.claude/hooks/osprey_approval.py`` reads (no ``OSPREY_CONFIG`` is
+    exported for an SDK session, so the hook falls back to the config beside
+    the ``.claude/`` directory the session obeys). Nothing in the deployed
+    containers reads it — they were configured at ``osprey up`` — and no MCP
+    server reads the ``approval`` block, so this moves one gate and nothing
+    else.
+
+    The original TEXT is restored, not a re-serialization: this file is shared
+    with every other test in the module and with two more attempts of this one
+    under ``flaky``, and a round-tripped YAML would quietly reformat it.
+
+    Raises:
+        AssertionError: if the key is not there to remove — the module's
+            ``_EXTRA_CONFIG`` changed, and this context manager would
+            otherwise be a silent no-op that leaves the test asserting a
+            prompt that can never fire.
+    """
+    config_path = render_dir(repo) / "config.yml"
+    original = config_path.read_text(encoding="utf-8")
+    config = yaml.safe_load(original) or {}
+    tools = (config.get("approval") or {}).get("tools") or {}
+    assert "queue_start" in tools, (
+        f"{config_path} has no approval.tools.queue_start to remove (approval "
+        f"tools: {sorted(tools)}). This test arms the queue_start prompt by "
+        "dropping the module's `skip` override; with the override already "
+        "gone it would be arming nothing"
+    )
+    del config["approval"]["tools"]["queue_start"]
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    try:
+        yield
+    finally:
+        config_path.write_text(original, encoding="utf-8")
+
+
+def assert_one_arming_approval(events: list[HookEvent]) -> None:
+    """Assert the operator was asked to arm the queue exactly once, and agreed.
+
+    ``queue_start`` is the moment hardware moves, and it is the ONE action this
+    flow costs an operator. Two prompts would mean the first start did not
+    take — which is what the removed mechanism did: a start that could not arm
+    used to come back having filed a request for someone to confirm elsewhere,
+    leaving the agent to ask again for an action it had already been granted.
+
+    The second clause reads every queue-control tool, not just the start, so a
+    new consent appearing anywhere on the way to motion — a second start, a
+    stop, a confirmation-shaped step — fails here rather than passing as "still
+    one start". Note what it does NOT prove: ``queue_add`` is ask-gated in the
+    shipped posture too, and its prompt is absent from this transcript only
+    because this deployment pins ``approval.tools.queue_add: skip`` (see
+    ``_EXTRA_CONFIG``). Composing a plan and arming the queue are separate
+    consents by design; the count this feature moved is the arming one.
+    """
+    arming = [e for e in events if e.tool_name == QUEUE_START]
+    assert len(arming) == 1, (
+        f"arming the queue took {len(arming)} approval prompt(s), not one. "
+        "Starting a queued scan is one operator action: approve queue_start, "
+        "and the queue drains. Zero prompts means the gate never fired at all "
+        "(the approval hook still has a policy for queue_start, so this test "
+        "counted nothing); two or more mean a start did not take.\n"
+        f"  every approval prompt, in order: "
+        f"{[(e.tool_name, e.decision) for e in events] or '(none)'}"
+    )
+    assert arming[0].decision == "allow", (
+        f"the arming prompt was answered {arming[0].decision!r} — this test's "
+        "operator approves it, so a denial means the policy matched a tool it "
+        f"should not have (input: {arming[0].tool_input})"
+    )
+
+    queue_prompts = [e.tool_name for e in events if e.tool_name in QUEUE_CONTROL]
+    assert queue_prompts == [QUEUE_START], (
+        f"the run stopped for a human {len(queue_prompts)} time(s) on the way "
+        f"to hardware motion: {queue_prompts}. Exactly one — the arming step — "
+        "is the flow this feature leaves. A second consent anywhere in staging, "
+        "queueing or starting is the two-action flow coming back"
+    )
+
+
+# ``"started": false`` as it appears in a tool result, in BOTH the forms a
+# result can reach the transcript in. A bare (non-MCP) result carries it
+# literally; a real MCP result is the FastMCP transport envelope, whose inner
+# JSON is re-encoded as a string, so every quote arrives backslash-escaped as
+# ``\"started\": false``. Matching only the bare spelling makes this clause
+# dead on every live run — which is what it was. ``\\?`` accepts either, and
+# ``\s*`` tolerates whichever separator spacing the encoder chose.
+_STARTED_FALSE = re.compile(r'\\?"started\\?"\s*:\s*false')
+
+
+def assert_no_start_request_was_filed(traces: list[ToolTrace]) -> None:
+    """Assert nothing in the run reported a filed start request.
+
+    The bridge route is gone (probed directly in the test) and the MCP server
+    no longer has a tokenless branch to file one. This closes the last gap
+    between those two facts: whatever the tool actually returned to the agent,
+    it did not carry the old ``{"started": false, "start_request": {...}}``
+    shape. ``queue_start`` has exactly one success shape now — ``started``
+    true — and anything else is a refusal.
+
+    Concretely, a result offends if it mentions ``start_request`` at all, or
+    if it reports ``started`` false. Both halves are checked against the raw
+    text in both the bare and MCP-enveloped encodings: ``start_request`` is a
+    bare identifier that survives escaping unchanged, while ``started`` false
+    is quoted and therefore does not, which is why it needs
+    :data:`_STARTED_FALSE` rather than a substring test.
+
+    The ``started`` false half is a BACKSTOP, not a live expectation — no
+    current code path can emit that shape (``queue_start`` returns
+    ``{"started": true, "msg"}`` on success and routes every refusal through
+    ``_relay_refusal``). It is kept, and kept working, so that reintroducing
+    the shape trips this assertion instead of passing silently.
+    """
+    offenders = [
+        f"{t.name}: {t.result!r}"
+        for t in traces
+        if t.result and ("start_request" in t.result or _STARTED_FALSE.search(t.result))
+    ]
+    assert not offenders, (
+        "a tool result reported a filed start request, or a start that did not "
+        "start. queue_start either starts the queue or refuses; the shape that "
+        "handed the operator a second action to confirm is gone:\n  " + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+# dockerbuild: see the orbit-response test above — same stack, same CI job.
+@pytest.mark.dockerbuild
+# Lane: agentic, not harness. The split is "does this drive the agent under
+# test", and this one does — a model that never reaches the arming step fails
+# it, exactly as it fails the two measurement tests above. That the ASSERTION
+# is about OSPREY's gate rather than the model's reasoning does not move it to
+# the harness lane, which is for floor checks that run with no agent at all
+# (every ``test_floor_*`` above). Gated by
+# ``tests/benchmark/test_matrix_lanes.py`` — exactly one lane marker, and that
+# gate lives outside ``tests/e2e/``, so this module's own run cannot see it.
+@pytest.mark.agentic_benchmark
+# The AGENT under test runs on this provider, not just the judge: the fixture
+# builds the project with ``provider=JUDGE_PROVIDER``. There is no judge in
+# this test — the whole grading is deterministic — but without the credential
+# there is no agent either.
+@pytest.mark.requires_als_apg
+@pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed")
+@pytest.mark.skipif(not is_claude_code_available(), reason="claude CLI not available")
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available")
+@pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
+@pytest.mark.asyncio
+async def test_starting_a_queued_scan_costs_one_operator_approval(
+    deployed_scan_stack: DeployedScanStack, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Asked for a measurement, the agent must reach the hardware through
+    exactly ONE operator approval — the one that arms the queue — and the scan
+    must then actually run.
+
+    Both halves are load-bearing. A run that asked once and then quietly did
+    nothing would satisfy a count on its own, so the count is paired with the
+    structural floor AND with the bridge's own record of the run reaching
+    ``completed`` on an empty queue. And a scan that ran after two consents
+    would satisfy the floor on its own, which is why the two measurement tests
+    above — which disarm the gate entirely — cannot stand in for this one.
+
+    The plan class is deliberately unpinned (:func:`is_any_staged_plan_state`).
+    Which measurement the agent picks says nothing about the arming gate, and
+    asking for the cheapest honest scan keeps this run short.
+    """
+    repo = deployed_scan_stack.repo
+    monkeypatch.setenv("BLUESKY_BRIDGE_URL", BRIDGE_URL)
+    monkeypatch.setenv("BLUESKY_LAUNCH_TOKEN", deployed_scan_stack.token)
+
+    # Before spending an agent run: the deployed bridge must not serve the
+    # route that carried the second action. Checked against the running
+    # container, which is the only place this suite can see the MCP server's
+    # expectations meet the bridge's real routing table.
+    _queue_drive.assert_start_request_route_is_gone(BRIDGE_URL)
+
+    with approval_hook_armed_for_queue_start(repo):
+        result = await run_sdk_query_with_hooks(
+            repo,
+            ONE_ACTION_OPERATOR_REQUEST,
+            approval_policy=_one_action_approval_policy,
+            max_turns=60,
+            max_budget_usd=10.0,
+            # Opus-tier, matching the tests above: this must be a run that gets
+            # as far as arming, or there is no transcript to count.
+            model=_default_opus_model(repo),
+            disallowed_tools=SCENARIO_INTEGRITY_DISALLOWED_TOOLS,
+        )
+
+    # The scan itself first: a transcript assertion over a run that never
+    # staged anything would be counting prompts that were never going to fire.
+    assert_a_scan_executed(result)
+    assert_one_arming_approval(result.hook_events)
+    assert_no_start_request_was_filed(result.tool_traces)
+
+    # ...and the queue really drained. The floor reads the agent's own trace;
+    # this reads the bridge, which is the only party that knows whether the one
+    # approved start put the plan on the hardware and left nothing behind.
+    chain = find_satisfying_chain(result.tool_traces, is_any_staged_plan_state)
+    assert chain is not None, "the floor accepted a run with no chain to bind"
+    add_idx, _start_idx, _read_idx = chain
+    run_id = _launched_run_id(result.tool_traces[add_idx])
+    assert run_id is not None, (
+        "the successful queue_add reported no run id, so the run it launched "
+        f"cannot be looked up on the bridge: {result.tool_traces[add_idx].result!r}"
+    )
+    record = _queue_drive.wait_for_terminal_status(
+        BRIDGE_URL, run_id, timeout=ONE_ACTION_TERMINAL_TIMEOUT_SEC
+    )
+    assert record.get("status") == "completed", (
+        f"the one approved start did not carry run {run_id} to completion — "
+        f"the bridge's last record says {record.get('status')!r}: {record}"
+    )
+    snapshot = _queue_snapshot()
+    assert snapshot["status"]["items_in_queue"] == 0, (
+        "the queue did not drain: "
+        f"{snapshot['status']['items_in_queue']} item(s) still pending after "
+        f"the run completed. Items: {[i.get('item_uid') for i in snapshot.get('items') or []]}"
+    )

--- a/tests/integration/test_bluesky_queue_contract.py
+++ b/tests/integration/test_bluesky_queue_contract.py
@@ -551,8 +551,8 @@ def test_the_queue_read_publishes_a_bounded_status_summary(
     client: TestClient, manager: MockQueueServer
 ) -> None:
     """`GET /queue` reports the manager's queue, and only the status keys the
-    contract names (plus the bridge-local ``start_request``) — the raw status
-    document carries 0MQ material that must never reach a consumer."""
+    contract names — the raw status document carries 0MQ material that must
+    never reach a consumer."""
     revision = _draft_revision(client)
     assert client.post("/queue/items", json={"draft_revision": revision}).status_code == 200
 
@@ -561,7 +561,7 @@ def test_the_queue_read_publishes_a_bounded_status_summary(
     assert set(body) == {"status", "items", "running_item"}
     assert [item["item_uid"] for item in body["items"]] == ["item-1"]
     assert body["running_item"] is None
-    assert set(body["status"]) == {"available", "start_request", *queue._SUMMARY_KEYS}
+    assert set(body["status"]) == {"available", *queue._SUMMARY_KEYS}
     assert body["status"]["available"] is True
     assert body["status"]["items_in_queue"] == 1
     assert "zmq_secret_key" not in json.dumps(body)
@@ -692,194 +692,6 @@ def test_all_three_arming_routes_refuse_with_one_code(
     assert "item_add" not in names
     assert "queue_stop_cancel" not in names
     assert draft._last_launched_revision == 0
-
-
-# ---------------------------------------------------------------------------
-# POST /queue/start-request — an untokened caller asks a token holder to start
-# ---------------------------------------------------------------------------
-
-
-def _enqueue(client: TestClient, num_points: int = 3) -> None:
-    resp = client.post("/queue/items", json={"draft_revision": _draft_revision(client, num_points)})
-    assert resp.status_code == 200, resp.text
-
-
-def test_filing_a_start_request_parks_it_and_starts_nothing(
-    client: TestClient, manager: MockQueueServer
-) -> None:
-    """The request is a published record, not an action: the manager sees no
-    start, and the queue summary carries the record for every consumer."""
-    _enqueue(client)
-
-    resp = client.post("/queue/start-request", json={"requested_by": "agent"})
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert "code" not in body
-    record = body["start_request"]
-    assert record["requested_by"] == "agent"
-    assert record["items_in_queue"] == 1
-    assert isinstance(record["request_id"], str) and record["request_id"]
-    assert isinstance(record["requested_at"], str) and record["requested_at"]
-
-    # Nothing was armed: no start reached the manager, the item still sits there.
-    assert "queue_start" not in manager.method_names()
-    assert manager.manager_state == "idle"
-
-    # The record rides the queue summary — the same place panels read state.
-    summary = client.get("/queue").json()["status"]
-    assert summary["start_request"] == record
-
-
-def test_a_start_request_defaults_its_requester(
-    client: TestClient, manager: MockQueueServer
-) -> None:
-    """No body at all is a valid filing; the requester defaults to 'agent'."""
-    _enqueue(client)
-    resp = client.post("/queue/start-request")
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["start_request"]["requested_by"] == "agent"
-
-
-def test_refiling_replaces_the_pending_start_request(
-    client: TestClient, manager: MockQueueServer
-) -> None:
-    """One pending request at a time: refiling replaces, never queues a second."""
-    _enqueue(client)
-    first = client.post("/queue/start-request").json()["start_request"]
-    second = client.post("/queue/start-request").json()["start_request"]
-    assert second["request_id"] != first["request_id"]
-    summary = client.get("/queue").json()["status"]
-    assert summary["start_request"]["request_id"] == second["request_id"]
-
-
-def test_a_start_request_refuses_an_empty_queue(
-    client: TestClient, manager: MockQueueServer
-) -> None:
-    """Nothing to start is a coded refusal, not a dangling request."""
-    resp = client.post("/queue/start-request")
-    assert resp.status_code == 409
-    detail = resp.json()["detail"]
-    assert detail["code"] == "queue_empty"
-    assert isinstance(detail["detail"], str) and detail["detail"]
-    assert client.get("/queue").json()["status"]["start_request"] is None
-
-
-def test_a_start_request_refuses_while_the_queue_is_already_moving(
-    client: TestClient, manager: MockQueueServer
-) -> None:
-    """A running queue has nothing to confirm — same code as a premature start."""
-    _enqueue(client)
-    _enqueue(client, num_points=5)
-    manager.begin_running()
-
-    resp = client.post("/queue/start-request")
-    assert resp.status_code == 409
-    assert resp.json()["detail"]["code"] == "manager_not_idle"
-    assert client.get("/queue").json()["status"]["start_request"] is None
-
-
-def test_a_browse_only_deployment_refuses_a_start_request(
-    client: TestClient,
-    manager: MockQueueServer,
-    connector: Callable[[str | Exception], None],
-) -> None:
-    """A deployment that can never execute must not park confirmable requests."""
-    connector("mock")
-    resp = client.post("/queue/start-request")
-    assert resp.status_code == 409
-    detail = resp.json()["detail"]
-    assert detail["code"] == "browse_only_connector"
-    assert detail["capability"]["can_execute"] is False
-
-
-def test_dismissing_a_start_request_is_ungated_and_idempotent(
-    client: TestClient, manager: MockQueueServer
-) -> None:
-    """Withdrawing a request is the safe direction — no token, ever."""
-    _enqueue(client)
-    client.post("/queue/start-request")
-
-    dismissed = client.delete("/queue/start-request")
-    assert dismissed.status_code == 200
-    assert dismissed.json() == {"dismissed": True}
-    assert client.get("/queue").json()["status"]["start_request"] is None
-
-    again = client.delete("/queue/start-request")
-    assert again.status_code == 200
-    assert again.json() == {"dismissed": False}
-
-
-def test_a_confirmed_start_clears_the_pending_request(
-    client: TestClient, manager: MockQueueServer, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The token-gated start IS the confirmation — the record does not outlive it."""
-    monkeypatch.setenv(_TOKEN_ENV, _TOKEN)
-    _enqueue(client)
-    client.post("/queue/start-request")
-
-    started = client.post("/queue/start", headers={"X-Launch-Token": _TOKEN})
-    assert started.status_code == 200, started.text
-    assert client.get("/queue").json()["status"]["start_request"] is None
-
-
-def test_a_refused_start_leaves_the_pending_request_in_place(
-    client: TestClient, manager: MockQueueServer, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Only a start that actually armed consumes the request; a refused
-    confirmation (wrong token here) leaves it for the next attempt."""
-    monkeypatch.setenv(_TOKEN_ENV, _TOKEN)
-    _enqueue(client)
-    record = client.post("/queue/start-request").json()["start_request"]
-
-    refused = client.post("/queue/start", headers={"X-Launch-Token": "not-the-token"})
-    assert refused.status_code == 403
-    assert client.get("/queue").json()["status"]["start_request"] == record
-
-
-def test_filing_a_start_request_never_arms_anything_even_with_a_token(
-    client: TestClient, manager: MockQueueServer, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The route declares no token header at all — there is nothing a header
-    could elevate it to. Negative control for accidental gating-by-edit."""
-    monkeypatch.setenv(_TOKEN_ENV, _TOKEN)
-    _enqueue(client)
-    resp = client.post("/queue/start-request", headers={"X-Launch-Token": _TOKEN})
-    assert resp.status_code == 200
-    assert "queue_start" not in manager.method_names()
-    assert manager.manager_state == "idle"
-
-
-async def test_the_event_stream_reports_a_start_request_and_its_dismissal(
-    connector: Callable[[str | Exception], None], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Filing and dismissing both reach a panel within one poll tick, on the
-    same full-snapshot frames every other queue change rides."""
-    monkeypatch.setattr(queue, "_POLL_INTERVAL_S", 0.01)
-    connector("virtual_accelerator")
-    mock = MockQueueServer()
-    app_module.set_queue_backend(QueueBackend(mock))
-
-    response = await queue.queue_events()
-    frames = response.body_iterator
-    try:
-        hello = _parse_frame(await asyncio.wait_for(frames.__anext__(), timeout=5))
-        assert hello["status"]["start_request"] is None
-
-        revision = await _draft_revision_direct()
-        await queue.add_queue_item(
-            queue.QueueAddRequest(draft_revision=revision), x_launch_token=""
-        )
-        await queue.request_queue_start(queue.StartRequestBody(requested_by="agent"))
-        frame = await _frame_where(frames, lambda f: f["status"]["start_request"] is not None)
-        assert frame["status"]["start_request"]["requested_by"] == "agent"
-
-        await queue.dismiss_queue_start_request()
-        await _frame_where(
-            frames,
-            lambda f: f["status"]["start_request"] is None and f["status"]["items_in_queue"] == 1,
-        )
-    finally:
-        await frames.aclose()
 
 
 # ---------------------------------------------------------------------------
@@ -1207,7 +1019,7 @@ def _assert_snapshot_frame(frame: dict[str, Any]) -> None:
     """Every frame on this stream is a full snapshot in one fixed shape."""
     assert set(frame) == {"type", "status", "items", "running_item"}
     assert frame["type"] in ("hello", "queue")
-    assert set(frame["status"]) == {"available", "start_request", *queue._SUMMARY_KEYS}
+    assert set(frame["status"]) == {"available", *queue._SUMMARY_KEYS}
     assert frame["status"]["available"] is True
     # Negative control: a snapshot is never a refusal, and never leaks the raw
     # status document's 0MQ material.

--- a/tests/interfaces/bluesky_panels/bluesky-panel.test.mjs
+++ b/tests/interfaces/bluesky_panels/bluesky-panel.test.mjs
@@ -25,6 +25,7 @@ import {
   ABORT_LABEL,
   CONFIRM_ABORT_LABEL,
   CONFIRM_WITHDRAW_STOP_LABEL,
+  QUEUE_ACTIVE_MANAGER_STATES,
   STOP_LABEL,
   WITHDRAW_STOP_LABEL,
   abortButtonClass,
@@ -38,7 +39,6 @@ import {
   createQueueStream,
   describeProgress,
   describeQueueStatus,
-  describeStartRequest,
   historyChanged,
   historyEmptyState,
   historyRecords,
@@ -50,7 +50,6 @@ import {
   queueEmptyState,
   reduceQueueFrame,
   refusalTone,
-  startRequest,
   stopButtonClass,
   stopButtonLabel,
   writeOutcomeTone,
@@ -200,75 +199,6 @@ describe('describeQueueStatus', () => {
   });
 });
 
-describe('start request (the tokenless agent asking this panel to arm)', () => {
-  test('startRequest surfaces the summary record, and only a real one', () => {
-    const record = {
-      request_id: 'r1',
-      requested_by: 'agent',
-      requested_at: '2026-08-12T20:00:00+00:00',
-      items_in_queue: 2,
-    };
-    const withRequest = reduceQueueFrame(
-      createInitialQueueState(),
-      frame({ status: summary({ start_request: record }) })
-    );
-    expect(startRequest(withRequest)).toEqual(record);
-
-    const without = reduceQueueFrame(createInitialQueueState(), frame());
-    expect(startRequest(without)).toBeNull();
-
-    // A summary that never mentions the key, a null status, and a malformed
-    // (non-object) record all read as "nothing to render", never a throw.
-    expect(startRequest(createInitialQueueState())).toBeNull();
-    const malformed = reduceQueueFrame(
-      createInitialQueueState(),
-      frame({ status: summary({ start_request: 'yes please' }) })
-    );
-    expect(startRequest(malformed)).toBeNull();
-  });
-
-  test('the request survives a manager outage frame — it is bridge state', () => {
-    const record = { request_id: 'r1', requested_by: 'agent', items_in_queue: 1 };
-    const outage = reduceQueueFrame(
-      createInitialQueueState(),
-      frame({
-        status: {
-          available: false,
-          reason: 'manager_unreachable',
-          start_request: record,
-        },
-      })
-    );
-    expect(startRequest(outage)).toEqual(record);
-  });
-
-  test('describeStartRequest names who asked, how much, and when', () => {
-    const sentence = describeStartRequest({
-      request_id: 'r1',
-      requested_by: 'agent',
-      requested_at: '2026-08-12T20:00:00+00:00',
-      items_in_queue: 2,
-    });
-    expect(sentence).toContain('The agent asks to start the queue');
-    expect(sentence).toContain('2 items at the time');
-    expect(sentence).toContain('requested ');
-    expect(sentence).toContain('exactly as listed below');
-  });
-
-  test('describeStartRequest omits what it cannot state truthfully', () => {
-    const sentence = describeStartRequest({ request_id: 'r1' });
-    expect(sentence).toContain('The agent asks to start the queue');
-    expect(sentence).toContain('the queued items');
-    expect(sentence).not.toContain('requested ');
-
-    // A singular count reads as one item, not "1 items".
-    expect(describeStartRequest({ items_in_queue: 1 })).toContain('1 item at the time');
-
-    // An unparseable timestamp is dropped, never rendered as "Invalid Date".
-    expect(describeStartRequest({ requested_at: 'not-a-date' })).not.toContain('Invalid');
-  });
-});
-
 describe('queueControls', () => {
   /**
    * @param {any} status
@@ -300,6 +230,57 @@ describe('queueControls', () => {
     const draining = queueControls(stateWith(summary({ manager_state: 'executing_queue' }), [item()]));
     expect(draining.start.disabled).toBe(true);
     expect(draining.start.reason).toContain('already running');
+  });
+
+  test('the three start states carry the exact words the operator reads', () => {
+    // The reason is the whole explanation an operator gets for a dead button,
+    // so each one is pinned verbatim rather than by substring.
+    expect(queueControls(stateWith(summary(), [item()])).start).toEqual({
+      disabled: false,
+      reason: null,
+    });
+    expect(queueControls(stateWith(summary())).start).toEqual({
+      disabled: true,
+      reason: 'Nothing is queued.',
+    });
+    const running = queueControls(
+      stateWith(summary({ manager_state: 'executing_queue' }), [item()])
+    );
+    expect(running.start).toEqual({ disabled: true, reason: 'The queue is already running.' });
+  });
+
+  test('a running queue reads as running even when nothing is left to start', () => {
+    // Both gates are shut at once here — active AND empty. The running one
+    // wins, because 'Nothing is queued.' would read as an invitation to queue
+    // something and then click a button that is dead for another reason.
+    const controls = queueControls(stateWith(summary({ manager_state: 'executing_queue' })));
+    expect(controls.start).toEqual({ disabled: true, reason: 'The queue is already running.' });
+  });
+
+  test('every active manager state closes start, and a drained one opens it', () => {
+    for (const managerState of QUEUE_ACTIVE_MANAGER_STATES) {
+      const controls = queueControls(stateWith(summary({ manager_state: managerState }), [item()]));
+      expect(controls.start).toEqual({ disabled: true, reason: 'The queue is already running.' });
+    }
+    // `idle` is where the bridge parks a drained manager, and it is the state
+    // an operator starts from.
+    const idle = queueControls(stateWith(summary({ manager_state: 'idle' }), [item()]));
+    expect(idle.start).toEqual({ disabled: false, reason: null });
+  });
+
+  test('an unreadable manager outranks whatever else the summary claims', () => {
+    // A summary that could not be read is not evidence the queue is idle, so
+    // that reason is the one shown even when a populated queue and a state
+    // this panel can still see would otherwise light the button up.
+    expect(queueControls(stateWith(null, [item()])).start).toEqual({
+      disabled: true,
+      reason: 'The queue manager could not be read.',
+    });
+    const stale = queueControls(stateWith({ available: false, manager_state: 'idle' }, [item()]));
+    expect(stale.start).toEqual({
+      disabled: true,
+      reason: 'The queue manager could not be read.',
+    });
   });
 
   test('the halt has NO disabled state in any queue condition', () => {

--- a/tests/interfaces/bluesky_panels/test_app_integration.py
+++ b/tests/interfaces/bluesky_panels/test_app_integration.py
@@ -277,11 +277,6 @@ def test_write_surface_is_exactly_draft_and_queue() -> None:
     # it is listed here for the same reason as the rest -- so a new write route
     # cannot appear without someone justifying it in this list.
     #
-    # The two /queue/start-request writes are likewise writes in the HTTP
-    # sense only: filing parks a "please start" record for a human to answer
-    # (the bridge starts nothing for it) and the DELETE withdraws it. The
-    # arming path they feed is /queue/start, already on this list.
-    #
     # Enumerated deliberately: a new write route must fail this test until
     # someone justifies it in this list.
     write_paths = {
@@ -297,8 +292,6 @@ def test_write_surface_is_exactly_draft_and_queue() -> None:
         ("/queue/items/{uid}/move", "post"),
         ("/queue/items/{uid}", "delete"),
         ("/queue/start", "post"),
-        ("/queue/start-request", "post"),
-        ("/queue/start-request", "delete"),
         ("/queue/stop", "post"),
         ("/queue/abort", "post"),
     }, f"unexpected write surface: {write_paths}"

--- a/tests/interfaces/bluesky_panels/test_queue_relay.py
+++ b/tests/interfaces/bluesky_panels/test_queue_relay.py
@@ -256,30 +256,6 @@ def test_start_queue_relays_success() -> None:
     assert seen[0].url.path == "/queue/start"
 
 
-def test_start_request_routes_relay_filing_and_dismissal_verbatim() -> None:
-    """Both start-request routes are plain relays: body in, body out, no policy."""
-    record = {"request_id": "r1", "requested_by": "operator", "items_in_queue": 2}
-    app, seen, contents = _recording_app(200, {"start_request": record})
-
-    with TestClient(app) as client:
-        filed = client.post("/queue/start-request", json={"requested_by": "operator"})
-
-    assert filed.status_code == 200
-    assert filed.json() == {"start_request": record}
-    assert seen[0].url.path == "/queue/start-request"
-    assert json.loads(contents[0]) == {"requested_by": "operator"}
-
-    app, seen, contents = _recording_app(200, {"dismissed": True})
-    with TestClient(app) as client:
-        dismissed = client.delete("/queue/start-request")
-
-    assert dismissed.status_code == 200
-    assert dismissed.json() == {"dismissed": True}
-    assert seen[0].method == "DELETE"
-    assert seen[0].url.path == "/queue/start-request"
-    assert contents[0] == b""
-
-
 def test_stop_queue_relays_success_and_forwards_cancel_verbatim() -> None:
     app, seen, contents = _recording_app(200, {"stop_pending": False, "msg": ""})
 
@@ -339,8 +315,6 @@ def test_a_uid_bearing_an_encoded_slash_never_reaches_the_bridge() -> None:
         ("post", "/queue/items/item-a/move", {"pos_dest": "front"}),
         ("delete", "/queue/items/item-a", None),
         ("post", "/queue/start", None),
-        ("post", "/queue/start-request", {"requested_by": "operator"}),
-        ("delete", "/queue/start-request", None),
         ("post", "/queue/stop", {"cancel": False}),
     ],
 )
@@ -367,10 +341,6 @@ def test_every_write_returns_502_when_the_bridge_is_unreachable(
         ("post", "/queue/items/item-a/move", {"pos_dest": "front"}),
         ("delete", "/queue/items/item-a", None),
         ("post", "/queue/start", None),
-        # The bridge gates neither start-request route and ignores this header
-        # on both — same reasoning as the abort below.
-        ("post", "/queue/start-request", {"requested_by": "operator"}),
-        ("delete", "/queue/start-request", None),
         ("post", "/queue/stop", {"cancel": True}),
         # The bridge gates the abort on nothing and ignores this header. It is
         # still on the list: an exception carved out here would be the same
@@ -928,7 +898,6 @@ def test_router_exposes_exactly_the_bridge_queue_surface() -> None:
         "/queue/items/{uid}/move": {"post"},
         "/queue/items/{uid}": {"delete"},
         "/queue/start": {"post"},
-        "/queue/start-request": {"post", "delete"},
         "/queue/stop": {"post"},
         "/queue/abort": {"post"},
         "/queue/events": {"get"},

--- a/tests/mcp_server/bluesky/test_queue_tools.py
+++ b/tests/mcp_server/bluesky/test_queue_tools.py
@@ -489,50 +489,30 @@ async def test_queue_start_missing_config_fails_closed(tmp_path, monkeypatch):
     mock_post.assert_not_called()
 
 
-async def test_queue_start_without_a_token_files_a_panel_start_request(tmp_path, monkeypatch):
-    """The tokenless deployment posture: queue_start hands the decision to the human.
+async def test_queue_start_without_a_token_asks_the_bridge_and_relays_its_refusal(
+    tmp_path, monkeypatch
+):
+    """A tokenless server still asks the bridge — it does not refuse locally.
 
-    In a deployed web terminal the launch token lives with the operator panels
-    sidecar and never enters the agent's environment — so a tokenless
-    queue_start must not dead-end in a refusal that reads like a config bug.
-    It files ``POST /queue/start-request`` (no token header: the route arms
-    nothing), and the result tells the agent exactly what happens next: the
-    operator confirms in the queue panel. ``/queue/start`` is never called.
+    The bridge is the one authority on arming, so a deployment that withheld
+    the launch token from this agent posts ``/queue/start`` anyway, with NO
+    token header (never a header carrying ``None``, which would not survive
+    the HTTP client), and relays the bridge's own ``launch_token_required``.
     """
     _configure(tmp_path, monkeypatch, writes=True, token=None)
-    record = {
-        "request_id": "abc123",
-        "requested_by": "agent",
-        "requested_at": "2026-08-12T20:00:00+00:00",
-        "items_in_queue": 2,
-    }
-    with patch(f"{_MOD}._http_post_json", return_value=(200, {"start_request": record})) as m:
-        with patch(f"{_MOD}.notify_agent_activity_async"):
-            result = await _start_fn()()
-
-    assert m.call_args.args[0] == "/queue/start-request"
-    assert m.call_args.kwargs["headers"] is None
-    body = extract_response_dict(result)
-    assert body["started"] is False
-    assert body["start_request"] == record
-    assert "queue panel" in body["message"]
-
-
-async def test_a_tokenless_start_request_relays_bridge_refusals(tmp_path, monkeypatch):
-    """An empty queue refuses the request with the bridge's own code, so the
-    agent hears "enqueue first", not a token problem."""
-    _configure(tmp_path, monkeypatch, writes=True, token=None)
-    body = _refusal("queue_empty", "the queue holds no items")
-    with patch(f"{_MOD}._http_post_json", return_value=(409, body)):
-        with assert_raises_error(error_type="queue_empty") as ctx:
+    body = _refusal("launch_token_required", "starting the queue requires the launch token")
+    with patch(f"{_MOD}._http_post_json", return_value=(403, body)) as m:
+        with assert_raises_error(error_type="launch_token_required") as ctx:
             await _start_fn()()
 
-    assert ctx["envelope"]["details"]["code"] == "queue_empty"
+    assert m.call_args.args[0] == "/queue/start"
+    assert m.call_args.kwargs["headers"] is None
+    assert ctx["envelope"]["details"]["code"] == "launch_token_required"
 
 
 async def test_a_tokenless_start_still_respects_the_kill_switch(tmp_path, monkeypatch):
-    """Writes disabled refuses BEFORE any start request is filed: a request the
-    panel shows as confirmable must never exist on a writes-off deployment."""
+    """Writes disabled refuses before the bridge is reached at all, token or
+    no token: the kill switch is checked ahead of every arming path."""
     _configure(tmp_path, monkeypatch, writes=False, token=None)
     with patch(f"{_MOD}._http_post_json") as mock_post:
         with assert_raises_error(error_type="writes_disabled"):

--- a/tests/mcp_server/test_backend_emit_sites.py
+++ b/tests/mcp_server/test_backend_emit_sites.py
@@ -321,31 +321,6 @@ async def test_queue_start_client_side_refusal_no_emit(_bluesky_context, monkeyp
     notify.assert_not_called()
 
 
-async def test_queue_start_tokenless_emits_the_start_request(_bluesky_context, monkeypatch):
-    """The tokenless path is agent activity too: filing the panel start
-    request emits under the same tool name, marked as a request."""
-    from osprey.mcp_server.bluesky.server_context import (
-        initialize_server_context,
-        reset_server_context,
-    )
-
-    monkeypatch.delenv("BLUESKY_LAUNCH_TOKEN", raising=False)
-    reset_server_context()
-    initialize_server_context()
-
-    body = {"start_request": {"request_id": "r1", "requested_by": "agent"}}
-    with (
-        patch(f"{_QUEUE_MOD}._http_post_json", return_value=(200, body)) as post,
-        patch(f"{_QUEUE_MOD}.notify_agent_activity_async") as notify,
-    ):
-        await _get_queue_tool("queue_start")()
-
-    assert post.call_args.args[0] == "/queue/start-request"
-    assert notify.call_count == 1
-    assert notify.call_args.args[:2] == ("queue_start", "run")
-    assert notify.call_args.kwargs["detail"] == "start-request"
-
-
 # ── artifact focus tools ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Starting a Bluesky queue took two confirmations: the agent's `queue_start` filed a start request, and the operator confirmed it separately in the BLUESKY panel. The second gate guarded an action the first had already gated, and split one decision across two surfaces.

## What changes

- A deployed web terminal now holds `BLUESKY_LAUNCH_TOKEN` when its persona is configured for control-system writes and runs the bluesky MCP server. Approving the agent's `queue_start` call in chat is the whole gate.
- The start-request route is removed from the bridge, the relay and the panel. The panel's own **Start queue** control is unchanged.
- Agent rules, skills and the queue how-tos describe the new posture.

## Safety

A deploy refuses to grant the token to a persona that may also run a shell. The approval gates the `queue_start` tool, not the shell, so such an agent could read the token out of its own environment and arm a queue with no approval at all.

The refusal names each offending persona and states both conditions. It is raised from the deploy preflight, the artifact writer and `decommission_user`: the lifecycle re-render and pre-recreate paths do not pass through the preflight, so a single call site would leave a real path uncovered.

Restoring the deny requires an image rebuild, not just a re-render — the `settings.json` the guard reads is the one baked into the image, and the per-user services declare only `image:`.

## Verification

- Full suite green: 20465 passed, 0 failed.
- The browser suites pass serially, matching how the `visual-theming` lane invokes them.
- The deploy refusal was exercised against a real `control-assistant` deployment. With `Bash` removed from the entitled persona's rendered deny list, `osprey up` aborts in 0.4s before touching any container and names the persona. With the deny restored, the deploy passes the guard and continues to the next provisioning step.
