### PR TITLE
feat(cli): show live progress while deploy phases run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ scripts/benchmark/_out/
 # Logs
 logs/
 *.log
+!tests/deployment/fixtures/*.log
 tensorboard/
 
 # Temporary files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,15 @@ repos:
         # creates spurious diffs on the next re-vendor / regeneration.
         # Golden render fixtures are byte-exact copies of renderer output;
         # normalizing whitespace here breaks the byte-for-byte render tests.
+        # The BuildKit captures are byte-exact for the same reason: a vertex
+        # line whose payload is empty ends in the space that separated them,
+        # and trimming it rewrites the thing the fixture exists to preserve.
         exclude: |
           (?x)^(
             .*\.min\.(js|css)|
             src/osprey/templates/apps/control_assistant/data/channel_databases/tiers/.*\.json|
-            tests/deployment/web_terminals/golden/.*
+            tests/deployment/web_terminals/golden/.*|
+            tests/deployment/fixtures/.*\.log
           )$
       # Ensure files end with a newline
       - id: end-of-file-fixer
@@ -37,7 +41,8 @@ repos:
           (?x)^(
             .*\.min\.(js|css)|
             src/osprey/templates/apps/control_assistant/data/channel_databases/tiers/.*\.json|
-            tests/deployment/web_terminals/golden/.*
+            tests/deployment/web_terminals/golden/.*|
+            tests/deployment/fixtures/.*\.log
           )$
       # Check for merge conflict markers
       - id: check-merge-conflict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Lifecycle commands no longer go quiet while they work. `osprey init`,
+  `build`, `up`, `restart`, `down` and `reset` keep a spinner and a running
+  elapsed under the phase they are in, and while images are building there is
+  a row per service naming the step it is on, what that step is doing right
+  now, and how long it has been at it; a service drops off the list as its
+  image lands. Phases that have finished keep the lines they always printed.
+  Where there is no terminal to repaint — piped to a file, or a CI log — each
+  service still building appends a line roughly every thirty seconds instead,
+  so a build that takes a quarter of an hour is never silent either way. No
+  percent bars, no estimated finish times, and nothing is kept about how long
+  earlier builds took.
+
 - Onboarding output is now written for the people who run accelerators rather
   than for the people who wrote OSPREY. `osprey init` prints the five entries
   you edit instead of a forty-line tour; the generated `profile.yml`,

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -256,9 +256,17 @@ def ensure_repo_env(repo_root: Path, config: dict[str, Any]) -> None:
     exported = os.environ.get(secret_var) if secret_var else None
 
     if exported and _stdin_is_a_terminal():
-        if click.confirm(
-            f"No .env in {repo_root}. Seed one from your shell ({secret_var})?", default=True
-        ):
+        from .phase_reporter import current_reporter
+
+        # The prompt and the reporter want the same terminal: a live region
+        # left mounted repaints over the question while the operator is still
+        # reading it. Suspended for the prompt only — the seed write below is
+        # the verb's own work and belongs back under the reporter.
+        with current_reporter().suspended():
+            seed_it = click.confirm(
+                f"No .env in {repo_root}. Seed one from your shell ({secret_var})?", default=True
+            )
+        if seed_it:
             from osprey.utils.dotenv import append_profile_env
 
             append_profile_env(env_path, {secret_var: exported}, _UP_SEEDED_ENV_BANNER)

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1187,22 +1187,32 @@ def _report(
     the entries they make decisions about. The plumbing they never open --
     ``.gitignore``, ``.env.example``, ``ci-extra.yml``, ``build/`` -- is in the
     README, which the last row points at.
+
+    Written through the reporter rather than with ``click.echo``: on a terminal
+    the reporter's console owns a live region, and a raw write to the same
+    stream lands INSIDE it -- half a report under a table that repaints over it.
+    See :meth:`~osprey.cli.phase_reporter.PhaseReporter.echo`; off a terminal it
+    is byte-for-byte what ``click.echo`` wrote, which is the parity the tests
+    pin.
     """
+    from .phase_reporter import current_reporter
     from .profile_cmd import _skipped_keys_note
 
-    click.echo(f"✓ Created {target.name}")
-    click.echo("")
+    echo = current_reporter().echo
+
+    echo(f"✓ Created {target.name}")
+    echo("")
     for line in _entry_list(target, materialized):
-        click.echo(line)
-    click.echo(f"\n  {git_note}")
+        echo(line)
+    echo(f"\n  {git_note}")
 
     if materialized.skipped_shell_keys:
         # Named rather than dropped in silence: they exported these, and have to
         # be able to account for the omission.
-        click.echo(f"  {_skipped_keys_note(materialized.skipped_shell_keys)}")
+        echo(f"  {_skipped_keys_note(materialized.skipped_shell_keys)}")
 
     for line in _ci_report(deploy_files, target):
-        click.echo(line)
+        echo(line)
 
 
 def _entry_list(target: Path, materialized: _MaterializedProfile) -> list[str]:

--- a/src/osprey/cli/live_render.py
+++ b/src/osprey/cli/live_render.py
@@ -1,0 +1,222 @@
+"""The live build region: a build snapshot in, one Rich renderable out.
+
+A cold ``compose build`` spends a quarter of an hour inside a single phase, and
+the plain ``→ Building services`` line that opens it says nothing for the rest of
+that time. On a terminal a live region is therefore drawn beneath that line: a
+spinner with a ticking duration, and under it one row per service, fed from
+:class:`osprey.deployment.build_progress.BuildModel`:
+
+.. code-block:: text
+
+    → Building services                    <- printed once, permanently
+      · compose config validated (1.2s)    <- printed once, permanently
+      ⠹ 4m12s                              <- from here down, the live region
+
+        virtual-accelerator   6/8         Downloading torch (2.1 GB)…   4m02s
+        bluesky-bridge        3/8         RUN pip install -e .          1m18s
+        event-dispatcher      exporting   exporting layers              3m41s
+
+The region never repeats the phase's title. The phase announced itself with a
+permanent ``→ title`` line the moment it opened, and a title redrawn underneath
+that line reads as a rendering glitch rather than as progress; what the region
+adds is the part that could not be printed once — a spinner and a duration that
+keep moving. Printing the title exactly once also keeps the terminal's scrollback
+identical to the output of a run that was piped to a file.
+
+The ticker sits at the indent of the ``  · step`` lines the phase reporter
+prints, so it reads as belonging to the ``→ title`` above it, and the rows sit
+one level deeper still, so the table reads as nested under the phase rather than
+as a peer of it.
+
+A service leaves the table the moment its image is finished. Its completion is
+already in the scrollback as a step line of its own, permanently, so repeating
+it here says nothing new while crowding out what the operator is actually
+waiting on — and the table shrinks as the build lands each image. It keeps this
+region honest against the off-terminal heartbeat too, which likewise stops
+reporting a service once its image is built.
+
+This module is the rendering half and nothing else: it owns no thread, no
+:class:`~rich.live.Live`, no console and no clock. Both timings arrive as
+arguments — the phase's ``elapsed`` and the caller's ``now`` — for the same
+reason :meth:`BuildModel.feed` takes its timestamp: the caller measures time
+once, and a fifteen-minute build renders identically from a fixture.
+
+Every style here is a semantic token from :mod:`osprey.cli.styles`, resolved
+through the active Rich theme. Nothing names a color, so a retheme (or
+``osprey theme-lab``) reaches this region like it reaches the rest of the CLI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from rich.console import Group, RenderableType
+from rich.padding import Padding
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+
+from osprey.deployment.build_progress import EXPORT_STEP, BuildRow
+
+from .styles import Styles, ThemeConfig
+
+#: Columns the service rows are indented by. The phase reporter's sub-steps sit
+#: at 2, so 4 nests the table one level below them.
+_INDENT = 4
+
+#: Columns the ticker is indented by — the reporter's own ``  · step`` indent,
+#: so the ticker reads as one more line belonging to the phase above it rather
+#: than as the start of something new.
+_TICKER_INDENT = 2
+
+#: Blank columns between two adjacent table columns.
+_GUTTER = 3
+
+#: The width the step column is held at. The step vocabulary is closed — a
+#: Dockerfile index, a header word (``internal``, ``auth``), or
+#: :data:`EXPORT_STEP` — and ``exporting`` is the widest of them. A build opens
+#: on ``None``/``internal``/``auth`` and only reaches ``exporting`` a quarter of
+#: an hour later, so a column sized from whatever has arrived would widen under
+#: the operator's eyes and shift every caption with it. Pinning it costs a few
+#: blank columns early and buys a table that never reflows.
+_STEP_WIDTH = len(EXPORT_STEP)
+
+#: The caption never shrinks below this, however narrow the terminal is. A
+#: caption clipped to a single ellipsis says less than a clipped word does.
+_MIN_CAPTION = 8
+
+#: Shown for a service whose step is not known yet — ``status_display``'s
+#: spelling for a cell with nothing in it.
+_NO_STEP = "-"
+
+
+def format_duration(seconds: float) -> str:
+    """Format a duration for the live region, always as ``MmSSs``.
+
+    Deliberately not :func:`osprey.cli.phase_reporter.format_elapsed`, which
+    switches from ``0.4s`` to ``1m20s`` at a minute. That switch is right for a
+    line printed once, and wrong for a counter repainted every fraction of a
+    second: the width would jump around under the operator's eyes, and a build
+    is measured in minutes anyway.
+
+    Args:
+        seconds: Elapsed seconds; negative values are treated as zero.
+
+    Returns:
+        The duration as ``4m02s``.
+    """
+    minutes, secs = divmod(max(0, int(seconds)), 60)
+    return f"{minutes}m{secs:02d}s"
+
+
+def render_live_region(
+    rows: Sequence[BuildRow],
+    *,
+    phase_open: bool,
+    elapsed: float,
+    now: float,
+    width: int,
+) -> RenderableType:
+    """Build the renderable for the live region.
+
+    Pure: it reads the arguments and returns a renderable. It never calls
+    :meth:`BuildModel.snapshot` itself — the caller passes the rows it already
+    holds, which is what keeps the model's lock off the render path.
+
+    Args:
+        rows: One :class:`~osprey.deployment.build_progress.BuildRow` per
+            service, in the order they should appear. Usually a
+            :meth:`BuildModel.snapshot`. Rows whose image is already finished
+            are dropped, so the table lists exactly what is still outstanding
+            and shrinks as the build lands each image.
+        phase_open: Whether a phase is open, and so whether the region carries a
+            ticker at all. A boolean rather than the phase's title, because the
+            title is not drawn here: it is already in the scrollback, printed
+            once, by the line that opened the phase.
+        elapsed: Seconds the open phase has been running, for its ticker.
+        now: The caller's current :func:`time.monotonic` reading, against which
+            each row's age is measured.
+        width: Columns the region may occupy — normally ``console.width``. Only
+            the caption gives way to it; the other columns are sized by content.
+
+    Returns:
+        A renderable of exactly zero height when there is no open phase and no
+        rows, so an idle live region leaves no blank line behind.
+    """
+    parts: list[RenderableType] = []
+    if phase_open:
+        parts.append(_phase_line(elapsed))
+    pending = [row for row in rows if row.finished is None]
+    if pending:
+        if parts:
+            parts.append(Text(""))
+        parts.append(Padding(_row_table(pending, now, width), (0, 0, 0, _INDENT), expand=False))
+    return Group(*parts)
+
+
+def _phase_line(elapsed: float) -> RenderableType:
+    """The open phase's ticker: ``  <spinner> <elapsed>``.
+
+    Title-less by design — see the module docstring: the phase already named
+    itself in the scrollback, and this line exists for the two things that could
+    not be printed once.
+
+    A grid rather than a single :class:`~rich.text.Text` because the spinner is
+    a renderable of its own; the spacing lives in the cells so the line reads
+    the way it prints. The spinner matches the one the health suite already
+    shows — same name, same themed style.
+    """
+    line = Table.grid()
+    line.add_column()
+    line.add_column()
+    line.add_row(
+        Spinner("dots", style=ThemeConfig.get_spinner_style()),
+        Text(f" {format_duration(elapsed)}", style=Styles.DIM),
+    )
+    return Padding(line, (0, 0, 0, _TICKER_INDENT), expand=False)
+
+
+def _row_table(rows: Sequence[BuildRow], now: float, width: int) -> RenderableType:
+    """The borderless service table: service, step, caption, age.
+
+    Column styles follow ``status_display._create_status_table``'s precedent —
+    the identifying column in accent, the trailing detail dimmed.
+    """
+    cells = [
+        (row.service, row.step or _NO_STEP, row.caption, format_duration(now - row.started_at))
+        for row in rows
+    ]
+    table = Table(box=None, show_header=False, padding=(0, 0, 0, _GUTTER), pad_edge=False)
+    table.add_column(style=Styles.ACCENT, no_wrap=True)
+    table.add_column(style=Styles.SUCCESS, no_wrap=True, min_width=_STEP_WIDTH)
+    table.add_column(
+        style=Styles.INFO,
+        no_wrap=True,
+        overflow="ellipsis",
+        max_width=_caption_width(cells, width),
+    )
+    table.add_column(style=Styles.DIM, no_wrap=True)
+    for service, step, caption, age in cells:
+        # Plain Text, never markup: a caption is BuildKit's output, and one
+        # holding a `[...]` would otherwise be read as a style tag.
+        table.add_row(Text(service), Text(step), Text(caption), Text(age))
+    return table
+
+
+def _caption_width(cells: Sequence[tuple[str, str, str, str]], width: int) -> int:
+    """How much room the caption column gets once the other three are placed.
+
+    The caption is the only column allowed to lose text: a truncated service
+    name or duration is worse than useless, while a truncated caption still
+    names what the step is doing. Rich clips it with an ellipsis from here.
+
+    The step column is measured at its pinned width rather than its contents,
+    so the caption budget stays put as the steps under it change shape.
+    """
+    service = max(len(cell[0]) for cell in cells)
+    step = max(_STEP_WIDTH, max(len(cell[1]) for cell in cells))
+    age = max(len(cell[3]) for cell in cells)
+    return max(_MIN_CAPTION, width - _INDENT - service - step - age - 3 * _GUTTER)
+
+
+__all__ = ["format_duration", "render_live_region"]

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -254,12 +254,32 @@ def lifecycle_reporter() -> Iterator["PhaseReporter"]:
 
     ctx = click.get_current_context(silent=True)
     verbose = bool(ctx.find_root().params.get("verbose")) if ctx is not None else False
-    reporter: PhaseReporter = NullReporter(verbose=True) if verbose else PhaseReporter()
+    reporter: PhaseReporter = NullReporter(verbose=True) if verbose else _tty_aware_reporter()
     previous = install_reporter(reporter)
     try:
+        reporter.start_rendering()
         yield reporter
     finally:
+        # The swap stops whatever the reporter had running: the monitor thread
+        # first, then the live region. Nothing else here needs to know which.
         install_reporter(previous)
+
+
+def _tty_aware_reporter() -> "PhaseReporter":
+    """The reporter for this stdout: live on a terminal, plain lines otherwise.
+
+    Asked once, here, rather than per line: a verb whose output is piped or
+    redirected gets the plain-line reporter for its whole run, and the live
+    region is never mounted at all. ``stdout`` is asked directly rather than the
+    console, which is ``force_terminal`` on win32.
+
+    The reporter is built immediately before it is installed, which is what
+    binds the live region's console to the themed one the rest of the CLI is
+    already using.
+    """
+    from .phase_reporter import LiveReporter, PhaseReporter
+
+    return LiveReporter() if sys.stdout.isatty() else PhaseReporter()
 
 
 def main():

--- a/src/osprey/cli/phase_reporter.py
+++ b/src/osprey/cli/phase_reporter.py
@@ -1,10 +1,18 @@
-"""Plain-line phase reporting for the OSPREY lifecycle verbs.
+"""Phase reporting for the OSPREY lifecycle verbs.
 
 Lifecycle verbs (``init``, ``build``, ``up``, ``restart``, ``down``, ``reset``)
 report progress as a short sequence of phases rendered as plain sequential
 lines on stdout: ``→ title`` when a phase starts, ``  ✓ title (elapsed)`` when
-it ends, ``  · name`` for sub-steps. No Rich Live, no spinners, no in-place
-repainting -- TTY and non-TTY share one code path and only color differs.
+it ends, ``  · name`` for sub-steps. Those lines are the permanent record on
+every path, terminal or not, and nothing rewrites them once printed.
+
+On a terminal :class:`LiveReporter` adds a live region *underneath* that record:
+the open phase repainted with a spinner and a ticking elapsed, and a row per
+service while a build runs (see :mod:`osprey.cli.live_render`). The region is
+decoration over the same lines -- it is transient, it never replaces a line, and
+switching it off leaves exactly the plain-line output. Off a terminal the same
+parsed build state drives append-only heartbeat lines instead, so a quarter-hour
+build is never silent either way.
 
 The active reporter is a module-level singleton (the same pattern as
 ``styles.console``): verbs call :func:`install_reporter` at entry, helpers deep
@@ -14,12 +22,61 @@ quiet :class:`NullReporter`, so helper calls are safe before any verb installs.
 
 from __future__ import annotations
 
+import logging
 import sys
+import threading
 import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import TracebackType
+from typing import TYPE_CHECKING
 
+import click
+from rich.console import Group
+from rich.live import Live
+from rich.logging import RichHandler
+from rich.text import Text
+
+from . import styles
+from .live_render import render_live_region
 from .styles import Styles, console
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from rich.console import Console
+
+    from osprey.deployment.build_progress import BuildModel, BuildRow
+
+#: How long a service may go unmentioned on stdout before a heartbeat line
+#: proves it is still working. A cold ``compose build`` runs a quarter of an
+#: hour with one step in front of it; off a TTY there is no live region to
+#: repaint, so the only way to tell that apart from a hang is to keep
+#: appending. Deliberately a constant: an operator should never have to
+#: configure "tell me you are alive".
+_HEARTBEAT_INTERVAL = 30.0
+
+#: How much of a BuildKit caption a heartbeat line carries. A step's opening
+#: caption is its entire ``RUN`` command -- hundreds of characters of shell
+#: that would swamp the log the heartbeat exists to keep readable.
+_CAPTION_LIMIT = 100
+
+#: How often the monitor thread wakes. Fast enough that a live region repaints
+#: as motion rather than as a slideshow, slow enough to cost nothing; the
+#: heartbeat's own interval is two orders of magnitude longer, so off a TTY
+#: almost every tick decides "not yet" and goes back to sleep.
+_MONITOR_INTERVAL = 0.25
+
+#: How long a stop waits for the monitor to notice. The loop only ever sleeps
+#: on its stop event, so this is reached only if a tick is wedged in terminal
+#: I/O -- and the thread is a daemon, so a wedged one must not hold up the exit.
+_MONITOR_JOIN_TIMEOUT = 2.0
+
+#: The monitor thread's name. Named rather than anonymous so that a leaked
+#: thread is identifiable in ``threading.enumerate()`` -- which is exactly how
+#: the tests assert that every teardown path really joined it.
+_MONITOR_THREAD_NAME = "osprey-phase-monitor"
 
 
 def format_elapsed(seconds: float) -> str:
@@ -44,7 +101,17 @@ class Phase:
     @property
     def elapsed(self) -> float:
         """Seconds since the phase started."""
-        return time.monotonic() - self._start
+        return self.elapsed_at(time.monotonic())
+
+    def elapsed_at(self, now: float) -> float:
+        """Seconds this phase had run as of ``now``.
+
+        The clock is injected so a live repaint can take ONE reading and spend
+        it on both the phase's ticker and the ages of the build rows under it:
+        two readings a microsecond apart would render a frame whose parts
+        disagree about what time it is.
+        """
+        return now - self._start
 
     def set_spool(self, path: Path | None) -> None:
         """Record the spool file the phase is currently writing to."""
@@ -73,20 +140,31 @@ class Phase:
         )
 
     def fail(self, replay: Path | None = None) -> None:
-        """Print the failure line, replaying ``replay``'s content in full."""
+        """Print the failure line, replaying ``replay``'s content in full.
+
+        Everything that moves stops first: the last thing an operator sees
+        after a failure must be the failure, not a heartbeat for a build that
+        died a moment ago, and the replayed spool must land as plain scrollback.
+        """
         if self._closed:
             return
         self._closed = True
+        self._reporter.stop_rendering()
         self._reporter.emit(
             f"  ✗ {self.title} ({format_elapsed(self.elapsed)})", style=Styles.ERROR
         )
         self._reporter.replay(replay)
 
     def interrupted(self) -> None:
-        """Print one line naming the partial spool instead of replaying it."""
+        """Print one line naming the partial spool instead of replaying it.
+
+        Stops the moving parts first, for the same reason :meth:`fail` does:
+        Ctrl-C's answer is one line, and nothing may print after it.
+        """
         if self._closed:
             return
         self._closed = True
+        self._reporter.stop_rendering()
         spool = f" — partial output: {self.spool}" if self.spool else ""
         self._reporter.emit(
             f"  ⚠ {self.title} interrupted ({format_elapsed(self.elapsed)}){spool}",
@@ -121,6 +199,22 @@ class Phase:
             self.fail(self.spool)
 
 
+@dataclass(eq=False)
+class _Watcher:
+    """One registered build, plus when each of its services last beat.
+
+    The beat state lives here rather than on the model so that it dies with
+    the registration: a model registered again starts from silence instead of
+    inheriting a stale schedule from its previous run.
+
+    Compared by identity, so that deregistering one of two registrations over
+    the same model removes that registration and not its twin.
+    """
+
+    model: BuildModel
+    last_beat: dict[str, float] = field(default_factory=dict)
+
+
 class PhaseReporter:
     """Prints phase lines to stdout through the themed console."""
 
@@ -130,16 +224,70 @@ class PhaseReporter:
         # The console is force_terminal on win32, so ask stdout directly.
         self.color = sys.stdout.isatty() if color is None else color
         self._phase: Phase | None = None
+        self._watchers: list[_Watcher] = []
+        self._watch_lock = threading.Lock()
+        self._monitor: threading.Thread | None = None
+        self._monitor_stop = threading.Event()
+        self._monitor_pinned = False
+        self._monitor_lock = threading.Lock()
+        self._suspend_depth = 0
+        self._handed_off = False
+
+    def out(self) -> Console:
+        """The console this reporter prints through.
+
+        Resolved per call rather than captured in ``__init__``: the module-level
+        console is the one a caller swaps to capture output. The live renderer
+        overrides this with the console its ``Live`` was built on -- the region
+        and the lines above it MUST be the same console, or each would repaint
+        over the other's cursor.
+        """
+        return console
 
     def emit(self, text: str, style: str | None = None) -> None:
         """Print one plain line -- styled only when stdout is a terminal."""
-        console.print(
+        self.out().print(
             text,
             style=style if self.color else None,
             markup=False,
             highlight=False,
             soft_wrap=True,
         )
+
+    def echo(self, text: str) -> None:
+        """Print one line of a verb's OWN output, rather than of the phase record.
+
+        Not :meth:`emit`: that is the phase record, and :class:`NullReporter`
+        swallows it under ``--verbose``. This is for the lines a verb owes its
+        operator whatever reporter is installed -- ``init``'s report of what it
+        created, ``reset``'s destruction plan -- so it is never silenced.
+
+        Routed through the console rather than written straight at stdout,
+        because on a terminal the console is what owns the cursor: a raw write
+        lands INSIDE a mounted live region instead of above it. Off a terminal
+        these are ``click.echo``'s bytes exactly, which is the parity the verbs'
+        tests pin -- no wrapping (both callers have lines well past 80 columns),
+        no markup and no highlighting (paths and brackets here are text, not
+        style tags).
+        """
+        self.out().print(text, markup=False, highlight=False, soft_wrap=True)
+
+    def echo_error(self, text: str) -> None:
+        """Print one line of trouble, on the channel its reader is watching.
+
+        Off a terminal that is stderr verbatim: a caller reading stdout for a
+        verb's output reads its trouble on the other stream, and which stream is
+        part of the contract rather than a detail.
+
+        While a region is mounted, stderr is not this process's to write to
+        directly -- a raw write lands in the middle of a repaint -- so the line
+        goes through the console instead. On a terminal the two are the same
+        device anyway, so nothing is lost by routing it.
+        """
+        if self._is_rendering():
+            self.echo(text)
+        else:
+            click.echo(text, err=True)
 
     def phase(self, title: str) -> Phase:
         """Start a phase, printing its opening line."""
@@ -156,6 +304,302 @@ class PhaseReporter:
         """Drop ``phase`` as the current one (no-op if it is not)."""
         if self._phase is phase:
             self._phase = None
+
+    # -- live builds --------------------------------------------------------
+
+    @contextmanager
+    def watch_build(self, model: BuildModel) -> Iterator[BuildModel]:
+        """Watch ``model``'s build for as long as the block runs.
+
+        Scoped to one ``run_captured`` call -- the production shape is::
+
+            with (report := compose_build_step_reporter()):
+                run_captured(..., on_line=report)
+
+        Deregistration happens on the way out however the block ends, which is
+        the whole point of the scope: a build that has returned (or raised)
+        must go quiet immediately. A model that is no longer registered never
+        heartbeats again and leaves the live table.
+
+        Yields the model itself, so a caller that has no other handle on it can
+        bind one.
+        """
+        watcher = _Watcher(model)
+        self._register(watcher)
+        try:
+            yield model
+        finally:
+            self._deregister(watcher)
+
+    def _register(self, watcher: _Watcher) -> None:
+        """Add ``watcher`` to the set the heartbeat pass reads.
+
+        The first registration is what puts a clock behind the heartbeat off a
+        TTY: nothing else in the process wakes up on its own, and a build that
+        has gone quiet is precisely the case where no line will arrive to drive
+        a pass. On a TTY the monitor is already running (the live region starts
+        it), and starting it again is a no-op.
+        """
+        with self._watch_lock:
+            self._watchers.append(watcher)
+            first = len(self._watchers) == 1
+        if first:
+            self._start_monitor()
+
+    def _deregister(self, watcher: _Watcher) -> None:
+        """Drop ``watcher`` and the beat state that went with it.
+
+        With the last build gone there is nothing left to beat for, so an
+        unpinned monitor stops here rather than idling for the rest of the verb.
+        A pinned one -- the live region's -- keeps running: it still has an open
+        phase's elapsed to tick.
+        """
+        with self._watch_lock:
+            if watcher in self._watchers:
+                self._watchers.remove(watcher)
+            idle = not self._watchers
+        if idle and not self._monitor_pinned:
+            self._stop_monitor()
+
+    def _heartbeat_pass(self, now: float) -> list[str]:
+        """The heartbeat lines due at ``now``, marking their services as beaten.
+
+        One line per registered service that has gone
+        :data:`_HEARTBEAT_INTERVAL` seconds without one, whether or not the
+        build has printed anything in the meantime -- a service that stops
+        producing output is exactly the case the line exists for.
+
+        ``now`` is injected, and nothing here reads a clock: that is what lets
+        a quarter-hour build's heartbeats be tested in milliseconds. Calling
+        this *is* what advances the beat state, so a caller that drops the
+        returned lines also silences the pass that would have followed them.
+
+        Runs under the watch lock, so a build that has already deregistered
+        cannot have a line produced for it after the fact.
+        """
+        lines = []
+        with self._watch_lock:
+            for watcher in self._watchers:
+                for row in watcher.model.snapshot():
+                    if row.finished is not None:
+                        continue  # Already named its image: no longer running.
+                    since = watcher.last_beat.get(row.service, row.started_at)
+                    if now - since <= _HEARTBEAT_INTERVAL:
+                        continue
+                    watcher.last_beat[row.service] = now
+                    lines.append(_heartbeat_line(row, now))
+        return lines
+
+    def _watched_rows(self) -> list[BuildRow]:
+        """Every registered build's rows, as one list for the live region.
+
+        The heartbeat pass's counterpart on the terminal side, and the only
+        place the live region touches the models: taken under the watch lock and
+        handed on as frozen rows, so the render itself holds no lock and cannot
+        see a build change shape halfway down a frame.
+
+        Concatenated rather than merged: two registrations at once means two
+        genuinely separate builds (a compose run and a single image), and the
+        service names that identify their rows do not collide.
+        """
+        with self._watch_lock:
+            return [row for watcher in self._watchers for row in watcher.model.snapshot()]
+
+    # -- monitor thread -----------------------------------------------------
+
+    def _start_monitor(self, *, pinned: bool = False) -> None:
+        """Start the monitor thread if it is not already running.
+
+        One daemon thread serves both renderers: on a TTY it repaints the live
+        region, off one it runs the heartbeat pass. It is a daemon because it
+        must never be the reason a process lingers -- everything it does is
+        decoration over work that has already finished by the time exit runs.
+
+        ``pinned`` says the monitor outlives the builds it watches, and is how
+        the live region starts it: a Live has an open phase's elapsed to tick
+        long after the last build deregistered, so it -- not the watcher set --
+        decides when the thread stops.
+
+        Idempotent, and safe to call from any thread: the first caller wins and
+        a later one only raises the pin.
+        """
+        with self._monitor_lock:
+            self._monitor_pinned = self._monitor_pinned or pinned
+            if self._monitor is not None:
+                return
+            self._monitor_stop = threading.Event()
+            self._monitor = threading.Thread(
+                target=self._monitor_loop,
+                args=(self._monitor_stop,),
+                name=_MONITOR_THREAD_NAME,
+                daemon=True,
+            )
+            self._monitor.start()
+
+    def _stop_monitor(self) -> None:
+        """Stop the monitor and JOIN it, so nothing of it can print afterwards.
+
+        Joining is the whole point rather than a nicety: a thread merely asked
+        to stop can still be mid-``emit``, and a heartbeat that lands after a
+        ``✗`` line reads as a build that failed and then kept building. Callers
+        are entitled to assume that when this returns, the monitor is silent.
+
+        Idempotent, and a no-op when called from the monitor thread itself.
+        """
+        with self._monitor_lock:
+            monitor, self._monitor = self._monitor, None
+            self._monitor_pinned = False
+            self._monitor_stop.set()
+        if monitor is not None and monitor is not threading.current_thread():
+            monitor.join(timeout=_MONITOR_JOIN_TIMEOUT)
+
+    def _monitor_loop(self, stop: threading.Event) -> None:
+        """Tick until stopped, sleeping on ``stop`` so a stop is felt at once.
+
+        The event is passed in rather than read off ``self``, so that a monitor
+        restarted while this one is on its way out cannot be stopped by its
+        predecessor's event or vice versa.
+
+        The interval is read per tick, which is what lets a test compress a
+        quarter-hour build into milliseconds.
+        """
+        while not stop.wait(_MONITOR_INTERVAL):
+            self._monitor_tick()
+
+    def _monitor_tick(self) -> None:
+        """One pass: repaint the live region, or emit the heartbeats due now.
+
+        Exactly one of the two -- a TTY that already shows a build table moving
+        does not also need lines saying it moved. Note that
+        :meth:`_heartbeat_pass` is what advances the beat state, so its lines
+        are emitted here and never dropped.
+        """
+        if self.refresh_live():
+            return
+        for line in self._heartbeat_pass(time.monotonic()):
+            self.emit(line)
+
+    def refresh_live(self) -> bool:
+        """Repaint the live region, reporting whether there was one to repaint.
+
+        False on this class: the base reporter prints plain lines and owns no
+        live region, so the monitor falls through to heartbeats. The TTY
+        renderer mounts a Rich ``Live`` and returns True from here, which is
+        what silences the heartbeat lines on a terminal.
+        """
+        return False
+
+    def start_rendering(self) -> None:
+        """Take over the terminal, if this reporter has anything to take it for.
+
+        Nothing on this class: a plain-line reporter owns no region and starts
+        its monitor at the first watcher instead. Defined here so that the
+        install site can call it on whatever it just installed -- the same
+        reason :meth:`stop_rendering` is defined here -- and so that the pair
+        reads as one seam: everything :meth:`stop_rendering` tears down is
+        exactly what this puts back.
+
+        Idempotent.
+        """
+
+    def stop_rendering(self) -> None:
+        """Quiesce everything that moves, before a final plain line is printed.
+
+        The teardown seam, called from :meth:`Phase.fail`, :meth:`Phase.
+        interrupted` and :func:`install_reporter`. Order matters for whoever
+        extends it: the monitor stops first, then the live region -- stopping
+        the region while a tick could still repaint it would put the cursor
+        back where the tick expects it and garble the line that follows.
+        """
+        self._stop_monitor()
+
+    def _is_rendering(self) -> bool:
+        """Whether this reporter is currently drawing something transient.
+
+        False on this class: plain lines are written and forgotten, and there is
+        nothing an interactive prompt could need paused. This is what makes
+        :meth:`suspended` a true no-op off a terminal -- it puts back exactly
+        what it took away, and so can never start something that was not running
+        when the block opened.
+        """
+        return False
+
+    @contextmanager
+    def suspended(self) -> Iterator[None]:
+        """Give the terminal back for as long as the block runs.
+
+        For interactive prompts -- the ``.env`` seed confirmation, reset's typed
+        destruction confirmation. A prompt asks its question and waits on the
+        same terminal the region repaints, so a region left mounted redraws over
+        the question while the operator is reading it.
+
+        Restores on the way out however the block ends. A prompt the operator
+        Ctrl-Cs is exactly the one that must not leave the rest of the verb
+        rendering nothing.
+
+        REENTRANT: nested blocks are counted and only the outermost one acts. An
+        inner block restarting on its own exit would remount the region on top
+        of the prompt the outer block is still waiting on.
+
+        Off a terminal this is a genuine no-op: nothing is rendering, so nothing
+        is stopped -- in particular the monitor thread that heartbeats a build
+        keeps running, since off a TTY it belongs to the watcher set and not to
+        this seam. Same after a repaint has degraded the region: a run that has
+        fallen back to plain lines stays fallen back, rather than being handed a
+        fresh region by the next prompt.
+
+        After :meth:`hand_off` the exit remounts nothing either -- the restart
+        goes through :meth:`start_rendering`, permanently a no-op by then.
+        """
+        self._suspend_depth += 1
+        # Whether the OUTERMOST block found something to pause. Held as a local
+        # so the restart is conditional on what this block actually stopped.
+        resume = self._suspend_depth == 1 and self._is_rendering()
+        if resume:
+            self.stop_rendering()
+        try:
+            yield
+        finally:
+            self._suspend_depth -= 1
+            if resume and self._suspend_depth == 0:
+                self.start_rendering()
+
+    def hand_off(self) -> None:
+        """Give the terminal up for good -- someone else is about to own it.
+
+        A non-detached ``up`` (and ``restart``) finishes by ``os.execvpe``\\
+        -replacing this process with compose: a moment later the process that
+        would have taken the region down does not exist, and a Live still
+        mounted at that point leaves the cursor hidden and its last frame
+        half-drawn under compose's own output.
+
+        So everything that moves stops and joins here, and the open phase's
+        transient state is committed as a permanent line -- the region showing
+        it is about to vanish with nothing to replace it.
+
+        The reporter then degrades to plain lines PERMANENTLY. That last part is
+        not tidiness: ``os.execvpe`` can raise (a missing compose binary is a
+        ``FileNotFoundError``), and the :meth:`Phase.fail` that follows runs in a
+        process whose terminal has already been given away. It must print its
+        ``✗`` and nothing else -- never mount a second region over output that
+        is no longer this process's to draw on.
+
+        Idempotent, and a no-op where there is nothing to hand over (the plain
+        reporter off a terminal, :class:`NullReporter`): the call sites invoke it
+        on whichever reporter the verb installed, without asking which it was.
+        """
+        if self._handed_off:
+            return
+        self._handed_off = True
+        self.stop_rendering()
+        self._commit_open_phase()
+
+    def _commit_open_phase(self) -> None:
+        """Write out anything about the open phase that was only ever drawn.
+
+        Nothing on this class: a plain-line reporter has already printed
+        everything it knows, so a hand-off here loses nothing to commit.
+        """
 
     def note_spool(self, path: Path | None) -> None:
         """Record a spool path on the open phase, for interrupt reporting."""
@@ -174,6 +618,272 @@ class PhaseReporter:
         self.emit("--- end ---")
 
 
+def _heartbeat_line(row: BuildRow, now: float) -> str:
+    """One service's heartbeat, in the sub-step shape the phases already use.
+
+    ``  · va 6/8 Downloading torch... (running 4m00s)``. The step is absent
+    before BuildKit has named one, and is a header word (``internal``,
+    ``exporting``) as often as a Dockerfile index, so the parts are joined
+    rather than laid out in fixed columns.
+
+    The state and the duration ride together in the trailing parenthetical the
+    surface already speaks -- ``  · step (lap)``, ``  ✓ title (elapsed)``. A
+    reader who has seen one line of this output has already learned where to
+    look for a time, and this line says only that the time is still running.
+    """
+    parts = (row.service, row.step, _clip(row.caption))
+    head = " ".join(part for part in parts if part)
+    return f"  · {head} (running {format_elapsed(now - row.started_at)})"
+
+
+def _clip(caption: str) -> str:
+    """Shorten a caption to something that reads as one line.
+
+    Progress captions (``Downloading torch...``) are already short and pass
+    through untouched; a step's opening ``RUN`` command is not.
+    """
+    if len(caption) <= _CAPTION_LIMIT:
+        return caption
+    return caption[: _CAPTION_LIMIT - 1].rstrip() + "…"
+
+
+class LiveReporter(PhaseReporter):
+    """The terminal reporter: the same plain lines, over a live region.
+
+    Installed in place of :class:`PhaseReporter` when stdout is a terminal. The
+    lines do not change -- ``phase``, ``step``, ``done`` and ``fail`` still go
+    through :meth:`emit` and still land in the scrollback permanently, in the
+    same words. What this adds is one Rich :class:`~rich.live.Live` for the
+    whole verb, repainted by the monitor thread with the open phase's spinner
+    and ticker and a row per service while a build runs.
+
+    The region is transient and holds nothing of its own: everything worth
+    keeping was printed as a line before it was ever drawn. That is what makes
+    the teardown paths safe -- a failure, a Ctrl-C or simply the end of the verb
+    takes the region down and leaves output identical to a run that never had
+    one.
+    """
+
+    def __init__(self, *, console: Console | None = None) -> None:
+        # Only ever installed on a terminal, so the lines are always styled.
+        super().__init__(color=True)
+        # Read off the module at construction -- which the install site does
+        # immediately before installing -- rather than from-imported at module
+        # load: applying a theme REBINDS ``styles.console``, so a load-time
+        # capture would hand the Live a console the rest of the CLI has already
+        # stopped printing through, and the two would repaint over each other.
+        self._console = console if console is not None else styles.console
+        self._live: Live | None = None
+        # The log handlers whose console this reporter has borrowed, each with
+        # the console object it is owed back. Empty whenever no region is up.
+        self._borrowed_log_consoles: list[tuple[RichHandler, Console]] = []
+
+    def out(self) -> Console:
+        """The console the ``Live`` was built on -- lines and region alike."""
+        return self._console
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        """Print one line, with the style riding on the TEXT.
+
+        A ``style=`` argument applies to everything the print call renders --
+        and while a region is mounted Rich appends it to that same call, so a
+        green ``✓`` line would repaint the whole table green underneath it. A
+        pre-styled :class:`~rich.text.Text` colors its own words and nothing
+        else.
+        """
+        self.out().print(Text(text, style=(style or "") if self.color else ""), soft_wrap=True)
+
+    def clear_phase(self, phase: Phase) -> None:
+        """Drop the phase, and take its ticker off the screen with it.
+
+        Repainted here rather than left to the next tick because this is the
+        one state change an operator would see lag: the closing ``✓`` line
+        prints immediately below a region still ticking away for the phase it
+        just reported finished.
+        """
+        super().clear_phase(phase)
+        self.refresh_live()
+
+    def start_rendering(self) -> None:
+        """Mount the region and start the thread that repaints it.
+
+        ``auto_refresh=False`` is load-bearing: the monitor thread is the SOLE
+        refresher, and Rich's own refresh thread would race it for the cursor.
+        ``redirect_stdout`` proxies raw ``sys.stdout`` writes through the
+        console, so a helper that has never heard of the reporter still prints
+        above the region instead of into it.
+
+        The monitor is pinned here: the region outlives the builds it shows, so
+        the last build deregistering ends the table and not the ticker over it.
+
+        The logging handler is lent this console too, and given its own back when
+        the region comes down -- see :meth:`_borrow_log_console`.
+
+        Idempotent. The verb that installs the reporter owns the region, and a
+        verb chained inside it (``init --up``) must not mount a second one.
+
+        Permanently a no-op after :meth:`hand_off`: the terminal belongs to
+        another process from then on, and every later call -- the exit of a
+        ``suspended()`` block that spanned the hand-off, an install site
+        starting the reporter it just swapped in -- must leave it alone.
+        """
+        if self._handed_off or self._live is not None:
+            return
+        live = Live(
+            # An explicitly empty region, not Rich's default of ``""`` -- which
+            # renders as one blank line the first repaint would then have to
+            # take back.
+            Group(),
+            console=self._console,
+            auto_refresh=False,
+            redirect_stdout=True,
+            transient=True,
+        )
+        live.start()
+        self._live = live
+        self._borrow_log_console()
+        self._start_monitor(pinned=True)
+
+    def stop_rendering(self) -> None:
+        """Stop the monitor, THEN the region -- in that order, always.
+
+        Reversing it leaves a tick free to repaint a region that is no longer
+        there, restoring the cursor onto the row the next plain line is about to
+        be written on. Call sites get the ordering by calling one method rather
+        than by remembering two: the base class stops the monitor, this override
+        adds the region, and inheritance keeps the sequence in one place.
+        """
+        super().stop_rendering()
+        self._close_live()
+
+    def _is_rendering(self) -> bool:
+        """True exactly while a region is mounted.
+
+        False again once a repaint has raised and taken the region down, which
+        is what keeps a run that degraded to plain lines degraded: the next
+        prompt pauses nothing and therefore restarts nothing.
+        """
+        return self._live is not None
+
+    def _commit_open_phase(self) -> None:
+        """Leave the phase's elapsed in the scrollback as the region vanishes.
+
+        An attached ``up`` is replaced by compose while its start phase is still
+        open, so that phase never prints a ``✓`` -- the only word on it was the
+        ticker in the region, which the hand-off erases mid-frame. This puts
+        that reading back as a permanent line, in the same shape a heartbeat
+        uses off a terminal, and for the same reason: the phase has not
+        finished, it has been taken over.
+
+        Printed after the region is down, so it lands as plain scrollback with
+        nothing repainting beneath it.
+        """
+        phase = self._phase
+        if phase is None:
+            return
+        self.emit(f"  · {phase.title} (running {format_elapsed(phase.elapsed)})")
+
+    def refresh_live(self) -> bool:
+        """Repaint the region from one clock reading; True while it is mounted.
+
+        True is also what silences the heartbeat lines here: the monitor does a
+        repaint or a heartbeat pass per tick, never both, and a table visibly
+        moving does not also need lines saying that it moved.
+
+        A repaint that raises takes the region down instead of the monitor with
+        it. The region is decoration over a deploy that is still running, and an
+        operator would rather lose the decoration than lose the phase lines and
+        heartbeats behind it -- so the next tick finds no Live, answers False,
+        and the run finishes as a plain-line run.
+        """
+        live = self._live
+        if live is None:
+            return False
+        now = time.monotonic()
+        phase = self._phase
+        try:
+            live.update(
+                render_live_region(
+                    self._watched_rows(),
+                    phase_open=phase is not None,
+                    elapsed=phase.elapsed_at(now) if phase is not None else 0.0,
+                    now=now,
+                    width=self._console.width,
+                ),
+                refresh=True,
+            )
+        except Exception:
+            self._close_live()
+            return False
+        return True
+
+    def _close_live(self) -> None:
+        """Take the region down once, whatever state it is in.
+
+        Blanked before it is stopped because stopping repaints one last time:
+        without this the frame the failure interrupted would be drawn again and
+        then erased, a flicker at exactly the moment the failure line is due.
+
+        Idempotent, and deliberately forgiving. This runs on the failure and
+        interrupt paths, and on a terminal that has stopped accepting writes
+        (``osprey up | head``) the region must not turn a failed build into a
+        traceback about a cursor.
+        """
+        live, self._live = self._live, None
+        if live is None:
+            return
+        try:
+            live.update(Group(), refresh=False)
+            live.stop()
+        except Exception:
+            pass
+        finally:
+            # Last, so that a record arriving while the region is coming down
+            # still goes through the console that knows a region is there.
+            self._return_log_console()
+
+    def _borrow_log_console(self) -> None:
+        """Print log records through the region's console, for as long as it is up.
+
+        A record written straight to stderr lands in the middle of a region that
+        is repainting itself and the two interleave into one garbled line. Rich
+        already knows how to put a line above a mounted ``Live`` -- but only for
+        the console that ``Live`` was built on, so the handler is lent that
+        console rather than having its stream redirected. (``Live(redirect_stderr
+        =True)`` cannot do this job: a stderr-bound Console unwraps the proxy
+        back to the real stream, by design.)
+
+        Only ever on a terminal, because only this class mounts a region: off one
+        the handler keeps the stderr it documents, which is what piped and CI
+        consumers read.
+
+        A root logger with no ``RichHandler`` is normal and not an error -- a
+        library caller or a test may never have configured logging, and then
+        there is nothing writing to stderr to garble anything.
+        """
+        self._borrowed_log_consoles = [
+            (handler, handler.console)
+            for handler in logging.getLogger().handlers
+            if isinstance(handler, RichHandler)
+        ]
+        for handler, _ in self._borrowed_log_consoles:
+            handler.console = self._console
+
+    def _return_log_console(self) -> None:
+        """Give each handler back the console OBJECT it started with.
+
+        Identity, not an equivalent rebuilt from the same arguments: the handler's
+        console is configured by whoever installed it (stderr, ``force_terminal``,
+        a fixed width), and a verb that drew a region must leave logging exactly
+        as it found it -- including for the process that keeps running afterwards.
+
+        Idempotent, and empty whenever nothing was borrowed.
+        """
+        for handler, original in self._borrowed_log_consoles:
+            handler.console = original
+        self._borrowed_log_consoles = []
+
+
 class NullReporter(PhaseReporter):
     """No-op reporter installed under the global ``--verbose`` flag."""
 
@@ -187,6 +897,14 @@ class NullReporter(PhaseReporter):
     def replay(self, path: Path | None) -> None:
         """Nothing to replay: the output already went to the terminal."""
 
+    def _start_monitor(self, *, pinned: bool = False) -> None:
+        """Run no thread at all: every line it could produce is swallowed.
+
+        Under ``--verbose`` the child's own output streams to the terminal, so
+        there is nothing for a heartbeat to prove and no live region to repaint
+        -- a monitor here would wake four times a second to discard its work.
+        """
+
 
 _reporter: PhaseReporter = NullReporter()
 
@@ -197,9 +915,20 @@ def current_reporter() -> PhaseReporter:
 
 
 def install_reporter(reporter: PhaseReporter) -> PhaseReporter:
-    """Install ``reporter`` as the active one and return the previous one."""
+    """Install ``reporter`` as the active one and return the previous one.
+
+    The swap itself quiesces the outgoing reporter. Only one reporter may own
+    the terminal at a time, and the handover is the one moment every path
+    through the code has in common: the verbs' ``finally`` in ``cli/main.py``,
+    but equally a test fixture or a library caller that swaps a reporter in and
+    back out by hand. Leaving that to the call sites would mean a fixture
+    forgetting it leaks a live thread into whatever runs next -- where it shows
+    up much later as an unrelated flaky test.
+    """
     global _reporter
     previous, _reporter = _reporter, reporter
+    if previous is not reporter:
+        previous.stop_rendering()
     return previous
 
 

--- a/src/osprey/cli/reset_cmd.py
+++ b/src/osprey/cli/reset_cmd.py
@@ -109,15 +109,32 @@ def reset(repo: Path | None, dry_run: bool, assume_yes: bool, purge_audit: bool)
     # reaches — the shared teardown helpers, which capture their subprocesses
     # and need a reporter to report a failure to, and which must stream instead
     # of spooling when `--verbose` was asked for.
-    with lifecycle_reporter():
+    with lifecycle_reporter() as reporter:
         try:
-            outcome = reset_deployment(
-                repo_root,
-                dry_run=dry_run,
-                assume_yes=assume_yes,
-                purge_audit=purge_audit,
-                emit=click.echo,
-            )
+            # The typed destruction confirmation is inside `reset_deployment`,
+            # and it reads the terminal through `input()` — which writes its
+            # prompt to the real stdout, underneath anything Rich has mounted
+            # there. So the region comes down for the call that contains it.
+            #
+            # The block spans the whole call rather than the prompt alone
+            # because the prompt is not reachable from here, and it costs
+            # nothing to hold: reset opens no phase and registers no build, so
+            # its region is zero-height from the first line to the last. What
+            # `suspended()` guarantees — it restarts only what it actually
+            # paused, and it is reentrant — is what makes the wider scope safe
+            # for anything reset later reaches that does open a phase.
+            with reporter.suspended():
+                # `echo`, never the reporter's `emit`: under the global
+                # `--verbose` that is a NullReporter and swallows its argument,
+                # and the plan is the one thing this verb may never go quiet
+                # about.
+                outcome = reset_deployment(
+                    repo_root,
+                    dry_run=dry_run,
+                    assume_yes=assume_yes,
+                    purge_audit=purge_audit,
+                    emit=reporter.echo,
+                )
         except ForeignCheckoutError as e:
             # Shown verbatim rather than summarized: the message is already the
             # whole explanation, and it is carefully scoped to what the labels
@@ -135,11 +152,15 @@ def reset(repo: Path | None, dry_run: bool, assume_yes: bool, purge_audit: bool)
             # state on disk, and this path leaves exactly the state a stuck removal
             # leaves. Reporting 1 here would tell a caller "nothing was touched"
             # about a half-wiped deployment.
-            click.echo(
+            #
+            # `echo_error` rather than `click.echo(err=True)`: piped, this is
+            # stderr verbatim, which is the channel a caller reading stdout for
+            # the plan watches for trouble; on a terminal it goes through the
+            # console that owns the region instead of into the middle of it.
+            reporter.echo_error(
                 "Reset interrupted while it was removing things. It does not roll back, so "
                 "this deployment is in a partly-reset state. Re-run `osprey reset` to finish; "
-                "it re-reads what is actually there.",
-                err=True,
+                "it re-reads what is actually there."
             )
             raise click.exceptions.Exit(PARTIAL_RESET_EXIT_CODE) from None
         except RuntimeError as e:

--- a/src/osprey/deployment/build_progress.py
+++ b/src/osprey/deployment/build_progress.py
@@ -1,0 +1,303 @@
+"""Live per-service state for an image build, parsed from BuildKit's own stream.
+
+A cold ``compose build`` runs for a quarter of an hour near-silent: the phase
+reporter prints one line when it starts and one when it ends, and everything in
+between goes to a spool file. BuildKit's plain-progress stream already carries
+what an operator needs to tell that apart from a hang — which service is
+working, which step it is on, and what that step is doing right now — so this
+module keeps that state instead of discarding it. :mod:`osprey.cli.phase_reporter`
+renders the result; nothing here touches a terminal.
+
+:class:`BuildModel` is deliberately a pure model. It owns no thread, no clock
+and no I/O: every line arrives through :meth:`BuildModel.feed` with the
+timestamp already measured by the caller, which is what makes a fifteen-minute
+build replayable from a fixture in milliseconds.
+
+The stream is messier than it looks, and three of its shapes will silently
+corrupt a naive parser:
+
+* **Vertex numbers are not unique.** ``compose build`` numbers each service's
+  sub-graph independently, so ``#7`` is ``[event-dispatcher 1/8]`` early and
+  ``[bluesky-bridge 1/8]`` later. Attribution therefore follows the most recent
+  header for a number, not the first one.
+* **Headers repeat and steps arrive out of order.** A vertex re-emits its full
+  header every time it resumes, and ``[ 2/13]`` can follow ``[ 5/13]``. The step
+  index is read from the header; it is never inferred from arrival order.
+* **Captions carry embedded carriage returns.** ``dpkg`` and ``pip`` redraw a
+  progress line in place, so one physical line holds a dozen overwrites. Only
+  the last one was ever visible, and only that one is kept.
+
+Anything unrecognized is dropped rather than guessed at. A stream with no
+BuildKit headers at all — a podman provider with its own progress format —
+leaves the model empty, which the renderer reads as "nothing to show" and falls
+back to its plain step lines.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+
+#: A plain-progress line: a vertex number, then either a bracketed header or a
+#: bare continuation caption.
+_VERTEX_LINE = re.compile(r"^#(?P<node>\d+)(?: (?P<rest>.*))?$")
+
+#: The bracketed header at the head of a vertex's line, and the caption after it.
+_HEADER = re.compile(r"^\[(?P<bracket>[^\]]*)\](?: (?P<caption>.*))?$")
+
+#: A Dockerfile step index, as it appears inside a header: ``1/13``.
+_STEP_INDEX = re.compile(r"^\d+/\d+$")
+
+#: The line that marks one image finished. Kept in step with the equivalent in
+#: :mod:`osprey.deployment.container_lifecycle`: the bare ``naming to`` line is
+#: emitted while the export is still running, so only the ``done`` form counts.
+_IMAGE_NAMED = re.compile(r"naming to (?P<ref>\S+?)(?: \d+(?:\.\d+)?s)? done\s*$")
+
+#: Bracket words that name build infrastructure rather than a service. On the
+#: single-image path the header is ``[internal] load build context`` — the word
+#: sits exactly where a service name sits on the compose path, and taking it at
+#: face value would mint a phantom "internal" service beside the real one. The
+#: two-word forms (``[va internal]``, ``[panels auth]``) are unaffected: those
+#: name a real service and are attributed to it.
+_INFRASTRUCTURE_BRACKETS = frozenset({"auth", "internal"})
+
+#: The pseudo-step for a service's export vertex. The export has no Dockerfile
+#: step index of its own, but it is the longest single stretch of a cold build
+#: and needs a name in the table.
+EXPORT_STEP = "exporting"
+
+#: The caption that opens an export vertex. Detected from the caption rather
+#: than the bracket shape, because the export is bracketed on the compose path
+#: (``#23 [virtual-accelerator] exporting to image``) and bare on the
+#: single-image path (``#22 exporting to image``).
+_EXPORT_CAPTION = "exporting to image"
+
+#: Stripped from a finished image's ref as registry noise. A real registry in
+#: the tag is the operator's own naming and stays.
+_IMPLICIT_REGISTRY = "docker.io/library/"
+
+
+def with_plain_build_progress(cmd: list[str]) -> list[str]:
+    """Pin BuildKit's plain renderer on a ``<runtime> build`` argv.
+
+    Everything in this module reads the plain-progress stream. ``auto`` does
+    degrade to plain under a capture pipe, but only as undocumented behaviour,
+    and a build that rendered anything else would parse into nothing at all --
+    silently, because an unrecognized line is dropped rather than reported. So
+    the flag is pinned rather than trusted, and it lives here, beside the parser
+    whose input it guarantees.
+
+    Docker only, the same caveat
+    :func:`osprey.deployment.runtime_helper.with_plain_progress` carries for
+    compose: ``podman build`` has no ``--progress``, and an unknown flag there
+    would turn a cosmetic improvement into a failed deploy.
+
+    Args:
+        cmd: A build argv whose first element is the runtime, e.g.
+            ``["docker", "build", "-t", ...]``. Extended in place and returned.
+            Call this BEFORE the build context is appended: ``--progress`` is an
+            argument of ``build``, and anything after the context is not read as
+            one.
+
+    Returns:
+        The same list, with the flag appended when the runtime is docker.
+    """
+    if cmd and cmd[0] == "docker":
+        cmd.extend(("--progress", "plain"))
+    return cmd
+
+
+@dataclass(frozen=True)
+class BuildRow:
+    """One service's current build state — one row of the live table.
+
+    Frozen so that :meth:`BuildModel.snapshot`'s shallow copy is a real
+    snapshot: a renderer holding a row cannot see it change underneath as the
+    build advances.
+    """
+
+    #: Service name, or the model's ``label`` for a single-image build.
+    service: str
+    #: Current step: a Dockerfile index (``6/8``), a header word (``internal``),
+    #: :data:`EXPORT_STEP`, or ``None`` before the first step is known.
+    step: str | None
+    #: What that step is doing right now, as last shown by BuildKit.
+    caption: str
+    #: When this service's first line arrived.
+    started_at: float
+    #: When its most recent line arrived — how a stalled service is spotted.
+    last_line_at: float
+    #: The finished image ref, once BuildKit has named it; ``None`` until then.
+    finished: str | None
+
+
+class BuildModel:
+    """Per-service build state, fed one output line at a time.
+
+    ``label`` names the service for a single-image build, whose headers carry
+    no service name of their own: ``[ 1/13]``, ``[internal]``, and every
+    bare continuation line bind to it. On the compose path there is no label —
+    every header names its service — and a line that cannot be attributed is
+    dropped rather than invented.
+
+    ``on_finished_image`` is called once per image, with the ref, the moment
+    BuildKit reports it named. It fires for every finished image, including one
+    on a vertex too anonymous to attribute to a row, because "an image is done"
+    is a fact about the build and not about any one service's row.
+
+    Feeding and snapshotting are both guarded by one lock: ``run_captured`` is
+    synchronous, so :meth:`feed` runs on the main thread while the renderer's
+    monitor thread calls :meth:`snapshot`. The callback is invoked *after* the
+    lock is released, so a callback that reads the model cannot deadlock.
+    """
+
+    def __init__(
+        self,
+        label: str | None = None,
+        *,
+        on_finished_image: Callable[[str], None] | None = None,
+    ) -> None:
+        self._label = label
+        self._on_finished_image = on_finished_image
+        self._lock = threading.Lock()
+        self._rows: dict[str, BuildRow] = {}
+        self._nodes: dict[int, str] = {}
+        self._named: set[str] = set()
+
+    def feed(self, line: str, now: float) -> None:
+        """Absorb one line of build output, timestamped by the caller.
+
+        ``now`` is injected rather than read here so the model stays pure: the
+        caller measures time once, and a test can replay a whole build against
+        a synthetic clock.
+        """
+        with self._lock:
+            ref = self._absorb(line, now)
+        if ref is not None and self._on_finished_image is not None:
+            self._on_finished_image(ref)
+
+    def snapshot(self) -> list[BuildRow]:
+        """The current rows, in the order their services first appeared.
+
+        A fresh list of frozen rows, so the caller can read it at leisure while
+        the build continues. Empty until a BuildKit header has been recognized.
+        """
+        with self._lock:
+            return list(self._rows.values())
+
+    # -- parsing ------------------------------------------------------------
+
+    def _absorb(self, line: str, now: float) -> str | None:
+        """Apply one line to the model; return a newly finished ref, if any.
+
+        Runs under the lock. The return value is the callback's argument rather
+        than the callback itself, so the caller can fire it lock-free.
+        """
+        vertex = _VERTEX_LINE.match(line.rstrip("\n"))
+        if vertex is None:
+            return None
+        node = int(vertex["node"])
+        rest = vertex["rest"] or ""
+
+        header = _HEADER.match(rest)
+        if header is None:
+            # A continuation line: it belongs to whichever service last claimed
+            # this vertex number, or to the single-image label.
+            service = self._nodes.get(node, self._label)
+            step = None
+            caption = _visible(rest)
+        else:
+            name, step = _split_bracket(header["bracket"])
+            if name is None and step is None:
+                return None  # An unrecognized bracket: ignored, never guessed.
+            service = name if name is not None else self._label
+            caption = _visible(header["caption"] or "")
+            if service is not None:
+                self._nodes[node] = service
+
+        if caption.startswith(_EXPORT_CAPTION):
+            step = EXPORT_STEP
+
+        ref = self._new_ref(caption)
+        if service is not None:
+            self._touch(service, step, caption, now, ref)
+        return ref
+
+    def _new_ref(self, caption: str) -> str | None:
+        """The image ref this caption finishes, unless it was already reported.
+
+        BuildKit repeats the ``naming to`` line — bare, then with a duration —
+        so an image would otherwise appear to build twice.
+        """
+        named = _IMAGE_NAMED.search(caption)
+        if named is None:
+            return None
+        ref = named["ref"].removeprefix(_IMPLICIT_REGISTRY)
+        if ref in self._named:
+            return None
+        self._named.add(ref)
+        return ref
+
+    def _touch(
+        self,
+        service: str,
+        step: str | None,
+        caption: str,
+        now: float,
+        ref: str | None,
+    ) -> None:
+        """Fold one line into a service's row, creating the row if it is new."""
+        row = self._rows.get(service)
+        if row is None:
+            self._rows[service] = BuildRow(
+                service=service,
+                step=step,
+                caption=caption,
+                started_at=now,
+                last_line_at=now,
+                finished=ref,
+            )
+            return
+        self._rows[service] = replace(
+            row,
+            step=step if step is not None else row.step,
+            caption=caption or row.caption,
+            last_line_at=now,
+            finished=ref if ref is not None else row.finished,
+        )
+
+
+def _split_bracket(bracket: str) -> tuple[str | None, str | None]:
+    """Read a header's brackets as ``(service, step)``.
+
+    ``[virtual-accelerator 6/8]`` and ``[va internal]`` name their service.
+    ``[ 1/13]`` and ``[internal]`` do not — they belong to the single-image
+    build's one service, and are returned with no name so the caller can bind
+    them to its label. A bare ``[virtual-accelerator]`` names a service but no
+    step, and anything else returns ``(None, None)`` to be dropped.
+    """
+    parts = bracket.split()
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    if len(parts) == 1:
+        token = parts[0]
+        if _STEP_INDEX.match(token) or token in _INFRASTRUCTURE_BRACKETS:
+            return None, token
+        return token, None
+    return None, None
+
+
+def _visible(text: str) -> str:
+    """What a terminal would have left on screen after the carriage returns.
+
+    ``dpkg`` and ``pip`` redraw one progress line in place, so a single line of
+    captured output can hold a whole animation. Only the last frame was ever
+    visible; a trailing carriage return leaves the frame before it showing.
+    """
+    for frame in reversed(text.split("\r")):
+        stripped = frame.strip()
+        if stripped:
+            return stripped
+    return ""

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -10,14 +10,18 @@ import subprocess
 import sys
 import tempfile
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
 from datetime import UTC, datetime
 from pathlib import Path
+from types import TracebackType
 from typing import NamedTuple
 
 import yaml
 
+from osprey.cli.phase_reporter import current_reporter
 from osprey.cli.phase_reporter import report_step as _report_step
+from osprey.deployment.build_progress import BuildModel, with_plain_build_progress
 from osprey.deployment.compose_generator import (
     COMPOSE_ENV_FILENAME,
     REPO_ID_LABEL,
@@ -1506,6 +1510,7 @@ def _project_image_build_cmd(
     ]
     if dev_mode:
         cmd.extend(["--build-arg", "OSPREY_DEV=1"])
+    with_plain_build_progress(cmd)
     cmd.append(project_root)
     return cmd
 
@@ -1594,12 +1599,16 @@ def _build_project_image(
         cmd = _project_image_build_cmd(config, runtime, project_root, dev_mode and wheel_staged)
         logger.debug("Building dispatch worker project image %s:", project_image)
         logger.debug("Running command:\n    %s", " ".join(cmd))
-        run_captured(
-            cmd,
-            env=env,
-            spool_name="build-project-image",
-            repo_root=resolve_repo_root(config),
-        )
+        # Watched for the duration of the build and no longer; the step line
+        # below is what reports the finished image.
+        with (report := single_image_build_reporter(project_image)):
+            run_captured(
+                cmd,
+                env=env,
+                spool_name="build-project-image",
+                repo_root=resolve_repo_root(config),
+                on_line=report,
+            )
         _report_step(f"project image {project_image}")
     finally:
         # Remove BOTH staged artifacts (wheel + requirements manifest) so
@@ -2591,42 +2600,117 @@ def deploy_up(
         )
 
 
-#: One image's completion in BuildKit's plain-progress stream: ``naming to``
-#: is the export stage assigning the built image its tag, and only the line
-#: carrying ``done`` marks it finished — the bare form appears while the
-#: export is still running. The optional duration is BuildKit's own
-#: (``naming to <ref> 0.1s done``).
-_IMAGE_NAMED_LINE = re.compile(r"naming to (?P<ref>\S+?)(?: \d+(?:\.\d+)?s)? done\s*$")
+class BuildProgressReporter:
+    """One build's captured stream, parsed once into one :class:`BuildModel`.
+
+    A build site wants a live view of what each service is doing right now, and
+    some sites want a step line each time an image finishes — and the one thing
+    none of them may do is parse the stream twice. So this is every half at once
+    over a single model:
+
+    * the ``on_line`` **callable** handed to :func:`run_captured`, and
+    * the **context manager** that registers that model with the phase reporter
+      for the duration of the run::
+
+          with (report := compose_build_step_reporter()):
+              run_captured(..., on_line=report)
+
+    Registration is scoped to the block: a build that has returned or raised
+    stops being watched immediately, however it left. Used as a bare callable
+    (no ``with``) it still reports its step lines — nothing here requires a
+    watcher, which is what keeps library callers and tests working.
+
+    Constructed through :func:`compose_build_step_reporter` or
+    :func:`single_image_build_reporter` rather than directly: the two of them
+    are what the arguments below mean at a real call site.
+
+    ``label`` names the service for a single-image build, whose BuildKit
+    headers carry no service name of their own; a ``compose build`` names every
+    service itself and passes none. ``step_prefix`` is the step line's wording
+    (``service image <ref>``); a site whose finished images are already
+    reported elsewhere passes ``None`` and gets the live view alone.
+    """
+
+    def __init__(self, label: str | None = None, *, step_prefix: str | None = None) -> None:
+        self._step_prefix = step_prefix
+        #: The one model. Exposed so a caller can snapshot it directly.
+        self.model = BuildModel(label, on_finished_image=self._report_image)
+        self._watch: AbstractContextManager[BuildModel] | None = None
+
+    def __call__(self, line: str) -> None:
+        """Absorb one line of the child's output, timestamped on arrival."""
+        self.model.feed(line, time.monotonic())
+
+    def __enter__(self) -> "BuildProgressReporter":
+        self._watch = current_reporter().watch_build(self.model)
+        self._watch.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Stop watching, whatever left the block — and never swallow it."""
+        watch, self._watch = self._watch, None
+        if watch is not None:
+            watch.__exit__(exc_type, exc, tb)
+
+    def _report_image(self, ref: str) -> None:
+        """Report one finished image as a step of the open phase.
+
+        Fires for every image BuildKit names, including one on a vertex too
+        anonymous to attribute to a service row — "an image is done" is a fact
+        about the build, and a step line for it must not go missing because the
+        stream's shape defeated attribution.
+        """
+        if self._step_prefix is not None:
+            _report_step(f"{self._step_prefix} {ref}")
 
 
-def compose_build_step_reporter() -> Callable[[str], None]:
+def compose_build_step_reporter() -> BuildProgressReporter:
     """Per-image progress steps for a ``compose build``, from BuildKit's own stream.
 
     ``compose build`` builds every service image in one parallel invocation —
     the longest step of a dev deploy, half an hour cold — and a single step
     line printed at the end reads as a hang for the whole build. Splitting the
     build per service would give progress at the price of the parallelism, so
-    the steps are derived instead: fed to :func:`run_captured` as ``on_line``,
-    this watches the captured stream and reports each image the moment BuildKit
-    finishes it.
+    the progress is derived instead: fed to :func:`run_captured` as ``on_line``,
+    this watches the captured stream, reports each image the moment BuildKit
+    finishes it, and — inside its ``with`` block — keeps the phase reporter's
+    live view of what every service is working on.
 
     Deduplicated per image, because BuildKit repeats the ``naming to`` line
     (bare, then with a duration). The implicit ``docker.io/library/`` prefix is
     stripped as registry noise; a real registry in the tag is the operator's
-    own naming and stays.
+    own naming and stays. Both behaviours live in :class:`BuildModel`.
     """
-    seen: set[str] = set()
+    return BuildProgressReporter(step_prefix="service image")
 
-    def report(line: str) -> None:
-        match = _IMAGE_NAMED_LINE.search(line)
-        if match is None:
-            return
-        ref = match.group("ref").removeprefix("docker.io/library/")
-        if ref not in seen:
-            seen.add(ref)
-            _report_step(f"service image {ref}")
 
-    return report
+def single_image_build_reporter(image_tag: str) -> BuildProgressReporter:
+    """The live view for one image's own ``<runtime> build``, labeled by its tag.
+
+    :func:`compose_build_step_reporter`'s counterpart for the sites that build a
+    single image directly — the dispatch worker's project image, a persona
+    image, the auth sidecar. Two things differ from the compose case, and both
+    are silent when a call site gets them wrong:
+
+    * A single-image build's BuildKit headers name no service (``#10 [ 2/13]``
+      where compose writes ``#10 [va 2/13]``), so an unlabeled model parses the
+      whole build into nothing — no rows, no error. The image tag is that label,
+      and its row then reads as the image the build is producing.
+    * No step lines. Each of these sites already reports its finished image as a
+      step of its own once the build returns, so a line from the parser would
+      report the same image twice. This is the live view alone.
+
+    Used exactly like its compose sibling::
+
+        with (report := single_image_build_reporter(tag)):
+            run_captured(..., on_line=report)
+    """
+    return BuildProgressReporter(image_tag, step_prefix=None)
 
 
 def _start_stack(
@@ -2865,13 +2949,17 @@ def _start_stack(
         # service that has no published upstream tag to pull.
         build_cmd = base_cmd + ["build"]
         logger.debug(f"Running command:\n    {' '.join(build_cmd)}")
-        run_captured(
-            build_cmd,
-            env=run_env,
-            spool_name="compose-build",
-            repo_root=repo_root,
-            on_line=compose_build_step_reporter(),
-        )
+        # Watched for the duration of the build and no longer: the live view
+        # (and its heartbeats) must go quiet the moment compose returns, before
+        # the closing step line below.
+        with (report := compose_build_step_reporter()):
+            run_captured(
+                build_cmd,
+                env=run_env,
+                spool_name="compose-build",
+                repo_root=repo_root,
+                on_line=report,
+            )
         _report_step("service images built")
 
     # --remove-orphans reconciles away containers whose service left the
@@ -2895,6 +2983,14 @@ def _start_stack(
         # execvpe replaces this process, so the summary must print first —
         # compose's own output follows it.
         log_endpoint_summary(config, compose_files)
+        # The terminal belongs to compose from the next line on, and this
+        # process will not exist to take anything down: whatever is rendering
+        # has to stop here, and the open start phase — which never closes on
+        # this path — has to be committed as a permanent line while there is
+        # still a process to write it. Unconditional: a no-op on a reporter
+        # with nothing to hand over, and inside the phase because a hand-off
+        # after it would find nothing left to commit.
+        current_reporter().hand_off()
         os.execvpe(cmd[0], cmd, run_env)
 
 

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -17,6 +17,7 @@ from typing import cast
 
 from osprey.build.claude_code_resolver import load_provider_spec
 from osprey.cli.phase_reporter import report_step as _report_step
+from osprey.deployment.build_progress import with_plain_build_progress
 from osprey.deployment.compose_generator import (
     _copy_local_framework_for_override,
     resolve_project_name,
@@ -155,6 +156,7 @@ def _persona_image_build_cmd(
     cmd.extend(["--build-arg", f"OSPREY_PIP_SPEC={_resolve_pip_spec(dev_mode=dev_mode)}"])
     if dev_mode:
         cmd.extend(["--build-arg", "OSPREY_DEV=1"])
+    with_plain_build_progress(cmd)
     cmd.append(context)
     return cmd
 
@@ -726,18 +728,28 @@ def build_persona_images(
                 project_label,
                 dev_mode and wheel_staged,
             )
-            logger.key_info("Building persona image %s-%s:local:", project, persona_name)
+            image_tag = f"{project}-{persona_name}:local"
+            logger.key_info("Building persona image %s:", image_tag)
             logger.debug("Running command:\n    %s", " ".join(cmd))
-            run_captured(
-                cmd,
-                env=env,
-                spool_name=f"build-persona-{project}-{persona_name}",
-                repo_root=repo_root,
-            )
+            # Function-level import for the same cycle reason as
+            # `_resolve_pip_spec` above: container_lifecycle imports this module
+            # at its own top level.
+            from osprey.deployment.container_lifecycle import single_image_build_reporter
+
+            # Watched for the duration of the build and no longer; the step line
+            # below is what reports the finished image.
+            with (report := single_image_build_reporter(image_tag)):
+                run_captured(
+                    cmd,
+                    env=env,
+                    spool_name=f"build-persona-{project}-{persona_name}",
+                    repo_root=repo_root,
+                    on_line=report,
+                )
             # One line per image, after its own build: the slowest step of a
             # local-mode deploy, and the only progress an operator gets while
             # a handful of multi-minute builds run one after another.
-            _report_step(f"persona image {project}-{persona_name}:local")
+            _report_step(f"persona image {image_tag}")
         finally:
             # Remove BOTH staged artifacts (wheel + requirements manifest) so
             # neither can poison a later non-dev build in this context.

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import yaml
 
 from osprey.cli.phase_reporter import report_step as _report_step
+from osprey.deployment.build_progress import with_plain_build_progress
 from osprey.deployment.compose_generator import (
     _stage_dev_wheel_for_context,
     compose_base_cmd,
@@ -546,11 +547,22 @@ def build_auth_sidecar_image(config: dict, dev_mode: bool, env: dict[str, str]) 
     ]
     if dev_mode:
         cmd.extend(["--build-arg", "OSPREY_DEV=1"])
+    with_plain_build_progress(cmd)
     cmd.append(str(context_dir))
 
     logger.key_info("Building auth sidecar image %s:", tag)
     logger.debug("Running command:\n    %s", " ".join(cmd))
-    run_captured(cmd, env=env, spool_name="build-auth-sidecar", repo_root=repo_root)
+    # Function-level import, like `compose_build_step_reporter` below:
+    # container_lifecycle imports this module at its own top level, so the
+    # favour cannot be returned there.
+    from osprey.deployment.container_lifecycle import single_image_build_reporter
+
+    # Watched for the duration of the build and no longer; the step line below
+    # is what reports the finished image.
+    with (report := single_image_build_reporter(tag)):
+        run_captured(
+            cmd, env=env, spool_name="build-auth-sidecar", repo_root=repo_root, on_line=report
+        )
     _report_step(f"auth sidecar image {tag}")
 
 
@@ -960,13 +972,16 @@ def deploy_up_web_terminals(
 
             services_build = services_base + ["build"]
             logger.debug(f"Running command:\n    {' '.join(services_build)}")
-            run_captured(
-                services_build,
-                env=run_env,
-                spool_name="build-services",
-                repo_root=repo_root,
-                on_line=compose_build_step_reporter(),
-            )
+            # Watched only for as long as the build runs — same scope as the
+            # plain path's build (see _start_stack).
+            with (report := compose_build_step_reporter()):
+                run_captured(
+                    services_build,
+                    env=run_env,
+                    spool_name="build-services",
+                    repo_root=repo_root,
+                    on_line=report,
+                )
             _report_step("built service images")
         services_cmd = services_base + ["up"]
         if dev_mode:

--- a/tests/cli/test_deploy_handoff.py
+++ b/tests/cli/test_deploy_handoff.py
@@ -1,0 +1,203 @@
+"""The deploy verbs' interactive prompt asks its question on a free terminal.
+
+``ensure_repo_env`` is the one place a start verb stops to ask something: with
+no ``.env`` and the provider's key exported, it offers to seed the file. The
+reporter is already installed and already drawing by then, and a live region
+repaints on its own schedule — over the question, while the operator is
+reading it, in a terminal where the answer is being typed.
+
+So the prompt runs inside ``suspended()``: the region comes down for exactly
+as long as the question is on screen, and goes back up however the block ends.
+These tests pin the call site, not the seam — that the prompt is wrapped at
+all, that the wrap is a no-op where nothing is rendering, and that a prompt
+the operator abandons still gives the terminal back.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import click
+import pytest
+
+from osprey.cli import deploy_cmd, phase_reporter
+from osprey.cli.phase_reporter import PhaseReporter, current_reporter, install_reporter
+
+#: The provider whose key the seed offer harvests, and the variable it lives in.
+_PROVIDER = "anthropic"
+_SECRET_VAR = "ANTHROPIC_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def parked_monitor(monkeypatch):
+    """Park the monitor's tick, so no thread of it lands mid-test.
+
+    A reporter that is rendering runs a real thread on the real clock. One
+    tick arriving while these tests are counting seam calls appends work
+    nobody asked about and silences the assertions after it.
+    """
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 3600.0)
+
+
+@pytest.fixture(autouse=True)
+def restore_installed_reporter():
+    """Leave the module singleton exactly as the test found it."""
+    original = current_reporter()
+    yield
+    install_reporter(original)
+
+
+class SeamRecorder(PhaseReporter):
+    """A reporter that IS rendering, recording every seam call in order.
+
+    ``_is_rendering`` is what decides whether ``suspended()`` has anything to
+    do, so claiming it here is what makes the real seam act — the block is
+    exercised, not stubbed out.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self.events: list[str] = []
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        """Swallow the line: only the seam calls are being counted."""
+
+    def _is_rendering(self) -> bool:
+        return True
+
+    def stop_rendering(self) -> None:
+        self.events.append("stop")
+        super().stop_rendering()
+
+    def start_rendering(self) -> None:
+        self.events.append("start")
+        super().start_rendering()
+
+
+def _repo(tmp_path: Path) -> Path:
+    """A deployment repo with no ``.env`` — the state that triggers the offer."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    return root
+
+
+def _config() -> dict:
+    return {"claude_code": {"provider": _PROVIDER}}
+
+
+@pytest.fixture
+def offered(monkeypatch):
+    """Everything ``ensure_repo_env`` needs to reach its prompt."""
+    monkeypatch.setenv(_SECRET_VAR, "sk-from-the-shell")
+    monkeypatch.setattr(deploy_cmd, "_stdin_is_a_terminal", lambda: True)
+
+
+def _answer(monkeypatch, reporter, answer=True):
+    """Answer the prompt, recording where in the seam it was asked."""
+
+    def _confirm(text, **kwargs):
+        reporter.events.append("prompt")
+        if isinstance(answer, BaseException):
+            raise answer
+        return answer
+
+    monkeypatch.setattr(deploy_cmd.click, "confirm", _confirm)
+
+
+def test_the_seed_prompt_is_asked_with_the_terminal_given_back(offered, monkeypatch, tmp_path):
+    """The question and the region want the same rows of the same terminal.
+
+    Ordering is the whole assertion: a prompt asked before the region came
+    down, or after it went back up, is the bug — and a test that only checked
+    that both happened would pass either way.
+    """
+    reporter = SeamRecorder()
+    install_reporter(reporter)
+    _answer(monkeypatch, reporter)
+
+    deploy_cmd.ensure_repo_env(_repo(tmp_path), _config())
+
+    assert reporter.events == ["stop", "prompt", "start"]
+
+
+def test_an_accepted_offer_still_seeds_the_file(offered, monkeypatch, tmp_path):
+    """The wrap changes where the question is asked, and nothing else.
+
+    The seed is the point of the prompt: a refactor that suspended the
+    reporter but stopped acting on the answer would leave the operator
+    agreeing to something that never happened.
+    """
+    reporter = SeamRecorder()
+    install_reporter(reporter)
+    _answer(monkeypatch, reporter)
+    repo = _repo(tmp_path)
+
+    deploy_cmd.ensure_repo_env(repo, _config())
+
+    env_path = repo / ".env"
+    assert f"{_SECRET_VAR}=sk-from-the-shell" in env_path.read_text(encoding="utf-8")
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+
+
+def test_a_declined_offer_refuses_with_the_terminal_back(offered, monkeypatch, tmp_path):
+    """The refusal that follows a "no" is a plain message, printed after the
+    region is back under the reporter's own control rather than into the
+    middle of a frame."""
+    reporter = SeamRecorder()
+    install_reporter(reporter)
+    _answer(monkeypatch, reporter, answer=False)
+    repo = _repo(tmp_path)
+
+    with pytest.raises(click.Abort):
+        deploy_cmd.ensure_repo_env(repo, _config())
+
+    assert reporter.events == ["stop", "prompt", "start"]
+    assert not (repo / ".env").exists()
+
+
+def test_an_abandoned_prompt_still_gives_the_terminal_back(offered, monkeypatch, tmp_path):
+    """A prompt the operator Ctrl-Cs is exactly the one that must not leave
+    the rest of the run rendering nothing — so the wrap has to be a ``with``
+    block, not a stop-then-start pair around the call."""
+    reporter = SeamRecorder()
+    install_reporter(reporter)
+    _answer(monkeypatch, reporter, answer=click.Abort())
+
+    with pytest.raises(click.Abort):
+        deploy_cmd.ensure_repo_env(_repo(tmp_path), _config())
+
+    assert reporter.events == ["stop", "prompt", "start"]
+
+
+def test_the_prompt_path_is_a_no_op_with_nothing_rendering(offered, monkeypatch, tmp_path):
+    """Off a terminal, under ``--verbose``, or from a library caller there is
+    no region to take down. The call site asks no questions about which
+    reporter it got, so the seam has to put back exactly what it took away —
+    here, nothing at all.
+    """
+    reporter = SeamRecorder()
+    monkeypatch.setattr(SeamRecorder, "_is_rendering", lambda self: False)
+    install_reporter(reporter)
+    _answer(monkeypatch, reporter)
+    repo = _repo(tmp_path)
+
+    deploy_cmd.ensure_repo_env(repo, _config())
+
+    assert reporter.events == ["prompt"], "a reporter drawing nothing was restarted"
+    assert (repo / ".env").exists()
+
+
+def test_the_default_reporter_survives_the_prompt(offered, monkeypatch, tmp_path):
+    """The seams live on the base class, so the quiet default answers them too.
+
+    This is the shape every non-verb caller reaches the prompt with — a
+    missing definition here is an ``AttributeError`` in production, on the one
+    path that exists to keep a deployment from starting with empty secrets.
+    """
+    monkeypatch.setattr(deploy_cmd.click, "confirm", lambda text, **kwargs: True)
+    repo = _repo(tmp_path)
+
+    deploy_cmd.ensure_repo_env(repo, _config())
+
+    assert (repo / ".env").exists()

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -23,6 +23,7 @@ different kinds of thing:
 
 from __future__ import annotations
 
+import io
 import stat
 import subprocess
 import sys
@@ -32,6 +33,7 @@ import click
 import pytest
 import yaml
 from click.testing import CliRunner
+from rich.console import Console
 
 from osprey.cli.init_cmd import (
     CI_EMITTED_PATHS,
@@ -41,7 +43,9 @@ from osprey.cli.init_cmd import (
     init,
 )
 from osprey.cli.main import cli
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
 from osprey.cli.profile_conventions import unknown_root_entries
+from osprey.cli.styles import osprey_theme
 from tests.fixtures.lifecycle_repo import EXEMPLAR_DIRNAME, exemplar_source_files
 
 #: The exemplar's display name — what ``init`` derives from the directory it
@@ -700,6 +704,101 @@ def test_unused_exported_keys_are_reported_not_dropped_silently(
     # The shell origin is the load-bearing half: it is why they are seeing this
     # at all, and without it the omission is unaccountable.
     assert "Your shell exports them" in result.output
+
+
+# ---------------------------------------------------------------------------
+# The report, and the terminal it shares with the live region
+# ---------------------------------------------------------------------------
+#
+# On a terminal the reporter mounts a live region that owns the cursor, so the
+# report is written through the reporter's console rather than straight at
+# stdout -- a raw write would land inside the region instead of above it. That
+# is a change to WHERE the bytes go, and the contract is that off a terminal it
+# changes nothing whatsoever.
+
+
+#: Exactly what ``_report`` writes for the exemplar, in the order it writes it.
+#: A golden rather than a handful of substrings, because every failure worth
+#: catching here is one a substring assertion sails past: a line re-wrapped at
+#: the console's width, a swallowed blank, a reordering, a lost trailing
+#: newline. The trailing blank line is real -- the git note is written with a
+#: leading newline, which is what separates it from the entry list.
+EXEMPLAR_REPORT = f"""\
+✓ Created {EXEMPLAR_DIRNAME}
+
+  profile.yml   your assistant's settings; edit this
+  data/         channel lists and facility docs; edit these
+  personas/     one per web login: readonly, readwrite
+  .env          empty; copy .env.example and add your API key
+  README.md     what everything here does
+
+  Started a git repo and made the first commit.
+"""
+
+
+def test_the_report_off_a_terminal_is_byte_for_byte_what_it_always_was(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    result = init_exemplar(runner, tmp_path / EXEMPLAR_DIRNAME)
+
+    assert result.exit_code == 0, result.output
+    assert EXEMPLAR_REPORT in result.stdout
+
+
+def test_a_report_line_past_the_console_width_is_not_wrapped(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rich wraps at 80 columns by default; ``click.echo`` never wrapped at all.
+
+    The skipped-keys note is the report's longest line and the one an operator
+    is most likely to copy a name out of, so it is the one this pins. Folding it
+    would not be cosmetic: it would put half a variable name on each of two
+    lines.
+    """
+    for name in ("OPENAI_API_KEY", "GOOGLE_API_KEY", "CBORG_API_KEY"):
+        monkeypatch.setenv(name, "not-a-real-key")
+
+    result = init_exemplar(runner, tmp_path / EXEMPLAR_DIRNAME)
+
+    note = (
+        "  Left out OPENAI_API_KEY, GOOGLE_API_KEY, CBORG_API_KEY. Your shell exports "
+        "them, but this assistant uses a different provider."
+    )
+    assert result.exit_code == 0, result.output
+    assert len(note) > 80
+    assert f"\n{note}\n" in result.stdout
+
+
+def test_the_report_is_written_through_the_reporters_console(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """The routing itself, asserted where it is visible.
+
+    Byte parity off a terminal is what the two tests above pin, and it is a
+    property ``click.echo`` also has -- so on its own it cannot tell the report
+    is going through the reporter at all. Installing a reporter whose console
+    records separates the two: the report lands in the recording console, and
+    the process's own stdout never sees it.
+    """
+    buffer = io.StringIO()
+    recorder = Console(file=buffer, width=200, theme=osprey_theme)
+
+    class Recording(PhaseReporter):
+        def out(self) -> Console:
+            return recorder
+
+    # Installed before the verb runs, so `lifecycle_reporter` reuses it rather
+    # than installing one of its own. Nothing is mounted and no thread starts:
+    # this is the plain reporter with its console swapped.
+    previous = install_reporter(Recording(color=False))
+    try:
+        result = init_exemplar(runner, tmp_path / EXEMPLAR_DIRNAME)
+    finally:
+        install_reporter(previous)
+
+    assert result.exit_code == 0, result.output
+    assert EXEMPLAR_REPORT in buffer.getvalue()
+    assert "Created" not in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_live_render.py
+++ b/tests/cli/test_live_render.py
@@ -1,0 +1,228 @@
+"""The live build region renders a snapshot, whatever shape the rows are in.
+
+Every assertion goes through a recording :class:`~rich.console.Console` built on
+the CLI's own theme, so a style token that does not resolve fails here rather
+than at the first cold build.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+from osprey.cli import live_render
+from osprey.cli.live_render import format_duration, render_live_region
+from osprey.cli.styles import ColorTheme, _build_rich_theme, osprey_theme
+from osprey.deployment.build_progress import EXPORT_STEP, BuildRow
+
+
+def make_row(
+    service: str = "virtual-accelerator",
+    step: str | None = "6/8",
+    caption: str = "RUN pip install -e .",
+    started_at: float = 0.0,
+    finished: str | None = None,
+) -> BuildRow:
+    """A row as ``BuildModel.snapshot`` would hand one over."""
+    return BuildRow(
+        service=service,
+        step=step,
+        caption=caption,
+        started_at=started_at,
+        last_line_at=started_at,
+        finished=finished,
+    )
+
+
+def render(rows, *, phase_open=False, elapsed=0.0, now=0.0, width=100, styles=False) -> str:
+    """Render the region at ``width`` and return what a terminal would show."""
+    console = Console(theme=osprey_theme, width=width, record=True, force_terminal=True)
+    console.print(
+        render_live_region(rows, phase_open=phase_open, elapsed=elapsed, now=now, width=width)
+    )
+    return console.export_text(styles=styles)
+
+
+# -- rows -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("step", ["6/8", "internal", "auth", EXPORT_STEP])
+def test_row_shows_every_step_shape(step: str) -> None:
+    """The step column is not always ``i/T``; each shape prints as itself."""
+    row = make_row(step=step, caption="exporting layers")
+    line = render([row], now=242.0).strip()
+    assert line.split() == ["virtual-accelerator", step, "exporting", "layers", "4m02s"]
+
+
+def test_row_without_a_step_keeps_its_other_columns() -> None:
+    """A row seen before its first header still renders — it does not blank."""
+    line = render([make_row(step=None)], now=78.0).strip()
+    assert line.split() == ["virtual-accelerator", "-", "RUN", "pip", "install", "-e", ".", "1m18s"]
+
+
+def test_rows_keep_snapshot_order_and_are_indented_under_the_phase() -> None:
+    """Insertion order is the model's; the table nests below the phase line."""
+    rows = [
+        make_row(service="virtual-accelerator", started_at=0.0),
+        make_row(service="bluesky-bridge", started_at=100.0),
+    ]
+    lines = render(rows, phase_open=True, elapsed=252.0, now=252.0).splitlines()
+    assert lines[0].endswith("4m12s")
+    assert lines[1] == ""
+    assert [line[:4] for line in lines[2:4]] == ["    ", "    "]
+    assert [line.split()[0] for line in lines[2:4]] == ["virtual-accelerator", "bluesky-bridge"]
+
+
+def test_row_age_is_measured_from_the_caller_s_clock() -> None:
+    """``now`` is injected, so a fifteen-minute build renders in a millisecond."""
+    row = make_row(started_at=1_000.0)
+    assert render([row], now=1_000.0).strip().endswith("0m00s")
+    assert render([row], now=1_925.0).strip().endswith("15m25s")
+
+
+def test_step_column_does_not_reflow_as_the_step_changes_shape() -> None:
+    """A real build walks None → internal → auth → 1/13 → 10/13 → exporting.
+
+    Those are 1, 8, 4, 4, 5 and 9 columns wide. A step column sized from
+    whatever has arrived would widen twice mid-build and drag every caption
+    sideways with it, so it is pinned at the widest step there is.
+    """
+    steps = [None, "internal", "auth", "1/13", "10/13", EXPORT_STEP]
+    starts = {render([make_row(step=step)]).index("RUN pip") for step in steps}
+    assert len(starts) == 1
+
+
+def test_caption_is_truncated_to_the_given_width() -> None:
+    """Only the caption gives way to a narrow terminal, and it says so with …."""
+    row = make_row(caption="Downloading torch (2.1 GB) from an unusually chatty mirror")
+    wide = render([row], width=120).strip()
+    narrow = render([row], width=60).strip()
+
+    assert wide.endswith("chatty mirror   0m00s")
+    assert "…" in narrow
+    assert "chatty mirror" not in narrow
+    # The columns that identify the row survive intact; the width is respected.
+    assert narrow.startswith("virtual-accelerator   6/8         ")
+    assert narrow.endswith("0m00s")
+    assert len(narrow) + 4 <= 60
+
+
+def test_ticker_carries_the_spinner_and_elapsed_but_never_the_title() -> None:
+    """The phase's title is printed once, permanently, by the reporter — so the
+    region that repaints under it carries only what keeps moving.
+
+    A ticker that repeated the title would show it twice on screen and read as a
+    rendering glitch, and the operator ruled that out.
+    """
+    line = render([], phase_open=True, elapsed=252.0).rstrip()
+    # The spinner frame itself is whichever one Rich is on; only that a frame
+    # was drawn ahead of the duration is asserted.
+    assert re.fullmatch(r" {2}\S {1}4m12s", line)
+
+
+def test_rows_render_without_an_open_phase() -> None:
+    """Watchers can outlive the phase that started them; the table stays."""
+    out = render([make_row()], phase_open=False)
+    assert out.splitlines()[0].lstrip().startswith("virtual-accelerator")
+
+
+def test_caption_is_never_read_as_markup() -> None:
+    """BuildKit captions contain brackets; none of them is a style tag."""
+    out = render([make_row(caption="load metadata for [internal] python:3.12")])
+    assert "[internal]" in out
+
+
+# -- finished services ------------------------------------------------------
+
+
+def test_finished_services_leave_the_table() -> None:
+    """A built image is already permanent in the scrollback; the table is for
+    what is still outstanding."""
+    rows = [
+        make_row(service="virtual-accelerator", finished="my-project/va:local"),
+        make_row(service="bluesky-bridge"),
+        make_row(service="event-dispatcher", finished="my-project/dispatch:local"),
+    ]
+    out = render(rows)
+    assert [line.split()[0] for line in out.splitlines()] == ["bluesky-bridge"]
+
+
+def test_all_finished_collapses_the_region() -> None:
+    """The last image lands on every successful build; nothing may be left
+    behind between then and the phase closing."""
+    console = Console(theme=osprey_theme, width=100)
+    rows = [make_row(finished="my-project/va:local")]
+    region = render_live_region(rows, phase_open=False, elapsed=0.0, now=0.0, width=100)
+    assert console.render_lines(region, pad=False) == []
+
+
+def test_all_finished_under_an_open_phase_leaves_no_blank_gap() -> None:
+    """The phase is still running, so its ticker stays; what goes is the table
+    and the blank line that separated it."""
+    rows = [make_row(finished="my-project/va:local")]
+    lines = render(rows, phase_open=True, elapsed=252.0).splitlines()
+    assert len(lines) == 1
+    assert lines[0].endswith("4m12s")
+
+
+# -- the empty region -------------------------------------------------------
+
+
+def test_empty_region_has_zero_height() -> None:
+    """No phase and no rows must cost zero lines, not one blank one."""
+    console = Console(theme=osprey_theme, width=100)
+    region = render_live_region([], phase_open=False, elapsed=0.0, now=0.0, width=100)
+    assert console.render_lines(region, pad=False) == []
+
+
+# -- durations --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [(0.0, "0m00s"), (0.4, "0m00s"), (54.9, "0m54s"), (252.0, "4m12s"), (-1.0, "0m00s")],
+)
+def test_format_duration(seconds: float, expected: str) -> None:
+    """Fixed ``MmSSs`` width, so a repainting counter does not jitter."""
+    assert format_duration(seconds) == expected
+
+
+# -- theming ----------------------------------------------------------------
+
+#: A literal color where a semantic token belongs: a hex triplet, or one of
+#: Rich's standard color names, quoted (optionally behind ``bold``/``dim``).
+_COLOR_LITERAL = re.compile(
+    r"""["'](?:(?:bold|dim|italic|bright)\s+)*"""
+    r"""(?:\#[0-9a-fA-F]{3,6}"""
+    r"""|black|red|green|yellow|blue|magenta|cyan|white"""
+    r"""|bright_\w+|grey\d*|gray\d*|purple|orange\w*|pink\w*)["']""",
+)
+
+
+def test_module_hardcodes_no_color() -> None:
+    """Every style is a token from ``styles.py``, so a retheme reaches here.
+
+    Grepped rather than trusted: a hardcoded ``"cyan"`` still renders, and would
+    only be noticed once ``osprey theme-lab`` showed one region ignoring the
+    theme.
+    """
+    source = Path(live_render.__file__).read_text()
+    assert _COLOR_LITERAL.search(source) is None
+
+
+def test_region_follows_the_active_theme() -> None:
+    """Swap the theme's colors and the rendered escape codes change with them."""
+    rows = [make_row()]
+    loud = ColorTheme(primary="#112233", accent="#445566", success="#778899", info="#aabbcc")
+
+    def styled(theme: ColorTheme) -> str:
+        console = Console(
+            theme=_build_rich_theme(theme), width=100, record=True, force_terminal=True
+        )
+        console.print(render_live_region(rows, phase_open=True, elapsed=1.0, now=1.0, width=100))
+        return console.export_text(styles=True)
+
+    assert styled(ColorTheme()) != styled(loud)

--- a/tests/cli/test_phase_reporter_live.py
+++ b/tests/cli/test_phase_reporter_live.py
@@ -1,0 +1,1051 @@
+"""Tests for the terminal live region (``LiveReporter``).
+
+The region is decoration over the plain lines, and every test here is about
+that relationship rather than about how the region looks (which
+``test_live_render.py`` owns): the same words still reach the scrollback, the
+region never outlives the moment it is torn down, and nothing it does can
+appear after a failure line.
+
+Everything runs on a recording console with ``force_terminal=True``, because a
+Rich ``Live`` on a non-terminal console silently renders nothing -- a test suite
+that forgot this would assert against a region that was never drawn.
+"""
+
+import io
+import logging
+import re
+import sys
+import threading
+import time
+from importlib import import_module
+from types import SimpleNamespace
+
+import click
+import pytest
+from rich.console import Console
+from rich.logging import RichHandler
+
+from osprey.cli import phase_reporter
+from osprey.cli.phase_reporter import (
+    LiveReporter,
+    NullReporter,
+    PhaseReporter,
+    current_reporter,
+    install_reporter,
+)
+from osprey.cli.styles import Styles, osprey_theme
+from osprey.deployment.build_progress import BuildModel
+from osprey_connectors.logger import get_logger
+
+#: The install site's module. Imported this way because ``osprey.cli`` exports a
+#: ``main`` FUNCTION of its own, which shadows the submodule of the same name
+#: under every ``import ... as`` spelling.
+cli_main = import_module("osprey.cli.main")
+
+#: Anything Rich writes that is not text: styles, cursor moves, erases.
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+#: The tail of a heartbeat line -- what must never appear on a terminal, where
+#: the region moving is the proof that the build is alive. Deliberately the same
+#: words the hand-off's committed line uses: they are one format, and a test
+#: that stopped matching both would go quietly half-blind.
+_HEARTBEAT_MARK = "(running "
+
+
+@pytest.fixture(autouse=True)
+def parked_monitor(monkeypatch):
+    """Park the monitor's tick, so only the tests about it feel it.
+
+    Mounting the region starts a real thread on the real clock, while these
+    tests drive phases and models from scripted timestamps. One tick landing
+    mid-test repaints a region full of "seconds since boot" and silences every
+    assertion after it -- an ordering-dependent flake with no visible cause.
+    The tests that exercise the thread install an interval of their own.
+    """
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 3600.0)
+
+
+@pytest.fixture(autouse=True)
+def restore_installed_reporter():
+    """Leave the module singleton exactly as the test found it."""
+    original = current_reporter()
+    yield
+    install_reporter(original)
+
+
+def recording_console() -> tuple[Console, io.StringIO]:
+    """A themed console that records everything written to it, escapes included.
+
+    ``force_terminal`` is what makes the ``Live`` real here: off a terminal Rich
+    skips the repaint entirely. The theme is not optional either -- the region's
+    styles are semantic tokens, and a bare ``Console()`` raises ``MissingStyle``
+    on the first one.
+    """
+    buffer = io.StringIO()
+    return (
+        Console(file=buffer, theme=osprey_theme, force_terminal=True, width=100),
+        buffer,
+    )
+
+
+@pytest.fixture
+def live():
+    """A started live reporter, its buffer, and a guaranteed teardown.
+
+    ``color`` is off so that the only escape sequences in the buffer come from
+    the region: with styled words every line would carry its own, and "nothing
+    moved after the failure line" would be unassertable.
+    """
+    console, buffer = recording_console()
+    reporter = LiveReporter(console=console)
+    reporter.color = False
+    reporter.start_rendering()
+    try:
+        yield reporter, buffer
+    finally:
+        reporter.stop_rendering()
+
+
+def visible_lines(text: str) -> list[str]:
+    """The words in ``text``, with escapes and blank lines dropped."""
+    return [line for line in _ANSI.sub("", text).splitlines() if line.strip()]
+
+
+def after(text: str, marker: str) -> str:
+    """Everything written after the line carrying ``marker``."""
+    index = text.index(marker)
+    return text[text.index("\n", index) + 1 :]
+
+
+def cursor_control(text: str) -> str | None:
+    """The first cursor control in ``text``, or None if it is all words.
+
+    An escape sequence OR a bare carriage return: a repaint opens its line with
+    a lone ``\\r``, which is cursor control in the same sense as the escapes but
+    matches none of their shapes. "Nothing moved after this line" asserted on
+    the escape pattern alone would miss exactly the repaint it looks for.
+    """
+    match = _ANSI.search(text)
+    if match is not None:
+        return match.group()
+    return "\r" if "\r" in text else None
+
+
+def monitor_threads() -> list[threading.Thread]:
+    """Every reporter monitor thread alive in the process."""
+    return [
+        thread
+        for thread in threading.enumerate()
+        if thread.name == phase_reporter._MONITOR_THREAD_NAME and thread.is_alive()
+    ]
+
+
+def build_with_rows() -> BuildModel:
+    """A model mid-build: two services, one of them several steps in."""
+    model = BuildModel()
+    model.feed("#1 [virtual-accelerator internal] load build definition", 1000.0)
+    model.feed("#2 [event-dispatcher 3/13] RUN pip install -e .", 1000.0)
+    model.feed("#2 1.234 Downloading torch (2.1 GB)", 1001.0)
+    return model
+
+
+# ---------------------------------------------------------------------------
+# The lines are the record; the region is decoration over them
+# ---------------------------------------------------------------------------
+
+
+def test_the_scrollback_is_content_identical_to_the_plain_reporter(monkeypatch):
+    """The point of the feature: a terminal gains a region, not different words.
+
+    Run the same script through both reporters and compare what a reader would
+    see. A phase line that gained a spinner, or a step that moved into the
+    region instead of the scrollback, would show up here.
+    """
+    plain_console, plain_buffer = recording_console()
+    monkeypatch.setattr(phase_reporter, "console", plain_console)
+    plain = PhaseReporter(color=False)
+
+    live_console, live_buffer = recording_console()
+    rich = LiveReporter(console=live_console)
+    rich.color = False
+    rich.start_rendering()
+    try:
+        for reporter in (plain, rich):
+            with reporter.phase("Building services") as phase:
+                phase.step("compose config")
+                phase.step("images built")
+    finally:
+        rich.stop_rendering()
+
+    assert visible_lines(live_buffer.getvalue()) == visible_lines(plain_buffer.getvalue())
+    assert [line.split(" (")[0] for line in visible_lines(plain_buffer.getvalue())] == [
+        "→ Building services",
+        "  · compose config",
+        "  · images built",
+        "  ✓ Building services",
+    ]
+
+
+def test_a_raw_stdout_write_is_proxied_through_the_console():
+    """``redirect_stdout`` is stated policy: a helper that never heard of the
+    reporter still prints above the region rather than into it.
+
+    Mounted inside the test body rather than from the fixture: pytest reassigns
+    ``sys.stdout`` between the setup and call phases, which would drop the
+    proxy the Live installed and prove nothing.
+    """
+    console, buffer = recording_console()
+    reporter = LiveReporter(console=console)
+    reporter.color = False
+
+    reporter.start_rendering()
+    try:
+        sys.stdout.write("straight to stdout\n")
+        sys.stdout.flush()
+    finally:
+        reporter.stop_rendering()
+
+    assert "straight to stdout" in visible_lines(buffer.getvalue())
+
+
+def test_the_live_is_configured_as_the_only_refresher(live):
+    """Each of these is load-bearing, so each is pinned.
+
+    Rich's own refresh thread would race the monitor for the cursor; a
+    non-transient region would freeze its last half-drawn frame into the
+    scrollback; and a second console would repaint over the lines.
+    """
+    reporter, _ = live
+
+    assert reporter._live.auto_refresh is False
+    assert reporter._live.transient is True
+    assert reporter._live._redirect_stdout is True
+    assert reporter._live.console is reporter.out()
+
+
+def test_starting_twice_mounts_one_region_and_one_thread(live):
+    """``init --up`` chains verbs through one reporter; the second must not
+    mount a region of its own over the first."""
+    reporter, _ = live
+    first = reporter._live
+
+    reporter.start_rendering()
+
+    assert reporter._live is first
+    assert len(monitor_threads()) == 1
+
+
+# ---------------------------------------------------------------------------
+# What the region shows
+# ---------------------------------------------------------------------------
+
+
+def test_a_repaint_draws_the_ticker_and_the_rows_under_it(live):
+    """One repaint, driven by hand: the ticker and every unfinished service.
+
+    The title is asserted to appear EXACTLY ONCE — as the permanent line the
+    phase opened with, never again in the region that repaints beneath it. A
+    substring check would pass on that one line alone and would go on passing if
+    the duplicate came back, which is the thing this pins.
+    """
+    reporter, buffer = live
+    reporter.phase("Building services")
+
+    with reporter.watch_build(build_with_rows()):
+        assert reporter.refresh_live() is True
+
+    # Carriage returns are cursor control, same as the escapes: a repaint opens
+    # its line with one, and they are not part of what the operator reads.
+    painted = _ANSI.sub("", buffer.getvalue()).replace("\r", "")
+    assert painted.count("Building services") == 1
+    assert "→ Building services" in painted
+    assert re.search(r"^ {2}\S {1}\d+m\d\ds$", painted, re.MULTILINE) is not None
+    assert "virtual-accelerator" in painted
+    assert "event-dispatcher" in painted
+    assert "Downloading torch (2.1 GB)" in painted
+
+
+def test_two_registered_builds_render_as_one_table(live):
+    """A compose run and a single image can be in flight at once, and the
+    operator is waiting on both."""
+    reporter, buffer = live
+    reporter.phase("Building services")
+    single = BuildModel(label="myrepo-project:local")
+    single.feed("#4 [ 2/13] RUN uv sync", 1000.0)
+
+    with reporter.watch_build(build_with_rows()), reporter.watch_build(single):
+        reporter.refresh_live()
+
+    painted = _ANSI.sub("", buffer.getvalue())
+    assert "event-dispatcher" in painted
+    assert "myrepo-project:local" in painted
+
+
+def test_closing_a_phase_takes_its_region_down_with_it(live):
+    """The ``✓`` must not print under a region still ticking for the phase it
+    just reported finished.
+
+    Rich appends the region to whatever print is passing through, so without a
+    repaint at the state change the stale frame lands *after* the closing line
+    and stays there until the next tick.
+    """
+    reporter, buffer = live
+    with reporter.phase("Building services"):
+        # The production shape: a build is watched for exactly one captured
+        # subprocess, inside the phase that reports it.
+        with reporter.watch_build(build_with_rows()):
+            reporter.refresh_live()
+    written = buffer.getvalue()
+
+    assert "virtual-accelerator" in written
+    assert "virtual-accelerator" not in after(written, "✓ Building services")
+
+
+def test_a_styled_line_does_not_take_the_region_with_it(monkeypatch):
+    """A ``style=`` argument applies to everything a print renders -- including
+    the region Rich appends to it, which would repaint the whole build table in
+    the colour of the line that happened to scroll past."""
+    monkeypatch.setattr(phase_reporter, "time", SimpleNamespace(monotonic=lambda: 1000.0))
+    regions = []
+
+    for style in (Styles.SUCCESS, None):
+        console, buffer = recording_console()
+        reporter = LiveReporter(console=console)
+        reporter.start_rendering()
+        try:
+            reporter.phase("Building services")
+            with reporter.watch_build(build_with_rows()):
+                reporter.refresh_live()
+                marker = "  the line"
+                reporter.emit(marker, style=style)
+                regions.append(after(buffer.getvalue(), marker))
+        finally:
+            reporter.stop_rendering()
+
+    assert regions[0] == regions[1]
+    assert "virtual-accelerator" in regions[0]
+
+
+def test_refresh_live_is_false_before_the_region_is_mounted():
+    """False is what hands the tick to the heartbeat pass instead."""
+    console, _ = recording_console()
+
+    assert LiveReporter(console=console).refresh_live() is False
+
+
+def test_refresh_live_is_false_again_once_the_region_is_stopped(live):
+    reporter, _ = live
+    reporter.stop_rendering()
+
+    assert reporter.refresh_live() is False
+
+
+def test_a_repaint_that_raises_degrades_to_plain_lines(live, monkeypatch):
+    """The region is decoration over a deploy that is still running: losing it
+    must not cost the phase lines and heartbeats behind it."""
+    reporter, buffer = live
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("render blew up")
+
+    monkeypatch.setattr(phase_reporter, "render_live_region", explode)
+
+    assert reporter.refresh_live() is False
+    assert reporter._live is None
+
+    reporter.emit("still reporting")
+    assert "still reporting" in visible_lines(buffer.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# The monitor drives the region -- and only the region
+# ---------------------------------------------------------------------------
+
+
+def test_the_monitor_repaints_instead_of_heartbeating(monkeypatch):
+    """The whole reason ``refresh_live`` reports back: a tick does one or the
+    other, and a table that visibly moves does not also need lines saying so.
+
+    The build here is stalled well past the heartbeat interval, which off a
+    terminal would print a line every pass.
+    """
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 0.01)
+    console, buffer = recording_console()
+    reporter = LiveReporter(console=console)
+    reporter.color = False
+    model = BuildModel()
+    model.feed("#2 [event-dispatcher 3/13] RUN pip install -e .", time.monotonic() - 600)
+
+    reporter.start_rendering()
+    try:
+        reporter.phase("Building services")
+        with reporter.watch_build(model):
+            time.sleep(0.1)
+    finally:
+        reporter.stop_rendering()
+
+    painted = _ANSI.sub("", buffer.getvalue())
+    assert "event-dispatcher" in painted
+    assert _HEARTBEAT_MARK not in painted
+
+
+def test_the_region_stops_before_the_reporter_lets_go(monkeypatch):
+    """A leaked monitor outlives its verb and repaints over whatever runs next.
+
+    Asserted through ``install_reporter``, because the swap -- not the verb's
+    ``finally`` -- is the path every caller has in common.
+    """
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 0.01)
+    console, _ = recording_console()
+    reporter = LiveReporter(console=console)
+    reporter.color = False
+
+    previous = install_reporter(reporter)
+    reporter.start_rendering()
+    assert len(monitor_threads()) == 1
+
+    install_reporter(previous)
+
+    assert monitor_threads() == []
+    assert reporter._live is None
+
+
+# ---------------------------------------------------------------------------
+# Teardown ordering: nothing moves after the last line
+# ---------------------------------------------------------------------------
+
+
+def test_teardown_stops_the_monitor_before_the_region():
+    """The ordering contract itself, asserted as a sequence rather than as a
+    symptom -- the symptom is a garbled line, which only appears if a tick
+    happens to land inside the microsecond between the two steps.
+
+    Taking the region down first leaves a tick free to repaint one that is no
+    longer there, restoring the cursor onto the row the next plain line is
+    about to be written on. The base class stops the monitor and the override
+    adds the region, so this order is a property of the inheritance and not of
+    any one of the four call sites.
+    """
+    console, _ = recording_console()
+    order = []
+
+    class _Order(LiveReporter):
+        def _stop_monitor(self) -> None:
+            order.append("monitor")
+            super()._stop_monitor()
+
+        def _close_live(self) -> None:
+            order.append("region")
+            super()._close_live()
+
+    reporter = _Order(console=console)
+    reporter.color = False
+    reporter.start_rendering()
+    reporter.stop_rendering()
+
+    assert order == ["monitor", "region"]
+
+
+def test_a_failure_line_is_the_last_thing_written(live, tmp_path):
+    """The contract this whole task is judged on.
+
+    After the ``✗`` the buffer must hold the replayed spool and nothing else:
+    no escape sequence (the region is down, so nothing can repaint over the
+    replay) and no heartbeat (the monitor is joined, so nothing can claim a
+    build that just died is still running).
+    """
+    reporter, buffer = live
+    spool = tmp_path / "build.log"
+    spool.write_text("compose stderr line one\ncompose stderr line two\n")
+    reporter.phase("Building services")
+
+    with reporter.watch_build(build_with_rows()):
+        reporter.refresh_live()
+        reporter.current_phase.fail(spool)
+
+    written = buffer.getvalue()
+    tail = after(written, "✗ Building services")
+    # The region really was painting up to the failure -- otherwise "nothing
+    # moved afterwards" would be true of a run that never moved at all.
+    assert _ANSI.search(written[: written.index("✗")]) is not None
+    assert _ANSI.search(tail) is None
+    assert _HEARTBEAT_MARK not in tail
+    assert "compose stderr line two" in tail
+    assert reporter._live is None
+    assert monitor_threads() == []
+
+
+def test_an_interrupt_line_is_the_last_thing_written(live):
+    """Ctrl-C's answer is one line, and nothing may print after it."""
+    reporter, buffer = live
+    phase = reporter.phase("Starting containers")
+    phase.set_spool(None)
+
+    with reporter.watch_build(build_with_rows()):
+        reporter.refresh_live()
+        phase.interrupted()
+
+    written = buffer.getvalue()
+    tail = after(written, "⚠ Starting containers")
+    assert _ANSI.search(written[: written.index("⚠")]) is not None
+    assert _ANSI.search(tail) is None
+    assert _HEARTBEAT_MARK not in tail
+    assert reporter._live is None
+    assert monitor_threads() == []
+
+
+def test_the_spool_replay_never_passes_through_the_live():
+    """Structural, not textual: the replay is a plain write by the time it runs.
+
+    A replay rendered through a live region would be re-wrapped and repainted
+    over -- and a failed build's spool is the one output an operator reads
+    line by line.
+    """
+    console, _ = recording_console()
+    seen = {}
+
+    class _Spy(LiveReporter):
+        def replay(self, path):
+            seen["reporter_live"] = self._live
+            seen["console_live"] = self.out()._live_stack
+            super().replay(path)
+
+    reporter = _Spy(console=console)
+    reporter.color = False
+    reporter.start_rendering()
+    try:
+        reporter.phase("Building services").fail(None)
+    finally:
+        reporter.stop_rendering()
+
+    assert seen["reporter_live"] is None
+    assert seen["console_live"] == []
+
+
+def test_the_plain_reporter_still_has_no_region_to_stop(monkeypatch):
+    """``stop_rendering`` and ``start_rendering`` are called unconditionally by
+    the install site, on whichever reporter it installed."""
+    console, _ = recording_console()
+    monkeypatch.setattr(phase_reporter, "console", console)
+
+    for reporter in (PhaseReporter(color=False), NullReporter(verbose=True)):
+        reporter.start_rendering()
+        reporter.stop_rendering()
+
+    assert monitor_threads() == []
+
+
+# ---------------------------------------------------------------------------
+# Giving the terminal up: temporarily (``suspended``) and for good (``hand_off``)
+# ---------------------------------------------------------------------------
+
+
+def test_a_suspend_takes_the_region_down_and_puts_it_back(live):
+    """The prompt case: a region left mounted repaints over the question while
+    the operator is still reading it."""
+    reporter, _ = live
+    reporter.phase("Preparing configuration")
+
+    with reporter.suspended():
+        assert reporter._live is None
+        assert monitor_threads() == []
+
+    assert reporter._live is not None
+    assert len(monitor_threads()) == 1
+
+
+def test_a_suspend_restores_the_region_when_the_prompt_raises(live):
+    """A prompt the operator Ctrl-Cs is exactly the one that must not leave the
+    rest of the verb rendering nothing."""
+    reporter, _ = live
+
+    with pytest.raises(KeyboardInterrupt), reporter.suspended():
+        raise KeyboardInterrupt
+
+    assert reporter._live is not None
+    assert len(monitor_threads()) == 1
+
+
+def test_nested_suspends_stop_once_and_restart_once():
+    """Reentrancy, asserted as counts and not only as an end state.
+
+    An inner block that restarted on its own exit would remount the region on
+    top of the prompt the outer block is still waiting on -- which leaves the
+    region mounted at the end either way, so the end state alone proves nothing.
+    """
+    console, _ = recording_console()
+    calls = []
+
+    class _Counted(LiveReporter):
+        def start_rendering(self) -> None:
+            calls.append("start")
+            super().start_rendering()
+
+        def stop_rendering(self) -> None:
+            calls.append("stop")
+            super().stop_rendering()
+
+    reporter = _Counted(console=console)
+    reporter.color = False
+    reporter.start_rendering()
+    try:
+        with reporter.suspended():
+            with reporter.suspended():
+                assert reporter._live is None
+            # The inner block is out and the region is still down: the prompt
+            # the outer block opened is still on the terminal.
+            assert reporter._live is None
+        assert reporter._live is not None
+    finally:
+        reporter.stop_rendering()
+
+    assert calls == ["start", "stop", "start", "stop"]
+
+
+def test_a_nested_suspend_leaves_the_region_alone_whatever_it_finds(live):
+    """Nesting is COUNTED, not inferred from what is on the screen.
+
+    Inferring it from "is a region mounted" holds only while nothing else
+    mounts one -- and a chained verb sharing this reporter (``init --up``)
+    does exactly that. An inner block acting on what it found would take that
+    region down and hand it back while the outer block's prompt is still
+    waiting for an answer.
+    """
+    reporter, _ = live
+
+    with reporter.suspended():
+        reporter.start_rendering()  # the chained verb, sharing this reporter
+        mounted = reporter._live
+
+        with reporter.suspended():
+            assert reporter._live is mounted
+
+        assert reporter._live is mounted
+
+
+def test_suspending_twice_in_a_row_is_safe(live):
+    """Two prompts in one verb -- reset asks its typed confirmation after the
+    seed prompt has already been answered."""
+    reporter, _ = live
+
+    for _ in range(2):
+        with reporter.suspended():
+            pass
+
+    assert reporter._live is not None
+    assert len(monitor_threads()) == 1
+
+
+def test_a_suspend_does_not_resurrect_a_region_that_degraded(live, monkeypatch):
+    """A run that fell back to plain lines stays fallen back.
+
+    ``refresh_live`` takes the region down when a repaint raises, and the run
+    finishes without one. A prompt afterwards must not hand it a fresh region
+    that the same failing repaint would only take down again.
+    """
+    reporter, _ = live
+    monkeypatch.setattr(phase_reporter, "render_live_region", _explode)
+    assert reporter.refresh_live() is False
+
+    with reporter.suspended():
+        pass
+
+    assert reporter._live is None
+
+
+def test_hand_off_stops_the_region_and_joins_the_monitor(live):
+    """The terminal is about to belong to compose: a Live still mounted when
+    ``os.execvpe`` lands leaves the cursor hidden and the last frame half-drawn
+    under compose's own output, in a process that no longer exists to fix it."""
+    reporter, _ = live
+    reporter.phase("Starting osprey-project")
+
+    with reporter.watch_build(build_with_rows()):
+        reporter.refresh_live()
+        reporter.hand_off()
+
+    assert reporter._live is None
+    assert monitor_threads() == []
+
+
+def test_hand_off_commits_the_open_phase_as_a_plain_line(live):
+    """The ticker was the only word on a phase that never prints a ``✓``.
+
+    An attached ``up`` is replaced by compose with its start phase still open,
+    so the hand-off erases the operator's only reading of it mid-frame. The
+    committed line is the LAST thing written: compose's own output starts on
+    the next row, and nothing of this process may repaint over it.
+    """
+    reporter, buffer = live
+    reporter.phase("Starting osprey-project")
+
+    with reporter.watch_build(build_with_rows()):
+        reporter.refresh_live()
+        reporter.hand_off()
+
+    written = buffer.getvalue()
+    committed = "  · Starting osprey-project (running "
+    assert committed in _ANSI.sub("", written)
+    # The region really was painting up to the hand-off -- otherwise "nothing
+    # follows the committed line" would be true of a run that never drew one.
+    assert _ANSI.search(written[: written.index("· Starting")]) is not None
+    assert "virtual-accelerator" not in after(written, committed)
+    assert cursor_control(after(written, committed)) is None
+
+
+def test_handing_off_twice_commits_one_line(live):
+    """Idempotent: ``up`` and ``restart`` both reach the exec point through
+    helpers that each hand off, and one phase must not report itself twice."""
+    reporter, buffer = live
+    reporter.phase("Starting osprey-project")
+
+    reporter.hand_off()
+    reporter.hand_off()
+
+    assert _ANSI.sub("", buffer.getvalue()).count(_HEARTBEAT_MARK) == 1
+
+
+def test_start_rendering_after_a_hand_off_never_remounts(live):
+    """The degrade is PERMANENT. Every later start -- an install site swapping
+    a reporter in, a ``suspended()`` block that spanned the hand-off -- must
+    leave the terminal to the process that owns it now."""
+    reporter, _ = live
+    reporter.hand_off()
+
+    reporter.start_rendering()
+
+    assert reporter._live is None
+    assert monitor_threads() == []
+
+
+def test_a_suspend_open_across_a_hand_off_does_not_remount(live):
+    """The seams compose: reset prompts, hands off, and the block still exits."""
+    reporter, _ = live
+    reporter.phase("Starting osprey-project")
+
+    with reporter.suspended():
+        reporter.hand_off()
+
+    assert reporter._live is None
+    assert monitor_threads() == []
+
+
+def test_a_failure_after_a_hand_off_prints_plain_lines_only(live, tmp_path):
+    """``os.execvpe`` raises when the compose binary is missing, and the
+    ``fail()`` that answers it runs in a process whose terminal has already
+    been given away. It prints its ``✗`` and its spool, and mounts nothing."""
+    reporter, buffer = live
+    spool = tmp_path / "compose.log"
+    spool.write_text("compose stderr line one\n")
+    phase = reporter.phase("Starting osprey-project")
+    reporter.hand_off()
+
+    phase.fail(spool)
+
+    written = buffer.getvalue()
+    assert "✗ Starting osprey-project" in _ANSI.sub("", written)
+    assert cursor_control(after(written, "✗ Starting osprey-project")) is None
+    assert "compose stderr line one" in written
+    assert reporter._live is None
+    assert monitor_threads() == []
+
+
+def test_the_seams_are_no_ops_with_nothing_to_render(monkeypatch):
+    """Both are called unconditionally by their call sites, on whichever
+    reporter the verb installed -- so a missing definition is an
+    ``AttributeError`` in production, and a definition that printed something
+    would put a line off a terminal that the terminal never shows."""
+    console, buffer = recording_console()
+    monkeypatch.setattr(phase_reporter, "console", console)
+
+    for reporter in (PhaseReporter(color=False), NullReporter(verbose=True)):
+        reporter.phase("Starting osprey-project")
+        with reporter.suspended():
+            with reporter.suspended():
+                pass
+        reporter.hand_off()
+        reporter.hand_off()
+
+    assert visible_lines(buffer.getvalue()) == ["→ Starting osprey-project"]
+    assert monitor_threads() == []
+
+
+def test_stdout_piped_while_stdin_is_a_terminal_prompts_with_no_region(monkeypatch):
+    """``osprey up | tee``: the prompt is real (stdin is still the operator's
+    terminal) while stdout is a pipe, so there is no region to pause for it.
+
+    The whole point of the no-op semantics -- the install site picked the plain
+    reporter, and the seams the prompt site wraps itself in must leave both the
+    prompt and the piped scrollback exactly as they were.
+    """
+    piped = _PipedStdout()
+    monkeypatch.setattr(cli_main.sys, "stdout", piped)
+    reporter = cli_main._tty_aware_reporter()
+    console, buffer = recording_console()
+    monkeypatch.setattr(phase_reporter, "console", console)
+
+    def answer(prompt: str) -> str:
+        """Stand in for the operator's terminal, writing the prompt as
+        ``input()`` does before it reads the reply."""
+        sys.stdout.write(prompt)
+        return "y"
+
+    monkeypatch.setattr(click.termui, "visible_prompt_func", answer)
+
+    reporter.phase("Preparing configuration")
+    with reporter.suspended():
+        answered = click.confirm("Create .env from the template")
+    reporter.hand_off()
+    reporter.start_rendering()
+
+    assert answered is True
+    assert "Create .env from the template [y/N]" in piped.getvalue()
+    assert visible_lines(buffer.getvalue()) == ["→ Preparing configuration"]
+    assert _ANSI.search(buffer.getvalue()) is None
+    assert monitor_threads() == []
+
+
+def _explode(*args, **kwargs):
+    """A repaint that fails, for the degrade paths."""
+    raise RuntimeError("render blew up")
+
+
+class _PipedStdout(io.StringIO):
+    """Stdout redirected to a file or a pipe: writable, but not a terminal."""
+
+    def isatty(self) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Which reporter the install site picks
+# ---------------------------------------------------------------------------
+
+
+def test_a_terminal_gets_the_live_reporter(monkeypatch):
+    monkeypatch.setattr(cli_main.sys, "stdout", _FakeStdout(tty=True))
+
+    assert isinstance(cli_main._tty_aware_reporter(), LiveReporter)
+
+
+def test_a_pipe_gets_the_plain_reporter(monkeypatch):
+    """Stdout piped while stdin is still a terminal (``osprey up | tee``) is
+    the case that must NOT mount a region."""
+    monkeypatch.setattr(cli_main.sys, "stdout", _FakeStdout(tty=False))
+
+    reporter = cli_main._tty_aware_reporter()
+
+    assert type(reporter) is PhaseReporter
+
+
+def test_the_install_site_starts_the_region_it_installed(monkeypatch):
+    """The region is mounted once, by the verb that owns the reporter."""
+    started = []
+
+    class _Spy(PhaseReporter):
+        def start_rendering(self) -> None:
+            started.append(current_reporter() is self)
+
+    monkeypatch.setattr(cli_main, "_tty_aware_reporter", lambda: _Spy(color=False))
+
+    with cli_main.lifecycle_reporter():
+        pass
+
+    assert started == [True]
+
+
+class _FakeStdout:
+    """Just enough stdout for the install site's one question."""
+
+    def __init__(self, *, tty: bool) -> None:
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+# ---------------------------------------------------------------------------
+# Log records while a region is mounted
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def log_handler():
+    """A ``RichHandler`` on the ROOT logger, writing to a stream of its own.
+
+    The shape ``configure_logging()`` installs, minus the parts that would make
+    the assertions about wrapping: one handler, one console, bound to a stream
+    that is emphatically NOT the reporter's -- which is the whole reason a record
+    can garble the region in the first place.
+
+    Removed again afterwards, level included: a handler left on the root logger
+    prints every later test's log records, and a swapped console left on it would
+    outlive the buffer it points at.
+    """
+    stream = io.StringIO()
+    own_console = Console(file=stream, force_terminal=True, width=100)
+    handler = RichHandler(
+        console=own_console,
+        show_time=False,
+        show_path=False,
+        markup=True,
+    )
+    root = logging.getLogger()
+    level = root.level
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)
+    try:
+        # The handler's OWN console is yielded rather than read back off it: by
+        # the time a test runs the region may already have borrowed it, and
+        # "restored" asserted against whatever is installed at that point would
+        # be asserting the borrow against itself.
+        yield handler, stream, own_console
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(level)
+
+
+@pytest.fixture
+def live_over_logging(log_handler):
+    """A live reporter mounted AFTER the log handler is on the root logger.
+
+    The ordering is the point, and is why these tests do not reuse ``live``:
+    the borrow happens when the region mounts, so a handler registered after
+    that is never borrowed and every assertion below would pass vacuously.
+    """
+    console, buffer = recording_console()
+    reporter = LiveReporter(console=console)
+    reporter.color = False
+    reporter.start_rendering()
+    try:
+        yield reporter, buffer, console
+    finally:
+        reporter.stop_rendering()
+
+
+def test_a_log_record_lands_as_one_intact_line_above_the_region(live_over_logging, log_handler):
+    """The symptom the swap exists for: a record written straight to stderr
+    lands in the middle of a repainting region and the two interleave.
+
+    Asserted on the reporter's buffer rather than on the absence of garbling,
+    because "not garbled" is only visible on a real terminal -- here the proof
+    is that the record went through the console the ``Live`` is mounted on, in
+    one piece, with its own stream left empty.
+    """
+    reporter, buffer, _console = live_over_logging
+    _handler, stderr, _own = log_handler
+    reporter.phase("Building services")
+
+    with reporter.watch_build(build_with_rows()):
+        reporter.refresh_live()
+        get_logger("deploy").key_info("pulling base image")
+        reporter.refresh_live()
+
+    written = buffer.getvalue()
+    # Rich pads a log line out to the console width, so the trailing run of
+    # spaces is the renderer's and not part of the record.
+    assert [line.rstrip() for line in visible_lines(written) if "pulling base image" in line] == [
+        "INFO     pulling base image"
+    ]
+    assert "pulling base image" not in stderr.getvalue()
+
+
+def test_the_plain_reporter_leaves_the_log_handler_on_stderr(monkeypatch, log_handler):
+    """Off a terminal the handler keeps the stderr it documents.
+
+    Piped and CI consumers read records on stderr and program output on stdout,
+    and there is no region off a TTY for a record to garble -- so the plain
+    reporter has nothing to borrow for and must not touch the handler at all.
+    """
+    handler, stderr, original = log_handler
+    console, buffer = recording_console()
+    monkeypatch.setattr(phase_reporter, "console", console)
+
+    reporter = PhaseReporter(color=False)
+    reporter.start_rendering()
+    reporter.phase("Building services")
+    get_logger("deploy").key_info("pulling base image")
+    reporter.stop_rendering()
+
+    assert handler.console is original
+    assert "pulling base image" in stderr.getvalue()
+    assert "pulling base image" not in buffer.getvalue()
+
+
+def test_the_handler_gets_its_own_console_back_on_uninstall(log_handler):
+    """Restored by IDENTITY, through the swap every caller has in common.
+
+    The handler's console is configured by whoever installed it -- stderr,
+    ``force_terminal``, a fixed width -- so an equivalent rebuilt from the same
+    arguments would not be giving it back. The borrowed one points at a buffer
+    that dies with the verb, and a run that drew a region must leave the process
+    logging exactly as it found it.
+    """
+    handler, _stderr, original = log_handler
+    console, _buffer = recording_console()
+    reporter = LiveReporter(console=console)
+    reporter.color = False
+
+    previous = install_reporter(reporter)
+    reporter.start_rendering()
+    borrowed = handler.console
+
+    install_reporter(previous)
+
+    assert borrowed is console
+    assert handler.console is original
+
+
+def test_the_handler_gets_its_own_console_back_on_hand_off(live_over_logging, log_handler):
+    """``os.execvpe`` is a moment away: the region is gone and so is the borrow.
+
+    A handler still pointing at a console whose ``Live`` no longer exists is the
+    one state that outlives this process's ownership of the terminal.
+    """
+    reporter, _buffer, console = live_over_logging
+    handler, _stderr, original = log_handler
+    reporter.phase("Starting osprey-project")
+    assert handler.console is console
+
+    reporter.hand_off()
+
+    assert handler.console is original
+
+
+def test_the_handler_is_restored_when_the_phase_raises(live_over_logging, log_handler):
+    """The failure path reaches teardown through ``Phase.fail``, not through a
+    tidy return -- and that is the path an operator actually hits."""
+    reporter, _buffer, console = live_over_logging
+    handler, _stderr, original = log_handler
+    assert original is not console
+
+    with pytest.raises(RuntimeError, match="compose exploded"):
+        with reporter.phase("Building services"):
+            assert handler.console is console
+            raise RuntimeError("compose exploded")
+
+    assert handler.console is original
+
+
+def test_a_root_logger_with_no_rich_handler_is_left_alone(monkeypatch):
+    """Nothing to borrow is normal, not an error.
+
+    A library caller or a test may never have called ``configure_logging()``,
+    and then no record is heading for stderr for a repaint to collide with. A
+    reporter that insisted on finding a handler would turn the region -- pure
+    decoration -- into a reason a deploy cannot start.
+    """
+    monkeypatch.setattr(logging.getLogger(), "handlers", [logging.NullHandler()])
+    console, buffer = recording_console()
+    reporter = LiveReporter(console=console)
+    reporter.color = False
+
+    reporter.start_rendering()
+    try:
+        assert reporter._borrowed_log_consoles == []
+        reporter.phase("Building services")
+        reporter.refresh_live()
+    finally:
+        reporter.stop_rendering()
+
+    assert "→ Building services" in visible_lines(buffer.getvalue())

--- a/tests/cli/test_phase_reporter_watchers.py
+++ b/tests/cli/test_phase_reporter_watchers.py
@@ -1,0 +1,481 @@
+"""Tests for the phase reporter's build watchers and its heartbeat pass.
+
+Every timestamp here is injected. Nothing in this file sleeps or reads a real
+clock: the heartbeat decision takes ``now`` as an argument precisely so a
+quarter-hour build can be replayed from a fixture in milliseconds. The monitor
+thread's tests are the one place a real clock is unavoidable -- and even there
+the wait is on an event with a timeout, never on a duration.
+"""
+
+import io
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import click
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+from osprey.cli import phase_reporter
+from osprey.cli.phase_reporter import (
+    PhaseReporter,
+    current_reporter,
+    install_reporter,
+)
+from osprey.cli.styles import osprey_theme
+from osprey.deployment.build_progress import BuildModel
+
+FIXTURES = Path(__file__).resolve().parents[1] / "deployment" / "fixtures"
+
+COLD_BUILD = "buildkit_cold_build.log"
+PROJECT_IMAGE = "buildkit_project_image.log"
+
+
+def fixture_lines(name: str) -> list[str]:
+    """Read a captured spool the way ``run_captured`` delivers it to ``on_line``.
+
+    Bytes split on newlines only: 188 of the cold build's lines carry embedded
+    carriage returns, and Python's universal-newline text mode would shred each
+    of those into several lines the child never emitted.
+    """
+    return (FIXTURES / name).read_bytes().decode().split("\n")
+
+
+def vertex_lines(name: str, node: int) -> list[str]:
+    """Every line one BuildKit vertex emitted, in order."""
+    prefix = f"#{node} "
+    return [line for line in fixture_lines(name) if line.startswith(prefix)]
+
+
+@pytest.fixture
+def sink(monkeypatch):
+    """Capture reporter output, as in ``test_phase_reporter``."""
+    buffer = io.StringIO()
+    monkeypatch.setattr(
+        phase_reporter,
+        "console",
+        Console(file=buffer, theme=osprey_theme, force_terminal=True, width=200),
+    )
+    return buffer
+
+
+def monitor_threads() -> list[threading.Thread]:
+    """Every live reporter monitor thread in the process.
+
+    Named threads are what makes a leak visible: a monitor that outlived its
+    reporter is still in this list long after the test that started it.
+    """
+    return [
+        thread
+        for thread in threading.enumerate()
+        if thread.name == phase_reporter._MONITOR_THREAD_NAME and thread.is_alive()
+    ]
+
+
+@pytest.fixture(autouse=True)
+def parked_monitor(monkeypatch):
+    """Park the monitor's tick, so only the tests about it feel it.
+
+    Registering a build starts the monitor, and the monitor reads the real
+    clock -- while every other test here feeds the model timestamps out of a
+    fixture. One tick landing inside such a test would mark every service as
+    beaten at "seconds since boot" and silence the assertions that follow it.
+    The tests that exercise the thread install an interval of their own.
+    """
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 3600.0)
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    """Drive the phase lines' own elapsed arithmetic from a scripted clock."""
+
+    def install(*ticks):
+        stream = iter(ticks)
+        monkeypatch.setattr(phase_reporter, "time", SimpleNamespace(monotonic=lambda: next(stream)))
+
+    return install
+
+
+def test_a_long_gap_between_lines_beats_inside_the_gap():
+    """The case the whole feature exists for: a silent step proves it is alive."""
+    lines = vertex_lines(COLD_BUILD, 17)
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    beats = []
+    with reporter.watch_build(model):
+        model.feed(lines[0], 1000.0)
+        # A 90s gap before the vertex's next line, ticked every 10s.
+        for tick in range(1010, 1091, 10):
+            beats.extend(reporter._heartbeat_pass(float(tick)))
+        model.feed(lines[1], 1090.0)
+
+    assert len(beats) == 2
+    assert beats[0].startswith("  · virtual-accelerator 6/8 RUN ")
+    assert beats[0].endswith(" (running 40.0s)")
+    assert beats[1].endswith(" (running 1m20s)")
+
+
+def test_a_service_that_keeps_talking_still_beats():
+    """Heartbeats are independent of line arrival, per the non-TTY contract.
+
+    A step that prints a line a second is not silent, but it is also not
+    finished, and the operator still needs to see it move.
+    """
+    lines = vertex_lines(COLD_BUILD, 17)
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        for offset, line in enumerate(lines[:40]):
+            model.feed(line, 1000.0 + offset)
+        assert reporter._heartbeat_pass(1039.0) != []
+
+
+def test_nothing_beats_before_the_interval_has_passed():
+    lines = vertex_lines(COLD_BUILD, 17)
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        model.feed(lines[0], 1000.0)
+        assert reporter._heartbeat_pass(1029.0) == []
+        assert reporter._heartbeat_pass(1030.0) == []
+        assert reporter._heartbeat_pass(1030.5) != []
+
+
+def test_a_deregistered_build_never_beats_again():
+    """The stale-heartbeat guard: a build that has returned goes quiet."""
+    lines = vertex_lines(COLD_BUILD, 17)
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        model.feed(lines[0], 1000.0)
+
+    assert reporter._heartbeat_pass(2000.0) == []
+    assert reporter._heartbeat_pass(9999.0) == []
+
+
+def test_deregistration_happens_when_the_block_raises():
+    """A failed build must go quiet exactly as a successful one does."""
+    lines = vertex_lines(COLD_BUILD, 17)
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with pytest.raises(RuntimeError):
+        with reporter.watch_build(model):
+            model.feed(lines[0], 1000.0)
+            raise RuntimeError("compose build failed")
+
+    assert reporter._heartbeat_pass(2000.0) == []
+
+
+def test_watch_build_yields_the_model_and_emits_nothing_itself(sink):
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model) as watched:
+        assert watched is model
+        model.feed(vertex_lines(COLD_BUILD, 17)[0], 1000.0)
+        reporter._heartbeat_pass(2000.0)
+
+    assert sink.getvalue() == ""
+
+
+def test_phase_lines_are_untouched_when_no_build_is_watched(sink, fake_clock):
+    """The regression guard for the whole feature.
+
+    Off a TTY the contract is that nothing about today's output changes except
+    the heartbeats that were not there before -- so with no build registered,
+    a phase's lines are byte-for-byte what they have always been.
+    """
+    fake_clock(0.0, 12.0, 90.0)
+
+    reporter = PhaseReporter(color=False)
+    with reporter.phase("Building images") as phase:
+        phase.step("web-terminal")
+
+    assert sink.getvalue() == (
+        "→ Building images\n  · web-terminal (12.0s)\n  ✓ Building images (1m30s)\n"
+    )
+
+
+def test_a_finished_service_stops_beating():
+    """``naming to ... done`` means the image is built, not running."""
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        for offset, line in enumerate(vertex_lines(COLD_BUILD, 23)):
+            model.feed(line, 1000.0 + offset)
+        assert reporter._heartbeat_pass(2000.0) == []
+
+
+def test_the_export_pseudo_step_beats_like_any_other():
+    """The longest stretch of a cold build carries no Dockerfile step index."""
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        model.feed("#23 [virtual-accelerator] exporting to image", 1000.0)
+        (beat,) = reporter._heartbeat_pass(1100.0)
+
+    assert beat == "  · virtual-accelerator exporting exporting to image (running 1m40s)"
+
+
+def test_an_infrastructure_step_word_renders_without_a_step_index():
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        model.feed(vertex_lines(COLD_BUILD, 1)[0], 1000.0)
+        (beat,) = reporter._heartbeat_pass(1031.0)
+
+    assert beat == (
+        "  · virtual-accelerator internal load build definition from Dockerfile (running 31.0s)"
+    )
+
+
+def test_a_single_image_build_beats_under_its_label():
+    """A nameless ``[ 3/13]`` header belongs to the model's label."""
+    reporter = PhaseReporter(color=False)
+    model = BuildModel(label="myrepo-project:local")
+
+    with reporter.watch_build(model):
+        model.feed(vertex_lines(PROJECT_IMAGE, 10)[0], 1000.0)
+        (beat,) = reporter._heartbeat_pass(1031.0)
+
+    assert beat.startswith("  · myrepo-project:local 3/13 RUN apt-get update")
+
+
+def test_every_service_of_a_compose_build_beats_once_per_interval():
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        for line in fixture_lines(COLD_BUILD)[:120]:
+            model.feed(line, 1000.0)
+        beats = reporter._heartbeat_pass(1031.0)
+
+    services = [beat.split()[1] for beat in beats]
+    assert services == [row.service for row in model.snapshot()]
+    assert len(services) == len(set(services))
+    assert reporter._heartbeat_pass(1032.0) == []
+
+
+def test_each_watched_build_beats_on_its_own_schedule():
+    reporter = PhaseReporter(color=False)
+    services, project = BuildModel(), BuildModel(label="myrepo-project:local")
+
+    with reporter.watch_build(services):
+        services.feed(vertex_lines(COLD_BUILD, 17)[0], 1000.0)
+        assert len(reporter._heartbeat_pass(1031.0)) == 1
+        with reporter.watch_build(project):
+            project.feed(vertex_lines(PROJECT_IMAGE, 10)[0], 1031.0)
+            assert len(reporter._heartbeat_pass(1062.0)) == 2
+        assert len(reporter._heartbeat_pass(1093.0)) == 1
+
+
+def test_beat_state_dies_with_the_registration():
+    """Re-registering a model starts from silence, not a stale schedule."""
+    lines = vertex_lines(COLD_BUILD, 17)
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        model.feed(lines[0], 1000.0)
+        assert len(reporter._heartbeat_pass(1031.0)) == 1
+        assert reporter._heartbeat_pass(1032.0) == []
+
+    with reporter.watch_build(model):
+        assert len(reporter._heartbeat_pass(1033.0)) == 1
+
+
+def test_a_long_run_caption_is_clipped_to_one_readable_line():
+    """A step's opening caption is its whole shell command; the log is not."""
+    lines = vertex_lines(COLD_BUILD, 17)
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        model.feed(lines[0], 1000.0)
+        (beat,) = reporter._heartbeat_pass(1031.0)
+
+    assert len(lines[0]) > 500
+    assert len(beat) < 160
+    assert "… (running 31.0s)" in beat
+
+
+def test_a_stream_with_no_buildkit_headers_never_beats():
+    """A podman provider's own progress format leaves the model empty."""
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        for line in ("STEP 1/13: FROM python:3.11-slim", "Copying blob sha256:abc123"):
+            model.feed(line, 1000.0)
+        assert reporter._heartbeat_pass(2000.0) == []
+
+
+def test_no_watchers_at_all_is_a_quiet_pass():
+    assert PhaseReporter(color=False)._heartbeat_pass(2000.0) == []
+
+
+# -- the monitor thread ------------------------------------------------------
+
+
+class _RecordingReporter(PhaseReporter):
+    """Records what was emitted, and what was still running when it was.
+
+    ``running_at_emit`` is how the teardown ORDER is asserted rather than
+    assumed: a line printed while the monitor was still alive is a line the
+    monitor could have printed over.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self.lines: list[str] = []
+        self.running_at_emit: list[int] = []
+        self.emitted = threading.Event()
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        super().emit(text, style)
+        self.lines.append(text)
+        self.running_at_emit.append(len(monitor_threads()))
+        self.emitted.set()
+
+
+def test_the_monitor_runs_for_exactly_as_long_as_a_build_is_watched():
+    """Off a TTY the watcher set owns the thread: first in starts, last out stops."""
+    reporter = PhaseReporter(color=False)
+    assert monitor_threads() == []
+
+    with reporter.watch_build(BuildModel()):
+        assert len(monitor_threads()) == 1
+        with reporter.watch_build(BuildModel(label="myrepo-project:local")):
+            assert len(monitor_threads()) == 1
+        assert len(monitor_threads()) == 1
+
+    assert monitor_threads() == []
+
+
+def test_a_pinned_monitor_outlives_the_builds_it_watched():
+    """The live region's monitor still has an open phase's elapsed to tick."""
+    reporter = PhaseReporter(color=False)
+    reporter._start_monitor(pinned=True)
+
+    with reporter.watch_build(BuildModel()):
+        assert len(monitor_threads()) == 1
+    assert len(monitor_threads()) == 1
+
+    reporter.stop_rendering()
+    assert monitor_threads() == []
+
+
+def test_the_monitor_thread_emits_every_heartbeat_the_pass_returns(sink, monkeypatch):
+    """The integration the thread exists for, on a clock the test drives.
+
+    The decision itself is covered above; what is proven here is that the loop
+    calls it on its own, that the lines it returns reach ``emit`` (dropping
+    them would silence the pass that followed), and that a beaten service is
+    not beaten again on the next tick.
+    """
+    clock = SimpleNamespace(value=1000.0)
+    monkeypatch.setattr(phase_reporter, "time", SimpleNamespace(monotonic=lambda: clock.value))
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 0.005)
+
+    reporter = _RecordingReporter()
+    model = BuildModel()
+
+    with reporter.watch_build(model):
+        model.feed(vertex_lines(COLD_BUILD, 17)[0], 1000.0)
+        assert reporter.lines == []  # Nothing is due in the first instant.
+        clock.value = 1031.0
+        assert reporter.emitted.wait(timeout=10.0), "the monitor never emitted a heartbeat"
+
+    assert len(reporter.lines) == 1
+    assert reporter.lines[0].startswith("  · virtual-accelerator 6/8 RUN ")
+    assert reporter.lines[0].endswith(" (running 31.0s)")
+    assert reporter.lines[0] in sink.getvalue()
+
+
+def test_a_failing_phase_stops_the_monitor_before_it_prints():
+    """Nothing may print after ``✗``: the failure is the last word."""
+    reporter = _RecordingReporter()
+    reporter._start_monitor(pinned=True)
+
+    with pytest.raises(RuntimeError):
+        with reporter.phase("Building images"):
+            assert len(monitor_threads()) == 1
+            raise RuntimeError("compose build failed")
+
+    assert monitor_threads() == []
+    assert reporter.lines[-1].startswith("  ✗ Building images")
+    assert reporter.running_at_emit[-1] == 0
+
+
+def test_an_interrupted_phase_stops_the_monitor_before_it_prints():
+    reporter = _RecordingReporter()
+    reporter._start_monitor(pinned=True)
+
+    with pytest.raises(KeyboardInterrupt):
+        with reporter.phase("Building images"):
+            raise KeyboardInterrupt
+
+    assert monitor_threads() == []
+    assert reporter.lines[-1].startswith("  ⚠ Building images interrupted")
+    assert reporter.running_at_emit[-1] == 0
+
+
+def test_a_direct_install_reporter_swap_leaves_no_thread_behind():
+    """The path a test fixture or a library caller takes -- no verb involved."""
+    reporter = PhaseReporter(color=False)
+    previous = install_reporter(reporter)
+    try:
+        reporter._start_monitor(pinned=True)
+        assert len(monitor_threads()) == 1
+    finally:
+        assert install_reporter(previous) is reporter
+
+    assert monitor_threads() == []
+    assert current_reporter() is previous
+
+
+def test_a_verb_under_the_cli_runner_leaves_no_thread_behind():
+    """The production path: ``lifecycle_reporter``'s uninstall quiesces the verb.
+
+    The pinned start stands in for the live region a TTY run would mount --
+    without it the watcher set would have stopped the monitor on its own, and
+    the uninstall would be proving nothing.
+    """
+    seen = []
+
+    @click.command()
+    def verb():
+        from osprey.cli.main import lifecycle_reporter
+
+        with lifecycle_reporter() as reporter:
+            reporter._start_monitor(pinned=True)
+            with reporter.watch_build(BuildModel()):
+                seen.append(len(monitor_threads()))
+
+    original = current_reporter()
+    result = CliRunner().invoke(verb, [])
+
+    assert result.exit_code == 0, result.output
+    assert seen == [1]
+    assert monitor_threads() == []
+    assert current_reporter() is original
+
+
+def test_the_quiet_verbose_reporter_runs_no_monitor_at_all():
+    """Under ``--verbose`` the child's own output streams; nothing to prove."""
+    reporter = phase_reporter.NullReporter(verbose=True)
+
+    with reporter.watch_build(BuildModel()):
+        assert monitor_threads() == []
+
+    reporter.stop_rendering()
+    assert monitor_threads() == []

--- a/tests/cli/test_printed_copy_style.py
+++ b/tests/cli/test_printed_copy_style.py
@@ -24,9 +24,10 @@ import pytest
 SRC = Path(__file__).resolve().parents[2] / "src" / "osprey"
 
 #: Calls whose string arguments land on a terminal, by attribute or bare name.
-#: ``emit`` is the phase reporter's, ``echo``/``secho`` are click's, ``print``
-#: is rich's console and the builtin.
-_PRINTERS = frozenset({"echo", "secho", "emit", "print"})
+#: ``emit``, ``echo`` and ``echo_error`` are the phase reporter's (``echo`` is
+#: also click's, along with ``secho``), and ``print`` is rich's console and the
+#: builtin.
+_PRINTERS = frozenset({"echo", "echo_error", "secho", "emit", "print"})
 
 #: In-house vocabulary. Each of these has a plain equivalent that costs no
 #: precision, and none of them is defined anywhere the reader will have been.

--- a/tests/cli/test_reset_verb.py
+++ b/tests/cli/test_reset_verb.py
@@ -1,0 +1,256 @@
+"""``osprey reset`` and the terminal it shares with the live region.
+
+What reset *destroys* is pinned in ``tests/deployment/test_reset_scoping.py``:
+the identity scoping, the refusal, the plan-equals-execution equality, the exit
+codes. None of that is repeated here, and this file borrows that module's
+fixtures rather than building a second deployment repo that could drift from it.
+
+What is pinned here is narrower and entirely about output. On a terminal the
+reporter mounts a live region that owns the cursor, so reset's plan is written
+through the reporter's console instead of straight at stdout, and the typed
+destruction confirmation takes the region down for as long as it is waiting on
+an answer. Both of those are changes to WHERE bytes go, and the contract is that
+off a terminal they change nothing at all:
+
+* the plan is byte for byte the lines the deployment layer emitted -- not a
+  substring of them, since a transport that re-wrapped at 80 columns or dropped
+  a trailing newline would pass every substring assertion ever written;
+* the interrupt notice is still on **stderr**. That one is asserted as a STREAM
+  rather than as text: it is the line a piped or CI caller watches for, and
+  moving it to stdout would break a consumer silently while every text
+  assertion kept passing.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+from osprey.cli import phase_reporter
+from osprey.cli.phase_reporter import LiveReporter, install_reporter
+from osprey.cli.reset_cmd import reset as reset_command
+from osprey.cli.styles import osprey_theme
+from osprey.deployment import reset as reset_mod
+from osprey.deployment.reset import confirmation_token, reset_deployment
+from tests.deployment import test_reset_scoping as scoping
+
+# The deployment repo, the recording runtime and the no-op ``down``, taken from
+# the module that specifies them. Duplicating them here would give this file a
+# second definition of "a deployment repo" to keep in step with the first.
+# Bound as attributes rather than imported so that a test parameter named after
+# a fixture is not read as shadowing an import.
+FakeRuntime = scoping.FakeRuntime
+make_probe = scoping.make_probe
+ours = scoping.ours
+repo = scoping.repo
+no_down = scoping.no_down
+
+#: Everything Rich writes that is not text: styles, cursor moves, erases -- and
+#: the bare carriage return a repaint opens its line with, which the escape
+#: pattern alone does not catch.
+_NOISE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\r")
+
+#: The interrupt notice, in full. Written out rather than imported so that a
+#: reword has to come past these tests and re-affirm the stream it goes to.
+INTERRUPT_NOTICE = (
+    "Reset interrupted while it was removing things. It does not roll back, so this "
+    "deployment is in a partly-reset state. Re-run `osprey reset` to finish; it re-reads "
+    "what is actually there."
+)
+
+#: Wide enough that the region's table has room, narrow enough that the notice
+#: and the longest plan lines are past it -- which is what makes "not wrapped"
+#: an observation rather than a coincidence.
+_WIDTH = 100
+
+
+@pytest.fixture
+def live_reporter(monkeypatch: pytest.MonkeyPatch):
+    """A mounted live region over a recording console, installed as THE reporter.
+
+    ``force_terminal`` is what makes the ``Live`` real: off a terminal Rich skips
+    the repaint entirely and there would be no region for any of this to be
+    about. The theme is not optional either -- the region's styles are semantic
+    tokens, and a bare ``Console`` raises ``MissingStyle`` on the first frame.
+
+    Installing it before the verb runs is what puts it in the verb's hands:
+    ``lifecycle_reporter`` reuses a reporter it finds already installed, and
+    therefore never mounts a second region -- so this fixture starts the one it
+    yields. Swapping the previous reporter back at the end stops it.
+
+    The monitor's tick is parked for the same reason every live test parks it:
+    mounting the region starts a real thread on the real clock, and one tick
+    landing mid-test repaints the region under the output being asserted on.
+    """
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 3600.0)
+    buffer = io.StringIO()
+    console = Console(
+        file=buffer,
+        force_terminal=True,
+        width=_WIDTH,
+        theme=osprey_theme,
+        legacy_windows=False,
+    )
+    reporter = LiveReporter(console=console)
+    previous = install_reporter(reporter)
+    reporter.start_rendering()
+    try:
+        yield reporter, buffer
+    finally:
+        install_reporter(previous)
+
+
+def rendered(buffer: io.StringIO) -> str:
+    """What a reader would see in the recording console, without the cursor work."""
+    return _NOISE.sub("", buffer.getvalue())
+
+
+def probe_for(fake: FakeRuntime, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the CLI's reset at ``fake`` instead of a container runtime."""
+    monkeypatch.setattr(reset_mod, "_default_probe", lambda root: make_probe(fake))
+
+
+# ---------------------------------------------------------------------------
+# Off a terminal: not one byte moves
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_off_a_terminal_is_byte_for_byte_the_lines_reset_emitted(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The console transport must be exactly ``click.echo`` where nothing renders.
+
+    Both halves are the same ``--dry-run`` against the same repo, so the plan
+    they describe is identical by construction and the only thing left to
+    disagree about is the transport. Equality rather than containment: wrapping
+    at the console's width, a swallowed blank line, a missing trailing newline
+    -- the failures worth catching here are all invisible to a substring check.
+    """
+    fake = FakeRuntime(volumes={"mine-vol": ours(repo)})
+    probe_for(fake, monkeypatch)
+
+    emitted: list[str] = []
+    reset_deployment(repo, probe=make_probe(fake), dry_run=True, emit=emitted.append)
+
+    result = CliRunner().invoke(reset_command, ["--repo", str(repo), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == "".join(f"{line}\n" for line in emitted)
+    # Guard on the guard: a plan of only short lines would let a re-wrapping
+    # transport through this test unnoticed.
+    assert max(len(line) for line in emitted) > _WIDTH
+
+
+def test_the_interrupt_notice_off_a_terminal_is_still_on_stderr(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stream is the contract, so the stream is what is asserted.
+
+    A piped ``osprey reset`` has a caller reading stdout for the plan and stderr
+    for trouble. Routing this notice through the reporter's console would put it
+    on stdout, where that caller never looks -- and every assertion about its
+    WORDING would keep passing while it did.
+
+    Read ``result.stdout`` and ``result.stderr``, never ``result.output``: that
+    third one is the two streams CONCATENATED, and an assertion made against it
+    cannot tell them apart at all. The equality below is what keeps this honest
+    even so -- stderr must hold the notice and NOTHING else, so a capture that
+    collapsed the streams would fail it on the plan rather than pass it by
+    accident.
+    """
+
+    def interrupt_during_teardown(_root: Path) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(reset_mod, "down_deployment", interrupt_during_teardown)
+    probe_for(FakeRuntime(volumes={"mine-vol": ours(repo)}), monkeypatch)
+
+    result = CliRunner().invoke(reset_command, ["--repo", str(repo), "-y"])
+
+    assert result.exit_code == 3
+    assert result.stderr == f"{INTERRUPT_NOTICE}\n"
+    assert "partly-reset" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# On a terminal: through the console that owns the region
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_is_written_through_the_console_that_owns_the_region(
+    repo: Path, monkeypatch: pytest.MonkeyPatch, live_reporter
+) -> None:
+    """A raw write to stdout would land inside the region, not above it."""
+    _, buffer = live_reporter
+    probe_for(FakeRuntime(volumes={"mine-vol": ours(repo)}), monkeypatch)
+
+    result = CliRunner().invoke(reset_command, ["--repo", str(repo), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "WILL BE REMOVED" in rendered(buffer)
+    assert "WILL BE REMOVED" not in result.stdout
+
+
+def test_the_typed_confirmation_runs_with_the_region_taken_down(
+    repo: Path, no_down, monkeypatch: pytest.MonkeyPatch, live_reporter
+) -> None:
+    """The prompt asks its question on a terminal nothing else is repainting.
+
+    ``input()`` writes its prompt to the real stdout, underneath anything Rich
+    has mounted there, so a region left up redraws over the question while the
+    operator is reading it -- on the one prompt in OSPREY that destroys data.
+
+    Both halves matter. Nothing may be rendering while the answer is being
+    typed, and the region must be back afterwards: ``suspended()`` restores on
+    the way out, and a reset that finished with its region gone would leave the
+    verb's remaining output unsequenced.
+    """
+    reporter, _ = live_reporter
+    at_the_prompt: dict[str, object] = {}
+
+    def answer(_prompt: str) -> str:
+        at_the_prompt["rendering"] = reporter._is_rendering()
+        at_the_prompt["depth"] = reporter._suspend_depth
+        return confirmation_token(repo)
+
+    monkeypatch.setattr("builtins.input", answer)
+    probe_for(FakeRuntime(volumes={"mine-vol": ours(repo)}), monkeypatch)
+
+    result = CliRunner().invoke(reset_command, ["--repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert at_the_prompt == {"rendering": False, "depth": 1}
+    assert reporter._is_rendering()
+
+
+def test_the_interrupt_notice_goes_through_the_console_while_a_region_is_up(
+    repo: Path, monkeypatch: pytest.MonkeyPatch, live_reporter
+) -> None:
+    """On a terminal the notice belongs to the console, on ONE line.
+
+    stdout and stderr are the same device here, so nothing is lost by routing
+    it; what would be lost by not routing it is the line itself, written into a
+    region that is about to repaint over it. Asserted as an unwrapped line
+    because that is the observable difference: anything reaching this terminal
+    other than through the console arrives without the soft wrap and comes back
+    folded at the console's width.
+    """
+
+    _, buffer = live_reporter
+
+    def interrupt_during_teardown(_root: Path) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(reset_mod, "down_deployment", interrupt_during_teardown)
+    probe_for(FakeRuntime(volumes={"mine-vol": ours(repo)}), monkeypatch)
+
+    result = CliRunner().invoke(reset_command, ["--repo", str(repo), "-y"])
+
+    assert result.exit_code == 3
+    assert len(INTERRUPT_NOTICE) > _WIDTH
+    assert f"{INTERRUPT_NOTICE}\n" in rendered(buffer)

--- a/tests/deployment/fixtures/README.md
+++ b/tests/deployment/fixtures/README.md
@@ -1,0 +1,59 @@
+# BuildKit progress fixtures
+
+Two real BuildKit plain-progress spools, captured from OSPREY deploys and then
+thinned. They are the inputs for `tests/deployment/test_build_progress.py`,
+which parses the stream the lifecycle verbs render as a live build table.
+
+They are captures, not constructions. A hand-written line would assert only what
+its author already believed the format to be, which is the one thing these files
+exist to check. Nothing here may be authored or edited by hand.
+
+## Where they came from
+
+Both were written by an OSPREY lifecycle verb into the project's
+`var/logs/build-*.log` spool — the file the deploy already keeps, captured as
+the build ran.
+
+- `buildkit_cold_build.log` — a cold `compose build` of a four-service project
+  (`bluesky-bridge`, `bluesky-panels`, `event-dispatcher`,
+  `virtual-accelerator`). Every service name in the stream is a real service.
+- `buildkit_project_image.log` — a single project-image build. It has 13
+  nameless step headers, in both shapes BuildKit emits: space-padded below ten
+  (`#10 [ 2/13]`) and unpadded from ten on (`#18 [10/13]`). It also carries the
+  bare `[auth]` and `[internal]` vertices that have no service behind them at
+  all.
+
+## What may be trimmed
+
+Only *repetitions* of a line type that is still represented elsewhere in the
+file. Never the last instance of a type.
+
+The bulk of a cold build is pip and apt output — timestamped caption lines of
+the form `#17 3.551 <text>` under a long `RUN`. Those are safe to thin, and are
+the only thing that has been thinned here. Each thinned vertex keeps its head
+and tail captions, dropping the run of repeats between them.
+
+The caption text, caption order, and each vertex's first/last timestamps are
+real. The gap between the kept head slice and the kept tail slice is a
+trimming artifact, not a real pause — at some vertices it is several times
+larger than any genuine gap in the untrimmed source. **Do not assert on
+inter-caption timing or caption rate**: doing so would encode a trimming
+artifact as expected BuildKit behavior.
+
+Left untouched, in stream order, byte for byte:
+
+- every vertex header, in all of its shapes
+- `DONE`, `CACHED`, and the `#N ...` pause marker
+- `exporting`, `unpacking to`, `naming to`, and the pull/`sha256:` progress
+  lines, including the bare-then-duration repeats a parser has to dedup
+- the `auth` token vertices
+
+Both fixtures capture successful builds. Neither contains an `#N ERROR`
+terminator or a `CANCELED` line, so the failure path is not covered by either
+one — a maintainer who needs it will have to capture a new fixture.
+
+Do not reorder lines, renumber `#N` vertices, or split a physical line. Some
+lines carry embedded carriage returns from `dpkg` progress bars; they are single
+lines and must stay that way — the cold-build fixture has 188 such lines, a
+count of its own trimmed content, not a count preserved from the untrimmed
+source.

--- a/tests/deployment/fixtures/buildkit_cold_build.log
+++ b/tests/deployment/fixtures/buildkit_cold_build.log
@@ -1,0 +1,860 @@
+Compose can now delegate builds to bake for better performance.
+ To do so, set COMPOSE_BAKE=true.
+#0 building with "desktop-linux" instance using docker driver
+
+#1 [virtual-accelerator internal] load build definition from Dockerfile
+#1 transferring dockerfile: 10.59kB done
+#1 DONE 0.0s
+
+#2 [event-dispatcher internal] load build definition from Dockerfile
+#2 transferring dockerfile: 6.11kB done
+#2 DONE 0.0s
+
+#3 [virtual-accelerator internal] load metadata for docker.io/library/python:3.11-slim
+#3 DONE 1.2s
+
+#4 [event-dispatcher internal] load metadata for docker.io/library/python:3.11-slim
+#4 DONE 1.2s
+
+#5 [virtual-accelerator internal] load .dockerignore
+#5 transferring context: 574B done
+#5 DONE 0.0s
+
+#6 [event-dispatcher internal] load .dockerignore
+#6 transferring context: 698B done
+#6 DONE 0.0s
+
+#7 [event-dispatcher 1/8] FROM docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1
+#7 resolve docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1 done
+#7 ...
+
+#8 [virtual-accelerator internal] load build context
+#8 transferring context: 5.06MB 0.1s done
+#8 DONE 0.1s
+
+#9 [event-dispatcher internal] load build context
+#9 transferring context: 5.06MB 0.1s done
+#9 DONE 0.1s
+
+#7 [event-dispatcher 1/8] FROM docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1
+#7 sha256:477af7c3a936b1f5ddbcde585bdf7736346cff6f3ab0b1d4a3b1a170daee70ae 0B / 249B 0.2s
+#7 sha256:477af7c3a936b1f5ddbcde585bdf7736346cff6f3ab0b1d4a3b1a170daee70ae 249B / 249B 0.2s done
+#7 sha256:00430733972ce348d8ce3bdbaf6f2007cc5056d2e254943606d1ea1114dd3298 3.15MB / 14.40MB 0.2s
+#7 sha256:dce7fdcbadc617c8284289e67f7796c24f259677c5506cbdc1e17fe4e4e8c548 0B / 1.27MB 0.2s
+#7 sha256:00430733972ce348d8ce3bdbaf6f2007cc5056d2e254943606d1ea1114dd3298 14.40MB / 14.40MB 0.3s done
+#7 sha256:dce7fdcbadc617c8284289e67f7796c24f259677c5506cbdc1e17fe4e4e8c548 1.27MB / 1.27MB 0.3s done
+#7 extracting sha256:dce7fdcbadc617c8284289e67f7796c24f259677c5506cbdc1e17fe4e4e8c548 0.0s done
+#7 extracting sha256:00430733972ce348d8ce3bdbaf6f2007cc5056d2e254943606d1ea1114dd3298
+#7 extracting sha256:00430733972ce348d8ce3bdbaf6f2007cc5056d2e254943606d1ea1114dd3298 0.2s done
+#7 extracting sha256:477af7c3a936b1f5ddbcde585bdf7736346cff6f3ab0b1d4a3b1a170daee70ae done
+#7 DONE 1.1s
+
+#10 [virtual-accelerator 1/8] FROM docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1
+#10 resolve docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1 0.0s done
+#10 sha256:605d2cb1fe61c64de721db128eab03d7fdb885947126722e2d98a49b18147fe2 249B / 249B 0.1s done
+#10 sha256:daff6f8ae2ef893f1b47c500d35ae0ba6f0c1bb82a4bf0f084f84a4a363644c3 14.45MB / 14.45MB 0.4s done
+#10 sha256:7ce8f1a1db8f7a913c17b3b6aa717c65c735bb723a8b6c3958e3a122a971869f 1.29MB / 1.29MB 0.4s done
+#10 sha256:26c307b5e35a59ce911f5fde5b9458120ec8734e831ea2da5649a9ad14abfd3d 5.24MB / 29.78MB 1.1s
+#10 ...
+
+#11 [event-dispatcher 2/8] RUN find /etc/apt ( -name '*.sources' -o -name '*.list' )     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} +  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
+#11 DONE 0.2s
+
+#10 [virtual-accelerator 1/8] FROM docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1
+#10 sha256:26c307b5e35a59ce911f5fde5b9458120ec8734e831ea2da5649a9ad14abfd3d 8.39MB / 29.78MB 1.2s
+#10 sha256:26c307b5e35a59ce911f5fde5b9458120ec8734e831ea2da5649a9ad14abfd3d 13.63MB / 29.78MB 1.4s
+#10 sha256:26c307b5e35a59ce911f5fde5b9458120ec8734e831ea2da5649a9ad14abfd3d 22.02MB / 29.78MB 1.5s
+#10 sha256:26c307b5e35a59ce911f5fde5b9458120ec8734e831ea2da5649a9ad14abfd3d 29.78MB / 29.78MB 1.6s done
+#10 extracting sha256:26c307b5e35a59ce911f5fde5b9458120ec8734e831ea2da5649a9ad14abfd3d
+#10 extracting sha256:26c307b5e35a59ce911f5fde5b9458120ec8734e831ea2da5649a9ad14abfd3d 0.4s done
+#10 DONE 2.1s
+
+#12 [event-dispatcher 3/8] RUN apt-get update     && apt-get install -y --no-install-recommends curl ca-certificates gnupg     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash -     && apt-get install -y --no-install-recommends nodejs     && npm install -g @anthropic-ai/claude-code@2.1.146     && apt-get purge -y curl gnupg     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*
+#12 0.322 Hit:1 https://deb.debian.org/debian trixie InRelease
+#12 0.344 Get:2 https://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
+#12 0.390 Get:3 https://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
+#12 0.442 Get:4 https://deb.debian.org/debian trixie/main arm64 Packages [9607 kB]
+#12 ...
+
+#10 [virtual-accelerator 1/8] FROM docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1
+#10 extracting sha256:7ce8f1a1db8f7a913c17b3b6aa717c65c735bb723a8b6c3958e3a122a971869f 0.0s done
+#10 extracting sha256:daff6f8ae2ef893f1b47c500d35ae0ba6f0c1bb82a4bf0f084f84a4a363644c3 0.2s done
+#10 DONE 2.4s
+
+#10 [virtual-accelerator 1/8] FROM docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1
+#10 extracting sha256:605d2cb1fe61c64de721db128eab03d7fdb885947126722e2d98a49b18147fe2 done
+#10 DONE 2.4s
+
+#13 [virtual-accelerator 2/8] WORKDIR /app
+#13 DONE 0.1s
+
+#12 [event-dispatcher 3/8] RUN apt-get update     && apt-get install -y --no-install-recommends curl ca-certificates gnupg     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash -     && apt-get install -y --no-install-recommends nodejs     && npm install -g @anthropic-ai/claude-code@2.1.146     && apt-get purge -y curl gnupg     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*
+#12 ...
+
+#14 [virtual-accelerator 3/8] RUN arch="$(dpkg --print-architecture)"; [ "$arch" = "amd64" ]     || { echo "ERROR: the virtual accelerator image is linux/amd64 only (this build is $arch). No pcaspy wheel exists for linux/aarch64 at any interpreter, so an aarch64 image would carry no Channel Access server." >&2; exit 1; }
+#14 DONE 0.1s
+
+#12 [event-dispatcher 3/8] RUN apt-get update     && apt-get install -y --no-install-recommends curl ca-certificates gnupg     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash -     && apt-get install -y --no-install-recommends nodejs     && npm install -g @anthropic-ai/claude-code@2.1.146     && apt-get purge -y curl gnupg     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*
+#12 1.294 Get:5 https://deb.debian.org/debian trixie-updates/main arm64 Packages [4424 B]
+#12 1.316 Get:6 https://deb.debian.org/debian-security trixie-security/main arm64 Packages [244 kB]
+#12 ...
+
+#15 [virtual-accelerator 4/8] RUN find /etc/apt ( -name '*.sources' -o -name '*.list' )     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} +  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
+#15 DONE 0.2s
+
+#16 [virtual-accelerator 5/8] COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
+#16 DONE 0.0s
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 0.424 Hit:1 https://deb.debian.org/debian trixie InRelease
+#17 0.425 Get:2 https://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
+#17 0.461 Get:3 https://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
+#17 0.527 Get:4 https://deb.debian.org/debian trixie/main amd64 Packages [9673 kB]
+#17 0.851 Get:5 https://deb.debian.org/debian trixie-updates/main amd64 Packages [4412 B]
+#17 0.851 Get:6 https://deb.debian.org/debian-security trixie-security/main amd64 Packages [242 kB]
+#17 1.699 Fetched 10.0 MB in 1s (6811 kB/s)
+#17 1.699 Reading package lists...
+#17 2.328 Reading package lists...
+#17 2.899 Building dependency tree...
+#17 3.062 Reading state information...
+#17 3.551 The following additional packages will be installed:
+#17 3.551   binutils binutils-common binutils-x86-64-linux-gnu bzip2 cpp cpp-14
+#17 3.551   cpp-14-x86-64-linux-gnu cpp-x86-64-linux-gnu dpkg-dev g++ g++-14
+#17 3.551   g++-14-x86-64-linux-gnu g++-x86-64-linux-gnu gcc gcc-14
+#17 3.551   gcc-14-x86-64-linux-gnu gcc-x86-64-linux-gnu libasan8 libatomic1 libbinutils
+#17 3.551   libc-dev-bin libc6-dev libcc1-0 libcrypt-dev libctf-nobfd0 libctf0
+#17 3.551   libdpkg-perl libexpat1 libexpat1-dev libgcc-14-dev libgdbm-compat4t64
+#17 3.552   libgomp1 libgprofng0 libhwasan0 libisl23 libitm1 libjansson4 libjs-jquery
+#17 3.552   libjs-sphinxdoc libjs-underscore liblsan0 libmpc3 libmpfr6 libperl5.40
+#17 3.552   libpython3-dev libpython3-stdlib libpython3.13 libpython3.13-dev
+#17 3.553   libpython3.13-minimal libpython3.13-stdlib libquadmath0 libsframe1
+#17 3.553   libstdc++-14-dev libtsan2 libubsan1 linux-libc-dev make media-types patch
+#17 3.553   perl perl-modules-5.40 python3 python3-minimal python3.13 python3.13-dev
+#17 3.554   python3.13-minimal rpcsvc-proto xz-utils zlib1g-dev
+#17 3.556 Suggested packages:
+#17 3.556   binutils-doc gprofng-gui binutils-gold bzip2-doc cpp-doc gcc-14-locales
+#17 3.556   cpp-14-doc debian-keyring debian-tag2upload-keyring g++-multilib
+#17 3.556   g++-14-multilib gcc-14-doc gcc-multilib manpages-dev autoconf automake
+#17 3.556   libtool flex bison gdb gcc-doc gcc-14-multilib gdb-x86-64-linux-gnu
+#17 3.556   libc-devtools glibc-doc sq | sqop | rsop | gosop | pgpainless-cli | gpg-sq
+#17 3.556   | gnupg sensible-utils git bzr libstdc++-14-doc make-doc ed diffutils-doc
+#17 3.556   perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl
+#17 3.556   libtap-harness-archive-perl python3-doc python3-tk python3-venv
+#17 3.556   python3.13-venv python3.13-doc binfmt-support
+#17 3.556 Recommended packages:
+#17 3.556   fakeroot sq | sqop | rsop | gosop | pgpainless-cli | gpg-sq | gnupg
+#17 3.556   libalgorithm-merge-perl manpages manpages-dev libfile-fcntllock-perl
+#17 3.556   liblocale-gettext-perl javascript-common
+#17 3.812 The following NEW packages will be installed:
+#17 3.812   binutils binutils-common binutils-x86-64-linux-gnu build-essential bzip2 cpp
+#17 3.812   cpp-14 cpp-14-x86-64-linux-gnu cpp-x86-64-linux-gnu dpkg-dev g++ g++-14
+#17 3.812   g++-14-x86-64-linux-gnu g++-x86-64-linux-gnu gcc gcc-14
+#17 3.813   gcc-14-x86-64-linux-gnu gcc-x86-64-linux-gnu libasan8 libatomic1 libbinutils
+#17 3.813   libc-dev-bin libc6-dev libcc1-0 libcrypt-dev libctf-nobfd0 libctf0
+#17 3.813   libdpkg-perl libexpat1 libexpat1-dev libgcc-14-dev libgdbm-compat4t64
+#17 3.813   libgomp1 libgprofng0 libhwasan0 libisl23 libitm1 libjansson4 libjs-jquery
+#17 3.813   libjs-sphinxdoc libjs-underscore liblsan0 libmpc3 libmpfr6 libperl5.40
+#17 3.813   libpython3-dev libpython3-stdlib libpython3.13 libpython3.13-dev
+#17 3.813   libpython3.13-minimal libpython3.13-stdlib libquadmath0 libsframe1
+#17 3.814   libstdc++-14-dev libtsan2 libubsan1 linux-libc-dev make media-types patch
+#17 3.814   perl perl-modules-5.40 python3 python3-dev python3-minimal python3.13
+#17 3.814   python3.13-dev python3.13-minimal rpcsvc-proto xz-utils zlib1g-dev
+#17 4.034 0 upgraded, 71 newly installed, 0 to remove and 9 not upgraded.
+#17 4.034 Need to get 98.1 MB of archives.
+#17 4.034 After this operation, 399 MB of additional disk space will be used.
+#17 4.034 Get:1 https://deb.debian.org/debian-security trixie-security/main amd64 libexpat1 amd64 2.8.2-1~deb13u1 [122 kB]
+#17 4.103 Get:2 https://deb.debian.org/debian trixie-updates/main amd64 libpython3.13-minimal amd64 3.13.5-2+deb13u4 [863 kB]
+#17 4.154 Get:3 https://deb.debian.org/debian trixie-updates/main amd64 python3.13-minimal amd64 3.13.5-2+deb13u4 [2217 kB]
+#17 4.202 Get:4 https://deb.debian.org/debian trixie/main amd64 python3-minimal amd64 3.13.5-1 [27.2 kB]
+#17 4.204 Get:5 https://deb.debian.org/debian trixie/main amd64 media-types all 13.0.0 [29.3 kB]
+#17 4.204 Get:6 https://deb.debian.org/debian trixie-updates/main amd64 libpython3.13-stdlib amd64 3.13.5-2+deb13u4 [1957 kB]
+#17 4.251 Get:7 https://deb.debian.org/debian trixie-updates/main amd64 python3.13 amd64 3.13.5-2+deb13u4 [757 kB]
+#17 4.273 Get:8 https://deb.debian.org/debian trixie/main amd64 libpython3-stdlib amd64 3.13.5-1 [10.2 kB]
+#17 4.273 Get:9 https://deb.debian.org/debian trixie/main amd64 python3 amd64 3.13.5-1 [28.2 kB]
+#17 4.274 Get:10 https://deb.debian.org/debian trixie/main amd64 bzip2 amd64 1.0.8-6 [40.5 kB]
+#17 4.275 Get:11 https://deb.debian.org/debian trixie/main amd64 perl-modules-5.40 all 5.40.1-6 [3019 kB]
+#17 4.312 Get:12 https://deb.debian.org/debian trixie/main amd64 libgdbm-compat4t64 amd64 1.24-2 [50.3 kB]
+#17 4.313 Get:13 https://deb.debian.org/debian trixie/main amd64 libperl5.40 amd64 5.40.1-6 [4341 kB]
+#17 4.389 Get:14 https://deb.debian.org/debian trixie/main amd64 perl amd64 5.40.1-6 [267 kB]
+#17 4.393 Get:15 https://deb.debian.org/debian trixie/main amd64 xz-utils amd64 5.8.1-1+deb13u1 [659 kB]
+#17 4.403 Get:16 https://deb.debian.org/debian trixie/main amd64 libsframe1 amd64 2.44-3 [78.4 kB]
+#17 4.403 Get:17 https://deb.debian.org/debian trixie/main amd64 binutils-common amd64 2.44-3 [2509 kB]
+#17 4.454 Get:18 https://deb.debian.org/debian trixie/main amd64 libbinutils amd64 2.44-3 [534 kB]
+#17 4.462 Get:19 https://deb.debian.org/debian trixie/main amd64 libgprofng0 amd64 2.44-3 [808 kB]
+#17 4.474 Get:20 https://deb.debian.org/debian trixie/main amd64 libctf-nobfd0 amd64 2.44-3 [156 kB]
+#17 4.476 Get:21 https://deb.debian.org/debian trixie/main amd64 libctf0 amd64 2.44-3 [88.6 kB]
+#17 4.478 Get:22 https://deb.debian.org/debian trixie/main amd64 libjansson4 amd64 2.14-2+b3 [39.8 kB]
+#17 4.478 Get:23 https://deb.debian.org/debian trixie/main amd64 binutils-x86-64-linux-gnu amd64 2.44-3 [1014 kB]
+#17 4.512 Get:24 https://deb.debian.org/debian trixie/main amd64 binutils amd64 2.44-3 [265 kB]
+#17 4.516 Get:25 https://deb.debian.org/debian trixie/main amd64 libc-dev-bin amd64 2.41-12+deb13u3 [59.8 kB]
+#17 4.516 Get:26 https://deb.debian.org/debian-security trixie-security/main amd64 linux-libc-dev all 6.12.101-1 [2901 kB]
+#17 4.563 Get:27 https://deb.debian.org/debian trixie/main amd64 libcrypt-dev amd64 1:4.4.38-1 [119 kB]
+#17 4.566 Get:28 https://deb.debian.org/debian trixie/main amd64 rpcsvc-proto amd64 1.4.3-1 [63.3 kB]
+#17 4.567 Get:29 https://deb.debian.org/debian trixie/main amd64 libc6-dev amd64 2.41-12+deb13u3 [1992 kB]
+#17 4.597 Get:30 https://deb.debian.org/debian trixie/main amd64 libisl23 amd64 0.27-1 [659 kB]
+#17 4.626 Get:31 https://deb.debian.org/debian trixie/main amd64 libmpfr6 amd64 4.2.2-1 [729 kB]
+#17 4.636 Get:32 https://deb.debian.org/debian trixie/main amd64 libmpc3 amd64 1.3.1-1+b3 [52.2 kB]
+#17 4.638 Get:33 https://deb.debian.org/debian trixie/main amd64 cpp-14-x86-64-linux-gnu amd64 14.2.0-19 [11.0 MB]
+#17 4.861 Get:34 https://deb.debian.org/debian trixie/main amd64 cpp-14 amd64 14.2.0-19 [1280 B]
+#17 4.861 Get:35 https://deb.debian.org/debian trixie/main amd64 cpp-x86-64-linux-gnu amd64 4:14.2.0-1 [4840 B]
+#17 4.861 Get:36 https://deb.debian.org/debian trixie/main amd64 cpp amd64 4:14.2.0-1 [1568 B]
+#17 4.861 Get:37 https://deb.debian.org/debian trixie/main amd64 libcc1-0 amd64 14.2.0-19 [42.8 kB]
+#17 4.865 Get:38 https://deb.debian.org/debian trixie/main amd64 libgomp1 amd64 14.2.0-19 [137 kB]
+#17 4.865 Get:39 https://deb.debian.org/debian trixie/main amd64 libitm1 amd64 14.2.0-19 [26.0 kB]
+#17 4.865 Get:40 https://deb.debian.org/debian trixie/main amd64 libatomic1 amd64 14.2.0-19 [9308 B]
+#17 4.865 Get:41 https://deb.debian.org/debian trixie/main amd64 libasan8 amd64 14.2.0-19 [2725 kB]
+#17 4.905 Get:42 https://deb.debian.org/debian trixie/main amd64 liblsan0 amd64 14.2.0-19 [1204 kB]
+#17 4.923 Get:43 https://deb.debian.org/debian trixie/main amd64 libtsan2 amd64 14.2.0-19 [2460 kB]
+#17 4.964 Get:44 https://deb.debian.org/debian trixie/main amd64 libubsan1 amd64 14.2.0-19 [1074 kB]
+#17 4.995 Get:45 https://deb.debian.org/debian trixie/main amd64 libhwasan0 amd64 14.2.0-19 [1488 kB]
+#17 5.019 Get:46 https://deb.debian.org/debian trixie/main amd64 libquadmath0 amd64 14.2.0-19 [145 kB]
+#17 5.022 Get:47 https://deb.debian.org/debian trixie/main amd64 libgcc-14-dev amd64 14.2.0-19 [2672 kB]
+#17 5.063 Get:48 https://deb.debian.org/debian trixie/main amd64 gcc-14-x86-64-linux-gnu amd64 14.2.0-19 [21.4 MB]
+#17 5.448 Get:49 https://deb.debian.org/debian trixie/main amd64 gcc-14 amd64 14.2.0-19 [540 kB]
+#17 5.466 Get:50 https://deb.debian.org/debian trixie/main amd64 gcc-x86-64-linux-gnu amd64 4:14.2.0-1 [1436 B]
+#17 5.466 Get:51 https://deb.debian.org/debian trixie/main amd64 gcc amd64 4:14.2.0-1 [5136 B]
+#17 5.467 Get:52 https://deb.debian.org/debian trixie/main amd64 libstdc++-14-dev amd64 14.2.0-19 [2376 kB]
+#17 5.507 Get:53 https://deb.debian.org/debian trixie/main amd64 g++-14-x86-64-linux-gnu amd64 14.2.0-19 [12.1 MB]
+#17 5.735 Get:54 https://deb.debian.org/debian trixie/main amd64 g++-14 amd64 14.2.0-19 [22.5 kB]
+#17 5.735 Get:55 https://deb.debian.org/debian trixie/main amd64 g++-x86-64-linux-gnu amd64 4:14.2.0-1 [1200 B]
+#17 5.735 Get:56 https://deb.debian.org/debian trixie/main amd64 g++ amd64 4:14.2.0-1 [1344 B]
+#17 5.735 Get:57 https://deb.debian.org/debian trixie/main amd64 make amd64 4.4.1-2 [463 kB]
+#17 5.740 Get:58 https://deb.debian.org/debian trixie/main amd64 libdpkg-perl all 1.22.22 [651 kB]
+#17 5.751 Get:59 https://deb.debian.org/debian trixie/main amd64 patch amd64 2.8-2 [134 kB]
+#17 5.753 Get:60 https://deb.debian.org/debian trixie/main amd64 dpkg-dev all 1.22.22 [1337 kB]
+#17 5.773 Get:61 https://deb.debian.org/debian trixie/main amd64 build-essential amd64 12.12 [4624 B]
+#17 5.774 Get:62 https://deb.debian.org/debian-security trixie-security/main amd64 libexpat1-dev amd64 2.8.2-1~deb13u1 [178 kB]
+#17 5.775 Get:63 https://deb.debian.org/debian trixie/main amd64 libjs-jquery all 3.6.1+dfsg+~3.5.14-1 [326 kB]
+#17 5.780 Get:64 https://deb.debian.org/debian trixie/main amd64 libjs-underscore all 1.13.4~dfsg+~1.11.4-3 [116 kB]
+#17 5.781 Get:65 https://deb.debian.org/debian trixie/main amd64 libjs-sphinxdoc all 8.1.3-5 [30.5 kB]
+#17 5.781 Get:66 https://deb.debian.org/debian trixie-updates/main amd64 libpython3.13 amd64 3.13.5-2+deb13u4 [2161 kB]
+#17 5.816 Get:67 https://deb.debian.org/debian trixie/main amd64 zlib1g-dev amd64 1:1.3.dfsg+really1.3.1-1+b1 [920 kB]
+#17 5.848 Get:68 https://deb.debian.org/debian trixie-updates/main amd64 libpython3.13-dev amd64 3.13.5-2+deb13u4 [5276 kB]
+#17 5.939 Get:69 https://deb.debian.org/debian trixie/main amd64 libpython3-dev amd64 3.13.5-1 [10.4 kB]
+#17 5.939 Get:70 https://deb.debian.org/debian trixie-updates/main amd64 python3.13-dev amd64 3.13.5-2+deb13u4 [504 kB]
+#17 5.947 Get:71 https://deb.debian.org/debian trixie/main amd64 python3-dev amd64 3.13.5-1 [26.1 kB]
+#17 6.308 debconf: unable to initialize frontend: Dialog
+#17 6.308 debconf: (TERM is not set, so the dialog frontend is not usable.)
+#17 6.308 debconf: falling back to frontend: Readline
+#17 6.309 debconf: unable to initialize frontend: Readline
+#17 6.309 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8, <STDIN> line 71.)
+#17 6.309 debconf: falling back to frontend: Teletype
+#17 6.364 debconf: unable to initialize frontend: Teletype
+#17 6.364 debconf: (This frontend requires a controlling tty.)
+#17 6.364 debconf: falling back to frontend: Noninteractive
+#17 ...
+
+#12 [event-dispatcher 3/8] RUN apt-get update     && apt-get install -y --no-install-recommends curl ca-certificates gnupg     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash -     && apt-get install -y --no-install-recommends nodejs     && npm install -g @anthropic-ai/claude-code@2.1.146     && apt-get purge -y curl gnupg     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*
+#12 2.042 Fetched 9947 kB in 2s (5192 kB/s)
+#12 2.042 Reading package lists...
+#12 2.420 Reading package lists...
+#12 2.773 Building dependency tree...
+#12 2.872 Reading state information...
+#12 3.000 ca-certificates is already the newest version (20250419).
+#12 3.000 The following additional packages will be installed:
+#12 3.000   dirmngr gnupg-l10n gpg gpg-agent gpgconf gpgsm libassuan9 libbrotli1
+#12 3.000   libcom-err2 libcurl4t64 libgcrypt20 libgnutls30t64 libgpg-error0
+#12 3.000   libgssapi-krb5-2 libidn2-0 libk5crypto3 libkeyutils1 libkrb5-3
+#12 3.000   libkrb5support0 libksba8 libldap2 libnghttp2-14 libnghttp3-9 libnpth0t64
+#12 3.000   libp11-kit0 libpsl5t64 librtmp1 libsasl2-2 libsasl2-modules-db libssh2-1t64
+#12 3.000   libtasn1-6 libunistring5 pinentry-curses
+#12 3.001 Suggested packages:
+#12 3.001   dbus-user-session libpam-systemd pinentry-gnome3 tor gpg-wks-server
+#12 3.001   parcimonie xloadimage scdaemon tpm2daemon rng-tools gnutls-bin krb5-doc
+#12 3.001   krb5-user pinentry-doc
+#12 3.001 Recommended packages:
+#12 3.001   bash-completion gnupg-utils gpg-wks-client gpgv libgpg-error-l10n
+#12 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 8.411 Fetched 98.1 MB in 2s (46.4 MB/s)
+#17 8.493 Selecting previously unselected package libexpat1:amd64.
+#17 8.494 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 5645 files and directories currently installed.)
+#17 8.497 Preparing to unpack .../libexpat1_2.8.2-1~deb13u1_amd64.deb ...
+#17 8.501 Unpacking libexpat1:amd64 (2.8.2-1~deb13u1) ...
+#17 8.608 Selecting previously unselected package libpython3.13-minimal:amd64.
+#17 8.609 Preparing to unpack .../libpython3.13-minimal_3.13.5-2+deb13u4_amd64.deb ...
+#17 8.610 Unpacking libpython3.13-minimal:amd64 (3.13.5-2+deb13u4) ...
+#17 8.750 Selecting previously unselected package python3.13-minimal.
+#17 8.750 Preparing to unpack .../python3.13-minimal_3.13.5-2+deb13u4_amd64.deb ...
+#17 8.795 Unpacking python3.13-minimal (3.13.5-2+deb13u4) ...
+#17 8.953 Setting up libpython3.13-minimal:amd64 (3.13.5-2+deb13u4) ...
+#17 8.975 Setting up libexpat1:amd64 (2.8.2-1~deb13u1) ...
+#17 8.978 Setting up python3.13-minimal (3.13.5-2+deb13u4) ...
+#17 9.969 Selecting previously unselected package python3-minimal.
+#17 9.970 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 5979 files and directories currently installed.)
+#17 9.973 Preparing to unpack .../python3-minimal_3.13.5-1_amd64.deb ...
+#17 9.977 Unpacking python3-minimal (3.13.5-1) ...
+#17 10.08 Selecting previously unselected package media-types.
+#17 10.08 Preparing to unpack .../media-types_13.0.0_all.deb ...
+#17 10.08 Unpacking media-types (13.0.0) ...
+#17 10.18 Selecting previously unselected package libpython3.13-stdlib:amd64.
+#17 10.18 Preparing to unpack .../libpython3.13-stdlib_3.13.5-2+deb13u4_amd64.deb ...
+#17 10.18 Unpacking libpython3.13-stdlib:amd64 (3.13.5-2+deb13u4) ...
+#17 10.36 Selecting previously unselected package python3.13.
+#17 10.36 Preparing to unpack .../python3.13_3.13.5-2+deb13u4_amd64.deb ...
+#17 10.36 Unpacking python3.13 (3.13.5-2+deb13u4) ...
+#17 10.47 Selecting previously unselected package libpython3-stdlib:amd64.
+#17 10.47 Preparing to unpack .../libpython3-stdlib_3.13.5-1_amd64.deb ...
+#17 10.47 Unpacking libpython3-stdlib:amd64 (3.13.5-1) ...
+#17 10.54 Setting up python3-minimal (3.13.5-1) ...
+#17 11.07 Selecting previously unselected package python3.
+#17 11.07 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6433 files and directories currently installed.)
+#17 11.07 Preparing to unpack .../00-python3_3.13.5-1_amd64.deb ...
+#17 11.12 Unpacking python3 (3.13.5-1) ...
+#17 11.22 Selecting previously unselected package bzip2.
+#17 11.22 Preparing to unpack .../01-bzip2_1.0.8-6_amd64.deb ...
+#17 11.22 Unpacking bzip2 (1.0.8-6) ...
+#17 11.32 Selecting previously unselected package perl-modules-5.40.
+#17 11.32 Preparing to unpack .../02-perl-modules-5.40_5.40.1-6_all.deb ...
+#17 11.32 Unpacking perl-modules-5.40 (5.40.1-6) ...
+#17 11.56 Selecting previously unselected package libgdbm-compat4t64:amd64.
+#17 11.57 Preparing to unpack .../03-libgdbm-compat4t64_1.24-2_amd64.deb ...
+#17 11.57 Unpacking libgdbm-compat4t64:amd64 (1.24-2) ...
+#17 11.68 Selecting previously unselected package libperl5.40:amd64.
+#17 11.68 Preparing to unpack .../04-libperl5.40_5.40.1-6_amd64.deb ...
+#17 11.68 Unpacking libperl5.40:amd64 (5.40.1-6) ...
+#17 11.96 Selecting previously unselected package perl.
+#17 11.96 Preparing to unpack .../05-perl_5.40.1-6_amd64.deb ...
+#17 11.96 Unpacking perl (5.40.1-6) ...
+#17 12.08 Selecting previously unselected package xz-utils.
+#17 12.08 Preparing to unpack .../06-xz-utils_5.8.1-1+deb13u1_amd64.deb ...
+#17 12.08 Unpacking xz-utils (5.8.1-1+deb13u1) ...
+#17 12.21 Selecting previously unselected package libsframe1:amd64.
+#17 12.21 Preparing to unpack .../07-libsframe1_2.44-3_amd64.deb ...
+#17 12.21 Unpacking libsframe1:amd64 (2.44-3) ...
+#17 12.33 Selecting previously unselected package binutils-common:amd64.
+#17 12.33 Preparing to unpack .../08-binutils-common_2.44-3_amd64.deb ...
+#17 12.33 Unpacking binutils-common:amd64 (2.44-3) ...
+#17 12.53 Selecting previously unselected package libbinutils:amd64.
+#17 12.53 Preparing to unpack .../09-libbinutils_2.44-3_amd64.deb ...
+#17 12.53 Unpacking libbinutils:amd64 (2.44-3) ...
+#17 12.67 Selecting previously unselected package libgprofng0:amd64.
+#17 12.67 Preparing to unpack .../10-libgprofng0_2.44-3_amd64.deb ...
+#17 12.67 Unpacking libgprofng0:amd64 (2.44-3) ...
+#17 12.82 Selecting previously unselected package libctf-nobfd0:amd64.
+#17 12.82 Preparing to unpack .../11-libctf-nobfd0_2.44-3_amd64.deb ...
+#17 12.82 Unpacking libctf-nobfd0:amd64 (2.44-3) ...
+#17 12.94 Selecting previously unselected package libctf0:amd64.
+#17 12.94 Preparing to unpack .../12-libctf0_2.44-3_amd64.deb ...
+#17 12.94 Unpacking libctf0:amd64 (2.44-3) ...
+#17 13.05 Selecting previously unselected package libjansson4:amd64.
+#17 13.05 Preparing to unpack .../13-libjansson4_2.14-2+b3_amd64.deb ...
+#17 13.05 Unpacking libjansson4:amd64 (2.14-2+b3) ...
+#17 13.15 Selecting previously unselected package binutils-x86-64-linux-gnu.
+#17 13.15 Preparing to unpack .../14-binutils-x86-64-linux-gnu_2.44-3_amd64.deb ...
+#17 13.15 Unpacking binutils-x86-64-linux-gnu (2.44-3) ...
+#17 13.31 Selecting previously unselected package binutils.
+#17 13.31 Preparing to unpack .../15-binutils_2.44-3_amd64.deb ...
+#17 13.33 Unpacking binutils (2.44-3) ...
+#17 13.43 Selecting previously unselected package libc-dev-bin.
+#17 13.43 Preparing to unpack .../16-libc-dev-bin_2.41-12+deb13u3_amd64.deb ...
+#17 13.43 Unpacking libc-dev-bin (2.41-12+deb13u3) ...
+#17 13.53 Selecting previously unselected package linux-libc-dev.
+#17 13.53 Preparing to unpack .../17-linux-libc-dev_6.12.101-1_all.deb ...
+#17 13.53 Unpacking linux-libc-dev (6.12.101-1) ...
+#17 13.74 Selecting previously unselected package libcrypt-dev:amd64.
+#17 13.74 Preparing to unpack .../18-libcrypt-dev_1%3a4.4.38-1_amd64.deb ...
+#17 13.80 Unpacking libcrypt-dev:amd64 (1:4.4.38-1) ...
+#17 13.90 Selecting previously unselected package rpcsvc-proto.
+#17 13.90 Preparing to unpack .../19-rpcsvc-proto_1.4.3-1_amd64.deb ...
+#17 13.91 Unpacking rpcsvc-proto (1.4.3-1) ...
+#17 14.01 Selecting previously unselected package libc6-dev:amd64.
+#17 14.01 Preparing to unpack .../20-libc6-dev_2.41-12+deb13u3_amd64.deb ...
+#17 14.02 Unpacking libc6-dev:amd64 (2.41-12+deb13u3) ...
+#17 14.19 Selecting previously unselected package libisl23:amd64.
+#17 14.19 Preparing to unpack .../21-libisl23_0.27-1_amd64.deb ...
+#17 14.19 Unpacking libisl23:amd64 (0.27-1) ...
+#17 14.32 Selecting previously unselected package libmpfr6:amd64.
+#17 14.32 Preparing to unpack .../22-libmpfr6_4.2.2-1_amd64.deb ...
+#17 14.32 Unpacking libmpfr6:amd64 (4.2.2-1) ...
+#17 14.43 Selecting previously unselected package libmpc3:amd64.
+#17 14.43 Preparing to unpack .../23-libmpc3_1.3.1-1+b3_amd64.deb ...
+#17 14.44 Unpacking libmpc3:amd64 (1.3.1-1+b3) ...
+#17 14.54 Selecting previously unselected package cpp-14-x86-64-linux-gnu.
+#17 14.54 Preparing to unpack .../24-cpp-14-x86-64-linux-gnu_14.2.0-19_amd64.deb ...
+#17 14.54 Unpacking cpp-14-x86-64-linux-gnu (14.2.0-19) ...
+#17 14.99 Selecting previously unselected package cpp-14.
+#17 15.00 Preparing to unpack .../25-cpp-14_14.2.0-19_amd64.deb ...
+#17 15.00 Unpacking cpp-14 (14.2.0-19) ...
+#17 ...
+
+#12 [event-dispatcher 3/8] RUN apt-get update     && apt-get install -y --no-install-recommends curl ca-certificates gnupg     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash -     && apt-get install -y --no-install-recommends nodejs     && npm install -g @anthropic-ai/claude-code@2.1.146     && apt-get purge -y curl gnupg     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*
+#12 16.37 Removing libgpg-error0:arm64 (1.51-4) ...
+#12 16.38 Removing libk5crypto3:arm64 (1.21.3-5+deb13u1) ...
+#12 16.39 Removing libkeyutils1:arm64 (1.6.3-6) ...
+#12 16.41 Removing libkrb5support0:arm64 (1.21.3-5+deb13u1) ...
+#12 16.42 Removing libldap2:arm64 (2.6.10+dfsg-1) ...
+#12 16.43 Removing libnghttp2-14:arm64 (1.64.0-1.1+deb13u1) ...
+#12 16.44 Removing libnghttp3-9:arm64 (1.8.0-1) ...
+#12 16.45 Removing libnpth0t64:arm64 (1.8-3) ...
+#12 16.47 Removing libp11-kit0:arm64 (0.25.5-3) ...
+#12 16.48 Removing libpsl5t64:arm64 (0.21.2-1.1+b1) ...
+#12 16.49 Removing libsasl2-2:arm64 (2.1.28+dfsg1-9) ...
+#12 16.50 Removing libsasl2-modules-db:arm64 (2.1.28+dfsg1-9) ...
+#12 16.52 Removing libssh2-1t64:arm64 (1.11.1-1+deb13u1) ...
+#12 16.53 Removing libtasn1-6:arm64 (4.20.0-2+deb13u1) ...
+#12 16.55 Processing triggers for libc-bin (2.41-12+deb13u3) ...
+#12 DONE 17.2s
+
+#18 [event-dispatcher 4/8] WORKDIR /app
+#18 DONE 0.0s
+
+#19 [event-dispatcher 5/8] COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
+#19 DONE 0.0s
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 15.68 Selecting previously unselected package cpp-x86-64-linux-gnu.
+#17 15.68 Preparing to unpack .../26-cpp-x86-64-linux-gnu_4%3a14.2.0-1_amd64.deb ...
+#17 15.68 Unpacking cpp-x86-64-linux-gnu (4:14.2.0-1) ...
+#17 15.79 Selecting previously unselected package cpp.
+#17 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 0.139 Get:1 https://deb.nodesource.com/node_20.x nodistro InRelease [12.1 kB]
+#20 0.159 Get:2 https://deb.nodesource.com/node_20.x nodistro/main arm64 Packages [14.4 kB]
+#20 0.171 Get:3 https://deb.debian.org/debian trixie InRelease [140 kB]
+#20 0.237 Get:4 https://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
+#20 0.260 Get:5 https://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
+#20 0.289 Get:6 https://deb.debian.org/debian trixie/main arm64 Packages [9607 kB]
+#20 0.492 Get:7 https://deb.debian.org/debian trixie-updates/main arm64 Packages [4424 B]
+#20 0.513 Get:8 https://deb.debian.org/debian-security trixie-security/main arm64 Packages [244 kB]
+#20 1.231 Fetched 10.1 MB in 1s (8901 kB/s)
+#20 1.231 Reading package lists...
+#20 1.592 Reading package lists...
+#20 1.939 Building dependency tree...
+#20 2.037 Reading state information...
+#20 2.163 The following additional packages will be installed:
+#20 2.163   binutils binutils-aarch64-linux-gnu binutils-common bzip2 cpp cpp-14
+#20 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#17 [virtual-accelerator 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework[virtual-accelerator]==2026.6.2.post1145+gfce915d02" --only-binary pcaspy          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework[virtual-accelerator]" --only-binary pcaspy ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#17 166.8 Removing rpcsvc-proto (1.4.3-1) ...
+#17 166.8 Removing xz-utils (5.8.1-1+deb13u1) ...
+#17 166.9 Removing gcc-14 (14.2.0-19) ...
+#17 166.9 Removing binutils (2.44-3) ...
+#17 166.9 Removing libgprofng0:amd64 (2.44-3) ...
+#17 166.9 Removing gcc-14-x86-64-linux-gnu (14.2.0-19) ...
+#17 166.9 Removing binutils-x86-64-linux-gnu (2.44-3) ...
+#17 166.9 Removing libctf0:amd64 (2.44-3) ...
+#17 166.9 Removing libbinutils:amd64 (2.44-3) ...
+#17 167.0 Removing binutils-common:amd64 (2.44-3) ...
+#17 167.0 Removing cpp-14 (14.2.0-19) ...
+#17 167.0 Removing cpp-14-x86-64-linux-gnu (14.2.0-19) ...
+#17 167.0 Removing libgcc-14-dev:amd64 (14.2.0-19) ...
+#17 167.0 Removing libasan8:amd64 (14.2.0-19) ...
+#17 167.0 Removing libatomic1:amd64 (14.2.0-19) ...
+#17 167.0 Removing libcc1-0:amd64 (14.2.0-19) ...
+#17 167.0 Removing libctf-nobfd0:amd64 (2.44-3) ...
+#17 167.0 Removing libgomp1:amd64 (14.2.0-19) ...
+#17 167.1 Removing libhwasan0:amd64 (14.2.0-19) ...
+#17 167.1 Removing libisl23:amd64 (0.27-1) ...
+#17 167.1 Removing libitm1:amd64 (14.2.0-19) ...
+#17 167.1 Removing libjansson4:amd64 (2.14-2+b3) ...
+#17 167.1 Removing liblsan0:amd64 (14.2.0-19) ...
+#17 167.1 Removing libmpc3:amd64 (1.3.1-1+b3) ...
+#17 167.1 Removing libmpfr6:amd64 (4.2.2-1) ...
+#17 167.2 Removing libquadmath0:amd64 (14.2.0-19) ...
+#17 167.2 Removing libsframe1:amd64 (2.44-3) ...
+#17 167.2 Removing libtsan2:amd64 (14.2.0-19) ...
+#17 167.2 Removing libubsan1:amd64 (14.2.0-19) ...
+#17 167.2 Processing triggers for libc-bin (2.41-12+deb13u3) ...
+#17 DONE 167.7s
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#21 [virtual-accelerator 7/8] COPY .dockerignore *.wh[l] /tmp/ctx/
+#21 DONE 0.3s
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#22 [virtual-accelerator 8/8] RUN if ls /tmp/ctx/*.whl >/dev/null 2>&1; then         echo "Overlaying locally-built osprey wheel (dev build)"         && whl="$(ls /tmp/ctx/osprey_framework-*.whl)"         && pip install --no-cache-dir "${whl}[virtual-accelerator]" /tmp/ctx/osprey_connectors-*.whl --only-binary pcaspy         && pip install --no-cache-dir --no-deps --force-reinstall /tmp/ctx/*.whl         && pip check ;     fi     && rm -rf /tmp/ctx
+#22 0.135 Overlaying locally-built osprey wheel (dev build)
+#22 1.915 Processing /tmp/ctx/osprey_framework-2026.6.2.post1145+gfce915d02-py3-none-any.whl (from osprey-framework==2026.6.2.post1145+gfce915d02)
+#22 1.972 Processing /tmp/ctx/osprey_connectors-0.1.0-py3-none-any.whl
+#22 2.068 Requirement already satisfied: accelerator-toolbox>=0.7.1 in /usr/local/lib/python3.11/site-packages (from accelerator-toolbox[plot]>=0.7.1->osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (0.8.0)
+#22 2.078 Requirement already satisfied: aiofiles>=25.1.0 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (25.1.0)
+#22 2.083 Requirement already satisfied: aiohttp-socks>=0.8.0 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (0.12.0)
+#22 2.083 Requirement already satisfied: aiohttp>=3.10 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (3.14.3)
+#22 2.083 Requirement already satisfied: anthropic in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (0.122.0)
+#22 2.085 Requirement already satisfied: authlib>=1.6.5 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (1.7.2)
+#22 2.089 Requirement already satisfied: bluesky-queueserver-api==0.0.13 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (0.0.13)
+#22 2.093 Requirement already satisfied: bluesky>=1.15.1 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (1.15.1)
+#22 2.099 Requirement already satisfied: bokeh>=3.9.1 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (3.9.2)
+#22 2.101 Requirement already satisfied: build in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (1.5.0)
+#22 2.103 Requirement already satisfied: certifi>=2025.4.26 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (2026.7.22)
+#22 2.107 Requirement already satisfied: charset-normalizer>=3.4.9 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02->osprey-framework==2026.6.2.post1145+gfce915d02) (3.5.0)
+#22 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 ...
+
+#22 [virtual-accelerator 8/8] RUN if ls /tmp/ctx/*.whl >/dev/null 2>&1; then         echo "Overlaying locally-built osprey wheel (dev build)"         && whl="$(ls /tmp/ctx/osprey_framework-*.whl)"         && pip install --no-cache-dir "${whl}[virtual-accelerator]" /tmp/ctx/osprey_connectors-*.whl --only-binary pcaspy         && pip install --no-cache-dir --no-deps --force-reinstall /tmp/ctx/*.whl         && pip check ;     fi     && rm -rf /tmp/ctx
+#22 17.28   Attempting uninstall: osprey-connectors
+#22 17.29     Found existing installation: osprey-connectors 0.1.0
+#22 17.29     Uninstalling osprey-connectors-0.1.0:
+#22 17.29       Successfully uninstalled osprey-connectors-0.1.0
+#22 17.35 Successfully installed osprey-connectors-0.1.0 osprey-framework-2026.6.2.post1145+gfce915d02
+#22 17.35 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#22 17.51 
+#22 17.51 [notice] A new release of pip is available: 24.0 -> 26.2.1
+#22 17.51 [notice] To update, run: pip install --upgrade pip
+#22 19.43 No broken requirements found.
+#22 DONE 19.9s
+
+#23 [virtual-accelerator] exporting to image
+#23 exporting layers
+#23 ...
+
+#20 [event-dispatcher 6/8] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#20 183.5 Removing libisl23:arm64 (0.27-1) ...
+#20 183.5 Removing libitm1:arm64 (14.2.0-19) ...
+#20 183.5 Removing libjansson4:arm64 (2.14-2+b3) ...
+#20 183.5 Removing liblsan0:arm64 (14.2.0-19) ...
+#20 183.6 Removing libmpc3:arm64 (1.3.1-1+b3) ...
+#20 183.6 Removing libmpfr6:arm64 (4.2.2-1) ...
+#20 183.6 Removing libsframe1:arm64 (2.44-3) ...
+#20 183.6 Removing libtsan2:arm64 (14.2.0-19) ...
+#20 183.7 Removing libubsan1:arm64 (14.2.0-19) ...
+#20 183.7 Processing triggers for libc-bin (2.41-12+deb13u3) ...
+#20 DONE 184.1s
+
+#23 [virtual-accelerator] exporting to image
+#23 ...
+
+#24 [event-dispatcher 7/8] COPY .dockerignore *.wh[l] /tmp/ctx/
+#24 DONE 0.3s
+
+#23 [virtual-accelerator] exporting to image
+#23 ...
+
+#25 [event-dispatcher 8/8] RUN if ls /tmp/ctx/*.whl >/dev/null 2>&1; then         echo "Overlaying locally-built osprey wheel (dev build)"         && pip install --no-cache-dir /tmp/ctx/*.whl         && pip install --no-cache-dir --no-deps --force-reinstall /tmp/ctx/*.whl         && pip check ;     fi     && rm -rf /tmp/ctx
+#25 0.088 Overlaying locally-built osprey wheel (dev build)
+#25 0.321 Processing /tmp/ctx/osprey_connectors-0.1.0-py3-none-any.whl
+#25 0.325 Processing /tmp/ctx/osprey_framework-2026.6.2.post1145+gfce915d02-py3-none-any.whl
+#25 0.334 Requirement already satisfied: numpy>=2.2.6 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (2.4.6)
+#25 0.339 Requirement already satisfied: pandas>=2.2.3 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (3.0.5)
+#25 0.339 Requirement already satisfied: pyepics in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (3.5.10)
+#25 0.340 Requirement already satisfied: python-dateutil>=2.9.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (2.9.0.post0)
+#25 0.340 Requirement already satisfied: python-dotenv>=1.1.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (1.2.2)
+#25 0.341 Requirement already satisfied: pyyaml>=6.0.2 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (6.0.3)
+#25 0.342 Requirement already satisfied: rich>=14.0.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (15.0.0)
+#25 0.378 Requirement already satisfied: accelerator-toolbox>=0.7.1 in /usr/local/lib/python3.11/site-packages (from accelerator-toolbox[plot]>=0.7.1->osprey-framework==2026.6.2.post1145+gfce915d02) (0.8.0)
+#25 0.379 Requirement already satisfied: aiofiles>=25.1.0 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (25.1.0)
+#25 0.380 Requirement already satisfied: aiohttp-socks>=0.8.0 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (0.12.0)
+#25 0.380 Requirement already satisfied: aiohttp>=3.10 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (3.14.3)
+#25 0.381 Requirement already satisfied: anthropic in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (0.122.0)
+#25 6.920   Attempting uninstall: osprey-connectors
+#25 6.923     Found existing installation: osprey-connectors 0.1.0
+#25 6.925     Uninstalling osprey-connectors-0.1.0:
+#25 6.925       Successfully uninstalled osprey-connectors-0.1.0
+#25 6.966 Successfully installed osprey-connectors-0.1.0 osprey-framework-2026.6.2.post1145+gfce915d02
+#25 6.966 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#25 7.069 
+#25 7.069 [notice] A new release of pip is available: 24.0 -> 26.2.1
+#25 7.069 [notice] To update, run: pip install --upgrade pip
+#25 8.170 No broken requirements found.
+#25 DONE 8.3s
+
+#23 [virtual-accelerator] exporting to image
+#23 ...
+
+#26 [event-dispatcher] exporting to image
+#26 exporting layers
+#26 ...
+
+#23 [virtual-accelerator] exporting to image
+#23 exporting layers 57.2s done
+#23 exporting manifest sha256:1cb57dd82d84f2a40761db0a614ede98e5a231ad5a3e45cb6871bef23635c1db done
+#23 exporting config sha256:8a8dc264dd25176f055c2d6c4b8eb18f18a4333cd9990692a5c7f34d4a2c5335 done
+#23 exporting attestation manifest sha256:0542a56c26084ff392fea850636f717fd93a85218324e7b1694a76564bfbefe4 done
+#23 exporting manifest list sha256:86cc1d0f3d889226e010de65f900de700aeb825e6898ef601b3dc0901e570668 done
+#23 naming to docker.io/library/my-control-assistant-va:local done
+#23 DONE 57.2s
+
+#27 [virtual-accelerator] resolving provenance for metadata file
+#27 DONE 0.0s
+
+#26 [event-dispatcher] exporting to image
+#26 ...
+
+#28 [bluesky-bridge internal] load build definition from Dockerfile
+#28 transferring dockerfile: 7.29kB done
+#28 DONE 0.0s
+
+#4 [bluesky-bridge internal] load metadata for docker.io/library/python:3.11-slim
+#4 DONE 1.7s
+
+#26 [event-dispatcher] exporting to image
+#26 ...
+
+#7 [bluesky-bridge 1/8] FROM docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1
+#7 resolve docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1 done
+#7 sha256:477af7c3a936b1f5ddbcde585bdf7736346cff6f3ab0b1d4a3b1a170daee70ae 249B / 249B 0.2s done
+#7 sha256:00430733972ce348d8ce3bdbaf6f2007cc5056d2e254943606d1ea1114dd3298 14.40MB / 14.40MB 0.3s done
+#7 sha256:dce7fdcbadc617c8284289e67f7796c24f259677c5506cbdc1e17fe4e4e8c548 1.27MB / 1.27MB 0.3s done
+#7 extracting sha256:dce7fdcbadc617c8284289e67f7796c24f259677c5506cbdc1e17fe4e4e8c548 0.0s done
+#7 extracting sha256:00430733972ce348d8ce3bdbaf6f2007cc5056d2e254943606d1ea1114dd3298 0.2s done
+#7 extracting sha256:477af7c3a936b1f5ddbcde585bdf7736346cff6f3ab0b1d4a3b1a170daee70ae done
+#7 DONE 1.1s
+
+#29 [bluesky-bridge internal] load .dockerignore
+#29 transferring context: 720B done
+#29 DONE 0.0s
+
+#30 [bluesky-bridge 2/7] WORKDIR /app
+#30 DONE 0.1s
+
+#31 [bluesky-bridge internal] load build context
+#31 transferring context: 5.06MB 0.0s done
+#31 DONE 0.1s
+
+#32 [bluesky-bridge 3/7] RUN find /etc/apt ( -name '*.sources' -o -name '*.list' )     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} +  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
+#32 DONE 0.1s
+
+#33 [bluesky-bridge 4/7] COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
+#33 DONE 0.0s
+
+#34 [bluesky-bridge 5/7] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && pip install --no-cache-dir "bluesky-queueserver==0.0.25"     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && { [ "1" = "1" ] || pip check ; }     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#34 0.235 Hit:1 https://deb.debian.org/debian trixie InRelease
+#34 0.253 Get:2 https://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
+#34 0.297 Get:3 https://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
+#34 0.322 Get:4 https://deb.debian.org/debian trixie/main arm64 Packages [9607 kB]
+#34 0.624 Get:5 https://deb.debian.org/debian trixie-updates/main arm64 Packages [4424 B]
+#34 0.644 Get:6 https://deb.debian.org/debian-security trixie-security/main arm64 Packages [244 kB]
+#34 1.357 Fetched 9947 kB in 1s (8071 kB/s)
+#34 1.357 Reading package lists...
+#34 1.718 Reading package lists...
+#34 2.060 Building dependency tree...
+#34 2.167 Reading state information...
+#34 2.319 The following additional packages will be installed:
+#34 2.319   binutils binutils-aarch64-linux-gnu binutils-common bzip2 cpp cpp-14
+#34 2.319   cpp-14-aarch64-linux-gnu cpp-aarch64-linux-gnu dpkg-dev g++ g++-14
+#34 2.319   g++-14-aarch64-linux-gnu g++-aarch64-linux-gnu gcc gcc-14
+#34 ...
+
+#26 [event-dispatcher] exporting to image
+#26 exporting layers 51.5s done
+#26 exporting manifest sha256:0f051ce5794a8942b2c58d321c0a6f3d68eb66dd1121768d2620b82330ed3c20 done
+#26 exporting config sha256:79035bfd299ba030281539060e294f10ea2a7dccea17d26f65ad6a1443654ade done
+#26 exporting attestation manifest sha256:0d73b2036d6aa4d1682feb0c016ddbaf109a2bad196d26d28ce2535d2f5508a8 done
+#26 exporting manifest list sha256:868137a994ea82d6ff9886e370f6384dc4264ecd46a9ae87276ef6a11e308a33 done
+#26 naming to docker.io/library/my-control-assistant-dispatch:local done
+#26 unpacking to docker.io/library/my-control-assistant-dispatch:local
+#26 unpacking to docker.io/library/my-control-assistant-dispatch:local 11.8s done
+#26 DONE 63.3s
+
+#35 [event-dispatcher] resolving provenance for metadata file
+#35 DONE 0.0s
+
+#34 [bluesky-bridge 5/7] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && pip install --no-cache-dir "bluesky-queueserver==0.0.25"     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && { [ "1" = "1" ] || pip check ; }     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#34 171.3 Removing libisl23:arm64 (0.27-1) ...
+#34 171.3 Removing libitm1:arm64 (14.2.0-19) ...
+#34 171.3 Removing libjansson4:arm64 (2.14-2+b3) ...
+#34 171.3 Removing liblsan0:arm64 (14.2.0-19) ...
+#34 171.3 Removing libmpc3:arm64 (1.3.1-1+b3) ...
+#34 171.4 Removing libmpfr6:arm64 (4.2.2-1) ...
+#34 171.4 Removing libsframe1:arm64 (2.44-3) ...
+#34 171.4 Removing libtsan2:arm64 (14.2.0-19) ...
+#34 171.4 Removing libubsan1:arm64 (14.2.0-19) ...
+#34 171.4 Processing triggers for libc-bin (2.41-12+deb13u3) ...
+#34 DONE 171.9s
+
+#36 [bluesky-bridge 6/7] COPY .dockerignore *.wh[l] /tmp/ctx/
+#36 DONE 0.3s
+
+#37 [bluesky-bridge 7/7] RUN if ls /tmp/ctx/*.whl >/dev/null 2>&1; then         echo "Overlaying locally-built osprey wheel (dev build)"         && pip install --no-cache-dir /tmp/ctx/*.whl         && pip install --no-cache-dir --no-deps --force-reinstall /tmp/ctx/*.whl         && pip check ;     fi     && rm -rf /tmp/ctx
+#37 0.087 Overlaying locally-built osprey wheel (dev build)
+#37 0.299 Processing /tmp/ctx/osprey_connectors-0.1.0-py3-none-any.whl
+#37 0.303 Processing /tmp/ctx/osprey_framework-2026.6.2.post1145+gfce915d02-py3-none-any.whl
+#37 0.311 Requirement already satisfied: numpy>=2.2.6 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (2.4.6)
+#37 0.316 Requirement already satisfied: pandas>=2.2.3 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (3.0.5)
+#37 0.316 Requirement already satisfied: pyepics in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (3.5.10)
+#37 0.317 Requirement already satisfied: python-dateutil>=2.9.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (2.9.0.post0)
+#37 0.318 Requirement already satisfied: python-dotenv>=1.1.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (1.2.2)
+#37 0.319 Requirement already satisfied: pyyaml>=6.0.2 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (6.0.3)
+#37 0.319 Requirement already satisfied: rich>=14.0.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (15.0.0)
+#37 0.353 Requirement already satisfied: accelerator-toolbox>=0.7.1 in /usr/local/lib/python3.11/site-packages (from accelerator-toolbox[plot]>=0.7.1->osprey-framework==2026.6.2.post1145+gfce915d02) (0.8.0)
+#37 0.354 Requirement already satisfied: aiofiles>=25.1.0 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (25.1.0)
+#37 0.355 Requirement already satisfied: aiohttp-socks>=0.8.0 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (0.12.0)
+#37 0.355 Requirement already satisfied: aiohttp>=3.10 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (3.14.3)
+#37 0.356 Requirement already satisfied: anthropic in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (0.122.0)
+#37 6.176   Attempting uninstall: osprey-connectors
+#37 6.179     Found existing installation: osprey-connectors 0.1.0
+#37 6.181     Uninstalling osprey-connectors-0.1.0:
+#37 6.181       Successfully uninstalled osprey-connectors-0.1.0
+#37 6.216 Successfully installed osprey-connectors-0.1.0 osprey-framework-2026.6.2.post1145+gfce915d02
+#37 6.216 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#37 6.273 
+#37 6.273 [notice] A new release of pip is available: 24.0 -> 26.2.1
+#37 6.273 [notice] To update, run: pip install --upgrade pip
+#37 7.283 No broken requirements found.
+#37 DONE 7.6s
+
+#38 [bluesky-bridge] exporting to image
+#38 exporting layers
+#38 exporting layers 47.1s done
+#38 exporting manifest sha256:c251067b51eea17f9ec68e50f26b3ed54ab390aa12fe7163fe8bd8bf3ee5d1fe done
+#38 exporting config sha256:3e7cc86e98d4f2ec2806d66d4803676d6da63735413fa23a4788ea6c2587df2b done
+#38 exporting attestation manifest sha256:8e160b0ed7435df883110719261827dda53220c177c3beea84bd73c848e0a4b2 0.0s done
+#38 exporting manifest list sha256:729285f1f01c5f97b4f955483542f0b6c34cd1dd2b7297a70f6bc44686d56c91 done
+#38 naming to docker.io/library/my-control-assistant-bluesky-bridge:local done
+#38 unpacking to docker.io/library/my-control-assistant-bluesky-bridge:local
+#38 unpacking to docker.io/library/my-control-assistant-bluesky-bridge:local 9.7s done
+#38 DONE 56.9s
+
+#39 [bluesky-bridge] resolving provenance for metadata file
+#39 DONE 0.0s
+
+#40 [bluesky-panels internal] load build definition from Dockerfile
+#40 transferring dockerfile: 5.33kB done
+#40 DONE 0.0s
+
+#41 [bluesky-panels auth] library/python:pull token for registry-1.docker.io
+#41 DONE 0.0s
+
+#4 [bluesky-panels internal] load metadata for docker.io/library/python:3.11-slim
+#4 DONE 2.3s
+
+#42 [bluesky-panels internal] load .dockerignore
+#42 transferring context: 635B done
+#42 DONE 0.0s
+
+#7 [bluesky-panels 1/7] FROM docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1
+#7 resolve docker.io/library/python:3.11-slim@sha256:a630a63cdb314e2d138a2fca3e375e319e8568346ffafac5b980f888630ac4f1 done
+#7 DONE 1.1s
+
+#43 [bluesky-panels internal] load build context
+#43 transferring context: 5.06MB 0.0s done
+#43 DONE 0.0s
+
+#30 [bluesky-panels 2/7] WORKDIR /app
+#30 CACHED
+
+#32 [bluesky-panels 3/7] RUN find /etc/apt ( -name '*.sources' -o -name '*.list' )     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} +  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
+#32 CACHED
+
+#44 [bluesky-panels 4/7] COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
+#44 DONE 0.8s
+
+#45 [bluesky-panels 5/7] RUN [ -n "2026.6.2.post1145+gfce915d02" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; }     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { pip install --no-cache-dir "osprey-framework==2026.6.2.post1145+gfce915d02"          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir "osprey-framework" ;             else                 exit 1 ;             fi ; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt ;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#45 0.282 Hit:1 https://deb.debian.org/debian trixie InRelease
+#45 0.297 Get:2 https://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
+#45 0.342 Get:3 https://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
+#45 0.368 Get:4 https://deb.debian.org/debian trixie/main arm64 Packages [9607 kB]
+#45 0.639 Get:5 https://deb.debian.org/debian trixie-updates/main arm64 Packages [4424 B]
+#45 0.661 Get:6 https://deb.debian.org/debian-security trixie-security/main arm64 Packages [244 kB]
+#45 1.332 Fetched 9947 kB in 1s (8183 kB/s)
+#45 1.332 Reading package lists...
+#45 1.644 Reading package lists...
+#45 1.938 Building dependency tree...
+#45 2.024 Reading state information...
+#45 2.139 The following additional packages will be installed:
+#45 2.139   binutils binutils-aarch64-linux-gnu binutils-common bzip2 cpp cpp-14
+#45 2.139   cpp-14-aarch64-linux-gnu cpp-aarch64-linux-gnu dpkg-dev g++ g++-14
+#45 2.139   g++-14-aarch64-linux-gnu g++-aarch64-linux-gnu gcc gcc-14
+#45 140.7 Removing libisl23:arm64 (0.27-1) ...
+#45 140.7 Removing libitm1:arm64 (14.2.0-19) ...
+#45 140.7 Removing libjansson4:arm64 (2.14-2+b3) ...
+#45 140.7 Removing liblsan0:arm64 (14.2.0-19) ...
+#45 140.7 Removing libmpc3:arm64 (1.3.1-1+b3) ...
+#45 140.7 Removing libmpfr6:arm64 (4.2.2-1) ...
+#45 140.7 Removing libsframe1:arm64 (2.44-3) ...
+#45 140.8 Removing libtsan2:arm64 (14.2.0-19) ...
+#45 140.8 Removing libubsan1:arm64 (14.2.0-19) ...
+#45 140.8 Processing triggers for libc-bin (2.41-12+deb13u3) ...
+#45 DONE 141.3s
+
+#46 [bluesky-panels 6/7] COPY .dockerignore *.wh[l] /tmp/ctx/
+#46 DONE 0.2s
+
+#47 [bluesky-panels 7/7] RUN if ls /tmp/ctx/*.whl >/dev/null 2>&1; then         echo "Overlaying locally-built osprey wheel (dev build)"         && pip install --no-cache-dir /tmp/ctx/*.whl         && pip install --no-cache-dir --no-deps --force-reinstall /tmp/ctx/*.whl         && pip check ;     fi     && rm -rf /tmp/ctx
+#47 0.090 Overlaying locally-built osprey wheel (dev build)
+#47 0.317 Processing /tmp/ctx/osprey_connectors-0.1.0-py3-none-any.whl
+#47 0.321 Processing /tmp/ctx/osprey_framework-2026.6.2.post1145+gfce915d02-py3-none-any.whl
+#47 0.330 Requirement already satisfied: numpy>=2.2.6 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (2.4.6)
+#47 0.335 Requirement already satisfied: pandas>=2.2.3 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (3.0.5)
+#47 0.335 Requirement already satisfied: pyepics in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (3.5.10)
+#47 0.336 Requirement already satisfied: python-dateutil>=2.9.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (2.9.0.post0)
+#47 0.337 Requirement already satisfied: python-dotenv>=1.1.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (1.2.2)
+#47 0.337 Requirement already satisfied: pyyaml>=6.0.2 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (6.0.3)
+#47 0.338 Requirement already satisfied: rich>=14.0.0 in /usr/local/lib/python3.11/site-packages (from osprey-connectors==0.1.0) (15.0.0)
+#47 0.372 Requirement already satisfied: accelerator-toolbox>=0.7.1 in /usr/local/lib/python3.11/site-packages (from accelerator-toolbox[plot]>=0.7.1->osprey-framework==2026.6.2.post1145+gfce915d02) (0.8.0)
+#47 0.373 Requirement already satisfied: aiofiles>=25.1.0 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (25.1.0)
+#47 0.373 Requirement already satisfied: aiohttp-socks>=0.8.0 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (0.12.0)
+#47 0.374 Requirement already satisfied: aiohttp>=3.10 in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (3.14.3)
+#47 0.374 Requirement already satisfied: anthropic in /usr/local/lib/python3.11/site-packages (from osprey-framework==2026.6.2.post1145+gfce915d02) (0.122.0)
+#47 6.329   Attempting uninstall: osprey-connectors
+#47 6.332     Found existing installation: osprey-connectors 0.1.0
+#47 6.334     Uninstalling osprey-connectors-0.1.0:
+#47 6.334       Successfully uninstalled osprey-connectors-0.1.0
+#47 6.373 Successfully installed osprey-connectors-0.1.0 osprey-framework-2026.6.2.post1145+gfce915d02
+#47 6.373 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#47 6.435 
+#47 6.435 [notice] A new release of pip is available: 24.0 -> 26.2.1
+#47 6.435 [notice] To update, run: pip install --upgrade pip
+#47 7.445 No broken requirements found.
+#47 DONE 7.8s
+
+#48 [bluesky-panels] exporting to image
+#48 exporting layers
+#48 exporting layers 48.0s done
+#48 exporting manifest sha256:350a93f85b388851235c4bf9a2ae8f91cd33ac975c48d031e8b1091474ec9cdf done
+#48 exporting config sha256:968d20fe5f2608eb12bcf1b38b3938ef39a47e2bac3c35188e3d71db0ff70495 done
+#48 exporting attestation manifest sha256:93941d11790572c4619bad9b5ef5e6f1ee96d359713a8371942769a2286faa6b done
+#48 exporting manifest list sha256:44a3e0f37ceb2e0bb4125aabb58bebfa6dfd6aedfa0c287e35f9ba531b549d42 done
+#48 naming to docker.io/library/my-control-assistant-bluesky-panels:local done
+#48 unpacking to docker.io/library/my-control-assistant-bluesky-panels:local
+#48 unpacking to docker.io/library/my-control-assistant-bluesky-panels:local 9.9s done
+#48 DONE 57.9s
+
+#49 [bluesky-panels] resolving provenance for metadata file
+#49 DONE 0.0s
+ bluesky-bridge  Built
+ bluesky-panels  Built
+ event-dispatcher  Built
+ virtual-accelerator  Built

--- a/tests/deployment/fixtures/buildkit_project_image.log
+++ b/tests/deployment/fixtures/buildkit_project_image.log
@@ -1,0 +1,393 @@
+#0 building with "desktop-linux" instance using docker driver
+
+#1 [internal] load build definition from Dockerfile
+#1 transferring dockerfile: 8.88kB done
+#1 DONE 0.0s
+
+#2 resolve image config for docker-image://docker.io/docker/dockerfile:1
+#2 ...
+
+#3 [auth] docker/dockerfile:pull token for registry-1.docker.io
+#3 DONE 0.0s
+
+#2 resolve image config for docker-image://docker.io/docker/dockerfile:1
+#2 DONE 1.0s
+
+#4 docker-image://docker.io/docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+#4 resolve docker.io/docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32 done
+#4 CACHED
+
+#5 [internal] load metadata for docker.io/library/python:3.12-slim
+#5 ...
+
+#6 [auth] library/python:pull token for registry-1.docker.io
+#6 DONE 0.0s
+
+#5 [internal] load metadata for docker.io/library/python:3.12-slim
+#5 DONE 0.6s
+
+#7 [internal] load .dockerignore
+#7 transferring context: 1.30kB done
+#7 DONE 0.0s
+
+#8 [ 1/13] FROM docker.io/library/python:3.12-slim@sha256:dd29372629eeba2dd003fd9e9d35a5b8236c44727875a0364254b5127af88e65
+#8 resolve docker.io/library/python:3.12-slim@sha256:dd29372629eeba2dd003fd9e9d35a5b8236c44727875a0364254b5127af88e65 done
+#8 DONE 0.0s
+
+#9 [internal] load build context
+#9 transferring context: 6.12MB 0.1s done
+#9 DONE 0.1s
+
+#10 [ 3/13] RUN apt-get update  && apt-get install -y --no-install-recommends curl git procps ca-certificates gnupg  && curl -fsSL https://deb.nodesource.com/setup_20.x | bash -  && apt-get install -y --no-install-recommends nodejs  && apt-get purge -y gnupg  && apt-get autoremove -y  && rm -rf /var/lib/apt/lists/*
+#10 CACHED
+
+#11 [ 4/13] RUN npm install -g "@anthropic-ai/claude-code@2.1.146"
+#11 CACHED
+
+#12 [ 5/13] COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
+#12 CACHED
+
+#13 [ 2/13] RUN find /etc/apt ( -name '*.sources' -o -name '*.list' )     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} +  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
+#13 CACHED
+
+#14 [ 6/13] RUN export NO_PROXY="" no_proxy=""     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt     && apt-get update     && apt-get install -y --no-install-recommends build-essential python3-dev     && { case "osprey-framework==2026.6.2" in            git+*) pip install --no-cache-dir "osprey-connectors @ osprey-framework==2026.6.2#subdirectory=packages/osprey-connectors"                   || echo "WARNING: could not pre-install osprey-connectors from the git spec; resolving from PyPI" ;;          esac; }     && { pip install --no-cache-dir "osprey-framework==2026.6.2" 'pymongo>=4.0'          || if [ "1" = "1" ]; then                 echo "WARNING: pin unreleased, priming with latest"                 && pip install --no-cache-dir osprey-framework 'pymongo>=4.0';             else exit 1; fi; }     && if [ -f /tmp/deps-ctx/osprey-local-requirements.txt ]; then            pip install --no-cache-dir -r /tmp/deps-ctx/osprey-local-requirements.txt;        fi     && apt-get purge -y build-essential python3-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/* /tmp/deps-ctx
+#14 CACHED
+
+#15 [ 7/13] COPY .dockerignore *.wh[l] /tmp/ctx/
+#15 DONE 0.0s
+
+#16 [ 8/13] RUN if ls /tmp/ctx/*.whl >/dev/null 2>&1; then         pip install --no-cache-dir /tmp/ctx/*.whl         && pip install --no-cache-dir --no-deps --force-reinstall /tmp/ctx/*.whl         && pip check;     fi     && rm -rf /tmp/ctx
+#16 0.770 Processing /tmp/ctx/osprey_connectors-0.1.0-py3-none-any.whl
+#16 0.775 Processing /tmp/ctx/osprey_framework-2026.6.2.post1137+g125523326-py3-none-any.whl
+#16 0.789 Requirement already satisfied: numpy>=2.2.6 in /usr/local/lib/python3.12/site-packages (from osprey-connectors==0.1.0) (2.5.2)
+#16 0.789 Requirement already satisfied: pandas>=2.2.3 in /usr/local/lib/python3.12/site-packages (from osprey-connectors==0.1.0) (3.0.5)
+#16 0.790 Requirement already satisfied: pyepics in /usr/local/lib/python3.12/site-packages (from osprey-connectors==0.1.0) (3.5.10)
+#16 0.790 Requirement already satisfied: python-dateutil>=2.9.0 in /usr/local/lib/python3.12/site-packages (from osprey-connectors==0.1.0) (2.9.0.post0)
+#16 0.790 Requirement already satisfied: python-dotenv>=1.1.0 in /usr/local/lib/python3.12/site-packages (from osprey-connectors==0.1.0) (1.2.2)
+#16 0.790 Requirement already satisfied: pyyaml>=6.0.2 in /usr/local/lib/python3.12/site-packages (from osprey-connectors==0.1.0) (6.0.3)
+#16 0.791 Requirement already satisfied: rich>=14.0.0 in /usr/local/lib/python3.12/site-packages (from osprey-connectors==0.1.0) (15.0.0)
+#16 0.793 Requirement already satisfied: accelerator-toolbox>=0.7.1 in /usr/local/lib/python3.12/site-packages (from accelerator-toolbox[plot]>=0.7.1->osprey-framework==2026.6.2.post1137+g125523326) (0.8.0)
+#16 0.793 Requirement already satisfied: aiofiles>=25.1.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (25.1.0)
+#16 0.793 Requirement already satisfied: aiohttp-socks>=0.8.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.12.0)
+#16 0.793 Requirement already satisfied: aiohttp>=3.10 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.14.3)
+#16 0.793 Requirement already satisfied: anthropic in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.122.0)
+#16 0.793 Requirement already satisfied: authlib>=1.6.5 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.7.2)
+#16 0.794 Requirement already satisfied: bluesky-queueserver-api==0.0.13 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.0.13)
+#16 0.794 Requirement already satisfied: bluesky>=1.15.1 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.15.1)
+#16 0.794 Requirement already satisfied: bokeh>=3.9.1 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.9.2)
+#16 0.795 Requirement already satisfied: build in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.5.0)
+#16 0.795 Requirement already satisfied: certifi>=2025.4.26 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (2026.7.22)
+#16 0.795 Requirement already satisfied: charset-normalizer>=3.4.9 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.5.0)
+#16 0.796 Requirement already satisfied: claude-agent-sdk==0.2.110 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.2.110)
+#16 0.796 Requirement already satisfied: click>=8.4.2 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (8.4.2)
+#16 0.796 Requirement already satisfied: duckdb>=1.5.4 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.5.5)
+#16 0.797 Requirement already satisfied: fastapi>=0.141.1 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.141.1)
+#16 0.797 Requirement already satisfied: fastmcp>=3.4.4 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.4.7)
+#16 0.798 Requirement already satisfied: google-generativeai in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.8.6)
+#16 0.798 Requirement already satisfied: httpx>=0.28.1 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.28.1)
+#16 0.798 Requirement already satisfied: idna>=3.18 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.18)
+#16 0.798 Requirement already satisfied: ipywidgets in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (8.1.8)
+#16 0.799 Requirement already satisfied: itsdangerous>=2.2.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (2.2.0)
+#16 0.799 Requirement already satisfied: jinja2>=3.1.6 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.1.6)
+#16 0.800 Requirement already satisfied: litellm>=1.56.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.95.1)
+#16 0.800 Requirement already satisfied: lume-base==0.5.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.5.0)
+#16 0.800 Requirement already satisfied: lume-pyat==0.1.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.1.0)
+#16 0.802 Requirement already satisfied: markdown>=3.5 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.10.3)
+#16 0.802 Requirement already satisfied: markupsafe>=3.0.2 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.0.3)
+#16 0.802 Requirement already satisfied: matplotlib>=3.11.1 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.11.1)
+#16 0.802 Requirement already satisfied: nbclient in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.11.0)
+#16 0.802 Requirement already satisfied: nbconvert>=7.0.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (7.17.1)
+#16 0.802 Requirement already satisfied: nbformat>=5.0.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (5.11.0)
+#16 0.802 Requirement already satisfied: nltk>=3.10.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.10.3)
+#16 0.802 Requirement already satisfied: ollama>=0.6.2 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.6.2)
+#16 0.802 Requirement already satisfied: openai>=2.45.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (2.54.0)
+#16 0.802 Requirement already satisfied: ophyd-async<1.0,>=0.16 in /usr/local/lib/python3.12/site-packages (from ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (0.21.1)
+#16 0.802 Requirement already satisfied: playwright>=1.61.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.62.0)
+#16 0.802 Requirement already satisfied: plotly>=5.0.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (6.9.0)
+#16 0.803 Requirement already satisfied: psycopg-pool<4.0.0,>=3.3.1 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (3.3.1)
+#16 0.804 Requirement already satisfied: psycopg<4.0.0,>=3.3.4 in /usr/local/lib/python3.12/site-packages (from psycopg[binary,pool]<4.0.0,>=3.3.4->osprey-framework==2026.6.2.post1137+g125523326) (3.3.4)
+#16 0.804 Requirement already satisfied: python-multipart>=0.0.18 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.0.32)
+#16 0.805 Requirement already satisfied: questionary>=2.1.1 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (2.1.1)
+#16 0.805 Requirement already satisfied: requests>=2.34.2 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (2.34.2)
+#16 0.805 Requirement already satisfied: ruamel-yaml>=0.18.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.18.0)
+#16 0.806 Requirement already satisfied: scikit-learn in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.9.0)
+#16 0.806 Requirement already satisfied: scipy>=1.17.1 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.18.0)
+#16 0.807 Requirement already satisfied: seaborn in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (0.13.2)
+#16 0.807 Requirement already satisfied: tenacity>=9.1.4 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (9.1.4)
+#16 0.807 Requirement already satisfied: tiled>=0.2.14 in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.2.15)
+#16 0.808 Requirement already satisfied: typing-extensions>=4.16.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (4.16.0)
+#16 0.809 Requirement already satisfied: unique-namer>=1.6.2 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.6.2)
+#16 0.809 Requirement already satisfied: urllib3>=2.7.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (2.7.0)
+#16 0.809 Requirement already satisfied: uvicorn>=0.52.1 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]>=0.52.1->osprey-framework==2026.6.2.post1137+g125523326) (0.52.3)
+#16 0.810 Requirement already satisfied: watchdog>=6.0.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (6.0.0)
+#16 0.810 Requirement already satisfied: websocket-client>=1.7.0 in /usr/local/lib/python3.12/site-packages (from osprey-framework==2026.6.2.post1137+g125523326) (1.9.0)
+#16 0.812 Requirement already satisfied: bluesky-queueserver in /usr/local/lib/python3.12/site-packages (from bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (0.0.25)
+#16 0.812 Requirement already satisfied: websockets in /usr/local/lib/python3.12/site-packages (from bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (17.0.1)
+#16 0.815 Requirement already satisfied: anyio>=4.0.0 in /usr/local/lib/python3.12/site-packages (from claude-agent-sdk==0.2.110->osprey-framework==2026.6.2.post1137+g125523326) (4.14.2)
+#16 0.815 Requirement already satisfied: mcp<2.0.0,>=1.23.0 in /usr/local/lib/python3.12/site-packages (from claude-agent-sdk==0.2.110->osprey-framework==2026.6.2.post1137+g125523326) (1.29.0)
+#16 0.816 Requirement already satisfied: sniffio>=1.0.0 in /usr/local/lib/python3.12/site-packages (from claude-agent-sdk==0.2.110->osprey-framework==2026.6.2.post1137+g125523326) (1.3.1)
+#16 0.817 Requirement already satisfied: openpmd-beamphysics in /usr/local/lib/python3.12/site-packages (from lume-base==0.5.0->osprey-framework==2026.6.2.post1137+g125523326) (0.16.0)
+#16 0.818 Requirement already satisfied: h5py in /usr/local/lib/python3.12/site-packages (from lume-base==0.5.0->osprey-framework==2026.6.2.post1137+g125523326) (3.16.0)
+#16 0.818 Requirement already satisfied: pydantic in /usr/local/lib/python3.12/site-packages (from lume-base==0.5.0->osprey-framework==2026.6.2.post1137+g125523326) (2.12.5)
+#16 0.826 Requirement already satisfied: aiohappyeyeballs>=2.5.0 in /usr/local/lib/python3.12/site-packages (from aiohttp>=3.10->osprey-framework==2026.6.2.post1137+g125523326) (2.7.1)
+#16 0.827 Requirement already satisfied: aiosignal>=1.4.0 in /usr/local/lib/python3.12/site-packages (from aiohttp>=3.10->osprey-framework==2026.6.2.post1137+g125523326) (1.4.0)
+#16 0.827 Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.12/site-packages (from aiohttp>=3.10->osprey-framework==2026.6.2.post1137+g125523326) (26.1.0)
+#16 0.827 Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.12/site-packages (from aiohttp>=3.10->osprey-framework==2026.6.2.post1137+g125523326) (1.8.0)
+#16 0.828 Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.12/site-packages (from aiohttp>=3.10->osprey-framework==2026.6.2.post1137+g125523326) (6.7.1)
+#16 0.828 Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.12/site-packages (from aiohttp>=3.10->osprey-framework==2026.6.2.post1137+g125523326) (0.5.2)
+#16 0.828 Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.12/site-packages (from aiohttp>=3.10->osprey-framework==2026.6.2.post1137+g125523326) (1.24.5)
+#16 0.830 Requirement already satisfied: python-socks<4.0.0,>=2.4.3 in /usr/local/lib/python3.12/site-packages (from python-socks[asyncio]<4.0.0,>=2.4.3->aiohttp-socks>=0.8.0->osprey-framework==2026.6.2.post1137+g125523326) (3.0.0)
+#16 0.832 Requirement already satisfied: cryptography in /usr/local/lib/python3.12/site-packages (from authlib>=1.6.5->osprey-framework==2026.6.2.post1137+g125523326) (50.0.0)
+#16 0.832 Requirement already satisfied: joserfc>=1.6.0 in /usr/local/lib/python3.12/site-packages (from authlib>=1.6.5->osprey-framework==2026.6.2.post1137+g125523326) (1.7.4)
+#16 0.836 Requirement already satisfied: cycler in /usr/local/lib/python3.12/site-packages (from bluesky>=1.15.1->osprey-framework==2026.6.2.post1137+g125523326) (0.12.1)
+#16 0.836 Requirement already satisfied: event-model>=1.23.1 in /usr/local/lib/python3.12/site-packages (from bluesky>=1.15.1->osprey-framework==2026.6.2.post1137+g125523326) (1.24.0)
+#16 0.836 Requirement already satisfied: historydict in /usr/local/lib/python3.12/site-packages (from bluesky>=1.15.1->osprey-framework==2026.6.2.post1137+g125523326) (1.2.6)
+#16 0.836 Requirement already satisfied: msgpack in /usr/local/lib/python3.12/site-packages (from bluesky>=1.15.1->osprey-framework==2026.6.2.post1137+g125523326) (1.2.1)
+#16 0.837 Requirement already satisfied: msgpack-numpy in /usr/local/lib/python3.12/site-packages (from bluesky>=1.15.1->osprey-framework==2026.6.2.post1137+g125523326) (0.4.8)
+#16 0.837 Requirement already satisfied: opentelemetry-api in /usr/local/lib/python3.12/site-packages (from bluesky>=1.15.1->osprey-framework==2026.6.2.post1137+g125523326) (1.44.0)
+#16 0.837 Requirement already satisfied: toolz in /usr/local/lib/python3.12/site-packages (from bluesky>=1.15.1->osprey-framework==2026.6.2.post1137+g125523326) (1.1.0)
+#16 0.838 Requirement already satisfied: tqdm>=4.44 in /usr/local/lib/python3.12/site-packages (from bluesky>=1.15.1->osprey-framework==2026.6.2.post1137+g125523326) (4.70.0)
+#16 0.840 Requirement already satisfied: contourpy>=1.2 in /usr/local/lib/python3.12/site-packages (from bokeh>=3.9.1->osprey-framework==2026.6.2.post1137+g125523326) (1.3.3)
+#16 0.840 Requirement already satisfied: narwhals>=1.13 in /usr/local/lib/python3.12/site-packages (from bokeh>=3.9.1->osprey-framework==2026.6.2.post1137+g125523326) (2.24.0)
+#16 0.840 Requirement already satisfied: packaging>=16.8 in /usr/local/lib/python3.12/site-packages (from bokeh>=3.9.1->osprey-framework==2026.6.2.post1137+g125523326) (26.3)
+#16 0.841 Requirement already satisfied: pillow>=7.1.0 in /usr/local/lib/python3.12/site-packages (from bokeh>=3.9.1->osprey-framework==2026.6.2.post1137+g125523326) (12.3.0)
+#16 0.841 Requirement already satisfied: tornado>=6.2 in /usr/local/lib/python3.12/site-packages (from bokeh>=3.9.1->osprey-framework==2026.6.2.post1137+g125523326) (6.5.8)
+#16 0.842 Requirement already satisfied: xyzservices>=2021.09.1 in /usr/local/lib/python3.12/site-packages (from bokeh>=3.9.1->osprey-framework==2026.6.2.post1137+g125523326) (2026.3.0)
+#16 0.863 Requirement already satisfied: starlette>=0.46.0 in /usr/local/lib/python3.12/site-packages (from fastapi>=0.141.1->osprey-framework==2026.6.2.post1137+g125523326) (1.6.0)
+#16 0.863 Requirement already satisfied: typing-inspection>=0.4.2 in /usr/local/lib/python3.12/site-packages (from fastapi>=0.141.1->osprey-framework==2026.6.2.post1137+g125523326) (0.4.4)
+#16 0.864 Requirement already satisfied: annotated-doc>=0.0.2 in /usr/local/lib/python3.12/site-packages (from fastapi>=0.141.1->osprey-framework==2026.6.2.post1137+g125523326) (0.0.5)
+#16 0.867 Requirement already satisfied: fastmcp-slim==3.4.7 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (3.4.7)
+#16 0.871 Requirement already satisfied: platformdirs>=4.0.0 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim==3.4.7->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (4.11.3)
+#16 0.871 Requirement already satisfied: pydantic-settings>=2.0.0 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim==3.4.7->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (2.11.0)
+#16 0.875 Requirement already satisfied: exceptiongroup>=1.2.2 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (1.3.1)
+#16 0.875 Requirement already satisfied: py-key-value-aio<0.5.0,>=0.4.4 in /usr/local/lib/python3.12/site-packages (from py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (0.4.5)
+#16 0.875 Requirement already satisfied: cyclopts>=4.0.0 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (4.22.5)
+#16 0.876 Requirement already satisfied: griffelib>=2.0.0 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (2.1.0)
+#16 0.876 Requirement already satisfied: jsonref>=1.1.0 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (1.1.0)
+#16 0.876 Requirement already satisfied: jsonschema-path>=0.3.4 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (0.5.0)
+#16 0.877 Requirement already satisfied: openapi-pydantic>=0.5.1 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (0.5.1)
+#16 0.877 Requirement already satisfied: pyperclip>=1.9.0 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (1.11.0)
+#16 0.878 Requirement already satisfied: uncalled-for>=0.2.0 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (0.4.0)
+#16 0.878 Requirement already satisfied: watchfiles>=1.0.0 in /usr/local/lib/python3.12/site-packages (from fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (1.2.0)
+#16 0.880 Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.12/site-packages (from httpx>=0.28.1->osprey-framework==2026.6.2.post1137+g125523326) (1.0.9)
+#16 0.883 Requirement already satisfied: h11>=0.16 in /usr/local/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.28.1->osprey-framework==2026.6.2.post1137+g125523326) (0.16.0)
+#16 0.895 Requirement already satisfied: fastuuid<1.0,>=0.14.0 in /usr/local/lib/python3.12/site-packages (from litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (0.14.0)
+#16 0.896 Requirement already satisfied: tiktoken<1.0,>=0.8.0 in /usr/local/lib/python3.12/site-packages (from litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (0.13.0)
+#16 0.897 Requirement already satisfied: importlib-metadata<9.0,>=8.0.0 in /usr/local/lib/python3.12/site-packages (from litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (8.9.0)
+#16 0.897 Requirement already satisfied: tokenizers<1.0,>=0.21.0 in /usr/local/lib/python3.12/site-packages (from litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (0.23.1)
+#16 0.898 Requirement already satisfied: jsonschema<5.0,>=4.0.0 in /usr/local/lib/python3.12/site-packages (from litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (4.26.0)
+#16 0.906 Requirement already satisfied: fonttools>=4.28.2 in /usr/local/lib/python3.12/site-packages (from matplotlib>=3.11.1->osprey-framework==2026.6.2.post1137+g125523326) (4.63.0)
+#16 0.906 Requirement already satisfied: kiwisolver>=1.3.1 in /usr/local/lib/python3.12/site-packages (from matplotlib>=3.11.1->osprey-framework==2026.6.2.post1137+g125523326) (1.5.0)
+#16 0.907 Requirement already satisfied: pyparsing>=3 in /usr/local/lib/python3.12/site-packages (from matplotlib>=3.11.1->osprey-framework==2026.6.2.post1137+g125523326) (3.3.2)
+#16 0.911 Requirement already satisfied: beautifulsoup4 in /usr/local/lib/python3.12/site-packages (from nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (4.15.0)
+#16 0.911 Requirement already satisfied: bleach!=5.0.0 in /usr/local/lib/python3.12/site-packages (from bleach[css]!=5.0.0->nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (6.4.0)
+#16 0.911 Requirement already satisfied: defusedxml in /usr/local/lib/python3.12/site-packages (from nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (0.7.1)
+#16 0.912 Requirement already satisfied: jupyter-core>=4.7 in /usr/local/lib/python3.12/site-packages (from nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (5.9.1)
+#16 0.912 Requirement already satisfied: jupyterlab-pygments in /usr/local/lib/python3.12/site-packages (from nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (0.3.0)
+#16 0.912 Requirement already satisfied: mistune<4,>=2.0.3 in /usr/local/lib/python3.12/site-packages (from nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (3.3.4)
+#16 0.913 Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.12/site-packages (from nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (1.5.1)
+#16 0.913 Requirement already satisfied: pygments>=2.4.1 in /usr/local/lib/python3.12/site-packages (from nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (2.20.0)
+#16 0.913 Requirement already satisfied: traitlets>=5.1 in /usr/local/lib/python3.12/site-packages (from nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (5.16.1)
+#16 0.917 Requirement already satisfied: jupyter-client>=7.0.0 in /usr/local/lib/python3.12/site-packages (from nbclient->osprey-framework==2026.6.2.post1137+g125523326) (8.9.1)
+#16 0.920 Requirement already satisfied: fastjsonschema>=2.15 in /usr/local/lib/python3.12/site-packages (from nbformat>=5.0.0->osprey-framework==2026.6.2.post1137+g125523326) (2.22.1)
+#16 0.923 Requirement already satisfied: joblib in /usr/local/lib/python3.12/site-packages (from nltk>=3.10.0->osprey-framework==2026.6.2.post1137+g125523326) (1.5.3)
+#16 0.924 Requirement already satisfied: regex>=2021.8.3 in /usr/local/lib/python3.12/site-packages (from nltk>=3.10.0->osprey-framework==2026.6.2.post1137+g125523326) (2026.7.19)
+#16 0.931 Requirement already satisfied: distro<2,>=1.7.0 in /usr/local/lib/python3.12/site-packages (from openai>=2.45.0->osprey-framework==2026.6.2.post1137+g125523326) (1.9.0)
+#16 0.932 Requirement already satisfied: jiter<1,>=0.10.0 in /usr/local/lib/python3.12/site-packages (from openai>=2.45.0->osprey-framework==2026.6.2.post1137+g125523326) (0.16.0)
+#16 0.934 Requirement already satisfied: colorlog in /usr/local/lib/python3.12/site-packages (from ophyd-async<1.0,>=0.16->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (6.12.0)
+#16 0.935 Requirement already satisfied: pydantic-numpy in /usr/local/lib/python3.12/site-packages (from ophyd-async<1.0,>=0.16->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (9.0.2)
+#16 0.935 Requirement already satisfied: stamina>=23.1.0 in /usr/local/lib/python3.12/site-packages (from ophyd-async<1.0,>=0.16->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (26.1.0)
+#16 0.936 Requirement already satisfied: scanspec>=1.0.0 in /usr/local/lib/python3.12/site-packages (from ophyd-async<1.0,>=0.16->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (1.0.0)
+#16 0.936 Requirement already satisfied: velocity-profile in /usr/local/lib/python3.12/site-packages (from ophyd-async<1.0,>=0.16->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (1.0.0)
+#16 0.938 Requirement already satisfied: aioca>=2.0a4 in /usr/local/lib/python3.12/site-packages (from ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (2.1)
+#16 0.949 Requirement already satisfied: pyee<14,>=13 in /usr/local/lib/python3.12/site-packages (from playwright>=1.61.0->osprey-framework==2026.6.2.post1137+g125523326) (13.0.1)
+#16 0.949 Requirement already satisfied: greenlet<4.0.0,>=3.1.1 in /usr/local/lib/python3.12/site-packages (from playwright>=1.61.0->osprey-framework==2026.6.2.post1137+g125523326) (3.5.5)
+#16 0.961 Requirement already satisfied: psycopg-binary==3.3.4 in /usr/local/lib/python3.12/site-packages (from psycopg[binary,pool]<4.0.0,>=3.3.4->osprey-framework==2026.6.2.post1137+g125523326) (3.3.4)
+#16 0.966 Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/site-packages (from python-dateutil>=2.9.0->osprey-connectors==0.1.0) (1.17.0)
+#16 0.974 Requirement already satisfied: prompt_toolkit<4.0,>=2.0 in /usr/local/lib/python3.12/site-packages (from questionary>=2.1.1->osprey-framework==2026.6.2.post1137+g125523326) (3.0.53)
+#16 0.978 Requirement already satisfied: markdown-it-py>=2.2.0 in /usr/local/lib/python3.12/site-packages (from rich>=14.0.0->osprey-connectors==0.1.0) (4.2.0)
+#16 0.981 Requirement already satisfied: ruamel.yaml.clib>=0.2.7 in /usr/local/lib/python3.12/site-packages (from ruamel-yaml>=0.18.0->osprey-framework==2026.6.2.post1137+g125523326) (0.2.15)
+#16 0.997 Requirement already satisfied: json-merge-patch in /usr/local/lib/python3.12/site-packages (from tiled>=0.2.14->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.3.0)
+#16 0.997 Requirement already satisfied: jsonpatch in /usr/local/lib/python3.12/site-packages (from tiled>=0.2.14->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (1.33)
+#16 0.997 Requirement already satisfied: orjson in /usr/local/lib/python3.12/site-packages (from tiled>=0.2.14->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (3.11.9)
+#16 0.998 Requirement already satisfied: typer in /usr/local/lib/python3.12/site-packages (from tiled>=0.2.14->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.27.1)
+#16 1.002 Requirement already satisfied: awkward>=2.4.3 in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (2.12.0)
+#16 1.002 Requirement already satisfied: blosc2 in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (4.11.0)
+#16 1.002 Requirement already satisfied: dask[array] in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (2026.7.1)
+#16 1.003 Requirement already satisfied: entrypoints in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.4)
+#16 1.003 Requirement already satisfied: lz4 in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (4.4.5)
+#16 1.003 Requirement already satisfied: ndindex in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (1.10.1)
+#16 1.003 Requirement already satisfied: numba>=0.59.0 in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.67.0)
+#16 1.004 Requirement already satisfied: pyarrow>=14.0.1 in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (25.0.1)
+#16 1.004 Requirement already satisfied: ragged in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.3.0)
+#16 1.005 Requirement already satisfied: sparse>=0.15.5 in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.19.2)
+#16 1.005 Requirement already satisfied: xarray in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (2026.7.0)
+#16 1.006 Requirement already satisfied: zstandard in /usr/local/lib/python3.12/site-packages (from tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.25.0)
+#16 1.017 Requirement already satisfied: httptools>=0.8.0 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]>=0.52.1->osprey-framework==2026.6.2.post1137+g125523326) (0.8.0)
+#16 1.018 Requirement already satisfied: uvloop>=0.15.1 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]>=0.52.1->osprey-framework==2026.6.2.post1137+g125523326) (0.22.1)
+#16 1.025 Requirement already satisfied: docstring-parser<1,>=0.15 in /usr/local/lib/python3.12/site-packages (from anthropic->osprey-framework==2026.6.2.post1137+g125523326) (0.18.0)
+#16 1.029 Requirement already satisfied: pyproject_hooks in /usr/local/lib/python3.12/site-packages (from build->osprey-framework==2026.6.2.post1137+g125523326) (1.2.0)
+#16 1.031 Requirement already satisfied: google-ai-generativelanguage==0.6.15 in /usr/local/lib/python3.12/site-packages (from google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (0.6.15)
+#16 1.031 Requirement already satisfied: google-api-core in /usr/local/lib/python3.12/site-packages (from google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (2.33.0)
+#16 1.032 Requirement already satisfied: google-api-python-client in /usr/local/lib/python3.12/site-packages (from google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (2.198.0)
+#16 1.032 Requirement already satisfied: google-auth>=2.15.0 in /usr/local/lib/python3.12/site-packages (from google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (2.56.3)
+#16 1.032 Requirement already satisfied: protobuf in /usr/local/lib/python3.12/site-packages (from google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (5.29.6)
+#16 1.036 Requirement already satisfied: proto-plus<2.0.0dev,>=1.22.3 in /usr/local/lib/python3.12/site-packages (from google-ai-generativelanguage==0.6.15->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (1.28.2)
+#16 1.038 Requirement already satisfied: comm>=0.1.3 in /usr/local/lib/python3.12/site-packages (from ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (0.2.3)
+#16 1.038 Requirement already satisfied: ipython>=6.1.0 in /usr/local/lib/python3.12/site-packages (from ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (9.16.1)
+#16 1.039 Requirement already satisfied: widgetsnbextension~=4.0.14 in /usr/local/lib/python3.12/site-packages (from ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (4.0.15)
+#16 1.039 Requirement already satisfied: jupyterlab_widgets~=3.0.15 in /usr/local/lib/python3.12/site-packages (from ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (3.0.16)
+#16 1.048 Requirement already satisfied: threadpoolctl>=3.5.0 in /usr/local/lib/python3.12/site-packages (from scikit-learn->osprey-framework==2026.6.2.post1137+g125523326) (3.6.0)
+#16 1.055 Requirement already satisfied: epicscorelibs>=7.0.3.99.4.0 in /usr/local/lib/python3.12/site-packages (from aioca>=2.0a4->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (7.0.10.99.0.1)
+#16 1.068 Requirement already satisfied: awkward-cpp==55 in /usr/local/lib/python3.12/site-packages (from awkward>=2.4.3->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (55)
+#16 1.068 Requirement already satisfied: fsspec>=2022.11.0 in /usr/local/lib/python3.12/site-packages (from awkward>=2.4.3->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (2026.7.0)
+#16 1.074 Requirement already satisfied: webencodings in /usr/local/lib/python3.12/site-packages (from bleach!=5.0.0->bleach[css]!=5.0.0->nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (0.5.1)
+#16 1.076 Requirement already satisfied: tinycss2>=1.1.0 in /usr/local/lib/python3.12/site-packages (from bleach[css]!=5.0.0->nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (1.5.1)
+#16 1.104 Requirement already satisfied: googleapis-common-protos<2.0.0,>=1.63.2 in /usr/local/lib/python3.12/site-packages (from google-api-core->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (1.75.0)
+#16 1.109 Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.12/site-packages (from google-auth>=2.15.0->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (0.4.2)
+#16 1.113 Requirement already satisfied: cffi>=2.0.0 in /usr/local/lib/python3.12/site-packages (from cryptography->authlib>=1.6.5->osprey-framework==2026.6.2.post1137+g125523326) (2.1.1)
+#16 1.125 Requirement already satisfied: zipp>=3.20 in /usr/local/lib/python3.12/site-packages (from importlib-metadata<9.0,>=8.0.0->litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (4.1.0)
+#16 1.129 Requirement already satisfied: ipython-pygments-lexers>=1.0.0 in /usr/local/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (1.1.1)
+#16 1.130 Requirement already satisfied: jedi>=0.18.2 in /usr/local/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (0.20.0)
+#16 1.130 Requirement already satisfied: matplotlib-inline>=0.1.6 in /usr/local/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (0.2.2)
+#16 1.131 Requirement already satisfied: pexpect>4.6 in /usr/local/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (4.9.0)
+#16 1.132 Requirement already satisfied: psutil>=7 in /usr/local/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (7.2.2)
+#16 1.132 Requirement already satisfied: stack_data>=0.6.0 in /usr/local/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (0.6.3)
+#16 1.142 Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /usr/local/lib/python3.12/site-packages (from jsonschema<5.0,>=4.0.0->litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (2025.9.1)
+#16 1.143 Requirement already satisfied: referencing>=0.28.4 in /usr/local/lib/python3.12/site-packages (from jsonschema<5.0,>=4.0.0->litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (0.37.0)
+#16 1.143 Requirement already satisfied: rpds-py>=0.25.0 in /usr/local/lib/python3.12/site-packages (from jsonschema<5.0,>=4.0.0->litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (2026.6.3)
+#16 1.147 Requirement already satisfied: pyzmq>=25.0 in /usr/local/lib/python3.12/site-packages (from jupyter-client>=7.0.0->nbclient->osprey-framework==2026.6.2.post1137+g125523326) (27.1.0)
+#16 1.159 Requirement already satisfied: mdurl~=0.1 in /usr/local/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=14.0.0->osprey-connectors==0.1.0) (0.1.2)
+#16 1.163 Requirement already satisfied: httpx-sse>=0.4 in /usr/local/lib/python3.12/site-packages (from mcp<2.0.0,>=1.23.0->claude-agent-sdk==0.2.110->osprey-framework==2026.6.2.post1137+g125523326) (0.4.3)
+#16 1.164 Requirement already satisfied: pyjwt>=2.10.1 in /usr/local/lib/python3.12/site-packages (from pyjwt[crypto]>=2.10.1->mcp<2.0.0,>=1.23.0->claude-agent-sdk==0.2.110->osprey-framework==2026.6.2.post1137+g125523326) (2.13.0)
+#16 1.164 Requirement already satisfied: sse-starlette>=1.6.1 in /usr/local/lib/python3.12/site-packages (from mcp<2.0.0,>=1.23.0->claude-agent-sdk==0.2.110->osprey-framework==2026.6.2.post1137+g125523326) (3.4.8)
+#16 1.178 Requirement already satisfied: llvmlite<0.50,>=0.49.0dev0 in /usr/local/lib/python3.12/site-packages (from numba>=0.59.0->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (0.49.0)
+#16 1.195 Requirement already satisfied: wcwidth>=0.1.4 in /usr/local/lib/python3.12/site-packages (from prompt_toolkit<4.0,>=2.0->questionary>=2.1.1->osprey-framework==2026.6.2.post1137+g125523326) (0.8.2)
+#16 1.205 Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.12/site-packages (from pydantic->lume-base==0.5.0->osprey-framework==2026.6.2.post1137+g125523326) (0.8.0)
+#16 1.206 Requirement already satisfied: pydantic-core==2.41.5 in /usr/local/lib/python3.12/site-packages (from pydantic->lume-base==0.5.0->osprey-framework==2026.6.2.post1137+g125523326) (2.41.5)
+#16 1.257 Requirement already satisfied: huggingface-hub<2.0,>=0.16.4 in /usr/local/lib/python3.12/site-packages (from tokenizers<1.0,>=0.21.0->litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (1.27.0)
+#16 1.301 Requirement already satisfied: soupsieve>=1.6.1 in /usr/local/lib/python3.12/site-packages (from beautifulsoup4->nbconvert>=7.0.0->osprey-framework==2026.6.2.post1137+g125523326) (2.9.2)
+#16 1.306 Requirement already satisfied: numexpr>=2.14.1 in /usr/local/lib/python3.12/site-packages (from blosc2->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (2.14.2)
+#16 1.311 Requirement already satisfied: ipykernel in /usr/local/lib/python3.12/site-packages (from bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (7.3.0)
+#16 1.311 Requirement already satisfied: jupyter-console in /usr/local/lib/python3.12/site-packages (from bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (6.6.3)
+#16 1.312 Requirement already satisfied: numpydoc in /usr/local/lib/python3.12/site-packages (from bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (1.10.0)
+#16 1.312 Requirement already satisfied: openpyxl in /usr/local/lib/python3.12/site-packages (from bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (3.1.5)
+#16 1.313 Requirement already satisfied: ophyd in /usr/local/lib/python3.12/site-packages (from bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (1.11.2)
+#16 1.314 Requirement already satisfied: redis[hiredis] in /usr/local/lib/python3.12/site-packages (from bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (8.1.0)
+#16 1.322 Requirement already satisfied: cloudpickle>=3.0.0 in /usr/local/lib/python3.12/site-packages (from dask[array]; extra == "client"->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (3.1.2)
+#16 1.323 Requirement already satisfied: partd>=1.4.0 in /usr/local/lib/python3.12/site-packages (from dask[array]; extra == "client"->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (1.4.2)
+#16 1.347 Requirement already satisfied: httplib2<1.0.0,>=0.19.0 in /usr/local/lib/python3.12/site-packages (from google-api-python-client->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (0.32.0)
+#16 1.348 Requirement already satisfied: google-auth-httplib2<1.0.0,>=0.2.0 in /usr/local/lib/python3.12/site-packages (from google-api-python-client->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (0.4.1)
+#16 1.349 Requirement already satisfied: uritemplate<5,>=3.0.1 in /usr/local/lib/python3.12/site-packages (from google-api-python-client->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (4.2.0)
+#16 1.360 Requirement already satisfied: jsonpointer>=1.9 in /usr/local/lib/python3.12/site-packages (from jsonpatch->tiled>=0.2.14->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (3.1.1)
+#16 1.393 Requirement already satisfied: compress-pickle[lz4] in /usr/local/lib/python3.12/site-packages (from pydantic-numpy->ophyd-async<1.0,>=0.16->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (2.1.0)
+#16 1.394 Requirement already satisfied: semver~=3.0.4 in /usr/local/lib/python3.12/site-packages (from pydantic-numpy->ophyd-async<1.0,>=0.16->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (3.0.4)
+#16 1.408 Requirement already satisfied: shellingham>=1.3.0 in /usr/local/lib/python3.12/site-packages (from typer->tiled>=0.2.14->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (1.5.4)
+#16 1.427 Requirement already satisfied: pycparser in /usr/local/lib/python3.12/site-packages (from cffi>=2.0.0->cryptography->authlib>=1.6.5->osprey-framework==2026.6.2.post1137+g125523326) (3.0)
+#16 1.436 Requirement already satisfied: rich-rst<3.0.0,>=1.3.1 in /usr/local/lib/python3.12/site-packages (from cyclopts>=4.0.0->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (2.1.0)
+#16 1.440 Requirement already satisfied: setuptools in /usr/local/lib/python3.12/site-packages (from epicscorelibs>=7.0.3.99.4.0->aioca>=2.0a4->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (83.0.0)
+#16 1.441 Requirement already satisfied: setuptools-dso>=2.11a2 in /usr/local/lib/python3.12/site-packages (from epicscorelibs>=7.0.3.99.4.0->aioca>=2.0a4->ophyd-async[ca]<1.0,>=0.16->osprey-framework==2026.6.2.post1137+g125523326) (2.12.3)
+#16 1.457 Requirement already satisfied: grpcio<2.0.0,>=1.41.0 in /usr/local/lib/python3.12/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.1->google-ai-generativelanguage==0.6.15->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (1.83.0)
+#16 1.458 Requirement already satisfied: grpcio-status<2.0.0,>=1.41.0 in /usr/local/lib/python3.12/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.1->google-ai-generativelanguage==0.6.15->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (1.71.2)
+#16 1.486 Requirement already satisfied: filelock>=3.10.0 in /usr/local/lib/python3.12/site-packages (from huggingface-hub<2.0,>=0.16.4->tokenizers<1.0,>=0.21.0->litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (3.32.3)
+#16 1.486 Requirement already satisfied: hf-xet<2.0.0,>=1.5.2 in /usr/local/lib/python3.12/site-packages (from huggingface-hub<2.0,>=0.16.4->tokenizers<1.0,>=0.21.0->litellm>=1.56.0->osprey-framework==2026.6.2.post1137+g125523326) (1.6.0)
+#16 1.497 Requirement already satisfied: parso<0.9.0,>=0.8.6 in /usr/local/lib/python3.12/site-packages (from jedi>=0.18.2->ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (0.8.7)
+#16 1.507 Requirement already satisfied: pathable<0.7.0,>=0.6.0 in /usr/local/lib/python3.12/site-packages (from jsonschema-path>=0.3.4->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (0.6.0)
+#16 1.537 Requirement already satisfied: locket in /usr/local/lib/python3.12/site-packages (from partd>=1.4.0->dask[array]; extra == "client"->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (1.0.0)
+#16 1.541 Requirement already satisfied: ptyprocess>=0.5 in /usr/local/lib/python3.12/site-packages (from pexpect>4.6->ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (0.7.0)
+#16 1.558 Requirement already satisfied: beartype>=0.20.0 in /usr/local/lib/python3.12/site-packages (from py-key-value-aio<0.5.0,>=0.4.4->py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (0.22.9)
+#16 1.563 Requirement already satisfied: aiofile>=3.5.0 in /usr/local/lib/python3.12/site-packages (from py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (3.12.3)
+#16 1.563 Requirement already satisfied: keyring>=25.6.0 in /usr/local/lib/python3.12/site-packages (from py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (25.7.0)
+#16 1.564 Requirement already satisfied: cachetools>=5.0.0 in /usr/local/lib/python3.12/site-packages (from py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (7.1.7)
+#16 1.574 Requirement already satisfied: pyasn1<0.7.0,>=0.6.1 in /usr/local/lib/python3.12/site-packages (from pyasn1-modules>=0.2.1->google-auth>=2.15.0->google-generativeai->osprey-framework==2026.6.2.post1137+g125523326) (0.6.4)
+#16 1.578 Requirement already satisfied: email-validator>=2.0.0 in /usr/local/lib/python3.12/site-packages (from pydantic[email]>=2.11.7->fastmcp-slim==3.4.7->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (2.3.0)
+#16 1.625 Requirement already satisfied: executing>=1.2.0 in /usr/local/lib/python3.12/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (2.2.1)
+#16 1.625 Requirement already satisfied: asttokens>=2.1.0 in /usr/local/lib/python3.12/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (3.0.2)
+#16 1.626 Requirement already satisfied: pure-eval in /usr/local/lib/python3.12/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets->osprey-framework==2026.6.2.post1137+g125523326) (0.2.3)
+#16 1.663 Requirement already satisfied: h2<5,>=3 in /usr/local/lib/python3.12/site-packages (from httpx[http2]->blosc2->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (4.4.1)
+#16 1.668 Requirement already satisfied: debugpy>=1.6.5 in /usr/local/lib/python3.12/site-packages (from ipykernel->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (1.8.21)
+#16 1.668 Requirement already satisfied: nest-asyncio2>=1.7.0 in /usr/local/lib/python3.12/site-packages (from ipykernel->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (1.7.2)
+#16 1.679 Requirement already satisfied: sphinx>=6 in /usr/local/lib/python3.12/site-packages (from numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (9.1.0)
+#16 1.684 Requirement already satisfied: et-xmlfile in /usr/local/lib/python3.12/site-packages (from openpyxl->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (2.0.0)
+#16 1.689 Requirement already satisfied: networkx>=2.0 in /usr/local/lib/python3.12/site-packages (from ophyd->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (3.6.1)
+#16 1.690 Requirement already satisfied: pint in /usr/local/lib/python3.12/site-packages (from ophyd->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (0.25.3)
+#16 1.696 Requirement already satisfied: hiredis>=3.2.0 in /usr/local/lib/python3.12/site-packages (from redis[hiredis]->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (3.4.1)
+#16 1.701 Requirement already satisfied: caio~=0.12.0 in /usr/local/lib/python3.12/site-packages (from aiofile>=3.5.0->py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (0.12.2)
+#16 1.730 Requirement already satisfied: dnspython>=2.0.0 in /usr/local/lib/python3.12/site-packages (from email-validator>=2.0.0->pydantic[email]>=2.11.7->fastmcp-slim==3.4.7->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (2.8.0)
+#16 1.750 Requirement already satisfied: hyperframe<7,>=6.1 in /usr/local/lib/python3.12/site-packages (from h2<5,>=3->httpx[http2]->blosc2->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (6.1.0)
+#16 1.751 Requirement already satisfied: hpack<5,>=4.2 in /usr/local/lib/python3.12/site-packages (from h2<5,>=3->httpx[http2]->blosc2->tiled[client]>=0.2.14->osprey-framework==2026.6.2.post1137+g125523326) (4.2.0)
+#16 1.764 Requirement already satisfied: SecretStorage>=3.2 in /usr/local/lib/python3.12/site-packages (from keyring>=25.6.0->py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (3.5.0)
+#16 1.765 Requirement already satisfied: jeepney>=0.4.2 in /usr/local/lib/python3.12/site-packages (from keyring>=25.6.0->py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (0.9.0)
+#16 1.765 Requirement already satisfied: jaraco.classes in /usr/local/lib/python3.12/site-packages (from keyring>=25.6.0->py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (3.4.0)
+#16 1.765 Requirement already satisfied: jaraco.functools in /usr/local/lib/python3.12/site-packages (from keyring>=25.6.0->py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (4.6.0)
+#16 1.765 Requirement already satisfied: jaraco.context in /usr/local/lib/python3.12/site-packages (from keyring>=25.6.0->py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (6.1.2)
+#16 1.805 Requirement already satisfied: sphinxcontrib-applehelp>=1.0.7 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (2.0.0)
+#16 1.805 Requirement already satisfied: sphinxcontrib-devhelp>=1.0.6 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (2.0.0)
+#16 1.806 Requirement already satisfied: sphinxcontrib-htmlhelp>=2.0.6 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (2.1.0)
+#16 1.806 Requirement already satisfied: sphinxcontrib-jsmath>=1.0.1 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (1.0.1)
+#16 1.806 Requirement already satisfied: sphinxcontrib-qthelp>=1.0.6 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (2.0.0)
+#16 1.806 Requirement already satisfied: sphinxcontrib-serializinghtml>=1.1.9 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (2.0.0)
+#16 1.807 Requirement already satisfied: docutils<0.23,>=0.21 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (0.22.4)
+#16 1.807 Requirement already satisfied: snowballstemmer>=2.2 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (3.1.1)
+#16 1.807 Requirement already satisfied: babel>=2.13 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (2.18.0)
+#16 1.808 Requirement already satisfied: alabaster>=0.7.14 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (1.0.0)
+#16 1.808 Requirement already satisfied: imagesize>=1.3 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (2.0.0)
+#16 1.808 Requirement already satisfied: roman-numerals>=1.0.0 in /usr/local/lib/python3.12/site-packages (from sphinx>=6->numpydoc->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (4.1.0)
+#16 1.826 Requirement already satisfied: flexcache>=0.3 in /usr/local/lib/python3.12/site-packages (from pint->ophyd->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (0.3)
+#16 1.826 Requirement already satisfied: flexparser>=0.4 in /usr/local/lib/python3.12/site-packages (from pint->ophyd->bluesky-queueserver->bluesky-queueserver-api==0.0.13->osprey-framework==2026.6.2.post1137+g125523326) (0.4)
+#16 1.934 Requirement already satisfied: more-itertools in /usr/local/lib/python3.12/site-packages (from jaraco.classes->keyring>=25.6.0->py-key-value-aio[filetree,keyring,memory]<0.5.0,>=0.4.4; extra == "client"->fastmcp-slim[client,server]==3.4.7->fastmcp>=3.4.4->osprey-framework==2026.6.2.post1137+g125523326) (11.1.0)
+#16 2.110 Installing collected packages: osprey-connectors, osprey-framework
+#16 2.192   Attempting uninstall: osprey-framework
+#16 2.197     Found existing installation: osprey-framework 2026.6.2
+#16 2.850     Uninstalling osprey-framework-2026.6.2:
+#16 4.915       Successfully uninstalled osprey-framework-2026.6.2
+#16 5.605 Successfully installed osprey-connectors-0.1.0 osprey-framework-2026.6.2.post1137+g125523326
+#16 5.605 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
+#16 5.828 
+#16 5.828 [notice] A new release of pip is available: 25.0.1 -> 26.2.1
+#16 5.828 [notice] To update, run: pip install --upgrade pip
+#16 6.098 Processing /tmp/ctx/osprey_connectors-0.1.0-py3-none-any.whl
+#16 6.101 Processing /tmp/ctx/osprey_framework-2026.6.2.post1137+g125523326-py3-none-any.whl
+#16 6.115 Installing collected packages: osprey-framework, osprey-connectors
+#16 6.115   Attempting uninstall: osprey-framework
+#16 6.117     Found existing installation: osprey-framework 2026.6.2.post1137+g125523326
+#16 6.147     Uninstalling osprey-framework-2026.6.2.post1137+g125523326:
+#16 6.154       Successfully uninstalled osprey-framework-2026.6.2.post1137+g125523326
+#16 6.795   Attempting uninstall: osprey-connectors
+#16 6.798     Found existing installation: osprey-connectors 0.1.0
+#16 6.800     Uninstalling osprey-connectors-0.1.0:
+#16 6.800       Successfully uninstalled osprey-connectors-0.1.0
+#16 6.858 Successfully installed osprey-connectors-0.1.0 osprey-framework-2026.6.2.post1137+g125523326
+#16 6.858 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
+#16 6.922 
+#16 6.922 [notice] A new release of pip is available: 25.0.1 -> 26.2.1
+#16 6.922 [notice] To update, run: pip install --upgrade pip
+#16 7.384 No broken requirements found.
+#16 DONE 7.5s
+
+#17 [ 9/13] RUN if [ "0" = "1" ]; then osprey vendor fetch; fi
+#17 DONE 0.1s
+
+#18 [10/13] COPY . /app/my-control-assistant/
+#18 DONE 0.1s
+
+#19 [11/13] RUN mkdir -p /app/my-control-assistant/var/agent_data/api_calls
+#19 DONE 0.1s
+
+#20 [12/13] RUN useradd --create-home --shell /bin/bash osprey  && chown -R osprey:osprey /app/my-control-assistant
+#20 DONE 0.4s
+
+#21 [13/13] WORKDIR /app/my-control-assistant
+#21 DONE 0.0s
+
+#22 exporting to image
+#22 exporting layers
+#22 exporting layers 0.7s done
+#22 exporting manifest sha256:cfc3f2bed2072504e939f95161c5e960419deaf14578410c9e2e05a5d89fe667 done
+#22 exporting config sha256:0eae22bb04fa050e8949ee88bf277e0bea5ce9c5f2d82b8bf83653afc7c1b6d4 done
+#22 exporting attestation manifest sha256:bbaf3e93c212445c603979d847c7887c32997167bfd9fbe7d3c0a314eb54dd39 done
+#22 exporting manifest list sha256:916a7101536fd922943ff943fbb15aeda8a0310711bc4aa08c306d4ab3f01019 done
+#22 naming to docker.io/library/my-control-assistant:local done
+#22 unpacking to docker.io/library/my-control-assistant:local
+#22 unpacking to docker.io/library/my-control-assistant:local 18.2s done
+#22 DONE 19.0s

--- a/tests/deployment/test_bluesky_token_mint.py
+++ b/tests/deployment/test_bluesky_token_mint.py
@@ -37,13 +37,17 @@ def captured_argv(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
 
-    def _fake_run(cmd, env=None, check=False, **kwargs):
+    def _fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
         # run_captured hangs its spool path off the result, so the stand-in has
         # to be an object, and it passes redirection kwargs this ignores.
         return subprocess.CompletedProcess(list(cmd), 0)
 
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    # Stubbed at `run_captured`, the one seam every deploy child goes through:
+    # a watched capture (the image builds pass `on_line=`) reads its child
+    # through a pipe instead of `subprocess.run`, so a `subprocess.run` stub
+    # would be walked straight past and this test would run a real build.
+    monkeypatch.setattr(container_lifecycle, "run_captured", _fake_run)
     return captured
 
 
@@ -159,8 +163,8 @@ def test_bluesky_alongside_dispatch_mints_both_independently(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
     monkeypatch.setattr(
-        container_lifecycle.subprocess,
-        "run",
+        container_lifecycle,
+        "run_captured",
         lambda cmd, **k: subprocess.CompletedProcess(list(cmd), 0),
     )
 

--- a/tests/deployment/test_build_progress.py
+++ b/tests/deployment/test_build_progress.py
@@ -1,0 +1,421 @@
+"""The BuildKit stream parser behind the live build table.
+
+Most of these tests replay a real captured build. The two fixtures were taken
+from actual runs and kept verbatim, because every shape that breaks a parser
+here — reused vertex numbers, repeated headers, out-of-order step indices,
+carriage-return progress captions — is one nobody would have thought to write
+by hand.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment.build_progress import BuildModel, BuildRow
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+#: A compose build of four service images in one parallel invocation.
+COLD_BUILD = FIXTURES / "buildkit_cold_build.log"
+
+#: A single-image build, whose headers carry no service name at all.
+PROJECT_IMAGE = FIXTURES / "buildkit_project_image.log"
+
+
+def replay(path: Path, model: BuildModel) -> list[dict[str, str | None]]:
+    """Feed a fixture through a model, recording the step each line left set.
+
+    The file is split on newlines only. Python's text mode would translate the
+    carriage returns inside ``dpkg`` and ``pip`` progress captions into
+    newlines, shredding one physical line into dozens and replaying a stream
+    that ``run_captured`` never delivers.
+    """
+    lines = path.read_bytes().decode().split("\n")
+    seen: list[dict[str, str | None]] = []
+    for tick, line in enumerate(lines):
+        model.feed(line, float(tick))
+        seen.append({row.service: row.step for row in model.snapshot()})
+    return seen
+
+
+def steps_per_service(seen: list[dict[str, str | None]]) -> dict[str, set[str]]:
+    """Every step value each service passed through during a replay.
+
+    The final snapshot only shows where a service ended up; a build's progress
+    is the sequence, so the assertions need the whole path.
+    """
+    steps: dict[str, set[str]] = {}
+    for snapshot in seen:
+        for service, step in snapshot.items():
+            if step is not None:
+                steps.setdefault(service, set()).add(step)
+    return steps
+
+
+def rows_by_service(model: BuildModel) -> dict[str, BuildRow]:
+    return {row.service: row for row in model.snapshot()}
+
+
+# ---------------------------------------------------------------------------
+# The compose path: four services in one stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cold_build() -> tuple[BuildModel, list[str], list[dict[str, str | None]]]:
+    finished: list[str] = []
+    model = BuildModel(on_finished_image=finished.append)
+    return model, finished, replay(COLD_BUILD, model)
+
+
+def test_a_parallel_build_gets_one_row_per_service(cold_build):
+    model, _, _ = cold_build
+
+    assert [row.service for row in model.snapshot()] == [
+        "virtual-accelerator",
+        "event-dispatcher",
+        "bluesky-bridge",
+        "bluesky-panels",
+    ]
+
+
+def test_build_infrastructure_never_becomes_a_service(cold_build):
+    """`[va internal]` and `[bluesky-panels auth]` name a real service and are
+    attributed to it — only the bare, nameless forms are infrastructure.
+
+    This stream has no bare forms at all, so the absence assertions here would
+    hold even with the filter removed. What it does prove is the other half:
+    that the filter is not over-eager, because the two-word forms survive as
+    steps on their services below. The filter itself is proved by the
+    single-image replay, which is where the bare forms actually occur.
+    """
+    model, _, _ = cold_build
+
+    services = {row.service for row in model.snapshot()}
+    assert "internal" not in services
+    assert "auth" not in services
+
+
+def test_every_service_image_is_reported_once(cold_build):
+    _, finished, _ = cold_build
+
+    assert finished == [
+        "my-control-assistant-va:local",
+        "my-control-assistant-dispatch:local",
+        "my-control-assistant-bluesky-bridge:local",
+        "my-control-assistant-bluesky-panels:local",
+    ]
+
+
+def test_each_image_lands_on_the_service_that_built_it(cold_build):
+    """The export vertices carry no step index and share their numbers with
+    earlier sub-graphs; attribution has to come from their headers."""
+    model, _, _ = cold_build
+
+    rows = rows_by_service(model)
+    assert rows["virtual-accelerator"].finished == "my-control-assistant-va:local"
+    assert rows["event-dispatcher"].finished == "my-control-assistant-dispatch:local"
+    assert rows["bluesky-bridge"].finished == "my-control-assistant-bluesky-bridge:local"
+    assert rows["bluesky-panels"].finished == "my-control-assistant-bluesky-panels:local"
+
+
+def test_each_service_walks_its_own_dockerfile_steps(cold_build):
+    """Step indices are read from the headers, never counted from arrival
+    order — they interleave across services and arrive out of sequence.
+
+    `bluesky-bridge` genuinely reports `1/8` for its FROM vertex and `2/7`
+    onwards for the rest: BuildKit shares that vertex with another service's
+    sub-graph and it keeps that Dockerfile's total. The row reports what the
+    stream said rather than repairing it.
+    """
+    _, _, seen = cold_build
+
+    steps = steps_per_service(seen)
+    assert steps["virtual-accelerator"] == {f"{n}/8" for n in range(1, 9)} | {
+        "internal",
+        "exporting",
+    }
+    assert steps["event-dispatcher"] == {f"{n}/8" for n in range(1, 9)} | {
+        "internal",
+        "exporting",
+    }
+    assert steps["bluesky-bridge"] == {"1/8"} | {f"{n}/7" for n in range(2, 8)} | {
+        "internal",
+        "exporting",
+    }
+    assert steps["bluesky-panels"] == {f"{n}/7" for n in range(1, 8)} | {
+        "auth",
+        "internal",
+        "exporting",
+    }
+
+
+def test_a_service_carries_a_caption_for_what_it_is_doing(cold_build):
+    """The caption is the whole point of the table: without it a long step is
+    indistinguishable from a hung one."""
+    _, _, seen = cold_build
+    model, _, _ = cold_build
+
+    rows = rows_by_service(model)
+    assert all(row.caption for row in rows.values())
+    assert rows["virtual-accelerator"].started_at < rows["bluesky-panels"].started_at
+
+
+# ---------------------------------------------------------------------------
+# The single-image path: headers with no service name
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_image() -> tuple[BuildModel, list[str], list[dict[str, str | None]]]:
+    finished: list[str] = []
+    model = BuildModel("my-control-assistant", on_finished_image=finished.append)
+    return model, finished, replay(PROJECT_IMAGE, model)
+
+
+def test_a_single_image_build_is_one_row_under_its_label(project_image):
+    """Its headers are `[ 1/13]`, `[internal]` and `[auth]` — none of them name
+    a service, so the label is the only thing that can name this row."""
+    model, _, _ = project_image
+
+    assert [row.service for row in model.snapshot()] == ["my-control-assistant"]
+
+
+def test_a_nameless_header_does_not_invent_a_service(project_image):
+    """`[auth]` and `[internal]` sit exactly where a service name sits here.
+    Taken at face value each would open a phantom row beside the real one."""
+    model, _, _ = project_image
+
+    services = {row.service for row in model.snapshot()}
+    assert "auth" not in services
+    assert "internal" not in services
+
+
+def test_the_single_image_reports_once_under_its_label(project_image):
+    model, finished, _ = project_image
+
+    assert finished == ["my-control-assistant:local"]
+    assert model.snapshot()[0].finished == "my-control-assistant:local"
+
+
+def test_nameless_step_indices_bind_to_the_label(project_image):
+    """The indices arrive out of order — `[ 2/13]` lands after `[ 5/13]` —
+    which is exactly why the row reads the header rather than counting."""
+    _, _, seen = project_image
+
+    steps = steps_per_service(seen)
+    assert steps["my-control-assistant"] == {f"{n}/13" for n in range(1, 14)} | {
+        "auth",
+        "internal",
+        "exporting",
+    }
+
+
+def test_a_bare_export_vertex_still_finds_its_row(project_image):
+    """This build's export vertex never carries a header at all — it is bare
+    `#22 exporting to image` — so it can only belong to the labelled row."""
+    model, _, _ = project_image
+
+    assert model.snapshot()[0].step == "exporting"
+
+
+# ---------------------------------------------------------------------------
+# Degrading on a stream that is not BuildKit's
+# ---------------------------------------------------------------------------
+
+
+def test_a_non_buildkit_stream_leaves_the_model_empty():
+    """A provider with its own progress format must not be half-parsed into a
+    misleading table; an empty model is the renderer's cue to stay out of the
+    way."""
+    finished: list[str] = []
+    model = BuildModel("proj", on_finished_image=finished.append)
+
+    for line in [
+        "STEP 1/13: FROM docker.io/library/python:3.12-slim",
+        "--> Using cache 4f3a1c0b9e77",
+        "STEP 2/13: RUN apt-get update && apt-get install -y curl",
+        "Successfully tagged localhost/proj:local",
+        "",
+    ]:
+        model.feed(line, 0.0)
+
+    assert model.snapshot() == []
+    assert finished == []
+
+
+def test_an_unrecognized_bracket_is_dropped_rather_than_guessed_at():
+    """Labelled, so this pins the bracket as unrecognized rather than merely
+    unbound: a nameless header would have opened the label's row here."""
+    model = BuildModel("proj")
+
+    model.feed("#1 [one two three] something", 0.0)
+    model.feed("#2 [] something", 1.0)
+
+    assert model.snapshot() == []
+
+
+def test_a_nameless_header_with_no_label_is_dropped():
+    """On the compose path every header names its service, so a nameless one
+    has nothing to bind to — inventing a row for it would be a fabrication."""
+    model = BuildModel()
+
+    model.feed("#1 [ 2/13] RUN true", 0.0)
+    model.feed("#1 DONE 0.1s", 1.0)
+
+    assert model.snapshot() == []
+
+
+# ---------------------------------------------------------------------------
+# Shapes the fixtures prove, pinned in isolation
+# ---------------------------------------------------------------------------
+
+
+def test_a_reused_vertex_number_follows_its_latest_header():
+    """`compose build` numbers each service's sub-graph independently, so the
+    same `#7` belongs to a different service later in the same stream. Keyed on
+    the number alone, captions cross silently between services."""
+    model = BuildModel()
+
+    model.feed("#7 [event-dispatcher 1/8] FROM python:3.12-slim", 0.0)
+    model.feed("#7 sha256:abc extracting", 1.0)
+    model.feed("#7 [bluesky-bridge 1/8] FROM python:3.11-slim", 2.0)
+    model.feed("#7 resolving python:3.11-slim", 3.0)
+
+    rows = rows_by_service(model)
+    assert rows["event-dispatcher"].caption == "sha256:abc extracting"
+    assert rows["bluesky-bridge"].caption == "resolving python:3.11-slim"
+
+
+def test_a_repeated_infrastructure_header_stays_on_the_labelled_row():
+    """The single-image build's bare `[internal]` headers occupy four distinct
+    vertices but appear five times — one of them re-emits its header after a
+    pause, interleaved with another vertex.
+
+    Both halves of that shape can leak. Filtering the name but still mapping
+    the vertex would send the continuation lines to a phantom row; counting
+    occurrences rather than vertices would make the repeat look like a fifth
+    vertex. Neither is visible from the final row unless the interleave is
+    replayed, which is what this does.
+    """
+    model = BuildModel("proj")
+
+    model.feed("#5 [internal] load metadata for docker.io/library/python:3.12-slim", 0.0)
+    model.feed("#5 ...", 1.0)
+    model.feed("#6 [auth] library/python:pull token for registry-1.docker.io", 2.0)
+    model.feed("#6 DONE 0.0s", 3.0)
+    model.feed("#5 [internal] load metadata for docker.io/library/python:3.12-slim", 4.0)
+    model.feed("#5 DONE 0.6s", 5.0)
+
+    rows = model.snapshot()
+    assert [row.service for row in rows] == ["proj"]
+    assert rows[0].caption == "DONE 0.6s"
+    assert rows[0].started_at == 0.0
+
+
+def test_a_redrawn_progress_caption_keeps_only_its_last_frame():
+    """`dpkg` redraws one line in place, so a single captured line holds a
+    dozen overwrites; only the last was ever on screen."""
+    model = BuildModel()
+
+    model.feed("#17 [va 6/8] RUN apt-get install", 0.0)
+    model.feed("#17 8.494 (Reading database ... \r(Reading database ... 45%\r", 1.0)
+
+    assert model.snapshot()[0].caption == "(Reading database ... 45%"
+
+
+def test_a_resumed_vertex_repeats_its_header_without_restarting_the_row():
+    model = BuildModel()
+
+    model.feed("#20 [va 6/8] RUN pip install", 0.0)
+    model.feed("#20 [va 6/8] RUN pip install", 5.0)
+
+    row = model.snapshot()[0]
+    assert row.started_at == 0.0
+    assert row.last_line_at == 5.0
+
+
+def test_a_snapshot_does_not_change_underneath_its_reader():
+    """The renderer's monitor thread snapshots while the main thread feeds."""
+    model = BuildModel()
+    model.feed("#20 [va 6/8] RUN pip install", 0.0)
+    before = model.snapshot()
+
+    model.feed("#20 [va 7/8] COPY . /app", 1.0)
+
+    assert before[0].step == "6/8"
+    assert model.snapshot()[0].step == "7/8"
+
+
+# ---------------------------------------------------------------------------
+# Finished-image reporting
+# ---------------------------------------------------------------------------
+#
+# The callback is what container_lifecycle's step reporter is built on, and the
+# fixtures cannot prove it: all four of the cold build's `naming to` lines
+# arrive already `done`-suffixed and unrepeated. These pin the same behaviour
+# the reporter's own tests pin, at the level the model owns it.
+
+
+def test_each_finished_image_is_reported_once():
+    finished: list[str] = []
+    model = BuildModel(on_finished_image=finished.append)
+
+    for line in [
+        "#12 [va internal] load build context",
+        "#37 naming to docker.io/library/proj-va:local",
+        "#37 naming to docker.io/library/proj-va:local 0.1s done",
+        "#41 naming to docker.io/library/proj-dispatch:local done",
+    ]:
+        model.feed(line, 0.0)
+
+    assert finished == ["proj-va:local", "proj-dispatch:local"]
+
+
+def test_an_image_named_twice_reports_once():
+    """BuildKit repeats the `naming to` line (bare, then with a duration); an
+    image must not appear to build twice."""
+    finished: list[str] = []
+    model = BuildModel(on_finished_image=finished.append)
+
+    model.feed("#37 naming to docker.io/library/proj-va:local done", 0.0)
+    model.feed("#37 naming to docker.io/library/proj-va:local 0.0s done", 1.0)
+
+    assert finished == ["proj-va:local"]
+
+
+def test_registry_qualified_tags_keep_their_registry():
+    """Only the implicit docker.io/library/ prefix is noise; a real registry in
+    the tag is the operator's own naming and stays."""
+    finished: list[str] = []
+    model = BuildModel(on_finished_image=finished.append)
+
+    model.feed("#9 naming to ghcr.io/lab/proj-svc:2026.6 done", 0.0)
+
+    assert finished == ["ghcr.io/lab/proj-svc:2026.6"]
+
+
+def test_unfinished_naming_lines_report_nothing():
+    """The bare `naming to` line appears while the export is still running; a
+    step for it would announce an image that may yet fail."""
+    finished: list[str] = []
+    model = BuildModel(on_finished_image=finished.append)
+
+    model.feed("#37 naming to docker.io/library/proj-va:local", 0.0)
+    model.feed("#37 DONE 0.2s", 1.0)
+
+    assert finished == []
+
+
+def test_an_unattributable_image_is_still_reported():
+    """A finished image is a fact about the build, not about one row: the step
+    line must not go missing because the vertex was too anonymous to place."""
+    finished: list[str] = []
+    model = BuildModel(on_finished_image=finished.append)
+
+    model.feed("#37 naming to docker.io/library/proj-va:local done", 0.0)
+
+    assert finished == ["proj-va:local"]
+    assert model.snapshot() == []

--- a/tests/deployment/test_clean_path_capture.py
+++ b/tests/deployment/test_clean_path_capture.py
@@ -18,7 +18,7 @@ import logging
 
 import pytest
 
-from osprey.cli.phase_reporter import install_reporter
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
 from osprey.deployment import compose_generator
 
 
@@ -32,9 +32,20 @@ class _RecordingPhase:
         self.steps.append(name)
 
 
-class _RecordingReporter:
+class _RecordingReporter(PhaseReporter):
+    """A reporter whose only job is to hand ``clean_deployment`` an open phase.
+
+    Subclasses the real reporter rather than duck-typing it, and must keep doing
+    so: the reporter's terminal-ownership hooks (``stop_rendering`` today, and
+    the no-ops the deploy call sites invoke unconditionally) are defined on the
+    base class, so a standalone fake breaks on each one as it arrives.
+
+    ``current_phase`` is a read-only property on the base, hence ``_phase``.
+    """
+
     def __init__(self, phase):
-        self.current_phase = phase
+        super().__init__(color=False)
+        self._phase = phase
 
 
 @pytest.fixture(autouse=True)

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -1625,6 +1625,62 @@ def test_project_image_build_cmd_dev_adds_osprey_dev_build_arg():
 
 
 # ---------------------------------------------------------------------------
+# `--progress plain` on the project image build, docker only. The live build
+# view is parsed from BuildKit's plain stream; relying on `auto` degrading to
+# plain under the capture pipe would make that parse depend on undocumented
+# behaviour. Podman is excluded for the same reason `with_plain_progress`
+# excludes it: `podman build` has no such flag and would fail the deploy.
+# ---------------------------------------------------------------------------
+
+
+def test_project_image_build_cmd_pins_plain_progress_on_docker():
+    cmd = container_lifecycle._project_image_build_cmd(
+        {"project_name": "myfacility"}, "docker", "/proj"
+    )
+    assert cmd[cmd.index("--progress") + 1] == "plain"
+    assert cmd[-1] == "/proj"  # the flag lands ahead of the context, not after
+
+
+def test_project_image_build_cmd_omits_plain_progress_on_podman():
+    cmd = container_lifecycle._project_image_build_cmd(
+        {"project_name": "myfacility"}, "podman", "/proj"
+    )
+    assert "--progress" not in cmd
+    assert cmd[-1] == "/proj"
+
+
+# ---------------------------------------------------------------------------
+# The project image build is watched, labeled with its own tag. A single-image
+# build's BuildKit headers name no service (`#10 [ 2/13]`), so an unlabeled
+# model parses the whole build into nothing -- silently, with no error. The
+# assertion is therefore behavioural: feed the watcher a nameless header and
+# require the row to come back under the image tag.
+# ---------------------------------------------------------------------------
+
+
+def test_build_project_image_watches_the_build_under_its_image_tag(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(container_lifecycle, "get_runtime_command", lambda config: ["docker"])
+    calls = []
+    monkeypatch.setattr(
+        container_lifecycle,
+        "run_captured",
+        lambda cmd, **kwargs: calls.append(kwargs) or _FakeCompletedProcess(),
+    )
+    config = {"project_name": "myfacility", "deployed_services": ["dispatch_worker"]}
+
+    container_lifecycle._build_project_image(config, dev_mode=False, env={})
+
+    (kwargs,) = calls
+    watcher = kwargs["on_line"]
+    assert watcher is not None, "the project image build runs unwatched"
+    watcher("#10 [ 2/13] RUN pip install --no-cache-dir osprey-framework")
+    (row,) = watcher.model.snapshot()
+    assert row.service == "myfacility:local"
+    assert row.step == "2/13"
+
+
+# ---------------------------------------------------------------------------
 # _build_project_image -- OSPREY_DEV is keyed on ACTUAL wheel-staging success
 # (fail-closed). A --dev build whose wheel build/staging failed must NOT pass
 # the pin-relaxing OSPREY_DEV=1 arg: with an unreleased pin that arg would
@@ -1646,9 +1702,13 @@ def _project_image_dev_build_cmds(monkeypatch, tmp_path, staging_result):
         lambda project_root: staging_result,
     )
     calls = []
+    # Stubbed at `run_captured`, not at `subprocess.run`: the build is watched
+    # (`on_line=`), and a watched capture reads the child through a pipe rather
+    # than writing it straight to the spool — so a `subprocess.run` stub would
+    # be walked straight past and this test would launch a real `docker build`.
     monkeypatch.setattr(
-        container_lifecycle.subprocess,
-        "run",
+        container_lifecycle,
+        "run_captured",
         lambda cmd, **k: calls.append(cmd) or _FakeCompletedProcess(),
     )
     config = {"project_name": "myfacility", "deployed_services": ["dispatch_worker"]}
@@ -1683,7 +1743,7 @@ def test_build_project_image_dev_cleans_staged_wheel_and_manifest(monkeypatch, t
         container_lifecycle, "_copy_local_framework_for_override", _fake_wheel_and_manifest_stage
     )
     monkeypatch.setattr(
-        container_lifecycle.subprocess, "run", lambda cmd, **k: _FakeCompletedProcess()
+        container_lifecycle, "run_captured", lambda cmd, **k: _FakeCompletedProcess()
     )
     config = {"project_name": "myfacility", "deployed_services": ["dispatch_worker"]}
 
@@ -1705,7 +1765,7 @@ def test_build_project_image_dev_cleans_staged_artifacts_on_build_failure(monkey
     def _failing_build(cmd, **k):
         raise subprocess.CalledProcessError(1, cmd)
 
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", _failing_build)
+    monkeypatch.setattr(container_lifecycle, "run_captured", _failing_build)
     config = {"project_name": "myfacility", "deployed_services": ["dispatch_worker"]}
 
     with pytest.raises(subprocess.CalledProcessError):

--- a/tests/deployment/test_lifecycle_capture.py
+++ b/tests/deployment/test_lifecycle_capture.py
@@ -35,11 +35,15 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
+import time
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
+from osprey.cli import phase_reporter
 from osprey.cli.phase_reporter import PhaseReporter, install_reporter
 from osprey.deployment import container_lifecycle
 from osprey.simulation import archiver_seed as seed_mod
@@ -64,6 +68,18 @@ class RecordingReporter(PhaseReporter):
         return [
             _DURATION.sub("", line.strip()[2:]) for line in self.lines if line.startswith("  ·")
         ]
+
+
+@pytest.fixture(autouse=True)
+def parked_monitor(monkeypatch):
+    """Park the monitor's tick, so no thread of it lands mid-test.
+
+    Registering a build starts a real thread on the real clock, while these
+    tests drive builds from synthetic timestamps. One tick arriving mid-test
+    emits heartbeats measured against boot time and silences every assertion
+    after it -- an ordering-dependent flake with no visible cause.
+    """
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 3600.0)
 
 
 @pytest.fixture
@@ -188,7 +204,7 @@ def test_the_image_step_is_reported_after_the_build(reporter, image_build_stubs,
     charged to whatever step came next.
     """
 
-    def _marking(cmd, *, env=None, spool_name, repo_root=None, check=True):
+    def _marking(cmd, *, env=None, spool_name, repo_root=None, check=True, on_line=None):
         reporter.lines.append("<<ran>>")
         return subprocess.CompletedProcess(list(cmd), 0)
 
@@ -390,12 +406,12 @@ def start_stack_stubs(monkeypatch):
     )
 
 
-def _start(repo: Path, *, dev_mode: bool = False) -> None:
+def _start(repo: Path, *, dev_mode: bool = False, detached: bool = True) -> None:
     container_lifecycle._start_stack(
         {"project_name": "proj", "deployed_services": ["postgresql"]},
         ["build/services/docker-compose.0.yml"],
         repo,
-        detached=True,
+        detached=detached,
         dev_mode=dev_mode,
         env_path=repo / ".env",
     )
@@ -507,6 +523,67 @@ def test_unfinished_naming_lines_report_nothing(reporter):
     assert reporter.steps == []
 
 
+@contextmanager
+def _watch_spy(reporter, watched):
+    """Record every model registered for watching, then register it for real."""
+    real = reporter.watch_build
+
+    @contextmanager
+    def spy(model):
+        watched.append(model)
+        with real(model) as watched_model:
+            yield watched_model
+
+    previous, reporter.watch_build = reporter.watch_build, spy
+    try:
+        yield
+    finally:
+        reporter.watch_build = previous
+
+
+def test_the_watcher_and_the_step_lines_share_one_model(reporter):
+    """One stream, one parse. The live view and the step lines are two readings
+    of the SAME model — a second parser over the same output would double every
+    line's cost and could drift from what the operator was just told."""
+    watched: list = []
+    report = container_lifecycle.compose_build_step_reporter()
+
+    with _watch_spy(reporter, watched), report:
+        report("#7 [va 1/8] RUN pip install torch")
+        report("#37 naming to docker.io/library/proj-va:local done")
+
+    assert watched == [report.model]
+    assert [row.service for row in report.model.snapshot()] == ["va"]
+    assert reporter.steps == ["service image proj-va:local"]
+
+
+def test_a_failed_build_stops_being_watched(reporter):
+    """The watch is scoped to the run, and a build that raised is over: a live
+    row still heartbeating after the failure line would claim work is ongoing."""
+    report = container_lifecycle.compose_build_step_reporter()
+
+    with pytest.raises(RuntimeError):
+        with report:
+            report("#7 [va 1/8] RUN pip install torch")
+            raise RuntimeError("compose build failed")
+
+    # An hour later — long past any heartbeat interval — nothing is due.
+    assert reporter._heartbeat_pass(time.monotonic() + 3600) == []
+
+
+def test_the_dev_build_watches_the_model_it_feeds(
+    captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path
+):
+    """The wiring the site must get right: the model registered for the live
+    view is the very object handed to ``run_captured`` as ``on_line``."""
+    watched: list = []
+
+    with _watch_spy(reporter, watched):
+        _start(_repo(tmp_path), dev_mode=True)
+
+    assert watched == [captured.call("compose-build")["on_line"].model]
+
+
 def test_the_dev_build_streams_per_image_progress(
     captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path
 ):
@@ -548,3 +625,84 @@ def test_steps_are_silent_without_an_open_phase(captured, start_stack_stubs, tmp
     _start(_repo(tmp_path), dev_mode=True)
 
     assert captured.spool_names == ["compose-rm", "compose-build", "compose-up"]
+
+
+# ---------------------------------------------------------------------------
+# Handing the terminal to compose
+# ---------------------------------------------------------------------------
+
+
+def _exec_spy(reporter, monkeypatch):
+    """One mock recording the hand-off and the exec in the order they happen.
+
+    Attached to a single manager rather than spied separately: the bug this
+    guards against is the two happening in the WRONG order, which every
+    "both were called" assertion passes cleanly. ``wraps`` keeps the real
+    hand-off running, so the reporter is genuinely quiesced by the time the
+    exec is recorded.
+    """
+    manager = mock.Mock()
+    manager.attach_mock(mock.Mock(wraps=reporter.hand_off), "hand_off")
+    manager.attach_mock(mock.Mock(), "execvpe")
+    monkeypatch.setattr(reporter, "hand_off", manager.hand_off)
+    monkeypatch.setattr(container_lifecycle.os, "execvpe", manager.execvpe)
+    # execvp too: an exec that lost its env would otherwise replace the test
+    # process instead of failing an assertion.
+    monkeypatch.setattr(
+        container_lifecycle.os,
+        "execvp",
+        lambda *a: pytest.fail("the attached start must exec WITH its env"),
+    )
+    return manager
+
+
+def test_the_attached_start_hands_the_terminal_over_before_it_execs(
+    captured, reporter, start_stack_stubs, monkeypatch, tmp_path
+):
+    """``os.execvpe`` replaces this process with compose.
+
+    A live region still mounted at that moment leaves the cursor hidden and
+    its last frame half-drawn under compose's own output, in a process that no
+    longer exists to take it down. So the hand-off has to land BEFORE the exec
+    -- reversed, it is dead code that never runs at all.
+    """
+    manager = _exec_spy(reporter, monkeypatch)
+
+    _start(_repo(tmp_path), detached=False)
+
+    assert [name for name, _, _ in manager.mock_calls] == ["hand_off", "execvpe"]
+    assert "up" in manager.execvpe.call_args.args[1]
+
+
+def test_the_attached_start_hands_off_inside_its_open_phase(
+    captured, reporter, start_stack_stubs, monkeypatch, tmp_path
+):
+    """The hand-off commits the open phase, and closes nothing.
+
+    Committing is what leaves the operator a permanent reading of the phase
+    that never gets its own closing line. It only has something to commit
+    while the phase is open -- and it deliberately leaves it open, so an
+    ``execvpe`` that raises (a missing compose binary) still gets its ``✗``.
+    """
+    _exec_spy(reporter, monkeypatch)
+
+    _start(_repo(tmp_path), detached=False)
+
+    assert reporter._phase is not None, "the hand-off closed the phase it committed"
+
+
+def test_the_detached_start_hands_nothing_over(
+    captured, reporter, start_stack_stubs, monkeypatch, tmp_path
+):
+    """``-d`` returns to a process that keeps the terminal.
+
+    The hand-off degrades the reporter to plain lines permanently, so making
+    it unconditional here would silence the phases and the summary card of
+    every detached deploy.
+    """
+    handed_off = mock.Mock(wraps=reporter.hand_off)
+    monkeypatch.setattr(reporter, "hand_off", handed_off)
+
+    _start(_repo(tmp_path))
+
+    handed_off.assert_not_called()

--- a/tests/deployment/test_service_token_unconditional_mint.py
+++ b/tests/deployment/test_service_token_unconditional_mint.py
@@ -52,13 +52,17 @@ def captured_argv(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
 
-    def _fake_run(cmd, env=None, check=False, **kwargs):
+    def _fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
         # run_captured hangs its spool path off the result, so the stand-in has
         # to be an object, and it passes redirection kwargs this ignores.
         return subprocess.CompletedProcess(list(cmd), 0)
 
-    monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    # Stubbed at `run_captured`, the one seam every deploy child goes through:
+    # a watched capture (the image builds pass `on_line=`) reads its child
+    # through a pipe instead of `subprocess.run`, so a `subprocess.run` stub
+    # would be walked straight past and this test would run a real build.
+    monkeypatch.setattr(container_lifecycle, "run_captured", _fake_run)
     return captured
 
 

--- a/tests/deployment/test_web_terminals_capture.py
+++ b/tests/deployment/test_web_terminals_capture.py
@@ -218,6 +218,41 @@ def test_default_view_hides_buildkit_lines_but_the_spool_keeps_them(
         assert line in spooled
 
 
+def test_persona_build_is_watched_under_its_own_image_tag(monkeypatch, tmp_path, reporter):
+    """A single-image build's BuildKit headers name no service (`#10 [ 2/13]`),
+    so the watcher carries the image tag as its label. Without it the whole
+    build parses into nothing — silently, with no error — so the assertion is
+    behavioural: a nameless header must come back attributed to the tag."""
+    _stub_persona_builds(monkeypatch, tmp_path, [_unit("demo", "ops", tmp_path)])
+    recorder = RunRecorder()
+    monkeypatch.setattr(persona_images, "run_captured", recorder)
+
+    persona_images.build_persona_images(_persona_config(), [], False, {})
+
+    watcher = recorder.by_spool("build-persona-demo-ops")["on_line"]
+    assert watcher is not None, "the persona build runs unwatched"
+    watcher("#10 [ 2/13] RUN pip install --no-cache-dir osprey-framework")
+    (row,) = watcher.model.snapshot()
+    assert row.service == "demo-ops:local"
+    assert row.step == "2/13"
+
+
+def test_persona_image_build_cmd_pins_plain_progress_on_docker(tmp_path):
+    """The live view is parsed from BuildKit's plain stream, so plain is pinned
+    rather than left to `auto` degrading under the capture pipe."""
+    cmd = persona_images._persona_image_build_cmd("docker", str(tmp_path), "demo", "ops", "demo")
+    assert cmd[cmd.index("--progress") + 1] == "plain"
+    assert cmd[-1] == str(tmp_path)  # the flag lands ahead of the context
+
+
+def test_persona_image_build_cmd_omits_plain_progress_on_podman(tmp_path):
+    """`podman build` has no `--progress` — the same caveat `with_plain_progress`
+    carries for compose. An unknown flag there would fail the deploy outright."""
+    cmd = persona_images._persona_image_build_cmd("podman", str(tmp_path), "demo", "ops", "demo")
+    assert "--progress" not in cmd
+    assert cmd[-1] == str(tmp_path)
+
+
 # --------------------------------------------------------------------------
 # provision.build_auth_sidecar_image
 # --------------------------------------------------------------------------
@@ -251,6 +286,54 @@ def test_auth_sidecar_build_is_captured_and_reported(monkeypatch, tmp_path, repo
     assert call["repo_root"] == tmp_path
     assert call["check"] is True
     assert reporter.steps == [f"auth sidecar image {provision.auth_sidecar_local_tag(config)}"]
+
+
+def _sidecar_build(monkeypatch, tmp_path, runtime: str) -> tuple[RunRecorder, dict]:
+    """Run the sidecar build against `runtime`; return the recorder and config."""
+    monkeypatch.chdir(tmp_path)
+    context = tmp_path / "build" / "auth"
+    context.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config: [runtime])
+    monkeypatch.setattr(
+        provision, "_materialize_auth_build_context", lambda repo_root, dev_mode: context
+    )
+    recorder = RunRecorder()
+    monkeypatch.setattr(provision, "run_captured", recorder)
+    config = {
+        "project_name": "demo",
+        "modules": {"web_terminals": {"image_source": "local", "auth": {"method": "password"}}},
+    }
+    provision.build_auth_sidecar_image(config, False, {})
+    return recorder, config
+
+
+def test_auth_sidecar_build_is_watched_under_its_own_image_tag(monkeypatch, tmp_path, reporter):
+    """Same single-image trap as the persona build: the sidecar's BuildKit
+    headers name no service, so an unlabeled watcher would parse the whole
+    build into nothing without ever erroring."""
+    recorder, config = _sidecar_build(monkeypatch, tmp_path, "docker")
+
+    watcher = recorder.by_spool("build-auth-sidecar")["on_line"]
+    assert watcher is not None, "the auth sidecar build runs unwatched"
+    watcher("#10 [ 2/13] RUN apk add --no-cache nginx")
+    (row,) = watcher.model.snapshot()
+    assert row.service == provision.auth_sidecar_local_tag(config)
+    assert row.step == "2/13"
+
+
+def test_auth_sidecar_build_pins_plain_progress_on_docker(monkeypatch, tmp_path, reporter):
+    recorder, _ = _sidecar_build(monkeypatch, tmp_path, "docker")
+
+    cmd = recorder.by_spool("build-auth-sidecar")["cmd"]
+    assert cmd[cmd.index("--progress") + 1] == "plain"
+    assert cmd[-1].endswith("auth")  # the flag lands ahead of the context
+
+
+def test_auth_sidecar_build_omits_plain_progress_on_podman(monkeypatch, tmp_path, reporter):
+    """`podman build` has no `--progress`; passing it would fail the deploy."""
+    recorder, _ = _sidecar_build(monkeypatch, tmp_path, "podman")
+
+    assert "--progress" not in recorder.by_spool("build-auth-sidecar")["cmd"]
 
 
 # --------------------------------------------------------------------------

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -610,7 +610,11 @@ def _capture_build(monkeypatch):
         recorded.append(list(cmd))
         return _FakeCompletedProcess()
 
-    monkeypatch.setattr(provision.subprocess, "run", _fake_run)
+    # Stubbed at `run_captured`, not at `subprocess.run`: the sidecar build is
+    # watched (`on_line=`), and a watched capture reads its child through a pipe
+    # rather than writing it straight to the spool — so a `subprocess.run` stub
+    # would be walked straight past and this test would run a real build.
+    monkeypatch.setattr(provision, "run_captured", _fake_run)
     monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["podman", "compose"])
     return recorded
 


### PR DESCRIPTION
The lifecycle verbs report progress as plain sequential lines. A long step
prints nothing until it finishes, and a cold dev-mode `compose build` runs
about seventeen minutes near-silent, which reads as a hang and gets killed.
The BuildKit progress stream already carries a live caption and a per-node
elapsed for every concurrent service, and all of it was discarded into the
spool file.

Parse that stream into one row per service, and drive the phase from a monitor
tick rather than from output arrival. On a terminal a Rich live region repaints
a spinner, an elapsed, and a row per service still building. Off a terminal
there is nothing to repaint, so each service still building appends a line
about every thirty seconds. The scrollback record is identical either way,
which is what keeps a piped log readable as the same thing an operator saw.

Two choices worth disagreeing with:

Heartbeat staleness is measured from the last heartbeat, not the last line of
build output. Off a terminal that output goes to a spool rather than to the
operator, so a chatty step looks busy to the code and silent to the person
watching. Gating on output would quiet the longest builds first, which is
exactly where the silence hurts.

No percent bars, no estimated finish times, and no persisted build durations.
Builds are rare enough that duration history cannot be assumed, so a timings
store would be guessing at the numbers it displayed.

On coverage, so a reviewer can weigh it: what the suite proves is the
configuration that produces the live behaviour, not the wall-clock behaviour
itself. The monitor interval, the heartbeat interval, the monitor being the
sole refresher, and the TTY monitor repainting rather than emitting lines are
each asserted. Perceived liveness over a real seventeen-minute build is only
observable by hand.

The two BuildKit captures under `tests/deployment/fixtures/` are real builds
that succeeded, so neither carries an ERROR or CANCELED vertex and the failure
path has no fixture behind it.

## How it hangs together

```text
              container build subprocess (compose / project / persona / sidecar)
                                     |
                        BuildKit plain-progress lines
                                     |
                                     v
                   run_captured(..., on_line=report)  ---> spool file
                                     |
                                     v
                        BuildProgressReporter          (watcher, scoped to
                                     |                  the build via `with`)
                compose_build_step_reporter()  |  single_image_build_reporter(tag)
                                     |
                                     v
                                 BuildModel
                       one BuildRow per service:
                       step . caption . started . finished
                    (a row retires when its image is named)
                                     |
                                     v
                          monitor thread, sole refresher
                          ticks every _MONITOR_INTERVAL = 0.25s
                                     |
                    +----------------+----------------+
                    |                                 |
              stdout IS a tty                   stdout is NOT a tty
                    |                                 |
                    v                                 v
             LiveReporter                        PhaseReporter
                    |                                 |
          render_live_region()               heartbeat line per row,
        repaints in place, 0.25s             _HEARTBEAT_INTERVAL = 30s
                    |                        gated on last_beat, NOT
        spinner . elapsed . one row          on last line of output
        per service still building                    |
                    |                                 |
                    +----------------+----------------+
                                     |
                                     v
                       scrollback record, IDENTICAL in both:
                         -> phase title   (printed once)
                          . step lines
                         v phase title
```
