### PR TITLE
fix(templates): point argo at the serving API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -519,8 +519,12 @@ Compatibility is documented in release notes, not encoded in the version string.
   everyone's as down.
 
 - The `vllm`, `deepseek`, `ollama` and `argo` providers now ship a base URL that
-  can actually be reached, and `ARGO_BASE_URL` is declared where the credential
-  tooling can see it.
+  can actually be reached.
+
+- New projects reach Argo again. The scaffolded `config.yml` pointed at
+  `https://argo-bridge.cels.anl.gov`, which no longer serves; it now uses
+  `https://apps.inside.anl.gov/argoapi/v1` and reads `ARGO_BASE_URL`, so you can
+  redirect a deployed project at another gateway without editing the file.
 
 - Logbook watch results keep `entries_updated`, which was dropped between the
   service and the CLI, so an update reported as zero changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -526,6 +526,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   `https://apps.inside.anl.gov/argoapi/v1` and reads `ARGO_BASE_URL`, so you can
   redirect a deployed project at another gateway without editing the file.
 
+- The CLI reference described a `--project` option on `osprey web` that the
+  command does not have. It takes `--repo`.
+
 - Logbook watch results keep `entries_updated`, which was dropped between the
   service and the CLI, so an update reported as zero changes.
 

--- a/docs/source/cli-reference/index.rst
+++ b/docs/source/cli-reference/index.rst
@@ -656,7 +656,7 @@ Launch the Web Terminal interface. See :doc:`/how-to/web-terminal/operate`.
 
    ``--shell TEXT`` — Shell command to run (default: ``claude``).
 
-   ``--project DIRECTORY`` — Project directory (default: current directory).
+   ``--repo PATH`` — Deployment repo to act on (default: nearest ``profile.yml`` at or above cwd).
 
    ``--detach`` — Run in background (PID written to ``.osprey-web.pid``).
 

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -102,7 +102,7 @@ api:
         opus: gpt-oss:120b
     argo:
       api_key: ${ARGO_API_KEY}
-      base_url: https://argo-bridge.cels.anl.gov
+      base_url: ${ARGO_BASE_URL:-https://apps.inside.anl.gov/argoapi/v1}
       models:                        # Argo spells its model IDs without punctuation
         haiku: claudehaiku45
         sonnet: claudesonnet45

--- a/src/osprey/templates/apps/hello_world/config.yml.j2
+++ b/src/osprey/templates/apps/hello_world/config.yml.j2
@@ -83,7 +83,7 @@ api:
         opus: gpt-oss:120b
     argo:
       api_key: ${ARGO_API_KEY}
-      base_url: https://argo-bridge.cels.anl.gov
+      base_url: ${ARGO_BASE_URL:-https://apps.inside.anl.gov/argoapi/v1}
       models:                        # Argo spells its model IDs without punctuation
         haiku: claudehaiku45
         sonnet: claudesonnet45

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -506,7 +506,7 @@ api:
         opus: gpt-oss:120b
     argo:
       api_key: ${ARGO_API_KEY}
-      base_url: https://argo-bridge.cels.anl.gov
+      base_url: ${ARGO_BASE_URL:-https://apps.inside.anl.gov/argoapi/v1}
       models:                        # Argo spells its model IDs without punctuation
         haiku: claudehaiku45
         sonnet: claudesonnet45

--- a/tests/cli/test_base_url_override.py
+++ b/tests/cli/test_base_url_override.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pytest
 
 from osprey.build.claude_code_resolver import CLAUDE_CODE_PROVIDERS, ClaudeCodeModelResolver
+from osprey.models.provider_registry import get_provider_registry
 
 FACILITY_GATEWAY = "https://llm.facility.example.org"
 
@@ -197,6 +198,39 @@ class TestEnvVarBreakGlassOverride:
             environ={"ALS_APG_BASE_URL": f"{FACILITY_GATEWAY}/v1"},
         )
         assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://api.cborg.lbl.gov"
+
+
+class TestEnvVarParityWithProviderAdapters:
+    """Both provider tables must name the same override var for a provider.
+
+    ``CLAUDE_CODE_PROVIDERS`` (the Claude Code launch path) and the provider
+    adapter classes (the LiteLLM path) are separate tables on purpose: they
+    resolve the URL by deliberately different rules, since :meth:`resolve`
+    refuses to read ``os.environ`` — see
+    :class:`TestResolveNeverReadsAmbientEnviron` — while
+    :meth:`BaseProvider.effective_base_url` must. What they cannot disagree on
+    is the *name* of the variable an operator exports. A drift there gives the
+    documented break-glass lever a silent half-life: it redirects one path and
+    not the other, which reads as "the override didn't work" with nothing in
+    any log to say why.
+
+    Deriving one table from the other would force :mod:`osprey.build` to import
+    the adapter classes, defeating the registry's lazy loading (the point of
+    which is to keep air-gapped machines from triggering import side effects).
+    The duplication is therefore deliberate, and a guard is the honest way to
+    hold it together.
+    """
+
+    def test_every_claude_code_provider_has_an_adapter(self):
+        """Non-vacuity guard: the parametrized case below asserts nothing without this."""
+        registry = get_provider_registry()
+        missing = [name for name in CLAUDE_CODE_PROVIDERS if registry.get_provider(name) is None]
+        assert not missing, f"no provider adapter resolves for: {missing}"
+
+    @pytest.mark.parametrize("provider", sorted(CLAUDE_CODE_PROVIDERS))
+    def test_tables_agree_on_the_override_var(self, provider):
+        adapter = get_provider_registry().get_provider(provider)
+        assert CLAUDE_CODE_PROVIDERS[provider].get("base_url_env_var") == adapter.base_url_env_var
 
 
 class TestResolveNeverReadsAmbientEnviron:


### PR DESCRIPTION
A project scaffolded from any of the three config templates configured Argo with a gateway host that no longer answers. Selecting `argo` in a new project therefore produced a provider that could not reach a model, with nothing in the config to suggest the endpoint was the thing at fault.

The templates now name the Argo API endpoint, and read `ARGO_BASE_URL` ahead of it. The adapter has always honoured that variable — on both the litellm and the httpx request path — so this mints no new environment variable; what was missing was any sign of it where an operator actually looks. Declaring it in the template puts the lever next to the value it overrides, the same way the `als-apg` block already does, and lets a deployment whose config is baked into an image be redirected without a rebuild.

Two smaller corrections ride along.

- The CLI reference documented a `--project` option on `osprey web`. The command takes `--repo`, and the stated default was wrong as well: it is the nearest `profile.yml` at or above the working directory, not the current directory. A reader following the page hit a usage error.

- A guard asserts that the Claude Code provider table and the provider adapters name the same override variable. The two deliberately resolve a base URL by different rules — the adapter reads `os.environ`, the resolver refuses to, because it also renders `settings.json` at build time where an ambient read would bake the builder's gateway into the artifact — so collapsing them into one table is not available. A disagreement over the variable's *name*, though, would leave the documented override working on one path and silently ignored on the other, which is the failure the guard exists to catch. It is paired with a non-vacuity assertion, since the parametrized comparison would otherwise pass while asserting nothing if a provider stopped resolving to an adapter.

One CHANGELOG entry under `[Unreleased]` is corrected rather than added to: it claimed `ARGO_BASE_URL` was declared where the credential tooling could see it. It was not, and that tooling is the wrong home for it — the credential report covers API keys and prints a missing one as "the agent cannot reach the model", whereas for a break-glass redirect, unset is the normal and healthy state.
