### PR TITLE
ci: install workspace deps from the built dist

### DIFF
--- a/.github/workflows/validate-install-docs.yml
+++ b/.github/workflows/validate-install-docs.yml
@@ -1,8 +1,13 @@
 name: Validate Install Docs
 
-# Builds a wheel from the current SHA, installs it via `uv tool`, and runs
-# the bash blocks extracted from installation.rst and osprey-build-interview.rst.
+# Builds every workspace package from the current SHA, installs osprey via
+# `uv tool` against those wheels, and runs the bash blocks extracted from
+# installation.rst and osprey-build-interview.rst.
 # This catches doc-vs-wheel drift before it reaches a release tag.
+#
+# `uv tool install` runs outside the uv workspace, so `[tool.uv.sources]` does
+# not apply and workspace siblings would otherwise be pulled from PyPI rather
+# than from the commit under test. `--find-links dist` keeps them local.
 
 on:
   pull_request:
@@ -28,11 +33,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Build wheel from current SHA
-        run: uv build
+      - name: Build wheels from current SHA
+        run: uv build --all-packages
 
-      - name: Install osprey from built wheel (NOT PyPI)
-        run: uv tool install ./dist/osprey_framework-*.whl
+      - name: Install osprey from built wheels (NOT PyPI)
+        run: uv tool install --find-links dist ./dist/osprey_framework-*.whl
 
       - name: Verify osprey on PATH
         run: osprey --version


### PR DESCRIPTION
## Problem

The `Validate Install Docs` lane builds the top-level wheel and installs it with
`uv tool install`. That command runs **outside** the uv workspace, so the
`[tool.uv.sources]` entry mapping `osprey-connectors` to the workspace does not
apply — the dependency is resolved from PyPI instead of from the commit under test.

Two consequences:

1. The lane validates a branch's own code against whatever sibling version happens
   to be published, rather than the sibling in the same commit.
2. While a workspace sibling is unreleased, the lane cannot resolve at all.
   `osprey-connectors` has never been published, so the lane fails outright:

   ```
   Because osprey-connectors was not found in the package registry and
   osprey-framework==... depends on osprey-connectors>=0.1.0,<0.2.0,
   ... your requirements are unsatisfiable.
   ```

The lane is path-gated on six paths that exclude `pyproject.toml`, so this went
unnoticed until a change happened to touch one of the gated doc/skill paths.

## Change

Build every workspace package and resolve the install against the resulting `dist`:

```diff
-        run: uv build
+        run: uv build --all-packages

-        run: uv tool install ./dist/osprey_framework-*.whl
+        run: uv tool install --find-links dist ./dist/osprey_framework-*.whl
```

This preserves the lane's stated purpose — catching doc-vs-wheel drift before a
release tag — while making it test the wheels from the commit it is checking.

## Verification

Reproduced both halves locally in an isolated `UV_TOOL_DIR`:

| Command | Result |
| --- | --- |
| `uv tool install ./dist/osprey_framework-*.whl` | fails with the CI error above |
| `uv build --all-packages` + `uv tool install --find-links dist ...` | installs; `osprey --version` reports the built version |

## Note

This does not remove the need to publish `osprey-connectors`. A release cut from
`main` today would declare a dependency that cannot be resolved from PyPI, so the
package would be uninstallable for users. That is tracked separately.