### PR TITLE
fix(bluesky): sweep ORM correctors relative to working point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,6 +524,17 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The `orm` scan plan now kicks each corrector either side of where it found it
+  and puts it back there. It previously drove absolute currents either side of
+  zero and ended every corrector's sweep at 0 A, which is only correct on a
+  machine whose correctors idle at zero — on a ring holding a corrected orbit it
+  would have measured about a point the machine was not at and then dropped the
+  correction. `span_a` is now the size of the kick away from a corrector's
+  working point, and its 10 A ceiling is gone: what a corrector will take is the
+  deployment's own `channel_limits.json`, which is checked on every write. A
+  corrector whose read-back is not a number is refused before anything is
+  written to it.
+
 - The source-tree sweep behind the lifecycle criteria no longer fails when a
   file disappears while it is reading. It walks the live tree, so a temporary
   file another test had staged under `src/` could be listed and then deleted

--- a/src/osprey/services/bluesky_bridge/orm_analysis.py
+++ b/src/osprey/services/bluesky_bridge/orm_analysis.py
@@ -22,12 +22,14 @@ Four pieces:
 `build_response_matrix`'s fit depends on an invariant the real `orm` plan
 upholds (see `plans_core/orm.py`'s `build_plan` docstring): every emitted row carries
 EVERY corrector's current, not just the one being swept — a non-swept
-corrector simply reads back its idle (~0 A) value in that row. The fit still
+corrector simply reads back its idle value in that row. The fit still
 recovers the right slope only because each corrector's own sweep is
-symmetric about 0 and its idle reading is (numerically) exactly 0: together
-those put every idle sample at the fit's x-mean, so it carries zero leverage
-on the polyfit slope no matter what BPM reading that row actually carries
-(driven by whichever OTHER corrector was being swept at the time).
+symmetric about that same idle value: together those put every idle sample
+at the fit's x-mean, so it carries zero leverage on the polyfit slope no
+matter what BPM reading that row actually carries (driven by whichever OTHER
+corrector was being swept at the time). The idle value is NOT assumed to be
+zero — the plan sweeps each corrector about its own pre-scan working point,
+which on a ring running corrected orbit is nonzero, and restores it there.
 `build_response_matrix` checks this per corrector and raises
 `DegenerateFitError` if it's violated — see its docstring below.
 
@@ -69,12 +71,13 @@ def _match_value(row: Mapping[str, Any], device_name: str) -> Any | None:
     return None
 
 
-#: Tolerance for the zero-mean-sweep guard in `build_response_matrix`: a
-#: corrector's collected currents fail the check when their mean exceeds this
-#: fraction of their spread (max - min). Floating-point noise on an exactly
-#: symmetric sweep + exactly-zero idle readings sits around 1e-15 relative,
-#: so this leaves ~9 orders of magnitude of margin before a genuine
-#: asymmetric sweep or biased idle reading is required to trip it.
+#: Tolerance for the centred-sweep guard in `build_response_matrix`: a
+#: corrector's collected currents fail the check when their mean differs from
+#: their median by more than this fraction of their spread (max - min).
+#: Floating-point noise on an exactly symmetric sweep + exactly-equal idle
+#: readings sits around 1e-15 relative, so this leaves ~9 orders of magnitude
+#: of margin before a genuine off-centre sweep or biased idle reading is
+#: required to trip it.
 _SWEEP_SYMMETRY_TOL = 1e-6
 
 
@@ -93,17 +96,29 @@ def build_response_matrix(
     (current, BPM reading) sample; `numpy.polyfit` (degree 1) over those
     samples gives the response slope for each (BPM, corrector) pair.
 
-    This only recovers the correct slope because the real plan's sweep is
-    symmetric about 0 and idle correctors read back (numerically) exactly 0:
-    together those put the fit's x-mean at 0, so every idle-corrector sample
-    sits exactly at that mean and carries zero leverage on the fitted slope —
-    regardless of what BPM reading that row actually carries (driven by
-    whichever OTHER corrector was being swept at the time). Before fitting,
-    each corrector's collected currents are checked against that zero-mean
-    invariant (see `_SWEEP_SYMMETRY_TOL`); a sweep that isn't symmetric about
-    0, or an idle reading with a non-negligible bias, would silently corrupt
-    the slope, so a violation raises `DegenerateFitError` naming the
-    corrector instead of fitting garbage.
+    This only recovers the correct slope because the real plan sweeps each
+    corrector symmetrically about the very value that corrector reads back
+    while idle — its pre-scan working point. That puts the fit's x-mean
+    exactly at the idle value (the sweep's own offsets sum to zero), so every
+    idle-corrector sample sits exactly at that mean and carries zero leverage
+    on the fitted slope — regardless of what BPM reading that row actually
+    carries (driven by whichever OTHER corrector was being swept at the
+    time). Note the invariant is "centred on the idle value", not "centred on
+    zero": zero is simply where a machine with no orbit to correct happens to
+    idle, and a real ring's correctors do not.
+
+    Before fitting, each corrector's collected currents are checked against
+    that invariant (see `_SWEEP_SYMMETRY_TOL`) by comparing their mean to
+    their median. The median IS the idle value for any run this function is
+    meant to take: idle samples are `(n_correctors - 1) / n_correctors` of a
+    corrector's rows, so they are at least half of them whenever more than
+    one corrector was swept, and for a single corrector every sample is a
+    swept one and a symmetric sweep's median is its centre either way. A
+    sweep not centred on where the corrector idles — an off-centre sweep, a
+    one-sided (`monodirectional`) one, or an idle reading with a bias —
+    separates mean from median and would silently corrupt the slope, so it
+    raises `DegenerateFitError` naming the corrector instead of fitting
+    garbage.
 
     A row missing a given corrector's key entirely — not the real plan's
     shape, but a valid input for a caller building rows by hand (e.g. this
@@ -119,7 +134,8 @@ def build_response_matrix(
 
     Raises:
         DegenerateFitError: a corrector's collected currents are not
-            symmetric about 0 within `_SWEEP_SYMMETRY_TOL` — see above.
+            symmetric about that corrector's own idle value within
+            `_SWEEP_SYMMETRY_TOL` — see above.
     """
     matrix = np.zeros((len(detectors), len(correctors)))
 
@@ -139,16 +155,18 @@ def build_response_matrix(
             continue  # not enough points along this corrector to fit a slope
 
         mean_current = float(np.mean(currents))
+        idle_current = float(np.median(currents))
         spread = float(np.max(currents) - np.min(currents))
-        if spread > 0 and abs(mean_current) > _SWEEP_SYMMETRY_TOL * spread:
+        if spread > 0 and abs(mean_current - idle_current) > _SWEEP_SYMMETRY_TOL * spread:
             raise DegenerateFitError(
-                f"corrector {corrector!r}'s sweep is not symmetric about 0 "
-                f"(mean current {mean_current:.6g} over a spread of "
-                f"{spread:.6g}): build_response_matrix's polyfit depends on "
-                f"a zero-mean sweep so idle-corrector rows carry zero "
-                f"leverage on the fitted slope -- an asymmetric sweep or a "
-                f"nonzero idle reading would silently bias every slope for "
-                f"this corrector"
+                f"corrector {corrector!r}'s sweep is not symmetric about its "
+                f"idle value (mean current {mean_current:.6g} against an idle "
+                f"value of {idle_current:.6g}, over a spread of {spread:.6g}): "
+                f"build_response_matrix's polyfit depends on idle-corrector "
+                f"rows sitting at the fit's x-mean so they carry zero leverage "
+                f"on the fitted slope -- an off-centre sweep, or an idle "
+                f"reading that is not where the sweep is centred, would "
+                f"silently bias every slope for this corrector"
             )
 
         for i in range(len(detectors)):
@@ -240,11 +258,14 @@ def sliced_response_matrix(
     `rows[j * num : (j + 1) * num]` — no need to infer which rows belong to
     which corrector from the data. Each corrector's slope is then fitted
     against its OWN currents over its OWN slice only, which drops
-    `build_response_matrix`'s zero-mean-sweep requirement entirely: idle
+    `build_response_matrix`'s centred-sweep requirement entirely: idle
     correctors' rows are never in the slice to begin with, so a
     `monodirectional` sweep over `[0, span_a]` (which that function rejects
-    with `DegenerateFitError`, its polyfit having no way to tell an
-    asymmetric sweep from a biased idle reading) fits correctly here.
+    with `DegenerateFitError`, its polyfit having no way to tell a one-sided
+    sweep from a biased idle reading) fits correctly here. A slope is
+    invariant to a shift in its x axis, so this path needs to know nothing
+    about where a corrector's sweep is centred — a sweep about a nonzero
+    working point fits exactly as a sweep about zero does.
 
     The caller owes that slicing invariant: *rows* must be the run's events
     in emission order, un-truncated at the front and with nothing dropped in

--- a/src/osprey/services/bluesky_bridge/plans_core/orm.py
+++ b/src/osprey/services/bluesky_bridge/plans_core/orm.py
@@ -1,9 +1,9 @@
 """Shipped plan: ``orm``, an orbit-response-matrix sweep.
 
 Discovered via the layered directory catalog's ``shipped`` tier (a folder
-scan of this package's ``plans_core/`` dir — see ``plan_loader.py``): sweep
-each corrector, one at a time, over a bounded current range, reading every
-BPM detector at each point.
+scan of this package's ``plans_core/`` dir — see ``plan_loader.py``): kick
+each corrector, one at a time, either side of the working point it was
+already holding, reading every BPM detector at each point, then put it back.
 
 Device-agnostic: ``correctors``/``detectors`` are resolved by string name
 against whatever ``devices`` dict the bridge passes in; nothing here names a
@@ -48,8 +48,9 @@ logger = logging.getLogger("osprey.services.bluesky_bridge.plans_core.orm")
 PLAN_METADATA = {
     "name": "orm",
     "description": (
-        "Sweep each corrector over a bounded current range, reading all BPM "
-        "detectors at every point, to measure an orbit-response matrix."
+        "Kick each corrector either side of its own pre-scan working point, "
+        "reading all BPM detectors at every point, to measure an "
+        "orbit-response matrix. Every corrector is put back where it was."
     ),
     "category": "accelerator",
     "required_devices": ["correctors", "detectors"],
@@ -61,11 +62,21 @@ class PARAMS(BaseModel):
     """Parameters for ``orm``: correctors to sweep, BPMs to read.
 
     Sweeps each corrector in ``correctors``, one at a time, over ``num``
-    evenly-spaced currents, reading every detector in ``detectors`` at each
-    point. ``sweep`` selects the current range: ``bidirectional`` spans the
-    symmetric ``[-span_a, +span_a]`` (kicks both ways, so a linear fit rejects
-    a corrector's hysteresis/offset); ``monodirectional`` spans ``[0, span_a]``
-    (one-sided, for a corrector that should never be driven negative).
+    evenly-spaced kicks *away from that corrector's own pre-scan working
+    point*, reading every detector in ``detectors`` at each point. ``sweep``
+    selects the kick range: ``bidirectional`` spans the symmetric
+    ``[-span_a, +span_a]`` (kicks both ways, so a linear fit rejects a
+    corrector's hysteresis/offset); ``monodirectional`` spans ``[0, span_a]``
+    (one-sided, for a corrector that should never be driven below where it
+    already sits).
+
+    ``span_a`` carries no upper bound of its own. It is an excursion, not an
+    absolute setpoint, and how large an excursion a corrector tolerates is a
+    property of the deployment, not of this schema — the connector's
+    reference monitor checks every setpoint against that project's own
+    ``channel_limits.json`` at write time and refuses (aborting the run) what
+    the machine will not take. A literal ceiling here would only ever be one
+    facility's number.
 
     The ``x-widget`` schema hints steer the plan panel's parameter GUI —
     device lists render as scrollable channel columns, ``sweep`` as a two-way
@@ -89,9 +100,12 @@ class PARAMS(BaseModel):
     span_a: float = Field(
         ...,
         gt=0,
-        le=10.0,
+        allow_inf_nan=False,
         title="Max kick (A)",
-        description="Maximum corrector kick, in amps, at the far end of the sweep.",
+        description=(
+            "Largest kick, in amps, away from a corrector's own pre-scan "
+            "working point at the far end of the sweep."
+        ),
     )
     num: int = Field(
         ...,
@@ -122,26 +136,55 @@ class PARAMS(BaseModel):
 def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
     """Build the orbit-response-matrix sweep generator.
 
-    Mirrors the built-in ``orm`` plan's (``plans.py``) idiom: for each
-    corrector, sweep ``num`` currents evenly spaced over the range ``sweep``
-    selects — ``[-span_a, +span_a]`` (bidirectional) or ``[0, +span_a]``
-    (monodirectional) — moving the corrector then ``trigger_and_read``-ing
-    every corrector together with every BPM detector in one bundle, so each
-    point emits exactly one event carrying the driven corrector's current
-    alongside every BPM reading. Each corrector is restored to 0 A once its
-    own sweep finishes, including on abort (the ``try``/``finally`` runs on
+    For each corrector in turn: read where it is already sitting, sweep it
+    over ``num`` kicks evenly spaced across the range ``sweep`` selects —
+    ``[-span_a, +span_a]`` (bidirectional) or ``[0, +span_a]``
+    (monodirectional) — and put it back. Each kick is applied *relative to
+    that corrector's own pre-scan working point*, and at each point the plan
+    ``trigger_and_read``-s every corrector together with every BPM detector
+    in one bundle, so each point emits exactly one event carrying the driven
+    corrector's current alongside every BPM reading.
+
+    **Relative, because a machine with beam in it is not at zero.** A ring
+    running corrected orbit holds every corrector at a nonzero
+    orbit-correction working point. Sweeping absolute currents about zero
+    would measure the response about a point the machine is not at, and
+    "restoring" to a literal 0 A would drop the entire correction the ring
+    was holding — on a stored beam, that is the orbit gone. Reading each
+    corrector's working point costs one extra read per corrector and makes
+    the plan mean the same thing on a real ring as on a virtual accelerator
+    whose correctors happen to idle at zero.
+
+    The read is `bps.rd`, so the working point is the corrector's own
+    readback — which is the right value to restore under this bridge's
+    device contract, where a settable's ``set()`` does not complete until
+    the readback agrees with the demand (see ``devices/connector.py``'s
+    ``ConnectorSettable``). It happens BEFORE the ``try``, so a corrector
+    whose read fails is never entered at all and the restore below can never
+    run without a target.
+
+    Each corrector is restored to its recorded working point once its own
+    sweep finishes, including on abort (the ``try``/``finally`` runs on
     ``GeneratorExit`` too) — a restore failure is caught and logged rather
     than allowed to replace an in-flight sweep exception.
+
+    Raises:
+        ValueError: A corrector read back a non-finite working point. Every
+            setpoint derived from it would be non-finite too, and a NaN
+            demand is not something a limits check can refuse (``nan <
+            low`` and ``nan > high`` are both false), so it would reach the
+            IOC and only then fail as a readback-settle timeout. Refusing
+            here means no write is attempted at all.
     """
     correctors = [(name, devices[name]) for name in params.correctors]
     corrector_devices = [corrector for _, corrector in correctors]
     detector_devices = [devices[name] for name in params.detectors]
     if params.sweep == "monodirectional":
         step = params.span_a / (params.num - 1)
-        currents = [i * step for i in range(params.num)]
+        kicks = [i * step for i in range(params.num)]
     else:
         step = (2 * params.span_a) / (params.num - 1)
-        currents = [-params.span_a + i * step for i in range(params.num)]
+        kicks = [-params.span_a + i * step for i in range(params.num)]
 
     all_devices = corrector_devices + detector_devices
 
@@ -149,18 +192,26 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
     @bpp.run_decorator()
     def _sweep():
         for name, corrector in correctors:
+            working_point = float((yield from bps.rd(corrector)))
+            if not math.isfinite(working_point):
+                raise ValueError(
+                    f"orm plan: corrector {name!r} read back a non-finite working "
+                    f"point ({working_point}); refusing to sweep relative to it"
+                )
             try:
-                for current in currents:
-                    yield from bps.mv(corrector, current)
+                for kick in kicks:
+                    yield from bps.mv(corrector, working_point + kick)
                     yield from bps.trigger_and_read(all_devices)
             finally:
                 try:
-                    yield from bps.mv(corrector, 0.0)
+                    yield from bps.mv(corrector, working_point)
                 except Exception:
                     logger.warning(
-                        "orm plan: failed to restore corrector %s to 0 A "
-                        "during cleanup; preserving the original error",
+                        "orm plan: failed to restore corrector %s to its pre-scan "
+                        "working point (%r) during cleanup; preserving the original "
+                        "error",
                         name,
+                        working_point,
                         exc_info=True,
                     )
 

--- a/src/osprey/templates/claude_code/claude/skills/writing-bluesky-plans/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/writing-bluesky-plans/SKILL.md
@@ -56,8 +56,9 @@ optional fourth, `render` — see *The plan's own view* below):
 **Study the two shipped plans for the full worked pattern — do not
 invent new accelerator physics:**
 - `orm` (`src/osprey/services/bluesky_bridge/plans_core/orm.py`)
-  — sweeps each corrector over a bounded current range, reading every BPM
-  detector at each point, to measure an orbit-response matrix.
+  — kicks each corrector either side of its own pre-scan working point,
+  reading every BPM detector at each point, to measure an orbit-response
+  matrix.
 - `grid_scan` (`src/osprey/services/bluesky_bridge/plans_core/grid_scan.py`)
   — steps a set of setpoint devices over a rectangular grid, reading a set of
   detectors at every grid point.
@@ -65,6 +66,41 @@ invent new accelerator physics:**
 These are the ONLY accelerator scan patterns this framework ships. Never
 propose or author a BBA (beam-based alignment) or tune-scan plan — they are
 explicitly out of scope.
+
+## A plan that moves a device sweeps relative, and puts it back
+
+**Never write an absolute setpoint you did not read first, and never restore
+to a literal.** A running machine is not at zero: correctors hold an
+orbit-correction working point, and a magnet, mover, or phase shifter sits
+wherever operations left it. A plan that drives absolute values measures
+about a point the machine is not at, and one that "restores" to `0.0` does
+not restore anything — it drives the machine to zero, which on a stored beam
+is the orbit gone.
+
+The idiom, per device, is three lines (`orm`'s `build_plan` is the worked
+version):
+
+```python
+working_point = float((yield from bps.rd(device)))   # before the try
+try:
+    for step in steps:                               # steps are OFFSETS
+        yield from bps.mv(device, working_point + step)
+        yield from bps.trigger_and_read(all_devices)
+finally:
+    yield from bps.mv(device, working_point)         # never a literal
+```
+
+Read **before** the `try`, not inside it, so a device whose read fails is
+never entered and the `finally` can never run without a target. Your range
+parameters are then *excursions*, not absolute setpoints — say so in their
+descriptions, and do not give them a magnitude ceiling of your own: what a
+device tolerates is the deployment's `channel_limits.json`, which the
+connector's reference monitor enforces on every write.
+
+`grid_scan` is the deliberate exception: a grid's whole purpose is to visit
+declared absolute coordinates, so it neither reads nor restores. If your
+plan maps a space, follow `grid_scan`; if it perturbs a working machine to
+measure a response, follow `orm`.
 
 **The plan's name must be a valid Python identifier that does not begin with
 an underscore.** A leading-underscore name is rejected at authoring time

--- a/tests/cli/test_phase_reporter_live.py
+++ b/tests/cli/test_phase_reporter_live.py
@@ -80,10 +80,21 @@ def recording_console() -> tuple[Console, io.StringIO]:
     skips the repaint entirely. The theme is not optional either -- the region's
     styles are semantic tokens, and a bare ``Console()`` raises ``MissingStyle``
     on the first one.
+
+    ``get_time`` is frozen because the spinner frame is picked from it: Rich's
+    ``Spinner`` asks the console for the time on every render, so a spinner that
+    outlives one render advances on wall-clock alone. Any test comparing two
+    renders would then be comparing the machine's speed, not its own subject.
     """
     buffer = io.StringIO()
     return (
-        Console(file=buffer, theme=osprey_theme, force_terminal=True, width=100),
+        Console(
+            file=buffer,
+            theme=osprey_theme,
+            force_terminal=True,
+            width=100,
+            get_time=lambda: 1000.0,
+        ),
         buffer,
     )
 

--- a/tests/e2e/test_bluesky_queue_e2e.py
+++ b/tests/e2e/test_bluesky_queue_e2e.py
@@ -1067,6 +1067,11 @@ def test_4_unknown_run_data_is_404_not_an_empty_scan(stack: QueueStack) -> None:
 # ===========================================================================
 
 # An orm-shaped session plan body, mirroring plans_core/orm.py's house style.
+# Deliberately NOT a copy of that plan: it is the smallest body that exercises
+# author -> validate -> upload -> enqueue -> execute, so it carries no `sweep`
+# mode, no `render`, and an absolute sweep rather than the shipped plan's
+# read-relative-restore idiom. Nothing here asserts corrector physics, and the
+# idiom adds no import, so it would exercise nothing this file tests.
 # NO `from __future__ import annotations`: `POST /plans/session` writes
 # `f"PLAN_METADATA = {...}\n\n{body}"`, so the generated metadata assignment
 # always precedes this text, and Python requires a __future__ import to be the

--- a/tests/e2e/test_bluesky_sandbox_escape_e2e.py
+++ b/tests/e2e/test_bluesky_sandbox_escape_e2e.py
@@ -242,6 +242,11 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
 # natively on Python 3.9+ without it -- see PEP 585), so this body simply
 # omits the future import; `typing`/`logging` have no such positional rule
 # and are used exactly as the shipped exemplar does.
+#
+# What this body mirrors is the exemplar's IMPORTS and module shape -- the
+# only thing the stage-1 allowlist this test exists to probe can see. It does
+# not carry the shipped plan's read-relative-restore sweep idiom, which adds
+# no import and so is invisible to that allowlist.
 _POSITIVE_PLAN_BODY = '''"""Session-authored positive plan body for the sandbox-escape e2e
 (tests/e2e/test_bluesky_sandbox_escape_e2e.py) -- mirrors plans_core/
 orm.py's PARAMS/build_plan, proving the author -> validate ->

--- a/tests/e2e/test_orm_roundtrip.py
+++ b/tests/e2e/test_orm_roundtrip.py
@@ -692,8 +692,11 @@ def test_orm_roundtrip_matches_model_with_no_corrector_hang(
     measured = build_response_matrix(rows, correctors=list(correctors), detectors=list(bpms))
 
     # (a) matches the model oracle: the same symmetric-sweep currents the
-    # deployed orm plan itself computes (plans.py's _orm_plan), so the model
-    # is driven identically to how the plan drove the real stack.
+    # deployed orm plan itself computes (plans_core/orm.py's build_plan), so
+    # the model is driven identically to how the plan drove the real stack.
+    # The plan kicks each corrector about its own pre-scan working point; the
+    # VA's correctors idle at 0 A, so here those kicks ARE these absolute
+    # currents and the model needs no offset of its own.
     step = (2 * SPAN_A) / (NUM_POINTS - 1)
     currents = [-SPAN_A + i * step for i in range(NUM_POINTS)]
     model = _model_response_matrix(correctors, bpms, currents)

--- a/tests/services/bluesky_bridge/test_builtin_plans.py
+++ b/tests/services/bluesky_bridge/test_builtin_plans.py
@@ -111,12 +111,28 @@ def test_orm_params_rejects_an_empty_detector_list() -> None:
         ORMParams(correctors=["hcm1"], detectors=[], span_a=2.0, num=5)
 
 
-def test_orm_params_rejects_a_span_beyond_the_channel_limits_band() -> None:
-    """`channel_limits.json` bounds a corrector `:SP` to +-12 A; ORMParams'
-    own `span_a` bound (+-10 A, the response model's typical linear-kick
-    range — see `lattice/response.py`) is tighter and rejected first."""
+def test_orm_params_accepts_a_span_larger_than_any_one_facilitys_band() -> None:
+    """`span_a` carries no schema-level magnitude cap.
+
+    It is an *excursion* about each corrector's own pre-scan working point,
+    expressed in whatever unit that corrector's channel speaks — so any
+    literal ceiling here would be one facility's number standing in for
+    every facility's. The real bound is the deployment's own
+    `channel_limits.json`, enforced by the connector's reference monitor
+    when the plan actually writes: an out-of-band setpoint is refused
+    there, aborting the run, rather than being guessed at here.
+    """
+    params = ORMParams(correctors=["hcm1"], detectors=["bpm1"], span_a=120.0, num=5)
+    assert params.span_a == 120.0
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
+def test_orm_params_rejects_a_non_finite_span(value: float) -> None:
+    """With the upper bound gone, `gt=0` is the only magnitude constraint —
+    and `inf > 0` is true, so infinity would sail through and generate a
+    sweep of non-finite setpoints. Non-finite spans are rejected outright."""
     with pytest.raises(ValidationError):
-        ORMParams(correctors=["hcm1"], detectors=["bpm1"], span_a=12.0, num=5)
+        ORMParams(correctors=["hcm1"], detectors=["bpm1"], span_a=value, num=5)
 
 
 def test_orm_params_rejects_a_non_positive_span() -> None:
@@ -166,38 +182,78 @@ def test_orm_params_rejects_an_unknown_sweep() -> None:
         ORMParams(correctors=["hcm1"], detectors=["bpm1"], span_a=2.0, num=5, sweep="sideways")
 
 
-def _corrector_sweep_setpoints(params: ORMParams) -> list[float]:
-    """Drive the `orm` generator directly (no RunEngine) and collect, in
-    order, the current values it commands onto its single corrector — the
-    sweep points followed by the restore-to-0 in the `finally`. Iterating a
-    plan just walks its `Msg` stream; none of `orm`'s control flow branches on
-    a yielded value, so this needs no RunEngine."""
-    devices = asyncio.run(build_devices(motor_names=["hcm1"], detector_names=["bpm1"]))
-    corrector = devices["hcm1"]
+def _corrector_sweep_setpoints(params: ORMParams, working_point: float = 0.0) -> list[float]:
+    """Run `orm` against a corrector idling at *working_point* and collect,
+    in order, the current values it commands onto that corrector — the sweep
+    points followed by the restore in the `finally`.
+
+    Driven by a real `RunEngine` with a `msg_hook`, NOT by iterating the
+    generator by hand. The plan reads each corrector's pre-scan working point
+    with `bps.rd`, and `bps.rd` walked by hand runs in bluesky's "list-ify"
+    mode: nothing answers its `read`, so it silently returns its
+    `default_value` of 0 instead of the device's real value. A hand-walked
+    stream would therefore report a sweep centred on zero no matter what the
+    plan does — it would keep passing against an absolute sweep and pin
+    nothing. The `msg_hook` gets the identical `Msg` stream with a live
+    device on the other end of it.
+    """
+    corrector = MockMotor("hcm1", initial_value=working_point)
+    devices = asyncio.run(connect_all({"hcm1": corrector, "bpm1": MockDetector("bpm1")}))
+
     setpoints: list[float] = []
-    for msg in orm_plan(devices, params):
+
+    def _record(msg) -> None:
         if msg.command == "set" and msg.obj is corrector:
             setpoints.append(msg.args[0])
+
+    RE = RunEngine(context_managers=[])
+    RE.msg_hook = _record
+    RE(orm_plan(devices, params))
     return setpoints
 
 
-def test_orm_bidirectional_sweep_spans_symmetric_range() -> None:
-    """The default sweep drives the corrector across the symmetric
-    `[-span_a, +span_a]` (both signs present), then restores it to 0."""
+@pytest.mark.parametrize("working_point", [0.0, 2.5])
+def test_orm_bidirectional_sweep_is_symmetric_about_the_working_point(
+    working_point: float,
+) -> None:
+    """The default sweep kicks the corrector both ways about wherever it was
+    already sitting — `working_point ± span_a` — then puts it back there.
+
+    The `0.0` case is the virtual accelerator, whose correctors do idle at
+    zero; the `2.5` case is a real ring, whose correctors hold an
+    orbit-correction working point. Both are the same arithmetic, which is
+    the point: the plan no longer has a privileged origin.
+    """
     params = ORMParams(correctors=["hcm1"], detectors=["bpm1"], span_a=3.0, num=4)
-    setpoints = _corrector_sweep_setpoints(params)
-    assert setpoints == [-3.0, -1.0, 1.0, 3.0, 0.0]
+    setpoints = _corrector_sweep_setpoints(params, working_point)
+    assert setpoints == [
+        working_point - 3.0,
+        working_point - 1.0,
+        working_point + 1.0,
+        working_point + 3.0,
+        working_point,
+    ]
 
 
-def test_orm_monodirectional_sweep_spans_zero_to_span() -> None:
-    """A monodirectional sweep never drives the corrector negative: it spans
-    `[0, +span_a]` only, then restores to 0."""
+@pytest.mark.parametrize("working_point", [0.0, 2.5])
+def test_orm_monodirectional_sweep_never_kicks_below_the_working_point(
+    working_point: float,
+) -> None:
+    """A monodirectional sweep is one-sided about the working point: it spans
+    `[working_point, working_point + span_a]` and never drives the corrector
+    below where it started, then restores it."""
     params = ORMParams(
         correctors=["hcm1"], detectors=["bpm1"], span_a=3.0, num=4, sweep="monodirectional"
     )
-    setpoints = _corrector_sweep_setpoints(params)
-    assert setpoints == [0.0, 1.0, 2.0, 3.0, 0.0]
-    assert all(value >= 0.0 for value in setpoints)
+    setpoints = _corrector_sweep_setpoints(params, working_point)
+    assert setpoints == [
+        working_point,
+        working_point + 1.0,
+        working_point + 2.0,
+        working_point + 3.0,
+        working_point,
+    ]
+    assert all(value >= working_point for value in setpoints)
 
 
 # =========================================================================
@@ -219,8 +275,13 @@ class _FailOnValueMotor(MockMotor):
     device without needing a real connector.
     """
 
-    def __init__(self, name: str, fail_values: dict[float, Exception]) -> None:
-        super().__init__(name=name)
+    def __init__(
+        self,
+        name: str,
+        fail_values: dict[float, Exception],
+        initial_value: float = 0.0,
+    ) -> None:
+        super().__init__(name=name, initial_value=initial_value)
         self._fail_values = fail_values
 
     @AsyncStatus.wrap
@@ -234,26 +295,31 @@ class _FailOnValueMotor(MockMotor):
 def test_orm_plan_restore_refusal_does_not_mask_the_original_sweep_error(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """CC-1: if BOTH a mid-sweep move and the cleanup restore-to-0 raise, the
+    """CC-1: if BOTH a mid-sweep move and the cleanup restore raise, the
     exception that surfaces from the RunEngine must be the ORIGINAL sweep
     failure, not the restore's — and the restore failure must be logged, not
     silently dropped, so the operator still learns the corrector was left
-    off-zero.
+    away from its working point.
 
     The RunEngine wraps a device `set()` error in its own
     `bluesky.utils.FailedStatus` (which carries the underlying exception's
     message), so the check below matches on that wrapper's message rather
     than the bare `RuntimeError` type.
     """
-    # span_a=3.0, num=4 -> currents = [-3.0, -1.0, 1.0, 3.0]; 0.0 (the
-    # restore target) is deliberately NOT among the swept currents, so the
-    # two failures below are unambiguous distinct write attempts.
+    # The corrector idles at 2.5, so span_a=3.0, num=4 sweeps
+    # [-0.5, 1.5, 3.5, 5.5] and restores to 2.5. Failing the FIRST swept
+    # point and the restore target covers both writes, and 2.5 is
+    # deliberately NOT among the swept currents, so the two failures below
+    # are unambiguous distinct write attempts. A nonzero idle value is what
+    # makes the restore target observable at all: at zero it would coincide
+    # with the value the plan used to hard-code.
     hcm1 = _FailOnValueMotor(
         "hcm1",
         fail_values={
-            -3.0: RuntimeError("ORIGINAL sweep failure"),
-            0.0: RuntimeError("RESTORE refused"),
+            -0.5: RuntimeError("ORIGINAL sweep failure"),
+            2.5: RuntimeError("RESTORE refused"),
         },
+        initial_value=2.5,
     )
     devices = asyncio.run(connect_all({"hcm1": hcm1, "bpm1": MockDetector("bpm1")}))
 
@@ -277,8 +343,9 @@ def test_orm_plan_restore_refusal_does_not_mask_the_original_sweep_error(
 
 
 def test_orm_plan_restores_every_corrector_to_zero_when_no_refusal_occurs() -> None:
-    """The ordinary (non-error) path: with no write refused, every corrector
-    still ends its own sweep restored to 0 A."""
+    """The ordinary (non-error) path on a machine whose correctors idle at
+    zero — the virtual accelerator: with no write refused, every corrector
+    ends its own sweep back at 0 A."""
     devices = asyncio.run(build_devices(motor_names=["hcm1", "hcm2"], detector_names=["bpm1"]))
     params = ORMParams(correctors=["hcm1", "hcm2"], detectors=["bpm1"], span_a=2.0, num=3)
     plan = orm_plan(devices, params)
@@ -289,3 +356,63 @@ def test_orm_plan_restores_every_corrector_to_zero_when_no_refusal_occurs() -> N
     for name in ("hcm1", "hcm2"):
         readback = asyncio.run(devices[name].readback.get_value())
         assert readback == 0.0
+
+
+def test_orm_plan_refuses_to_sweep_a_corrector_reading_back_non_finite() -> None:
+    """A corrector whose readback is NaN — dead, disconnected, or unscaled —
+    has no working point to sweep about, and every setpoint derived from it
+    would be NaN too.
+
+    That must fail before the first write, not at it: a NaN demand passes a
+    limits check (`nan < low` and `nan > high` are both false, so the
+    reference monitor has nothing to refuse), reaches the IOC, and only then
+    surfaces as a readback-settle timeout — having already written. The plan
+    refuses up front, and no `set` is ever issued.
+    """
+    hcm1 = MockMotor("hcm1", initial_value=float("nan"))
+    devices = asyncio.run(connect_all({"hcm1": hcm1, "bpm1": MockDetector("bpm1")}))
+    params = ORMParams(correctors=["hcm1"], detectors=["bpm1"], span_a=2.0, num=3)
+
+    writes: list[float] = []
+
+    def _record(msg) -> None:
+        if msg.command == "set" and msg.obj is hcm1:
+            writes.append(msg.args[0])
+
+    RE = RunEngine(context_managers=[])
+    RE.msg_hook = _record
+    with pytest.raises(ValueError, match="non-finite"):
+        RE(orm_plan(devices, params))
+
+    assert writes == []
+
+
+def test_orm_plan_restores_every_corrector_to_its_own_pre_scan_working_point() -> None:
+    """The same path on a real ring: correctors holding an orbit-correction
+    working point are each put back where THEY were, not where the plan
+    assumed they were.
+
+    Two different nonzero working points, because a single shared one could
+    be passed by a plan that recorded one corrector's value and restored all
+    of them to it. Parking these at 0 A — what the plan used to do — is what
+    would destroy a stored-beam orbit.
+    """
+    working_points = {"hcm1": 2.5, "hcm2": -1.25}
+    devices = asyncio.run(
+        connect_all(
+            {
+                **{
+                    name: MockMotor(name, initial_value=value)
+                    for name, value in working_points.items()
+                },
+                "bpm1": MockDetector("bpm1"),
+            }
+        )
+    )
+    params = ORMParams(correctors=["hcm1", "hcm2"], detectors=["bpm1"], span_a=2.0, num=3)
+
+    RE = RunEngine(context_managers=[])
+    RE(orm_plan(devices, params))
+
+    for name, value in working_points.items():
+        assert asyncio.run(devices[name].readback.get_value()) == value

--- a/tests/services/bluesky_bridge/test_exemplar_plans.py
+++ b/tests/services/bluesky_bridge/test_exemplar_plans.py
@@ -109,7 +109,8 @@ def test_orm_plan_runs_to_completion_and_buffers_rows(orm_devices: dict) -> None
     for row in buf["rows"]:
         assert all(value is not None for value in row)
 
-    # Each corrector restored to 0 A after its own sweep.
+    # Each corrector restored to its pre-scan working point after its own
+    # sweep. These mock motors start at 0 A, so here that value is 0 A.
     assert asyncio.run(orm_devices["hcm1"].readback.get_value()) == 0.0
     assert asyncio.run(orm_devices["hcm2"].readback.get_value()) == 0.0
 

--- a/tests/services/bluesky_bridge/test_orm_analysis.py
+++ b/tests/services/bluesky_bridge/test_orm_analysis.py
@@ -120,10 +120,11 @@ def _real_shape_rows(
 
 
 def test_guard_is_quiet_on_a_real_shaped_symmetric_sweep() -> None:
-    """Every idle-corrector row (current 0.0) sits at the fit's x-mean when
-    each corrector's own sweep is symmetric about 0, so it carries zero
-    leverage on the slope -- the guard must not fire on this, the real
-    plan's shape.
+    """Every idle-corrector row sits at the fit's x-mean when each
+    corrector's own sweep is symmetric about the value it idles at, so it
+    carries zero leverage on the slope -- the guard must not fire on this,
+    the real plan's shape. Here the idle value is 0.0, the virtual
+    accelerator's; see the nonzero-working-point case below for a ring's.
     """
     currents = np.linspace(-1.0, 1.0, 5)
     rows = _real_shape_rows(KNOWN_MATRIX, CORRECTORS, DETECTORS, [currents] * len(CORRECTORS))
@@ -133,18 +134,83 @@ def test_guard_is_quiet_on_a_real_shaped_symmetric_sweep() -> None:
     assert np.allclose(result, KNOWN_MATRIX)
 
 
+def _relative_shape_rows(
+    matrix: np.ndarray,
+    correctors: list[str],
+    detectors: list[str],
+    kicks: np.ndarray,
+    working_points: list[float],
+) -> list[dict]:
+    """Rows shaped like a real `orm` run on a ring with a corrected orbit.
+
+    The difference from `_real_shape_rows` is the whole point of the relative
+    sweep: each corrector holds its own nonzero working point, is swept
+    *about* it, and is put back — so an idle corrector's key carries ITS
+    working point rather than 0.0. BPM readings respond to the kick away from
+    the working point (`matrix @ kick`) on top of the arbitrary corrected
+    orbit those working points are already holding, so a fit that mistook the
+    absolute setpoint for the kick would land on the wrong slope.
+    """
+    base_orbit = np.linspace(-3e-4, 3e-4, len(detectors))
+    rows = []
+    for j, corrector in enumerate(correctors):
+        for kick in kicks:
+            row = {name: working_points[k] for k, name in enumerate(correctors)}
+            row[corrector] = working_points[j] + float(kick)
+            for i, detector in enumerate(detectors):
+                row[detector] = float(base_orbit[i] + matrix[i, j] * kick)
+            rows.append(row)
+    return rows
+
+
+def test_guard_is_quiet_on_a_sweep_about_a_nonzero_working_point() -> None:
+    """The real plan sweeps each corrector about its own pre-scan working
+    point, so an idle corrector reads back that working point, not 0.0.
+
+    The zero-leverage argument survives that intact — a sweep symmetric about
+    `w` puts the fit's x-mean exactly at `w`, which is precisely where every
+    idle sample sits — so the guard must stay quiet and the fitted slopes
+    must still be the truth. The invariant was never "about zero"; zero was
+    only the value a machine with no orbit to correct happens to idle at.
+    """
+    working_points = [2.5, -1.25, 4.0]
+    kicks = np.linspace(-1.0, 1.0, 5)
+    rows = _relative_shape_rows(KNOWN_MATRIX, CORRECTORS, DETECTORS, kicks, working_points)
+
+    result = build_response_matrix(rows, CORRECTORS, DETECTORS)
+
+    assert np.allclose(result, KNOWN_MATRIX)
+
+
+def test_guard_fires_on_a_sweep_not_centred_on_the_idle_value() -> None:
+    """A corrector swept about something other than where it idles is still
+    rejected. Widening the invariant to "symmetric about the working point"
+    must not widen it to "anything goes": here the corrector idles at 2.5 but
+    is swept about 7.5, so the idle rows sit off the fit's x-mean and would
+    bias its slope exactly as before.
+    """
+    working_points = [2.5, -1.25, 4.0]
+    kicks = np.linspace(-1.0, 1.0, 5)
+    rows = _relative_shape_rows(KNOWN_MATRIX, CORRECTORS, DETECTORS, kicks, working_points)
+    for row in rows[: len(kicks)]:
+        row[CORRECTORS[0]] += 5.0  # swept about 7.5 while idling at 2.5
+
+    with pytest.raises(DegenerateFitError, match="symmetric about"):
+        build_response_matrix(rows, CORRECTORS, DETECTORS)
+
+
 def test_guard_fires_on_a_real_shaped_asymmetric_sweep() -> None:
-    """A corrector swept off-center (here [4, 6] instead of [-1, 1]) breaks
-    the zero-mean invariant `build_response_matrix` depends on -- idle rows
-    from the *other* correctors' symmetric sweeps no longer sit at this
-    corrector's x-mean, so they would silently bias its fitted slope. The
-    guard must raise instead of fitting garbage.
+    """A corrector swept off-center (here [4, 6] while idling at 0.0) breaks
+    the invariant `build_response_matrix` depends on -- idle rows from the
+    *other* correctors' sweeps no longer sit at this corrector's x-mean, so
+    they would silently bias its fitted slope. The guard must raise instead
+    of fitting garbage.
     """
     currents = np.linspace(-1.0, 1.0, 5)
-    off_center = currents + 5.0  # [4.0, ..., 6.0] -- not symmetric about 0
+    off_center = currents + 5.0  # [4.0, ..., 6.0] -- not centred on the 0.0 idle value
     rows = _real_shape_rows(KNOWN_MATRIX, CORRECTORS, DETECTORS, [off_center, currents, currents])
 
-    with pytest.raises(DegenerateFitError, match="symmetric about 0"):
+    with pytest.raises(DegenerateFitError, match="symmetric about its idle value"):
         build_response_matrix(rows, CORRECTORS, DETECTORS)
 
 

--- a/tests/services/bluesky_bridge/test_orm_plan_integration.py
+++ b/tests/services/bluesky_bridge/test_orm_plan_integration.py
@@ -1,14 +1,8 @@
 """RunEngine integration test for the shipped `orm` plan.
 
-Runs ONLY in a bluesky-capable environment — `bluesky`/`ophyd-async` are
-never installed in the main worktree venv, so every test here is skipped via
-`pytest.importorskip` rather than failing, keeping `ci_check` green with no
-bluesky installed at all. To actually run this file:
-
-    uv venv /tmp/bluesky-orm-scratch
-    /tmp/bluesky-orm-scratch/bin/pip install -e . --python 3.11
-    /tmp/bluesky-orm-scratch/bin/python -m pytest \
-        tests/services/bluesky_bridge/test_orm_plan_integration.py -q
+The bluesky stack is a core dependency, so these run in the normal unit
+lane; the `pytest.importorskip` guards below only skip them in a slimmed
+install where `bluesky`/`ophyd-async` are absent.
 
 Drives a real bluesky `RunEngine` through the real `orm` plan
 (`plans_core/orm.py`, resolved through the layered directory loader —
@@ -31,7 +25,13 @@ bluesky = pytest.importorskip("bluesky")
 ophyd_async = pytest.importorskip("ophyd_async")
 
 from osprey.services.bluesky_bridge import live_rows, plan_loader  # noqa: E402
-from osprey.services.bluesky_bridge.devices.mock import build_devices  # noqa: E402
+from osprey.services.bluesky_bridge.devices._connect import connect_all  # noqa: E402
+from osprey.services.bluesky_bridge.devices.mock import (  # noqa: E402
+    MockDetector,
+    MockMotor,
+    build_devices,
+)
+from osprey.services.bluesky_bridge.orm_analysis import build_response_matrix  # noqa: E402
 
 from .bluesky_plan_drive import run_plan  # noqa: E402
 
@@ -50,10 +50,10 @@ def orm_devices() -> dict:
     """Two mock correctors + three mock BPM detectors, fresh per test.
 
     Unlike `test_runengine_integration.py`'s module-scoped `mock_devices`,
-    this is function-scoped: the `orm` plan drives each corrector to a
-    nonzero current and back, so a stale motor position from a previous test
-    would silently pass a bug (starting-from-zero is part of what "restore to
-    0 after its sweep" proves).
+    this is function-scoped: the `orm` plan kicks each corrector away from
+    where it found it and back, so a stale motor position carried over from
+    a previous test would move the working point these tests assert against
+    out from under them.
     """
     return asyncio.run(
         build_devices(
@@ -97,9 +97,16 @@ def test_orm_plan_runs_to_completion_and_buffers_one_row_per_point(
         assert all(value is not None for value in row)
 
 
-def test_orm_plan_restores_each_corrector_to_zero_after_its_sweep(
+def test_orm_plan_restores_each_corrector_through_the_real_loader_path(
     orm_devices: dict,
 ) -> None:
+    """Restore survives the round trip through the real plan loader and
+    `run_plan` wrapper, not just a directly-built generator.
+
+    These mock motors start at 0 A, so the working point each corrector is
+    put back to is 0 A here; `test_builtin_plans.py` covers the nonzero case
+    that distinguishes "put back where it was" from "driven to zero".
+    """
     run_plan(
         "orm",
         {
@@ -116,6 +123,54 @@ def test_orm_plan_restores_each_corrector_to_zero_after_its_sweep(
     hcm2_readback = asyncio.run(orm_devices["hcm2"].readback.get_value())
     assert hcm1_readback == 0.0
     assert hcm2_readback == 0.0
+
+
+def test_orm_plan_output_is_fittable_by_the_analysis_it_feeds() -> None:
+    """The seam: rows the plan actually emits must be rows
+    `orm_analysis.build_response_matrix` can actually fit.
+
+    The two halves hold the same invariant from opposite sides — the plan
+    sweeps each corrector symmetrically about its own working point, and the
+    fit needs every idle sample to sit at the fit's x-mean — and nothing but
+    a test spanning both notices when one side moves. Drive the real plan
+    against correctors idling at nonzero working points and hand its own
+    buffered rows straight to the fit: before the relative sweep, this raised
+    `DegenerateFitError` on the plan's own output.
+
+    The mock detector is a counter, not a machine, so the fitted *values* are
+    meaningless here and go unasserted; that the fit accepts the rows at all
+    is the whole claim.
+    """
+    correctors = {"hcm1": 2.5, "hcm2": -1.25}
+    devices = asyncio.run(
+        connect_all(
+            {
+                **{name: MockMotor(name, initial_value=v) for name, v in correctors.items()},
+                "bpm1": MockDetector("bpm1"),
+                "bpm2": MockDetector("bpm2"),
+            }
+        )
+    )
+    detectors = ["bpm1", "bpm2"]
+    run_uid = run_plan(
+        "orm",
+        {
+            "correctors": list(correctors),
+            "detectors": detectors,
+            "span_a": 2.0,
+            "num": 5,
+        },
+        devices=devices,
+        plans=plan_loader.get_facility_plans().plans,
+    )
+
+    buf = live_rows.get(run_uid)
+    assert buf is not None
+    rows = [dict(zip(buf["columns"], row, strict=True)) for row in buf["rows"]]
+
+    matrix = build_response_matrix(rows, list(correctors), detectors)
+
+    assert matrix.shape == (len(detectors), len(correctors))
 
 
 def test_orm_plan_single_corrector_produces_exactly_num_rows(orm_devices: dict) -> None:

--- a/tests/services/bluesky_bridge/test_orm_render.py
+++ b/tests/services/bluesky_bridge/test_orm_render.py
@@ -102,7 +102,8 @@ def test_monodirectional_run_renders_a_full_response_matrix() -> None:
 
     That contrast is the whole reason `render` fits by acquisition index:
     `build_response_matrix` needs every corrector's samples to be symmetric
-    about 0, which a `monodirectional` sweep is not.
+    about that corrector's idle value, which a `monodirectional` sweep — one
+    that starts AT the idle value and only goes one way — is not.
     """
     correctors, detectors = ["hcm1", "hcm2"], ["bpm1", "bpm2", "bpm3"]
     truth = _truth(len(detectors), len(correctors))

--- a/tests/services/bluesky_bridge/test_sliced_response_matrix.py
+++ b/tests/services/bluesky_bridge/test_sliced_response_matrix.py
@@ -107,7 +107,7 @@ def test_matches_polyfit_within_1e_12_on_a_bidirectional_sweep():
 
 
 def test_fits_a_monodirectional_sweep_that_the_legacy_path_rejects():
-    """Index slicing drops the zero-mean-sweep requirement entirely."""
+    """Index slicing drops the centred-sweep requirement entirely."""
     correctors = ["CH1", "CH2"]
     detectors = ["BPM1", "BPM2", "BPM3"]
     truth = _truth_matrix(len(detectors), len(correctors))
@@ -121,7 +121,7 @@ def test_fits_a_monodirectional_sweep_that_the_legacy_path_rejects():
 
     # The per-pair polyfit path cannot take this input at all: a one-sided
     # sweep leaves the idle-corrector rows with real leverage on the fit.
-    with pytest.raises(DegenerateFitError, match="not symmetric about 0"):
+    with pytest.raises(DegenerateFitError, match="not symmetric about its idle value"):
         build_response_matrix(rows, correctors, detectors)
 
 

--- a/tests/va/test_orm_crosscheck.py
+++ b/tests/va/test_orm_crosscheck.py
@@ -36,8 +36,11 @@ from osprey.services.virtual_accelerator.ioc.physics_bridge import PhysicsBridge
 from osprey.services.virtual_accelerator.lattice import inventory, orbit_response
 
 # Symmetric sweep parameters, matching the real `orm` plan's contract
-# (`plans.py::_orm_plan`): a zero-mean sweep is required by
-# `build_response_matrix`'s degenerate-fit guard.
+# (`plans_core/orm.py`'s `build_plan`): a sweep centred on each corrector's
+# own idle value is required by `build_response_matrix`'s degenerate-fit
+# guard. The VA's correctors idle at 0 A, so here that centre IS zero — on a
+# ring holding a corrected orbit it would be the working point instead, and
+# the same symmetric sweep would be written about that.
 SPAN_A = 5.0
 NUM_POINTS = 5
 
@@ -75,7 +78,7 @@ def _corrector_and_bpm_names() -> tuple[list[str], list[str]]:
 
 
 def _sweep_currents(span: float, num: int) -> list[float]:
-    """The same symmetric, zero-mean current sequence `_orm_plan` sweeps."""
+    """The symmetric kick sequence `build_plan` sweeps, about a 0 A idle."""
     step = (2 * span) / (num - 1)
     return [-span + i * step for i in range(num)]
 


### PR DESCRIPTION
## Summary

- The built-in `orm` plan swept correctors over **absolute** currents and "restored" them to zero, so running it at a nonzero working point would slam correctors to the kick values and then leave them at 0 A.
- The plan now reads each corrector's readback first, sweeps `working_point + kick`, and restores the recorded value afterwards — the read happens before the try block, so the restore can never run without a valid target.
- Non-finite readbacks are refused before any write: a NaN demand passes a limits check and would otherwise only surface later as a settle timeout.

## Changes

- `plans_core/orm.py` — read-relative-restore sweep; non-finite readback guard; `span_a` allows values above 10.0 but rejects inf/NaN.
- `orm_analysis.py` — degeneracy guard generalized from `|mean| > tol·spread` to `|mean − median| > tol·spread`, so symmetric sweeps around a nonzero working point pass while one-sided data is still rejected. Reduces to the old check at a zero working point.
- `writing-bluesky-plans` skill — documents the read-relative-restore idiom (with `grid_scan` named as the deliberate absolute-coordinates exception), since it points plan authors at `orm` as the pattern to copy.
- Test prose corrected across seven test files; changelog entry added.

## Test plan

- 10 new tests written first and each watched fail for its own reason before any production change, including a seam test proving the analysis module accepts the plan's actual output at a nonzero working point.
- The two plan-sequence tests now drive a real RunEngine with a `msg_hook` (hand-walked `bps.rd` silently returns 0, which would have kept the old assertions vacuously green).
- Full unit lane green locally (21355 passed via quick_check; full lane 21614 passed with one pre-existing, unrelated browser-test failure that reproduces identically on clean `main`).
- The containerized e2e lane (including `test_orm_roundtrip.py` against the virtual accelerator) runs on this PR — that is the remaining verdict local testing can't buy.
