### PR TITLE
fix(tests): tolerate a file that vanishes mid-sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,6 +524,11 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The source-tree sweep behind the lifecycle criteria no longer fails when a
+  file disappears while it is reading. It walks the live tree, so a temporary
+  file another test had staged under `src/` could be listed and then deleted
+  before its turn came, failing a criterion that was never evaluated.
+
 - A control-system write whose read-back could not be verified now fails instead
   of reporting success. `write_channel` logged `Wrote <channel>` whenever the
   write itself returned, so an operator could be told a setpoint had moved when

--- a/tests/cli/test_lifecycle_invariants.py
+++ b/tests/cli/test_lifecycle_invariants.py
@@ -114,7 +114,12 @@ def _scan(pattern: re.Pattern[str]) -> list[tuple[str, int, str]]:
     for path in _shipped_files():
         try:
             text = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:  # pragma: no cover - defensive, no such file today
+        except (UnicodeDecodeError, FileNotFoundError):
+            # A file that is gone by the time we read it ships nothing, so it
+            # cannot violate a criterion. Tests elsewhere stage a temp artifact
+            # under ``src/`` to model a source checkout that has run the
+            # benchmark; under xdist its owning worker can unlink it between
+            # this scan's glob and this read.
             continue
         lines = text.splitlines()
         stripped = [_COMMENT_LEAD.sub("", line.strip()) for line in lines]
@@ -541,6 +546,23 @@ def test_every_retired_spelling_exemption_still_has_something_to_explain() -> No
     }
     stale = sorted(set(_RETIRED_SPELLING_ALLOWLIST) - seen)
     assert stale == [], f"allowlist entries with no remaining occurrence: {stale}"
+
+
+def test_scan_tolerates_a_file_that_vanishes_between_the_glob_and_the_read(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The sweep walks the live tree, so its file list can go stale as it reads.
+
+    ``test_benchmark_results_in_a_source_checkout_are_not_materialized`` writes
+    a real artifact under ``src/`` to model a checkout that has run the
+    benchmark, then unlinks it. Run under xdist, that unlink can land while this
+    module's sweep is mid-walk, and a sweep that dies on the missing file fails
+    a criterion it never actually evaluated — on whichever test drew the race.
+    """
+    vanished = tmp_path / "gone.py"  # deliberately never created
+    monkeypatch.setattr(sys.modules[__name__], "_shipped_files", lambda: [vanished])
+
+    assert _scan(re.compile(r"anything")) == []
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- CI on `main` is intermittently red with `FileNotFoundError` raised from the lifecycle-criteria sweep. It has hit `test_no_shipped_text_names_a_command_or_layout_that_is_gone` and `test_every_retired_spelling_exemption_still_has_something_to_explain`, on both macOS and Linux — the victim is whichever criterion is mid-walk, which is why it reads as a different test each time.
- The sweep lists every text file under `src/` and then reads each one. That list describes a live tree, so it can go stale before the read reaches a given path.
- `test_benchmark_results_in_a_source_checkout_are_not_materialized` writes a real `data/benchmarks/results/run-from-a-test.json` under `src/` to model a checkout that has run the benchmark, then unlinks it in a `finally`. Run under xdist, that unlink lands while another worker's sweep is walking.

## Changes

- `_scan` now skips a file that raises `FileNotFoundError`, alongside the `UnicodeDecodeError` it already skipped. A file that is gone ships no text and so cannot violate a criterion.
- Added a regression test that points the sweep at a path that does not exist and asserts it reports cleanly rather than raising.

The guard goes in the reader rather than in the test that stages the artifact: the sweep enumerates a live tree, so staleness between the listing and the read is inherent to it. Fixing the one polluting test would leave the next one to rediscover this.

## Test plan

- The new test fails with the exact CI exception (`FileNotFoundError` out of `read_text`) against the unpatched `_scan`, and passes with it — confirmed by reverting the guard and re-running.
- `tests/cli/test_lifecycle_invariants.py` and `tests/cli/test_persona_profile_emission.py` together: 78 passed.
