### PR TITLE
fix: restore release gate and close deploy, health and test gaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,10 @@ on:
 # ORDERING: the framework wheel depends on osprey-connectors from PyPI
 # (workspace sources apply only to local dev), so a connectors release
 # satisfying the framework's `osprey-connectors` requirement must be published
-# BEFORE a v*.*.* tag that needs it — validate-install-docs resolves the
-# framework wheel's deps from PyPI and blocks the publish otherwise.
+# BEFORE a v*.*.* tag that needs it — verify-pypi-resolvable installs the built
+# framework wheel with its dependencies resolved from PyPI alone and blocks the
+# publish otherwise. (validate-install-docs cannot be that gate: it installs
+# with `--find-links dist`, so unpublished siblings resolve locally there.)
 
 permissions:
   contents: write  # Required for creating GitHub releases
@@ -76,9 +78,35 @@ jobs:
     if: startsWith(github.ref_name, 'v')
     uses: ./.github/workflows/validate-install-docs.yml
 
+  verify-pypi-resolvable:
+    name: Verify Deps Resolve From PyPI
+    needs: [build]
+    if: startsWith(github.ref_name, 'v')
+    runs-on: ubuntu-latest
+
+    # The wheel about to be published, installed the way the docs tell users to
+    # install it: every dependency — workspace siblings included — must resolve
+    # from the index, with no --find-links escape hatch. This is what refuses to
+    # publish a framework wheel whose `osprey-connectors` pin nothing on PyPI
+    # satisfies yet.
+    steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Install framework wheel with deps from PyPI only
+      run: |
+        uv tool install ./dist/osprey_framework-*.whl
+        osprey --version
+
   publish-to-pypi:
     name: Publish to PyPI
-    needs: [build, validate-install-docs]
+    needs: [build, validate-install-docs, verify-pypi-resolvable]
     if: startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -529,6 +529,34 @@ Compatibility is documented in release notes, not encoded in the version string.
   file another test had staged under `src/` could be listed and then deleted
   before its turn came, failing a criterion that was never evaluated.
 
+- Deploys with the ARIEL logbook store no longer break on podman-compose hosts:
+  the store's own `up` was the one compose invocation still built in the docker
+  shape, so it aborted the deploy (or ran against the wrong project directory
+  with `.env.shared` dropped) in the middle of an otherwise podman-shaped start.
+
+- `osprey users nuke` now completes on podman-compose hosts. Its container
+  teardown is built like every other compose command — rendered files, provider
+  shape, pinned project directory — instead of a bare `docker compose -p down`
+  only Docker can parse.
+
+- A `$` in an `.env.shared` value now stops a deploy on every compose provider,
+  not only podman-compose. Docker Compose interpolates env-file values, so such
+  a secret reached containers truncated or spliced with host values, silently.
+
+- The host-port preflight and the `osprey up` closing summary now cover any
+  facility service placed on the host network, read from its
+  `services.<name>.port` key. A host-mode service without that key is named in
+  a warning instead of silently escaping the check.
+
+- `osprey health --project <repo>` run from another directory now resolves the
+  target repo's whole env chain — `.env.shared` included — the way build, chat
+  and compose do, and the long-lived health surfaces notice `.env.shared`
+  edits instead of answering from a stale environment forever.
+
+- The release pipeline again verifies that the framework wheel's dependencies
+  resolve from PyPI before anything is published; the check had been quietly
+  lost when the install-docs lane switched to local wheels for PR runs.
+
 - A control-system write whose read-back could not be verified now fails instead
   of reporting success. `write_channel` logged `Wrote <channel>` whenever the
   write itself returned, so an operator could be told a setpoint had moved when

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -487,6 +487,9 @@ out — two projects whose dispatch pairs are both on the host network take the
 same default ports (``8020`` for the dispatcher, ``9190`` upward for the
 workers), and no ``ports:`` line anywhere would have shown it. Give the second
 project its own ``dispatch.dispatcher_port`` and ``dispatch.worker_port_base``.
+A facility service you place on the host network is covered the same way,
+read from its ``services.<name>.port`` key; one without that key cannot be
+checked, and ``osprey up`` says so rather than skipping it silently.
 
 .. _deployment-env-chain:
 

--- a/packages/osprey-connectors/src/osprey_connectors/workspace.py
+++ b/packages/osprey-connectors/src/osprey_connectors/workspace.py
@@ -10,6 +10,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from osprey_connectors.dotenv import ENV_CHAIN_FILENAMES
+
 logger = logging.getLogger("osprey_connectors.workspace")
 
 #: Zone directory names inside a deployment repo. ``build/`` is the render zone,
@@ -279,20 +281,47 @@ def deployment_env_path(config_path: Path | str) -> Path:
     on a host, where the config is ``<repo>/build/config.yml``, and the right
     one in a container, whose project directory *is* the render.
 
-    Both are covered the way :func:`osprey.mcp_env.load_dotenv_from_project`
-    covers them: prefer the repo root, fall back to the config's directory when
-    nothing is there. The fallback is what keeps the container case working
-    without a second rule.
+    Both are covered by one rule: prefer the repo root, fall back to the
+    config's directory when nothing is there. The fallback is what keeps the
+    container case working without a second rule.
 
-    Spelled here rather than at each caller because the callers that ask this
-    have to agree exactly — a reader that watches one file for changes and a
-    signature that stats another produces a cache which never invalidates, and
-    reports nothing at all while doing it.
+    This answers for the SINGLE local file only. A consumer that reads or
+    watches the deployment's whole environment wants
+    :func:`deployment_env_chain`, which applies the same anchoring to every
+    chain member — ``.env.shared`` included.
     """
     root_env = repo_root_for_config(config_path) / ".env"
     if root_env.is_file():
         return root_env
     return Path(config_path).parent / ".env"
+
+
+def deployment_env_chain(config_path: Path | str) -> list[Path]:
+    """Every env-chain file of the deployment whose config is *config_path*.
+
+    The chain counterpart of :func:`deployment_env_path`, with the same
+    root-then-container anchoring: the repo root's chain when any member exists
+    there, else the config's own directory (the container case, whose project
+    directory *is* the render). Paths come back in ascending precedence —
+    ``.env.shared`` before ``.env`` — so an ``override=True`` loader can walk
+    the list as-is and land on local-wins.
+
+    Every member path is returned whether or not the file exists. A watcher
+    has to stat the places a member could *appear*, or a ``.env`` created
+    after start-up never invalidates anything — the same reason
+    :func:`deployment_env_path` is spelled once for its readers and watchers.
+
+    Spelled here rather than at each caller because the callers that ask this
+    have to agree exactly — a reader that loads one set of files and a
+    signature that stats another produces a cache which never invalidates, and
+    reports nothing at all while doing it.
+    """
+    root = repo_root_for_config(config_path)
+    if any((root / name).is_file() for name in ENV_CHAIN_FILENAMES):
+        base = root
+    else:
+        base = Path(config_path).parent
+    return [base / name for name in ENV_CHAIN_FILENAMES]
 
 
 def repo_root_for_agent_data(

--- a/src/osprey/cli/health_cmd.py
+++ b/src/osprey/cli/health_cmd.py
@@ -111,36 +111,41 @@ def _resolve_anchors(project_path: Path) -> tuple[Path, Path, Path]:
     flat spelling a container project directory uses — the same order
     :func:`osprey.utils.workspace.resolve_config_path` reads, and the same one
     the ``channel-finder`` group resolves through), the repo root is derived from
-    wherever that landed, and the ``.env`` comes from
-    :func:`osprey.utils.workspace.deployment_env_path` — the same
+    wherever that landed, and the env chain comes from
+    :func:`osprey.utils.workspace.deployment_env_chain` — the same
     repo-root-with-container-fallback rule the loader uses, spelled once so the
-    two cannot disagree.
+    two cannot disagree. The CHAIN, not just ``.env``: resolved through the
+    config path rather than the working directory, so ``--project`` from
+    another directory reads the target repo's ``.env.shared`` the same way
+    build/chat/query/compose do.
 
     Returns:
-        ``(config_path, repo_root, env_path)``. Nothing is required to exist;
+        ``(config_path, repo_root, env_paths)``. Nothing is required to exist;
         a missing config is reported by the ``configuration`` category.
     """
-    from osprey.utils.workspace import deployment_env_path, repo_root_for_config
+    from osprey.utils.workspace import deployment_env_chain, repo_root_for_config
 
     from .project_utils import project_config_path
 
     config_path = project_config_path(project_path)
-    return config_path, repo_root_for_config(config_path), deployment_env_path(config_path)
+    return config_path, repo_root_for_config(config_path), deployment_env_chain(config_path)
 
 
-def _load_project_env(dotenv_path: Path) -> None:
-    """Load the deployment's ``.env`` into ``os.environ`` with override semantics.
+def _load_project_env(dotenv_paths: list[Path]) -> None:
+    """Load the deployment's env chain into ``os.environ`` with override semantics.
 
-    The ``.env`` file is the source of truth for API keys and facility settings,
-    so it overrides any pre-existing process environment. A missing file or a
-    missing ``python-dotenv`` is silently ignored.
+    The chain is the source of truth for API keys and facility settings, so it
+    overrides any pre-existing process environment — walked in ascending
+    precedence (``.env.shared`` before ``.env``) so the local file wins. A
+    missing file or a missing ``python-dotenv`` is silently ignored.
     """
     try:
         from dotenv import load_dotenv
     except ImportError:
         return
-    if dotenv_path.exists():
-        load_dotenv(dotenv_path, override=True)
+    for dotenv_path in dotenv_paths:
+        if dotenv_path.exists():
+            load_dotenv(dotenv_path, override=True)
 
 
 def _validate_categories(
@@ -296,15 +301,15 @@ def health(
 
     try:
         project_path = resolve_project_path(project)
-        config_path, repo_root, env_path = _resolve_anchors(project_path)
+        config_path, repo_root, env_paths = _resolve_anchors(project_path)
 
         with _quiet_run_logs(as_json=as_json, verbose=verbose):
             config_state, expanded, settings, config_ok = load_config(config_path, repo_root)
 
-            # Load the deployment .env after the config load so its values are
-            # present in os.environ for the run-time checks (provider canaries,
-            # env scan).
-            _load_project_env(env_path)
+            # Load the deployment env chain after the config load so its values
+            # are present in os.environ for the run-time checks (provider
+            # canaries, env scan).
+            _load_project_env(env_paths)
 
             suite_timeout_s = settings.suite_timeout_s if settings else DEFAULT_SUITE_TIMEOUT_S
             on_demand_timeout_s = settings.on_demand_timeout_s if settings else None

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -407,6 +407,20 @@ def _ensure_service_tokens(
         if offenders:
             raise ComposeInterpolationError(offenders, env_path)
 
+    # The rest of the chain rides the SAME two routes: `.env.shared` is one of
+    # the `--env-file` fragments on the docker shape and a member of the
+    # worker's `env_file:` list, so a `$` there is mangled exactly like one in
+    # `.env`. The podman shape re-scans the chain in
+    # _write_env_merged_for_compose, but that runs only on the podman branch —
+    # this scan is the one every provider gets. (`.env` is re-scanned as a
+    # chain member; the file-specific refusal above keeps its precise path.)
+    chain_offenders = compose_unsafe_vars_in_chain(env_path.parent)
+    if chain_offenders:
+        raise ComposeInterpolationError(
+            chain_offenders,
+            " + ".join(str(path) for path in chain_files(env_path.parent)),
+        )
+
     if required_vars:
         existing = parse_dotenv_file(env_path) if env_path.is_file() else {}
 
@@ -3001,7 +3015,7 @@ def _migrate_ariel_store(ariel_config: dict) -> None:
     asyncio.run(run_migrate(ariel_config))
 
 
-def _stage_ariel_store(config, compose_files, env, project_dir) -> None:
+def _stage_ariel_store(config, compose_files, env, project_dir, *, provider=None) -> None:
     """Start ARIEL's store, create its schema, and seed a first narrative.
 
     The logbook counterpart of :func:`_stage_archiver_store`, and staged ahead of
@@ -3030,18 +3044,25 @@ def _stage_ariel_store(config, compose_files, env, project_dir) -> None:
     :param compose_files: Rendered compose file paths for this deploy.
     :param env: The environment the deploy hands compose.
     :param project_dir: Root of the built project (holds ``.env``).
+    :param provider: The compose provider this deploy resolved, so the staging
+        invocation is shaped like the ``up`` that follows it. ``None`` is the
+        docker shape.
     """
     if not _ariel_store_deployed(config):
         return
 
     from osprey.simulation import apply as simulation_apply
 
-    run_env = runtime_env(config, env)
+    run_env = runtime_env(config, {**env, **compose_provider_env(provider, project_dir)})
+    # The invocation contract, same as _stage_archiver_store: one
+    # provider-shaped base, anchored on the repo root, so the store this brings
+    # up joins the same compose project the `up` below it starts.
     base_cmd = compose_base_cmd(
         get_runtime_command(config),
         compose_files,
         project_dir,
-        _env_file_args(project_dir),
+        _env_file_args(project_dir, provider),
+        provider,
     )
 
     up_cmd = base_cmd + ["up", "-d", _ARIEL_STORE_SERVICE]
@@ -3483,7 +3504,7 @@ def _start_stack(
     # it. Ordered AFTER the archiver so the logbook is seeded against a machine
     # whose history is already in place — the two halves of one narrative, in the
     # order they document each other.
-    _stage_ariel_store(config, compose_files, env, Path(repo_root))
+    _stage_ariel_store(config, compose_files, env, Path(repo_root), provider=provider)
 
     if web_terminals_enabled:
         # The provider goes down with the fragment it shaped: that fragment is

--- a/src/osprey/deployment/host_ports.py
+++ b/src/osprey/deployment/host_ports.py
@@ -59,6 +59,12 @@ _SERVICE_REMEDY_KEYS = {
 # Compose service key of worker ``i``, and the prefix its remedy is keyed on.
 _WORKER_SERVICE_PREFIX = "dispatch-worker"
 
+# Bundled services that legitimately run host-mode WITHOUT binding a port:
+# outbound-only bridges with no listening socket (their templates say so).
+# Exempt from the "host-mode service escapes the preflight" warning, which
+# exists for services that DO bind something the framework cannot derive.
+_HOST_MODE_PORTLESS_SERVICES = frozenset({"nextcloud_bridge", "gchat_bridge"})
+
 # Config values the host-mode templates fall back on. Both worker keys are
 # absent from a bridge-mode render, and a hand-authored config may omit any of
 # them, so the defaults are spelled here exactly as the templates spell theirs.
@@ -304,7 +310,20 @@ def derive_host_network_bindings(config):
       named by its optional ``bind`` override;
     - worker ``i`` (1-based) binds
       ``worker_port_base + (i - 1) * worker_port_stride``, one port per
-      ``worker_count``.
+      ``worker_count``;
+    - every OTHER host-mode service block binds ``services.<name>.port`` — the
+      same per-service convention :func:`_remedy_for_service` already names as
+      the generic remedy — on its optional ``bind`` override. A facility
+      template is free to bind something the framework cannot know about, so a
+      host-mode block with no usable ``port`` key is *announced* as escaping
+      the preflight rather than silently skipped: the whole failure mode this
+      derivation exists for is a port that appears in no ``ports:`` block. The
+      bundled outbound-only bridges (:data:`_HOST_MODE_PORTLESS_SERVICES`)
+      bind nothing and are exempt from both the derivation and the warning.
+
+    Derived bindings are labeled with the service's CONFIG key (``my_ioc_gw``),
+    not a compose service name: the binding comes from the rendered config, and
+    that spelling is what makes the generic remedy key correct as written.
 
     :param config: Loaded (rendered) configuration dictionary
     :type config: dict
@@ -338,6 +357,37 @@ def derive_host_network_bindings(config):
                 HostPortBinding(
                     service=f"{_WORKER_SERVICE_PREFIX}-{index}",
                     host_ip=_HOST_NETWORK_BIND,
+                    host_port=port,
+                    container_port=port,
+                    compose_file=_DERIVED_SOURCE,
+                    host_network=True,
+                )
+            )
+
+    services = config.get("services") if isinstance(config, dict) else None
+    if isinstance(services, dict):
+        for name, block in services.items():
+            if name in ("event_dispatcher", "dispatch_worker"):
+                continue  # specialized above (bind override / worker fan-out)
+            if name in _HOST_MODE_PORTLESS_SERVICES:
+                continue  # outbound-only: nothing bound, nothing to preflight
+            block = block if isinstance(block, dict) else {}
+            if not _on_host_network(block):
+                continue
+            try:
+                port = int(block.get("port"))
+            except (TypeError, ValueError):
+                logger.warning(
+                    f"Service {name!r} runs on the host network but declares no integer "
+                    f"`services.{name}.port`, so whatever it binds is NOT covered by "
+                    "the host-port preflight or the deploy summary. A collision there "
+                    'will surface as the runtime\'s bare "address already in use".'
+                )
+                continue
+            bindings.append(
+                HostPortBinding(
+                    service=str(name),
+                    host_ip=str(block.get("bind") or _HOST_NETWORK_BIND),
                     host_port=port,
                     container_port=port,
                     compose_file=_DERIVED_SOURCE,

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -80,6 +80,7 @@ from pathlib import Path
 from typing import Any, NoReturn
 
 from osprey.deployment.compose_generator import (
+    compose_base_cmd,
     compose_provider_env,
     resolve_project_name,
     resolve_repo_root,
@@ -498,6 +499,7 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
     runtime = runtime_cmd[0]
     env = runtime_env(config, ignore_orphans=True)
     project = resolve_project_name(config)
+    repo_root = resolve_repo_root(config, config_path)
     facility_prefix = as_dict(config.get("facility")).get("prefix") or ""
 
     volumes: list[str] = []
@@ -580,7 +582,7 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
     if not confirm_destroy(prompt, assume_yes, expected="nuke"):
         raise RuntimeError("Nuke aborted: confirmation did not match.")
 
-    result = _compose_down_project(runtime_cmd, project, env=env)
+    result = _compose_down_project(config, project, repo_root=Path(repo_root))
     if result.returncode != 0:
         print(f"nuke: 'compose down' failed (exit {result.returncode}): {result.stderr.strip()}")
         raise RuntimeError(
@@ -960,16 +962,32 @@ def rotate_user_password(config_path: str | Path, user: str, password: str) -> N
 
 
 def _compose_down_project(
-    runtime_cmd: list[str], project: str, *, env: dict[str, str] | None = None
+    config: dict, project: str, *, repo_root: Path
 ) -> subprocess.CompletedProcess:
     """Project-scoped ``compose down`` — containers/networks only, never volumes.
 
-    ``-p <project>`` is the only resource selector: compose resolves it against
+    Built through the invocation seam like every other compose command — the
+    pinned base plus the provider env — because a bare ``-p <project> down``
+    is an argv only the docker shape can act on: podman-compose has no
+    file-less, label-only ``down``, takes its project directory from the first
+    ``-f`` file's dirname (or ``COMPOSE_PROJECT_DIR``, 1.4.1+), and exits
+    non-zero, which aborted every nuke on a podman-compose host before it
+    removed anything.
+
+    ``-p <project>`` still pins the project name — compose resolves it against
     the ``com.docker.compose.project`` label every container this project ever
-    started carries, so this reaches exactly this project's containers with no
-    name enumeration and no wildcard. Never passed ``--volumes``/``-v`` — volume
-    destruction is the caller's responsibility, one exact name at a time (see
-    :func:`nuke_stack`).
+    started carries — and ``--remove-orphans`` keeps the file-less
+    invocation's reach: containers of services no longer in the rendered files
+    (a renamed roster, a dropped service) go down with the roster, matching
+    the off-roster volume sweep beside this call. The subprocess environment
+    is built WITHOUT ``COMPOSE_IGNORE_ORPHANS``: docker compose hard-errors on
+    that variable combined with ``--remove-orphans`` rather than letting one
+    win. Never passed ``--volumes``/``-v`` — volume destruction is the
+    caller's responsibility, one exact name at a time (see :func:`nuke_stack`).
+
+    A repo with no rendered compose files at all falls back to the bare
+    file-less argv: there is nothing for the seam to address, and the docker
+    shape is the one provider that can still act on labels alone.
 
     Does not raise on a non-zero exit and does not itself decide what a failure
     means — :func:`nuke_stack` is the caller that must inspect
@@ -978,18 +996,49 @@ def _compose_down_project(
     again downstream while masking the real error.
 
     Args:
-        runtime_cmd: Full runtime+compose command, e.g. ``["docker", "compose"]``
-            (the return value of
-            :func:`osprey.deployment.runtime_helper.get_runtime_command`).
+        config: Raw deploy config, for the runtime, the provider probe and the
+            env chain.
         project: Exact compose project name to tear down. Never a glob.
-        env: Environment for the subprocess call.
+        repo_root: The deployment repo — the compose project directory.
 
     Returns:
         The completed subprocess. The caller must check ``returncode`` — this
         function does not raise on failure.
     """
+    # Function-local imports: container_lifecycle and provision both import
+    # pieces of this module at their top level, so importing them back at
+    # module scope would be a cycle (the module's established pattern).
+    from osprey.deployment.container_lifecycle import _env_file_args, as_built_compose_files
+    from osprey.deployment.web_terminals.artifacts import web_compose_file
+    from osprey.deployment.web_terminals.provision import _resolved_compose_provider
+
+    runtime_cmd = get_runtime_command(config)
+    compose_files = [str(path) for path in as_built_compose_files(config, repo_root)]
+    web_file = web_compose_file(repo_root)
+    if web_file.is_file():
+        compose_files.append(str(web_file))
+
+    if not compose_files:
+        return subprocess.run(
+            [*runtime_cmd, "-p", project, "down"],
+            capture_output=True,
+            text=True,
+            env=runtime_env(config, ignore_orphans=True),
+        )
+
+    provider = _resolved_compose_provider(config, None)
+    cmd = compose_base_cmd(
+        runtime_cmd,
+        compose_files,
+        repo_root,
+        _env_file_args(repo_root, provider),
+        provider,
+    )
     return subprocess.run(
-        [*runtime_cmd, "-p", project, "down"], capture_output=True, text=True, env=env
+        [*cmd, "-p", project, "down", "--remove-orphans"],
+        capture_output=True,
+        text=True,
+        env=runtime_env(config, compose_provider_env(provider, repo_root)),
     )
 
 

--- a/src/osprey/health/loader.py
+++ b/src/osprey/health/loader.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from osprey.health.signatures import stat_signature
-from osprey.utils.workspace import deployment_env_path, repo_root_for_config
+from osprey.utils.workspace import deployment_env_chain, repo_root_for_config
 
 if TYPE_CHECKING:
     from osprey.health.config import CategoryRecord, HealthSettings
@@ -58,18 +58,22 @@ class LoadedHealthConfig(NamedTuple):
     config_ok: bool
 
 
-def _load_project_env(env_path: Path) -> None:
-    """Load *env_path* into ``os.environ`` with override semantics (best-effort).
+def _load_project_env(env_paths: list[Path]) -> None:
+    """Load the env chain into ``os.environ`` with override semantics (best-effort).
 
-    A missing file or a missing ``python-dotenv`` is silently ignored, matching
-    the CLI's ``.env`` handling.
+    Walked in the ascending order :func:`deployment_env_chain` returns —
+    ``.env.shared`` before ``.env`` — so with ``override=True`` the local file
+    wins, the same local-over-shared contract every other loader resolves. A
+    missing file or a missing ``python-dotenv`` is silently ignored, matching
+    the CLI's handling.
     """
     try:
         from dotenv import load_dotenv
     except ImportError:
         return
-    if env_path.exists():
-        load_dotenv(env_path, override=True)
+    for env_path in env_paths:
+        if env_path.exists():
+            load_dotenv(env_path, override=True)
 
 
 def _load_config(
@@ -114,23 +118,24 @@ class HealthConfigLoader:
         """
         self._config_path_override = config_path
         self._config_sig: tuple[int, int] | None = None
-        self._env_sig: tuple[int, int] | None = None
+        self._env_sig: tuple[tuple[int, int], ...] | None = None
         self._cached: LoadedHealthConfig | None = None
 
     def load(self) -> LoadedHealthConfig:
         """Run one synchronous refresh phase and return the resolved inputs."""
         config_path = self._resolve_path()
-        # The deployment's own `.env` at the repo root, not the config's
+        # The deployment's own env CHAIN at the repo root, not the config's
         # sibling. `build/.env` is a file no build writes, so watching it
         # meant an edit or a token rotation in the real `.env` never
-        # invalidated this cache — canaries and env scans kept answering
-        # from the environment as it was at process start. Paired with
-        # `signatures.disk_signature`, which must stat the same file or the
-        # two disagree silently.
-        env_path = deployment_env_path(config_path)
+        # invalidated this cache — and watching `.env` alone meant an edit to
+        # `.env.shared` never did either: canaries and env scans kept
+        # answering from the environment as it was at process start. Paired
+        # with `signatures.disk_signature`, which must stat the same files or
+        # the two disagree silently.
+        env_paths = deployment_env_chain(config_path)
 
         config_sig = stat_signature(config_path)
-        env_sig = stat_signature(env_path)
+        env_sig = tuple(stat_signature(path) for path in env_paths)
 
         first_run = self._cached is None
         env_changed = first_run or env_sig != self._env_sig
@@ -142,10 +147,10 @@ class HealthConfigLoader:
             assert self._cached is not None  # narrowed by ``first_run`` above
             return self._cached
 
-        # A changed ``.env`` must precede builder construction so ``${VAR}``
+        # A changed chain must precede builder construction so ``${VAR}``
         # placeholders expand against the fresh environment.
         if env_changed:
-            _load_project_env(env_path)
+            _load_project_env(env_paths)
 
         result = self._build(config_path)
 
@@ -178,7 +183,7 @@ class HealthConfigLoader:
         # — the `.env` presence check, the `registry_path` join, the disk
         # sample — all belong to the repo, while the config it was resolved
         # from lives one level down in `build/`. The same split the CLI makes
-        # (health_cmd._resolve_anchors) and the same root `deployment_env_path`
+        # (health_cmd._resolve_anchors) and the same root `deployment_env_chain`
         # above just watched, so the loader cannot report on one deployment
         # while watching another.
         project_path = repo_root_for_config(config_path)

--- a/src/osprey/health/signatures.py
+++ b/src/osprey/health/signatures.py
@@ -35,16 +35,20 @@ def stat_signature(path: Path) -> tuple[int, int] | None:
     return (st.st_mtime_ns, st.st_size)
 
 
-def disk_signature(config_path: str | Path | None) -> tuple[Any, Any]:
-    """Stat ``config.yml`` and the deployment's ``.env`` as one change probe.
+def disk_signature(config_path: str | Path | None) -> tuple[Any, ...]:
+    """Stat ``config.yml`` and the deployment's env chain as one change probe.
 
-    The ``.env`` is the one at the REPO ROOT, not a sibling of the config: the
-    config is a render under ``build/``, which no build writes an ``.env`` into.
+    The chain files are the ones at the REPO ROOT, not siblings of the config:
+    the config is a render under ``build/``, which no build writes an ``.env``
+    into. Every chain member is statted — ``.env.shared`` included — because an
+    edit to the shared defaults changes the environment the checks answer from
+    exactly the way an edit to ``.env`` does.
 
     Resolves *config_path* (or the CLI default via
-    :func:`osprey.utils.workspace.resolve_config_path` when ``None``) and returns
-    the pair of per-file :func:`stat_signature` values the breaker/validity checks
-    compare across cycles. A changed pair forces a refresh regardless of age.
+    :func:`osprey.utils.workspace.resolve_config_path` when ``None``) and
+    returns the per-file :func:`stat_signature` values the breaker/validity
+    checks compare across cycles as one opaque tuple. A changed tuple forces a
+    refresh regardless of age.
     """
     if config_path is not None:
         path = Path(config_path)
@@ -53,8 +57,11 @@ def disk_signature(config_path: str | Path | None) -> tuple[Any, Any]:
 
         path = resolve_config_path()
     # Same rule as `loader.HealthConfigLoader.load` — deliberately, and
-    # through the same helper. A signature that stats a different `.env`
+    # through the same helper. A signature that stats different files
     # than the loader watches is a cache that never invalidates.
-    from osprey.utils.workspace import deployment_env_path
+    from osprey.utils.workspace import deployment_env_chain
 
-    return (stat_signature(path), stat_signature(deployment_env_path(path)))
+    return (
+        stat_signature(path),
+        *(stat_signature(env_path) for env_path in deployment_env_chain(path)),
+    )

--- a/src/osprey/interfaces/health/engine.py
+++ b/src/osprey/interfaces/health/engine.py
@@ -276,6 +276,6 @@ class HealthCheckEngine:
 
     # -- default disk-change probe ----------------------------------------------
 
-    def _default_disk_signature(self) -> tuple[Any, Any]:
-        """Stat ``config.yml`` and its sibling ``.env`` for the breaker fast-path."""
+    def _default_disk_signature(self) -> tuple[Any, ...]:
+        """Stat ``config.yml`` and the deployment's env chain for the breaker fast-path."""
         return _resolve_disk_signature(self._config_path)

--- a/src/osprey/mcp_server/health/server_context.py
+++ b/src/osprey/mcp_server/health/server_context.py
@@ -342,8 +342,8 @@ class HealthServerContext:
 
     # -- default disk-change probe ----------------------------------------------
 
-    def _default_disk_signature(self) -> tuple[Any, Any]:
-        """Stat ``config.yml`` and its sibling ``.env`` for the validity probe."""
+    def _default_disk_signature(self) -> tuple[Any, ...]:
+        """Stat ``config.yml`` and the deployment's env chain for the validity probe."""
         return _resolve_disk_signature(self._config_path)
 
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -44,6 +44,23 @@ def _guard_os_exit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(os, "_exit", _raise)
 
 
+@pytest.fixture(autouse=True)
+def _neutral_color_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip color-forcing variables from the environment CLI tests run under.
+
+    Leak guarded: Rich and Click honor ``FORCE_COLOR``/``CLICOLOR_FORCE`` as a
+    documented opt-in, so a developer whose terminal exports either gets ANSI
+    escapes inside ``CliRunner``'s captured output — and a false-red lane on
+    pristine main (seven tests: exact-output asserts, plus two whose captured
+    YAML stops parsing on ``\\x1b``). CI is green only because its runners
+    never export them; this makes the suite hermetic instead of lucky.
+    ``NO_COLOR`` is left alone: unset it is the same default CI runs under,
+    and pinning it would hide a command that fails to honor the opt-out.
+    """
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("CLICOLOR_FORCE", raising=False)
+
+
 @pytest.fixture
 def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect ``Path.home()`` and ``$HOME`` to a tmp directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,10 +44,11 @@ _PRISTINE_LOGGING = {
 # spawn share their ports), so a key is removed only when it BOTH appeared
 # during collection AND carries exactly the value an ancestor .env defines.
 
-# Color-forcing variables must be gone BEFORE collection imports any osprey
-# module: `osprey.cli.styles` builds its module-level Rich Console at import
-# time and Rich reads FORCE_COLOR in `Console.__init__`, so a fixture runs too
-# late to un-force a console that already exists. A developer terminal that
+# import-time required because `osprey.cli.styles` builds its module-level
+# Rich Console at import time and Rich reads FORCE_COLOR in `Console.__init__`,
+# so a fixture runs too late to un-force a console that already exists: the
+# color-forcing variables must be gone BEFORE collection imports any osprey
+# module. A developer terminal that
 # exports FORCE_COLOR otherwise turns CliRunner captures into ANSI-laced text
 # and fails seven CLI tests on pristine main — CI is green only because its
 # runners never export it. `NO_COLOR` is left alone: unset is the same default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,17 @@ _PRISTINE_LOGGING = {
 # spawn share their ports), so a key is removed only when it BOTH appeared
 # during collection AND carries exactly the value an ancestor .env defines.
 
+# Color-forcing variables must be gone BEFORE collection imports any osprey
+# module: `osprey.cli.styles` builds its module-level Rich Console at import
+# time and Rich reads FORCE_COLOR in `Console.__init__`, so a fixture runs too
+# late to un-force a console that already exists. A developer terminal that
+# exports FORCE_COLOR otherwise turns CliRunner captures into ANSI-laced text
+# and fails seven CLI tests on pristine main — CI is green only because its
+# runners never export it. `NO_COLOR` is left alone: unset is the same default
+# CI runs under.
+os.environ.pop("FORCE_COLOR", None)
+os.environ.pop("CLICOLOR_FORCE", None)
+
 _PRE_COLLECTION_ENV = dict(os.environ)
 
 

--- a/tests/deployment/test_ariel_store_stage.py
+++ b/tests/deployment/test_ariel_store_stage.py
@@ -146,6 +146,43 @@ def test_a_project_without_ariel_stages_nothing(ariel_stubs, tmp_path):
     assert ariel_stubs["migrated"] == []
 
 
+def test_the_staging_invocation_is_shaped_by_the_provider_it_is_handed(
+    ariel_stubs, tmp_path, monkeypatch
+):
+    """The provider must reach all three halves of the invocation contract:
+    the argv builder, the env-file arguments, and the process environment.
+    Left unthreaded, the store's `up` runs docker-shaped in the middle of a
+    podman-shaped deploy."""
+    from osprey.deployment.runtime_helper import ComposeProvider
+
+    seen: dict = {}
+
+    def _record_base(runtime_cmd, files, root, env_args, provider=None):
+        seen["base_provider"] = provider
+        return ["docker", "compose"]
+
+    def _record_env_files(root=None, provider=None):
+        seen["env_file_provider"] = provider
+        return []
+
+    def _record_run(cmd, *, env=None, **kwargs):
+        seen["run_env"] = dict(env or {})
+
+    monkeypatch.setattr(container_lifecycle, "compose_base_cmd", _record_base)
+    monkeypatch.setattr(container_lifecycle, "_env_file_args", _record_env_files)
+    monkeypatch.setattr(container_lifecycle, "run_captured", _record_run)
+
+    # Act
+    container_lifecycle._stage_ariel_store(
+        ARIEL_CONFIG, ["compose.yml"], {}, tmp_path, provider=ComposeProvider.PODMAN_COMPOSE
+    )
+
+    # Assert
+    assert seen["base_provider"] is ComposeProvider.PODMAN_COMPOSE
+    assert seen["env_file_provider"] is ComposeProvider.PODMAN_COMPOSE
+    assert seen["run_env"]["COMPOSE_PROJECT_DIR"] == str(tmp_path)
+
+
 def test_an_unreachable_store_warns_and_leaves_the_deploy_standing(
     ariel_stubs, tmp_path, monkeypatch, caplog
 ):

--- a/tests/deployment/test_compose_env_interpolation.py
+++ b/tests/deployment/test_compose_env_interpolation.py
@@ -167,6 +167,36 @@ def test_ensure_service_tokens_refuses_a_dollar_outside_the_validated_vars(tmp_p
     assert "battery" not in str(excinfo.value)
 
 
+def test_ensure_service_tokens_refuses_a_dollar_in_the_shared_defaults(tmp_path) -> None:
+    """`.env.shared` rides the same two routes out of the repo as `.env`.
+
+    On the docker shape it is one of the `--env-file` fragments and a member of
+    the worker's `env_file:` list, so a `$` there is mangled identically — but
+    the only chain-wide scan used to live on the podman branch (the merged-file
+    writer), leaving the DEFAULT provider unguarded. The scan must be
+    provider-independent.
+    """
+    (tmp_path / ".env").write_text("CLEAN=value\n", encoding="utf-8")
+    (tmp_path / ".env.shared").write_text("SHARED_TOKEN=s3cr3t$HOME\n", encoding="utf-8")
+
+    with pytest.raises(ComposeInterpolationError) as excinfo:
+        container_lifecycle._ensure_service_tokens({}, False, tmp_path / ".env")
+
+    assert "SHARED_TOKEN" in str(excinfo.value)
+    assert "s3cr3t" not in str(excinfo.value)
+
+
+def test_ensure_service_tokens_scans_the_shared_file_when_no_local_env_exists(tmp_path) -> None:
+    """A fresh clone can carry `.env.shared` (git-tracked) with no `.env` yet;
+    the chain scan must not be gated on the local file existing."""
+    (tmp_path / ".env.shared").write_text("SHARED_TOKEN=s3cr3t$HOME\n", encoding="utf-8")
+
+    with pytest.raises(ComposeInterpolationError) as excinfo:
+        container_lifecycle._ensure_service_tokens({}, False, tmp_path / ".env")
+
+    assert "SHARED_TOKEN" in str(excinfo.value)
+
+
 def test_ensure_service_tokens_refuses_before_minting_anything(tmp_path) -> None:
     """A refused deploy must not leave freshly minted tokens behind.
 

--- a/tests/deployment/test_compose_invocation.py
+++ b/tests/deployment/test_compose_invocation.py
@@ -617,6 +617,32 @@ def test_the_archiver_staging_runs_in_the_shape_the_start_resolved(
     assert staged[0]["provider"] is ComposeProvider.PODMAN_COMPOSE
 
 
+def test_the_ariel_staging_runs_in_the_shape_the_start_resolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The logbook twin of the archiver test above, for the same reason.
+
+    ARIEL's store is brought up by its own invocation of the same project;
+    unthreaded it would run docker-shaped in the middle of a podman-shaped
+    ``up``, addressing a different project directory with part of the env chain
+    dropped.
+    """
+    repo = _started_repo(tmp_path)
+    _podman_host(monkeypatch)
+    staged: list[dict] = []
+    monkeypatch.setattr(container_lifecycle, "_ariel_store_deployed", lambda config: True)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_stage_ariel_store",
+        lambda *args, **kwargs: staged.append(kwargs),
+    )
+
+    container_lifecycle.up_as_built(repo, detached=True)
+
+    assert staged, "the ARIEL staging step never ran"
+    assert staged[0]["provider"] is ComposeProvider.PODMAN_COMPOSE
+
+
 def test_a_refused_provider_still_reaches_the_label_sweep(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/deployment/test_env_chain_matrix.py
+++ b/tests/deployment/test_env_chain_matrix.py
@@ -377,6 +377,35 @@ def resolve_via_users_cli(repo: Path, monkeypatch: pytest.MonkeyPatch) -> dict[s
     return chain_keys_of(parse_dotenv_text(result.output))
 
 
+def resolve_via_health_cli(repo: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """``osprey health --project <repo>``'s pre-check env load, from ANOTHER cwd.
+
+    The anchors resolve through the config path, never the working directory —
+    this row runs without chdir-ing into the repo, which is exactly the stance
+    that used to drop ``.env.shared`` (the cwd-rooted chain load never saw the
+    target repo, and the repo-anchored reload knew only ``.env``).
+    """
+    from osprey.cli.health_cmd import _load_project_env, _resolve_anchors
+
+    _render_repo(repo)
+    _config_path, _repo_root, env_paths = _resolve_anchors(repo)
+    _load_project_env(env_paths)
+    return chain_keys_of(os.environ)
+
+
+def resolve_via_health_loader(repo: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """The long-lived health surface's refresh-cycle loader.
+
+    The one loader that also WATCHES what it reads: the chain it loads here is
+    the same file set ``signatures.disk_signature`` stats, so an ``.env.shared``
+    edit both reloads and invalidates.
+    """
+    from osprey.health.loader import HealthConfigLoader
+
+    HealthConfigLoader(config_path=_render_repo(repo)).load()
+    return chain_keys_of(os.environ)
+
+
 LOADERS = [
     pytest.param(resolve_via_load_project_dotenv, id="load_project_dotenv"),
     pytest.param(resolve_via_chat_overlay, id="chat-overlay"),
@@ -387,6 +416,8 @@ LOADERS = [
     pytest.param(resolve_via_mcp_env, id="mcp_env-reversed"),
     pytest.param(resolve_via_users_env_file, id="env-users-derivation"),
     pytest.param(resolve_via_users_cli, id="users-env-cli"),
+    pytest.param(resolve_via_health_cli, id="health-cli-cross-cwd"),
+    pytest.param(resolve_via_health_loader, id="health-loader"),
 ]
 
 

--- a/tests/deployment/test_host_ports.py
+++ b/tests/deployment/test_host_ports.py
@@ -339,6 +339,46 @@ class TestHostNetworkDerivation:
         )
         assert [b.host_port for b in bindings] == [9190, 9200, 9210]
 
+    def test_a_facility_host_mode_service_derives_from_its_port_key(self):
+        """The docs invite a facility to put its own service on the host
+        network; the preflight and the deploy summary must see it there.
+        Derived from ``services.<name>.port`` — the same per-service
+        convention the generic remedy key already assumes."""
+        (binding,) = derive_host_network_bindings(
+            _host_config(my_ioc_gw={"network": "host", "port": 5075})
+        )
+        assert binding.service == "my_ioc_gw"
+        assert (binding.host_ip, binding.host_port) == ("127.0.0.1", 5075)
+        assert binding.host_network is True
+        # The config-key spelling is what makes the generic remedy correct.
+        assert host_ports._remedy_for_service(binding.service) == "services.my_ioc_gw.port"
+
+    def test_a_facility_service_bind_override_is_honoured(self):
+        (binding,) = derive_host_network_bindings(
+            _host_config(my_ioc_gw={"network": "host", "port": 5075, "bind": "0.0.0.0"})
+        )
+        assert binding.host_ip == "0.0.0.0"
+
+    def test_a_portless_host_mode_service_is_announced_not_silently_skipped(self, caplog):
+        """A host-mode block with no usable port key cannot be derived — and
+        the whole failure mode this derivation exists for is a silent gap, so
+        the escape is said out loud."""
+        with caplog.at_level("WARNING"):
+            bindings = derive_host_network_bindings(_host_config(my_ioc_gw={"network": "host"}))
+        assert bindings == []
+        assert "my_ioc_gw" in caplog.text
+        assert "preflight" in caplog.text
+
+    def test_the_outbound_only_bridges_neither_derive_nor_warn(self, caplog):
+        """The bundled bridges legitimately run host-mode with no listening
+        socket; a warning for them would be noise on a valid config."""
+        with caplog.at_level("WARNING"):
+            bindings = derive_host_network_bindings(
+                _host_config(nextcloud_bridge={"network": "host"}, gchat_bridge={"network": "host"})
+            )
+        assert bindings == []
+        assert "host network" not in caplog.text
+
     def test_both_halves_on_host_derive_both(self):
         bindings = derive_host_network_bindings(
             _host_config(

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -835,6 +835,83 @@ def test_nuke_sweeps_off_roster_orphan_volumes_too(
     ]
 
 
+def test_nuke_compose_down_runs_through_the_invocation_seam_when_files_exist(
+    tmp_path, monkeypatch, fake_runtime_nuke
+):
+    """The teardown must carry the pinned base, not a bare ``-p <project> down``.
+
+    With rendered compose files on disk, the down is built through
+    ``compose_base_cmd``: project directory pinned in argv (docker shape),
+    the rendered files as ``-f``, the project still pinned with ``-p``, and
+    ``--remove-orphans`` preserving the file-less invocation's reach.
+    """
+    calls, listing, _down_result, _image_labels = fake_runtime_nuke
+    monkeypatch.chdir(tmp_path)
+    config = _config(["alice"], project_name="demo-project")
+    config_path = _write_config(tmp_path, config)
+    (tmp_path / "build").mkdir(exist_ok=True)
+    web_file = tmp_path / "build" / "docker-compose.web.yml"
+    web_file.write_text("services: {}\n", encoding="utf-8")
+    _assert_no_input_prompt(monkeypatch)
+
+    lifecycle.nuke_stack(str(config_path), assume_yes=True)
+
+    down_calls = [c for c in calls if "down" in c]
+    assert len(down_calls) == 1
+    argv = down_calls[0]
+    assert argv[:2] == ["docker", "compose"]
+    assert "--project-directory" in argv, f"unpinned project directory: {argv}"
+    assert str(web_file) in argv, f"rendered web compose file not addressed: {argv}"
+    assert argv[-4:] == ["-p", "demo-project", "down", "--remove-orphans"]
+
+
+def test_nuke_compose_down_emits_the_podman_shape_on_a_podman_host(
+    tmp_path, monkeypatch, fake_runtime_nuke
+):
+    """The defect this seam routing exists for: podman-compose cannot parse the
+    bare label-only ``down`` at all, so on that host class the nuke aborted
+    before removing anything. The podman shape is the single merged ``-f``
+    plus ``COMPOSE_PROJECT_DIR`` in the environment — and the environment must
+    NOT carry ``COMPOSE_IGNORE_ORPHANS`` beside ``--remove-orphans``, a
+    combination docker compose hard-errors on."""
+    from osprey.deployment.runtime_helper import ComposeProvider
+
+    calls, listing, _down_result, _image_labels = fake_runtime_nuke
+    monkeypatch.chdir(tmp_path)
+    config = _config(["alice"], project_name="demo-project")
+    config_path = _write_config(tmp_path, config)
+    (tmp_path / "build").mkdir(exist_ok=True)
+    (tmp_path / "build" / "docker-compose.web.yml").write_text("services: {}\n", encoding="utf-8")
+    _assert_no_input_prompt(monkeypatch)
+
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(
+        container_lifecycle, "_compose_provider", lambda config=None: ComposeProvider.PODMAN_COMPOSE
+    )
+    down_envs: list[dict] = []
+    fixture_run = lifecycle.subprocess.run
+
+    def _spy(argv, capture_output=True, text=True, env=None, **kwargs):
+        if "down" in argv:
+            down_envs.append(dict(env or {}))
+        return fixture_run(argv, capture_output=capture_output, text=text, env=env, **kwargs)
+
+    monkeypatch.setattr(lifecycle.subprocess, "run", _spy)
+
+    lifecycle.nuke_stack(str(config_path), assume_yes=True)
+
+    down_calls = [c for c in calls if "down" in c]
+    assert len(down_calls) == 1
+    argv = down_calls[0]
+    assert "--project-directory" not in argv, f"podman-compose parses no such flag: {argv}"
+    assert argv.count("-f") == 1, f"podman shape is ONE merged file: {argv}"
+    assert argv[argv.index("-f") + 1].endswith(".osprey-compose.yml")
+    assert argv[-4:] == ["-p", "demo-project", "down", "--remove-orphans"]
+    assert down_envs[0].get("COMPOSE_PROJECT_DIR") == str(tmp_path)
+    assert "COMPOSE_IGNORE_ORPHANS" not in down_envs[0]
+
+
 def test_nuke_aborts_before_removing_any_volume_when_compose_down_fails(
     tmp_path, monkeypatch, fake_runtime_nuke
 ):

--- a/tests/docs/test_deploy_ops_retired.py
+++ b/tests/docs/test_deploy_ops_retired.py
@@ -35,6 +35,14 @@ SCAN_SUFFIXES = (
     ".toml",
     ".sh",
 )
+
+#: Shipped files with no extension, admitted by name — the same clause as the
+#: sibling gates (``test_env_production_retired.py``, ``test_zone_vocabulary``):
+#: a suffix-only rule cannot see the ``gitignore``/``dockerignore``/
+#: ``Dockerfile`` templates the scaffold emits verbatim. Matched with any
+#: leading dot stripped, because the same kind of file ships both ways.
+SCAN_STEMS = frozenset({"gitignore", "dockerignore", "Dockerfile"})
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -45,7 +53,9 @@ def _shipped_sources() -> list[Path]:
         if not base.exists():
             continue
         for path in base.rglob("*"):
-            if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+            if not path.is_file():
+                continue
+            if path.suffix not in SCAN_SUFFIXES and path.name.lstrip(".") not in SCAN_STEMS:
                 continue
             if "__pycache__" in path.parts:
                 continue

--- a/tests/docs/test_zone_vocabulary.py
+++ b/tests/docs/test_zone_vocabulary.py
@@ -64,6 +64,15 @@ SCAN_SUFFIXES = (
     ".sh",
 )
 
+#: Shipped files that carry no extension at all, admitted by name instead — the
+#: same clause as ``test_env_production_retired.py``, and for the same reason:
+#: an extension-only rule cannot see them, and the two files that actually
+#: narrate the zones to an operator both live in that class (the project
+#: ``gitignore`` and ``dockerignore`` templates, emitted verbatim into every
+#: scaffolded repo). Matched with any leading dot stripped, because the same
+#: kind of file ships both ways.
+SCAN_STEMS = frozenset({"gitignore", "dockerignore", "Dockerfile"})
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 #: Coincidental "three ... zone" pairs that are not about the zone count at
@@ -85,7 +94,9 @@ def _shipped_sources() -> list[Path]:
         if not base.exists():
             continue
         for path in base.rglob("*"):
-            if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+            if not path.is_file():
+                continue
+            if path.suffix not in SCAN_SUFFIXES and path.name.lstrip(".") not in SCAN_STEMS:
                 continue
             if "__pycache__" in path.parts:
                 continue
@@ -107,7 +118,9 @@ def _stale_count_hits(root_dir: Path | None = None) -> list[tuple[str, str]]:
         if not base.exists():
             continue
         for path in base.rglob("*"):
-            if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+            if not path.is_file():
+                continue
+            if path.suffix not in SCAN_SUFFIXES and path.name.lstrip(".") not in SCAN_STEMS:
                 continue
             if "__pycache__" in path.parts:
                 continue
@@ -163,6 +176,23 @@ def test_four_zones_is_actually_live() -> None:
     assert hits > 0, "no shipped text says 'four zones' — the vocabulary rename regressed"
 
 
+def test_the_extensionless_zone_narrators_are_actually_swept() -> None:
+    """The two shipped files that narrate the zones carry no extension at all.
+
+    The project ``gitignore``/``dockerignore`` templates are emitted verbatim
+    into every scaffolded repo and explain the layout in comments — exactly the
+    operator-facing prose this gate exists for. A suffix-only admission rule
+    silently skips both, so their membership is pinned here rather than
+    assumed.
+    """
+    swept = {str(path.relative_to(_REPO_ROOT)) for path in _shipped_sources()}
+    for expected in (
+        "src/osprey/templates/project/gitignore",
+        "src/osprey/templates/project/dockerignore",
+    ):
+        assert expected in swept, f"{expected} is outside the sweep's admission rule"
+
+
 @pytest.mark.parametrize(
     "path_parts,text",
     (
@@ -171,6 +201,10 @@ def test_four_zones_is_actually_live() -> None:
         (
             ("src", "osprey", "regress_wrapped.py"),
             "# the source zone is tracked, and the three\n# generated or secret zones never are\n",
+        ),
+        (
+            ("src", "osprey", "gitignore"),
+            "# SECRETS zone — one of the repo's three generated zones\n",
         ),
     ),
 )

--- a/tests/health/test_loader.py
+++ b/tests/health/test_loader.py
@@ -174,6 +174,30 @@ class TestChangeGate:
         loader.load()
         assert os.environ["OSPREY_LOADER_CANARY"] == "v2"
 
+    def test_shared_env_change_reloads_the_chain(self, project):
+        """``.env.shared`` is a chain member like ``.env``: an edit must both
+        invalidate the cache and be reloaded. Watching ``.env`` alone left the
+        long-lived surface unconditionally blind to shared-default edits."""
+        shared_path = project / ".env.shared"
+        shared_path.write_text("OSPREY_LOADER_CANARY=shared-v1\n")
+        loader = HealthConfigLoader(project / "config.yml")
+        loader.load()
+        assert os.environ["OSPREY_LOADER_CANARY"] == "shared-v1"
+
+        shared_path.write_text("OSPREY_LOADER_CANARY=shared-v2\n")
+        _bump_mtime(shared_path)
+        loader.load()
+        assert os.environ["OSPREY_LOADER_CANARY"] == "shared-v2"
+
+    def test_the_local_file_wins_the_chain_conflict(self, project):
+        """Ascending-order load with override semantics: `.env` over `.env.shared`."""
+        (project / ".env.shared").write_text("OSPREY_LOADER_CANARY=from-shared\n")
+        (project / ".env").write_text("OSPREY_LOADER_CANARY=from-local\n")
+
+        HealthConfigLoader(project / "config.yml").load()
+
+        assert os.environ["OSPREY_LOADER_CANARY"] == "from-local"
+
     def test_edit_observed_between_loads(self, project):
         config_path = project / "config.yml"
         loader = HealthConfigLoader(config_path)

--- a/tests/infrastructure/test_import_time_audit.py
+++ b/tests/infrastructure/test_import_time_audit.py
@@ -39,6 +39,10 @@ WHITELIST: dict[str, set[str]] = {
     "benchmark/test_matrix_lanes.py": {"sys.modules"},
     "scripts/test_config_key_guard.py": {"sys.modules"},
     "va/e2e/conftest.py": {"sys.modules"},
+    # the root conftest scrubs FORCE_COLOR/CLICOLOR_FORCE before collection
+    # imports any osprey module: osprey.cli.styles builds its Console at import
+    # time, so a fixture would un-force a console that already exists.
+    "conftest.py": {"os.environ"},
 }
 
 #: Marker every whitelisted site must carry, next to the mutation.


### PR DESCRIPTION
Closes a set of consistency gaps between what the deploy, health and release
surfaces claim and what they actually do.

## Release
- `release.yml` gains a `verify-pypi-resolvable` job that installs the built
  framework wheel with dependencies resolved from PyPI alone; `publish-to-pypi`
  now requires it. A wheel whose dependencies cannot be resolved publicly can
  no longer be published.

## Deploy
- The ARIEL logbook store's `up` is built through the shared compose seam —
  provider shape, rendered files, pinned project directory — like every other
  compose invocation, so podman-compose hosts no longer abort mid-deploy.
- `osprey users nuke` builds its `down` through `compose_base_cmd` with the
  provider env and `--remove-orphans`, instead of a bare `docker compose -p down`.
- A `$` in any `.env.shared` value stops the deploy on every compose provider,
  not only podman-compose.
- The host-port preflight and the `osprey up` closing summary cover any facility
  service on the host network via its `services.<name>.port` key; a host-mode
  service without that key gets a named warning instead of silently escaping
  the check. Outbound-only bridges are exempt.

## Health
- `osprey health --project <repo>` resolves the target repo's whole env chain,
  `.env.shared` included, and the long-lived health surfaces watch the chain
  for edits instead of answering from a stale environment.

## Tests
- `FORCE_COLOR`/`CLICOLOR_FORCE` are scrubbed at root-conftest import, before
  `osprey.cli.styles` builds its Console, fixing 7 tests that broke under a
  color-forcing environment.
- The docs vocabulary sweeps and removal gates cover extensionless templates
  and the scan-stem vocabulary, with membership pins so the coverage cannot
  silently narrow again.

Docs: `deploy-project.rst` updated to match the host-port coverage; CHANGELOG
entries added.