### PR TITLE
feat(cli): give the CLI a single output hierarchy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,17 @@ jobs:
       # Linux runner. tests/deployment/test_ci_workflow_wiring.py pins both
       # this invocation and the conftest override, so the flag cannot outlive
       # the scheduler that makes it safe.
+      #
+      # -m "not pty" hands the real-terminal suite to the serial step below.
+      # Those scenarios assert on repaint cadence and on a spinner ADVANCING
+      # between two frames, so they measure the box as much as the code, and
+      # three other xdist workers competing for it is exactly the load that
+      # turns "the monitor thread is running" into an intermittent red.
+      # Written as a marker deselection rather than `--ignore=tests/pty`
+      # because tests/pty/test_stub_coverage.py is unmarked on purpose and
+      # belongs in this lane: it scans the deploy path for runtime argv the
+      # stub cannot answer, needs no terminal, and is what makes the serial
+      # step's failures worth reading.
       run: |
         if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
           COV_ARGS="--cov=src/osprey --cov=packages/osprey-connectors/src/osprey_connectors --cov-report=xml --cov-report=term"
@@ -197,7 +208,7 @@ jobs:
         # minutes later in an unrelated test and EPICS' signal handling turns
         # it into a silent wedge rather than a death. A live CA client/server
         # pair is only safe in a process of its own.
-        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -v --tb=short -n 4 --dist loadgroup $COV_ARGS
+        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -m "not pty" -v --tb=short -n 4 --dist loadgroup $COV_ARGS
 
     # The two steps below are the reason the step above has its own timeout.
     # They run on success too: on a green lane the summary is one line, and on
@@ -223,6 +234,47 @@ jobs:
         path: ci-diag/
         retention-days: 14
         if-no-files-found: warn
+
+    - name: Run real-terminal pty suite serially
+      # Linux only, and not because the suite cannot run elsewhere: it is POSIX
+      # and passes on macOS too (it self-skips only off-POSIX, which no cell in
+      # this matrix is). It is pinned here because the scenarios assert on
+      # timing (a spinner ADVANCING between two frames, a late line arriving
+      # after a kill), and the macOS runners are the noisier, slower, more
+      # contended ones, so they would be where this suite starts flaking. What
+      # it covers is not OS-specific either: it is how OSPREY's own renderer
+      # drives a terminal. Both Linux Python cells run it, so it is not
+      # single-interpreter, and a developer on macOS runs it locally.
+      if: matrix.os == 'ubuntu-latest'
+      # Serial by construction, and no xdist flags. Each scenario allocates a
+      # pty, starts a real verb on it in its own session, and asserts on what
+      # the terminal showed, including that a spinner ADVANCED between two
+      # frames, which is how the monitor thread is proven to be running. That
+      # measures the box as much as the code, so it is exactly the assertion a
+      # loaded runner turns into an intermittent red. Hence its own step here
+      # rather than a share of the parallel lane above, which deselects the
+      # marker.
+      #
+      # `-m pty` and not the bare directory: tests/pty/test_stub_coverage.py is
+      # unmarked on purpose, needs no terminal, and already ran in the parallel
+      # step. Selecting the directory alone would run it twice.
+      #
+      # No actions/cache for .cache/pty-exemplar. The session fixture renders
+      # that repo with the real `osprey init` and `osprey build` in ~1.2 s for
+      # ~380 KB, which is less than a cache round trip costs, and its key is a
+      # content hash of the templates plus the scaffolder that stamps them out:
+      # every PR touching a rendered file would miss the cache anyway. The
+      # checkout is writable, so the fixture writes there and the runner throws
+      # it away with everything else.
+      #
+      # The job cap above stays at 45 rather than growing to absorb this step.
+      # 40 (the unit step) plus 10 (here) exceeds it on paper, but only in a run
+      # where the unit step has already burned its own cap, which is a red lane
+      # whatever happens next: nothing is lost by the job cap cutting a step
+      # short in that case. On a healthy lane this step costs well under a
+      # minute, so the tail margin the job cap comment argues for is untouched.
+      timeout-minutes: 10
+      run: uv run pytest tests/pty/ -m pty -v --tb=short
 
     - name: Run live Channel Access suites in isolation
       # One pytest process per module via the live-CA gate — the same venue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- What the CLI prints is now a progress report rather than a log. A verb prints
+  the phase it is in, the steps under it, and a summary at the end; the
+  timestamped `INFO` records that used to scroll past no longer reach the
+  screen, though every one of them still reaches the sinks the deployment
+  configures. `osprey -v <verb>` brings the whole transcript back. Warnings and
+  failures read the same way in every verb now (a one-line summary, the cause
+  under it, and what to do about it), and every one of them goes to stderr, so a
+  script reading a command's output no longer has to filter trouble out of it.
+  Under `--json`, stdout carries the JSON document and nothing else.
+
 - Lifecycle commands no longer go quiet while they work. `osprey init`,
   `build`, `up`, `restart`, `down` and `reset` keep a spinner and a running
   elapsed under the phase they are in, and while images are building there is

--- a/docs/source/cli-reference/index.rst
+++ b/docs/source/cli-reference/index.rst
@@ -53,7 +53,12 @@ Global Options
    Show framework version and exit.
 
 ``-v, --verbose``
-   Show debug output, including every container command run.
+   Show debug output, including every container command run. The transcript
+   takes the place of the progress report rather than joining it, so under
+   ``-v`` no phase or step lines are printed at all. Without it, a run prints
+   the progress report and the command's own output only; log records below
+   WARNING never reach the screen, though they still reach every sink the
+   deployment configures.
 
 ``--help``
    Show help for any command (e.g., ``osprey build --help``).

--- a/docs/source/getting-started/control-assistant.rst
+++ b/docs/source/getting-started/control-assistant.rst
@@ -77,16 +77,26 @@ recorder service — that holds what those channels did.
 
 **The first deploy seeds the archive**, and it is the step that takes the
 longest. It writes about a month of history for every channel the machine
-serves, printing a progress line every 15 seconds or so while it works. The
-duration on each line is how long that slice of the seeding took:
+serves, reporting a step under the start phase every 15 seconds or so while it
+works. The duration at the end of each step is how long that slice took:
+
+.. Renderer-generated block, not a captured run: a real seed needs a container
+   runtime, the store, and several minutes, so the shape below was produced by
+   printing the deploy path's own strings through the real phase reporter. The
+   counts and durations are historical, carried over from an earlier capture.
+   To regenerate: build each line the way ``container_lifecycle`` does (the two
+   ``_report_step`` literals around the seed, plus
+   ``SeedReport.describe()`` for the last one) and print them through
+   ``Phase.step`` on a ``LiveReporter``.
 
 .. code-block:: text
 
-   Seeding 2,908 channels over 30 days (48h at 10s, then 60s). This takes minutes on a first deploy.
+   → Starting my-control-assistant
+     · seeding the archive base: 2,908 channels over 30 days (minutes on a first deploy)
      · seeding archive: 8,960 documents written across 2,908 channels (17.4s)
      · seeding archive: 17,920 documents written across 2,908 channels (15.0s)
      ...
-   seeded 57,600 documents x 2,908 channels (2026-07-12 09:14 to 2026-08-11 09:14 UTC) in 96.3s
+     · archive base: seeded 57,600 documents x 2,908 channels (2026-07-12 09:14 to 2026-08-11 09:14 UTC) in 96.3s (14.2s)
 
 Each of those documents holds one instant across every channel, which is why
 the count is in the tens of thousands rather than the millions. Expect a minute

--- a/docs/source/getting-started/hello-world-tutorial.rst
+++ b/docs/source/getting-started/hello-world-tutorial.rst
@@ -32,13 +32,21 @@ Create a ready-to-run deployment, then render it:
    osprey build
 
 ``osprey init`` writes one git repository with the preset's configuration
-spelled out in full:
+spelled out in full, and prints the entries you edit:
 
 .. code-block:: text
 
-   my-first-agent/
-     profile.yml   the manifest — your editable source of truth
-     build/        rendered by `osprey build`; disposable
+   ✓ Created my-first-agent
+
+     profile.yml   your assistant's settings; edit this
+     data/         channel lists and facility docs; edit these
+     .env          from your shell: ANTHROPIC_API_KEY. Not in git
+     .env.shared   settings shared by every host; your .env wins
+     README.md     what everything here does
+     ...
+
+``osprey build`` adds ``build/`` beside them, which is disposable and rendered
+again on every build.
 
 ``osprey init`` copies the preset into ``profile.yml``; every later build reads
 that file as it stands. Nothing in this tutorial needs you to edit it, but that

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -91,13 +91,14 @@ Step 1 — Create the facility repository
    cd demo-facility
 
 The command writes the whole repository, runs ``git init`` at its root, and
-commits nothing. It prints the directory layout, the two persona deltas it
-rendered, and where the secrets go.
+commits nothing. It prints the handful of entries you edit: the profile, the
+data directory, the two personas it rendered, the two env files, and the
+README.
 
-It also tells you there is no CI pipeline yet. That is expected: the profile
-ships with its ``deploy:`` block commented out, so there are no coordinates to
-render a pipeline from. Step 5 fills the block in and Step 7 renders the
-pipeline from it.
+It says nothing about CI, which is expected: the profile ships with its
+``deploy:`` block commented out, so there are no coordinates to render a
+pipeline from. Step 5 fills the block in and Step 7 renders the pipeline from
+it.
 
 
 Step 2 — Trim the profile to this facility's stack

--- a/docs/source/how-to/use-cli-chat.rst
+++ b/docs/source/how-to/use-cli-chat.rst
@@ -54,9 +54,9 @@ On startup, ``osprey chat`` launches the same companion servers as
 
 .. code-block:: text
 
-   Companion servers:
-     * Artifact gallery  http://127.0.0.1:8086
-     * ARIEL server      http://127.0.0.1:8085
+   Companion servers
+     Artifact gallery   http://127.0.0.1:8086
+     ARIEL server       http://127.0.0.1:8085
 
 Open any of these URLs in a browser to access the service while the Osprey agent
 runs in your terminal. Which servers start depends on your ``config.yml`` —

--- a/packages/osprey-connectors/src/osprey_connectors/logger.py
+++ b/packages/osprey-connectors/src/osprey_connectors/logger.py
@@ -57,6 +57,11 @@ class ComponentLogger:
     - timing: Timing information
     - approval: Approval messages
     - resume: Resume messages
+
+    Every emitted record carries the name of the method that produced it as the
+    ``osprey_intent`` attribute, so handlers and filters can tell intents apart
+    where the level cannot (``info`` and ``key_info`` both log at INFO). It is
+    metadata only: no level is remapped and no formatter reads it.
     """
 
     def __init__(
@@ -80,63 +85,79 @@ class ComponentLogger:
         self.color = color
         self._state = state
 
-    def _log(self, level: int, message: str, *args, **kwargs) -> None:
-        """Core logging method that delegates to the stdlib logger."""
+    def _log(self, level: int, message: str, *args, intent: str, **kwargs) -> None:
+        """Core logging method that delegates to the stdlib logger.
+
+        Args:
+            level: Standard library level for the record.
+            message: Log message, possibly a %-style format string.
+            *args: %-style format arguments for ``message``.
+            intent: Name of the public intent method that produced this record.
+                Rides along as the ``osprey_intent`` record attribute so
+                handlers can tell intents apart without guessing from the level
+                (``info`` and ``key_info`` both log at INFO). Metadata only —
+                it changes no level and nothing about rendering.
+            **kwargs: Forwarded to :meth:`logging.Logger.log`. A caller-supplied
+                ``extra`` mapping is merged, not replaced; its dict is left
+                unmutated.
+        """
         # Strip event-system kwargs that callers may still pass
         kwargs.pop("error", None)
         kwargs.pop("error_type", None)
         kwargs.pop("recoverable", None)
         kwargs.pop("stack_trace", None)
         kwargs.pop("warning", None)
-        self.base_logger.log(level, message, *args, **kwargs)
+        caller_extra = kwargs.pop("extra", None)
+        extra = {**(caller_extra or {}), "osprey_intent": intent}
+        self.base_logger.log(level, message, *args, extra=extra, **kwargs)
 
     def status(self, message: str, *args, **kwargs) -> None:
         """Status update — high-level progress messages."""
-        self._log(logging.INFO, message, *args, **kwargs)
+        self._log(logging.INFO, message, *args, intent="status", **kwargs)
 
     def key_info(self, message: str, *args, **kwargs) -> None:
         """Important operational information."""
-        self._log(logging.INFO, message, *args, **kwargs)
+        self._log(logging.INFO, message, *args, intent="key_info", **kwargs)
 
     def info(self, message: str, *args, **kwargs) -> None:
         """Normal operational messages."""
-        self._log(logging.INFO, message, *args, **kwargs)
+        self._log(logging.INFO, message, *args, intent="info", **kwargs)
 
     def debug(self, message: str, *args, **kwargs) -> None:
         """Debug-level messages."""
-        self._log(logging.DEBUG, message, *args, **kwargs)
+        self._log(logging.DEBUG, message, *args, intent="debug", **kwargs)
 
     def warning(self, message: str, *args, **kwargs) -> None:
         """Warning messages."""
-        self._log(logging.WARNING, message, *args, **kwargs)
+        self._log(logging.WARNING, message, *args, intent="warning", **kwargs)
 
     def error(self, message: str, *args, exc_info: bool = False, **kwargs) -> None:
         """Error messages."""
-        self._log(logging.ERROR, message, *args, exc_info=exc_info, **kwargs)
+        self._log(logging.ERROR, message, *args, intent="error", exc_info=exc_info, **kwargs)
 
     def success(self, message: str, *args, **kwargs) -> None:
         """Success messages."""
-        self._log(logging.INFO, message, *args, **kwargs)
+        self._log(logging.INFO, message, *args, intent="success", **kwargs)
 
     def timing(self, message: str, *args, **kwargs) -> None:
         """Timing information."""
-        self._log(logging.INFO, message, *args, **kwargs)
+        self._log(logging.INFO, message, *args, intent="timing", **kwargs)
 
     def approval(self, message: str, *args, **kwargs) -> None:
         """Approval messages."""
-        self._log(logging.INFO, message, *args, **kwargs)
+        self._log(logging.INFO, message, *args, intent="approval", **kwargs)
 
     def resume(self, message: str, *args, **kwargs) -> None:
         """Resume messages."""
-        self._log(logging.INFO, message, *args, **kwargs)
+        self._log(logging.INFO, message, *args, intent="resume", **kwargs)
 
     def critical(self, message: str, *args, **kwargs) -> None:
         """Critical error messages."""
-        self._log(logging.CRITICAL, message, *args, **kwargs)
+        self._log(logging.CRITICAL, message, *args, intent="critical", **kwargs)
 
     def exception(self, message: str, *args, **kwargs) -> None:
         """Exception with traceback."""
-        self._log(logging.ERROR, message, *args, exc_info=True, **kwargs)
+        self._log(logging.ERROR, message, *args, intent="exception", exc_info=True, **kwargs)
 
     # Delegate stdlib Logger interface so callers can treat ComponentLogger as a Logger.
     @property
@@ -166,11 +187,18 @@ QUIET_THIRD_PARTY_LOGGERS: tuple[str, ...] = (
 )
 
 
-def _build_rich_handler() -> RichHandler:
+def _build_rich_handler(console: Console | None = None) -> RichHandler:
     """Build the Osprey ``RichHandler``, writing to **stderr**.
 
     stdout is reserved for program output — MCP stdio JSON-RPC frames and
     ``--json`` CLI payloads — so log records must never land there.
+
+    Args:
+        console: Console to render records through. ``None`` — every non-CLI
+            entry point, and every external consumer of this package — builds
+            the fixed-width stderr console this module has always built, so
+            their output is unchanged. The CLI passes the terminal-sized
+            stderr console it already owns.
     """
     try:
         # Security-conscious defaults: hide locals to prevent sensitive data exposure
@@ -184,13 +212,14 @@ def _build_rich_handler() -> RichHandler:
         show_traceback_locals = False
         show_full_paths = False
 
-    # force_terminal keeps colors in containers and CI, where stderr is a pipe.
-    console = Console(
-        stderr=True,
-        force_terminal=True,
-        width=120,
-        color_system="truecolor",
-    )
+    if console is None:
+        # force_terminal keeps colors in containers and CI, where stderr is a pipe.
+        console = Console(
+            stderr=True,
+            force_terminal=True,
+            width=120,
+            color_system="truecolor",
+        )
 
     return RichHandler(
         console=console,
@@ -201,6 +230,37 @@ def _build_rich_handler() -> RichHandler:
         show_level=True,
         tracebacks_show_locals=show_traceback_locals,
     )
+
+
+def set_handler_console(console: Console) -> RichHandler | None:
+    """Render root-logger records through ``console`` from now on.
+
+    For entry points that already own a console of their own — the CLI owns the
+    themed, terminal-sized stderr console every command prints through — so
+    that logging and printed output share one renderer instead of interleaving
+    two consoles with different widths on the same stream.
+
+    Deliberately separate from ``configure_logging()``, which stays untouched:
+    the 15+ non-CLI entry points and external consumers of this package call
+    that and must keep the console it has always built for them.
+
+    Repointing an existing handler rather than rebuilding it keeps this safe to
+    call any number of times in one process — CLI invocations repeat inside a
+    single test process — with no handler ever stacking on the root logger.
+
+    Args:
+        console: Console the Rich handler should render through.
+
+    Returns:
+        The handler that was repointed, so a caller can go on to configure that
+        same instance; ``None`` if the root logger has no ``RichHandler`` (a
+        caller that has not called ``configure_logging()`` yet).
+    """
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, RichHandler):
+            handler.console = console
+            return handler
+    return None
 
 
 def configure_logging(level: int = logging.INFO) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -505,6 +505,7 @@ markers = [
     "dockerbuild: E2E tests that run a real docker build (skipped when docker is unavailable)",
     "real_workspace_watcher: Web-terminal app test that needs a live filesystem observer — opts out of the conftest stub that keeps broadcaster assertions deterministic",
     "real_http_posters: MCP-server test of the HTTP posters themselves — opts out of the conftest stub that keeps notify_* POSTs from reaching a live web terminal",
+    "pty: Real-terminal tests that run an osprey verb on a pty and read back the bytes an operator would have seen. POSIX-only (they self-skip elsewhere), and deselected from the parallel lane because they assert on repaint cadence and on a spinner advancing between frames, which three other xdist workers loading the box would distort; they get their own serial CI step instead. Carried per-test, not per-directory: tests/pty/test_stub_coverage.py needs no terminal and stays in the parallel lane.",
 ]
 
 # Ruff configuration for modern Python linting

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -85,11 +85,25 @@ fi
 echo ""
 
 echo "→ Running pytest with coverage..."
-if ! uv run pytest tests/ --ignore=tests/e2e -n 4 --dist loadgroup -v --tb=short --cov=src/osprey --cov-report=xml --cov-report=term; then
+if ! uv run pytest tests/ --ignore=tests/e2e -m "not pty" -n 4 --dist loadgroup -v --tb=short --cov=src/osprey --cov-report=xml --cov-report=term; then
     FAILED_CHECKS+=("pytest")
     echo "❌ Tests failed"
 else
     echo "✅ Tests passed"
+fi
+echo ""
+
+# The real-terminal suite, deselected above and re-run here on its own, exactly
+# as the CI lane does it. Each scenario drives a verb on a pty and asserts on
+# what the terminal showed, including that a spinner advanced between frames,
+# so it must not compete with four workers for the machine. Deselecting it
+# without this step would make a green run here mean less than it did before.
+echo "→ Running the real-terminal pty suite (serial)..."
+if ! uv run pytest tests/pty -m pty -v --tb=short; then
+    FAILED_CHECKS+=("pytest-pty")
+    echo "❌ Real-terminal tests failed"
+else
+    echo "✅ Real-terminal tests passed"
 fi
 echo ""
 

--- a/scripts/premerge_check.sh
+++ b/scripts/premerge_check.sh
@@ -43,7 +43,10 @@ fi
 # --maxfail=1 (same option -x aliases): fast-fail under xdist is approximate —
 # the other workers still finish their in-flight tests, so a short-circuited
 # run can report more than one failure.
-if ! uv run pytest tests/ --ignore=tests/e2e -n 4 --dist loadgroup --maxfail=1 --tb=no -q >/dev/null 2>&1; then
+# -m "not pty": the real-terminal suite times its own repaints and cannot share
+# the machine with four workers. This script is the fast pre-merge sweep, so it
+# does not re-run the suite serially; ci_check.sh does, and so does CI.
+if ! uv run pytest tests/ --ignore=tests/e2e -m "not pty" -n 4 --dist loadgroup --maxfail=1 --tb=no -q >/dev/null 2>&1; then
   echo "✗ Tests failing"
   ERRORS=$((ERRORS + 1))
 else

--- a/scripts/quick_check.sh
+++ b/scripts/quick_check.sh
@@ -30,7 +30,10 @@ echo "ℹ️  Browser-based theming tests are slow-marked; they run in ci_check.
 # the other workers still finish their in-flight tests, so a short-circuited
 # run can report more than one failure.
 echo "→ Running fast unit tests..."
-uv run pytest tests/ --ignore=tests/e2e -m "not slow" -n 4 --dist loadgroup --maxfail=1 --tb=line -q
+# "not pty" alongside "not slow": the real-terminal suite is ~40s on its own and
+# has to run serially (it times its own repaints), which is both halves of what
+# this check exists to avoid. ci_check.sh runs it before you push.
+uv run pytest tests/ --ignore=tests/e2e -m "not slow and not pty" -n 4 --dist loadgroup --maxfail=1 --tb=line -q
 
 echo ""
 echo "✅ Quick checks passed! Safe to commit."

--- a/src/osprey/cli/altitude.py
+++ b/src/osprey/cli/altitude.py
@@ -1,0 +1,104 @@
+"""Altitude policy for the CLI: what a normal run renders to the terminal.
+
+A normal ``osprey`` run should read as a report, not as a transcript. The
+policy that makes that true is a single :class:`logging.Filter` installed on the
+``RichHandler`` **instance** that renders log records to stderr — never inside
+:func:`~osprey.utils.logger.configure_logging`, so the entry points that are not
+the CLI (MCP servers, bridges, services, workers) and every external consumer of
+the ``osprey-connectors`` distribution keep today's logging behavior exactly.
+
+Gating at the handler means gating at *rendering*, not at emission: a dropped
+record is still emitted, still reaches ``caplog``, and still reaches any other
+handler or sink on the root logger. Nothing is lost — it is only not painted.
+
+``-v``/``--verbose`` lifts the gate and restores the full transcript. Levels are
+never remapped; the gate reads a record's level and nothing else.
+"""
+
+import logging
+
+from rich.logging import RichHandler
+
+__all__ = ["gate_installed", "install_gate", "lift_gate"]
+
+
+class _AltitudeGate(logging.Filter):
+    """Drop INFO-and-below records at the handler; pass WARNING and above.
+
+    The policy is deliberately level-based. Records emitted through
+    :class:`~osprey.utils.logger.ComponentLogger` also carry an
+    ``osprey_intent`` attribute naming the method that emitted them, but the
+    shipped policy does not read it — INFO-family intents are separated by
+    rewriting their call sites as report lines, not by filtering on intent.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return True when this record should be rendered."""
+        return record.levelno >= logging.WARNING
+
+
+def _root_rich_handler() -> RichHandler | None:
+    """Return the first ``RichHandler`` on the root logger, if there is one.
+
+    This is the same predicate :func:`~osprey.utils.logger.configure_logging`
+    and :func:`~osprey.utils.logger.set_handler_console` use, so all three
+    resolve to the same handler instance.
+    """
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, RichHandler):
+            return handler
+    return None
+
+
+def lift_gate(handler: logging.Handler | None = None) -> None:
+    """Remove every altitude gate from ``handler``, restoring the transcript.
+
+    Args:
+        handler: Handler to lift the gate from. Defaults to the root
+            ``RichHandler`` — the seam a subcommand's own ``--verbose`` uses to
+            lift the gate for its own run without knowing where the gate lives.
+
+    Note:
+        This restores what the *handler* renders. The root logger's level is a
+        separate floor: a normal run configures it to INFO, so lifting the gate
+        alone surfaces the INFO transcript, not DEBUG records.
+    """
+    if handler is None:
+        handler = _root_rich_handler()
+    if handler is None:
+        return
+    for existing in list(handler.filters):
+        if isinstance(existing, _AltitudeGate):
+            handler.removeFilter(existing)
+
+
+def install_gate(handler: logging.Handler | None = None, *, verbose: bool = False) -> None:
+    """Install the altitude gate on ``handler`` for this CLI invocation.
+
+    Self-correcting within a process: any gate left by an earlier invocation is
+    removed first, then exactly one fresh gate is added — or none, under
+    ``verbose``. The ``RichHandler`` outlives a single CLI invocation (the test
+    suite runs the CLI many times in one process), so installing without
+    removing first would stack filters.
+
+    Args:
+        handler: Handler to gate. Defaults to the root ``RichHandler``.
+        verbose: When True the gate is lifted rather than installed, and the
+            run renders its full transcript.
+    """
+    if handler is None:
+        handler = _root_rich_handler()
+    if handler is None:
+        return
+    lift_gate(handler)
+    if not verbose:
+        handler.addFilter(_AltitudeGate())
+
+
+def gate_installed(handler: logging.Handler | None = None) -> bool:
+    """Return True when an altitude gate is currently gating ``handler``."""
+    if handler is None:
+        handler = _root_rich_handler()
+    if handler is None:
+        return False
+    return any(isinstance(existing, _AltitudeGate) for existing in handler.filters)

--- a/src/osprey/cli/ariel.py
+++ b/src/osprey/cli/ariel.py
@@ -9,6 +9,9 @@ See 04_OSPREY_INTEGRATION.md Sections 13 for specification.
 from __future__ import annotations
 
 import asyncio
+import json
+import sys
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import click
@@ -16,6 +19,8 @@ import click
 # Import get_config_value at module level for easier patching in tests
 from osprey.utils.config import get_config_value
 from osprey.utils.logger import get_logger
+
+from . import output
 
 logger = get_logger("ariel")
 
@@ -28,11 +33,32 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
+def _emit_json_document(payload: object) -> None:
+    """Write *payload* to stdout as one JSON document and nothing else.
+
+    This module's machine-output seam, in the shape
+    :func:`osprey.health.render.render_json` established: it writes at the
+    stream rather than through the renderer, so no human line can reach the
+    document. Everything human a ``--json`` run produces goes to stderr
+    instead, because the caller holds
+    :func:`~osprey.cli.output.machine_mode` open around the whole body.
+
+    :param payload: The already-assembled result to serialize.
+    """
+    sys.stdout.write(json.dumps(payload, indent=2))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
 def _load_ariel_config() -> dict:
     """Load ARIEL config dict, raising SystemExit if missing."""
     config_dict = get_config_value("ariel", {})
     if not config_dict:
-        click.echo("Error: ARIEL not configured in config.yml", err=True)
+        output.fail(
+            "ARIEL is not configured in config.yml",
+            None,
+            "add an `ariel:` section to config.yml, then run `osprey build`",
+        )
         raise SystemExit(1)
     return config_dict
 
@@ -41,8 +67,11 @@ def _handle_db_error(e: Exception) -> None:
     """Raise SystemExit on database connection errors, otherwise return."""
     msg = str(e)
     if "connection" in msg.lower() or "connect" in msg.lower():
-        click.echo("Error: Cannot connect to the ARIEL database.", err=True)
-        click.echo("Make sure the database is running: osprey up", err=True)
+        output.fail(
+            "cannot connect to the ARIEL database",
+            None,
+            "start the database with `osprey up`",
+        )
         raise SystemExit(1) from None
 
 
@@ -50,8 +79,11 @@ def _handle_missing_tables(e: Exception) -> None:
     """Raise SystemExit on missing-table errors, otherwise return."""
     msg = str(e)
     if "relation" in msg and "does not exist" in msg:
-        click.echo("Error: ARIEL database is not initialized.", err=True)
-        click.echo("Run 'osprey ariel migrate' to create the required tables.", err=True)
+        output.fail(
+            "the ARIEL database is not initialized",
+            None,
+            "run `osprey ariel migrate` to create the required tables",
+        )
         raise SystemExit(1) from None
 
 
@@ -81,25 +113,35 @@ def status_command(output_json: bool) -> None:
 
     Displays database connection, embedding tables, and enhancement stats.
     """
-    import json as json_module
-
     from osprey.services.ariel_search.cli_operations import get_status
 
     config_dict = get_config_value("ariel", {})
-    result = asyncio.run(get_status(config_dict))
 
-    if output_json:
-        click.echo(json_module.dumps(result, indent=2))
-    else:
-        click.echo(f"ARIEL Status: {result['status']}")
-        click.echo(f"  {result['message']}")
+    # Under ``--json`` the whole body runs in machine mode, so every renderer
+    # line goes to stderr and stdout carries one document for a script to parse.
+    with output.machine_mode() if output_json else nullcontext():
+        result = asyncio.run(get_status(config_dict))
+
+        if output_json:
+            _emit_json_document(result)
+            return
+
+        output.report(f"ARIEL Status: {result['status']}")
+        output.note(result["message"])
         if result["status"] != "error":
-            click.echo(f"\nDatabase: {result['database']['uri']}")
-            click.echo(f"Total Entries: {result['entries']}")
-            click.echo("\nEmbedding Tables:")
+            output.report("")
+            output.section(
+                "",
+                {
+                    "Database": result["database"]["uri"],
+                    "Total entries": result["entries"],
+                },
+            )
+            output.report("")
+            output.report("Embedding tables:")
             for table in result.get("embedding_tables", []):
                 active = " (active)" if table["active"] else ""
-                click.echo(f"  - {table['table']}: {table['entries']} entries{active}")
+                output.note(f"- {table['table']}: {table['entries']} entries{active}")
 
 
 @ariel_group.command("migrate")
@@ -112,7 +154,7 @@ def migrate_command() -> None:
 
     config_dict = _load_ariel_config()
     try:
-        asyncio.run(run_migrate(config_dict, progress=click.echo))
+        asyncio.run(run_migrate(config_dict, progress=output.report))
     except Exception as e:
         _handle_db_error(e)
         raise
@@ -136,15 +178,16 @@ def sync_command(limit: int | None) -> None:
 
     config_dict = _load_ariel_config()
     try:
-        result = asyncio.run(run_sync(config_dict, limit=limit, progress=click.echo))
-        click.echo(
-            f"\nSync complete: "
+        result = asyncio.run(run_sync(config_dict, limit=limit, progress=output.report))
+        output.report("")
+        output.report(
+            f"Sync complete: "
             f"{result.entries_ingested} ingested, "
             f"{result.entries_enhanced} enhanced, "
             f"{result.entries_failed} failed"
         )
         if result.migrations_applied:
-            click.echo(f"  Migrations applied: {result.migrations_applied}")
+            output.note(f"Migrations applied: {result.migrations_applied}")
     except DatabaseQueryError as e:
         _handle_missing_tables(e)
         raise
@@ -184,16 +227,17 @@ def ingest_command(
     config_dict = _load_ariel_config()
     try:
         result = asyncio.run(
-            run_ingest(config_dict, source, adapter, since, limit, dry_run, progress=click.echo)
+            run_ingest(config_dict, source, adapter, since, limit, dry_run, progress=output.report)
         )
+        output.report("")
         if result.dry_run:
-            click.echo(f"\nDry run complete: {result.count} entries would be ingested")
+            output.report(f"Dry run complete: {result.count} entries would be ingested")
             if result.enhancer_names:
-                click.echo(f"Enhancement modules would run: {result.enhancer_names}")
+                output.note(f"Enhancement modules would run: {result.enhancer_names}")
         else:
-            click.echo(f"\nIngestion complete: {result.count} entries stored")
+            output.report(f"Ingestion complete: {result.count} entries stored")
             if result.enhancer_names:
-                click.echo(f"Enhancement complete: {result.enhanced_count} enhancements applied")
+                output.note(f"Enhancement complete: {result.enhanced_count} enhancements applied")
     except DatabaseQueryError as e:
         _handle_missing_tables(e)
         raise
@@ -241,27 +285,29 @@ def watch_command(
     config_dict = _load_ariel_config()
     try:
         result = asyncio.run(
-            run_watch(config_dict, source, adapter, once, interval, dry_run, progress=click.echo)
+            run_watch(config_dict, source, adapter, once, interval, dry_run, progress=output.report)
         )
         if result is not None:
             prefix = "[dry-run] " if result.dry_run else ""
-            click.echo(
-                f"\n{prefix}Poll complete: "
+            output.report("")
+            output.report(
+                f"{prefix}Poll complete: "
                 f"{result.entries_added} added, "
                 f"{result.entries_updated} updated, "
                 f"{result.entries_failed} failed "
                 f"({result.duration_seconds:.1f}s)"
             )
             if result.since:
-                click.echo(f"  Since: {result.since.isoformat()}")
+                output.note(f"Since: {result.since.isoformat()}")
     except ValueError as e:
-        click.echo(f"Error: {e}", err=True)
+        output.fail(str(e))
         raise SystemExit(1) from None
     except DatabaseQueryError as e:
         _handle_missing_tables(e)
         raise
     except KeyboardInterrupt:
-        click.echo("\nStopping watcher...")
+        output.report("")
+        output.report("Stopping the watcher.")
     except Exception as e:
         _handle_db_error(e)
         raise
@@ -285,9 +331,10 @@ def enhance_command(module: str | None, force: bool, limit: int) -> None:
     from osprey.services.ariel_search.cli_operations import run_enhance
 
     config_dict = _load_ariel_config()
-    result = asyncio.run(run_enhance(config_dict, module, force, limit, progress=click.echo))
+    result = asyncio.run(run_enhance(config_dict, module, force, limit, progress=output.report))
     if result.entries_processed > 0:
-        click.echo(f"\nEnhancement complete: {result.entries_processed} entries processed")
+        output.report("")
+        output.report(f"Enhancement complete: {result.entries_processed} entries processed")
 
 
 @ariel_group.command("models")
@@ -302,16 +349,17 @@ def models_command() -> None:
     tables = asyncio.run(list_models(config_dict))
 
     if not tables:
-        click.echo("No embedding tables found.")
+        output.report("No embedding tables found.")
         return
 
-    click.echo("Embedding Models:")
+    output.report("Embedding models:")
     for table in tables:
         active = " (active)" if table["is_active"] else ""
-        click.echo(f"\n  {table['table_name']}{active}")
-        click.echo(f"    Entries: {table['entry_count']}")
+        items: dict[str, object] = {"Entries": table["entry_count"]}
         if table["dimension"]:
-            click.echo(f"    Dimension: {table['dimension']}")
+            items["Dimension"] = table["dimension"]
+        output.report("")
+        output.section(f"{table['table_name']}{active}", items)
 
 
 @ariel_group.command("search")
@@ -324,39 +372,43 @@ def search_command(query: str, mode: str, limit: int, output_json: bool) -> None
 
     Execute a search query using the ARIEL agent.
     """
-    import json as json_module
-
     from osprey.services.ariel_search.cli_operations import run_search
 
     config_dict = get_config_value("ariel", {})
-    result = asyncio.run(run_search(config_dict, query, mode, limit))
 
-    if output_json:
-        click.echo(json_module.dumps(result, indent=2))
-    else:
-        if result.get("error"):
-            click.echo(f"Error: {result['error']}", err=True)
+    # Under ``--json`` the whole body runs in machine mode, so every renderer
+    # line goes to stderr and stdout carries one document for a script to parse.
+    with output.machine_mode() if output_json else nullcontext():
+        result = asyncio.run(run_search(config_dict, query, mode, limit))
+
+        if output_json:
+            _emit_json_document(result)
             return
 
-        click.echo(f"Query: {result['query']}")
-        click.echo(f"Modes: {', '.join(result['search_modes']) or 'none'}")
-        click.echo()
+        if result.get("error"):
+            output.fail(str(result["error"]))
+            return
+
+        output.report(f"Query: {result['query']}")
+        output.report(f"Modes: {', '.join(result['search_modes']) or 'none'}")
+        output.report("")
 
         if result["answer"]:
-            click.echo(result["answer"])
+            output.report(result["answer"])
             if result["sources"]:
-                click.echo(f"\nSources: {', '.join(result['sources'])}")
+                output.report("")
+                output.report(f"Sources: {', '.join(result['sources'])}")
         elif result.get("entries"):
             # Direct (non-RAG) modes return entries without a composed answer.
             for idx, entry in enumerate(result["entries"], 1):
                 timestamp = entry.get("timestamp", "")[:16].replace("T", " ")
                 header = f"{idx}. [{entry.get('entry_id', '?')}] {entry.get('title', '')}"
-                click.echo(header)
+                output.report(header)
                 byline = "   ".join(part for part in (timestamp, entry.get("author", "")) if part)
                 if byline:
-                    click.echo(f"   {byline}")
+                    output.note(byline)
         else:
-            click.echo("No results found.")
+            output.report("No results found.")
 
 
 @ariel_group.command("reembed")
@@ -385,13 +437,20 @@ def reembed_command(
 
     config_dict = _load_ariel_config()
     result = asyncio.run(
-        run_reembed(config_dict, model, dimension, batch_size, dry_run, force, progress=click.echo)
+        run_reembed(
+            config_dict, model, dimension, batch_size, dry_run, force, progress=output.report
+        )
     )
     if not result.dry_run:
-        click.echo("\nRe-embedding complete:")
-        click.echo(f"  Processed: {result.processed}")
-        click.echo(f"  Skipped (existing): {result.skipped}")
-        click.echo(f"  Errors: {result.errors}")
+        output.report("")
+        output.section(
+            "Re-embedding complete:",
+            {
+                "Processed": result.processed,
+                "Skipped (existing)": result.skipped,
+                "Errors": result.errors,
+            },
+        )
 
 
 @ariel_group.command("quickstart")
@@ -417,7 +476,7 @@ def quickstart_command(source: str | None) -> None:
 
     config_dict = _load_ariel_config()
     try:
-        asyncio.run(run_quickstart(config_dict, source, progress=click.echo))
+        asyncio.run(run_quickstart(config_dict, source, progress=output.report))
     except Exception as e:
         _handle_db_error(e)
         raise
@@ -441,15 +500,17 @@ def web_command(port: int, host: str, reload: bool) -> None:
     """
     _load_ariel_config()
 
-    click.echo(f"Starting ARIEL Web Interface on http://{host}:{port}")
-    click.echo("Press Ctrl+C to stop\n")
+    output.report(f"Starting ARIEL Web Interface on http://{host}:{port}")
+    output.note("Press Ctrl+C to stop")
+    output.report("")
 
     try:
         from osprey.interfaces.ariel import run_web
 
         run_web(host=host, port=port, reload=reload)
     except KeyboardInterrupt:
-        click.echo("\nShutting down...")
+        output.report("")
+        output.report("Shutting down...")
 
 
 @ariel_group.command("purge")
@@ -476,22 +537,26 @@ def purge_command(yes: bool, embeddings_only: bool) -> None:
         _handle_db_error(e)
         raise
 
-    click.echo("\n⚠️  WARNING: This will permanently delete:")
     if embeddings_only:
-        click.echo(f"  - Embedding tables: {info.embedding_tables or '(none)'}")
-        click.echo(f"  - Entries will be KEPT ({info.entry_count} entries)")
+        detail = (
+            f"embedding tables: {info.embedding_tables or '(none)'}\n"
+            f"the {info.entry_count} logbook entries are kept"
+        )
     else:
-        click.echo(f"  - All {info.entry_count} logbook entries")
-        click.echo(f"  - All embedding tables: {info.embedding_tables or '(none)'}")
-        click.echo("  - All ingestion history")
+        detail = (
+            f"all {info.entry_count} logbook entries\n"
+            f"all embedding tables: {info.embedding_tables or '(none)'}\n"
+            "all ingestion history"
+        )
+    output.warn("this deletes ARIEL data for good", detail)
 
     if not yes:
         if not click.confirm("\nAre you sure you want to continue?"):
-            click.echo("Aborted.")
+            output.report("Nothing was deleted.")
             return
 
     try:
-        asyncio.run(execute_purge(config_dict, embeddings_only, progress=click.echo))
+        asyncio.run(execute_purge(config_dict, embeddings_only, progress=output.report))
     except Exception as e:
         _handle_db_error(e)
         raise

--- a/src/osprey/cli/artifacts_cmd.py
+++ b/src/osprey/cli/artifacts_cmd.py
@@ -5,6 +5,8 @@ Provides `osprey artifacts web` to launch the gallery server manually.
 
 import click
 
+from . import output
+
 
 @click.group("artifacts")
 def artifacts():
@@ -51,8 +53,9 @@ def web(port: int | None, host: str | None, reload: bool) -> None:
     host = host or default_host
     port = port or default_port
 
-    click.echo(f"Starting OSPREY Artifact Gallery on http://{host}:{port}")
-    click.echo("Press Ctrl+C to stop\n")
+    output.report(f"Starting OSPREY Artifact Gallery on http://{host}:{port}")
+    output.note("Press Ctrl+C to stop")
+    output.report("")
 
     try:
         if reload:
@@ -71,4 +74,5 @@ def web(port: int | None, host: str | None, reload: bool) -> None:
 
             run_server(host=host, port=port)
     except KeyboardInterrupt:
-        click.echo("\nShutting down...")
+        output.report("")
+        output.report("Shutting down...")

--- a/src/osprey/cli/audit_cmd.py
+++ b/src/osprey/cli/audit_cmd.py
@@ -10,18 +10,23 @@ import asyncio
 import re
 import tempfile
 import uuid
+from contextlib import nullcontext
 from pathlib import Path
 
 import click
+from rich.text import Text
 
-from .styles import Messages, Styles, console
+from . import output
+from .altitude import lift_gate
+from .styles import Styles, data_table, panel
 
-try:
-    from rich.panel import Panel
-    from rich.table import Table
-except ImportError:
-    Panel = None  # type: ignore[assignment, misc]
-    Table = None  # type: ignore[assignment, misc]
+#: The token each severity prints in, spelled once so the findings table and the
+#: detail list below it agree on what "error" looks like.
+_SEVERITY_STYLES = {
+    "error": Styles.ERROR,
+    "warning": Styles.WARNING,
+    "info": Styles.INFO,
+}
 
 # SDK imports are deferred to runtime to provide a helpful error message
 _SDK_AVAILABLE = False
@@ -101,7 +106,7 @@ async def _run_audit(
                 if isinstance(block, TextBlock):
                     collected_text.append(block.text)
                     if verbose:
-                        console.print(f"[dim]{block.text[:200]}...[/dim]")
+                        output.note(f"{block.text[:200]}...")
         elif isinstance(message, ResultMessage):
             total_cost = getattr(message, "total_cost_usd", None)
             num_turns = getattr(message, "num_turns", None)
@@ -112,6 +117,9 @@ async def _run_audit(
 def _display_report(report, json_output: bool, verbose: bool, cost=None, turns=None):
     """Display the audit report using Rich or JSON."""
     if json_output:
+        # The one machine seam in this verb: stdout carries the report document
+        # and nothing else, so it goes out through click rather than through the
+        # renderer. Its key set is pinned by tests/cli/test_json_keyset_capture.py.
         click.echo(report.model_dump_json(indent=2))
         return
 
@@ -122,54 +130,49 @@ def _display_report(report, json_output: bool, verbose: bool, cost=None, turns=N
         "high": Styles.ERROR,
     }.get(report.overall_risk, Styles.INFO)
 
-    console.print()
-    console.print(
-        Panel(
-            f"[{risk_style}]{report.overall_risk.upper()} RISK[/{risk_style}]\n\n{report.summary}",
-            title="Audit Summary",
-            border_style=Styles.BORDER_DIM,
-        )
-    )
+    # Built as spans rather than as markup: the renderer prints with markup off
+    # and Rich carries that into nested renderables, so a "[error]...[/error]"
+    # body would show its own tags. Only the verdict wears the token -- a summary
+    # painted the same red competes with the line that states the risk.
+    summary = Text()
+    summary.append(f"{report.overall_risk.upper()} RISK", style=risk_style)
+    summary.append(f"\n\n{report.summary}")
+
+    output.report("")
+    output.table(panel(summary, title="Audit Summary"))
 
     if not report.findings:
-        console.print(f"\n  {Messages.success('No findings — clean audit!')}\n")
+        output.report("")
+        output.report("✓ No findings. The audit came back clean.", style=Styles.SUCCESS)
+        output.report("")
         return
 
     # Findings table
-    if Table is not None:
-        table = Table(border_style=Styles.BORDER_DIM, show_lines=True)
-        table.add_column("Severity", width=8)
-        table.add_column("Category", width=12)
-        table.add_column("Title")
-        table.add_column("File", width=30)
+    table = data_table(show_lines=True)
+    table.add_column("Severity", width=8)
+    table.add_column("Category", width=12)
+    table.add_column("Title")
+    table.add_column("File", width=30)
 
-        for f in report.findings:
-            sev_fmt = {
-                "error": Messages.error(f.severity),
-                "warning": Messages.warning(f.severity),
-                "info": Messages.info(f.severity),
-            }.get(f.severity, f.severity)
-            table.add_row(sev_fmt, f.category, f.title, f.file_path)
+    for f in report.findings:
+        severity = Text(f.severity, style=_SEVERITY_STYLES.get(f.severity, ""))
+        table.add_row(severity, f.category, f.title, f.file_path)
 
-        console.print(table)
+    output.table(table)
 
     # Detailed findings
     for f in report.findings:
-        sev_fmt = {
-            "error": Messages.error(f.title),
-            "warning": Messages.warning(f.title),
-            "info": Messages.info(f.title),
-        }.get(f.severity, f.title)
-
-        console.print(f"\n  {sev_fmt}")
-        console.print(f"  [dim]{f.explanation}[/dim]")
-        console.print(f"  Recommendation: {f.recommendation}")
+        output.report("")
+        output.report(f.title, style=_SEVERITY_STYLES.get(f.severity))
+        output.note(f.explanation)
+        output.section("", [("Recommendation", f.recommendation)])
 
     # Stats
     errors = sum(1 for f in report.findings if f.severity == "error")
     warnings = sum(1 for f in report.findings if f.severity == "warning")
     infos = sum(1 for f in report.findings if f.severity == "info")
-    console.print(f"\n  Findings: {errors} errors, {warnings} warnings, {infos} info")
+    output.report("")
+    output.report(f"Findings: {errors} errors, {warnings} warnings, {infos} info")
 
     if verbose and (cost is not None or turns is not None):
         parts = []
@@ -177,9 +180,9 @@ def _display_report(report, json_output: bool, verbose: bool, cost=None, turns=N
             parts.append(f"Cost: ${cost:.4f}")
         if turns is not None:
             parts.append(f"Turns: {turns}")
-        console.print(f"  [dim]{' | '.join(parts)}[/dim]")
+        output.note(" | ".join(parts))
 
-    console.print()
+    output.report("")
 
 
 @click.command()
@@ -211,80 +214,107 @@ def audit(
       osprey audit profile.yml --build   Build then audit
       osprey audit project/ --json       JSON output
     """
-    if not _SDK_AVAILABLE:
-        console.print(
-            f"  {Messages.error('claude-agent-sdk is not installed.')}\n"
-            "  Install it with: pip install claude-agent-sdk\n"
-            "  Or: uv add claude-agent-sdk"
-        )
-        raise SystemExit(1)
+    # Every --json verb runs its whole body in machine mode, so a renderer line
+    # from anywhere in the stack lands on stderr and stdout carries one document.
+    with output.machine_mode() if json_output else nullcontext():
+        if verbose:
+            # --verbose lifts the altitude gate for this run, so the reviewer's own
+            # transcript reaches the terminal alongside the extra detail the flag
+            # already prints (the raw answer on a parse failure, cost and turns).
+            lift_gate()
 
-    from .audit_prompts import AuditReport, build_audit_prompt
-
-    target_type = _detect_target_type(target)
-    target_dir = Path(target)
-
-    # Optionally build the profile first
-    tmpdir = None
-    if build_first:
-        if target_type != "profile":
-            console.print(
-                f"  {Messages.error('--build requires a .yml/.yaml profile, not a directory.')}"
+        if not _SDK_AVAILABLE:
+            output.fail(
+                "claude-agent-sdk is not installed",
+                "The audit verb reviews the target with an agent, which needs the SDK.",
+                "install it with: uv add claude-agent-sdk",
             )
             raise SystemExit(1)
 
-        tmpdir = tempfile.mkdtemp(prefix="osprey-audit-")
-        project_name = f"audit-{uuid.uuid4().hex[:8]}"
+        from .audit_prompts import AuditReport, build_audit_prompt
 
-        if not json_output:
-            console.print(f"  Building profile to temp dir: {tmpdir}")
+        target_type = _detect_target_type(target)
+        target_dir = Path(target)
 
-        from .build_cmd import build as build_cmd
+        # Optionally build the profile first
+        tmpdir = None
+        if build_first:
+            if target_type != "profile":
+                output.fail(
+                    "--build needs a .yml or .yaml profile, not a directory",
+                    f"The target is a directory: {target}",
+                    "drop --build to audit the directory as it stands",
+                )
+                raise SystemExit(1)
 
-        ctx = click.get_current_context()
-        ctx.invoke(
-            build_cmd,
-            project_name=project_name,
-            profile=str(target),
-            output_dir=tmpdir,
-            force=False,
-            stream=False,
-        )
-        target_dir = Path(tmpdir) / project_name
-        target_type = "project"
+            tmpdir = tempfile.mkdtemp(prefix="osprey-audit-")
+            project_name = f"audit-{uuid.uuid4().hex[:8]}"
 
-    try:
-        if not json_output:
-            console.print(f"  Auditing {target_type}: {Messages.path(str(target_dir))}")
-            console.print(f"  Model: {model} | Budget: ${budget:.2f}")
+            if not json_output:
+                output.section("", [("Building profile to", tmpdir)])
 
-        file_listing = _list_files(target_dir)
-        prompt = build_audit_prompt(target_type, target_dir, file_listing)
+            from .build_cmd import build as build_cmd
 
-        # Run the agent
-        raw_text, cost, turns = asyncio.run(_run_audit(prompt, model, target_dir, budget, verbose))
-
-        # Parse the result
-        json_str = _extract_json(raw_text)
-        if json_str is None:
-            console.print(f"  {Messages.error('Agent did not produce valid JSON output.')}")
-            if verbose:
-                console.print(f"  [dim]Raw output: {raw_text[:500]}[/dim]")
-            raise SystemExit(1)
+            ctx = click.get_current_context()
+            ctx.invoke(
+                build_cmd,
+                project_name=project_name,
+                profile=str(target),
+                output_dir=tmpdir,
+                force=False,
+                stream=False,
+            )
+            target_dir = Path(tmpdir) / project_name
+            target_type = "project"
 
         try:
-            report = AuditReport.model_validate_json(json_str)
-        except Exception as e:
-            console.print(f"  {Messages.error(f'Failed to parse audit report: {e}')}")
-            if verbose:
-                console.print(f"  [dim]JSON: {json_str[:500]}[/dim]")
-            raise SystemExit(1) from None
+            if not json_output:
+                output.section(
+                    "",
+                    [
+                        ("Auditing", f"{target_type}: {target_dir}"),
+                        ("Model", model),
+                        ("Budget", f"${budget:.2f}"),
+                    ],
+                )
 
-        _display_report(report, json_output, verbose, cost=cost, turns=turns)
+            file_listing = _list_files(target_dir)
+            prompt = build_audit_prompt(target_type, target_dir, file_listing)
 
-    finally:
-        # Clean up temp dir if we created one
-        if tmpdir is not None:
-            import shutil
+            # Run the agent
+            raw_text, cost, turns = asyncio.run(
+                _run_audit(prompt, model, target_dir, budget, verbose)
+            )
 
-            shutil.rmtree(tmpdir, ignore_errors=True)
+            # Parse the result
+            json_str = _extract_json(raw_text)
+            if json_str is None:
+                output.fail(
+                    "The reviewer did not return a report",
+                    "Its answer held no JSON document, so there is nothing to read.",
+                    "run it again with -v to see what it did say",
+                )
+                if verbose:
+                    output.note(f"Raw output: {raw_text[:500]}")
+                raise SystemExit(1)
+
+            try:
+                report = AuditReport.model_validate_json(json_str)
+            except Exception as e:
+                output.fail(
+                    "Could not read the audit report",
+                    str(e),
+                    "run it again with -v to see the document that failed to parse",
+                )
+                if verbose:
+                    output.note(f"JSON: {json_str[:500]}")
+                raise SystemExit(1) from None
+
+            _display_report(report, json_output, verbose, cost=cost, turns=turns)
+
+        finally:
+            # Clean up temp dir if we created one
+            if tmpdir is not None:
+                import shutil
+
+                shutil.rmtree(tmpdir, ignore_errors=True)

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -91,6 +91,21 @@ from .templates.manager import TemplateManager
 
 logger = get_logger("build")
 
+
+def _report_fact(message: str) -> None:
+    """Report ``message`` under this module's logger.
+
+    The promotion contract lives in :func:`osprey.cli.output.report_fact`; this
+    binds it to the build logger so call sites pass the line alone.
+
+    Args:
+        message: The finished line, built by the caller.
+    """
+    from . import output
+
+    output.report_fact(logger, message)
+
+
 __all__ = [
     "_SHELL_METACHARACTERS",
     "_apply_config_overrides",
@@ -900,8 +915,8 @@ def _openobserve_endpoint_errors(
         logger.warning(
             "  services.openobserve.port publishes the store on %s, while %s runs on the "
             "host network and derives the telemetry endpoint's port from a pinned %s. "
-            "Nothing is broken today — claude_code.telemetry is not deriving an endpoint "
-            "— but enabling it with backend: openobserve will need "
+            "Nothing is broken today, since claude_code.telemetry is not deriving an "
+            "endpoint. Enabling it with backend: openobserve will need "
             "claude_code.telemetry.endpoint set explicitly.",
             published,
             named,
@@ -984,10 +999,9 @@ def _render_compose_files(
         ``None`` when compose generation did not run.
     """
     if runtime_root:
-        logger.info(
-            "  Compose files not rendered: --runtime-root points this build at %s, "
-            "and compose bind sources are resolved on the host that deploys it.",
-            runtime_root,
+        _report_fact(
+            f"Compose files not rendered: --runtime-root points this build at {runtime_root}, "
+            "and compose bind sources are resolved on the host that deploys it."
         )
         return None
 
@@ -1007,7 +1021,9 @@ def _render_compose_files(
         os.chdir(previous)
     if network_errors:
         raise click.UsageError("Network axis check failed:\n  - " + "\n  - ".join(network_errors))
-    logger.info("  ✓ Rendered %d compose file(s)", len(compose_files))
+    # Not reported here: the render phase's `compose files` step fires the
+    # moment this returns and says the same thing.
+    logger.debug("Rendered %d compose file(s)", len(compose_files))
     return dict(config)
 
 
@@ -1966,8 +1982,8 @@ def _wire_build_derived_env(repo_root: Path, build_dir: Path) -> None:
         for key in sorted(BUILD_DERIVED_KEYS & on_file.keys()):
             logger.warning(
                 "  %s is set in %s, but this build generated no virtual-accelerator "
-                "channel manifest for it to point at. The value was left alone — it is "
-                "yours, not the build's — but the IOC will fail to start against a "
+                "channel manifest for it to point at. The value was left alone, since it is "
+                "yours and not the build's. The IOC will fail to start against a "
                 "manifest that is not there. Remove the line, or restore the channel "
                 "databases the manifest is generated from.",
                 key,
@@ -1990,18 +2006,20 @@ def _wire_build_derived_env(repo_root: Path, build_dir: Path) -> None:
     result = append_profile_env(env_path, entries, BUILD_DERIVED_BANNER)
 
     if result.added:
-        logger.info(
-            "  ✓ Pointed %s at the generated channel manifest (%s)",
-            COMPOSE_ENV_FILENAME,
-            ", ".join(sorted(result.added)),
+        # The build's one write outside build/, into a file that is the
+        # operator's rather than a build artifact. It runs after the render
+        # phase has closed, so it is reported rather than stepped.
+        _report_fact(
+            f"Pointed {COMPOSE_ENV_FILENAME} at the generated channel manifest "
+            f"({', '.join(sorted(result.added))})"
         )
     for conflict in result.conflicts:
         # Named, never valued: the store this reads is the one holding the
         # facility's provider keys, and a warning is not a safe place for it.
         logger.warning(
-            "  %s in %s disagrees with what this build generated. Your value was kept — "
-            "the build never overwrites this file — so the IOC will serve the channel set "
-            "you named, not the one in build/. Remove the line to take the build's.",
+            "  %s in %s disagrees with what this build generated. Your value was kept, "
+            "because the build never overwrites this file. The IOC will serve the channel "
+            "set you named, not the one in build/. Remove the line to take the build's.",
             conflict.key,
             env_path,
         )
@@ -2098,9 +2116,16 @@ def _build_repo(
             )
         _check_osprey_version_requirement(build_profile)
 
-        logger.info("  Profile: %s", build_profile.name)
-        logger.info("  Data bundle: %s", build_profile.data_bundle)
-        logger.info("  Tier: %d", build_profile.resolved_tier())
+        # Outside every phase, on purpose. The next thing this build opens is
+        # `Preparing the project environment`, the long pole: hung under a
+        # phase this identity would arrive minutes after the wait it labels,
+        # and as a step it would vanish entirely (no phase is open here).
+        from . import output
+
+        output.report(
+            f"profile {build_profile.name} (bundle {build_profile.data_bundle}, "
+            f"tier {build_profile.resolved_tier()})"
+        )
 
         # A fresh staging tree, and the output zone it will replace. Both are
         # created now: the venv below is written into `build/` directly, at the
@@ -2269,11 +2294,7 @@ def _build_repo(
 
     if backup_dir is not None:
         logger.debug("  ✓ Previous Claude Code artifacts saved to %s", backup_dir)
-    logger.info("✓ Rendered %s", zones.build_dir)
     _warn_if_deployment_running(config, name)
-
-    if (zones.build_dir / "data" / "simulation" / "scenarios").is_dir():
-        logger.info("  → Seed the demo logbook with: osprey sim apply nominal")
 
 
 def _check_osprey_version_requirement(build_profile: Any) -> None:
@@ -2439,8 +2460,8 @@ def _inject_services(build_profile: Any, profile_dir: Path, project_path: Path) 
     """
     if not build_profile.deploy_services:
         logger.debug(
-            "deploy_services: false — attached project; no services scaffolded "
-            "(connects to a shared OSPREY services stack)"
+            "deploy_services: false. This is an attached project, so no services were "
+            "scaffolded (it connects to a shared OSPREY services stack)."
         )
         return []
 

--- a/src/osprey/cli/build_environment.py
+++ b/src/osprey/cli/build_environment.py
@@ -159,13 +159,15 @@ def report_provider_credentials(
     if selected is None:
         # Keyless provider, or a name outside the registry (custom adapter).
         if provider in PROVIDER_API_KEYS:
-            logger.debug("  ✓ Provider: %s — no API key required", provider)
+            logger.debug("  ✓ Provider: %s. No API key required.", provider)
         else:
-            logger.debug("  ✓ Provider: %s — no known API key env var; skipping check", provider)
+            logger.debug(
+                "  ✓ Provider: %s. No known API key env var, so this check is skipped.", provider
+            )
     elif selected.found:
-        logger.debug("  ✓ Provider: %s — %s found (%s)", provider, selected.var, selected.source)
+        logger.debug("  ✓ Provider: %s. %s found (%s).", provider, selected.var, selected.source)
     else:
-        logger.warning("  ✗ Provider: %s — %s NOT SET", provider, selected.var)
+        logger.warning("  ✗ Provider: %s. %s is NOT SET.", provider, selected.var)
         logger.warning("      The build will complete, but the agent cannot reach the model.")
         # Name the PROFILE .env, not the render's. `build/` is output — wiped
         # and re-rendered whole by every build — so a key hand-added to a file
@@ -175,8 +177,8 @@ def report_provider_credentials(
         # Exporting is offered only as what it actually is — a host-local run,
         # not something the build records.
         logger.warning(
-            "      Add %s to %s — the repo owns this deployment's secrets — "
-            "or export it for a host-local run.",
+            "      Add %s to %s, the file where the repo keeps this deployment's secrets. "
+            "You can also export it for a host-local run.",
             selected.var,
             profile_dir / ".env",
         )
@@ -670,7 +672,7 @@ def freeze_base_environment(python_path: Path, inherit_exclude: list[str]) -> li
 
     started = time.perf_counter()
     if not _base_is_venv(python_path):
-        logger.debug("Base interpreter %s is not a venv — nothing to freeze", python_path)
+        logger.debug("Base interpreter %s is not a venv. There is nothing to freeze.", python_path)
         return []
 
     excluded = {canonicalize_name(name) for name in inherit_exclude}
@@ -884,7 +886,8 @@ def _create_project_venv(project_path: Path, profile: Any) -> list[str]:
         #   2. The normal install path above will work again
         # ---------------------------------------------------------------
         logger.warning(
-            "  litellm unavailable on PyPI (quarantined) — inheriting from build environment"
+            "  litellm is unavailable on PyPI (quarantined). "
+            "Inheriting it from the build environment."
         )
         # Install osprey (no transitive deps) + profile deps
         if uv_path:

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -96,7 +96,10 @@ def _refresh_service_dir(src_dir: Path, dest_dir: Path, name: str, owned: set[st
     user-owned and the project copy was left untouched.
     """
     if name in owned:
-        logger.debug("  ⏭  services/%s is user-owned — left untouched (scaffold claim)", name)
+        logger.debug(
+            "  ⏭  services/%s is user-owned. The project copy was left untouched (scaffold claim).",
+            name,
+        )
         return False
     if dest_dir.exists():
         shutil.rmtree(dest_dir)
@@ -171,7 +174,7 @@ def _copy_service_templates(project_path: Path) -> int:
     pkg_services = _locate_pkg_services()
 
     if not pkg_services.is_dir():
-        logger.warning("Service templates directory not found — skipping")
+        logger.warning("Service templates directory not found. Skipping the service copy.")
         return 0
 
     dest_services_root = project_path / "services"
@@ -215,7 +218,10 @@ def _copy_service_templates(project_path: Path) -> int:
         elif len(parts) == 1:
             src_dir = pkg_services / name
         else:
-            logger.warning("Skipping service %r — unsupported naming for template copy", name)
+            logger.warning(
+                "Skipping service %r. Its name is not a supported spelling for a template copy.",
+                name,
+            )
             continue
 
         if not src_dir.is_dir():
@@ -292,7 +298,7 @@ def _inject_profile_services(
             # one unresolvable service must not abort the whole build. A missing
             # profile-relative dir is already a validation error, so in practice
             # this only fires for an unknown ``osprey.<name>``.
-            logger.warning("No template for profile service %r at %s — skipping", name, src_dir)
+            logger.warning("No template for profile service %r at %s. Skipping it.", name, src_dir)
             continue
 
         # Copy template directory (skipped for claimed services)
@@ -417,7 +423,7 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
     # 3. Write config.yml entries + register in deployed_services.
     config_path = project_path / "config.yml"
     if not config_path.exists():
-        logger.warning("config.yml not found — skipping dispatch config registration")
+        logger.warning("config.yml not found. Skipping the dispatch config registration.")
         return
 
     yaml = YAML()
@@ -570,7 +576,7 @@ def _inject_bluesky(bluesky: BlueskyConfig, project_path: Path) -> None:
     # 2. Write config.yml entries + register in deployed_services.
     config_path = project_path / "config.yml"
     if not config_path.exists():
-        logger.warning("config.yml not found — skipping bluesky config registration")
+        logger.warning("config.yml not found. Skipping the bluesky config registration.")
         return
 
     yaml = YAML()
@@ -671,7 +677,9 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
     # 2. Write config.yml entries + register in deployed_services.
     config_path = project_path / "config.yml"
     if not config_path.exists():
-        logger.warning("config.yml not found — skipping virtual_accelerator config registration")
+        logger.warning(
+            "config.yml not found. Skipping the virtual_accelerator config registration."
+        )
         return
 
     yaml = YAML()
@@ -715,9 +723,9 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
     )
     logger.debug(
         "    Images:     `osprey up` builds the virtual-accelerator image "
-        "locally for your native architecture (first run is slow — the native deps "
-        "are compiled from source, so no prebuilt aarch64 wheels are "
-        "needed). Use `--dev` to bake in your local osprey checkout; "
+        "locally for your native architecture. The first run is slow: the native "
+        "deps are compiled from source, so no prebuilt aarch64 wheels are "
+        "needed. Use `--dev` to bake in your local osprey checkout; "
         "set OSPREY_VA_IMAGE to use a published image."
     )
 
@@ -733,8 +741,8 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
 _RESULTS_PANEL_DEPRECATION = (
     "web.panels.results is deprecated: the RESULTS panel is now BLUESKY "
     "(web.panels.bluesky, served at /bluesky/). The `results` id keeps working for "
-    "ONE release — the sidecar serves the same bundle at /results/ — and is removed "
-    "after that. Rename `results` to `bluesky` in the build profile's web_panels "
+    "ONE release and is removed after that. Until then the sidecar serves the same "
+    "bundle at /results/. Rename `results` to `bluesky` in the build profile's web_panels "
     "list and in any web.panels.results.* config override."
 )
 
@@ -746,8 +754,8 @@ _RESULTS_PANEL_DEPRECATION = (
 _PLAN_PANEL_DEPRECATION = (
     "web.panels.plan is deprecated: the PLAN panel is now the Plans tab of BLUESKY "
     "(web.panels.bluesky, served at /bluesky/). The `plan` id keeps working for "
-    "ONE release — the sidecar serves the same bundle at /plan/ — and is removed "
-    "after that. Drop `plan` from the build profile's web_panels list, along with "
+    "ONE release and is removed after that. Until then the sidecar serves the same "
+    "bundle at /plan/. Drop `plan` from the build profile's web_panels list, along with "
     "any web.panels.plan.* config override."
 )
 
@@ -813,7 +821,7 @@ def _inject_bluesky_panels(bluesky_panels: BlueskyPanelsConfig, project_path: Pa
     # 2. Write config.yml entries + register in deployed_services.
     config_path = project_path / "config.yml"
     if not config_path.exists():
-        logger.warning("config.yml not found — skipping bluesky_panels config registration")
+        logger.warning("config.yml not found. Skipping the bluesky_panels config registration.")
         return
 
     yaml = YAML()
@@ -884,7 +892,7 @@ def _inject_bluesky_panels(bluesky_panels: BlueskyPanelsConfig, project_path: Pa
     # 4. Post-build hint.
     logger.debug("  ✓ Injected bluesky-panels sidecar (port %d)", bluesky_panels.port)
     logger.debug(
-        "    Panels:     BLUESKY (Plans | Queue | Results) — reached through the "
+        "    Panels:     BLUESKY (Plans | Queue | Results). Reach it through the "
         "web-terminal proxy at /panel/bluesky."
     )
     logger.debug(
@@ -941,7 +949,7 @@ def _inject_nextcloud_bridge(
     # 2. Write config.yml entries + register in deployed_services.
     config_path = project_path / "config.yml"
     if not config_path.exists():
-        logger.warning("config.yml not found — skipping nextcloud_bridge config registration")
+        logger.warning("config.yml not found. Skipping the nextcloud_bridge config registration.")
         return
 
     yaml = YAML()
@@ -979,9 +987,9 @@ def _inject_nextcloud_bridge(
     logger.debug(
         "    Credentials: set NEXTCLOUD_BASE_URL, NEXTCLOUD_BOT_ACCOUNT, "
         "NEXTCLOUD_APP_PASSWORD and NEXTCLOUD_ROOMS in the project .env before "
-        "`osprey up`. These are user-supplied — unlike the dispatch "
-        "tokens, deploy does not mint them, and the bridge aborts at boot "
-        "naming whichever is missing."
+        "`osprey up`. These are user-supplied. Unlike the dispatch tokens, deploy "
+        "does not mint them, and the bridge aborts at boot naming whichever is "
+        "missing."
     )
     logger.debug(
         "    Rooms:       NEXTCLOUD_ROOMS is a comma-separated list of Talk room "
@@ -1040,7 +1048,7 @@ def _inject_gchat_bridge(gchat_bridge: GChatBridgeProfileConfig, project_path: P
     # 2. Write config.yml entries + register in deployed_services.
     config_path = project_path / "config.yml"
     if not config_path.exists():
-        logger.warning("config.yml not found — skipping gchat_bridge config registration")
+        logger.warning("config.yml not found. Skipping the gchat_bridge config registration.")
         return
 
     yaml = YAML()
@@ -1075,15 +1083,15 @@ def _inject_gchat_bridge(gchat_bridge: GChatBridgeProfileConfig, project_path: P
         "    Credentials: set GCHAT_SA_KEY (host path to the service-account JSON "
         "key, mounted read-only at the same path in the container), "
         "GCHAT_SUBSCRIPTION and GCHAT_APP_ID in the project .env before "
-        "`osprey up`. These are user-supplied — unlike the dispatch "
-        "tokens, deploy does not mint them, and the bridge aborts at boot "
-        "naming whichever is missing."
+        "`osprey up`. These are user-supplied. Unlike the dispatch tokens, deploy "
+        "does not mint them, and the bridge aborts at boot naming whichever is "
+        "missing."
     )
     logger.debug(
         "    Subscription: deploy exactly ONE bridge per Pub/Sub subscription. "
         "Pub/Sub load-balances a subscription across its consumers, so a second "
-        "deployment on the same name does not duplicate events — it silently "
-        "splits them, and each half answers only what it received. Give every "
+        "deployment on the same name does not duplicate events. It silently splits "
+        "them, and each half answers only what it received. Give every "
         "deployment its own subscription on the topic."
     )
     logger.debug(
@@ -1152,7 +1160,7 @@ def _inject_va_archiver(va_archiver: VAArchiverConfig, project_path: Path) -> No
     # 2. Write config.yml entries + register in deployed_services.
     config_path = project_path / "config.yml"
     if not config_path.exists():
-        logger.warning("config.yml not found — skipping archiver config registration")
+        logger.warning("config.yml not found. Skipping the archiver config registration.")
         return
 
     yaml = YAML()
@@ -1210,6 +1218,6 @@ def _inject_va_archiver(va_archiver: VAArchiverConfig, project_path: Path) -> No
     )
     logger.debug(
         "    Recording:  the recorder writes only while control_system.type is "
-        "'virtual_accelerator' — on any other control system it idles. It "
+        "'virtual_accelerator'. On any other control system it idles. It "
         "re-reads that setting on an interval, so the flip needs no restart."
     )

--- a/src/osprey/cli/build_lifecycle.py
+++ b/src/osprey/cli/build_lifecycle.py
@@ -4,6 +4,15 @@ Runs the ``pre_build`` / ``post_build`` / ``validate`` command phases declared
 in a build profile, with the shared subprocess environment (the project's
 merged env chain, project venv on ``PATH``, ``_mcp_servers`` on ``PYTHONPATH``), streaming
 and quiet output modes, timeout handling, and the JUnit test-results summary.
+
+Output here splits two ways. What a step's run looks like from outside -- the
+phase header, the line naming a streamed step as it starts -- is phase record,
+so it goes through the installed reporter and is silenced under ``--verbose``
+with the rest of the record. What a step actually reported -- its child's
+lines, its pass or failure, the tests it ran -- is the operator's answer, so it
+goes through :mod:`osprey.cli.output` and prints whatever reporter is
+installed. Everything else the module knows is a diagnostic and stays on the
+logger.
 """
 
 from __future__ import annotations
@@ -14,24 +23,53 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
+
+from rich.text import Text
 
 from osprey.errors import BuildProfileError
 from osprey.utils.dotenv import chain_files, merge_chain
 from osprey.utils.logger import get_logger
+
+from .output import fail, report, warn
+from .phase_reporter import current_reporter
+from .styles import Styles, data_table
 
 logger = get_logger("build")
 
 
 _SHELL_METACHARACTERS = ("|", "&&", "||", "$(", "`")
 
+_EXIT_GRACE_SECONDS = 5.0
+"""Seconds a streamed step's child gets to exit once its stdout has drained.
+
+Some test frameworks (a pyepics CA context, for one) keep background threads
+alive that stop the process exiting promptly after its last line.
+"""
+
+_DRAIN_SHUTDOWN_SECONDS = 5.0
+"""Seconds the drain thread gets to notice its step is over and end."""
+
+_DRAIN_THREAD_NAME = "osprey-lifecycle-drain"
+
 
 def _format_junit_summary(xml_path: Path) -> None:
-    """Parse JUnit XML and print a Rich summary table of test results."""
-    import xml.etree.ElementTree as ET
+    """Parse JUnit XML and print a summary table of the test results.
 
-    from rich.console import Console
-    from rich.table import Table
+    Report content, not phase record: the step ran these tests because the
+    operator asked it to, so the answer prints whichever reporter is installed.
+    It goes through the reporter's own console rather than a private one, which
+    is what puts it ABOVE a mounted live region instead of inside it, and takes
+    the CLI's one data-table look from :func:`~osprey.cli.styles.data_table`.
+
+    A missing or unparseable file is not an error here: most steps produce no
+    test results at all, and a step that failed on its way to writing them has
+    already reported why.
+
+    Args:
+        xml_path: The JUnit XML a step may have left behind.
+    """
+    import xml.etree.ElementTree as ET
 
     if not xml_path.exists():
         return
@@ -43,8 +81,8 @@ def _format_junit_summary(xml_path: Path) -> None:
 
     root = tree.getroot()
 
-    table = Table(title="Integration Test Results", show_header=True, padding=(0, 1))
-    table.add_column("Test", style="bold", no_wrap=True)
+    table = data_table(title="Integration Test Results")
+    table.add_column("Test", style=Styles.BOLD, no_wrap=True)
     table.add_column("Status", justify="center", width=6)
     table.add_column("Time", justify="right", width=8)
 
@@ -57,18 +95,95 @@ def _format_junit_summary(xml_path: Path) -> None:
             error = testcase.find("error")
             skipped = testcase.find("skipped")
 
+            # Pre-styled cells rather than markup tags: the echo path prints
+            # with markup off, so a `[red]` tag would reach the operator as
+            # four literal characters.
             if failure is not None or error is not None:
-                status = "[red]✗[/red]"
+                status = Text("✗", style=Styles.ERROR)
             elif skipped is not None:
-                status = "[dim]skip[/dim]"
+                status = Text("skip", style=Styles.DIM)
             else:
-                status = "[green]✓[/green]"
+                status = Text("✓", style=Styles.SUCCESS)
 
             table.add_row(name, status, f"{float(time_s):.2f}s")
 
     if table.row_count > 0:
-        render_console = Console(force_terminal=True, width=120)
-        render_console.print(table)
+        current_reporter().out().print(table)
+
+
+def _drain_stdout(stdout: IO[str], stop: threading.Event) -> None:
+    """Emit a streaming step's stdout, line by line, until ``stop`` is set.
+
+    Reads with ``readline`` rather than iterating the file so the loop reaches
+    the stop check once per line instead of once per read-ahead buffer, and
+    checks the flag after the read as well as before it: the read is where this
+    thread spends its time, so a line that only arrives once the step is over
+    must be dropped rather than emitted over whatever the CLI draws next.
+
+    Lines go through the installed reporter rather than ``print`` so they take
+    the reporter's ordering like every other CLI line. A raw write from this
+    thread would land inside a mounted live region instead of above it.
+
+    They go through :meth:`~osprey.cli.phase_reporter.PhaseReporter.echo` and
+    not ``emit``: this is the step's own output, which the operator asked for
+    with ``--stream``, and the emit path is silenced under global ``--verbose``.
+    ``osprey --verbose build --stream`` would then be the one invocation asking
+    hardest for the child's lines and the one showing none of them. ``echo``
+    gives the same console ordering without the silencing.
+
+    Args:
+        stdout: The child's piped stdout, in text mode.
+        stop: Set by :func:`_stop_drain` once the step's result is decided.
+    """
+    try:
+        while not stop.is_set():
+            line = stdout.readline()
+            if not line:
+                break
+            if stop.is_set():
+                break
+            current_reporter().echo(f"    {line.rstrip()}")
+    except (ValueError, OSError):
+        # The pipe was closed under the read. The step is long over by then and
+        # there is nobody left to tell.
+        return
+
+
+def _stop_drain(reader: threading.Thread, stop: threading.Event, stdout: IO[str]) -> None:
+    """Retire a finished step's drain thread before its result is reported.
+
+    The ordering here is load-bearing, and not the obvious one. Closing
+    ``stdout`` to unblock the reader deadlocks the caller: a thread blocked in
+    ``readline`` holds the buffered-IO lock, so ``close()`` from another thread
+    waits for exactly the read it is trying to interrupt -- for as long as the
+    child holds the pipe open. The child is therefore already dead by the time
+    this is called (the caller's exit grace kills it), which drops the write end
+    and lets the blocked ``readline`` return EOF; only then is the close free.
+
+    The flag alone would not do either, since a reader blocked in a read that
+    never returns never sees it. Together they bound the thread's life at
+    ``_DRAIN_SHUTDOWN_SECONDS`` and, whether or not it ever ends, guarantee it
+    emits nothing once its step has been reported.
+
+    Args:
+        reader: The drain thread for the step that just finished.
+        stop: The stop flag that thread is watching.
+        stdout: The child's piped stdout.
+    """
+    stop.set()
+    reader.join(timeout=_DRAIN_SHUTDOWN_SECONDS)
+    if reader.is_alive():
+        # Still blocked on a pipe something outlived the child holding open --
+        # a grandchild that inherited the write end. Leaving the descriptor to
+        # the daemon thread is the honest trade: closing it here would hang the
+        # CLI on the lock that thread holds, and with the flag set the thread is
+        # already silent.
+        logger.debug("Lifecycle drain thread outlived its step; left silenced")
+        return
+    try:
+        stdout.close()
+    except OSError:  # pragma: no cover - the pipe is at EOF by this point
+        pass
 
 
 def _run_lifecycle_phase(
@@ -123,7 +238,10 @@ def _run_lifecycle_phase(
         )
         logger.info("Prepended _mcp_servers to lifecycle PYTHONPATH: %s", mcp_servers_dir)
 
-    logger.info("  Running %s commands...", phase_name)
+    # Phase record: what the build is doing right now, in the same voice as the
+    # phases around it, and silenced with the rest of the record under
+    # `--verbose` (where the logger below is carrying the detail instead).
+    current_reporter().emit(f"  Running {phase_name} commands...")
     for step in steps:
         cmd_str = step.run.replace("{project_root}", str(project_path))
 
@@ -145,7 +263,9 @@ def _run_lifecycle_phase(
                 # Stream mode: show output in real-time, prefix with step name.
                 # Uses a threaded reader so proc.wait(timeout=...) can enforce
                 # the timeout even when the subprocess stalls mid-output.
-                logger.info("  > %s", step.name)
+                # Also phase record: it names the step whose lines are about to
+                # arrive, and says nothing the lines themselves will not.
+                current_reporter().emit(f"  > {step.name}")
                 proc = subprocess.Popen(
                     cmd,
                     shell=use_shell,
@@ -157,33 +277,38 @@ def _run_lifecycle_phase(
                 )
                 assert proc.stdout is not None  # noqa: S101
 
-                def _drain_stdout(stdout=proc.stdout) -> None:
-                    for line in stdout:
-                        print(f"    {line}", end="", flush=True)
-
-                reader = threading.Thread(target=_drain_stdout, daemon=True)
+                stop_drain = threading.Event()
+                reader = threading.Thread(
+                    target=_drain_stdout,
+                    args=(proc.stdout, stop_drain),
+                    name=_DRAIN_THREAD_NAME,
+                    daemon=True,
+                )
                 reader.start()
                 # Wait for stdout to drain (tests finished) with the full
-                # timeout, then give the process a short grace period to
-                # exit.  Some test frameworks (pyepics CA context) keep
-                # background threads alive that prevent clean exit.
+                # timeout, then give the process a short grace period to exit.
                 reader.join(timeout=step.timeout)
                 try:
-                    proc.wait(timeout=5)
+                    proc.wait(timeout=_EXIT_GRACE_SECONDS)
                 except subprocess.TimeoutExpired:
                     proc.kill()
                     proc.wait()
+                # The step is decided: retire its reader before the result line
+                # is printed, so nothing of this step can print after it.
+                _stop_drain(reader, stop_drain, proc.stdout)
                 elapsed = time.monotonic() - t0
                 if proc.returncode != 0:
                     msg = f"Lifecycle {phase_name} step '{step.name}' failed (exit {proc.returncode}, {elapsed:.1f}s)"
                     if abort_on_failure:
-                        logger.error("  ✗ %s", msg)
+                        # No cause under the summary: the child's own output is
+                        # already on the screen above it, streamed line by line.
+                        fail(msg)
                         _format_junit_summary(project_path / "check_results.xml")
                         raise BuildProfileError(msg)
                     else:
-                        logger.warning("  ! %s", msg)
+                        warn(msg)
                 else:
-                    logger.info("  ✓ %s (%.1fs)", step.name, elapsed)
+                    report(f"  ✓ {step.name} ({elapsed:.1f}s)", style=Styles.SUCCESS)
                 # Show JUnit summary if test results were produced
                 _format_junit_summary(project_path / "check_results.xml")
             else:
@@ -201,29 +326,32 @@ def _run_lifecycle_phase(
 
                 if result.returncode != 0:
                     output = (result.stdout + result.stderr).strip()
-                    msg = f"Lifecycle {phase_name} step '{step.name}' failed (exit {result.returncode}, {elapsed:.1f}s)"
-                    if output:
-                        msg += f":\n{output}"
+                    headline = f"Lifecycle {phase_name} step '{step.name}' failed (exit {result.returncode}, {elapsed:.1f}s)"
+                    msg = f"{headline}:\n{output}" if output else headline
                     if abort_on_failure:
-                        logger.error("  ✗ %s", msg)
+                        # The captured output is the cause, printed under the
+                        # summary rather than run into it: nobody streamed it,
+                        # so this is the operator's only sight of it.
+                        fail(headline, output)
                         _format_junit_summary(project_path / "check_results.xml")
                         raise BuildProfileError(msg)
                     else:
-                        logger.warning("  ! %s", msg)
+                        warn(headline, output)
                 else:
-                    success_msg = f"{step.name} ({elapsed:.1f}s)"
+                    success_msg = f"  ✓ {step.name} ({elapsed:.1f}s)"
                     output = (result.stdout + result.stderr).strip()
                     if output:
                         summary = output.rstrip().rsplit("\n", 1)[-1].strip()
                         if summary:
-                            success_msg += f" — {summary}"
-                    logger.info("  ✓ %s", success_msg)
+                            success_msg += f": {summary}"
+                    report(success_msg, style=Styles.SUCCESS)
                 # Show JUnit summary if test results were produced
                 _format_junit_summary(project_path / "check_results.xml")
 
         except subprocess.TimeoutExpired as e:
             elapsed = time.monotonic() - t0
-            msg = f"Lifecycle {phase_name} step '{step.name}' timed out ({elapsed:.0f}s)"
+            headline = f"Lifecycle {phase_name} step '{step.name}' timed out ({elapsed:.0f}s)"
+            msg = headline
             # Show partial output captured before timeout (quiet mode only;
             # stream mode already printed output in real-time).
             _out = (
@@ -237,20 +365,22 @@ def _run_lifecycle_phase(
                 else (e.stderr or "")
             )
             partial = _out + _err
+            cause = ""
             if partial.strip():
                 tail = "\n".join(partial.strip().splitlines()[-20:])
-                msg += f"\n  Last output:\n{tail}"
+                cause = f"Last output:\n{tail}"
+                msg += f"\n  {cause}"
             if abort_on_failure:
-                logger.error("  ✗ %s", msg)
+                fail(headline, cause)
                 _format_junit_summary(project_path / "check_results.xml")
                 raise BuildProfileError(msg) from None
             else:
-                logger.warning("  ! %s", msg)
+                warn(headline, cause)
             _format_junit_summary(project_path / "check_results.xml")
         except OSError as exc:
-            msg = f"Lifecycle {phase_name} step '{step.name}' failed to start: {exc}"
+            msg = f"Lifecycle {phase_name} step '{step.name}' failed to start"
             if abort_on_failure:
-                logger.error("  ✗ %s", msg)
-                raise BuildProfileError(msg) from exc
+                fail(msg, str(exc))
+                raise BuildProfileError(f"{msg}: {exc}") from exc
             else:
-                logger.warning("  ! %s", msg)
+                warn(msg, str(exc))

--- a/src/osprey/cli/build_persistence.py
+++ b/src/osprey/cli/build_persistence.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 from osprey.errors import BuildProfileError
 from osprey.utils.logger import get_logger
 
+from .phase_reporter import report_step
+
 logger = get_logger("build")
 
 
@@ -38,7 +40,7 @@ def _apply_config_overrides(project_path: Path, config_dict: dict[str, Any]) -> 
 
     config_path = project_path / "config.yml"
     if not config_path.exists():
-        logger.warning("config.yml not found at %s — skipping config overrides", config_path)
+        logger.warning("config.yml not found at %s. Skipping the config overrides.", config_path)
         return
     config_update_fields(config_path, config_dict)
 
@@ -310,7 +312,9 @@ def _apply_conventions(
         if shadowed:
             # Anything already at the destination was rendered by this build
             # (step 11 runs on a fresh or force-cleared tree).
-            logger.info("  ↷ profile overrides framework %s '%s'", entry_nouns[copy.category], name)
+            logger.debug(
+                "  ↷ profile overrides framework %s '%s'", entry_nouns[copy.category], name
+            )
         canonical = ownership_canonical(copy)
         if canonical is not None:
             result.owned_artifacts.append(canonical)
@@ -321,23 +325,24 @@ def _apply_conventions(
     if result.departed_users:
         logger.warning(
             "  %s/ has context for %d user(s) not on the roster: %s\n"
-            "     Skipped — add them to modules.web_terminals.users or remove the "
-            "directory from the profile.",
+            "     They were skipped. Add them to modules.web_terminals.users, or remove "
+            "the directory from the profile.",
             per_user_source,
             len(result.departed_users),
             ", ".join(result.departed_users),
         )
     if result.seeded_users:
-        logger.info(
-            "  ✓ Seeded %d empty context directory/ies in the profile: %s",
-            len(result.seeded_users),
+        # A write into the operator's own profile, outside build/: it stays in
+        # the default view, as a step under the render phase.
+        report_step(f"seeded {len(result.seeded_users)} empty context dir(s) in the profile")
+        logger.debug(
+            "Seeded empty context directories: %s",
             ", ".join(f"{per_user_source}/{user}" for user in result.seeded_users),
         )
     if PROJECT_MIRROR_DIR in result.by_category:
-        logger.info(
-            "  ✓ Mirrored %d file(s) from %s/ onto the project root",
-            result.by_category[PROJECT_MIRROR_DIR],
-            PROJECT_MIRROR_DIR,
+        # As above: this one lands on the project root.
+        report_step(
+            f"mirrored {result.by_category[PROJECT_MIRROR_DIR]} file(s) onto the project root"
         )
     return result
 

--- a/src/osprey/cli/build_profile_merge.py
+++ b/src/osprey/cli/build_profile_merge.py
@@ -495,7 +495,7 @@ def _warn_shadowed_bare_exclusions(root_dir: Path, shadow_candidates: set[str]) 
         source, _, name = artifact.partition("/")
         _LOGGER.warning(
             "Profile %s excludes the bare name %r under %r, but it also ships its own "
-            "%r in %s — that file still renders, so the exclusion has no effect. "
+            "%r in %s. That file still renders, so the exclusion has no effect. "
             "Did you mean %r? A bare name only unselects the BUILT-IN artifact, which "
             "this profile already shadows; the qualified spelling omits the profile's "
             "own file, which is what makes the built-in version render again.",
@@ -525,7 +525,7 @@ def _warn_unmatched_exclusions(root_dir: Path, artifacts: set[str]) -> None:
             continue
         source, _, _name = artifact.partition("/")
         _LOGGER.warning(
-            "Profile %s excludes %r, but no such artifact exists under %s — the "
+            "Profile %s excludes %r, but no such artifact exists under %s. The "
             "exclusion has no effect. Check the spelling.",
             root_dir,
             artifact,

--- a/src/osprey/cli/build_profile_model.py
+++ b/src/osprey/cli/build_profile_model.py
@@ -617,8 +617,8 @@ class BuildProfile:
                         "web_panels entry 'results' is deprecated: the RESULTS panel is now "
                         "BLUESKY. Rename it to 'bluesky' (and any web.panels.results.* config "
                         "override to web.panels.bluesky.*). The old id keeps working for ONE "
-                        "release — the bluesky-panels sidecar serves the same bundle at "
-                        "/results/ — and is removed after that.",
+                        "release and is removed after that. Until then the bluesky-panels sidecar "
+                        "serves the same bundle at /results/.",
                         UserWarning,
                         stacklevel=2,
                     )
@@ -627,8 +627,8 @@ class BuildProfile:
                         "web_panels entry 'plan' is deprecated: the PLAN panel is now the "
                         "Plans tab of BLUESKY. Drop it (and any web.panels.plan.* config "
                         "override); 'bluesky' covers it. The old id keeps working for ONE "
-                        "release — the bluesky-panels sidecar serves the same bundle at "
-                        "/plan/ — and is removed after that.",
+                        "release and is removed after that. Until then the bluesky-panels sidecar "
+                        "serves the same bundle at /plan/.",
                         UserWarning,
                         stacklevel=2,
                     )

--- a/src/osprey/cli/channel_finder_cmd.py
+++ b/src/osprey/cli/channel_finder_cmd.py
@@ -12,6 +12,7 @@ import os
 
 import click
 
+from osprey.cli.altitude import lift_gate
 from osprey.cli.styles import Messages, Styles, console
 
 
@@ -42,20 +43,16 @@ def _setup_config(project: str | None):
     os.environ["CONFIG_FILE"] = str(config_path)
 
 
-def _initialize_registry(verbose: bool = False):
-    """Initialize the Osprey registry with appropriate logging.
+def _initialize_registry():
+    """Initialize the Osprey registry without its start-up chatter.
 
-    Args:
-        verbose: If True, show detailed initialization logs.
+    Sets no logger levels of its own: what a run renders is the CLI's altitude
+    policy, applied once for every command. The named loggers below are silenced
+    for the duration of this call only — registry wiring narrates each component
+    it loads, and that transcript belongs to ``-v``, not to a database command
+    that happens to need a registry first.
     """
-    import logging
-
     from osprey.registry import initialize_registry
-
-    if not verbose:
-        logging.getLogger("osprey").setLevel(logging.WARNING)
-        logging.getLogger("channel_finder").setLevel(logging.WARNING)
-
     from osprey.utils.log_filter import quiet_logger
 
     with quiet_logger(
@@ -144,6 +141,11 @@ def channel_finder(ctx, project: str | None, verbose: bool):
     ctx.ensure_object(dict)
     ctx.obj["project"] = project
     ctx.obj["verbose"] = verbose
+    if verbose:
+        # The group's own --verbose lifts the CLI altitude gate for this run, so
+        # every subcommand under it renders its transcript rather than only
+        # warnings and errors. Idempotent, and a no-op when nothing is gated.
+        lift_gate()
 
 
 @channel_finder.command("build-database")
@@ -292,11 +294,16 @@ def validate(ctx, database: str | None, verbose: bool, pipeline: str | None):
       osprey channel-finder validate --verbose
       osprey channel-finder validate --pipeline hierarchical
     """
+    if verbose:
+        # Lifts the altitude gate for this run, on top of the detailed
+        # statistics the flag already asks ``run_validation`` for.
+        lift_gate()
+
     project = ctx.obj.get("project")
 
     try:
         _setup_config(project)
-        _initialize_registry(verbose=False)
+        _initialize_registry()
     except click.ClickException:
         if not database:
             raise
@@ -377,7 +384,7 @@ def preview(
     if not database:
         try:
             _setup_config(project)
-            _initialize_registry(verbose=False)
+            _initialize_registry()
         except click.ClickException:
             raise
 
@@ -680,6 +687,13 @@ def benchmark(
       osprey channel-finder benchmark --model ollama/gemma3:4b --queries 0:5
       osprey channel-finder benchmark --model anthropic/claude-haiku-4-5 --runs-per-query 3
     """
+    if verbose:
+        # One half of what --verbose means here: the altitude gate is lifted, so
+        # this run's records are rendered instead of only its warnings. The
+        # other half is the level floor set below, which is what lets the
+        # framework's DEBUG records be emitted in the first place.
+        lift_gate()
+
     import asyncio
     import logging
     from pathlib import Path
@@ -725,7 +739,10 @@ def benchmark(
     indices = _parse_query_indices(queries, len(all_queries))
 
     if verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        # A level floor, and only that: raising the framework logger is what
+        # lets its DEBUG records be emitted at all. Whether an emitted record
+        # reaches the terminal is the CLI's altitude policy — the gate lifted at
+        # the top of this body.
         logging.getLogger("osprey").setLevel(logging.DEBUG)
 
     console.print(

--- a/src/osprey/cli/chat_cmd.py
+++ b/src/osprey/cli/chat_cmd.py
@@ -31,9 +31,32 @@ from pathlib import Path
 
 import click
 
-from osprey.cli.styles import console
+from osprey.cli import output
 
+from .altitude import lift_gate
+from .phase_reporter import NullReporter, install_reporter
 from .repo_resolver import find_repo_root, repo_option
+
+
+def _stand_down_output_policy() -> None:
+    """Take OSPREY's output policy off the terminal the agent is about to own.
+
+    One switch, called once, for the whole session. Past this point the screen
+    belongs to the agent's own interface, and what OSPREY has to say about how a
+    verb's output should read stops applying to it: the altitude gate that
+    decides which log records are painted comes off, and the phase reporter that
+    decorates a verb's progress is replaced by the quiet one. Agent text reaches
+    the terminal exactly as the agent wrote it.
+
+    What this does not do is silence the process. The pin it replaces set the
+    root logger to CRITICAL, which stopped records from being emitted at all --
+    so a warning worth having was dropped rather than merely unpainted, and the
+    companion-server failure in :func:`_launch_companion_servers` had to be
+    printed by hand to get past it. No level is touched here, so every record is
+    still emitted and still reaches every sink the deployment configured.
+    """
+    lift_gate()
+    install_reporter(NullReporter())
 
 
 def _overlay_repo_env(repo_root: Path) -> None:
@@ -133,8 +156,6 @@ def _launch_companion_servers(project_dir: Path) -> list[tuple[str, str]]:
     Returns:
         ``(display_name, url)`` for each server that ended up running.
     """
-    import logging
-
     from osprey.infrastructure.server_launcher import _launchers, ensure_web_server
     from osprey.registry.web import FRAMEWORK_WEB_SERVERS
     from osprey.utils.workspace import reset_config_cache
@@ -143,10 +164,6 @@ def _launch_companion_servers(project_dir: Path) -> list[tuple[str, str]]:
     if config_file.exists():
         os.environ["OSPREY_CONFIG"] = str(config_file)
     reset_config_cache()
-
-    # Silence ALL logging so daemon-thread output cannot interfere with the TUI.
-    # In CLI mode, server logs are not useful — debug via `osprey web` instead.
-    logging.getLogger().setLevel(logging.CRITICAL)
 
     started: list[tuple[str, str]] = []
     for key, defn in FRAMEWORK_WEB_SERVERS.items():
@@ -158,17 +175,14 @@ def _launch_companion_servers(project_dir: Path) -> list[tuple[str, str]]:
                 started.append((defn.name, f"http://{host}:{port}"))
         except Exception as exc:
             # Fail OPEN — a companion panel that will not start is not a reason
-            # to withhold the agent session — but not fail SILENT. Reported on
-            # stderr rather than through logging, because the root logger was
-            # just pinned to CRITICAL above: a warning would be swallowed, and
-            # raising the level to get it through would misreport a missing
-            # panel as a critical fault. Printed here, before the TUI takes the
-            # terminal, so the operator learns which panel is absent instead of
-            # discovering it as a dead link mid-session.
-            click.echo(
-                f"⚠ {defn.name} did not start: {type(exc).__name__}: {exc}\n"
-                f"  The session continues without it. Run `osprey web` to see why.",
-                err=True,
+            # to withhold the agent session — but not fail SILENT. Reported
+            # here, before the TUI takes the terminal, so the operator learns
+            # which panel is absent instead of discovering it as a dead link
+            # mid-session.
+            output.warn(
+                f"{defn.name} did not start",
+                f"{type(exc).__name__}: {exc}\n"
+                "The session continues without it. Run `osprey web` to see why.",
             )
     return started
 
@@ -199,13 +213,12 @@ def _report_drift(repo_root: Path, build_dir: Path) -> None:
         )
 
     if report.refuses:
-        console.print(f"[warning]⚠ {report.message}[/warning]")
-        console.print("[dim]Starting the agent against build/ as it was last rendered.[/dim]")
+        output.warn(report.message, "Starting the agent against build/ as it was last rendered.")
 
     # Independent of the verdict above: a build can be a faithful render of the
     # current profile and still predate the installed framework.
     if report.version_skew:
-        console.print(f"[warning]⚠ {report.version_skew.message}[/warning]")
+        output.warn(report.version_skew.message)
 
 
 @click.command()
@@ -276,9 +289,7 @@ def chat(
     # refuse to launch rather than start against the wrong provider.
     policy_conflicts = detect_managed_policy_conflicts()
     if policy_conflicts:
-        console.print(
-            f"[error]✗ Refusing to launch.\n{format_managed_policy_conflicts(policy_conflicts)}[/error]"
-        )
+        output.fail("Refusing to launch", format_managed_policy_conflicts(policy_conflicts))
         raise SystemExit(1)
 
     # This call refuses when there is no build, so it has to run before anything
@@ -323,9 +334,9 @@ def chat(
         _restore_managed_env(shell_managed_env)
     else:
         if spec.auth_secret_env and not os.environ.get(spec.auth_secret_env):
-            console.print(
-                f"[warning]⚠ ${spec.auth_secret_env} is not set. "
-                f"provider '{spec.provider}' may not authenticate[/warning]"
+            output.warn(
+                f"${spec.auth_secret_env} is not set",
+                f"The '{spec.provider}' provider may not authenticate.",
             )
         # The repo root, not the render: `.env` is the durable SECRETS zone and
         # deliberately does not live in the disposable build output.
@@ -339,9 +350,9 @@ def chat(
             project_dir=repo_root,
         )
         if injected:
-            console.print(f"[dim]Injected: {', '.join(injected)}[/dim]")
+            output.note(f"Injected: {', '.join(injected)}")
         if spec.auth_secret_env and os.environ.get(spec.auth_env_var):
-            console.print(f"[dim]Set ${spec.auth_env_var} from ${spec.auth_secret_env}[/dim]")
+            output.note(f"Set ${spec.auth_env_var} from ${spec.auth_secret_env}")
 
         # Start translation proxy for OpenAI-compatible providers
         if spec.needs_proxy and spec.upstream_base_url:
@@ -352,9 +363,7 @@ def chat(
                 os.environ.get(spec.auth_env_var),
             )
             os.environ["ANTHROPIC_BASE_URL"] = f"http://127.0.0.1:{proxy_port}"
-            console.print(
-                f"[dim]Translation proxy started on :{proxy_port} → {spec.upstream_base_url}[/dim]"
-            )
+            output.note(f"Translation proxy on :{proxy_port} forwards to {spec.upstream_base_url}")
 
     # Build the agent CLI args (it uses cwd as the project root — there is no
     # --project-dir flag). When claude_code.cli_version is set,
@@ -383,13 +392,16 @@ def chat(
 
     started_servers = _launch_companion_servers(build_dir)
     if started_servers:
-        console.print("[dim]Companion servers:[/dim]")
-        for name, url in started_servers:
-            console.print(f"  [success]*[/success] {name}  [dim]{url}[/dim]")
-        console.print()
+        output.section("Companion servers", started_servers)
+        output.report("")
 
-    # Flush all output before the agent's TUI takes over the terminal.
-    console.print(f"[dim]Launching the agent in {build_dir}...[/dim]\n")
+    output.note(f"Launching the agent in {build_dir}...")
+    output.report("")
+
+    # Everything this verb had to say is now on screen. The switch takes
+    # OSPREY's output policy off the terminal, and the flush empties what is
+    # still buffered, before the agent's TUI takes it over.
+    _stand_down_output_policy()
     sys.stdout.flush()
     sys.stderr.flush()
 

--- a/src/osprey/cli/config_cmd.py
+++ b/src/osprey/cli/config_cmd.py
@@ -21,7 +21,8 @@ import click
 from jinja2 import Template
 from rich.syntax import Syntax
 
-from osprey.cli.styles import Styles, console
+from osprey.cli import output, styles
+from osprey.cli.styles import Styles
 
 from .repo_resolver import PROFILE_FILENAME, find_repo_root, repo_option
 
@@ -54,23 +55,38 @@ def _render_framework_defaults() -> str:
     return Template(template_path.read_text(encoding="utf-8")).render(**_DEFAULTS_EXAMPLE_CONTEXT)
 
 
+# UNGUARDED: copy passed to this wrapper is not seen by the house-style guard in
+# `tests/cli/test_printed_copy_style.py`, which matches printer names exactly. The
+# name cannot join its set, because `cli/deploy_scaffold.py` has an `_emit` that
+# writes a FILE, and registering the bare name would judge that one's arguments as
+# prose. What reaches a person from here is a label and a config file's own bytes
+# rather than sentences, so the gap costs little; a sentence added here is review's
+# to catch.
 def _emit(text: str, *, label: str, source: Path | None) -> None:
     """Print configuration *text*, highlighted for a human, raw for a pipe.
 
     ``osprey config > deployment.yml`` has to produce the file it showed, so
-    when stdout is not a terminal the content goes out unchanged and unadorned
-    — no header, no rewrapping, no highlight escapes. The header and the syntax
+    when stdout is not a terminal the content goes out unchanged and unadorned:
+    no header, no rewrapping, no highlight escapes. The header and the syntax
     colouring are for the interactive reader, who needs to know which of the
     three views they are looking at and where it lives on disk.
+
+    The off-terminal branch is a machine seam, the same class as a ``--json``
+    payload: it writes a file's bytes to stdout rather than copy at a person,
+    so it goes out through :func:`click.echo` rather than through the renderer.
+    Rich expands tabs and can pad a line, and a config the CLI showed must be
+    the config it writes.
     """
-    if not console.is_terminal:
+    if not styles.console.is_terminal:
         click.echo(text)
         return
 
-    console.print(f"\n[bold]{label}[/bold]", soft_wrap=True)
+    output.report("")
+    output.report(label, style=Styles.BOLD)
     if source is not None:
-        console.print(f"{source}\n", style=Styles.DIM, soft_wrap=True)
-    console.print(Syntax(text, "yaml", theme="monokai", line_numbers=False, word_wrap=True))
+        output.note(str(source))
+    output.report("")
+    output.table(Syntax(text, "yaml", theme="monokai", line_numbers=False, word_wrap=True))
 
 
 @click.command(name="config")

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 import click
 
+from osprey.cli import output
 from osprey.cli.styles import Styles, console
 from osprey.deployment.errors import DeploymentPreconditionError
 from osprey.utils.config import load_project_config
@@ -29,6 +30,19 @@ if TYPE_CHECKING:
 
 logger = get_logger("deploy")
 
+
+def _report_fact(message: str) -> None:
+    """Report ``message`` under this module's logger.
+
+    The promotion contract lives in :func:`osprey.cli.output.report_fact`; this
+    binds it to the deploy logger so call sites pass the line alone.
+
+    Args:
+        message: The finished line, built by the caller.
+    """
+    output.report_fact(logger, message)
+
+
 # ---------------------------------------------------------------------------
 # osprey up — the four-zone start verb
 # ---------------------------------------------------------------------------
@@ -40,39 +54,57 @@ logger = get_logger("deploy")
 _UP_SEEDED_ENV_BANNER = "# ── Seeded by `osprey up` from your shell ──"
 
 
-def _abort(message: str) -> NoReturn:
-    """Log a refusal and stop, with no traceback and exit code 1."""
-    logger.error(message)
+def _abort(
+    summary: str,
+    cause: str | None = None,
+    remedy: str | None = None,
+    *,
+    mark: bool = True,
+) -> NoReturn:
+    """Render a refusal in the CLI's one failure shape, then stop.
+
+    :func:`osprey.cli.output.fail` only prints, so the ``click.Abort`` below is
+    what ends the run: no traceback, exit code 1, exactly as before.
+
+    Args:
+        summary: What the verb will not do, in one line and without the glyph.
+        cause: Why, and what is unchanged as a result. Multi-line is fine.
+        remedy: The one thing to do about it, or ``None`` when there is nothing
+            honest to name.
+        mark: Whether to open with ``✗``. Pass ``False`` only where a phase has
+            already printed one for this same failure — the block then continues
+            that line instead of reading as a second thing having gone wrong.
+    """
+    output.fail(summary, cause, remedy, mark=mark)
     raise click.Abort()
 
 
 def _abort_unmet_precondition(
-    exc: DeploymentPreconditionError, *, nothing_done: str | None = None
+    exc: DeploymentPreconditionError,
+    *,
+    nothing_done: str | None = None,
+    mark: bool = True,
 ) -> NoReturn:
-    """Render an unmet deploy precondition — what is not true, then the one fix.
+    """Render an unmet deploy precondition: what is not true, then the one fix.
 
     Every :class:`~osprey.deployment.errors.DeploymentPreconditionError` carries
-    the same two fields, so ONE renderer serves all of them: no verb hand-writes
-    a per-error string, and a new precondition needs no new handler here.
-
-    No ``✗`` of its own. These are raised from inside a reporter phase whose
-    failure line has already marked the run, and two markers for one refusal
-    read as two things having gone wrong.
+    the same three fields, so ONE renderer serves all of them: no verb
+    hand-writes a per-error string, and a new precondition needs no new handler
+    here. The fields land on :func:`_abort`'s three in order, which is why the
+    error type was given them.
 
     Args:
         exc: The refusal, carrying ``summary``/``reason``/``remedy``.
         nothing_done: What is unchanged as a result ("Nothing was started."),
             for the verbs that act. ``None`` for the read-only verbs, which
             changed nothing whether they refused or not.
+        mark: ``False`` where the refusal left through an open phase, whose ``✗``
+            is already the run's one failure marker. Decided by the CALLER, not
+            here: this same renderer serves the read-only verbs, which refuse
+            outside any phase and so have no marker to continue.
     """
-    console.print(f"\n{exc.summary}: {exc.reason}\n", style=Styles.ERROR)
-    for line in exc.remedy.splitlines():
-        console.print(f"  {line}" if line else "")
-    if nothing_done is not None:
-        console.print(f"\n  {nothing_done}\n", style=Styles.WARNING)
-    else:
-        console.print()
-    raise click.Abort() from None
+    cause = exc.reason if nothing_done is None else f"{exc.reason}\n{nothing_done}"
+    _abort(exc.summary, cause, exc.remedy, mark=mark)
 
 
 def _stdin_is_a_terminal() -> bool:
@@ -163,16 +195,17 @@ def gate_start_from_build(
 
     report = check_drift(repo_root)
     if report.version_skew:
-        logger.warning(report.version_skew.message)
+        output.warn(report.version_skew.message)
 
     if report.state is DriftState.NO_BUILD:
         note = ""
         if as_built:
             note = "\n--as-built starts a build that already exists; this repo has none to start."
         _abort(
-            f"No build found in {report.build_dir}. Run `osprey build` first — "
-            f"`osprey {verb}` starts what a build rendered and never renders it "
-            f"itself.{note}\nNothing was started."
+            f"No build found in {report.build_dir}",
+            f"`osprey {verb}` starts what a build rendered, and never renders one "
+            f"itself.{note}\nNothing was started.",
+            "run `osprey build` first",
         )
 
     if not report.refuses:
@@ -190,17 +223,21 @@ def gate_start_from_build(
             else "Whether the running stack matches profile.yml is unknown, and stays "
             "unknown until the comparison can be made."
         )
-        logger.warning(
-            "Starting build/ as it was rendered (--as-built). %s %s", report.message, consequence
+        output.warn(
+            "Starting build/ as it was rendered (--as-built)", f"{report.message} {consequence}"
         )
         return
 
+    # No `→` remedy line here, deliberately: there are two valid ways through
+    # and they are not interchangeable. Naming one of them as *the* remedy
+    # would be a recommendation this verb cannot honestly make, so both are
+    # spelled in the cause as an aligned block and the operator picks.
     _abort(
-        f"{report.message}\n"
-        f"  osprey {verb} --build      re-render build/ from profile.yml, then start it\n"
-        f"  osprey {verb} --as-built   start build/ as it was rendered, leaving the "
+        report.message,
+        f"osprey {verb} --build      re-render build/ from profile.yml, then start it\n"
+        f"osprey {verb} --as-built   start build/ as it was rendered, leaving the "
         f"change unbuilt\n"
-        "Nothing was started."
+        "Nothing was started.",
     )
 
 
@@ -235,7 +272,7 @@ def _chain_build(ctx: click.Context, repo_root: Path, *, dev: bool = False) -> N
     ctx.invoke(build_cmd, repo=repo_root, dev=dev)
 
 
-def ensure_repo_env(repo_root: Path, config: dict[str, Any]) -> None:
+def ensure_repo_env(repo_root: Path, config: dict[str, Any], *, mark: bool = True) -> None:
     """Refuse to start a deployment repo that has no ``.env``, offering to seed one.
 
     ``.env`` at the repo root is the deployment's whole secret store and the
@@ -261,6 +298,10 @@ def ensure_repo_env(repo_root: Path, config: dict[str, Any]) -> None:
     Args:
         repo_root: The deployment repo.
         config: The rendered ``build/config.yml``, which names the provider.
+        mark: Whether the refusal opens with ``✗``. ``False`` from inside an
+            open phase, whose own ``✗`` is already the run's failure marker.
+            Defaults to ``True`` because this function is also called on its
+            own, with no phase above it to carry the mark.
 
     Raises:
         click.Abort: When there is no ``.env`` and none was seeded.
@@ -299,7 +340,7 @@ def ensure_repo_env(repo_root: Path, config: dict[str, Any]) -> None:
             from osprey.utils.dotenv import append_profile_env
 
             append_profile_env(env_path, {secret_var: exported}, _UP_SEEDED_ENV_BANNER)
-            logger.key_info("Seeded %s (mode 0600) with %s", env_path, secret_var)
+            _report_fact(f"Seeded {env_path} (mode 0600) with {secret_var}")
             return
 
     needed = f" It needs {secret_var} for provider {provider!r}." if secret_var else ""
@@ -307,14 +348,17 @@ def ensure_repo_env(repo_root: Path, config: dict[str, Any]) -> None:
     # .env.example has been removed would otherwise be told to copy a file that
     # is not there — a small lie that costs an operator a minute of hunting.
     remedy = (
-        "    cp .env.example .env\nthen fill it in and re-run."
+        "cp .env.example .env, then fill it in and re-run"
         if (repo_root / ".env.example").is_file()
-        else f"Create {env_path} with that variable in it and re-run."
+        else f"create {env_path} with that variable in it, then re-run"
     )
     _abort(
-        f"No .env in {repo_root}. It is this deployment's only secret store, and every "
-        f"compose invocation reads it — without it the stack starts with every "
-        f"credential empty.{needed}\n{remedy} Nothing was started."
+        f"No .env in {repo_root}",
+        f"It is this deployment's only secret store, and every compose invocation "
+        f"reads it. Without it the stack starts with every credential "
+        f"empty.{needed}\nNothing was started.",
+        remedy,
+        mark=mark,
     )
 
 
@@ -339,14 +383,20 @@ def _preflight(repo_root: Path, reporter: PhaseReporter, *, nothing_done: str) -
     """
     from osprey.deployment.container_lifecycle import as_built_config_path
 
+    # Both refusals below leave through the open phase, which fails it with its
+    # own ✗ on the way out — so neither prints one of its own.
     with reporter.phase("Preflight") as phase:
         config_path = as_built_config_path(repo_root)
         if not config_path.is_file():
             _abort(
-                f"No build found at {config_path.parent}. Run `osprey build` to render it. "
-                f"{nothing_done}"
+                f"No build found at {config_path.parent}",
+                nothing_done,
+                "run `osprey build` to render it",
+                mark=False,
             )
-        ensure_repo_env(repo_root, load_project_config(str(config_path), wrap_errors=True))
+        ensure_repo_env(
+            repo_root, load_project_config(str(config_path), wrap_errors=True), mark=False
+        )
         phase.done("build/ and .env are in place")
 
 
@@ -475,15 +525,17 @@ def up_verb(
             # One handler for every unmet precondition on this path — a missing
             # render, a --dev that cannot be honored, an unreleased pin. They
             # differ only in their reason and remedy, which the renderer reads
-            # off the exception.
-            _abort_unmet_precondition(e, nothing_done="Nothing was deployed.")
+            # off the exception. The start phase closed with its own ✗ on the
+            # way out, so this block continues that line rather than marking it
+            # a second time.
+            _abort_unmet_precondition(e, nothing_done="Nothing was deployed.", mark=False)
         except KeyboardInterrupt:
-            console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+            output.warn("Operation cancelled by user")
             raise click.Abort() from None
         except (click.Abort, click.ClickException):
             raise
         except Exception as e:
-            _abort(f"Deployment failed: {e}")
+            _abort("Deployment failed", str(e))
         finally:
             os.chdir(previous)
 
@@ -552,12 +604,12 @@ def down_verb(repo: Path | None) -> None:
                 down_deployment(repo_root)
             print_summary_card(repo_root, "stopped")
     except KeyboardInterrupt:
-        console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+        output.warn("Operation cancelled by user")
         raise click.Abort() from None
     except (click.Abort, click.ClickException):
         raise
     except Exception as e:
-        _abort(f"Could not stop this deployment: {e}")
+        _abort("Could not stop this deployment", str(e))
     finally:
         os.chdir(previous)
 
@@ -680,14 +732,14 @@ def restart_verb(
         except DeploymentPreconditionError as e:
             # Same single handler as `up`; the restart phase's ✗ is the run's
             # marker, so the renderer adds none of its own.
-            _abort_unmet_precondition(e, nothing_done="Nothing was stopped.")
+            _abort_unmet_precondition(e, nothing_done="Nothing was stopped.", mark=False)
         except KeyboardInterrupt:
-            console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+            output.warn("Operation cancelled by user")
             raise click.Abort() from None
         except (click.Abort, click.ClickException):
             raise
         except Exception as e:
-            _abort(f"Restart failed: {e}")
+            _abort("Restart failed", str(e))
         finally:
             os.chdir(previous)
 
@@ -747,12 +799,12 @@ def status_verb(repo: Path | None, show_agents: bool) -> None:
     try:
         show_repo_status(repo_root, console=console, styles=Styles, show_agents=show_agents)
     except KeyboardInterrupt:
-        console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+        output.warn("Operation cancelled by user")
         raise click.Abort() from None
     except (click.Abort, click.ClickException):
         raise
     except Exception as e:
-        _abort(f"Could not report this deployment's status: {e}")
+        _abort("Could not report this deployment's status", str(e))
 
 
 @click.command("logs")
@@ -806,11 +858,13 @@ def logs_verb(repo: Path | None, service: str | None, follow: bool, tail: int | 
     try:
         follow_logs(repo_root, service=service, follow=follow, tail=tail)
     except DeploymentPreconditionError as e:
+        # Keeps its ✗: `logs` reads, so it opens no phase, and a refusal with no
+        # phase line above it is the only marker this run will get.
         _abort_unmet_precondition(e)
     except KeyboardInterrupt:
-        console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+        output.warn("Operation cancelled by user")
         raise click.Abort() from None
     except (click.Abort, click.ClickException):
         raise
     except Exception as e:
-        _abort(f"Could not read this deployment's logs: {e}")
+        _abort("Could not read this deployment's logs", str(e))

--- a/src/osprey/cli/eject_cmd.py
+++ b/src/osprey/cli/eject_cmd.py
@@ -17,6 +17,8 @@ import click
 
 from osprey.utils.logger import get_logger
 
+from .output import fail, note, report, section, warn
+
 logger = get_logger("osprey.cli")
 
 
@@ -85,18 +87,11 @@ def eject_list():
     provider = FrameworkRegistryProvider()
     config = provider.get_registry_config()
 
-    click.echo("\nEjectable Framework Components:")
-    click.echo("=" * 50)
-
-    # List services
-    click.echo("\nServices:")
-    for svc in config.services:
-        click.echo(f"  {svc.name:<25} {svc.description}")
-
-    click.echo()
-    click.echo("Usage:")
-    click.echo("  osprey eject service <name>       Copy service to local project")
-    click.echo()
+    report("")
+    section("Ejectable services", {svc.name: svc.description for svc in config.services})
+    report("")
+    report("Usage:")
+    note("osprey eject service <name>   Copy a service into your project")
 
 
 @eject.command("service")
@@ -127,21 +122,20 @@ def eject_service(name: str, output: str | None, include_tests: bool):
 
     if not svc_reg:
         available = [svc.name for svc in config.services]
-        click.echo(f"Error: Unknown service '{name}'", err=True)
-        click.echo(f"Available: {', '.join(available)}", err=True)
+        fail(f"Unknown service '{name}'", f"Available: {', '.join(available)}")
         raise SystemExit(1)
 
     # Find source directory (service module path points to the service.py file)
     # We want the parent directory (the service package)
     source_path = _get_module_source_path(svc_reg.module_path)
     if not source_path or not source_path.exists():
-        click.echo(f"Error: Cannot locate source for '{svc_reg.module_path}'", err=True)
+        fail(f"Could not find the source for '{svc_reg.module_path}'")
         raise SystemExit(1)
 
     # Service source is the parent directory of the module file
     source_dir = source_path.parent
     if not source_dir.is_dir():
-        click.echo(f"Error: Expected directory at {source_dir}", err=True)
+        fail(f"Expected a directory at {source_dir}")
         raise SystemExit(1)
 
     # Determine output path
@@ -150,24 +144,24 @@ def eject_service(name: str, output: str | None, include_tests: bool):
     else:
         pkg_dir = _get_project_package_dir()
         if not pkg_dir:
-            click.echo(
-                "Error: Cannot find project package directory. "
-                "Run from project root or use --output.",
-                err=True,
+            fail(
+                "Could not find the project package directory",
+                None,
+                "Run this from the project root, or name a target with --output.",
             )
             raise SystemExit(1)
         output_dir = pkg_dir / "services" / name
 
     # Copy the entire service directory
     if output_dir.exists():
-        click.echo(f"Warning: {output_dir} already exists. Overwriting.", err=True)
+        warn(f"{output_dir} already exists", "Its contents were replaced.")
         shutil.rmtree(output_dir)
 
     shutil.copytree(source_dir, output_dir)
 
     # Count files copied
     file_count = sum(1 for _ in output_dir.rglob("*.py"))
-    click.echo(f"Ejected service '{name}' to {output_dir} ({file_count} Python files)")
+    report(f"Ejected service '{name}' to {output_dir} ({file_count} Python files)")
 
     # Copy tests if requested
     if include_tests:
@@ -179,9 +173,10 @@ def eject_service(name: str, output: str | None, include_tests: bool):
         if tests_root.exists():
             shutil.copytree(tests_root, test_dir, dirs_exist_ok=True)
             test_count = sum(1 for _ in test_dir.rglob("test_*.py"))
-            click.echo(f"  Copied {test_count} test files to {test_dir}")
+            note(f"Copied {test_count} test files to {test_dir}")
 
-    click.echo("\nNext steps:")
-    click.echo(f"  1. Modify files in {output_dir} for your needs")
-    click.echo("  2. Update imports in your capabilities to use local service")
-    click.echo("  3. Run 'osprey health' to verify")
+    report("")
+    report("Next steps:")
+    note(f"1. Modify files in {output_dir} for your needs")
+    note("2. Update imports in your capabilities to use the local service")
+    note("3. Run 'osprey health' to check it")

--- a/src/osprey/cli/health_cmd.py
+++ b/src/osprey/cli/health_cmd.py
@@ -16,13 +16,13 @@ Design contracts honored here:
   while the rest of the report still renders.
 * **``--full`` is the sole on_demand gate.** ``--category`` selects which
   categories run but never elevates cost class.
-* **Machine-clean ``--json``.** In ``--json`` mode every human-facing line
-  (progress spinner, deprecation warning) is routed to a stderr console so
-  stdout is a single JSON document that round-trips through :func:`json.loads`.
+* **Machine-clean ``--json``.** The ``--json`` run happens inside
+  :func:`osprey.cli.output.machine_mode`, which sends every renderer line — and
+  the progress spinner's live region — to stderr. Stdout therefore carries a
+  single JSON document that round-trips through :func:`json.loads`.
 
-The module-level ``console`` is intentionally patchable (tests replace
-``osprey.cli.health_cmd.console``); ``resolve_project_path`` is imported locally
-inside the command so patching it at its source module takes effect.
+``resolve_project_path`` is imported locally inside the command so patching it
+at its source module takes effect.
 """
 
 from __future__ import annotations
@@ -32,13 +32,14 @@ import logging
 import os
 import sys
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
 
-from osprey.cli.styles import console
+from osprey.cli import output, styles
+from osprey.cli.altitude import lift_gate
 from osprey.health.records import build_records, load_config
 
 if TYPE_CHECKING:
@@ -272,99 +273,105 @@ def health(
       # A repo or rendered project directory
       $ osprey health --project ~/projects/my-agent
     """
-    from rich.console import Console
-
     from osprey.health.config import DEFAULT_SUITE_TIMEOUT_S
     from osprey.health.offload import abandoned_count
     from osprey.health.render import render_json, render_report, run_progress
 
     from .project_utils import resolve_project_path
 
-    # A dedicated stderr console for out-of-band notices (progress, deprecation,
-    # failure messages) that must never touch stdout. In ``--json`` mode it is
-    # also the human console so stdout stays a pure JSON document.
-    err_console = Console(stderr=True)
-    human_console = err_console if as_json else console
+    # ``-v`` keeps its display meaning below (the per-check recap, the
+    # traceback) and additionally lifts the CLI's altitude gate, like every
+    # other subcommand's ``--verbose``. The gated handler renders at stderr, so
+    # a lifted gate cannot reach the ``--json`` document on stdout; the
+    # silencing ``_quiet_run_logs`` does for ``--json`` is untouched.
+    if verbose:
+        lift_gate()
 
-    if basic:
-        # Deprecation notice is unconditionally stderr — stdout carries only the
-        # report (or, under ``--json``, only the JSON document).
-        err_console.print(
-            "[dim]Warning: --basic is deprecated and has no effect; on_demand checks "
-            "are now opt-in via --full.[/dim]"
-        )
-
-    try:
-        project_path = resolve_project_path(project)
-        config_path, repo_root, env_path = _resolve_anchors(project_path)
-
-        with _quiet_run_logs(as_json=as_json, verbose=verbose):
-            config_state, expanded, settings, config_ok = load_config(config_path, repo_root)
-
-            # Load the deployment .env after the config load so its values are
-            # present in os.environ for the run-time checks (provider canaries,
-            # env scan).
-            _load_project_env(env_path)
-
-            suite_timeout_s = settings.suite_timeout_s if settings else DEFAULT_SUITE_TIMEOUT_S
-            on_demand_timeout_s = settings.on_demand_timeout_s if settings else None
-
-            records, extra_rows = build_records(
-                config_state,
-                expanded,
-                settings,
-                config_ok,
-                repo_root,
-                suite_timeout_s,
-                # Both anchors from the one resolver above: the repo root for
-                # what belongs to the repo, the render for what a build wrote.
-                render_path=config_path.parent,
+    # Under ``--json`` the whole run happens in machine mode: every renderer line
+    # goes to stderr, so the only thing reaching stdout is the JSON document
+    # ``render_json`` writes at the stream.
+    with output.machine_mode() if as_json else nullcontext():
+        if basic:
+            output.warn(
+                "--basic is deprecated and has no effect",
+                "on_demand checks are now opt-in via --full",
             )
-            selected = _validate_categories(
-                categories, {r.name for r in records}, config_ok=config_ok
-            )
-            # A config-load failure is a global fault: its ``configuration``
-            # error rows (and the resulting exit 2) must surface even when a
-            # ``--category`` filter would otherwise scope them out.
-            if selected is not None and not config_ok and "configuration" not in selected:
-                selected = ("configuration", *selected)
 
-            control_system_config = (expanded or {}).get("control_system", {}) or {}
+        try:
+            project_path = resolve_project_path(project)
+            config_path, repo_root, env_path = _resolve_anchors(project_path)
 
-            with run_progress(console=human_console):
-                report = asyncio.run(
-                    _run_suite(
-                        records,
-                        control_system_config,
-                        full=full,
-                        categories=selected,
-                        suite_timeout_s=suite_timeout_s,
-                        on_demand_timeout_s=on_demand_timeout_s,
-                    )
+            with _quiet_run_logs(as_json=as_json, verbose=verbose):
+                config_state, expanded, settings, config_ok = load_config(config_path, repo_root)
+
+                # Load the deployment .env after the config load so its values
+                # are present in os.environ for the run-time checks (provider
+                # canaries, env scan).
+                _load_project_env(env_path)
+
+                suite_timeout_s = settings.suite_timeout_s if settings else DEFAULT_SUITE_TIMEOUT_S
+                on_demand_timeout_s = settings.on_demand_timeout_s if settings else None
+
+                records, extra_rows = build_records(
+                    config_state,
+                    expanded,
+                    settings,
+                    config_ok,
+                    repo_root,
+                    suite_timeout_s,
+                    # Both anchors from the one resolver above: the repo root for
+                    # what belongs to the repo, the render for what a build wrote.
+                    render_path=config_path.parent,
                 )
+                selected = _validate_categories(
+                    categories, {r.name for r in records}, config_ok=config_ok
+                )
+                # A config-load failure is a global fault: its ``configuration``
+                # error rows (and the resulting exit 2) must surface even when a
+                # ``--category`` filter would otherwise scope them out.
+                if selected is not None and not config_ok and "configuration" not in selected:
+                    selected = ("configuration", *selected)
 
-        # Plugin-load diagnostics are surfaced only on an unfiltered run; a
-        # ``--category`` selection keeps the output scoped to what was asked for.
-        if selected is None and extra_rows:
-            report.results.extend(extra_rows)
+                control_system_config = (expanded or {}).get("control_system", {}) or {}
 
-        if as_json:
-            render_json(report)
-        else:
-            render_report(report, verbose=verbose, console=console)
+                # The spinner picks its own stream: in machine mode it mounts on
+                # the stderr console, so it never animates over the document.
+                with run_progress():
+                    report = asyncio.run(
+                        _run_suite(
+                            records,
+                            control_system_config,
+                            full=full,
+                            categories=selected,
+                            suite_timeout_s=suite_timeout_s,
+                            on_demand_timeout_s=on_demand_timeout_s,
+                        )
+                    )
 
-        exit_code = report.exit_code
+            # Plugin-load diagnostics are surfaced only on an unfiltered run; a
+            # ``--category`` selection keeps the output scoped to what was asked for.
+            if selected is None and extra_rows:
+                report.results.extend(extra_rows)
 
-    except click.UsageError:
-        raise
-    except KeyboardInterrupt:
-        human_console.print("\n[yellow]Health check interrupted[/yellow]")
-        exit_code = 130
-    except Exception as exc:  # noqa: BLE001 - top-level guard: any failure is exit 3
-        human_console.print(f"\n[red]Health check failed: {exc}[/red]")
-        if verbose:
-            human_console.print_exception()
-        exit_code = 3
+            if as_json:
+                render_json(report)
+            else:
+                render_report(report, verbose=verbose)
+
+            exit_code = report.exit_code
+
+        except click.UsageError:
+            raise
+        except KeyboardInterrupt:
+            output.warn("Health check interrupted")
+            exit_code = 130
+        except Exception as exc:  # noqa: BLE001 - top-level guard: any failure is exit 3
+            output.fail("Health check failed", str(exc))
+            if verbose:
+                # A traceback is a block, not a line: it goes at the one stderr
+                # console rather than through a line-shaped primitive.
+                styles.err_console.print_exception()
+            exit_code = 3
 
     # A hung sync check leaves a daemon thread running; a normal ``sys.exit`` can
     # then wedge on interpreter teardown. Fall back to ``os._exit`` so an

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -44,6 +44,7 @@ from osprey.utils.dotenv import ENV_SHARED_FILENAME
 from osprey.utils.logger import get_logger
 from osprey.utils.workspace import STATE_ZONE_DIRS
 
+from . import output
 from .profile_conventions import BUILD_OUTPUT_DIR, STATE_DIR
 from .repo_resolver import HELD_SOURCE_ZONE_DIRNAME
 
@@ -624,12 +625,11 @@ def _reinstate_held_source_zone(target: Path) -> None:
 
     unrecognized = sorted(entry.name for entry in stash.iterdir())
     if unrecognized:
-        click.echo(
-            f"\n⚠ Put your files back from {stash}, but left "
-            f"{', '.join(unrecognized)} in it. This version of osprey has no "
-            f"place for anything by those names, and nothing will read them. "
-            f"Move them out, or delete that directory yourself.",
-            err=True,
+        output.warn(
+            f"Put your files back from {stash}, but left {', '.join(unrecognized)} in it",
+            "This version of osprey has no place for anything by those names, "
+            "and nothing will read them. Move them out, or delete that "
+            "directory yourself.",
         )
         return
     shutil.rmtree(stash, ignore_errors=True)
@@ -734,11 +734,11 @@ def _replacing_source_zone(target: Path, *, active: bool) -> Iterator[None]:
     # this entry existed would sweep it into the next `git add --all`.
     shutil.rmtree(stash, ignore_errors=True)
     if stash.exists():
-        click.echo(
-            f"\n⚠ Could not remove {stash}. It holds the files that were just "
-            f"replaced, so everything in it is an older copy of what is now in "
-            f"the repo. Remove it before you commit.",
-            err=True,
+        output.warn(
+            f"Could not remove {stash}",
+            "It holds the files that were just replaced, so everything in it "
+            "is an older copy of what is now in the repo. Remove it before "
+            "you commit.",
         )
 
 
@@ -1132,8 +1132,16 @@ def init(
             # and `reset` pulls in the whole deployment stack.
             from osprey.deployment.reset import reset_deployment
 
+            # `output.report`, and NOT a logger call: the destruction plan is
+            # this verb's own output, not a transcript line. Routed through the
+            # logger it is an INFO record, which the altitude gate drops on a
+            # normal run -- so `osprey init --reset` used to destroy a
+            # deployment without ever showing the operator the list of what it
+            # was about to take, while `osprey reset` printed the same plan in
+            # full. One printer for both call sites is what keeps the two paths
+            # line-identical rather than merely similar.
             with reporter.phase(f"Discarding the previous {target.name}"):
-                reset_deployment(target, assume_yes=True, emit=logger.key_info)
+                reset_deployment(target, assume_yes=True, emit=output.report)
 
             # `reset` removes only what carries this checkout's repo-id label,
             # so a deployment predating that label survives it — correctly, since
@@ -1191,9 +1199,9 @@ def _abort_incomplete_reset(target: Path, survivors: list[str]) -> None:
     logger.error(
         "✗ --reset could not clear %s: %d resource(s) of this project remain.\n\n%s\n\n"
         "`osprey reset` removes only what carries this checkout's `com.osprey.repo-id` "
-        "label. These predate it — a deployment created before the label existed — so it "
-        "cannot prove they are this repo's and declines to touch them, which is what keeps "
-        "one checkout from destroying another's.\n\n"
+        "label, and these were created before that label existed. It cannot prove they "
+        "belong to this repo, so it leaves them alone, which is what keeps one checkout "
+        "from destroying another's.\n\n"
         "Remove them yourself, once, and every later deployment of this name will carry the "
         "label and reset cleanly:\n"
         "    docker ps -aq --filter label=com.docker.compose.project=%s | xargs docker rm -f\n"

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import click
 
+from .output import fail, note, report, warn
+
 
 @click.group()
 def knowledge() -> None:
@@ -72,8 +74,8 @@ def regen_index(bundle: Path | None) -> None:
 
     written = regenerate_indexes(bundle)
     for path in written:
-        click.echo(str(path))
-    click.echo(f"Wrote {len(written)} index file(s).")
+        report(str(path))
+    report(f"Wrote {len(written)} index file(s).")
 
 
 @knowledge.command("validate")
@@ -123,12 +125,13 @@ def validate(bundle: Path | None) -> None:
                 failures.append((md_path, str(exc)))
 
     if not failures:
-        click.echo(f"All files in {bundle} are valid.")
+        report(f"All files in {bundle} are valid.")
         return
 
-    click.echo(f"{len(failures)} file(s) failed validation:", err=True)
-    for path, msg in failures:
-        click.echo(f"  {path}: {msg}", err=True)
+    fail(
+        f"{len(failures)} file(s) failed validation",
+        "\n".join(f"{path}: {msg}" for path, msg in failures),
+    )
     raise SystemExit(1)
 
 
@@ -197,23 +200,20 @@ def seed_from_ttl(ttl: Path, bundle: Path, force: bool) -> None:
         if concept_path.exists():
             existing = concept_path.read_text(encoding="utf-8")
             if existing == stub.body:
-                click.echo(f"  unchanged  {concept_path.name}")
+                note(f"unchanged   {concept_path.name}")
                 skipped_same += 1
                 continue
             if not force:
-                click.echo(
-                    f"  differs    {concept_path.name}  (use --force to overwrite)",
-                    err=True,
-                )
+                note(f"differs     {concept_path.name}")
                 skipped_differs += 1
                 continue
             concept_path.write_text(stub.body, encoding="utf-8")
-            click.echo(f"  overwritten {concept_path.name}")
+            note(f"overwritten {concept_path.name}")
             overwritten += 1
         else:
             concept_path.parent.mkdir(parents=True, exist_ok=True)
             concept_path.write_text(stub.body, encoding="utf-8")
-            click.echo(f"  written    {concept_path.name}")
+            note(f"written     {concept_path.name}")
             written += 1
 
     parts = []
@@ -224,5 +224,13 @@ def seed_from_ttl(ttl: Path, bundle: Path, force: bool) -> None:
     if skipped_same:
         parts.append(f"{skipped_same} unchanged")
     if skipped_differs:
-        parts.append(f"{skipped_differs} skipped (differs; use --force)")
-    click.echo(", ".join(parts) + "." if parts else "Nothing to do.")
+        parts.append(f"{skipped_differs} left alone")
+    report(", ".join(parts) + "." if parts else "Nothing to do.")
+
+    # The one line that asks the operator for a decision, so it is a warning and
+    # not another entry in the per-file record above.
+    if skipped_differs:
+        warn(
+            f"{skipped_differs} file(s) already exist with different content",
+            "They were left as they are. Re-run with --force to overwrite them.",
+        )

--- a/src/osprey/cli/live_render.py
+++ b/src/osprey/cli/live_render.py
@@ -20,8 +20,8 @@ The region never repeats the phase's title. The phase announced itself with a
 permanent ``→ title`` line the moment it opened, and a title redrawn underneath
 that line reads as a rendering glitch rather than as progress; what the region
 adds is the part that could not be printed once — a spinner and a duration that
-keep moving. Printing the title exactly once also keeps the terminal's scrollback
-identical to the output of a run that was piped to a file.
+keep moving. Printing the title exactly once also keeps the phase lines in the
+terminal's scrollback in the same words a piped run writes them.
 
 The ticker sits at the indent of the ``  · step`` lines the phase reporter
 prints, so it reads as belonging to the ``→ title`` above it, and the rows sit
@@ -42,8 +42,8 @@ reason :meth:`BuildModel.feed` takes its timestamp: the caller measures time
 once, and a fifteen-minute build renders identically from a fixture.
 
 Every style here is a semantic token from :mod:`osprey.cli.styles`, resolved
-through the active Rich theme. Nothing names a color, so a retheme (or
-``osprey theme-lab``) reaches this region like it reaches the rest of the CLI.
+through the active Rich theme. Nothing names a color, so a ``cli.theme`` change
+reaches this region like it reaches the rest of the CLI.
 """
 
 from __future__ import annotations
@@ -58,7 +58,7 @@ from rich.text import Text
 
 from osprey.deployment.build_progress import EXPORT_STEP, BuildRow
 
-from .styles import Styles, ThemeConfig
+from .styles import LAYOUT_TABLE_GUTTER, Styles, ThemeConfig, layout_table
 
 #: Columns the service rows are indented by. The phase reporter's sub-steps sit
 #: at 2, so 4 nests the table one level below them.
@@ -69,8 +69,10 @@ _INDENT = 4
 #: than as the start of something new.
 _TICKER_INDENT = 2
 
-#: Blank columns between two adjacent table columns.
-_GUTTER = 3
+#: Blank columns between two adjacent table columns. Owned by
+#: :mod:`osprey.cli.styles` along with the rest of the layout table's shape;
+#: aliased here because the caption budget has to subtract it.
+_GUTTER = LAYOUT_TABLE_GUTTER
 
 #: The width the step column is held at. The step vocabulary is closed — a
 #: Dockerfile index, a header word (``internal``, ``auth``), or
@@ -186,7 +188,7 @@ def _row_table(rows: Sequence[BuildRow], now: float, width: int) -> RenderableTy
         (row.service, row.step or _NO_STEP, row.caption, format_duration(now - row.started_at))
         for row in rows
     ]
-    table = Table(box=None, show_header=False, padding=(0, 0, 0, _GUTTER), pad_edge=False)
+    table = layout_table()
     table.add_column(style=Styles.ACCENT, no_wrap=True)
     table.add_column(style=Styles.SUCCESS, no_wrap=True, min_width=_STEP_WIDTH)
     table.add_column(

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -191,9 +191,10 @@ def cli(ctx, verbose):
     import logging
 
     from osprey.utils.config import load_project_dotenv
-    from osprey.utils.logger import configure_logging
+    from osprey.utils.logger import configure_logging, set_handler_console
 
-    from .styles import initialize_theme_from_config
+    from .altitude import install_gate
+    from .styles import err_console, initialize_theme_from_config
 
     # The CLI is a process entry point: nothing else populates the environment
     # from `.env`, and importing the framework deliberately does not. Do this
@@ -211,12 +212,33 @@ def cli(ctx, verbose):
     # needs when reproducing a deploy step by hand.
     configure_logging(logging.DEBUG if verbose else logging.INFO)
 
+    # Logging is configured for entry points that have no console of their own,
+    # so it builds one — a second stderr renderer, at a fixed width that fights
+    # the real terminal's. The CLI does have one, so the handler is pointed at
+    # it: one console owns stderr, and log lines wrap where printed lines do.
+    handler = set_handler_console(err_console)
+
+    # The altitude policy lives on that handler, and only for the CLI: a normal
+    # run renders WARNING and above, `-v` renders everything. Gating here rather
+    # than inside configure_logging() leaves every non-CLI entry point — and
+    # every external consumer of the shared logging package — untouched, and
+    # gating at the handler drops records from the *terminal* only: they are
+    # still emitted, so caplog and any other sink still see them.
+    #
+    # The handler outlives one invocation, so install_gate() removes whatever a
+    # previous invocation left before deciding what this one wants.
+    install_gate(handler, verbose=verbose)
+
     initialize_theme_from_config()
 
     if ctx.invoked_subcommand is None:
         # The bare command lists what there is to run. Every verb is
         # zero-argument, so the help is the menu — an interactive wrapper would
         # be a surface with nothing to wrap.
+        #
+        # ALLOWLISTED raw click.echo, not a renderer primitive: Click has
+        # already laid this text out, `\b`-preformatted blocks included, and
+        # putting it through Rich would re-wrap it to a different width.
         click.echo(ctx.get_help())
 
 
@@ -284,13 +306,21 @@ def _tty_aware_reporter() -> "PhaseReporter":
 
 def main():
     """Entry point for the osprey CLI."""
+    # Imported here rather than at module scope: this module is the whole of
+    # what `osprey --help` loads, and the renderer pulls in the phase reporter
+    # and the themed consoles. Both handlers below run only after `cli()` has
+    # already loaded them, so the import costs nothing on the path that matters.
     try:
         cli()
     except KeyboardInterrupt:
-        click.echo("\nGoodbye!", err=True)
+        from .output import warn
+
+        warn("Interrupted. Goodbye!")
         sys.exit(130)
     except Exception as e:
-        click.echo(f"Error: {e}", err=True)
+        from .output import fail
+
+        fail(str(e))
         sys.exit(1)
 
 

--- a/src/osprey/cli/output.py
+++ b/src/osprey/cli/output.py
@@ -1,0 +1,440 @@
+"""The single output renderer for the OSPREY CLI.
+
+Every primitive here is echo-class: it prints a verb's OWN output, so it
+survives whichever reporter is installed -- including the ``NullReporter`` that
+global ``--verbose`` installs, where the phase record itself is swallowed.
+Phase, step and ticker decoration is emit-class and stays in
+:mod:`osprey.cli.phase_reporter`; nothing in this module is ever used for it.
+
+The primitives resolve their console at call time, never at import: on a
+terminal the installed reporter owns the cursor, and its console is the only
+one that can put a line ABOVE a mounted live region instead of inside it. That
+holds for the trouble primitives too: :func:`warn` and :func:`fail` are stderr
+off a terminal, and follow the region while one is mounted -- joining every
+other stderr writer in the process, which a mounted ``Live`` has been proxying
+onto the region's console all along. :func:`_target_console` states the
+mechanism and what it costs. Under :func:`machine_mode` every primitive writes
+to stderr instead, so a ``--json`` verb leaves stdout carrying one pure JSON
+document and nothing else.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+
+from . import styles
+from .phase_reporter import current_reporter
+from .styles import Styles
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+    from rich.console import Console, RenderableType
+
+    from osprey_connectors.logger import ComponentLogger
+
+__all__ = [
+    "fail",
+    "machine_mode",
+    "machine_mode_active",
+    "note",
+    "report",
+    "report_fact",
+    "section",
+    "table",
+    "warn",
+]
+
+#: The one indentation step. Everything subordinate -- a note, a section's rows
+#: -- is one step in from the line it belongs under, which is the same step the
+#: phase record already uses for ``  · name`` and ``  ✓ title``. Structure, not
+#: color: it is the half of "subordinate" that survives a pipe, where no style
+#: reaches the reader at all.
+_INDENT = "  "
+
+#: The gap between a section's label column and its values. Wide enough that a
+#: ragged label column still reads as two columns rather than as one sentence.
+_GUTTER = "   "
+
+#: What a failure or a refusal opens with -- the same mark
+#: :meth:`Messages.error <osprey.cli.styles.Messages.error>` has always used, and
+#: the one this module's trouble path spells. One reported failure wears exactly
+#: one of these, which is the part that takes care -- see :func:`fail`'s
+#: ``mark``, which is how a handler explains a failure the phase record has
+#: already marked without putting a second one in front of it.
+_FAIL_GLYPH = "✗"
+
+#: What a warning opens with -- the mark the phase record's interrupted line
+#: already uses, so a warning reads the same wherever it comes from.
+_WARN_GLYPH = "⚠"
+
+#: What marks the line telling the operator what to do about it. Content, not
+#: decoration: it survives a pipe, and it is what makes a remedy findable in a
+#: scrollback full of causes.
+_REMEDY_GLYPH = "→"
+
+#: True for as long as a :func:`machine_mode` block is open. Process-scoped
+#: rather than task- or thread-scoped: the CLI is single-threaded at these call
+#: sites, and a ``--json`` verb wraps its whole body in one block.
+_machine_mode = False
+
+
+def _region_is_mounted() -> bool:
+    """Whether the installed reporter is drawing a live region right now.
+
+    The reporter's own predicate rather than a second copy of it:
+    :meth:`PhaseReporter.is_rendering
+    <osprey.cli.phase_reporter.PhaseReporter.is_rendering>` is the same answer
+    :meth:`~osprey.cli.phase_reporter.PhaseReporter.suspended` branches on, and
+    an answer maintained twice is an answer that will disagree with itself.
+    Named for what this module is asking, which is where the region is, not what
+    the reporter is doing about it.
+    """
+    return current_reporter().is_rendering()
+
+
+def _target_console(*, err: bool) -> Console:
+    """The console this call must print through.
+
+    Machine mode wins over everything: the point of the block is that stdout
+    carries the JSON document and nothing else, so human output goes to stderr
+    even where a reporter would have had somewhere better to put it.
+
+    Otherwise stdout output goes through the installed reporter's console --
+    which on a terminal is the console the live region was built on, the only
+    one Rich can place a line above the region with. Read per call, because
+    installing a reporter is what changes the answer.
+
+    Trouble takes ``styles.err_console``, because its stream is part of its
+    contract -- EXCEPT while a live region is mounted, where writing at stderr
+    damages the screen. Rich unwraps its own ``FileProxy`` for a stderr-bound
+    console, so ``Live`` never sees that write: the line lands at whatever
+    column the region left the cursor on and welds a dead spinner and a frozen
+    ticker to its front, permanently, because the region redraws a row lower and
+    never takes that one back. So a mounted region borrows the trouble line for
+    as long as it is up, exactly as it borrows the log handler's console (see
+    :meth:`LiveReporter._borrow_log_console
+    <osprey.cli.phase_reporter.LiveReporter._borrow_log_console>`), and gives it
+    back the moment the region comes down.
+
+    THE MECHANISM, and the scope of what this changes: a mounted ``Live``
+    already proxies the process's stderr onto the region's console. Everything
+    that writes there -- a log record, a library's warning, a traceback on the
+    way out -- has been arriving on the region's console, which is stdout's, for
+    as long as regions have existed. ``styles.err_console`` was the single
+    escapee, because Rich resolves a console's file through
+    ``rich_proxied_file`` and so unwraps the very proxy that redirect installs;
+    escaping is exactly what welded the line to the frame. This module stops
+    escaping, rather than moving a stream that was otherwise being kept.
+
+    The cost is therefore real but bounded, and it is the region's cost rather
+    than this function's: while a region is mounted, ``osprey up 2>errors.log``
+    on a terminal writes its trouble to the screen and not to the file -- as it
+    already did for that run's log records and tracebacks. A region only mounts
+    when stdout is a terminal, so a piped or redirected run, where the two
+    streams are genuinely separate files and a reader is relying on the
+    difference, never mounts one and never takes this path.
+
+    The check and the print are not one atomic step, and that is affordable
+    rather than overlooked. A region coming down between them sends the line to
+    the console it was about to leave -- the same device stderr would have
+    reached, since a region only exists on a terminal. The other direction
+    cannot be reached at all: a region is mounted at the verb's entry, before
+    anything that could call this from another thread exists. A lock would buy
+    an ordering nobody can observe.
+    """
+    if _machine_mode:
+        return styles.err_console
+    if err and not _region_is_mounted():
+        return styles.err_console
+    return current_reporter().out()
+
+
+def _echo(renderable: RenderableType, *, err: bool = False) -> None:
+    """Print one renderable on the never-silenced echo path.
+
+    The same console and the same print keywords :meth:`PhaseReporter.echo
+    <osprey.cli.phase_reporter.PhaseReporter.echo>` uses, and for its reasons:
+    no markup and no highlighting (paths, brackets and version numbers in a
+    verb's output are text, not style tags), no wrapping (callers pass lines
+    that are already the shape they want).
+
+    Style rides on a pre-styled :class:`~rich.text.Text` rather than on a
+    ``style=`` argument, which is :meth:`LiveReporter.emit
+    <osprey.cli.phase_reporter.LiveReporter.emit>`'s precedent: Rich applies a
+    ``style=`` to everything the call renders, so while a region is mounted it
+    would repaint the table underneath in the line's color.
+
+    ``err`` marks a line whose stream is part of its contract -- the seam the
+    trouble primitives print through. It is a claim about the reader, not about
+    a file descriptor: :func:`_target_console` still routes it through a mounted
+    region's console, because there is no reader on a terminal for whom raw
+    stderr would be the better answer.
+    """
+    _target_console(err=err).print(renderable, markup=False, highlight=False, soft_wrap=True)
+
+
+def report(text: str, /, *, style: str | None = None) -> None:
+    """Print ``text`` as a report line -- a verb's primary output.
+
+    The default altitude for anything an operator ran the verb to find out:
+    what was created, where it answers, what changed. Printed under every
+    reporter, so ``osprey -v <verb>`` still ends with its verb's own report.
+
+    Pass an empty string for a blank separator line.
+
+    :param text: The line, already in the shape it should appear in.
+        Positional-ONLY by API contract -- the copy guard reads prose out of
+        positional arguments, so a printed sentence that arrived as a keyword
+        would be a sentence the guard never saw. Declaring it positional-only
+        makes that unwritable rather than merely discouraged.
+    :param style: A semantic token from :class:`~osprey.cli.styles.Styles` for
+        the whole line (a card's title line, say). Keyword-only because it is
+        not prose; omitted, the line prints in the terminal's own color.
+    """
+    _echo(Text(text, style=style or ""))
+
+
+def report_fact(logger: ComponentLogger, message: str) -> None:
+    """Print an operator-critical fact, and keep its record for the log sinks.
+
+    The promotion contract, spelled once for every module that carries facts a
+    person running the verb has to read: credentials a deploy minted, secret
+    files it wrote or renamed, host state it changed, a posture it chose. All of
+    them printed through ``logger.key_info`` alone, which the CLI's altitude
+    gate drops at the handler on a normal run, so the fact never reached the
+    terminal at all.
+
+    :func:`report` puts the fact in the default view, where the person running
+    the verb reads it. The log record stays at the level it always had, so file
+    and aggregation sinks keep the transcript they always kept. On a normal run
+    the gate drops the record at the handler and the fact reaches the terminal
+    once; under ``-v`` the gate is lifted and it appears twice, once as the
+    verb's own output and once in the transcript that flag asked for.
+
+    :param logger: The calling module's logger, passed in rather than made here,
+        so the record still names the module that holds the fact.
+    :param message: The finished line. The caller builds it, because every one
+        of these facts names a value only the caller holds: a path, a variable
+        name, a count.
+    """
+    report(message)
+    logger.key_info(message)
+
+
+def note(text: str, /) -> None:
+    """Print ``text`` as a note -- secondary detail under what came before.
+
+    For the sentence an operator does not need in order to act, but is glad to
+    have when they read: what a default was resolved from, what a skipped step
+    would have done. Subordinate two ways, because only one of them survives a
+    pipe -- indented one step, and dim on a terminal.
+
+    :param text: The note. Positional-only by API contract, as for
+        :func:`report`.
+    """
+    _echo(Text(f"{_INDENT}{text}", style=Styles.DIM))
+
+
+def section(title: str, items: Mapping[str, object] | Sequence[tuple[str, object]], /) -> None:
+    """Print a key/value block: ``title``, then one indented row per item.
+
+    The one shape for "here are the facts about this thing" -- an endpoint
+    list, a summary card's rows, a config dump. Labels are padded to a common
+    width so the values line up as a column; values are rendered with
+    :func:`str`, so a caller may hand over paths, ports and booleans as they
+    are.
+
+    An empty ``items`` prints the title alone, and an empty ``title`` prints
+    the rows alone -- a section that continues the line above it.
+
+    :param title: The block's heading. Positional-only by API contract, as for
+        :func:`report`.
+    :param items: The rows, as a mapping or as an ordered sequence of
+        ``(label, value)`` pairs. A sequence when the order is meaningful and
+        labels may repeat; either way the rows print in iteration order.
+    """
+    rows = list(items.items()) if isinstance(items, Mapping) else list(items)
+    if title:
+        _echo(Text(title, style=Styles.BOLD))
+    width = max((len(label) for label, _ in rows), default=0)
+    for label, value in rows:
+        line = Text(_INDENT)
+        line.append(label.ljust(width), style=Styles.LABEL)
+        line.append(_GUTTER)
+        line.append(str(value))
+        _echo(line)
+
+
+def table(renderable: RenderableType, /) -> None:
+    """Print one built renderable -- a table, a panel, a syntax block.
+
+    The echo-class way to put something that is not a line of text on screen.
+    Named for the case that brought it: tables are what the CLI builds most, via
+    :func:`~osprey.cli.styles.data_table` and
+    :func:`~osprey.cli.styles.layout_table`. Anything Rich can render is
+    accepted, and a :class:`~rich.panel.Panel` from
+    :func:`~osprey.cli.styles.panel` goes through the same door.
+
+    Printed through the same seam as every other primitive, so a table lands
+    above a mounted live region rather than inside it, survives ``osprey -v``,
+    and moves to stderr inside :func:`machine_mode` with the lines around it.
+
+    **Cells must be :class:`~rich.text.Text`, never markup strings.** This
+    primitive inherits the module's ``markup=False``, and Rich propagates that
+    into every nested renderable: a cell holding ``"[success]OK[/success]"``
+    prints those brackets literally and takes the column widths with it. Style a
+    cell by building ``Text("OK", style=Styles.SUCCESS)``. With ``Text`` cells
+    the output is byte-identical to a bare ``console.print(table)`` -- a table
+    computes its own column widths, so the module's ``soft_wrap`` changes
+    nothing about how it renders.
+
+    :param renderable: A built Rich renderable. Positional-only for uniformity
+        with the rest of the module, though there is no prose here for the copy
+        guard to read.
+    """
+    _echo(renderable)
+
+
+def _trouble(glyph: str, style: str, summary: str, body: Sequence[str]) -> None:
+    """Print one trouble event: a marked summary line, then its indented body.
+
+    The one shape for everything that went wrong, so that a reader who has seen
+    one failure can read every other one. Only the summary line carries the
+    color token -- a cause printed in red is a cause competing with the line
+    that says what failed, and dim would push it below the altitude an operator
+    reads at. Structure carries the subordination instead, which is also the
+    half of it that survives a pipe.
+
+    Stderr, because the stream is part of the contract for trouble: a caller
+    piping stdout somewhere keeps its warnings and failures on the terminal.
+    While a live region is mounted the lines go through the region's console
+    instead, which is what puts them ABOVE it in one piece -- see
+    :func:`_target_console` for the mechanism and what it costs.
+
+    :param glyph: The mark opening the summary line, or an empty string for a
+        failure that is already marked somewhere else -- see :func:`fail`'s
+        ``mark``. The summary then opens with its own first word, and nothing
+        else about the block changes.
+    :param style: The :class:`~osprey.cli.styles.Styles` token for that line.
+    :param summary: What happened, in one line.
+    :param body: The already-prefixed lines under it, each printed one
+        :data:`_INDENT` in.
+    """
+    _echo(Text(f"{glyph} {summary}" if glyph else summary, style=style), err=True)
+    for line in body:
+        _echo(Text(f"{_INDENT}{line}"), err=True)
+
+
+def warn(summary: str, detail: str | None = None, /) -> None:
+    """Print a warning: something the operator should know went sideways.
+
+    For what the verb worked around rather than stopped for -- a key it could
+    not read and defaulted, a step it skipped, a deprecation it honored anyway.
+    Use :func:`fail` when the verb is not going to deliver what it was asked
+    for.
+
+    Prints to stderr under every reporter -- above a live region rather than
+    onto it while one is mounted -- and inside :func:`machine_mode` like
+    everything else here, so a ``--json`` caller never finds a warning in its
+    document.
+
+    :param summary: What went sideways, in one line and without the glyph.
+        Positional-ONLY, as for :func:`report`: the copy guard reads prose out
+        of positional arguments, so a keyword would hide a printed sentence
+        from it.
+    :param detail: What an operator needs in order to judge it -- the value
+        that was rejected, what was used instead. Printed one indent step
+        under the summary; multi-line detail is indented line by line.
+        Positional-only for the same reason.
+    """
+    _trouble(_WARN_GLYPH, Styles.WARNING, summary, detail.splitlines() if detail else ())
+
+
+def fail(
+    summary: str,
+    cause: str | None = None,
+    remedy: str | None = None,
+    /,
+    *,
+    mark: bool = True,
+) -> None:
+    """Print a failure or a refusal: ``✗ summary``, its cause, its remedy.
+
+    The single shape for every way the CLI declines to deliver -- an error it
+    caught, a precondition it will not proceed without, a write it refuses.
+    Whichever it is, the operator reads the same three parts: what failed, why,
+    and what to do about it.
+
+    This function only prints. It does not raise, exit, or set an exit code:
+    the caller stays in charge of its own :class:`click.Abort` and its own exit
+    status, so adopting the shape never changes what a script sees.
+
+    :param summary: What failed, in one line and without the glyph.
+        Positional-ONLY, as for :func:`report`.
+    :param cause: Why -- the bound port, the missing key, the exception's
+        message. Printed one indent step under the summary; multi-line cause is
+        indented line by line. Positional-only.
+    :param remedy: The one thing to do about it, printed as ``→ remedy`` under
+        the cause. Omit it when there is nothing honest to suggest -- a remedy
+        that does not work costs more than none. Positional-only.
+    :param mark: Whether to open with ``✗``. Pass ``False`` where the failure
+        already wears one: a refusal raised inside an open phase leaves through
+        :meth:`Phase.fail <osprey.cli.phase_reporter.Phase.fail>`, which has
+        printed ``✗ title`` for it already. The mark means "here is a thing that
+        failed", and there is one thing to say it about -- a second mark reads
+        as a second failure, so the handler that says WHY prints the same block
+        unmarked. What continues is the READING, not the record: the phase line
+        is the reporter's and goes to stdout, this block is trouble and goes to
+        stderr as it always does, so the two are one failure to somebody
+        watching a terminal and two independent records to anything reading the
+        streams apart. The block keeps this function's own geometry too --
+        column-zero summary, cause one step in -- rather than nesting under the
+        phase line it follows. Only the glyph is dropped. Keyword-only, because
+        it is not prose and the copy guard reads prose out of the positional
+        arguments.
+    """
+    body = list(cause.splitlines()) if cause else []
+    if remedy:
+        body.append(f"{_REMEDY_GLYPH} {remedy}")
+    _trouble(_FAIL_GLYPH if mark else "", Styles.ERROR, summary, body)
+
+
+@contextmanager
+def machine_mode() -> Iterator[None]:
+    """Send every renderer line to stderr for as long as the block runs.
+
+    What a ``--json`` verb wraps its body in. The caller writes its document to
+    stdout and everything else in the process -- a warning from three frames
+    down, a note a shared helper prints -- lands on stderr, so the reader of
+    stdout parses one document rather than a document with prose in it.
+
+    Reentrant: a nested block restores the state it found rather than switching
+    the mode off, so a ``--json`` verb calling another one keeps the redirect
+    for its whole body.
+
+    Process-scoped, and deliberately so -- the primitives are called from
+    helpers deep in the call stack that hold no handle on the verb, which is
+    the same reason the reporter itself is a module singleton.
+    """
+    global _machine_mode
+    previous, _machine_mode = _machine_mode, True
+    try:
+        yield
+    finally:
+        _machine_mode = previous
+
+
+def machine_mode_active() -> bool:
+    """Whether a :func:`machine_mode` block is open right now.
+
+    Lets a call site that mounts a console of its own -- a progress spinner, a
+    live region -- pick the stderr console while a ``--json`` path is running,
+    rather than painting over the document on stdout. The primitives here
+    already do this for themselves; this is for the ones that cannot.
+    """
+    return _machine_mode

--- a/src/osprey/cli/phase_reporter.py
+++ b/src/osprey/cli/phase_reporter.py
@@ -32,7 +32,6 @@ from pathlib import Path
 from types import TracebackType
 from typing import TYPE_CHECKING
 
-import click
 from rich.console import Group
 from rich.live import Live
 from rich.logging import RichHandler
@@ -272,23 +271,6 @@ class PhaseReporter:
         """
         self.out().print(text, markup=False, highlight=False, soft_wrap=True)
 
-    def echo_error(self, text: str) -> None:
-        """Print one line of trouble, on the channel its reader is watching.
-
-        Off a terminal that is stderr verbatim: a caller reading stdout for a
-        verb's output reads its trouble on the other stream, and which stream is
-        part of the contract rather than a detail.
-
-        While a region is mounted, stderr is not this process's to write to
-        directly -- a raw write lands in the middle of a repaint -- so the line
-        goes through the console instead. On a terminal the two are the same
-        device anyway, so nothing is lost by routing it.
-        """
-        if self._is_rendering():
-            self.echo(text)
-        else:
-            click.echo(text, err=True)
-
     def phase(self, title: str) -> Phase:
         """Start a phase, printing its opening line."""
         self.emit(f"→ {title}", style=Styles.BOLD)
@@ -444,7 +426,9 @@ class PhaseReporter:
         ``✗`` line reads as a build that failed and then kept building. Callers
         are entitled to assume that when this returns, the monitor is silent.
 
-        Idempotent, and a no-op when called from the monitor thread itself.
+        Idempotent. Called from the monitor thread itself it still signals the
+        stop and drops the handle; only the join is skipped, because a thread
+        cannot join itself.
         """
         with self._monitor_lock:
             monitor, self._monitor = self._monitor, None
@@ -496,8 +480,9 @@ class PhaseReporter:
         its monitor at the first watcher instead. Defined here so that the
         install site can call it on whatever it just installed -- the same
         reason :meth:`stop_rendering` is defined here -- and so that the pair
-        reads as one seam: everything :meth:`stop_rendering` tears down is
-        exactly what this puts back.
+        reads as one seam in the subclass that has one: everything
+        :meth:`LiveReporter.stop_rendering` tears down is exactly what
+        :meth:`LiveReporter.start_rendering` puts back.
 
         Idempotent.
         """
@@ -513,7 +498,7 @@ class PhaseReporter:
         """
         self._stop_monitor()
 
-    def _is_rendering(self) -> bool:
+    def is_rendering(self) -> bool:
         """Whether this reporter is currently drawing something transient.
 
         False on this class: plain lines are written and forgotten, and there is
@@ -521,6 +506,11 @@ class PhaseReporter:
         :meth:`suspended` a true no-op off a terminal -- it puts back exactly
         what it took away, and so can never start something that was not running
         when the block opened.
+
+        Public because it answers a question outside this module too:
+        :mod:`osprey.cli.output` routes a trouble line onto the region's console
+        for as long as one is up, and asks here rather than keeping a second
+        answer of its own.
         """
         return False
 
@@ -554,7 +544,7 @@ class PhaseReporter:
         self._suspend_depth += 1
         # Whether the OUTERMOST block found something to pause. Held as a local
         # so the restart is conditional on what this block actually stopped.
-        resume = self._suspend_depth == 1 and self._is_rendering()
+        resume = self._suspend_depth == 1 and self.is_rendering()
         if resume:
             self.stop_rendering()
         try:
@@ -667,11 +657,11 @@ class LiveReporter(PhaseReporter):
     def __init__(self, *, console: Console | None = None) -> None:
         # Only ever installed on a terminal, so the lines are always styled.
         super().__init__(color=True)
-        # Read off the module at construction -- which the install site does
-        # immediately before installing -- rather than from-imported at module
-        # load: applying a theme REBINDS ``styles.console``, so a load-time
-        # capture would hand the Live a console the rest of the CLI has already
-        # stopped printing through, and the two would repaint over each other.
+        # Read off the module at construction rather than from-imported at
+        # module load, so a caller that swapped ``styles.console`` (tests do) is
+        # what the Live is built on. A theme change needs no such care:
+        # ``set_theme`` re-themes the module consoles in place and they keep
+        # their identity for the process lifetime.
         self._console = console if console is not None else styles.console
         self._live: Live | None = None
         # The log handlers whose console this reporter has borrowed, each with
@@ -756,7 +746,7 @@ class LiveReporter(PhaseReporter):
         super().stop_rendering()
         self._close_live()
 
-    def _is_rendering(self) -> bool:
+    def is_rendering(self) -> bool:
         """True exactly while a region is mounted.
 
         False again once a repaint has raised and taken the region down, which

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -33,6 +33,7 @@ import click
 from osprey.errors import BuildProfileError
 from osprey.utils.logger import get_logger
 
+from .output import report
 from .profile_conventions import BUILD_OUTPUT_DIR, PER_USER_CONTEXT_DIRNAME
 
 if TYPE_CHECKING:
@@ -61,7 +62,7 @@ def echo_preset_names() -> None:
     from .build_profile import list_presets
 
     for name in list_presets():
-        click.echo(name)
+        report(name)
 
 
 @profile.command()

--- a/src/osprey/cli/project_utils.py
+++ b/src/osprey/cli/project_utils.py
@@ -30,7 +30,8 @@ from pathlib import Path
 
 from osprey.agent_runner.project_paths import encode_claude_project_path
 
-from .styles import Messages, console
+from .output import report
+from .styles import Styles
 
 
 def _clear_claude_code_project_state(project_path: Path) -> None:
@@ -68,7 +69,7 @@ def _clear_claude_code_project_state(project_path: Path) -> None:
         cleared = True
 
     if cleared:
-        console.print(f"  {Messages.success('Cleared Claude Code project state')}")
+        report("✓ Cleared Claude Code project state", style=Styles.SUCCESS)
 
 
 def project_config_path(project_path: Path) -> Path:

--- a/src/osprey/cli/query_cmd.py
+++ b/src/osprey/cli/query_cmd.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+from contextlib import ExitStack
 from pathlib import Path
 
 import click
@@ -48,8 +49,16 @@ from osprey.agent_runner import (
     read_only_disallowed_tools,
     run_query,
 )
+from osprey.cli import output
 
 from .repo_resolver import find_repo_root, repo_option
+
+#: Why a repo with no render has nothing to answer with. Spelled here because
+#: the check that refuses and the line that prints the refusal sit in different
+#: functions.
+_NOTHING_RENDERED = (
+    "`osprey query` asks the rendered deployment, and there is nothing rendered yet."
+)
 
 
 def _overlay_repo_env(repo_root: Path) -> None:
@@ -83,14 +92,16 @@ def _overlay_repo_env(repo_root: Path) -> None:
 def _report_drift(repo_root: Path, build_dir: Path) -> None:
     """Say what the build no longer matches, then let the query proceed.
 
-    Written to stderr rather than stdout: ``osprey query`` is built to be piped
-    — ``--json`` especially — and a warning mixed into that stream would break
-    the consumer it was meant to inform.
+    Every line here reaches stderr, because the renderer's warnings always do:
+    ``osprey query`` is built to be piped — ``--json`` especially — and a
+    warning mixed into that stream would break the consumer it was meant to
+    inform.
 
     Raises:
-        click.ClickException: When there is no build to query at all. Its exit
-            code is remapped to :data:`EXIT_USAGE` by the caller, which owns
-            the documented exit-code contract.
+        click.ClickException: When there is no build to query at all. The
+            message is one line, the summary the caller prints; the caller also
+            owns the cause, the remedy, and the remap of the exit code to
+            :data:`EXIT_USAGE`.
     """
     from osprey.deployment.staleness import DriftState, check_drift
 
@@ -102,20 +113,15 @@ def _report_drift(repo_root: Path, build_dir: Path) -> None:
     # config.yml is what the runner unconditionally parses for the provider and
     # model (``resolve_default_model``, ``provider_env_for_project``).
     if report.state is DriftState.NO_BUILD or not (build_dir / "config.yml").is_file():
-        raise click.ClickException(
-            f"no build found at {build_dir} — run `osprey build` first.\n\n"
-            "`osprey query` asks the rendered deployment, and there is "
-            "nothing rendered yet."
-        )
+        raise click.ClickException(f"No build found at {build_dir}")
 
     if report.refuses:
-        click.echo(f"WARNING: {report.message}", err=True)
-        click.echo("Answering from build/ as it was last rendered.", err=True)
+        output.warn(report.message, "Answering from build/ as it was last rendered.")
 
     # Independent of the verdict above: a build can be a faithful render of the
     # current profile and still predate the installed framework.
     if report.version_skew:
-        click.echo(f"WARNING: {report.version_skew.message}", err=True)
+        output.warn(report.version_skew.message)
 
 
 def _build_json_output(result: SDKWorkflowResult, exit_code: int) -> str:
@@ -180,45 +186,58 @@ def query(ctx: click.Context, prompt: str, as_json: bool, repo: Path | None) -> 
     repo_root = find_repo_root(repo)
     build_dir = repo_root / BUILD_DIRNAME
 
-    try:
-        _report_drift(repo_root, build_dir)
-    except click.ClickException as exc:
-        # Remapped rather than left to Click's exit 1: "there is nothing to
-        # query" is a usage error under this command's documented contract, and
-        # a caller distinguishing 1 from 2 must not read it as a failed verdict.
-        click.echo(f"Error: {exc.format_message()}", err=True)
-        ctx.exit(EXIT_USAGE)
-        return
+    with ExitStack() as stack:
+        if as_json:
+            # The whole body, so that a warning raised three frames down lands
+            # on stderr with the rest: `--json` promises stdout carries one
+            # document, and a caller parsing it gets no say in what else in the
+            # process felt like printing.
+            stack.enter_context(output.machine_mode())
 
-    # Before any provider resolution: the secret lives at the repo root, the
-    # provider that needs it is declared in the render.
-    _overlay_repo_env(repo_root)
+        try:
+            _report_drift(repo_root, build_dir)
+        except click.ClickException as exc:
+            # Remapped rather than left to Click's exit 1: "there is nothing to
+            # query" is a usage error under this command's documented contract,
+            # and a caller distinguishing 1 from 2 must not read it as a failed
+            # verdict.
+            output.fail(exc.format_message(), _NOTHING_RENDERED, "run `osprey build` first")
+            ctx.exit(EXIT_USAGE)
+            return
 
-    disallowed_tools = read_only_disallowed_tools(build_dir)
-    expected = expected_mcp_servers(build_dir)
+        # Before any provider resolution: the secret lives at the repo root, the
+        # provider that needs it is declared in the render.
+        _overlay_repo_env(repo_root)
 
-    try:
-        result = asyncio.run(run_query(build_dir, prompt, disallowed_tools=disallowed_tools))
-    except (ImportError, RuntimeError) as exc:
-        # SDK not installed, or run_query wrapped an SDK/connection failure.
-        click.echo(f"Error: {exc}", err=True)
-        ctx.exit(EXIT_USAGE)
-        return
-    except (OSError, yaml.YAMLError, ValueError) as exc:
-        # Config resolution (read before the SDK run) hit a missing/malformed
-        # config.yml, or an unknown/misconfigured provider (the resolver raises
-        # ValueError naming the valid providers) — a usage error, not a verdict
-        # failure. The exception message is echoed so the actionable hint
-        # (e.g. "Built-in providers: …") reaches the user.
-        click.echo(f"Error: could not load project configuration: {exc}", err=True)
-        ctx.exit(EXIT_USAGE)
-        return
+        disallowed_tools = read_only_disallowed_tools(build_dir)
+        expected = expected_mcp_servers(build_dir)
 
-    code = evaluate_verdict(result, expected)
+        try:
+            result = asyncio.run(run_query(build_dir, prompt, disallowed_tools=disallowed_tools))
+        except (ImportError, RuntimeError) as exc:
+            # SDK not installed, or run_query wrapped an SDK/connection failure.
+            output.fail("The query could not run", str(exc))
+            ctx.exit(EXIT_USAGE)
+            return
+        except (OSError, yaml.YAMLError, ValueError) as exc:
+            # Config resolution (read before the SDK run) hit a missing/malformed
+            # config.yml, or an unknown/misconfigured provider (the resolver raises
+            # ValueError naming the valid providers) — a usage error, not a verdict
+            # failure. The exception message is carried through so the actionable
+            # hint (e.g. "Built-in providers: …") reaches the user.
+            output.fail("Could not load the project configuration", str(exc))
+            ctx.exit(EXIT_USAGE)
+            return
 
-    if as_json:
-        click.echo(_build_json_output(result, code))
-    else:
-        click.echo("\n".join(result.text_blocks))
+        code = evaluate_verdict(result, expected)
+
+        # Both branches are pass-through seams and stay on click.echo: the
+        # renderer would style, indent, or (under machine mode) move to stderr
+        # what has to reach stdout exactly as it is — the JSON document a script
+        # parses, and the agent's own words.
+        if as_json:
+            click.echo(_build_json_output(result, code))
+        else:
+            click.echo("\n".join(result.text_blocks))
 
     sys.exit(code)

--- a/src/osprey/cli/registry_cmd.py
+++ b/src/osprey/cli/registry_cmd.py
@@ -1,10 +1,9 @@
 """Registry display for the Osprey CLI (osprey registry)."""
 
-from rich.panel import Panel
-from rich.table import Table
 from rich.text import Text
 
-from osprey.cli.styles import Messages, Styles, ThemeConfig, console
+from osprey.cli import output
+from osprey.cli.styles import Styles, data_table, panel
 from osprey.registry import get_registry
 
 
@@ -21,7 +20,7 @@ def display_registry_contents(verbose: bool = False):
         with quiet_logger(["registry", "CONFIG"]):
             registry = get_registry()
             if not registry.get_stats()["initialized"]:
-                console.print("\n[dim]Initializing registry...[/dim]")
+                output.note("Initializing registry...")
             # Idempotent -- self-guards when already initialized.
             registry.initialize()
 
@@ -29,20 +28,13 @@ def display_registry_contents(verbose: bool = False):
         stats = registry.get_stats()
 
         # Display header
-        console.print()
-        console.print(
-            Panel(
-                Text("Registry Contents", style=Styles.HEADER),
-                border_style=ThemeConfig.get_border_style(),
-                expand=False,
-            )
-        )
-        console.print()
+        output.report("")
+        output.table(panel(Text("Registry Contents", style=Styles.HEADER), expand=False))
+        output.report("")
 
         # Display summary
-        console.print(f"[{Styles.HEADER}]Registry Summary[/{Styles.HEADER}]")
-        console.print(f"  [{Styles.ACCENT}]•[/{Styles.ACCENT}] Services: {stats['services']}")
-        console.print()
+        output.section("Registry Summary", {"Services": stats["services"]})
+        output.report("")
 
         # Display services
         if stats["service_names"]:
@@ -53,10 +45,10 @@ def display_registry_contents(verbose: bool = False):
         if providers:
             _display_providers_table(registry, providers, verbose)
 
-        console.print()
+        output.report("")
 
     except Exception as e:
-        console.print(Messages.error(f"Error displaying registry: {e}"))
+        output.fail("Could not display the registry", str(e))
         if verbose:
             import traceback
 
@@ -68,12 +60,10 @@ def display_registry_contents(verbose: bool = False):
 
 def _display_services_table(registry, verbose: bool):
     """Display services in a formatted table."""
-    console.print(f"[{Styles.HEADER}]Services[/{Styles.HEADER}]\n")
+    output.report("Services", style=Styles.HEADER)
+    output.report("")
 
-    table = Table(
-        show_header=True, header_style=Styles.HEADER, border_style=Styles.DIM, expand=False
-    )
-
+    table = data_table(expand=False)
     table.add_column("Name", style=Styles.ACCENT, no_wrap=True)
     table.add_column("Type", style=Styles.VALUE)
 
@@ -83,18 +73,16 @@ def _display_services_table(registry, verbose: bool):
         service_type = type(service).__name__ if service else "Unknown"
         table.add_row(name, service_type)
 
-    console.print(table)
-    console.print()
+    output.table(table)
+    output.report("")
 
 
 def _display_providers_table(registry, providers: list, verbose: bool):
     """Display providers in a formatted table."""
-    console.print(f"[{Styles.HEADER}]AI Providers[/{Styles.HEADER}]\n")
+    output.report("AI Providers", style=Styles.HEADER)
+    output.report("")
 
-    table = Table(
-        show_header=True, header_style=Styles.HEADER, border_style=Styles.DIM, expand=False
-    )
-
+    table = data_table(expand=False)
     table.add_column("Name", style=Styles.ACCENT, no_wrap=True)
     table.add_column("Available", style=Styles.VALUE)
 
@@ -116,5 +104,5 @@ def _display_providers_table(registry, providers: list, verbose: bool):
         else:
             table.add_row(provider_name, "✗")
 
-    console.print(table)
-    console.print()
+    output.table(table)
+    output.report("")

--- a/src/osprey/cli/reset_cmd.py
+++ b/src/osprey/cli/reset_cmd.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import click
 
+from . import output
 from .repo_resolver import find_repo_root, repo_option
 
 
@@ -124,16 +125,18 @@ def reset(repo: Path | None, dry_run: bool, assume_yes: bool, purge_audit: bool)
             # paused, and it is reentrant — is what makes the wider scope safe
             # for anything reset later reaches that does open a phase.
             with reporter.suspended():
-                # `echo`, never the reporter's `emit`: under the global
-                # `--verbose` that is a NullReporter and swallows its argument,
-                # and the plan is the one thing this verb may never go quiet
-                # about.
+                # `output.report`, never the reporter's `emit`: report is
+                # echo-class, so it survives the NullReporter the global
+                # `--verbose` installs, and the plan is the one thing this verb
+                # may never go quiet about. It is also the printer
+                # `init --reset` hands the same call, so the plan an operator
+                # reads is line-identical on both paths.
                 outcome = reset_deployment(
                     repo_root,
                     dry_run=dry_run,
                     assume_yes=assume_yes,
                     purge_audit=purge_audit,
-                    emit=reporter.echo,
+                    emit=output.report,
                 )
         except ForeignCheckoutError as e:
             # Shown verbatim rather than summarized: the message is already the
@@ -153,14 +156,14 @@ def reset(repo: Path | None, dry_run: bool, assume_yes: bool, purge_audit: bool)
             # leaves. Reporting 1 here would tell a caller "nothing was touched"
             # about a half-wiped deployment.
             #
-            # `echo_error` rather than `click.echo(err=True)`: piped, this is
+            # `output.fail` rather than `click.echo(err=True)`: this is the one
+            # shape every refusal in the CLI wears, and it puts the notice on
             # stderr verbatim, which is the channel a caller reading stdout for
-            # the plan watches for trouble; on a terminal it goes through the
-            # console that owns the region instead of into the middle of it.
-            reporter.echo_error(
-                "Reset interrupted while it was removing things. It does not roll back, so "
-                "this deployment is in a partly-reset state. Re-run `osprey reset` to finish; "
-                "it re-reads what is actually there."
+            # the plan watches for trouble.
+            output.fail(
+                "Reset interrupted while it was removing things",
+                "It does not roll back, so this deployment is in a partly-reset state.",
+                "re-run `osprey reset` to finish; it re-reads what is actually there",
             )
             raise click.exceptions.Exit(PARTIAL_RESET_EXIT_CODE) from None
         except RuntimeError as e:

--- a/src/osprey/cli/set_cmd.py
+++ b/src/osprey/cli/set_cmd.py
@@ -31,7 +31,9 @@ from typing import Any
 
 import click
 
+from .output import note, report, warn
 from .repo_resolver import PROFILE_FILENAME, find_repo_root, repo_option
+from .styles import Styles
 
 #: CLI-only shorthand absorbed from ``osprey config set-epics-gateway
 #: --facility NAME``. It never reaches the profile under this name: it is
@@ -180,20 +182,20 @@ def set(pairs: tuple[str, ...], repo: Path | None) -> None:
     except BuildProfileError as e:
         raise click.UsageError(str(e)) from e
 
-    click.echo(f"✓ Wrote {len(written)} setting(s) into {profile_path}")
+    report(f"✓ Wrote {len(written)} setting(s) into {profile_path}", style=Styles.SUCCESS)
     for key in written:
-        click.echo(f"    {key}")
+        note(key)
 
     unrecognized = _unrecognized_top_level_keys(expanded)
     if unrecognized:
-        click.echo(
-            f"⚠ Not a profile key: {', '.join(unrecognized)}. It was written, but the "
-            "profile schema is closed, so `osprey build` will refuse this profile "
-            "until it is corrected or removed. To address the rendered config "
-            "instead, prefix the key with `config.`."
+        warn(
+            f"Not a profile key: {', '.join(unrecognized)}",
+            "It was written, but the profile schema is closed, so `osprey build` will "
+            "refuse this profile until it is corrected or removed. To address the "
+            "rendered config instead, prefix the key with `config.`.",
         )
 
     # The build this edit just invalidated, named while the operator is still
     # here. `check_drift` never raises, so a repo with no build/ — the common
     # case right after `init` — reports that rather than failing the write.
-    click.echo(check_drift(repo_root).status_line)
+    report(check_drift(repo_root).status_line)

--- a/src/osprey/cli/sim.py
+++ b/src/osprey/cli/sim.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import click
 
+from osprey.cli import output
 from osprey.utils.config import load_config
 from osprey.utils.logger import get_logger
 
@@ -45,7 +46,10 @@ def _parse_now(now_iso: str) -> datetime:
     try:
         anchor = datetime.fromisoformat(now_iso)
     except ValueError:
-        click.echo(f"Error: --now value {now_iso!r} is not valid ISO-8601.", err=True)
+        output.fail(
+            f"The --now value {now_iso!r} is not valid ISO-8601",
+            "An instant looks like 2024-03-18T12:00:00.",
+        )
         raise SystemExit(1) from None
     if anchor.tzinfo is None:
         from osprey.utils.config import get_facility_timezone
@@ -91,8 +95,11 @@ def _resolve_deployment(repo: Path | None) -> tuple[Path, dict]:
     repo_root = find_repo_root(repo)
     config_path = rendered_config_path(repo_root)
     if not config_path.is_file():
-        click.echo(f"Error: no build found at {repo_root / BUILD_DIR_NAME}.", err=True)
-        click.echo("Run 'osprey build' first. The scenarios are created by the build.", err=True)
+        output.fail(
+            f"No build found at {repo_root / BUILD_DIR_NAME}",
+            "The scenarios are created by the build.",
+            "run 'osprey build' first",
+        )
         raise SystemExit(1)
     click.get_current_context().with_resource(config_anchored_at(config_path))
     return repo_root, load_config(str(config_path))
@@ -110,15 +117,14 @@ def _load_project_engine(repo: Path | None):
     repo_root, config = _resolve_deployment(repo)
     machine_path, active_type, type_key, mock_key = resolve_simulation_file(config, repo_root)
     if machine_path is None:
+        detail = "This project does not use the simulation engine."
         if active_type == MOCK:
-            click.echo("Error: no mock 'simulation_file' configured in config.yml.", err=True)
+            output.fail("No mock 'simulation_file' is configured in config.yml", detail)
         else:
-            click.echo(
-                f"Error: no simulation_file configured for control_system.type "
-                f"'{active_type}' (tried {type_key} and {mock_key}).",
-                err=True,
+            output.fail(
+                f"No simulation_file is configured for control_system.type '{active_type}'",
+                f"Tried {type_key} and {mock_key}.\n{detail}",
             )
-        click.echo("This project does not use the simulation engine.", err=True)
         raise SystemExit(1)
     engine = SimulationEngine.from_file(
         machine_path, state_dir=resolve_state_dir(config, repo_root)
@@ -142,12 +148,11 @@ def _echo_physics_notice(config: dict, rendered: dict[str, str]) -> None:
     if "virtual_accelerator" not in (config.get("deployed_services") or []):
         return
     if rendered:
-        click.echo("! Physics fault rendered to .env: " + ", ".join(sorted(rendered)) + ".")
+        output.report("Physics fault written to .env: " + ", ".join(sorted(rendered)) + ".")
     else:
-        click.echo("! Cleared the previous scenario's physics fault from .env.")
-    click.echo("  The virtual accelerator reads this only when its container is created,")
-    click.echo("  so run 'osprey up' to recreate it. A plain 'docker restart' keeps")
-    click.echo("  the old environment.")
+        output.report("Cleared the previous scenario's physics fault from .env.")
+    output.note("The virtual accelerator reads this only when its container is created.")
+    output.note("Run 'osprey up' to recreate it. 'docker restart' reuses the old environment.")
 
 
 def _confirm_archive_rewrite(store: dict) -> None:
@@ -165,7 +170,7 @@ def _confirm_archive_rewrite(store: dict) -> None:
     decide, and a prompt about a store that does not exist trains people to hit
     enter.
     """
-    click.echo(
+    output.report(
         f"This will REWRITE the scenario's event windows in the stored archive "
         f"({store['host']}:{store['port']}/{store['database']}.{store['collection']}), "
         f"restoring any windows a previous scenario touched."
@@ -202,9 +207,13 @@ def list_command(repo: Path | None) -> None:
     for name, description in engine.list_scenarios().items():
         has_log = len(engine.scenario_logbook(name)) > 0
         marker = "*" if name in active else " "
-        click.echo(f"{marker} {name}  (logbook: {'yes' if has_log else 'no'})")
+        output.report(f"{marker} {name}  (logbook: {'yes' if has_log else 'no'})")
         if description:
-            click.echo(f"    {description}")
+            # A second step in, on top of the one `note` already applies: the
+            # marker column means the name itself does not start at column 0,
+            # so a description one step in would line up under the marker
+            # rather than under the name it describes.
+            output.note(f"  {description}")
 
 
 @sim_group.command("status")
@@ -213,9 +222,14 @@ def status_command(repo: Path | None) -> None:
     """Show the currently active scenario set."""
     *_, engine = _load_project_engine(repo)
     active = engine.active_scenarios()
-    click.echo("Active scenarios: " + ", ".join(active))
     logbook = engine.active_logbook()
-    click.echo(f"Composed logbook entries: {len(logbook)}")
+    output.section(
+        "",
+        [
+            ("Active scenarios", ", ".join(active)),
+            ("Composed logbook entries", len(logbook)),
+        ],
+    )
 
 
 @sim_group.command("apply")
@@ -295,12 +309,12 @@ def apply_command(
         # collisions) rather than raising; an empty list is the only "OK".
         problems = engine.validate_composition(resolve_active_scenarios(names))
         if problems:
-            click.echo("Error: cannot activate scenarios: " + "; ".join(problems), err=True)
+            output.fail("Cannot activate these scenarios", "; ".join(problems))
             raise SystemExit(1)
         try:
             physics = compute_scenario_physics_env(repo_root, list(names))
         except ValueError as exc:
-            click.echo(f"Error: {exc}", err=True)
+            output.fail("Cannot activate these scenarios", str(exc))
             raise SystemExit(1) from None
 
         # The archive rewrite's own refusals belong here too, not inside it: a
@@ -312,7 +326,7 @@ def apply_command(
             try:
                 store = preflight_archive_rewrite(repo_root, config, machine_path, list(names))
             except (ValueError, RuntimeError) as exc:
-                click.echo(f"Error: {exc}", err=True)
+                output.fail("The stored archive cannot be rewritten", str(exc))
                 raise SystemExit(1) from None
 
     if seed_logbook and not yes and ariel_config:
@@ -323,7 +337,7 @@ def apply_command(
         except Exception:
             info = None  # DB unreachable — apply will surface the error below
         if info is not None:
-            click.echo(
+            output.report(
                 f"This will PURGE {info.entry_count} existing logbook "
                 f"entr{'y' if info.entry_count == 1 else 'ies'} and reseed from the "
                 f"active scenarios."
@@ -347,31 +361,31 @@ def apply_command(
             seed_archive=seed_archive,
             now=now,
         )
-    except ValueError as exc:
-        click.echo(f"Error: {exc}", err=True)
-        raise SystemExit(1) from None
-    except RuntimeError as exc:
-        click.echo(f"Error: {exc}", err=True)
+    except (ValueError, RuntimeError) as exc:
+        output.fail("The scenarios could not be applied", str(exc))
         raise SystemExit(1) from None
     except Exception as exc:
         msg = str(exc)
         if "connect" in msg.lower():
-            click.echo("Error: cannot connect to the ARIEL database.", err=True)
-            click.echo("Start it with 'osprey up', or pass --no-seed.", err=True)
+            output.fail(
+                "Cannot connect to the ARIEL database",
+                None,
+                "start it with 'osprey up', or pass --no-seed",
+            )
             raise SystemExit(1) from None
         raise
 
-    click.echo("✓ Active scenarios: " + ", ".join(result.active))
+    output.report("✓ Active scenarios: " + ", ".join(result.active))
     if not seed_logbook:
-        click.echo("  (logbook unchanged)")
+        output.note("(logbook unchanged)")
     elif result.logbook_seeded:
-        click.echo(f"✓ Seeded {result.logbook_seeded} logbook entries (purged and reseeded).")
+        output.report(f"✓ Seeded {result.logbook_seeded} logbook entries (purged and reseeded).")
     elif ariel_config is None:
-        click.echo("  (no ARIEL configured, so the logbook was not seeded)")
+        output.note("(no ARIEL configured, so the logbook was not seeded)")
 
     if not seed_archive:
-        click.echo("  (stored archive unchanged)")
+        output.note("(stored archive unchanged)")
     elif result.archiver is not None and not result.archiver.skipped:
-        click.echo(f"✓ Archive rewritten: {result.archiver.describe()}")
+        output.report(f"✓ Archive rewritten: {result.archiver.describe()}")
     elif result.archiver is not None:
-        click.echo(f"  ({result.archiver.skipped})")
+        output.note(f"({result.archiver.skipped})")

--- a/src/osprey/cli/skills_cmd.py
+++ b/src/osprey/cli/skills_cmd.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import click
 
+from .output import fail, report, warn
+
 _SKILL_SOURCES: dict[str, str] = {
     "osprey-build-interview": "templates/skills/osprey-build-interview",
     "osprey-contribute": "templates/skills/osprey-contribute",
@@ -69,9 +71,10 @@ def install(name: str, target: Path | None) -> None:
     previous version of the skill is never lost.
     """
     if name not in _SKILL_SOURCES:
-        click.echo(
-            f"Unknown skill '{name}'. Available: {sorted(_SKILL_SOURCES)}",
-            err=True,
+        fail(
+            f"Unknown skill '{name}'",
+            f"Available: {', '.join(sorted(_SKILL_SOURCES))}",
+            "Name one of those, or run `osprey skills install --help`.",
         )
         sys.exit(1)
 
@@ -83,7 +86,7 @@ def install(name: str, target: Path | None) -> None:
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
         backup = skills_dir / f"{name}.bak.{ts}"
         install_path.rename(backup)
-        click.echo(f"Warning: existing '{name}' moved to {backup}", err=True)
+        warn(f"Replaced an existing '{name}'", f"The previous copy is at {backup}")
     elif install_path.exists():
         install_path.rmdir()
 
@@ -91,4 +94,4 @@ def install(name: str, target: Path | None) -> None:
     with as_file(src_traversable) as src_path:
         shutil.copytree(src_path, install_path)
 
-    click.echo(f"Installed '{name}' to {install_path}")
+    report(f"Installed '{name}' to {install_path}")

--- a/src/osprey/cli/styles.py
+++ b/src/osprey/cli/styles.py
@@ -9,12 +9,20 @@ Design Philosophy:
 - Rich console markup helpers for inline styling
 - Questionary style integration for interactive prompts
 - Clear separation between fixed UI standards and customizable theme colors
+- One data-table look and one panel look, built by the factories at the bottom of
+  this module, so box/padding/border tokens are spelled here rather than at the
+  call sites the structure guard walks
 """
 
 import sys
 from dataclasses import dataclass
+from typing import Any
 
-from rich.console import Console
+from rich import box
+from rich.box import Box
+from rich.console import Console, RenderableType
+from rich.panel import Panel
+from rich.table import Table
 from rich.theme import Theme
 
 from osprey.utils.logger import get_logger
@@ -128,19 +136,18 @@ def get_active_theme() -> ColorTheme:
 
 
 def set_theme(theme: ColorTheme):
-    """Set a new active theme and rebuild console/styles.
+    """Set a new active theme, re-theming the existing consoles in place.
+
+    The module-level consoles keep their identity for the process lifetime, so
+    ``from .styles import console`` aliases taken at import time stay correct
+    after a theme switch.
 
     Args:
         theme: The ColorTheme to activate
     """
-    global _active_theme, console, custom_style
+    global _active_theme, custom_style
     _active_theme = theme
-    # Rebuild theme-dependent objects
-    # On Windows, force UTF-8 encoding to support Unicode characters
-    if sys.platform == "win32":
-        console = Console(theme=_build_rich_theme(theme), force_terminal=True, legacy_windows=False)
-    else:
-        console = Console(theme=_build_rich_theme(theme))
+    _retheme_consoles(theme)
     custom_style = _build_questionary_style(theme)
 
 
@@ -293,12 +300,53 @@ osprey_theme = _build_rich_theme(_active_theme)
 custom_style = _build_questionary_style(_active_theme)
 
 
-# Singleton console instance with theme
-# On Windows, force UTF-8 encoding to support Unicode characters (✓, ✗, ⚠️, etc.)
-if sys.platform == "win32":
-    console = Console(theme=osprey_theme, force_terminal=True, legacy_windows=False)
-else:
-    console = Console(theme=osprey_theme)
+def _make_console(*, stderr: bool = False) -> Console:
+    """Construct a themed console with the platform-constant terminal settings.
+
+    The Windows special case (treat the stream as a terminal, and use the modern
+    console renderer rather than the legacy one, so Unicode characters such as
+    ✓, ✗ and ⚠️ render) is platform-constant, so it is applied once here at
+    construction and never revisited when the theme changes.
+
+    Args:
+        stderr: If True, the console writes to stderr instead of stdout
+
+    Returns:
+        A themed Console instance
+    """
+    if sys.platform == "win32":
+        return Console(theme=osprey_theme, force_terminal=True, legacy_windows=False, stderr=stderr)
+    return Console(theme=osprey_theme, stderr=stderr)
+
+
+# Singleton console instances with theme: one for stdout, one for stderr.
+# Both are identity-stable for the process lifetime - set_theme() re-themes them
+# in place rather than rebuilding them.
+console = _make_console()
+err_console = _make_console(stderr=True)
+
+# Whether a theme has been pushed on top of the consoles' base theme. Guards the
+# pop half of the pop-before-push so the first set_theme() call is safe.
+_theme_pushed = False
+
+
+def _retheme_consoles(theme: ColorTheme) -> None:
+    """Re-theme the module consoles in place, keeping the theme stack flat.
+
+    Pops the previously pushed theme (if any) before pushing the new one, so any
+    number of theme switches leaves the consoles' theme stack at constant depth.
+
+    Args:
+        theme: The ColorTheme to apply to both consoles
+    """
+    global _theme_pushed
+
+    rich_theme = _build_rich_theme(theme)
+    for target in (console, err_console):
+        if _theme_pushed:
+            target.pop_theme()
+        target.push_theme(rich_theme, inherit=False)
+    _theme_pushed = True
 
 
 def get_questionary_style() -> "QuestionaryStyle | None":
@@ -403,8 +451,9 @@ class Messages:
 class ThemeConfig:
     """Configuration utilities for theme customization.
 
-    Provides helper methods for accessing theme settings consistently.
-    Future enhancement: Load custom themes from config file.
+    Provides helper methods for accessing theme settings consistently. Loading a
+    theme from config, custom palettes included, is
+    :func:`load_theme_from_config`.
     """
 
     @staticmethod
@@ -430,6 +479,139 @@ class ThemeConfig:
         return Styles.BANNER
 
 
+# ---------------------------------------------------------------------------
+# Table and panel factories
+#
+# Every data table and panel under ``cli/``, ``deployment/`` and
+# ``health/render.py`` is built here, which is the reach
+# ``tests/cli/test_output_structure_guard.py`` enforces. A call site picks the
+# *kind* of surface it wants and passes its own columns and content, never its
+# own borders, so retheming reaches all of them at once and a look that needs to
+# change changes here. Outside that reach the tables under
+# ``services/channel_finder/tools/`` still spell their own box and padding.
+#
+# The defaults are the dominant shape of what the CLI already prints — a
+# bordered table with a themed header row, and a rounded panel — so adopting a
+# factory is a no-op for most call sites.
+# ---------------------------------------------------------------------------
+
+#: Box drawing for a data table: Rich's default heavy-ruled header, which a
+#: table that names no box of its own already inherits.
+DATA_TABLE_BOX: Box = box.HEAVY_HEAD
+
+#: Cell padding for a data table, as ``(top, right, bottom, left)`` collapsed to
+#: the vertical/horizontal pair Rich accepts.
+DATA_TABLE_PADDING: tuple[int, int] = (0, 1)
+
+#: Style of the header row. ``header`` and ``bold_primary`` resolve to the same
+#: rendered style, so this is the single spelling of what call sites variously
+#: reached for.
+TABLE_HEADER_STYLE: str = Styles.HEADER
+
+#: Style of every rule and frame the factories draw -- table rules and panel
+#: borders alike, so the two never disagree about how a border looks.
+BORDER_STYLE: str = Styles.BORDER_DIM
+
+#: Blank columns between two adjacent columns of a layout table. A layout table
+#: has no rules, so the gutter is the only thing separating its columns.
+LAYOUT_TABLE_GUTTER: int = 3
+
+#: Cell padding for a layout table: the gutter on the left of every cell and
+#: nothing anywhere else.
+LAYOUT_TABLE_PADDING: tuple[int, int, int, int] = (0, 0, 0, LAYOUT_TABLE_GUTTER)
+
+#: Box drawing for a panel: Rich's rounded frame, which the CLI's panels already
+#: inherit.
+PANEL_BOX: Box = box.ROUNDED
+
+#: Padding between a panel's frame and its contents.
+PANEL_PADDING: tuple[int, int] = (0, 1)
+
+
+def data_table(**overrides: Any) -> Table:
+    """Build the CLI's data table: bordered, with a themed header row.
+
+    This is the one look for a table that *presents data* — a list of services,
+    a set of audit findings, a status matrix. Callers add columns and rows; they
+    do not choose borders.
+
+    Args:
+        **overrides: Any :class:`~rich.table.Table` keyword, passed straight
+            through and winning over the defaults. Use it for the table's
+            content-shaped options (``title``, ``show_lines``, ``expand``), not
+            to reopen the look.
+
+    Returns:
+        An empty :class:`~rich.table.Table` ready for ``add_column``/``add_row``.
+
+    Examples:
+        >>> table = data_table(title="Services")
+        >>> table.add_column("Name", style=Styles.ACCENT)
+    """
+    params: dict[str, Any] = {
+        "box": DATA_TABLE_BOX,
+        "show_header": True,
+        "header_style": TABLE_HEADER_STYLE,
+        "border_style": BORDER_STYLE,
+        "padding": DATA_TABLE_PADDING,
+    }
+    params.update(overrides)
+    return Table(**params)
+
+
+def layout_table(**overrides: Any) -> Table:
+    """Build a layout table: no box, no header, columns separated by a gutter.
+
+    Deliberately not a data table. A layout table draws nothing of its own — it
+    exists to align columns of text that would otherwise be spaced by hand, so
+    the reader sees aligned text rather than a table. The live build region is
+    the standing example.
+
+    Args:
+        **overrides: Any :class:`~rich.table.Table` keyword, passed straight
+            through and winning over the defaults.
+
+    Returns:
+        An empty :class:`~rich.table.Table` ready for ``add_column``/``add_row``.
+    """
+    params: dict[str, Any] = {
+        "box": None,
+        "show_header": False,
+        "padding": LAYOUT_TABLE_PADDING,
+        "pad_edge": False,
+    }
+    params.update(overrides)
+    return Table(**params)
+
+
+def panel(renderable: RenderableType, **overrides: Any) -> Panel:
+    """Build the CLI's panel: a rounded, themed frame around one renderable.
+
+    A panel sets its contents apart from the surrounding output — a summary, a
+    heading block. It is the one panel look; call sites choose the ``title`` and
+    the contents, not the frame.
+
+    Args:
+        renderable: What goes inside the frame — a string (Rich markup is
+            honoured), a :class:`~rich.text.Text`, or any renderable.
+        **overrides: Any :class:`~rich.panel.Panel` keyword, passed straight
+            through and winning over the defaults (``title``, ``expand``, …).
+
+    Returns:
+        The :class:`~rich.panel.Panel`, ready to print.
+
+    Examples:
+        >>> console.print(panel("All checks passed", title="Summary"))
+    """
+    params: dict[str, Any] = {
+        "box": PANEL_BOX,
+        "border_style": BORDER_STYLE,
+        "padding": PANEL_PADDING,
+    }
+    params.update(overrides)
+    return Panel(renderable, **params)
+
+
 __all__ = [
     # Theme management
     "ColorTheme",
@@ -443,10 +625,23 @@ __all__ = [
     "osprey_theme",
     # Console and styles
     "console",
+    "err_console",
     "get_questionary_style",
     "custom_style",
     # Style helpers
     "Styles",
     "Messages",
     "ThemeConfig",
+    # Table and panel factories
+    "data_table",
+    "layout_table",
+    "panel",
+    "DATA_TABLE_BOX",
+    "DATA_TABLE_PADDING",
+    "TABLE_HEADER_STYLE",
+    "BORDER_STYLE",
+    "LAYOUT_TABLE_GUTTER",
+    "LAYOUT_TABLE_PADDING",
+    "PANEL_BOX",
+    "PANEL_PADDING",
 ]

--- a/src/osprey/cli/summary_card.py
+++ b/src/osprey/cli/summary_card.py
@@ -6,11 +6,18 @@ where it answers, where the command output went, and which command comes next.
 One renderer for all five, so the five cannot describe the same deployment in
 five shapes.
 
-It prints through the installed phase reporter, after the last phase has
-closed, so it shares that module's plain-line path -- color only on a terminal,
-and nothing at all under the global ``--verbose``, where the real output was
-streamed instead of spooled. Attached (non-``-d``) starts print no card at all:
-``compose up`` replaces this process and the terminal belongs to the log stream.
+It prints after the last phase has closed, through the CLI's renderer
+(:mod:`osprey.cli.output`) rather than through the phase reporter. The card is
+the verb's own output, not decoration on its progress: it says what the run
+left behind, so it is echo-class and prints under every reporter -- including
+the one the global ``--verbose`` installs, where the phase record itself is
+swallowed. Attached (non-``-d``) starts print no card at all: ``compose up``
+replaces this process and the terminal belongs to the log stream.
+
+The rows are a key/value block, which is what :func:`osprey.cli.output.section`
+renders, so the card is laid out by the same code as every other block of facts
+the CLI prints. Only the wording stays here: which states exist and what to run
+next are this module's business, not the renderer's.
 """
 
 from __future__ import annotations
@@ -19,9 +26,10 @@ from pathlib import Path
 
 from osprey.deployment.subprocess_capture import SPOOL_DIR
 from osprey.utils.logger import get_logger
+from osprey.utils.workspace import BUILD_DIR_NAME
 
+from . import output
 from .phase_reporter import NullReporter, current_reporter
-from .styles import Styles
 
 logger = get_logger("cli.summary_card")
 
@@ -33,6 +41,33 @@ _NEXT_STEPS = {
     "running": "osprey status · osprey logs · osprey down",
     "stopped": "osprey up -d · osprey status",
 }
+
+#: Where a rendered project keeps the demo scenarios ``osprey sim apply`` reads.
+#: Relative to the build directory, which is the tree the build wrote, not the
+#: repo the operator is standing in.
+_SCENARIOS_DIR = Path("data") / "simulation" / "scenarios"
+
+#: The command that seeds the demo logbook from those scenarios. Appended to the
+#: ``built`` card's next step, so the one next-step surface carries it instead of
+#: a line of its own.
+_SEED_DEMO_LOGBOOK = "osprey sim apply nominal"
+
+
+def _next_step(root: Path, state: str) -> str:
+    """What to run next for a deployment in ``state``, rooted at ``root``.
+
+    Fixed per state, with one exception the map cannot hold: a build that
+    rendered demo scenarios can seed its logbook from them, and one that did not
+    must not be told to run a command with nothing to apply. So the answer is
+    read off the rendered tree rather than declared.
+
+    :param root: The deployment repo. The build it rendered is one directory in.
+    :param state: One of ``created``, ``built``, ``running``, ``stopped``
+    """
+    step = _NEXT_STEPS.get(state, "osprey status")
+    if state == "built" and (root / BUILD_DIR_NAME / _SCENARIOS_DIR).is_dir():
+        return f"{step} · {_SEED_DEMO_LOGBOOK}"
+    return step
 
 
 def owns_summary_card() -> bool:
@@ -49,8 +84,12 @@ def owns_summary_card() -> bool:
     return isinstance(active, NullReporter) and not active.verbose
 
 
-def format_summary_card(repo_root: Path | str, state: str) -> list[str]:
-    """Render the card for ``repo_root`` in ``state`` as plain lines.
+def _card_parts(repo_root: Path | str, state: str) -> tuple[str, list[tuple[str, str]]]:
+    """The card's heading and its rows, before either is laid out.
+
+    The one derivation of what the card says. Both the printer and the
+    plain-text renderer start here, so there is no way for the card an operator
+    reads to differ from the card a test reads.
 
     :param repo_root: The deployment repo -- its directory name IS the
         deployment's name, the same one the compose project carries
@@ -59,35 +98,46 @@ def format_summary_card(repo_root: Path | str, state: str) -> list[str]:
     from osprey.deployment.deploy_summary import as_built_endpoint_entries
 
     root = Path(repo_root)
-    rows = []
+    rows: list[tuple[str, str]] = []
     if state == "running":
         # URLs only: a card is the "what now" surface, and the addresses someone
         # can act on are the ones they can open. The full list, bare addresses
         # and the not-configured facts included, is `osprey status`.
         rows += [(s, a) for s, a in as_built_endpoint_entries(root) if a.startswith("http://")]
     rows.append(("command output", str(root / SPOOL_DIR)))
-    rows.append(("next", _NEXT_STEPS.get(state, "osprey status")))
+    rows.append(("next", _next_step(root, state)))
+    return f"{root.name} — {state}", rows
 
+
+def format_summary_card(repo_root: Path | str, state: str) -> list[str]:
+    """Render the card for ``repo_root`` in ``state`` as plain lines.
+
+    The same lines :func:`print_summary_card` puts on screen, with no styling
+    on them -- for a caller that wants the card as text rather than as output.
+    The row shape is :func:`osprey.cli.output.section`'s, which is what makes
+    the two agree; ``test_summary_card.py`` pins them against each other so
+    they cannot drift apart.
+
+    :param repo_root: The deployment repo -- its directory name IS the
+        deployment's name, the same one the compose project carries
+    :param state: One of ``created``, ``built``, ``running``, ``stopped``
+    """
+    title, rows = _card_parts(repo_root, state)
     width = max(len(label) for label, _ in rows)
-    return [f"{root.name} — {state}"] + [
-        f"  {label.ljust(width)}   {value}" for label, value in rows
-    ]
+    return [title] + [f"  {label.ljust(width)}   {value}" for label, value in rows]
 
 
 def print_summary_card(repo_root: Path | str, state: str) -> None:
-    """Print the card through the installed reporter; advisory, never raises.
+    """Print the card through the CLI renderer; advisory, never raises.
 
     A verb that has done its work has succeeded, and a card that cannot be
     rendered -- an unreadable render, a compose file that moved -- must not turn
     that into a failure.
     """
     try:
-        lines = format_summary_card(repo_root, state)
+        title, rows = _card_parts(repo_root, state)
     except Exception as exc:
         logger.debug("Summary card skipped: %s", exc)
         return
-    reporter = current_reporter()
-    reporter.emit("")
-    reporter.emit(lines[0], style=Styles.BOLD)
-    for line in lines[1:]:
-        reporter.emit(line)
+    output.report("")
+    output.section(title, rows)

--- a/src/osprey/cli/theme_lab_cmd.py
+++ b/src/osprey/cli/theme_lab_cmd.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 
 import click
 
+from . import output
+
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
@@ -101,7 +103,7 @@ def theme_lab(port: int | None, no_browser: bool) -> None:
     try:
         app = create_app()
     except FileNotFoundError as exc:
-        click.echo(f"ERROR: {exc}", err=True)
+        output.fail("Cannot start the Theme Lab", str(exc))
         sys.exit(1)
 
     serve_port = port if port is not None else free_port()
@@ -115,12 +117,14 @@ def theme_lab(port: int | None, no_browser: bool) -> None:
 
             _open_browser_when_ready(url)
         except Exception as exc:
-            click.echo(f"WARNING: could not open a browser ({exc}).", err=True)
+            output.warn("Could not open a browser", str(exc))
 
-    click.echo(f"Theme Lab: {url}")
-    click.echo("Press Ctrl+C to stop\n")
+    output.report(f"Starting the OSPREY Theme Lab on {url}")
+    output.note("Press Ctrl+C to stop")
+    output.report("")
 
     try:
         uvicorn.run(app, host="127.0.0.1", port=serve_port, log_level="warning")
     except KeyboardInterrupt:
-        click.echo("\nShutting down...")
+        output.report("")
+        output.report("Shutting down...")

--- a/src/osprey/cli/users_cmd.py
+++ b/src/osprey/cli/users_cmd.py
@@ -31,8 +31,9 @@ from typing import Any, NamedTuple
 
 import click
 
+from osprey.cli.output import fail, note, report, warn
 from osprey.cli.repo_resolver import PROFILE_FILENAME, find_repo_root, repo_option
-from osprey.cli.styles import Styles, console
+from osprey.cli.styles import Styles
 from osprey.utils.logger import get_logger
 
 logger = get_logger("users")
@@ -298,19 +299,16 @@ def _users_session(repo: Path | None, *, announce: bool = True) -> Iterator[_Rep
     config_path = _rendered_config_path(repo_root)
 
     if not config_path.is_file():
-        console.print(
-            f"\n✗ No build found in [accent]{repo_root}[/accent]: {config_path} does not exist.",
-            style=Styles.ERROR,
-        )
-        console.print(
-            "\nWeb-terminal users are managed through the rendered config the "
-            "stack runs from.\nRun [command]osprey build[/command] first.\n",
-            style=Styles.WARNING,
+        fail(
+            f"No build found in {repo_root}",
+            f"{config_path} does not exist. Web-terminal users are managed through "
+            "the rendered config the stack runs from.",
+            "run `osprey build` first",
         )
         raise click.Abort()
 
     if announce:
-        console.print(f"Web-terminal roster: [bold]{action}[/bold] in {repo_root}")
+        report(f"Web-terminal roster: {action} in {repo_root}")
 
     # Restored afterwards so a verb cannot leave the process somewhere else than
     # it was invoked from. Nothing here defers work past the yield, so the
@@ -322,14 +320,15 @@ def _users_session(repo: Path | None, *, announce: bool = True) -> Iterator[_Rep
     except (click.Abort, click.ClickException):
         raise
     except KeyboardInterrupt:
-        console.print("\n!  Operation cancelled by user", style=Styles.WARNING)
+        warn("Operation cancelled by user")
         raise click.Abort() from None
     except Exception as e:
-        console.print(f"✗ {action} failed: {e}", style=Styles.ERROR)
+        cause = str(e)
         if os.environ.get("DEBUG"):
             import traceback
 
-            console.print(traceback.format_exc(), style=Styles.DIM)
+            cause = f"{cause}\n{traceback.format_exc()}"
+        fail(f"{action} failed", cause)
         raise click.Abort() from None
     finally:
         os.chdir(previous_cwd)
@@ -443,11 +442,10 @@ def remove(user: str, repo: Path | None, archive: bool, purge: bool, yes: bool) 
             profile_path, user
         )
         if resuming:
-            console.print(
-                f"{user} is already off the deployed roster; completing the removal in "
-                "profile.yml. Any container or volume left behind is removed by "
-                "[command]osprey users prune[/command].",
-                style=Styles.WARNING,
+            warn(
+                f"{user} is already off the deployed roster",
+                "Completing the removal in profile.yml. Any container or volume left "
+                "behind is removed by `osprey users prune`.",
             )
         else:
             # The engine, unchanged: it owns the typed confirmation and every
@@ -465,55 +463,47 @@ def remove(user: str, repo: Path | None, archive: bool, purge: bool, yes: bool) 
             # this point the destruction has succeeded and only the bookkeeping
             # failed. Every way this write can fail — an unwritable file, a full
             # disk, a profile.yml that no longer parses — leaves the same true
-            # state and has the same two remedies, so they are caught together.
-            console.print(
-                f"\n✗ {user}'s workspace WAS removed, but this repo's profile.yml could "
-                f"not be updated: {exc}",
-                style=Styles.ERROR,
-            )
-            console.print(
-                f"\n  Done: the container and volumes were removed.\n"
-                f"  Not done: profile.yml still lists {user}, so the next "
-                "[command]osprey build[/command] would put them back on the roster.\n\n"
-                f"  Fix it either way:\n"
-                f"    • re-run [command]osprey users remove {user}[/command]. It notices the "
-                "half-finished removal and only edits the profile\n"
-                f"    • or delete {user}'s entry from profile.yml by hand",
-                style=Styles.WARNING,
+            # state and has the same way forward, so they are caught together.
+            fail(
+                f"{user}'s workspace WAS removed, but this repo's profile.yml could not be updated",
+                f"{exc}\n"
+                "Done: the container and volumes were removed.\n"
+                f"Not done: profile.yml still lists {user}, so the next `osprey build` "
+                "would put them back on the roster.\n"
+                "Re-running notices the half-finished removal and only edits the "
+                f"profile; failing that, delete {user}'s entry from profile.yml by hand.",
+                f"re-run `osprey users remove {user}`",
             )
             raise click.Abort() from None
 
         if edit.changed:
-            console.print(f"\n✓ Removed [accent]{user}[/accent] from the roster in {profile_path}")
+            report("")
+            report(f"✓ Removed {user} from the roster in {profile_path}", style=Styles.SUCCESS)
             if edit.expanded_bare_entries:
-                console.print(
-                    "  The remaining roster entries were written out with explicit "
+                note(
+                    "The remaining roster entries were written out with explicit "
                     "'index:' values, which keeps each survivor's ports exactly where "
-                    "they were.",
-                    style=Styles.DIM,
+                    "they were."
                 )
         elif resuming:
             # Unreachable in practice — `resuming` was true because the profile
             # listed the user — but a roster that changed under us must not be
             # reported as a successful edit.
-            console.print(
-                f"\n! {user} is no longer in this repo's profile.yml roster; nothing to do.",
-                style=Styles.WARNING,
-            )
+            warn(f"{user} is no longer in this repo's profile.yml roster; nothing to do.")
         else:
             # Said plainly rather than passed over: the containers and volumes
             # are already gone, so silence here would leave the operator
             # believing the removal was complete while the next build re-adds
             # the user and the next up gives them a terminal again.
-            console.print(
-                f"\n! {user} was removed from the deployment, but this repo's profile.yml "
-                "does not spell the web-terminal roster, so there was nothing to edit "
-                "there. If the roster comes from an 'extends:' preset, remove the user "
-                f"in the profile by hand, or the next build will restore them.",
-                style=Styles.WARNING,
+            warn(
+                f"{user} was removed from the deployment, but this repo's profile.yml "
+                "does not spell the web-terminal roster",
+                "There was nothing to edit there. If the roster comes from an "
+                "'extends:' preset, remove the user in the profile by hand, or the "
+                "next build will restore them.",
             )
 
-        console.print(check_drift(session.root).status_line)
+        report(check_drift(session.root).status_line)
 
 
 @users.command()
@@ -581,9 +571,11 @@ def passwd(user: str, repo: Path | None) -> None:
         # is skipped (with its own warning) and the change takes effect at
         # the next `osprey up`. Stating the consequence without asserting
         # the timing keeps this true on both paths.
-        console.print(
-            f"\n✓ Password changed for [accent]{user}[/accent]. Any session they "
-            "still hold stops working as soon as the sidecar is running this change."
+        report("")
+        report(f"✓ Password changed for {user}", style=Styles.SUCCESS)
+        note(
+            "Any session they still hold stops working as soon as the sidecar is "
+            "running this change."
         )
 
 
@@ -654,10 +646,12 @@ def env_production(repo: Path | None, env_file: str | None, output: str | None) 
             # the operator pointed at it, and rendering from something else
             # would silently answer a different question than the one asked.
             if not env_file_path.is_file():
-                logger.error(
-                    f"Cannot render {USERS_ENV_FILENAME}: {env_file_path} does not exist. "
-                    "Point --env-file at the secrets file to render from, or drop "
-                    "the option to render from the repo root's env chain."
+                fail(
+                    f"Cannot render {USERS_ENV_FILENAME}",
+                    f"{env_file_path} does not exist.\n"
+                    "Dropping the option renders from the repo root's env chain "
+                    "instead.",
+                    "point --env-file at the secrets file to render from",
                 )
                 raise click.Abort()
             dotenv = parse_dotenv_file(env_file_path)
@@ -668,11 +662,12 @@ def env_production(repo: Path | None, env_file: str | None, output: str | None) 
             # key only the committed defaults carry still reaches the terminals.
             sources = chain_files(project_root)
             if not sources:
-                logger.error(
-                    f"Cannot render {USERS_ENV_FILENAME}: {project_root / ENV_LOCAL_FILENAME} "
-                    f"does not exist, and neither does {project_root / ENV_SHARED_FILENAME}. "
-                    "Point --env-file at the secrets file to render from, or create "
-                    ".env at the repo root."
+                fail(
+                    f"Cannot render {USERS_ENV_FILENAME}",
+                    f"{project_root / ENV_LOCAL_FILENAME} does not exist, and neither "
+                    f"does {project_root / ENV_SHARED_FILENAME}.\n"
+                    "Or point --env-file at the secrets file to render from.",
+                    "create .env at the repo root",
                 )
                 raise click.Abort()
             dotenv = merge_chain(project_root)
@@ -687,10 +682,10 @@ def env_production(repo: Path | None, env_file: str | None, output: str | None) 
             # the deploy path's call (see ensure_env_production, which does
             # refuse). Rendering anyway is what lets an operator SEE the gap.
             needs = "; ".join(f"{origin} needs {var}" for var, origin in missing.items())
-            logger.warning(
-                f"Rendering without provider auth secret(s) absent from {source_desc}: "
+            warn(
+                f"Rendering without provider auth secret(s) absent from {source_desc}",
                 f"{needs}. Web terminals started with this file will fail "
-                "authentication unless they authenticate another way."
+                "authentication unless they authenticate another way.",
             )
 
         subset = _build_env_production_subset(
@@ -701,8 +696,10 @@ def env_production(repo: Path | None, env_file: str | None, output: str | None) 
         rendered = "".join(f"{format_env_line(key, value)}\n" for key, value in subset.items())
 
         if output_path is None:
-            # click.echo, not the Rich console: these are file bytes, and Rich
-            # would wrap a long secret across lines.
+            # ALLOWLISTED raw click.echo, not a renderer primitive: stdout here
+            # is a file, byte for byte, the way a `--json` verb's stdout is one
+            # document. Nothing may decorate it, and nothing else may print to
+            # this stream, which is why `users env` runs with `announce=False`.
             click.echo(rendered, nl=False)
             return
 

--- a/src/osprey/cli/validate_cmd.py
+++ b/src/osprey/cli/validate_cmd.py
@@ -29,7 +29,9 @@ import click
 
 from osprey.errors import BuildProfileError
 
+from .output import note, report, section
 from .repo_resolver import PROFILE_FILENAME, find_repo_root, repo_option
+from .styles import Styles
 
 
 def profile_file_at(target: Path) -> Path:
@@ -93,17 +95,21 @@ def check_profile_file(profile_file: Path) -> None:
         # the "Build profile validation failed" header for its own errors.
         raise click.UsageError("Profile validation failed:\n  - " + "\n  - ".join(web_errors))
 
-    click.echo(f"✓ Profile is valid: {profile_file}")
-    click.echo(f"  Name: {build_profile.name}")
+    report(f"✓ Profile is valid: {profile_file}", style=Styles.SUCCESS)
+
+    rows: list[tuple[str, object]] = [("Name", build_profile.name)]
     # Named separately because "valid" says nothing about whether the deploy
     # coordinates were read at all: a profile that omits the block and one whose
     # block checked out otherwise print the same line.
     if build_profile.deploy is not None:
         deploy = build_profile.deploy
-        click.echo(f"  Deploy: {deploy.ci} CI → {deploy.host.user}@{deploy.host.name}")
-    click.echo("\nNext steps:")
-    click.echo("  1. Render the deployment: osprey build")
-    click.echo("  2. Re-run this command after editing the profile")
+        rows.append(("Deploy", f"{deploy.ci} CI → {deploy.host.user}@{deploy.host.name}"))
+    section("", rows)
+
+    report("")
+    report("Next steps:")
+    note("1. Render the deployment: osprey build")
+    note("2. Re-run this command after editing the profile")
 
 
 @click.command()

--- a/src/osprey/cli/vendor_cmd.py
+++ b/src/osprey/cli/vendor_cmd.py
@@ -2,6 +2,8 @@
 
 import click
 
+from .output import fail, report
+
 
 @click.group("vendor")
 def vendor():
@@ -35,16 +37,16 @@ def fetch(quiet: bool, insecure: bool) -> None:
     from osprey.interfaces.vendor import fetch_all
 
     if not quiet:
-        click.echo("Fetching vendor assets...")
+        report("Fetching vendor assets...")
     try:
         downloaded = fetch_all(quiet=quiet, insecure=insecure)
     except RuntimeError as exc:
-        click.echo(f"\n{exc}", err=True)
+        fail("Could not fetch the vendor assets", str(exc))
         raise SystemExit(1) from exc
     if downloaded:
-        click.echo(f"Downloaded {len(downloaded)} file(s).")
+        report(f"Downloaded {len(downloaded)} file(s).")
     else:
-        click.echo("All vendor assets already up to date.")
+        report("All vendor assets already up to date.")
 
 
 @vendor.command()
@@ -54,8 +56,10 @@ def verify() -> None:
 
     ok, problems = verify_all()
     if problems:
-        click.echo(f"{len(problems)} problem(s) found:", err=True)
-        for p in problems:
-            click.echo(f"  {p}", err=True)
+        fail(
+            f"{len(problems)} vendor file(s) did not verify",
+            "\n".join(str(p) for p in problems),
+            "Download them again with `osprey vendor fetch`.",
+        )
         raise SystemExit(1)
-    click.echo(f"All {len(ok)} vendor files verified OK.")
+    report(f"All {len(ok)} vendor files verified OK.")

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -34,6 +34,7 @@ import click
 
 from osprey.utils.workspace import STATE_DIR_NAME
 
+from . import output
 from .repo_resolver import find_repo_root, repo_option
 
 #: The detached server's PID and log files, relative to the repo root and in
@@ -209,12 +210,14 @@ def _preflight_vendor_check() -> None:
     if not problems:
         return
 
-    click.echo("ERROR: offline mode is on but vendor assets are missing or corrupt:", err=True)
-    for p in problems[:5]:
-        click.echo(f"  {p}", err=True)
+    listed = [str(p) for p in problems[:5]]
     if len(problems) > 5:
-        click.echo(f"  ... and {len(problems) - 5} more", err=True)
-    click.echo("\nFix:  uv run osprey vendor fetch", err=True)
+        listed.append(f"and {len(problems) - 5} more")
+    output.fail(
+        "Offline mode is on but vendor assets are missing or corrupt",
+        "\n".join(listed),
+        "fetch them with: uv run osprey vendor fetch",
+    )
     raise SystemExit(1)
 
 
@@ -430,10 +433,9 @@ def _notice_declared_override(env_var: str, flag_name: str, flag_value: object, 
     """
     declared = os.environ.get(env_var)
     if declared and flag_value is not None and str(flag_value) != declared:
-        click.echo(
-            f"NOTICE: {env_var}={declared} is authoritative for the "
-            f"multi-user reverse-proxy {what}; ignoring {flag_name} {flag_value}.",
-            err=True,
+        output.warn(
+            f"{env_var}={declared} is authoritative for the multi-user reverse-proxy {what}",
+            f"Ignoring {flag_name} {flag_value}.",
         )
 
 
@@ -532,8 +534,7 @@ def web(
     # so an unresolvable one must abort here rather than degrade into a mystery
     # terminal serving another directory's defaults.
     repo_root, build_dir, project_config = _resolve_render(repo)
-    click.echo(f"Repo:  {repo_root}")
-    click.echo(f"Build: {build_dir}")
+    output.section("", {"Repo": repo_root, "Build": build_dir})
 
     _preflight_vendor_check()
 
@@ -553,7 +554,7 @@ def web(
     try:
         shell_command = _resolve_web_shell_command(cc_config, user_shell_override, wt_config)
     except FileNotFoundError as e:
-        click.echo(f"ERROR: {e}", err=True)
+        output.fail("Cannot resolve the shell the terminal should run", str(e))
         raise SystemExit(1) from e
 
     if not skip_preflight:
@@ -563,12 +564,13 @@ def web(
             load_osprey_config(), repo_root, build_dir, project_config, host, port
         )
         for warning in warnings:
-            click.echo(f"WARNING: {warning}", err=True)
+            output.warn(warning)
         if failures:
-            click.echo("ERROR: pre-flight checks failed:", err=True)
-            for finding in failures:
-                click.echo(f"  - {finding}", err=True)
-            click.echo("\nRun with --skip-preflight to bypass (not recommended).", err=True)
+            output.fail(
+                "Pre-flight checks failed",
+                "\n".join(f"- {finding}" for finding in failures),
+                "fix the findings above, or pass --skip-preflight to start anyway",
+            )
             raise SystemExit(1)
 
     if detach:
@@ -578,8 +580,10 @@ def web(
     # -- foreground (original behavior) ------------------------------------
 
     if host == "0.0.0.0":
-        click.echo("WARNING: Binding to 0.0.0.0 exposes the terminal to the network.")
-        click.echo("This is a single-user tool. Add authentication before you expose it.\n")
+        output.warn(
+            "Binding to 0.0.0.0 exposes the terminal to the network",
+            "This is a single-user tool. Add authentication before you expose it.",
+        )
 
     # Pre-flight: check if port is already in use. SO_REUSEADDR matches
     # uvicorn's own bind semantics — without it, TIME_WAIT sockets from a
@@ -591,9 +595,11 @@ def web(
             s.bind((host, port))
         except OSError as exc:
             if port_pinned:
-                click.echo(f"ERROR: Port {port} is already in use.", err=True)
-                click.echo(f"  Find the process:  lsof -i :{port}", err=True)
-                click.echo(f"  Or use another:    osprey web --port {port + 1}", err=True)
+                output.fail(
+                    f"Port {port} is already in use",
+                    f"Find the process holding it with: lsof -i :{port}",
+                    f"or start on another port with: osprey web --port {port + 1}",
+                )
                 raise SystemExit(1) from exc
             # Port was left unspecified and the default is taken — let the OS
             # assign a free one instead of hard-failing (single-user QoL). A
@@ -603,7 +609,7 @@ def web(
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as free_sock:
                 free_sock.bind((host, 0))
                 port = free_sock.getsockname()[1]
-            click.echo(f"Port {busy_port} is in use, so this is on :{port} instead.")
+            output.warn(f"Port {busy_port} is in use, so this is on port {port} instead")
 
     # Publish the ACTUAL port to every child process (PTY shells, their MCP
     # servers): web_terminal_url() resolves OSPREY_WEB_PORT first, and
@@ -612,9 +618,10 @@ def web(
     # reporting success while the real terminal never hears the event.
     os.environ["OSPREY_WEB_PORT"] = str(port)
 
-    click.echo(f"Starting OSPREY Web Terminal on http://{host}:{port}")
-    click.echo(f"Shell: {' '.join(shell_command)}")
-    click.echo("Press Ctrl+C to stop\n")
+    output.report(f"Starting OSPREY Web Terminal on http://{host}:{port}")
+    output.note(f"Shell: {' '.join(shell_command)}")
+    output.note("Press Ctrl+C to stop")
+    output.report("")
 
     try:
         if reload:
@@ -646,7 +653,8 @@ def web(
                 project_dir=str(build_dir),
             )
     except KeyboardInterrupt:
-        click.echo("\nShutting down...")
+        output.report("")
+        output.report("Shutting down...")
 
 
 def _start_detached(host: str, port: int, shell: str | None, repo_root: Path) -> None:
@@ -665,8 +673,8 @@ def _start_detached(host: str, port: int, shell: str | None, repo_root: Path) ->
     # Idempotent: if already running, just report
     existing = _read_pid(repo_root)
     if existing is not None:
-        click.echo(f"Web terminal already running (PID {existing}).")
-        click.echo("  Stop with: osprey web stop")
+        output.report(f"Web terminal already running (PID {existing}).")
+        output.note("Stop it with: osprey web stop")
         return
 
     # Build the child command (no --detach to avoid recursion). --skip-preflight
@@ -706,19 +714,26 @@ def _start_detached(host: str, port: int, shell: str | None, repo_root: Path) ->
     _write_pid(repo_root, proc.pid)
 
     if _wait_for_server(host, port, proc):
-        click.echo(f"Web terminal started (PID {proc.pid}).")
-        click.echo(f"  URL:  http://{host}:{port}")
-        click.echo(f"  Log:  {log_path}")
-        click.echo("  Stop: osprey web stop")
+        output.report(f"Web terminal started (PID {proc.pid}).")
+        output.section(
+            "",
+            {"URL": f"http://{host}:{port}", "Log": log_path, "Stop": "osprey web stop"},
+        )
     else:
         exit_code = proc.poll()
         if exit_code is not None:
-            click.echo(f"Server exited immediately (code {exit_code}). Check {log_path}")
+            output.fail(
+                f"The web terminal exited immediately with code {exit_code}",
+                None,
+                f"read what it wrote to {log_path}",
+            )
             (repo_root / PID_FILE).unlink(missing_ok=True)
         else:
-            click.echo(f"Server started (PID {proc.pid}) but not yet responding on port {port}.")
-            click.echo(f"  Log: {log_path}")
-            click.echo("  Stop: osprey web stop")
+            output.warn(
+                f"The web terminal started with PID {proc.pid} "
+                f"but is not answering on port {port} yet",
+                f"Log:  {log_path}\nStop: osprey web stop",
+            )
 
 
 @web.command("stop")
@@ -744,23 +759,23 @@ def web_stop(ctx: click.Context, repo: Path | None) -> None:
     log_path = repo_root / LOG_FILE
 
     if not pid_path.exists():
-        click.echo("No running web terminal found (no PID file).")
+        output.report("No running web terminal found. There is no PID file.")
         return
 
     try:
         pid = int(pid_path.read_text().strip())
     except (ValueError, OSError):
-        click.echo("Removing a corrupt PID file.")
+        output.warn("Removing a corrupt PID file", str(pid_path))
         pid_path.unlink(missing_ok=True)
         return
 
     try:
         os.kill(pid, signal.SIGTERM)
-        click.echo(f"Stopped web terminal (PID {pid}).")
+        output.report(f"Stopped web terminal (PID {pid}).")
     except ProcessLookupError:
-        click.echo(f"Process {pid} not found (already stopped). Cleaning up.")
+        output.report(f"Process {pid} not found, so it had already stopped. Cleaning up.")
     except PermissionError:
-        click.echo(f"Permission denied killing PID {pid}.")
+        output.fail(f"Permission denied stopping the web terminal (PID {pid})")
         return
 
     pid_path.unlink(missing_ok=True)

--- a/src/osprey/deployment/build_progress.py
+++ b/src/osprey/deployment/build_progress.py
@@ -13,7 +13,7 @@ and no I/O: every line arrives through :meth:`BuildModel.feed` with the
 timestamp already measured by the caller, which is what makes a fifteen-minute
 build replayable from a fixture in milliseconds.
 
-The stream is messier than it looks, and three of its shapes will silently
+The stream is messier than it looks, and four of its shapes will silently
 corrupt a naive parser:
 
 * **Vertex numbers are not unique.** ``compose build`` numbers each service's
@@ -26,6 +26,11 @@ corrupt a naive parser:
 * **Captions carry embedded carriage returns.** ``dpkg`` and ``pip`` redraw a
   progress line in place, so one physical line holds a dozen overwrites. Only
   the last one was ever visible, and only that one is kept.
+* **Most continuation lines are not captions.** Six lines in ten carry either
+  BuildKit's elapsed stopwatch (``3.551 Reading package lists...``) or a
+  vertex's own status (``DONE 0.0s``, ``sha256:… 249B / 249B``). Passed
+  through, they turn the table into a column of ``DONE 0.0s``; the stopwatch is
+  stripped and the status lines only prove the service is still alive.
 
 Anything unrecognized is dropped rather than guessed at. A stream with no
 BuildKit headers at all — a podman provider with its own progress format —
@@ -49,6 +54,20 @@ _HEADER = re.compile(r"^\[(?P<bracket>[^\]]*)\](?: (?P<caption>.*))?$")
 
 #: A Dockerfile step index, as it appears inside a header: ``1/13``.
 _STEP_INDEX = re.compile(r"^\d+/\d+$")
+
+#: BuildKit's stopwatch, stamped onto every line a step's own command writes:
+#: ``#17 3.551 Reading package lists...``. It is a property of the vertex, not
+#: of what the step is doing, and left in place it reads as a second step index
+#: in the table (``6/8  21.51 Collecting scikit-learn``). Stripped from the
+#: visible frame, so the token that survives a carriage-return redraw goes too.
+_ELAPSED_PREFIX = re.compile(r"^\d+\.\d+\s+")
+
+#: Continuation lines that report the vertex's own state rather than its work.
+#: ``DONE``/``CACHED``/``ERROR`` close a vertex and ``sha256:`` lines are layer
+#: transfer accounting; none of them says what the service is doing, and all of
+#: them arrive last, so a row that showed them would read ``DONE 0.0s`` for the
+#: whole of a fifteen-minute build.
+_STATUS_ECHO = re.compile(r"^(?:DONE\b|CACHED\b|ERROR\b|sha256:)")
 
 #: The line that marks one image finished. Kept in step with the equivalent in
 #: :mod:`osprey.deployment.container_lifecycle`: the bare ``naming to`` line is
@@ -207,7 +226,15 @@ class BuildModel:
             # this vertex number, or to the single-image label.
             service = self._nodes.get(node, self._label)
             step = None
-            caption = _visible(rest)
+            caption = _ELAPSED_PREFIX.sub("", _visible(rest))
+            if _STATUS_ECHO.match(caption):
+                # Vertex-level status, not work: it proves the service is still
+                # alive and nothing else. In particular it does not finish the
+                # row — a vertex closes many times during a build, while the
+                # service is finished only by its `naming to ... done` line.
+                if service is not None:
+                    self._touch_time(service, now)
+                return None
         else:
             name, step = _split_bracket(header["bracket"])
             if name is None and step is None:
@@ -267,6 +294,17 @@ class BuildModel:
             last_line_at=now,
             finished=ref if ref is not None else row.finished,
         )
+
+    def _touch_time(self, service: str, now: float) -> None:
+        """Record that a service is still producing output, and nothing else.
+
+        An unknown service opens no row: a bare ``DONE`` carries no step and no
+        caption, so a row minted from one would be a blank line in the table
+        saying only that something happened somewhere.
+        """
+        row = self._rows.get(service)
+        if row is not None:
+            self._rows[service] = replace(row, last_line_at=now)
 
 
 def _split_bracket(bracket: str) -> tuple[str | None, str | None]:

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -22,6 +22,7 @@ from pathlib import Path, PurePosixPath
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
+from osprey.cli import output
 from osprey.cli.phase_reporter import report_step
 from osprey.deployment.runtime_helper import ComposeProvider, get_runtime_command, runtime_env
 from osprey.deployment.subprocess_capture import run_captured
@@ -43,6 +44,19 @@ from osprey.utils.log_filter import quiet_logger
 from osprey.utils.logger import get_logger
 
 logger = get_logger("deployment.compose")
+
+
+def _report_fact(message: str) -> None:
+    """Report ``message`` under this module's logger.
+
+    The promotion contract lives in :func:`osprey.cli.output.report_fact`; this
+    binds it to the compose logger so call sites pass the line alone.
+
+    Args:
+        message: The finished line, built by the caller.
+    """
+    output.report_fact(logger, message)
+
 
 SERVICES_DIR = "services"
 SRC_DIR = "src"
@@ -226,10 +240,13 @@ def compose_env_file_args(repo_root):
     """
     chain = dotenv.chain_files(Path(repo_root))
     if not chain:
+        # The remedy rides on the warning rather than on a line of its own: it
+        # is the second half of the same fact, and on its own it reads as an
+        # instruction nobody asked for.
         logger.warning(
-            "No .env file found - services will start with default/empty environment variables"
+            "No .env file found - services will start with default/empty environment variables\n"
+            "  → cp .env.example .env, then edit .env to fill in the API keys"
         )
-        logger.info("To configure API keys: cp .env.example .env && edit .env")
         return []
 
     args = []
@@ -893,7 +910,7 @@ def render_kernel_templates(source_dir, config, out_dir):
         )
 
         render_template(template_path, config, kernel_out_dir)
-        logger.info(f"Rendered kernel template: {template_path} -> {kernel_out_dir}/kernel.json")
+        logger.debug(f"Rendered kernel template: {template_path} -> {kernel_out_dir}/kernel.json")
 
 
 def _ensure_agent_data_structure(config):
@@ -1218,7 +1235,7 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
 
         # Render kernel templates if specified in service configuration
         if container_cfg.get("render_kernel_templates", False):
-            logger.info(f"Processing kernel templates for {source_dir}")
+            logger.debug(f"Processing kernel templates for {source_dir}")
             render_kernel_templates(source_dir, config, out_dir)
 
     return compose_filepath
@@ -1384,7 +1401,8 @@ def clean_deployment(compose_files, config=None, repo_root=None):
         one OSPREY can invoke correctly. A clean that guessed the shape would
         leave the containers and volumes it claimed to remove.
     """
-    logger.key_info("Cleaning up deployment...")
+    # No announcement here: the two steps below name what is being removed as
+    # they remove it, which is the same fact with an outcome attached.
 
     # Deferred for the same reason compose_base_cmd defers it: the lifecycle
     # module owns the probe seam and the merged env file, and it imports this one.
@@ -1413,7 +1431,7 @@ def clean_deployment(compose_files, config=None, repo_root=None):
     )
     cmd_down.extend(["down", "--volumes", "--remove-orphans"])
 
-    logger.info(f"Running: {' '.join(cmd_down)}")
+    logger.debug(f"Running: {' '.join(cmd_down)}")
     report_step("Removing containers and volumes")
     # No check: a clean over a deployment that was never up exits non-zero, and
     # that has always been tolerated here. Capturing must not turn it into a
@@ -1428,13 +1446,13 @@ def clean_deployment(compose_files, config=None, repo_root=None):
     )
     cmd_rmi.extend(["down", "--rmi", "all"])
 
-    logger.info(f"Running: {' '.join(cmd_rmi)}")
+    logger.debug(f"Running: {' '.join(cmd_rmi)}")
     report_step("Removing images")
     run_captured(
         cmd_rmi, env=run_env, spool_name="compose-clean-rmi", repo_root=repo_root, check=False
     )
 
-    logger.success("Cleanup completed")
+    logger.debug("Cleanup completed")
 
 
 def prepare_compose_files(config_path, dev_mode=False, expose_network=False, output_root=None):
@@ -1500,13 +1518,14 @@ def prepare_compose_files(config_path, dev_mode=False, expose_network=False, out
         )
     elif "bind_address" not in config.get("deployment", {}):
         config["deployment"]["bind_address"] = "127.0.0.1"
-        logger.info("Services will bind to localhost only (127.0.0.1) for security")
+        _report_fact("Services will bind to localhost only (127.0.0.1) for security")
 
     # Get deployed services list
     deployed_services = config.get("deployed_services", [])
     if deployed_services:
+        # Not announced: the render phase's `compose files` step already says
+        # this pass ran, and `osprey status` is where the list is read.
         deployed_service_names = [str(service) for service in deployed_services]
-        logger.info(f"Deployed services: {', '.join(deployed_service_names)}")
     else:
         logger.warning("No deployed_services list found, no services will be processed")
         deployed_service_names = []

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -22,6 +22,7 @@ from typing import NamedTuple
 
 import yaml
 
+from osprey.cli import output
 from osprey.cli.phase_reporter import current_reporter
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.build_progress import BuildModel, with_plain_build_progress
@@ -259,6 +260,52 @@ _QSERVER_ZMQ_PRIVATE_KEY_VAR = "BLUESKY_QSERVER_ZMQ_PRIVATE_KEY"
 _QSERVER_ZMQ_PUBLIC_KEY_VAR = "BLUESKY_QSERVER_ZMQ_PUBLIC_KEY"
 
 
+def _report_fact(message: str) -> None:
+    """Report ``message`` under this module's logger.
+
+    The promotion contract lives in :func:`osprey.cli.output.report_fact`; this
+    binds it to the lifecycle logger so call sites pass the line alone.
+
+    Args:
+        message: The finished line, built by the caller.
+    """
+    output.report_fact(logger, message)
+
+
+#: What the knob diff below is a diff of. Named once because both halves of the
+#: report -- the block the operator reads and the record the sinks keep -- open
+#: with it, and a heading that said two different things would read as two
+#: different findings.
+_KNOB_DIFF_TITLE = "The archive's knobs changed since it was seeded:"
+
+
+def _report_knob_diff(comparison) -> None:
+    """Print the archive's knob diff, and keep its record for the log sinks.
+
+    A knob diff is a block of facts about one thing, which is the shape
+    :func:`osprey.cli.output.section` renders: the heading, then one indented
+    ``knob   stored -> expected`` row per field that moved. The rows are built
+    from the comparison's own ``differences`` rather than from its one-line
+    ``describe()``, so the column the operator scans is a real column instead of
+    a sentence that happens to line up.
+
+    The record stays exactly what it was -- the heading and ``describe()``, at
+    the level they always had -- so a log file still reads the way it read
+    before. The altitude gate drops both on a normal run, which is what keeps
+    the printed block from arriving twice.
+
+    Args:
+        comparison: The seeder's fingerprint verdict, carrying the
+            ``(key, stored, expected)`` triples for the fields that moved.
+    """
+    output.section(
+        _KNOB_DIFF_TITLE,
+        [(key, f"{stored!r} -> {expected!r}") for key, stored, expected in comparison.differences],
+    )
+    logger.key_info(_KNOB_DIFF_TITLE)
+    logger.key_info(comparison.describe())
+
+
 def _append_env_block(env_path: Path, comment: str, values: dict[str, str]) -> None:
     """Append a commented block of ``KEY=value`` lines to the project ``.env``.
 
@@ -424,11 +471,10 @@ def _ensure_service_tokens(
                 "Auto-generated service auth tokens (osprey deploy up)",
                 generated,
             )
-            # Log the path and which keys — NEVER the values.
-            logger.key_info(
-                "Generated auth token(s) %s in %s (gitignored) — keep them secret",
-                ", ".join(generated),
-                env_path.resolve(),
+            # Report the path and which keys — NEVER the values.
+            _report_fact(
+                f"Generated auth token(s) {', '.join(generated)} in "
+                f"{env_path.resolve()} (gitignored). Keep them secret."
             )
 
             # A mint is the moment the volume-initialized vars become a hazard:
@@ -686,12 +732,10 @@ def _adopt_original_credentials(
             "Edit the file by hand, or re-run without --reuse-stores."
         )
 
-    logger.key_info(
-        "Adopted %d pre-existing data volume(s): restored the credential(s) %s they were "
-        "initialized with into %s. Values are never printed.",
-        len(stale),
-        ", ".join(var for var, _ in stale),
-        env_path.resolve(),
+    _report_fact(
+        f"Adopted {len(stale)} pre-existing data volume(s): restored the credential(s) "
+        f"{', '.join(var for var, _ in stale)} they were initialized with into "
+        f"{env_path.resolve()}. Values are never printed."
     )
 
 
@@ -843,7 +887,7 @@ def _ensure_bluesky_substrate_env(config: dict, env_path: Path | None = None) ->
     # system that actually speaks CA.
     control_system_type = str(config.get("control_system", {}).get("type", "mock")).strip().lower()
     if control_system_type == "mock":
-        logger.info(
+        _report_fact(
             "control_system.type is 'mock': this deployment is browse-only -- plans can "
             "be listed and composed but never executed. Skipping "
             "BLUESKY_EPICS_SUBSTRATE auto-configuration (scan devices need an "
@@ -893,11 +937,9 @@ def _ensure_bluesky_substrate_env(config: dict, env_path: Path | None = None) ->
         "Auto-configured bluesky bridge scan devices (osprey deploy up)",
         generated,
     )
-    logger.key_info(
-        "Auto-configured bluesky bridge scan devices %s in %s from the project's "
-        "own channel_limits.json",
-        ", ".join(generated),
-        env_path.resolve(),
+    _report_fact(
+        f"Auto-configured bluesky bridge scan devices {', '.join(generated)} in "
+        f"{env_path.resolve()} from the project's own channel_limits.json"
     )
 
 
@@ -980,15 +1022,15 @@ def _ensure_bluesky_document_plane_certs(config: dict, env_path: Path | None = N
     certs = ("proxy_secret", "publisher_secret", "proxy_public", "publisher_public")
     present = [name for name in certs if paths[name].is_file()]
     if len(present) == len(certs):
-        logger.info(
-            "Bluesky document-plane CURVE certificates already present in %s — keeping them",
+        logger.debug(
+            "Bluesky document-plane CURVE certificates are already present in %s. Keeping them.",
             paths["bridge"].parent,
         )
         return
     if present:
         logger.warning(
             "Bluesky document-plane CURVE certificates in %s are incomplete (%d of %d "
-            "present) — regenerating the whole set, since a certificate's secret half "
+            "present). Regenerating the whole set, since a certificate's secret half "
             "cannot be rebuilt from its public one. Every container currently running "
             "against the old set must be recreated to pick these up: pyzmq's CURVE "
             "authenticator reads the accepted-client directory once, when the socket is "
@@ -1011,12 +1053,12 @@ def _ensure_bluesky_document_plane_certs(config: dict, env_path: Path | None = N
         )
         return
 
-    logger.key_info(
-        "Generated bluesky document-plane CURVE certificates under %s (gitignored, like "
-        "the project .env). Both containers read them at startup, so certificates written "
-        "or replaced while the stack is running take effect only after the bridge and "
-        "queueserver containers are recreated.",
-        paths["bridge"].parent,
+    _report_fact(
+        f"Generated bluesky document-plane CURVE certificates under "
+        f"{paths['bridge'].parent} (gitignored, like the project .env). Both containers "
+        "read them at startup, so certificates written or replaced while the stack is "
+        "running take effect only after the bridge and queueserver containers are "
+        "recreated."
     )
 
 
@@ -1171,7 +1213,7 @@ def _ensure_bluesky_control_plane_keys(config: dict, env_path: Path | None = Non
         logger.warning(
             "%s is set but %s is not. A CURVE public key cannot be turned back into its "
             "private half, and minting a fresh private key would silently orphan the "
-            "public one you set, so nothing is generated here — the deploy will stop at "
+            "public one you set, so nothing is generated here. The deploy will stop at "
             "the compose template's fail-closed guard on the private key rather than "
             "start the manager in plaintext. Set %s to the private half of that keypair, "
             "or unset %s to let `osprey up` mint a fresh pair.",
@@ -1212,13 +1254,11 @@ def _ensure_bluesky_control_plane_keys(config: dict, env_path: Path | None = Non
         # this deploy instead and re-derive it every time — the pair then always
         # comes from the same source, and nothing on disk can go stale.
         os.environ.update(generated)
-        logger.key_info(
-            "Derived %s from the %s in this environment for this deploy only; not written "
-            "to %s, since the private half is not there either and a lone public key on "
-            "disk would fail the next deploy from a clean shell.",
-            ", ".join(generated),
-            _QSERVER_ZMQ_PRIVATE_KEY_VAR,
-            env_path.resolve(),
+        _report_fact(
+            f"Derived {', '.join(generated)} from the {_QSERVER_ZMQ_PRIVATE_KEY_VAR} in "
+            f"this environment for this deploy only; not written to {env_path.resolve()}, "
+            "since the private half is not there either and a lone public key on disk "
+            "would fail the next deploy from a clean shell."
         )
         return
 
@@ -1231,12 +1271,10 @@ def _ensure_bluesky_control_plane_keys(config: dict, env_path: Path | None = Non
     # private one (see the function docstring on why the public key is bearer
     # material here). Matches _ensure_service_tokens' "log which keys, never
     # what they are" convention.
-    logger.key_info(
-        "Generated bluesky RE manager control-socket keypair %s in %s (gitignored). "
-        "Treat both values as secrets — the public half alone is enough to reach the "
-        "manager's control socket.",
-        ", ".join(generated),
-        env_path.resolve(),
+    _report_fact(
+        f"Generated bluesky RE manager control-socket keypair {', '.join(generated)} in "
+        f"{env_path.resolve()} (gitignored). Treat both values as secrets. The public "
+        "half alone is enough to reach the manager's control socket."
     )
 
 
@@ -1581,11 +1619,9 @@ def _build_project_image(
     target = _worker_image_target(config, env)
     project_image = f"{resolve_project_name(config)}:local"
     if target != project_image:
-        logger.key_info(
-            "Dispatch worker uses image %r (OSPREY_WORKER_IMAGE / pinned "
-            "services.dispatch_worker.image) — skipping %s build.",
-            target,
-            project_image,
+        _report_fact(
+            f"Dispatch worker uses image {target!r} (OSPREY_WORKER_IMAGE / pinned "
+            f"services.dispatch_worker.image). Skipping the {project_image} build."
         )
         return
 
@@ -1980,14 +2016,11 @@ def _report_chain_overrides(repo_root: Path) -> tuple[list[str], list[str]]:
     deliberate, stale = _classify_local_overrides(shared, local, previous)
 
     if deliberate:
-        logger.info(
-            "Local %s overrides %s for %d variable(s): %s. "
-            "That is the chain working as intended — the local file wins — so this is "
-            "reported once, by name, and never with a value.",
-            COMPOSE_ENV_FILENAME,
-            ENV_SHARED_FILENAME,
-            len(deliberate),
-            ", ".join(deliberate),
+        _report_fact(
+            f"Local {COMPOSE_ENV_FILENAME} overrides {ENV_SHARED_FILENAME} for "
+            f"{len(deliberate)} variable(s): {', '.join(deliberate)}. That is the chain "
+            "working as intended, with the local file winning. This is reported once, by "
+            "name, and never with a value."
         )
 
     if stale:
@@ -1998,7 +2031,7 @@ def _report_chain_overrides(repo_root: Path) -> tuple[list[str], list[str]]:
             "stack starts on the superseded value and looks healthy doing it. Values are "
             "never printed.\n"
             "  To adopt the shared value: remove the listed name(s) from %s. To keep a local "
-            "value deliberately: set it to the value this host wants — an override that is "
+            "value on purpose: set it to the value this host wants. An override that is "
             "not just the old default is reported at info level, not here.",
             COMPOSE_ENV_FILENAME,
             ENV_SHARED_FILENAME,
@@ -2157,7 +2190,7 @@ def _preflight_env_chain_drift(compose_files: list[str], repo_root: Path | str) 
         "Env chain drift: this project was built to read %s, but %s is on disk now.\n"
         "%s\n"
         "  Which env files the stack reads is decided when the project is rendered, not when "
-        "it starts — so a file added afterwards contributes nothing, and one removed "
+        "it starts. A file added afterwards contributes nothing, and one removed "
         "afterwards leaves the render pointing at a path that is gone. Either way the stack "
         "would start on a set of values nobody chose.\n"
         "  Run `osprey build` to re-render against the chain as it stands, then `osprey up`.",
@@ -2376,14 +2409,42 @@ def _web_terminals_enabled(config: dict) -> bool:
     return bool(web_terminals.get("enabled"))
 
 
+def _report_port_conflicts(conflicts):
+    """Render the host-port conflict report as the CLI's one failure shape.
+
+    :func:`~osprey.deployment.host_ports.format_conflict_report` already writes
+    the three parts a failure has, in the order :func:`osprey.cli.output.fail`
+    wants them: its first line is what failed, its last is the one thing to do
+    about it, and every line between is why. Splitting it there is what lets the
+    report keep its own wording while wearing the ``✗``/``→`` shape every other
+    refusal wears. Blank spacer lines are dropped -- the indent under the summary
+    is what makes the body subordinate, so the spacers have nothing left to do.
+
+    The report goes to stderr, because :func:`~osprey.cli.output.fail` always
+    does: a caller piping stdout somewhere keeps its failures on the terminal.
+    The record moves to the INFO family with it. An ``ERROR`` record renders
+    through the altitude gate, so keeping one would print the whole report a
+    second time underneath the block above it; the failure itself still reaches
+    the caller as the :class:`RuntimeError` raised next to this call.
+
+    :param conflicts: Conflicts from
+        :func:`~osprey.deployment.host_ports.find_port_conflicts`
+    """
+    report = format_conflict_report(conflicts)
+    summary, *rest = report.splitlines()
+    remedy = rest.pop() if rest else None
+    output.fail(summary, "\n".join(line for line in rest if line.strip()) or None, remedy)
+    logger.key_info(report)
+
+
 def _preflight_host_ports(config, compose_files):
     """Abort the deploy if a published host port is already taken.
 
     Parses the published bindings out of the rendered compose files and checks
     them for intra-deploy duplicates and external listeners (see
-    :mod:`osprey.deployment.host_ports`). On any conflict the report is logged
-    and a :class:`RuntimeError` is raised so the caller aborts before running
-    a single container-touching command.
+    :mod:`osprey.deployment.host_ports`). On any conflict the report is printed
+    in the CLI's one failure shape and a :class:`RuntimeError` is raised so the
+    caller aborts before running a single container-touching command.
 
     :param config: Loaded configuration dictionary
     :type config: dict
@@ -2395,7 +2456,7 @@ def _preflight_host_ports(config, compose_files):
     conflicts = find_port_conflicts(bindings, resolve_project_name(config), config)
     if not conflicts:
         return
-    logger.error(format_conflict_report(conflicts))
+    _report_port_conflicts(conflicts)
     raise RuntimeError(
         f"host port preflight failed: {len(conflicts)} "
         f"conflict{'' if len(conflicts) == 1 else 's'} (see report above)"
@@ -2576,7 +2637,7 @@ def _reapply_active_scenarios(config: dict, project_dir: Path, engine) -> None:
     from osprey.simulation.engine import DEFAULT_SCENARIO
 
     if engine is None:
-        logger.info("No machine model in this project; no scenarios to re-apply after the reseed")
+        logger.debug("No machine model in this project; no scenarios to re-apply after the reseed")
         return
 
     names = engine.active_scenarios()
@@ -2597,7 +2658,16 @@ def _reapply_active_scenarios(config: dict, project_dir: Path, engine) -> None:
             f"Re-run `osprey sim apply {' '.join(faults)}` from {project_dir} to put the "
             f"event windows back. Cause: {exc}"
         ) from exc
-    logger.key_info(f"Re-applied scenarios {list(result.active)!r} onto the rebuilt archive")
+    # The reseed's closing line. The archive rewrite that ran inside
+    # `apply_scenarios` has no step of its own, so its counts ride here rather
+    # than on a second line -- but only when there was a rewrite to report: a
+    # `None` archiver means it never ran, and a `skipped` one already says so
+    # in words the reseed has no room for.
+    step = f"scenarios re-applied: {', '.join(result.active)}"
+    archiver = result.archiver
+    if archiver is not None and not archiver.skipped:
+        step += f" ({archiver.describe()})"
+    _report_step(step)
 
 
 def _wait_for_archiver_store(
@@ -2831,12 +2901,11 @@ def _stage_archiver_store(
         comparison = compare_fingerprint(collection, fingerprint)
 
         if comparison.state is SeedState.MATCH:
-            logger.key_info("Archive already covers the configured window; skipping the base seed")
+            _report_step("archive already seeded, skipping the base seed")
             return
 
         if comparison.state is SeedState.MISMATCH:
-            logger.key_info("The archive's knobs changed since it was seeded:")
-            logger.key_info(comparison.describe())
+            _report_knob_diff(comparison)
             if keep_base:
                 logger.warning(
                     "Keeping the existing base (--keep-archiver-base). The stored history "
@@ -2844,8 +2913,8 @@ def _stage_archiver_store(
                     "this profile declares."
                 )
                 return
-            logger.key_info(
-                "Rebuilding the base series. Recorded history is discarded with it — the "
+            _report_fact(
+                "Rebuilding the base series. Recorded history is discarded with it. The "
                 "recorder's samples share the collection being dropped. Pass "
                 "--keep-archiver-base to skip this."
             )
@@ -2874,10 +2943,11 @@ def _stage_archiver_store(
                 )
 
         collection.drop()
-        logger.key_info(
-            f"Seeding {len(channels):,} channels over {knobs.retention_days} days "
-            f"({knobs.hot_span_hours}h at {knobs.hot_cadence_sec}s, then "
-            f"{knobs.tail_cadence_sec}s). This takes minutes on a first deploy."
+        # Before the work, not after it: this is the only warning an operator
+        # gets that the next thing to happen is measured in minutes.
+        _report_step(
+            f"seeding the archive base: {len(channels):,} channels over "
+            f"{knobs.retention_days} days (minutes on a first deploy)"
         )
         report = seed_base(
             collection,
@@ -2889,7 +2959,7 @@ def _stage_archiver_store(
             compression=compression,
             progress=_seed_progress_reporter(),
         )
-        logger.key_info(report.describe())
+        _report_step(f"archive base: {report.describe()}")
 
     # Outside the store connection: re-applying opens its own, and holding this
     # one across it would keep an idle client alive for the whole rewrite.
@@ -3073,7 +3143,7 @@ def _stage_ariel_store(config, compose_files, env, project_dir) -> None:
         )
         return
     if seeded:
-        logger.key_info(f"Seeded {seeded} logbook entries from the active scenarios")
+        _report_step(f"logbook seeded: {seeded} entries")
 
 
 def deploy_up(
@@ -3317,8 +3387,8 @@ def _start_stack(
     # A web-terminals-only deploy (no backend services) is valid, so the
     # early-return below must not fire on empty deployed_services in that case.
     if not config.get("deployed_services") and not web_terminals_enabled:
-        logger.key_info(
-            "No services configured for this project — deployed_services is empty in "
+        _report_fact(
+            "No services are configured for this project: deployed_services is empty in "
             "config.yml. Skipping osprey up."
         )
         # Still say what is (not) reachable — an unexpectedly empty deploy is
@@ -3441,7 +3511,7 @@ def _start_stack(
     env = {**os.environ, **dotenv_shell_overrides()}
     if dev_mode:
         env["DEV_MODE"] = "true"
-        logger.key_info("Development mode: DEV_MODE environment variable set for containers")
+        _report_fact("Development mode: DEV_MODE environment variable set for containers")
 
     # Fail-fast web-terminal preflight (persona render + credential gate)
     # BEFORE the minutes-long image build below: a deploy that is doomed to
@@ -4144,24 +4214,21 @@ def _down_by_label(config: dict | None, repo_root: Path) -> None:
 
     container_ids = listing.stdout.split()
     if not container_ids:
-        logger.key_info(
-            "Nothing to stop. There are no compose files in %s to run a `down` from, and "
-            "no container is labelled %s for this repo. Containers get that label when "
-            "they are CREATED, so a stack started before this repo's containers were "
-            "labelled is not visible here and may still be running — `osprey build` "
-            "restores build/, after which `osprey down` works normally.",
-            repo_root / BUILD_DIRNAME,
-            label_filter.removeprefix("label="),
+        _report_fact(
+            f"Nothing to stop. There are no compose files in {repo_root / BUILD_DIRNAME} "
+            f"to run a `down` from, and no container is labelled "
+            f"{label_filter.removeprefix('label=')} for this repo. Containers get that "
+            "label when they are CREATED, so a stack started before this repo's "
+            "containers were labelled is not visible here and may still be running. "
+            "`osprey build` restores build/, after which `osprey down` works normally."
         )
         return
 
-    logger.key_info(
-        "No compose files in %s — stopping the %d container(s) labelled %s instead. "
-        "Volumes are kept, as they are by a compose `down`; the compose network is not "
-        "labelled and stays.",
-        repo_root / BUILD_DIRNAME,
-        len(container_ids),
-        label_filter.removeprefix("label="),
+    _report_fact(
+        f"No compose files in {repo_root / BUILD_DIRNAME}. Stopping the "
+        f"{len(container_ids)} container(s) labelled "
+        f"{label_filter.removeprefix('label=')} instead. Volumes are kept, as they are "
+        "by a compose `down`; the compose network is not labelled and stays."
     )
 
     # stop, then rm: the same two steps, in the same order, that `compose down`
@@ -4400,12 +4467,12 @@ def deploy_down(config_path, dev_mode=False):
 
     # If no existing compose files found, rebuild them
     if not compose_files:
-        logger.info("No existing compose files found, rebuilding...")
+        logger.debug("No existing compose files found, rebuilding...")
         _, compose_files = prepare_compose_files(config_path, dev_mode)
     else:
-        logger.info("Using existing compose files for 'down' operation:")
+        logger.debug("Using existing compose files for 'down' operation:")
         for f in compose_files:
-            logger.info(f"  - {f}")
+            logger.debug(f"  - {f}")
 
     cmd = compose_base_cmd(
         with_plain_progress(get_runtime_command(config)),
@@ -4503,7 +4570,7 @@ def deploy_restart(config_path, detached=False, expose_network=False):
 
     # If detached mode requested, detach after restart
     if detached:
-        logger.info("Services restarted. Running in detached mode.")
+        logger.debug("Services restarted. Running in detached mode.")
 
 
 def rebuild_deployment(config_path, detached=False, dev_mode=False, expose_network=False):

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from osprey.cli import output
 from osprey.deployment.compose_generator import resolve_project_name
 from osprey.deployment.host_ports import (
     _WILDCARD_HOSTS,
@@ -125,6 +126,16 @@ def as_built_endpoint_entries(repo_root: Path | str) -> list[tuple[str, str]]:
     return endpoint_entries(config, files)
 
 
+def _summary_title(config: dict) -> str:
+    """The heading both the printed section and the logged block carry."""
+    return f"Service endpoints ({resolve_project_name(config)}):"
+
+
+def _summary_text(title: str, entries: list[tuple[str, str]]) -> str:
+    """Lay ``entries`` out under ``title`` as the block a caller wants as text."""
+    return "\n".join([title] + [f"  {service:<20} {address}" for service, address in entries])
+
+
 def format_endpoint_summary(config: dict, compose_files: list[str]) -> str:
     """Render :func:`endpoint_entries` as the text block a deploy or report prints.
 
@@ -133,16 +144,35 @@ def format_endpoint_summary(config: dict, compose_files: list[str]) -> str:
         resolvable from the working directory — they are opened here
     :return: Multi-line summary text
     """
-    lines = [f"Service endpoints ({resolve_project_name(config)}):"]
-    lines += [
-        f"  {service:<20} {address}" for service, address in endpoint_entries(config, compose_files)
-    ]
-    return "\n".join(lines)
+    return _summary_text(_summary_title(config), endpoint_entries(config, compose_files))
 
 
 def log_endpoint_summary(config: dict, compose_files: list[str]) -> None:
-    """Log the endpoint summary; advisory, never fails a deploy."""
+    """Print the endpoint summary, and keep it in the record for sinks.
+
+    Where a deployment answers is what the operator ran ``osprey up`` to find
+    out, so it is printed as the verb's own output rather than logged: an
+    INFO record is not rendered on a normal run, and a fact that only a
+    ``--verbose`` run shows is a fact the deploy did not report. Every exit
+    path of ``deploy_up`` calls this function, so all of them inherit the
+    printed form from here.
+
+    The logged block stays as it was, at the same level, so file and
+    aggregation sinks keep the whole summary in one record. It reaches a
+    terminal only on a ``--verbose`` run, where the transcript is what was
+    asked for.
+
+    Advisory: a summary that cannot be derived is reported to the debug record
+    and never fails a deploy that otherwise succeeded.
+
+    :param config: Loaded configuration dictionary
+    :param compose_files: Rendered compose file paths, spelled absolutely or
+        resolvable from the working directory — they are opened here
+    """
     try:
-        logger.key_info(format_endpoint_summary(config, compose_files))
+        title = _summary_title(config)
+        entries = endpoint_entries(config, compose_files)
+        output.section(title, entries)
+        logger.key_info(_summary_text(title, entries))
     except Exception as exc:
         logger.debug(f"Endpoint summary skipped: {exc}")

--- a/src/osprey/deployment/host_ports.py
+++ b/src/osprey/deployment/host_ports.py
@@ -637,18 +637,18 @@ def format_conflict_report(conflicts):
     """
     count = len(conflicts)
     lines = [
-        f"Host port preflight found {count} conflict{'' if count == 1 else 's'} — "
-        "aborting before touching any containers:"
+        f"Host port preflight found {count} conflict{'' if count == 1 else 's'}. "
+        "No containers were touched."
     ]
     for conflict in conflicts:
         if conflict.kind == "duplicate":
-            reason = f"already claimed by {conflict.holder} in this deployment"
+            reason = f"It is already claimed by {conflict.holder} in this deployment."
         else:
-            reason = f"{conflict.holder} is already listening on it"
+            reason = f"It is already in use by {conflict.holder}."
         where = " (host network)" if conflict.host_network else ""
         lines.append(
             f"  - port {conflict.host_port} ({conflict.bind_address}): "
-            f"service '{conflict.service}'{where} cannot bind — {reason}. "
+            f"service '{conflict.service}'{where} cannot bind. {reason} "
             f"Set a different {conflict.remedy}."
         )
     lines.append("")
@@ -659,8 +659,8 @@ def format_conflict_report(conflicts):
     # why a port with no `ports:` entry anywhere is contested.
     if any(conflict.host_network for conflict in conflicts):
         lines.append(
-            "Services on the host network namespace bind these ports directly — "
-            "no published mapping stands between them and the host, so every "
+            "Services on the host network namespace bind these ports directly. "
+            "No published mapping stands between them and the host, so every "
             "project deployed here needs its own ports."
         )
         lines.append("")
@@ -675,8 +675,8 @@ def format_conflict_report(conflicts):
     )
     if foreign_stack:
         lines.append(
-            "Another OSPREY stack already publishes these service ports on this host — "
-            "either attach this project to that shared services stack instead of "
+            "Another OSPREY stack already publishes these service ports on this host. "
+            "Either attach this project to that shared services stack instead of "
             "deploying its own copies, or change the listed config keys to free ports."
         )
     else:

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -1435,9 +1435,9 @@ def reset_deployment(
     dry_run: bool = False,
     assume_yes: bool = False,
     purge_audit: bool = False,
-    emit: Callable[[str], None] = print,
+    emit: Callable[[str], None],
     probe: RuntimeProbe | None = None,
-) -> bool:
+) -> ResetOutcome:
     """Plan, show, confirm, and carry out a factory reset.
 
     Args:
@@ -1446,6 +1446,8 @@ def reset_deployment(
         assume_yes: Skip the typed confirmation — the scripted path.
         purge_audit: Destroy ``var/audit`` too, under the same gate.
         emit: Where the plan is written. The CLI passes its own printer.
+            Required rather than defaulted, so no caller can fall through to a
+            raw write that lands inside a mounted live region.
         probe: The runtime seam. Resolved from the deployment's configured
             runtime when not supplied; tests inject one.
 

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -28,8 +28,10 @@ import json
 import subprocess
 from pathlib import Path
 
-from rich.table import Table
+from rich.text import Text
 
+from osprey.cli import output
+from osprey.cli.styles import Styles, data_table
 from osprey.deployment.compose_generator import (
     REPO_ID_LABEL,
     repo_identity,
@@ -53,41 +55,31 @@ logger = get_logger("deployment.status")
 PROJECT_LABEL = "osprey.project.name"
 
 
-class _DefaultStyles:
-    """Fallback styles when cli.styles is not available."""
-
-    BOLD_PRIMARY = "bold"
-    ACCENT = "cyan"
-    SUCCESS = "green"
-    PRIMARY = "bold"
-    INFO = "cyan"
-    DIM = "dim"
-    ERROR = "red"
-    WARNING = "yellow"
-
-
-def _format_state(state, styles):
-    """Format a container ``State`` value as a colored Rich status label.
+def _format_state(state):
+    """Format a container ``State`` value as a colored status label.
 
     Shared by the project/other container tables (``_add_container_to_table``)
-    and the per-user web terminal table (``_format_container_health``) so the
-    state->label mapping can't drift between the two.
+    and the per-user web terminal table so the state->label mapping can't drift
+    between the two.
+
+    A pre-styled :class:`~rich.text.Text`, never a markup string: the renderer
+    prints with ``markup=False``, and Rich propagates that into every nested
+    renderable, so a cell holding ``"[success]● Running[/success]"`` would print
+    those brackets literally and take the column widths with it.
 
     :param state: Raw ``State`` value from the container runtime's ps output
     :type state: str
-    :param styles: Style constants object with SUCCESS/ERROR/WARNING/DIM attributes
-    :type styles: object
-    :return: Rich markup string, e.g. ``"[green]● Running[/green]"``
-    :rtype: str
+    :return: The label, styled for the state
+    :rtype: rich.text.Text
     """
     if state == "running":
-        return f"[{styles.SUCCESS}]● Running[/{styles.SUCCESS}]"
+        return Text("● Running", style=Styles.SUCCESS)
     elif state == "exited":
-        return f"[{styles.ERROR}]● Stopped[/{styles.ERROR}]"
+        return Text("● Stopped", style=Styles.ERROR)
     elif state == "restarting":
-        return f"[{styles.WARNING}]● Restarting[/{styles.WARNING}]"
+        return Text("● Restarting", style=Styles.WARNING)
     else:
-        return f"[{styles.DIM}]● {state}[/{styles.DIM}]"
+        return Text(f"● {state}", style=Styles.DIM)
 
 
 def _extract_web_terminal_user_names(users_raw):
@@ -159,7 +151,7 @@ def _container_display_name(container):
     return names[0] if names else "unknown"
 
 
-def _query_containers(config, console):
+def _query_containers(config):
     """Every container on this host, or ``None`` when the runtime could not say.
 
     ``ps -a``, so a stopped container is part of the answer: "the database
@@ -172,7 +164,6 @@ def _query_containers(config, console):
     "nothing is deployed", which is the one wrong answer that looks right.
 
     :param config: Rendered config, for runtime selection; may be ``None``
-    :param console: Where to report a failed query
     :return: Decoded ``ps`` records, or ``None`` when the query failed
     """
     try:
@@ -180,8 +171,10 @@ def _query_containers(config, console):
             get_ps_command(config, all_containers=True), capture_output=True, text=True, timeout=10
         )
         if result.returncode != 0:
-            console.print("\n[red]Error: Could not query container status[/red]")
-            console.print(f"[dim]Command failed with return code {result.returncode}[/dim]\n")
+            output.fail(
+                "Could not query container status",
+                f"the runtime's ps command exited with code {result.returncode}",
+            )
             return None
 
         containers = []
@@ -195,18 +188,17 @@ def _query_containers(config, console):
                         containers.append(json.loads(line))
         return containers
     except subprocess.TimeoutExpired:
-        console.print("\n[red]Error: Container query timed out[/red]\n")
+        output.fail("Could not query container status", "the container query timed out")
         return None
     except json.JSONDecodeError as e:
-        console.print("\n[red]Error: Could not parse container data[/red]")
-        console.print(f"[dim]{e}[/dim]\n")
+        output.fail("Could not parse container data", str(e))
         return None
     except Exception as e:
-        console.print(f"\n[red]Error: {e}[/red]\n")
+        output.fail("Could not query container status", str(e))
         return None
 
 
-def _existing_volume_names(config, console, styles):
+def _existing_volume_names(config):
     """Names of every volume the runtime has, or ``None`` when it could not say.
 
     Read-only: volumes are listed, never created or removed.
@@ -221,11 +213,11 @@ def _existing_volume_names(config, console, styles):
         )
         if result.returncode == 0:
             return {line.strip() for line in result.stdout.splitlines() if line.strip()}
-        console.print(f"[{styles.DIM}]Warning: could not query volumes for user status[/]")
+        output.warn("Could not query volumes for user status")
     except subprocess.TimeoutExpired:
-        console.print(f"[{styles.DIM}]Warning: volume query timed out[/]")
+        output.warn("The volume query timed out")
     except Exception as e:
-        console.print(f"[{styles.DIM}]Warning: could not query volumes ({e})[/]")
+        output.warn("Could not query volumes for user status", str(e))
     return None
 
 
@@ -234,14 +226,19 @@ def _existing_volume_names(config, console, styles):
 # ---------------------------------------------------------------------------
 
 
-def _create_status_table(styles):
-    """Create a status table with consistent styling."""
-    table = Table(show_header=True, header_style=styles.BOLD_PRIMARY)
-    table.add_column("Service", style=styles.ACCENT, no_wrap=True)
-    table.add_column("Project", style=styles.SUCCESS, no_wrap=True)
-    table.add_column("Status", style=styles.PRIMARY)
-    table.add_column("Ports", style=styles.INFO)
-    table.add_column("Image", style=styles.DIM)
+def _create_status_table():
+    """Create a status table with consistent styling.
+
+    Built by the shared :func:`~osprey.cli.styles.data_table` factory, so the
+    box, the header style and the border are the CLI's one data-table look
+    rather than this module's own.
+    """
+    table = data_table()
+    table.add_column("Service", style=Styles.ACCENT, no_wrap=True)
+    table.add_column("Project", style=Styles.SUCCESS, no_wrap=True)
+    table.add_column("Status", style=Styles.PRIMARY)
+    table.add_column("Ports", style=Styles.INFO)
+    table.add_column("Image", style=Styles.DIM)
     return table
 
 
@@ -265,7 +262,7 @@ def _format_ports(container):
     return ", ".join(port_list) if port_list else "-"
 
 
-def _add_container_to_table(table, container, styles):
+def _add_container_to_table(table, container):
     """Add a container as a row in the status table."""
     project_name = _container_label(container, PROJECT_LABEL) or "unknown"
     if len(project_name) > 12:
@@ -278,21 +275,21 @@ def _add_container_to_table(table, container, styles):
     table.add_row(
         _container_display_name(container),
         project_name,
-        _format_state(container.get("State", "unknown"), styles),
+        _format_state(container.get("State", "unknown")),
         _format_ports(container),
         image,
     )
 
 
-def _container_table(containers, styles):
+def _container_table(containers):
     """A populated status table for *containers*."""
-    table = _create_status_table(styles)
+    table = _create_status_table()
     for container in containers:
-        _add_container_to_table(table, container, styles)
+        _add_container_to_table(table, container)
     return table
 
 
-def _show_web_terminal_users(config, all_containers, console, styles):
+def _show_web_terminal_users(config, all_containers):
     """Print the per-user web terminal table, when this deployment has one.
 
     One row per rostered user: whether their container exists and what state it
@@ -322,34 +319,36 @@ def _show_web_terminal_users(config, all_containers, console, styles):
         for name in _container_names(container):
             by_name.setdefault(name, container)
 
-    existing_volumes = _existing_volume_names(config, console, styles)
+    existing_volumes = _existing_volume_names(config)
 
     def _format_volume_status(volume_name):
+        """One volume cell, pre-styled -- see :func:`_format_state` on markup."""
         if existing_volumes is None:
-            return f"[{styles.DIM}]? {volume_name} (unknown)[/{styles.DIM}]"
+            return Text(f"? {volume_name} (unknown)", style=Styles.DIM)
         if volume_name in existing_volumes:
-            return f"[{styles.SUCCESS}]✓ {volume_name}[/{styles.SUCCESS}]"
-        return f"[{styles.ERROR}]✗ {volume_name} (missing)[/{styles.ERROR}]"
+            return Text(f"✓ {volume_name}", style=Styles.SUCCESS)
+        return Text(f"✗ {volume_name} (missing)", style=Styles.ERROR)
 
-    table = Table(show_header=True, header_style=styles.BOLD_PRIMARY)
-    table.add_column("User", style=styles.ACCENT, no_wrap=True)
-    table.add_column("Container", style=styles.PRIMARY)
-    table.add_column("Claude Config Volume", style=styles.INFO)
-    table.add_column("Agent Data Volume", style=styles.INFO)
+    table = data_table()
+    table.add_column("User", style=Styles.ACCENT, no_wrap=True)
+    table.add_column("Container", style=Styles.PRIMARY)
+    table.add_column("Claude Config Volume", style=Styles.INFO)
+    table.add_column("Agent Data Volume", style=Styles.INFO)
 
-    console.print("\n[bold]Web Terminal Users:[/bold]")
+    output.report("")
+    output.section("Web Terminal Users:", ())
     for user in user_names:
         container = by_name.get(web_container_name(facility_prefix, user))
         claude_config_volume, agent_data_volume = resolve_user_volume_names(config, user)
         table.add_row(
             user,
-            f"[{styles.DIM}]● Not created[/{styles.DIM}]"
+            Text("● Not created", style=Styles.DIM)
             if container is None
-            else _format_state(container.get("State", "unknown"), styles),
+            else _format_state(container.get("State", "unknown")),
             _format_volume_status(claude_config_volume),
             _format_volume_status(agent_data_volume),
         )
-    console.print(table)
+    output.table(table)
 
 
 def show_status(config_path, *, console=None, styles=None):
@@ -364,26 +363,17 @@ def show_status(config_path, *, console=None, styles=None):
 
     :param config_path: Path to the configuration file
     :type config_path: str
-    :param console: Rich Console instance for output (default: creates new Console)
-    :type console: rich.console.Console, optional
-    :param styles: Style constants object with attributes like SUCCESS, ERROR, etc.
-        (default: uses _DefaultStyles with standard Rich markup)
-    :type styles: object, optional
+    :param console: Accepted and ignored. Output goes through the CLI renderer,
+        which resolves its own console per call.
+    :param styles: Accepted and ignored, for the same reason.
     """
-    if console is None:
-        from rich.console import Console
-
-        console = Console()
-    if styles is None:
-        styles = _DefaultStyles
-
     config = load_project_config(config_path, wrap_errors=True)
 
     # Advisory render-provenance note: a stale project deploys an out-of-date
     # service set that looks perfectly healthy here, so status is the other
     # place (besides osprey up) the drift must be visible.
     for reason in staleness_reasons(Path(config_path).resolve().parent):
-        console.print(f"[yellow]⚠ The build is out of date: {reason}. Re-run osprey build[/yellow]")
+        output.warn(f"The build is out of date: {reason}", "Re-run `osprey build`.")
 
     deployed_services = config.get("deployed_services", [])
     deployed_service_names = (
@@ -397,7 +387,7 @@ def show_status(config_path, *, console=None, styles=None):
     # its own containers show up under "other Osprey containers".
     current_project = resolve_project_name(config)
 
-    all_containers = _query_containers(config, console)
+    all_containers = _query_containers(config)
     if all_containers is None:
         return
 
@@ -414,26 +404,25 @@ def show_status(config_path, *, console=None, styles=None):
         elif container_project != "unknown":
             other_containers.append(container)
 
-    console.print("\n[bold]Service Status:[/bold]")
+    output.report("")
+    output.section("Service Status:", ())
 
     if project_containers:
-        console.print(_container_table(project_containers, styles))
+        output.table(_container_table(project_containers))
     else:
-        console.print(
-            f"\n[warning]ℹ️  No services running for project '{current_project}'[/warning]"
-        )
+        output.note(f"No services running for project '{current_project}'")
         if deployed_service_names:
-            console.print(f"[dim]Configured services: {', '.join(deployed_service_names)}[/dim]")
-        console.print("\n[info]Start services with:[/info]")
-        console.print("  • [command]osprey up[/command]")
+            output.note(f"Configured services: {', '.join(deployed_service_names)}")
+        output.note("Start them with `osprey up`.")
 
     if other_containers:
-        console.print("\n[bold]Other Osprey Containers:[/bold]")
-        console.print(_container_table(other_containers, styles))
+        output.report("")
+        output.section("Other Osprey Containers:", ())
+        output.table(_container_table(other_containers))
 
-    _show_web_terminal_users(config, all_containers, console, styles)
+    _show_web_terminal_users(config, all_containers)
 
-    console.print()
+    output.report("")
 
 
 # ---------------------------------------------------------------------------
@@ -441,7 +430,7 @@ def show_status(config_path, *, console=None, styles=None):
 # ---------------------------------------------------------------------------
 
 
-def _print_build_section(repo_root, console, styles):
+def _print_build_section(repo_root):
     """Print what ``build/`` is, and return the drift report the rest reads.
 
     Three facts, in the order an operator needs them: whether ``build/`` still
@@ -458,27 +447,24 @@ def _print_build_section(repo_root, console, styles):
     :return: The drift report, so callers can key later sections off its state
     """
     from osprey.cli.templates.manifest import get_framework_release_version
-    from osprey.deployment.staleness import DriftState, build_manifest_path, check_drift
+    from osprey.deployment.staleness import build_manifest_path, check_drift
 
     report = check_drift(repo_root)
 
-    state_style = {
-        DriftState.CLEAN: styles.SUCCESS,
-        DriftState.DRIFT: styles.WARNING,
-        DriftState.UNRESOLVABLE: styles.WARNING,
-        DriftState.NO_BUILD: styles.ERROR,
-    }[report.state]
-    console.print("\n[bold]Build:[/bold]")
-    console.print(f"  [{state_style}]{report.status_line}[/{state_style}]")
+    # ``status_line`` already opens with its own ``build:`` label, which is the
+    # section's first row label here — carrying both would print it twice.
+    rows = [("build", report.status_line.removeprefix("build: "))]
     if report.refuses:
-        console.print(
-            f"  [{styles.DIM}]`osprey up` and `osprey restart` refuse until this is "
-            f"resolved: {report.remedy}[/{styles.DIM}]"
+        rows.append(
+            (
+                "start",
+                f"`osprey up` and `osprey restart` refuse until this is resolved: {report.remedy}",
+            )
         )
 
     installed = get_framework_release_version()
     if report.version_skew:
-        console.print(f"  [{styles.WARNING}]{report.version_skew.message}[/{styles.WARNING}]")
+        rows.append(("version", report.version_skew.message))
     else:
         # The stamp itself, read from the same manifest `check_drift` read.
         # `version_skew` is only populated when the two versions DIFFER, so a
@@ -486,14 +472,19 @@ def _print_build_section(repo_root, console, styles):
         # build recorded no version to compare — and those are different facts.
         stamped = _stamped_version(build_manifest_path(repo_root))
         if stamped == installed:
-            console.print(f"  [{styles.DIM}]rendered by osprey {installed} (installed)[/]")
+            rows.append(("version", f"rendered by osprey {installed} (installed)"))
         elif stamped:
-            console.print(f"  [{styles.DIM}]rendered by osprey {stamped}[/]")
+            rows.append(("version", f"rendered by osprey {stamped}"))
         else:
-            console.print(
-                f"  [{styles.DIM}]osprey {installed} installed; build/ records no "
-                f"version that rendered it[/]"
+            rows.append(
+                (
+                    "version",
+                    f"osprey {installed} installed; build/ records no version that rendered it",
+                )
             )
+
+    output.report("")
+    output.section("Build:", rows)
     return report
 
 
@@ -558,7 +549,7 @@ def _partition_by_checkout(containers, identity, project_name):
     return mine, unlabelled, foreign, others
 
 
-def _print_containers_section(repo_root, config, console, styles):
+def _print_containers_section(repo_root, config):
     """Print what is running for this deployment, and what else is on the host.
 
     Returns every container the runtime reported, so the caller can answer the
@@ -576,8 +567,9 @@ def _print_containers_section(repo_root, config, console, styles):
     project_name = resolve_project_name(config) if config else Path(repo_root).name
     provenance = "project" if config else "project, from the directory name"
 
-    console.print(f"\n[bold]Containers[/bold] [{styles.DIM}]({provenance} {project_name})[/]")
-    all_containers = _query_containers(config, console)
+    output.report("")
+    output.section("Containers", [(provenance, project_name)])
+    all_containers = _query_containers(config)
     if all_containers is None:
         return None
 
@@ -586,23 +578,23 @@ def _print_containers_section(repo_root, config, console, styles):
     )
 
     if mine or unlabelled:
-        console.print(_container_table([*mine, *unlabelled], styles))
+        output.table(_container_table([*mine, *unlabelled]))
     else:
-        console.print(f"  [{styles.DIM}]Nothing is running for this deployment.[/]")
-        console.print(f"  [{styles.DIM}]Start it with `osprey up -d`.[/]")
+        output.note("Nothing is running for this deployment.")
+        output.note("Start it with `osprey up -d`.")
 
     if unlabelled:
         # Not a footnote for tidiness: these are exactly the containers
         # `osprey down`'s label fallback cannot see, so an operator who deletes
         # build/ and runs `down` would be told nothing was found while these
         # kept running.
-        console.print(
-            f"  [{styles.WARNING}]{len(unlabelled)} of these were matched by name, not by "
-            f"label ({', '.join(_container_display_name(c) for c in unlabelled)}): they "
-            f"carry no {REPO_ID_LABEL} label, because they were started before this repo "
-            f"began labelling its containers. `osprey down` finds them through build/'s "
-            f"compose files, but not through the label fallback that takes over when "
-            f"build/ is gone.[/{styles.WARNING}]"
+        output.warn(
+            f"{len(unlabelled)} of these were matched by name, not by label "
+            f"({', '.join(_container_display_name(c) for c in unlabelled)})",
+            f"They carry no {REPO_ID_LABEL} label, because they were started before this "
+            f"repo began labelling its containers. `osprey down` finds them through "
+            f"build/'s compose files, but not through the label fallback that takes over "
+            f"when build/ is gone.",
         )
 
     if foreign:
@@ -613,19 +605,20 @@ def _print_containers_section(repo_root, config, console, styles):
         # them too. The label is what distinguishes them HERE; claiming it
         # isolates them would be exactly backwards for the operator who then
         # runs `osprey down`.
-        console.print(
-            f"\n  [{styles.WARNING}]{len(foreign)} container(s) named for '{project_name}' "
-            f"were started from a DIFFERENT copy of this deployment "
+        output.warn(
+            f"{len(foreign)} container(s) named for '{project_name}' were started from a "
+            f"DIFFERENT copy of this deployment "
             f"({', '.join(sorted({_container_label(c, REPO_ID_LABEL) or '?' for c in foreign}))}; "
-            f"this copy is {identity}). They share a name with yours, so `osprey down` run "
-            f"here stops them too. Only their label tells the two copies "
-            f"apart.[/{styles.WARNING}]"
+            f"this copy is {identity})",
+            "They share a name with yours, so `osprey down` run here stops them too. "
+            "Only their label tells the two copies apart.",
         )
-        console.print(_container_table(foreign, styles))
+        output.table(_container_table(foreign))
 
     if others:
-        console.print("\n[bold]Other OSPREY containers on this host:[/bold]")
-        console.print(_container_table(others, styles))
+        output.report("")
+        output.section("Other OSPREY containers on this host:", ())
+        output.table(_container_table(others))
 
     return all_containers
 
@@ -648,26 +641,28 @@ def _absolute_compose_files(compose_files, repo_root):
     ]
 
 
-def _print_endpoints_section(config, compose_files, console, styles):
+def _print_endpoints_section(config, compose_files):
     """Print where this deployment's services are reachable, as ``build/`` declares it.
 
     Derived from the published ports in the rendered compose files — the same
     source the post-deploy summary uses — so what status prints and what ``up``
     printed cannot diverge. It says where a service *would* answer, not that it
     is answering: whether it is running is the table above.
-    """
-    from osprey.deployment.deploy_summary import format_endpoint_summary
 
-    console.print()
+    The pairs come from :func:`~osprey.deployment.deploy_summary.endpoint_entries`
+    rather than from the formatted text block above it, so the rows are laid out
+    by the renderer's section vocabulary rather than by a second one.
+    """
+    from osprey.deployment.deploy_summary import endpoint_entries
+
+    output.report("")
     try:
-        summary = format_endpoint_summary(config, compose_files)
+        entries = endpoint_entries(config, compose_files)
     except Exception as exc:
-        console.print(f"  [{styles.DIM}]Endpoints unavailable: {exc}[/]")
+        output.warn("The endpoint list could not be read from the build", str(exc))
         return
-    console.print(f"[bold]{summary.splitlines()[0]}[/bold]")
-    for line in summary.splitlines()[1:]:
-        console.print(line)
-    console.print(f"  [{styles.DIM}](listed by the build; nothing was contacted to check)[/]")
+    output.section(f"Service endpoints ({resolve_project_name(config)}):", entries)
+    output.note("(listed by the build; nothing was contacted to check)")
 
 
 def _auth_availability(secret_env, repo_root):
@@ -754,7 +749,7 @@ def _artifact_drift(repo_root, build_dir, config):
             logger.debug("Artifact dry run said: %s", chatter.getvalue().strip())
 
 
-def _print_agent_section(repo_root, build_dir, config, console, styles, *, show_agents):
+def _print_agent_section(repo_root, build_dir, config, *, show_agents):
     """Print how the agent in this deployment is configured, and whether it is in sync.
 
     Reports the provider, the environment block its settings carry, whether the
@@ -764,20 +759,27 @@ def _print_agent_section(repo_root, build_dir, config, console, styles, *, show_
     The per-agent model assignments are behind *show_agents* rather than
     printed always: there are a dozen of them, and a status report whose longest
     section is a model table buries the two lines an operator came for.
+
+    Every fact is a row of ONE section, sub-blocks included: a label column that
+    restarted for each sub-block would read as several unrelated reports. What
+    went sideways is not a row at all — it goes to the trouble primitives, and
+    therefore to stderr, after the block it qualifies.
     """
     import os
 
     from osprey.build.claude_code_resolver import AGENT_DEFAULT_TIERS, load_provider_spec
 
-    console.print("\n[bold]Agent:[/bold]")
+    rows: list[tuple[str, object]] = []
+    notes: list[str] = []
+    troubles: list[tuple[str, str | None]] = []
 
     claude_code = (config or {}).get("claude_code") or {}
     provider_name = claude_code.get("provider")
     if not provider_name:
-        console.print(f"  [{styles.DIM}]provider: not configured[/]")
-        console.print(
-            f"  [{styles.DIM}]Set claude_code.provider in profile.yml and rebuild to "
-            f"resolve models and provider environment automatically.[/]"
+        rows.append(("provider", "not configured"))
+        notes.append(
+            "Set claude_code.provider in profile.yml and rebuild to resolve models "
+            "and provider environment automatically."
         )
     else:
         try:
@@ -791,86 +793,92 @@ def _print_agent_section(repo_root, build_dir, config, console, styles, *, show_
             spec = load_provider_spec(build_dir, env_dir=repo_root)
         except Exception as exc:
             spec = None
-            console.print(f"  [{styles.ERROR}]provider {provider_name}: {exc}[/{styles.ERROR}]")
+            troubles.append(
+                (f"provider {provider_name} could not be read from the build", str(exc))
+            )
         else:
             if spec is None:
                 # The config names a provider and the resolver declined to
                 # resolve one. Reporting the name alone would present a
                 # configured provider where there is none in effect.
-                console.print(
-                    f"  [{styles.WARNING}]provider {provider_name}: named in the build, but "
-                    f"could not be resolved from it[/{styles.WARNING}]"
+                troubles.append(
+                    (
+                        f"provider {provider_name} is named in the build, but could not be "
+                        f"resolved from it",
+                        None,
+                    )
                 )
 
         if spec is not None:
-            console.print(f"  provider: {spec.provider}")
+            rows.append(("provider", spec.provider))
 
             available, where = _auth_availability(spec.auth_secret_env, repo_root)
             if available:
-                console.print(
-                    f"  auth:     [{styles.SUCCESS}]✓[/{styles.SUCCESS}] ${spec.auth_secret_env} "
-                    f"[{styles.DIM}]({where})[/]"
-                )
+                rows.append(("auth", f"✓ ${spec.auth_secret_env} ({where})"))
             else:
-                console.print(
-                    f"  auth:     [{styles.ERROR}]✗[/{styles.ERROR}] ${spec.auth_secret_env} not "
-                    f"found in this shell or in {repo_root / '.env'}"
+                rows.append(
+                    (
+                        "auth",
+                        f"✗ ${spec.auth_secret_env} not found in this shell or in "
+                        f"{repo_root / '.env'}",
+                    )
                 )
 
             if spec.env_block:
-                console.print(f"  [{styles.DIM}]environment (rendered into settings.json):[/]")
-                for key, value in spec.env_block.items():
-                    console.print(f"    {key} = [{styles.DIM}]{value}[/]")
+                rows.append(("environment", "rendered into settings.json"))
+                rows.extend((key, value) for key, value in spec.env_block.items())
 
-            console.print(f"  [{styles.DIM}]model tiers:[/]")
+            rows.append(("model tiers", ""))
             model_overrides = claude_code.get("models") or {}
             for tier in ("haiku", "sonnet", "opus"):
-                suffix = f" [{styles.DIM}](override)[/]" if tier in model_overrides else ""
-                console.print(f"    {tier:8s} → {spec.tier_to_model.get(tier, '?')}{suffix}")
+                suffix = " (override)" if tier in model_overrides else ""
+                rows.append((tier, f"{spec.tier_to_model.get(tier, '?')}{suffix}"))
 
             if show_agents:
-                console.print(f"  [{styles.DIM}]agent models:[/]")
+                rows.append(("agent models", ""))
                 agent_overrides = claude_code.get("agent_models") or {}
                 for agent_name, default_tier in sorted(AGENT_DEFAULT_TIERS.items()):
                     if agent_name in agent_overrides:
-                        note = f"(override: {agent_overrides[agent_name]})"
+                        origin = f"(override: {agent_overrides[agent_name]})"
                     else:
-                        note = f"({default_tier})"
-                    console.print(
-                        f"    {agent_name:28s} → {spec.agent_model(agent_name)} "
-                        f"[{styles.DIM}]{note}[/]"
-                    )
+                        origin = f"({default_tier})"
+                    rows.append((agent_name, f"{spec.agent_model(agent_name)} {origin}"))
 
             conflicts = spec.detect_env_conflicts(dict(os.environ))
             if conflicts:
-                console.print(
-                    f"  [{styles.WARNING}]⚠ this shell sets provider variables that "
-                    f"disagree with the build:[/{styles.WARNING}]"
-                )
-                for var, (shell_val, settings_val) in sorted(conflicts.items()):
-                    console.print(f"    {var}: shell {shell_val} / build {settings_val}")
-                console.print(
-                    f"  [{styles.DIM}]`osprey chat` resolves these in favour of the build.[/]"
+                detail = [
+                    f"{var}: shell {shell_val} / build {settings_val}"
+                    for var, (shell_val, settings_val) in sorted(conflicts.items())
+                ]
+                detail.append("`osprey chat` resolves these in favour of the build.")
+                troubles.append(
+                    (
+                        "this shell sets provider variables that disagree with the build",
+                        "\n".join(detail),
+                    )
                 )
 
     result = _artifact_drift(repo_root, build_dir, config)
+    changed = (result or {}).get("changed") or []
+    unchanged = (result or {}).get("unchanged") or []
     if result is None:
-        console.print(f"  [{styles.DIM}]artifacts: could not be checked[/]")
-        return
-    changed = result.get("changed") or []
-    unchanged = result.get("unchanged") or []
-    if changed:
-        console.print(
-            f"  [{styles.WARNING}]artifacts: {len(changed)} no longer match "
-            f"build/config.yml. Run `osprey build`[/{styles.WARNING}]"
+        rows.append(("artifacts", "could not be checked"))
+    elif changed:
+        troubles.append(
+            (
+                f"artifacts: {len(changed)} no longer match build/config.yml. Run `osprey build`",
+                "\n".join(str(path) for path in changed),
+            )
         )
-        for path in changed:
-            console.print(f"    [{styles.WARNING}]~[/{styles.WARNING}] {path}")
     else:
-        console.print(
-            f"  artifacts: [{styles.SUCCESS}]in sync[/{styles.SUCCESS}] "
-            f"[{styles.DIM}]({len(unchanged)} files)[/]"
-        )
+        rows.append(("artifacts", f"in sync ({len(unchanged)} files)"))
+
+    output.report("")
+    output.section("Agent:", rows)
+    for line in notes:
+        output.note(line)
+    for summary, detail in troubles:
+        output.warn(summary, detail)
 
 
 def show_repo_status(repo_root, *, console=None, styles=None, show_agents=False):
@@ -899,18 +907,12 @@ def show_repo_status(repo_root, *, console=None, styles=None, show_agents=False)
     was deleted is exactly the case an operator most needs to see.
 
     :param repo_root: The deployment repo — the directory holding ``profile.yml``
-    :param console: Rich Console to print to (default: a fresh one)
-    :param styles: Style constants object (default: :class:`_DefaultStyles`)
+    :param console: Accepted and ignored. Output goes through the CLI renderer,
+        which resolves its own console per call.
+    :param styles: Accepted and ignored, for the same reason.
     :param show_agents: Also print the per-agent model assignments
     """
     from osprey.deployment.container_lifecycle import as_built_compose_files, as_built_config_path
-
-    if console is None:
-        from rich.console import Console
-
-        console = Console()
-    if styles is None:
-        styles = _DefaultStyles
 
     repo_root = Path(repo_root)
     build_dir = repo_root / BUILD_DIRNAME
@@ -919,30 +921,31 @@ def show_repo_status(repo_root, *, console=None, styles=None, show_agents=False)
         load_project_config(str(config_path), wrap_errors=True) if config_path.is_file() else None
     )
 
-    console.print(f"\n[bold]{repo_root}[/bold]")
+    output.report("")
+    output.report(str(repo_root), style=Styles.BOLD)
 
-    _print_build_section(repo_root, console, styles)
-    all_containers = _print_containers_section(repo_root, config, console, styles)
+    _print_build_section(repo_root)
+    all_containers = _print_containers_section(repo_root, config)
 
     if config is None:
         # Both remaining sections are read out of build/config.yml. Saying that
         # once beats letting two whole sections silently not appear, which reads
         # as a deployment that has no endpoints and no agent.
-        console.print(
-            f"\n[{styles.DIM}]Endpoints and agent are read from build/config.yml, "
-            f"which this repo has none of yet.[/]"
+        output.report("")
+        output.note(
+            "Endpoints and agent are read from build/config.yml, which this repo has none of yet."
         )
     else:
         compose_files = _absolute_compose_files(
             as_built_compose_files(config, repo_root), repo_root
         )
         if compose_files:
-            _print_endpoints_section(config, compose_files, console, styles)
+            _print_endpoints_section(config, compose_files)
         if all_containers is not None:
-            _show_web_terminal_users(config, all_containers, console, styles)
-        _print_agent_section(repo_root, build_dir, config, console, styles, show_agents=show_agents)
+            _show_web_terminal_users(config, all_containers)
+        _print_agent_section(repo_root, build_dir, config, show_agents=show_agents)
 
-    console.print()
+    output.report("")
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/deployment/web_terminals/auth_credentials.py
+++ b/src/osprey/deployment/web_terminals/auth_credentials.py
@@ -39,6 +39,7 @@ from pathlib import Path
 # The service-token recipes are imported rather than restated so the signing
 # secrets below are minted and validated exactly like every other deploy-time
 # secret, and pick up any constraint registered for them later.
+from osprey.cli.output import report_fact
 from osprey.deployment.errors import ComposeInterpolationError
 from osprey.deployment.service_tokens import (
     _generate_token,
@@ -202,8 +203,8 @@ def _normalize_mode(env_auth_path: Path) -> None:
         os.chmod(env_auth_path, 0o600)
     except OSError as exc:
         logger.warning(
-            "Could not set 0600 permissions on %s (%s); check them by hand — "
-            "it holds web-terminal auth secrets.",
+            "Could not set 0600 permissions on %s (%s). Check them by hand, since "
+            "the file holds web-terminal auth secrets.",
             env_auth_path,
             exc,
         )
@@ -250,7 +251,7 @@ def ensure_auth_credentials(
     usernames: Iterable[str],
     project_root: str | Path,
     *,
-    echo: Callable[[str], None] = print,
+    echo: Callable[[str], None],
 ) -> AuthCredentialsResult:
     """Establish a password hash in ``.env.auth`` for every roster user.
 
@@ -292,8 +293,10 @@ def ensure_auth_credentials(
             ``normalize_users`` entry. Order is preserved; a name repeated
             verbatim is one user listed twice and is processed once.
         project_root: Directory holding ``.env`` and ``.env.auth``.
-        echo: Sink for the one-time minted-password notice. Defaults to
-            :func:`print` — deliberately not the logger, which ships elsewhere.
+        echo: Sink for the one-time minted-password notice. Required rather
+            than defaulted, because a password is the one line that must not
+            reach a stream nobody chose: every caller says where it goes.
+            Deliberately not the logger, which ships elsewhere.
 
     Returns:
         An :class:`AuthCredentialsResult` describing what happened, including
@@ -361,10 +364,10 @@ def ensure_auth_credentials(
             changed = True
             # Log the variable names only — a hash identifies a credential
             # generation and must not travel to a log sink.
-            logger.key_info(
-                "Provisioned web-terminal auth credential(s) %s in %s (gitignored, 0600)",
-                ", ".join(pending),
-                env_auth_path,
+            report_fact(
+                logger,
+                f"Provisioned web-terminal auth credential(s) {', '.join(pending)} "
+                f"in {env_auth_path} (gitignored, 0600)",
             )
             for name in minted:
                 echo(
@@ -482,10 +485,10 @@ def ensure_auth_session_secrets(project_root: str | Path) -> AuthSecretsResult:
         else:
             changed = True
             # Names only — a signing secret must never reach a log sink.
-            logger.key_info(
-                "Provisioned web-terminal auth secret(s) %s in %s (gitignored, 0600)",
-                ", ".join(pending),
-                env_auth_path,
+            report_fact(
+                logger,
+                f"Provisioned web-terminal auth secret(s) {', '.join(pending)} "
+                f"in {env_auth_path} (gitignored, 0600)",
             )
 
     _normalize_mode(env_auth_path)
@@ -556,8 +559,8 @@ def purge_auth_credentials(username: str, project_root: str | Path) -> bool:
         return False
 
     _atomic_rewrite(env_auth_path, kept)
-    logger.key_info(
-        "Removed web-terminal auth credential(s) for %r from %s", username, env_auth_path
+    report_fact(
+        logger, f"Removed web-terminal auth credential(s) for {username!r} from {env_auth_path}"
     )
     return True
 
@@ -672,7 +675,7 @@ def set_auth_password(username: str, password: str, project_root: str | Path) ->
 
     # The variable name only — a hash identifies a credential generation and
     # must not travel to a log sink, and the password never does at all.
-    logger.key_info("Replaced web-terminal auth credential %s in %s", hash_var, env_auth_path)
+    report_fact(logger, f"Replaced web-terminal auth credential {hash_var} in {env_auth_path}")
     return env_auth_path
 
 

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import yaml
 
+from osprey.cli.output import report_fact
 from osprey.deployment.errors import ComposeInterpolationError
 from osprey.deployment.web_terminals.personas import effective_image_source
 from osprey.utils.dotenv import (
@@ -78,11 +79,10 @@ def migrate_users_env(project_root: str | Path) -> Path | None:
     # through to os.replace below, which fails loudly with the leftover intact.
     if users_path.is_file():
         legacy_path.unlink()
-        logger.key_info(
-            "Removed %s: %s is the current name for the web terminals' runtime "
-            "secrets and already exists, so the older file was a leftover.",
-            legacy_path,
-            users_path,
+        report_fact(
+            logger,
+            f"Removed {legacy_path}: {users_path} is the current name for the web "
+            "terminals' runtime secrets and already exists, so the older file was a leftover.",
         )
         return users_path
 
@@ -94,10 +94,10 @@ def migrate_users_env(project_root: str | Path) -> Path | None:
     # umask) would otherwise arrive under the new name still world-readable.
     # Every other write of this file lands at 0600; a migrated one does too.
     os.chmod(users_path, 0o600)
-    logger.key_info(
-        "Renamed %s to %s: the web terminals' runtime secrets now live under the current name.",
-        legacy_path,
-        users_path,
+    report_fact(
+        logger,
+        f"Renamed {legacy_path} to {users_path}: the web terminals' runtime secrets "
+        "now live under the current name.",
     )
     return users_path
 
@@ -553,11 +553,9 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
     # reset on its own.
     os.chmod(users_env_path, 0o600)
 
-    logger.key_info(
-        "Generated %s from %s (mode 0600): %s",
-        users_env_path,
-        sources_desc,
-        ", ".join(subset),
+    report_fact(
+        logger,
+        f"Generated {users_env_path} from {sources_desc} (mode 0600): {', '.join(subset)}",
     )
 
     return users_env_path

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -79,6 +79,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, NoReturn
 
+from osprey.cli.output import fail, note, report
 from osprey.deployment.compose_generator import (
     compose_provider_env,
     resolve_project_name,
@@ -356,20 +357,20 @@ def prune_users(
     orphan_users = sorted(set(orphan_containers) | set(orphan_volumes))
 
     if not orphan_users:
-        print("prune: no off-roster web-terminal resources found; nothing to do.")
+        report("prune: no off-roster web-terminal resources found; nothing to do.")
         return
 
     policy = "archive" if archive else "purge" if purge else "retain"
-    print(f"prune: found {len(orphan_users)} off-roster user(s) (volume policy: {policy}):")
+    report(f"prune: found {len(orphan_users)} off-roster user(s) (volume policy: {policy}):")
     for user in orphan_users:
         container = orphan_containers.get(user)
         if container:
-            print(f"  - {user}: remove container {container!r}")
+            note(f"- {user}: remove container {container!r}")
         for volume in orphan_volumes.get(user, []):
-            print(f"      volume {volume!r}: {policy}")
+            note(f"    volume {volume!r}: {policy}")
 
     if dry_run:
-        print("prune: dry run, so nothing was removed.")
+        report("prune: dry run, so nothing was removed.")
         return
 
     prompt = (
@@ -554,21 +555,21 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
             continue
         images_to_remove.append(image)
 
-    print(
+    report(
         f"nuke: this will tear down project {project!r}'s entire web-terminal and "
         f"service stack: every container in the project, {len(volumes)} "
         f"volume(s) ({len(roster_names)} roster user(s), "
         f"{len(orphan_volumes)} off-roster user(s)), and {len(images_to_remove)} "
         "image(s):"
     )
-    print(f"  - containers: {' '.join(runtime_cmd)} -p {project} down")
+    note(f"- containers: {' '.join(runtime_cmd)} -p {project} down")
     for volume in volumes:
-        print(f"  - volume {volume!r}: removed permanently (no retain/archive)")
+        note(f"- volume {volume!r}: removed permanently (no retain/archive)")
     for image in images_to_remove:
-        print(f"  - image {image!r}: removed permanently (com.osprey.project verified)")
+        note(f"- image {image!r}: removed permanently (com.osprey.project verified)")
     for image, label_value in skipped_images:
-        print(
-            f"  - image {image!r}: SKIPPED. Its com.osprey.project label {label_value!r} "
+        note(
+            f"- image {image!r}: SKIPPED. Its com.osprey.project label {label_value!r} "
             f"does not match this deployment's project {project!r}"
         )
 
@@ -582,7 +583,11 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
 
     result = _compose_down_project(runtime_cmd, project, env=env)
     if result.returncode != 0:
-        print(f"nuke: 'compose down' failed (exit {result.returncode}): {result.stderr.strip()}")
+        fail(
+            f"nuke: 'compose down' failed (exit {result.returncode})",
+            result.stderr.strip(),
+            "No volumes were removed. Fix the reported problem and run nuke again.",
+        )
         raise RuntimeError(
             f"Nuke aborted: 'compose down' for project {project!r} failed (exit "
             f"{result.returncode}); no volumes were removed."
@@ -703,7 +708,7 @@ def _reconcile_auth_after_user_removal(
         logger.warning(
             "Could not check whether a removed web-terminal user's plaintext password "
             "survives in %s (%s). If that file sets %s<USER> for any of %s, remove the "
-            "line by hand — the next `osprey up` would otherwise hash it back in.",
+            "line by hand. The next `osprey up` would otherwise hash it back in.",
             repo_root / ".env",
             exc,
             PW_PLAINTEXT_VAR_PREFIX,
@@ -825,7 +830,7 @@ def _warn_if_plaintext_password_survives(removed: list[str], project_root: Path)
             logger.warning(
                 "%s still sets %s for the removed web-terminal user %r. Their password "
                 "was purged from %s, but the next `osprey up` would hash that "
-                "plaintext back in — so re-adding this username would re-establish the "
+                "plaintext back in, so re-adding this username would re-establish the "
                 "DEPARTED holder's password. Remove that line from %s.",
                 dotenv_path,
                 variable,

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -211,7 +211,7 @@ def _referenced_personas(config: dict, resolved_users: list[dict]) -> list[dict[
             seen.add(persona_name)
             logger.warning(
                 "Persona %r is referenced but its catalog entry has no "
-                "project_path configured — skipping its local build. "
+                "project_path configured. Skipping its local build. "
                 "compose up will fail on the unbuilt %r tag.",
                 persona_name,
                 entry.get("image"),
@@ -729,7 +729,9 @@ def build_persona_images(
                 dev_mode and wheel_staged,
             )
             image_tag = f"{project}-{persona_name}:local"
-            logger.key_info("Building persona image %s:", image_tag)
+            # No "building X:" announcement: the live build region carries the
+            # progress while it runs, and the step line below reports the
+            # finished image.
             logger.debug("Running command:\n    %s", " ".join(cmd))
             # Function-level import for the same cycle reason as
             # `_resolve_pip_spec` above: container_lifecycle imports this module

--- a/src/osprey/deployment/web_terminals/postup_hooks.py
+++ b/src/osprey/deployment/web_terminals/postup_hooks.py
@@ -16,6 +16,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from osprey.cli.output import report_fact
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.compose_generator import resolve_repo_root
 from osprey.deployment.runtime_helper import get_runtime_command
@@ -53,7 +54,7 @@ def enable_linger(config: dict, run_env: dict[str, str]) -> None:
         return  # linger is a rootless-podman/systemd concept; docker has no analog
 
     if shutil.which("loginctl") is None:
-        logger.warning("loginctl not found on PATH — skipping podman linger enable")
+        logger.warning("loginctl not found on PATH. Skipping the podman linger enable.")
         return
 
     try:
@@ -76,7 +77,7 @@ def enable_linger(config: dict, run_env: dict[str, str]) -> None:
             timeout=10,
         )
         if status.returncode == 0 and status.stdout.strip() == "Linger=yes":
-            logger.debug(f"Linger already enabled for {deploy_user} — nothing to do")
+            logger.debug(f"Linger already enabled for {deploy_user}. There is nothing to do.")
             return
     except (OSError, subprocess.TimeoutExpired) as exc:
         logger.warning(f"Could not check linger status for {deploy_user}: {exc}")
@@ -91,7 +92,7 @@ def enable_linger(config: dict, run_env: dict[str, str]) -> None:
             timeout=10,
         )
         if enable.returncode == 0:
-            logger.info(f"Enabled systemd linger for {deploy_user} (podman persistence)")
+            report_fact(logger, f"Enabled systemd linger for {deploy_user} (podman persistence)")
         else:
             logger.warning(
                 f"loginctl enable-linger {deploy_user} failed (exit {enable.returncode}): "
@@ -141,7 +142,8 @@ def run_verify_script(project_root: str, run_env: dict[str, str]) -> None:
     if not verify_path.is_file():
         return
 
-    logger.key_info("Running post-up smoke check: %s", verify_path)
+    # No announcement before the run: the step line below reports the same
+    # script WITH its exit code, so an "about to run it" line adds only latency.
     try:
         # check=False: the exit code is advisory (see above), so a site-
         # customized script that exits non-zero must not raise from here.
@@ -161,10 +163,8 @@ def run_verify_script(project_root: str, run_env: dict[str, str]) -> None:
         logger.warning("Could not run %s or capture its output: %s", verify_path, exc)
         return
 
-    _report_step(f"smoke check {verify_path.name} — exit {result.returncode}")
-    if result.returncode == 0:
-        logger.key_info("%s completed (exit 0)", verify_path)
-    else:
+    _report_step(f"smoke check {verify_path.name}: exit {result.returncode}")
+    if result.returncode != 0:
         # Read off the result, not the reporter: this hook has callers that run
         # it with no phase open, and they need the path just as much.
         # None only under --verbose, where the output already streamed past.
@@ -279,12 +279,11 @@ def warn_if_web_stack_unreachable(
 
     if on_docker_desktop and web_cmd:
         restart_cmd = web_cmd + ["restart"]
-        logger.key_info(
-            "%s is not reachable from this host yet. On Docker Desktop this is "
+        report_fact(
+            logger,
+            f"{url} is not reachable from this host yet. On Docker Desktop this is "
             "usually a stale host-network port registration; bouncing the web "
-            "stack to re-register it:\n    %s",
-            url,
-            " ".join(restart_cmd),
+            f"stack to re-register it:\n    {' '.join(restart_cmd)}",
         )
         try:
             # Spooled, not inherited: the restart's compose chatter would bury
@@ -303,7 +302,9 @@ def warn_if_web_stack_unreachable(
         else:
             _report_step("bounced the web stack for host-port re-registration")
             if _host_port_answers(url, attempts, delay):
-                logger.key_info("%s is reachable now.", url)
+                # The bounce's payoff. Without it the step above is the last
+                # word and never says whether the remediation worked.
+                _report_step("web endpoint reachable")
                 return
 
     hint = ""

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import yaml
 
+from osprey.cli.output import report_fact
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.build_progress import with_plain_build_progress
 from osprey.deployment.compose_generator import (
@@ -270,8 +271,9 @@ def _report_unshown_mints(credentials: AuthCredentialsResult) -> None:
     logger.warning(
         "Minted a login password for web-terminal user(s) %s and did NOT print it: stdout "
         "is not a terminal here, and this output can be retained (a CI job log is readable "
-        "by everyone with access to the project). The plaintext is gone — only the hash is "
-        "stored in %s. Set a password you choose with `osprey users passwd <user>`, or put "
+        "by everyone with access to the project). The plaintext is gone, and only the hash "
+        "is stored in %s. Set a password you choose with `osprey users passwd <user>`, or "
+        "put "
         "OSPREY_AUTH_PW_<USER> in .env before the first deploy and it will be hashed in "
         "instead of a random one being minted.",
         users,
@@ -377,7 +379,7 @@ def _warn_if_env_auth_not_gitignored(repo_root: Path) -> None:
         return
     logger.warning(
         "%s does not ignore %s. That file holds this deployment's web-terminal "
-        "password hashes and session-signing secrets — add a %s line to %s so it "
+        "password hashes and session-signing secrets. Add a %s line to %s so it "
         "cannot be committed.",
         gitignore_path,
         AUTH_ENV_FILENAME,
@@ -529,10 +531,10 @@ def build_auth_sidecar_image(
     if effective_image_source(web_terminals) != "local":
         return
     if auth_ctx["auth_image"]:
-        logger.info(
+        report_fact(
+            logger,
             "Skipping the local auth-sidecar build: modules.web_terminals.auth.image "
-            "pins %s, so the deployment supplies the image.",
-            auth_ctx["auth_image"],
+            f"pins {auth_ctx['auth_image']}, so the deployment supplies the image.",
         )
         return
 
@@ -568,7 +570,8 @@ def build_auth_sidecar_image(
     with_plain_build_progress(cmd)
     cmd.append(str(context_dir))
 
-    logger.key_info("Building auth sidecar image %s:", tag)
+    # No "building X:" announcement: the live build region carries the progress
+    # while it runs, and the step line below reports the finished image.
     logger.debug("Running command:\n    %s", " ".join(cmd))
     # Function-level import, like `compose_build_step_reporter` below:
     # container_lifecycle imports this module at its own top level, so the
@@ -778,7 +781,7 @@ def force_recreate_auth_sidecar(
     compose_file = web_compose_file(root)
     if not compose_file.exists():
         logger.warning(
-            "No rendered web stack at %s — skipping the auth sidecar recreate. "
+            "No rendered web stack at %s. Skipping the auth sidecar recreate. "
             "Any %s change takes effect at the next `osprey up`.",
             compose_file,
             AUTH_ENV_FILENAME,
@@ -796,8 +799,8 @@ def force_recreate_auth_sidecar(
     except (ValueError, OSError) as exc:
         logger.warning(
             "Could not re-render the web-terminal artifacts before the auth sidecar "
-            "recreate (%s). Recreating against the existing docker-compose.web.yml — "
-            "the recreated container still bakes the current %s, but its digest label "
+            "recreate (%s). Recreating against the existing docker-compose.web.yml. "
+            "The recreated container still bakes the current %s, but its digest label "
             "lags until the next `osprey up` re-renders (costing one extra "
             "sidecar recreate there).",
             exc,
@@ -1326,7 +1329,7 @@ def deploy_down_web_terminals(
     )
     if result.returncode != 0:
         logger.warning(
-            "web-terminal stack down failed (rc=%s) — its containers may still be running:\n%s",
+            "web-terminal stack down failed (rc=%s). Its containers may still be running:\n%s",
             result.returncode,
             result.stderr,
         )

--- a/src/osprey/deployment/web_terminals/seeding.py
+++ b/src/osprey/deployment/web_terminals/seeding.py
@@ -38,6 +38,7 @@ import tarfile
 from pathlib import Path
 from typing import Any
 
+from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.compose_generator import resolve_repo_root
 from osprey.deployment.runtime_helper import get_runtime_command, runtime_env
 from osprey.deployment.web_terminals.naming import web_container_name
@@ -264,9 +265,9 @@ def seed_user_containers(
         )
     base_content = base_md_path.read_text(encoding="utf-8") if base_md_exists else ""
 
-    logger.info("Seeding per-user CLAUDE.md and skills into claude-config volumes...")
     attempted = 0
     failed = 0
+    skipped: list[str] = []
     for entry in targets:
         resolved = resolved_by_name[entry["name"]]
         # Project scope, not $CLAUDE_CONFIG_DIR — the launcher runs the CLI with
@@ -283,10 +284,23 @@ def seed_user_containers(
             env=run_env,
         )
         if outcome is None:
-            continue  # container not ready — never counts toward the systemic check
+            # Container not ready — never counts toward the systemic check, but
+            # the count below and the warning after it keep it visible.
+            skipped.append(entry["name"])
+            continue
         attempted += 1
         if not outcome:
             failed += 1
+
+    # Counts, not an announcement: the per-user lines are DEBUG now, so a short
+    # seed has to be legible on this line alone.
+    _report_step(f"seeded {attempted - failed}/{len(targets)} user contexts")
+    if skipped:
+        logger.warning(
+            f"No container was running for web-terminal user(s) {', '.join(skipped)}, "
+            "so their context was not seeded. Re-run this once those containers "
+            "are up, or those users start with no CLAUDE.md and no skills."
+        )
 
     if attempted and failed == attempted:
         raise RuntimeError(
@@ -326,7 +340,7 @@ def _seed_one_user(
     """
     container = web_container_name(facility_prefix, user)
     if not _container_exists(runtime, container, env=env):
-        logger.info(f"  (skipped {user}: container not ready)")
+        logger.debug(f"  (skipped {user}: container not ready)")
         return None
     try:
         owner = _container_seed_owner(runtime, container, env=env)
@@ -335,7 +349,7 @@ def _seed_one_user(
         _seed_claude_md(runtime, container, payload, owner, env=env)
         skills_src = context_dir / user / "skills"
         _seed_skills(runtime, container, skills_src, project_skills_dir, owner, env=env)
-        logger.info(f"  seeded {user}")
+        logger.debug(f"  seeded {user}")
         return True
     except Exception as exc:
         logger.warning(f"  (skipped {user}: seeding failed: {_describe_seed_error(exc)})")

--- a/src/osprey/deployment/wheel_build.py
+++ b/src/osprey/deployment/wheel_build.py
@@ -23,6 +23,7 @@ import re
 import shutil
 from pathlib import Path
 
+from osprey.cli.phase_reporter import report_step
 from osprey.deployment.errors import DevModeUnavailableError
 from osprey.utils.logger import get_logger
 
@@ -244,8 +245,9 @@ def _build_dev_wheel_cached(osprey_source_root):
         return _wheel_build_cache[key]
 
     cached_wheel = None
-    # Build the wheel package from local source
-    logger.info("Building osprey wheel from local source...")
+    # Build the wheel package from local source. Not announced first: the build
+    # is memoized to one shot per process, and the step below carries the fact
+    # with its outcome attached.
     with tempfile.TemporaryDirectory() as tmpdir:
         # Use sys.executable, NOT bare "python3": in a non-activated venv,
         # PATH "python3" resolves to the system/pyenv interpreter (which
@@ -293,7 +295,7 @@ def _build_dev_wheel_cached(osprey_source_root):
                         _wheel_cache_cleanup_registered = True
                 cached_wheel = Path(_wheel_cache_dir) / wheel_files[0].name
                 shutil.copy2(wheel_files[0], cached_wheel)
-                logger.success(f"Built osprey wheel: {wheel_files[0].name}")
+                report_step("built osprey wheel from the local checkout")
 
     _wheel_build_cache[key] = cached_wheel
     return cached_wheel
@@ -408,7 +410,10 @@ def _copy_local_framework_for_override(out_dir):
                 "dependencies.\nCheck that the build context directory is writable.",
             ) from manifest_error
 
-        logger.success(f"Copied osprey wheels: {cached_wheel.name}, {cached_connectors_wheel.name}")
+        # Fires once per build context -- the deployment, each persona, each
+        # image copy -- so as a step it would repeat one fact N times. The step
+        # on the build above states it once.
+        logger.debug(f"Copied osprey wheels: {cached_wheel.name}, {cached_connectors_wheel.name}")
 
         return True
 

--- a/src/osprey/health/render.py
+++ b/src/osprey/health/render.py
@@ -1,21 +1,26 @@
-"""Rich and JSON rendering for a completed health-check report.
+"""Human and JSON rendering for a completed health-check report.
 
 The runner produces a :class:`~osprey.health.models.CheckReport`; this module
 turns it into operator-facing output. Two surfaces are provided:
 
-* :func:`render_report` — grouped, per-category Rich output following the
-  ``cli/styles.py`` conventions (``✓``/``!``/``✗`` glyphs, a dim ``-`` for
-  skips, ``[bold]`` category headers) followed by a summary panel. In verbose
-  mode the panel gains a details section listing every warning and error.
+* :func:`render_report` — the human report, printed entirely through the CLI
+  renderer (:mod:`osprey.cli.output`). Category headers and per-check rows are
+  report-class lines on stdout, because the grouped report is the document an
+  operator ran the verb to read; the verbose recap of every degraded check uses
+  the renderer's warning and failure shapes, which land on stderr like all other
+  trouble.
 * :func:`render_json` — the machine-clean path: ``json.dumps(report.to_dict())``
-  and nothing else on the target stream (stdout by default). All human output
-  (the progress spinner, deprecation warnings) is expected to be routed to
-  stderr by the caller, keeping stdout a pure JSON document.
+  and nothing else on the target stream (stdout by default). This is the one
+  documented emission seam in the module: it writes to the stream directly
+  rather than through the renderer, so nothing can slip a human sentence into
+  the document. The caller wraps the whole run in
+  :func:`osprey.cli.output.machine_mode`, which sends every renderer line to
+  stderr, leaving stdout a single JSON document.
 
 :func:`run_progress` supplies the during-the-run indicator (a transient Rich
-``Live`` spinner). Every entry point takes an optional ``console`` so the CLI
-can direct human output to a stderr console when ``--json`` is in effect while
-the report JSON goes to stdout.
+``Live`` spinner) on the reporter's own console, so it can never repaint over a
+line the renderer is printing — or on the stderr console in machine mode, where
+stdout is carrying the document.
 """
 
 from __future__ import annotations
@@ -26,17 +31,41 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import IO
 
-from rich.console import Console
 from rich.live import Live
-from rich.panel import Panel
 from rich.spinner import Spinner
+from rich.text import Text
 
-from osprey.cli.styles import Messages, ThemeConfig
-from osprey.cli.styles import console as _default_console
+from osprey.cli import output, styles
+from osprey.cli.phase_reporter import current_reporter
+from osprey.cli.styles import Styles, ThemeConfig
 from osprey.health.models import CheckReport, CheckResult, Status
 
-_PANEL_TITLE = "Osprey Health Check Results"
 _DEFAULT_PROGRESS_TEXT = "Running health checks…"
+
+#: The renderer's one indentation step, spelled here because
+#: :func:`~osprey.cli.output.report` prints its line verbatim: a check row is
+#: subordinate to its category header, and structure is the half of that which
+#: survives a pipe.
+_INDENT = "  "
+
+#: The mark each status opens its row with. Content rather than decoration —
+#: these are the marks the renderer and :data:`~osprey.health.models.STATUS_ICONS`
+#: already use, so a health row reads like every other line the CLI prints and
+#: still says which way a check went once the color is gone.
+_GLYPHS = {
+    Status.OK: "✓",
+    Status.WARNING: "⚠",
+    Status.ERROR: "✗",
+    Status.SKIP: "-",
+}
+
+#: The style token each status' row carries. Skips are absent: they render as
+#: notes, which are dim by construction.
+_ROW_STYLES = {
+    Status.OK: Styles.SUCCESS,
+    Status.WARNING: Styles.WARNING,
+    Status.ERROR: Styles.ERROR,
+}
 
 
 def _humanize(category: str) -> str:
@@ -49,20 +78,21 @@ def _humanize(category: str) -> str:
     return category.replace("_", " ").title()
 
 
-def _format_row(result: CheckResult) -> str:
-    """Format one result as a Rich-markup line: glyph, message, optional value."""
-    text = result.message
+def _row_text(result: CheckResult) -> str:
+    """The prose half of one row: its message, with its value in parentheses."""
     if result.value:
-        text = f"{text} [dim]({result.value})[/dim]"
+        return f"{result.message} ({result.value})"
+    return result.message
 
-    if result.status is Status.OK:
-        return f"  {Messages.success(text)}"
-    if result.status is Status.WARNING:
-        return f"  {Messages.warning(text)}"
-    if result.status is Status.ERROR:
-        return f"  {Messages.error(text)}"
-    # Status.SKIP — dim dash, consistent with STATUS_ICONS in models.
-    return f"  [dim]- {text}[/dim]"
+
+def _render_row(result: CheckResult) -> None:
+    """Print one check as a row under its category header."""
+    text = _row_text(result)
+    if result.status is Status.SKIP:
+        # A note is already indented and dim, which is what a skipped check is.
+        output.note(f"{_GLYPHS[Status.SKIP]} {text}")
+        return
+    output.report(f"{_INDENT}{_GLYPHS[result.status]} {text}", style=_ROW_STYLES[result.status])
 
 
 def _group_by_category(results: list[CheckResult]) -> dict[str, list[CheckResult]]:
@@ -73,64 +103,54 @@ def _group_by_category(results: list[CheckResult]) -> dict[str, list[CheckResult
     return grouped
 
 
-def _build_panel(report: CheckReport, *, verbose: bool) -> Panel:
-    """Build the summary panel; include a details section when verbose."""
-    lines = [f"Summary: {report.summary_line()}"]
+def _render_details(report: CheckReport) -> None:
+    """Print every warning and error again in the renderer's trouble shape.
 
-    if verbose and (report.warning_count or report.error_count):
-        lines.append("")
-        lines.append("Details:")
-        for result in report.results:
-            if result.status in (Status.WARNING, Status.ERROR):
-                symbol = "!" if result.status is Status.WARNING else "✗"
-                lines.append(f"  {symbol} {result.name}: {result.message}")
-                if result.details:
-                    lines.append(f"     {result.details}")
-
-    return Panel(
-        "\n".join(lines),
-        title=_PANEL_TITLE,
-        border_style="dim",
-        expand=False,
-        padding=(1, 2),
-    )
+    The grouped report says what each category found; this recap says what an
+    operator has to act on, in the same shape every other warning and failure in
+    the CLI wears, and on stderr like all of them. Only reached under
+    ``--verbose``.
+    """
+    for result in report.results:
+        summary = f"{result.name}: {result.message}"
+        if result.status is Status.WARNING:
+            output.warn(summary, result.details)
+        elif result.status is Status.ERROR:
+            output.fail(summary, result.details)
 
 
-def render_report(
-    report: CheckReport,
-    *,
-    verbose: bool = False,
-    console: Console | None = None,
-) -> None:
-    """Render a completed report as grouped per-category Rich output.
+def render_report(report: CheckReport, *, verbose: bool = False) -> None:
+    """Render a completed report as grouped per-category output.
 
-    Prints a ``[bold]`` header per category followed by one glyphed line per
-    check, then a summary :class:`~rich.panel.Panel`. When ``verbose`` is set the
-    panel also lists every warning and error with its details.
+    Prints a bold header per category followed by one glyphed row per check,
+    then the summary line. When ``verbose`` is set, every warning and error is
+    printed again through the renderer's warning and failure shapes.
 
     Args:
         report: The completed report to render.
-        verbose: Whether to include the panel's per-row details section.
-        console: Target console; defaults to the shared themed CLI console. Pass
-            a stderr-bound console to keep stdout clean alongside ``--json``.
+        verbose: Whether to add the per-check details recap.
     """
-    out = console or _default_console
-
     for category, results in _group_by_category(report.results).items():
-        out.print(f"\n[bold]{_humanize(category)}[/bold]")
+        output.report("")
+        output.report(_humanize(category), style=Styles.BOLD)
         for result in results:
-            out.print(_format_row(result))
+            _render_row(result)
 
-    out.print()
-    out.print(_build_panel(report, verbose=verbose))
+    output.report("")
+    output.report(f"Summary: {report.summary_line()}", style=Styles.BOLD)
+
+    if verbose and (report.warning_count or report.error_count):
+        _render_details(report)
 
 
 def render_json(report: CheckReport, *, out: IO[str] | None = None) -> None:
     """Write the report as a single JSON document and nothing else.
 
     Emits ``json.dumps(report.to_dict())`` followed by a newline to ``out``
-    (stdout by default). No human-facing text is written here, so a caller that
-    routes progress and warnings to stderr leaves stdout a pure JSON document.
+    (stdout by default). This is the module's machine-output seam: it writes at
+    the stream rather than through the renderer, so no human line can reach the
+    document. Everything human the run produces goes to stderr instead, because
+    the caller holds :func:`osprey.cli.output.machine_mode` open around it.
 
     Args:
         report: The completed report to serialize.
@@ -143,26 +163,29 @@ def render_json(report: CheckReport, *, out: IO[str] | None = None) -> None:
 
 
 @contextmanager
-def run_progress(
-    description: str = _DEFAULT_PROGRESS_TEXT,
-    *,
-    console: Console | None = None,
-) -> Iterator[None]:
+def run_progress(description: str = _DEFAULT_PROGRESS_TEXT) -> Iterator[None]:
     """Show a transient spinner while the suite runs.
 
     The spinner is rendered via a Rich :class:`~rich.live.Live` in transient
-    mode, so it leaves no residue once the run completes. In ``--json`` mode the
-    caller passes a stderr-bound console so the indicator never touches stdout.
+    mode, so it leaves no residue once the run completes. It mounts on the
+    installed reporter's console — the one that owns the cursor — so a line the
+    renderer prints during the run lands above the region rather than inside it.
+
+    A live region paints at its console's stream, which is the one thing a
+    ``--json`` run cannot afford on stdout, so in machine mode the region mounts
+    on the stderr console instead: the operator still sees that the suite is
+    running, and the document stays a document. This is the case the primitives
+    handle for themselves and a mounted region cannot, which is what
+    :func:`~osprey.cli.output.machine_mode_active` is for.
 
     Args:
         description: Text shown next to the spinner.
-        console: Target console; defaults to the shared themed CLI console.
     """
-    out = console or _default_console
+    console = styles.err_console if output.machine_mode_active() else current_reporter().out()
     spinner = Spinner(
-        "dots", text=f"[dim]{description}[/dim]", style=ThemeConfig.get_spinner_style()
+        "dots", text=Text(description, style=Styles.DIM), style=ThemeConfig.get_spinner_style()
     )
-    with Live(spinner, console=out, transient=True):
+    with Live(spinner, console=console, transient=True):
         yield
 
 

--- a/src/osprey/interfaces/okf_panel/validation.py
+++ b/src/osprey/interfaces/okf_panel/validation.py
@@ -213,6 +213,12 @@ def log_validation_summary(
             plain callable such as :func:`print`. A ``logging.Logger`` works.
     """
 
+    # UNGUARDED: copy passed to this wrapper is not seen by the house-style guard
+    # in `tests/cli/test_printed_copy_style.py`, which matches printer names
+    # exactly. The name cannot join its set, because `cli/deploy_scaffold.py` has
+    # an `_emit` that writes a FILE, and registering the bare name would judge
+    # that one's arguments as prose. The summary lines below are read by whoever
+    # ran the sweep, so keep them to the same house style by hand.
     def _emit(message: str) -> None:
         try:
             # Prefer a logger's .warning, then .info, else treat as callable.

--- a/src/osprey/simulation/apply.py
+++ b/src/osprey/simulation/apply.py
@@ -264,8 +264,11 @@ def apply_scenarios(
     # the narrative hours away from its archiver evidence on a non-UTC facility.
     t0 = now or datetime.now(get_facility_timezone())
     # set_active_scenarios validates composition and raises on collisions/unknowns.
+    # Not announced here. Both callers already say it: `osprey sim apply` echoes
+    # `✓ Active scenarios: …`, and the deploy-time reseed closes with a step
+    # naming the same scenarios. The anchor is internal -- the reseed reuses the
+    # persisted one precisely so nothing slides.
     active = engine.set_active_scenarios(names, anchor=t0)
-    logger.info(f"Activated scenarios {list(active)!r} with anchor {t0.isoformat()}")
 
     seeded = 0
     purged = False
@@ -822,7 +825,8 @@ def seed_archiver(
             f"{result.uncovered} dense sample(s) an event window called for were left out: "
             f"the archive has no coverage there to densify."
         )
-    logger.info(result.describe())
+    # As above: `osprey sim apply` echoes `✓ Archive rewritten: <describe()>`
+    # itself, and on a deploy the reseed's closing step carries the same counts.
     return result
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -170,9 +170,12 @@ already be baked into the snapshot and preserved instead of undone.
 
 ### Marker vocabulary
 
-Markers are declared in `pyproject.toml` under `[tool.pytest.ini_options]`, and
-`--strict-markers` is on — a marker you have not declared there is an error, not
-a silent no-op. Four groups matter day to day:
+Markers are declared in `pyproject.toml` under `[tool.pytest.ini_options]`.
+`--strict-markers` is listed in `addopts`, but on the pinned pytest it only bites
+when you pass it on the command line yourself: in a normal run an undeclared
+marker is a `PytestUnknownMarkWarning`, not an error. So declare your marker, and
+run `pytest --strict-markers …` when you want a typo to fail collection rather
+than scroll past in the warnings summary. Four groups matter day to day:
 
 - **`requires_<resource>`** (`requires_ollama`, `requires_als_apg`, …) — declares
   an external dependency. `pytest_collection_modifyitems` in `tests/conftest.py`

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -7,10 +7,16 @@ The guards here keep that blast radius contained.
 
 from __future__ import annotations
 
+import logging
 import os
+from collections.abc import Iterator
+from io import StringIO
 from pathlib import Path
 
 import pytest
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.text import Text
 
 # The gold-standard three-zone deployment repo, re-exported so every lifecycle
 # test under tests/cli/ can ask for it by name. Defined in tests/fixtures/ with
@@ -62,3 +68,258 @@ def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: home)
     return home
+
+
+# ===================================================================
+# Terminal probe — what the operator's terminal actually shows
+# ===================================================================
+
+
+class _ProbeRecordSink(logging.Handler):
+    """Every record the loggers emitted, captured before any handler filter."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+class TerminalProbe:
+    """Both halves of a rendering question: what was painted, what was emitted.
+
+    ``rendered_text`` is what the root ``RichHandler`` actually painted — the
+    operator's terminal, after the altitude gate
+    (``osprey.cli.altitude``) has had its say. ``records`` is the raw record
+    stream reaching the root logger, which the gate never touches: it is a
+    handler filter, so a record it drops is still emitted and still observable.
+    Holding the two side by side is the only way to state the honest form of an
+    altitude claim — *this fact no longer clutters the terminal, and nothing was
+    lost.*
+
+    Attributes:
+        console: The Rich console the handler paints through, writing into an
+            in-memory buffer.
+    """
+
+    def __init__(self, console: Console, buffer: StringIO, sink: _ProbeRecordSink) -> None:
+        self.console = console
+        self._buffer = buffer
+        self._sink = sink
+
+    @property
+    def styled_text(self) -> str:
+        """Painted output with its ANSI escape sequences intact.
+
+        Use for style assertions (``"\\x1b[1m" in probe.styled_text``); use
+        :attr:`rendered_text` for anything about the words themselves.
+        """
+        return self._buffer.getvalue()
+
+    @property
+    def rendered_text(self) -> str:
+        """Painted output as plain text, ANSI escape sequences removed.
+
+        The needle surface: ``assert "the fact" in probe.rendered_text``. Lines
+        are padded out to the console width, so prefer substring checks or
+        :attr:`lines` over comparing a whole line for equality.
+        """
+        return Text.from_ansi(self.styled_text).plain
+
+    @property
+    def lines(self) -> list[str]:
+        """:attr:`rendered_text` split into lines, each right-stripped."""
+        return [line.rstrip() for line in self.rendered_text.splitlines()]
+
+    @property
+    def records(self) -> list[logging.LogRecord]:
+        """Every record that reached the root logger, in emission order."""
+        return list(self._sink.records)
+
+    @property
+    def messages(self) -> list[str]:
+        """The formatted message of every captured record."""
+        return [record.getMessage() for record in self._sink.records]
+
+    def arm(self) -> RichHandler:
+        """Point the current root ``RichHandler`` at the probe console again.
+
+        Only needed by a test that installs logging itself in a way the fixture
+        cannot intercept — the fixture already covers the ordinary paths
+        (a handler that existed beforehand, ``configure_logging()`` called from
+        the test body, and the CLI's own ``set_handler_console()``).
+
+        Returns:
+            The handler now painting into the probe buffer.
+        """
+        handler = _first_rich_handler()
+        if handler is None:
+            handler = _build_probe_handler(self.console)
+            logging.getLogger().addHandler(handler)
+        else:
+            handler.console = self.console
+        return handler
+
+    def clear(self) -> None:
+        """Drop everything captured so far, painted and emitted alike."""
+        self._buffer.seek(0)
+        self._buffer.truncate(0)
+        self._sink.records.clear()
+
+
+def _first_rich_handler() -> RichHandler | None:
+    """The root handler the CLI configures and gates, or None if there is none.
+
+    Same predicate ``configure_logging``, ``set_handler_console`` and
+    ``osprey.cli.altitude`` use, so all four agree on which handler is *the*
+    handler.
+    """
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, RichHandler):
+            return handler
+    return None
+
+
+def _build_probe_handler(console: Console) -> RichHandler:
+    """A stand-in for the handler ``configure_logging()`` would have installed.
+
+    Mirrors ``osprey_connectors.logger._build_rich_handler``'s secure defaults
+    without its config lookup, which would pull the config machinery — and its
+    ``.env`` load — into a fixture.
+    """
+    return RichHandler(
+        console=console,
+        rich_tracebacks=True,
+        markup=True,
+        show_path=False,
+        show_time=True,
+        show_level=True,
+        tracebacks_show_locals=False,
+    )
+
+
+@pytest.fixture
+def terminal_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    restore_root_logging: None,
+) -> Iterator[TerminalProbe]:
+    """Capture what the terminal shows *and* what the loggers emitted.
+
+    The instrument for altitude and promotion claims. The gate the CLI installs
+    is a filter on the root ``RichHandler``, so a record it drops still reaches
+    every record-level observer — ``caplog``, a record sink, ``debug_probe``.
+    Those instruments structurally cannot see a handler gate; this one can,
+    because it owns the console the handler paints through.
+
+    Which instrument to reach for:
+
+    * **This fixture** for anything about the *rendered* terminal: a promoted
+      fact appearing in the default view, its old log form no longer appearing,
+      or a WARNING still getting through. Both halves of that claim come from
+      one object, so the "and nothing was lost" half cannot be forgotten.
+    * **``debug_probe``** (``tests/cli/test_lifecycle_phases.py``) for anything
+      about *emission* alone: whether a demoted call site logs at all under the
+      level a flag chose. It emits from inside a running verb and reads the
+      level the group callback applied, which is a different link in the chain
+      from what the handler paints.
+    * **``caplog``** stays fine for ordinary "was this logged, with what
+      message" assertions that make no claim about the terminal.
+
+    Console settings, and what they let you assert:
+
+    * ``width=100`` — a fixed width, so wrapping is reproducible across
+      machines. Long facts do wrap; assert on a distinctive fragment.
+    * ``force_terminal=True`` with the CLI's own theme — the handler paints
+      exactly the styled output a real terminal gets, theme style names
+      (``[success]``, ``[warning]``…) resolve instead of raising, and
+      :attr:`~TerminalProbe.styled_text` exposes the escape sequences. Plain
+      assertions stay safe because :attr:`~TerminalProbe.rendered_text` strips
+      them back off.
+
+    Interplay with a CLI invocation:
+
+        def test_the_fact_is_in_the_default_view(terminal_probe, monkeypatch):
+            # The group callback loads an ancestor .env straight into os.environ.
+            monkeypatch.setattr(
+                "osprey.utils.config.load_project_dotenv", lambda *a, **k: None
+            )
+            result = CliRunner().invoke(cli, ["up"])
+
+            assert "deployment is browse-only" in result.output       # printed
+            assert "browse-only" not in terminal_probe.rendered_text  # not logged
+            assert any("browse-only" in m for m in terminal_probe.messages)
+
+    The CLI points the handler at its own stderr console; the fixture wraps
+    ``set_handler_console`` so the probe console wins instead, for the whole
+    run rather than only afterwards. That splits the two streams cleanly:
+    printed output (echo-class ``report()``/``section()`` lines) lands in
+    ``CliRunner``'s ``result.output``, while anything the *logging* path painted
+    lands in ``rendered_text``. Invoking the CLI before or after asking for the
+    probe both work.
+
+    Note:
+        A mounted live region borrows the handler's console and restores it by
+        identity (``PhaseReporter._borrow_log_console()``), so records logged
+        while a progress display is up are painted by the reporter, not here.
+        That is the production behaviour, not a fixture artefact.
+
+    Note:
+        The root logger's level is left alone. A DEBUG record under a default
+        (INFO) run is therefore absent from ``records`` too — which is the
+        truth about that run, and what makes a real demotion detectable.
+
+    Yields:
+        The :class:`TerminalProbe` for the test body.
+    """
+    # Imported here, not at module scope: a conftest import runs for every test
+    # under tests/cli/, and the theme module pulls in the CLI package.
+    from osprey.cli.styles import osprey_theme
+
+    buffer = StringIO()
+    console = Console(
+        file=buffer,
+        width=100,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        theme=osprey_theme,
+    )
+
+    root = logging.getLogger()
+    sink = _ProbeRecordSink()
+    root.addHandler(sink)
+
+    existing = _first_rich_handler()
+    previous_console = existing.console if existing is not None else None
+    if existing is not None:
+        existing.console = console
+        probe_handler = existing
+        probe_owns_handler = False
+    else:
+        # Installed up front so a later ``configure_logging()`` — which only
+        # adds a handler when the root logger has no RichHandler — keeps this
+        # one instead of building a stderr console the probe cannot see.
+        probe_handler = _build_probe_handler(console)
+        root.addHandler(probe_handler)
+        probe_owns_handler = True
+
+    import osprey_connectors.logger as logger_mod
+
+    real_set_handler_console = logger_mod.set_handler_console
+
+    def _set_probe_console(_console: Console) -> RichHandler | None:
+        """Redirect the caller's console to the probe's, then behave normally."""
+        handler: RichHandler | None = real_set_handler_console(console)
+        return handler
+
+    monkeypatch.setattr(logger_mod, "set_handler_console", _set_probe_console)
+
+    try:
+        yield TerminalProbe(console, buffer, sink)
+    finally:
+        root.removeHandler(sink)
+        if probe_owns_handler:
+            root.removeHandler(probe_handler)
+        elif previous_console is not None:
+            probe_handler.console = previous_console

--- a/tests/cli/data/json_keysets/ariel_search.json
+++ b/tests/cli/data/json_keysets/ariel_search.json
@@ -1,0 +1,13 @@
+[
+  "answer",
+  "entries",
+  "entries[].author",
+  "entries[].entry_id",
+  "entries[].score",
+  "entries[].timestamp",
+  "entries[].title",
+  "query",
+  "reasoning",
+  "search_modes",
+  "sources"
+]

--- a/tests/cli/data/json_keysets/ariel_status.json
+++ b/tests/cli/data/json_keysets/ariel_status.json
@@ -1,0 +1,19 @@
+[
+  "database",
+  "database.connected",
+  "database.uri",
+  "embedding_tables",
+  "embedding_tables[].active",
+  "embedding_tables[].dimension",
+  "embedding_tables[].entries",
+  "embedding_tables[].table",
+  "enhancement_modules",
+  "enhancement_modules.semantic_processor",
+  "enhancement_modules.text_embedding",
+  "entries",
+  "message",
+  "search_modules",
+  "search_modules.keyword",
+  "search_modules.semantic",
+  "status"
+]

--- a/tests/cli/data/json_keysets/audit.json
+++ b/tests/cli/data/json_keysets/audit.json
@@ -1,0 +1,11 @@
+[
+  "findings",
+  "findings[].category",
+  "findings[].explanation",
+  "findings[].file_path",
+  "findings[].recommendation",
+  "findings[].severity",
+  "findings[].title",
+  "overall_risk",
+  "summary"
+]

--- a/tests/cli/data/json_keysets/health.json
+++ b/tests/cli/data/json_keysets/health.json
@@ -1,0 +1,11 @@
+[
+  "deadline_hit",
+  "elapsed_ms",
+  "errors",
+  "ok",
+  "results",
+  "skips",
+  "summary",
+  "total",
+  "warnings"
+]

--- a/tests/cli/data/json_keysets/query.json
+++ b/tests/cli/data/json_keysets/query.json
@@ -1,0 +1,10 @@
+[
+  "exit_code",
+  "final_text",
+  "mcp_servers",
+  "tool_traces",
+  "tool_traces[].input",
+  "tool_traces[].is_error",
+  "tool_traces[].name",
+  "tool_traces[].result"
+]

--- a/tests/cli/test_altitude_gate.py
+++ b/tests/cli/test_altitude_gate.py
@@ -1,0 +1,250 @@
+"""Tests for the CLI altitude gate.
+
+The gate is a filter on the stderr ``RichHandler``: in a normal ``osprey`` run
+INFO-and-below records are not rendered, WARNING and above are, and ``-v`` lifts
+the gate entirely. Gating happens at rendering, so a dropped record is still
+emitted and still reaches ``caplog`` — that honesty half is pinned here too.
+"""
+
+import logging
+from io import StringIO
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+from rich.logging import RichHandler
+
+from osprey.cli.altitude import _AltitudeGate, gate_installed, install_gate, lift_gate
+from osprey.cli.main import cli
+
+INFO_MARKER = "INFOMARKER"
+WARNING_MARKER = "WARNMARKER"
+
+
+def _root_handler() -> RichHandler:
+    """The stderr RichHandler the CLI gates — the same instance it installs."""
+    handlers = [h for h in logging.getLogger().handlers if isinstance(h, RichHandler)]
+    assert handlers, "the CLI run should have left a RichHandler on the root logger"
+    return handlers[0]
+
+
+def _gate_count(handler: logging.Handler) -> int:
+    return sum(1 for f in handler.filters if isinstance(f, _AltitudeGate))
+
+
+@pytest.fixture
+def run_cli(monkeypatch: pytest.MonkeyPatch):
+    """Invoke the CLI group callback the way a real run does.
+
+    The bare command runs the whole callback (logging, handler console, gate)
+    and then prints help. ``load_project_dotenv`` is stubbed out: it writes an
+    ancestor ``.env`` straight into ``os.environ``, which outlives the test.
+    """
+    monkeypatch.setattr("osprey.utils.config.load_project_dotenv", lambda *a, **k: None)
+    runner = CliRunner()
+
+    def _run(*args: str) -> None:
+        result = runner.invoke(cli, list(args))
+        assert result.exit_code == 0, result.output
+
+    return _run
+
+
+@pytest.fixture
+def rendered() -> StringIO:
+    """Capture what the handler actually paints, after the CLI has configured it."""
+    return StringIO()
+
+
+def _capture_renders(buffer: StringIO) -> RichHandler:
+    """Point the CLI's handler at ``buffer`` without touching its filters."""
+    handler = _root_handler()
+    handler.console = Console(file=buffer, width=200, force_terminal=False)
+    return handler
+
+
+class TestGateFilter:
+    """The filter itself: level-based, nothing else."""
+
+    @pytest.mark.parametrize(
+        ("level", "passes"),
+        [
+            (logging.DEBUG, False),
+            (logging.INFO, False),
+            (logging.WARNING, True),
+            (logging.ERROR, True),
+            (logging.CRITICAL, True),
+        ],
+    )
+    def test_levels(self, level: int, passes: bool):
+        record = logging.LogRecord("osprey.test", level, __file__, 1, "msg", None, None)
+        assert _AltitudeGate().filter(record) is passes
+
+    def test_record_without_intent_attribute_transits(self):
+        """Bare logging and third-party records carry no ``osprey_intent``."""
+        record = logging.LogRecord("httpx", logging.WARNING, __file__, 1, "msg", None, None)
+        assert not hasattr(record, "osprey_intent")
+        assert _AltitudeGate().filter(record) is True
+
+    def test_intent_attribute_does_not_change_the_verdict(self):
+        """The shipped policy reads the level, never the intent marker."""
+        gated = logging.LogRecord("osprey.test", logging.INFO, __file__, 1, "msg", None, None)
+        gated.osprey_intent = "key_info"  # type: ignore[attr-defined]
+        assert _AltitudeGate().filter(gated) is False
+
+
+class TestNormalRun:
+    """A plain ``osprey`` invocation renders a report, not a transcript."""
+
+    def test_gate_is_installed(self, run_cli):
+        run_cli()
+        assert gate_installed(_root_handler()) is True
+
+    def test_info_is_not_rendered(self, run_cli, rendered: StringIO):
+        run_cli()
+        _capture_renders(rendered)
+
+        logging.getLogger("osprey.altitude_probe").info(INFO_MARKER)
+
+        assert INFO_MARKER not in rendered.getvalue()
+
+    def test_warning_and_above_are_rendered(self, run_cli, rendered: StringIO):
+        run_cli()
+        _capture_renders(rendered)
+
+        logger = logging.getLogger("osprey.altitude_probe")
+        logger.warning(WARNING_MARKER)
+        logger.error("ERRORMARKER")
+
+        painted = rendered.getvalue()
+        assert WARNING_MARKER in painted
+        assert "ERRORMARKER" in painted
+
+    def test_bare_logger_records_transit_the_gate(self, run_cli, rendered: StringIO):
+        """Records with no ``osprey_intent`` are gated by level, not dropped."""
+        run_cli()
+        _capture_renders(rendered)
+
+        bare = logging.getLogger("third_party_probe")
+        bare.info(INFO_MARKER)
+        bare.warning(WARNING_MARKER)
+
+        painted = rendered.getvalue()
+        assert INFO_MARKER not in painted
+        assert WARNING_MARKER in painted
+
+    def test_gated_records_still_reach_caplog(self, run_cli, rendered: StringIO, caplog):
+        """Nothing is lost: the gate stops rendering, not emission."""
+        run_cli()
+        _capture_renders(rendered)
+
+        with caplog.at_level(logging.INFO, logger="osprey.altitude_probe"):
+            logging.getLogger("osprey.altitude_probe").info(INFO_MARKER)
+
+        assert gate_installed(_root_handler()) is True
+        assert INFO_MARKER in caplog.text
+        assert INFO_MARKER not in rendered.getvalue()
+
+
+class TestVerboseRun:
+    """``-v`` lifts the gate and restores today's full transcript."""
+
+    def test_no_gate_installed(self, run_cli):
+        run_cli("-v")
+        assert gate_installed(_root_handler()) is False
+        assert _root_handler().filters == []
+
+    def test_info_is_rendered(self, run_cli, rendered: StringIO):
+        run_cli("--verbose")
+        _capture_renders(rendered)
+
+        logging.getLogger("osprey.altitude_probe").info(INFO_MARKER)
+
+        assert INFO_MARKER in rendered.getvalue()
+
+
+class TestSameProcessReinstall:
+    """The handler outlives an invocation; the gate is decided per invocation."""
+
+    def test_verbose_then_plain(self, run_cli):
+        run_cli("-v")
+        assert gate_installed(_root_handler()) is False
+
+        run_cli()
+        handler = _root_handler()
+        assert gate_installed(handler) is True
+        assert _gate_count(handler) == 1
+
+    def test_plain_then_verbose(self, run_cli):
+        run_cli()
+        assert gate_installed(_root_handler()) is True
+
+        run_cli("-v")
+        handler = _root_handler()
+        assert gate_installed(handler) is False
+        assert _gate_count(handler) == 0
+
+    def test_repeated_plain_runs_never_stack_filters(self, run_cli):
+        for _ in range(3):
+            run_cli()
+            handler = _root_handler()
+            assert _gate_count(handler) == 1
+            assert len(handler.filters) == 1
+
+    def test_the_handler_is_the_same_instance_across_invocations(self, run_cli):
+        run_cli()
+        first = _root_handler()
+        run_cli("-v")
+        assert _root_handler() is first
+
+
+class TestPublicSeam:
+    """The API a subcommand's own ``--verbose`` uses (Task 5.6)."""
+
+    def test_lift_gate_defaults_to_the_root_handler(self, run_cli):
+        run_cli()
+        assert gate_installed() is True
+
+        lift_gate()
+
+        assert gate_installed() is False
+
+    def test_install_gate_defaults_to_the_root_handler(self, run_cli):
+        run_cli("-v")
+        assert gate_installed() is False
+
+        install_gate()
+
+        assert gate_installed() is True
+        assert _gate_count(_root_handler()) == 1
+
+    def test_install_gate_is_idempotent(self):
+        handler = logging.NullHandler()
+        for _ in range(3):
+            install_gate(handler)
+        assert _gate_count(handler) == 1
+
+        install_gate(handler, verbose=True)
+        assert handler.filters == []
+
+    def test_lift_gate_leaves_foreign_filters_alone(self):
+        handler = logging.NullHandler()
+        foreign = logging.Filter("some.logger")
+        handler.addFilter(foreign)
+        install_gate(handler)
+
+        lift_gate(handler)
+
+        assert handler.filters == [foreign]
+
+    def test_no_rich_handler_is_a_no_op(self, monkeypatch: pytest.MonkeyPatch):
+        """Non-CLI processes have no RichHandler to gate; nothing raises."""
+        root = logging.getLogger()
+        monkeypatch.setattr(
+            root, "handlers", [h for h in root.handlers if not isinstance(h, RichHandler)]
+        )
+
+        install_gate()
+        lift_gate()
+
+        assert gate_installed() is False

--- a/tests/cli/test_audit_cmd.py
+++ b/tests/cli/test_audit_cmd.py
@@ -273,7 +273,8 @@ class TestBuildFlag:
     def test_build_flag_requires_profile(self, runner, tmp_project):
         result = runner.invoke(self._get_audit_cmd(), [str(tmp_project), "--build"])
         assert result.exit_code == 1
-        assert "requires a .yml/.yaml profile" in result.output
+        # Re-pinned for the renderer's failure shape: summary, cause, remedy.
+        assert "--build needs a .yml or .yaml profile" in result.output
 
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")

--- a/tests/cli/test_audit_display.py
+++ b/tests/cli/test_audit_display.py
@@ -1,0 +1,214 @@
+"""What ``osprey audit`` shows a person, and what it hands a program.
+
+The verb has two audiences and one body. ``--json`` writes the report document
+to stdout and nothing else, which is the seam
+``tests/cli/test_json_keyset_capture.py`` pins the key set of. Everything else
+goes through the CLI renderer: report / note / section lines for prose, and the
+shared factories for the summary panel and the findings table.
+
+The look assertions read the renderable rather than the painted output, because
+a border style is a theme token the console resolves at render time: the object
+is where the factory's choice is observable at all.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from rich import box
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from osprey.cli.audit_cmd import _display_report
+from osprey.cli.audit_prompts import AuditFinding, AuditReport
+from osprey.cli.styles import Styles
+
+
+@pytest.fixture
+def printed():
+    """Every renderable ``audit`` handed to ``output.table``, in order."""
+    recorded: list[object] = []
+    with patch("osprey.cli.output.table", side_effect=recorded.append):
+        yield recorded
+
+
+def _finding(severity: str = "error", **overrides: str) -> AuditFinding:
+    """One finding, with every field filled and any of them replaceable."""
+    fields = {
+        "category": "safety",
+        "severity": severity,
+        "title": "Critical issue",
+        "explanation": "The hook does not check the channel name.",
+        "file_path": "hooks.sh",
+        "recommendation": "Check it before the write.",
+    }
+    fields.update(overrides)
+    return AuditFinding(**fields)  # type: ignore[arg-type]
+
+
+def _report(*findings: AuditFinding, risk: str = "high") -> AuditReport:
+    """A report carrying ``findings``."""
+    return AuditReport(summary="Issues found", overall_risk=risk, findings=list(findings))
+
+
+class TestMachineOutput:
+    """``--json`` owns stdout: one document, nothing beside it."""
+
+    def test_json_output_is_the_document_alone(self, capsys, printed):
+        report = _report(_finding())
+
+        _display_report(report, json_output=True, verbose=False)
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out)["overall_risk"] == "high"
+        assert printed == []
+
+    def test_json_output_prints_no_panel_and_no_table(self, capsys, printed):
+        """The renderer is not reached at all on the machine path."""
+        _display_report(_report(_finding()), json_output=True, verbose=True, cost=0.05, turns=10)
+
+        assert not [r for r in printed if isinstance(r, Panel | Table)]
+
+
+class TestSummaryPanel:
+    """The risk verdict, framed by the shared panel factory."""
+
+    def test_panel_comes_from_the_shared_factory(self, printed):
+        _display_report(_report(), json_output=False, verbose=False)
+
+        panels = [r for r in printed if isinstance(r, Panel)]
+        assert len(panels) == 1
+        assert panels[0].border_style == Styles.BORDER_DIM
+        assert panels[0].box is box.ROUNDED
+        assert panels[0].title == "Audit Summary"
+
+    def test_risk_verdict_carries_the_severity_token(self, printed):
+        """The verdict is a styled ``Text``, not a markup string.
+
+        The renderer prints with markup off, and Rich carries that option into
+        every nested renderable, so a panel body written as ``[error]…[/error]``
+        would show its tags to the operator.
+        """
+        _display_report(_report(risk="high"), json_output=False, verbose=False)
+
+        body = [r for r in printed if isinstance(r, Panel)][0].renderable
+        assert isinstance(body, Text)
+        assert body.plain.startswith("HIGH RISK")
+        assert body.spans[0].style == Styles.ERROR
+
+    @pytest.mark.parametrize(
+        ("risk", "expected"),
+        [("low", Styles.SUCCESS), ("medium", Styles.WARNING), ("high", Styles.ERROR)],
+    )
+    def test_each_risk_level_has_its_own_token(self, risk, expected, printed):
+        _display_report(_report(risk=risk), json_output=False, verbose=False)
+
+        body = [r for r in printed if isinstance(r, Panel)][0].renderable
+        assert body.spans[0].style == expected
+
+
+class TestFindings:
+    """The findings table and the detail block under it."""
+
+    def test_table_comes_from_the_shared_factory(self, printed):
+        _display_report(_report(_finding()), json_output=False, verbose=False)
+
+        tables = [r for r in printed if isinstance(r, Table)]
+        assert len(tables) == 1
+        assert tables[0].border_style == Styles.BORDER_DIM
+        assert tables[0].header_style == Styles.HEADER
+        assert tables[0].box is box.HEAVY_HEAD
+        assert tables[0].show_lines is True
+
+    def test_severity_cells_are_styled_text_not_markup(self, printed):
+        """Same trap as the panel body: a cell of markup would show its tags."""
+        _display_report(
+            _report(_finding("error"), _finding("warning"), _finding("info")),
+            json_output=False,
+            verbose=False,
+        )
+
+        table = [r for r in printed if isinstance(r, Table)][0]
+        cells = list(table.columns[0].cells)
+        assert all(isinstance(cell, Text) for cell in cells)
+        assert [cell.style for cell in cells] == [Styles.ERROR, Styles.WARNING, Styles.INFO]
+        assert [cell.plain for cell in cells] == ["error", "warning", "info"]
+
+    def test_an_unknown_severity_still_lands_in_the_table(self, printed):
+        """A model the reviewer invented a level for still shows its finding."""
+        _display_report(_report(_finding("critical")), json_output=False, verbose=False)
+
+        table = [r for r in printed if isinstance(r, Table)][0]
+        cell = list(table.columns[0].cells)[0]
+        assert cell.plain == "critical"
+
+    def test_detail_block_reads_at_three_altitudes(self, capsys, printed):
+        """Title, then the explanation as a note, then the recommendation."""
+        _display_report(_report(_finding()), json_output=False, verbose=False)
+
+        lines = [line.rstrip() for line in capsys.readouterr().out.splitlines() if line.strip()]
+        assert "Critical issue" in lines
+        assert "  The hook does not check the channel name." in lines
+        assert "  Recommendation   Check it before the write." in lines
+
+    def test_stats_line_counts_every_severity(self, capsys, printed):
+        _display_report(
+            _report(_finding("error"), _finding("warning"), _finding("info")),
+            json_output=False,
+            verbose=False,
+        )
+
+        assert "Findings: 1 errors, 1 warnings, 1 info" in capsys.readouterr().out
+
+
+class TestCleanAudit:
+    """A report with nothing in it still says so."""
+
+    def test_clean_audit_says_so_and_prints_no_table(self, capsys, printed):
+        _display_report(_report(risk="low"), json_output=False, verbose=False)
+
+        assert "No findings" in capsys.readouterr().out
+        assert not [r for r in printed if isinstance(r, Table)]
+
+
+class TestVerboseFooter:
+    """``-v`` adds what the run cost, as a note under the counts."""
+
+    def test_cost_and_turns_print_as_a_note(self, capsys, printed):
+        _display_report(_report(_finding()), json_output=False, verbose=True, cost=0.05, turns=10)
+
+        assert "  Cost: $0.0500 | Turns: 10" in capsys.readouterr().out
+
+    def test_no_footer_without_the_flag(self, capsys, printed):
+        _display_report(_report(_finding()), json_output=False, verbose=False, cost=0.05, turns=10)
+
+        assert "Cost:" not in capsys.readouterr().out
+
+
+class TestVerbTrouble:
+    """What the verb prints when it will not deliver a report."""
+
+    def test_missing_sdk_fails_on_stderr(self, tmp_path):
+        from osprey.cli.audit_cmd import audit
+
+        with patch("osprey.cli.audit_cmd._SDK_AVAILABLE", False):
+            result = CliRunner().invoke(audit, [str(tmp_path)])
+
+        assert result.exit_code == 1
+        # Re-pinned: trouble is stderr's, so the name is no longer in stdout.
+        assert "claude-agent-sdk is not installed" in result.stderr
+        assert "uv add claude-agent-sdk" in result.stderr
+        assert "claude-agent-sdk" not in result.stdout
+
+    def test_build_flag_on_a_directory_fails_on_stderr(self, tmp_path):
+        from osprey.cli.audit_cmd import audit
+
+        with patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True):
+            result = CliRunner().invoke(audit, [str(tmp_path), "--build"])
+
+        assert result.exit_code == 1
+        assert "--build needs a .yml or .yaml profile" in result.stderr

--- a/tests/cli/test_build_conventions.py
+++ b/tests/cli/test_build_conventions.py
@@ -301,7 +301,10 @@ def test_missing_user_directory_is_seeded_in_the_profile(
 ):
     _write(profile_dir / "web-terminal-context" / "alice" / "extra.md")
 
-    with caplog.at_level(logging.INFO):
+    # Renderer migration (disposition row 36): the default view now carries only
+    # the count, as a render sub-step; the list of seeded directories stayed on
+    # the logger and dropped to DEBUG.
+    with caplog.at_level(logging.DEBUG):
         applied = _apply_conventions(profile_dir, project_path, ["alice", "bob"])
 
     assert applied.seeded_users == ["bob"]

--- a/tests/cli/test_build_lifecycle_drain.py
+++ b/tests/cli/test_build_lifecycle_drain.py
@@ -1,0 +1,257 @@
+"""Deterministic shutdown of the streaming lifecycle step's drain thread.
+
+A streamed lifecycle step reads its child's stdout on a daemon thread. A child
+that outlives its step's timeout used to keep that thread printing into
+whatever the CLI drew next; these tests pin that it stops instead -- bounded,
+silent, and without hanging the caller on the pipe it was reading.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+import threading
+import time
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from osprey.cli import build_lifecycle
+from osprey.cli.build_profile_schema import LifecycleStep
+from osprey.cli.phase_reporter import NullReporter, PhaseReporter, install_reporter
+from osprey.errors import BuildProfileError
+
+# Every wait here is a deadline an assertion polls to, never a sleep sized to
+# what the child "should" take.
+_POLL_INTERVAL = 0.02
+_DEADLINE = 5.0
+
+
+class _RecordingReporter(PhaseReporter):
+    """A reporter that keeps the lines it is handed instead of printing them.
+
+    Subclasses :class:`PhaseReporter` because that is the seam the drain thread
+    calls: a bare stand-in would satisfy the calls this test makes and miss the
+    ones the code makes.
+
+    The two output classes are kept apart. A child's streamed lines arrive on
+    ``echo`` (the never-silenced path a verb's own output takes) and the phase
+    record's own lines on ``emit``, so a test that asserts on one of them is
+    never handed the other.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self._lock = threading.Lock()
+        self._lines: list[str] = []
+        self._emitted: list[str] = []
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        with self._lock:
+            self._emitted.append(text)
+
+    def echo(self, text: str) -> None:
+        with self._lock:
+            self._lines.append(text)
+
+    def lines(self) -> list[str]:
+        """The child's lines so far -- safe to read while the thread runs."""
+        with self._lock:
+            return list(self._lines)
+
+    def emitted(self) -> list[str]:
+        """The phase-record lines so far, in order."""
+        with self._lock:
+            return list(self._emitted)
+
+
+@pytest.fixture
+def reporter() -> Iterator[_RecordingReporter]:
+    """Install a recording reporter for the duration of one test."""
+    recording = _RecordingReporter()
+    previous = install_reporter(recording)
+    try:
+        yield recording
+    finally:
+        install_reporter(previous)
+
+
+def _script_cmd(path: Path, body: str) -> str:
+    """Write a child script and return the command that runs it unbuffered."""
+    path.write_text(body)
+    return f"{shlex.quote(sys.executable)} -u {shlex.quote(str(path))}"
+
+
+def _drain_threads() -> list[threading.Thread]:
+    """Every drain thread currently alive, from this step or any other."""
+    return [t for t in threading.enumerate() if t.name == build_lifecycle._DRAIN_THREAD_NAME]
+
+
+def _wait_until(predicate: Callable[[], bool], deadline: float = _DEADLINE) -> bool:
+    """Poll ``predicate`` until it holds or ``deadline`` seconds have passed."""
+    stop_at = time.monotonic() + deadline
+    while time.monotonic() < stop_at:
+        if predicate():
+            return True
+        time.sleep(_POLL_INTERVAL)
+    return predicate()
+
+
+def test_normal_child_emits_every_line_in_order(
+    tmp_path: Path, reporter: _RecordingReporter
+) -> None:
+    """A child that finishes inside its timeout still gets every line through."""
+    run = _script_cmd(
+        tmp_path / "well_behaved.py",
+        "for i in range(1, 4):\n    print(f'line {i}')\n",
+    )
+    steps = [LifecycleStep(name="stream ok", run=run, timeout=30, stream=True)]
+
+    build_lifecycle._run_lifecycle_phase("post_build", steps, tmp_path, tmp_path)
+
+    assert reporter.lines() == ["    line 1", "    line 2", "    line 3"]
+    assert _drain_threads() == []
+
+
+@pytest.mark.parametrize(
+    ("make_reporter", "record_visible"),
+    [
+        pytest.param(lambda: PhaseReporter(color=False), True, id="printing-reporter"),
+        pytest.param(lambda: NullReporter(verbose=True), False, id="verbose-reporter"),
+    ],
+)
+def test_a_streamed_child_is_visible_under_every_reporter(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    make_reporter: Callable[[], PhaseReporter],
+    record_visible: bool,
+) -> None:
+    """``--stream`` shows the child's lines even where the record is silenced.
+
+    ``osprey --verbose build --stream`` installs the reporter that swallows the
+    phase record, and the child's transcript is the one thing that invocation
+    asks hardest for. It rides the echo path for that reason: the record around
+    it goes quiet, the transcript does not.
+    """
+    run = _script_cmd(tmp_path / "chatty.py", "print('from the child')\n")
+    steps = [LifecycleStep(name="stream visible", run=run, timeout=30, stream=True)]
+
+    previous = install_reporter(make_reporter())
+    try:
+        build_lifecycle._run_lifecycle_phase("post_build", steps, tmp_path, tmp_path)
+    finally:
+        install_reporter(previous)
+
+    printed = capsys.readouterr().out
+    assert "    from the child" in printed
+    assert ("Running post_build commands" in printed) is record_visible
+
+
+def test_overrunning_child_is_cut_off_at_its_timeout(
+    tmp_path: Path, reporter: _RecordingReporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A child sleeping past its timeout ends the step; its later line is lost."""
+    monkeypatch.setattr(build_lifecycle, "_EXIT_GRACE_SECONDS", 0.3)
+    run = _script_cmd(
+        tmp_path / "overrunning.py",
+        "import time\nprint('early')\ntime.sleep(30)\nprint('late')\n",
+    )
+    steps = [LifecycleStep(name="stream overrun", run=run, timeout=1, stream=True)]
+
+    started = time.monotonic()
+    with pytest.raises(BuildProfileError, match="stream overrun"):
+        build_lifecycle._run_lifecycle_phase("post_build", steps, tmp_path, tmp_path)
+    elapsed = time.monotonic() - started
+
+    # Bounded by the step's own timeout plus the grace, not the child's sleep.
+    assert elapsed < 5
+    assert reporter.lines() == ["    early"]
+    assert _drain_threads() == []
+
+
+def test_drain_thread_is_silenced_when_a_grandchild_holds_the_pipe(
+    tmp_path: Path, reporter: _RecordingReporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A line written after the step ends is dropped, not emitted.
+
+    The child leaves a grandchild holding the inherited write end, so killing
+    the child does not close the pipe and the drain thread stays blocked in its
+    read. This is the case the stop flag exists for -- and the case where
+    closing the pipe from the caller would hang it on the reader's lock.
+    """
+    monkeypatch.setattr(build_lifecycle, "_EXIT_GRACE_SECONDS", 0.3)
+    monkeypatch.setattr(build_lifecycle, "_DRAIN_SHUTDOWN_SECONDS", 0.3)
+    marker = tmp_path / "grandchild-wrote.txt"
+    grandchild = tmp_path / "grandchild.py"
+    # Sleeps well past the step's own end (timeout + grace, ~1.3s here), so the
+    # line reaches the pipe only once the step has been reported.
+    grandchild.write_text(
+        "import time\n"
+        "time.sleep(3)\n"
+        "print('late from grandchild', flush=True)\n"
+        f"open({str(marker)!r}, 'w').write('done')\n"
+    )
+    run = _script_cmd(
+        tmp_path / "leaves_grandchild.py",
+        "import subprocess, sys, time\n"
+        "print('early')\n"
+        f"subprocess.Popen([sys.executable, '-u', {str(grandchild)!r}])\n"
+        "time.sleep(30)\n",
+    )
+    steps = [LifecycleStep(name="stream leaky", run=run, timeout=1, stream=True)]
+
+    with pytest.raises(BuildProfileError, match="stream leaky"):
+        build_lifecycle._run_lifecycle_phase("post_build", steps, tmp_path, tmp_path)
+
+    during_step = reporter.lines()
+    assert during_step == ["    early"]
+
+    # Wait for proof the grandchild actually put its line in the pipe, then
+    # assert the drain thread read it and passed nothing on.
+    assert _wait_until(marker.exists, deadline=15.0), "grandchild never wrote its line"
+    assert _wait_until(lambda: not _drain_threads()), "drain thread never ended"
+    assert reporter.lines() == during_step
+
+
+def test_stop_drain_returns_promptly_when_the_reader_cannot_be_unblocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shutdown helper never waits on a read it cannot interrupt.
+
+    Closing a pipe under a blocked ``readline`` blocks the caller until that
+    read returns on its own. This pins the guard that keeps the CLI out of it.
+    """
+    monkeypatch.setattr(build_lifecycle, "_DRAIN_SHUTDOWN_SECONDS", 0.2)
+    release = threading.Event()
+    closed: list[bool] = []
+
+    class _StuckPipe:
+        def readline(self) -> str:
+            release.wait(timeout=_DEADLINE)
+            return ""
+
+        def close(self) -> None:
+            closed.append(True)
+
+    stop = threading.Event()
+    pipe = _StuckPipe()
+    reader = threading.Thread(
+        target=build_lifecycle._drain_stdout,
+        args=(pipe, stop),
+        name=build_lifecycle._DRAIN_THREAD_NAME,
+        daemon=True,
+    )
+    reader.start()
+
+    started = time.monotonic()
+    build_lifecycle._stop_drain(reader, stop, pipe)  # type: ignore[arg-type]
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2, "shutdown waited on a read it cannot interrupt"
+    assert stop.is_set()
+    assert closed == [], "closed a pipe the reader is still blocked on"
+
+    release.set()
+    reader.join(timeout=_DEADLINE)
+    assert not reader.is_alive()

--- a/tests/cli/test_build_lifecycle_report.py
+++ b/tests/cli/test_build_lifecycle_report.py
@@ -1,0 +1,261 @@
+"""What a lifecycle step reports, and which class each line belongs to.
+
+A lifecycle phase prints two kinds of line. The header and the line naming a
+streamed step are phase record: they describe the build's progress and go quiet
+with the rest of the record under global ``--verbose``. The pass line, the
+failure, the child's transcript and the test-results table are the step's own
+report -- the answer the operator ran the build to get -- so they print through
+the renderer whichever reporter is installed.
+
+These tests pin that split, the shape of each line, and the fact that the
+messages the module raises did not change with the way it prints them.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from osprey.cli import build_lifecycle
+from osprey.cli.build_profile_schema import LifecycleStep
+from osprey.cli.phase_reporter import NullReporter, PhaseReporter, install_reporter
+from osprey.errors import BuildProfileError
+
+_JUNIT_XML = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="checks" tests="3">
+    <testcase name="reads_config" time="0.5"/>
+    <testcase name="writes_output" time="1.25"><failure message="boom">boom</failure></testcase>
+    <testcase name="needs_hardware" time="0"><skipped/></testcase>
+  </testsuite>
+</testsuites>
+"""
+
+
+class _RecordingReporter(PhaseReporter):
+    """A reporter that keeps its phase-record lines instead of printing them.
+
+    Subclasses :class:`PhaseReporter` so the module meets the seam it actually
+    calls. Only ``emit`` is intercepted: the renderer's own output does not pass
+    through here, and a test reads that off the captured streams instead.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(color=False)
+        self._lock = threading.Lock()
+        self._emitted: list[str] = []
+
+    def emit(self, text: str, style: str | None = None) -> None:
+        with self._lock:
+            self._emitted.append(text)
+
+    def emitted(self) -> list[str]:
+        """The phase-record lines so far, in order."""
+        with self._lock:
+            return list(self._emitted)
+
+
+@pytest.fixture
+def recorder() -> Iterator[_RecordingReporter]:
+    """Install a reporter that records the phase record for one test."""
+    recording = _RecordingReporter()
+    previous = install_reporter(recording)
+    try:
+        yield recording
+    finally:
+        install_reporter(previous)
+
+
+@pytest.fixture
+def verbose_reporter() -> Iterator[None]:
+    """Install the reporter global ``--verbose`` installs, for one test."""
+    previous = install_reporter(NullReporter(verbose=True))
+    try:
+        yield
+    finally:
+        install_reporter(previous)
+
+
+def _echo_step(name: str, text: str = "all good", *, timeout: int = 30) -> LifecycleStep:
+    """A quiet step that prints ``text`` and succeeds."""
+    return LifecycleStep(name=name, run=f"echo {text}", timeout=timeout)
+
+
+def test_the_phase_header_is_phase_record(tmp_path: Path, recorder: _RecordingReporter) -> None:
+    """The header naming the phase goes through the reporter, not the renderer."""
+    build_lifecycle._run_lifecycle_phase("post_build", [], tmp_path, tmp_path)
+
+    assert recorder.emitted() == ["  Running post_build commands..."]
+
+
+def test_a_streamed_step_is_named_on_the_record(
+    tmp_path: Path, recorder: _RecordingReporter
+) -> None:
+    """The line opening a streamed step is record too, and comes after the header."""
+    steps = [LifecycleStep(name="stream me", run="echo hello", timeout=30, stream=True)]
+
+    build_lifecycle._run_lifecycle_phase("validate", steps, tmp_path, tmp_path)
+
+    assert recorder.emitted() == ["  Running validate commands...", "  > stream me"]
+
+
+def test_a_passing_step_reports_through_the_renderer(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The pass line carries the step, its cost and the tail of its output."""
+    build_lifecycle._run_lifecycle_phase(
+        "post_build", [_echo_step("quiet step")], tmp_path, tmp_path
+    )
+
+    printed = capsys.readouterr().out
+    assert re.search(r"  ✓ quiet step \(\d+\.\ds\): all good", printed), printed
+    assert "—" not in printed
+
+
+def test_a_pass_line_survives_the_verbose_reporter(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], verbose_reporter: None
+) -> None:
+    """``osprey -v build`` still gets the step's own result: it is not record."""
+    build_lifecycle._run_lifecycle_phase(
+        "post_build", [_echo_step("quiet step")], tmp_path, tmp_path
+    )
+
+    printed = capsys.readouterr().out
+    assert "✓ quiet step" in printed
+    assert "Running post_build commands" not in printed
+
+
+def test_a_failing_step_fails_on_stderr_and_still_raises(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The failure takes the renderer's shape; the raised message is unchanged."""
+    steps = [LifecycleStep(name="bad step", run="sh -c 'echo the reason; exit 3'", timeout=30)]
+
+    with pytest.raises(BuildProfileError) as raised:
+        build_lifecycle._run_lifecycle_phase("post_build", steps, tmp_path, tmp_path)
+
+    captured = capsys.readouterr()
+    assert re.search(
+        r"✗ Lifecycle post_build step 'bad step' failed \(exit 3, \d+\.\ds\)", captured.err
+    ), captured.err
+    assert "  the reason" in captured.err
+    # The step's own output belongs on the trouble stream with the failure, not
+    # in whatever a caller is piping stdout into.
+    assert "the reason" not in captured.out
+    assert str(raised.value).startswith("Lifecycle post_build step 'bad step' failed (exit 3")
+    assert str(raised.value).endswith(":\nthe reason")
+
+
+def test_a_tolerated_failure_warns_instead(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``validate`` reports a failed step as a warning and carries on."""
+    steps = [
+        LifecycleStep(name="soft step", run="sh -c 'echo the reason; exit 1'", timeout=30),
+        _echo_step("after it"),
+    ]
+
+    build_lifecycle._run_lifecycle_phase(
+        "validate", steps, tmp_path, tmp_path, abort_on_failure=False
+    )
+
+    captured = capsys.readouterr()
+    assert "⚠ Lifecycle validate step 'soft step' failed" in captured.err
+    assert "  the reason" in captured.err
+    assert "✓ after it" in captured.out
+
+
+def test_a_timed_out_step_reports_its_last_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A timeout names itself, then the tail of what the step managed to say."""
+    steps = [
+        LifecycleStep(name="slow step", run="sh -c 'echo nearly there; sleep 30'", timeout=1),
+    ]
+
+    with pytest.raises(BuildProfileError) as raised:
+        build_lifecycle._run_lifecycle_phase("post_build", steps, tmp_path, tmp_path)
+
+    captured = capsys.readouterr()
+    assert "✗ Lifecycle post_build step 'slow step' timed out" in captured.err
+    assert "  Last output:" in captured.err
+    assert "  nearly there" in captured.err
+    assert "\n  Last output:\nnearly there" in str(raised.value)
+
+
+def test_a_step_that_cannot_start_reports_the_reason(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A command that is not there fails with the OS error as its cause."""
+    steps = [LifecycleStep(name="missing tool", run="osprey-no-such-command", timeout=30)]
+
+    with pytest.raises(BuildProfileError) as raised:
+        build_lifecycle._run_lifecycle_phase("post_build", steps, tmp_path, tmp_path)
+
+    captured = capsys.readouterr()
+    assert "✗ Lifecycle post_build step 'missing tool' failed to start" in captured.err
+    assert "No such file or directory" in captured.err
+    assert str(raised.value).startswith(
+        "Lifecycle post_build step 'missing tool' failed to start: "
+    )
+
+
+def test_the_test_results_table_prints_through_the_renderer(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A step that left JUnit results gets them summarised under its pass line."""
+    (tmp_path / "check_results.xml").write_text(_JUNIT_XML)
+
+    build_lifecycle._run_lifecycle_phase("post_build", [_echo_step("checks")], tmp_path, tmp_path)
+
+    printed = capsys.readouterr().out
+    assert "Integration Test Results" in printed
+    for cell in ("reads_config", "writes_output", "needs_hardware", "0.50s", "1.25s", "skip"):
+        assert cell in printed, printed
+    # Statuses are pre-styled text, so no markup tag reaches the operator.
+    assert "[red]" not in printed
+    assert "[green]" not in printed
+
+
+def test_the_test_results_table_survives_the_verbose_reporter(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], verbose_reporter: None
+) -> None:
+    """The table is the step's report, so ``--verbose`` does not swallow it."""
+    (tmp_path / "check_results.xml").write_text(_JUNIT_XML)
+
+    build_lifecycle._run_lifecycle_phase("post_build", [_echo_step("checks")], tmp_path, tmp_path)
+
+    assert "Integration Test Results" in capsys.readouterr().out
+
+
+def test_results_that_are_absent_or_unreadable_print_nothing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Most steps leave no test results, and a half-written file is not an error."""
+    build_lifecycle._format_junit_summary(tmp_path / "check_results.xml")
+    (tmp_path / "check_results.xml").write_text("<testsuites>")
+    build_lifecycle._format_junit_summary(tmp_path / "check_results.xml")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_the_module_owns_no_console_of_its_own() -> None:
+    """Every line here goes through the reporter or the renderer, nothing else."""
+    source = Path(build_lifecycle.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    direct = [
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"Console", "print"}
+    ]
+
+    assert direct == []
+    assert "click.echo" not in source

--- a/tests/cli/test_build_output_quiet.py
+++ b/tests/cli/test_build_output_quiet.py
@@ -139,34 +139,26 @@ class TestLoggerDemotions:
             f"{DEMOTED_NEEDLES[needle]} vanished entirely; demotion must keep it at DEBUG"
         )
 
-    def test_logger_keeps_the_builds_one_success_line_at_info(
-        self, build_records: _Capture
-    ) -> None:
-        """The sweep is a demotion, not a blanket silencing.
+    # The logger's own ``✓ Rendered <build_dir>`` success line used to be pinned
+    # here. Disposition row 28 retires it: the closing summary card is the
+    # verb's "it worked, here is what now" surface, and it says so by name.
+    # ``tests/cli/test_lifecycle_promotions.py`` holds the replacement — that
+    # the line is gone from INFO, and that the card header carries the name.
 
-        A build that says nothing at all on success would pass every assertion
-        above while being strictly worse than the noise it replaced.
-        """
-        assert any(
-            m.startswith("✓ Rendered") for m in build_records.messages(at_least=logging.INFO)
-        ), f"no success line survived: {build_records.messages(at_least=logging.INFO)}"
-
-    def test_logger_spells_the_build_path_out_only_in_that_success_line(
-        self, build_records: _Capture
-    ) -> None:
-        """One absolute path in the whole default view, and it is the useful one.
+    def test_logger_spells_no_build_path_at_info_at_all(self, build_records: _Capture) -> None:
+        """Not one absolute path left in the default view.
 
         Every demoted line above named the tree it had just written to, so a
-        build spelled its own output path out once per render and each one wrapped
-        across a normal terminal. Where the build landed is worth saying — once,
-        at the end. Asserted as equality rather than as a count so a *different*
-        line reacquiring a path cannot pass by replacing this one.
+        build spelled its own output path out once per render and each one
+        wrapped across a normal terminal. The last one to survive was the
+        success line, and row 28 retires that too: the card names the build,
+        and a path nobody has to retype does not belong on screen at all.
         """
         assert build_records.repo is not None
         carrying = [
             m for m in build_records.messages(at_least=logging.INFO) if str(build_records.repo) in m
         ]
-        assert carrying == [f"✓ Rendered {build_records.repo / 'build'}"]
+        assert not carrying, f"the build path is still at INFO: {carrying}"
 
     def test_reporter_names_the_injected_services_once(self, build_records: _Capture) -> None:
         """The injector highlights survive the demotion, as one step line.

--- a/tests/cli/test_channel_finder_logging.py
+++ b/tests/cli/test_channel_finder_logging.py
@@ -1,0 +1,220 @@
+"""What a channel-finder run does to logging, and what it must no longer do.
+
+The group used to run its own altitude policy: ``_initialize_registry`` pinned
+the ``osprey`` and ``channel_finder`` loggers to WARNING, so a non-verbose run
+never *emitted* an INFO record at all. The CLI's altitude gate
+(``osprey.cli.altitude``) now owns that policy for every command, and it is a
+handler filter — a record it drops is still emitted and still observable.
+
+The difference is the point of this module: what the terminal shows is
+unchanged, but nothing is destroyed on the way there any more.
+"""
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.altitude import gate_installed
+from osprey.cli.main import cli
+from tests.cli.conftest import TerminalProbe
+
+# The two loggers the group used to pin. Both are framework loggers, so a pin on
+# either silences call sites far outside this command group.
+PINNED_LOGGERS = ("osprey", "channel_finder")
+
+INFO_MARKER = "CHANNELFINDERINFOMARKER"
+WARNING_MARKER = "CHANNELFINDERWARNMARKER"
+
+
+@pytest.fixture
+def unpinned_loggers() -> Iterator[None]:
+    """Start from NOTSET on both loggers, and hand back whatever was there.
+
+    Levels are process-global and a pin left by some other module would fail
+    these tests for a reason they are not about. Resetting first makes the
+    assertion the exact claim: *this run* set no level. Under the old code the
+    same test fails, because ``_initialize_registry`` pinned both to WARNING.
+    """
+    loggers = [logging.getLogger(name) for name in PINNED_LOGGERS]
+    saved = [logger.level for logger in loggers]
+    for logger in loggers:
+        logger.setLevel(logging.NOTSET)
+    try:
+        yield
+    finally:
+        for logger, level in zip(loggers, saved, strict=True):
+            logger.setLevel(level)
+
+
+@pytest.fixture
+def stub_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let the real ``_initialize_registry`` run without building a registry.
+
+    Patching ``_initialize_registry`` itself — what the other channel-finder
+    suites do — would make every claim here vacuous: the deleted pins lived
+    inside it. Only the registry build underneath is stubbed.
+    """
+    monkeypatch.setattr("osprey.registry.initialize_registry", lambda *a, **k: None)
+
+
+@pytest.fixture
+def in_context_database(tmp_path: Path) -> str:
+    """A minimal in-context database ``validate`` can actually load."""
+    db_file = tmp_path / "channel_db.json"
+    db_file.write_text(
+        '{"channels": [{"template": false, "channel": "CH1", '
+        '"address": "PV:CH1", "description": "Test channel"}]}',
+        encoding="utf-8",
+    )
+    return str(db_file)
+
+
+@pytest.fixture
+def run_validate(monkeypatch: pytest.MonkeyPatch, in_context_database: str):
+    """Invoke ``osprey channel-finder validate`` through the real CLI group.
+
+    Through ``cli``, not the ``channel_finder`` group directly: the group
+    callback is what installs the altitude gate, so anything asserted about
+    rendering has to go the whole way round. ``load_project_dotenv`` is stubbed
+    — it writes an ancestor ``.env`` straight into ``os.environ``, outliving the
+    test — and ``_setup_config`` is stubbed so the run needs no built project.
+    """
+    monkeypatch.setattr("osprey.utils.config.load_project_dotenv", lambda *a, **k: None)
+    monkeypatch.setattr("osprey.cli.channel_finder_cmd._setup_config", lambda *a, **k: None)
+    runner = CliRunner()
+
+    def _run(*args: str):
+        return runner.invoke(
+            cli,
+            [
+                "channel-finder",
+                "validate",
+                "--database",
+                in_context_database,
+                "--pipeline",
+                "in_context",
+                *args,
+            ],
+        )
+
+    return _run
+
+
+class TestNoPrivateLevelPins:
+    """Neither the registry init nor a whole command sets a logger level."""
+
+    def test_registry_init_pins_nothing(self, unpinned_loggers, stub_registry):
+        from osprey.cli.channel_finder_cmd import _initialize_registry
+
+        _initialize_registry()
+
+        assert [logging.getLogger(n).level for n in PINNED_LOGGERS] == [
+            logging.NOTSET,
+            logging.NOTSET,
+        ]
+
+    def test_a_command_run_pins_nothing(self, unpinned_loggers, stub_registry, run_validate):
+        result = run_validate()
+
+        # The command reached its own work — otherwise it could pin nothing for
+        # an uninteresting reason.
+        assert "VALID" in result.output
+        assert [logging.getLogger(n).level for n in PINNED_LOGGERS] == [
+            logging.NOTSET,
+            logging.NOTSET,
+        ]
+
+    def test_the_loggers_inherit_the_run_level(self, unpinned_loggers, stub_registry, run_validate):
+        """NOTSET is not merely "unset": it is the run's level, inherited."""
+        run_validate()
+
+        assert logging.getLogger("channel_finder").getEffectiveLevel() == logging.INFO
+        assert logging.getLogger("osprey").getEffectiveLevel() == logging.INFO
+
+    def test_the_module_configures_no_logging_of_its_own(self):
+        """``basicConfig`` is gone — the CLI entry point owns that call.
+
+        It was dead where it stood: the group callback runs
+        ``configure_logging`` before any subcommand body, so the root logger
+        always has a handler by then and ``basicConfig`` returns without
+        touching level or handlers.
+        """
+        import osprey.cli.channel_finder_cmd as module
+
+        source = Path(module.__file__).read_text(encoding="utf-8")
+
+        assert "basicConfig" not in source
+        assert "setLevel(logging.WARNING)" not in source
+
+
+class TestGatePolicyStillHolds:
+    """What the operator sees is unchanged; what survives underneath is not."""
+
+    @pytest.fixture
+    def noisy_validation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Make ``validate``'s own work log one INFO and one WARNING record.
+
+        Emitted from inside the running command, on the group's own logger, so
+        the gate is asked the question in situ rather than after the fact.
+        """
+
+        def _run_validation(**kwargs) -> int:
+            logger = logging.getLogger("channel_finder.validate")
+            logger.info(INFO_MARKER)
+            logger.warning(WARNING_MARKER)
+            return 0
+
+        monkeypatch.setattr(
+            "osprey.services.channel_finder.tools.validate_database.run_validation",
+            _run_validation,
+        )
+
+    def test_warning_still_renders(
+        self,
+        unpinned_loggers,
+        stub_registry,
+        noisy_validation,
+        run_validate,
+        terminal_probe: TerminalProbe,
+    ):
+        run_validate()
+
+        assert gate_installed() is True
+        assert WARNING_MARKER in terminal_probe.rendered_text
+
+    def test_info_does_not_render_but_is_still_emitted(
+        self,
+        unpinned_loggers,
+        stub_registry,
+        noisy_validation,
+        run_validate,
+        terminal_probe: TerminalProbe,
+    ):
+        """The honest form of the claim: gated from the terminal, not destroyed.
+
+        The WARNING is the armed witness — against a console nothing reaches,
+        the absence assertion would pass for the wrong reason. And the record
+        half is what the old pins made impossible: at WARNING on the
+        ``channel_finder`` logger, this INFO was never emitted at all.
+        """
+        run_validate()
+
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER not in terminal_probe.rendered_text
+        assert INFO_MARKER in terminal_probe.messages
+
+    def test_the_gated_record_keeps_its_level_and_name(
+        self,
+        unpinned_loggers,
+        stub_registry,
+        noisy_validation,
+        run_validate,
+        terminal_probe: TerminalProbe,
+    ):
+        run_validate()
+
+        gated = [r for r in terminal_probe.records if r.getMessage() == INFO_MARKER]
+        assert [(r.levelno, r.name) for r in gated] == [(logging.INFO, "channel_finder.validate")]

--- a/tests/cli/test_chat_gate_switch.py
+++ b/tests/cli/test_chat_gate_switch.py
@@ -1,0 +1,278 @@
+"""``osprey chat``'s one switch: OSPREY's output policy stands down for the REPL.
+
+The verb ends by handing the terminal to another program. Everything OSPREY has
+to say about how output should look — the altitude gate on the log handler, the
+phase reporter's decoration — applies to OSPREY's own report and not to a
+full-screen agent session, so a single call turns both off immediately before the
+handoff.
+
+What that call replaced was a root-logger pin to CRITICAL. The pin silenced the
+process rather than the painting: records were never emitted, so a warning worth
+having was gone rather than merely unpainted, and the companion-server failure
+path had to print by hand to get around it. These tests pin the switch's three
+observable effects and the absence of that pin.
+
+Every test stops at the handoff boundary. ``subprocess.run`` is replaced by a
+recorder that reads the logging and reporter state at the exact moment the agent
+would have started, which is the only moment the assertions are about.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.altitude import gate_installed, install_gate
+from osprey.cli.chat_cmd import (
+    _launch_companion_servers,
+    _stand_down_output_policy,
+    chat,
+)
+from osprey.cli.phase_reporter import LiveReporter, NullReporter, current_reporter, install_reporter
+from osprey.utils.logger import configure_logging
+from tests.cli._lifecycle_build import stub_build
+from tests.cli._scoped_subprocess import patch_subprocess
+
+
+@dataclass
+class Handoff:
+    """The output-policy state read at the moment the agent CLI starts."""
+
+    gate_installed: bool
+    root_level: int
+    reporter: object
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _restore_process_state():
+    """Undo what an in-process launch does to the interpreter's globals.
+
+    ``chat`` chdirs into ``build/``, overlays the deployment's ``.env`` onto
+    ``os.environ``, and installs a reporter — all deliberate, all process-global,
+    and all able to reach every test that runs after this one in the same worker.
+    """
+    cwd = Path.cwd()
+    environ = dict(os.environ)
+    reporter = current_reporter()
+    yield
+    install_reporter(reporter)
+    os.chdir(cwd)
+    os.environ.clear()
+    os.environ.update(environ)
+
+
+@pytest.fixture(autouse=True)
+def _no_managed_policy(monkeypatch: pytest.MonkeyPatch):
+    """Pin the managed-policy scan to "no conflicts".
+
+    It reads OS-standard policy files, so on a machine that has one every launch
+    here would refuse for a reason none of these tests is about.
+    """
+    monkeypatch.setattr(
+        "osprey.build.claude_code_resolver.detect_managed_policy_conflicts",
+        lambda paths=None: {},
+    )
+
+
+@pytest.fixture
+def gated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Put the CLI's normal starting state on the root logger.
+
+    ``runner.invoke(chat, ...)`` reaches the subcommand without passing through
+    the group callback that configures logging and installs the gate, so a test
+    that wants to watch the gate come off has to put it on first. The root
+    conftest's ``restore_root_logging`` takes both back off afterwards.
+
+    A live reporter goes with it: the default reporter is already the quiet one,
+    so a switch asserted against that default would pass while doing nothing.
+    """
+    monkeypatch.setattr("osprey.utils.config.load_project_dotenv", lambda *a, **k: None)
+    configure_logging()
+    install_gate()
+    assert gate_installed(), "the fixture failed to install the gate it is about to watch"
+    install_reporter(LiveReporter())
+
+
+@pytest.fixture
+def handoff(monkeypatch: pytest.MonkeyPatch) -> list[Handoff]:
+    """Record the output-policy state instead of starting an agent."""
+    recorded: list[Handoff] = []
+
+    def fake_run(argv, *args, **kwargs):
+        recorded.append(
+            Handoff(
+                gate_installed=gate_installed(),
+                root_level=logging.getLogger().level,
+                reporter=current_reporter(),
+            )
+        )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("osprey.cli.chat_cmd._launch_companion_servers", lambda project_dir: [])
+    with patch_subprocess("osprey.cli.chat_cmd", side_effect=fake_run):
+        yield recorded
+
+
+class TestTheSwitchItself:
+    """Called directly, with no verb around it."""
+
+    def test_it_lifts_the_gate(self, gated: None) -> None:
+        _stand_down_output_policy()
+        assert gate_installed() is False
+
+    def test_it_installs_the_quiet_reporter(self, gated: None) -> None:
+        _stand_down_output_policy()
+        reporter = current_reporter()
+        assert isinstance(reporter, NullReporter)
+        assert reporter.verbose is False
+
+    def test_it_touches_no_logger_level(self, gated: None) -> None:
+        """Standing down is about painting, not about what is emitted."""
+        before = logging.getLogger().level
+        _stand_down_output_policy()
+        assert logging.getLogger().level == before
+        assert logging.getLogger().level != logging.CRITICAL
+
+    def test_it_is_safe_without_a_handler_to_lift_from(self) -> None:
+        """A library caller may have configured no Rich handler at all."""
+        for handler in list(logging.getLogger().handlers):
+            logging.getLogger().removeHandler(handler)
+        _stand_down_output_policy()
+        assert gate_installed() is False
+
+
+class TestAtTheHandoff:
+    """The state the agent process is actually started in."""
+
+    def test_the_gate_is_lifted_before_the_agent_starts(
+        self, runner: CliRunner, gated: None, handoff: list[Handoff], lifecycle_repo: Path
+    ) -> None:
+        stub_build(lifecycle_repo)
+
+        result = runner.invoke(chat, ["--repo", str(lifecycle_repo)])
+
+        assert result.exit_code == 0
+        assert len(handoff) == 1
+        assert handoff[0].gate_installed is False
+
+    def test_the_root_logger_is_not_pinned_to_critical(
+        self, runner: CliRunner, gated: None, handoff: list[Handoff], lifecycle_repo: Path
+    ) -> None:
+        """The hack this replaced set the root logger to CRITICAL right here."""
+        stub_build(lifecycle_repo)
+        before = logging.getLogger().level
+
+        result = runner.invoke(chat, ["--repo", str(lifecycle_repo)])
+
+        assert result.exit_code == 0
+        assert handoff[0].root_level != logging.CRITICAL
+        assert handoff[0].root_level == before
+
+    def test_the_reporter_is_the_quiet_one(
+        self, runner: CliRunner, gated: None, handoff: list[Handoff], lifecycle_repo: Path
+    ) -> None:
+        stub_build(lifecycle_repo)
+
+        result = runner.invoke(chat, ["--repo", str(lifecycle_repo)])
+
+        assert result.exit_code == 0
+        assert isinstance(handoff[0].reporter, NullReporter)
+
+
+class TestCompanionServers:
+    """The function the deleted pin lived in."""
+
+    def test_launching_them_leaves_every_logger_level_alone(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No level is pinned, so a warning from a daemon thread survives.
+
+        Silencing by level was the wrong instrument twice over: it dropped the
+        records instead of not painting them, and it swallowed exactly the
+        warnings the launch path exists to report.
+
+        Every server is offered its chance and declines to have started, which
+        is what keeps this a test of the logging levels and not of the servers.
+        The stubs go on ``server_launcher``'s own names rather than on
+        ``registry.web.FRAMEWORK_WEB_SERVERS``: that registry is read at IMPORT
+        time to build ``_launchers`` and the auto-launch checkers, so emptying
+        it around the first import of ``server_launcher`` in a worker builds
+        those tables empty and leaves them that way for every test afterwards.
+        """
+        from osprey.infrastructure import server_launcher
+
+        monkeypatch.setattr(server_launcher, "ensure_web_server", lambda key: None)
+        monkeypatch.setattr(
+            server_launcher,
+            "_launchers",
+            defaultdict(lambda: SimpleNamespace(_launched=False)),
+        )
+        root = logging.getLogger()
+        before = root.level
+
+        assert _launch_companion_servers(tmp_path) == []
+
+        assert root.level == before
+        assert root.level != logging.CRITICAL
+
+
+class TestAgentTextPassesThrough:
+    """FR1: what the agent writes is not OSPREY's to shape."""
+
+    def test_the_agent_stream_is_never_captured(
+        self, runner: CliRunner, lifecycle_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No pipe, no capture: the child inherits the terminal's own streams.
+
+        This is the whole mechanism behind "streams exactly as written" — a
+        ``stdout=PIPE`` here would put OSPREY between the agent and the reader,
+        and every guarantee about the text would then depend on what OSPREY did
+        with it next.
+        """
+        stub_build(lifecycle_repo)
+        monkeypatch.setattr("osprey.cli.chat_cmd._launch_companion_servers", lambda p: [])
+
+        with patch_subprocess("osprey.cli.chat_cmd") as fake:
+            fake.run.return_value = SimpleNamespace(returncode=0)
+            result = runner.invoke(chat, ["--repo", str(lifecycle_repo)])
+
+        assert result.exit_code == 0
+        assert fake.run.call_args.kwargs == {}
+        assert len(fake.run.call_args.args) == 1
+
+    def test_agent_text_reaches_the_reader_unchanged(
+        self, runner: CliRunner, gated: None, lifecycle_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Byte-for-byte, including what the renderer would have eaten.
+
+        The line carries a Rich markup tag, a box-drawing character and trailing
+        spaces: markup would be interpreted, a themed console would restyle it,
+        and soft-wrapping or a `.strip()` anywhere on the path would lose the
+        tail. The recorder writes it the way the agent process would.
+        """
+        agent_line = "[bold]literal[/bold] │ 100%   "
+        stub_build(lifecycle_repo)
+        monkeypatch.setattr("osprey.cli.chat_cmd._launch_companion_servers", lambda p: [])
+
+        def fake_run(argv, *args, **kwargs):
+            sys.stdout.write(agent_line + "\n")
+            return SimpleNamespace(returncode=0)
+
+        with patch_subprocess("osprey.cli.chat_cmd", side_effect=fake_run):
+            result = runner.invoke(chat, ["--repo", str(lifecycle_repo)])
+
+        assert result.exit_code == 0
+        assert agent_line + "\n" in result.stdout

--- a/tests/cli/test_config_view_render.py
+++ b/tests/cli/test_config_view_render.py
@@ -1,0 +1,149 @@
+"""How ``osprey config`` puts a configuration on screen, and into a file.
+
+The verb has one body and two audiences, and the split is the terminal check in
+``_emit``. An interactive reader gets a header, the file's location and syntax
+colouring, all of it through the CLI renderer. A pipe gets the file's BYTES:
+``osprey config > deployment.yml`` has to write the configuration it just
+showed, so that branch stays on :func:`click.echo` rather than going through
+Rich, which expands tabs and can pad a line out to the console width.
+
+Both halves are pinned here because only one of them is reachable from a
+``CliRunner``: the runner is never a terminal, so every other config test in the
+suite exercises the byte path and none of them exercise the rendered one.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+from rich.syntax import Syntax
+from rich.text import Text
+
+from osprey.cli import config_cmd, phase_reporter, styles
+
+#: A configuration with the two things Rich would not leave alone: a tab inside
+#: a quoted scalar, and a line long enough that an 80-column console would wrap
+#: it. Both are legal YAML and both must survive the pipe untouched.
+_LONG_VALUE = "x" * 120
+AWKWARD_YAML = f'# what the facility wrote\ngreeting: "a\tb"\nnote: {_LONG_VALUE}\nport: 8080\n'
+
+
+@pytest.fixture
+def terminal(monkeypatch: pytest.MonkeyPatch) -> StringIO:
+    """Make the CLI's console a terminal, painting into a buffer.
+
+    Two names, one console. ``config_cmd`` asks ``styles.console`` whether it is
+    talking to a terminal, and the renderer prints through the reporter's, which
+    ``phase_reporter`` bound from ``styles`` at import; patching only one of them
+    would pin a path the CLI never takes.
+
+    Returns:
+        The buffer the console paints into, escape sequences and all.
+    """
+    buffer = StringIO()
+    console = Console(
+        file=buffer,
+        force_terminal=True,
+        width=100,
+        theme=styles.osprey_theme,
+        legacy_windows=False,
+    )
+    monkeypatch.setattr(styles, "console", console)
+    monkeypatch.setattr(phase_reporter, "console", console)
+    return buffer
+
+
+def _plain(buffer: StringIO) -> str:
+    """What the buffer shows, with its escape sequences removed."""
+    return Text.from_ansi(buffer.getvalue()).plain
+
+
+class TestThePipeGetsTheFile:
+    """Off a terminal the verb writes bytes, not copy."""
+
+    def test_the_text_goes_out_unchanged(self, capsys):
+        config_cmd._emit(AWKWARD_YAML, label="Source profile", source=Path("/etc/profile.yml"))
+
+        # click.echo supplies the one trailing newline, as it always has.
+        assert capsys.readouterr().out == AWKWARD_YAML + "\n"
+
+    def test_the_tab_survives(self, capsys):
+        """The reason this branch is not the renderer's: Rich expands tabs."""
+        config_cmd._emit(AWKWARD_YAML, label="Source profile", source=None)
+
+        assert '"a\tb"' in capsys.readouterr().out
+
+    def test_the_long_line_is_not_wrapped(self, capsys):
+        config_cmd._emit(AWKWARD_YAML, label="Source profile", source=None)
+
+        assert f"note: {_LONG_VALUE}" in capsys.readouterr().out
+
+    def test_no_header_and_no_location(self, capsys):
+        """A header in the file would make the file invalid."""
+        config_cmd._emit(AWKWARD_YAML, label="Source profile", source=Path("/etc/profile.yml"))
+
+        out = capsys.readouterr().out
+        assert "Source profile" not in out
+        assert "/etc/profile.yml" not in out
+
+
+class TestTheTerminalGetsTheView:
+    """On a terminal the verb prints through the renderer."""
+
+    def test_label_and_location_and_content_all_appear(self, terminal):
+        config_cmd._emit("port: 8080\n", label="Source profile", source=Path("/etc/profile.yml"))
+
+        rendered = _plain(terminal)
+        assert "Source profile" in rendered
+        assert "/etc/profile.yml" in rendered
+        assert "port: 8080" in rendered
+
+    def test_the_location_is_subordinate_to_the_label(self, terminal):
+        """It answers "where", which is detail under the view's name."""
+        config_cmd._emit("port: 8080\n", label="Source profile", source=Path("/etc/profile.yml"))
+
+        lines = [line.rstrip() for line in _plain(terminal).splitlines()]
+        assert "Source profile" in lines
+        assert "  /etc/profile.yml" in lines
+
+    def test_the_defaults_view_shows_no_location(self, terminal):
+        """The framework template is not a file in the operator's deployment."""
+        config_cmd._emit("port: 8080\n", label="Framework default configuration", source=None)
+
+        rendered = _plain(terminal)
+        assert "Framework default configuration" in rendered
+        assert "port: 8080" in rendered
+
+    def test_the_content_is_painted(self, terminal):
+        """Syntax colouring is half of why the interactive view exists."""
+        config_cmd._emit("port: 8080\n", label="Source profile", source=None)
+
+        assert "\x1b[" in terminal.getvalue()
+
+
+class TestTheCodeBlockGoesThroughTheRenderer:
+    """The YAML block is a built renderable, printed by the one primitive."""
+
+    def test_the_syntax_block_is_handed_to_output_table(self, terminal):
+        recorded: list[object] = []
+        with patch("osprey.cli.output.table", side_effect=recorded.append):
+            config_cmd._emit(AWKWARD_YAML, label="Source profile", source=None)
+
+        assert len(recorded) == 1
+        block = recorded[0]
+        assert isinstance(block, Syntax)
+        assert "yaml" in block.lexer.name.lower()
+        assert block.code == AWKWARD_YAML
+        assert block.word_wrap is True
+
+    def test_the_pipe_reaches_the_renderer_not_at_all(self):
+        """Off a terminal there is no renderable, and no renderer call."""
+        recorded: list[object] = []
+        with patch("osprey.cli.output.table", side_effect=recorded.append):
+            config_cmd._emit(AWKWARD_YAML, label="Source profile", source=None)
+
+        assert recorded == []

--- a/tests/cli/test_deploy_handoff.py
+++ b/tests/cli/test_deploy_handoff.py
@@ -51,7 +51,7 @@ def restore_installed_reporter():
 class SeamRecorder(PhaseReporter):
     """A reporter that IS rendering, recording every seam call in order.
 
-    ``_is_rendering`` is what decides whether ``suspended()`` has anything to
+    ``is_rendering`` is what decides whether ``suspended()`` has anything to
     do, so claiming it here is what makes the real seam act — the block is
     exercised, not stubbed out.
     """
@@ -63,7 +63,7 @@ class SeamRecorder(PhaseReporter):
     def emit(self, text: str, style: str | None = None) -> None:
         """Swallow the line: only the seam calls are being counted."""
 
-    def _is_rendering(self) -> bool:
+    def is_rendering(self) -> bool:
         return True
 
     def stop_rendering(self) -> None:
@@ -177,7 +177,7 @@ def test_the_prompt_path_is_a_no_op_with_nothing_rendering(offered, monkeypatch,
     here, nothing at all.
     """
     reporter = SeamRecorder()
-    monkeypatch.setattr(SeamRecorder, "_is_rendering", lambda self: False)
+    monkeypatch.setattr(SeamRecorder, "is_rendering", lambda self: False)
     install_reporter(reporter)
     _answer(monkeypatch, reporter)
     repo = _repo(tmp_path)

--- a/tests/cli/test_discovery_rewire.py
+++ b/tests/cli/test_discovery_rewire.py
@@ -432,7 +432,7 @@ class TestQueryResolvesTheRepo:
         result = run_query_cmd(runner, ["anything"], nested(lifecycle_repo))
 
         assert result.exit_code == 2
-        assert "no build found" in result.output
+        assert "No build found" in result.output
         assert "osprey build" in result.output
         assert query_call.project_dir is None
 
@@ -455,7 +455,12 @@ class TestQueryResolvesTheRepo:
 
 
 class TestQueryWarnsOnDrift:
-    """The warning chat gives, given here too — and never in place of an answer."""
+    """The warning chat gives, given here too — and never in place of an answer.
+
+    The needle is the renderer's warning glyph rather than a "WARNING:" prefix:
+    every warning the CLI prints now opens with that mark and nothing else does,
+    so it is what tells a warning apart from the answer around it.
+    """
 
     def test_profile_drift_warns_and_still_answers(self, runner, lifecycle_repo, query_call):
         build = stub_build(lifecycle_repo, stamped_hash="a-build-the-profile-moved-on-from")
@@ -463,7 +468,7 @@ class TestQueryWarnsOnDrift:
         result = run_query_cmd(runner, ["anything"], nested(lifecycle_repo))
 
         assert result.exit_code == 0, result.output
-        assert "WARNING" in result.output
+        assert "⚠" in result.output
         assert query_call.project_dir == build
 
     def test_unverifiable_build_warns_and_still_answers(self, runner, lifecycle_repo, query_call):
@@ -472,7 +477,7 @@ class TestQueryWarnsOnDrift:
         result = run_query_cmd(runner, ["anything"], nested(lifecycle_repo))
 
         assert result.exit_code == 0, result.output
-        assert "WARNING" in result.output
+        assert "⚠" in result.output
 
     def test_version_skew_warns_independently(self, runner, lifecycle_repo, query_call):
         """A build can be a faithful render and still predate the framework."""
@@ -481,7 +486,7 @@ class TestQueryWarnsOnDrift:
         result = run_query_cmd(runner, ["anything"], nested(lifecycle_repo))
 
         assert result.exit_code == 0, result.output
-        assert "WARNING" in result.output
+        assert "⚠" in result.output
 
     def test_a_clean_build_says_nothing(self, runner, lifecycle_repo, query_call):
         stub_build(lifecycle_repo)
@@ -489,7 +494,7 @@ class TestQueryWarnsOnDrift:
         result = run_query_cmd(runner, ["anything"], nested(lifecycle_repo))
 
         assert result.exit_code == 0, result.output
-        assert "WARNING" not in result.output
+        assert "⚠" not in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -534,7 +539,7 @@ class TestSimResolvesTheRepo:
         result = run_sim(runner, ["list"], nested(lifecycle_repo))
 
         assert result.exit_code == 1
-        assert "no build found" in result.output
+        assert "No build found" in result.output
 
     def test_apply_writes_state_under_var_not_into_the_render(self, runner, lifecycle_repo):
         """The scenario an operator activates has to survive the next build.

--- a/tests/cli/test_eject_cmd.py
+++ b/tests/cli/test_eject_cmd.py
@@ -21,7 +21,7 @@ class TestEjectList:
         """Test that eject list shows available components."""
         result = runner.invoke(eject, ["list"])
         assert result.exit_code == 0
-        assert "Services:" in result.output
+        assert "Ejectable services" in result.output
 
     def test_list_shows_channel_finder_service(self, runner):
         """Test that channel_finder service appears in ejectable list."""

--- a/tests/cli/test_failure_replay.py
+++ b/tests/cli/test_failure_replay.py
@@ -91,27 +91,38 @@ def stubs(monkeypatch, repo: Path):
 
 
 @pytest.fixture
-def errors_on_stdout():
-    """Tee ERROR records onto stdout, so their order against the replay is visible.
+def errors_on_stdout(monkeypatch):
+    """Point the renderer's trouble stream at stdout, so its order against the replay is visible.
 
-    The reporter prints to stdout and ``_abort`` logs to stderr. Two streams
+    The reporter prints to stdout and ``_abort`` renders to stderr. Two streams
     carry no order relative to one another, and "the spool came first" is
-    exactly what has to be asserted — so the record is echoed a second time onto
-    the stream the replay uses. Production behaviour is untouched: this adds a
-    handler for the duration of the test and removes it again.
+    exactly what has to be asserted — so for the duration of the test the stderr
+    console is a stdout-bound one, and the failure lands on the stream the
+    replay uses. Production behaviour is untouched.
+
+    Redirects the console the module already owns rather than substituting a
+    fresh one. ``set_theme`` re-themes ``styles.err_console`` in place by
+    popping the theme it pushed last, and a substitute built here would have
+    nothing on its stack to pop — the theme initialisation that runs on every
+    ``cli.main`` would die on it. Rich resolves ``_file or sys.stderr`` per
+    write, so setting it redirects and clearing it back to ``None`` restores the
+    dynamic lookup exactly as it was.
+
+    The redirect target is a proxy rather than ``sys.stdout`` itself, because
+    pytest's capture swaps that object out from under a long-lived reference and
+    closes the one captured here.
     """
+    import sys
 
-    class Tee(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            print(f"LOGGED {record.getMessage()}", flush=True)
+    from osprey.cli import styles
 
-    handler = Tee(level=logging.ERROR)
-    verb_logger = logging.getLogger("deploy")
-    verb_logger.addHandler(handler)
-    try:
-        yield
-    finally:
-        verb_logger.removeHandler(handler)
+    class _LiveStdout:
+        """Whatever ``sys.stdout`` is at the moment of the write."""
+
+        def __getattr__(self, name: str):
+            return getattr(sys.stdout, name)
+
+    monkeypatch.setattr(styles.err_console, "_file", _LiveStdout())
 
 
 def poisoned(*args, **kwargs) -> None:
@@ -156,26 +167,27 @@ def test_a_failed_captured_step_replays_its_spool_before_the_error(
     out = capfd.readouterr().out
     assert POISON in out, out
     assert out.index("✗ Stopping") < out.index(POISON)
-    assert out.index(POISON) < out.index("LOGGED Could not stop this deployment")
+    assert out.index(POISON) < out.index("✗ Could not stop this deployment")
 
 
-def test_the_error_message_names_the_spool_it_replayed(monkeypatch, caplog, wide, stubs, repo):
+def test_the_error_message_names_the_spool_it_replayed(monkeypatch, capfd, wide, stubs, repo):
     """The replay is for now; the path is for the operator who comes back later.
 
-    Read off the record rather than off stderr: the log console is a Rich one,
-    which wraps a long path across lines and colours the pieces, so an
-    assertion on what it printed would be an assertion about terminal width.
+    Read off stderr, where the failure is rendered. This used to read the log
+    record instead, because the log console wrapped a long path across lines and
+    an assertion on it would have been an assertion about terminal width; the
+    renderer prints unwrapped, so the path arrives whole and can be asserted
+    where the operator actually reads it.
     """
     from osprey.deployment import container_lifecycle
 
     monkeypatch.setattr(container_lifecycle, "down_deployment", poisoned)
 
-    with caplog.at_level(logging.ERROR):
-        status = run_verb("down")
+    status = run_verb("down")
 
     assert status != 0
     spool = spools(repo)[0]
-    assert str(spool) in caplog.text
+    assert str(spool) in capfd.readouterr().err
 
 
 def test_a_failed_captured_step_replays_its_spool_only_once(
@@ -208,7 +220,7 @@ def test_a_start_that_fails_on_a_captured_child_replays_it_too(
     out = capfd.readouterr().out
     assert out.count(POISON) == 1
     assert out.index("✗ Starting") < out.index(POISON)
-    assert out.index(POISON) < out.index("LOGGED Deployment failed")
+    assert out.index(POISON) < out.index("✗ Deployment failed")
 
 
 # ---------------------------------------------------------------------------
@@ -293,7 +305,10 @@ def test_a_dev_refusal_prints_one_failure_marker(monkeypatch, capfd, wide, stubs
     """The ✗ belongs to the phase that stopped, and there is one of those.
 
     The handler's job is the reason and the remedy; a second ✗ in front of them
-    reads as a second thing having gone wrong.
+    reads as a second thing having gone wrong. So the phase owns the only mark,
+    on stdout, and the handler's block continues it markless on the trouble
+    stream — one failure to read, two records to anything reading the streams
+    apart.
     """
     from osprey.deployment import container_lifecycle
     from osprey.deployment.errors import DevModeUnavailableError
@@ -306,10 +321,40 @@ def test_a_dev_refusal_prints_one_failure_marker(monkeypatch, capfd, wide, stubs
     status = run_verb("up", "-d", "--dev")
 
     assert status != 0
-    out = capfd.readouterr().out
-    assert out.count("✗") == 1, out
-    assert "--dev cannot be honored: this render carries no wheel" in out
-    assert "osprey build --dev" in out
+    captured = capfd.readouterr()
+    out, err = captured.out, captured.err
+    assert out.count("✗") == 1, out  # the phase's mark, and only it
+    assert err.count("✗") == 0, err  # the continuation adds none
+    # The positive half: without it the counts above pass on an empty stream.
+    # Summary, reason and remedy are the three lines of the one trouble shape.
+    assert "--dev cannot be honored" in err
+    assert "this render carries no wheel" in err
+    assert "osprey build --dev" in err
+
+
+def test_an_unexpected_error_wears_its_own_marker(monkeypatch, capfd, wide, stubs, repo):
+    """A refusal continues the phase's mark; an unexpected error does not.
+
+    The two cases differ in what the handler has to say. A refusal restates the
+    failure the phase already marked — same fact, second voice — so it continues
+    that line markless. An unexpected error is a SECOND fact: the phase says
+    which step stopped, and the handler says that the verb hit something it does
+    not have a refusal for. Two facts, two marks, and this pins them landing on
+    the two streams they belong to rather than doubling up on one.
+    """
+    from osprey.deployment import container_lifecycle
+
+    monkeypatch.setattr(container_lifecycle, "down_deployment", poisoned)
+
+    status = run_verb("down")
+
+    assert status != 0
+    captured = capfd.readouterr()
+    out, err = captured.out, captured.err
+    assert out.count("✗") == 1, out  # the phase's, on the reporter's stream
+    assert "✗ Stopping" in out
+    assert err.count("✗") == 1, err  # the handler's, on the trouble stream
+    assert "✗ Could not stop this deployment" in err
 
 
 def test_a_captured_build_failure_is_not_reported_as_unexpected(monkeypatch, caplog, tmp_path):

--- a/tests/cli/test_health_cmd_output.py
+++ b/tests/cli/test_health_cmd_output.py
@@ -1,0 +1,207 @@
+"""``osprey health``'s output surface, after the move onto the CLI renderer.
+
+``test_health_cmd.py`` owns what the command *decides* (anchors, category
+selection, exit codes, the wire shape of ``--json``). This module owns what it
+*prints*, and on which stream:
+
+* the default view is renderer output and nothing else — category headers,
+  glyphed rows and the summary line, with no log-shaped line from health itself;
+* ``--json`` runs in machine mode, so stdout is exactly one JSON document and
+  every human line (deprecation notice, progress, the verbose recap) is on
+  stderr;
+* a degraded check read back under ``-v`` wears the renderer's warning and
+  failure shapes, and health's own failures wear the failure shape;
+* off a terminal every line is plain: no escape sequence reaches either stream.
+
+The suite is patched at ``_run_suite`` so a report of a known shape is rendered
+without running a single check.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.health_cmd import health
+from osprey.health.models import CheckReport, CheckResult, Status
+
+# A line a logging handler would have written: a level name at the head of the
+# line, or a bracketed logger name. The renderer emits neither.
+_LOG_SHAPED = re.compile(r"^\s*(DEBUG|INFO|WARNING|ERROR|CRITICAL)\b|^\s*\[(CONFIG|registry)\]")
+
+_ESCAPE = "\x1b["
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """A Click CLI test runner (stdout and stderr are captured separately)."""
+    return CliRunner()
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A project directory whose ``config.yml`` parses and touches no network."""
+    path = tmp_path / "proj"
+    path.mkdir()
+    (path / "config.yml").write_text(
+        "project_name: health_output\n"
+        "models:\n"
+        "  python_code_generator:\n"
+        "    provider: mock\n"
+        "    model_id: mock-model\n"
+    )
+    return path
+
+
+def _result(status: Status, name: str, message: str, **kw: object) -> CheckResult:
+    return CheckResult(name=name, category="demo", status=status, message=message, **kw)
+
+
+def _mixed_report() -> CheckReport:
+    """One check of every status, so each row shape is exercised at once."""
+    return CheckReport(
+        results=[
+            _result(Status.OK, "fine", "everything is fine"),
+            _result(Status.WARNING, "shaky", "the store is stale", details="last write 3d ago"),
+            _result(Status.ERROR, "broken", "the port is bound", details="8080 belongs to pid 42"),
+            _result(Status.SKIP, "absent", "no container runtime"),
+        ],
+        elapsed_ms=1.5,
+        deadline_hit=False,
+    )
+
+
+def _run(cli_runner: CliRunner, project: Path, *args: str, report: CheckReport | None = None):
+    """Invoke ``health`` over *project* with the suite patched to return *report*."""
+    payload = _mixed_report() if report is None else report
+    with patch("osprey.cli.health_cmd._run_suite", AsyncMock(return_value=payload)):
+        return cli_runner.invoke(health, ["--project", str(project), *args])
+
+
+# --------------------------------------------------------------------------- #
+# The default view
+# --------------------------------------------------------------------------- #
+
+
+class TestDefaultView:
+    def test_renders_header_rows_and_summary(self, cli_runner, project) -> None:
+        result = _run(cli_runner, project)
+        lines = result.stdout.splitlines()
+        assert "Demo" in lines
+        assert "  ✓ everything is fine" in lines
+        assert "  ⚠ the store is stale" in lines
+        assert "  ✗ the port is bound" in lines
+        assert "  - no container runtime" in lines
+        assert any(line.startswith("Summary: ") for line in lines)
+
+    def test_no_log_shaped_line_reaches_either_stream(self, cli_runner, project) -> None:
+        # Health's own output is renderer output; a level-prefixed or
+        # logger-bracketed line would mean loader chatter leaked into the report.
+        result = _run(cli_runner, project)
+        for stream in (result.stdout, result.stderr):
+            offenders = [line for line in stream.splitlines() if _LOG_SHAPED.match(line)]
+            assert offenders == []
+
+    def test_report_stays_on_stdout(self, cli_runner, project) -> None:
+        # Without -v the report is the whole human output: nothing on stderr.
+        result = _run(cli_runner, project)
+        assert "the port is bound" in result.stdout
+        assert result.stderr == ""
+
+    def test_off_terminal_output_is_plain(self, cli_runner, project) -> None:
+        result = _run(cli_runner, project, "-v")
+        assert _ESCAPE not in result.stdout
+        assert _ESCAPE not in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# Degraded checks and health's own failures
+# --------------------------------------------------------------------------- #
+
+
+class TestTroubleShapes:
+    def test_verbose_recap_wears_the_warn_and_fail_shapes(self, cli_runner, project) -> None:
+        result = _run(cli_runner, project, "-v")
+        err = result.stderr.splitlines()
+        assert "⚠ shaky: the store is stale" in err
+        assert "  last write 3d ago" in err
+        assert "✗ broken: the port is bound" in err
+        assert "  8080 belongs to pid 42" in err
+
+    def test_verbose_keeps_its_display_detail_semantics(self, cli_runner, project) -> None:
+        # -v is health's own detail switch: it adds the per-check recap and
+        # changes nothing else about the report or the exit code.
+        plain = _run(cli_runner, project)
+        verbose = _run(cli_runner, project, "-v")
+        assert plain.stdout == verbose.stdout
+        assert plain.exit_code == verbose.exit_code
+        assert "shaky: the store is stale" not in plain.stderr
+        assert "shaky: the store is stale" in verbose.stderr
+
+    def test_deprecated_basic_flag_warns_on_stderr_only(self, cli_runner, project) -> None:
+        result = _run(cli_runner, project, "--basic")
+        assert "⚠ --basic is deprecated and has no effect" in result.stderr
+        assert "deprecated" not in result.stdout
+
+    def test_a_failed_run_wears_the_fail_shape_on_stderr(self, cli_runner, project) -> None:
+        with patch("osprey.cli.health_cmd._run_suite", AsyncMock(side_effect=RuntimeError("boom"))):
+            result = cli_runner.invoke(health, ["--project", str(project)])
+        assert result.exit_code == 3
+        err = result.stderr.splitlines()
+        assert "✗ Health check failed" in err
+        assert "  boom" in err
+        assert "Health check failed" not in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# Machine mode
+# --------------------------------------------------------------------------- #
+
+
+class TestJsonIsMachineClean:
+    def test_stdout_is_exactly_one_json_document(self, cli_runner, project) -> None:
+        result = _run(cli_runner, project, "--json")
+        payload = json.loads(result.stdout)  # must not raise
+        assert payload["summary"]
+        # One document, one trailing newline, nothing before or after it.
+        assert result.stdout.endswith("\n")
+        assert result.stdout.count("\n") == 1
+
+    def test_no_human_line_reaches_stdout(self, cli_runner, project) -> None:
+        result = _run(cli_runner, project, "--json")
+        for marker in ("✓", "⚠", "✗", "Summary:", "Demo"):
+            assert marker not in result.stdout
+
+    def test_human_output_lands_on_stderr(self, cli_runner, project) -> None:
+        result = _run(cli_runner, project, "--json", "--basic")
+        assert "⚠ --basic is deprecated and has no effect" in result.stderr
+        json.loads(result.stdout)
+
+    def test_the_progress_region_does_not_paint_on_stdout(self, cli_runner, project) -> None:
+        # The spinner still runs under --json; machine mode moves its live
+        # region to the stderr console so the document is never painted over.
+        result = _run(cli_runner, project, "--json")
+        assert json.loads(result.stdout)
+        assert _ESCAPE not in result.stdout
+
+    def test_verbose_adds_no_prose_to_a_json_run(self, cli_runner, project) -> None:
+        # ``--json`` renders the document instead of the human report, so -v has
+        # no recap to add: the details are already in every row of the payload.
+        result = _run(cli_runner, project, "--json", "-v")
+        payload = json.loads(result.stdout)
+        assert payload["results"][1]["details"] == "last write 3d ago"
+        assert "shaky: the store is stale" not in result.stderr
+
+    def test_a_failed_run_leaves_stdout_empty(self, cli_runner, project) -> None:
+        # No document was produced, so stdout carries nothing at all: a caller
+        # piping it to a parser sees an empty stream rather than half a report.
+        with patch("osprey.cli.health_cmd._run_suite", AsyncMock(side_effect=RuntimeError("boom"))):
+            result = cli_runner.invoke(health, ["--project", str(project), "--json"])
+        assert result.exit_code == 3
+        assert result.stdout == ""
+        assert "✗ Health check failed" in result.stderr

--- a/tests/cli/test_hooks_channel.py
+++ b/tests/cli/test_hooks_channel.py
@@ -164,7 +164,9 @@ def test_claimed_hook_shadows_the_framework_render_on_the_next_build(
     (profile_dir / "hooks" / FRAMEWORK_HOOK).write_text("# facility edit\n", encoding="utf-8")
 
     rebuilt = _render_project(tmp_path / "again", "claim-then-build")
-    with caplog.at_level(logging.INFO):
+    # Renderer migration (disposition row 35): the shadow notice stayed on the
+    # logger and dropped to DEBUG, so `-v` is what surfaces it.
+    with caplog.at_level(logging.DEBUG):
         applied = _apply_conventions(profile_dir, rebuilt)
     registered = _register_convention_artifacts(rebuilt, applied)
 
@@ -679,7 +681,9 @@ def test_excluding_a_shadowed_hook_restores_the_framework_render(
     _write(profile / "hooks" / "facility_guard.py", "print('guard')\n")
     framework_body = (project / ".claude" / "hooks" / FRAMEWORK_HOOK).read_text(encoding="utf-8")
 
-    with caplog.at_level(logging.INFO):
+    # DEBUG, not INFO: row 35 moved the notice down a level, and capturing above
+    # it would pass here no matter what the build did.
+    with caplog.at_level(logging.DEBUG):
         applied = _apply_conventions(profile, project, excluded={f"hooks/{FRAMEWORK_HOOK}"})
 
     landed = project / ".claude" / "hooks" / FRAMEWORK_HOOK

--- a/tests/cli/test_json_contracts.py
+++ b/tests/cli/test_json_contracts.py
@@ -1,0 +1,455 @@
+"""Standing structural contracts for every ``--json`` path the CLI exposes.
+
+Five verbs have a ``--json`` flag: ``audit``, ``health``, ``query``,
+``ariel status`` and ``ariel search``. Whatever the output hierarchy does to a
+verb's *human* output, its *machine* output has one job -- a caller pipes stdout
+into ``json.load`` and gets the document it expected. Three things have to hold
+for that, and each is pinned here for all five paths:
+
+1. **stdout is exactly one JSON document.** It parses from the first byte (no
+   banner, no progress line ahead of it) and nothing follows it (no trailing
+   prose, no second document). This is what a naive ``osprey ... --json | jq``
+   depends on.
+2. **The top-level key set is the pre-migration one.** The goldens in
+   ``tests/cli/data/json_keysets/`` were captured before any verb moved onto the
+   renderer; a bare entry in one of those arrays is a top-level key (entries
+   holding a ``.`` pin nested shapes and belong to
+   ``test_json_keyset_capture.py``, which owns the deep comparison). Those files
+   are read-only here: a failure means the payload moved, not that the golden is
+   stale.
+3. **Human lines land on stderr.** Each verb's body is driven with a renderer
+   call injected into it, from the same depth a real warning would come from,
+   and the line has to come out on stderr with stdout still holding one clean
+   document. That is the ``osprey.cli.output.machine_mode`` contract, tested
+   through the verb rather than against the context manager directly. Two
+   probes, because they can fail apart: ``output.report`` is redirected *only*
+   by an open machine-mode block, so it is what proves the block is really
+   around the body; ``output.warn`` prints to stderr under every mode, so it
+   pins the trouble stream independently of how the verb opts into machine
+   mode.
+
+**Known limit -- error payloads are not golden-pinned.** ``ariel status`` and
+``ariel search`` also emit failure documents (``{"status": ..., "message": ...}``
+and ``{"error": ...}``), whose shapes have no golden and are deliberately not
+pinned here: the capture suite recorded success payloads only, and inventing a
+golden for the error forms now would pin a shape nobody captured before the
+migration rather than protect one. The three contracts above are asserted for
+the success path of each verb; a caller relying on the error shape of an ARIEL
+verb has no test standing behind it.
+
+All five verbs now hold contract 3 the same way, by opening a machine-mode block
+over the whole verb body. ``audit`` was the last one to do so: it used to rely on
+``if not json_output:`` guards, which cover the lines audit itself prints and
+nothing else, so a renderer line from deeper in the stack landed on stdout ahead
+of the document. That was not hypothetical -- under ``-v`` the reviewer's own
+transcript is echoed from inside the agent loop, where no guard reaches, and it
+broke the document outright. Both halves are pinned below: the shared contract-3
+test for the guard-independent case, and
+``test_audit_verbose_keeps_the_reviewer_transcript_off_the_document`` for the
+``-v`` path specifically.
+
+**Capture seams.** Every verb runs end-to-end through ``CliRunner`` with only
+its outermost I/O boundary faked, mirroring ``test_json_keyset_capture.py`` so
+that both files exercise the same production path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from osprey.agent_runner import SDKWorkflowResult, ToolTrace
+from osprey.cli import output
+from osprey.cli.ariel import ariel_group
+from osprey.cli.audit_prompts import AuditFinding, AuditReport
+from osprey.cli.health_cmd import health
+from osprey.cli.query_cmd import query
+from osprey.health.models import CheckReport, CheckResult, Status
+from tests.cli._lifecycle_build import stub_build
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# --------------------------------------------------------------------------- #
+# Contract helpers
+# --------------------------------------------------------------------------- #
+
+_GOLDEN_DIR = Path(__file__).parent / "data" / "json_keysets"
+
+#: The line injected into a verb's body to prove where human output goes. No
+#: spaces and no punctuation a console might re-wrap or re-style, so a failure
+#: means the stream moved rather than that the text was reshaped.
+_PROBE = "json-contract-probe-line"
+
+
+def _sole_document(stdout: str) -> dict[str, Any]:
+    """Parse *stdout* as one JSON object, failing if anything else is there.
+
+    Args:
+        stdout: The verb's stdout, verbatim.
+
+    Returns:
+        The parsed document.
+    """
+    assert stdout, "the verb wrote no document to stdout"
+    assert stdout[0] == "{", f"stdout does not open with the document: {stdout[:120]!r}"
+    payload, end = json.JSONDecoder().raw_decode(stdout)
+    assert isinstance(payload, dict), f"the document is a {type(payload).__name__}, not an object"
+    assert not stdout[end:].strip(), (
+        f"stdout carries more than the document: {stdout[end:][:120]!r}"
+    )
+    return payload
+
+
+def _golden_top_level(verb: str) -> list[str]:
+    """Return the recorded top-level keys for *verb*.
+
+    Args:
+        verb: Golden name, i.e. the stem of a file in the golden directory.
+
+    Returns:
+        The sorted bare (dot-free) entries of the golden key-path array.
+    """
+    paths = json.loads((_GOLDEN_DIR / f"{verb}.json").read_text())
+    return sorted(path for path in paths if "." not in path)
+
+
+# --------------------------------------------------------------------------- #
+# Per-verb invocation
+# --------------------------------------------------------------------------- #
+#
+# Each invoker drives one verb's ``--json`` path and calls ``hook`` once from
+# inside the verb body, at the point where the verb is waiting on its own
+# outermost boundary -- the agent run, the check suite, the ARIEL service. That
+# is the depth a warning from a shared helper would print from, which is the
+# thing ``machine_mode`` exists to redirect.
+
+
+def _audit_project(tmp_path: Path) -> Path:
+    """Write the minimal directory ``audit`` classifies as a project."""
+    (tmp_path / "config.yml").write_text("name: test\n")
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "pre_write.sh").write_text("#!/bin/bash\n")
+    return tmp_path
+
+
+def _audit_report() -> AuditReport:
+    """The report the faked reviewer returns."""
+    return AuditReport(
+        summary="Contract run",
+        overall_risk="low",
+        findings=[
+            AuditFinding(
+                category="permissions",
+                severity="warning",
+                title="Open permission",
+                explanation="A permission is too broad",
+                file_path="settings.json",
+                recommendation="Restrict the permission scope",
+            ),
+        ],
+    )
+
+
+def _invoke_audit(
+    runner: CliRunner, tmp_path: Path, repo: Path, hook: Callable[[], None]
+) -> Result:
+    """Run ``audit --json`` over a minimal project with the agent faked."""
+    project = _audit_project(tmp_path)
+    report = _audit_report()
+
+    def _run(coro: Any) -> tuple[str, float, int]:
+        coro.close()
+        hook()
+        return report.model_dump_json(), 0.01, 5
+
+    from osprey.cli.audit_cmd import audit
+
+    with (
+        patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True),
+        patch("osprey.cli.audit_cmd.asyncio") as mock_asyncio,
+    ):
+        mock_asyncio.run.side_effect = _run
+        return runner.invoke(audit, [str(project), "--json"])
+
+
+def _invoke_health(
+    runner: CliRunner, tmp_path: Path, repo: Path, hook: Callable[[], None]
+) -> Result:
+    """Run ``health --json`` with the check suite faked."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "config.yml").write_text(
+        "project_name: json_contracts\n"
+        "models:\n"
+        "  python_code_generator:\n"
+        "    provider: mock\n"
+        "    model_id: mock-model\n"
+    )
+    report = CheckReport(
+        results=[CheckResult(name="contract", category="demo", status=Status.OK, message="ok")],
+        elapsed_ms=1.5,
+        deadline_hit=False,
+    )
+
+    def _suite(*args: Any, **kwargs: Any) -> CheckReport:
+        hook()
+        return report
+
+    with patch("osprey.cli.health_cmd._run_suite", AsyncMock(side_effect=_suite)):
+        return runner.invoke(health, ["--project", str(project), "--json"])
+
+
+def _invoke_query(
+    runner: CliRunner, tmp_path: Path, repo: Path, hook: Callable[[], None]
+) -> Result:
+    """Run ``query --json`` over a stub build with the agent faked."""
+    build = stub_build(repo, config="api:\n  providers: {}\n")
+    (build / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"controls": {"command": "osprey-controls"}}})
+    )
+
+    result_msg = MagicMock()
+    result_msg.is_error = False
+    result_msg.subtype = "end_turn"
+    workflow = SDKWorkflowResult(
+        text_blocks=["Beam current is 42 mA."],
+        tool_traces=[
+            ToolTrace(
+                name="mcp__controls__read_pv",
+                input={"pv": "BEAM:CURRENT"},
+                result="42 mA",
+                is_error=False,
+            )
+        ],
+        mcp_servers=[{"name": "controls", "status": "connected", "tools": []}],
+    )
+    workflow.result = result_msg
+
+    def _run_query(*args: Any, **kwargs: Any) -> SDKWorkflowResult:
+        hook()
+        return workflow
+
+    with (
+        patch("osprey.cli.query_cmd.run_query", new=AsyncMock(side_effect=_run_query)),
+        patch(
+            "osprey.cli.query_cmd.read_only_disallowed_tools",
+            return_value=["mcp__controls__channel_write"],
+        ),
+        patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
+    ):
+        return runner.invoke(query, ["--repo", str(repo), "--json", "beam current"])
+
+
+# A config section ``ARIELConfig.from_dict`` accepts without a project on disk;
+# no connection is ever opened because the service boundary is stubbed.
+_ARIEL_CONFIG = {"database": {"uri": "postgresql://localhost/test"}}
+
+
+class _StubService:
+    """Async-context-manager stub standing in for the ARIEL service."""
+
+    def __init__(self, *, repository: Any = None, search_result: Any = None) -> None:
+        self.repository = repository or MagicMock()
+        self._search_result = search_result
+
+    async def __aenter__(self) -> _StubService:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def health_check(self) -> tuple[bool, str]:
+        return True, "OK"
+
+    async def search(self, **kwargs: Any) -> Any:
+        return self._search_result
+
+
+def _install_ariel_service(service: _StubService) -> Any:
+    """Return a patch context routing ``create_ariel_service`` to *service*."""
+
+    async def _create(config: Any) -> _StubService:
+        return service
+
+    return patch("osprey.services.ariel_search.create_ariel_service", new=_create)
+
+
+def _invoke_ariel_status(
+    runner: CliRunner, tmp_path: Path, repo: Path, hook: Callable[[], None]
+) -> Result:
+    """Run ``ariel status --json`` against a stub repository."""
+
+    def _stats() -> dict[str, int]:
+        hook()
+        return {"total_entries": 7}
+
+    repository = MagicMock()
+    repository.get_enhancement_stats = AsyncMock(side_effect=_stats)
+    repository.get_embedding_tables = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                table_name="text_embeddings_nomic",
+                entry_count=7,
+                dimension=768,
+                is_active=True,
+            )
+        ]
+    )
+
+    with (
+        _install_ariel_service(_StubService(repository=repository)),
+        patch("osprey.cli.ariel.get_config_value", new=lambda *a, **kw: dict(_ARIEL_CONFIG)),
+    ):
+        return runner.invoke(ariel_group, ["status", "--json"])
+
+
+def _invoke_ariel_search(
+    runner: CliRunner, tmp_path: Path, repo: Path, hook: Callable[[], None]
+) -> Result:
+    """Run ``ariel search --json`` against a stub service."""
+    from osprey.services.ariel_search.models import SearchMode
+
+    search_result = SimpleNamespace(
+        answer="Two coupler trips overnight.",
+        sources=["E1"],
+        search_modes_used=[SearchMode.KEYWORD],
+        reasoning="keyword match on 'coupler'",
+        entries=[{"entry_id": "E1", "author": "op", "raw_text": "coupler trip", "_score": 0.9}],
+    )
+
+    class _HookingService(_StubService):
+        async def search(self, **kwargs: Any) -> Any:
+            hook()
+            return await super().search(**kwargs)
+
+    with (
+        _install_ariel_service(_HookingService(search_result=search_result)),
+        patch("osprey.cli.ariel.get_config_value", new=lambda *a, **kw: dict(_ARIEL_CONFIG)),
+    ):
+        return runner.invoke(ariel_group, ["search", "coupler", "--json"])
+
+
+#: Golden name -> the invoker that drives that verb's ``--json`` path.
+_INVOKERS: dict[str, Any] = {
+    "ariel_search": _invoke_ariel_search,
+    "ariel_status": _invoke_ariel_status,
+    "audit": _invoke_audit,
+    "health": _invoke_health,
+    "query": _invoke_query,
+}
+
+
+@pytest.fixture
+def json_run(runner: CliRunner, tmp_path: Path, lifecycle_repo: Path):
+    """Return ``run(verb, hook=None)``, driving one verb's ``--json`` path."""
+
+    def _run(verb: str, hook: Callable[[], None] | None = None) -> Result:
+        return _INVOKERS[verb](runner, tmp_path, lifecycle_repo, hook or (lambda: None))
+
+    return _run
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """A Click runner that keeps stdout and stderr apart."""
+    return CliRunner()
+
+
+# --------------------------------------------------------------------------- #
+# The contracts
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("verb", sorted(_INVOKERS))
+def test_stdout_carries_exactly_one_json_document(verb: str, json_run) -> None:
+    """stdout opens with the document, and nothing follows it."""
+    result = json_run(verb)
+
+    assert result.exit_code == 0, result.output
+    _sole_document(result.stdout)
+
+
+@pytest.mark.parametrize("verb", sorted(_INVOKERS))
+def test_top_level_keys_are_the_pre_migration_golden(verb: str, json_run) -> None:
+    """The document still has exactly the top-level keys captured before."""
+    payload = _sole_document(json_run(verb).stdout)
+
+    assert sorted(payload) == _golden_top_level(verb)
+
+
+@pytest.mark.parametrize("verb", sorted(_INVOKERS))
+def test_human_lines_from_inside_the_verb_land_on_stderr(verb: str, json_run) -> None:
+    """A renderer line printed mid-run reaches stderr, not the document."""
+    result = json_run(verb, hook=lambda: output.report(_PROBE))
+
+    assert _PROBE in result.stderr, "the human line did not reach stderr"
+    assert _PROBE not in result.stdout, "the human line landed in the document's stream"
+    _sole_document(result.stdout)
+
+
+@pytest.mark.parametrize("verb", sorted(_INVOKERS))
+def test_trouble_from_inside_the_verb_lands_on_stderr(verb: str, json_run) -> None:
+    """A warning printed mid-run reaches stderr, not the document."""
+    result = json_run(verb, hook=lambda: output.warn(_PROBE))
+
+    assert _PROBE in result.stderr, "the warning did not reach stderr"
+    assert _PROBE not in result.stdout, "the warning landed in the document's stream"
+    _sole_document(result.stdout)
+
+
+def test_audit_verbose_keeps_the_reviewer_transcript_off_the_document(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """``audit --json -v`` prints the transcript to stderr, document intact.
+
+    The one path that used to break the document rather than merely risk it:
+    ``-v`` makes ``_run_audit`` echo every block the reviewer says, from inside
+    the agent loop where no ``if not json_output:`` guard reaches. The SDK
+    boundary is faked at ``query`` -- one assistant turn, then a result -- so
+    the real ``_run_audit`` does the echoing.
+    """
+    # Imported here, not at module scope: the SDK is optional to ``audit_cmd``,
+    # and a missing one should cost this test alone rather than the whole file.
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+    project = _audit_project(tmp_path)
+    transcript = "reading the permission block"
+    answer = f"{transcript}\n{_audit_report().model_dump_json()}"
+
+    async def _query(**kwargs: Any):
+        yield AssistantMessage(content=[TextBlock(text=answer)], model="stub-model")
+        yield ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="stub-session",
+            total_cost_usd=0.01,
+        )
+
+    from osprey.cli.audit_cmd import audit
+
+    with (
+        patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True),
+        patch("osprey.cli.audit_cmd.query", new=_query),
+    ):
+        result = runner.invoke(audit, [str(project), "--json", "-v"])
+
+    assert result.exit_code == 0, result.output
+    assert transcript in result.stderr, "the reviewer transcript did not reach stderr"
+    assert transcript not in result.stdout, "the transcript landed in the document's stream"
+    assert sorted(_sole_document(result.stdout)) == _golden_top_level("audit")
+
+
+def test_every_json_verb_has_a_golden_and_an_invoker() -> None:
+    """The contracts cover every ``--json`` verb the goldens record."""
+    assert {path.stem for path in _GOLDEN_DIR.glob("*.json")} == set(_INVOKERS)

--- a/tests/cli/test_json_keyset_capture.py
+++ b/tests/cli/test_json_keyset_capture.py
@@ -1,0 +1,386 @@
+"""Pre-migration capture of every ``--json`` payload shape the CLI emits.
+
+Five verbs have a ``--json`` path: ``audit``, ``health``, ``query``,
+``ariel status`` and ``ariel search``. The output-hierarchy work reroutes each
+verb's *human* output through a single renderer; none of it is allowed to move
+a key in the *machine* output. These tests record what each payload looks like
+today so that a later migration which quietly reshapes one is caught here
+rather than in a downstream consumer.
+
+**What is captured.** Payload *values* are non-deterministic by construction
+(timestamps, live probes, model text), so only the key set is pinned. Each
+golden in ``tests/cli/data/json_keysets/`` is a sorted JSON array of key paths:
+
+* a bare name (``"summary"``) is a top-level key;
+* ``"parent.child"`` is a key of a nested object;
+* ``"parent[].child"`` is a key of every element of a nested array.
+
+**Why only some nesting.** One level deeper is pinned only where the nested
+shape is a literal dict written out in the source — it cannot vary at runtime,
+so equality is a real contract rather than a fixture artifact:
+
+* ``audit`` → ``findings[]`` (the ``AuditFinding`` pydantic model);
+* ``query`` → ``tool_traces[]`` (a literal dict comprehension in
+  ``_build_json_output``);
+* ``ariel status`` → ``database``, ``embedding_tables[]``,
+  ``enhancement_modules``, ``search_modules`` (all literal dicts in
+  ``get_status``);
+* ``ariel search`` → ``entries[]`` (``_entry_summary``'s fixed projection).
+
+Deliberately **not** nested: ``health``'s ``results[]`` rows, whose ``value`` /
+``latency_ms`` / ``details`` keys are emitted only when truthy, so the row key
+set varies per check and per run; and ``query``'s ``mcp_servers``, whose keys
+are server *names* from the deployment rather than a schema.
+
+**Capture seams.** Every verb is driven end-to-end through ``CliRunner`` with
+only its outermost I/O boundary faked, so the payload is assembled by the real
+production code path:
+
+* ``audit`` — ``_SDK_AVAILABLE``/``asyncio`` patched (as in
+  ``test_audit_cmd.py``); the report is still parsed and re-serialised by
+  ``_display_report``.
+* ``health`` — ``osprey.cli.health_cmd._run_suite`` patched to return a
+  ``CheckReport``; ``render_json`` does the serialising.
+* ``query`` — ``run_query`` / ``read_only_disallowed_tools`` /
+  ``expected_mcp_servers`` patched (as in ``test_query_cmd.py``) over a stub
+  build.
+* ``ariel status`` / ``ariel search`` — ``osprey.cli.ariel.get_config_value``
+  supplies a config section and
+  ``osprey.services.ariel_search.create_ariel_service`` is routed to a stub
+  service (as in ``tests/services/ariel_search/test_cli_operations.py``), so
+  the real ``get_status`` / ``run_search`` assemble the dict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.agent_runner import SDKWorkflowResult, ToolTrace
+from osprey.cli.ariel import ariel_group
+from osprey.cli.audit_prompts import AuditFinding, AuditReport
+from osprey.cli.health_cmd import health
+from osprey.cli.query_cmd import query
+from osprey.health.models import CheckReport, CheckResult, Status
+from tests.cli._lifecycle_build import stub_build
+
+# --------------------------------------------------------------------------- #
+# Golden handling
+# --------------------------------------------------------------------------- #
+
+_GOLDEN_DIR = Path(__file__).parent / "data" / "json_keysets"
+
+# Nested paths pinned per verb. ``name[]`` expands the element shape of a list;
+# ``name`` expands the keys of an object. See the module docstring for why each
+# one is safe to pin and why the omitted ones are not.
+_NESTED: dict[str, tuple[str, ...]] = {
+    "audit": ("findings[]",),
+    "health": (),
+    "query": ("tool_traces[]",),
+    "ariel_status": (
+        "database",
+        "embedding_tables[]",
+        "enhancement_modules",
+        "search_modules",
+    ),
+    "ariel_search": ("entries[]",),
+}
+
+
+def _golden(verb: str) -> list[str]:
+    """Return the recorded key paths for *verb*."""
+    return json.loads((_GOLDEN_DIR / f"{verb}.json").read_text())
+
+
+def _keyset(payload: dict[str, Any], verb: str) -> list[str]:
+    """Project *payload* onto the sorted key-path list recorded for *verb*.
+
+    Args:
+        payload: The parsed ``--json`` document.
+        verb: Golden name, which selects the nested paths to expand.
+
+    Returns:
+        Sorted key paths: top-level keys plus one expanded level for every
+        path in ``_NESTED[verb]``.
+    """
+    paths = list(payload)
+    for spec in _NESTED[verb]:
+        is_list = spec.endswith("[]")
+        key = spec[:-2] if is_list else spec
+        node = payload[key]
+        if is_list:
+            assert node, f"{verb}: {spec} must be non-empty to capture its shape"
+            shapes = {tuple(sorted(item)) for item in node}
+            assert len(shapes) == 1, f"{verb}: {spec} elements disagree on keys"
+            node = node[0]
+        paths.extend(f"{spec}.{k}" for k in node)
+    return sorted(paths)
+
+
+def _assert_matches_golden(payload: dict[str, Any], verb: str) -> None:
+    """Fail unless *payload* still has exactly the recorded key paths."""
+    assert _keyset(payload, verb) == _golden(verb)
+
+
+# --------------------------------------------------------------------------- #
+# Shared fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """A Click runner that captures stdout and stderr separately."""
+    return CliRunner()
+
+
+# --------------------------------------------------------------------------- #
+# osprey audit --json
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def audit_project(tmp_path: Path) -> Path:
+    """A minimal directory that ``audit`` classifies as a project."""
+    (tmp_path / "config.yml").write_text("name: test\n")
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "pre_write.sh").write_text("#!/bin/bash\n")
+    return tmp_path
+
+
+@patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
+@patch("osprey.cli.audit_cmd.asyncio")
+def test_audit_json_keyset(mock_asyncio: MagicMock, runner: CliRunner, audit_project: Path) -> None:
+    """``audit --json`` emits the recorded ``AuditReport`` key set."""
+    report = AuditReport(
+        summary="Capture run",
+        overall_risk="low",
+        findings=[
+            AuditFinding(
+                category="permissions",
+                severity="warning",
+                title="Open permission",
+                explanation="A permission is too broad",
+                file_path="settings.json",
+                recommendation="Restrict the permission scope",
+            ),
+        ],
+    )
+    mock_asyncio.run.return_value = (report.model_dump_json(), 0.01, 5)
+
+    result = runner.invoke(_audit_cmd(), [str(audit_project), "--json"])
+
+    assert result.exit_code == 0, result.output
+    _assert_matches_golden(json.loads(result.stdout), "audit")
+
+
+def _audit_cmd():
+    """Import the ``audit`` command lazily, as ``test_audit_cmd.py`` does."""
+    from osprey.cli.audit_cmd import audit
+
+    return audit
+
+
+# --------------------------------------------------------------------------- #
+# osprey health --json
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def health_project(tmp_path: Path) -> Path:
+    """A project whose ``config.yml`` parses and touches no network."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "config.yml").write_text(
+        "project_name: keyset_capture\n"
+        "models:\n"
+        "  python_code_generator:\n"
+        "    provider: mock\n"
+        "    model_id: mock-model\n"
+    )
+    return project
+
+
+def test_health_json_keyset(runner: CliRunner, health_project: Path) -> None:
+    """``health --json`` emits the recorded ``CheckReport`` wire shape."""
+    report = CheckReport(
+        results=[
+            CheckResult(
+                name="capture",
+                category="demo",
+                status=Status.OK,
+                message="ok",
+            )
+        ],
+        elapsed_ms=1.5,
+        deadline_hit=False,
+    )
+    with patch("osprey.cli.health_cmd._run_suite", AsyncMock(return_value=report)):
+        result = runner.invoke(health, ["--project", str(health_project), "--json"])
+
+    assert result.exit_code == 0, result.output
+    _assert_matches_golden(json.loads(result.stdout), "health")
+
+
+# --------------------------------------------------------------------------- #
+# osprey query --json
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def query_deployment(lifecycle_repo: Path) -> Path:
+    """A repo with a render that declares a ``controls`` MCP server."""
+    build = stub_build(lifecycle_repo, config="api:\n  providers: {}\n")
+    (build / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"controls": {"command": "osprey-controls"}}})
+    )
+    return lifecycle_repo
+
+
+def test_query_json_keyset(runner: CliRunner, query_deployment: Path) -> None:
+    """``query --json`` emits the recorded ``_build_json_output`` shape."""
+    result_msg = MagicMock()
+    result_msg.is_error = False
+    result_msg.subtype = "end_turn"
+    workflow = SDKWorkflowResult(
+        text_blocks=["Beam current is 42 mA."],
+        tool_traces=[
+            ToolTrace(
+                name="mcp__controls__read_pv",
+                input={"pv": "BEAM:CURRENT"},
+                result="42 mA",
+                is_error=False,
+            )
+        ],
+        mcp_servers=[{"name": "controls", "status": "connected", "tools": []}],
+    )
+    workflow.result = result_msg
+
+    with (
+        patch("osprey.cli.query_cmd.run_query", new=AsyncMock(return_value=workflow)),
+        patch(
+            "osprey.cli.query_cmd.read_only_disallowed_tools",
+            return_value=["mcp__controls__channel_write"],
+        ),
+        patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
+    ):
+        result = runner.invoke(query, ["--repo", str(query_deployment), "--json", "beam current"])
+
+    assert result.exit_code == 0, result.output
+    _assert_matches_golden(json.loads(result.stdout), "query")
+
+
+# --------------------------------------------------------------------------- #
+# osprey ariel status --json / osprey ariel search --json
+# --------------------------------------------------------------------------- #
+
+# A config section that ``ARIELConfig.from_dict`` accepts without a project on
+# disk; no connection is ever opened because the service boundary is stubbed.
+_ARIEL_CONFIG = {"database": {"uri": "postgresql://localhost/test"}}
+
+
+class _StubService:
+    """Async-context-manager stub standing in for the ARIEL service."""
+
+    def __init__(self, *, repository: Any = None, search_result: Any = None) -> None:
+        self.repository = repository or MagicMock()
+        self._search_result = search_result
+
+    async def __aenter__(self) -> _StubService:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def health_check(self) -> tuple[bool, str]:
+        return True, "OK"
+
+    async def search(self, **kwargs: Any) -> Any:
+        return self._search_result
+
+
+@pytest.fixture
+def ariel_service(monkeypatch: pytest.MonkeyPatch):
+    """Route ``create_ariel_service`` to a caller-supplied stub service."""
+    import osprey.services.ariel_search as ariel_pkg
+
+    def _install(service: _StubService) -> None:
+        async def _fake_create(config: Any) -> _StubService:
+            return service
+
+        monkeypatch.setattr(ariel_pkg, "create_ariel_service", _fake_create)
+
+    return _install
+
+
+def test_ariel_status_json_keyset(
+    runner: CliRunner, ariel_service, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ariel status --json`` emits the recorded ``get_status`` shape."""
+    repository = MagicMock()
+    repository.get_enhancement_stats = AsyncMock(return_value={"total_entries": 7})
+    repository.get_embedding_tables = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                table_name="text_embeddings_nomic",
+                entry_count=7,
+                dimension=768,
+                is_active=True,
+            )
+        ]
+    )
+    ariel_service(_StubService(repository=repository))
+    monkeypatch.setattr("osprey.cli.ariel.get_config_value", lambda *a, **kw: dict(_ARIEL_CONFIG))
+
+    result = runner.invoke(ariel_group, ["status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    _assert_matches_golden(json.loads(result.stdout), "ariel_status")
+
+
+def test_ariel_search_json_keyset(
+    runner: CliRunner, ariel_service, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ariel search --json`` emits the recorded ``run_search`` shape."""
+    from osprey.services.ariel_search.models import SearchMode
+
+    search_result = SimpleNamespace(
+        answer="Two coupler trips overnight.",
+        sources=["E1"],
+        search_modes_used=[SearchMode.KEYWORD],
+        reasoning="keyword match on 'coupler'",
+        entries=[{"entry_id": "E1", "author": "op", "raw_text": "coupler trip", "_score": 0.9}],
+    )
+    ariel_service(_StubService(search_result=search_result))
+    monkeypatch.setattr("osprey.cli.ariel.get_config_value", lambda *a, **kw: dict(_ARIEL_CONFIG))
+
+    result = runner.invoke(ariel_group, ["search", "coupler", "--json"])
+
+    assert result.exit_code == 0, result.output
+    _assert_matches_golden(json.loads(result.stdout), "ariel_search")
+
+
+# --------------------------------------------------------------------------- #
+# Golden-file hygiene
+# --------------------------------------------------------------------------- #
+
+
+def test_goldens_are_exactly_the_five_json_verbs() -> None:
+    """The golden directory covers every ``--json`` verb and nothing else."""
+    assert {p.stem for p in _GOLDEN_DIR.glob("*.json")} == set(_NESTED)
+
+
+@pytest.mark.parametrize("verb", sorted(_NESTED))
+def test_golden_is_sorted_and_newline_terminated(verb: str) -> None:
+    """Goldens stay stable-sorted so a formatter never rewrites them."""
+    text = (_GOLDEN_DIR / f"{verb}.json").read_text()
+    assert text.endswith("\n")
+    paths = json.loads(text)
+    assert paths == sorted(paths)
+    assert len(paths) == len(set(paths))

--- a/tests/cli/test_lifecycle_promotions.py
+++ b/tests/cli/test_lifecycle_promotions.py
@@ -1,0 +1,2025 @@
+"""Promotion and disposition needles for the deploy path's INFO narration.
+
+One question per test, asked of the two instruments together:
+
+* **printed** -- did the fact reach the default view, as the verb's own output?
+  Echo-class lines go through :mod:`osprey.cli.output`, which resolves
+  ``current_reporter().out()`` per call, so the capture reporter below is what
+  reads them.
+* **painted / recorded** -- did the *old* log form stay out of the terminal
+  while its record stayed in the sink? That pair is the honesty half: a
+  promotion that quietly deleted the record would pass a "not in the terminal"
+  assertion for entirely the wrong reason.
+
+Every absence assertion here carries an armed witness (see
+:func:`assert_promoted`), because a console nothing can reach satisfies every
+``not in`` there is.
+
+Tasks 3.3, 3.4 and 3.7 append their own sections below; the fixtures and
+helpers above the first section marker are shared.
+
+A WARNING is a third case, and it belongs to neither half: the altitude gate
+passes it, so it stays on the *painted* side. The needle for one of those
+(Task 3.3's unshown-mint warning) asserts presence in ``rendered_text``, which
+is the opposite of what ``assert_promoted`` asks.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import os
+import re
+import subprocess
+from collections.abc import Iterator
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+from osprey.cli import build_cmd, build_persistence, deploy_cmd
+from osprey.cli.build_persistence import _apply_conventions
+from osprey.cli.main import cli
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+from osprey.cli.profile_conventions import PROJECT_MIRROR_DIR
+from osprey.deployment import compose_generator, container_lifecycle, wheel_build
+from osprey.deployment.web_terminals import (
+    auth_credentials,
+    env_production,
+    persona_images,
+    postup_hooks,
+    provision,
+    seeding,
+)
+from osprey.simulation import apply
+from tests.cli.conftest import TerminalProbe
+
+# The witness logger and its marker. A WARNING is above the altitude gate, so
+# it MUST reach the probe console; if it does not, the console is not armed and
+# nothing else this module asserts about absence means anything.
+_WITNESS_LOGGER = "osprey.lifecycle_promotion_witness"
+_WITNESS = "PROMOTIONWITNESSMARKER"
+
+
+# ---------------------------------------------------------------------------
+# Instruments
+# ---------------------------------------------------------------------------
+
+
+class _CaptureReporter(PhaseReporter):
+    """A reporter whose console is a buffer, so printed lines are readable.
+
+    ``out()`` is the seam every echo-class primitive resolves per call, and
+    :meth:`osprey.cli.phase_reporter.Phase.step` prints through ``emit`` on the
+    same console -- so one buffer holds both a verb's report lines and the
+    ``  · name`` sub-steps hung off its phase.
+    """
+
+    def __init__(self, console: Console) -> None:
+        super().__init__(color=False)
+        self._console = console
+
+    def out(self) -> Console:
+        return self._console
+
+
+class Printed:
+    """What the operator saw, plus the phase machinery to hang steps off."""
+
+    def __init__(self, reporter: _CaptureReporter, buffer: StringIO) -> None:
+        self.reporter = reporter
+        self._buffer = buffer
+
+    @property
+    def text(self) -> str:
+        """Everything printed so far, soft-wrapped exactly as a terminal gets it."""
+        return self._buffer.getvalue()
+
+    @property
+    def flowed(self) -> str:
+        """:attr:`text` with every run of whitespace collapsed to one space.
+
+        The capture console is 100 columns wide, so a long report line wraps.
+        Assert a multi-word fragment against this rather than against
+        :attr:`text`.
+        """
+        return " ".join(self.text.split())
+
+    def open_phase(self, title: str = "Starting services") -> None:
+        """Open a phase, so ``report_step`` has somewhere to hang its lines."""
+        self.reporter.phase(title)
+
+
+@pytest.fixture
+def printed() -> Iterator[Printed]:
+    """Install a capture reporter for the duration of one test."""
+    # Imported here for the same reason conftest does it: the theme module
+    # pulls in the CLI package, and this conftest runs for all of tests/cli.
+    from osprey.cli.styles import osprey_theme
+
+    buffer = StringIO()
+    console = Console(
+        file=buffer,
+        width=100,
+        force_terminal=False,
+        legacy_windows=False,
+        theme=osprey_theme,
+    )
+    reporter = _CaptureReporter(console)
+    previous = install_reporter(reporter)
+    try:
+        yield Printed(reporter, buffer)
+    finally:
+        install_reporter(previous)
+
+
+@pytest.fixture
+def default_altitude(
+    terminal_probe: TerminalProbe, monkeypatch: pytest.MonkeyPatch
+) -> TerminalProbe:
+    """A default (``-v``-less) run's logging state, with the probe watching it.
+
+    Invoking the bare group runs the real callback -- ``configure_logging``,
+    the handler console swap, and ``install_gate`` -- so what the handler does
+    with a record here is what it does under ``osprey up``.
+    ``load_project_dotenv`` is stubbed because it writes an ancestor ``.env``
+    straight into ``os.environ``, which would outlive the test.
+    """
+    monkeypatch.setattr("osprey.utils.config.load_project_dotenv", lambda *a, **k: None)
+    result = CliRunner().invoke(cli, [])
+    assert result.exit_code == 0, result.output
+    logging.getLogger().setLevel(logging.INFO)
+    return terminal_probe
+
+
+def assert_promoted(probe: TerminalProbe, printed: Printed, fragment: str) -> None:
+    """The promotion needle, all three halves plus the witness.
+
+    Args:
+        probe: The terminal probe, armed by ``default_altitude``.
+        printed: The capture reporter's buffer.
+        fragment: A distinctive piece of the fact, short enough to survive the
+            capture console's wrapping.
+    """
+    assert fragment in printed.flowed, f"not in the default view: {fragment!r}"
+    assert fragment not in probe.rendered_text, f"still painted by the log handler: {fragment!r}"
+    assert any(fragment in message for message in probe.messages), (
+        f"no record kept for: {fragment!r}"
+    )
+
+    # Armed witness, in the same test: a WARNING is above the gate, so its
+    # absence would mean the probe console was never reachable and the
+    # absence assertion above proved nothing.
+    logging.getLogger(_WITNESS_LOGGER).warning(_WITNESS)
+    assert _WITNESS in probe.rendered_text, "the probe console is not armed"
+
+
+def assert_sub_step(printed: Printed, name: str) -> None:
+    """A ``sub-step`` row's needle: the phase record carries ``· name``."""
+    assert re.search(rf"·\s+{re.escape(name)}", printed.flowed), (
+        f"no sub-step line for: {name!r}\n{printed.flowed}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# --- Task 3.2: container_lifecycle promotions ---
+# ---------------------------------------------------------------------------
+
+
+BLUESKY_VA = {"deployed_services": ["bluesky", "virtual_accelerator"]}
+
+#: A project that runs ARIEL's own store, which is what makes the staged
+#: bring-up do anything at all (see ``_ariel_store_deployed``).
+ARIEL_PROJECT = {"deployed_services": ["postgresql"], "ariel": {"database": "ariel"}}
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A project directory holding an empty ``.env``, the provisioners' target."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("", encoding="utf-8")
+    return env_path
+
+
+class TestMintedSecretsAreReported:
+    """Anything this deploy created that the operator now owns."""
+
+    def test_a_minted_auth_token_names_its_keys_and_its_file(
+        self, default_altitude, printed, project, monkeypatch
+    ):
+        monkeypatch.delenv("EVENT_DISPATCHER_TOKEN", raising=False)
+        monkeypatch.delenv("DISPATCH_WORKER_TOKEN", raising=False)
+
+        container_lifecycle._ensure_service_tokens(
+            {"deployed_services": ["event_dispatcher"]}, False, project
+        )
+
+        assert_promoted(default_altitude, printed, "Generated auth token(s)")
+        assert "EVENT_DISPATCHER_TOKEN" in printed.flowed
+        assert "Keep them secret." in printed.flowed
+
+    def test_an_adopted_volume_credential_names_the_variables_never_the_values(
+        self, default_altitude, printed, project
+    ):
+        store = container_lifecycle._VOLUME_INITIALIZED_VARS["MONGO_ROOT_PASSWORD"]
+        project.write_text("MONGO_ROOT_PASSWORD=freshmint\n", encoding="utf-8")
+
+        container_lifecycle._adopt_original_credentials(
+            project,
+            [("MONGO_ROOT_PASSWORD", store)],
+            {"MONGO_ROOT_PASSWORD": "theoriginal"},
+        )
+
+        assert_promoted(default_altitude, printed, "Adopted 1 pre-existing data volume(s)")
+        assert "MONGO_ROOT_PASSWORD" in printed.flowed
+        assert "theoriginal" not in printed.flowed
+
+    def test_a_minted_qserver_keypair_says_both_halves_are_secret(
+        self, default_altitude, printed, project, monkeypatch
+    ):
+        monkeypatch.delenv(container_lifecycle._QSERVER_ZMQ_PRIVATE_KEY_VAR, raising=False)
+        monkeypatch.delenv(container_lifecycle._QSERVER_ZMQ_PUBLIC_KEY_VAR, raising=False)
+
+        container_lifecycle._ensure_bluesky_control_plane_keys(
+            {"deployed_services": ["bluesky"]}, project
+        )
+
+        assert_promoted(
+            default_altitude, printed, "Generated bluesky RE manager control-socket keypair"
+        )
+        assert "Treat both values as secrets." in printed.flowed
+
+    def test_a_derived_public_half_says_it_was_not_written_to_disk(
+        self, default_altitude, printed, project, monkeypatch
+    ):
+        """The private half lives only in this shell, so nothing lands on disk."""
+        private = container_lifecycle._derive_qserver_keypair("")[
+            container_lifecycle._QSERVER_ZMQ_PRIVATE_KEY_VAR
+        ]
+        monkeypatch.setenv(container_lifecycle._QSERVER_ZMQ_PRIVATE_KEY_VAR, private)
+        monkeypatch.delenv(container_lifecycle._QSERVER_ZMQ_PUBLIC_KEY_VAR, raising=False)
+
+        container_lifecycle._ensure_bluesky_control_plane_keys(
+            {"deployed_services": ["bluesky"]}, project
+        )
+
+        assert_promoted(default_altitude, printed, "for this deploy only")
+        assert container_lifecycle._QSERVER_ZMQ_PUBLIC_KEY_VAR in printed.flowed
+
+    def test_generated_curve_certificates_say_when_they_take_effect(
+        self, default_altitude, printed, project, monkeypatch
+    ):
+        monkeypatch.setattr(
+            container_lifecycle, "_generate_bluesky_curve_certs", lambda paths: None
+        )
+
+        container_lifecycle._ensure_bluesky_document_plane_certs(
+            {"deployed_services": ["bluesky"]}, project
+        )
+
+        assert_promoted(
+            default_altitude, printed, "Generated bluesky document-plane CURVE certificates"
+        )
+        assert "containers are recreated" in printed.flowed
+
+
+class TestDegradationsAreReported:
+    """A deployment that will not do what it looks like it does says so."""
+
+    def test_a_mock_control_system_reports_the_browse_only_deployment(
+        self, default_altitude, printed, project
+    ):
+        container_lifecycle._ensure_bluesky_substrate_env(
+            {**BLUESKY_VA, "control_system": {"type": "mock"}}, project
+        )
+
+        assert_promoted(default_altitude, printed, "this deployment is browse-only")
+        assert "osprey set connector=virtual_accelerator" in printed.flowed
+
+    def test_a_pinned_worker_image_reports_the_build_it_skipped(
+        self, default_altitude, printed, monkeypatch
+    ):
+        monkeypatch.setattr(container_lifecycle, "resolve_project_name", lambda config: "demo")
+
+        container_lifecycle._build_project_image(
+            {"deployed_services": ["dispatch_worker"]},
+            False,
+            {"OSPREY_WORKER_IMAGE": "ghcr.io/example/worker:1"},
+        )
+
+        assert_promoted(default_altitude, printed, "Dispatch worker uses image")
+        assert "ghcr.io/example/worker:1" in printed.flowed
+        assert "Skipping the demo:local build." in printed.flowed
+
+    def test_an_empty_service_roster_says_nothing_was_started(
+        self, default_altitude, printed, tmp_path
+    ):
+        container_lifecycle._start_stack({}, [], tmp_path)
+
+        assert_promoted(default_altitude, printed, "No services are configured for this project")
+        assert "Skipping osprey up." in printed.flowed
+
+
+class TestAutonomousHostChangesAreReported:
+    """What the deploy wrote, or decided, without being asked to."""
+
+    def test_derived_scan_devices_name_the_file_they_came_from(
+        self, default_altitude, printed, project, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "osprey.services.bluesky_bridge.substrate_devices.derive_substrate_env",
+            lambda project_dir: {"BLUESKY_EPICS_MOTORS": "SR:C01:COR"},
+        )
+
+        container_lifecycle._ensure_bluesky_substrate_env(
+            {**BLUESKY_VA, "control_system": {"type": "virtual_accelerator"}}, project
+        )
+
+        assert_promoted(default_altitude, printed, "Auto-configured bluesky bridge scan devices")
+        assert "channel_limits.json" in printed.flowed
+
+    def test_a_local_env_override_is_reported_by_name(self, default_altitude, printed, tmp_path):
+        from osprey.utils.dotenv import ENV_SHARED_FILENAME
+
+        (tmp_path / ENV_SHARED_FILENAME).write_text("ARIEL_DB_PASSWORD=shared\n", encoding="utf-8")
+        (tmp_path / ".env").write_text("ARIEL_DB_PASSWORD=mine\n", encoding="utf-8")
+
+        container_lifecycle._report_chain_overrides(tmp_path)
+
+        assert_promoted(default_altitude, printed, "ARIEL_DB_PASSWORD")
+        assert "the local file winning" in printed.flowed
+        assert "mine" not in printed.flowed.split("ARIEL_DB_PASSWORD")[-1]
+
+    def test_dev_mode_reports_the_variable_it_set_for_the_containers(
+        self, default_altitude, printed, tmp_path, monkeypatch
+    ):
+        _stub_start_stack_preflights(monkeypatch)
+
+        with pytest.raises(_StopBeforeTheBuild):
+            container_lifecycle._start_stack(
+                {"deployed_services": ["event_dispatcher"]}, [], tmp_path, dev_mode=True
+            )
+
+        assert_promoted(default_altitude, printed, "Development mode: DEV_MODE")
+
+
+class TestDestructiveActionsAreReported:
+    """Anything the operator would want to have been told before it happened."""
+
+    def test_the_archive_rebuild_says_history_is_discarded(
+        self, default_altitude, printed, archiver_stubs, tmp_path
+    ):
+        archiver_stubs["state"] = _seed_state("MISMATCH")
+
+        container_lifecycle._stage_archiver_store(
+            {"deployed_services": ["archiver_store"]}, ["compose.yml"], {}, tmp_path
+        )
+
+        assert_promoted(default_altitude, printed, "Rebuilding the base series")
+        assert "--keep-archiver-base" in printed.flowed
+
+    def test_a_label_sweep_says_how_many_containers_it_will_stop(
+        self, default_altitude, printed, tmp_path, monkeypatch
+    ):
+        _stub_label_sweep(monkeypatch, container_ids=["abc123", "def456"])
+
+        container_lifecycle._down_by_label({}, tmp_path)
+
+        assert_promoted(default_altitude, printed, "Stopping the 2 container(s) labelled")
+        assert "Volumes are kept" in printed.flowed
+
+    def test_finding_nothing_to_stop_states_the_limit_of_the_sweep(
+        self, default_altitude, printed, tmp_path, monkeypatch
+    ):
+        _stub_label_sweep(monkeypatch, container_ids=[])
+
+        container_lifecycle._down_by_label({}, tmp_path)
+
+        assert_promoted(default_altitude, printed, "Nothing to stop.")
+        assert "may still be running" in printed.flowed
+
+
+class TestSubStepRows:
+    """The disposition table's ``sub-step`` rows, at the default altitude."""
+
+    def test_a_matching_fingerprint_says_why_the_seed_did_not_run(
+        self, default_altitude, printed, archiver_stubs, tmp_path
+    ):
+        archiver_stubs["state"] = _seed_state("MATCH")
+        printed.open_phase()
+
+        container_lifecycle._stage_archiver_store(
+            {"deployed_services": ["archiver_store"]}, ["compose.yml"], {}, tmp_path
+        )
+
+        assert_sub_step(printed, "archive already seeded, skipping the base seed")
+
+    def test_the_base_seed_sets_the_expectation_before_it_starts(
+        self, default_altitude, printed, archiver_stubs, tmp_path
+    ):
+        printed.open_phase()
+
+        container_lifecycle._stage_archiver_store(
+            {"deployed_services": ["archiver_store"]}, ["compose.yml"], {}, tmp_path
+        )
+
+        assert_sub_step(printed, "seeding the archive base: 2 channels over 7 days")
+        assert "(minutes on a first deploy)" in printed.flowed
+
+    def test_the_finished_base_seed_reports_what_it_wrote(
+        self, default_altitude, printed, archiver_stubs, tmp_path
+    ):
+        printed.open_phase()
+
+        container_lifecycle._stage_archiver_store(
+            {"deployed_services": ["archiver_store"]}, ["compose.yml"], {}, tmp_path
+        )
+
+        assert_sub_step(printed, "archive base: seeded 10 documents")
+
+    def test_the_reseed_closes_on_the_scenarios_it_put_back(
+        self, default_altitude, printed, tmp_path, monkeypatch
+    ):
+        _stub_reapply(monkeypatch, active=("nominal", "bpm_dropout"), archiver_describe="rewrote 3")
+        printed.open_phase()
+
+        container_lifecycle._reapply_active_scenarios(
+            {}, tmp_path, _engine("nominal", "bpm_dropout")
+        )
+
+        assert_sub_step(printed, "scenarios re-applied: nominal, bpm_dropout")
+        assert "(rewrote 3)" in printed.flowed
+
+    def test_a_skipped_archive_rewrite_is_not_appended_to_the_reseed_line(
+        self, default_altitude, printed, tmp_path, monkeypatch
+    ):
+        """Row 1's condition: the parenthetical is the rewrite's counts or nothing.
+
+        ``skipped`` already says why nothing happened, in words that do not fit
+        on the end of a step name -- and a ``None`` archiver never ran at all.
+        """
+        _stub_reapply(monkeypatch, active=("nominal",), archiver_describe=None)
+        printed.open_phase()
+
+        container_lifecycle._reapply_active_scenarios({}, tmp_path, _engine("nominal"))
+
+        assert_sub_step(printed, "scenarios re-applied: nominal")
+        assert "(" not in printed.flowed.split("scenarios re-applied")[-1]
+
+    def test_no_archiver_at_all_leaves_the_reseed_line_bare(
+        self, default_altitude, printed, tmp_path, monkeypatch
+    ):
+        _stub_reapply(monkeypatch, active=("nominal",), archiver=None)
+        printed.open_phase()
+
+        container_lifecycle._reapply_active_scenarios({}, tmp_path, _engine("nominal"))
+
+        assert_sub_step(printed, "scenarios re-applied: nominal")
+        assert "(" not in printed.flowed.split("scenarios re-applied")[-1]
+
+    def test_the_seeded_logbook_reports_its_count(
+        self, default_altitude, printed, tmp_path, monkeypatch
+    ):
+        _stub_ariel_stage(monkeypatch, seeded=12)
+        printed.open_phase()
+
+        container_lifecycle._stage_ariel_store(ARIEL_PROJECT, ["compose.yml"], {}, tmp_path)
+
+        assert_sub_step(printed, "logbook seeded: 12 entries")
+
+
+class TestDemotedRows:
+    """Appendix A, plus the *legacy* rows: emitted, but below the default view."""
+
+    def test_present_curve_certificates_are_a_debug_line(self, project, caplog):
+        paths = container_lifecycle._bluesky_curve_paths(project.parent)
+        for role in ("proxy_secret", "publisher_secret", "proxy_public", "publisher_public"):
+            paths[role].parent.mkdir(parents=True, exist_ok=True)
+            paths[role].write_text("key", encoding="utf-8")
+
+        with caplog.at_level(logging.DEBUG):
+            container_lifecycle._ensure_bluesky_document_plane_certs(
+                {"deployed_services": ["bluesky"]}, project
+            )
+
+        assert _levels_for(caplog, "already present") == {logging.DEBUG}
+
+    def test_having_no_machine_model_to_reseed_is_a_debug_line(self, tmp_path, caplog):
+        with caplog.at_level(logging.DEBUG):
+            container_lifecycle._reapply_active_scenarios({}, tmp_path, None)
+
+        assert _levels_for(caplog, "no scenarios to re-apply") == {logging.DEBUG}
+
+    def test_the_legacy_down_compose_file_listing_is_a_debug_line(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        _stub_legacy_down(monkeypatch, tmp_path, compose_files=["docker-compose.yml"])
+
+        # `deploy_down` exits the process on the runtime's status, which is 0
+        # here; the narration under test has already been emitted by then.
+        with caplog.at_level(logging.DEBUG), pytest.raises(SystemExit):
+            container_lifecycle.deploy_down(tmp_path / "config.yml")
+
+        assert _levels_for(caplog, "Using existing compose files") == {logging.DEBUG}
+        assert _levels_for(caplog, "- docker-compose.yml") == {logging.DEBUG}
+
+    def test_the_legacy_down_rerender_is_a_debug_line(self, tmp_path, monkeypatch, caplog):
+        _stub_legacy_down(monkeypatch, tmp_path, compose_files=[])
+
+        with caplog.at_level(logging.DEBUG), pytest.raises(SystemExit):
+            container_lifecycle.deploy_down(tmp_path / "config.yml")
+
+        assert _levels_for(caplog, "No existing compose files found") == {logging.DEBUG}
+
+    def test_the_legacy_detached_restart_line_is_a_debug_line(self, tmp_path, monkeypatch, caplog):
+        _stub_legacy_restart(monkeypatch, tmp_path)
+
+        with caplog.at_level(logging.DEBUG):
+            container_lifecycle.deploy_restart(tmp_path / "config.yml", detached=True)
+
+        assert _levels_for(caplog, "Running in detached mode") == {logging.DEBUG}
+
+
+class TestVerboseKeepsThePrimaryOutput:
+    """Criterion 3, for this module: ``-v`` adds the transcript, loses nothing."""
+
+    def test_a_promoted_fact_is_printed_under_verbose_too(
+        self, terminal_probe, printed, project, monkeypatch
+    ):
+        monkeypatch.setattr("osprey.utils.config.load_project_dotenv", lambda *a, **k: None)
+        assert CliRunner().invoke(cli, ["-v"]).exit_code == 0
+
+        container_lifecycle._ensure_bluesky_substrate_env(
+            {**BLUESKY_VA, "control_system": {"type": "mock"}}, project
+        )
+
+        # Printed by the renderer, AND painted from the record: under -v the
+        # transcript is what was asked for, so the fact appears in both.
+        assert "this deployment is browse-only" in printed.flowed
+        assert "browse-only" in terminal_probe.rendered_text
+
+
+class TestPromotedCopyStyle:
+    """The copy guard's rules, reapplied where the guard cannot see.
+
+    ``_report_fact`` takes the finished line, so the literals at its call sites
+    are invisible to ``tests/cli/test_printed_copy_style.py`` (which matches on
+    the printer's own name). These facts are printed at an operator, so the
+    same rules hold: this walk is what holds them.
+    """
+
+    def _literals(self) -> list[tuple[int, str]]:
+        source = Path(container_lifecycle.__file__).read_text(encoding="utf-8")
+        found: list[tuple[int, str]] = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            name = getattr(node.func, "id", "") or getattr(node.func, "attr", "")
+            if name not in {"_report_fact", "_report_step"}:
+                continue
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    found.append((node.lineno, arg.value))
+                elif isinstance(arg, ast.JoinedStr):
+                    found.append(
+                        (
+                            node.lineno,
+                            "".join(
+                                part.value
+                                for part in arg.values
+                                if isinstance(part, ast.Constant) and isinstance(part.value, str)
+                            ),
+                        )
+                    )
+        return found
+
+    def test_the_walk_reaches_the_promoted_lines(self):
+        """A rename that hides these call sites fails here, not silently."""
+        literals = self._literals()
+        assert len(literals) >= 14, f"only {len(literals)} promoted literals found"
+
+    def test_no_promoted_line_carries_an_em_dash(self):
+        offences = [f"{line}: {text}" for line, text in self._literals() if "—" in text]
+        assert not offences, "Em-dash in a promoted line:\n  " + "\n  ".join(offences)
+
+    def test_no_promoted_line_carries_in_house_jargon(self):
+        from tests.cli.test_printed_copy_style import _JARGON
+
+        offences = [
+            f"{line}: {term!r} -> {plain}"
+            for line, text in self._literals()
+            for term, plain in _JARGON.items()
+            if re.search(rf"\b{re.escape(term)}\b", text.lower())
+        ]
+        assert not offences, "In-house jargon in a promoted line:\n  " + "\n  ".join(offences)
+
+
+# ---------------------------------------------------------------------------
+# Task 3.2 stubs
+# ---------------------------------------------------------------------------
+
+
+class _StopBeforeTheBuild(RuntimeError):
+    """Sentinel: ``_start_stack`` reached the image build, so the test is done."""
+
+
+def _stub_start_stack_preflights(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reduce ``_start_stack`` to the dev-mode branch and stop at the build.
+
+    Every preflight between the roster check and the ``DEV_MODE`` line asks the
+    host a question this test has no answer for; each is covered by its own
+    module's tests.
+    """
+    for name in (
+        "_check_shared_disk_preflight",
+        "_preflight_host_ports",
+        "_preflight_archiver_pymongo",
+        "_preflight_stale_store_volumes",
+        "_ensure_bluesky_substrate_env",
+        "_ensure_bluesky_control_plane_keys",
+        "_ensure_bluesky_document_plane_certs",
+        "_preflight_env_chain_drift",
+        "_preflight_env_shadowing",
+    ):
+        monkeypatch.setattr(container_lifecycle, name, lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: set())
+    monkeypatch.setattr(container_lifecycle, "_compose_provider", lambda config: None)
+
+    def _stop(*args, **kwargs):
+        raise _StopBeforeTheBuild
+
+    monkeypatch.setattr(container_lifecycle, "_build_project_image", _stop)
+
+
+def _stub_label_sweep(monkeypatch: pytest.MonkeyPatch, *, container_ids: list[str]) -> None:
+    """Answer the label sweep's ``ps`` with ``container_ids`` and nothing else."""
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+
+    def _run(cmd, **kwargs):
+        stdout = "\n".join(container_ids) + ("\n" if container_ids else "")
+        return subprocess.CompletedProcess(list(cmd), 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", _run)
+
+
+def _seed_state(name: str):
+    """The archiver seeder's fingerprint verdict, by ``SeedState`` member name."""
+    from osprey.simulation import archiver_seed
+
+    return getattr(archiver_seed.SeedState, name)
+
+
+@pytest.fixture
+def archiver_stubs(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Reduce ``_stage_archiver_store`` to the lines this module owns.
+
+    The store connection, the fingerprint comparison and the base rewrite are
+    each covered by their own module's tests; what is under test here is which
+    of them says something, and at what altitude.
+    """
+    from osprey.simulation import apply as apply_mod
+    from osprey.simulation import archiver_seed as seed_mod
+
+    state: dict = {"state": _seed_state("ABSENT")}
+
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_archiver_store_connection",
+        lambda config, project_dir: {
+            "password": "pw",
+            "password_env": "MONGO_PW",
+            "username": "root",
+            "host": "localhost",
+            "port": 27017,
+        },
+    )
+    monkeypatch.setattr(container_lifecycle, "runtime_env", lambda config, env: dict(env))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle, "compose_base_cmd", lambda *a, **k: ["docker"])
+    monkeypatch.setattr(container_lifecycle, "_env_file_args", lambda *a, **k: [])
+    monkeypatch.setattr(container_lifecycle, "run_captured", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_archiver_seed_inputs",
+        lambda config, project_dir: (
+            [{"address": "SR:BPM1:X"}, {"address": "SR:BPM2:X"}],
+            None,
+            {},
+        ),
+    )
+    monkeypatch.setattr(container_lifecycle, "_wait_for_archiver_store", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_reapply_active_scenarios", lambda *a, **k: None)
+
+    knobs = SimpleNamespace(
+        retention_days=7, hot_span_hours=6, hot_cadence_sec=1, tail_cadence_sec=60
+    )
+    monkeypatch.setattr(
+        seed_mod, "SeedKnobs", SimpleNamespace(from_config=staticmethod(lambda config: knobs))
+    )
+    monkeypatch.setattr(seed_mod, "seed_fingerprint", lambda *a, **k: "fp")
+    # The real comparison object, not a stand-in: the knob diff is rendered from
+    # its `differences` and recorded from its `describe()`, so a fake carrying
+    # only one of the two would let the other half of that pairing rot.
+    monkeypatch.setattr(
+        seed_mod,
+        "compare_fingerprint",
+        lambda collection, fingerprint: seed_mod.FingerprintComparison(
+            state=state["state"], differences=(("retention_days", 5, 7),)
+        ),
+    )
+    monkeypatch.setattr(
+        seed_mod,
+        "seed_base",
+        lambda *a, **k: SimpleNamespace(describe=lambda: "seeded 10 documents x 2 channels"),
+    )
+
+    class _Collection:
+        def drop(self) -> None:
+            pass
+
+    class _Connection:
+        def __enter__(self):
+            return _Collection()
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(apply_mod, "archiver_collection", lambda store: _Connection())
+    return state
+
+
+def _stub_reapply(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    active: tuple[str, ...],
+    archiver_describe: str | None = None,
+    archiver: object = ...,
+) -> None:
+    """Hand ``_reapply_active_scenarios`` a finished ``ApplyResult``.
+
+    Args:
+        active: Scenario names the re-apply put back.
+        archiver_describe: The rewrite's one-line summary, or ``None`` for a
+            result that was skipped and says why.
+        archiver: Pass ``None`` for a result whose rewrite never ran at all.
+    """
+    from osprey.simulation import apply as apply_mod
+
+    if archiver is ...:
+        archiver = SimpleNamespace(
+            skipped=None if archiver_describe else "the archive has not been seeded yet",
+            describe=lambda: archiver_describe or "archive not rewritten",
+        )
+    result = SimpleNamespace(active=active, archiver=archiver)
+
+    monkeypatch.setattr(apply_mod, "apply_scenarios", lambda *a, **k: result)
+    monkeypatch.setattr(apply_mod, "persisted_scenario_anchor", lambda config, project_dir: None)
+
+
+def _engine(*active: str) -> SimpleNamespace:
+    """A machine model that reports ``active`` as its live scenario set."""
+    return SimpleNamespace(active_scenarios=lambda: list(active))
+
+
+def _stub_ariel_stage(monkeypatch: pytest.MonkeyPatch, *, seeded: int) -> None:
+    """Reduce ``_stage_ariel_store`` to its logbook seed."""
+    from osprey.simulation import apply as apply_mod
+
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle, "compose_base_cmd", lambda *a, **k: ["docker"])
+    monkeypatch.setattr(container_lifecycle, "_env_file_args", lambda *a, **k: [])
+    monkeypatch.setattr(container_lifecycle, "runtime_env", lambda config, env: dict(env))
+    monkeypatch.setattr(container_lifecycle, "run_captured", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_ariel_store_config", lambda *a, **k: {})
+    monkeypatch.setattr(container_lifecycle, "_wait_for_ariel_store", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_migrate_ariel_store", lambda *a, **k: None)
+    monkeypatch.setattr(apply_mod, "seed_active_logbook", lambda *a, **k: seeded)
+
+
+def _stub_legacy_down(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, compose_files: list[str]
+) -> None:
+    """Reduce the *legacy* ``deploy_down`` to its compose-file narration.
+
+    ``tmp_path`` becomes the working directory because the captured `down`
+    spools a file under ``var/logs/`` relative to it.
+    """
+    from osprey.deployment import compose_generator
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(container_lifecycle, "load_project_config", lambda *a, **k: {})
+    monkeypatch.setattr(container_lifecycle, "_web_terminals_enabled", lambda config: False)
+    monkeypatch.setattr(
+        compose_generator, "find_existing_compose_files", lambda *a, **k: list(compose_files)
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "prepare_compose_files", lambda *a, **k: ({}, ["rendered.yml"])
+    )
+    monkeypatch.setattr(container_lifecycle, "resolve_repo_root", lambda *a, **k: Path("."))
+    monkeypatch.setattr(container_lifecycle, "_compose_provider", lambda config: None)
+    monkeypatch.setattr(container_lifecycle, "compose_base_cmd", lambda *a, **k: ["docker"])
+    monkeypatch.setattr(container_lifecycle, "_env_file_args", lambda *a, **k: [])
+    monkeypatch.setattr(container_lifecycle, "runtime_env", lambda config, env: dict(env))
+    monkeypatch.setattr(
+        container_lifecycle, "with_plain_progress", lambda cmd: list(cmd) if cmd else ["docker"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(list(cmd), 0),
+    )
+
+
+def _stub_legacy_restart(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Reduce the *legacy* ``deploy_restart`` to its detached-mode line."""
+    _stub_legacy_down(monkeypatch, tmp_path, compose_files=["docker-compose.yml"])
+    monkeypatch.setattr(
+        container_lifecycle, "_ensure_bluesky_control_plane_keys", lambda *a, **k: None
+    )
+
+
+def _levels_for(caplog: pytest.LogCaptureFixture, fragment: str) -> set[int]:
+    """The levels every captured record carrying ``fragment`` was emitted at."""
+    levels = {record.levelno for record in caplog.records if fragment in record.getMessage()}
+    assert levels, f"nothing was logged carrying: {fragment!r}"
+    return levels
+
+
+# ---------------------------------------------------------------------------
+# --- Task 3.4: the remaining deploy-path sites ---
+# ---------------------------------------------------------------------------
+#
+# The disposition table's rows for ``compose_generator``, ``wheel_build``,
+# ``deploy_cmd``, ``build_persistence`` and ``build_cmd``, plus the two rows in
+# ``simulation/apply.py`` the reseed absorbs. Stubs for this section sit in the
+# labelled block at the very bottom of the module.
+
+
+class TestPromotedFactsOnTheMiscDeployPath:
+    """Appendix C's rows for these files: printed, unpainted, still recorded."""
+
+    def test_the_env_file_a_start_verb_seeds_is_reported(
+        self, default_altitude, printed, monkeypatch, tmp_path
+    ):
+        """``osprey up`` writing the operator's secret store is not a detail."""
+        _offer_the_env_seed(monkeypatch, answer=True)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        deploy_cmd.ensure_repo_env(repo, {"claude_code": {"provider": _SEED_PROVIDER}})
+
+        assert (repo / ".env").is_file(), "the seed never happened"
+        assert_promoted(default_altitude, printed, "(mode 0600) with")
+
+    def test_a_runtime_root_build_says_why_no_compose_was_rendered(self, default_altitude, printed):
+        """The build silently produced no compose files; that has to be said."""
+        assert build_cmd._render_compose_files(None, "/srv/osprey", dev_mode=False) is None
+
+        assert_promoted(default_altitude, printed, "Compose files not rendered")
+
+    def test_the_one_env_write_outside_build_is_reported(self, default_altitude, printed, tmp_path):
+        """The build's only write into the operator's own file, named."""
+        _repo_with_a_channel_manifest(tmp_path)
+
+        build_cmd._wire_build_derived_env(tmp_path, tmp_path / "build")
+
+        assert (tmp_path / ".env").is_file()
+        assert_promoted(default_altitude, printed, "at the generated channel manifest")
+
+
+class TestSubStepRowsOnTheMiscDeployPath:
+    """Rows 22, 36 and 37: a ``  · name`` line under the open phase."""
+
+    def test_the_dev_wheel_build_reports_one_step(self, printed, monkeypatch, tmp_path):
+        """Row 22. Under ``--dev`` this is the proof the flag was honored."""
+        printed.open_phase("Rendering the configuration")
+        _stub_a_successful_wheel_build(monkeypatch)
+
+        assert wheel_build._build_dev_wheel_cached(tmp_path) is not None
+
+        assert_sub_step(printed, "built osprey wheel from the local checkout")
+
+    def test_seeding_a_profile_context_dir_is_a_step(self, printed, tmp_path):
+        """Row 36: the build wrote into the operator's profile, outside build/."""
+        printed.open_phase("Rendering the configuration")
+        project_path = _rendered_project(tmp_path, "context-seed")
+        profile_dir = tmp_path / "profile"
+        profile_dir.mkdir()
+
+        applied = _apply_conventions(profile_dir, project_path, ["alice"])
+
+        assert applied.seeded_users == ["alice"]
+        assert_sub_step(printed, "seeded 1 empty context dir(s) in the profile")
+
+    def test_mirroring_onto_the_project_root_is_a_step(self, printed, tmp_path):
+        """Row 37: the build wrote onto the project root, outside build/."""
+        printed.open_phase("Rendering the configuration")
+        project_path = _rendered_project(tmp_path, "mirror-step")
+        profile_dir = tmp_path / "profile"
+        (profile_dir / PROJECT_MIRROR_DIR).mkdir(parents=True)
+        (profile_dir / PROJECT_MIRROR_DIR / "runbook.md").write_text("# ops\n", encoding="utf-8")
+
+        _apply_conventions(profile_dir, project_path, None)
+
+        assert (project_path / "runbook.md").is_file()
+        assert_sub_step(printed, "mirrored 1 file(s) onto the project root")
+
+
+class TestTheBuildsIdentityLine:
+    """Row 24 and the two rows it absorbs, read off one real build."""
+
+    def test_the_three_identity_fields_arrive_as_one_line(self, built_exemplar):
+        assert re.search(r"profile .+? \(bundle \S+, tier \d\)", built_exemplar.flowed), (
+            built_exemplar.flowed
+        )
+
+    def test_the_indented_key_value_spelling_is_gone(self, built_exemplar):
+        """Rows 25 and 26: three lines for three fields, retired."""
+        for retired in ("Data bundle:", "Tier:"):
+            assert retired not in built_exemplar.flowed, retired
+            assert not [m for m in built_exemplar.records(logging.INFO) if retired in m], retired
+
+    def test_the_identity_line_lands_before_the_first_phase(self, built_exemplar):
+        """It labels the wait, so it cannot arrive after the wait it labels."""
+        identity = built_exemplar.flowed.index("profile ")
+        first_phase = built_exemplar.flowed.index("→ ")
+        assert identity < first_phase, built_exemplar.flowed
+
+    def test_the_localhost_bind_posture_is_reported(self, built_exemplar):
+        """Appendix C's ``compose_generator`` row, on the same run.
+
+        A security posture the build chose on the operator's behalf, so it is
+        printed rather than logged. The record is kept for the sinks.
+        """
+        assert "bind to localhost only" in built_exemplar.flowed
+        assert any("bind to localhost only" in m for m in built_exemplar.records(logging.INFO))
+
+
+class TestAbsorbedRowsSayNothingOfTheirOwn:
+    """Rows whose fact another line already carries: the call is gone."""
+
+    def test_the_build_no_longer_counts_its_compose_files_at_info(self, built_exemplar):
+        """Row 27: the render phase's ``compose files`` step says it instead."""
+        assert not [m for m in built_exemplar.records(logging.INFO) if "compose file(s)" in m]
+        assert any("compose file(s)" in m for m in built_exemplar.records(logging.DEBUG))
+        assert re.search(r"·\s+compose files", built_exemplar.flowed), built_exemplar.flowed
+
+    def test_the_build_no_longer_announces_the_tree_it_rendered(self, built_exemplar):
+        """Row 28: the closing card is the "it worked" surface, so this is gone.
+
+        Read off a real build, so the absence is the absence of a line that had
+        every chance to fire: this run rendered, and said nothing about where.
+        """
+        assert not [m for m in built_exemplar.records(logging.INFO) if "✓ Rendered" in m]
+        assert "✓ Rendered" not in built_exemplar.flowed
+
+    def test_the_card_header_names_the_build_that_finished(self, tmp_path):
+        """Row 28's absorber, asserted on the card rather than on its caller.
+
+        The header names the deployment, not the tree: the operator asked for
+        this build by name and reads the card by the same name. The path is in
+        neither, which is the point of retiring the line that carried it.
+        """
+        from osprey.cli.summary_card import format_summary_card
+
+        repo = tmp_path / "beamline-ops"
+
+        assert format_summary_card(repo, "built")[0] == "beamline-ops — built"
+        assert str(repo) not in format_summary_card(repo, "built")[0]
+
+    def test_the_demo_seed_hint_is_not_a_line_of_its_own(self, built_exemplar):
+        """Row 29: a next step belongs in the card's ``next`` row, once.
+
+        Source-level as well as behavioral, because the hint fired only for a
+        profile shipping simulation scenarios: an exemplar without them would
+        satisfy the run assertion without the call site ever going away.
+        """
+        source = Path(build_cmd.__file__).read_text(encoding="utf-8")
+        assert "Seed the demo logbook" not in source
+        assert not [m for m in built_exemplar.records(logging.INFO) if "sim apply nominal" in m]
+
+    def test_the_service_list_is_no_longer_announced(self, built_exemplar):
+        """Row 11: ``osprey status`` is where the list is read."""
+        assert "Deployed services:" not in built_exemplar.flowed
+        assert not [m for m in built_exemplar.records(logging.DEBUG) if "Deployed services:" in m]
+
+    def test_the_wheel_build_is_not_announced_before_it_runs(self, monkeypatch, tmp_path, caplog):
+        """Row 21: announce-then-confirm, for a build memoized to one shot."""
+        _stub_a_successful_wheel_build(monkeypatch)
+
+        with caplog.at_level(logging.DEBUG):
+            wheel_build._build_dev_wheel_cached(tmp_path)
+
+        assert not [r for r in caplog.records if "Building osprey wheel" in r.getMessage()]
+
+    def test_the_clean_no_longer_announces_itself(self):
+        """Row 9: the two steps below it name what they remove as they remove it."""
+        source = Path(compose_generator.__file__).read_text(encoding="utf-8")
+        assert "Cleaning up deployment" not in source
+
+    def test_the_missing_env_remedy_rides_on_its_warning(self, tmp_path, caplog):
+        """Row 12: the remedy is the warning's second half, not a fact of its own."""
+        with caplog.at_level(logging.DEBUG):
+            assert compose_generator.compose_env_file_args(tmp_path) == []
+
+        remedies = [r for r in caplog.records if ".env.example" in r.getMessage()]
+        assert len(remedies) == 1, remedies
+        assert remedies[0].levelno == logging.WARNING
+        assert "No .env file found" in remedies[0].getMessage()
+
+    def test_activating_scenarios_says_nothing_of_its_own(self):
+        """Row 2: the reseed's closing step and ``osprey sim apply`` both say it."""
+        source = Path(apply.__file__).read_text(encoding="utf-8")
+        assert "Activated scenarios" not in source
+
+    def test_the_archive_rewrite_counts_are_not_logged_twice(self):
+        """Row 3: row 1's parenthetical and ``sim apply``'s echo carry them."""
+        source = Path(apply.__file__).read_text(encoding="utf-8")
+        assert "logger.info(result.describe())" not in source
+
+
+class TestDemotedRowsOnTheMiscDeployPath:
+    """Appendix A's rows for these files, plus row 23."""
+
+    def test_the_per_context_wheel_copy_is_a_debug_line(self, monkeypatch, tmp_path, caplog):
+        """Row 23: fires once per build context; as a step it would repeat."""
+        _stub_a_successful_wheel_build(monkeypatch)
+        out_dir = tmp_path / "context"
+        out_dir.mkdir()
+
+        with caplog.at_level(logging.DEBUG):
+            assert wheel_build._copy_local_framework_for_override(str(out_dir)) is True
+
+        assert _levels_for(caplog, "Copied osprey wheels") == {logging.DEBUG}
+
+    def test_the_shadowed_artifact_notice_is_a_debug_line(self, tmp_path, caplog):
+        """Row 35: one line per overridden artifact, inside the render loop.
+
+        The shadow is real, not simulated: the profile's copy lands on top of a
+        framework file that was already there, which is the condition the notice
+        reports on.
+        """
+        project_path = _rendered_project(tmp_path, "shadow-notice")
+        framework_rule = project_path / ".claude" / "rules" / "safety.md"
+        framework_rule.parent.mkdir(parents=True, exist_ok=True)
+        framework_rule.write_text("# shipped\n", encoding="utf-8")
+        profile_dir = tmp_path / "profile"
+        (profile_dir / "rules").mkdir(parents=True)
+        (profile_dir / "rules" / "safety.md").write_text("# facility\n", encoding="utf-8")
+
+        with caplog.at_level(logging.DEBUG):
+            _apply_conventions(profile_dir, project_path, None)
+
+        assert framework_rule.read_text(encoding="utf-8") == "# facility\n"
+        assert _levels_for(caplog, "profile overrides framework rule") == {logging.DEBUG}
+
+    def test_the_kernel_template_render_is_a_debug_line(self, monkeypatch, tmp_path, caplog):
+        """Rows 40 and 41: a per-file path inside a loop, and its announcement."""
+        source_dir, out_dir = _a_kernel_template(tmp_path)
+        # The render itself is jinja's business; only what it narrates is under
+        # test, and a real render needs the loader root the pipeline sets up.
+        monkeypatch.setattr(compose_generator, "render_template", lambda *a, **k: None)
+
+        with caplog.at_level(logging.DEBUG):
+            compose_generator.render_kernel_templates(str(source_dir), {}, str(out_dir))
+
+        assert _levels_for(caplog, "Rendered kernel template") == {logging.DEBUG}
+
+    def test_the_legacy_clean_narration_is_debug_lines(self, monkeypatch, tmp_path, caplog):
+        """Rows 10, 38 and 39: raw argv, and a bare completion with no phase."""
+        _stub_the_legacy_clean(monkeypatch, tmp_path)
+
+        with caplog.at_level(logging.DEBUG):
+            compose_generator.clean_deployment(
+                ["docker-compose.yml"], config={}, repo_root=tmp_path
+            )
+
+        assert _levels_for(caplog, "Running: ") == {logging.DEBUG}
+        assert _levels_for(caplog, "Cleanup completed") == {logging.DEBUG}
+
+
+class TestMiscDeployCopyStyle:
+    """The copy guard's rules, reapplied where the guard cannot see.
+
+    ``_report_fact`` and ``report_step`` take the finished line, so their call
+    sites are invisible to ``tests/cli/test_printed_copy_style.py`` (which
+    matches on the printer's own name). These lines are printed at an operator,
+    so the same rules hold.
+    """
+
+    #: Every module Task 3.4 promoted or stepped a line in.
+    _MODULES = (compose_generator, wheel_build, deploy_cmd, build_persistence, build_cmd)
+
+    def _literals(self) -> list[tuple[str, int, str]]:
+        found: list[tuple[str, int, str]] = []
+        for module in self._MODULES:
+            source = Path(module.__file__).read_text(encoding="utf-8")
+            for node in ast.walk(ast.parse(source)):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = getattr(node.func, "id", "") or getattr(node.func, "attr", "")
+                if name not in {"_report_fact", "report_step"}:
+                    continue
+                for arg in node.args:
+                    text = _prose_of(arg)
+                    if text:
+                        found.append((module.__name__, node.lineno, text))
+        return found
+
+    def test_the_walk_reaches_the_promoted_lines(self):
+        """A rename that hides these call sites fails here, not silently."""
+        literals = self._literals()
+        modules = {module for module, _, _ in literals}
+        assert len(literals) >= 6, f"only {len(literals)} literals found: {literals}"
+        assert len(modules) >= 4, f"only {len(modules)} modules matched: {modules}"
+
+    def test_no_promoted_line_carries_an_em_dash(self):
+        offences = [f"{mod}:{line}: {text}" for mod, line, text in self._literals() if "—" in text]
+        assert not offences, "Em-dash in a promoted line:\n  " + "\n  ".join(offences)
+
+    def test_no_promoted_line_carries_in_house_jargon(self):
+        from tests.cli.test_printed_copy_style import _JARGON
+
+        offences = [
+            f"{mod}:{line}: {term!r} -> {plain}"
+            for mod, line, text in self._literals()
+            for term, plain in _JARGON.items()
+            if re.search(rf"\b{re.escape(term)}\b", text.lower())
+        ]
+        assert not offences, "In-house jargon in a promoted line:\n  " + "\n  ".join(offences)
+
+
+# ---------------------------------------------------------------------------
+# Task 3.4 stubs
+# ---------------------------------------------------------------------------
+
+#: The provider whose secret the ``.env`` seed offer harvests from the shell.
+_SEED_PROVIDER = "anthropic"
+
+
+class _BuildRun:
+    """One real ``osprey build``: what it printed, and what it logged."""
+
+    def __init__(self, text: str, records: list[logging.LogRecord]) -> None:
+        self._text = text
+        self._records = records
+
+    @property
+    def flowed(self) -> str:
+        """Everything printed, whitespace collapsed (the console wraps at 100)."""
+        return " ".join(self._text.split())
+
+    def records(self, at_least: int) -> list[str]:
+        """The messages of every record emitted at ``at_least`` or above."""
+        return [r.getMessage() for r in self._records if r.levelno >= at_least]
+
+
+@pytest.fixture(scope="module")
+def built_exemplar(tmp_path_factory: pytest.TempPathFactory) -> _BuildRun:
+    """One build of the exemplar repo, with its output and its records kept.
+
+    Module-scoped because the build is the expensive part and every assertion
+    reading it asks about the same run. ``--skip-deps``/``--skip-lifecycle``
+    drop the venv install and the profile's shell phases: neither carries a
+    disposition row, and both cost minutes.
+    """
+    from osprey.cli.styles import osprey_theme
+    from tests.fixtures.lifecycle_repo import EXEMPLAR_DIRNAME, build_exemplar_repo
+
+    repo = build_exemplar_repo(tmp_path_factory.mktemp("misc-deploy") / EXEMPLAR_DIRNAME)
+
+    buffer = StringIO()
+    console = Console(
+        file=buffer, width=100, force_terminal=False, legacy_windows=False, theme=osprey_theme
+    )
+    sink = _RecordSink()
+    root = logging.getLogger()
+    previous_level = root.level
+    root.addHandler(sink)
+    root.setLevel(logging.DEBUG)
+    previous_cwd = Path.cwd()
+    os.chdir(repo)
+    previous_reporter = install_reporter(_CaptureReporter(console))
+    try:
+        result = CliRunner().invoke(build_cmd.build, ["--skip-deps", "--skip-lifecycle"])
+    finally:
+        install_reporter(previous_reporter)
+        os.chdir(previous_cwd)
+        root.removeHandler(sink)
+        root.setLevel(previous_level)
+
+    assert result.exit_code == 0, result.output
+    return _BuildRun(buffer.getvalue(), sink.records)
+
+
+class _RecordSink(logging.Handler):
+    """Every record the build emitted, kept whole so level and text stay paired."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _prose_of(node: ast.expr) -> str:
+    """The literal prose in ``node``, or empty for anything that is not prose."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            part.value
+            for part in node.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        )
+    return ""
+
+
+def _offer_the_env_seed(monkeypatch: pytest.MonkeyPatch, *, answer: bool) -> None:
+    """Put ``ensure_repo_env`` in the state where it offers to seed a ``.env``."""
+    from osprey.build.claude_code_resolver import provider_auth_secret_env
+
+    secret_var = provider_auth_secret_env(_SEED_PROVIDER, None)
+    assert secret_var, "the seed offer needs a provider with a secret variable"
+    monkeypatch.setenv(secret_var, "sk-from-the-shell")
+    monkeypatch.setattr(deploy_cmd, "_stdin_is_a_terminal", lambda: True)
+    monkeypatch.setattr(deploy_cmd.click, "confirm", lambda *a, **k: answer)
+
+
+def _repo_with_a_channel_manifest(repo: Path) -> None:
+    """A repo whose build produced the manifest the ``.env`` pointer names."""
+    from osprey.services.virtual_accelerator.manifest.build import MANIFEST_FILENAME
+
+    simulation = repo / "build" / "data" / "simulation"
+    simulation.mkdir(parents=True)
+    (simulation / MANIFEST_FILENAME).write_text('{"channels": []}', encoding="utf-8")
+
+
+def _stub_a_successful_wheel_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``python -m build`` produce a wheel without running a build.
+
+    The memo is reset on the way in: it is process-wide, so a stubbed wheel
+    left in it would be handed to whatever asks next.
+    """
+    wheel_build._reset_wheel_build_cache()
+
+    def _fake_build(argv, **kwargs):
+        outdir = Path(argv[argv.index("--outdir") + 1])
+        (outdir / "osprey-0.0.0-py3-none-any.whl").write_bytes(b"")
+        return subprocess.CompletedProcess(list(argv), 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_build)
+    monkeypatch.setattr(wheel_build, "_wheel_base_requirements", lambda path: [])
+
+
+def _rendered_project(tmp_path: Path, name: str) -> Path:
+    """A project tree the convention application can be run against."""
+    from osprey.cli.templates.manager import TemplateManager
+
+    return TemplateManager().create_project(
+        project_name=name, output_dir=tmp_path, data_bundle="hello_world"
+    )
+
+
+def _a_kernel_template(tmp_path: Path) -> tuple[Path, Path]:
+    """A source tree holding one kernel template, and somewhere to render it."""
+    source_dir = tmp_path / "service"
+    (source_dir / "kernels").mkdir(parents=True)
+    (source_dir / "kernels" / "kernel.json.j2").write_text("{}", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    return source_dir, out_dir
+
+
+def _stub_the_legacy_clean(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Reduce the *legacy* ``clean_deployment`` to its narration."""
+    monkeypatch.setattr(compose_generator, "run_captured", lambda *a, **k: None)
+    monkeypatch.setattr(compose_generator, "get_runtime_command", lambda config: "docker")
+    monkeypatch.setattr(compose_generator, "runtime_env", lambda config, env: dict(env))
+    monkeypatch.setattr(compose_generator, "resolve_repo_root", lambda config: tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# --- Task 3.3: the web_terminals package ---
+# ---------------------------------------------------------------------------
+#
+# Appendix C's rows for ``auth_credentials``, ``env_production``,
+# ``postup_hooks`` and ``provision``, plus the disposition table's rows 13-20
+# for the same package. Stubs for this section sit in the labelled block at the
+# very bottom of the module.
+#
+# Row 15 (``· web endpoint reachable``) is asserted here through ``printed``,
+# and again in ``tests/deployment/test_web_terminals_capture.py`` through the
+# reporter's step list -- that one pins the ORDER of the bounce and its payoff,
+# which a single-fragment needle cannot state.
+
+
+class TestWebTerminalSecretsAreReported:
+    """The credentials and secret files this deploy created, moved or replaced.
+
+    Names only, in every one of them: a hash identifies a credential
+    generation, a signing secret authenticates a session, and neither may
+    travel to a log sink or to a terminal. Each test asserts the variable IS
+    named and the value is NOT.
+    """
+
+    def test_provisioned_credentials_name_the_variables_never_the_hash(
+        self, default_altitude, printed, tmp_path
+    ):
+        result = auth_credentials.ensure_auth_credentials(["alice"], tmp_path, echo=_swallow)
+
+        assert_promoted(default_altitude, printed, "Provisioned web-terminal auth credential(s)")
+        assert "OSPREY_AUTH_PW_HASH_ALICE" in printed.flowed
+        assert "(gitignored, 0600)" in printed.flowed
+        assert _stored_value(result.env_auth_path, "OSPREY_AUTH_PW_HASH_ALICE") not in printed.text
+
+    def test_provisioned_session_secrets_name_the_variables_never_the_values(
+        self, default_altitude, printed, tmp_path
+    ):
+        result = auth_credentials.ensure_auth_session_secrets(tmp_path)
+
+        assert_promoted(default_altitude, printed, "Provisioned web-terminal auth secret(s)")
+        for var in auth_credentials.SESSION_SECRET_VARS:
+            assert var in printed.flowed
+            assert _stored_value(result.env_auth_path, var) not in printed.text
+
+    def test_a_removed_credential_names_the_user_and_the_file(
+        self, default_altitude, printed, tmp_path
+    ):
+        """``osprey users remove`` deletes a login. That is not a detail."""
+        auth_credentials.ensure_auth_credentials(["alice"], tmp_path, echo=_swallow)
+
+        assert auth_credentials.purge_auth_credentials("alice", tmp_path) is True
+
+        assert_promoted(default_altitude, printed, "Removed web-terminal auth credential(s)")
+        assert "'alice'" in printed.flowed
+        assert ".env.auth" in printed.flowed
+
+    def test_a_rotated_password_names_the_variable_never_the_password(
+        self, default_altitude, printed, tmp_path
+    ):
+        """Every live session of that user dies here, so the rotation is said."""
+        auth_credentials.ensure_auth_credentials(["alice"], tmp_path, echo=_swallow)
+
+        auth_credentials.set_auth_password("alice", "a-chosen-password", tmp_path)
+
+        assert_promoted(default_altitude, printed, "Replaced web-terminal auth credential")
+        assert "OSPREY_AUTH_PW_HASH_ALICE" in printed.flowed
+        assert "a-chosen-password" not in printed.text
+
+    def test_a_generated_users_env_names_its_sources_and_its_variables(
+        self, default_altitude, printed, tmp_path
+    ):
+        """A secret file the deploy wrote, at a mode it chose. Names, not values."""
+        (tmp_path / ".env").write_text("CBORG_API_KEY=llm-secret\n", encoding="utf-8")
+
+        env_production.ensure_env_production(_LOCAL_WEB_CONFIG, tmp_path)
+
+        assert_promoted(default_altitude, printed, "(mode 0600)")
+        assert "CBORG_API_KEY" in printed.flowed
+        assert "llm-secret" not in printed.text
+
+    def test_a_renamed_secrets_file_names_both_paths(self, default_altitude, printed, tmp_path):
+        """The deploy moved the operator's secrets to a different filename."""
+        (tmp_path / env_production.LEGACY_USERS_ENV_FILENAME).write_text("A=1\n", encoding="utf-8")
+
+        assert env_production.migrate_users_env(tmp_path) == tmp_path / ".env.users"
+
+        assert_promoted(default_altitude, printed, "now live under the current name")
+        assert env_production.LEGACY_USERS_ENV_FILENAME in printed.flowed
+        assert ".env.users" in printed.flowed
+
+    def test_a_deleted_leftover_secrets_file_says_which_one_it_removed(
+        self, default_altitude, printed, tmp_path
+    ):
+        """The other half of the migration: a delete, of a file holding secrets."""
+        (tmp_path / env_production.LEGACY_USERS_ENV_FILENAME).write_text("A=1\n", encoding="utf-8")
+        (tmp_path / ".env.users").write_text("B=2\n", encoding="utf-8")
+
+        assert env_production.migrate_users_env(tmp_path) == tmp_path / ".env.users"
+
+        assert_promoted(default_altitude, printed, "the older file was a leftover")
+        assert not (tmp_path / env_production.LEGACY_USERS_ENV_FILENAME).exists()
+
+
+class TestWebTerminalHostChangesAreReported:
+    """What the web-terminal deploy changed on the host, or decided for it."""
+
+    def test_enabling_systemd_linger_is_reported(self, default_altitude, printed, monkeypatch):
+        """A logind setting that outlives the deploy, and the operator's login."""
+        _stub_linger(monkeypatch, enable_returncode=0)
+
+        postup_hooks.enable_linger({}, {})
+
+        assert_promoted(default_altitude, printed, "Enabled systemd linger for deployuser")
+        assert "(podman persistence)" in printed.flowed
+
+    def test_the_host_port_bounce_says_what_it_is_about_to_restart(
+        self, default_altitude, printed, monkeypatch, tmp_path
+    ):
+        """Remediation this deploy performed on its own, with the argv it ran."""
+        _stub_the_host_port_bounce(monkeypatch, tmp_path, answers=[False, True])
+
+        postup_hooks.warn_if_web_stack_unreachable(
+            {"modules": {"web_terminals": {"nginx_port": 8080}}},
+            attempts=1,
+            delay=0,
+            web_cmd=["docker", "compose", "-f", "web.yml"],
+            run_env={},
+        )
+
+        assert_promoted(default_altitude, printed, "is not reachable from this host yet")
+        assert "docker compose -f web.yml restart" in printed.flowed
+
+    def test_a_pinned_sidecar_image_reports_the_build_it_skipped(
+        self, default_altitude, printed, tmp_path, monkeypatch
+    ):
+        """The deployment supplies the image, so nothing local was built."""
+        monkeypatch.chdir(tmp_path)
+
+        provision.build_auth_sidecar_image(_PINNED_SIDECAR_CONFIG, False, {})
+
+        assert_promoted(default_altitude, printed, "Skipping the local auth-sidecar build")
+        assert "ghcr.io/example/auth:2" in printed.flowed
+
+
+class TestTheUnshownMintWarningStillReachesTheTerminal:
+    """The pinned minted-password warning, re-pinned to its reworded copy.
+
+    It is a WARNING, so the altitude gate passes it: this one is painted by the
+    log handler rather than printed by the renderer, and that is the whole
+    claim. The fragments are the ones ``tests/deployment/test_up_as_built.py``
+    pins, asserted here against what a default-altitude terminal shows.
+    """
+
+    def test_the_pinned_fragments_survive_at_the_default_altitude(self, default_altitude, tmp_path):
+        result = auth_credentials.ensure_auth_credentials(["alice"], tmp_path, echo=_swallow)
+
+        provision._report_unshown_mints(result)
+
+        painted = " ".join(default_altitude.rendered_text.split())
+        for fragment in (
+            "Minted a login password",
+            "did NOT print it",
+            "osprey users passwd",
+            "OSPREY_AUTH_PW_<USER>",
+        ):
+            assert fragment in painted, fragment
+
+    def test_the_password_itself_is_in_neither_stream(self, default_altitude, printed, tmp_path):
+        """The point of the warning: the plaintext went nowhere, and is gone."""
+        shown: list[str] = []
+        result = auth_credentials.ensure_auth_credentials(["alice"], tmp_path, echo=shown.append)
+
+        provision._report_unshown_mints(result)
+
+        assert result.minted == ("alice",)
+        assert "alice" in " ".join(default_altitude.rendered_text.split())
+        for line in shown:
+            assert line not in printed.text
+            assert line not in default_altitude.rendered_text
+
+
+class TestWebTerminalSubStepRows:
+    """The disposition table's ``sub-step`` rows for this package."""
+
+    def test_a_bounce_that_worked_reports_the_endpoint_as_reachable(
+        self, printed, monkeypatch, tmp_path
+    ):
+        """Row 15: without it the bounce never says whether it worked."""
+        _stub_the_host_port_bounce(monkeypatch, tmp_path, answers=[False, True])
+        printed.open_phase()
+
+        postup_hooks.warn_if_web_stack_unreachable(
+            {"modules": {"web_terminals": {"nginx_port": 8080}}},
+            attempts=1,
+            delay=0,
+            web_cmd=["docker", "compose"],
+            run_env={},
+        )
+
+        assert_sub_step(printed, "web endpoint reachable")
+
+    def test_the_seed_loop_reports_its_counts(self, printed, monkeypatch, tmp_path):
+        """Row 16: counts, not an announcement, now that the loop is quiet."""
+        _stub_the_seed_loop(monkeypatch, tmp_path, outcomes={"alice": True, "bob": True})
+        printed.open_phase()
+
+        seeding.seed_user_containers(_seed_config(["alice", "bob"]))
+
+        assert_sub_step(printed, "seeded 2/2 user contexts")
+
+    def test_a_short_seed_is_legible_on_the_count_line_alone(self, printed, monkeypatch, tmp_path):
+        """Row 16's whole reason for being a count: ``<n>`` seeded of ``<total>``."""
+        _stub_the_seed_loop(monkeypatch, tmp_path, outcomes={"alice": True, "bob": None})
+        printed.open_phase()
+
+        seeding.seed_user_containers(_seed_config(["alice", "bob"]))
+
+        assert_sub_step(printed, "seeded 1/2 user contexts")
+
+    def test_a_container_that_was_not_ready_names_the_user_it_cost(
+        self, printed, monkeypatch, tmp_path, caplog
+    ):
+        """Rows 16 and 17's joint condition: the count alone would not say WHO.
+
+        The not-ready branch is excluded from the systemic check by design, so
+        without this warning a demoted per-user line would hide a real
+        degradation behind a number.
+        """
+        _stub_the_seed_loop(monkeypatch, tmp_path, outcomes={"alice": True, "bob": None})
+        printed.open_phase()
+
+        with caplog.at_level(logging.WARNING):
+            seeding.seed_user_containers(_seed_config(["alice", "bob"]))
+
+        assert _levels_for(caplog, "No container was running") == {logging.WARNING}
+        assert "bob" in caplog.text
+        assert "alice" not in caplog.text
+
+    def test_a_fully_ready_roster_warns_about_nobody(self, printed, monkeypatch, tmp_path, caplog):
+        """The warning is the exception, not a line every deploy carries."""
+        _stub_the_seed_loop(monkeypatch, tmp_path, outcomes={"alice": True, "bob": True})
+        printed.open_phase()
+
+        with caplog.at_level(logging.WARNING):
+            seeding.seed_user_containers(_seed_config(["alice", "bob"]))
+
+        assert "No container was running" not in caplog.text
+
+
+class TestWebTerminalAbsorbedRowsSayNothingOfTheirOwn:
+    """Rows 13, 14, 19 and 20: an announcement the step line already carries."""
+
+    def test_the_smoke_check_is_not_announced_before_it_runs(self, tmp_path, caplog):
+        """Rows 13 and 14, on a real script: the step reports it WITH its exit."""
+        _write_a_verify_script(tmp_path)
+
+        with caplog.at_level(logging.DEBUG):
+            postup_hooks.run_verify_script(str(tmp_path), {})
+
+        assert not [r for r in caplog.records if "Running post-up smoke check" in r.getMessage()]
+        assert not [r for r in caplog.records if "completed (exit 0)" in r.getMessage()]
+
+    def test_the_smoke_checks_step_still_carries_the_script_and_its_exit(self, printed, tmp_path):
+        """Rows 13 and 14's absorber, on the same code path."""
+        _write_a_verify_script(tmp_path)
+        printed.open_phase()
+
+        postup_hooks.run_verify_script(str(tmp_path), {})
+
+        assert_sub_step(printed, "smoke check verify.sh: exit 0")
+
+    def test_the_persona_image_build_is_not_announced(self):
+        """Row 19: the live build region carries the progress in between."""
+        source = Path(persona_images.__file__).read_text(encoding="utf-8")
+        assert "Building persona image" not in source
+
+    def test_the_auth_sidecar_build_is_not_announced(self, monkeypatch, tmp_path, caplog):
+        """Row 20, source-level AND on a real build: the step says it instead."""
+        source = Path(provision.__file__).read_text(encoding="utf-8")
+        assert "Building auth sidecar image" not in source
+
+        _stub_the_sidecar_build(monkeypatch, tmp_path)
+        with caplog.at_level(logging.DEBUG):
+            provision.build_auth_sidecar_image(_LOCAL_SIDECAR_CONFIG, False, {})
+
+        assert not [r for r in caplog.records if "auth sidecar image" in r.getMessage()]
+
+
+class TestWebTerminalDemotedRows:
+    """Rows 17 and 18: per-user chatter, emitted below the default view."""
+
+    def test_a_not_ready_container_is_a_debug_line(self, monkeypatch, tmp_path, caplog):
+        """Row 17. Safe only because row 16's count and its warning cover it."""
+        monkeypatch.setattr(seeding, "_container_exists", lambda *a, **k: False)
+
+        with caplog.at_level(logging.DEBUG):
+            outcome = seeding._seed_one_user(
+                "docker", "alice", "dls", "", "/skills", tmp_path, env=None
+            )
+
+        assert outcome is None
+        assert _levels_for(caplog, "(skipped alice: container not ready)") == {logging.DEBUG}
+
+    def test_a_seeded_user_is_a_debug_line(self, monkeypatch, tmp_path, caplog):
+        """Row 18: one line per user; row 16's step carries the count."""
+        _stub_one_users_seed(monkeypatch)
+
+        with caplog.at_level(logging.DEBUG):
+            outcome = seeding._seed_one_user(
+                "docker", "alice", "dls", "", "/skills", tmp_path, env=None
+            )
+
+        assert outcome is True
+        assert _levels_for(caplog, "seeded alice") == {logging.DEBUG}
+
+
+class TestWebTerminalCopyStyle:
+    """The copy guard's rules, reapplied where the guard cannot see.
+
+    ``report_fact`` and ``report_step`` take the finished line, so their call
+    sites are invisible to ``tests/cli/test_printed_copy_style.py`` (which
+    matches on the printer's own name). These lines are printed at an operator,
+    so the same rules hold.
+    """
+
+    #: Every module Task 3.3 promoted or stepped a line in.
+    _MODULES = (
+        auth_credentials,
+        env_production,
+        persona_images,
+        postup_hooks,
+        provision,
+        seeding,
+    )
+
+    def _literals(self) -> list[tuple[str, int, str]]:
+        found: list[tuple[str, int, str]] = []
+        for module in self._MODULES:
+            source = Path(module.__file__).read_text(encoding="utf-8")
+            for node in ast.walk(ast.parse(source)):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = getattr(node.func, "id", "") or getattr(node.func, "attr", "")
+                if name not in {"report_fact", "_report_step"}:
+                    continue
+                for arg in node.args:
+                    text = _prose_of(arg)
+                    if text:
+                        found.append((module.__name__, node.lineno, text))
+        return found
+
+    def test_the_walk_reaches_the_promoted_lines(self):
+        """A rename that hides these call sites fails here, not silently."""
+        literals = self._literals()
+        modules = {module for module, _, _ in literals}
+        assert len(literals) >= 12, f"only {len(literals)} literals found: {literals}"
+        assert len(modules) >= 5, f"only {len(modules)} modules matched: {modules}"
+
+    def test_no_promoted_line_carries_an_em_dash(self):
+        offences = [f"{mod}:{line}: {text}" for mod, line, text in self._literals() if "—" in text]
+        assert not offences, "Em-dash in a promoted line:\n  " + "\n  ".join(offences)
+
+    def test_no_promoted_line_carries_in_house_jargon(self):
+        from tests.cli.test_printed_copy_style import _JARGON
+
+        offences = [
+            f"{mod}:{line}: {term!r} -> {plain}"
+            for mod, line, text in self._literals()
+            for term, plain in _JARGON.items()
+            if re.search(rf"\b{re.escape(term)}\b", text.lower())
+        ]
+        assert not offences, "In-house jargon in a promoted line:\n  " + "\n  ".join(offences)
+
+
+# ---------------------------------------------------------------------------
+# Task 3.3 stubs
+# ---------------------------------------------------------------------------
+
+
+def _swallow(_line: str) -> None:
+    """The mint sink on a non-terminal stdout: a password goes nowhere."""
+
+
+def _stored_value(env_auth_path: Path, var: str) -> str:
+    """The value ``.env.auth`` actually holds for ``var``.
+
+    Read back off the file rather than fabricated, so the "never printed"
+    assertions are about the real secret this run generated.
+    """
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    value = parse_dotenv_file(env_auth_path).get(var, "")
+    assert value, f"nothing was stored for {var}"
+    return value
+
+
+#: A local-mode web-terminal deployment, the only mode ``.env.users`` generates in.
+_LOCAL_WEB_CONFIG = {
+    "facility": {"name": "Demo", "prefix": "dls", "timezone": "UTC"},
+    "llm": {"provider": "cborg", "api_key_env_var": "CBORG_API_KEY"},
+    "modules": {"web_terminals": {"enabled": True, "image_source": "local"}},
+}
+
+#: Local mode with ``auth.image`` pinned: nothing to build, and that is the fact.
+_PINNED_SIDECAR_CONFIG = {
+    "project_name": "demo",
+    "modules": {
+        "web_terminals": {
+            "image_source": "local",
+            "auth": {"method": "password", "image": "ghcr.io/example/auth:2"},
+        }
+    },
+}
+
+#: Local mode with nothing pinned: the build runs, and reports one step.
+_LOCAL_SIDECAR_CONFIG = {
+    "project_name": "demo",
+    "modules": {"web_terminals": {"image_source": "local", "auth": {"method": "password"}}},
+}
+
+
+def _stub_linger(monkeypatch: pytest.MonkeyPatch, *, enable_returncode: int) -> None:
+    """Reduce ``enable_linger`` to its narration: podman, ``loginctl`` present."""
+    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["podman", "compose"])
+    monkeypatch.setattr(postup_hooks.shutil, "which", lambda name: "/usr/bin/loginctl")
+    monkeypatch.setattr(postup_hooks.getpass, "getuser", lambda: "deployuser")
+
+    def _run(argv, **kwargs):
+        # `show-user` reports linger off, so the enable below actually runs.
+        returncode = 0 if argv[1] == "show-user" else enable_returncode
+        return SimpleNamespace(returncode=returncode, stdout="Linger=no", stderr="")
+
+    monkeypatch.setattr(postup_hooks.subprocess, "run", _run)
+
+
+def _stub_the_host_port_bounce(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, answers: list[bool]
+) -> None:
+    """A Docker Desktop host whose port answers only after the bounce."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
+    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker"])
+    replies = iter(answers)
+    monkeypatch.setattr(
+        postup_hooks, "_host_port_answers", lambda url, attempts, delay: next(replies)
+    )
+    monkeypatch.setattr(postup_hooks, "run_captured", lambda *a, **k: None)
+
+
+def _stub_the_sidecar_build(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Reduce the sidecar image build to its narration."""
+    monkeypatch.chdir(tmp_path)
+    context = tmp_path / "build" / "auth"
+    context.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["docker"])
+    monkeypatch.setattr(
+        provision, "_materialize_auth_build_context", lambda repo_root, dev_mode: context
+    )
+    monkeypatch.setattr(provision, "run_captured", lambda *a, **k: None)
+
+
+def _write_a_verify_script(project_root: Path) -> None:
+    """The scaffolded post-up smoke check, exiting 0 as its convention says."""
+    scripts = project_root / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    (scripts / "verify.sh").write_text("#!/usr/bin/env bash\necho ok\n", encoding="utf-8")
+
+
+def _seed_config(users: list[str]) -> dict:
+    """A roster the seed loop can resolve personas for."""
+    return {
+        "project_name": "demo",
+        "facility": {"name": "Demo", "prefix": "dls", "timezone": "UTC"},
+        "modules": {"web_terminals": {"enabled": True, "users": users}},
+    }
+
+
+def _stub_the_seed_loop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, outcomes: dict[str, bool | None]
+) -> None:
+    """Drive ``seed_user_containers``' loop by per-user outcome.
+
+    ``_seed_one_user`` is the seam: ``True`` seeded, ``False`` ready but failed,
+    ``None`` container not ready. Stubbing it rather than the runtime keeps the
+    counts under the test's control, which is what rows 16 and 17 are about.
+    """
+    monkeypatch.chdir(tmp_path)
+    context = tmp_path / "build" / "docker" / "web-terminal-context"
+    context.mkdir(parents=True, exist_ok=True)
+    (context / "base.md").write_text("# base\n", encoding="utf-8")
+    monkeypatch.setattr(seeding, "get_runtime_command", lambda config=None: ["docker", "compose"])
+    monkeypatch.setattr(seeding, "runtime_env", lambda config, **kw: {})
+    monkeypatch.setattr(seeding, "_seed_one_user", lambda runtime, user, *a, **k: outcomes[user])
+
+
+def _stub_one_users_seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reduce ``_seed_one_user`` to its narration, for a container that is up."""
+    monkeypatch.setattr(seeding, "_container_exists", lambda *a, **k: True)
+    monkeypatch.setattr(seeding, "_container_seed_owner", lambda *a, **k: "1000:1000")
+    monkeypatch.setattr(seeding, "_resolve_extra_md", lambda user, context_dir: "")
+    monkeypatch.setattr(seeding, "_seed_claude_md", lambda *a, **k: None)
+    monkeypatch.setattr(seeding, "_seed_skills", lambda *a, **k: None)
+
+
+# ---------------------------------------------------------------------------
+# --- Task 3.7: the last two report-through-logger sites ---
+# ---------------------------------------------------------------------------
+#
+# Both were reports the logger carried because there was nowhere else to put
+# them. Each now has a renderer shape of its own -- the knob diff is a block of
+# facts about one thing (``section``), the port report is a refusal (``fail``)
+# -- and each keeps the record it always had.
+#
+# The port report needs a second instrument. ``fail`` always writes to stderr,
+# which is ``styles.err_console`` and NOT the reporter's console, so
+# ``printed`` cannot see it: ``printed_err`` below is the seam for that half.
+
+
+class TestTheArchiveKnobDiff:
+    """The diff an operator reads before a rebuild discards their history."""
+
+    def test_the_changed_knobs_reach_the_default_view(
+        self, default_altitude, printed, archiver_stubs, tmp_path
+    ):
+        archiver_stubs["state"] = _seed_state("MISMATCH")
+
+        container_lifecycle._stage_archiver_store(
+            {"deployed_services": ["archiver_store"]}, ["compose.yml"], {}, tmp_path
+        )
+
+        assert_promoted(
+            default_altitude, printed, "The archive's knobs changed since it was seeded"
+        )
+        assert "retention_days 5 -> 7" in printed.flowed
+
+    def test_the_diff_is_a_block_of_rows_under_its_heading(
+        self, default_altitude, printed, archiver_stubs, tmp_path
+    ):
+        """One row per knob that moved, indented under the heading -- the shape
+        every other block of facts the CLI prints uses."""
+        archiver_stubs["state"] = _seed_state("MISMATCH")
+
+        container_lifecycle._stage_archiver_store(
+            {"deployed_services": ["archiver_store"]}, ["compose.yml"], {}, tmp_path
+        )
+
+        lines = [line.rstrip() for line in printed.text.splitlines() if line.strip()]
+        heading = lines.index("The archive's knobs changed since it was seeded:")
+        assert lines[heading + 1].startswith("  retention_days")
+        assert lines[heading + 1].endswith("5 -> 7")
+
+    def test_the_old_logged_diff_stays_out_of_the_terminal(
+        self, default_altitude, printed, archiver_stubs, tmp_path
+    ):
+        """`describe()`'s own spelling carries a colon the printed rows do not,
+        so it is the fragment that tells the two forms apart."""
+        archiver_stubs["state"] = _seed_state("MISMATCH")
+
+        container_lifecycle._stage_archiver_store(
+            {"deployed_services": ["archiver_store"]}, ["compose.yml"], {}, tmp_path
+        )
+
+        assert "retention_days: 5 -> 7" not in default_altitude.rendered_text
+        assert any("retention_days: 5 -> 7" in message for message in default_altitude.messages), (
+            "the log sinks lost the diff"
+        )
+        logging.getLogger(_WITNESS_LOGGER).warning(_WITNESS)
+        assert _WITNESS in default_altitude.rendered_text, "the probe console is not armed"
+
+    def test_a_matching_fingerprint_prints_no_diff(
+        self, default_altitude, printed, archiver_stubs, tmp_path
+    ):
+        """Nothing moved, so there is nothing to say about what moved."""
+        archiver_stubs["state"] = _seed_state("MATCH")
+
+        container_lifecycle._stage_archiver_store(
+            {"deployed_services": ["archiver_store"]}, ["compose.yml"], {}, tmp_path
+        )
+
+        assert "knobs changed" not in printed.flowed
+
+
+@pytest.fixture
+def printed_err(monkeypatch: pytest.MonkeyPatch) -> Iterator[Printed]:
+    """Capture what the trouble primitives put on stderr.
+
+    ``output.fail`` resolves ``styles.err_console`` per call, so standing a
+    buffered console in its place is the whole instrument. Reuses ``Printed``
+    for its ``flowed`` reader: a failure's cause lines wrap exactly as a report
+    line does.
+    """
+    from osprey.cli import styles
+    from osprey.cli.styles import osprey_theme
+
+    buffer = StringIO()
+    console = Console(
+        file=buffer,
+        width=100,
+        force_terminal=False,
+        legacy_windows=False,
+        theme=osprey_theme,
+    )
+    monkeypatch.setattr(styles, "err_console", console)
+    yield Printed(_CaptureReporter(console), buffer)
+
+
+def _stub_one_port_conflict(monkeypatch: pytest.MonkeyPatch, *, host_network: bool = False) -> None:
+    """Hand the preflight one external conflict to report."""
+    from osprey.deployment.host_ports import PortConflict
+
+    conflict = PortConflict(
+        host_port=8080,
+        bind_address="127.0.0.1",
+        service="web-terminal",
+        kind="external",
+        holder="another process",
+        remedy="modules.web_terminals.nginx_port",
+        host_network=host_network,
+    )
+    monkeypatch.setattr(container_lifecycle, "parse_host_port_bindings", lambda files: [])
+    monkeypatch.setattr(container_lifecycle, "resolve_project_name", lambda config: "demo")
+    monkeypatch.setattr(container_lifecycle, "find_port_conflicts", lambda *a, **k: [conflict])
+
+
+class TestTheHostPortConflictReport:
+    """The preflight's refusal, in the shape every other refusal wears."""
+
+    def test_the_report_lands_on_stderr_as_a_failure(
+        self, default_altitude, printed_err, monkeypatch
+    ):
+        _stub_one_port_conflict(monkeypatch)
+
+        with pytest.raises(RuntimeError):
+            container_lifecycle._preflight_host_ports({}, ["compose.yml"])
+
+        assert "✗ Host port preflight found 1 conflict" in printed_err.flowed
+        assert "port 8080 (127.0.0.1)" in printed_err.flowed
+        assert "modules.web_terminals.nginx_port" in printed_err.flowed
+
+    def test_the_remedy_is_the_line_that_says_what_to_do(
+        self, default_altitude, printed_err, monkeypatch
+    ):
+        """The report's closing hint becomes the ``→`` line, which is what makes
+        a remedy findable in a scrollback full of causes."""
+        _stub_one_port_conflict(monkeypatch)
+
+        with pytest.raises(RuntimeError):
+            container_lifecycle._preflight_host_ports({}, ["compose.yml"])
+
+        assert "→ Change the listed config keys to free ports before deploying." in (
+            printed_err.flowed
+        )
+
+    def test_the_report_is_no_longer_painted_by_the_log_handler(
+        self, default_altitude, printed_err, monkeypatch
+    ):
+        _stub_one_port_conflict(monkeypatch)
+
+        with pytest.raises(RuntimeError):
+            container_lifecycle._preflight_host_ports({}, ["compose.yml"])
+
+        assert "Host port preflight found" not in default_altitude.rendered_text
+        logging.getLogger(_WITNESS_LOGGER).warning(_WITNESS)
+        assert _WITNESS in default_altitude.rendered_text, "the probe console is not armed"
+
+    def test_the_record_is_still_the_whole_report(self, default_altitude, printed_err, monkeypatch):
+        """A log file reads exactly what it read before: the report as one
+        record, spacer lines and all."""
+        _stub_one_port_conflict(monkeypatch)
+
+        with pytest.raises(RuntimeError):
+            container_lifecycle._preflight_host_ports({}, ["compose.yml"])
+
+        assert any(
+            "Host port preflight found 1 conflict" in message and "port 8080" in message
+            for message in default_altitude.messages
+        ), "the log sinks lost the report"
+
+    def test_the_host_network_note_survives_as_a_cause_line(
+        self, default_altitude, printed_err, monkeypatch
+    ):
+        """The report's middle paragraphs are the failure's cause, so a
+        multi-paragraph report keeps every paragraph."""
+        _stub_one_port_conflict(monkeypatch, host_network=True)
+
+        with pytest.raises(RuntimeError):
+            container_lifecycle._preflight_host_ports({}, ["compose.yml"])
+
+        assert "bind these ports directly" in printed_err.flowed
+
+    def test_the_abort_is_unchanged(self, default_altitude, printed_err, monkeypatch):
+        """`fail` only prints. The caller's own RuntimeError is still what stops
+        the deploy, and it still carries the sentence it always carried."""
+        _stub_one_port_conflict(monkeypatch)
+
+        with pytest.raises(RuntimeError) as raised:
+            container_lifecycle._preflight_host_ports({}, ["compose.yml"])
+
+        assert "host port preflight failed: 1 conflict" in str(raised.value)
+
+    def test_no_conflicts_reports_nothing_and_returns(
+        self, default_altitude, printed_err, monkeypatch
+    ):
+        monkeypatch.setattr(container_lifecycle, "parse_host_port_bindings", lambda files: [])
+        monkeypatch.setattr(container_lifecycle, "resolve_project_name", lambda config: "demo")
+        monkeypatch.setattr(container_lifecycle, "find_port_conflicts", lambda *a, **k: [])
+
+        container_lifecycle._preflight_host_ports({}, ["compose.yml"])
+
+        assert printed_err.text == ""

--- a/tests/cli/test_lifecycle_promotions.py
+++ b/tests/cli/test_lifecycle_promotions.py
@@ -849,6 +849,11 @@ def _stub_legacy_restart(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
     monkeypatch.setattr(
         container_lifecycle, "_ensure_bluesky_control_plane_keys", lambda *a, **k: None
     )
+    # `restart` probes the runtime where `down` does not, and raises its own
+    # error rather than going through the stubbed `get_runtime_command`. Without
+    # this the narration under test is unreachable on any host with no container
+    # runtime installed.
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
 
 
 def _levels_for(caplog: pytest.LogCaptureFixture, fragment: str) -> set[int]:
@@ -1311,6 +1316,13 @@ def _stub_the_legacy_clean(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     monkeypatch.setattr(compose_generator, "get_runtime_command", lambda config: "docker")
     monkeypatch.setattr(compose_generator, "runtime_env", lambda config, env: dict(env))
     monkeypatch.setattr(compose_generator, "resolve_repo_root", lambda config: tmp_path)
+    # `clean_deployment` imports these two INSIDE the function, so they never
+    # enter this module's namespace and patching it here would miss them. The
+    # deferred import resolves the attribute off `container_lifecycle` at call
+    # time, which is what makes patching them there take effect. Left unpatched,
+    # `_compose_provider` probes for a real runtime and raises.
+    monkeypatch.setattr(container_lifecycle, "_compose_provider", lambda config: None)
+    monkeypatch.setattr(container_lifecycle, "_env_file_args", lambda *a, **k: [])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_live_render.py
+++ b/tests/cli/test_live_render.py
@@ -16,7 +16,13 @@ from rich.console import Console
 from osprey.cli import live_render
 from osprey.cli.live_render import format_duration, render_live_region
 from osprey.cli.styles import ColorTheme, _build_rich_theme, osprey_theme
-from osprey.deployment.build_progress import EXPORT_STEP, BuildRow
+from osprey.deployment.build_progress import EXPORT_STEP, BuildModel, BuildRow
+from tests.deployment.test_build_progress import BOOKKEEPING, PINNED_CAPTIONS
+
+FIXTURES = Path(__file__).resolve().parents[1] / "deployment" / "fixtures"
+
+#: The compose build the parser's own tests replay, rendered here as a table.
+COLD_BUILD = FIXTURES / "buildkit_cold_build.log"
 
 
 def make_row(
@@ -133,6 +139,59 @@ def test_caption_is_never_read_as_markup() -> None:
     """BuildKit captions contain brackets; none of them is a style tag."""
     out = render([make_row(caption="load metadata for [internal] python:3.12")])
     assert "[internal]" in out
+
+
+# -- what the fixture actually puts in the caption column --------------------
+
+#: One rendered row, split back into its columns. The caption is the only one
+#: that may hold spaces, and the duration anchors the split from the right.
+_RENDERED_ROW = re.compile(
+    r" {4}(?P<service>\S+)\s{2,}(?P<step>\S+)\s{2,}(?P<caption>.*?)\s{2,}\d+m\d{2}s"
+)
+
+
+def replay_rendered_captions() -> list[str]:
+    """Every caption the table showed while replaying the cold build.
+
+    The region is re-rendered only when a row actually changed, which is what
+    keeps a 860-line replay to a few hundred frames; the states themselves are
+    all still visited.
+    """
+    model = BuildModel()
+    captions: list[str] = []
+    previous: object = None
+    for tick, line in enumerate(COLD_BUILD.read_bytes().decode().split("\n")):
+        model.feed(line, float(tick))
+        rows = model.snapshot()
+        state = [(row.service, row.step, row.caption, row.finished) for row in rows]
+        if state == previous:
+            continue
+        previous = state
+        for rendered in render(rows, now=float(tick), width=200).splitlines():
+            if not rendered.strip():
+                continue
+            parsed = _RENDERED_ROW.fullmatch(rendered.rstrip())
+            assert parsed is not None, rendered
+            captions.append(parsed["caption"])
+    return captions
+
+
+def test_the_table_never_shows_buildkit_bookkeeping() -> None:
+    """The symptom that started this: a table whose every caption read
+    `DONE 0.0s`, or a step column doubled by BuildKit's own stopwatch
+    (`6/8  21.51 Collecting scikit-learn`)."""
+    captions = replay_rendered_captions()
+
+    assert captions
+    assert [caption for caption in captions if BOOKKEEPING.match(caption)] == []
+
+
+def test_the_table_shows_the_work_the_stream_reported() -> None:
+    """The same five captions the model and the heartbeat lines pin, at the
+    surface an operator on a terminal actually reads."""
+    captions = set(replay_rendered_captions())
+
+    assert [caption for caption in PINNED_CAPTIONS if caption not in captions] == []
 
 
 # -- finished services ------------------------------------------------------

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -195,8 +195,7 @@ class TestMainFunction:
         assert mock_cli.called
 
     @mock.patch("osprey.cli.main.cli")
-    @mock.patch("click.echo")
-    def test_main_handles_keyboard_interrupt(self, mock_echo, mock_cli):
+    def test_main_handles_keyboard_interrupt(self, mock_cli, capsys):
         """Test main handles Ctrl+C gracefully."""
         mock_cli.side_effect = KeyboardInterrupt()
 
@@ -206,12 +205,16 @@ class TestMainFunction:
         # Should exit with 130 (standard for SIGINT)
         assert exc_info.value.code == 130
 
-        # Should print goodbye message
-        assert mock_echo.called
+        # An interruption is a warning: stderr, with the warning mark. Asserted
+        # on what reaches the stream rather than on which function printed it,
+        # so the pin survives the next change of printer.
+        captured = capsys.readouterr()
+        assert "⚠" in captured.err
+        assert "Goodbye" in captured.err
+        assert captured.out == ""
 
     @mock.patch("osprey.cli.main.cli")
-    @mock.patch("click.echo")
-    def test_main_handles_general_exception(self, mock_echo, mock_cli):
+    def test_main_handles_general_exception(self, mock_cli, capsys):
         """Test main handles exceptions gracefully."""
         mock_cli.side_effect = Exception("Test error")
 
@@ -221,10 +224,12 @@ class TestMainFunction:
         # Should exit with 1
         assert exc_info.value.code == 1
 
-        # Should print error message
-        assert mock_echo.called
-        call_args = str(mock_echo.call_args)
-        assert "error" in call_args.lower()
+        # The last-resort failure wears the same mark as every other one, and
+        # lands on stderr so a caller piping stdout still sees it.
+        captured = capsys.readouterr()
+        assert "✗" in captured.err
+        assert "Test error" in captured.err
+        assert captured.out == ""
 
 
 class TestLazyLoading:

--- a/tests/cli/test_output_primitives.py
+++ b/tests/cli/test_output_primitives.py
@@ -1,0 +1,897 @@
+"""Tests for the CLI's core output primitives (``osprey.cli.output``).
+
+Four things are being pinned here, and they are the whole contract eleven
+migration tasks depend on:
+
+* **Echo class.** Every primitive prints under every reporter, ``NullReporter``
+  included -- ``osprey -v <verb>`` keeps its verb's own output even though the
+  phase record is swallowed. Each primitive is exercised under
+  ``PhaseReporter``, under a ``LiveReporter`` with a region actually mounted,
+  and under ``NullReporter``.
+* **Trouble's stream.** ``warn`` and ``fail`` take stderr, except while a live
+  region is mounted: there they take the region's own console, which is the only
+  one that can put the line ABOVE the region rather than onto the row it is
+  about to redraw. The borrow ends with the region.
+* **Machine mode.** Inside the block stdout stays empty and every line lands on
+  stderr, so a ``--json`` caller reads one document.
+* **Plainness off a terminal.** Piped output carries no escape sequences at
+  all, so subordination has to be structural (indentation) rather than only
+  dim.
+
+The reporter fakes here subclass ``PhaseReporter`` rather than standing in for
+it, per repo convention: a fake that only looks like one would not prove that
+the real ``out()``/``echo`` seam is the one being used.
+"""
+
+import io
+import re
+
+import pytest
+from rich.console import Console
+from rich.text import Text
+
+from osprey.cli import output, phase_reporter, styles
+from osprey.cli.output import (
+    fail,
+    machine_mode,
+    machine_mode_active,
+    note,
+    report,
+    section,
+    table,
+    warn,
+)
+from osprey.cli.phase_reporter import (
+    LiveReporter,
+    NullReporter,
+    PhaseReporter,
+    current_reporter,
+    install_reporter,
+)
+from osprey.cli.styles import data_table, osprey_theme, panel
+
+#: Anything Rich writes that is not text: styles, cursor moves, erases.
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+#: Just the color half of that. A line printed above a mounted region carries
+#: the region's own erase (``\x1b[2K``) whether or not it is styled, so "is this
+#: line colored" has to be asked of the select-graphic-rendition sequences alone.
+_SGR = re.compile(r"\x1b\[[0-9;]*m")
+
+
+@pytest.fixture(autouse=True)
+def restore_installed_reporter():
+    """Leave the module singleton exactly as the test found it."""
+    original = current_reporter()
+    yield
+    install_reporter(original)
+
+
+@pytest.fixture(autouse=True)
+def machine_mode_off():
+    """Prove no test leaks the process-scoped redirect into the next one."""
+    yield
+    assert output._machine_mode is False
+
+
+@pytest.fixture(autouse=True)
+def parked_monitor(monkeypatch):
+    """Park the monitor's tick: these tests drive the region by hand.
+
+    A real tick landing mid-test repaints the region and writes cursor control
+    into the buffer the assertions read.
+    """
+    monkeypatch.setattr(phase_reporter, "_MONITOR_INTERVAL", 3600.0)
+
+
+def recording_console() -> tuple[Console, io.StringIO]:
+    """A themed terminal console that records everything written to it.
+
+    ``force_terminal`` is what makes a ``Live`` real: off a terminal Rich skips
+    the repaint entirely. The theme is not optional either -- the primitives'
+    styles are semantic tokens, and a bare ``Console()`` raises ``MissingStyle``
+    on the first one.
+    """
+    buffer = io.StringIO()
+    return (
+        Console(file=buffer, theme=osprey_theme, force_terminal=True, width=100),
+        buffer,
+    )
+
+
+class RecordingReporter(PhaseReporter):
+    """A plain-line reporter whose console is a buffer, not the terminal."""
+
+    def __init__(self, console: Console) -> None:
+        super().__init__(color=False)
+        self._console = console
+
+    def out(self) -> Console:
+        return self._console
+
+
+def visible(text: str) -> list[str]:
+    """The words in ``text``, with escapes and blank lines dropped."""
+    return [line for line in _ANSI.sub("", text).splitlines() if line.strip()]
+
+
+def visible_raw(text: str) -> list[str]:
+    """The same lines, with their escapes left ON.
+
+    ``visible``'s counterpart for the tests that are about the styling rather
+    than the words: whether a line is colored can only be asked of a line that
+    still carries its escapes.
+    """
+    return [line for line in text.splitlines() if _ANSI.sub("", line).strip()]
+
+
+@pytest.fixture
+def err_buffer(monkeypatch):
+    """Stand a recording terminal console in for ``styles.err_console``.
+
+    The trouble primitives resolve stderr through the ``styles`` module alias at
+    call time, so this is the seam -- and it is the only way to see what they
+    would put on a *terminal*, which is where the colors are. It is also the one
+    way to ask whether the stderr console was used AT ALL, which ``capsys``
+    cannot: a ``Live`` swaps ``sys.stderr`` for a proxy of its own while a region
+    is mounted, so the descriptor a line reached says nothing about the console
+    it went through.
+
+    It REPLACES the console object, which is safe here only because nothing in
+    this module drives the CLI: ``styles.set_theme`` re-themes whatever console
+    the module global holds at call time and pops before it pushes, so a run
+    that reaches ``cli.main`` with a substituted console meets an empty theme
+    stack. A test here that ever invokes a verb must redirect the real console's
+    ``_file`` instead of swapping the object. The substitution is what buys the
+    ``force_terminal`` console the color assertions need, which redirecting a
+    non-terminal stderr console cannot.
+    """
+    console, buffer = recording_console()
+    monkeypatch.setattr(styles, "err_console", console)
+    return buffer
+
+
+@pytest.fixture
+def recording_err(err_buffer):
+    """The same recording stderr console, under the plain-line reporter."""
+    install_reporter(PhaseReporter(color=False))
+    return err_buffer
+
+
+@pytest.fixture
+def live():
+    """A ``LiveReporter`` with its region mounted, installed, torn down after."""
+    console, buffer = recording_console()
+    reporter = LiveReporter(console=console)
+    install_reporter(reporter)
+    reporter.start_rendering()
+    try:
+        yield reporter, buffer
+    finally:
+        reporter.stop_rendering()
+
+
+# -- report -----------------------------------------------------------------
+
+
+def test_report_prints_under_the_plain_reporter(capsys):
+    install_reporter(PhaseReporter(color=False))
+    report("deployment created at /srv/beamline")
+    assert visible(capsys.readouterr().out) == ["deployment created at /srv/beamline"]
+
+
+def test_report_prints_under_null_reporter(capsys):
+    """The whole point of echo class: ``-v`` keeps the verb's own output."""
+    install_reporter(NullReporter(verbose=True))
+    report("deployment created at /srv/beamline")
+    assert visible(capsys.readouterr().out) == ["deployment created at /srv/beamline"]
+
+
+def test_null_reporter_still_swallows_the_phase_record(capsys):
+    """The control for the test above -- emit class really is silenced here."""
+    reporter = NullReporter(verbose=True)
+    install_reporter(reporter)
+    reporter.emit("→ preparing")
+    report("deployment created at /srv/beamline")
+    assert visible(capsys.readouterr().out) == ["deployment created at /srv/beamline"]
+
+
+def test_report_prints_through_the_mounted_region(live, capsys):
+    """On a terminal the reporter's console owns the cursor, so the line uses it."""
+    reporter, buffer = live
+    report("deployment created at /srv/beamline")
+    assert "deployment created at /srv/beamline" in _ANSI.sub("", buffer.getvalue())
+    # Nothing bypassed the region onto raw stdout.
+    assert capsys.readouterr().out == ""
+    # And the region survived the line rather than being torn down by it.
+    assert reporter.is_rendering() is True
+
+
+def test_report_style_rides_on_the_text_not_the_call():
+    """A ``style=`` argument would repaint a mounted region in the line's color."""
+    console, buffer = recording_console()
+    install_reporter(RecordingReporter(console))
+    report("osprey-demo — running", style="bold")
+    assert "\x1b[1m" in buffer.getvalue()
+    assert visible(buffer.getvalue()) == ["osprey-demo — running"]
+
+
+def test_report_takes_prose_positionally():
+    """The copy guard reads prose out of positional arguments only.
+
+    Positional-only, so a call site cannot quietly hide a printed sentence from
+    the guard by naming the argument.
+    """
+    with pytest.raises(TypeError):
+        report(text="deployment created")  # type: ignore[call-arg]
+
+
+def test_report_prints_a_blank_separator_line():
+    console, buffer = recording_console()
+    install_reporter(RecordingReporter(console))
+    report("")
+    assert _ANSI.sub("", buffer.getvalue()) == "\n"
+
+
+# -- note -------------------------------------------------------------------
+
+
+def test_note_is_indented_one_step(capsys):
+    install_reporter(PhaseReporter(color=False))
+    report("using profile als-demo")
+    note("resolved from OSPREY_PROFILE")
+    assert visible(capsys.readouterr().out) == [
+        "using profile als-demo",
+        "  resolved from OSPREY_PROFILE",
+    ]
+
+
+def test_note_prints_under_null_reporter(capsys):
+    install_reporter(NullReporter(verbose=True))
+    note("resolved from OSPREY_PROFILE")
+    assert visible(capsys.readouterr().out) == ["  resolved from OSPREY_PROFILE"]
+
+
+def test_note_prints_through_the_mounted_region(live, capsys):
+    _reporter, buffer = live
+    note("resolved from OSPREY_PROFILE")
+    assert "  resolved from OSPREY_PROFILE" in _ANSI.sub("", buffer.getvalue())
+    assert capsys.readouterr().out == ""
+
+
+def test_note_is_dim_on_a_terminal():
+    """Dim is the other half of subordinate -- the half a pipe cannot carry."""
+    console, buffer = recording_console()
+    install_reporter(RecordingReporter(console))
+    note("resolved from OSPREY_PROFILE")
+    assert "\x1b[" in buffer.getvalue()
+
+
+def test_note_takes_prose_positionally():
+    with pytest.raises(TypeError):
+        note(text="resolved from OSPREY_PROFILE")  # type: ignore[call-arg]
+
+
+# -- section ----------------------------------------------------------------
+
+
+def test_section_aligns_its_values_into_a_column(capsys):
+    install_reporter(PhaseReporter(color=False))
+    section("endpoints", {"web": "http://localhost:8080", "openobserve": "http://localhost:5080"})
+    assert visible(capsys.readouterr().out) == [
+        "endpoints",
+        "  web           http://localhost:8080",
+        "  openobserve   http://localhost:5080",
+    ]
+
+
+def test_section_accepts_ordered_pairs_with_repeated_labels(capsys):
+    install_reporter(PhaseReporter(color=False))
+    section("mounts", [("volume", "osprey-data"), ("volume", "osprey-logs")])
+    assert visible(capsys.readouterr().out) == [
+        "mounts",
+        "  volume   osprey-data",
+        "  volume   osprey-logs",
+    ]
+
+
+def test_section_renders_non_string_values(capsys):
+    install_reporter(PhaseReporter(color=False))
+    section("ports", {"web": 8080, "detached": True})
+    assert visible(capsys.readouterr().out) == [
+        "ports",
+        "  web        8080",
+        "  detached   True",
+    ]
+
+
+def test_section_without_rows_prints_its_title_alone(capsys):
+    install_reporter(PhaseReporter(color=False))
+    section("endpoints", {})
+    assert visible(capsys.readouterr().out) == ["endpoints"]
+
+
+def test_section_without_a_title_prints_its_rows_alone(capsys):
+    install_reporter(PhaseReporter(color=False))
+    section("", {"web": "http://localhost:8080"})
+    assert visible(capsys.readouterr().out) == ["  web   http://localhost:8080"]
+
+
+def test_section_prints_under_null_reporter(capsys):
+    install_reporter(NullReporter(verbose=True))
+    section("endpoints", {"web": "http://localhost:8080"})
+    assert visible(capsys.readouterr().out) == [
+        "endpoints",
+        "  web   http://localhost:8080",
+    ]
+
+
+def test_section_prints_through_the_mounted_region(live, capsys):
+    _reporter, buffer = live
+    section("endpoints", {"web": "http://localhost:8080"})
+    assert visible(buffer.getvalue())[-2:] == [
+        "endpoints",
+        "  web   http://localhost:8080",
+    ]
+    assert capsys.readouterr().out == ""
+
+
+def test_section_takes_its_title_positionally():
+    with pytest.raises(TypeError):
+        section(title="endpoints", items={})  # type: ignore[call-arg]
+
+
+# -- warn -------------------------------------------------------------------
+
+
+def test_warn_marks_its_summary_and_indents_its_detail(capsys):
+    install_reporter(PhaseReporter(color=False))
+    warn("no theme in the profile", "used the default theme instead")
+    captured = capsys.readouterr()
+    assert visible(captured.err) == [
+        "⚠ no theme in the profile",
+        "  used the default theme instead",
+    ]
+    assert captured.out == ""
+
+
+def test_warn_without_detail_prints_the_summary_alone(capsys):
+    install_reporter(PhaseReporter(color=False))
+    warn("no theme in the profile")
+    assert visible(capsys.readouterr().err) == ["⚠ no theme in the profile"]
+
+
+def test_warn_treats_empty_detail_as_absent(capsys):
+    install_reporter(PhaseReporter(color=False))
+    warn("no theme in the profile", "")
+    assert visible(capsys.readouterr().err) == ["⚠ no theme in the profile"]
+
+
+def test_warn_indents_a_multi_line_detail_line_by_line(capsys):
+    install_reporter(PhaseReporter(color=False))
+    warn("two keys were ignored", "cli.colour is not a key\ncli.thème is not a key")
+    assert visible(capsys.readouterr().err) == [
+        "⚠ two keys were ignored",
+        "  cli.colour is not a key",
+        "  cli.thème is not a key",
+    ]
+
+
+def test_warn_is_colored_on_a_terminal_and_only_on_its_summary(recording_err):
+    """One colored line per warning: the detail stays at reading contrast."""
+    warn("no theme in the profile", "used the default theme instead")
+    assert _ANSI.sub("", recording_err.getvalue()).splitlines() == [
+        "⚠ no theme in the profile",
+        "  used the default theme instead",
+    ]
+    lines = recording_err.getvalue().splitlines()
+    assert "\x1b[" in lines[0]
+    assert "\x1b[" not in lines[1]
+
+
+def test_warn_takes_its_prose_positionally():
+    with pytest.raises(TypeError):
+        warn(summary="no theme in the profile")  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        warn("no theme in the profile", detail="used the default")  # type: ignore[call-arg]
+
+
+def test_warn_prints_under_null_reporter(capsys):
+    """Trouble is echo class too: ``-v`` never swallows a warning."""
+    install_reporter(NullReporter(verbose=True))
+    warn("no theme in the profile")
+    assert visible(capsys.readouterr().err) == ["⚠ no theme in the profile"]
+
+
+# -- fail -------------------------------------------------------------------
+
+
+def test_fail_prints_what_failed_then_why_then_what_to_do(capsys):
+    """The whole shape, in one place -- FR6's single form for every refusal."""
+    install_reporter(PhaseReporter(color=False))
+    fail(
+        "could not start the web service",
+        "port 8080 is already bound",
+        "free the port, or set deploy.web.port",
+    )
+    captured = capsys.readouterr()
+    assert visible(captured.err) == [
+        "✗ could not start the web service",
+        "  port 8080 is already bound",
+        "  → free the port, or set deploy.web.port",
+    ]
+    assert captured.out == ""
+
+
+def test_fail_without_cause_or_remedy_prints_the_summary_alone(capsys):
+    install_reporter(PhaseReporter(color=False))
+    fail("could not start the web service")
+    assert visible(capsys.readouterr().err) == ["✗ could not start the web service"]
+
+
+def test_fail_with_a_cause_and_no_remedy(capsys):
+    """Nothing honest to suggest is a reason to say nothing, not to invent one."""
+    install_reporter(PhaseReporter(color=False))
+    fail("could not start the web service", "port 8080 is already bound")
+    assert visible(capsys.readouterr().err) == [
+        "✗ could not start the web service",
+        "  port 8080 is already bound",
+    ]
+
+
+def test_fail_with_a_remedy_and_no_cause(capsys):
+    install_reporter(PhaseReporter(color=False))
+    fail("no profile is selected", None, "pick one with osprey use <profile>")
+    assert visible(capsys.readouterr().err) == [
+        "✗ no profile is selected",
+        "  → pick one with osprey use <profile>",
+    ]
+
+
+def test_fail_indents_a_multi_line_cause_line_by_line(capsys):
+    install_reporter(PhaseReporter(color=False))
+    fail("two services did not come up", "web: port 8080 is bound\napi: image not found", "retry")
+    assert visible(capsys.readouterr().err) == [
+        "✗ two services did not come up",
+        "  web: port 8080 is bound",
+        "  api: image not found",
+        "  → retry",
+    ]
+
+
+def test_fail_treats_empty_cause_and_remedy_as_absent(capsys):
+    install_reporter(PhaseReporter(color=False))
+    fail("could not start the web service", "", "")
+    assert visible(capsys.readouterr().err) == ["✗ could not start the web service"]
+
+
+def test_fail_only_prints(capsys):
+    """No raise, no exit, no exit code -- the caller keeps its own Abort."""
+    install_reporter(PhaseReporter(color=False))
+    assert fail("could not start the web service", "port 8080 is already bound") is None
+    report("and the verb decided what to do about it")
+    captured = capsys.readouterr()
+    assert visible(captured.out) == ["and the verb decided what to do about it"]
+
+
+def test_fail_is_colored_on_a_terminal_and_only_on_its_summary(recording_err):
+    fail("could not start the web service", "port 8080 is already bound", "free the port")
+    lines = recording_err.getvalue().splitlines()
+    assert "\x1b[" in lines[0]
+    assert "\x1b[" not in lines[1]
+    assert "\x1b[" not in lines[2]
+    assert _ANSI.sub("", recording_err.getvalue()).splitlines() == [
+        "✗ could not start the web service",
+        "  port 8080 is already bound",
+        "  → free the port",
+    ]
+
+
+def test_fail_takes_its_prose_positionally():
+    with pytest.raises(TypeError):
+        fail(summary="could not start the web service")  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        fail("could not start", cause="port 8080 is bound")  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        fail("could not start", None, remedy="free the port")  # type: ignore[call-arg]
+
+
+# -- fail without the mark ---------------------------------------------------
+
+
+def test_an_unmarked_failure_is_the_marked_one_minus_its_glyph(capsys):
+    """One failure wears one ``✗``, so the handler explaining it wears none.
+
+    A refusal raised inside an open phase leaves through ``Phase.fail``, which
+    has already printed ``✗ title`` for it. The handler that says WHY prints the
+    same block with the mark left off -- same words, same indentation, same
+    stream -- so the two read as one failure rather than two.
+    """
+    install_reporter(PhaseReporter(color=False))
+    fail("--dev cannot be honored", "this render carries no wheel", "osprey build --dev")
+    marked = visible(capsys.readouterr().err)
+    fail(
+        "--dev cannot be honored",
+        "this render carries no wheel",
+        "osprey build --dev",
+        mark=False,
+    )
+    unmarked = visible(capsys.readouterr().err)
+
+    assert unmarked == [
+        "--dev cannot be honored",
+        "  this render carries no wheel",
+        "  → osprey build --dev",
+    ]
+    # The same block, and the mark is the whole of the difference.
+    assert marked == [f"✗ {unmarked[0]}", *unmarked[1:]]
+
+
+def test_an_unmarked_failure_prints_no_glyph_at_all(capsys):
+    """The point of the form, asserted as the property it exists for."""
+    install_reporter(PhaseReporter(color=False))
+    fail("--dev cannot be honored", "this render carries no wheel", "osprey build --dev")
+    fail("--dev cannot be honored", "this render carries no wheel", mark=False)
+    assert capsys.readouterr().err.count("✗") == 1
+
+
+def test_an_unmarked_failure_keeps_its_summary_colored(recording_err):
+    """Losing the mark does not lower it out of the altitude an operator reads at."""
+    fail("--dev cannot be honored", "this render carries no wheel", mark=False)
+    lines = recording_err.getvalue().splitlines()
+    assert "\x1b[" in lines[0]
+    assert "\x1b[" not in lines[1]
+
+
+def test_an_unmarked_failure_prints_under_null_reporter(capsys):
+    """Echo class like the rest: ``osprey -v`` never swallows a refusal's reason."""
+    install_reporter(NullReporter(verbose=True))
+    fail("--dev cannot be honored", "this render carries no wheel", mark=False)
+    assert visible(capsys.readouterr().err) == [
+        "--dev cannot be honored",
+        "  this render carries no wheel",
+    ]
+
+
+def test_an_unmarked_failure_lands_above_a_mounted_region(live, err_buffer, capsys):
+    """It takes the region-aware routing whole, because it is the same seam."""
+    reporter, buffer = live
+    fail("--dev cannot be honored", "this render carries no wheel", mark=False)
+    assert visible(buffer.getvalue())[-2:] == [
+        "--dev cannot be honored",
+        "  this render carries no wheel",
+    ]
+    assert err_buffer.getvalue() == ""
+    assert capsys.readouterr().err == ""
+    assert reporter.is_rendering() is True
+
+
+def test_an_unmarked_failure_honors_machine_mode(capsys):
+    """A ``--json`` caller reads one document, refusals included."""
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        fail("--dev cannot be honored", "this render carries no wheel", mark=False)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert visible(captured.err) == [
+        "--dev cannot be honored",
+        "  this render carries no wheel",
+    ]
+
+
+def test_fail_takes_its_mark_as_a_keyword():
+    """Prose stays positional and the flag stays keyword: neither can pass as the other."""
+    with pytest.raises(TypeError):
+        fail("--dev cannot be honored", None, None, False)  # type: ignore[call-arg]
+
+
+def test_fail_prints_under_null_reporter(capsys):
+    install_reporter(NullReporter(verbose=True))
+    fail("could not start the web service", "port 8080 is already bound", "free the port")
+    assert visible(capsys.readouterr().err) == [
+        "✗ could not start the web service",
+        "  port 8080 is already bound",
+        "  → free the port",
+    ]
+
+
+def test_trouble_lands_above_a_mounted_region_through_its_console(live, err_buffer, capsys):
+    """A mounted region borrows the trouble lines, so they land above it whole.
+
+    Writing at the real stderr while a region is up puts the line wherever the
+    region left the cursor -- Rich unwraps its own ``FileProxy``
+    (``rich_proxied_file``) for a stderr ``Console``, so ``Live`` never sees the
+    write and never takes that row back. The region's own console is the only
+    one that can place a line above it, which is the same borrow the log handler
+    already gets, so trouble takes it too for as long as the region is up.
+    """
+    reporter, buffer = live
+    warn("no theme in the profile")
+    fail("could not start the web service", "port 8080 is already bound", "free the port")
+    captured = capsys.readouterr()
+    assert visible(buffer.getvalue())[-4:] == [
+        "⚠ no theme in the profile",
+        "✗ could not start the web service",
+        "  port 8080 is already bound",
+        "  → free the port",
+    ]
+    # Nothing went past the region: not through the stderr console it cannot
+    # see, and not onto a raw stream either.
+    assert err_buffer.getvalue() == ""
+    assert captured.err == ""
+    assert captured.out == ""
+    # And the region survived the lines rather than being torn down by them.
+    assert reporter.is_rendering() is True
+
+
+def test_trouble_keeps_its_colors_through_a_mounted_region(live):
+    """The borrow changes the stream, not the shape: one colored summary line."""
+    _reporter, buffer = live
+    warn("no theme in the profile", "used the default theme instead")
+    summary, detail = visible_raw(buffer.getvalue())[-2:]
+    # Named first, so the colors below are judged on the warning's own rows and
+    # not on whatever the region happened to paint last.
+    assert [_ANSI.sub("", line).strip() for line in (summary, detail)] == [
+        "⚠ no theme in the profile",
+        "used the default theme instead",
+    ]
+    assert _SGR.search(summary)
+    assert not _SGR.search(detail)
+
+
+def test_trouble_goes_back_to_stderr_once_the_region_comes_down(live, err_buffer):
+    """The other half of the borrow: the console is given back at teardown.
+
+    A verb that drew a region and then failed after it came down must put its
+    ``✗`` back on the stream its contract names, rather than keep whichever
+    console the region happened to leave behind.
+    """
+    reporter, buffer = live
+    reporter.stop_rendering()
+    before = buffer.getvalue()
+    warn("no theme in the profile")
+    assert visible(err_buffer.getvalue()) == ["⚠ no theme in the profile"]
+    assert buffer.getvalue() == before
+
+
+def test_machine_mode_keeps_trouble_off_a_mounted_region(live, err_buffer):
+    """Stdout purity outranks the region for trouble as it does for report.
+
+    A ``--json`` verb's document is the one thing on stdout, so inside the block
+    a warning takes the stderr console even where the region would have had
+    somewhere better to put it.
+    """
+    _reporter, buffer = live
+    with machine_mode():
+        warn("no theme in the profile")
+    assert "no theme in the profile" not in buffer.getvalue()
+    assert visible(err_buffer.getvalue()) == ["⚠ no theme in the profile"]
+
+
+# -- table ------------------------------------------------------------------
+
+
+def a_table():
+    """One two-column data table whose cells are ``Text``, as the contract asks."""
+    built = data_table()
+    built.add_column("Service")
+    built.add_column("Status")
+    built.add_row("dispatch", Text("● Running", style="success"))
+    return built
+
+
+def test_table_prints_under_the_plain_reporter(capsys):
+    install_reporter(PhaseReporter(color=False))
+    table(a_table())
+    printed = "\n".join(visible(capsys.readouterr().out))
+    assert "Service" in printed
+    assert "dispatch" in printed
+    assert "● Running" in printed
+
+
+def test_table_prints_under_null_reporter(capsys):
+    """Echo class: ``osprey -v status`` keeps the table it ran the verb for."""
+    install_reporter(NullReporter(verbose=True))
+    table(a_table())
+    assert "dispatch" in capsys.readouterr().out
+
+
+def test_table_prints_through_the_mounted_region(live, capsys):
+    """A table lands ABOVE the region, on the console that owns the cursor."""
+    reporter, buffer = live
+    table(a_table())
+    assert "dispatch" in _ANSI.sub("", buffer.getvalue())
+    assert capsys.readouterr().out == ""
+    assert reporter.is_rendering() is True
+
+
+def test_table_moves_to_stderr_in_machine_mode(capsys):
+    """A ``--json`` verb's stdout is one document, tables included."""
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        table(a_table())
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "dispatch" in captured.err
+
+
+def test_table_renders_exactly_as_a_bare_console_print_would(capsys):
+    """The module's ``soft_wrap`` changes nothing: a table sizes its own columns.
+
+    Pinned because it is the reason this primitive can route through the same
+    seam as the text ones instead of needing print keywords of its own.
+    """
+    install_reporter(PhaseReporter(color=False))
+    table(a_table())
+    through_the_primitive = capsys.readouterr().out
+
+    # The same width the primitive just rendered at, read off the console it
+    # used: a hard-coded 80 would disagree with any run that sets ``COLUMNS``.
+    buffer = io.StringIO()
+    Console(file=buffer, theme=osprey_theme, width=styles.console.width).print(a_table())
+
+    assert through_the_primitive == buffer.getvalue()
+
+
+def test_a_markup_string_cell_prints_its_brackets(capsys):
+    """The trap this primitive's docstring exists for, pinned as behaviour.
+
+    ``markup=False`` propagates into every nested renderable, so a cell built as
+    a markup STRING renders its tags literally and drags the column widths out
+    with them. Cells are ``Text``; there is no second way.
+    """
+    install_reporter(PhaseReporter(color=False))
+    built = data_table()
+    built.add_column("Status")
+    built.add_row("[success]● Running[/success]")
+    table(built)
+    assert "[success]" in capsys.readouterr().out
+
+
+def test_table_takes_its_renderable_positionally():
+    """Uniform with the prose primitives, so every call in the module reads alike."""
+    with pytest.raises(TypeError):
+        table(renderable=a_table())  # type: ignore[call-arg]
+
+
+def test_a_panel_goes_through_the_same_door(capsys):
+    """Named for tables, but it is the generic renderable printer."""
+    install_reporter(PhaseReporter(color=False))
+    table(panel(Text("nothing is deployed")))
+    assert "nothing is deployed" in capsys.readouterr().out
+
+
+# -- machine mode -----------------------------------------------------------
+
+
+def test_machine_mode_keeps_stdout_pure(capsys):
+    """A ``--json`` verb's stdout is one document; the prose goes to stderr."""
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        report("deployment created at /srv/beamline")
+        note("resolved from OSPREY_PROFILE")
+        section("endpoints", {"web": "http://localhost:8080"})
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert visible(captured.err) == [
+        "deployment created at /srv/beamline",
+        "  resolved from OSPREY_PROFILE",
+        "endpoints",
+        "  web   http://localhost:8080",
+    ]
+
+
+def test_machine_mode_redirects_even_with_a_region_mounted(live, capsys):
+    """Stdout purity outranks the region: the block exists for the JSON reader."""
+    _reporter, buffer = live
+    with machine_mode():
+        report("deployment created at /srv/beamline")
+    assert "deployment created" not in buffer.getvalue()
+    assert "deployment created at /srv/beamline" in capsys.readouterr().err
+
+
+def test_machine_mode_restores_stdout_after_the_block(capsys):
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        report("inside")
+    report("outside")
+    captured = capsys.readouterr()
+    assert visible(captured.out) == ["outside"]
+    assert visible(captured.err) == ["inside"]
+
+
+def test_machine_mode_restores_on_an_exception(capsys):
+    install_reporter(PhaseReporter(color=False))
+    with pytest.raises(RuntimeError), machine_mode():
+        report("inside")
+        raise RuntimeError("boom")
+    report("outside")
+    captured = capsys.readouterr()
+    assert visible(captured.out) == ["outside"]
+    assert visible(captured.err) == ["inside"]
+
+
+def test_machine_mode_nests_without_ending_the_redirect_early(capsys):
+    """A ``--json`` verb calling another one keeps the redirect for its body."""
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        with machine_mode():
+            report("inner")
+        report("after inner")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert visible(captured.err) == ["inner", "after inner"]
+
+
+def test_machine_mode_leaves_trouble_where_it_already_was(capsys):
+    """``warn``/``fail`` are stderr either way; the block changes nothing here."""
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        warn("no theme in the profile")
+        fail("could not start the web service", "port 8080 is already bound", "free the port")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert visible(captured.err) == [
+        "⚠ no theme in the profile",
+        "✗ could not start the web service",
+        "  port 8080 is already bound",
+        "  → free the port",
+    ]
+
+
+# -- machine_mode_active -----------------------------------------------------
+
+
+def test_machine_mode_active_is_false_outside_the_block():
+    assert machine_mode_active() is False
+
+
+def test_machine_mode_active_is_true_inside_the_block():
+    """What a call site mounting its own console asks before it picks one."""
+    with machine_mode():
+        assert machine_mode_active() is True
+    assert machine_mode_active() is False
+
+
+def test_machine_mode_active_is_restored_after_an_exception():
+    with pytest.raises(RuntimeError):
+        with machine_mode():
+            assert machine_mode_active() is True
+            raise RuntimeError("the verb blew up mid-document")
+    assert machine_mode_active() is False
+
+
+# -- plainness off a terminal ------------------------------------------------
+
+
+def test_every_primitive_is_plain_off_a_terminal(capsys):
+    """Piped output carries no escapes at all, whatever the styles say."""
+    install_reporter(PhaseReporter(color=False))
+    report("deployment created", style="bold")
+    note("resolved from OSPREY_PROFILE")
+    section("endpoints", {"web": "http://localhost:8080"})
+    warn("no theme in the profile", "used the default theme instead")
+    fail("could not start the web service", "port 8080 is already bound", "free the port")
+    captured = capsys.readouterr()
+    assert "\x1b" not in captured.out
+    assert "\x1b" not in captured.err
+
+
+def test_trouble_keeps_its_glyphs_off_a_terminal(capsys):
+    """``✗`` and ``→`` are content, not styling: a pipe still gets them."""
+    install_reporter(PhaseReporter(color=False))
+    warn("no theme in the profile")
+    fail("could not start the web service", "port 8080 is already bound", "free the port")
+    err = capsys.readouterr().err
+    assert "⚠ no theme in the profile" in err
+    assert "✗ could not start the web service" in err
+    assert "  → free the port" in err
+
+
+def test_machine_mode_output_is_plain_off_a_terminal(capsys):
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        report("deployment created", style="bold")
+        note("resolved from OSPREY_PROFILE")
+        section("endpoints", {"web": "http://localhost:8080"})
+    assert "\x1b" not in capsys.readouterr().err

--- a/tests/cli/test_output_structure_guard.py
+++ b/tests/cli/test_output_structure_guard.py
@@ -1,0 +1,731 @@
+"""The structural guard on how OSPREY's CLI reaches a terminal.
+
+The output migration moved every printed line onto one renderer and every table
+and panel onto one pair of factories. That work is done; this file is what keeps
+it done. It is a drift tripwire, not a test of behaviour -- it reads the source
+of ``src/osprey/cli``, ``src/osprey/deployment`` and ``src/osprey/health/render.py``
+with :mod:`ast` and asks four structural questions:
+
+1. Is a :class:`~rich.console.Console` built anywhere but ``styles.py``? The two
+   consoles there are the process's only consoles, and they are identity-stable
+   for its lifetime, so a third one built elsewhere writes past the theme, past
+   ``set_theme``'s re-theming, and past any live region that owns the cursor.
+2. Is ``click.echo`` called outside the handful of seams that genuinely need
+   raw bytes? ``click.echo`` writes at the stream. It does not know about the
+   renderer's altitudes, it does not know a live region is mounted, and it does
+   not know which stream a machine reader is parsing.
+3. Is the builtin ``print`` called at all? It has no legal use here.
+4. Is a :class:`~rich.table.Table` or :class:`~rich.panel.Panel` constructed
+   outside ``styles.py``? The box, padding and border tokens are spelled in the
+   factories and nowhere else, so a hand-built surface is a look that retheming
+   cannot reach.
+
+**How to answer a failure.** Almost always: route the line through
+:mod:`osprey.cli.output` (``report``/``note``/``section``/``warn``/``fail``), or
+build the surface with :func:`osprey.cli.styles.data_table`,
+:func:`~osprey.cli.styles.layout_table` or :func:`~osprey.cli.styles.panel`. Only
+when a caller's contract is the *bytes* -- a ``--json`` document, ``--help``
+text, a diff piped to a file -- does an allowlist entry below become the right
+answer, and then it needs a sentence saying which caller reads those bytes.
+
+**Two dispositions, on purpose.** Rules 1, 3 and 4 are zero-tolerance: their
+allowlists are *exact*, so the console inventory and the set of hand-built
+surfaces cannot drift in either direction without somebody looking at it. Rule 2
+is a *ratchet*: its entries are upper bounds, so retiring an echo seam never reds
+this file, while adding one to an already-listed file trips the guard exactly
+like adding one to a clean file. The asymmetry is deliberate -- a migration that
+removes a raw echo must not have to edit this guard in the same breath, whereas
+a fifth Console appearing anywhere is news either way.
+
+**On matching.** Everything here matches on the shape of the call, never on a
+line number, so the allowlist survives the files moving underneath it. Import
+aliases are read per module, so renaming an import on the way in
+(``from rich.table import Table as RT``) does not buy an exemption.
+
+Rich's two classmethod constructors are decided one at a time rather than
+inheriting whatever their spelling implies: ``Table.grid()`` is allowed, because
+a layout table draws nothing and so carries none of the tokens ``styles.py``
+owns (``live_render.py`` relies on this); ``Panel.fit()`` is forbidden and
+matched explicitly, because it spells border and padding exactly like the
+constructor does.
+
+*Standing rule for whoever adds rule 5.* A guard that matches on the called name
+inherits a family of exemptions it never chose -- every classmethod constructor,
+every import alias. So when you add a rule, enumerate the constructor's alternate
+spellings (``.fit``, ``.grid``, ``.from_*``) and decide each one here in writing.
+The spellings you do not name are the ones a well-meaning developer will reach
+for.
+
+**Scope, and what sits outside it.** The trees below are this feature's scope.
+Two live CLI output surfaces are outside them and are NOT guarded:
+``services/channel_finder/tools/validate_database.py`` and ``preview_database.py``,
+which render everything ``osprey channel-finder validate`` and ``osprey
+channel-finder preview`` print. Both hand-build their tables and panels and hold
+a module-level console. The CLI injects the shared console when it calls them, so
+the theme does reach that output, but their box and padding tokens are spelled
+outside ``styles.py``. A green run here is therefore not a claim about the CLI's
+entire visual surface -- only about the trees named below.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "osprey"
+
+#: Whole trees walked by every rule.
+_GUARDED_TREES = (SRC / "cli", SRC / "deployment")
+
+#: Single files walked by every rule. ``health/render.py`` is here rather than
+#: the whole of ``health`` because it is the only module in that package that
+#: prints; its ``render_json`` is the repo's reference machine seam.
+_GUARDED_FILES = (SRC / "health" / "render.py",)
+
+
+# ---------------------------------------------------------------------------
+# Call matchers
+#
+# Each takes one ast.Call and the names that module bound from click and rich,
+# and answers whether the call is the thing its rule forbids. They match the
+# CALLED NAME, so an attribute call (``console.print``, ``Table.grid``) is a
+# different call from the bare one, which is exactly the distinction the rules
+# need -- with the named exceptions below, each of which was decided rather than
+# inherited.
+# ---------------------------------------------------------------------------
+
+
+def _called_name(call: ast.Call) -> str | None:
+    """The final name in ``call``'s callee: ``a.b.C()`` gives ``"C"``.
+
+    Returns ``None`` for a callee that is not a name at all -- a subscript, a
+    call of a call -- because such a callee names nothing this file can rule on.
+    """
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+@dataclass(frozen=True)
+class _Bindings:
+    """What one module called the printing machinery it imported.
+
+    Matching on the called name alone reads only the *unaliased* spelling, which
+    hands anyone an accidental exemption by renaming an import. A module that
+    already has its own ``Table`` or ``Console`` would alias on import for
+    ordinary reasons, so the aliased spelling is not an exotic case; collecting
+    the bindings per module is what keeps the rules reading the same code a
+    person does.
+    """
+
+    #: Names bound to click's raw stream writers (``echo``, ``secho``).
+    click_writers: frozenset[str]
+    #: Names bound to :class:`rich.console.Console`.
+    consoles: frozenset[str]
+    #: Names bound to :class:`rich.table.Table` or :class:`rich.panel.Panel`.
+    surfaces: frozenset[str]
+    #: Names bound to rich's module-level ``print``.
+    rich_prints: frozenset[str]
+    #: Names bound to the ``rich`` package itself, for the dotted ``rich.print``.
+    rich_modules: frozenset[str]
+
+
+#: Where each guarded name lives, as ``module -> {imported name: binding field}``.
+_IMPORT_SOURCES: dict[str, dict[str, str]] = {
+    "click": {"echo": "click_writers", "secho": "click_writers"},
+    "rich": {"print": "rich_prints"},
+    "rich.console": {"Console": "consoles"},
+    "rich.table": {"Table": "surfaces"},
+    "rich.panel": {"Panel": "surfaces"},
+}
+
+#: The unaliased spellings, always in scope. A module that imports nothing still
+#: gets these, so ``rich.table.Table(...)`` is matched on its trailing name.
+_DEFAULT_BINDINGS: dict[str, frozenset[str]] = {
+    "click_writers": frozenset(),
+    "consoles": frozenset({"Console"}),
+    "surfaces": frozenset({"Table", "Panel"}),
+    "rich_prints": frozenset({"print"}),
+    "rich_modules": frozenset(),
+}
+
+
+def _bindings(tree: ast.Module) -> _Bindings:
+    """Read one module's import statements into a :class:`_Bindings`.
+
+    Handles ``from X import Y``, ``from X import Y as Z`` and ``import rich [as
+    r]``. Deliberately does NOT chase re-exports or module-attribute rebinding
+    (``T = Table``): those are not idioms anybody reaches for by accident, and
+    chasing them would mean interpreting the module rather than reading it.
+    """
+    collected: dict[str, set[str]] = {
+        field: set(names) for field, names in _DEFAULT_BINDINGS.items()
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for imported, field in _IMPORT_SOURCES.get(node.module or "", {}).items():
+                for alias in node.names:
+                    if alias.name == imported:
+                        collected[field].add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "rich":
+                    collected["rich_modules"].add(alias.asname or "rich")
+    return _Bindings(**{field: frozenset(names) for field, names in collected.items()})
+
+
+def _is_console_construction(call: ast.Call, bindings: _Bindings) -> bool:
+    """A ``Console(...)`` construction, however the name was imported.
+
+    Matches the bare ``Console(...)``, the dotted ``console.Console(...)`` (whose
+    trailing name is the same), and any alias the module bound, such as
+    ``from rich.console import Console as C``.
+    """
+    return _called_name(call) in bindings.consoles
+
+
+def _is_click_echo(call: ast.Call, bindings: _Bindings) -> bool:
+    """A raw ``click.echo``/``click.secho``, dotted or imported bare.
+
+    Deliberately NOT every ``.echo``: the phase reporter's ``echo`` is a
+    renderer method that routes through the console, and
+    ``echo = current_reporter().echo`` is a legal alias several verbs take. Only
+    click's own writer is raw, so only click's own writer is matched -- via the
+    dotted ``click.`` receiver, or via a name the module imported from click.
+
+    Known gap: ``import click as c; c.echo(...)`` is missed, because the dotted
+    branch pins the receiver to the literal name ``click``. Left as-is on the
+    reviewer's measurement that nobody writes that import, and recorded here so
+    the asymmetry with the rich aliases is a decision rather than an oversight.
+    """
+    func = call.func
+    if isinstance(func, ast.Attribute) and func.attr in ("echo", "secho"):
+        return isinstance(func.value, ast.Name) and func.value.id == "click"
+    return isinstance(func, ast.Name) and func.id in bindings.click_writers
+
+
+def _is_bare_print(call: ast.Call, bindings: _Bindings) -> bool:
+    """A call of the builtin ``print``, and nothing that merely ends in it.
+
+    ``current_reporter().out().print(table)`` and ``_target_console().print(...)``
+    are Rich console prints and are how the CLI is supposed to draw. Matching on
+    :class:`ast.Name` rather than on the trailing attribute is what separates the
+    two, and getting that wrong would make this rule fire on the renderer itself.
+
+    Also matches rich's own ``print``, under both spellings: ``from rich import
+    print`` binds the same bare name, and the dotted ``rich.print(...)`` is
+    caught through the module binding. Rich's ``print`` draws on rich's global
+    console, past ``styles.py`` and past any mounted live region, which is the
+    failure rule 1 exists to prevent.
+
+    **Known blind spot: the builtin bound as a DEFAULT PARAMETER VALUE.** This
+    rule matches calls, so ``def f(..., emit: Callable[[str], None] = print)``
+    is invisible to it. No such site is left in the trees this guard walks --
+    the two that existed (``auth_credentials.ensure_auth_credentials``'s
+    ``echo`` and ``reset.reset_deployment``'s ``emit``) now require the sink --
+    but nothing here would catch a new one, so a green run is not proof that
+    the trees hold no reachable builtin print.
+    """
+    func = call.func
+    if isinstance(func, ast.Attribute) and func.attr == "print":
+        return isinstance(func.value, ast.Name) and func.value.id in bindings.rich_modules
+    return isinstance(func, ast.Name) and func.id in bindings.rich_prints
+
+
+def _is_surface_construction(call: ast.Call, bindings: _Bindings) -> bool:
+    """A ``Table(...)`` or ``Panel(...)`` construction, however it is spelled.
+
+    Aliases count: ``from rich.table import Table as RT`` then ``RT(box=None)``
+    is the same construction wearing a different name.
+
+    Rich offers two classmethod constructors here, and they are decided
+    separately rather than sharing the fate their spelling gives them:
+
+    - ``Table.grid()`` is **allowed**. It returns a layout table whose whole
+      point is that it draws nothing, so it carries no box, padding or border
+      tokens for ``styles.py`` to own. ``live_render.py`` uses it.
+    - ``Panel.fit()`` is **forbidden**, and matched here explicitly. It is a full
+      panel construction -- ``Panel.fit(text, border_style=..., padding=...)``
+      spells exactly the tokens the factory exists to hold. Reading it as exempt
+      would be an accident of it being a classmethod, not a decision.
+
+    Matching ``.fit`` on any bound surface name is exact enough in practice:
+    ``Table`` has no ``fit`` and ``Panel`` has no ``grid``, so neither name can
+    borrow the other's disposition.
+    """
+    func = call.func
+    if isinstance(func, ast.Attribute) and func.attr == "fit":
+        return isinstance(func.value, ast.Name) and func.value.id in bindings.surfaces
+    return _called_name(call) in bindings.surfaces
+
+
+# ---------------------------------------------------------------------------
+# Allowlists
+#
+# Keyed by path relative to ``src/osprey``, POSIX-spelled. The value is a count
+# and the reason for it. Under a zero-tolerance rule the count is exact; under
+# the ratchet it is an upper bound. Read the reason before adding a line to one
+# of these files: it says what makes the existing calls legal, and a new call is
+# only covered if the same sentence is true of it.
+# ---------------------------------------------------------------------------
+
+#: Rule 1, zero-tolerance. The whole console inventory of the process, exactly.
+_CONSOLE_ALLOWLIST: dict[str, tuple[int, str]] = {
+    "cli/styles.py": (
+        2,
+        "The stdout and stderr consoles, both built by _make_console. These are "
+        "the CLI's only consoles: set_theme() re-themes them in place so that "
+        "`from .styles import console` aliases taken at import time stay correct, "
+        "which only works while nothing else builds one.",
+    ),
+}
+
+#: Rule 2, the ratchet. Seams whose contract is the bytes. Upper bounds, so a
+#: seam that is later migrated away only ever lowers a number here.
+_ECHO_ALLOWLIST: dict[str, tuple[int, str]] = {
+    # --- Reviewed seams. Each of these is deliberate and was ruled on during
+    # --- the output migration.
+    "cli/main.py": (
+        1,
+        "The bare-group `ctx.get_help()` echo. Help text is click's own rendered "
+        "bytes and belongs on stdout unwrapped.",
+    ),
+    "cli/audit_cmd.py": (
+        1,
+        "_display_report's `click.echo(report.model_dump_json(indent=2))`. The "
+        "verb's body runs inside output.machine_mode(), so every human line is "
+        "on stderr and this is the one document on stdout. It does not route "
+        "through the renderer precisely so the document lands on real stdout.",
+    ),
+    "cli/users_cmd.py": (
+        1,
+        "The users-env byte render. A caller redirects this to a file, so the "
+        "bytes are the contract.",
+    ),
+    "cli/config_cmd.py": (
+        1,
+        "config_cmd._emit, the module's own single byte seam.",
+    ),
+    "cli/query_cmd.py": (
+        2,
+        "The two machine seams: the --json document, and the agent-text "
+        "passthrough that a caller pipes.",
+    ),
+    "cli/scaffold_cmd.py": (
+        4,
+        "Two classes, both already blessed elsewhere. Two are help passthrough "
+        "seams -- `click.echo(ctx.get_help())` on a bare group, the same class as "
+        "main.py. The other two are byte-parity diff seams, the same class as "
+        "users_cmd's byte render: each echoes a joined difflib.unified_diff with "
+        "framework:/yours: headers and nothing else, for a reader who is piping "
+        "or applying it. The matching no-differences branches print through the "
+        "console with markup, so the theming lives on the human path and the raw "
+        "path carries diff bytes only.",
+    ),
+}
+
+#: Rule 3, zero-tolerance. Nothing, anywhere. The builtin has no legal use in
+#: these trees, and as of this guard's first run there was not one call of it to
+#: grandfather, so this allowlist starts empty and should stay that way.
+_PRINT_ALLOWLIST: dict[str, tuple[int, str]] = {}
+
+#: Rule 4, zero-tolerance. The factory bodies, exactly.
+_SURFACE_ALLOWLIST: dict[str, tuple[int, str]] = {
+    "cli/styles.py": (
+        3,
+        "The three factory bodies: data_table, layout_table and panel. This is "
+        "the module the rule exists to funnel everything into, so the "
+        "constructions here are the rule being satisfied rather than broken.",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class _Rule:
+    """One structural question, its matcher, its budget and its remedy."""
+
+    #: What a failure calls the thing, in the words a reader would search for.
+    label: str
+    #: Takes a call and its module's :class:`_Bindings`; True if it violates.
+    matches: object
+    #: Path relative to ``src/osprey`` mapped to (count, reason).
+    allowlist: dict[str, tuple[int, str]]
+    #: The sentence a failure ends with, telling the reader what to do.
+    remedy: str
+    #: True for a zero-tolerance rule, whose counts are exact in both
+    #: directions. False for the ratchet, whose counts are upper bounds.
+    exact: bool
+
+
+_RULES: dict[str, _Rule] = {
+    "console": _Rule(
+        label="Console(...) construction",
+        matches=_is_console_construction,
+        allowlist=_CONSOLE_ALLOWLIST,
+        remedy=(
+            "Import `console` or `err_console` from osprey.cli.styles instead of "
+            "building one, or print through osprey.cli.output."
+        ),
+        exact=True,
+    ),
+    "click_echo": _Rule(
+        label="raw click.echo/click.secho call",
+        matches=_is_click_echo,
+        allowlist=_ECHO_ALLOWLIST,
+        remedy=(
+            "Print through osprey.cli.output (report/note/section/warn/fail). If "
+            "the bytes really are the contract -- a --json document, --help text "
+            "-- add an entry to _ECHO_ALLOWLIST saying which caller reads them."
+        ),
+        exact=False,
+    ),
+    "bare_print": _Rule(
+        label="builtin print(...) call",
+        matches=_is_bare_print,
+        allowlist=_PRINT_ALLOWLIST,
+        remedy=(
+            "Print through osprey.cli.output. A raw write lands inside a mounted "
+            "live region instead of above it, and takes no altitude."
+        ),
+        exact=True,
+    ),
+    "surface": _Rule(
+        label="direct rich Table(...)/Panel(...) construction",
+        matches=_is_surface_construction,
+        allowlist=_SURFACE_ALLOWLIST,
+        remedy=(
+            "Build it with osprey.cli.styles.data_table(), layout_table() or "
+            "panel(). Pass content-shaped options (title, show_lines) as "
+            "keywords; do not respell box, padding or border."
+        ),
+        exact=True,
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+
+def _guarded_sources() -> list[tuple[str, str]]:
+    """Every guarded module, as ``(path relative to src/osprey, source)``."""
+    paths: list[Path] = []
+    for tree in _GUARDED_TREES:
+        paths.extend(sorted(tree.rglob("*.py")))
+    paths.extend(path for path in _GUARDED_FILES if path.exists())
+    return [(path.relative_to(SRC).as_posix(), path.read_text(encoding="utf-8")) for path in paths]
+
+
+def _find(rule: _Rule, source: str) -> list[int]:
+    """Line numbers in ``source`` where ``rule`` matches, in order."""
+    tree = ast.parse(source)
+    bindings = _bindings(tree)
+    return sorted(
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and rule.matches(node, bindings)
+    )
+
+
+def _over_budget(rule: _Rule, sources: Iterable[tuple[str, str]]) -> list[str]:
+    """Failure lines for every guarded file that does not match its allowance.
+
+    An empty list means the tree is clean under ``rule``. This is the whole
+    decision, so the standing test and every self-test below drive it: a guard
+    that cannot be shown to go red is not a guard.
+
+    Under a zero-tolerance rule a file holding FEWER calls than its entry is
+    reported too. That is not an obstacle to cleanup -- the message says the
+    news is good and to lower the number -- it is what keeps the console and
+    surface inventories honest, because an entry nobody ever has to revisit
+    stops describing the tree.
+    """
+    problems: list[str] = []
+    for relpath, source in sources:
+        found = _find(rule, source)
+        allowed, reason = rule.allowlist.get(relpath, (0, ""))
+        if len(found) == allowed:
+            continue
+        if len(found) < allowed:
+            if not rule.exact:
+                continue
+            problems.append(
+                f"{relpath} holds {len(found)} {rule.label}(s) but its entry "
+                f"claims {allowed}. This is good news: lower the number in the "
+                f"allowlist to {len(found)}, and reword the reason if it no "
+                f"longer describes what is left.\n"
+                f"    what the entry says today: {reason}"
+            )
+            continue
+        locations = ", ".join(f"{relpath}:{line}" for line in found)
+        if allowed:
+            limit = "exactly" if rule.exact else "at most"
+            problems.append(
+                f"{relpath} holds {len(found)} of the {rule.label}s but is "
+                f"allowed {limit} {allowed}.\n"
+                f"    at: {locations}\n"
+                f"    why the existing ones are allowed: {reason}\n"
+                f"    {rule.remedy}"
+            )
+        else:
+            problems.append(
+                f"{relpath} holds {len(found)} {rule.label}(s) and is on no "
+                f"allowlist.\n"
+                f"    at: {locations}\n"
+                f"    {rule.remedy}"
+            )
+    return problems
+
+
+@pytest.mark.parametrize("rule_name", sorted(_RULES))
+def test_output_stays_inside_the_hierarchy(rule_name: str) -> None:
+    """No guarded module reaches a terminal outside the renderer and factories."""
+    problems = _over_budget(_RULES[rule_name], _guarded_sources())
+    assert not problems, (
+        f"\n\n{len(problems)} file(s) drifted out of the CLI output hierarchy:\n\n"
+        + "\n\n".join(problems)
+        + "\n"
+    )
+
+
+def test_the_pending_review_block_stays_separable() -> None:
+    """Pending entries stay labelled and stay out of the permanent allowlist.
+
+    Written for whoever retires the block: it catches a half-deletion that left
+    a ``PENDING REVIEW.`` entry behind among the blessed seams, and it catches
+    the reverse mistake of promoting an entry by moving it without dropping the
+    label. It passes once the block is gone, because the pending dict is read
+    through :func:`globals` rather than referenced directly.
+    """
+    pending: dict[str, tuple[int, str]] = globals().get("_ECHO_PENDING_REVIEW", {})
+    for relpath, (_allowed, reason) in _ECHO_ALLOWLIST.items():
+        labelled = reason.startswith("PENDING REVIEW.")
+        if relpath in pending:
+            assert labelled, f"{relpath} is in the pending block but is not labelled as pending"
+        else:
+            assert not labelled, (
+                f"{relpath} is labelled PENDING REVIEW but sits outside the pending block. "
+                "Either move it back inside the block, or drop the label now that it is blessed."
+            )
+
+
+def test_the_guarded_trees_are_actually_being_read() -> None:
+    """The scan reaches real modules, so a green run means something.
+
+    A file list that silently came back empty -- a moved package, a typo in a
+    path constant -- would make all four rules pass by reading nothing.
+    """
+    sources = _guarded_sources()
+    relpaths = {relpath for relpath, _ in sources}
+    assert len(sources) > 50, f"only {len(sources)} guarded modules found under {SRC}"
+    for expected in ("cli/styles.py", "cli/output.py", "health/render.py"):
+        assert expected in relpaths, f"{expected} is not being scanned"
+
+
+@pytest.mark.parametrize("rule_name", sorted(_RULES))
+def test_no_allowlist_entry_outlives_its_file(rule_name: str) -> None:
+    """Every allowlisted path still exists in the scanned set.
+
+    ``_over_budget`` iterates sources and looks each one up in the allowlist, so
+    an entry whose file was deleted or renamed is simply never visited and would
+    survive forever with nothing to trip it. That is the staleness direction the
+    exact rules claim to own -- their shrink-check only fires while the file is
+    still there -- so it is pinned here rather than assumed.
+    """
+    relpaths = {relpath for relpath, _ in _guarded_sources()}
+    stale = sorted(set(_RULES[rule_name].allowlist) - relpaths)
+    assert not stale, (
+        f"{rule_name} allows {stale}, which the scan does not reach. Either the "
+        "file moved (update the key) or it is gone (drop the entry)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Proof the guard can go red
+#
+# Every rule is driven against source that violates it, through the same
+# _over_budget the standing test uses. If a matcher is ever loosened into
+# uselessness -- or a budget is raised to infinity -- these fail rather than the
+# guard quietly passing forever.
+# ---------------------------------------------------------------------------
+
+#: One violating module per rule, plus the near-miss each matcher must NOT
+#: flag. The near-misses are the real content here: they are the calls that
+#: actually appear in the guarded trees, and a matcher that flags them would
+#: have to be defanged to get the suite green again.
+_VIOLATION_SAMPLES: dict[str, tuple[str, str]] = {
+    "console": (
+        "from rich.console import Console\nextra = Console(stderr=True)\n",
+        "from .styles import console\nconsole.print('hello')\n",
+    ),
+    "click_echo": (
+        "import click\nclick.echo('raw bytes')\n",
+        "from .phase_reporter import current_reporter\n"
+        "echo = current_reporter().echo\n"
+        "echo('through the reporter')\n",
+    ),
+    "bare_print": (
+        "print('straight at stdout')\n",
+        "from .phase_reporter import current_reporter\n"
+        "current_reporter().out().print('through the console')\n",
+    ),
+    "surface": (
+        "from rich.table import Table\ntable = Table(box=None)\n",
+        "from rich.table import Table\nfrom .styles import data_table\n"
+        "grid = Table.grid(padding=(0, 1))\ntable = data_table(title='Services')\n",
+    ),
+}
+
+
+@pytest.mark.parametrize("rule_name", sorted(_RULES))
+def test_each_rule_fires_on_a_violation(rule_name: str) -> None:
+    """A new offending module in an unlisted file is reported by name."""
+    violating, _ = _VIOLATION_SAMPLES[rule_name]
+    problems = _over_budget(_RULES[rule_name], [("cli/newly_added_cmd.py", violating)])
+    assert len(problems) == 1, f"{rule_name} did not fire on its violation sample"
+    assert "cli/newly_added_cmd.py" in problems[0]
+    assert _RULES[rule_name].remedy.split(".")[0] in problems[0]
+
+
+@pytest.mark.parametrize("rule_name", sorted(_RULES))
+def test_each_rule_ignores_its_near_miss(rule_name: str) -> None:
+    """The legal spelling next door stays legal, so the guard is not a blunt grep."""
+    _, near_miss = _VIOLATION_SAMPLES[rule_name]
+    assert not _over_budget(_RULES[rule_name], [("cli/newly_added_cmd.py", near_miss)])
+
+
+#: The alternate spellings of a guarded call, and whether each is a violation.
+#: Every entry is a decision recorded in the docstrings above; this table is
+#: what stops a decision from quietly reverting. ``id`` doubles as the reason.
+_ALTERNATE_SPELLINGS: list[tuple[str, str, bool, str]] = [
+    (
+        "surface",
+        "from rich.panel import Panel\np = Panel.fit('boxed')\n",
+        True,
+        "Panel.fit is a full construction: it spells border and padding itself",
+    ),
+    (
+        "surface",
+        "from rich.table import Table\ng = Table.grid(padding=(0, 1))\n",
+        False,
+        "Table.grid draws nothing, so it holds none of the tokens styles.py owns",
+    ),
+    (
+        "surface",
+        "from rich.table import Table as RT\nt = RT(box=None)\n",
+        True,
+        "an aliased Table is the same construction under another name",
+    ),
+    (
+        "surface",
+        "from rich.panel import Panel as P\np = P.fit('boxed')\n",
+        True,
+        "Panel.fit through an alias is still Panel.fit",
+    ),
+    (
+        "console",
+        "from rich.console import Console as C\nc = C(stderr=True)\n",
+        True,
+        "an aliased Console is still a third console",
+    ),
+    (
+        "console",
+        "from rich import console\nc = console.Console()\n",
+        True,
+        "the dotted spelling resolves to the same trailing name",
+    ),
+    (
+        "bare_print",
+        "import rich\nrich.print('x')\n",
+        True,
+        "rich.print draws on rich's global console, past styles.py",
+    ),
+    (
+        "bare_print",
+        "from rich import print\nprint('x')\n",
+        True,
+        "rich's print rebinds the same bare name the builtin uses",
+    ),
+    (
+        "click_echo",
+        "from click import echo as e\ne('x')\n",
+        True,
+        "an aliased click.echo is still a raw write",
+    ),
+    (
+        "click_echo",
+        "import click as c\nc.echo('x')\n",
+        False,
+        "KNOWN GAP, documented in _is_click_echo: the dotted branch pins the "
+        "receiver to the literal name click",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("rule_name", "source", "should_fire", "why"),
+    _ALTERNATE_SPELLINGS,
+    ids=[f"{rule}-{why[:40]}" for rule, _src, _fire, why in _ALTERNATE_SPELLINGS],
+)
+def test_alternate_spellings_are_decided_not_inherited(
+    rule_name: str, source: str, should_fire: bool, why: str
+) -> None:
+    """Each classmethod and alias spelling keeps the disposition it was given.
+
+    Matching on the called name hands out exemptions nobody chose. Every one of
+    those spellings is pinned here, including the two that are deliberately NOT
+    violations, so a later edit cannot silently flip one.
+    """
+    problems = _over_budget(_RULES[rule_name], [("cli/newly_added_cmd.py", source)])
+    assert bool(problems) is should_fire, why
+
+
+@pytest.mark.parametrize("rule_name", sorted(_RULES))
+def test_a_budgeted_file_still_trips_when_it_grows(rule_name: str) -> None:
+    """An allowlisted file gets a budget, not an exemption.
+
+    Adding one more raw call to a file that already has entries is the likeliest
+    way this guard would be defeated by accident, so it is the case pinned here:
+    the offending file's own budget is reused and exceeded by exactly one.
+    """
+    rule = _RULES[rule_name]
+    if not rule.allowlist:
+        pytest.skip(f"{rule_name} allows nothing anywhere, so there is no budget to exceed")
+    relpath, (budget, _reason) = next(iter(rule.allowlist.items()))
+    violating, _ = _VIOLATION_SAMPLES[rule_name]
+    # The sample's single violating statement, repeated one past the budget.
+    body = violating.rsplit("\n", 2)[-2]
+    grown = violating + "\n".join([body] * budget) + "\n"
+    problems = _over_budget(rule, [(relpath, grown)])
+    assert len(problems) == 1, f"{relpath} exceeded its budget without tripping {rule_name}"
+    assert f"allowed {'exactly' if rule.exact else 'at most'} {budget}" in problems[0]
+    assert "why the existing ones are allowed" in problems[0]
+
+
+@pytest.mark.parametrize("rule_name", sorted(_RULES))
+def test_a_zero_tolerance_rule_trips_when_its_inventory_shrinks(rule_name: str) -> None:
+    """An exact entry is checked in both directions, so it cannot go stale.
+
+    The ratchet is exempt by design: retiring an echo seam must not red this
+    file. For the other three, an entry claiming more than the tree holds is a
+    description that has stopped being true, and the message says so in those
+    words rather than reading as a failure the reader has to undo.
+    """
+    rule = _RULES[rule_name]
+    if not rule.exact:
+        pytest.skip(f"{rule_name} is the ratchet: fewer calls is always fine")
+    if not rule.allowlist:
+        pytest.skip(f"{rule_name} allows nothing anywhere, so nothing can shrink")
+    relpath, (allowed, _reason) = next(iter(rule.allowlist.items()))
+    problems = _over_budget(rule, [(relpath, "x = 1\n")])
+    assert len(problems) == 1, f"{relpath} lost all {allowed} of its calls without tripping"
+    assert "This is good news" in problems[0]
+    assert "lower the number in the allowlist to 0" in problems[0]

--- a/tests/cli/test_ownership_derivation.py
+++ b/tests/cli/test_ownership_derivation.py
@@ -164,7 +164,9 @@ def test_shadowed_file_gets_a_uniform_notice(
     _write(project_path / ".claude" / "rules" / "safety.md", "# framework\n")
     _write(profile_dir / "rules" / "safety.md", "# profile\n")
 
-    with caplog.at_level(logging.INFO):
+    # Renderer migration (disposition row 35): the shadow notice stayed on the
+    # logger and dropped to DEBUG, so `-v` is what surfaces it.
+    with caplog.at_level(logging.DEBUG):
         _apply_conventions(profile_dir, project_path)
 
     assert "overrides framework rule 'rules/safety'" in caplog.text
@@ -177,7 +179,9 @@ def test_shadowed_directory_gets_a_uniform_notice(
     _write(project_path / ".claude" / "skills" / "orbit-check" / "SKILL.md", "# framework\n")
     _write(profile_dir / "skills" / "orbit-check" / "SKILL.md", "# profile\n")
 
-    with caplog.at_level(logging.INFO):
+    # Renderer migration (disposition row 35): the shadow notice stayed on the
+    # logger and dropped to DEBUG, so `-v` is what surfaces it.
+    with caplog.at_level(logging.DEBUG):
         _apply_conventions(profile_dir, project_path)
 
     assert "overrides framework skill 'skills/orbit-check'" in caplog.text
@@ -188,7 +192,9 @@ def test_unshadowed_copies_get_no_notice(
 ):
     _write(profile_dir / "rules" / "facility-ops.md")
 
-    with caplog.at_level(logging.INFO):
+    # DEBUG, not INFO: row 35 moved the notice down a level, and capturing above
+    # it would pass here no matter what the build did.
+    with caplog.at_level(logging.DEBUG):
         _apply_conventions(profile_dir, project_path)
 
     assert "overrides framework" not in caplog.text
@@ -204,7 +210,9 @@ def test_excluded_shadow_restores_the_framework_render(
     _write(profile_dir / "rules" / "safety.md", "# profile\n")
     _write(profile_dir / "rules" / "facility-ops.md")
 
-    with caplog.at_level(logging.INFO):
+    # DEBUG, not INFO: row 35 moved the notice down a level, and capturing above
+    # it would pass here no matter what the build did.
+    with caplog.at_level(logging.DEBUG):
         applied = _apply_conventions(profile_dir, project_path, excluded={"rules/safety"})
 
     assert (project_path / ".claude" / "rules" / "safety.md").read_text() == "# framework\n"

--- a/tests/cli/test_phase_reporter_live.py
+++ b/tests/cli/test_phase_reporter_live.py
@@ -24,8 +24,10 @@ import click
 import pytest
 from rich.console import Console
 from rich.logging import RichHandler
+from rich.spinner import Spinner
 
 from osprey.cli import phase_reporter
+from osprey.cli.altitude import gate_installed, install_gate, lift_gate
 from osprey.cli.phase_reporter import (
     LiveReporter,
     NullReporter,
@@ -50,6 +52,13 @@ _ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
 #: words the hand-off's committed line uses: they are one format, and a test
 #: that stopped matching both would go quietly half-blind.
 _HEARTBEAT_MARK = "(running "
+
+#: Every frame of the ticker's spinner -- ``dots``, the one
+#: ``live_render.render_live_region`` builds. Which frame a repaint catches is
+#: read off the wall clock rather than off any state these tests set, so it is
+#: the one character in a painted region that two paints milliseconds apart can
+#: legitimately disagree about.
+_SPINNER_FRAMES = re.compile(f"[{re.escape(Spinner('dots').frames)}]")
 
 
 @pytest.fixture(autouse=True)
@@ -109,6 +118,17 @@ def live():
 def visible_lines(text: str) -> list[str]:
     """The words in ``text``, with escapes and blank lines dropped."""
     return [line for line in _ANSI.sub("", text).splitlines() if line.strip()]
+
+
+def without_the_spinner_frame(text: str) -> str:
+    """``text`` with whichever spinner frame it caught pinned to one glyph.
+
+    For comparing two paints of the same region. Everything else a region shows
+    is state these tests set -- the rows, the elapsed clock, and the style
+    escapes around them -- so normalising the frame away leaves a comparison
+    that is still byte-exact about all of it.
+    """
+    return _SPINNER_FRAMES.sub("*", text)
 
 
 def after(text: str, marker: str) -> str:
@@ -304,7 +324,16 @@ def test_closing_a_phase_takes_its_region_down_with_it(live):
 def test_a_styled_line_does_not_take_the_region_with_it(monkeypatch):
     """A ``style=`` argument applies to everything a print renders -- including
     the region Rich appends to it, which would repaint the whole build table in
-    the colour of the line that happened to scroll past."""
+    the colour of the line that happened to scroll past.
+
+    The property is style SURVIVAL: the region painted under a styled line must
+    carry the same escapes as the one painted under a bare line. Asserted as an
+    escapes-included comparison of the two paints, with the spinner frame -- the
+    one thing in a region that comes off the wall clock rather than off the
+    state set here -- normalised out of both. Comparing the frames too would
+    fail whenever the two loop passes straddle one of its 80ms boundaries, on a
+    difference of a single glyph that says nothing about styles.
+    """
     monkeypatch.setattr(phase_reporter, "time", SimpleNamespace(monotonic=lambda: 1000.0))
     regions = []
 
@@ -322,7 +351,10 @@ def test_a_styled_line_does_not_take_the_region_with_it(monkeypatch):
         finally:
             reporter.stop_rendering()
 
-    assert regions[0] == regions[1]
+    # A region that painted no styles at all would compare equal to anything,
+    # so the escapes are asserted present before they are asserted identical.
+    assert _ANSI.search(regions[0]) is not None
+    assert without_the_spinner_frame(regions[0]) == without_the_spinner_frame(regions[1])
     assert "virtual-accelerator" in regions[0]
 
 
@@ -867,6 +899,14 @@ class _FakeStdout:
 # ---------------------------------------------------------------------------
 # Log records while a region is mounted
 # ---------------------------------------------------------------------------
+#
+# Two contracts meet here. The altitude gate (``osprey.cli.altitude``) decides
+# WHETHER a record is painted at all -- WARNING and above in a normal run,
+# everything under ``-v``. The borrow decides WHERE a painted record lands: on
+# the console the region is mounted on, above it and in one piece, rather than
+# straight down the handler's own stream and through the middle of a repaint.
+# The gate is a handler filter, so a record it drops is still emitted and still
+# reaches ``caplog``; only the terminal is quieter.
 
 
 @pytest.fixture
@@ -877,6 +917,11 @@ def log_handler():
     the assertions about wrapping: one handler, one console, bound to a stream
     that is emphatically NOT the reporter's -- which is the whole reason a record
     can garble the region in the first place.
+
+    Ungated, as ``configure_logging()`` leaves it: the gate is the CLI's, put on
+    by the group callback, so a test that wants one installs the altitude it
+    means to assert about. Teardown is the suite's ``restore_root_logging``,
+    which strips gates off every root ``RichHandler`` either side of a test.
 
     Removed again afterwards, level included: a handler left on the root logger
     prints every later test's log records, and a swapped console left on it would
@@ -923,17 +968,85 @@ def live_over_logging(log_handler):
         reporter.stop_rendering()
 
 
-def test_a_log_record_lands_as_one_intact_line_above_the_region(live_over_logging, log_handler):
+def painted_records(buffer: io.StringIO, message: str) -> list[str]:
+    """Every line in ``buffer`` carrying ``message``, padding dropped.
+
+    Rich pads a log line out to the console width, so the trailing run of
+    spaces is the renderer's and not part of the record. A list rather than a
+    membership test: a record that arrived in two pieces, or twice, is exactly
+    what these tests are looking for.
+    """
+    return [line.rstrip() for line in visible_lines(buffer.getvalue()) if message in line]
+
+
+def test_a_warning_lands_as_one_intact_line_above_the_region(live_over_logging, log_handler):
     """The symptom the swap exists for: a record written straight to stderr
     lands in the middle of a repainting region and the two interleave.
 
-    Asserted on the reporter's buffer rather than on the absence of garbling,
-    because "not garbled" is only visible on a real terminal -- here the proof
-    is that the record went through the console the ``Live`` is mounted on, in
-    one piece, with its own stream left empty.
+    A WARNING under an installed gate is the record a normal run actually
+    paints, so it is the one this asserts on. Asserted on the reporter's buffer
+    rather than on the absence of garbling, because "not garbled" is only
+    visible on a real terminal -- here the proof is that the record went through
+    the console the ``Live`` is mounted on, in one piece, with its own stream
+    left empty.
     """
     reporter, buffer, _console = live_over_logging
-    _handler, stderr, _own = log_handler
+    handler, stderr, _own = log_handler
+    install_gate(handler)
+    reporter.phase("Building services")
+
+    with reporter.watch_build(build_with_rows()):
+        reporter.refresh_live()
+        get_logger("deploy").warning("pulling base image")
+        reporter.refresh_live()
+
+    assert gate_installed(handler) is True
+    assert painted_records(buffer, "pulling base image") == ["WARNING  pulling base image"]
+    assert "pulling base image" not in stderr.getvalue()
+
+
+def test_the_gate_keeps_an_info_record_off_the_region(live_over_logging, log_handler, caplog):
+    """A normal run's INFO transcript is not painted above the region.
+
+    The WARNING beside it is, and is asserted in the same test: without that
+    witness the assertion would go on passing for a reporter that had stopped
+    painting records at all, or for a logger call that never reached a handler.
+
+    The dropped record is still EMITTED -- the gate filters the handler, not the
+    logger -- so ``caplog`` sees it. Nothing downstream of the terminal loses a
+    line to the altitude policy.
+    """
+    reporter, buffer, _console = live_over_logging
+    handler, stderr, _own = log_handler
+    install_gate(handler)
+    reporter.phase("Building services")
+
+    with reporter.watch_build(build_with_rows()):
+        reporter.refresh_live()
+        get_logger("deploy").key_info("pulling base image")
+        get_logger("deploy").warning("image pull failed")
+        reporter.refresh_live()
+
+    assert painted_records(buffer, "pulling base image") == []
+    assert painted_records(buffer, "image pull failed") == ["WARNING  image pull failed"]
+    # Not on the handler's own stream either: gated means unrendered, not
+    # rendered somewhere the region cannot be garbled.
+    assert "pulling base image" not in stderr.getvalue()
+    assert "pulling base image" in caplog.text
+
+
+def test_a_lifted_gate_paints_the_info_transcript_above_the_region(live_over_logging, log_handler):
+    """``-v`` restores the transcript, and the borrow carries it unchanged.
+
+    The two seams are independent: lifting the gate changes which records are
+    painted, never where they land. An INFO record under a lifted gate takes the
+    same route a WARNING does -- one intact line on the region's console, and
+    nothing down the handler's own stream.
+    """
+    reporter, buffer, _console = live_over_logging
+    handler, stderr, _own = log_handler
+    install_gate(handler)
+    lift_gate(handler)
     reporter.phase("Building services")
 
     with reporter.watch_build(build_with_rows()):
@@ -941,12 +1054,8 @@ def test_a_log_record_lands_as_one_intact_line_above_the_region(live_over_loggin
         get_logger("deploy").key_info("pulling base image")
         reporter.refresh_live()
 
-    written = buffer.getvalue()
-    # Rich pads a log line out to the console width, so the trailing run of
-    # spaces is the renderer's and not part of the record.
-    assert [line.rstrip() for line in visible_lines(written) if "pulling base image" in line] == [
-        "INFO     pulling base image"
-    ]
+    assert gate_installed(handler) is False
+    assert painted_records(buffer, "pulling base image") == ["INFO     pulling base image"]
     assert "pulling base image" not in stderr.getvalue()
 
 
@@ -956,19 +1065,26 @@ def test_the_plain_reporter_leaves_the_log_handler_on_stderr(monkeypatch, log_ha
     Piped and CI consumers read records on stderr and program output on stdout,
     and there is no region off a TTY for a record to garble -- so the plain
     reporter has nothing to borrow for and must not touch the handler at all.
+
+    Gated, and a WARNING: the altitude policy is the whole run's, not the live
+    region's, and off a terminal it decides what reaches the pipe exactly as it
+    decides what reaches the screen.
     """
     handler, stderr, original = log_handler
+    install_gate(handler)
     console, buffer = recording_console()
     monkeypatch.setattr(phase_reporter, "console", console)
 
     reporter = PhaseReporter(color=False)
     reporter.start_rendering()
     reporter.phase("Building services")
-    get_logger("deploy").key_info("pulling base image")
+    get_logger("deploy").warning("pulling base image")
+    get_logger("deploy").key_info("resolving the image tag")
     reporter.stop_rendering()
 
     assert handler.console is original
     assert "pulling base image" in stderr.getvalue()
+    assert "resolving the image tag" not in stderr.getvalue()
     assert "pulling base image" not in buffer.getvalue()
 
 

--- a/tests/cli/test_phase_reporter_watchers.py
+++ b/tests/cli/test_phase_reporter_watchers.py
@@ -8,6 +8,7 @@ the wait is on an event with a timeout, never on a duration.
 """
 
 import io
+import re
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -25,6 +26,7 @@ from osprey.cli.phase_reporter import (
 )
 from osprey.cli.styles import osprey_theme
 from osprey.deployment.build_progress import BuildModel
+from tests.deployment.test_build_progress import BOOKKEEPING, PINNED_CAPTIONS
 
 FIXTURES = Path(__file__).resolve().parents[1] / "deployment" / "fixtures"
 
@@ -46,6 +48,41 @@ def vertex_lines(name: str, node: int) -> list[str]:
     """Every line one BuildKit vertex emitted, in order."""
     prefix = f"#{node} "
     return [line for line in fixture_lines(name) if line.startswith(prefix)]
+
+
+#: One heartbeat line, split back into its parts. Every service in the cold
+#: build carries a step by the time it first beats -- its opening line is a
+#: header -- so the step is matched rather than allowed for, which keeps a
+#: mis-split from being read as a caption.
+_BEAT = re.compile(
+    r"  · (?P<service>\S+) (?P<step>\d+/\d+|internal|auth|exporting) (?P<caption>.*)"
+)
+
+
+def beat_caption(beat: str) -> str:
+    """The caption a heartbeat line put on screen."""
+    parsed = _BEAT.fullmatch(beat.rsplit(" (running ", 1)[0])
+    assert parsed is not None, beat
+    return parsed["caption"]
+
+
+def replay_heartbeats(name: str) -> list[str]:
+    """Beat every service after every line of a fixture, and collect the lines.
+
+    A beat is due 30s after the last one, so the replay clock advances 31s per
+    line: every state a row passes through is put on screen exactly once, which
+    is what makes "no heartbeat ever showed X" a claim about the whole build
+    rather than about the moments a real clock happened to land on.
+    """
+    reporter = PhaseReporter(color=False)
+    model = BuildModel()
+    beats: list[str] = []
+    with reporter.watch_build(model):
+        for tick, line in enumerate(fixture_lines(name)):
+            now = 1000.0 + 31.0 * tick
+            model.feed(line, now)
+            beats.extend(reporter._heartbeat_pass(now + 1.0))
+    return beats
 
 
 @pytest.fixture
@@ -306,6 +343,24 @@ def test_a_long_run_caption_is_clipped_to_one_readable_line():
     assert len(lines[0]) > 500
     assert len(beat) < 160
     assert "… (running 31.0s)" in beat
+
+
+def test_no_heartbeat_line_ever_carries_buildkit_bookkeeping():
+    """Off a TTY these lines are the only build output an operator sees, so a
+    caption that is really the vertex's stopwatch or its status reads as the
+    build itself: `· virtual-accelerator 6/8 DONE 0.0s (running 4m10s)`."""
+    captions = [beat_caption(beat) for beat in replay_heartbeats(COLD_BUILD)]
+
+    assert captions
+    assert [caption for caption in captions if BOOKKEEPING.match(caption)] == []
+
+
+def test_a_genuine_caption_reaches_the_heartbeat_line_verbatim():
+    """The filter is between the model and both surfaces; this is the half of
+    it that has to survive the trip to this one."""
+    captions = {beat_caption(beat) for beat in replay_heartbeats(COLD_BUILD)}
+
+    assert [caption for caption in PINNED_CAPTIONS if caption not in captions] == []
 
 
 def test_a_stream_with_no_buildkit_headers_never_beats():

--- a/tests/cli/test_printed_copy_style.py
+++ b/tests/cli/test_printed_copy_style.py
@@ -24,10 +24,51 @@ import pytest
 SRC = Path(__file__).resolve().parents[2] / "src" / "osprey"
 
 #: Calls whose string arguments land on a terminal, by attribute or bare name.
-#: ``emit``, ``echo`` and ``echo_error`` are the phase reporter's (``echo`` is
-#: also click's, along with ``secho``), and ``print`` is rich's console and the
-#: builtin.
-_PRINTERS = frozenset({"echo", "echo_error", "secho", "emit", "print"})
+#: ``emit`` and ``echo`` are the phase reporter's (``echo`` is also click's,
+#: along with ``secho``), and ``print`` is rich's console and the builtin.
+#:
+#: ``report``, ``note``, ``section``, ``table``, ``warn`` and ``fail`` are
+#: :mod:`osprey.cli.output`'s primitives, the renderer every printed line is
+#: moving onto. Matching is by bare name, so ``warn`` also catches
+#: ``warnings.warn`` -- which is the right reach anyway: a deprecation warning
+#: is read by whoever runs the build, not by whoever wrote it. ``table`` takes a
+#: renderable rather than prose, so it normally contributes nothing; it is here
+#: so that a string handed to it is caught rather than silently exempt.
+#:
+#: The last three are wrappers rather than primitives, and they are here because
+#: of the rule they state: a wrapper around a renderer primitive either joins
+#: this set, or carries a comment at its own definition saying its copy is
+#: unguarded and why. A wrapper that does neither reads as covered while being
+#: invisible, which is the one outcome this file exists to prevent.
+#:
+#: ``_abort`` is ``deploy_cmd``'s refusal wrapper, which hands its three
+#: arguments straight to ``fail`` and then stops the run. ``_report_fact`` and
+#: ``report_fact`` are the promotion wrappers: each prints through ``report``
+#: and keeps a log record at the level it already had, and between them they
+#: carry the deploy and web-terminal facts an operator reads.
+#:
+#: Named exception, so the rule above is enforced rather than merely stated:
+#: ``_emit`` at ``cli/config_cmd.py`` and ``interfaces/okf_panel/validation.py``
+#: prints, and stays out. Matching is by bare name, and ``cli/deploy_scaffold.py``
+#: has an ``_emit`` that writes a FILE -- registering the name would judge a
+#: file's contents as prose. Both printing ``_emit``s carry the comment.
+_PRINTERS = frozenset(
+    {
+        "echo",
+        "secho",
+        "emit",
+        "print",
+        "report",
+        "note",
+        "section",
+        "table",
+        "warn",
+        "fail",
+        "_abort",
+        "_report_fact",
+        "report_fact",
+    }
+)
 
 #: In-house vocabulary. Each of these has a plain equivalent that costs no
 #: precision, and none of them is defined anywhere the reader will have been.
@@ -153,17 +194,39 @@ def test_the_walk_still_reaches_the_output_people_read() -> None:
     a wrapper this does not match should fail HERE, loudly, rather than quietly
     switching the lint off.
 
-    The floors are well under today's numbers (438 literals across 48 files) --
-    this is a canary for the walk breaking, not a quota on how much OSPREY is
-    allowed to print.
+    Two reaches it cannot pin, both of them the same shape -- the walk reads the
+    POSITIONAL ARGUMENTS of a printing call, and nothing else:
+
+    * copy built elsewhere and handed over in a variable, however loudly it
+      prints afterwards. ``format_conflict_report`` is the worked example, and
+      it is pinned in its own test instead.
+    * copy passed by KEYWORD, even where the callee is registered here. Live
+      today at ``deploy_cmd``'s ``nothing_done="Nothing was deployed."``, which
+      is concatenated into a printed cause this walk never reads.
+
+    Widening the matcher to keywords is not obviously right (it would start
+    reading ``style=`` and every other non-prose keyword), so both stay review's
+    job. What matters is that they are written down: a blind spot nobody has
+    named reads as coverage.
+
+    Measured on rebaseline: 454 literals across 55 files. That is the reading of
+    one run rather than a constant, since every line of copy added or deleted
+    moves it. The floors sit about
+    10% under that, which is room for ordinary copy churn and not much more --
+    a block getting deleted should not turn this red, and the walk losing a
+    whole module should. Re-derive both numbers from a real run when they next
+    move, and note that the count moves whenever a WRAPPER joins ``_PRINTERS``,
+    not only when copy changes. Do not raise them to whatever the day's count
+    happens to be: a floor pinned to the ceiling fails on the next honest
+    deletion.
     """
     strings = _printed_strings()
     files = {path for path, _, _ in strings}
 
-    assert len(strings) > 300, (
+    assert len(strings) > 405, (
         f"only {len(strings)} printed literals found -- has _PRINTERS drifted?"
     )
-    assert len(files) > 30, f"only {len(files)} files matched -- has the walk stopped descending?"
+    assert len(files) > 49, f"only {len(files)} files matched -- has the walk stopped descending?"
 
     # The onboarding path specifically, since that is what these rules exist for.
     # `validate_cmd.py` rather than `profile_cmd.py`: the profile group's verdict

--- a/tests/cli/test_profile_validate_deploy_block.py
+++ b/tests/cli/test_profile_validate_deploy_block.py
@@ -436,7 +436,7 @@ def test_validate_says_nothing_about_deploy_when_the_block_is_absent(
     result = runner.invoke(profile, ["validate", str(_write_profile(tmp_path, None))])
 
     assert result.exit_code == 0, result.output
-    assert "Deploy:" not in result.output
+    assert "Deploy" not in result.output
 
 
 def test_validate_exits_nonzero_and_names_the_problem(runner: CliRunner, tmp_path: Path) -> None:

--- a/tests/cli/test_query_output.py
+++ b/tests/cli/test_query_output.py
@@ -1,0 +1,234 @@
+"""What ``osprey query`` writes, and which stream it writes it on.
+
+The verb has two registers and they must never mix. Its framing — the drift
+warning, the refusal when there is no render, the failure when the SDK will not
+start — is OSPREY's own copy and goes through the renderer onto stderr. Its
+payload is somebody else's: the agent's own words, or the ``--json`` document a
+script parses, both onto stdout exactly as produced.
+
+``--json`` is the stricter half. The document has to be alone on stdout, and it
+is not enough that this command prints nothing else there: a helper three frames
+down that reports through the renderer would land in the middle of it. The verb
+opens :func:`osprey.cli.output.machine_mode` for its whole body so that anything
+in the process reaching for the renderer is redirected to stderr, and that is
+what these tests pin.
+
+``result.stdout`` and ``result.stderr`` are asserted separately throughout, never
+``result.output``: click folds both into ``output`` in the order they were
+written, so a line on the wrong stream would be invisible there — the exact bug
+this module exists to catch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.agent_runner import EXIT_PASS, EXIT_USAGE, SDKWorkflowResult
+from osprey.cli import output
+from osprey.cli.query_cmd import query
+from tests.cli._lifecycle_build import stub_build
+
+
+def _make_result(text_blocks: list[str]) -> SDKWorkflowResult:
+    """A minimal completed run whose expected servers are all connected."""
+    result = SDKWorkflowResult(
+        text_blocks=text_blocks,
+        tool_traces=[],
+        mcp_servers=[{"name": "controls", "status": "connected", "tools": []}],
+    )
+    result.result = MagicMock(is_error=False, subtype="end_turn")
+    return result
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def deployment(lifecycle_repo: Path) -> Path:
+    """A clean deployment whose render declares one MCP server."""
+    build = stub_build(lifecycle_repo, config="api:\n  providers: {}\n")
+    (build / ".mcp.json").write_text(json.dumps({"mcpServers": {"controls": {"command": "x"}}}))
+    return lifecycle_repo
+
+
+@pytest.fixture
+def drifted(lifecycle_repo: Path) -> Path:
+    """A deployment whose profile has moved on since the build was rendered."""
+    build = stub_build(
+        lifecycle_repo, stamped_hash="stale-fingerprint", config="api:\n  providers: {}\n"
+    )
+    (build / ".mcp.json").write_text(json.dumps({"mcpServers": {"controls": {"command": "x"}}}))
+    return lifecycle_repo
+
+
+def _run(runner: CliRunner, repo: Path, *args: str, answer: str = "42 mA", printer=None):
+    """Invoke ``query`` over a stubbed agent run.
+
+    Args:
+        printer: Called instead of the agent run, for a test that needs
+            something else in the process to print while the verb is open.
+    """
+
+    async def stubbed(*_args, **_kwargs):
+        if printer is not None:
+            printer()
+        return _make_result([answer])
+
+    with (
+        patch("osprey.cli.query_cmd.run_query", new=stubbed),
+        patch("osprey.cli.query_cmd.read_only_disallowed_tools", return_value=[]),
+        patch("osprey.cli.query_cmd.expected_mcp_servers", return_value={"controls"}),
+    ):
+        return runner.invoke(query, ["--repo", str(repo), *args, "beam current"])
+
+
+class TestPayloadPassesThrough:
+    """Neither register of the payload is OSPREY's to shape."""
+
+    def test_agent_text_is_alone_on_stdout_and_unchanged(
+        self, runner: CliRunner, deployment: Path
+    ) -> None:
+        """Including the characters a renderer would have interpreted.
+
+        Markup tags, a box-drawing rule and trailing spaces all survive: the
+        answer is written the way the agent wrote it, not the way OSPREY would
+        have styled it.
+        """
+        answer = "[bold]literal[/bold] │ 100%   "
+
+        result = _run(runner, deployment, answer=answer)
+
+        assert result.exit_code == EXIT_PASS
+        assert result.stdout == answer + "\n"
+
+    def test_json_is_the_whole_of_stdout(self, runner: CliRunner, deployment: Path) -> None:
+        result = _run(runner, deployment, "--json")
+
+        assert result.exit_code == EXIT_PASS
+        assert json.loads(result.stdout)["final_text"] == "42 mA"
+
+    def test_a_renderer_line_from_inside_the_run_cannot_reach_the_document(
+        self, runner: CliRunner, deployment: Path
+    ) -> None:
+        """The point of the machine-mode block, and the thing it alone buys.
+
+        The verb prints nothing of its own here. What would break the document
+        is any of the code it calls reaching for the renderer, so the stub does
+        exactly that: a report line and a note, from inside the run.
+        """
+        marker = "renderer-probe-marker"
+
+        def printer() -> None:
+            output.report(marker)
+            output.note(marker)
+
+        result = _run(runner, deployment, "--json", printer=printer)
+
+        assert result.exit_code == EXIT_PASS
+        assert json.loads(result.stdout)["final_text"] == "42 mA"
+        assert marker not in result.stdout
+        # Non-vacuous: the lines really were printed, and they went to stderr.
+        assert result.stderr.count(marker) == 2
+
+    def test_without_json_the_renderer_still_owns_stdout(
+        self, runner: CliRunner, deployment: Path
+    ) -> None:
+        """Machine mode is entered for ``--json`` only, not for every run."""
+        marker = "renderer-probe-marker"
+
+        result = _run(runner, deployment, printer=lambda: output.report(marker))
+
+        assert result.exit_code == EXIT_PASS
+        assert marker in result.stdout
+
+
+class TestFramingIsOnStderr:
+    """Warnings and refusals leave the pipe alone."""
+
+    def test_a_drift_warning_never_touches_stdout(self, runner: CliRunner, drifted: Path) -> None:
+        result = _run(runner, drifted)
+
+        assert result.exit_code == EXIT_PASS
+        assert result.stdout == "42 mA\n"
+        assert "⚠" in result.stderr
+        assert "Answering from build/ as it was last rendered." in result.stderr
+
+    def test_a_drift_warning_stays_off_a_json_document(
+        self, runner: CliRunner, drifted: Path
+    ) -> None:
+        result = _run(runner, drifted, "--json")
+
+        assert result.exit_code == EXIT_PASS
+        assert json.loads(result.stdout)["final_text"] == "42 mA"
+        assert "⚠" in result.stderr
+
+    def test_no_render_is_refused_in_the_failure_shape(
+        self, runner: CliRunner, lifecycle_repo: Path
+    ) -> None:
+        """``✗ what failed`` / cause / ``→ remedy``, and the exit code is usage."""
+        result = runner.invoke(query, ["--repo", str(lifecycle_repo), "beam current"])
+
+        assert result.exit_code == EXIT_USAGE
+        assert result.stdout == ""
+        assert "✗ No build found at" in result.stderr
+        assert "nothing rendered yet" in result.stderr
+        assert "→ run `osprey build` first" in result.stderr
+
+    def test_a_run_that_cannot_start_is_reported_on_stderr(
+        self, runner: CliRunner, deployment: Path
+    ) -> None:
+        with (
+            patch(
+                "osprey.cli.query_cmd.run_query",
+                side_effect=RuntimeError("provider not configured"),
+            ),
+            patch("osprey.cli.query_cmd.read_only_disallowed_tools", return_value=[]),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value=set()),
+        ):
+            result = runner.invoke(query, ["--repo", str(deployment), "beam current"])
+
+        assert result.exit_code == EXIT_USAGE
+        assert result.stdout == ""
+        assert "provider not configured" in result.stderr
+
+    def test_a_config_failure_carries_the_resolvers_own_hint(
+        self, runner: CliRunner, deployment: Path
+    ) -> None:
+        """The actionable half of the message is the exception's, so keep it."""
+        with (
+            patch(
+                "osprey.cli.query_cmd.run_query",
+                side_effect=ValueError("Unknown provider 'typo'. Built-in providers: anthropic"),
+            ),
+            patch("osprey.cli.query_cmd.read_only_disallowed_tools", return_value=[]),
+            patch("osprey.cli.query_cmd.expected_mcp_servers", return_value=set()),
+        ):
+            result = runner.invoke(query, ["--repo", str(deployment), "beam current"])
+
+        assert result.exit_code == EXIT_USAGE
+        assert "Could not load the project configuration" in result.stderr
+        assert "Built-in providers: anthropic" in result.stderr
+
+
+class TestMachineModeIsClosed:
+    """The block is a context manager, so it cannot leak past the verb."""
+
+    def test_it_is_off_again_after_a_json_run(self, runner: CliRunner, deployment: Path) -> None:
+        result = _run(runner, deployment, "--json")
+
+        assert result.exit_code == EXIT_PASS
+        assert output.machine_mode_active() is False
+
+    def test_it_is_off_again_after_a_refusal(self, runner: CliRunner, lifecycle_repo: Path) -> None:
+        """A verb that exits from inside the block still closes it."""
+        result = runner.invoke(query, ["--repo", str(lifecycle_repo), "--json", "beam current"])
+
+        assert result.exit_code == EXIT_USAGE
+        assert output.machine_mode_active() is False

--- a/tests/cli/test_registry_cmd.py
+++ b/tests/cli/test_registry_cmd.py
@@ -1,22 +1,38 @@
 """Tests for registry CLI command display functionality.
 
-This test module verifies the registry display functions.
+The registry verb prints through the CLI renderer: prose goes out as report /
+note / section lines, and its panel and tables are built by the shared
+factories in ``osprey.cli.styles``. The tests below pin both halves -- the words
+an operator reads, and the fact that the surfaces come from the factories rather
+than from borders spelled at the call site.
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
+from rich import box
+from rich.panel import Panel
+from rich.table import Table
 
 from osprey.cli.registry_cmd import (
     _display_providers_table,
     _display_services_table,
     display_registry_contents,
 )
+from osprey.cli.styles import Styles
 
 
-def _printed_text(mock_console) -> str:
-    """Join every positional argument passed to a patched ``console.print``."""
-    return " ".join(str(call.args[0]) for call in mock_console.print.call_args_list if call.args)
+@pytest.fixture
+def printed():
+    """Every renderable the module handed to ``output.table``, in order.
+
+    The renderable is the honest surface for a look assertion: the border style
+    is a theme token resolved at render time, so reading it off the object is
+    what proves which factory built it.
+    """
+    recorded: list[object] = []
+    with patch("osprey.cli.output.table", side_effect=recorded.append):
+        yield recorded
 
 
 @pytest.fixture
@@ -44,40 +60,51 @@ def mock_registry():
 class TestDisplayRegistryContents:
     """Test display_registry_contents function."""
 
-    def test_displays_registry_with_initialized_registry(self, mock_registry):
+    def test_displays_registry_with_initialized_registry(self, mock_registry, capsys, printed):
         """Test displaying registry contents when registry is already initialized."""
         with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
             with patch("osprey.utils.log_filter.quiet_logger"):
-                with patch("osprey.cli.registry_cmd.console") as mock_console:
-                    mock_get_registry.return_value = mock_registry
+                mock_get_registry.return_value = mock_registry
 
-                    result = display_registry_contents(verbose=False)
+                result = display_registry_contents(verbose=False)
 
-                    # Should succeed
-                    assert result is True
-                    # Should get stats
-                    assert mock_registry.get_stats.called
-                    # Already initialized -- no progress notice
-                    assert "Initializing registry" not in _printed_text(mock_console)
+                # Should succeed
+                assert result is True
+                # Should get stats
+                assert mock_registry.get_stats.called
+                # Already initialized -- no progress notice
+                assert "Initializing registry" not in capsys.readouterr().out
 
-    def test_initializes_registry_if_not_initialized(self, mock_registry):
+    def test_initializes_registry_if_not_initialized(self, mock_registry, capsys, printed):
         """Test that uninitialized registry gets initialized."""
         mock_registry.get_stats.return_value["initialized"] = False
 
         with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
             with patch("osprey.utils.log_filter.quiet_logger"):
-                with patch("osprey.cli.registry_cmd.console") as mock_console:
-                    mock_get_registry.return_value = mock_registry
+                mock_get_registry.return_value = mock_registry
 
-                    result = display_registry_contents(verbose=False)
+                result = display_registry_contents(verbose=False)
 
-                    # Should initialize registry
-                    assert mock_registry.initialize.called
-                    assert result is True
-                    # Cold run announces the load, which is otherwise silent
-                    assert "Initializing registry" in _printed_text(mock_console)
+                # Should initialize registry
+                assert mock_registry.initialize.called
+                assert result is True
+                # Cold run announces the load, which is otherwise silent
+                assert "Initializing registry" in capsys.readouterr().out
 
-    def test_handles_exceptions_gracefully(self):
+    def test_summary_prints_the_service_count_as_a_section(self, mock_registry, capsys, printed):
+        """The counts are facts about the registry, so they print as a section."""
+        with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
+            with patch("osprey.utils.log_filter.quiet_logger"):
+                mock_get_registry.return_value = mock_registry
+
+                display_registry_contents(verbose=False)
+
+        out = capsys.readouterr().out
+        assert "Registry Summary" in out
+        assert "Services" in out
+        assert "1" in out
+
+    def test_handles_exceptions_gracefully(self, capsys):
         """Test that exceptions are handled gracefully."""
         with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
             with patch("osprey.utils.log_filter.quiet_logger"):
@@ -88,7 +115,39 @@ class TestDisplayRegistryContents:
                 # Should return False on error
                 assert result is False
 
-    def test_verbose_mode_shows_additional_info(self, mock_registry):
+    def test_failure_reaches_stderr_with_its_cause(self, capsys):
+        """Trouble is stderr's, whatever the caller does with stdout."""
+        with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
+            with patch("osprey.utils.log_filter.quiet_logger"):
+                mock_get_registry.side_effect = Exception("Test error")
+
+                display_registry_contents(verbose=False)
+
+        captured = capsys.readouterr()
+        assert "✗ Could not display the registry" in captured.err
+        assert "Test error" in captured.err
+        assert "Could not display the registry" not in captured.out
+
+    def test_header_panel_comes_from_the_shared_factory(self, mock_registry, printed):
+        """The panel's frame is the factory's, not the call site's.
+
+        Re-pinned: this panel used to ask ``ThemeConfig.get_border_style()`` for
+        a ``border`` frame. The factory gives every panel and every data table
+        the one dim border, which is the convergence the shared look is for.
+        """
+        with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
+            with patch("osprey.utils.log_filter.quiet_logger"):
+                mock_get_registry.return_value = mock_registry
+
+                display_registry_contents(verbose=False)
+
+        panels = [r for r in printed if isinstance(r, Panel)]
+        assert len(panels) == 1
+        assert panels[0].border_style == Styles.BORDER_DIM
+        assert panels[0].box is box.ROUNDED
+        assert panels[0].expand is False
+
+    def test_verbose_mode_shows_additional_info(self, mock_registry, printed):
         """Test that verbose mode displays additional information."""
         with patch("osprey.cli.registry_cmd.get_registry") as mock_get_registry:
             with patch("osprey.utils.log_filter.quiet_logger"):
@@ -103,7 +162,7 @@ class TestDisplayRegistryContents:
 class TestDisplayServicesTable:
     """Test _display_services_table function."""
 
-    def test_displays_services(self, mock_registry):
+    def test_displays_services(self, mock_registry, printed):
         """Test displaying services table."""
         # Should not raise exception
         _display_services_table(mock_registry, verbose=False)
@@ -111,11 +170,29 @@ class TestDisplayServicesTable:
         # Should get stats for service names
         assert mock_registry.get_stats.called
 
+    def test_table_comes_from_the_shared_factory(self, mock_registry, printed):
+        """Re-pinned: the table used to spell ``dim`` for its own border."""
+        _display_services_table(mock_registry, verbose=False)
+
+        tables = [r for r in printed if isinstance(r, Table)]
+        assert len(tables) == 1
+        assert tables[0].border_style == Styles.BORDER_DIM
+        assert tables[0].header_style == Styles.HEADER
+        assert tables[0].box is box.HEAVY_HEAD
+
+    def test_heading_and_rows_reach_stdout(self, mock_registry, capsys):
+        """The heading is the verb's own output, so it survives any reporter."""
+        _display_services_table(mock_registry, verbose=False)
+
+        out = capsys.readouterr().out
+        assert "Services" in out
+        assert "test_service" in out
+
 
 class TestDisplayProvidersTable:
     """Test _display_providers_table function."""
 
-    def test_displays_providers(self, mock_registry):
+    def test_displays_providers(self, mock_registry, printed):
         """Test displaying providers table."""
         providers = ["test_provider", "another_provider"]
 
@@ -125,17 +202,33 @@ class TestDisplayProvidersTable:
         # Should get provider classes
         assert mock_registry.get_provider.called
 
-    def test_displays_providers_verbose(self, mock_registry):
+    def test_displays_providers_verbose(self, mock_registry, printed):
         """Test displaying providers table in verbose mode."""
         providers = ["test_provider"]
 
         # Should not raise exception
         _display_providers_table(mock_registry, providers, verbose=True)
 
-    def test_handles_missing_provider(self, mock_registry):
+        tables = [r for r in printed if isinstance(r, Table)]
+        assert len(tables) == 1
+        assert [column.header for column in tables[0].columns] == [
+            "Name",
+            "Available",
+            "Description",
+        ]
+
+    def test_handles_missing_provider(self, mock_registry, printed):
         """Test handling of provider that doesn't exist."""
         mock_registry.get_provider.return_value = None
         providers = ["nonexistent_provider"]
 
         # Should not raise exception
         _display_providers_table(mock_registry, providers, verbose=False)
+
+    def test_table_comes_from_the_shared_factory(self, mock_registry, printed):
+        """Re-pinned, for the providers table's own border."""
+        _display_providers_table(mock_registry, ["test_provider"], verbose=False)
+
+        tables = [r for r in printed if isinstance(r, Table)]
+        assert tables[0].border_style == Styles.BORDER_DIM
+        assert tables[0].header_style == Styles.HEADER

--- a/tests/cli/test_reset_plan_parity.py
+++ b/tests/cli/test_reset_plan_parity.py
@@ -1,0 +1,308 @@
+"""The destruction plan reads the same whichever verb is about to destroy.
+
+``osprey reset`` and ``osprey init --reset`` run the same wipe through the same
+``reset_deployment`` call, but until now they handed it two different printers:
+``reset`` passed the CLI's echo path, ``init`` passed ``logger.key_info``. An
+INFO record is what the altitude gate drops on a normal run, so the plan
+listing every container, volume and file about to go simply did not appear on
+the ``init --reset`` path -- on the one command in OSPREY that destroys data
+without asking, because ``--reset`` means unattended.
+
+Both call sites now pass :func:`osprey.cli.output.report`, and this file pins
+that as an equality rather than as two separate presence checks: the same lines
+in the same order, sliced out of each path's stdout by the SAME rule. A
+transport that re-wrapped at the console width, swallowed a blank separator or
+dropped the trailing summary would satisfy every substring assertion ever
+written about a plan and fail the comparison below.
+
+Nothing here reaches a container runtime, and nothing here removes anything:
+the runtime is the recording fake ``tests/deployment/test_reset_scoping``
+already specifies, and ``execute_reset`` is stubbed out. That is not only for
+speed -- it is what lets both halves plan against a repo in *identical* state,
+which is the precondition that makes line-identity a claim about the transport
+rather than about two different deployments.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner, Result
+
+from osprey.cli import init_cmd
+from osprey.cli.main import cli
+from osprey.deployment import reset as reset_mod
+from osprey.deployment.compose_generator import REPO_ID_LABEL, repo_identity
+from osprey.deployment.reset import RuntimeProbe, confirmation_token
+from tests.deployment import test_reset_scoping as scoping
+
+FakeRuntime = scoping.FakeRuntime
+
+#: The deployment name both paths work on. It is the directory name, which is
+#: where a repo with no ``build/`` gets its compose project name from -- so an
+#: initialized-but-not-yet-built repo and a reset of that same repo resolve the
+#: same project, and the plan's header line matches on both.
+PROJECT = "demo"
+
+#: The first line of every rendered plan, and the last. The slice between them
+#: is the plan; everything outside it belongs to whichever verb was running.
+PLAN_OPENS_WITH = "osprey reset "
+PLAN_CLOSES_WITH = "Reset complete."
+
+#: A line deep inside the plan body, used where the question is presence rather
+#: than equality. It is a heading rather than a resource name, so it is there in
+#: every plan this file drives.
+PLAN_HEADING = "WILL BE REMOVED"
+
+
+def ours(repo_root: Path) -> dict[str, str]:
+    """Labels a resource created by a deploy of ``repo_root`` would carry.
+
+    ``scoping.ours`` hardcodes that module's project name; this is the same two
+    labels against the project name used here.
+    """
+    return {
+        reset_mod.COMPOSE_PROJECT_LABEL: PROJECT,
+        REPO_ID_LABEL: repo_identity(repo_root.resolve()),
+    }
+
+
+@pytest.fixture
+def target(tmp_path: Path) -> Path:
+    """Where the deployment goes. It must not exist yet -- ``init`` creates it."""
+    return tmp_path / PROJECT
+
+
+@pytest.fixture
+def runtime(target: Path, monkeypatch: pytest.MonkeyPatch) -> FakeRuntime:
+    """A runtime holding one container and one volume labelled for ``target``.
+
+    A plan with nothing on it returns early with "nothing to reset" and would
+    make the comparison below pass on an empty removal list, so the fake is
+    stocked: the plan under test has resources, files and a kept section.
+    """
+    fake = FakeRuntime(
+        containers={f"{PROJECT}-dispatch": ours(target)},
+        volumes={f"{PROJECT}_dispatch_workspace": ours(target)},
+    )
+    monkeypatch.setattr(reset_mod, "_default_probe", lambda root: RuntimeProbe("docker", run=fake))
+    return fake
+
+
+@pytest.fixture
+def no_destruction(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    """Stub the removals, and record that they were reached.
+
+    The recorder is what makes "the gate held" observable: a declined reset must
+    leave this list empty. Stubbing here rather than at the runtime is also what
+    keeps the repo's files where they are, so the second path plans the same
+    deployment the first one did.
+    """
+    reached: list[object] = []
+
+    def record(plan: object, **kwargs: object) -> None:
+        reached.append(plan)
+
+    monkeypatch.setattr(reset_mod, "execute_reset", record)
+    return reached
+
+
+@pytest.fixture
+def no_survivor_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence ``init``'s post-reset survivor probe.
+
+    It builds a real :class:`RuntimeProbe` from the configured runtime rather
+    than going through the seam the rest of this file injects at, so on a host
+    with a live daemon it would ask a real docker about a repo that only exists
+    in ``tmp_path``. What it guards is pinned in ``tests/cli/test_init_verb.py``;
+    it is not this file's subject.
+    """
+    monkeypatch.setattr(init_cmd, "_surviving_project_resources", lambda repo_root: [])
+
+
+def plan_lines(stdout: str) -> list[str]:
+    """The rendered destruction plan, sliced out of a verb's whole output.
+
+    The same rule is applied to both paths -- open at the header line, close at
+    the completion line, keep everything between. Anything the plan lost in
+    transport is lost from the slice too, which is the point: the slice is not
+    allowed to be a filter that agrees with itself.
+    """
+    lines = stdout.splitlines()
+    opens = [i for i, line in enumerate(lines) if line.startswith(PLAN_OPENS_WITH)]
+    closes = [i for i, line in enumerate(lines) if line.startswith(PLAN_CLOSES_WITH)]
+    assert opens, f"no plan header in:\n{stdout}"
+    assert closes, f"no plan completion line in:\n{stdout}"
+    return lines[opens[0] : closes[-1] + 1]
+
+
+def run_init_reset(target: Path) -> Result:
+    """``osprey init <target> --reset``, through the group that installs the gate.
+
+    Invoked on the top-level ``cli`` rather than on the ``init`` command
+    directly, because the altitude gate is installed by the group callback and
+    the default view is exactly what the gate makes.
+    """
+    return CliRunner().invoke(
+        cli,
+        ["init", str(target), "--preset", "hello-world", "--no-git", "--reset"],
+        catch_exceptions=False,
+    )
+
+
+def run_reset(repo_root: Path, *args: str) -> Result:
+    """``osprey reset --repo <repo_root>``, with whatever extra flags."""
+    return CliRunner().invoke(
+        cli, ["reset", "--repo", str(repo_root), *args], catch_exceptions=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# FR4: one plan, two verbs
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_is_line_identical_on_both_paths(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check
+) -> None:
+    """The two verbs print the same plan, line for line and in the same order.
+
+    Ordering matters: ``init --reset`` runs first and leaves the repo it just
+    created, and because nothing was actually removed the ``reset`` below plans
+    that same repo in that same state. Equality is therefore a statement about
+    the printer, which is the only thing that differs between the two calls.
+    """
+    from_init = run_init_reset(target)
+    assert from_init.exit_code == 0, from_init.output
+
+    from_reset = run_reset(target, "-y")
+    assert from_reset.exit_code == 0, from_reset.output
+
+    init_plan = plan_lines(from_init.stdout)
+    reset_plan = plan_lines(from_reset.stdout)
+
+    assert init_plan == reset_plan
+    # Guard on the guard. A plan of two lines, or one whose longest line is
+    # comfortably inside a console width, would let a truncating or re-wrapping
+    # transport through the equality above without anyone noticing.
+    assert len(init_plan) > 20
+    assert max(len(line) for line in init_plan) > 100
+
+
+def test_the_reset_verbs_whole_output_is_the_plan(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check
+) -> None:
+    """The slice is not dropping anything on the side where it can be checked.
+
+    ``osprey reset`` prints its plan and nothing else, so on that path the
+    sliced plan must be the entire stdout. That is what stops
+    :func:`plan_lines` from quietly becoming a filter that makes any two
+    outputs agree.
+    """
+    run_init_reset(target)
+
+    result = run_reset(target, "-y")
+
+    assert result.exit_code == 0, result.output
+    assert "".join(f"{line}\n" for line in plan_lines(result.stdout)) == result.stdout
+
+
+def test_the_plan_is_printed_on_the_default_init_reset_view(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check, terminal_probe
+) -> None:
+    """The bug: on a normal run the plan reached the operator on neither channel.
+
+    Routed through ``logger.key_info`` the plan was an INFO record, which the
+    altitude gate drops -- so the destructive verb that never asks also never
+    said what it was taking. Both halves are asserted, because either alone
+    passes for the wrong reason: the plan is on stdout NOW, and it is no longer
+    a log record at all (an absence the gate would have faked either way, so it
+    is checked against ``records``, which the gate never touches).
+    """
+    result = run_init_reset(target)
+
+    assert result.exit_code == 0, result.output
+    assert PLAN_HEADING in result.stdout
+    assert not any(PLAN_HEADING in message for message in terminal_probe.messages)
+    # Witness: the record sink is live, so the absence above is an observation
+    # rather than an empty buffer agreeing with everything.
+    logging.getLogger("osprey.test.reset_plan_parity").info("plan parity witness")
+    assert any("plan parity witness" in message for message in terminal_probe.messages)
+
+
+def test_the_plan_survives_the_verbose_reporter_on_both_paths(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check
+) -> None:
+    """``-v`` installs the NullReporter, which swallows the phase record only.
+
+    The plan is echo-class on both paths now, so the flag that turns the run
+    into a transcript must not be the flag that loses the destruction list.
+    """
+    from_init = CliRunner().invoke(
+        cli,
+        ["-v", "init", str(target), "--preset", "hello-world", "--no-git", "--reset"],
+        catch_exceptions=False,
+    )
+    assert from_init.exit_code == 0, from_init.output
+
+    from_reset = run_reset(target, "-y")
+
+    assert PLAN_HEADING in from_init.stdout
+    assert plan_lines(from_init.stdout) == plan_lines(from_reset.stdout)
+
+
+# ---------------------------------------------------------------------------
+# The typed gate, on both paths
+# ---------------------------------------------------------------------------
+
+
+def test_the_typed_gate_still_refuses_a_wrong_answer(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check, monkeypatch
+) -> None:
+    """``osprey reset`` without ``-y`` still destroys nothing on a mistyped token."""
+    run_init_reset(target)
+    no_destruction.clear()
+    monkeypatch.setattr("builtins.input", lambda prompt: "not-the-token")
+
+    result = run_reset(target)
+
+    assert result.exit_code == 1
+    assert "confirmation did not match" in result.stdout
+    assert no_destruction == [], "a declined reset must not reach the removals"
+
+
+def test_the_typed_gate_still_accepts_the_token(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check, monkeypatch
+) -> None:
+    """And the right token still gets through it, on the same path."""
+    run_init_reset(target)
+    no_destruction.clear()
+    monkeypatch.setattr("builtins.input", lambda prompt: confirmation_token(target))
+
+    result = run_reset(target)
+
+    assert result.exit_code == 0, result.output
+    assert len(no_destruction) == 1
+
+
+def test_init_reset_waives_the_prompt_rather_than_answering_it(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check, monkeypatch
+) -> None:
+    """``--reset`` is the unattended path: it passes ``assume_yes``, so nothing asks.
+
+    Worth pinning next to the two above: the gate is *waived* here, by a flag
+    the operator typed, and not silently answered on their behalf somewhere in
+    the plumbing. A prompt reached by an unattended run would hang it.
+    """
+
+    def refuse(prompt: str) -> str:
+        raise AssertionError(f"init --reset must not prompt, but asked: {prompt!r}")
+
+    monkeypatch.setattr("builtins.input", refuse)
+
+    result = run_init_reset(target)
+
+    assert result.exit_code == 0, result.output
+    assert len(no_destruction) == 1

--- a/tests/cli/test_reset_verb.py
+++ b/tests/cli/test_reset_verb.py
@@ -31,7 +31,7 @@ import pytest
 from click.testing import CliRunner
 from rich.console import Console
 
-from osprey.cli import phase_reporter
+from osprey.cli import phase_reporter, styles
 from osprey.cli.phase_reporter import LiveReporter, install_reporter
 from osprey.cli.reset_cmd import reset as reset_command
 from osprey.cli.styles import osprey_theme
@@ -55,17 +55,19 @@ no_down = scoping.no_down
 #: pattern alone does not catch.
 _NOISE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\r")
 
-#: The interrupt notice, in full. Written out rather than imported so that a
-#: reword has to come past these tests and re-affirm the stream it goes to.
+#: The interrupt notice, in full, exactly as the renderer's failure shape lays
+#: it out: what failed, then why, then the one thing to do. Written out rather
+#: than imported so that a reword has to come past these tests and re-affirm
+#: both the wording and the stream it goes to.
 INTERRUPT_NOTICE = (
-    "Reset interrupted while it was removing things. It does not roll back, so this "
-    "deployment is in a partly-reset state. Re-run `osprey reset` to finish; it re-reads "
-    "what is actually there."
+    "✗ Reset interrupted while it was removing things\n"
+    "  It does not roll back, so this deployment is in a partly-reset state.\n"
+    "  → re-run `osprey reset` to finish; it re-reads what is actually there\n"
 )
 
-#: Wide enough that the region's table has room, narrow enough that the notice
-#: and the longest plan lines are past it -- which is what makes "not wrapped"
-#: an observation rather than a coincidence.
+#: Wide enough that the region's table has room, narrow enough that the longest
+#: plan lines are past it -- which is what makes "not wrapped" an observation
+#: rather than a coincidence.
 _WIDTH = 100
 
 
@@ -173,7 +175,7 @@ def test_the_interrupt_notice_off_a_terminal_is_still_on_stderr(
     result = CliRunner().invoke(reset_command, ["--repo", str(repo), "-y"])
 
     assert result.exit_code == 3
-    assert result.stderr == f"{INTERRUPT_NOTICE}\n"
+    assert result.stderr == INTERRUPT_NOTICE
     assert "partly-reset" not in result.stdout
 
 
@@ -214,7 +216,7 @@ def test_the_typed_confirmation_runs_with_the_region_taken_down(
     at_the_prompt: dict[str, object] = {}
 
     def answer(_prompt: str) -> str:
-        at_the_prompt["rendering"] = reporter._is_rendering()
+        at_the_prompt["rendering"] = reporter.is_rendering()
         at_the_prompt["depth"] = reporter._suspend_depth
         return confirmation_token(repo)
 
@@ -225,23 +227,32 @@ def test_the_typed_confirmation_runs_with_the_region_taken_down(
 
     assert result.exit_code == 0, result.output
     assert at_the_prompt == {"rendering": False, "depth": 1}
-    assert reporter._is_rendering()
+    assert reporter.is_rendering()
 
 
 def test_the_interrupt_notice_goes_through_the_console_while_a_region_is_up(
     repo: Path, monkeypatch: pytest.MonkeyPatch, live_reporter
 ) -> None:
-    """On a terminal the notice belongs to the console, on ONE line.
+    """On a terminal the notice still belongs to the console that owns the region.
 
     stdout and stderr are the same device here, so nothing is lost by routing
-    it; what would be lost by not routing it is the line itself, written into a
-    region that is about to repaint over it. Asserted as an unwrapped line
-    because that is the observable difference: anything reaching this terminal
-    other than through the console arrives without the soft wrap and comes back
-    folded at the console's width.
+    it; what would be lost by not routing it is the notice itself, written into
+    a region that is about to repaint over it. The renderer's trouble path
+    borrows the region's console for exactly that reason, so the notice is read
+    out of the region's buffer and NOT out of the stderr console, which is
+    replaced here with a recording one and asserted to have taken nothing.
+
+    Asserted as the whole three-line block rather than as a substring: a
+    transport that folded it at the console's width, or dropped the indent that
+    makes the cause and the remedy subordinate, would pass every substring
+    assertion ever written against it.
     """
 
     _, buffer = live_reporter
+    err_buffer = io.StringIO()
+    monkeypatch.setattr(
+        styles, "err_console", Console(file=err_buffer, width=_WIDTH, theme=osprey_theme)
+    )
 
     def interrupt_during_teardown(_root: Path) -> None:
         raise KeyboardInterrupt
@@ -252,5 +263,5 @@ def test_the_interrupt_notice_goes_through_the_console_while_a_region_is_up(
     result = CliRunner().invoke(reset_command, ["--repo", str(repo), "-y"])
 
     assert result.exit_code == 3
-    assert len(INTERRUPT_NOTICE) > _WIDTH
-    assert f"{INTERRUPT_NOTICE}\n" in rendered(buffer)
+    assert INTERRUPT_NOTICE in rendered(buffer)
+    assert err_buffer.getvalue() == ""

--- a/tests/cli/test_set_verb.py
+++ b/tests/cli/test_set_verb.py
@@ -270,7 +270,10 @@ def test_a_key_the_schema_does_not_know_is_written_but_called_out(runner, lifecy
 
     assert result.exit_code == 0, result.output
     assert "modle: sonnet" in _profile_text(lifecycle_repo)
-    assert "Not a profile key: modle" in result.output
+    # On stderr, like every warning: a caller piping the write report somewhere
+    # still sees this on the terminal.
+    assert "Not a profile key: modle" in result.stderr
+    assert "Not a profile key" not in result.stdout
 
 
 def test_recognized_and_config_prefixed_keys_are_never_called_out(runner, lifecycle_repo):

--- a/tests/cli/test_skills_cmd.py
+++ b/tests/cli/test_skills_cmd.py
@@ -57,7 +57,11 @@ def test_install_backs_up_existing(fake_home: Path) -> None:
 
     assert result.exit_code == 0, (result.output, result.stderr)
     assert (target / "SKILL.md").is_file()  # new content installed
-    assert "Warning" in result.stderr  # backup notice goes to stderr
+    # The backup notice is a warning, so it carries the ⚠ mark and goes to
+    # stderr: a caller redirecting stdout still learns the old copy moved.
+    assert "⚠" in result.stderr
+    assert "osprey-build-interview.bak." in result.stderr
+    assert "⚠" not in result.stdout
 
     backups = list((fake_home / ".claude" / "skills").glob("osprey-build-interview.bak.*"))
     assert len(backups) == 1
@@ -70,10 +74,11 @@ def test_install_unknown_name_errors(fake_home: Path) -> None:
     result = runner.invoke(skills, ["install", "nonexistent-skill"])
 
     assert result.exit_code != 0
-    combined = (result.output or "") + (result.stderr or "")
-    assert "nonexistent-skill" in combined
-    assert "osprey-build-interview" in combined
-    assert "osprey-contribute" in combined
+    # A refusal, so it is on stderr with the ✗ mark and nothing lands on stdout.
+    assert "nonexistent-skill" in result.stderr
+    assert "osprey-build-interview" in result.stderr
+    assert "osprey-contribute" in result.stderr
+    assert result.stdout == ""
 
 
 def test_resource_path_resolves() -> None:

--- a/tests/cli/test_styles_console_identity.py
+++ b/tests/cli/test_styles_console_identity.py
@@ -1,0 +1,117 @@
+"""Pins for the identity-stable, in-place re-themed CLI consoles.
+
+`styles.py` owns exactly two Console instances - one for stdout, one for stderr.
+Both must keep their identity for the process lifetime so that module-level
+``from .styles import console`` aliases (taken at import time, before any theme
+is applied) stay correct after `set_theme()`.
+"""
+
+import sys
+from collections.abc import Iterator
+
+import pytest
+from rich.style import Style
+from rich.text import Text
+
+from osprey.cli import styles
+from osprey.cli.styles import ColorTheme, console, err_console, get_active_theme, set_theme
+
+
+@pytest.fixture(autouse=True)
+def restore_theme() -> Iterator[None]:
+    """Restore the theme active before the test, so globals stay clean."""
+    original = get_active_theme()
+    yield
+    set_theme(original)
+
+
+def _theme_stack_depth(target: object) -> int:
+    """Return the number of entries on a console's theme stack."""
+    return len(target._theme_stack._entries)  # type: ignore[attr-defined]
+
+
+def _rendered_style(target: object, markup: str) -> Style:
+    """Return the resolved Style of the first non-blank segment of `markup`."""
+    segments = [seg for seg in target.render(Text.from_markup(markup)) if seg.text.strip()]  # type: ignore[attr-defined]
+    assert segments, f"no visible segments rendered for {markup!r}"
+    return segments[0].style
+
+
+def test_console_identity_stable_across_theme_switches() -> None:
+    """Both consoles keep their object identity across repeated set_theme calls."""
+    stdout_id, stderr_id = id(console), id(err_console)
+
+    for color in ("#00ff00", "#0000ff", "#ff00ff"):
+        set_theme(ColorTheme(success=color))
+        assert styles.console is console
+        assert styles.err_console is err_console
+        assert id(styles.console) == stdout_id
+        assert id(styles.err_console) == stderr_id
+
+
+def test_import_time_alias_sees_new_theme() -> None:
+    """An alias captured before theming (as command modules do) stays correct."""
+    aliased = console  # what `from .styles import console` yields at import time
+
+    set_theme(ColorTheme(success="#00ff00"))
+
+    assert aliased is styles.console
+    assert aliased.get_style("success").color.name == "#00ff00"
+
+
+def test_theme_stack_depth_constant_across_repeated_switches() -> None:
+    """Pop-before-push keeps the theme stack flat, however often the theme changes."""
+    set_theme(ColorTheme(success="#00ff00"))
+    stdout_depth, stderr_depth = _theme_stack_depth(console), _theme_stack_depth(err_console)
+
+    for color in ("#0000ff", "#ff00ff", "#00ffff", "#ffff00"):
+        set_theme(ColorTheme(success=color))
+        assert _theme_stack_depth(console) == stdout_depth
+        assert _theme_stack_depth(err_console) == stderr_depth
+
+    # Base theme plus exactly one pushed theme.
+    assert stdout_depth == 2
+    assert stderr_depth == 2
+
+
+def test_err_console_writes_to_stderr_and_is_themed() -> None:
+    """The stderr console is a real stderr console carrying the same theme."""
+    assert err_console.stderr is True
+    assert err_console.file is sys.stderr
+    assert console.stderr is False
+    assert console.file is sys.stdout
+
+    set_theme(ColorTheme(success="#00ff00", path="#123456"))
+
+    assert err_console.get_style("success") == console.get_style("success")
+    assert err_console.get_style("path").color.name == "#123456"
+
+
+def test_rendered_styles_change_after_set_theme() -> None:
+    """Re-theming actually changes rendered output, on both consoles."""
+    set_theme(ColorTheme(success="#00ff00"))
+    before_out = _rendered_style(console, "[success]ok[/success]")
+    before_err = _rendered_style(err_console, "[success]ok[/success]")
+    assert before_out.color.triplet == (0, 255, 0)
+    assert before_err.color.triplet == (0, 255, 0)
+
+    set_theme(ColorTheme(success="#0000ff"))
+    after_out = _rendered_style(console, "[success]ok[/success]")
+    after_err = _rendered_style(err_console, "[success]ok[/success]")
+
+    assert after_out.color.triplet == (0, 0, 255)
+    assert after_err.color.triplet == (0, 0, 255)
+    assert after_out != before_out
+    assert after_err != before_err
+
+
+def test_default_theme_restored_by_switching_back() -> None:
+    """Switching back to the default theme restores the default styles."""
+    default_success = console.get_style("success")
+
+    set_theme(ColorTheme(success="#00ff00"))
+    assert console.get_style("success") != default_success
+
+    set_theme(styles.OSPREY_THEME)
+    assert console.get_style("success") == default_success
+    assert err_console.get_style("success") == default_success

--- a/tests/cli/test_subcommand_verbose_flags.py
+++ b/tests/cli/test_subcommand_verbose_flags.py
@@ -1,0 +1,386 @@
+"""Every subcommand ``-v``/``--verbose`` lifts the altitude gate for its own run.
+
+The CLI's altitude gate (:mod:`osprey.cli.altitude`) is installed by the group
+callback and drops INFO-and-below at the rendering handler, so a normal run
+reads as a report. A subcommand's own verbose flag is the operator asking for
+the transcript of *that* run, and it has to mean the same thing everywhere:
+``audit``, ``health``, and the three channel-finder flags.
+
+Each flag is pinned twice, in the shape the ``terminal_probe`` fixture calls for:
+
+* under the flag, an INFO record emitted from inside the running command is
+  painted by the handler;
+* without it, the same record is not painted — asserted next to an **armed
+  witness**, a WARNING from the same logger in the same run. Without that
+  witness an absence assertion passes for a console nothing ever reached.
+
+Each flag's own display semantics are unchanged and are pinned by the suites
+that own them (``test_audit_display.py``, ``test_health_cmd_output.py``,
+``test_channel_finder_logging.py``); what is new here is only the gate lift.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.altitude import gate_installed
+from osprey.cli.main import cli
+from tests.cli.conftest import TerminalProbe
+
+INFO_MARKER = "VERBOSEFLAGINFOMARKER"
+WARNING_MARKER = "VERBOSEFLAGWARNMARKER"
+
+
+def _log_markers(logger_name: str) -> None:
+    """Emit the needle and its armed witness on *logger_name*."""
+    logger = logging.getLogger(logger_name)
+    logger.info(INFO_MARKER)
+    logger.warning(WARNING_MARKER)
+
+
+@pytest.fixture(autouse=True)
+def stub_project_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the group callback from writing an ancestor ``.env`` into the process.
+
+    ``load_project_dotenv`` runs for every ``osprey`` invocation and its writes
+    to ``os.environ`` outlive the test that triggered them.
+    """
+    monkeypatch.setattr("osprey.utils.config.load_project_dotenv", lambda *a, **k: None)
+
+
+@pytest.fixture
+def unpinned_osprey_logger() -> Iterator[None]:
+    """Hand back the ``osprey`` logger's level, and start from a known one.
+
+    ``channel-finder benchmark --verbose`` raises that logger to DEBUG as its
+    emission floor. Levels are process-global, so the pin has to be undone or it
+    leaks into every later test in the session.
+    """
+    logger = logging.getLogger("osprey")
+    saved = logger.level
+    logger.setLevel(logging.NOTSET)
+    try:
+        yield
+    finally:
+        logger.setLevel(saved)
+
+
+# --------------------------------------------------------------------------- #
+# osprey audit
+# --------------------------------------------------------------------------- #
+
+AUDIT_LOGGER = "osprey.audit.verbose_probe"
+
+
+@pytest.fixture
+def run_audit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Invoke ``osprey audit`` with the reviewer agent replaced by a stub.
+
+    The stub logs from inside the command body — after the flag has had its
+    chance to lift the gate — and hands back a report document the real parsing
+    path accepts, so the run reaches its normal end rather than a failure path.
+    """
+    monkeypatch.setattr("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
+
+    async def _fake_run_audit(*args: object, **kwargs: object) -> tuple[str, float, int]:
+        _log_markers(AUDIT_LOGGER)
+        document = json.dumps(
+            {"summary": "Nothing alarming", "overall_risk": "low", "findings": []}
+        )
+        return document, 0.01, 2
+
+    monkeypatch.setattr("osprey.cli.audit_cmd._run_audit", _fake_run_audit)
+
+    target = tmp_path / "audited-project"
+    target.mkdir()
+    (target / "config.yml").write_text("project_name: audited\n", encoding="utf-8")
+    runner = CliRunner()
+
+    def _run(*args: str):
+        return runner.invoke(cli, ["audit", str(target), *args])
+
+    return _run
+
+
+class TestAuditVerbose:
+    """``audit -v`` is a display flag today; it lifts the gate as well."""
+
+    def test_verbose_renders_the_transcript(self, run_audit, terminal_probe: TerminalProbe):
+        result = run_audit("-v")
+
+        assert result.exit_code == 0, result.output
+        assert INFO_MARKER in terminal_probe.rendered_text
+        assert gate_installed() is False
+
+    def test_a_default_run_renders_no_transcript(self, run_audit, terminal_probe: TerminalProbe):
+        result = run_audit()
+
+        assert result.exit_code == 0, result.output
+        assert gate_installed() is True
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER not in terminal_probe.rendered_text
+        assert INFO_MARKER in terminal_probe.messages
+
+
+# --------------------------------------------------------------------------- #
+# osprey health
+# --------------------------------------------------------------------------- #
+
+HEALTH_LOGGER = "osprey.health.verbose_probe"
+
+
+@pytest.fixture
+def run_health(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Invoke ``osprey health`` over a throwaway project, checks stubbed out.
+
+    ``load_config`` is wrapped rather than replaced: the markers are emitted at
+    the point of the real call, inside ``_quiet_run_logs``, which is where a
+    gate lift has to survive health's own silencing to be worth anything. The
+    marker logger is deliberately not one of ``_NOISY_LOADER_LOGGERS``, so what
+    the assertions read is the gate and not that silencing.
+    """
+    import osprey.cli.health_cmd as health_cmd
+
+    real_load_config = health_cmd.load_config
+
+    def _noisy_load_config(*args: object, **kwargs: object):
+        _log_markers(HEALTH_LOGGER)
+        return real_load_config(*args, **kwargs)
+
+    monkeypatch.setattr(health_cmd, "load_config", _noisy_load_config)
+
+    project = tmp_path / "health-project"
+    project.mkdir()
+    (project / "config.yml").write_text("project_name: verbose_flags\n", encoding="utf-8")
+    runner = CliRunner()
+
+    def _run(*args: str):
+        from osprey.health.models import CheckReport
+
+        empty = CheckReport(results=[], elapsed_ms=1.0, deadline_hit=False)
+        with patch("osprey.cli.health_cmd._run_suite", AsyncMock(return_value=empty)):
+            return runner.invoke(cli, ["health", "--project", str(project), *args])
+
+    return _run
+
+
+class TestHealthVerbose:
+    """``health -v`` keeps its detail meaning and gains the gate lift."""
+
+    def test_verbose_renders_the_transcript(self, run_health, terminal_probe: TerminalProbe):
+        run_health("-v")
+
+        assert INFO_MARKER in terminal_probe.rendered_text
+        assert gate_installed() is False
+
+    def test_a_default_run_renders_no_transcript(self, run_health, terminal_probe: TerminalProbe):
+        run_health()
+
+        assert gate_installed() is True
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER not in terminal_probe.rendered_text
+        assert INFO_MARKER in terminal_probe.messages
+
+    def test_json_stdout_is_still_one_document_under_verbose(self, run_health):
+        """The lift must not put a log line where a machine reads a document.
+
+        The handler renders at stderr and ``--json`` silences every root handler
+        for the loading stretch, so a lifted gate cannot reach stdout.
+        """
+        result = run_health("-v", "--json")
+
+        assert json.loads(result.stdout)["results"] == []
+
+
+# --------------------------------------------------------------------------- #
+# osprey channel-finder (group --verbose, validate --verbose)
+# --------------------------------------------------------------------------- #
+
+VALIDATE_LOGGER = "channel_finder.validate.verbose_probe"
+
+
+@pytest.fixture
+def run_validate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Invoke ``osprey channel-finder validate`` through the real CLI group.
+
+    Through ``cli`` so the group callback installs the gate in the first place.
+    ``_setup_config`` is stubbed (no built project is needed), the registry
+    build underneath ``_initialize_registry`` is stubbed rather than the
+    function itself, and ``run_validation`` — the command's own work — is what
+    emits the markers, so the gate is asked its question in situ.
+    """
+    monkeypatch.setattr("osprey.cli.channel_finder_cmd._setup_config", lambda *a, **k: None)
+    monkeypatch.setattr("osprey.registry.initialize_registry", lambda *a, **k: None)
+
+    def _run_validation(**kwargs: object) -> int:
+        _log_markers(VALIDATE_LOGGER)
+        return 0
+
+    monkeypatch.setattr(
+        "osprey.services.channel_finder.tools.validate_database.run_validation",
+        _run_validation,
+    )
+
+    database = tmp_path / "channel_db.json"
+    database.write_text(
+        '{"channels": [{"template": false, "channel": "CH1", '
+        '"address": "PV:CH1", "description": "Test channel"}]}',
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    def _run(*group_args: str, subcommand_args: tuple[str, ...] = ()):
+        return runner.invoke(
+            cli,
+            [
+                "channel-finder",
+                *group_args,
+                "validate",
+                "--database",
+                str(database),
+                "--pipeline",
+                "in_context",
+                *subcommand_args,
+            ],
+        )
+
+    return _run
+
+
+class TestChannelFinderGroupVerbose:
+    """``channel-finder -v <anything>`` lifts the gate for the whole subcommand."""
+
+    def test_verbose_renders_the_transcript(self, run_validate, terminal_probe: TerminalProbe):
+        result = run_validate("-v")
+
+        assert result.exit_code == 0, result.output
+        assert INFO_MARKER in terminal_probe.rendered_text
+        assert gate_installed() is False
+
+    def test_a_default_run_renders_no_transcript(self, run_validate, terminal_probe: TerminalProbe):
+        result = run_validate()
+
+        assert result.exit_code == 0, result.output
+        assert gate_installed() is True
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER not in terminal_probe.rendered_text
+        assert INFO_MARKER in terminal_probe.messages
+
+
+class TestChannelFinderValidateVerbose:
+    """``validate -v`` carries its own lift, without the group flag."""
+
+    def test_verbose_renders_the_transcript(self, run_validate, terminal_probe: TerminalProbe):
+        result = run_validate(subcommand_args=("-v",))
+
+        assert result.exit_code == 0, result.output
+        assert INFO_MARKER in terminal_probe.rendered_text
+        assert gate_installed() is False
+
+    def test_a_default_run_renders_no_transcript(self, run_validate, terminal_probe: TerminalProbe):
+        assert run_validate().exit_code == 0
+
+        assert gate_installed() is True
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER not in terminal_probe.rendered_text
+
+
+# --------------------------------------------------------------------------- #
+# osprey channel-finder benchmark
+# --------------------------------------------------------------------------- #
+
+BENCHMARK_LOGGER = "osprey.benchmark.verbose_probe"
+
+
+@pytest.fixture
+def run_benchmark(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Invoke ``osprey channel-finder benchmark`` with a stub runner.
+
+    The stub logs while loading queries and then refuses to run them, so the
+    command reaches its own work — and the gate decision that precedes it —
+    without a provider, a dataset, or a network call. The refusal lands in the
+    command's own ``except`` arm, which aborts: exit code 1 is the run getting
+    that far, not the flag failing.
+    """
+    from osprey.services.channel_finder.benchmarks import runner as runner_module
+
+    class _StubRunner:
+        provider = "stub"
+        model = "stub/model"
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def load_queries(self) -> list[str]:
+            _log_markers(BENCHMARK_LOGGER)
+            return ["one query"]
+
+        async def run_queries(self, **kwargs: object):
+            raise RuntimeError("the stub runner runs nothing")
+
+    monkeypatch.setattr(runner_module, "BenchmarkRunner", _StubRunner)
+
+    project = tmp_path / "benchmark-project"
+    project.mkdir()
+    (project / "config.yml").write_text("project_name: verbose_flags\n", encoding="utf-8")
+    runner = CliRunner()
+
+    def _run(*args: str):
+        return runner.invoke(
+            cli,
+            [
+                "channel-finder",
+                "--project",
+                str(project),
+                "benchmark",
+                "--model",
+                "stub/model",
+                *args,
+            ],
+        )
+
+    return _run
+
+
+class TestChannelFinderBenchmarkVerbose:
+    """``benchmark -v`` composes the gate lift with its DEBUG emission floor."""
+
+    def test_verbose_renders_the_transcript(
+        self, run_benchmark, unpinned_osprey_logger, terminal_probe: TerminalProbe
+    ):
+        result = run_benchmark("-v")
+
+        assert result.exit_code == 1, result.output
+        assert INFO_MARKER in terminal_probe.rendered_text
+        assert gate_installed() is False
+
+    def test_a_default_run_renders_no_transcript(
+        self, run_benchmark, unpinned_osprey_logger, terminal_probe: TerminalProbe
+    ):
+        result = run_benchmark()
+
+        assert result.exit_code == 1, result.output
+        assert gate_installed() is True
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER not in terminal_probe.rendered_text
+        assert INFO_MARKER in terminal_probe.messages
+
+    def test_verbose_still_lowers_the_emission_floor(
+        self, run_benchmark, unpinned_osprey_logger, terminal_probe: TerminalProbe
+    ):
+        """The lift is the render half; the level floor stays what it was.
+
+        Lifting the gate alone would surface INFO and no more — the framework
+        logger's DEBUG floor is a separate line, and both are needed for a
+        DEBUG record to be painted.
+        """
+        run_benchmark("-v")
+
+        assert logging.getLogger("osprey").level == logging.DEBUG

--- a/tests/cli/test_summary_card.py
+++ b/tests/cli/test_summary_card.py
@@ -1,25 +1,33 @@
 """The closing summary card, and which verbs print one.
 
 Three things are asserted here and kept apart on purpose: what the card SAYS
-(rendered from a repo and a state), that it says it through the phase reporter,
-and WHICH verb prints one — a detached start, never an attached one, and exactly
-one for a whole ``init --up`` chain rather than one per verb in it.
+(rendered from a repo and a state), that it says it through the CLI's renderer
+and therefore under every reporter, and WHICH verb prints one — a detached
+start, never an attached one, and exactly one for a whole ``init --up`` chain
+rather than one per verb in it.
 
-Card lines are read off a recording reporter or off the renderer directly,
-never out of ``result.output``: reporter output goes through the Rich console
-singleton, which wraps to whatever width a CliRunner presents, so an assertion
-on captured stdout is an assertion about wrapping — and the card carries a
-filesystem path, which is exactly what wrapping breaks.
+The card is echo class: it is the verb's own closing output, not decoration on
+its progress, so it goes out through :mod:`osprey.cli.output` and survives the
+``NullReporter`` that global ``--verbose`` installs. That is a change in what
+``osprey -v up`` prints, and it is pinned here rather than left to be noticed.
+
+Card lines are read off a recording console or off the plain-text renderer
+directly, never out of ``result.output``: the renderer prints through whichever
+console the installed reporter owns, and a CliRunner presents one of its own
+width — so an assertion on captured stdout is an assertion about wrapping, and
+the card carries a filesystem path, which is exactly what wrapping breaks.
 """
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from rich.console import Console
 
-from osprey.cli import summary_card
+from osprey.cli import phase_reporter, summary_card
 from osprey.cli.main import cli
 from osprey.cli.phase_reporter import (
     NullReporter,
@@ -27,18 +35,47 @@ from osprey.cli.phase_reporter import (
     current_reporter,
     install_reporter,
 )
+from osprey.cli.styles import osprey_theme
 from osprey.cli.summary_card import format_summary_card, owns_summary_card, print_summary_card
 
 
+def recording_console(*, terminal: bool = False) -> tuple[Console, io.StringIO]:
+    """A themed console writing into a buffer instead of at a terminal.
+
+    The theme is not optional: the card's heading and labels are semantic
+    tokens, and a bare ``Console()`` raises ``MissingStyle`` on the first one.
+    ``terminal`` asks for the styled rendering; the default plain one is what
+    every line assertion here reads.
+    """
+    buffer = io.StringIO()
+    return Console(file=buffer, theme=osprey_theme, force_terminal=terminal, width=200), buffer
+
+
 class RecordingReporter(PhaseReporter):
-    """A real reporter that keeps its lines instead of printing them."""
+    """A real reporter whose console is a buffer, not the terminal.
 
-    def __init__(self) -> None:
+    Overrides ``out()``, not ``emit()``: ``out()`` is the seam the renderer
+    resolves per call, so a fake that intercepted ``emit`` would see nothing the
+    card prints any more.
+    """
+
+    def __init__(self, console: Console) -> None:
         super().__init__(color=False)
-        self.lines: list[str] = []
+        self._console = console
 
-    def emit(self, text: str, style: str | None = None) -> None:
-        self.lines.append(text)
+    def out(self) -> Console:
+        return self._console
+
+
+class Recorded:
+    """The lines written to a recording console so far."""
+
+    def __init__(self, buffer: io.StringIO) -> None:
+        self._buffer = buffer
+
+    @property
+    def lines(self) -> list[str]:
+        return self._buffer.getvalue().splitlines()
 
 
 @pytest.fixture
@@ -49,10 +86,10 @@ def runner() -> CliRunner:
 @pytest.fixture
 def recorder():
     """Install a recording reporter for the duration of one test."""
-    recording = RecordingReporter()
-    previous = install_reporter(recording)
+    console, buffer = recording_console()
+    previous = install_reporter(RecordingReporter(console))
     try:
-        yield recording
+        yield Recorded(buffer)
     finally:
         install_reporter(previous)
 
@@ -169,6 +206,28 @@ class TestCardContent:
     ) -> None:
         assert expected in format_summary_card(repo, state)[-1]
 
+    def test_a_build_that_rendered_scenarios_offers_the_demo_seed(self, repo: Path) -> None:
+        """The seed hint has no line of its own any more, so the one next-step
+        surface has to carry it -- and it is a next step: an operator who just
+        built a project with demo scenarios can put data behind them."""
+        (repo / "build" / "data" / "simulation" / "scenarios").mkdir(parents=True)
+
+        card = "\n".join(format_summary_card(repo, "built"))
+
+        assert "osprey sim apply nominal" in card
+
+    def test_a_build_with_no_scenarios_is_not_told_to_apply_one(self, repo: Path) -> None:
+        """A command with nothing to apply is worse advice than no advice."""
+        assert "osprey sim apply" not in "\n".join(format_summary_card(repo, "built"))
+
+    @pytest.mark.parametrize("state", ["created", "running", "stopped"])
+    def test_the_seed_hint_belongs_to_the_built_card_alone(self, repo: Path, state: str) -> None:
+        """`built` is the state the deleted hint was printed in. A running
+        deployment's next step is reading it, not reseeding it."""
+        (repo / "build" / "data" / "simulation" / "scenarios").mkdir(parents=True)
+
+        assert "osprey sim apply" not in "\n".join(format_summary_card(repo, state))
+
     def test_the_endpoints_come_from_the_endpoint_summary_module(
         self, repo: Path, monkeypatch
     ) -> None:
@@ -197,19 +256,57 @@ class TestCardContent:
 
 
 class TestCardPrinting:
-    def test_the_card_prints_through_the_installed_reporter(
-        self, repo: Path, recorder: RecordingReporter
-    ) -> None:
-        """Same path as the phase lines, so the card is plain, unwrapped, and
-        colored only when stdout is a terminal."""
+    def test_the_card_prints_through_the_renderer(self, repo: Path, recorder: Recorded) -> None:
+        """Out through `osprey.cli.output`, on the console the installed
+        reporter owns — so the card lands above a mounted live region rather
+        than inside it, unwrapped, and colored only on a terminal."""
         print_summary_card(repo, "running")
 
         assert recorder.lines[0] == ""
         assert recorder.lines[1] == f"{repo.name} — running"
         assert any("http://127.0.0.1:8080" in line for line in recorder.lines)
 
+    def test_the_printed_card_is_the_one_the_text_renderer_renders(
+        self, repo: Path, recorder: Recorded
+    ) -> None:
+        """The rows are laid out by `output.section` and by
+        `format_summary_card` separately — one for the screen, one for a caller
+        that wants the card as text. Pinned against each other so the two
+        layouts cannot drift into two different cards."""
+        print_summary_card(repo, "running")
+
+        assert recorder.lines == [""] + format_summary_card(repo, "running")
+
+    def test_a_verbose_run_still_ends_with_the_card(
+        self, repo: Path, restore_reporter, monkeypatch
+    ) -> None:
+        """The card is echo class: it says what the run left behind, which is
+        the verb's own output rather than decoration on its progress. Under
+        `--verbose` the phase record is swallowed and the card is not."""
+        console, buffer = recording_console()
+        monkeypatch.setattr(phase_reporter, "console", console)
+        install_reporter(NullReporter(verbose=True))
+
+        print_summary_card(repo, "running")
+
+        assert Recorded(buffer).lines == [""] + format_summary_card(repo, "running")
+
+    def test_the_heading_is_styled_on_a_terminal(
+        self, repo: Path, restore_reporter, monkeypatch
+    ) -> None:
+        """The card keeps its bold heading through the renderer. Asserted as
+        "carries styling" rather than as an exact escape sequence: which bold
+        the theme resolves to is the theme's business."""
+        console, buffer = recording_console(terminal=True)
+        install_reporter(RecordingReporter(console))
+
+        print_summary_card(repo, "running")
+
+        heading = next(line for line in buffer.getvalue().splitlines() if repo.name in line)
+        assert "\x1b[" in heading
+
     def test_a_card_that_cannot_be_rendered_does_not_fail_the_verb(
-        self, repo: Path, recorder: RecordingReporter, monkeypatch
+        self, repo: Path, recorder: Recorded, monkeypatch
     ) -> None:
         """The work succeeded. An unreadable render is not a reason to end a
         successful deploy with an error."""
@@ -281,6 +378,17 @@ class TestVerbsThatPrintOne:
         self, runner, deploy_stubs, restore_reporter, cards, repo: Path, verb: str
     ) -> None:
         result = runner.invoke(cli, [verb, "-d"])
+
+        assert result.exit_code == 0, result.output
+        assert cards == [(repo, "running")]
+
+    def test_a_verbose_start_asks_for_a_card_too(
+        self, runner, deploy_stubs, restore_reporter, cards, repo: Path
+    ) -> None:
+        """`--verbose` changes which reporter the run installs, not who owns the
+        run: the outermost verb still finds the quiet default and still asks for
+        the card. Printing it is `print_summary_card`'s half, pinned above."""
+        result = runner.invoke(cli, ["-v", "up", "-d"])
 
         assert result.exit_code == 0, result.output
         assert cards == [(repo, "running")]
@@ -395,7 +503,7 @@ class TestTheInitChain:
 
 class TestResetGetsALineNotACard:
     def test_reset_says_it_is_finished_through_its_own_emit_callback(
-        self, recorder: RecordingReporter, monkeypatch, tmp_path: Path
+        self, recorder: Recorded, monkeypatch, tmp_path: Path
     ) -> None:
         """`reset` prints a plan, asks, and destroys; its ending belongs to that
         transcript, in the same voice and through the same callback, not on a

--- a/tests/cli/test_table_factories.py
+++ b/tests/cli/test_table_factories.py
@@ -1,0 +1,253 @@
+"""The table and panel factories are the CLI's single table and panel look.
+
+These tests pin the three things a call site is allowed to rely on: the defaults
+each factory bakes in, that an override wins over a default, and that the look
+is expressed in *theme tokens* rather than colors — so a table built before a
+theme switch renders in the new theme afterwards.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from rich import box
+from rich.panel import Panel
+from rich.segment import Segment
+from rich.table import Table
+from rich.text import Text
+
+from osprey.cli import styles
+from osprey.cli.styles import (
+    BORDER_STYLE,
+    DATA_TABLE_BOX,
+    DATA_TABLE_PADDING,
+    LAYOUT_TABLE_GUTTER,
+    LAYOUT_TABLE_PADDING,
+    PANEL_BOX,
+    PANEL_PADDING,
+    TABLE_HEADER_STYLE,
+    ColorTheme,
+    Styles,
+    data_table,
+    layout_table,
+    panel,
+)
+
+
+@pytest.fixture
+def restore_theme() -> Iterator[None]:
+    """Put the process-wide theme back after a test switches it."""
+    original = styles.get_active_theme()
+    try:
+        yield
+    finally:
+        styles.set_theme(original)
+
+
+def _segments(renderable: object) -> list[Segment]:
+    """Render on the module console and keep the segments that carry text.
+
+    Under pytest neither console is a terminal, so a captured string carries no
+    ANSI. Styles are only visible on the segments themselves.
+    """
+    return [seg for seg in styles.console.render(renderable) if seg.text.strip()]
+
+
+def _style_of(renderable: object, text: str) -> object:
+    """The resolved style of the first rendered segment whose text is ``text``."""
+    for seg in _segments(renderable):
+        if seg.text.strip() == text:
+            return seg.style
+    raise AssertionError(f"no rendered segment with text {text!r}")
+
+
+# ---------------------------------------------------------------------------
+# data_table
+# ---------------------------------------------------------------------------
+
+
+def test_data_table_defaults_are_the_bordered_themed_look():
+    table = data_table()
+
+    assert isinstance(table, Table)
+    assert table.box is DATA_TABLE_BOX
+    assert table.box is box.HEAVY_HEAD
+    assert table.show_header is True
+    assert table.header_style == TABLE_HEADER_STYLE
+    assert table.border_style == BORDER_STYLE
+    # Rich normalizes padding to (top, right, bottom, left).
+    assert DATA_TABLE_PADDING == (0, 1)
+    assert table.padding == (0, 1, 0, 1)
+
+
+def test_data_table_style_defaults_are_semantic_tokens_not_colors():
+    table = data_table()
+
+    assert TABLE_HEADER_STYLE == Styles.HEADER
+    assert BORDER_STYLE == Styles.BORDER_DIM
+    for value in (table.header_style, table.border_style):
+        assert isinstance(value, str)
+        assert not str(value).startswith("#")
+
+
+def test_data_table_returns_a_fresh_table_each_call():
+    first, second = data_table(), data_table()
+
+    assert first is not second
+    first.add_column("Name")
+    assert second.columns == []
+
+
+def test_data_table_overrides_pass_through():
+    table = data_table(title="Services", show_lines=True, expand=False)
+
+    assert table.title == "Services"
+    assert table.show_lines is True
+    assert table.expand is False
+    # Untouched defaults survive an override of something else.
+    assert table.box is DATA_TABLE_BOX
+    assert table.header_style == TABLE_HEADER_STYLE
+
+
+def test_data_table_overrides_win_over_the_defaults():
+    table = data_table(box=None, header_style=Styles.ACCENT, border_style=Styles.ERROR, padding=0)
+
+    assert table.box is None
+    assert table.header_style == Styles.ACCENT
+    assert table.border_style == Styles.ERROR
+    assert table.padding == (0, 0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# layout_table
+# ---------------------------------------------------------------------------
+
+
+def test_layout_table_is_boxless_and_headerless():
+    table = layout_table()
+
+    assert isinstance(table, Table)
+    assert table.box is None
+    assert table.show_header is False
+    assert table.pad_edge is False
+    assert table.padding == LAYOUT_TABLE_PADDING
+    assert LAYOUT_TABLE_PADDING == (0, 0, 0, LAYOUT_TABLE_GUTTER)
+
+
+def test_layout_table_draws_no_rules():
+    table = layout_table()
+    table.add_column()
+    table.add_column()
+    table.add_row(Text("alpha"), Text("beta"))
+
+    rendered = "".join(seg.text for seg in styles.console.render(table))
+    assert "alpha" in rendered and "beta" in rendered
+    # No box means no rule characters anywhere in the output.
+    assert not any(char in rendered for char in "─│┌┐└┘━┃┏┓┗┛")
+
+
+def test_layout_table_overrides_pass_through():
+    table = layout_table(padding=(0, 2), pad_edge=True, show_header=True)
+
+    assert table.padding == (0, 2, 0, 2)
+    assert table.pad_edge is True
+    assert table.show_header is True
+    assert table.box is None
+
+
+def test_live_region_uses_the_layout_table_gutter():
+    """The live region's gutter is the factory's, not a second spelling of 3."""
+    from osprey.cli import live_render
+
+    assert live_render._GUTTER is LAYOUT_TABLE_GUTTER
+
+
+# ---------------------------------------------------------------------------
+# panel
+# ---------------------------------------------------------------------------
+
+
+def test_panel_defaults_are_the_single_panel_look():
+    built = panel("contents")
+
+    assert isinstance(built, Panel)
+    assert built.box is PANEL_BOX
+    assert built.box is box.ROUNDED
+    assert built.border_style == BORDER_STYLE
+    assert built.padding == PANEL_PADDING
+    assert built.title is None
+
+
+def test_panel_wraps_the_renderable_it_is_given():
+    body = Text("Registry Contents", style=Styles.HEADER)
+    built = panel(body)
+
+    assert built.renderable is body
+
+
+def test_panel_overrides_pass_through():
+    built = panel("contents", title="Audit Summary", expand=False, border_style=Styles.ERROR)
+
+    assert built.title == "Audit Summary"
+    assert built.expand is False
+    assert built.border_style == Styles.ERROR
+    assert built.box is PANEL_BOX
+
+
+def test_panel_renders_its_contents_inside_a_rounded_frame():
+    rendered = "".join(seg.text for seg in styles.console.render(panel("contents")))
+
+    assert "contents" in rendered
+    assert "╭" in rendered and "╯" in rendered
+
+
+# ---------------------------------------------------------------------------
+# The factories follow the active theme
+# ---------------------------------------------------------------------------
+
+
+def test_data_table_header_follows_set_theme(restore_theme):
+    table = data_table()
+    table.add_column("Name")
+    table.add_row("registry")
+
+    before = _style_of(table, "Name")
+
+    styles.set_theme(ColorTheme(primary="#00ff00"))
+    after = _style_of(table, "Name")
+
+    assert before != after
+    assert after.color.triplet.hex == "#00ff00"
+    assert after.bold is True
+
+
+def test_panel_border_follows_set_theme(restore_theme):
+    built = panel("contents")
+
+    def border_style():
+        return next(seg.style for seg in _segments(built) if "╭" in seg.text)
+
+    before = border_style()
+
+    styles.set_theme(ColorTheme(border_dim="#0000ff"))
+    after = border_style()
+
+    assert before != after
+    assert after.color.triplet.hex == "#0000ff"
+
+
+def test_a_table_built_before_a_theme_switch_renders_in_the_new_theme(restore_theme):
+    """The factory bakes tokens, not colors, so instances outlive a retheme."""
+    table = data_table()
+    table.add_column("Name")
+    table.add_row("registry")
+
+    styles.set_theme(ColorTheme(primary="#123456"))
+    switched = _style_of(table, "Name")
+
+    styles.set_theme(ColorTheme(primary="#654321"))
+    switched_again = _style_of(table, "Name")
+
+    assert switched.color.triplet.hex == "#123456"
+    assert switched_again.color.triplet.hex == "#654321"

--- a/tests/cli/test_terminal_probe.py
+++ b/tests/cli/test_terminal_probe.py
@@ -1,0 +1,233 @@
+"""Tests for the ``terminal_probe`` fixture — the instrument, not a subject.
+
+Every altitude and promotion needle downstream reads its verdict off this
+fixture, so the fixture's own claims have to be pinned first: that
+``rendered_text`` really is what the gated handler painted, that ``records``
+really is the ungated stream, that a CLI run cannot steal the console back, and
+that nothing survives the test that installed it.
+"""
+
+import logging
+from io import StringIO
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+from rich.logging import RichHandler
+
+from osprey.cli.altitude import gate_installed
+from osprey.cli.main import cli
+from osprey_connectors.logger import configure_logging
+from tests.cli.conftest import TerminalProbe, _ProbeRecordSink
+
+INFO_MARKER = "PROBEINFOMARKER"
+WARNING_MARKER = "PROBEWARNMARKER"
+
+PROBE_LOGGER = "osprey.terminal_probe_subject"
+
+
+@pytest.fixture
+def run_cli(monkeypatch: pytest.MonkeyPatch):
+    """Invoke the CLI group callback the way a real run does.
+
+    The bare command runs the whole callback (logging, handler console, gate)
+    and then prints help. ``load_project_dotenv`` is stubbed out: it writes an
+    ancestor ``.env`` straight into ``os.environ``, which outlives the test.
+    """
+    monkeypatch.setattr("osprey.utils.config.load_project_dotenv", lambda *a, **k: None)
+    runner = CliRunner()
+
+    def _run(*args: str) -> None:
+        result = runner.invoke(cli, list(args))
+        assert result.exit_code == 0, result.output
+
+    return _run
+
+
+def _root_rich_handlers() -> list[RichHandler]:
+    return [h for h in logging.getLogger().handlers if isinstance(h, RichHandler)]
+
+
+class TestGatedRun:
+    """A default run: the gate decides the terminal, not what was emitted."""
+
+    def test_info_is_absent_from_the_terminal_but_present_in_the_records(
+        self, run_cli, terminal_probe: TerminalProbe
+    ):
+        run_cli()
+
+        logger = logging.getLogger(PROBE_LOGGER)
+        logger.info(INFO_MARKER)
+        # A live-console witness in the same test: an absence assertion against
+        # a console nothing can reach passes for the wrong reason.
+        logger.warning(WARNING_MARKER)
+
+        assert gate_installed() is True
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER not in terminal_probe.rendered_text
+        assert INFO_MARKER in terminal_probe.messages
+
+    def test_warning_is_present_in_both(self, run_cli, terminal_probe: TerminalProbe):
+        run_cli()
+
+        logging.getLogger(PROBE_LOGGER).warning(WARNING_MARKER)
+
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert WARNING_MARKER in terminal_probe.messages
+
+    def test_records_are_the_records_themselves(self, run_cli, terminal_probe: TerminalProbe):
+        """``records`` yields ``LogRecord``s, so needles can read level and name."""
+        run_cli()
+
+        logging.getLogger(PROBE_LOGGER).info(INFO_MARKER)
+
+        gated = [r for r in terminal_probe.records if r.getMessage() == INFO_MARKER]
+        assert [(r.levelno, r.name) for r in gated] == [(logging.INFO, PROBE_LOGGER)]
+
+    def test_the_probe_does_not_disturb_the_gate(self, run_cli, terminal_probe: TerminalProbe):
+        """Swapping the console must not cost the handler its filter."""
+        run_cli()
+
+        handler = _root_rich_handlers()[0]
+        assert handler.console is terminal_probe.console
+        assert gate_installed(handler) is True
+
+
+class TestVerboseRun:
+    """``-v`` lifts the gate; the probe sees the full transcript."""
+
+    def test_info_reaches_the_terminal(self, run_cli, terminal_probe: TerminalProbe):
+        run_cli("-v")
+
+        logging.getLogger(PROBE_LOGGER).info(INFO_MARKER)
+
+        assert gate_installed() is False
+        assert INFO_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER in terminal_probe.messages
+
+
+class TestInvocationOrder:
+    """The CLI repoints the handler mid-run; the probe has to win anyway."""
+
+    def test_probe_first_then_cli(self, terminal_probe: TerminalProbe, run_cli):
+        """``set_handler_console(err_console)`` must not steal the console."""
+        from osprey.cli.styles import err_console
+
+        run_cli()
+
+        handler = _root_rich_handlers()[0]
+        assert handler.console is terminal_probe.console
+        assert handler.console is not err_console
+
+    def test_cli_first_then_probe(self, run_cli, request: pytest.FixtureRequest):
+        """A run in an earlier fixture is fine: the probe repoints on setup."""
+        run_cli()
+        probe: TerminalProbe = request.getfixturevalue("terminal_probe")
+
+        logging.getLogger(PROBE_LOGGER).warning(WARNING_MARKER)
+
+        assert _root_rich_handlers()[0].console is probe.console
+        assert WARNING_MARKER in probe.rendered_text
+
+    def test_repeated_invocations_keep_the_probe_console(
+        self, terminal_probe: TerminalProbe, run_cli
+    ):
+        for args in ((), ("-v",), ()):
+            run_cli(*args)
+            assert _root_rich_handlers()[0].console is terminal_probe.console
+
+
+class TestWithoutTheCli:
+    """The instrument works for a bare entry point too — no CLI, no gate."""
+
+    def test_bare_configure_logging_paints_into_the_probe(self, terminal_probe: TerminalProbe):
+        configure_logging()
+
+        logging.getLogger(PROBE_LOGGER).info(INFO_MARKER)
+
+        assert len(_root_rich_handlers()) == 1
+        assert gate_installed() is False
+        assert INFO_MARKER in terminal_probe.rendered_text
+        assert INFO_MARKER in terminal_probe.messages
+
+    def test_no_configuration_at_all(self, terminal_probe: TerminalProbe):
+        """The fixture installs the handler itself when nobody else has."""
+        logging.getLogger(PROBE_LOGGER).warning(WARNING_MARKER)
+
+        assert WARNING_MARKER in terminal_probe.rendered_text
+        assert WARNING_MARKER in terminal_probe.messages
+
+    def test_the_root_level_is_left_alone(self, terminal_probe: TerminalProbe):
+        """A real demotion stays detectable: DEBUG under INFO never emits."""
+        configure_logging()
+
+        logging.getLogger(PROBE_LOGGER).debug("a demoted call site speaking")
+
+        assert terminal_probe.messages == []
+
+
+class TestRenderedTextShape:
+    """Styled and plain assertions are both possible off one render."""
+
+    def test_styled_text_keeps_the_escape_sequences(self, terminal_probe: TerminalProbe):
+        logging.getLogger(PROBE_LOGGER).warning("[success]%s[/success] tail", WARNING_MARKER)
+
+        assert "\x1b[" in terminal_probe.styled_text
+        assert f"{WARNING_MARKER} tail" in terminal_probe.rendered_text
+        assert "\x1b[" not in terminal_probe.rendered_text
+
+    def test_theme_style_names_resolve(self, terminal_probe: TerminalProbe):
+        """The CLI's own theme is on the probe console, so its markup renders."""
+        logging.getLogger(PROBE_LOGGER).warning("[warning]%s[/warning]", WARNING_MARKER)
+
+        assert WARNING_MARKER in terminal_probe.rendered_text
+
+    def test_lines_are_right_stripped(self, terminal_probe: TerminalProbe):
+        logging.getLogger(PROBE_LOGGER).warning(WARNING_MARKER)
+
+        painted = [line for line in terminal_probe.lines if WARNING_MARKER in line]
+        assert painted and painted[0].endswith(WARNING_MARKER)
+
+    def test_clear_drops_both_halves(self, terminal_probe: TerminalProbe):
+        logging.getLogger(PROBE_LOGGER).warning(WARNING_MARKER)
+        assert terminal_probe.rendered_text
+
+        terminal_probe.clear()
+
+        assert terminal_probe.rendered_text == ""
+        assert terminal_probe.records == []
+
+        logging.getLogger(PROBE_LOGGER).warning("AFTERCLEAR")
+        assert "AFTERCLEAR" in terminal_probe.rendered_text
+
+    def test_arm_repoints_a_handler_installed_behind_the_fixtures_back(
+        self, terminal_probe: TerminalProbe
+    ):
+        """The escape hatch for a test that rebuilds logging itself."""
+        root = logging.getLogger()
+        for handler in _root_rich_handlers():
+            root.removeHandler(handler)
+        root.addHandler(RichHandler(console=Console(file=StringIO())))
+
+        terminal_probe.arm()
+
+        logging.getLogger(PROBE_LOGGER).warning(WARNING_MARKER)
+        assert WARNING_MARKER in terminal_probe.rendered_text
+
+
+class TestNoLeak:
+    """Nothing the probe installs may outlive the test that asked for it."""
+
+    def test_a_run_under_the_probe(self, run_cli, terminal_probe: TerminalProbe):
+        run_cli()
+        logging.getLogger(PROBE_LOGGER).warning(WARNING_MARKER)
+        assert WARNING_MARKER in terminal_probe.rendered_text
+
+    def test_the_next_test_sees_no_probe_console(self):
+        for handler in _root_rich_handlers():
+            assert not isinstance(handler.console.file, StringIO)
+
+    def test_the_next_test_sees_no_probe_sink(self):
+        assert not any(
+            isinstance(handler, _ProbeRecordSink) for handler in logging.getLogger().handlers
+        )

--- a/tests/cli/test_users_group.py
+++ b/tests/cli/test_users_group.py
@@ -824,7 +824,7 @@ class TestProfileRosterWrite:
         assert "Read-only file system" in flat
         assert "still lists alice" in flat
         assert "osprey users remove alice" in flat  # the converging remedy
-        assert "by hand" in flat  # the manual remedy
+        assert "by hand" in flat  # the fallback, named in the cause
 
     def test_an_unparseable_profile_gets_the_same_true_state_message(
         self, cli_runner, tmp_path, monkeypatch
@@ -1099,11 +1099,15 @@ class TestUsersEnv:
         assert result.exit_code == 0
         assert "STALE" not in (repo_root / "out.env").read_text(encoding="utf-8")
 
-    def test_a_missing_secrets_file_aborts(self, cli_runner, tmp_path, monkeypatch, caplog):
+    def test_a_missing_secrets_file_aborts(self, cli_runner, tmp_path, monkeypatch):
         repo_root = _make_repo(tmp_path, USERS_ENV_CONFIG)
         monkeypatch.chdir(repo_root)
 
         result = cli_runner.invoke(users, ["env"])
 
         assert result.exit_code != 0
-        assert "does not exist" in caplog.text
+        # On stderr, and stdout left empty: in the default mode this verb's
+        # stdout IS the rendered secrets file, so a diagnostic printed there
+        # would corrupt a `> .env.production` redirect.
+        assert "does not exist" in result.stderr
+        assert result.stdout == ""

--- a/tests/cli/test_web_bind.py
+++ b/tests/cli/test_web_bind.py
@@ -172,8 +172,9 @@ class TestWebCommandHonorsDeclaredBindEnv:
             catch_exceptions=False,
         )
 
-        assert "NOTICE" in result.output
-        assert DECLARED_BIND_ENV in result.output
+        # The notice is a warning now, so it lands on stderr under the ⚠ mark.
+        assert "is authoritative" in result.stderr
+        assert DECLARED_BIND_ENV in result.stderr
 
     def test_single_user_no_env_keeps_0000(self, runner, monkeypatch):
         """Without the declared env (single-user `osprey web`), --host 0.0.0.0
@@ -321,8 +322,9 @@ class TestWebCommandHonorsDeclaredWebPortEnv:
             catch_exceptions=False,
         )
 
-        assert "NOTICE" in result.output
-        assert DECLARED_WEB_PORT_ENV in result.output
+        # The notice is a warning now, so it lands on stderr under the ⚠ mark.
+        assert "is authoritative" in result.stderr
+        assert DECLARED_WEB_PORT_ENV in result.stderr
 
     def test_single_user_no_env_keeps_explicit_port(self, runner, monkeypatch):
         """Without the declared env (single-user `osprey web`), --port must

--- a/tests/cli/test_web_cmd.py
+++ b/tests/cli/test_web_cmd.py
@@ -318,8 +318,9 @@ class TestDeploymentResolution:
         result = runner.invoke(web, ["--detach"])
 
         assert result.exit_code == 0
-        assert f"Repo:  {deployment}" in result.output
-        assert f"Build: {deployment / 'build'}" in result.output
+        # One section, so the two paths line up as a column under padded labels.
+        assert f"Repo    {deployment}" in result.stdout
+        assert f"Build   {deployment / 'build'}" in result.stdout
 
     def test_ambient_osprey_config_does_not_choose_the_deployment(
         self, runner, tmp_path, monkeypatch, deployment
@@ -922,8 +923,10 @@ class TestPreflightAuthSecret:
         )
 
         assert result.exit_code == 0
-        assert "WARNING" in result.output
-        assert "ANTHROPIC_API_KEY" in result.output
+        # A pre-flight warning is trouble, so it goes to stderr wearing the
+        # renderer's warning mark rather than a hand-typed "WARNING:" prefix.
+        assert "⚠" in result.stderr
+        assert "ANTHROPIC_API_KEY" in result.stderr
 
     def test_no_provider_configured_skipped(self, runner, monkeypatch, deployment):
         self._stub_launch(monkeypatch)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,16 +259,34 @@ def restore_root_logging():
     Only ``RichHandler`` instances are ever removed. ``caplog`` installs its
     ``LogCaptureHandler`` around each test, and anything a test or fixture owns
     itself, are left alone.
+
+    The CLI adds a fourth process-global change: it installs its altitude gate
+    (``osprey.cli.altitude``) as a filter on that ``RichHandler``, which decides
+    what a run renders. A handler a test survives with — one that was already
+    pristine, or one a fixture owns — would carry that gate into every later
+    test on the worker, so any gate is stripped as well.
     """
     root = logging.getLogger()
     # `in` on handlers is an identity check — they define no __eq__.
     pristine_handlers = _PRISTINE_LOGGING["root_handlers"]
 
+    def _strip_altitude_gate(handler: logging.Handler) -> None:
+        # A RichHandler carries no filters until the CLI gates it, so the
+        # import — which pulls in osprey.cli — stays out of runs that never
+        # touch the CLI.
+        if not handler.filters:
+            return
+        from osprey.cli.altitude import lift_gate
+
+        lift_gate(handler)
+
     def _reset() -> None:
         root.setLevel(_PRISTINE_LOGGING["root_level"])
         for handler in list(root.handlers):
-            if isinstance(handler, RichHandler) and handler not in pristine_handlers:
-                root.removeHandler(handler)
+            if isinstance(handler, RichHandler):
+                _strip_altitude_gate(handler)
+                if handler not in pristine_handlers:
+                    root.removeHandler(handler)
         for name, level in _PRISTINE_LOGGING["third_party"].items():
             logging.getLogger(name).setLevel(level)
 

--- a/tests/deployment/test_build_progress.py
+++ b/tests/deployment/test_build_progress.py
@@ -9,6 +9,7 @@ by hand.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,27 @@ COLD_BUILD = FIXTURES / "buildkit_cold_build.log"
 
 #: A single-image build, whose headers carry no service name at all.
 PROJECT_IMAGE = FIXTURES / "buildkit_project_image.log"
+
+#: BuildKit bookkeeping that is not a caption: the vertex stopwatch and the
+#: vertex's own status. Before the parser told the two apart, six caption
+#: observations in ten of the cold build replay matched this — the whole table
+#: read ``DONE 0.0s`` for most of a quarter-hour build.
+BOOKKEEPING = re.compile(r"^(\d+\.\d+\s|DONE\b|CACHED\b|ERROR\b|sha256:)")
+
+#: Real captions from the cold build, pinned verbatim. Filtering bookkeeping is
+#: only half the job: a filter that also ate these would leave a tidy table that
+#: says nothing. Each one is chosen for a different shape the filters could trip
+#: over — a stopwatch-prefixed line whose text starts with a word and a colon,
+#: one carrying its own digits-and-dots, one ending in ``done``, and two that
+#: never carried a stopwatch at all. All five arrive before their service's
+#: image is named, so all three surfaces are still showing that row.
+PINNED_CAPTIONS = [
+    "Hit:1 https://deb.debian.org/debian trixie InRelease",
+    "Fetched 10.0 MB in 1s (6811 kB/s)",
+    "Reading package lists...",
+    "transferring dockerfile: 10.59kB done",
+    "exporting layers",
+]
 
 
 def replay(path: Path, model: BuildModel) -> list[dict[str, str | None]]:
@@ -56,6 +78,23 @@ def steps_per_service(seen: list[dict[str, str | None]]) -> dict[str, set[str]]:
 
 def rows_by_service(model: BuildModel) -> dict[str, BuildRow]:
     return {row.service: row for row in model.snapshot()}
+
+
+def caption_trace(path: Path) -> dict[str, list[str]]:
+    """Every caption each service's row carried during a replay, in order.
+
+    Consecutive repeats are collapsed: what a caption filter can get wrong is
+    which strings reach a row, not how many ticks each one stayed there.
+    """
+    model = BuildModel()
+    trace: dict[str, list[str]] = {}
+    for tick, line in enumerate(path.read_bytes().decode().split("\n")):
+        model.feed(line, float(tick))
+        for row in model.snapshot():
+            captions = trace.setdefault(row.service, [])
+            if not captions or captions[-1] != row.caption:
+                captions.append(row.caption)
+    return trace
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +200,128 @@ def test_a_service_carries_a_caption_for_what_it_is_doing(cold_build):
     rows = rows_by_service(model)
     assert all(row.caption for row in rows.values())
     assert rows["virtual-accelerator"].started_at < rows["bluesky-panels"].started_at
+
+
+# ---------------------------------------------------------------------------
+# Captions carry work, never bookkeeping
+# ---------------------------------------------------------------------------
+#
+# Most of what a vertex prints is not a caption. BuildKit stamps its own
+# stopwatch onto every line a step's command writes, and reports each vertex's
+# status on lines of the same shape -- and both used to land in the caption
+# column, where the stopwatch reads as a second step index (`6/8  21.51
+# Collecting scikit-learn`) and `DONE 0.0s` reads as a finished build. The
+# replay is the instrument: no hand-written line would have found sixty
+# percent.
+
+
+def test_no_caption_is_buildkit_bookkeeping():
+    """The stopwatch and the vertex-status lines never reach a row."""
+    trace = caption_trace(COLD_BUILD)
+
+    polluted = [
+        (service, caption)
+        for service, captions in trace.items()
+        for caption in captions
+        if BOOKKEEPING.match(caption)
+    ]
+    assert polluted == []
+
+
+def test_genuine_captions_survive_the_filter_verbatim():
+    """The other half: a filter that ate the work too would pass the test above
+    with an empty table."""
+    trace = caption_trace(COLD_BUILD)
+
+    seen = {caption for captions in trace.values() for caption in captions}
+    assert [caption for caption in PINNED_CAPTIONS if caption not in seen] == []
+
+
+def test_filtering_captions_changes_no_row(cold_build):
+    """Bookkeeping lines still prove their service is alive, so the rows they
+    belong to must all still be there — the filter drops text, not rows."""
+    model, _, _ = cold_build
+
+    assert list(caption_trace(COLD_BUILD)) == [row.service for row in model.snapshot()]
+
+
+def test_the_vertex_stopwatch_is_not_part_of_the_caption():
+    """`#12 0.322 Hit:1 ...` is one caption with a timestamp in front of it, and
+    the timestamp is the vertex's, not the step's."""
+    model = BuildModel()
+
+    model.feed("#12 [virtual-accelerator 5/8] RUN apt-get update", 0.0)
+    model.feed("#12 0.322 Hit:1 https://deb.debian.org/debian trixie InRelease", 1.0)
+
+    assert model.snapshot()[0].caption == "Hit:1 https://deb.debian.org/debian trixie InRelease"
+
+
+def test_the_stopwatch_is_stripped_from_the_frame_that_survived():
+    """The stamp is per write, so a redrawn line carries one on every frame —
+    including the last one, which is the only one anybody saw."""
+    model = BuildModel()
+
+    model.feed("#17 [virtual-accelerator 6/8] RUN pip install", 0.0)
+    model.feed("#17 21.51 Collecting numpy\r21.52 Collecting scikit-learn", 1.0)
+
+    assert model.snapshot()[0].caption == "Collecting scikit-learn"
+
+
+@pytest.mark.parametrize(
+    "echo",
+    [
+        "DONE 0.0s",
+        "CACHED",
+        "ERROR: process did not complete successfully: exit code 1",
+        "sha256:00430733972c 14.40MB / 14.40MB 0.3s done",
+    ],
+)
+def test_a_vertex_status_echo_leaves_the_row_s_work_on_screen(echo: str):
+    """These close a vertex; they do not describe what the service is doing.
+    They arrive last, so a row that showed them would show nothing else."""
+    model = BuildModel()
+
+    model.feed("#12 [virtual-accelerator 5/8] RUN pip install osprey-framework", 0.0)
+    model.feed("#12 3.551 Collecting scikit-learn", 1.0)
+    model.feed(f"#12 {echo}", 2.0)
+
+    row = model.snapshot()[0]
+    assert row.caption == "Collecting scikit-learn"
+    assert row.step == "5/8"
+
+
+def test_a_status_echo_still_proves_its_service_is_alive():
+    """It is the one thing such a line does say, and the heartbeats read it:
+    dropping the line outright would make a chatty service look stalled."""
+    model = BuildModel()
+
+    model.feed("#12 [virtual-accelerator 5/8] RUN pip install", 0.0)
+    model.feed("#12 DONE 4.2s", 9.0)
+
+    assert model.snapshot()[0].last_line_at == 9.0
+
+
+def test_a_mid_build_vertex_done_does_not_finish_the_service():
+    """A service's Dockerfile is a dozen vertices and every one of them reports
+    `DONE`. Only `naming to ... done` means the image is built — reading the
+    first `DONE` as one would drop a still-building service from the table and
+    silence its heartbeats for the rest of the build."""
+    model = BuildModel()
+
+    model.feed("#12 [virtual-accelerator 5/8] RUN pip install", 0.0)
+    model.feed("#12 DONE 4.2s", 1.0)
+
+    assert model.snapshot()[0].finished is None
+
+
+def test_a_status_echo_alone_opens_no_row():
+    """Labelled, so the line could have bound to a row — it carries no step and
+    no caption, so the row it would open is a blank line in the table."""
+    model = BuildModel("proj")
+
+    model.feed("#1 DONE 0.1s", 0.0)
+
+    assert model.snapshot() == []
 
 
 # ---------------------------------------------------------------------------
@@ -280,12 +441,12 @@ def test_a_reused_vertex_number_follows_its_latest_header():
     model = BuildModel()
 
     model.feed("#7 [event-dispatcher 1/8] FROM python:3.12-slim", 0.0)
-    model.feed("#7 sha256:abc extracting", 1.0)
+    model.feed("#7 extracting sha256:abc", 1.0)
     model.feed("#7 [bluesky-bridge 1/8] FROM python:3.11-slim", 2.0)
     model.feed("#7 resolving python:3.11-slim", 3.0)
 
     rows = rows_by_service(model)
-    assert rows["event-dispatcher"].caption == "sha256:abc extracting"
+    assert rows["event-dispatcher"].caption == "extracting sha256:abc"
     assert rows["bluesky-bridge"].caption == "resolving python:3.11-slim"
 
 
@@ -311,8 +472,10 @@ def test_a_repeated_infrastructure_header_stays_on_the_labelled_row():
 
     rows = model.snapshot()
     assert [row.service for row in rows] == ["proj"]
-    assert rows[0].caption == "DONE 0.6s"
+    assert rows[0].caption == "load metadata for docker.io/library/python:3.12-slim"
     assert rows[0].started_at == 0.0
+    # The `DONE` lines carry no caption, but they are still this row's output.
+    assert rows[0].last_line_at == 5.0
 
 
 def test_a_redrawn_progress_caption_keeps_only_its_last_frame():

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -123,6 +123,31 @@ PARALLEL_FLAGS = ("-n 4", "--dist loadgroup")
 SCHEDULER_HOOK = "pytest_xdist_make_scheduler"
 SCHEDULER_CLASS = "FileOrGroupScheduling"
 
+#: An xdist worker count on a pytest invocation. Used by two jobs that must
+#: stay serial for different reasons, so it lives here rather than beside
+#: either. The lookbehind keeps it from matching inside a longer flag.
+_XDIST_WORKERS_RE = re.compile(r"(?<!\S)-n\s+\d")
+
+PTY_STEP = "Run real-terminal pty suite serially"
+PTY_MARKER = "pty"
+#: The directory the serial step selects, and therefore the only place a
+#: ``pty``-marked test can live and still be run by anything.
+PTY_TESTS_DIR = "tests/pty/"
+#: Exact spellings, matched as literal substrings on the two invocations that
+#: form the pair: the parallel lane hands the marker away, the serial step
+#: picks it up. Single spaces and the quoting are part of the pin.
+PTY_DESELECT = '-m "not pty"'
+PTY_SELECT = "-m pty"
+_PTY_MARK_RE = re.compile(r"pytest\.mark\.pty\b")
+#: The local check scripts that run the same wholesale `pytest tests/` sweep the
+#: CI lane does, and therefore inherit the same problem. Matched on the term
+#: rather than on the CI lane's exact spelling because quick_check.sh combines
+#: it with another one (`-m "not slow and not pty"`).
+LANE_SCRIPTS = ("scripts/quick_check.sh", "scripts/premerge_check.sh", "scripts/ci_check.sh")
+#: The one that claims to mirror the lane, and so must also run what it drops.
+CI_CHECK_SCRIPT = "scripts/ci_check.sh"
+PTY_DESELECT_TERM = "not pty"
+
 
 def _load_workflow() -> dict[str, Any]:
     with CI_YML.open() as f:
@@ -765,6 +790,395 @@ def test_conftest_scheduler_override__mutation_drops_loadgroup_guard() -> None:
 
 
 # ---------------------------------------------------------------------------
+# The real-terminal suite: out of the parallel lane, into a serial step
+# ---------------------------------------------------------------------------
+
+# ``tests/pty/`` runs osprey's own verbs on a real terminal and asserts on the
+# bytes that reached it, including that a spinner ADVANCED between two frames
+# (which is how the monitor thread is proven to be running). Assertions like
+# that read the machine as much as they read the code, so the suite is handed
+# out of the four-worker lane and given a step of its own.
+#
+# Both halves of that handover are silently droppable, in opposite directions,
+# which is why each is pinned here. Lose the deselection and the scenarios go
+# back to running beside three loaded workers, where they do not fail now but
+# flake in someone else's PR weeks later. Lose the step and they run nowhere
+# at all, with every check still green: the same "an unnamed suite never runs"
+# shape the rest of this module exists to prevent.
+
+
+def _pty_step(wf: dict[str, Any]) -> dict[str, Any]:
+    return _find_named_step(wf, UNIT_TEST_JOB, PTY_STEP)
+
+
+def test_unit_lane_hands_the_pty_suite_away(workflow: dict[str, Any]) -> None:
+    """The parallel lane must deselect the marker. It collects ``tests/``
+    wholesale, so without this the pty scenarios are simply part of it."""
+    line = _unit_test_pytest_line(workflow)
+    assert PTY_DESELECT in line, (
+        f"the '{UNIT_TEST_JOB}' job must run pytest with {PTY_DESELECT} so the "
+        f"real-terminal scenarios are left to the '{PTY_STEP}' step; got: {line.strip()!r}"
+    )
+
+
+def test_unit_lane_hands_the_pty_suite_away__mutation_drops_the_deselection() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, UNIT_TEST_JOB, "Run unit tests")
+    original = step["run"]
+    step["run"] = original.replace(f" {PTY_DESELECT}", "")
+    assert step["run"] != original, "deselection not found; mutation is stale"
+    with pytest.raises(AssertionError):
+        test_unit_lane_hands_the_pty_suite_away(mutated)
+
+
+def test_unit_lane_hands_the_pty_suite_away__mutation_parks_it_in_a_comment() -> None:
+    """Same hole the parallel-flag pin found: a deselection that survives only
+    in a trailing shell comment, which is exactly how a temporary revert gets
+    written. ``_unit_test_pytest_line`` strips comments, so it must not count."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, UNIT_TEST_JOB, "Run unit tests")
+    original = step["run"]
+    step["run"] = original.replace(f" {PTY_DESELECT}", f"  # TODO restore {PTY_DESELECT}")
+    assert step["run"] != original, "deselection not found; mutation is stale"
+    with pytest.raises(AssertionError):
+        test_unit_lane_hands_the_pty_suite_away(mutated)
+
+
+def test_pty_suite_runs_in_its_own_serial_step(workflow: dict[str, Any]) -> None:
+    """And the step must actually pick the marker back up, serially. No worker
+    count and no dist mode: a second scenario running alongside is the load the
+    deselection was for, and running it inside this step would be no better
+    than leaving it in the lane."""
+    step = _pty_step(workflow)
+    run = step["run"]
+    assert "uv run pytest " in run, f"'{PTY_STEP}' must invoke pytest; got: {run!r}"
+    assert PTY_TESTS_DIR in run, f"'{PTY_STEP}' must select {PTY_TESTS_DIR}; got: {run!r}"
+    assert PTY_SELECT in run, (
+        f"'{PTY_STEP}' must select the marker with {PTY_SELECT!r}, so the unmarked "
+        f"files under {PTY_TESTS_DIR} are not run a second time here; got: {run!r}"
+    )
+    assert not _XDIST_WORKERS_RE.search(run), (
+        f"'{PTY_STEP}' runs pytest with xdist workers; the scenarios time their own "
+        f"repaints and must not compete with each other"
+    )
+    assert "--dist" not in run, f"'{PTY_STEP}' sets an xdist dist mode; it must stay serial"
+
+
+def test_pty_suite_runs_in_its_own_serial_step__mutation_drops_the_step() -> None:
+    """Deleting the step is the failure that costs nothing at the time: the
+    deselection above keeps the suite out of the lane, so CI goes green over a
+    suite nobody runs."""
+    mutated = copy.deepcopy(_load_workflow())
+    _jobs(mutated)[UNIT_TEST_JOB]["steps"].remove(_pty_step(mutated))
+    with pytest.raises(AssertionError):
+        test_pty_suite_runs_in_its_own_serial_step(mutated)
+
+
+def test_pty_suite_runs_in_its_own_serial_step__mutation_adds_xdist_workers() -> None:
+    """Speeding the step up with ``-n 2`` reinstates precisely the contention
+    the suite was moved here to escape."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _pty_step(mutated)
+    step["run"] = step["run"].replace("--tb=short", "--tb=short -n 2")
+    with pytest.raises(AssertionError, match="xdist workers"):
+        test_pty_suite_runs_in_its_own_serial_step(mutated)
+
+
+def test_pty_suite_runs_in_its_own_serial_step__mutation_drops_the_marker() -> None:
+    """Selecting the bare directory instead would re-run the unmarked
+    ``test_stub_coverage.py``, which already ran in the parallel lane."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _pty_step(mutated)
+    original = step["run"]
+    step["run"] = original.replace(f" {PTY_SELECT}", "")
+    assert step["run"] != original, "marker selection not found; mutation is stale"
+    with pytest.raises(AssertionError):
+        test_pty_suite_runs_in_its_own_serial_step(mutated)
+
+
+def test_pty_step_runs_only_where_a_terminal_is_real(workflow: dict[str, Any]) -> None:
+    """Pinned to the Linux cells. The scenarios self-skip where a pty is not a
+    thing, and a step whose whole suite skipped reports green over nothing, so
+    the venue is chosen rather than discovered, by the same rule the live Channel
+    Access step in this job already follows."""
+    condition = _pty_step(workflow).get("if", "")
+    assert "matrix.os" in condition and "ubuntu-latest" in condition, (
+        f"'{PTY_STEP}' must be gated on the Linux matrix cells; got if: {condition!r}"
+    )
+
+
+def test_pty_step_runs_only_where_a_terminal_is_real__mutation_drops_the_gate() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    del _pty_step(mutated)["if"]
+    with pytest.raises(AssertionError):
+        test_pty_step_runs_only_where_a_terminal_is_real(mutated)
+
+
+def _registered_markers(pyproject: dict[str, Any]) -> list[str]:
+    """The marker NAMES declared in ``[tool.pytest.ini_options]``, without the
+    ``name: description`` prose after the first colon."""
+    declared = pyproject["tool"]["pytest"]["ini_options"]["markers"]
+    return [entry.split(":", 1)[0].strip() for entry in declared]
+
+
+def test_pty_marker_is_registered(pyproject: dict[str, Any]) -> None:
+    """Both invocations above name the marker as a bare string, and pyproject is
+    the only place that says what it means. Unregistered, the suite collects
+    with an unknown-mark warning under the lane's own invocation (measured) and
+    errors outright under an explicit ``--strict-markers`` run, while the
+    deselection and the selection go on matching nothing but each other."""
+    assert PTY_MARKER in _registered_markers(pyproject), (
+        f"register the '{PTY_MARKER}' marker in [tool.pytest.ini_options].markers; "
+        f"ci.yml selects and deselects it by name"
+    )
+
+
+def test_pty_marker_is_registered__mutation_drops_it() -> None:
+    mutated = _load_pyproject()
+    ini = mutated["tool"]["pytest"]["ini_options"]
+    original = ini["markers"]
+    ini["markers"] = [e for e in original if e.split(":", 1)[0].strip() != PTY_MARKER]
+    assert ini["markers"] != original, "marker not registered; mutation is stale"
+    with pytest.raises(AssertionError):
+        test_pty_marker_is_registered(mutated)
+
+
+def _test_module_sources() -> dict[str, str]:
+    """Every test module under ``tests/``, keyed by repo-relative posix path.
+
+    This module excludes itself: it is the scanner, and its own source spells
+    the marker it searches for: in the constant above, in these docstrings,
+    and in the synthetic file the mutation below invents. A scanner that found
+    itself would report a permanent false positive.
+    """
+    root = CI_YML.parents[2]
+    me = Path(__file__).resolve()
+    return {
+        path.relative_to(root).as_posix(): path.read_text(encoding="utf-8")
+        for path in (root / "tests").rglob("test_*.py")
+        if path.resolve() != me
+    }
+
+
+def _pty_marked_files_outside_the_step(sources: dict[str, str]) -> list[str]:
+    """Marked files the serial step's path does not reach (empty = all reachable)."""
+    return sorted(
+        name
+        for name, source in sources.items()
+        if _PTY_MARK_RE.search(source) and not name.startswith(PTY_TESTS_DIR)
+    )
+
+
+def test_every_pty_marked_file_lives_where_the_serial_step_looks() -> None:
+    """The deselection is repo-wide but the step selects one directory, so a
+    ``pty``-marked file written anywhere else is dropped by the lane and picked
+    up by nothing. It would not fail, it would not skip, and it would not
+    appear in any summary: it would simply stop being run, which is the one
+    outcome this module exists to make impossible."""
+    sources = _test_module_sources()
+    marked = [name for name, source in sources.items() if _PTY_MARK_RE.search(source)]
+    assert marked, (
+        f"no test file carries {PTY_MARKER!r} any more. Either the suite was removed "
+        f"(drop the lane wiring with it) or the marker scan broke"
+    )
+    stray = _pty_marked_files_outside_the_step(sources)
+    assert stray == [], (
+        f"{PTY_MARKER}-marked file(s) outside {PTY_TESTS_DIR}: {stray}. The parallel lane "
+        f"deselects the marker everywhere, so these run nowhere. Move them under "
+        f"{PTY_TESTS_DIR} or widen the '{PTY_STEP}' step to select them."
+    )
+
+
+def test_every_pty_marked_file_lives_where_the_serial_step_looks__mutation_strays() -> None:
+    """A future marked file one directory over must be reported, not tolerated
+    because the suite it was modelled on is still in the right place."""
+    sources = _test_module_sources()
+    phantom = "tests/cli/test_future_terminal_scenarios.py"
+    sources[phantom] = "pytestmark = [pytest.mark.pty]\n"
+    assert _pty_marked_files_outside_the_step(sources) == [phantom]
+
+
+def _imports_stdlib_pty(source: str) -> bool:
+    """Whether *source* imports the stdlib ``pty`` module, at any nesting.
+
+    Parsed rather than grepped, for both directions. The file that does it today
+    imports inside an ``if os.name == "posix":`` guard (an unguarded import
+    raises at COLLECTION, which is before any ``skipif`` can apply), so a scan
+    that only looked at top-level statements would miss it. And the letters
+    "pty" are in every path, docstring and fixture name in that directory, so a
+    substring search would match everything.
+    """
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import) and any(alias.name == "pty" for alias in node.names):
+            return True
+        if isinstance(node, ast.ImportFrom) and node.module == "pty":
+            return True
+    return False
+
+
+def _unmarked_terminal_files(sources: dict[str, str]) -> list[str]:
+    """Files under the pty directory that open a terminal without the marker."""
+    return sorted(
+        name
+        for name, source in sources.items()
+        if name.startswith(PTY_TESTS_DIR)
+        and _imports_stdlib_pty(source)
+        and not _PTY_MARK_RE.search(source)
+    )
+
+
+def test_every_file_that_opens_a_terminal_carries_the_marker() -> None:
+    """The other direction, and the one that fails quietly. A new file under
+    ``tests/pty/`` that allocates a terminal but forgets the marker is not
+    deselected, so it runs in the four-worker lane against three loaded
+    siblings, and what it reports there is the runner rather than the code.
+
+    Scoped to files that import the stdlib module rather than to the directory,
+    because the exception is deliberate and must stay clean:
+    ``test_stub_coverage.py`` lives here, needs no terminal, imports no ``pty``,
+    and belongs in the parallel lane. ``tests/interfaces/web_terminal/`` also
+    opens ptys and is correctly unmarked, which is why the scope is this
+    directory and not the whole tree."""
+    sources = _test_module_sources()
+    terminal_files = [
+        name
+        for name, source in sources.items()
+        if name.startswith(PTY_TESTS_DIR) and _imports_stdlib_pty(source)
+    ]
+    assert terminal_files, (
+        f"no file under {PTY_TESTS_DIR} imports the stdlib pty module any more; either "
+        f"the suite left or the import scan broke"
+    )
+    unmarked = _unmarked_terminal_files(sources)
+    assert unmarked == [], (
+        f"file(s) under {PTY_TESTS_DIR} open a terminal without the {PTY_MARKER!r} marker: "
+        f"{unmarked}. They would run in the parallel lane, where a scenario that times its "
+        f"own repaints measures the runner. Add `pytest.mark.{PTY_MARKER}`."
+    )
+
+
+def test_every_file_that_opens_a_terminal_carries_the_marker__mutation_forgets_it() -> None:
+    """The concrete case this is here for: a new scenario file lands under
+    ``tests/pty/``, opens a pty inside the usual POSIX guard, and nobody
+    notices the missing marker because it passes on an idle machine."""
+    sources = _test_module_sources()
+    phantom = f"{PTY_TESTS_DIR}test_future_scenarios.py"
+    sources[phantom] = 'import os\n\nif os.name == "posix":\n    import pty\n'
+    assert _unmarked_terminal_files(sources) == [phantom]
+
+
+def test_every_file_that_opens_a_terminal_carries_the_marker__mutation_marked_is_accepted() -> None:
+    """And the same file WITH the marker must pass, so the guard is reporting
+    the missing marker rather than the import."""
+    sources = _test_module_sources()
+    sources[f"{PTY_TESTS_DIR}test_future_scenarios.py"] = (
+        'import os\n\nimport pytest\n\nif os.name == "posix":\n    import pty\n'
+        "\npytestmark = [pytest.mark.pty]\n"
+    )
+    assert _unmarked_terminal_files(sources) == []
+
+
+# The same premise applied to the local check scripts. They run the identical
+# wholesale sweep, so without the deselection a developer's pre-commit check is
+# where the timing scenarios flake, and the report is unreadable there: no
+# artifacts, no diagnostics, just a red that does not reproduce.
+
+
+def _script_pytest_lines(source: str) -> list[str]:
+    return [line for line in source.splitlines() if "uv run pytest " in line]
+
+
+def _script_source(name: str) -> str:
+    return (CI_YML.parents[2] / name).read_text(encoding="utf-8")
+
+
+def _lane_invocations(source: str) -> list[str]:
+    """The script's wholesale ``pytest tests/`` sweeps, ignoring narrower runs."""
+    return [line for line in _script_pytest_lines(source) if "--ignore=tests/e2e" in line]
+
+
+def _sweeps_missing_the_deselection(source: str) -> list[str]:
+    """Wholesale sweeps in *source* that do not hand the marker away (empty =
+    all of them do)."""
+    return [line.strip() for line in _lane_invocations(source) if PTY_DESELECT_TERM not in line]
+
+
+def _drop_the_deselection(source: str) -> str:
+    """*source* with the deselection removed, in either spelling it appears in
+    (quick_check.sh combines it with ``not slow``)."""
+    return source.replace(f' -m "not slow and {PTY_DESELECT_TERM}"', ' -m "not slow"').replace(
+        f" {PTY_DESELECT}", ""
+    )
+
+
+@pytest.mark.parametrize("script", LANE_SCRIPTS)
+def test_local_check_scripts_deselect_the_pty_marker(script: str) -> None:
+    """Every local script that sweeps ``tests/`` must hand the suite away too.
+    The premise of the whole handover is that these scenarios cannot share a
+    machine with four workers, and that is as true on a laptop as on a runner.
+    It is worse on a laptop, in fact: there are no artifacts and no per-worker
+    diagnostics there, so the flake arrives as a red that does not reproduce."""
+    source = _script_source(script)
+    assert _lane_invocations(source), (
+        f"{script} no longer runs a wholesale `pytest tests/` sweep; this pin is stale"
+    )
+    assert _sweeps_missing_the_deselection(source) == [], (
+        f"{script} sweeps tests/ without deselecting the {PTY_MARKER!r} marker: "
+        f"{_sweeps_missing_the_deselection(source)}"
+    )
+
+
+@pytest.mark.parametrize("script", LANE_SCRIPTS)
+def test_local_check_scripts_deselect_the_pty_marker__mutation_drops_it(script: str) -> None:
+    source = _script_source(script)
+    mutated = _drop_the_deselection(source)
+    assert mutated != source, f"no deselection in {script}; mutation is stale"
+    assert _sweeps_missing_the_deselection(mutated) != []
+
+
+def _missing_ci_check_serial_run(source: str) -> list[str]:
+    """What ``ci_check.sh``'s serial follow-up is missing (empty = wired)."""
+    serial = [line for line in _script_pytest_lines(source) if PTY_SELECT in line]
+    if not serial:
+        return ["a serial pty invocation"]
+    return [
+        f"xdist flags on {line.strip()!r}"
+        for line in serial
+        if _XDIST_WORKERS_RE.search(line) or "--dist" in line
+    ]
+
+
+def test_ci_check_also_runs_what_it_deselects() -> None:
+    """``ci_check.sh`` is the local mirror of the CI lane, so it owes the same
+    serial follow-up the lane has. The other two scripts are documented fast
+    sweeps and legitimately stop at the deselection; this one would otherwise
+    quietly cover less than it did before the marker existed."""
+    assert _missing_ci_check_serial_run(_script_source(CI_CHECK_SCRIPT)) == [], (
+        f"{CI_CHECK_SCRIPT} deselects the {PTY_MARKER!r} marker in its sweep but does not "
+        f"run it serially afterwards: add `uv run pytest {PTY_TESTS_DIR} {PTY_SELECT}`"
+    )
+
+
+def test_ci_check_also_runs_what_it_deselects__mutation_drops_the_serial_run() -> None:
+    """Dropping the follow-up leaves a script that covers strictly less than it
+    used to while printing the same green summary."""
+    source = _script_source(CI_CHECK_SCRIPT)
+    mutated = "\n".join(line for line in source.splitlines() if PTY_SELECT not in line)
+    assert mutated != source, f"no serial pty invocation in {CI_CHECK_SCRIPT}; mutation is stale"
+    assert _missing_ci_check_serial_run(mutated) == ["a serial pty invocation"]
+
+
+def test_ci_check_also_runs_what_it_deselects__mutation_parallelizes_it() -> None:
+    """And speeding the follow-up up with workers must be reported: it would
+    put the scenarios back on a contended machine, which is what the sweep
+    dropped them to avoid."""
+    source = _script_source(CI_CHECK_SCRIPT)
+    mutated = source.replace(f"{PTY_SELECT} -v", f"{PTY_SELECT} -n 4 -v")
+    assert mutated != source, "serial pty invocation not found; mutation is stale"
+    assert _missing_ci_check_serial_run(mutated) != []
+
+
+# ---------------------------------------------------------------------------
 # (e) the dockerbuild --ignore guard
 # ---------------------------------------------------------------------------
 
@@ -1311,9 +1725,6 @@ def test_shared_lane_ignores_emulator_files__mutation_drops_smoke_ignore() -> No
     assert _run_step_ignores_all(mutated, [GCHAT_TEST_FILE]) == []  # the other survives
     with pytest.raises(AssertionError):
         test_shared_lane_ignores_every_emulator_container_file(mutated)
-
-
-_XDIST_WORKERS_RE = re.compile(r"(?<!\S)-n\s+\d")
 
 
 def _gchat_pytest_steps(wf: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/deployment/test_deploy_summary.py
+++ b/tests/deployment/test_deploy_summary.py
@@ -4,13 +4,32 @@ Every ``osprey up`` ends with a summary of what is reachable where,
 derived from the rendered compose files' published host ports — plus an
 unconditional web-terminal line, so a project *without* a web tier says so
 explicitly instead of silently binding nothing.
+
+The summary is the deploy's own output, so it is *printed* rather than logged:
+an INFO record is not rendered on a normal run, and a fact only a
+``--verbose`` run shows is a fact the deploy did not report. The needle tests
+below hold both halves of that claim side by side — the block is in the default
+view, its logged form no longer paints there, and the record is still emitted
+for file and aggregation sinks.
 """
 
 from __future__ import annotations
 
-import pytest
+import io
+import logging
+import re
 
+import pytest
+from rich.console import Console
+from rich.logging import RichHandler
+
+from osprey.cli.altitude import install_gate, lift_gate
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+from osprey.cli.styles import osprey_theme
 from osprey.deployment import deploy_summary
+
+#: Anything Rich writes that is not text: styles, cursor moves, erases.
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
 
 
 @pytest.fixture
@@ -72,3 +91,209 @@ def test_summary_handles_no_published_ports(tmp_path):
 def test_log_endpoint_summary_never_raises(tmp_path):
     """Advisory output must not be able to fail a deploy that succeeded."""
     deploy_summary.log_endpoint_summary({"project_name": "demo"}, [str(tmp_path / "missing.yml")])
+
+
+# ---------------------------------------------------------------------------
+# The promoted summary: printed, not logged
+# ---------------------------------------------------------------------------
+
+
+class _RecordingReporter(PhaseReporter):
+    """A reporter whose console is a buffer, so printed output is readable.
+
+    Subclasses the real reporter rather than standing in for it: what is being
+    pinned is that the summary goes through the renderer's own ``out()`` seam,
+    which a look-alike would not prove.
+    """
+
+    def __init__(self, console: Console) -> None:
+        super().__init__(color=False)
+        self._console = console
+
+    def out(self) -> Console:
+        return self._console
+
+
+class _RecordSink(logging.Handler):
+    """Every record the loggers emitted, captured before any handler filter."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+class _Probe:
+    """What the terminal showed, and what the loggers emitted, side by side.
+
+    ``printed`` is the echo path — where a promoted fact now lives.
+    ``rendered`` is what the root ``RichHandler`` painted, after the altitude
+    gate has had its say. ``messages`` is the raw record stream, which the gate
+    never touches: it is a handler filter, so a record it drops is still
+    emitted and still reaches every sink.
+    """
+
+    def __init__(
+        self,
+        printed: io.StringIO,
+        painted: io.StringIO,
+        sink: _RecordSink,
+        handler: RichHandler,
+    ) -> None:
+        self._printed = printed
+        self._painted = painted
+        self._sink = sink
+        self.handler = handler
+
+    @property
+    def printed(self) -> str:
+        """The verb's own output, with escape sequences stripped."""
+        return _ANSI.sub("", self._printed.getvalue())
+
+    @property
+    def rendered(self) -> str:
+        """What the logging handler painted, with escape sequences stripped."""
+        return _ANSI.sub("", self._painted.getvalue())
+
+    @property
+    def messages(self) -> list[str]:
+        """The formatted message of every captured record."""
+        return [record.getMessage() for record in self._sink.records]
+
+
+@pytest.fixture
+def probe(restore_root_logging):
+    """Capture the printed stream and the painted log stream of one call.
+
+    A local instrument rather than ``tests/cli``'s ``terminal_probe`` fixture,
+    which that package's ``conftest`` does not share with this one. Both halves
+    are built the same way: a themed terminal console writing into a buffer, the
+    altitude gate a normal run installs, and a record sink underneath the gate.
+    """
+    printed = io.StringIO()
+    painted = io.StringIO()
+    console_kwargs = {
+        "theme": osprey_theme,
+        "force_terminal": True,
+        "width": 100,
+        "color_system": "truecolor",
+    }
+
+    previous = install_reporter(_RecordingReporter(Console(file=printed, **console_kwargs)))
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    handler = RichHandler(
+        console=Console(file=painted, **console_kwargs),
+        markup=True,
+        show_path=False,
+        show_time=False,
+        show_level=True,
+    )
+    install_gate(handler)
+    sink = _RecordSink()
+    root.addHandler(handler)
+    root.addHandler(sink)
+    try:
+        yield _Probe(printed, painted, sink, handler)
+    finally:
+        root.removeHandler(handler)
+        root.removeHandler(sink)
+        install_reporter(previous)
+
+
+def test_the_endpoint_summary_is_in_the_default_view(probe, compose_file):
+    """The needle: printed on a normal run, no longer painted by the logger."""
+    deploy_summary.log_endpoint_summary({"project_name": "demo"}, [compose_file])
+    logging.getLogger("deployment.summary").warning("armed witness")
+
+    # Echoed: what the operator ran the verb to find out.
+    assert "Service endpoints (demo):" in probe.printed
+    assert "event-dispatcher" in probe.printed
+    assert "http://127.0.0.1:8020" in probe.printed
+
+    # The armed witness proves the painting console is live and the gate is the
+    # only reason the summary is missing from it — an absence assertion against
+    # a console nobody ever wrote to passes for the wrong reason.
+    assert "armed witness" in probe.rendered
+    assert "Service endpoints" not in probe.rendered
+    assert "http://127.0.0.1:8020" not in probe.rendered
+
+    # Nothing was lost: the record still carries the whole block for sinks.
+    assert any("Service endpoints (demo):" in message for message in probe.messages)
+    assert any("http://127.0.0.1:8020" in message for message in probe.messages)
+
+
+def test_the_logged_block_still_reaches_a_verbose_transcript(probe, compose_file):
+    """Lifting the gate is what ``-v`` does, and the record paints again there.
+
+    The record half is kept at its old level deliberately: a file or
+    aggregation sink gets the whole summary in one record, and a transcript run
+    is the one place a reader asked for it twice.
+    """
+    lift_gate(probe.handler)
+
+    deploy_summary.log_endpoint_summary({"project_name": "demo"}, [compose_file])
+
+    assert "Service endpoints (demo):" in probe.printed  # echo class is unconditional
+    assert "Service endpoints (demo):" in probe.rendered
+
+
+def test_printed_summary_keeps_the_entries_and_their_order(probe, compose_file):
+    """Same endpoints, same order — only the vocabulary changed."""
+    config = {
+        "project_name": "demo",
+        "modules": {"web_terminals": {"enabled": True, "nginx_port": 9080}},
+    }
+    entries = deploy_summary.endpoint_entries(config, [compose_file])
+
+    deploy_summary.log_endpoint_summary(config, [compose_file])
+
+    rows = [line for line in probe.printed.splitlines() if line.startswith("  ")]
+    assert len(rows) == len(entries)
+    for row, (service, address) in zip(rows, entries, strict=True):
+        assert row.startswith(f"  {service}")
+        assert row.rstrip().endswith(address)
+
+
+def test_printed_summary_uses_the_section_shape(probe, compose_file):
+    """``output.section`` vocabulary: a title, then one indented aligned row."""
+    deploy_summary.log_endpoint_summary({"project_name": "demo"}, [compose_file])
+
+    lines = [line.rstrip() for line in probe.printed.splitlines() if line.strip()]
+    assert lines[0] == "Service endpoints (demo):"
+    rows = lines[1:]
+    assert all(row.startswith("  ") for row in rows)
+    # Labels are padded to one width, so the addresses line up as a column.
+    starts = {row.index("http") for row in rows if "http" in row}
+    assert len(starts) == 1
+
+
+def test_a_failed_summary_prints_nothing_and_is_recorded(probe, monkeypatch):
+    """A summary that cannot be derived stays silent on the operator's terminal."""
+
+    def boom(config, compose_files):
+        raise RuntimeError("no compose files")
+
+    monkeypatch.setattr(deploy_summary, "endpoint_entries", boom)
+    # The reason lives at debug grade, so the run has to be one that emits it.
+    logging.getLogger().setLevel(logging.DEBUG)
+    deploy_summary.log_endpoint_summary({"project_name": "demo"}, [])
+
+    assert "Service endpoints" not in probe.printed
+    assert any("Endpoint summary skipped" in message for message in probe.messages)
+
+
+def test_every_deploy_exit_path_shares_this_one_seam():
+    """The exit paths inherit the printed form because they all land here.
+
+    ``deploy_up`` reports its endpoints from several exits — the empty-stack
+    early return, the web-terminals-only return, the detached run and the
+    foreground ``execvpe`` — and each calls this one function, so the promotion
+    lives in one place rather than in four.
+    """
+    from osprey.deployment import container_lifecycle
+
+    assert container_lifecycle.log_endpoint_summary is deploy_summary.log_endpoint_summary

--- a/tests/deployment/test_down_restart_gates.py
+++ b/tests/deployment/test_down_restart_gates.py
@@ -250,7 +250,7 @@ def test_the_working_directory_survives_a_down(lifecycle_repo, runtime, no_web, 
 
 
 def test_a_failed_compose_down_says_the_containers_may_still_be_running(
-    lifecycle_repo, runtime, no_web, caplog
+    lifecycle_repo, runtime, no_web
 ):
     render_build(lifecycle_repo)
     runtime["fail"]["down"] = 1
@@ -258,7 +258,9 @@ def test_a_failed_compose_down_says_the_containers_may_still_be_running(
     result = run_down(lifecycle_repo)
 
     assert result.exit_code != 0
-    assert "may still be running" in caplog.text
+    assert "✗ Could not stop this deployment" in result.stderr
+    assert "may still be running" in result.stderr
+    assert "may still be running" not in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +355,12 @@ def test_finding_no_labelled_container_does_not_claim_the_stack_is_down(
     # All five elements of the message, because each carries a different part of
     # the answer: WHERE it looked, WHAT it looked for, WHY that can miss, what
     # may therefore still be true, and what to do about it.
+    #
+    # Log seam, not the renderer: this path's emitters live in
+    # container_lifecycle and web_terminals/provision, which stayed on the
+    # logger. The refusal assertions elsewhere in this module read
+    # result.stderr because their emitter moved to the renderer; both are
+    # deliberate, and which one applies is decided by who emits.
     text = caplog.text
     assert str(lifecycle_repo / "build") in text
     assert REPO_ID_LABEL in text
@@ -362,7 +370,7 @@ def test_finding_no_labelled_container_does_not_claim_the_stack_is_down(
 
 
 def test_a_failed_label_listing_refuses_rather_than_reporting_success(
-    lifecycle_repo, runtime, no_web, caplog
+    lifecycle_repo, runtime, no_web
 ):
     render_build(lifecycle_repo)
     runtime["fail"]["ps"] = 1
@@ -371,12 +379,13 @@ def test_a_failed_label_listing_refuses_rather_than_reporting_success(
     result = run_down(lifecycle_repo)
 
     assert result.exit_code != 0
-    assert "Could not list" in caplog.text
+    assert "Could not list" in result.stderr
+    assert "Could not list" not in result.stdout
     assert verbs_in_order(runtime) == ["ps"]
 
 
 def test_a_failed_label_stop_says_the_containers_may_still_be_running(
-    lifecycle_repo, runtime, no_web, caplog
+    lifecycle_repo, runtime, no_web
 ):
     render_build(lifecycle_repo)
     runtime["ps_stdout"] = "abc123\n"
@@ -386,7 +395,8 @@ def test_a_failed_label_stop_says_the_containers_may_still_be_running(
     result = run_down(lifecycle_repo)
 
     assert result.exit_code != 0
-    assert "may still be running" in caplog.text
+    assert "may still be running" in result.stderr
+    assert "may still be running" not in result.stdout
 
 
 def test_a_build_with_a_config_but_no_compose_files_still_stops_by_label(
@@ -466,7 +476,7 @@ def test_restart_starts_the_compose_files_the_build_left(lifecycle_repo, runtime
 # ---------------------------------------------------------------------------
 
 
-def test_drift_refuses_the_restart_and_stops_nothing(lifecycle_repo, runtime, no_web, caplog):
+def test_drift_refuses_the_restart_and_stops_nothing(lifecycle_repo, runtime, no_web):
     """The property that makes the gate worth having on this verb.
 
     A restart that stopped the stack and *then* discovered it could not start it
@@ -480,21 +490,22 @@ def test_drift_refuses_the_restart_and_stops_nothing(lifecycle_repo, runtime, no
 
     assert result.exit_code != 0
     assert runtime["cmds"] == []
-    assert "osprey restart --build" in caplog.text
-    assert "osprey restart --as-built" in caplog.text
+    assert "osprey restart --build" in result.stderr
+    assert "osprey restart --as-built" in result.stderr
+    assert "osprey restart --build" not in result.stdout
 
 
-def test_the_drift_refusal_names_this_verb_not_up(lifecycle_repo, runtime, no_web, caplog):
+def test_the_drift_refusal_names_this_verb_not_up(lifecycle_repo, runtime, no_web):
     """The remedies have to be commands the operator can actually type."""
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo, stamped_hash="stale")
 
-    run_restart(lifecycle_repo, "-d")
+    result = run_restart(lifecycle_repo, "-d")
 
-    assert "osprey up --build" not in caplog.text
+    assert "osprey up --build" not in result.output
 
 
-def test_as_built_restarts_the_drifted_build_and_says_so(lifecycle_repo, runtime, no_web, caplog):
+def test_as_built_restarts_the_drifted_build_and_says_so(lifecycle_repo, runtime, no_web):
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo, stamped_hash="stale")
 
@@ -502,7 +513,8 @@ def test_as_built_restarts_the_drifted_build_and_says_so(lifecycle_repo, runtime
 
     assert result.exit_code == 0, result.output
     assert verbs_in_order(runtime).index("down") < verbs_in_order(runtime).index("up")
-    assert "--as-built" in caplog.text
+    assert "⚠ Starting build/ as it was rendered (--as-built)" in result.stderr
+    assert "Starting build/ as it was rendered (--as-built)" not in result.stdout
 
 
 def test_build_chains_the_render_then_stops_and_starts(
@@ -537,24 +549,26 @@ def test_build_and_as_built_are_refused_together(lifecycle_repo, runtime, no_web
     assert runtime["cmds"] == []
 
 
-def test_a_missing_build_refuses_and_stops_nothing(lifecycle_repo, runtime, no_web, caplog):
+def test_a_missing_build_refuses_and_stops_nothing(lifecycle_repo, runtime, no_web):
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
 
     result = run_restart(lifecycle_repo, "-d")
 
     assert result.exit_code != 0
     assert runtime["cmds"] == []
-    assert "osprey build" in caplog.text
+    assert "→ run `osprey build` first" in result.stderr
+    assert "run `osprey build` first" not in result.stdout
 
 
-def test_as_built_is_not_an_escape_from_having_no_build(lifecycle_repo, runtime, no_web, caplog):
+def test_as_built_is_not_an_escape_from_having_no_build(lifecycle_repo, runtime, no_web):
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
 
     result = run_restart(lifecycle_repo, "-d", "--as-built")
 
     assert result.exit_code != 0
     assert runtime["cmds"] == []
-    assert "--as-built starts a build that already exists" in caplog.text
+    assert "--as-built starts a build that already exists" in result.stderr
+    assert "--as-built starts a build that already exists" not in result.stdout
 
 
 def test_dev_mode_refuses_before_anything_is_stopped(lifecycle_repo, runtime, no_web, monkeypatch):
@@ -572,17 +586,23 @@ def test_dev_mode_refuses_before_anything_is_stopped(lifecycle_repo, runtime, no
 
     assert result.exit_code != 0
     assert runtime["cmds"] == []
-    assert "Nothing was stopped" in result.output
+    assert "Nothing was stopped" in result.stderr
+    assert "Nothing was stopped" not in result.stdout
 
 
-def test_a_missing_env_refuses_before_anything_is_stopped(lifecycle_repo, runtime, no_web, caplog):
+def test_a_missing_env_refuses_before_anything_is_stopped(lifecycle_repo, runtime, no_web):
     render_build(lifecycle_repo)
 
     result = run_restart(lifecycle_repo, "-d")
 
     assert result.exit_code != 0
     assert runtime["cmds"] == []
-    assert "No .env in" in caplog.text
+    # Markless: the refusal is raised inside the open Preflight phase, whose own
+    # ✗ on the way out is this run's one failure marker.
+    assert "No .env in" in result.stderr
+    assert "No .env in" not in result.stdout
+    assert result.stdout.count("✗") == 1, result.stdout
+    assert result.stderr.count("✗") == 0, result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_env_chain_matrix.py
+++ b/tests/deployment/test_env_chain_matrix.py
@@ -478,14 +478,14 @@ class TestUsersEnvChainBranch:
         assert result.exit_code == 0, result.output
         assert chain_keys_of(parse_dotenv_text(result.output)) == {CONFLICT: "from-the-named-file"}
 
-    def test_no_chain_file_at_all_is_refused_naming_both(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_no_chain_file_at_all_is_refused_naming_both(self, tmp_path: Path) -> None:
         """Nothing to render from, and the refusal says which files were looked for.
 
-        Read from the log rather than stdout on purpose: in the default mode
+        Read off stderr rather than stdout on purpose: in the default mode
         stdout IS the rendered file, so a diagnostic printed there would
-        corrupt a ``> .env.production`` redirect.
+        corrupt a ``> .env.production`` redirect. Asserting stdout is EMPTY is
+        what turns that from an intention into a guarantee -- the refusal moved
+        from the log to the renderer, and a renderer prints where it is told to.
         """
         repo = tmp_path / "repo"
         repo.mkdir()
@@ -493,9 +493,10 @@ class TestUsersEnvChainBranch:
         result = self._run(repo)
 
         assert result.exit_code != 0
-        assert ENV_SHARED_FILENAME in caplog.text
-        assert ENV_LOCAL_FILENAME in caplog.text
-        assert result.output.strip() == "Aborted!"
+        assert ENV_SHARED_FILENAME in result.stderr
+        assert ENV_LOCAL_FILENAME in result.stderr
+        assert result.stdout == ""
+        assert result.stderr.rstrip().endswith("Aborted!")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_host_ports.py
+++ b/tests/deployment/test_host_ports.py
@@ -243,6 +243,51 @@ class TestReport:
         # Nothing here binds on the host namespace, so that paragraph stays out.
         assert "host network namespace" not in report
 
+    def test_the_report_carries_no_em_dash_asides(self):
+        """The house style for printed copy, pinned where the guard cannot see it.
+
+        ``tests/cli/test_printed_copy_style.py`` reads the arguments of printing
+        calls, and this report reaches the terminal as a variable instead: it is
+        built here, returned, and handed to ``output.fail`` by
+        ``container_lifecycle._report_port_conflicts``. So the em-dash rule has
+        to be pinned at the source, or it is not pinned at all.
+        """
+        conflicts = [
+            PortConflict(
+                host_port=5432,
+                bind_address="127.0.0.1",
+                service="postgresql",
+                kind="external",
+                holder="container 'other-ariel-postgres' (compose project 'other')",
+                remedy="services.postgresql.port_host",
+            ),
+            PortConflict(
+                host_port=9190,
+                bind_address="127.0.0.1",
+                service="dispatch-worker-1",
+                kind="duplicate",
+                holder="service 'dispatch-worker-0'",
+                remedy="dispatch.worker_port_base",
+                host_network=True,
+            ),
+        ]
+
+        # Both branches of every paragraph, so no wording is exempt by luck.
+        # Each call carries a positive anchor too: an absence assertion alone
+        # stays green on a report that degenerated to an empty string, which
+        # would read as clean copy while printing nothing at all.
+        both = format_conflict_report(conflicts)
+        assert "shared services stack" in both and "host network namespace" in both
+        assert "—" not in both
+
+        foreign_only = format_conflict_report(conflicts[:1])
+        assert "shared services stack" in foreign_only
+        assert "—" not in foreign_only
+
+        host_network_only = format_conflict_report(conflicts[1:])
+        assert "host network namespace" in host_network_only
+        assert "—" not in host_network_only
+
 
 class TestHostNetworkDerivation:
     """Ports of services that bind on the host namespace and publish nothing."""

--- a/tests/deployment/test_status_display.py
+++ b/tests/deployment/test_status_display.py
@@ -12,6 +12,9 @@ import json
 import pytest
 from rich.console import Console
 
+from osprey.cli import styles
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+from osprey.cli.styles import osprey_theme
 from osprey.deployment import status_display
 
 _CONFIGS: dict[str, dict] = {}
@@ -68,6 +71,30 @@ def _patch_config_loader(monkeypatch):
     _CONFIGS.clear()
 
 
+@pytest.fixture(autouse=True)
+def rendered(monkeypatch):
+    """Capture BOTH renderer streams into one wide recording console.
+
+    ``show_status`` prints through :mod:`osprey.cli.output`, which resolves its
+    console per call -- report/note/section through the installed reporter,
+    warnings and failures through ``styles.err_console``. Both are pointed here
+    so an assertion reads what an operator sees on either stream. Wide, because
+    a wrapped sentence defeats a substring assertion.
+    """
+    console = Console(record=True, width=200, theme=osprey_theme)
+
+    class _Recording(PhaseReporter):
+        # Untyped on purpose: rich's ``Console`` is Any to this repo's mypy
+        # settings, so an annotated override trips ``no-any-return``.
+        def out(self):
+            return console
+
+    previous = install_reporter(_Recording(color=False))
+    monkeypatch.setattr(styles, "err_console", console)
+    yield console
+    install_reporter(previous)
+
+
 @pytest.fixture
 def runtime_calls(monkeypatch):
     """Patch get_runtime_command/get_ps_command and subprocess.run.
@@ -103,7 +130,7 @@ def runtime_calls(monkeypatch):
     return calls
 
 
-def test_per_user_section_reports_running_and_present(runtime_calls):
+def test_per_user_section_reports_running_and_present(runtime_calls, rendered):
     config = _base_config(users=["alice", "bob"])
     _register_config("cfg.yml", config)
 
@@ -118,9 +145,8 @@ def test_per_user_section_reports_running_and_present(runtime_calls):
         [claude_vol_alice, agent_vol_alice]  # bob's volumes absent
     )
 
-    console = Console(record=True, width=200)
-    status_display.show_status("cfg.yml", console=console)
-    output = console.export_text()
+    status_display.show_status("cfg.yml")
+    output = rendered.export_text()
 
     assert "Web Terminal Users" in output
     assert "alice" in output and "bob" in output
@@ -137,32 +163,30 @@ def test_per_user_section_reports_running_and_present(runtime_calls):
     assert len(volume_calls) == 1
 
 
-def test_per_user_section_reports_not_created(runtime_calls):
+def test_per_user_section_reports_not_created(runtime_calls, rendered):
     config = _base_config(users=["carol"])
     _register_config("cfg.yml", config)
 
     runtime_calls["ps_stdout"] = ""  # no containers at all
     runtime_calls["volume_stdout"] = ""  # no volumes at all
 
-    console = Console(record=True, width=200)
-    status_display.show_status("cfg.yml", console=console)
-    output = console.export_text()
+    status_display.show_status("cfg.yml")
+    output = rendered.export_text()
 
     assert "Web Terminal Users" in output
     assert "Not created" in output
     assert "missing" in output
 
 
-def test_per_user_section_absent_when_disabled(runtime_calls):
+def test_per_user_section_absent_when_disabled(runtime_calls, rendered):
     config = _base_config(enabled=False, users=["alice"])
     _register_config("cfg.yml", config)
 
     runtime_calls["ps_stdout"] = ""
     runtime_calls["volume_stdout"] = ""
 
-    console = Console(record=True, width=200)
-    status_display.show_status("cfg.yml", console=console)
-    output = console.export_text()
+    status_display.show_status("cfg.yml")
+    output = rendered.export_text()
 
     assert "Web Terminal Users" not in output
     # volume ls should never be issued when the section doesn't render
@@ -170,21 +194,20 @@ def test_per_user_section_absent_when_disabled(runtime_calls):
     assert len(volume_calls) == 0
 
 
-def test_per_user_section_absent_when_no_users(runtime_calls):
+def test_per_user_section_absent_when_no_users(runtime_calls, rendered):
     config = _base_config(enabled=True, users=[])
     _register_config("cfg.yml", config)
 
     runtime_calls["ps_stdout"] = ""
     runtime_calls["volume_stdout"] = ""
 
-    console = Console(record=True, width=200)
-    status_display.show_status("cfg.yml", console=console)
-    output = console.export_text()
+    status_display.show_status("cfg.yml")
+    output = rendered.export_text()
 
     assert "Web Terminal Users" not in output
 
 
-def test_per_user_section_handles_object_form_users(runtime_calls):
+def test_per_user_section_handles_object_form_users(runtime_calls, rendered):
     """modules.web_terminals.users entries may be {"name": ..., "index": ...} objects."""
     config = _base_config(users=[{"name": "dana", "index": 0}])
     _register_config("cfg.yml", config)
@@ -193,16 +216,15 @@ def test_per_user_section_handles_object_form_users(runtime_calls):
     claude_vol, agent_vol = status_display.resolve_user_volume_names(config, "dana")
     runtime_calls["volume_stdout"] = "\n".join([claude_vol, agent_vol])
 
-    console = Console(record=True, width=200)
-    status_display.show_status("cfg.yml", console=console)
-    output = console.export_text()
+    status_display.show_status("cfg.yml")
+    output = rendered.export_text()
 
     assert "dana" in output
     assert "Running" in output
     assert claude_vol in output
 
 
-def test_existing_services_table_still_renders(runtime_calls):
+def test_existing_services_table_still_renders(runtime_calls, rendered):
     """The per-user section must not interfere with the existing services table."""
     config = _base_config(users=["alice"])
     _register_config("cfg.yml", config)
@@ -214,16 +236,40 @@ def test_existing_services_table_still_renders(runtime_calls):
     )
     runtime_calls["volume_stdout"] = ""
 
-    console = Console(record=True, width=200)
-    status_display.show_status("cfg.yml", console=console)
-    output = console.export_text()
+    status_display.show_status("cfg.yml")
+    output = rendered.export_text()
 
     assert "Service Status" in output
     assert "demo-project-service" in output
     assert "Web Terminal Users" in output
 
 
-def test_project_containers_match_the_normalized_project_name(runtime_calls):
+def test_table_cells_carry_no_markup_tags(runtime_calls, rendered):
+    """Cells are pre-styled ``Text``, never markup strings.
+
+    ``output.table`` prints with ``markup=False`` and Rich propagates that into
+    every nested renderable, so a cell built as ``"[success]● Running[/success]"``
+    would print its own tags AND count them toward the column width. This is the
+    guard that nobody reintroduces one.
+    """
+    config = _base_config(users=["alice"])
+    _register_config("cfg.yml", config)
+
+    runtime_calls["ps_stdout"] = _ps_stdout(
+        _ps_container("dls-web-alice", "running", labels={"osprey.project.name": "demo-project"})
+    )
+    runtime_calls["volume_stdout"] = ""
+
+    status_display.show_status("cfg.yml")
+    output = rendered.export_text()
+
+    assert "● Running" in output
+    assert "missing" in output  # the other pre-styled cell builder
+    for tag in ("[success]", "[error]", "[warning]", "[dim]"):
+        assert tag not in output
+
+
+def test_project_containers_match_the_normalized_project_name(runtime_calls, rendered):
     """A project whose name compose normalized still owns its own containers.
 
     Labels are stamped with ``resolve_project_name(config)`` — the normalized
@@ -241,9 +287,8 @@ def test_project_containers_match_the_normalized_project_name(runtime_calls):
         )
     )
 
-    console = Console(record=True, width=200)
-    status_display.show_status("cfg.yml", console=console)
-    output = console.export_text()
+    status_display.show_status("cfg.yml")
+    output = rendered.export_text()
 
     assert "demo_project-service" in output
     assert "Other Osprey Containers" not in output
@@ -254,7 +299,9 @@ def test_project_containers_match_the_normalized_project_name(runtime_calls):
 # ---------------------------------------------------------------------------
 
 
-def test_agent_section_expands_provider_placeholders_from_the_repo_env(tmp_path, monkeypatch):
+def test_agent_section_expands_provider_placeholders_from_the_repo_env(
+    tmp_path, monkeypatch, rendered
+):
     """A ``${VAR}`` in the render's provider block resolves from ``<repo>/.env``.
 
     The render is disposable and holds no secrets; the deployment keeps them at
@@ -279,16 +326,16 @@ def test_agent_section_expands_provider_placeholders_from_the_repo_env(tmp_path,
     )
     (repo_root / ".env").write_text("FACILITY_GATEWAY_URL=https://gw.test/v1\n", encoding="utf-8")
 
-    console = Console(record=True, width=200)
     status_display._print_agent_section(
         repo_root,
         build_dir,
         {"claude_code": {"provider": "cborg"}},
-        console,
-        status_display._DefaultStyles,
         show_agents=False,
     )
-    output = console.export_text()
+    output = rendered.export_text()
 
-    assert "ANTHROPIC_BASE_URL = https://gw.test" in output
+    # A section row, so the variable and its resolved value are two columns
+    # rather than one ``KEY = value`` sentence.
+    assert "ANTHROPIC_BASE_URL" in output
+    assert "https://gw.test" in output
     assert "${FACILITY_GATEWAY_URL}" not in output

--- a/tests/deployment/test_status_sections.py
+++ b/tests/deployment/test_status_sections.py
@@ -36,7 +36,10 @@ from click.testing import CliRunner
 from rich.console import Console
 
 import osprey.cli.deploy_cmd as deploy_cmd
+from osprey.cli import styles
 from osprey.cli.deploy_cmd import logs_verb, status_verb
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+from osprey.cli.styles import osprey_theme
 from osprey.deployment import status_display
 from osprey.deployment.compose_generator import REPO_ID_LABEL, repo_identity
 from tests.deployment.test_up_as_built import _RENDERED_CONFIG, render_build
@@ -106,16 +109,45 @@ def runtime(monkeypatch):
     return record
 
 
-def report(repo: Path, **kwargs) -> str:
-    """Render ``osprey status`` for *repo* into a wide recording console.
+#: Where :func:`report` reads the run it just made. The renderer resolves its
+#: own console per call, so a test cannot hand one in — the fixture below
+#: installs a reporter that answers with a recording console and leaves it here.
+_CAPTURE: dict[str, Console] = {}
 
-    Wide deliberately: the CLI's console wraps at the terminal width, and a
-    wrapped sentence defeats every substring assertion below. What is under test
-    is what status *says*, not how Rich folds it.
+
+@pytest.fixture(autouse=True)
+def renderer_capture(monkeypatch):
+    """Capture BOTH renderer streams into one wide recording console.
+
+    Status prints through :mod:`osprey.cli.output`, which sends report/note/
+    section lines to the installed reporter's console and warnings/failures to
+    ``styles.err_console``. Both are pointed at one console here so an assertion
+    reads what an operator sees, whichever stream a line went out on.
+
+    Wide deliberately: the console wraps at the terminal width, and a wrapped
+    sentence defeats every substring assertion below. What is under test is what
+    status *says*, not how Rich folds it.
     """
-    console = Console(record=True, width=200)
-    status_display.show_repo_status(repo, console=console, **kwargs)
-    return console.export_text()
+    console = Console(record=True, width=200, theme=osprey_theme)
+
+    class _Recording(PhaseReporter):
+        # Untyped on purpose: rich's ``Console`` is Any to this repo's mypy
+        # settings, so an annotated override trips ``no-any-return``.
+        def out(self):
+            return console
+
+    previous = install_reporter(_Recording(color=False))
+    monkeypatch.setattr(styles, "err_console", console)
+    _CAPTURE["console"] = console
+    yield console
+    _CAPTURE.clear()
+    install_reporter(previous)
+
+
+def report(repo: Path, **kwargs) -> str:
+    """Render ``osprey status`` for *repo* and return everything it printed."""
+    status_display.show_repo_status(repo, **kwargs)
+    return _CAPTURE["console"].export_text()
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +160,7 @@ def test_a_clean_build_is_reported_as_in_sync(lifecycle_repo, runtime):
 
     text = report(lifecycle_repo)
 
-    assert "build: in sync with profile.yml" in text
+    assert "in sync with profile.yml" in text
 
 
 def test_drift_names_what_moved_and_that_the_start_verbs_refuse(lifecycle_repo, runtime):
@@ -149,7 +181,7 @@ def test_a_repo_with_no_build_says_so_and_still_shows_its_containers(lifecycle_r
 
     text = report(lifecycle_repo)
 
-    assert "build: none — run `osprey build`" in text
+    assert "none — run `osprey build`" in text
     assert "dispatch" in text
     # The two sections that are read out of build/config.yml say they cannot be
     # computed rather than not appearing: two silently absent sections read as a
@@ -480,11 +512,11 @@ def test_an_artifact_check_that_cannot_run_is_not_a_passing_one(
 
     text = report(lifecycle_repo)
 
-    assert "artifacts: could not be checked" in text
+    assert "could not be checked" in text
     # Scoped to the artifact verdict: "in sync" alone also matches the BUILD
     # section's own clean verdict two sections above, and would pass here
     # whatever the artifact check reported.
-    assert "artifacts: in sync" not in text
+    assert "in sync (" not in text
 
 
 def test_the_per_agent_model_table_is_opt_in(lifecycle_repo, runtime):
@@ -494,9 +526,9 @@ def test_the_per_agent_model_table_is_opt_in(lifecycle_repo, runtime):
     default = report(lifecycle_repo)
     with_agents = report(lifecycle_repo, show_agents=True)
 
-    assert "agent models:" not in default
-    assert "agent models:" in with_agents
-    assert "model tiers:" in default
+    assert "agent models" not in default
+    assert "agent models" in with_agents
+    assert "model tiers" in default
 
 
 # ---------------------------------------------------------------------------
@@ -533,13 +565,19 @@ def test_status_never_announces_creating_the_files_it_did_not_create(
     command just rewrote their repo. The renderer now keeps that detail in the
     log rather than on the terminal, and this test is the guard that it stays
     there: it runs the real renderer, not a stub.
+
+    Pinned on BOTH halves of what a terminal shows: the process's own stdout,
+    where the artifact writer would print, and the text status itself renders.
+    Either one alone leaves a hole, since status prints through a console rather
+    than at stdout directly.
     """
     render_build(lifecycle_repo)
     capsys.readouterr()
 
-    report(lifecycle_repo)
+    text = report(lifecycle_repo)
 
     assert "Created" not in capsys.readouterr().out
+    assert "Created" not in text
 
 
 def test_status_only_ever_asks_the_runtime_to_list(lifecycle_repo, runtime):

--- a/tests/deployment/test_up_as_built.py
+++ b/tests/deployment/test_up_as_built.py
@@ -330,16 +330,19 @@ def test_a_start_leaves_no_config_anchor_behind_in_the_environment(
     assert "CONFIG_FILE" not in os.environ
 
 
-def test_a_missing_build_is_a_refusal_naming_the_build_verb(lifecycle_repo, started, caplog):
+def test_a_missing_build_is_a_refusal_naming_the_build_verb(lifecycle_repo, started):
     result = run_up(lifecycle_repo, "-d")
 
     assert result.exit_code == 1
-    assert "No build found" in caplog.text
-    assert "osprey build" in caplog.text
+    # The renderer's failure shape, on the stream trouble belongs on: someone
+    # piping stdout still sees the mark, the reason and the one fix.
+    assert "✗ No build found" in result.stderr
+    assert "→ run `osprey build` first" in result.stderr
+    assert "No build found" not in result.stdout
     assert not started
 
 
-def test_a_build_without_its_compose_files_is_not_silently_started(lifecycle_repo, started, caplog):
+def test_a_build_without_its_compose_files_is_not_silently_started(lifecycle_repo, started):
     """A manifest and a config alone are not a deployment.
 
     Starting an empty ``-f`` list would bring nothing up and report success —
@@ -352,13 +355,18 @@ def test_a_build_without_its_compose_files_is_not_silently_started(lifecycle_rep
     result = run_up(lifecycle_repo, "-d")
 
     assert result.exit_code == 1
-    # Rendered on the console by the shared unmet-precondition handler: the
-    # reason, then the one remedy. Collapse whitespace before matching -- the
-    # console wraps to the terminal width, so a phrase this long straddles a
-    # line break and would not be found verbatim.
-    flowed = " ".join(result.output.split())
-    assert "no compose files were rendered" in flowed
-    assert "osprey build" in flowed
+    # Rendered by the shared unmet-precondition handler through the renderer:
+    # the reason, then the remedy the exception carries.
+    #
+    # Matched verbatim, which DEPENDS ON `output._echo` printing with
+    # `soft_wrap=True`. This test used to collapse whitespace first, because the
+    # console it read then folded a phrase this long at the terminal width. If
+    # soft wrapping ever goes away, these needles are what breaks, and this is
+    # the reason why.
+    assert "no compose files were rendered" in result.stderr
+    assert "→ Re-render build/:" in result.stderr
+    assert "osprey build" in result.stderr
+    assert "no compose files were rendered" not in result.stdout
     assert not started
 
 
@@ -430,6 +438,9 @@ def test_a_dev_render_started_plain_warns_it_bakes_the_local_checkout(
 
     assert result.exit_code == 0, result.output
     assert started
+    # Log seam, not the renderer: emitted by container_lifecycle's dev-flavor
+    # check, which stayed on logger.warning. The altitude gate renders WARNING
+    # and above, so the operator sees it either way.
     assert "dev render" in caplog.text
     assert "local osprey checkout" in caplog.text
 
@@ -439,7 +450,7 @@ def test_a_dev_render_started_plain_warns_it_bakes_the_local_checkout(
 # ---------------------------------------------------------------------------
 
 
-def test_drift_refuses_and_names_what_changed(lifecycle_repo, started, caplog):
+def test_drift_refuses_and_names_what_changed(lifecycle_repo, started):
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo)
     profile = lifecycle_repo / "profile.yml"
@@ -448,16 +459,19 @@ def test_drift_refuses_and_names_what_changed(lifecycle_repo, started, caplog):
     result = run_up(lifecycle_repo, "-d")
 
     assert result.exit_code == 1
-    assert "profile.yml or a file it points at has changed" in caplog.text
-    assert "model" in caplog.text
-    # Both exits, spelled as the operator would type them.
-    assert "osprey up --build" in caplog.text
-    assert "osprey up --as-built" in caplog.text
-    assert "Nothing was started" in caplog.text
+    assert "profile.yml or a file it points at has changed" in result.stderr
+    assert "model" in result.stderr
+    # Both exits, spelled as the operator would type them. They ride in the
+    # cause rather than on a single remedy line: neither is THE fix, so
+    # promoting one would be a recommendation this verb cannot make.
+    assert "osprey up --build" in result.stderr
+    assert "osprey up --as-built" in result.stderr
+    assert "Nothing was started" in result.stderr
+    assert "Nothing was started" not in result.stdout
     assert not started
 
 
-def test_as_built_starts_the_drifted_build_and_says_so(lifecycle_repo, started, caplog):
+def test_as_built_starts_the_drifted_build_and_says_so(lifecycle_repo, started):
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo)
     profile = lifecycle_repo / "profile.yml"
@@ -467,8 +481,9 @@ def test_as_built_starts_the_drifted_build_and_says_so(lifecycle_repo, started, 
 
     assert result.exit_code == 0, result.output
     assert started
-    assert "as it was rendered" in caplog.text
-    assert "will not match profile.yml" in caplog.text
+    assert "⚠ Starting build/ as it was rendered (--as-built)" in result.stderr
+    assert "will not match profile.yml" in result.stderr
+    assert "will not match profile.yml" not in result.stdout
 
 
 def test_build_chains_the_render_then_starts(lifecycle_repo, started, monkeypatch):
@@ -498,16 +513,19 @@ def test_build_and_as_built_are_refused_together(lifecycle_repo, started):
     result = run_up(lifecycle_repo, "-d", "--build", "--as-built")
 
     assert result.exit_code == 2
-    assert "at most one" in result.output
+    # Click's own usage error rather than the renderer's, but answered on the
+    # stream every refusal in this verb answers on.
+    assert "at most one" in result.stderr
     assert not started
 
 
-def test_as_built_is_not_an_escape_from_having_no_build(lifecycle_repo, started, caplog):
+def test_as_built_is_not_an_escape_from_having_no_build(lifecycle_repo, started):
     """The one refusal ``--as-built`` does not answer, and it says so."""
     result = run_up(lifecycle_repo, "-d", "--as-built")
 
     assert result.exit_code == 1
-    assert "--as-built starts a build that already exists" in caplog.text
+    assert "--as-built starts a build that already exists" in result.stderr
+    assert "--as-built starts a build that already exists" not in result.stdout
     assert not started
 
 
@@ -521,22 +539,24 @@ def test_build_is_an_escape_from_having_no_build(lifecycle_repo, started, monkey
     assert started
 
 
-def test_an_unverifiable_build_refuses_with_the_as_built_escape(lifecycle_repo, started, caplog):
+def test_an_unverifiable_build_refuses_with_the_as_built_escape(lifecycle_repo, started):
     """A build carrying no fingerprint cannot be vouched for either way."""
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo, stamped_hash=None)
 
     refused = run_up(lifecycle_repo, "-d")
     assert refused.exit_code == 1
-    assert "cannot verify profile ↔ build consistency" in caplog.text
-    assert "osprey up --as-built" in caplog.text
+    assert "cannot verify profile ↔ build consistency" in refused.stderr
+    assert "osprey up --as-built" in refused.stderr
+    assert "cannot verify profile ↔ build consistency" not in refused.stdout
+    assert "osprey up --as-built" not in refused.stdout
     assert not started
 
     assert run_up(lifecycle_repo, "-d", "--as-built").exit_code == 0
     assert started
 
 
-def test_as_built_on_an_unverifiable_build_claims_no_mismatch(lifecycle_repo, started, caplog):
+def test_as_built_on_an_unverifiable_build_claims_no_mismatch(lifecycle_repo, started):
     """A failed comparison is not a finding.
 
     On DRIFT the mismatch is established and the warning says so. Here nothing
@@ -547,27 +567,30 @@ def test_as_built_on_an_unverifiable_build_claims_no_mismatch(lifecycle_repo, st
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo, stamped_hash=None)
 
-    assert run_up(lifecycle_repo, "-d", "--as-built").exit_code == 0
-    assert "stays unknown" in caplog.text
-    assert "will not match profile.yml" not in caplog.text
+    result = run_up(lifecycle_repo, "-d", "--as-built")
+    assert result.exit_code == 0
+    assert "stays unknown" in result.stderr
+    assert "stays unknown" not in result.stdout
+    assert "will not match profile.yml" not in result.stderr
 
 
 def test_the_env_remedy_only_says_copy_when_there_is_something_to_copy(
-    lifecycle_repo, started, monkeypatch, caplog
+    lifecycle_repo, started, monkeypatch
 ):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     (lifecycle_repo / ".env.example").unlink()
     render_build(lifecycle_repo)
 
-    assert run_up(lifecycle_repo, "-d").exit_code == 1
-    assert "cp .env.example .env" not in caplog.text
-    assert "Create" in caplog.text and ".env" in caplog.text
+    result = run_up(lifecycle_repo, "-d")
+    assert result.exit_code == 1
+    assert "cp .env.example .env" not in result.stderr
+    assert "create" in result.stderr and ".env" in result.stderr
+    # The remedy is still a remedy, whichever branch wrote it.
+    assert result.stderr.count("→ ") == 1
     assert not started
 
 
-def test_an_unparseable_profile_refuses_rather_than_reading_as_clean(
-    lifecycle_repo, started, caplog
-):
+def test_an_unparseable_profile_refuses_rather_than_reading_as_clean(lifecycle_repo, started):
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo)
     (lifecycle_repo / "profile.yml").write_text("{ not: [valid", encoding="utf-8")
@@ -575,11 +598,12 @@ def test_an_unparseable_profile_refuses_rather_than_reading_as_clean(
     result = run_up(lifecycle_repo, "-d")
 
     assert result.exit_code == 1
-    assert "cannot verify profile ↔ build consistency" in caplog.text
+    assert "cannot verify profile ↔ build consistency" in result.stderr
+    assert "cannot verify profile ↔ build consistency" not in result.stdout
     assert not started
 
 
-def test_version_skew_warns_and_starts(lifecycle_repo, started, caplog):
+def test_version_skew_warns_and_starts(lifecycle_repo, started):
     """A framework upgrade must not stand between an operator and their stack."""
     (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo, version="1900.1.1")
@@ -588,7 +612,8 @@ def test_version_skew_warns_and_starts(lifecycle_repo, started, caplog):
 
     assert result.exit_code == 0, result.output
     assert started
-    assert "rendered by osprey 1900.1.1" in caplog.text
+    assert "rendered by osprey 1900.1.1" in result.stderr
+    assert "rendered by osprey 1900.1.1" not in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -596,16 +621,25 @@ def test_version_skew_warns_and_starts(lifecycle_repo, started, caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_a_missing_env_refuses_and_names_the_example(lifecycle_repo, started, monkeypatch, caplog):
+def test_a_missing_env_refuses_and_names_the_example(lifecycle_repo, started, monkeypatch):
+    """One ✗ for one refusal, and the reason underneath it.
+
+    The refusal is raised inside the open Preflight phase, which fails with its
+    own ✗ on the way out; a second one in front of the reason would read as two
+    things having gone wrong.
+    """
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     render_build(lifecycle_repo)
 
     result = run_up(lifecycle_repo, "-d")
 
     assert result.exit_code == 1
-    assert "No .env" in caplog.text
-    assert "cp .env.example .env" in caplog.text
-    assert "ANTHROPIC_API_KEY" in caplog.text  # what to put in it
+    assert "No .env" in result.stderr
+    assert "→ cp .env.example .env" in result.stderr
+    assert "ANTHROPIC_API_KEY" in result.stderr  # what to put in it
+    assert "No .env" not in result.stdout
+    assert result.stdout.count("✗") == 1, result.stdout  # the phase's mark
+    assert result.stderr.count("✗") == 0, result.stderr  # the refusal adds none
     assert not (lifecycle_repo / ".env").exists()
     assert not started
 
@@ -627,6 +661,8 @@ def test_a_missing_env_is_not_seeded_without_a_terminal(
     assert result.exit_code == 1
     assert not (lifecycle_repo / ".env").exists()
     assert "sk-from-the-shell" not in result.output
+    # Both halves matter: result.output covers stdout and stderr together, and
+    # this covers the log sinks, where a secret would outlive the terminal.
     assert "sk-from-the-shell" not in caplog.text
     assert not started
 
@@ -758,7 +794,9 @@ def test_a_wildcard_build_is_treated_as_exposed_without_the_flag(
     result = run_up(lifecycle_repo, "-d")
 
     assert result.exit_code == 1
-    assert "refusing to start a deployment that is reachable off-host" in caplog.text
+    # The refusal itself is renderer output now; the reachability finding
+    # beneath it is still a log record from the lifecycle module.
+    assert "refusing to start a deployment that is reachable off-host" in result.stderr
     assert "event-dispatcher publish on 0.0.0.0" in caplog.text
     assert not started
 
@@ -791,6 +829,7 @@ def test_a_web_terminal_deploy_counts_as_exposed(lifecycle_repo, started, monkey
     )
 
     assert run_up(lifecycle_repo, "-d").exit_code == 0
+    # Log seam: container_lifecycle's reachability warning, still logger.warning.
     assert "web-terminal stack runs on the host network" in caplog.text
 
 
@@ -949,6 +988,8 @@ def test_a_mint_prints_no_password_when_stdout_is_not_a_terminal(
         assert value not in printed
         assert value not in caplog.text
 
+    # Log seam: web_terminals/provision's minted-password notice, deliberately
+    # left on logger.warning by the task that owns that module.
     assert "did NOT print it" in caplog.text
     assert "osprey users passwd" in caplog.text
     assert "OSPREY_AUTH_PW_<USER>" in caplog.text
@@ -1094,8 +1135,9 @@ def test_dev_mode_refuses_before_any_work_when_it_cannot_be_honored(
     result = run_up(lifecycle_repo, "-d", "--dev")
 
     assert result.exit_code == 1
-    assert "not an editable install" in result.output
-    assert "Nothing was deployed" in result.output  # rendered on the console, not logged
+    assert "not an editable install" in result.stderr
+    assert "Nothing was deployed" in result.stderr
+    assert "Nothing was deployed" not in result.stdout
     assert not started
 
 

--- a/tests/deployment/test_web_terminals_capture.py
+++ b/tests/deployment/test_web_terminals_capture.py
@@ -548,7 +548,7 @@ def test_verify_script_is_captured_from_the_project_root(monkeypatch, tmp_path, 
     # Advisory: the script's own convention is to always exit 0, and a
     # site-customized copy that does not must still never fail the deploy.
     assert call["check"] is False
-    assert reporter.steps == ["smoke check verify.sh — exit 0"]
+    assert reporter.steps == ["smoke check verify.sh: exit 0"]
 
 
 def test_verify_script_output_never_reaches_the_terminal(
@@ -562,7 +562,7 @@ def test_verify_script_output_never_reaches_the_terminal(
 
     out = capfd.readouterr().out
     assert not BUILDKIT_LINE.search(out)
-    assert "· smoke check verify.sh — exit 0" in out
+    assert "· smoke check verify.sh: exit 0" in out
     spooled = _spool_files(tmp_path)[0].read_text()
     for line in BUILDKIT_OUTPUT:
         assert line in spooled
@@ -637,6 +637,37 @@ def test_host_port_self_heal_restart_is_captured(monkeypatch, tmp_path, reporter
     assert call["repo_root"] == tmp_path
     assert call["check"] is False
     assert reporter.steps == ["bounced the web stack for host-port re-registration"]
+
+
+def test_a_bounce_that_worked_reports_the_endpoint_as_reachable(monkeypatch, tmp_path, reporter):
+    """Disposition row 15: the bounce's payoff is a step, not a log line.
+
+    Without it `bounced the web stack ...` is the last word the operator gets
+    and never says whether the remediation worked. The probe answers only on
+    its second call, which is the shape of a bounce that actually fixed the
+    stale port registration.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
+    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker"])
+    answers = iter([False, True])
+    monkeypatch.setattr(
+        postup_hooks, "_host_port_answers", lambda url, attempts, delay: next(answers)
+    )
+    monkeypatch.setattr(postup_hooks, "run_captured", RunRecorder())
+
+    postup_hooks.warn_if_web_stack_unreachable(
+        {"modules": {"web_terminals": {"nginx_port": 8080}}},
+        attempts=1,
+        delay=0,
+        web_cmd=["docker", "compose", "-f", "web.yml"],
+        run_env={},
+    )
+
+    assert reporter.steps == [
+        "bounced the web stack for host-port re-registration",
+        "web endpoint reachable",
+    ]
 
 
 def test_host_port_probe_that_answers_runs_nothing(monkeypatch, tmp_path, reporter):

--- a/tests/deployment/web_terminals/test_seeding.py
+++ b/tests/deployment/web_terminals/test_seeding.py
@@ -623,7 +623,9 @@ def test_one_of_two_ready_failing_does_not_raise(tmp_path, monkeypatch, fake_run
     ready.add(f"{_FACILITY_PREFIX}-web-bob")
     ready.failing.add(f"{_FACILITY_PREFIX}-web-alice")  # bob still succeeds
 
-    with caplog.at_level("INFO", logger="deployment.web_terminals.seeding"):
+    # DEBUG, not INFO: the per-user "seeded <user>" line is debug-grade now
+    # (disposition row 18) -- the default view gets the loop's count instead.
+    with caplog.at_level("DEBUG", logger="deployment.web_terminals.seeding"):
         seeding.seed_user_containers(_config(["alice", "bob"]))  # must not raise
 
     # alice's CLAUDE.md exec was attempted (and is recorded regardless of

--- a/tests/health/test_render.py
+++ b/tests/health/test_render.py
@@ -1,4 +1,10 @@
-"""Tests for health-report rendering (Rich grouped output and machine-clean JSON)."""
+"""Tests for health-report rendering (renderer output and machine-clean JSON).
+
+The human report prints through :mod:`osprey.cli.output`, so these tests read
+the two real streams (``capsys``) rather than handing the renderer a console:
+the grouped rows are report-class lines on stdout, and the verbose recap of
+degraded checks wears the renderer's warning/failure shape on stderr.
+"""
 
 from __future__ import annotations
 
@@ -7,15 +13,9 @@ from io import StringIO
 
 from rich.console import Console
 
+from osprey.cli import output
 from osprey.health.models import CheckReport, CheckResult, Status
 from osprey.health.render import render_json, render_report, run_progress
-
-
-def _capture_console() -> tuple[Console, StringIO]:
-    """A plain (no-color) console writing to an in-memory buffer for assertions."""
-    buf = StringIO()
-    console = Console(file=buf, force_terminal=False, no_color=True, width=200)
-    return console, buf
 
 
 def _report(*results: CheckResult, **kwargs) -> CheckReport:
@@ -44,85 +44,101 @@ def _skip(name: str, category: str = "file_system", **kw) -> CheckResult:
 
 
 class TestRenderReport:
-    def test_per_status_glyphs(self) -> None:
+    def test_per_status_glyphs(self, capsys) -> None:
         report = _report(
             _ok("a", message="alpha ok"),
             _warn("b", message="beta warn"),
             _err("c", message="gamma err"),
             _skip("d", message="delta skip"),
         )
-        console, buf = _capture_console()
-        render_report(report, console=console)
-        out = buf.getvalue()
+        render_report(report)
+        out = capsys.readouterr().out
         assert "✓ alpha ok" in out
-        assert "! beta warn" in out
+        # The warning mark is the renderer's, and STATUS_ICONS', mark: not "!".
+        assert "⚠ beta warn" in out
         assert "✗ gamma err" in out
         assert "- delta skip" in out
 
-    def test_humanized_category_headers(self) -> None:
+    def test_rows_are_indented_under_their_category_header(self, capsys) -> None:
+        report = _report(_ok("a", message="alpha ok"), _skip("d", message="delta skip"))
+        render_report(report)
+        lines = capsys.readouterr().out.splitlines()
+        assert "File System" in lines
+        assert "  ✓ alpha ok" in lines
+        assert "  - delta skip" in lines
+
+    def test_humanized_category_headers(self, capsys) -> None:
         report = _report(
             _ok("a", category="file_system"),
             _ok("b", category="python_environment"),
         )
-        console, buf = _capture_console()
-        render_report(report, console=console)
-        out = buf.getvalue()
+        render_report(report)
+        out = capsys.readouterr().out
         assert "File System" in out
         assert "Python Environment" in out
 
-    def test_grouping_preserves_first_seen_order(self) -> None:
+    def test_grouping_preserves_first_seen_order(self, capsys) -> None:
         report = _report(
             _ok("a", category="containers"),
             _ok("b", category="providers"),
             _ok("c", category="containers"),
         )
-        console, buf = _capture_console()
-        render_report(report, console=console)
-        out = buf.getvalue()
+        render_report(report)
+        out = capsys.readouterr().out
         assert out.index("Containers") < out.index("Providers")
 
-    def test_value_is_appended_in_parentheses(self) -> None:
+    def test_value_is_appended_in_parentheses(self, capsys) -> None:
         report = _report(_ok("beam", message="beam current", value="401.2 mA"))
-        console, buf = _capture_console()
-        render_report(report, console=console)
-        assert "(401.2 mA)" in buf.getvalue()
+        render_report(report)
+        assert "(401.2 mA)" in capsys.readouterr().out
 
-    def test_panel_title_and_summary_line(self) -> None:
+    def test_summary_line(self, capsys) -> None:
         report = _report(_ok("a"), _warn("b"))
-        console, buf = _capture_console()
-        render_report(report, console=console)
-        out = buf.getvalue()
-        assert "Osprey Health Check Results" in out
-        assert f"Summary: {report.summary_line()}" in out
+        render_report(report)
+        assert f"Summary: {report.summary_line()}" in capsys.readouterr().out
 
-    def test_verbose_details_section_lists_warnings_and_errors(self) -> None:
+    def test_rows_and_summary_are_stdout_not_stderr(self, capsys) -> None:
+        # The grouped report is the document the verb was run to produce, so all
+        # of it lands on stdout, including the error rows.
+        report = _report(_ok("a", message="alpha ok"), _err("c", message="gamma err"))
+        render_report(report)
+        captured = capsys.readouterr()
+        assert "gamma err" in captured.out
+        assert captured.err == ""
+
+    def test_verbose_recap_uses_the_warn_and_fail_shapes_on_stderr(self, capsys) -> None:
         report = _report(
             _ok("a", message="fine"),
             _warn("b", message="be careful", details="try X"),
             _err("c", message="broken", details="fix Y"),
         )
-        console, buf = _capture_console()
-        render_report(report, verbose=True, console=console)
-        out = buf.getvalue()
-        assert "Details:" in out
-        assert "b: be careful" in out
-        assert "try X" in out
-        assert "c: broken" in out
-        assert "fix Y" in out
-        # An ok row is not enumerated in the details section.
-        assert "a: fine" not in out
+        render_report(report, verbose=True)
+        err = capsys.readouterr().err
+        assert "⚠ b: be careful" in err
+        assert "  try X" in err
+        assert "✗ c: broken" in err
+        assert "  fix Y" in err
+        # An ok row is not enumerated in the recap.
+        assert "a: fine" not in err
 
-    def test_non_verbose_omits_details_section(self) -> None:
+    def test_non_verbose_omits_the_recap(self, capsys) -> None:
         report = _report(_ok("a"), _warn("b", details="hint"))
-        console, buf = _capture_console()
-        render_report(report, verbose=False, console=console)
-        assert "Details:" not in buf.getvalue()
+        render_report(report, verbose=False)
+        assert capsys.readouterr().err == ""
 
-    def test_details_section_absent_when_all_ok_even_if_verbose(self) -> None:
+    def test_recap_absent_when_all_ok_even_if_verbose(self, capsys) -> None:
         report = _report(_ok("a"), _ok("b"))
-        console, buf = _capture_console()
-        render_report(report, verbose=True, console=console)
-        assert "Details:" not in buf.getvalue()
+        render_report(report, verbose=True)
+        assert capsys.readouterr().err == ""
+
+    def test_off_terminal_output_is_plain(self, capsys) -> None:
+        # Under pytest the consoles are not terminals: no ANSI escape reaches
+        # either stream, so a piped report is readable as written.
+        report = _report(_ok("a", message="alpha ok"), _err("c", message="gamma err"))
+        render_report(report, verbose=True)
+        captured = capsys.readouterr()
+        assert "\x1b[" not in captured.out
+        assert "\x1b[" not in captured.err
 
 
 # --------------------------------------------------------------------------- #
@@ -144,26 +160,28 @@ class TestRenderJson:
         assert json.loads(captured.out) == report.to_dict()
         assert captured.err == ""
 
-    def test_stdout_stays_pure_json_when_human_output_goes_to_stderr(self) -> None:
-        # Simulate the CLI's --json wiring: human output to a stderr console,
-        # the JSON document to stdout. stdout must remain a single JSON object.
+    def test_stdout_stays_pure_json_when_the_report_renders_in_machine_mode(self, capsys) -> None:
+        # The CLI's --json wiring: the whole human report renders inside machine
+        # mode (every renderer line to stderr) while the document goes to stdout.
         report = _report(
             _ok("a", message="alpha ok"),
             _warn("b", message="beta warn"),
             _err("c", message="gamma err"),
         )
-        stderr_console, stderr_buf = _capture_console()
         stdout_buf = StringIO()
 
-        render_report(report, console=stderr_console)  # human output -> "stderr"
-        render_json(report, out=stdout_buf)  # machine output -> "stdout"
+        with output.machine_mode():
+            render_report(report)
+            render_json(report, out=stdout_buf)
 
+        captured = capsys.readouterr()
         # stdout parses cleanly and carries no human glyphs or headers.
         assert json.loads(stdout_buf.getvalue()) == report.to_dict()
-        for marker in ("✓", "!", "✗", "Summary:", "File System"):
+        for marker in ("✓", "⚠", "✗", "Summary:", "File System"):
             assert marker not in stdout_buf.getvalue()
-        # The human surface did carry them.
-        assert "beta warn" in stderr_buf.getvalue()
+        # Machine mode put every human line on stderr, and none on stdout.
+        assert "beta warn" in captured.err
+        assert captured.out == ""
 
     def test_output_is_single_line_document(self) -> None:
         report = _report(_ok("a"), _err("b"))
@@ -181,20 +199,40 @@ class TestRenderJson:
 
 class TestRunProgress:
     def test_context_manager_yields_and_exits_cleanly(self) -> None:
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True, width=80)
         entered = False
-        with run_progress("checking things", console=console):
+        with run_progress("checking things"):
             entered = True
         assert entered  # body ran and the context exited without error
 
-    def test_transient_spinner_leaves_no_residual_report_text(self) -> None:
-        # The spinner is transient; after exit the buffer should not retain the
+    def test_transient_spinner_leaves_no_residual_report_text(self, capsys) -> None:
+        # The spinner is transient; after exit nothing should retain the
         # description as visible content (Live erases it on close).
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True, width=80)
-        with run_progress("secret-marker", console=console):
+        with run_progress("secret-marker"):
             pass
-        # Transient Live erases its render; the plain description text should not
-        # survive as a stable visible line.
-        assert "secret-marker\n" not in buf.getvalue()
+        assert "secret-marker\n" not in capsys.readouterr().out
+
+    def test_spinner_mounts_on_the_reporters_console(self, monkeypatch) -> None:
+        # The region belongs to the console that owns the cursor: the installed
+        # reporter's, not one this module builds.
+        from osprey.cli import phase_reporter
+
+        buf = StringIO()
+        stub = Console(file=buf, force_terminal=True, width=80)
+        monkeypatch.setattr(phase_reporter.PhaseReporter, "out", lambda self: stub)
+        with run_progress("mounted here"):
+            pass
+        assert buf.getvalue() != ""
+
+    def test_machine_mode_moves_the_region_to_the_stderr_console(self, monkeypatch) -> None:
+        # A live region paints at its console's stream: under --json that must
+        # not be stdout, so machine mode moves it to the stderr console.
+        from osprey.cli import phase_reporter
+
+        stdout_buf = StringIO()
+        stub = Console(file=stdout_buf, force_terminal=True, width=80)
+        monkeypatch.setattr(phase_reporter.PhaseReporter, "out", lambda self: stub)
+
+        with output.machine_mode(), run_progress("mounted elsewhere"):
+            pass
+
+        assert stdout_buf.getvalue() == ""

--- a/tests/integration/test_profile_roundtrip.py
+++ b/tests/integration/test_profile_roundtrip.py
@@ -417,8 +417,13 @@ class TestEveryEditReachesTheProject:
         self, workspace: Roundtrip, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Silently replacing a framework artifact is how an operator loses
-        track of which version is running, so every shadow says so."""
-        with caplog.at_level(logging.INFO):
+        track of which version is running, so every shadow says so.
+
+        At DEBUG: disposition row 35 puts the per-artifact notice below the
+        default view, where the render it belongs to already narrates. ``-v``
+        is where an operator reads the full list, and this is that reader.
+        """
+        with caplog.at_level(logging.DEBUG):
             _assert_ok(
                 _build(workspace.profile_dir),
                 "rebuild for the shadow notice",

--- a/tests/pty/__init__.py
+++ b/tests/pty/__init__.py
@@ -1,0 +1,1 @@
+"""Real-terminal (pty) harness: the exemplar repo, the stub runtime, its gate."""

--- a/tests/pty/conftest.py
+++ b/tests/pty/conftest.py
@@ -1,0 +1,552 @@
+"""The two pillars the pty harness stands on: a real repo, and a fake runtime.
+
+Everything under ``tests/pty/`` drives OSPREY's own verbs on a real terminal and
+reads what an operator would have seen. That rests on two things this module
+provides:
+
+**A deployment repo rendered by the real machinery.** Not a fixture-authored
+tree — ``osprey init`` then ``osprey build``, the same two commands a user runs,
+in a subprocess so nothing about the render leaks into the test process. The
+result is cached under ``.cache/pty-exemplar/`` and keyed on the content of
+everything that decides what a render looks like: the template data, the
+scaffolder code that stamps it out, and the preset. Cold is a couple of
+seconds and paid once per session; warm is a directory copy.
+
+**A container runtime that is not there.** :mod:`tests.pty.stub_runtime` — a
+``docker`` executable earlier on ``PATH`` than any real one, plus
+``CONTAINER_RUNTIME=docker`` so the runtime probe pins to it. Every invocation
+is logged; :class:`StubRuntime` reads the log back.
+
+The exemplar is shared **read-only**. A start verb writes to the repo it starts
+— it mints service tokens into ``.env``, generates key material under ``data/``,
+and spools command output under ``var/`` — and the profile fingerprint notices,
+so a second test starting the same directory is refused as stale. Use
+``exemplar_copy`` for anything that runs a verb; the shared tree is for reading.
+
+The preset is ``hello-world`` for one reason: it is the only bundled preset that
+both deploys services and comes up against a stubbed runtime alone. The
+control-assistant family reaches past the runtime to real network services (the
+archiver's mongod, ARIEL's postgres) and blocks on them; the standalone presets
+deploy no services at all, so there is no start to watch.
+
+On top of those two, the fixtures every scenario module drives a verb with live
+here as well: ``pty_env`` (the child environment), ``unhurried_runtime`` (a real
+runtime's latency in front of the stub) and ``startable_repo`` (a writable copy
+whose published ports are free on this host). They are shared by more than one
+module, and a fixture pytest resolves by name is one no scenario module has to
+import from another.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+#: The preset the exemplar is rendered from. See the module docstring for why
+#: it is this one and not a richer profile.
+EXEMPLAR_PRESET = "hello-world"
+
+#: Directory name of the rendered repo inside its cache entry.
+EXEMPLAR_DIRNAME = "exemplar"
+
+#: A key baked into the render so a change to *this file's* render procedure
+#: invalidates cached repos that were produced by the old one. Bump it whenever
+#: the render steps or the seeded ``.env`` change.
+RENDER_RECIPE_VERSION = "1"
+
+#: The API key seeded into the rendered repo's ``.env``. A start verb refuses
+#: outright without a secret store (``.env`` is the only one), so this is part
+#: of the render, not of any one test. Obviously not a credential.
+STUB_API_KEY = "sk-ant-stub-0000000000000000000000000000"
+
+#: Everything whose content decides what a render looks like. The scaffolder
+#: code is in the key beside its data: a template that is stamped out
+#: differently renders differently, and a key that watched only the data would
+#: serve a stale repo for the rest of the session. So the two verbs that drive
+#: the render, the generator that writes the compose files, and the profile
+#: machinery that resolves the preset are all in the key beside the templates —
+#: each of them can change the rendered repo without a template changing at all.
+#:
+#: Targeted rather than "all of ``src/osprey``": a key over the whole package
+#: would re-render on every unrelated edit in the tree, which on a working
+#: checkout is every edit.
+_KEY_INPUTS = (
+    Path("src/osprey/templates"),
+    Path("src/osprey/cli/templates"),
+    Path("src/osprey/deployment/compose_generator.py"),
+    Path("src/osprey/cli/init_cmd.py"),
+    Path("src/osprey/cli/build_cmd.py"),
+    Path("src/osprey/profiles"),
+)
+
+#: Directories never worth hashing — build artifacts of the interpreter, not
+#: inputs to a render.
+_KEY_SKIP_DIRS = frozenset({"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache"})
+
+
+def repo_root() -> Path:
+    """The OSPREY checkout these tests run against."""
+    return Path(__file__).resolve().parents[2]
+
+
+def preset_path(preset: str = EXEMPLAR_PRESET) -> Path:
+    """The bundled preset file the exemplar is rendered from."""
+    return repo_root() / "src" / "osprey" / "profiles" / "presets" / f"{preset}.yml"
+
+
+def exemplar_cache_key(preset: str = EXEMPLAR_PRESET) -> str:
+    """A content hash of everything that decides what the render looks like.
+
+    Spelled as a content hash rather than as ``git rev-parse HEAD:<path>``
+    because a working tree is the thing under test: a developer editing a
+    template has not committed it yet, and a key that could not see the edit
+    would hand every test in the session a repo rendered from the old one.
+    Committed content hashes to the same value either way.
+
+    Args:
+        preset: Preset name, folded into the key with its file's content.
+
+    Returns:
+        A short hex digest, stable across processes and machines.
+    """
+    digest = hashlib.sha256()
+    digest.update(f"recipe={RENDER_RECIPE_VERSION}\npreset={preset}\n".encode())
+    digest.update(preset_path(preset).read_bytes())
+    for relative in _KEY_INPUTS:
+        root = repo_root() / relative
+        entries = sorted(root.rglob("*")) if root.is_dir() else [root]
+        for path in entries:
+            if not path.is_file() or set(path.parts) & _KEY_SKIP_DIRS:
+                continue
+            name = path.relative_to(root) if root.is_dir() else path.name
+            # NUL between the name and the bytes: without a separator the
+            # concatenation is ambiguous — renaming a file and editing the one
+            # before it can produce the same stream, and the key would then
+            # serve a repo rendered from templates that no longer exist. The
+            # executable bit is hashed with the content because a scaffolder's
+            # mode bit survives the render into the repo it stamps out.
+            digest.update(str(name).encode())
+            digest.update(b"\0")
+            digest.update(f"{path.stat().st_mode & 0o111:o}\0".encode())
+            digest.update(path.read_bytes())
+    return digest.hexdigest()[:16]
+
+
+def exemplar_cache_dir(preset: str = EXEMPLAR_PRESET) -> Path:
+    """Where a render of *preset* is cached.
+
+    Stable across runs and inside the checkout (``.cache/`` is gitignored), so
+    a CI lane can restore the parent directory wholesale: the key in the leaf
+    name is what decides whether a restored entry is actually usable, so a
+    coarse cache key on the CI side can never serve a stale repo.
+    """
+    return repo_root() / ".cache" / "pty-exemplar" / f"{preset}-{exemplar_cache_key(preset)}"
+
+
+# ---------------------------------------------------------------------------
+# rendering
+# ---------------------------------------------------------------------------
+
+
+def _cli(*args: str, cwd: Path, env: Mapping[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run one osprey verb in a subprocess of this interpreter.
+
+    A subprocess rather than ``CliRunner``: the render loads dotenv files into
+    the process environment, installs logging, and changes directory, and a
+    session-scoped fixture that did any of that in-process would hand every
+    later test a polluted one. ``sys.executable -c`` rather than the console
+    script so the render always runs the same interpreter — and therefore the
+    same checkout — as the tests.
+    """
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from osprey.cli.main import cli; sys.exit(cli())",
+            *args,
+        ],
+        cwd=cwd,
+        env=dict(env),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _render_env() -> dict[str, str]:
+    """Environment for the render subprocesses.
+
+    Every ``OSPREY_``/``COMPOSE_``/``DOCKER_`` variable the developer's shell
+    happens to carry is dropped first. The render is cached under a key computed
+    from repository content alone, so anything in the ambient environment that
+    can change what is rendered — a pointer to another config, a compose project
+    name, a daemon socket — would be a cache key the key does not have, and one
+    session's shell would decide what every later session is handed.
+
+    The stub runtime is then put on ``PATH``, even though a render does not talk
+    to a runtime today. If one ever probes, it must reach the stub rather than
+    the developer's daemon — a fixture that quietly started containers would be
+    discovered the hard way.
+    """
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("OSPREY_", "COMPOSE_", "DOCKER_"))
+    }
+    env["CONTAINER_RUNTIME"] = "docker"
+    env["PATH"] = f"{stub_runtime_dir()}{os.pathsep}{env.get('PATH', '')}"
+    env["NO_COLOR"] = "1"
+    return env
+
+
+def render_exemplar(destination: Path, preset: str = EXEMPLAR_PRESET) -> Path:
+    """Render one deployment repo into *destination* with the real verbs.
+
+    ``init`` (no git — a commit needs an identity CI may not have), a seeded
+    ``.env``, then ``build --skip-deps --skip-lifecycle``: the venv install and
+    the profile's shell phases cost minutes and render nothing.
+
+    Args:
+        destination: Directory to create the repo in. Created if absent.
+        preset: Bundled preset name.
+
+    Returns:
+        The rendered repo root.
+
+    Raises:
+        RuntimeError: When either verb fails, with its own output attached —
+            a broken render is a broken harness, and swallowing the reason
+            would leave every pty test failing for no visible cause.
+    """
+    destination.mkdir(parents=True, exist_ok=True)
+    env = _render_env()
+
+    result = _cli(
+        "init", EXEMPLAR_DIRNAME, "--preset", preset, "--no-git", cwd=destination, env=env
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"osprey init failed ({result.returncode}):\n{result.stdout}\n{result.stderr}"
+        )
+
+    repo = destination / EXEMPLAR_DIRNAME
+    (repo / ".env").write_text(f"ANTHROPIC_API_KEY={STUB_API_KEY}\n", encoding="utf-8")
+
+    result = _cli("build", "--skip-deps", "--skip-lifecycle", cwd=repo, env=env)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"osprey build failed ({result.returncode}):\n{result.stdout}\n{result.stderr}"
+        )
+    return repo
+
+
+def ensure_exemplar(preset: str = EXEMPLAR_PRESET) -> Path:
+    """The cached render of *preset*, rendering it first if there is none.
+
+    Built into a sibling scratch directory and moved into place, so a cache
+    entry either does not exist or is complete: a half-rendered repo left by an
+    interrupted session would otherwise be served to every later one.
+    """
+    cached = exemplar_cache_dir(preset)
+    repo = cached / EXEMPLAR_DIRNAME
+    if repo.is_dir():
+        return repo
+
+    staging = cached.with_name(f"{cached.name}.building-{os.getpid()}")
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        render_exemplar(staging, preset)
+        cached.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            staging.rename(cached)
+        except OSError:
+            # Another session won the race and put its own render here. Its
+            # render is this render — same key, same inputs — so take theirs.
+            if not repo.is_dir():
+                raise
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# the stub runtime
+# ---------------------------------------------------------------------------
+
+
+def stub_runtime_dir() -> Path:
+    """The directory holding the stub ``docker`` executable."""
+    return Path(__file__).resolve().parent / "stub_runtime"
+
+
+@dataclass(frozen=True)
+class StubRuntime:
+    """A configured stub runtime, and the log it writes.
+
+    Attributes:
+        directory: The directory to put first on ``PATH``.
+        log_path: JSONL file the stub appends one record per invocation to.
+        state_path: JSON file the stub keeps its "what is up" state in.
+    """
+
+    directory: Path
+    log_path: Path
+    state_path: Path
+
+    def env(self, base: Mapping[str, str] | None = None) -> dict[str, str]:
+        """*base* (default ``os.environ``) with the stub wired into it.
+
+        ``CONTAINER_RUNTIME=docker`` is not decoration: it is read by
+        :func:`osprey.deployment.runtime_helper._runtimes_to_try` ahead of
+        config, so the probe never falls through to podman and finds a real
+        one behind the stub.
+        """
+        env = dict(os.environ if base is None else base)
+        env["PATH"] = f"{self.directory}{os.pathsep}{env.get('PATH', '')}"
+        env["CONTAINER_RUNTIME"] = "docker"
+        env["OSPREY_STUB_RUNTIME_LOG"] = str(self.log_path)
+        env["OSPREY_STUB_RUNTIME_STATE"] = str(self.state_path)
+        return env
+
+    def invocations(self) -> list[dict[str, Any]]:
+        """Every invocation the stub has answered, in order."""
+        if not self.log_path.is_file():
+            return []
+        return [
+            json.loads(line)
+            for line in self.log_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    def seams(self) -> list[str]:
+        """The resolved seam of every invocation, in order (``"compose up"``)."""
+        return [record["seam"] for record in self.invocations()]
+
+    def unhandled(self) -> list[dict[str, Any]]:
+        """Invocations the stub did not recognize — the coverage gap, if any."""
+        return [record for record in self.invocations() if not record["handled"]]
+
+    def reset(self) -> None:
+        """Forget every invocation and every started container."""
+        self.log_path.unlink(missing_ok=True)
+        self.state_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the markers this directory's fixtures read.
+
+    Declared here rather than in ``pyproject.toml`` because the marker is a
+    contract with the ``stub_runtime`` fixture, and nothing outside this
+    directory can use it.
+    """
+    config.addinivalue_line(
+        "markers",
+        "allow_unhandled_runtime: the test exercises the stub runtime's "
+        "unhandled path on purpose, so the stub_runtime fixture must not fail "
+        "it for the invocations it could not answer.",
+    )
+
+
+@pytest.fixture(scope="session")
+def exemplar_preset() -> str:
+    """The preset the shared exemplar is rendered from."""
+    return EXEMPLAR_PRESET
+
+
+@pytest.fixture(scope="session")
+def exemplar_repo() -> Path:
+    """The shared, rendered deployment repo. **Read-only.**
+
+    Rendered once per session (cached across sessions) by the real ``init`` and
+    ``build``. Anything that runs a verb against it must take an
+    ``exemplar_copy`` first — see the module docstring.
+    """
+    return ensure_exemplar()
+
+
+@pytest.fixture
+def exemplar_copy(exemplar_repo: Path, tmp_path: Path) -> Path:
+    """A private, writable copy of the exemplar for one test.
+
+    The copy is what a start verb is allowed to scribble on: it mints tokens
+    into ``.env``, writes key material under ``data/``, and spools output under
+    ``var/``, all of which the profile fingerprint sees.
+    """
+    destination = tmp_path / exemplar_repo.name
+    shutil.copytree(exemplar_repo, destination, symlinks=True)
+    return destination
+
+
+@pytest.fixture
+def stub_runtime(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[StubRuntime]:
+    """A stub container runtime with a per-test invocation log.
+
+    Teardown fails the test on any invocation the stub could not answer. That
+    check belongs here rather than in each test: the stub exits 0 on an argv it
+    does not know (see :mod:`tests.pty.stub_runtime._stub_main`), so a deploy
+    that asked for something unscripted looks *successful* to everything above
+    it, and a test that only asserted on rendered output would keep passing
+    while measuring a deploy that half happened.
+
+    A test that is *about* the unhandled path marks itself
+    ``@pytest.mark.allow_unhandled_runtime``.
+    """
+    stub = StubRuntime(
+        directory=stub_runtime_dir(),
+        log_path=tmp_path / "stub-runtime.jsonl",
+        state_path=tmp_path / "stub-runtime-state.json",
+    )
+    yield stub
+
+    if "allow_unhandled_runtime" in request.keywords:
+        return
+    unhandled = stub.unhandled()
+    if unhandled:
+        pytest.fail(
+            "the stub runtime was asked for invocations it cannot answer, so this test "
+            "measured a deploy that only partly happened:\n  "
+            + "\n  ".join(" ".join(record["argv"]) for record in unhandled)
+            + "\nTeach tests/pty/stub_runtime/_stub_main.py the seam (handler + HANDLED_* "
+            "set), or mark the test @pytest.mark.allow_unhandled_runtime if the gap is "
+            "the point."
+        )
+
+
+@pytest.fixture
+def pty_env(stub_runtime: StubRuntime) -> dict[str, str]:
+    """The child's environment: stub runtime, a real terminal type, no color veto.
+
+    Every ambient ``OSPREY_``/``COMPOSE_``/``DOCKER_`` variable is dropped for
+    the same reason the exemplar render drops them — a developer's shell must
+    not decide what the scenario deploys. ``COLUMNS``/``LINES`` go too: Rich
+    reads them ahead of the pty's own window size, so leaving them in would let
+    the runner's terminal set the width the screen is asserted at.
+
+    The two secrets the scenarios drive with are cleared here and set back by
+    the scenarios that want them, so an exported key on the developer's shell
+    cannot arm or disarm a scenario silently.
+    """
+    base = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("OSPREY_", "COMPOSE_", "DOCKER_"))
+    }
+    for key in ("NO_COLOR", "FORCE_COLOR", "COLUMNS", "LINES", "ANTHROPIC_API_KEY"):
+        base.pop(key, None)
+    env = stub_runtime.env(base)
+    env["TERM"] = "xterm-256color"
+    return env
+
+
+#: Seconds of latency the unhurried runtime wrapper adds to each runtime call.
+#: Chosen against the monitor's 0.25 s tick: a deploy whose runtime answers
+#: instantly can finish a phase between two repaints, and a scenario about
+#: repainting would then be asserting about a region that never got the chance.
+RUNTIME_LATENCY = 0.4
+
+
+@pytest.fixture
+def unhurried_runtime(stub_runtime: StubRuntime, pty_env: dict[str, str], tmp_path: Path) -> None:
+    """Give the stub runtime the latency a real one has.
+
+    The stub answers in microseconds, which no container runtime does: a
+    ``compose up`` against a daemon is a round trip measured in tenths of a
+    second at best. Scenarios about the live region need that, because the
+    region repaints on a 0.25 s tick and a phase that opens and closes inside
+    one tick paints nothing at all — the harness would then be asserting about
+    a region the deploy was simply too fast to draw.
+
+    Spelled as a wrapper ahead of the stub on ``PATH`` rather than as a change
+    to the stub, so the invocation log, the seams and the answers are exactly
+    the ones every other pty test sees; the only difference is when they
+    arrive.
+    """
+    directory = tmp_path / "unhurried-runtime"
+    directory.mkdir()
+    launcher = directory / "docker"
+    launcher.write_text(
+        f'#!/bin/sh\nsleep {RUNTIME_LATENCY}\nexec "{stub_runtime.directory}/docker" "$@"\n',
+        encoding="utf-8",
+    )
+    launcher.chmod(0o755)
+    pty_env["PATH"] = f"{directory}{os.pathsep}{pty_env['PATH']}"
+
+
+def _free_host_ports(count: int) -> list[int]:
+    """*count* distinct ports, none of them listened on as of now.
+
+    Every probe socket is held open until the whole set has been allocated.
+    Asking the kernel *count* times in a row and closing each probe before the
+    next would let it hand back a port it has just released, and two services
+    published on one port is a deploy that fails for a reason that has nothing
+    to do with what the scenario is testing. Nothing binds these ports
+    afterwards — the runtime is a stub — so releasing them at the end is safe;
+    what matters is that they were distinct when they were chosen.
+    """
+    probes = []
+    try:
+        for _ in range(count):
+            probe = socket.socket()
+            probe.bind(("127.0.0.1", 0))
+            probes.append(probe)
+        return [int(probe.getsockname()[1]) for probe in probes]
+    finally:
+        for probe in probes:
+            probe.close()
+
+
+@pytest.fixture
+def startable_repo(exemplar_copy: Path) -> Path:
+    """An ``exemplar_copy`` whose published ports are free on this host.
+
+    The start verb's host-port preflight is a real socket probe and refuses the
+    deploy before touching the runtime when a port is taken — correctly, since
+    it cannot tell a stub deploy from a real one. On a developer box something
+    usually holds the exemplar's 5080 (a container runtime's own proxy, most
+    often), and the scenarios below are about the terminal, not about port
+    policy. So each published binding is moved to a free port in *this copy's*
+    rendered compose file, which is the same edit ``osprey up``'s own refusal
+    asks the operator for.
+
+    Rendered output only: nothing in ``profile.yml`` changes, so the build
+    fingerprint still matches and the start is not a stale one.
+    """
+    from osprey.deployment.container_lifecycle import as_built_compose_files, as_built_config_path
+    from osprey.deployment.host_ports import parse_host_port_bindings
+    from osprey.utils.config import load_project_config
+
+    config = load_project_config(str(as_built_config_path(exemplar_copy)), wrap_errors=True)
+    compose_files = [
+        str(path) if os.path.isabs(str(path)) else str(exemplar_copy / str(path))
+        for path in as_built_compose_files(config, exemplar_copy)
+    ]
+    bindings = parse_host_port_bindings(compose_files)
+    assert bindings, (
+        f"no published host ports were parsed out of {compose_files}; the rewrite below "
+        f"would be a no-op and the scenarios would depend on this host's free ports"
+    )
+    for binding, port in zip(bindings, _free_host_ports(len(bindings)), strict=True):
+        path = Path(binding.compose_file)
+        text = path.read_text(encoding="utf-8")
+        moved = text.replace(
+            f"{binding.host_ip}:{binding.host_port}:", f"{binding.host_ip}:{port}:"
+        )
+        assert moved != text, f"could not move {binding.service}'s published port in {path}"
+        path.write_text(moved, encoding="utf-8")
+    return exemplar_copy

--- a/tests/pty/stub_runtime/__init__.py
+++ b/tests/pty/stub_runtime/__init__.py
@@ -1,0 +1,5 @@
+"""The stub container runtime the pty harness puts on ``PATH``.
+
+The ``docker`` executable beside this file is a launcher; :mod:`._stub_main`
+holds the behaviour and the handled-seam sets the coverage gate reads.
+"""

--- a/tests/pty/stub_runtime/_stub_main.py
+++ b/tests/pty/stub_runtime/_stub_main.py
@@ -1,0 +1,764 @@
+"""The stub container runtime: every conversation the deploy path has with docker.
+
+The pty harness drives a real ``osprey up`` on a real terminal. Everything above
+the runtime is the code under test; the runtime itself is the one thing that
+cannot be real — a CI lane has no daemon, and a test that pulled images would
+measure the network rather than the output hierarchy. So the seam is cut at the
+process boundary: a ``docker`` executable earlier on ``PATH`` than any real one,
+plus ``CONTAINER_RUNTIME=docker`` so
+:func:`osprey.deployment.runtime_helper._runtimes_to_try` pins the probe to it
+and never falls through to podman.
+
+This module is the whole of that executable's behaviour. It is importable (the
+``docker`` script beside it is a five-line launcher) for one reason: the
+coverage gate — ``tests/pty/test_stub_coverage.py`` — reads :data:`HANDLED_PLAIN`
+and :data:`HANDLED_COMPOSE` out of it and checks them against the seams the
+deploy path actually builds. A stub whose handled set is a private detail could
+only be checked by running it, and a subcommand nobody thought to script would
+be discovered as a mysterious hang months later.
+
+Three contracts the callers depend on, each load-bearing:
+
+* **Exit 0, always.** Even for an argv nothing here recognizes. A stub that
+  failed closed would turn "the harness has not scripted this yet" into "the
+  deploy is broken", which is the harder failure to read. Unrecognized calls are
+  recorded with ``"handled": false`` instead, and the gate reads that flag.
+* **Every invocation is logged**, one JSON object per line, to
+  ``$OSPREY_STUB_RUNTIME_LOG`` — argv, cwd, stdin, the resolved seam, and
+  whether it was handled. Appended under an exclusive lock, because compose
+  invocations overlap.
+* **Answers are plausible, and consistent with each other.** ``compose up``
+  reads the service names out of the very compose files it was handed and
+  records them in ``$OSPREY_STUB_RUNTIME_STATE``, so the ``ps`` that follows
+  lists the containers the deploy just started. Image IDs are one constant, so
+  an image inspect and a container inspect agree and no caller sees drift it
+  would try to reconcile.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import select
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+#: Environment variable naming the JSONL invocation log. Every call appends one
+#: line; the tests read the file back.
+LOG_ENV = "OSPREY_STUB_RUNTIME_LOG"
+
+#: Environment variable naming the JSON state file (which services are "up").
+#: Absent, the stub is stateless and ``ps`` lists nothing.
+STATE_ENV = "OSPREY_STUB_RUNTIME_STATE"
+
+#: The one image ID every inspect answers with. Constant on purpose: image
+#: drift is computed by comparing an image inspect against a container inspect,
+#: and two different IDs would send the deploy into a recreate it never asked
+#: for.
+IMAGE_ID = "0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0"
+
+#: Version banners. The compose one is parsed by
+#: :func:`~osprey.deployment.runtime_helper.detect_compose_provider`, which
+#: fails closed on a banner it cannot place — so this string is a contract, not
+#: decoration.
+DOCKER_VERSION = "Docker version 27.3.1, build ce12230"
+COMPOSE_VERSION = "Docker Compose version v2.30.3"
+
+#: Plain-runtime seams the stub answers. Two-word entries are the namespaced
+#: subcommands (``docker image inspect``); the first word alone would not say
+#: which call it was.
+HANDLED_PLAIN = frozenset(
+    {
+        "build",
+        "container inspect",
+        "container rm",
+        "container stop",
+        "cp",
+        "create",
+        "events",
+        "exec",
+        "images",
+        "image inspect",
+        "image ls",
+        "image pull",
+        "image rm",
+        "info",
+        "inspect",
+        "kill",
+        "login",
+        "logout",
+        "logs",
+        "network create",
+        "network inspect",
+        "network ls",
+        "network rm",
+        "port",
+        "ps",
+        "pull",
+        "push",
+        "restart",
+        "rm",
+        "rmi",
+        "run",
+        "start",
+        "stats",
+        "stop",
+        "system df",
+        "tag",
+        "top",
+        "version",
+        "volume create",
+        "volume inspect",
+        "volume ls",
+        "volume rm",
+        "wait",
+    }
+)
+
+#: Compose seams the stub answers, spelled without the ``compose`` prefix.
+HANDLED_COMPOSE = frozenset(
+    {
+        "build",
+        "config",
+        "cp",
+        "create",
+        "down",
+        "events",
+        "exec",
+        "images",
+        "kill",
+        "logs",
+        "ls",
+        "port",
+        "ps",
+        "pull",
+        "push",
+        "restart",
+        "rm",
+        "run",
+        "start",
+        "stop",
+        "top",
+        "up",
+        "version",
+        "wait",
+    }
+)
+
+#: Namespaced plain subcommands: the seam is two words, not one.
+_NAMESPACES = frozenset({"container", "image", "network", "system", "volume", "builder", "buildx"})
+
+#: Compose's own flags that take a value, so the scanner walking argv for the
+#: subcommand skips the value too and does not mistake it for one.
+_COMPOSE_VALUE_FLAGS = frozenset(
+    {
+        "-f",
+        "--file",
+        "-p",
+        "--project-name",
+        "--project-directory",
+        "--env-file",
+        "--profile",
+        "--progress",
+        "--ansi",
+        "--parallel",
+        "--compatibility",
+    }
+)
+
+#: How compose reports each container-touching verb once it is done, so the
+#: stub's progress lines read like the ones the renderer will see in anger.
+_COMPOSE_PAST_TENSE = {
+    "create": "Created",
+    "kill": "Killed",
+    "restart": "Started",
+    "rm": "Removed",
+    "start": "Started",
+    "stop": "Stopped",
+    "wait": "Exited",
+}
+
+#: The same, for the plain runtime's global flags.
+_PLAIN_VALUE_FLAGS = frozenset(
+    {"-H", "--host", "--context", "-c", "--config", "--log-level", "-l", "--tls-verify"}
+)
+
+
+# ---------------------------------------------------------------------------
+# argv parsing
+# ---------------------------------------------------------------------------
+
+
+def split_argv(args: list[str]) -> tuple[bool, str, list[str]]:
+    """Resolve an argv tail into ``(is_compose, seam, remainder)``.
+
+    Args:
+        args: Everything after the executable name.
+
+    Returns:
+        Whether this is a ``compose`` invocation, the seam it resolves to
+        (``"up"``, ``"image inspect"``, ``""`` when there is no subcommand at
+        all), and the arguments that followed the subcommand.
+    """
+    rest = list(args)
+    is_compose = False
+    if rest and rest[0] == "compose":
+        is_compose = True
+        rest = rest[1:]
+
+    value_flags = _COMPOSE_VALUE_FLAGS if is_compose else _PLAIN_VALUE_FLAGS
+    index = 0
+    while index < len(rest):
+        token = rest[index]
+        if not token.startswith("-"):
+            break
+        if token in value_flags:
+            index += 2
+        elif "=" in token:
+            index += 1
+        else:
+            index += 1
+    else:
+        return is_compose, "", []
+
+    subcommand = rest[index]
+    remainder = rest[index + 1 :]
+    if not is_compose and subcommand in _NAMESPACES:
+        for candidate in remainder:
+            if not candidate.startswith("-"):
+                return is_compose, f"{subcommand} {candidate}", remainder[1:]
+        return is_compose, subcommand, remainder
+    return is_compose, subcommand, remainder
+
+
+def flag_value(args: list[str], *names: str) -> str | None:
+    """The value of the first of *names* present in *args*, or ``None``.
+
+    Handles both spellings a runtime accepts: ``--format json`` and
+    ``--format=json``.
+    """
+    for index, token in enumerate(args):
+        for name in names:
+            if token == name and index + 1 < len(args):
+                return args[index + 1]
+            if token.startswith(f"{name}="):
+                return token.split("=", 1)[1]
+    return None
+
+
+def _positional(args: list[str], value_flags: frozenset[str]) -> list[str]:
+    """The non-flag arguments, with the values of value-taking flags dropped."""
+    out: list[str] = []
+    skip = False
+    for token in args:
+        if skip:
+            skip = False
+            continue
+        if token.startswith("-"):
+            skip = token in value_flags
+            continue
+        out.append(token)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# state
+# ---------------------------------------------------------------------------
+
+
+def _state_path() -> Path | None:
+    raw = os.environ.get(STATE_ENV)
+    return Path(raw) if raw else None
+
+
+def read_state() -> dict[str, Any]:
+    """The containers this stub currently considers up; empty when stateless."""
+    path = _state_path()
+    if path is None or not path.is_file():
+        return {"containers": []}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"containers": []}
+    return loaded if isinstance(loaded, dict) else {"containers": []}
+
+
+def write_state(state: dict[str, Any]) -> None:
+    """Persist *state*, atomically, when a state file was configured."""
+    path = _state_path()
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(f".{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    os.replace(temporary, path)
+
+
+#: A ``services:`` key: two spaces of indent under the top-level block. Crude on
+#: purpose — the stub reads rendered compose files, which are emitted by
+#: OSPREY's own generator in exactly this shape, and a YAML dependency in a
+#: script that must run under the bare system interpreter is not worth it.
+_SERVICE_KEY = re.compile(r"^ {2}([A-Za-z0-9][A-Za-z0-9_.-]*):\s*$")
+_CONTAINER_NAME = re.compile(r"^\s+container_name:\s*['\"]?([^'\"\s]+)['\"]?\s*$")
+
+
+def services_in(compose_file: Path) -> list[tuple[str, str]]:
+    """``(service, container_name)`` pairs declared in one compose file.
+
+    A service with no explicit ``container_name`` is named the way compose
+    itself would name it if it had to: the service name stands in, and the
+    caller prefixes the project.
+    """
+    try:
+        lines = compose_file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    found: list[tuple[str, str]] = []
+    in_services = False
+    current: str | None = None
+    for line in lines:
+        if line.startswith("services:"):
+            in_services = True
+            continue
+        if line and not line[0].isspace() and not line.startswith("#"):
+            in_services = False
+            continue
+        if not in_services:
+            continue
+        match = _SERVICE_KEY.match(line)
+        if match:
+            current = match.group(1)
+            found.append((current, current))
+            continue
+        named = _CONTAINER_NAME.match(line)
+        if named and current is not None and found:
+            found[-1] = (current, named.group(1))
+    return found
+
+
+def _compose_files(args: list[str]) -> list[Path]:
+    """Every ``-f``/``--file`` path in an argv, in order.
+
+    A relative path is resolved the way compose resolves it — against the
+    working directory — and, failing that, against ``--project-directory``. The
+    fallback is what keeps a caller that pinned the project directory but
+    invoked from elsewhere readable, which is the shape the deploy path uses.
+    """
+    project_directory = flag_value(args, "--project-directory")
+    raw: list[str] = []
+    for index, token in enumerate(args):
+        if token in ("-f", "--file") and index + 1 < len(args):
+            raw.append(args[index + 1])
+        elif token.startswith("--file="):
+            raw.append(token.split("=", 1)[1])
+
+    files: list[Path] = []
+    for entry in raw:
+        path = Path(entry)
+        if not path.is_file() and not path.is_absolute() and project_directory:
+            path = Path(project_directory) / entry
+        files.append(path)
+    return files
+
+
+def _project_name(args: list[str]) -> str:
+    explicit = flag_value(args, "-p", "--project-name")
+    if explicit:
+        return explicit
+    return os.environ.get("COMPOSE_PROJECT_NAME", "osprey")
+
+
+def _container_record(project: str, service: str, name: str, index: int) -> dict[str, Any]:
+    """One ``ps``-shaped record, with the keys the status renderer reads."""
+    qualified = name if name != service else f"{project}-{service}-1"
+    return {
+        "ID": f"{index:012x}",
+        "Names": qualified,
+        "Image": f"{project}/{service}:local",
+        "Command": '"/entrypoint.sh"',
+        "State": "running",
+        "Status": "Up 3 seconds",
+        "Ports": "",
+        "Labels": f"com.docker.compose.project={project},com.docker.compose.service={service}",
+        "Networks": f"{project}_default",
+        "RunningFor": "3 seconds ago",
+        "Service": service,
+        "Project": project,
+        "Health": "healthy",
+    }
+
+
+# ---------------------------------------------------------------------------
+# logging
+# ---------------------------------------------------------------------------
+
+
+def log_invocation(record: dict[str, Any]) -> None:
+    """Append one JSON line to the invocation log, if one was configured.
+
+    Opened per call with ``O_APPEND``: compose runs overlap, and a handle held
+    open across them would interleave partial lines.
+    """
+    raw = os.environ.get(LOG_ENV)
+    if not raw:
+        return
+    path = Path(raw)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _read_stdin(deadline: float = 0.1) -> str:
+    """Whatever was piped in, or ``""`` when nothing was.
+
+    Deliberately not ``sys.stdin.read()``. Most runtime calls on the deploy path
+    inherit the parent's stdin rather than being handed one, and on the piped
+    lane that inherited descriptor is a pipe nobody is going to close — a
+    straight read would hang the whole harness on the first ``docker ps``. So
+    stdin is drained only while it is *ready*, and abandoned after *deadline*
+    seconds: the calls that really do pipe something in (``exec -i``) hand over
+    a closed-after-write pipe and read to EOF well inside it.
+
+    Args:
+        deadline: Seconds to keep draining before giving up.
+
+    Returns:
+        The decoded input, or ``""``.
+    """
+    if sys.stdin is None or sys.stdin.isatty():
+        return ""
+    try:
+        fd = sys.stdin.fileno()
+    except (OSError, ValueError):
+        return ""
+
+    chunks: list[bytes] = []
+    give_up_at = time.monotonic() + deadline
+    while time.monotonic() < give_up_at:
+        try:
+            ready, _, _ = select.select([fd], [], [], 0.01)
+        except (OSError, ValueError):
+            break
+        if not ready:
+            continue
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8", "replace")
+
+
+# ---------------------------------------------------------------------------
+# handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_plain(seam: str, args: list[str], remainder: list[str]) -> bool:
+    """Answer a plain-runtime seam. Returns whether it was recognized."""
+    out = sys.stdout
+    if seam == "version":
+        print(DOCKER_VERSION, file=out)
+        return True
+    if not seam and any(token in ("--version", "-v") for token in args):
+        # ``docker --version`` names no subcommand at all, so it arrives here
+        # with an empty seam. A probe that got silence back would read the stub
+        # as a runtime that is installed but broken, which is the one answer
+        # neither the harness nor the code under test knows what to do with.
+        print(DOCKER_VERSION, file=out)
+        return True
+    if seam == "info":
+        print("Client:\n Version:    27.3.1\n\nServer:\n Server Version: 27.3.1", file=out)
+        return True
+    if seam == "ps":
+        _handle_ps(args)
+        return True
+    if seam == "volume ls":
+        template = flag_value(args, "--format") or ""
+        names = sorted({f"{c['Project']}_{c['Service']}-data" for c in read_state()["containers"]})
+        if "{{" in template:
+            for name in names:
+                print(name, file=out)
+        else:
+            print("DRIVER    VOLUME NAME", file=out)
+            for name in names:
+                print(f"local     {name}", file=out)
+        return True
+    if seam in ("volume rm", "volume create", "volume inspect"):
+        for name in _positional(remainder, frozenset({"--format"})):
+            print(name, file=out)
+        return True
+    if seam in ("image inspect", "container inspect", "inspect"):
+        _handle_inspect(seam, args, remainder)
+        return True
+    if seam in ("image rm", "rmi"):
+        for tag in _positional(remainder, frozenset()):
+            print(f"Untagged: {tag}", file=out)
+        return True
+    if seam in ("image ls", "images"):
+        print("REPOSITORY   TAG       IMAGE ID       CREATED         SIZE", file=out)
+        return True
+    if seam == "build":
+        _handle_build(args)
+        return True
+    if seam == "exec":
+        _handle_exec(remainder)
+        return True
+    if seam in ("stop", "start", "rm", "kill", "restart", "container rm", "container stop", "wait"):
+        for name in _positional(remainder, frozenset()):
+            print(name, file=out)
+        return True
+    if seam in ("pull", "image pull", "push", "tag", "login", "logout", "cp", "port", "top"):
+        return True
+    if seam in ("network ls", "network create", "network rm", "network inspect"):
+        if seam == "network ls":
+            print("NETWORK ID     NAME      DRIVER    SCOPE", file=out)
+        return True
+    if seam in ("logs", "events", "stats", "system df", "create", "run"):
+        return True
+    return False
+
+
+def _handle_ps(args: list[str]) -> None:
+    """``ps`` in all four shapes the deploy path asks for it in."""
+    containers = read_state()["containers"]
+    label_filter = flag_value(args, "--filter", "-f")
+    if label_filter and label_filter.startswith("label="):
+        # Sliced rather than ``removeprefix``: this file runs under whatever
+        # ``/usr/bin/env python3`` finds on the host, which is not the version
+        # the rest of the repository is allowed to assume.
+        wanted = label_filter[len("label=") :]
+        containers = [c for c in containers if wanted in c["Labels"]]
+
+    template = flag_value(args, "--format") or ""
+    short = any(
+        token.startswith("-") and not token.startswith("--") and "q" in token for token in args
+    )
+
+    if "json" in template.lower():
+        for container in containers:
+            print(json.dumps(container), file=sys.stdout)
+        return
+    if "{{" in template:
+        field = "Names"
+        if ".ID" in template:
+            field = "ID"
+        elif ".Image" in template:
+            field = "Image"
+        for container in containers:
+            print(container[field], file=sys.stdout)
+        return
+    if short:
+        for container in containers:
+            print(container["ID"], file=sys.stdout)
+        return
+    print("CONTAINER ID   IMAGE   COMMAND   CREATED   STATUS   PORTS   NAMES", file=sys.stdout)
+    for container in containers:
+        print(
+            f"{container['ID']}   {container['Image']}   {container['Command']}   "
+            f"3 seconds ago   {container['Status']}      {container['Names']}",
+            file=sys.stdout,
+        )
+
+
+def _handle_inspect(seam: str, args: list[str], remainder: list[str]) -> None:
+    """``inspect`` for images, containers, and the bare ``--type container`` form.
+
+    Go templates are answered by what they ask for rather than by rendering
+    them: the four templates the deploy path uses are a closed set, and a
+    template engine in a stub would be a second implementation of docker's.
+    """
+    template = flag_value(args, "--format") or ""
+    if ".Id" in template or ".Image" in template:
+        print(f"sha256:{IMAGE_ID}" if ".Id" in template else IMAGE_ID, file=sys.stdout)
+        return
+    if "Labels" in template:
+        # ``{}`` rather than a fabricated label map: an empty map is what a
+        # container the stub never really created has, and it is the answer
+        # that makes every label-gated destructive path decline to act.
+        print("{}", file=sys.stdout)
+        return
+    if ".Config.Env" in template:
+        print("PATH=/usr/local/bin:/usr/bin:/bin", file=sys.stdout)
+        return
+    names = _positional(remainder, frozenset({"--format", "--type"}))
+    payload = [
+        {
+            "Id": f"sha256:{IMAGE_ID}",
+            "Name": f"/{name}",
+            "Config": {"Labels": {}, "Env": []},
+            "State": {"Status": "running", "Running": True},
+        }
+        for name in names
+    ] or [{"Id": f"sha256:{IMAGE_ID}", "Config": {"Labels": {}, "Env": []}}]
+    print(json.dumps(payload), file=sys.stdout)
+
+
+def _handle_build(args: list[str]) -> None:
+    """A buildkit-shaped plain-progress transcript.
+
+    Shaped, not decorative: ``build_progress`` parses exactly these lines out of
+    a real build, so the continuation-line rules it was fixed to honour
+    (``DONE``, ``CACHED``, ``sha256:``) are exercised by the stub too.
+    """
+    tag = flag_value(args, "-t", "--tag") or "stub:local"
+    for line in (
+        "#1 [internal] load build definition from Dockerfile",
+        "#1 transferring dockerfile: 2.31kB done",
+        "#1 DONE 0.0s",
+        "#2 [internal] load metadata for docker.io/library/python:3.11-slim",
+        "#2 DONE 0.1s",
+        "#3 [1/2] FROM docker.io/library/python:3.11-slim",
+        "#3 CACHED",
+        "#4 exporting to image",
+        f"#4 writing image sha256:{IMAGE_ID} done",
+        f"#4 naming to docker.io/library/{tag} done",
+        "#4 DONE 0.2s",
+    ):
+        print(line, file=sys.stderr)
+
+
+def _handle_exec(remainder: list[str]) -> None:
+    """``exec`` answers only what the deploy path actually asks a container."""
+    joined = " ".join(remainder)
+    if "id -u" in joined:
+        print("1000:1000", file=sys.stdout)
+
+
+def _handle_compose(seam: str, args: list[str], remainder: list[str]) -> bool:
+    """Answer a compose seam. Returns whether it was recognized."""
+    if seam == "version":
+        print(COMPOSE_VERSION, file=sys.stdout)
+        return True
+    if seam == "up":
+        _handle_compose_up(args, remainder)
+        return True
+    if seam == "down":
+        _handle_compose_down(args)
+        return True
+    if seam == "ps":
+        _handle_ps(args)
+        return True
+    if seam == "config":
+        print("services: {}", file=sys.stdout)
+        return True
+    if seam in ("images", "ls"):
+        print("CONTAINER   REPOSITORY   TAG   IMAGE ID   SIZE", file=sys.stdout)
+        return True
+    if seam == "build":
+        _handle_build(args)
+        return True
+    if seam in _COMPOSE_PAST_TENSE:
+        _report_compose_containers(args, remainder, verb=_COMPOSE_PAST_TENSE[seam])
+        return True
+    if seam in ("pull", "push", "logs", "exec", "run", "cp", "port", "top", "events"):
+        return True
+    return False
+
+
+def _selected_services(args: list[str], remainder: list[str]) -> list[tuple[str, str]]:
+    """The services this invocation targets: the named ones, else all of them."""
+    declared: list[tuple[str, str]] = []
+    for compose_file in _compose_files(args):
+        declared.extend(services_in(compose_file))
+    named = set(_positional(remainder, frozenset({"--scale", "--timeout", "-t"})))
+    if named:
+        return [pair for pair in declared if pair[0] in named]
+    return declared
+
+
+def _handle_compose_up(args: list[str], remainder: list[str]) -> None:
+    """Start the services the compose files declare, and record them as up."""
+    project = _project_name(args)
+    state = read_state()
+    existing = {c["Names"]: c for c in state["containers"]}
+    lines: list[str] = []
+    for index, (service, name) in enumerate(_selected_services(args, remainder), start=1):
+        record = _container_record(project, service, name, index)
+        was_running = record["Names"] in existing
+        existing[record["Names"]] = record
+        lines.append(f" Container {record['Names']}  {'Recreated' if was_running else 'Created'}")
+        lines.append(f" Container {record['Names']}  Started")
+    state["containers"] = list(existing.values())
+    write_state(state)
+    # Compose writes its progress to stderr and keeps stdout for data. The
+    # renderer under test relies on that split, so the stub must honour it.
+    for line in lines:
+        print(line, file=sys.stderr)
+
+
+def _handle_compose_down(args: list[str]) -> None:
+    """Stop everything this project has up, and forget it."""
+    project = _project_name(args)
+    state = read_state()
+    kept = []
+    for container in state["containers"]:
+        if container["Project"] == project:
+            print(f" Container {container['Names']}  Removed", file=sys.stderr)
+        else:
+            kept.append(container)
+    print(f" Network {project}_default  Removed", file=sys.stderr)
+    state["containers"] = kept
+    write_state(state)
+
+
+def _report_compose_containers(args: list[str], remainder: list[str], *, verb: str) -> None:
+    """Echo one compose-shaped progress line per targeted container."""
+    project = _project_name(args)
+    for _, name in _selected_services(args, remainder):
+        qualified = name if "-" in name else f"{project}-{name}-1"
+        print(f" Container {qualified}  {verb}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Answer one runtime invocation; always exits 0.
+
+    Args:
+        argv: Full argv including the program name. Defaults to ``sys.argv``.
+
+    Returns:
+        Always ``0`` — see the module docstring for why a stub must not fail
+        closed on an argv it does not know.
+    """
+    raw = list(sys.argv if argv is None else argv)
+    args = raw[1:]
+    stdin_text = _read_stdin()
+    is_compose, seam, remainder = split_argv(args)
+
+    handled = False
+    try:
+        if is_compose:
+            handled = _handle_compose(seam, args, remainder)
+        else:
+            handled = _handle_plain(seam, args, remainder)
+    finally:
+        log_invocation(
+            {
+                "argv": raw,
+                "args": args,
+                "compose": is_compose,
+                "seam": f"compose {seam}".strip() if is_compose else seam,
+                "handled": handled,
+                "cwd": os.getcwd(),
+                "stdin": stdin_text,
+                "pid": os.getpid(),
+                "ts": time.time(),
+            }
+        )
+
+    if not handled:
+        print(f"stub-runtime: unhandled invocation: {' '.join(raw)}", file=sys.stderr)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    return 0

--- a/tests/pty/stub_runtime/docker
+++ b/tests/pty/stub_runtime/docker
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""The stub ``docker`` the pty harness puts on PATH. All behaviour is in _stub_main."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+from _stub_main import main  # noqa: E402
+
+sys.exit(main())

--- a/tests/pty/test_live_region_real_terminal.py
+++ b/tests/pty/test_live_region_real_terminal.py
@@ -1,0 +1,1305 @@
+"""What an operator actually sees, read off a real terminal.
+
+Every other test in this repository reads the CLI's output through a capture
+object: a ``CliRunner``, a recording console, a probe handler. Each of those is
+a stand-in for a terminal, and each is right about a different half of it. None
+of them can answer the question this feature is about — whether a deploy that
+paints a live region over its own output leaves a screen a human can read.
+
+So this module asks the terminal. Each scenario allocates a pty with
+:func:`pty.openpty`, starts a real ``osprey`` verb on it as a subprocess against
+the exemplar repo and the stub runtime, and keeps every byte the process wrote
+to it, escape sequences included. The bytes are then replayed through
+:class:`Terminal` — a small emulator that understands exactly the control
+vocabulary Rich's ``Live`` uses — and the scenarios assert on the screen that
+comes out, not on the byte stream.
+
+**Garbling, operationally.** "The final screen is not garbled" is a judgement a
+test cannot make, so it is spelled here as four mechanical properties, checked
+together by :func:`assert_screen_is_intact`:
+
+1. *Every escape sequence in the stream is whole and understood.* The emulator
+   records any ``ESC`` that does not begin a complete sequence it models, and
+   any complete sequence outside that vocabulary. Interleaving — a log record
+   written into the middle of a repaint — shows up here first, because it
+   splits one sequence across another's bytes.
+2. *No region transient survives the teardown.* The region is ``transient``, so
+   once it is down no spinner frame and no table rule may remain on the screen.
+   A leftover row is a repaint the teardown did not take back.
+3. *No line is written twice.* A region that repaints over scrollback instead of
+   over itself duplicates the line under it; a permanent line may appear once.
+4. *The cursor is given back.* ``Live`` hides it on mount; a run that ends
+   without the matching show has left the operator's terminal broken.
+
+**Frame polling, never sleeps.** Nothing here waits a fixed time for the screen
+to reach a state. The reader loop polls the accumulated stream against a
+predicate with a generous deadline (:data:`RUN_TIMEOUT`), which is what makes
+the scenarios deterministic rather than merely usually-passing: a slow CI box
+takes longer, not a different path. The one thing that must be normalised out
+of any two-frame comparison is the spinner glyph — it advances on an 80 ms
+cadence and is the only wall-clock character the region draws.
+
+**Scenario 7 is the one an operator can see go wrong.** ``output.warn`` and
+``output.fail`` carry a stderr contract, and a stderr console escapes ``Live``'s
+redirection entirely — so a warning issued while a region is mounted used to be
+written at whatever column the region had left the cursor on, and stayed there
+with a dead spinner frame welded to its front. The renderer now hands those
+lines to the region's own console for as long as one is up, and scenario 7 pins
+that: the warning lands above the region, on its own row, in one piece.
+
+POSIX only. ``pty`` is a POSIX module and the whole module skips elsewhere.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import select
+import struct
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.pty,
+    pytest.mark.skipif(os.name != "posix", reason="a pty is a POSIX facility"),
+]
+
+# Guarded together, and for the same reason: all three are POSIX-only, and an
+# import error is raised at *collection*, which is before any skipif can apply.
+# An unguarded `import fcntl` would turn "this suite does not run on Windows"
+# into "the whole test session fails to collect on Windows".
+if os.name == "posix":  # pragma: no branch - the skip above covers the other side
+    import fcntl
+    import pty
+    import termios
+
+#: Terminal geometry every scenario runs in. Fixed so the screen a scenario
+#: asserts on is the same one everywhere: Rich takes its width from the pty's
+#: window size, and a developer's 210-column terminal would otherwise wrap
+#: different lines than CI's 80.
+TERMINAL_COLUMNS = 100
+TERMINAL_ROWS = 40
+
+#: How long any one scenario's process may take. Deliberately far above what
+#: the work costs (the slowest scenario is ~9 s, and that is a timeout it is
+#: *asserting* about): this is the harness giving up, and a generous ceiling is
+#: what keeps a loaded CI box from turning latency into a failure.
+RUN_TIMEOUT = 120.0
+
+#: How long :meth:`PtyProcess.wait_for` gives one screen state to appear.
+POLL_TIMEOUT = 60.0
+
+#: The bootstrap every scenario's subprocess runs. ``-c`` rather than the
+#: console script, so the run always uses the interpreter — and therefore the
+#: checkout — the tests are running from.
+CLI_BOOTSTRAP = "import sys; from osprey.cli.main import cli; sys.exit(cli())"
+
+#: Criterion 1's own shape: a ``RichHandler`` line at INFO with the timestamp
+#: column filled in.
+INFO_LINE = re.compile(r"\[\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\]\s+INFO")
+
+#: The same record when it is not the first of its second — ``RichHandler``
+#: leaves the timestamp column blank and prints the level alone. Criterion 1's
+#: regex alone would miss every INFO record but the first, so both are checked.
+INFO_LEVEL_COLUMN = re.compile(r"(?:^|\s)INFO {2,}\S")
+
+#: Rich's ``dots`` spinner, the region's only wall-clock character.
+SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+#: Box-drawing characters a rendered table rule is made of. None of the CLI's
+#: permanent lines use them, so one on the final screen is a region transient
+#: that outlived its region.
+BOX_DRAWING = "─│┌┐└┘├┤┬┴┼━┃╭╮╯╰"
+
+# ---------------------------------------------------------------------------
+# the terminal
+# ---------------------------------------------------------------------------
+
+
+class Terminal:
+    """A screen, replayed from what a process wrote to a pty.
+
+    Deliberately small. It models the control sequences Rich's ``Live`` and
+    ``Console`` actually emit — carriage return, line feed, erase-in-line,
+    erase-in-display, relative cursor motion, SGR, and cursor visibility — and
+    records anything else in :attr:`unsupported` rather than ignoring it. That
+    record is half of the garbling check: a stream this emulator cannot fully
+    parse is, by definition, a stream a terminal would have rendered as
+    something other than what the program meant.
+
+    Lines grow without bound: this is scrollback, not a viewport. A region is
+    drawn at the bottom of it and erased from the same place, which is exactly
+    how the real thing behaves for a region shorter than the screen.
+    """
+
+    #: One complete CSI sequence: ``ESC [`` parameters, final byte.
+    _CSI = re.compile(r"\x1b\[([0-9;?]*)([A-Za-z])")
+
+    def __init__(self) -> None:
+        self.lines: list[str] = [""]
+        self.row = 0
+        self.col = 0
+        self.cursor_hidden = False
+        #: Every ``ESC`` this emulator could not account for, as a repr of the
+        #: bytes around it. Non-empty means the screen below is a guess.
+        self.unsupported: list[str] = []
+        #: Cursor-visibility transitions, in order: ``"hide"`` / ``"show"``.
+        self.cursor_events: list[str] = []
+
+    # -- feeding ------------------------------------------------------------
+
+    def feed(self, data: str) -> None:
+        """Replay *data* onto the screen."""
+        index = 0
+        while index < len(data):
+            char = data[index]
+            if char == "\x1b":
+                index = self._escape(data, index)
+                continue
+            if char == "\r":
+                self.col = 0
+            elif char == "\n":
+                self._newline()
+            elif char == "\b":
+                self.col = max(0, self.col - 1)
+            elif char == "\t":
+                self._write(" " * (8 - self.col % 8))
+            elif char < " ":
+                # Any other C0 control would move the cursor in a way this
+                # emulator does not model; record it rather than drop it.
+                self.unsupported.append(repr(char))
+            else:
+                self._write(char)
+            index += 1
+
+    def _escape(self, data: str, index: int) -> int:
+        """Consume one escape sequence starting at *index*; return the next index."""
+        match = self._CSI.match(data, index)
+        if match is None:
+            self.unsupported.append(repr(data[index : index + 12]))
+            return index + 1
+        params, final = match.group(1), match.group(2)
+        self._csi(params, final, match.group(0))
+        return match.end()
+
+    def _csi(self, params: str, final: str, whole: str) -> None:
+        """Apply one parsed CSI sequence."""
+        if final == "m":  # SGR: styling only, no effect on the text
+            return
+        if params.startswith("?"):
+            if params == "?25" and final in "hl":
+                self.cursor_hidden = final == "l"
+                self.cursor_events.append("hide" if final == "l" else "show")
+                return
+            self.unsupported.append(repr(whole))
+            return
+        count = int(params) if params.isdigit() else (0 if params == "" else -1)
+        if count < 0:
+            self.unsupported.append(repr(whole))
+            return
+        if final == "A":
+            self.row = max(0, self.row - max(1, count))
+        elif final == "B":
+            for _ in range(max(1, count)):
+                self._newline(carriage_return=False)
+        elif final == "C":
+            self.col += max(1, count)
+        elif final == "D":
+            self.col = max(0, self.col - max(1, count))
+        elif final == "K":
+            self._erase_line(count)
+        elif final == "J":
+            self._erase_display(count)
+        else:
+            self.unsupported.append(repr(whole))
+
+    # -- primitives ---------------------------------------------------------
+
+    def _newline(self, *, carriage_return: bool = False) -> None:
+        self.row += 1
+        while len(self.lines) <= self.row:
+            self.lines.append("")
+        if carriage_return:
+            self.col = 0
+
+    def _write(self, text: str) -> None:
+        line = self.lines[self.row]
+        if len(line) < self.col:
+            line += " " * (self.col - len(line))
+        self.lines[self.row] = line[: self.col] + text + line[self.col + len(text) :]
+        self.col += len(text)
+
+    def _erase_line(self, mode: int) -> None:
+        line = self.lines[self.row]
+        if mode == 0:
+            self.lines[self.row] = line[: self.col]
+        elif mode == 1:
+            self.lines[self.row] = " " * min(self.col, len(line)) + line[self.col :]
+        else:
+            self.lines[self.row] = ""
+
+    def _erase_display(self, mode: int) -> None:
+        if mode in (0, 1):
+            self.lines[self.row] = self.lines[self.row][: self.col]
+            del self.lines[self.row + 1 :]
+        else:
+            self.lines = [""]
+            self.row = self.col = 0
+
+    # -- reading it back ----------------------------------------------------
+
+    def scrollback(self) -> list[str]:
+        """The screen as lines, right-stripped, with trailing blanks dropped.
+
+        Right-stripped because a repaint pads to the region's width and an
+        operator does not see the padding; trailing blanks dropped because the
+        teardown leaves the erased region's row behind as an empty one.
+        """
+        lines = [line.rstrip() for line in self.lines]
+        while lines and not lines[-1]:
+            lines.pop()
+        return lines
+
+
+def strip_ansi(text: str) -> str:
+    """*text* with every escape sequence removed, and nothing else changed."""
+    return re.sub(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b.", "", text)
+
+
+def without_spinner_frames(text: str) -> str:
+    """*text* with every spinner glyph normalised to a single placeholder.
+
+    Two paints of the same region differ by exactly this one character (plus
+    the ticker, which only moves once a second). Comparing paints without
+    normalising it compares the wall clock.
+    """
+    return re.sub(f"[{SPINNER_FRAMES}]", "*", text)
+
+
+# ---------------------------------------------------------------------------
+# running a verb on one
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PtyRun:
+    """One verb, run on a real terminal, and everything it wrote there."""
+
+    argv: list[str]
+    exit_code: int
+    raw: bytes
+    #: The screen after the last byte, as scrollback lines.
+    screen: list[str] = field(default_factory=list)
+    #: Everything ever written, escapes stripped — including region frames the
+    #: teardown has since erased. This is the *stream*, not the screen.
+    stream: str = ""
+    #: The undecodable or unmodelled escapes the emulator met, if any.
+    unsupported: list[str] = field(default_factory=list)
+    #: Cursor hide/show transitions, in order.
+    cursor_events: list[str] = field(default_factory=list)
+
+    @property
+    def screen_text(self) -> str:
+        """The final screen as one string."""
+        return "\n".join(self.screen)
+
+    def describe(self) -> str:
+        """A failure message worth reading: the exit code and the final screen."""
+        return f"argv={self.argv} exit={self.exit_code}\n--- final screen ---\n" + self.screen_text
+
+
+class PtyProcess:
+    """A verb running on a pty, readable while it runs.
+
+    Held open by :func:`run_on_pty` so a scenario can wait for something to
+    appear on the screen and then type at it — the interactive shape a
+    ``CliRunner`` cannot reproduce, because the prompt and the region are
+    competing for the same terminal.
+    """
+
+    def __init__(self, argv: list[str], cwd: Path, env: dict[str, str], bootstrap: str) -> None:
+        self.argv = argv
+        self._master, slave = pty.openpty()
+        fcntl.ioctl(
+            slave, termios.TIOCSWINSZ, struct.pack("HHHH", TERMINAL_ROWS, TERMINAL_COLUMNS, 0, 0)
+        )
+        self._buffer = bytearray()
+        self._master_closed = False
+        self._process = subprocess.Popen(  # noqa: S603 - argv is built here, not by input
+            [sys.executable, "-c", bootstrap, *argv],
+            cwd=str(cwd),
+            env=env,
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            # Its own session, so the pty is the child's controlling terminal
+            # and a signal aimed at the test runner's group cannot reach it.
+            start_new_session=True,
+            close_fds=True,
+        )
+        os.close(slave)
+
+    # -- reading ------------------------------------------------------------
+
+    def _pump(self, timeout: float) -> bool:
+        """Read whatever is available within *timeout*; False at end of stream."""
+        try:
+            ready, _, _ = select.select([self._master], [], [], timeout)
+        except OSError:
+            return False
+        if not ready:
+            return True
+        try:
+            chunk = os.read(self._master, 65536)
+        except OSError:
+            # Every slave descriptor is closed: on Linux that is EOF, on macOS
+            # it is EIO. Both mean the same thing here.
+            return False
+        if not chunk:
+            return False
+        self._buffer.extend(chunk)
+        return True
+
+    def text(self) -> str:
+        """Everything written so far, escapes stripped."""
+        return strip_ansi(self._buffer.decode("utf-8", "replace"))
+
+    def wait_for(self, pattern: str, *, timeout: float = POLL_TIMEOUT) -> None:
+        """Poll the stream until *pattern* appears, or fail saying what did.
+
+        The harness's whole substitute for sleeping. A scenario that needs the
+        screen to have reached a state waits for the state, so a slow machine
+        costs seconds rather than a red test.
+        """
+        deadline = time.monotonic() + timeout
+        compiled = re.compile(pattern)
+        while time.monotonic() < deadline:
+            if compiled.search(self.text()):
+                return
+            if not self._pump(0.05) and not compiled.search(self.text()):
+                break
+        pytest.fail(
+            f"{pattern!r} never appeared on the terminal within {timeout:.0f}s.\n"
+            f"--- stream so far ---\n{self.text()}"
+        )
+
+    def send(self, data: str) -> None:
+        """Type *data* at the terminal, as an operator's keyboard would."""
+        os.write(self._master, data.encode("utf-8"))
+
+    # -- ending -------------------------------------------------------------
+
+    def _close_master(self) -> None:
+        """Release the pty master, at most once."""
+        if not self._master_closed:
+            self._master_closed = True
+            os.close(self._master)
+
+    def abandon(self) -> None:
+        """Kill the child and release the pty, for a run that will not finish.
+
+        Every path out of a scenario that is not :meth:`finish` comes through
+        here. It matters more than it looks: the child is started in its own
+        session, so nothing aimed at the test runner's process group reaches
+        it, and it would outlive not just the test but the whole pytest run.
+        Scenario 6 is the sharp case — an ``osprey up -d`` waiting at a prompt
+        that no one is going to answer would sit there indefinitely, holding
+        its repo copy, its pty and its stub log open.
+        """
+        try:
+            self._process.kill()
+        except OSError:  # pragma: no cover - already reaped
+            pass
+        else:
+            self._process.wait()
+        self._close_master()
+
+    def finish(self, *, timeout: float = RUN_TIMEOUT) -> PtyRun:
+        """Read to end of stream, reap the process, and build the screen."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self._pump(0.1):
+                break
+        else:
+            self.abandon()
+            pytest.fail(
+                f"{self.argv} did not finish within {timeout:.0f}s.\n"
+                f"--- stream so far ---\n{self.text()}"
+            )
+        self._close_master()
+        try:
+            exit_code = self._process.wait(timeout=30)
+        except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+            self._process.kill()
+            exit_code = self._process.wait()
+
+        terminal = Terminal()
+        terminal.feed(bytes(self._buffer).decode("utf-8", "replace"))
+        return PtyRun(
+            argv=self.argv,
+            exit_code=exit_code,
+            raw=bytes(self._buffer),
+            screen=terminal.scrollback(),
+            stream=strip_ansi(bytes(self._buffer).decode("utf-8", "replace")),
+            unsupported=terminal.unsupported,
+            cursor_events=terminal.cursor_events,
+        )
+
+
+def run_on_pty(
+    argv: Sequence[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    bootstrap: str = CLI_BOOTSTRAP,
+    interact: Callable[[PtyProcess], None] | None = None,
+) -> PtyRun:
+    """Run one verb on a fresh pty and return everything it painted.
+
+    Args:
+        argv: Arguments after ``osprey``.
+        cwd: Directory to run in — a writable repo copy, never the exemplar.
+        env: The child's whole environment, stub runtime included.
+        bootstrap: The ``python -c`` program that starts the CLI. Scenarios that
+            need to reach inside the process (the degraded-region one) pass
+            their own, which is the only cross-process seam a subprocess has.
+        interact: Called with the live process once it is started, for scenarios
+            that answer a prompt. If it raises — a ``pytest.fail`` out of
+            ``wait_for``, an ``OSError`` out of ``send`` — the child is killed
+            and the pty released before the failure propagates. ``BaseException``
+            rather than ``Exception`` on purpose: ``pytest.fail`` raises one, and
+            catching the narrower class would leak the child on exactly the path
+            most likely to be taken.
+    """
+    process = PtyProcess(list(argv), cwd, env, bootstrap)
+    if interact is not None:
+        try:
+            interact(process)
+        except BaseException:
+            process.abandon()
+            raise
+    return process.finish()
+
+
+# ---------------------------------------------------------------------------
+# assertions
+# ---------------------------------------------------------------------------
+
+
+def assert_screen_is_intact(run: PtyRun) -> None:
+    """The four mechanical properties of an ungarbled screen (see module docs).
+
+    Held by every scenario without exception. There was one until the renderer
+    stopped writing trouble past a mounted region — scenario 7's warnings came
+    back with a spinner frame welded on — and the exemption that made room for
+    it is gone with the defect, deliberately: an escape hatch nothing needs is a
+    hatch the next damaged line slips through.
+    """
+    assert not run.unsupported, (
+        f"the terminal stream contains escape bytes this emulator could not parse as whole "
+        f"sequences, which is what an interleaved write looks like from outside: "
+        f"{run.unsupported[:5]}\n{run.describe()}"
+    )
+
+    leftovers = [
+        line
+        for line in run.screen
+        if any(glyph in line for glyph in SPINNER_FRAMES)
+        or any(glyph in line for glyph in BOX_DRAWING)
+    ]
+    assert not leftovers, f"region transients survived the teardown: {leftovers}\n{run.describe()}"
+
+    seen: dict[str, int] = {}
+    for line in run.screen:
+        if line.strip():
+            seen[line] = seen.get(line, 0) + 1
+    repeated = {line: count for line, count in seen.items() if count > 1}
+    assert not repeated, (
+        f"lines appear more than once on the final screen, which is what a repaint over "
+        f"scrollback leaves behind: {repeated}\n{run.describe()}"
+    )
+
+    assert run.cursor_events, f"no cursor visibility control at all\n{run.describe()}"
+    assert run.cursor_events[-1] == "show", (
+        f"the run ended with the cursor still hidden ({run.cursor_events}); the operator's "
+        f"terminal is left broken\n{run.describe()}"
+    )
+
+
+def info_shaped_lines(run: PtyRun) -> list[str]:
+    """Every line on the terminal that reads as a rendered INFO record.
+
+    Read off the whole *stream*, not the final screen: a record that flashed
+    inside a region and was erased by the next repaint was still on the
+    operator's terminal.
+    """
+    return [
+        line
+        for line in run.stream.splitlines()
+        if INFO_LINE.search(line) or INFO_LEVEL_COLUMN.search(line)
+    ]
+
+
+def assert_no_info_lines(run: PtyRun) -> None:
+    """Criterion 1: nothing INFO-shaped anywhere the operator could have seen it."""
+    offenders = info_shaped_lines(run)
+    assert not offenders, f"INFO-shaped lines in the default view: {offenders}\n{run.describe()}"
+
+
+def assert_region_was_mounted_when(run: PtyRun, needle: str) -> None:
+    """*needle* was written while the region was up, not before or after it.
+
+    Asked of the raw bytes rather than of the screen, because the screen is
+    what is left *after* the teardown and cannot say when a line arrived. A
+    region is up exactly while a cursor-hide has no matching show, so the test
+    is: count both in everything written before the needle.
+    """
+    text = run.raw.decode("utf-8", "replace")
+    at = text.find(needle)
+    assert at >= 0, f"{needle!r} is nowhere in the stream\n{run.describe()}"
+    before = text[:at]
+    assert before.count("\x1b[?25l") > before.count("\x1b[?25h"), (
+        f"{needle!r} was written with no region mounted, so this scenario is not about "
+        f"what it says it is about\n{run.describe()}"
+    )
+
+
+def region_frames(run: PtyRun) -> list[str]:
+    """Every write that carried a spinner glyph — one per repaint.
+
+    A repaint always starts with a carriage return (Rich returns to column
+    zero, erases, and draws), so splitting the stream on ``\\r`` cuts it into
+    candidate frames. The line feed a preceding permanent line ended with rides
+    along on the front of the frame that follows it and is stripped: it belongs
+    to the line above, not to the picture.
+    """
+    return [
+        segment.strip("\n")
+        for segment in run.stream.split("\r")
+        if any(glyph in segment for glyph in SPINNER_FRAMES)
+    ]
+
+
+def assert_region_was_live(run: PtyRun) -> None:
+    """The region mounted, repainted at least twice, and came down.
+
+    "Repainted" is asserted through the spinner *advancing*: one frame drawn
+    twice would be a static region, and the monitor thread is what this proves
+    is running.
+    """
+    assert run.cursor_events[:1] == ["hide"], (
+        f"the region never mounted (no cursor hide)\n{run.describe()}"
+    )
+    frames = region_frames(run)
+    assert len(frames) >= 2, f"the region painted {len(frames)} frame(s)\n{run.describe()}"
+    glyphs = {glyph for frame in frames for glyph in SPINNER_FRAMES if glyph in frame}
+    assert len(glyphs) >= 2, (
+        f"the region painted {len(frames)} frames but the spinner never advanced "
+        f"({glyphs}), so nothing was repainting it\n{run.describe()}"
+    )
+    assert run.cursor_events[-1] == "show", f"the region never came down\n{run.describe()}"
+
+
+# ---------------------------------------------------------------------------
+# scenario 0 — the harness cleans up after itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_harness_kills_a_child_it_gave_up_on(tmp_path: Path, pty_env: dict[str, str]) -> None:
+    """A scenario that fails mid-interaction must not leave its verb running.
+
+    This is about the harness rather than the CLI, and it is here because the
+    failure mode is invisible from inside a test run: children are started in
+    their own session, so nothing aimed at the runner's process group reaches
+    them, and one left behind by a failed interactive scenario would outlive
+    the whole pytest session holding a pty and a repo copy open. A developer
+    would meet it later as a machine with stray ``osprey up`` processes on it,
+    with nothing to connect them to the test that failed an hour earlier.
+
+    Driven with a bare sleeping program rather than a verb: what is under test
+    is the harness's cleanup path, and a real deploy would only make the same
+    assertion slower and less certain.
+    """
+    captured: list[PtyProcess] = []
+
+    def give_up(process: PtyProcess) -> None:
+        captured.append(process)
+        raise RuntimeError("this scenario gave up")
+
+    with pytest.raises(RuntimeError, match="gave up"):
+        run_on_pty(
+            [],
+            cwd=tmp_path,
+            env=pty_env,
+            bootstrap="import time; time.sleep(600)",
+            interact=give_up,
+        )
+
+    assert captured, "the interaction never ran, so nothing was under test"
+    process = captured[0]
+    assert process._process.poll() is not None, (
+        "the child outlived the scenario that gave up on it, and nothing in this "
+        "session will ever reap it"
+    )
+    assert process._master_closed, "the pty master was leaked"
+    with pytest.raises(OSError):
+        os.read(process._master, 1)
+
+
+# ---------------------------------------------------------------------------
+# scenario 1 — the default view
+# ---------------------------------------------------------------------------
+
+
+def test_the_scripted_deploy_shows_no_info_shaped_lines(
+    startable_repo: Path, pty_env: dict[str, str]
+) -> None:
+    """Criterion 1, on the terminal it is written about.
+
+    The scripted deploy is ``osprey up -d`` against the stub runtime: it runs
+    the real start path end to end, and every fact it decides to tell the
+    operator is a printed line rather than a log record. Nothing INFO-shaped
+    may reach the screen.
+    """
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env)
+
+    assert run.exit_code == 0, run.describe()
+    assert_no_info_lines(run)
+    assert "✓ Preflight" in run.screen_text, run.describe()
+    assert "running" in run.screen_text, run.describe()
+
+
+def test_verbose_puts_the_transcript_back_on_the_same_terminal(
+    startable_repo: Path, pty_env: dict[str, str]
+) -> None:
+    """The armed witness for the scenario above.
+
+    Zero INFO lines is only evidence of a gate if the same harness, on the same
+    verb, can see INFO lines when the gate is lifted. ``osprey -v up -d`` is
+    that run: the gate is off, and the records the default view withheld are
+    on the screen in the shape the regex is looking for.
+    """
+    run = run_on_pty(["-v", "up", "-d"], cwd=startable_repo, env=pty_env)
+
+    assert run.exit_code == 0, run.describe()
+    assert info_shaped_lines(run), (
+        f"the harness saw no INFO-shaped line even with the gate lifted, so its absence "
+        f"in the default view proves nothing\n{run.describe()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# scenario 2 — the region's own life
+# ---------------------------------------------------------------------------
+
+
+def test_the_region_mounts_repaints_and_tears_down_clean(
+    startable_repo: Path, pty_env: dict[str, str], unhurried_runtime: None
+) -> None:
+    """Mount, repaint, teardown — and a screen with nothing of the region left."""
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env)
+
+    assert run.exit_code == 0, run.describe()
+    assert_region_was_live(run)
+    assert_screen_is_intact(run)
+
+
+def test_two_paints_of_the_region_differ_only_by_the_clock(
+    startable_repo: Path, pty_env: dict[str, str], unhurried_runtime: None
+) -> None:
+    """Consecutive frames are the same picture, redrawn — not two pictures.
+
+    With the spinner normalised out, two adjacent frames of the same open phase
+    must be identical apart from the elapsed ticker. A frame that differs
+    otherwise is one that painted something else into the region's row.
+    """
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env)
+
+    assert run.exit_code == 0, run.describe()
+    frames = [without_spinner_frames(frame).rstrip() for frame in region_frames(run)]
+    assert len(frames) >= 2, run.describe()
+    normalised = {re.sub(r"\d+m\d+s", "<elapsed>", frame) for frame in frames}
+    assert len(normalised) == 1, (
+        f"the region's frames are not repaints of one picture: {normalised}\n{run.describe()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# scenario 3 — a record arriving while the region is up
+# ---------------------------------------------------------------------------
+
+
+def test_a_warning_lands_intact_above_a_mounted_region(
+    startable_repo: Path, pty_env: dict[str, str], unhurried_runtime: None
+) -> None:
+    """A real WARNING from the start path, on a real terminal, above the region.
+
+    Provoked rather than injected: the start path compares the shell's exports
+    against the deployment's env chain and warns when an exported value
+    disagrees with the pinned one for a variable the compose files interpolate.
+    Seeding ``ZO_ROOT_USER_PASSWORD`` into the repo's ``.env`` and exporting a
+    different value for the run is the operator mistake that produces it — and
+    it produces it in the middle of the start phase, with the region mounted
+    and the monitor thread repainting.
+
+    Intact means: the record's own lines are consecutive on the final screen,
+    with the ``RichHandler`` level column at its usual width, and no region
+    frame anywhere between them.
+    """
+    env_path = startable_repo / ".env"
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8") + "ZO_ROOT_USER_PASSWORD=Chain5ide!Value\n",
+        encoding="utf-8",
+    )
+    pty_env["ZO_ROOT_USER_PASSWORD"] = "Exp0rted!Value"
+
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env)
+
+    assert run.exit_code == 0, run.describe()
+    assert_screen_is_intact(run)
+
+    screen = run.screen
+    heads = [index for index, line in enumerate(screen) if re.search(r"\bWARNING {2}\S", line)]
+    assert len(heads) == 1, f"expected exactly one WARNING record\n{run.describe()}"
+    head = heads[0]
+    assert "Shell export disagrees with this deployment's env chain" in screen[head], run.describe()
+    assert_region_was_mounted_when(run, "Shell export disagrees")
+
+    # The record wraps at the terminal's width, so "intact" is about the block:
+    # every line of it is consecutive, the variable it names is in there, and
+    # no region frame is drawn between any two of its lines.
+    body = screen[head : head + 6]
+    assert "ZO_ROOT_USER_PASSWORD" in "".join(body), run.describe()
+    assert all(not any(glyph in line for glyph in SPINNER_FRAMES) for line in body), (
+        "a region frame is interleaved with the record:\n" + "\n".join(body)
+    )
+
+    # And it is above the region, not inside it: the phase the region was
+    # drawing for closes after the record.
+    closing = [index for index, line in enumerate(screen) if "✓ Starting" in line]
+    assert closing and closing[0] > head, (
+        f"the record did not land above the open phase's region\n{run.describe()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# scenario 4 — a step whose child outlives its timeout
+# ---------------------------------------------------------------------------
+
+
+#: A lifecycle step that leaves a grandchild holding its stdout, then hangs
+#: until the timeout kills it. The grandchild writes long after the step has
+#: been decided — which is the line that must never reach the terminal.
+OVERRUNNING_STEP = """\
+import subprocess
+import sys
+import time
+
+subprocess.Popen(
+    [
+        sys.executable,
+        "-c",
+        "import sys, time; time.sleep(8); "
+        "sys.stdout.write('LATE-LINE-FROM-GRANDCHILD\\\\n'); sys.stdout.flush()",
+    ]
+)
+sys.stdout.write("EARLY-LINE-FROM-STEP\\n")
+sys.stdout.flush()
+time.sleep(600)
+"""
+
+#: Appended to the copy's ``profile.yml``. ``stream: true`` is what puts the
+#: step's own output on the terminal through the drain thread; ``timeout: 1``
+#: is what makes it overrun.
+OVERRUN_LIFECYCLE = """
+lifecycle:
+  post_build:
+    - name: overrunning step
+      run: {python} {script}
+      timeout: 1
+      stream: true
+"""
+
+
+def test_a_step_whose_child_overruns_its_timeout_never_reaches_the_screen(
+    exemplar_copy: Path, pty_env: dict[str, str], tmp_path: Path
+) -> None:
+    """The stop-event fix, end to end on a terminal.
+
+    A streamed lifecycle step spawns a grandchild that inherits its stdout and
+    then hangs. The step's own timeout kills it; the grandchild survives,
+    holding the pipe open with the drain thread still blocked in ``readline``,
+    and writes a line seconds later — after the step has been reported failed.
+    That line must be dropped, because by then the terminal belongs to whatever
+    the CLI is drawing next.
+
+    The step script lives outside the repo: the build warns about unrecognized
+    top-level entries, and a stray file in the repo root would arm a different
+    scenario's assertion.
+    """
+    script = tmp_path / "overrunning_step.py"
+    script.write_text(OVERRUNNING_STEP, encoding="utf-8")
+    profile = exemplar_copy / "profile.yml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8")
+        + OVERRUN_LIFECYCLE.format(python=sys.executable, script=script),
+        encoding="utf-8",
+    )
+
+    run = run_on_pty(["build", "--skip-deps"], cwd=exemplar_copy, env=pty_env)
+
+    # The step failed, which is the point: it overran.
+    assert run.exit_code != 0, run.describe()
+    assert "EARLY-LINE-FROM-STEP" in run.stream, run.describe()
+    assert "LATE-LINE-FROM-GRANDCHILD" not in run.stream, (
+        f"a line from a step's orphaned grandchild reached the terminal after the step "
+        f"was reported\n{run.describe()}"
+    )
+    assert "overrunning step' failed" in run.stream, run.describe()
+    assert_no_info_lines(run)
+    assert_screen_is_intact(run)
+
+
+# ---------------------------------------------------------------------------
+# scenario 5 — a repaint that raises
+# ---------------------------------------------------------------------------
+
+
+#: The degraded-region seam. A repaint failure has no product-level trigger —
+#: it is Rich or the renderer going wrong — so the scenario reaches into the
+#: subprocess the only way a subprocess can be reached: by choosing the program
+#: that starts it. The patch is applied where ``PhaseReporter`` reads the name
+#: (it imports it into its own namespace), before the CLI is imported at all,
+#: and a marker file records that the injected failure really fired — without
+#: it the scenario could pass by never having degraded anything.
+DEGRADING_BOOTSTRAP = """
+import os
+import sys
+
+from osprey.cli import phase_reporter
+
+_real = phase_reporter.render_live_region
+_paints = [0]
+
+
+def _fail_after_the_second_paint(*args, **kwargs):
+    _paints[0] += 1
+    if _paints[0] > 2:
+        with open(os.environ["OSPREY_PTY_DEGRADE_MARKER"], "w") as handle:
+            handle.write(str(_paints[0]))
+        raise RuntimeError("injected repaint failure")
+    return _real(*args, **kwargs)
+
+
+phase_reporter.render_live_region = _fail_after_the_second_paint
+
+from osprey.cli.main import cli
+
+sys.exit(cli())
+"""
+
+
+def test_a_repaint_that_raises_degrades_to_plain_lines(
+    startable_repo: Path, pty_env: dict[str, str], tmp_path: Path, unhurried_runtime: None
+) -> None:
+    """The region dies; the deploy does not, and the screen stays readable.
+
+    A repaint that raises takes the region down and leaves the run to finish as
+    a plain-line run — decoration is the only thing an operator may lose. On a
+    real terminal that means: the run still exits 0 and still says everything
+    it was going to say, no half-drawn frame is left behind, and the cursor
+    comes back even though nothing ever called the normal teardown.
+    """
+    marker = tmp_path / "degraded.marker"
+    pty_env["OSPREY_PTY_DEGRADE_MARKER"] = str(marker)
+
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env, bootstrap=DEGRADING_BOOTSTRAP)
+
+    assert marker.is_file(), (
+        f"the injected repaint failure never fired, so nothing degraded and this scenario "
+        f"asserted nothing\n{run.describe()}"
+    )
+    assert run.exit_code == 0, run.describe()
+    assert "✓ Preflight" in run.screen_text, run.describe()
+    assert "running" in run.screen_text, run.describe()
+    assert_no_info_lines(run)
+    assert_screen_is_intact(run)
+
+
+# ---------------------------------------------------------------------------
+# scenario 6 — a prompt under a mounted region
+# ---------------------------------------------------------------------------
+
+
+def test_the_env_seed_prompt_is_readable_under_a_mounted_region(
+    startable_repo: Path, pty_env: dict[str, str]
+) -> None:
+    """The suspended-prompt path, with a real keyboard answer.
+
+    ``up`` refuses a repo with no ``.env``, and on an interactive terminal it
+    offers to seed one from the shell first. That question is asked inside the
+    Preflight phase, so the region is mounted and the monitor thread is
+    repainting a spinner one line below where the operator is reading. The
+    reporter suspends the region for the prompt; this asserts that it does,
+    from the outside: the question is on the screen intact, the answer echoes
+    after it, and no spinner is drawn over either.
+    """
+    (startable_repo / ".env").unlink()
+    pty_env["ANTHROPIC_API_KEY"] = "sk-ant-exported-0000000000000000000000"
+
+    def answer(process: PtyProcess) -> None:
+        process.wait_for(r"Seed one from your shell")
+        process.send("y\n")
+
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env, interact=answer)
+
+    assert run.exit_code == 0, run.describe()
+    assert (startable_repo / ".env").is_file(), run.describe()
+
+    asked = [line for line in run.screen if "Seed one from your shell" in line]
+    assert len(asked) == 1, f"the prompt is not on the screen once\n{run.describe()}"
+    assert "ANTHROPIC_API_KEY" in asked[0], run.describe()
+    assert not any(glyph in asked[0] for glyph in SPINNER_FRAMES), (
+        f"the region painted over the question\n{run.describe()}"
+    )
+    # The prompt's line carries the operator's own echoed answer, and the
+    # deploy continues below it.
+    assert asked[0].rstrip().endswith("y"), (
+        f"the typed answer did not echo on the prompt line\n{run.describe()}"
+    )
+    assert_no_info_lines(run)
+    assert_screen_is_intact(run)
+
+
+# ---------------------------------------------------------------------------
+# scenario 7 — warn()/fail() from inside a mounted phase
+# ---------------------------------------------------------------------------
+
+
+#: A validate-phase step that fails. The validate phase does not abort a build,
+#: so the renderer's ``warn()`` runs with the region still mounted and the build
+#: carries on to its summary card — which is what makes this the scenario that
+#: characterizes the stderr-console bypass.
+FAILING_VALIDATE_LIFECYCLE = """
+lifecycle:
+  validate:
+    - name: failing check
+      run: {python} -c "import sys; sys.stdout.write('CHECK-SAYS-NO\\n'); sys.exit(3)"
+      timeout: 60
+      stream: true
+"""
+
+
+def test_a_warn_from_inside_a_mounted_phase_does_not_take_the_screen_with_it(
+    exemplar_copy: Path, pty_env: dict[str, str]
+) -> None:
+    """The known hazard, characterized on a real terminal.
+
+    ``output.warn()`` and ``output.fail()`` print through ``styles.err_console``,
+    and Rich unwraps its own ``FileProxy`` for a stderr console — so a mounted
+    live region does not capture them and the line is written straight to the
+    terminal, possibly mid-repaint. The region survives (it is transient and
+    the next tick repaints it), but nothing places the line *above* the region
+    the way a borrowed log console does.
+
+    This pins what that actually looks like: a failing ``validate`` step, whose
+    ``warn()`` lands while the build's region is mounted and the build then
+    continues to its summary card. The assertion is the screen — the warning is
+    on it, whole and on its own line, and the region left nothing behind.
+    """
+    profile = exemplar_copy / "profile.yml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8")
+        + FAILING_VALIDATE_LIFECYCLE.format(python=sys.executable),
+        encoding="utf-8",
+    )
+
+    run = run_on_pty(["build", "--skip-deps"], cwd=exemplar_copy, env=pty_env)
+
+    assert run.exit_code == 0, run.describe()
+    warned = [line for line in run.screen if "failing check' failed" in line]
+    assert len(warned) == 1, f"the warning is not on the screen once\n{run.describe()}"
+    assert warned[0].lstrip().startswith("⚠"), (
+        f"the warning did not render as the renderer's warn shape\n{run.describe()}"
+    )
+    assert not any(glyph in warned[0] for glyph in SPINNER_FRAMES), (
+        f"a region frame is interleaved with the warning line\n{run.describe()}"
+    )
+    assert "built" in run.screen_text, (
+        f"the build did not finish after the warning\n{run.describe()}"
+    )
+    assert_region_was_mounted_when(run, "failing check' failed")
+    assert_no_info_lines(run)
+    assert_screen_is_intact(run)
+
+
+#: The dangerous position, occupied on purpose. The scenario above is the one a
+#: *shipped* call site can reach today, and it lands while the region is mounted
+#: but drawing nothing, because the lifecycle phases run outside any open phase.
+#: The position that used to weld is a ``warn()`` issued from inside an open
+#: phase, and no shipped call site sits there yet. So this bootstrap puts one
+#: there, at the worst instruction it could occupy: the return of ``Phase.step``,
+#: one statement after the reporter has printed the sub-step line and the region
+#: has redrawn itself under it. The cursor is parked at the end of that frame,
+#: and a line written straight at the terminal would go on top of it.
+#:
+#: Synchronous, not a thread. A background burst reached the same instant only
+#: for whichever warnings happened to fall right after a repaint — two of eight,
+#: measured. Riding the step call reaches it on purpose, so the scenario asserts
+#: a property of the code rather than of the scheduler.
+HAZARD_BOOTSTRAP = """
+import sys
+
+from osprey.cli import output, phase_reporter
+
+_real_step = phase_reporter.Phase.step
+_issued = []
+
+
+def _step(self, name):
+    _real_step(self, name)
+    index = len(_issued)
+    _issued.append(name)
+    output.warn(f"probe warning {index}", f"detail {index}, one statement after a repaint")
+
+
+phase_reporter.Phase.step = _step
+
+from osprey.cli.main import cli
+
+sys.exit(cli())
+"""
+
+#: The same injection point, handed straight to the reporter's console instead
+#: of going through the renderer's trouble primitive. The control for the
+#: scenario below: what differs between the two runs is the route the line
+#: takes, and nothing else.
+CONTROL_BOOTSTRAP = HAZARD_BOOTSTRAP.replace(
+    'output.warn(f"probe warning {index}", f"detail {index}, one statement after a repaint")',
+    'phase_reporter.current_reporter().out().print(f"probe warning {index}")',
+)
+assert CONTROL_BOOTSTRAP != HAZARD_BOOTSTRAP, (
+    "the control's substitution missed, so it would run the hazard's own program and "
+    "'proves the stream is what differs' would be measuring nothing"
+)
+
+#: The tail of the detail line :data:`HAZARD_BOOTSTRAP` prints under each
+#: warning. Spelled here as well as inside the bootstrap so the placement
+#: assertion can name it, with an import-time check that the two still agree —
+#: a reworded bootstrap would otherwise leave the assertion looking for copy
+#: nothing prints any more.
+HAZARD_DETAIL_TAIL = "one statement after a repaint"
+assert HAZARD_DETAIL_TAIL in HAZARD_BOOTSTRAP, (
+    "the detail copy asserted on is not the copy the hazard bootstrap prints"
+)
+
+#: A burst spaced to straddle several of the monitor's 0.25 s repaints, for the
+#: scenario that asks what concurrency alone does to the same line.
+BURST_BOOTSTRAP = """
+import sys
+import threading
+import time
+
+from osprey.cli import output, phase_reporter
+
+_real_step = phase_reporter.Phase.step
+_started = []
+
+
+def _burst():
+    for index in range(8):
+        output.warn(f"probe warning {index}", f"detail {index}, issued while the region drew")
+        time.sleep(0.1)
+
+
+def _step(self, name):
+    _real_step(self, name)
+    if not _started:
+        _started.append(True)
+        threading.Thread(target=_burst).start()
+
+
+phase_reporter.Phase.step = _step
+
+from osprey.cli.main import cli
+
+sys.exit(cli())
+"""
+
+#: How many warnings :data:`BURST_BOOTSTRAP` issues. The thread is deliberately
+#: NOT a daemon: a burst cut off by process exit would leave a half-written line
+#: that looks exactly like the garbling these scenarios exist to detect, and the
+#: harness must not manufacture its own evidence.
+BURST_WARNINGS = 8
+
+
+def probe_warning_rows(run: PtyRun) -> list[int]:
+    """The screen row of every line carrying a probe warning's summary."""
+    return [
+        row
+        for row, line in enumerate(run.screen)
+        if re.search(r"probe warning \d+$", line.rstrip())
+    ]
+
+
+def probe_warning_lines(run: PtyRun) -> list[str]:
+    """Every final-screen line carrying a probe warning's summary."""
+    return [run.screen[row] for row in probe_warning_rows(run)]
+
+
+def sub_step_lines(run: PtyRun) -> list[str]:
+    """Every sub-step line the deploy printed under an open phase.
+
+    The two bootstraps that ride ``Phase.step`` issue exactly one line per
+    sub-step, so this is what their count is checked against — a scenario that
+    hardcoded "two warnings" would go quietly vacuous the day the start path
+    gains or loses a step.
+    """
+    return [line for line in run.screen if re.match(r"\s*· \S", line)]
+
+
+def test_a_warn_issued_from_inside_an_open_phase_lands_above_the_region(
+    startable_repo: Path, pty_env: dict[str, str], unhurried_runtime: None
+) -> None:
+    """A warning from the worst instruction in the verb, read off the terminal.
+
+    ``warn()`` and ``fail()`` carry a stderr contract, and Rich unwraps its own
+    ``FileProxy`` for a stderr console — so a line written there while a region
+    is mounted goes straight at the terminal, at whatever column the cursor was
+    left at. One statement after a sub-step that column is the end of the frame
+    the region has just redrawn, so the warning used to be printed onto the
+    region's own row and left there: the region redraws a row lower and never
+    takes that one back.
+
+    The renderer now gives a mounted region the trouble line, the same borrow
+    the log handler gets, and this is what that buys on a real terminal: every
+    warning on its own row, its own first character first, its detail line
+    intact underneath it, and — through the unexempted
+    :func:`assert_screen_is_intact` — not one spinner frame left anywhere on the
+    final screen.
+    """
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env, bootstrap=HAZARD_BOOTSTRAP)
+
+    assert run.exit_code == 0, run.describe()
+    warnings = probe_warning_lines(run)
+    steps = sub_step_lines(run)
+    assert steps, f"the deploy printed no sub-step to ride\n{run.describe()}"
+    assert len(warnings) == len(steps), (
+        f"one warning per sub-step was issued but {len(warnings)} of {len(steps)} reached the "
+        f"screen\n{run.describe()}"
+    )
+    # The set asserted on below is pinned by an anchored pattern, so a warning
+    # whose line came out a different shape would drop out of it rather than
+    # fail it — the damage removing itself from the check. The two predicates
+    # are made to agree here, on this run's own screen, before either is used.
+    assert warnings == [line for line in run.screen if "probe warning" in line], (
+        f"a line carries a probe warning but is not shaped like one, so it escaped the "
+        f"assertions below\n{run.describe()}"
+    )
+
+    for index, line in enumerate(warnings):
+        assert line.strip() == f"⚠ probe warning {index}", (
+            f"the warning did not land on its own row in one piece: {line!r}. A region frame "
+            f"on the front of it means trouble is being written past the region again\n"
+            f"{run.describe()}"
+        )
+
+    # The detail belonging to each warning is on the row immediately below it,
+    # in one piece. Without this the docstring's "its detail line lands under
+    # it" would be a claim the test never checks.
+    for index, row in enumerate(probe_warning_rows(run)):
+        detail = run.screen[row + 1].strip()
+        assert detail == f"detail {index}, {HAZARD_DETAIL_TAIL}", (
+            f"the warning's detail line is not intact on the row under it: {detail!r}\n"
+            f"{run.describe()}"
+        )
+
+    assert_region_was_mounted_when(run, "probe warning 0")
+    assert_region_was_live(run)
+    assert_screen_is_intact(run)
+
+
+def test_control_the_same_line_through_the_reporter_console_never_welds(
+    startable_repo: Path, pty_env: dict[str, str], unhurried_runtime: None
+) -> None:
+    """CONTROL for the scenario above: same instruction, straight at the console.
+
+    Identical injection point, identical timing, but the line is handed to
+    ``current_reporter().out()`` by the bootstrap rather than routed there by the
+    renderer. That console is the one ``Live`` redirects, and it has always put a
+    line above the region on its own row with no frame attached — which is what
+    made it the specification the fix was written against.
+
+    It stays here as the independent witness. If this run ever starts welding
+    too, the cause is the pty, the emulator or the injection point rather than
+    anything about how trouble is routed, and the scenario above should be read
+    in that light.
+
+    The copy differs — a reporter line has no ``⚠`` glyph and no detail line,
+    because it is a console ``print`` rather than the renderer's trouble shape.
+    That is why this is a control for *placement* and nothing else.
+    """
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env, bootstrap=CONTROL_BOOTSTRAP)
+
+    assert run.exit_code == 0, run.describe()
+    lines = probe_warning_lines(run)
+    steps = sub_step_lines(run)
+    assert steps, f"the deploy printed no sub-step to ride\n{run.describe()}"
+    assert len(lines) == len(steps), (
+        f"the control must issue the same number of lines as the finding does, or the two "
+        f"runs are not comparable: {len(lines)} of {len(steps)}\n{run.describe()}"
+    )
+    for index, line in enumerate(lines):
+        assert line.strip() == f"probe warning {index}", (
+            f"a reporter-routed line did not land on its own row: {line!r}\n{run.describe()}"
+        )
+    assert_region_was_live(run)
+    assert_screen_is_intact(run)
+
+
+def test_a_burst_of_warnings_across_repaints_never_tears_a_line(
+    startable_repo: Path, pty_env: dict[str, str], unhurried_runtime: None
+) -> None:
+    """What concurrency alone costs, once the routing is right.
+
+    Eight warnings from their own thread at 0.1 s intervals, against a deploy
+    slowed to a real runtime's latency, so the burst straddles several of the
+    monitor's 0.25 s repaints. Nothing synchronises the two threads, so the
+    question this answers is whether a warning can land in the middle of a
+    repaint and split it — and whether the console the region lends out survives
+    being written to from a thread that is not the one repainting it.
+
+    It does. Each warning arrives whole, in order, on its own row, and the
+    region survives every one of them. Two of the eight used to come back with a
+    region frame welded on, run after run; none may now.
+    """
+    run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env, bootstrap=BURST_BOOTSTRAP)
+
+    assert run.exit_code == 0, run.describe()
+    warnings = probe_warning_lines(run)
+    assert len(warnings) == BURST_WARNINGS, (
+        f"expected {BURST_WARNINGS} probe warnings on the screen, found {len(warnings)}: "
+        f"{warnings}\n{run.describe()}"
+    )
+    # Same reason as the scenario above: the count is pinned by an anchored
+    # pattern, so a damaged line would leave the set instead of failing it. The
+    # two predicates are made to agree first.
+    assert warnings == [line for line in run.screen if "probe warning" in line], (
+        f"a line carries a probe warning but is not shaped like one, so it escaped the "
+        f"assertions below\n{run.describe()}"
+    )
+    for index, line in enumerate(warnings):
+        assert line.strip() == f"⚠ probe warning {index}", (
+            f"a warning issued mid-repaint did not land on its own row in one piece: "
+            f"{line!r}\n{run.describe()}"
+        )
+
+    assert_region_was_mounted_when(run, "probe warning 0")
+    assert_region_was_live(run)
+    assert_screen_is_intact(run)

--- a/tests/pty/test_piped_parity.py
+++ b/tests/pty/test_piped_parity.py
@@ -1,0 +1,400 @@
+"""The same deploy, on a terminal and down a pipe, says the same things.
+
+A terminal gets one device and a redirect gets two files, and the CLI knows the
+difference: on a terminal it mounts a live region, paints a spinner over its own
+output and hands every stderr writer in the process to that region's console;
+down a pipe it mounts nothing and writes plain lines to two separate streams.
+Criterion 9 is the claim that none of that changes *what is said* — that the
+decoration is decoration, and a redirect loses no line and gains none.
+
+That claim is spelled here as an arithmetic one, which is the only form of it a
+test can check without deciding for itself which lines "correspond":
+
+    TTY scrollback  -  piped stderr  ==  piped stdout, in order
+
+The left subtraction is over a multiset of lines: every line the piped run wrote
+to stderr is struck off the terminal's scrollback once, and whatever is left has
+to be the piped run's stdout, in the order it came out. Nothing is matched by
+position, by prefix or by eye. A line that only a terminal prints leaves a
+remainder stdout does not have; a line a redirect drops leaves stdout with one
+the remainder does not; either way the assertion fails and the diff names it.
+
+**The guard comes first.** The subtraction is only unambiguous if no single line
+is written to both piped streams — otherwise striking off a stderr line could
+strike a stdout line instead and the arithmetic would balance for the wrong
+reason. So the first assertion is that the scripted deploy has no such line, and
+a parity failure after it is therefore attributable to parity.
+
+**Region transients are not filtered out, they are proven absent.** The region is
+``transient``: it erases itself on teardown, so it is gone from the scrollback the
+subtraction reads, and :func:`assert_screen_is_intact` is what establishes that on
+this run rather than a filter that would hide a frame it failed to erase.
+
+**Both runs are the same deploy, to the letter.** The two runs are made
+comparable by construction rather than by normalisation wherever that is
+possible: they run the same bootstrap program, against the same repository at the
+same absolute path (restored from a pristine snapshot between them, so the second
+run is not reading the first one's residue), on the same published ports, with
+the same environment. Three things cannot be construction-equal and are
+normalised, each for a measured reason:
+
+* **The width.** Rich takes a pipe's width from ``COLUMNS`` and falls back to 80;
+  a terminal's comes from the pty, which this harness fixes at
+  :data:`~tests.pty.test_live_region_real_terminal.TERMINAL_COLUMNS`. Measured
+  without the pin: the wrapped WARNING record comes out 18 lines on the pipe
+  against 15 on the terminal, and the subtraction fails on wrapping alone. So the
+  piped run is told the terminal's width, and the two runs wrap alike.
+* **The clock.** A ``RichHandler`` record is stamped with the wall clock and a
+  phase line carries its own elapsed. Both are normalised to placeholders.
+* **Sub-second laps.** A lap under 50 ms prints with no duration at all
+  (``phase_reporter.Phase.step``), so against the instant stub the *presence* of a
+  parenthetical — not just its value — would be a coin toss between the two runs.
+  ``unhurried_runtime`` puts every runtime call an order of magnitude above that
+  threshold, which is why it is not optional here. It is also what gives the
+  terminal run a region worth comparing against: measured without it, the deploy
+  finishes so fast that the spinner never advances once, and a parity assertion
+  would then be comparing two runs that both printed plain lines.
+
+**The stderr side is armed on purpose.** The scripted deploy is quiet on stderr,
+and a subtraction with nothing to subtract would pass for no reason. So the run
+provokes the env-chain disagreement warning the way scenario 3 does — a real
+WARNING from the start path, not an injected line — and it is a 15-line wrapped
+record, which is the strongest shape available: every one of those lines has to
+appear on the terminal and be struck off, and any drift in how a redirect wraps
+or splits the record shows up as a leftover.
+
+POSIX only, like the rest of this directory.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from tests.pty.conftest import StubRuntime
+
+# The scenario runs on the sibling suite's harness rather than a second copy of
+# it: its emulator, its pty runner and its terminal geometry. The fixtures both
+# suites drive with -- ``startable_repo``, ``pty_env``, ``unhurried_runtime`` --
+# live in ``conftest.py``, so pytest resolves them by name and neither module
+# imports them.
+from tests.pty.test_live_region_real_terminal import (
+    CLI_BOOTSTRAP,
+    SPINNER_FRAMES,
+    TERMINAL_COLUMNS,
+    TERMINAL_ROWS,
+    assert_region_was_live,
+    assert_screen_is_intact,
+    run_on_pty,
+    strip_ansi,
+)
+
+pytestmark = [
+    pytest.mark.pty,
+    pytest.mark.skipif(os.name != "posix", reason="a pty is a POSIX facility"),
+]
+
+#: The ``RichHandler`` timestamp column, which is wall-clock and therefore
+#: differs between two runs seconds apart. Fixed width, so normalising it cannot
+#: move where the record wraps.
+TIMESTAMP = re.compile(r"\[\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\]")
+
+#: What that column reads as once normalised. Spelled once and used both by
+#: :func:`normalised` and by :data:`RECORD_HEAD`, so the pattern that finds a
+#: record's first line cannot drift from the placeholder that produces it.
+TIME_PLACEHOLDER = "[<time>]"
+
+#: The first line of a rendered log record, after normalisation: the timestamp
+#: column and the level. Wrap-immune by construction — the column is fixed width
+#: and the level is one word — which is what makes it a safe anchor for finding
+#: where a record starts. The record's head *phrase* is not safe for that: it is
+#: long enough to wrap, and matching it line by line reports a wrapping
+#: difference as a missing warning.
+RECORD_HEAD = re.compile(rf"^{re.escape(TIME_PLACEHOLDER)}\s+WARNING\b")
+
+#: A phase line's or a sub-step's trailing duration, in both shapes
+#: :func:`osprey.cli.phase_reporter.format_elapsed` produces.
+ELAPSED = re.compile(r"\((?:\d+\.\d+s|\d+m\d{2}s)\)")
+
+#: The variable the arming disagreement is about. Interpolated by the exemplar's
+#: compose files, which is what makes the start path compare it at all.
+ARMED_VARIABLE = "ZO_ROOT_USER_PASSWORD"
+
+#: The value pinned in the repository's own chain, and the different one exported
+#: into the run. Values are never printed by the warning, so neither is a secret
+#: in any sense; they only have to disagree.
+CHAIN_VALUE = "Chain5ide!Value"
+EXPORTED_VALUE = "Exp0rted!Value"
+
+#: The head of the record the disagreement produces. Asserted on the piped
+#: stderr capture before the subtraction, so a run whose arming silently stopped
+#: working fails as "nothing to subtract" rather than passing as parity.
+#:
+#: Looked for in the record with its wrapping collapsed, never line by line: the
+#: phrase is long enough to wrap, and a width the run did not expect would then
+#: fail the arming check and report a lost warning instead of the wrapping
+#: difference that is the actual finding.
+ARMED_WARNING_HEAD = "Shell export disagrees with this deployment's env chain"
+
+#: How many lines that record is expected to occupy, as a floor — and it is the
+#: **record's** size, not the capture's. A floor over the whole of stderr would
+#: be satisfied by any other chatter that happened to land there, which is the
+#: same set-derived-check-without-a-size-pin soft spot the earlier reviews on
+#: this suite closed: the set that is measured and the set whose copy is checked
+#: have to be one set.
+#:
+#: Pinned as a floor rather than exactly, because what matters is that the
+#: subtraction has a substantial, wrapped, multi-line record to work on and the
+#: copy is free to grow. One line would satisfy "non-empty" while testing almost
+#: nothing.
+ARMED_WARNING_MINIMUM_LINES = 10
+
+
+@dataclass
+class PipedRun:
+    """One verb run with both streams redirected, and the two captures."""
+
+    argv: list[str]
+    exit_code: int
+    stdout: str
+    stderr: str
+
+    def describe(self) -> str:
+        """A failure message worth reading: both captures, labelled."""
+        return (
+            f"argv={self.argv} exit={self.exit_code}\n"
+            f"--- piped stdout ---\n{self.stdout}\n"
+            f"--- piped stderr ---\n{self.stderr}"
+        )
+
+
+def run_piped(argv: list[str], *, cwd: Path, env: dict[str, str]) -> PipedRun:
+    """Run one verb with stdout and stderr redirected to separate pipes.
+
+    Deliberately spelled here rather than borrowed from ``conftest``'s render
+    helper: the whole premise of this module is that the two runs are the same
+    program on different devices, so both must demonstrably start from
+    :data:`~tests.pty.test_live_region_real_terminal.CLI_BOOTSTRAP` — the same
+    constant :class:`~tests.pty.test_live_region_real_terminal.PtyProcess` runs.
+    A second copy of that program somewhere else could drift from it and the
+    comparison would quietly become one between two different CLIs.
+
+    ``stdin`` is ``/dev/null`` rather than the runner's own: a verb that reached
+    a prompt here would read an immediate end of file and give up, which is a
+    failure the scenario can see. Inheriting pytest's stdin would leave it
+    waiting for a keystroke nobody is going to send.
+    """
+    result = subprocess.run(  # noqa: S603 - argv is built here, not by input
+        [sys.executable, "-c", CLI_BOOTSTRAP, *argv],
+        cwd=str(cwd),
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return PipedRun(
+        argv=list(argv),
+        exit_code=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def piped_env(env: dict[str, str]) -> dict[str, str]:
+    """*env* with the terminal's own geometry pinned for a run that has none.
+
+    The one environmental difference between the two runs, and it exists to
+    remove a difference rather than to make one: Rich reads ``COLUMNS`` ahead of
+    everything else, so this is how a process with no terminal is told the width
+    the other run's terminal had. See the module docstring for what happens
+    without it.
+    """
+    piped = dict(env)
+    piped["COLUMNS"] = str(TERMINAL_COLUMNS)
+    piped["LINES"] = str(TERMINAL_ROWS)
+    return piped
+
+
+def normalised(lines: list[str]) -> list[str]:
+    """*lines* reduced to what an operator reads, with the two clocks removed.
+
+    Escapes are stripped (the terminal's screen already is), lines are
+    right-stripped — a pipe pads a wrapped record's lines out to the console
+    width and a terminal's scrollback does not — and trailing blank lines are
+    dropped, which is the same rule
+    :meth:`~tests.pty.test_live_region_real_terminal.Terminal.scrollback` applies
+    to the screen. Interior blank lines are kept: one is part of what the deploy
+    prints, and both sides have to have it.
+    """
+    out = [
+        ELAPSED.sub("(<elapsed>)", TIMESTAMP.sub(TIME_PLACEHOLDER, strip_ansi(line))).rstrip()
+        for line in lines
+    ]
+    while out and not out[-1]:
+        out.pop()
+    return out
+
+
+def subtract(scrollback: list[str], subtrahend: list[str]) -> tuple[list[str], list[str]]:
+    """Strike each line of *subtrahend* off *scrollback* once.
+
+    Returns the remainder in its original order, and whatever could not be
+    struck off at all. A non-empty second element means the terminal never
+    carried a line the pipe did, which is a different failure from a parity
+    mismatch and is reported as one.
+    """
+    outstanding = Counter(subtrahend)
+    remainder = []
+    for line in scrollback:
+        if outstanding[line] > 0:
+            outstanding[line] -= 1
+        else:
+            remainder.append(line)
+    return remainder, sorted(outstanding.elements())
+
+
+def diff(expected: list[str], actual: list[str]) -> str:
+    """A unified diff of two line lists, for a failure message."""
+    return "\n".join(
+        difflib.unified_diff(expected, actual, "piped stdout", "terminal remainder", lineterm="")
+    )
+
+
+def test_the_scripted_deploy_reads_the_same_piped_as_it_does_on_a_terminal(
+    startable_repo: Path,
+    stub_runtime: StubRuntime,
+    pty_env: dict[str, str],
+    tmp_path: Path,
+    unhurried_runtime: None,
+) -> None:
+    """Criterion 9's comparison: two devices, one deploy, the same lines.
+
+    ``osprey up -d`` twice over — once on a real pty, once with both streams
+    redirected — against the same repository, restored to its pristine state in
+    between. The terminal run mounts a live region and proxies the process's
+    stderr onto it; the piped run mounts nothing and keeps the two streams apart.
+    Subtracting the piped run's stderr from the terminal's scrollback must leave
+    the piped run's stdout, in order.
+    """
+    # Arm the stderr side. A real disagreement between the shell's exports and
+    # the deployment's env chain, provoked the way scenario 3 provokes it: the
+    # repository pins a value for a variable the compose files interpolate, and
+    # the run exports a different one.
+    env_path = startable_repo / ".env"
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8") + f"{ARMED_VARIABLE}={CHAIN_VALUE}\n",
+        encoding="utf-8",
+    )
+    pty_env[ARMED_VARIABLE] = EXPORTED_VALUE
+
+    # The state both runs start from, byte for byte. Snapshotting the tree is
+    # what lets the second run use the *same absolute path* as the first: the
+    # repository's own path and its directory name are printed (in the summary
+    # card, and inside the wrapped warning), so two copies at two paths would
+    # differ in the copy itself and no normalisation could put them back
+    # together — the path is wrapped mid-string across several lines.
+    pristine = tmp_path / "pristine"
+    shutil.copytree(startable_repo, pristine, symlinks=True)
+
+    terminal_run = run_on_pty(["up", "-d"], cwd=startable_repo, env=pty_env)
+
+    assert terminal_run.exit_code == 0, terminal_run.describe()
+    # The terminal run has to be the interesting one, or the comparison is
+    # between two plain-line runs and says nothing about the region.
+    assert_region_was_live(terminal_run)
+    # And this is the "minus region transients" of the comparison: the region
+    # took every frame back, so the scrollback below carries none.
+    assert_screen_is_intact(terminal_run)
+
+    shutil.rmtree(startable_repo)
+    shutil.copytree(pristine, startable_repo, symlinks=True)
+    # The runtime forgets what it started, so the second deploy is a first
+    # deploy. Only the state file: the invocation log is what the ``stub_runtime``
+    # fixture checks for unanswered seams at teardown, and it must keep both
+    # runs' invocations in it.
+    stub_runtime.state_path.unlink(missing_ok=True)
+
+    piped_run = run_piped(["up", "-d"], cwd=startable_repo, env=piped_env(pty_env))
+
+    assert piped_run.exit_code == 0, piped_run.describe()
+
+    # The premise of the whole comparison: a pipe got no region. Asked of the raw
+    # captures, since a mounted region is a cursor hide and a spinner glyph.
+    for name, capture in (("stdout", piped_run.stdout), ("stderr", piped_run.stderr)):
+        assert "\x1b[?25l" not in capture, (
+            f"the piped run hid the cursor on {name}, so it mounted a region with no terminal "
+            f"to mount it on\n{piped_run.describe()}"
+        )
+        assert not any(glyph in capture for glyph in SPINNER_FRAMES), (
+            f"a spinner frame reached piped {name}\n{piped_run.describe()}"
+        )
+
+    scrollback = normalised(terminal_run.screen)
+    stdout = normalised(piped_run.stdout.splitlines())
+    stderr = normalised(piped_run.stderr.splitlines())
+
+    # Armed control. Without a record on stderr the subtraction below would
+    # subtract nothing and pass for that reason. Both halves of the check — how
+    # big it is and what it says — are asked of the same slice: the record, from
+    # its head line to the end of the capture, rather than of stderr as a whole.
+    heads = [index for index, line in enumerate(stderr) if RECORD_HEAD.match(line)]
+    assert len(heads) == 1, (
+        f"expected exactly one rendered record on the piped run's stderr, found {len(heads)}. "
+        f"The slice measured below runs from a record's head line to the end of the capture, "
+        f"so a second record makes it ambiguous: scope the slice to the armed record rather "
+        f"than dropping this check\n{piped_run.describe()}"
+    )
+    record = stderr[heads[0] :]
+    assert len(record) >= ARMED_WARNING_MINIMUM_LINES, (
+        f"the record on the piped run's stderr is {len(record)} line(s) long, so either the "
+        f"arming stopped working or the record no longer wraps, and this test has next to "
+        f"nothing to subtract\n{piped_run.describe()}"
+    )
+    unwrapped = " ".join(" ".join(record).split())
+    assert ARMED_WARNING_HEAD in unwrapped and ARMED_VARIABLE in unwrapped, (
+        f"the armed warning is not the record on stderr, so the subtraction is not the one "
+        f"this test is about\n{piped_run.describe()}"
+    )
+    assert stdout, f"the piped run printed nothing at all\n{piped_run.describe()}"
+
+    # THE GUARD, and it is first on purpose: the subtraction is only unambiguous
+    # while no line is written to both streams. Were there one, striking a stderr
+    # line off the scrollback could strike the stdout copy instead and the
+    # arithmetic could balance for a reason that has nothing to do with parity.
+    #
+    # A BLANK LINE IS NOT EXEMPT, and must never be made one. The deploy prints
+    # an interior blank on stdout; if stderr ever prints one too, the terminal's
+    # blank cannot be attributed to either stream and the subtraction is exactly
+    # as ambiguous as it would be for any shared line. Filtering blanks out of
+    # the comparison would not fix that — it would hide it, and quietly excuse
+    # the scrollback from carrying one.
+    ambiguous = sorted(set(stdout) & set(stderr))
+    assert not ambiguous, (
+        f"these lines are on both piped streams, so subtracting stderr from the terminal's "
+        f"scrollback cannot say which stream a scrollback line came from: {ambiguous}. This "
+        f"guard firing is the guard working, including on a blank line — the fix is to tell "
+        f"the two streams apart, never to exempt the line\n{piped_run.describe()}"
+    )
+
+    remainder, unstruck = subtract(scrollback, stderr)
+
+    assert not unstruck, (
+        f"the piped run wrote these to stderr but they are nowhere in the terminal's "
+        f"scrollback, so a redirect is being told something a terminal is not: {unstruck}\n"
+        f"{terminal_run.describe()}\n{piped_run.describe()}"
+    )
+    assert remainder == stdout, (
+        f"the terminal's scrollback, minus everything the piped run said on stderr, is not "
+        f"the piped run's stdout:\n{diff(stdout, remainder)}\n"
+        f"{terminal_run.describe()}\n{piped_run.describe()}"
+    )

--- a/tests/pty/test_stub_coverage.py
+++ b/tests/pty/test_stub_coverage.py
@@ -1,0 +1,585 @@
+"""Does the stub runtime answer everything the deploy path asks a runtime?
+
+The pty harness replaces ``docker`` with a script. That is only sound while the
+script answers every invocation the code under test makes — and the failure mode
+when it does not is the expensive one: a deploy that hangs, or worse, one that
+finishes and reports something the harness then asserts against.
+
+So the stub is checked against the source rather than against a wish list. This
+module walks :mod:`osprey.deployment` with the ``ast`` module, collects every
+runtime argv the package builds, resolves each to a seam (``compose up``,
+``image inspect``), and asserts the stub declares it handled — then runs the
+stub on each seam and asserts it really is. A new runtime call added anywhere on
+the deploy path fails this test on the commit that adds it, in the normal lane,
+without a terminal or a container.
+
+Deliberately **not** marked ``pty``: it needs no terminal. It is the pre-check
+that makes the pty lane's failures worth reading.
+
+Three things the scanner cannot do, and does not pretend to:
+
+* It reads argv *shapes*, not runtime values. A subcommand that only exists as a
+  variable is listed in :data:`DYNAMIC_TOKENS` with the literals it can take,
+  and an unlisted one is a failure naming its site — never a silent skip.
+* It scans the whole ``deployment`` package, not the ``up`` path alone. That is
+  a superset on purpose: reachability analysis would be the thing most likely
+  to be wrong, and answering a seam the ``up`` path never reaches costs the stub
+  four lines.
+* It cannot see what is not a subprocess. ``up`` also opens *network* clients
+  (the archiver's mongod, ARIEL's postgres) which no ``docker`` stub can stand
+  in for — which is exactly why the exemplar is rendered from a preset whose
+  services have none. See ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.pty.conftest import StubRuntime, repo_root, stub_runtime_dir
+from tests.pty.stub_runtime import _stub_main
+
+#: The package whose runtime conversations must be covered.
+DEPLOYMENT_PACKAGE = Path("src/osprey/deployment")
+
+#: Local names that hold a *compose* argv base (``["docker", "compose", …]``),
+#: so a subcommand appended to one is a compose seam rather than a plain one.
+_COMPOSE_BASE_NAMES = frozenset({"base", "cmd", "web_cmd", "services_base", "runtime_cmd"})
+
+#: Local names that hold the runtime *binary* alone, so the tokens after them
+#: are a plain-runtime subcommand.
+_RUNTIME_HEAD_NAMES = frozenset({"runtime", "runtime_bin"})
+
+#: Calls that answer the runtime command, so subscripting one is the binary.
+#: Half the package resolves the binary into a local first; the other half
+#: writes the call inline at the head of the argv it is building, and a scanner
+#: that only knew the local spelling would read those sites as no argv at all.
+_RUNTIME_CALL_NAMES = frozenset({"get_runtime_command"})
+
+#: Subcommands that are a namespace rather than a verb: the seam is two words.
+_NAMESPACES = _stub_main._NAMESPACES
+
+#: Flags that take a value, so the scanner steps over the value too.
+_VALUE_FLAGS = _stub_main._COMPOSE_VALUE_FLAGS | _stub_main._PLAIN_VALUE_FLAGS
+
+#: Every subcommand the deploy path spells as a variable, with the literals it
+#: can hold, and where. Listed rather than inferred: the point of the gate is
+#: that a runtime call cannot be added without someone deciding it is covered,
+#: and a scanner that quietly skipped what it could not read would give that up.
+DYNAMIC_TOKENS = {
+    # container_lifecycle._down_by_label: `for verb in ("stop", "rm")`
+    ("container_lifecycle.py", "verb"): ("stop", "rm"),
+    # reset.RuntimeProbe._labels_of: one inspect, three kinds of resource.
+    ("reset.py", "kind"): ("container", "volume", "image"),
+}
+
+#: Seams the scanner must find, or it is not looking at anything. Without this
+#: a scanner that silently matched nothing would pass every assertion below.
+ANCHOR_SEAMS = frozenset({"compose up", "compose down", "ps", "image inspect", "build"})
+
+
+# ---------------------------------------------------------------------------
+# the scanner
+# ---------------------------------------------------------------------------
+
+
+class _Seam:
+    """One runtime invocation the source builds, and where it builds it."""
+
+    def __init__(self, seam: str, module: str, lineno: int) -> None:
+        self.seam = seam
+        self.module = module
+        self.lineno = lineno
+
+    def __repr__(self) -> str:
+        return f"{self.seam!r} ({self.module}:{self.lineno})"
+
+
+def _constants(elements: list[ast.expr]) -> list[str | None]:
+    """Each element as its string constant, or ``None`` when it is dynamic."""
+    return [
+        node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+        for node in elements
+    ]
+
+
+def _verbs(tokens: list[str | None], module: str, dynamic_names: list[str | None]) -> list[str]:
+    """The seam(s) an argv tail resolves to.
+
+    Args:
+        tokens: The argv tail as constants, ``None`` for anything dynamic.
+        module: File name, for the dynamic-token lookup and for error text.
+        dynamic_names: The identifier behind each dynamic token, positionally.
+
+    Returns:
+        Zero seams (a tail that names no subcommand — a flag-only append), one,
+        or several (a dynamic subcommand expands to its listed literals).
+
+    Raises:
+        AssertionError: A dynamic subcommand that :data:`DYNAMIC_TOKENS` does
+            not account for.
+    """
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token is None:
+            name = dynamic_names[index]
+            if name is None:
+                # A value handed to a flag, or an unnamed expression in a
+                # value position; neither can be the subcommand.
+                index += 1
+                continue
+            key = (module, name)
+            assert key in DYNAMIC_TOKENS, (
+                f"{module} builds a runtime argv whose subcommand is the variable {name!r}. "
+                f"Add it to DYNAMIC_TOKENS with the literals it can hold, so the stub is "
+                f"checked against them."
+            )
+            tail = tokens[index + 1 :]
+            names = dynamic_names[index + 1 :]
+            expanded = []
+            for literal in DYNAMIC_TOKENS[key]:
+                expanded.extend(_verbs([literal, *tail], module, [None, *names]))
+            return expanded
+        if token.startswith("-"):
+            # A flag. Its value is skipped with it — read off the same flag
+            # tables the stub parses argv with, so the scanner and the stub
+            # cannot disagree about which flags take one.
+            index += 2 if token in _VALUE_FLAGS else 1
+            continue
+        if token in _NAMESPACES:
+            for follower in tokens[index + 1 :]:
+                if follower and not follower.startswith("-"):
+                    return [f"{token} {follower}"]
+            return [token]
+        return [token]
+    return []
+
+
+def _plain_seams(elements: list[ast.expr], module: str, lineno: int) -> list[_Seam]:
+    tokens = _constants(elements)
+    if "compose" in tokens:
+        # ``[runtime, "compose", "version"]`` builds the compose argv inline
+        # rather than from a base. A bare ``[runtime, "compose"]`` names no
+        # subcommand — it is the base itself — and yields nothing.
+        after = tokens.index("compose") + 1
+        return _compose_seams(elements[after:], module, lineno)
+    names = [node.id if isinstance(node, ast.Name) else None for node in elements]
+    return [_Seam(verb, module, lineno) for verb in _verbs(tokens, module, names)]
+
+
+def _compose_seams(elements: list[ast.expr], module: str, lineno: int) -> list[_Seam]:
+    tokens = _constants(elements)
+    names = [node.id if isinstance(node, ast.Name) else None for node in elements]
+    return [_Seam(f"compose {verb}", module, lineno) for verb in _verbs(tokens, module, names)]
+
+
+def _is_compose_base(node: ast.expr) -> bool:
+    """Whether *node* names a local holding a compose argv base."""
+    if not isinstance(node, ast.Name):
+        return False
+    return node.id in _COMPOSE_BASE_NAMES or node.id.endswith("_cmd") or node.id.endswith("_base")
+
+
+def _is_runtime_head(node: ast.expr) -> bool:
+    """Whether *node* is the runtime binary standing at the head of an argv.
+
+    Two spellings, both of them common in this package: a local the caller
+    resolved the binary into (``runtime = get_runtime_command(config)[0]``), and
+    the same call written inline where the local would have gone
+    (``[get_runtime_command(config)[0], "build", …]``). The inline one builds
+    real seams, so a scanner that only knew the local would read those sites as
+    a list of strings and find nothing.
+    """
+    if isinstance(node, ast.Name):
+        return node.id in _RUNTIME_HEAD_NAMES
+    if isinstance(node, ast.Subscript):
+        call = node.value
+        if not isinstance(call, ast.Call):
+            return False
+        function = call.func
+        if isinstance(function, ast.Name):
+            return function.id in _RUNTIME_CALL_NAMES
+        if isinstance(function, ast.Attribute):
+            return function.attr in _RUNTIME_CALL_NAMES
+    return False
+
+
+def _walk_seams(tree: ast.AST, module: str) -> list[_Seam]:
+    """Every runtime seam one parsed module builds.
+
+    Five shapes, which between them are how this package talks to a runtime:
+
+    * ``[runtime, "ps", "-a", …]`` — a plain-runtime argv;
+    * ``[*base, "version"]`` — a subcommand spliced onto a compose base;
+    * ``base_cmd + ["up", "-d"]`` — the same, written as a concatenation;
+    * ``cmd.append("down")`` — and again, written as a mutation;
+    * ``cmd.extend(["down", "--volumes"])`` — the mutation, several tokens at once.
+
+    Plus ``RuntimeProbe._capture([...])`` in ``reset.py``, whose argv omits the
+    binary because the class supplies it.
+
+    Shared with the scanner's own tests below, which feed it a snippet: two
+    walks would drift, and the one that drifted would be the one nothing checks.
+    """
+    found: list[_Seam] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.List) and node.elts:
+            head = node.elts[0]
+            if _is_runtime_head(head):
+                found.extend(_plain_seams(node.elts[1:], module, node.lineno))
+            elif isinstance(head, ast.Starred) and _is_compose_base(head.value):
+                found.extend(_compose_seams(node.elts[1:], module, node.lineno))
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            if _is_compose_base(node.left) and isinstance(node.right, ast.List):
+                found.extend(_compose_seams(node.right.elts, module, node.lineno))
+        elif isinstance(node, ast.Call):
+            found.extend(_call_seams(node, module))
+    return found
+
+
+def scan_module(path: Path) -> list[_Seam]:
+    """Every runtime seam one module builds."""
+    return _walk_seams(ast.parse(path.read_text(encoding="utf-8"), filename=str(path)), path.name)
+
+
+def _call_seams(node: ast.Call, module: str) -> list[_Seam]:
+    """Seams from ``cmd.append("down")``, ``cmd.extend([…])`` and ``self._capture([…])``."""
+    function = node.func
+    if isinstance(function, ast.Attribute):
+        if (
+            function.attr == "append"
+            and _is_compose_base(function.value)
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            # Constants only: an argv that appends a *value* (a build context,
+            # a service name) is appending to a subcommand it already carries,
+            # not naming one.
+            return _compose_seams(node.args[:1], module, node.lineno)
+        if (
+            function.attr == "extend"
+            and _is_compose_base(function.value)
+            and node.args
+            and isinstance(node.args[0], ast.List | ast.Tuple)
+            and node.args[0].elts
+        ):
+            # Only the first element, for the same reason ``append`` takes only
+            # a constant: everything after a subcommand is its arguments. It is
+            # also what keeps the scanner honest about a base it may have
+            # misread — ``ps_cmd`` is a plain argv the name test cannot tell
+            # from a compose one, and reading its tail would invent a compose
+            # subcommand out of a ``--format`` value.
+            return _compose_seams(node.args[0].elts[:1], module, node.lineno)
+        if function.attr == "_capture" and node.args and isinstance(node.args[0], ast.List):
+            return _plain_seams(node.args[0].elts, module, node.lineno)
+    return []
+
+
+def scan_deployment() -> list[_Seam]:
+    """Every runtime seam the deployment package builds, module by module."""
+    root = repo_root() / DEPLOYMENT_PACKAGE
+    found: list[_Seam] = []
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        found.extend(scan_module(path))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def discovered_seams() -> list[_Seam]:
+    """The scan, once — it parses the whole package."""
+    return scan_deployment()
+
+
+def _run_stub(argv: list[str], stub: StubRuntime, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke the stub ``docker`` exactly as a deploy would: found on ``PATH``."""
+    return subprocess.run(
+        ["docker", *argv],
+        cwd=cwd,
+        env=stub.env(),
+        capture_output=True,
+        text=True,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# the gate
+# ---------------------------------------------------------------------------
+
+
+class TestScanner:
+    """The instrument itself, before anything it measures."""
+
+    def test_scan_finds_the_seams_everyone_knows_about(self, discovered_seams: list[_Seam]) -> None:
+        """A scanner that matched nothing would pass every other test here."""
+        seams = {found.seam for found in discovered_seams}
+        missing = ANCHOR_SEAMS - seams
+        assert not missing, (
+            f"the AST scan missed seams the deploy path certainly has ({sorted(missing)}); "
+            f"it found {sorted(seams)} — the scanner is broken, not the stub"
+        )
+
+    def test_scan_reads_a_compose_concatenation(self) -> None:
+        """``base_cmd + ["up", "-d", svc]`` is a compose ``up``, not a plain one."""
+        source = 'base_cmd = x\nup_cmd = base_cmd + ["up", "-d", service]\n'
+        seams = _seams_of_source(source)
+        assert seams == ["compose up"]
+
+    def test_scan_reads_a_plain_argv_with_a_namespace(self) -> None:
+        """``[runtime, "image", "inspect", …]`` is two words, not one."""
+        source = 'cmd = [runtime, "image", "inspect", "--format", "{{.Id}}", image]\n'
+        assert _seams_of_source(source) == ["image inspect"]
+
+    def test_scan_skips_a_flag_only_append(self) -> None:
+        """``cmd.append("--follow")`` adds a flag to a seam, not a seam."""
+        assert _seams_of_source('cmd.append("--follow")\n') == []
+
+    def test_scan_reads_a_compose_extend(self) -> None:
+        """``cmd.extend(["down", "--volumes"])`` names a subcommand like an append does."""
+        assert _seams_of_source('cmd.extend(["down", "--volumes"])\n') == ["compose down"]
+
+    def test_scan_skips_a_flag_only_extend(self) -> None:
+        """``ps_cmd.extend(["--format", "json"])`` adds arguments to a seam, not a seam."""
+        assert _seams_of_source('ps_cmd.extend(["--format", "json"])\n') == []
+
+    def test_scan_reads_an_inline_runtime_binary(self) -> None:
+        """``[get_runtime_command(config)[0], "build", …]`` is a plain ``build``."""
+        source = 'cmd = [get_runtime_command(config)[0], "build", "-t", tag]\n'
+        assert _seams_of_source(source) == ["build"]
+
+
+def _seams_of_source(source: str) -> list[str]:
+    """Seams found in a source snippet, for the scanner's own tests."""
+    return [entry.seam for entry in _walk_seams(ast.parse(source), "snippet.py")]
+
+
+class TestStubCoverage:
+    """Every seam the source builds, answered by the stub."""
+
+    def test_stub_declares_every_seam_the_source_builds(
+        self, discovered_seams: list[_Seam]
+    ) -> None:
+        """The whole gate, in one assertion: nothing unanswered."""
+        gaps: list[_Seam] = []
+        for found in discovered_seams:
+            if found.seam.startswith("compose "):
+                handled = found.seam.removeprefix("compose ") in _stub_main.HANDLED_COMPOSE
+            else:
+                handled = found.seam in _stub_main.HANDLED_PLAIN
+            if not handled:
+                gaps.append(found)
+        assert not gaps, (
+            "the deploy path shells out to runtime subcommands the stub does not answer:\n  "
+            + "\n  ".join(repr(gap) for gap in gaps)
+            + "\nAdd them to tests/pty/stub_runtime/_stub_main.py (handler + HANDLED_* set)."
+        )
+
+    def test_stub_answers_every_seam_it_declares(self, stub: StubRuntime, tmp_path: Path) -> None:
+        """Declared is not answered: run each one and read the log back.
+
+        A seam could be listed in ``HANDLED_*`` and fall through every branch of
+        the dispatcher, which is precisely the failure the declaration was
+        supposed to rule out.
+        """
+        declared = [seam.split() for seam in sorted(_stub_main.HANDLED_PLAIN)]
+        declared += [["compose", *seam.split()] for seam in sorted(_stub_main.HANDLED_COMPOSE)]
+
+        failures = []
+        for argv in declared:
+            result = _run_stub(argv, stub, tmp_path)
+            if result.returncode != 0:
+                failures.append(f"{' '.join(argv)} exited {result.returncode}")
+        assert not failures, failures
+
+        unhandled = stub.unhandled()
+        assert not unhandled, [record["args"] for record in unhandled]
+        assert len(stub.invocations()) == len(declared)
+
+    @pytest.mark.allow_unhandled_runtime
+    def test_stub_records_an_invocation_it_cannot_answer(
+        self, stub: StubRuntime, tmp_path: Path
+    ) -> None:
+        """The gate can fail. A stub that reported everything handled proves nothing.
+
+        Exit 0 even here, on purpose: the harness must not turn "not scripted
+        yet" into "the deploy is broken" — the log carries the fact instead.
+        The marker is what keeps the ``stub_runtime`` teardown from failing the
+        one test whose whole subject is an unanswered invocation.
+        """
+        result = _run_stub(["frobnicate", "--hard"], stub, tmp_path)
+        assert result.returncode == 0
+        assert stub.unhandled(), "an unknown subcommand must be recorded as unhandled"
+        assert "unhandled" in result.stderr
+
+
+class TestStubIsReachable:
+    """The wiring the harness depends on, asserted rather than assumed."""
+
+    def test_stub_docker_is_executable(self) -> None:
+        """A lost mode bit is a silent fall-through to the real docker."""
+        stub_docker = stub_runtime_dir() / "docker"
+        assert os.access(stub_docker, os.X_OK), f"{stub_docker} is not executable"
+
+    def test_container_runtime_env_pins_the_probe_to_docker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``CONTAINER_RUNTIME`` beats config — the whole reason the stub is named docker."""
+        from osprey.deployment.runtime_helper import _runtimes_to_try
+
+        monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+        assert _runtimes_to_try({"container_runtime": "podman"}) == ("docker",)
+
+    def test_runtime_detection_selects_the_stub(
+        self, stub: StubRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``get_runtime_command`` finds the stub and is satisfied by its answers."""
+        from osprey.deployment import runtime_helper
+
+        for key, value in stub.env().items():
+            monkeypatch.setenv(key, value)
+        runtime_helper.reset_runtime_cache()
+        try:
+            assert runtime_helper.get_runtime_command(None) == ["docker", "compose"]
+        finally:
+            runtime_helper.reset_runtime_cache()
+
+    def test_compose_provider_probe_accepts_the_stub_banner(
+        self, stub: StubRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The provider probe fails closed on a banner it cannot place.
+
+        So the stub's version string is a contract with
+        :func:`~osprey.deployment.runtime_helper.detect_compose_provider`, not
+        decoration — pinned here rather than discovered as a refusal mid-deploy.
+        """
+        from osprey.deployment import runtime_helper
+
+        for key, value in stub.env().items():
+            monkeypatch.setenv(key, value)
+        runtime_helper.reset_runtime_cache()
+        try:
+            detected = runtime_helper.detect_compose_provider(["docker", "compose"])
+        finally:
+            runtime_helper.reset_runtime_cache()
+        assert detected.provider is runtime_helper.ComposeProvider.DOCKER_V2
+
+
+class TestStubAnswersPlausibly:
+    """Exit 0 is not enough: the answers have to be usable ones."""
+
+    def test_compose_up_starts_the_services_the_exemplar_declares(
+        self, stub: StubRuntime, exemplar_repo: Path, tmp_path: Path
+    ) -> None:
+        """The stub reads the rendered compose files rather than inventing services.
+
+        This is what makes the ``ps`` that follows an ``up`` say something true:
+        the containers it lists are the ones the repo under test declares.
+        """
+        from osprey.deployment.container_lifecycle import (
+            as_built_compose_files,
+            as_built_config_path,
+        )
+        from osprey.utils.config import load_project_config
+
+        config = load_project_config(str(as_built_config_path(exemplar_repo)), wrap_errors=True)
+        compose_files = as_built_compose_files(config, exemplar_repo)
+        assert compose_files, f"the exemplar rendered no compose files into {exemplar_repo}/build"
+
+        argv = ["compose", "--project-directory", str(exemplar_repo)]
+        for path in compose_files:
+            argv += ["-f", str(path)]
+
+        up = _run_stub([*argv, "-p", "ptyproj", "up", "-d"], stub, tmp_path)
+        assert up.returncode == 0
+        # Compose reports progress on stderr and keeps stdout for data; the
+        # renderer under test depends on that split.
+        assert "Started" in up.stderr
+
+        listing = _run_stub(["ps", "--format", "json"], stub, tmp_path)
+        records = [json.loads(line) for line in listing.stdout.splitlines() if line.strip()]
+        assert records, "ps saw nothing after a compose up"
+        assert all(record["Project"] == "ptyproj" for record in records)
+        assert {record["Service"] for record in records} == {"openobserve"}
+
+        down = _run_stub([*argv, "-p", "ptyproj", "down"], stub, tmp_path)
+        assert down.returncode == 0
+        after = _run_stub(["ps", "--format", "json"], stub, tmp_path)
+        assert after.stdout.strip() == "", "containers survived a compose down"
+
+    def test_image_and_container_inspect_agree(self, stub: StubRuntime, tmp_path: Path) -> None:
+        """Two IDs that disagreed would send every deploy into a recreate.
+
+        Image drift is decided by comparing these two answers, so a stub that
+        answered them independently would make the harness measure a
+        reconciliation that no real deployment would perform.
+        """
+        image = _run_stub(["image", "inspect", "--format", "{{.Id}}", "x:local"], stub, tmp_path)
+        container = _run_stub(
+            ["container", "inspect", "--format", "{{.Image}}", "x-1"], stub, tmp_path
+        )
+        assert image.stdout.strip().removeprefix("sha256:") == container.stdout.strip()
+
+    def test_build_speaks_buildkit_plain_progress(self, stub: StubRuntime, tmp_path: Path) -> None:
+        """``build_progress`` parses these lines, so the stub has to emit them."""
+        result = _run_stub(["build", "-t", "x:local", "."], stub, tmp_path)
+        assert result.returncode == 0
+        assert "DONE" in result.stderr
+        assert "CACHED" in result.stderr
+        assert "sha256:" in result.stderr
+
+    def test_the_log_carries_argv_and_stdin(self, stub: StubRuntime, tmp_path: Path) -> None:
+        """Both halves of an invocation, because ``exec -i`` is one of them."""
+        subprocess.run(
+            ["docker", "exec", "-i", "container", "sh", "-c", "cat"],
+            cwd=tmp_path,
+            env=stub.env(),
+            input="seeded-payload\n",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        record = stub.invocations()[-1]
+        assert record["args"][:2] == ["exec", "-i"]
+        assert record["stdin"] == "seeded-payload\n"
+        assert record["seam"] == "exec"
+
+
+@pytest.fixture
+def stub(stub_runtime: StubRuntime) -> StubRuntime:
+    """The stub, freshly reset — every test here reads its own log."""
+    stub_runtime.reset()
+    return stub_runtime
+
+
+def test_stub_runs_under_the_bare_system_interpreter() -> None:
+    """The stub is spawned by whatever ``PATH`` finds, not by the test venv.
+
+    Its shebang is ``/usr/bin/env python3``, so it has to keep to the standard
+    library — a stub that imported anything installed would work here and fail
+    on the first host whose ``python3`` is bare.
+    """
+    source = (stub_runtime_dir() / "_stub_main.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported.add(node.module.split(".")[0])
+    third_party = imported - set(sys.stdlib_module_names) - {"__future__"}
+    assert not third_party, f"the stub imports non-stdlib modules: {sorted(third_party)}"

--- a/tests/services/ariel_search/integration/test_cli.py
+++ b/tests/services/ariel_search/integration/test_cli.py
@@ -45,7 +45,7 @@ class TestCLIStatusCommand:
 
         # Should succeed
         assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
-        assert "ARIEL Status:" in result.output
+        assert "ARIEL Status:" in result.stdout
 
     def test_status_command_json_output(self, database_url):
         """Status command with --json outputs valid JSON."""
@@ -63,8 +63,9 @@ class TestCLIStatusCommand:
             result = runner.invoke(ariel_group, ["status", "--json"])
 
         assert result.exit_code == 0
-        # Should be valid JSON
-        data = json.loads(result.output)
+        # ``--json`` promises stdout is one document: parse the stream, not
+        # ``result.output``, which mixes stdout and stderr together.
+        data = json.loads(result.stdout)
         assert "status" in data
 
     def test_status_command_unconfigured(self):
@@ -253,7 +254,7 @@ class TestCLISearchCommand:
 
         # Should succeed (even if no results)
         assert result.exit_code == 0
-        assert "Query:" in result.output
+        assert "Query:" in result.stdout
 
     def test_search_command_json_output(self, database_url):
         """Search command with --json outputs valid JSON."""
@@ -272,8 +273,9 @@ class TestCLISearchCommand:
             result = runner.invoke(ariel_group, ["search", "test query", "--json"])
 
         assert result.exit_code == 0, f"Exit: {result.exit_code}, Output: {result.output}"
-        # Extract JSON from output (may have log messages before it)
-        output = result.output
+        # ``--json`` runs in machine mode, so every human line is on stderr and
+        # stdout is the document alone.
+        output = result.stdout
         # Find the JSON object in output (skip any log lines)
         json_start = output.find("{")
         if json_start >= 0:

--- a/tests/services/ariel_search/test_cli.py
+++ b/tests/services/ariel_search/test_cli.py
@@ -268,8 +268,10 @@ class TestARIELCLIGroup:
                 )
 
         assert result.exit_code == 1
-        assert "ARIEL database is not initialized" in result.output
-        assert "osprey ariel migrate" in result.output
+        # Trouble is stderr-only under the renderer, and ``result.output`` mixes
+        # both streams, so the stream itself is what gets pinned here.
+        assert "ARIEL database is not initialized" in result.stderr
+        assert "osprey ariel migrate" in result.stderr
 
 
 class TestWatchCommand:
@@ -339,8 +341,8 @@ class TestWatchCommand:
 
         assert result.exit_code == 0
         mock_poll.assert_called_once_with(dry_run=False)
-        assert "Poll complete" in result.output
-        assert "3 added" in result.output
+        assert "Poll complete" in result.stdout
+        assert "3 added" in result.stdout
 
     def test_watch_once_dry_run(self, runner, monkeypatch):
         """watch --once --dry-run shows dry-run prefix in output."""
@@ -386,8 +388,8 @@ class TestWatchCommand:
 
         assert result.exit_code == 0
         mock_poll.assert_called_once_with(dry_run=True)
-        assert "[dry-run]" in result.output
-        assert "Poll complete" in result.output
+        assert "[dry-run]" in result.stdout
+        assert "Poll complete" in result.stdout
 
     def test_watch_no_source_shows_error(self, runner, monkeypatch):
         """watch shows error when ingestion has no source_url."""
@@ -403,7 +405,7 @@ class TestWatchCommand:
         result = runner.invoke(ariel_group, ["watch", "--once"])
 
         assert result.exit_code == 1
-        assert "source" in result.output.lower()
+        assert "source" in result.stderr.lower()
 
     def test_watch_no_config_shows_error(self, runner, monkeypatch):
         """watch shows error when ARIEL not configured."""
@@ -413,7 +415,7 @@ class TestWatchCommand:
         )
         result = runner.invoke(ariel_group, ["watch", "--once"])
         assert result.exit_code == 1
-        assert "not configured" in result.output.lower()
+        assert "not configured" in result.stderr.lower()
 
     def test_watch_adapter_choices(self, runner):
         """watch command validates adapter choices."""
@@ -449,7 +451,7 @@ class TestQuickstartCommand:
         )
         result = runner.invoke(ariel_group, ["quickstart"])
         assert result.exit_code == 1
-        assert "not configured" in result.output.lower()
+        assert "not configured" in result.stderr.lower()
 
     def test_quickstart_connection_failure_shows_guidance(self, runner, monkeypatch):
         """quickstart shows 'osprey up' guidance on connection failure."""
@@ -472,7 +474,7 @@ class TestQuickstartCommand:
             result = runner.invoke(ariel_group, ["quickstart"])
 
         assert result.exit_code == 1
-        assert "osprey up" in result.output
+        assert "osprey up" in result.stderr
 
     def test_quickstart_success_flow(self, runner, monkeypatch, tmp_path):
         """quickstart completes successfully with mocked database."""
@@ -523,7 +525,7 @@ class TestQuickstartCommand:
             result = runner.invoke(ariel_group, ["quickstart"])
 
         assert result.exit_code == 0
-        assert "complete" in result.output.lower()
+        assert "complete" in result.stdout.lower()
 
 
 class TestSyncCommand:
@@ -566,9 +568,9 @@ class TestSyncCommand:
 
         assert result.exit_code == 0, result.output
         mock_sync.assert_called_once()
-        assert "42 ingested" in result.output
-        assert "5 enhanced" in result.output
-        assert "1 failed" in result.output
+        assert "42 ingested" in result.stdout
+        assert "5 enhanced" in result.stdout
+        assert "1 failed" in result.stdout
 
     def test_sync_with_limit(self, runner, monkeypatch):
         """sync passes --limit to run_sync."""
@@ -612,7 +614,7 @@ class TestSyncCommand:
         )
         result = runner.invoke(ariel_group, ["sync"])
         assert result.exit_code == 1
-        assert "not configured" in result.output.lower()
+        assert "not configured" in result.stderr.lower()
 
     def test_sync_connection_failure_shows_guidance(self, runner, monkeypatch):
         """sync shows 'osprey up' guidance on connection failure."""
@@ -635,7 +637,7 @@ class TestSyncCommand:
             result = runner.invoke(ariel_group, ["sync"])
 
         assert result.exit_code == 1
-        assert "osprey up" in result.output
+        assert "osprey up" in result.stderr
 
 
 class TestSearchResultRendering:
@@ -765,9 +767,9 @@ class TestSearchResultRendering:
         result = runner.invoke(ariel_group, ["search", "coupler vacuum CM2"])
 
         assert result.exit_code == 0
-        assert "No results found" not in result.output
-        assert "VL-001" in result.output
-        assert "CM2 coupler vacuum note 1" in result.output
+        assert "No results found" not in result.stdout
+        assert "VL-001" in result.stdout
+        assert "CM2 coupler vacuum note 1" in result.stdout
 
     def test_search_command_no_results_message_only_when_truly_empty(self, runner, monkeypatch):
         """'No results found.' is reserved for zero entries AND no answer."""
@@ -793,4 +795,4 @@ class TestSearchResultRendering:
         result = runner.invoke(ariel_group, ["search", "nonexistent"])
 
         assert result.exit_code == 0
-        assert "No results found" in result.output
+        assert "No results found" in result.stdout

--- a/tests/simulation/test_type_aware_lookup.py
+++ b/tests/simulation/test_type_aware_lookup.py
@@ -238,7 +238,7 @@ class TestSimCliTypeAwareness:
         monkeypatch.chdir(repo / "build")
         result = CliRunner().invoke(sim_group, ["list"])
         assert result.exit_code == 1
-        assert "Error: no mock 'simulation_file' configured in config.yml." in result.output
+        assert "✗ No mock 'simulation_file' is configured in config.yml" in result.output
         assert "This project does not use the simulation engine." in result.output
 
     def test_va_mode_lists_scenarios(self, tmp_path, monkeypatch):

--- a/tests/utils/test_component_logger_intent.py
+++ b/tests/utils/test_component_logger_intent.py
@@ -1,0 +1,180 @@
+"""Tests for the ``osprey_intent`` marker ``ComponentLogger`` puts on every record.
+
+The contract under test: every public intent method stamps its own name onto the
+emitted record as ``record.osprey_intent``, levels are unchanged, and a
+caller-supplied ``extra`` mapping survives the merge untouched. The attribute is
+metadata for handlers (the CLI altitude gate) — it is deliberately invisible to
+rendering, which ``test_noncli_handler_parity.py`` pins separately.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from osprey.utils.logger import ComponentLogger
+
+#: Every public intent method, with the record level it must keep emitting.
+#: Both halves are pinned here: a level remap would be as much a regression as a
+#: missing marker.
+INTENT_LEVELS: dict[str, int] = {
+    "status": logging.INFO,
+    "key_info": logging.INFO,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "success": logging.INFO,
+    "timing": logging.INFO,
+    "approval": logging.INFO,
+    "resume": logging.INFO,
+    "critical": logging.CRITICAL,
+    "exception": logging.ERROR,
+}
+
+
+class _RecordCollector(logging.Handler):
+    """Plain stdlib handler — no Rich — that keeps the records it is handed."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def captured(request):
+    """A ``ComponentLogger`` on an isolated base logger plus its record sink."""
+    base = logging.getLogger(f"osprey_intent_test.{request.node.name}")
+    base.setLevel(logging.DEBUG)
+    base.propagate = False  # keep records off the root handlers other tests own
+    collector = _RecordCollector()
+    base.handlers[:] = [collector]
+    try:
+        yield ComponentLogger(base, "test_component"), collector
+    finally:
+        base.handlers[:] = []
+
+
+class TestIntentAttribute:
+    @pytest.mark.parametrize("method", sorted(INTENT_LEVELS))
+    def test_method_stamps_its_own_name(self, captured, method):
+        logger, collector = captured
+
+        getattr(logger, method)("hello")
+
+        (record,) = collector.records
+        assert record.osprey_intent == method
+
+    @pytest.mark.parametrize(("method", "level"), sorted(INTENT_LEVELS.items()))
+    def test_level_is_not_remapped(self, captured, method, level):
+        logger, collector = captured
+
+        getattr(logger, method)("hello")
+
+        (record,) = collector.records
+        assert record.levelno == level
+
+    def test_attribute_reaches_a_plain_handler(self, captured):
+        """A non-Rich handler sees the marker as an ordinary record attribute."""
+        logger, collector = captured
+
+        logger.key_info("important")
+
+        (record,) = collector.records
+        assert getattr(record, "osprey_intent", None) == "key_info"
+        assert record.getMessage() == "important"
+
+    def test_intents_are_distinguishable_at_the_same_level(self, captured):
+        """``info`` and ``key_info`` share INFO — only the marker separates them."""
+        logger, collector = captured
+
+        logger.info("plain")
+        logger.key_info("important")
+
+        assert [r.levelno for r in collector.records] == [logging.INFO, logging.INFO]
+        assert [r.osprey_intent for r in collector.records] == ["info", "key_info"]
+
+    def test_percent_style_args_still_format(self, captured):
+        logger, collector = captured
+
+        logger.info("value is %s", 42)
+
+        (record,) = collector.records
+        assert record.getMessage() == "value is 42"
+        assert record.osprey_intent == "info"
+
+
+class TestCallerExtra:
+    def test_caller_keys_survive_alongside_the_marker(self, captured):
+        logger, collector = captured
+
+        logger.warning("careful", extra={"request_id": "abc", "attempt": 2})
+
+        (record,) = collector.records
+        assert record.request_id == "abc"
+        assert record.attempt == 2
+        assert record.osprey_intent == "warning"
+
+    def test_caller_dict_is_not_mutated(self, captured):
+        logger, _ = captured
+        caller_extra = {"request_id": "abc"}
+
+        logger.info("hello", extra=caller_extra)
+
+        assert caller_extra == {"request_id": "abc"}
+
+    def test_marker_wins_over_a_caller_supplied_intent(self, captured):
+        """The marker is Osprey's, not a caller's — the emitting method decides it."""
+        logger, collector = captured
+
+        logger.error("boom", extra={"osprey_intent": "spoofed"})
+
+        (record,) = collector.records
+        assert record.osprey_intent == "error"
+
+
+class TestPreservedBehaviour:
+    def test_event_system_kwargs_are_still_stripped(self, captured):
+        """Legacy callers pass these; they must not reach ``Logger.log``."""
+        logger, collector = captured
+
+        logger.error(
+            "boom",
+            error="ValueError",
+            error_type="ValueError",
+            recoverable=True,
+            stack_trace="...",
+            warning="w",
+        )
+
+        (record,) = collector.records
+        assert record.osprey_intent == "error"
+        assert not hasattr(record, "error_type")
+
+    def test_exception_still_attaches_traceback(self, captured):
+        logger, collector = captured
+
+        try:
+            raise ValueError("nope")
+        except ValueError:
+            logger.exception("failed")
+
+        (record,) = collector.records
+        assert record.exc_info is not None
+        assert record.osprey_intent == "exception"
+
+    def test_error_honours_exc_info_flag(self, captured):
+        logger, collector = captured
+
+        try:
+            raise ValueError("nope")
+        except ValueError:
+            logger.error("failed", exc_info=True)
+
+        (record,) = collector.records
+        assert record.exc_info is not None
+        assert record.osprey_intent == "error"

--- a/tests/utils/test_configure_logging.py
+++ b/tests/utils/test_configure_logging.py
@@ -7,6 +7,7 @@ loggers.
 
 from __future__ import annotations
 
+import io
 import logging
 import subprocess
 import sys
@@ -17,7 +18,13 @@ from rich.logging import RichHandler
 
 import osprey
 import osprey.utils.logger
-from osprey.utils.logger import QUIET_THIRD_PARTY_LOGGERS, configure_logging, get_logger
+from osprey.utils.logger import (
+    QUIET_THIRD_PARTY_LOGGERS,
+    _build_rich_handler,
+    configure_logging,
+    get_logger,
+    set_handler_console,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -222,6 +229,67 @@ class TestPackageRootExport:
             f"bare `import osprey` should import neither rich nor "
             f"osprey.utils.logger; got {result.stdout.strip()!r}"
         )
+
+
+class TestInjectedHandlerConsole:
+    """The handler's console is the CLI's to replace; nobody else's changes.
+
+    ``configure_logging()`` serves entry points with no console of their own —
+    MCP servers, bridges, services, and consumers of the connectors package
+    outside this repo — so it keeps building the stderr console it always has.
+    The CLI, which owns a themed terminal-sized stderr console already, points
+    the installed handler at that one afterwards.
+    """
+
+    def test_no_argument_builds_the_documented_stderr_console(self):
+        console = _build_rich_handler().console
+
+        assert console.stderr is True
+        assert console.is_terminal is True
+        assert console.width == 120
+        assert console.color_system == "truecolor"
+
+    def test_an_injected_console_is_used_as_is(self):
+        injected = Console(file=io.StringIO(), width=42)
+
+        handler = _build_rich_handler(injected)
+
+        assert handler.console is injected
+
+    def test_set_handler_console_repoints_the_installed_handler(self):
+        configure_logging()
+        injected = Console(file=io.StringIO(), width=42)
+
+        returned = set_handler_console(injected)
+
+        assert returned is _rich_handlers()[0]
+        assert returned.console is injected
+
+    def test_repointing_is_repeatable_and_stacks_nothing(self):
+        """15+ test files invoke the CLI more than once per process."""
+        configure_logging()
+        first = Console(file=io.StringIO(), width=42)
+        second = Console(file=io.StringIO(), width=42)
+
+        handler = set_handler_console(first)
+        again = set_handler_console(second)
+        configure_logging()
+
+        assert again is handler
+        assert _rich_handlers() == [handler]
+        assert handler.console is second
+
+    def test_records_render_through_the_injected_console(self):
+        configure_logging()
+        sink = io.StringIO()
+        set_handler_console(Console(file=sink, width=100))
+
+        logging.getLogger("osprey.test.injected_console").warning("injected-marker")
+
+        assert "injected-marker" in sink.getvalue()
+
+    def test_unconfigured_logging_has_no_handler_to_repoint(self):
+        assert set_handler_console(Console(file=io.StringIO())) is None
 
 
 class TestAcceptedStdoutLimitation:

--- a/tests/utils/test_noncli_handler_parity.py
+++ b/tests/utils/test_noncli_handler_parity.py
@@ -1,0 +1,392 @@
+"""Regression instrument: non-CLI consumers of ``osprey_connectors`` see no change.
+
+The CLI-output work touched two things in the shared logging module: every
+record now carries an ``osprey_intent`` attribute, and ``_build_rich_handler()``
+accepts an injected console. Everything else that calls ``configure_logging()``
+— service startups, the dispatch worker, MCP servers, and any external consumer
+of the published package — passes no console and must keep getting byte-for-byte
+the terminal output it got before.
+
+Two instruments pin that, both on a frozen clock so timestamps are deterministic
+and both rendering into a ``StringIO`` console:
+
+(a) **Render-inertness of the intent attribute** — one handler fed the same
+    records with and without ``osprey_intent`` produces identical bytes, both
+    for hand-built records and for the records a real ``ComponentLogger``
+    emits.
+(b) **Builder parity** — ``_build_rich_handler()`` with no injected console is
+    structurally identical to, and renders identically to, an inline frozen
+    replica of the pre-feature builder embedded in this file.
+
+The replica below is the baseline. It is a deliberate copy, not a call into the
+current module: if the shipped builder drifts, only the copy still describes the
+behavior external consumers were promised, and these tests fail.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import sys
+from datetime import datetime
+from typing import Literal, cast
+
+from rich.console import Console
+from rich.logging import RichHandler
+
+from osprey.utils.logger import ComponentLogger, _build_rich_handler
+from osprey_connectors.config import get_config_value
+
+#: Fixed wall-clock seed for every record. ``RichHandler.render`` derives the
+#: displayed timestamp from ``record.created`` alone, so pinning that field is
+#: the whole clock freeze — no patching of ``time`` is needed.
+FROZEN_EPOCH: float = datetime(2026, 1, 2, 3, 4, 5).timestamp()
+
+#: Level, intent name, and message for the shared record set. Several levels are
+#: covered, and one message carries Rich markup plus a bracketed literal that is
+#: *not* a tag — the handler is built with ``markup=True``, so markup handling is
+#: part of what has to stay identical.
+RECORD_SPECS: tuple[tuple[int, str, str], ...] = (
+    (logging.DEBUG, "debug", "Resolving handler chain"),
+    (logging.INFO, "info", "Connected to 3 channels"),
+    (logging.INFO, "key_info", "Profile: als-apg"),
+    (logging.INFO, "status", "[bold cyan]Deploying[/bold cyan] stack [1/3]"),
+    (logging.WARNING, "warning", "Retrying in 5s"),
+    (logging.ERROR, "error", "Write refused for SR:BPM1"),
+)
+
+
+def _prefeature_build_rich_handler() -> RichHandler:
+    """Inline frozen replica of ``_build_rich_handler`` as it stood pre-feature.
+
+    Copied from the shipped builder before the console parameter existed. It is
+    the baseline these tests compare against, so it must never be rewritten to
+    delegate to the current implementation — that would make the comparison
+    vacuous.
+
+    Returns:
+        A ``RichHandler`` configured exactly as non-CLI entry points used to get.
+    """
+    try:
+        # Security-conscious defaults: hide locals to prevent sensitive data exposure
+        rich_tracebacks = get_config_value("logging.rich_tracebacks", True)
+        show_traceback_locals = get_config_value("logging.show_traceback_locals", False)
+        show_full_paths = get_config_value("logging.show_full_paths", False)
+    except Exception:
+        rich_tracebacks = True
+        show_traceback_locals = False
+        show_full_paths = False
+
+    # force_terminal keeps colors in containers and CI, where stderr is a pipe.
+    console = Console(
+        stderr=True,
+        force_terminal=True,
+        width=120,
+        color_system="truecolor",
+    )
+
+    return RichHandler(
+        console=console,
+        rich_tracebacks=rich_tracebacks,
+        markup=True,
+        show_path=show_full_paths,
+        show_time=True,
+        show_level=True,
+        tracebacks_show_locals=show_traceback_locals,
+    )
+
+
+def _make_record(level: int, message: str, index: int, intent: str | None) -> logging.LogRecord:
+    """Build one fully deterministic record.
+
+    Args:
+        level: Standard library level for the record.
+        message: Already-formatted message text.
+        index: Position in the set; each record is one second after the previous
+            so no two render the same timestamp (``omit_repeated_times`` blanks
+            a repeat, which would make the comparison depend on ordering).
+        intent: Value for ``osprey_intent``, or ``None`` to leave the attribute
+            off entirely — the pre-feature shape.
+
+    Returns:
+        A ``LogRecord`` whose every render-visible field is fixed.
+    """
+    record = logging.LogRecord(
+        name="osprey.parity",
+        level=level,
+        pathname="/osprey/parity.py",
+        lineno=42,
+        msg=message,
+        args=(),
+        exc_info=None,
+        func="emit",
+    )
+    _freeze(record, index)
+    if intent is not None:
+        record.osprey_intent = intent
+    return record
+
+
+def _freeze(record: logging.LogRecord, index: int) -> logging.LogRecord:
+    """Pin every render-visible field of ``record`` that varies run to run."""
+    record.created = FROZEN_EPOCH + index
+    record.pathname = "/osprey/parity.py"
+    record.lineno = 42
+    record.name = "osprey.parity"
+    record.funcName = "emit"
+    return record
+
+
+def _record_set(*, with_intent: bool) -> list[logging.LogRecord]:
+    """The shared record set, with or without the ``osprey_intent`` attribute."""
+    return [
+        _make_record(level, message, index, intent if with_intent else None)
+        for index, (level, intent, message) in enumerate(RECORD_SPECS)
+    ]
+
+
+def _render(handler: RichHandler, records: list[logging.LogRecord]) -> str:
+    """Render ``records`` through ``handler`` into a string.
+
+    The handler's real console is swapped for a ``StringIO`` twin carrying the
+    same width, terminal flag, and color system, so a drift in any of those
+    still shows up in the captured bytes rather than being normalized away.
+
+    Args:
+        handler: Handler under test; its console is restored before returning.
+        records: Records to emit, in order.
+
+    Returns:
+        Everything the handler wrote, ANSI escapes included.
+    """
+    buffer = io.StringIO()
+    live_console = handler.console
+    handler.console = Console(
+        file=buffer,
+        force_terminal=live_console.is_terminal,
+        width=live_console.width,
+        # ``Console.color_system`` hands back the plain name it was built from.
+        color_system=cast(
+            "Literal['auto', 'standard', '256', 'truecolor', 'windows'] | None",
+            live_console.color_system,
+        ),
+    )
+    # LogRender remembers the last timestamp it printed; clear it so a pass never
+    # depends on what an earlier pass through the same handler rendered.
+    handler._log_render._last_time = None
+    try:
+        for record in records:
+            handler.emit(record)
+    finally:
+        handler.console = live_console
+    return buffer.getvalue()
+
+
+#: ANSI CSI sequences, for the readability guards below only.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _visible(rendered: str) -> str:
+    """Strip ANSI escapes so a guard can look for the text an operator reads.
+
+    Only the "did this really render something" guards use this. The parity
+    assertions themselves always compare the raw bytes, escapes included —
+    a color change is exactly the kind of drift they exist to catch. Rich's
+    highlighter styles numbers and brackets mid-token, so a raw substring
+    search for ``[1/3]`` or ``3 channels`` would miss.
+    """
+    return _ANSI.sub("", rendered)
+
+
+def _console_shape(console: Console) -> dict[str, object]:
+    """Every console setting the pre-feature builder pinned."""
+    return {
+        "file": console.file,
+        "stderr": console.stderr,
+        "is_terminal": console.is_terminal,
+        "width": console.width,
+        "color_system": console.color_system,
+        "no_color": console.no_color,
+    }
+
+
+def _handler_shape(handler: RichHandler) -> dict[str, object]:
+    """Every ``RichHandler`` constructor argument observable on the instance.
+
+    Includes the ``LogRender`` fields, which are where ``show_time``,
+    ``show_level``, and ``show_path`` end up.
+    """
+    render = handler._log_render
+    return {
+        "level": handler.level,
+        "markup": handler.markup,
+        "rich_tracebacks": handler.rich_tracebacks,
+        "enable_link_path": handler.enable_link_path,
+        "highlighter": type(handler.highlighter),
+        "keywords": handler.keywords,
+        "locals_max_length": handler.locals_max_length,
+        "locals_max_string": handler.locals_max_string,
+        "tracebacks_width": handler.tracebacks_width,
+        "tracebacks_code_width": handler.tracebacks_code_width,
+        "tracebacks_extra_lines": handler.tracebacks_extra_lines,
+        "tracebacks_theme": handler.tracebacks_theme,
+        "tracebacks_word_wrap": handler.tracebacks_word_wrap,
+        "tracebacks_show_locals": handler.tracebacks_show_locals,
+        "tracebacks_suppress": tuple(handler.tracebacks_suppress),
+        "tracebacks_max_frames": handler.tracebacks_max_frames,
+        "show_time": render.show_time,
+        "show_level": render.show_level,
+        "show_path": render.show_path,
+        "time_format": render.time_format,
+        "omit_repeated_times": render.omit_repeated_times,
+        "level_width": render.level_width,
+    }
+
+
+class TestIntentAttributeIsRenderInert:
+    """(a) ``osprey_intent`` must change nothing a terminal ever sees."""
+
+    def test_same_handler_renders_identical_bytes_with_and_without_intent(self) -> None:
+        handler = _build_rich_handler()
+        tagged = _record_set(with_intent=True)
+        untagged = _record_set(with_intent=False)
+
+        assert all(hasattr(record, "osprey_intent") for record in tagged)
+        assert not any(hasattr(record, "osprey_intent") for record in untagged)
+
+        rendered_tagged = _render(handler, tagged)
+        rendered_untagged = _render(handler, untagged)
+
+        # Guard against a vacuous pass on two empty strings.
+        assert "Connected to 3 channels" in _visible(rendered_untagged)
+        assert rendered_tagged == rendered_untagged
+
+    def test_rendered_output_never_mentions_the_attribute(self) -> None:
+        rendered = _visible(_render(_build_rich_handler(), _record_set(with_intent=True)))
+
+        assert "osprey_intent" not in rendered
+        for _level, intent, _message in RECORD_SPECS:
+            # Intent names double as message-free markers; none may leak. The
+            # names that also appear in level text ("debug", "warning",
+            # "error") are excluded — those are the level column, not the marker.
+            if intent in ("debug", "warning", "error"):
+                continue
+            assert intent not in rendered
+
+    def test_markup_message_still_renders_as_markup(self) -> None:
+        rendered = _visible(_render(_build_rich_handler(), _record_set(with_intent=True)))
+
+        # markup=True: the tags are consumed, the styled words and the
+        # bracketed non-tag survive verbatim.
+        assert "[bold cyan]" not in rendered
+        assert "Deploying" in rendered
+        assert "[1/3]" in rendered
+
+    def test_component_logger_records_render_like_plain_stdlib_records(self) -> None:
+        """The production path, not just hand-built records.
+
+        A real ``ComponentLogger`` call and a bare ``logging.Logger`` call with
+        the same level and text must reach the handler as records that render
+        identically — the merged ``extra`` being the only difference between
+        them.
+        """
+        component_records = _emit_and_collect(via_component_logger=True)
+        plain_records = _emit_and_collect(via_component_logger=False)
+
+        assert all(hasattr(record, "osprey_intent") for record in component_records)
+        assert not any(hasattr(record, "osprey_intent") for record in plain_records)
+        assert [record.levelno for record in component_records] == [
+            record.levelno for record in plain_records
+        ]
+
+        handler = _build_rich_handler()
+        rendered_component = _render(handler, component_records)
+        rendered_plain = _render(handler, plain_records)
+
+        assert "Connected to 3 channels" in _visible(rendered_plain)
+        assert rendered_component == rendered_plain
+
+
+class TestBuilderParityWithFrozenReplica:
+    """(b) The shipped builder, given no console, is the pre-feature builder."""
+
+    def test_console_matches_the_frozen_replica(self) -> None:
+        shipped = _build_rich_handler()
+        replica = _prefeature_build_rich_handler()
+
+        assert _console_shape(shipped.console) == _console_shape(replica.console)
+
+    def test_console_still_carries_the_pre_feature_literals(self) -> None:
+        console = _build_rich_handler().console
+
+        assert console.file is sys.stderr
+        assert console.stderr is True
+        assert console.is_terminal is True
+        assert console.width == 120
+        assert console.color_system == "truecolor"
+
+    def test_every_handler_constructor_argument_matches_the_replica(self) -> None:
+        shipped = _build_rich_handler()
+        replica = _prefeature_build_rich_handler()
+
+        assert _handler_shape(shipped) == _handler_shape(replica)
+
+    def test_handler_still_carries_the_pre_feature_literals(self) -> None:
+        shape = _handler_shape(_build_rich_handler())
+
+        assert shape["markup"] is True
+        assert shape["show_time"] is True
+        assert shape["show_level"] is True
+        assert shape["show_path"] is False
+        assert shape["tracebacks_show_locals"] is False
+        assert shape["rich_tracebacks"] is True
+
+    def test_both_handlers_render_identical_bytes(self) -> None:
+        shipped = _build_rich_handler()
+        replica = _prefeature_build_rich_handler()
+        records = _record_set(with_intent=True)
+
+        rendered_shipped = _render(shipped, records)
+        rendered_replica = _render(replica, _record_set(with_intent=False))
+
+        assert "Connected to 3 channels" in _visible(rendered_replica)
+        assert rendered_shipped == rendered_replica
+
+
+def _emit_and_collect(*, via_component_logger: bool) -> list[logging.LogRecord]:
+    """Emit ``RECORD_SPECS`` through the real logging path and freeze the records.
+
+    Args:
+        via_component_logger: ``True`` drives ``ComponentLogger``'s public intent
+            methods (which stamp ``osprey_intent``); ``False`` drives the bare
+            ``logging.Logger`` underneath it.
+
+    Returns:
+        The captured records, with every run-varying field pinned so two sets
+        differ only in the attribute under test.
+    """
+    which = "component" if via_component_logger else "plain"
+    base = logging.getLogger(f"osprey_parity_test.{which}")
+    base.setLevel(logging.DEBUG)
+    base.propagate = False  # keep records off root handlers other tests own
+    collected: list[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            collected.append(record)
+
+    base.handlers[:] = [_Collector()]
+    try:
+        component = ComponentLogger(base, "parity")
+        for level, intent, message in RECORD_SPECS:
+            if via_component_logger:
+                getattr(component, intent)(message)
+            else:
+                base.log(level, message)
+    finally:
+        base.handlers[:] = []
+
+    for index, record in enumerate(collected):
+        _freeze(record, index)
+    return collected


### PR DESCRIPTION
A normal `osprey up` interleaved six visual vocabularies in one scroll: the
phase-line report, timestamped INFO records, a heavy-box table, indented
key/value sections, the live build table, and bare prefixed lines. Repo-wide
that was 16 distinct output vocabularies across roughly 209 `click.echo` calls,
198 `console.print` calls against four separately constructed Consoles, 17 bare
`print()`, and 330 logger call sites.

An operator watching a deploy could not tell a report from a log line from a
diagnostic, because nothing in the code distinguished them.
`configure_logging(DEBUG if verbose else INFO)` was the entire altitude policy,
and `ComponentLogger` mapped all seven of its intent methods onto `INFO`, so
intent was erased at the point of emission and nothing downstream could filter
on it.

Five user-facing reports were routed through the logger rather than the
reporter, so they inherited a log line's shape: the endpoint summary on every
`up` exit path, the reset destruction plan on the `init --reset` path (but not
on `reset`, which did it correctly), the archive knob-diff before a destructive
rebuild, the host-port conflict report, and the whole pre/post-build step
report.

## Approach

One renderer owns the six primitives every verb prints through, and an altitude
gate decides what reaches the default view. The records still reach every sink
the deployment configures, so nothing is lost from the transcript, and `-v`
lifts the gate to bring all of it back. Warnings and failures read the same way
in every verb (a summary, the cause under it, and what to do about it) and go
to stderr, so a script reading a command's stdout no longer has to filter
trouble out of it. Under `--json`, stdout carries the document and nothing
else.

On a terminal the phases render as a live region that owns the single stream.
That ownership is the point: a raw write while a spinner is mounted lands
inside the repaint and garbles it, so every line routes through the console
instead of racing it. Off a terminal the same phases print as plain lines, and
a service still building appends a heartbeat roughly every thirty seconds, so a
piped build is never silent either.

Two standing guards keep this from rotting. An AST test walks the CLI,
deployment and health trees and pins the output inventory in both directions,
so an added console and a stale allowlist entry both fail. A copy canary's
floors are baselined from the real literal count, so they trip when the guard's
reach shrinks rather than describing an aspiration.

## Reviewing this

The commits are ordered so each builds on the one before it: the renderer and
the gate, then the surfaces, then the live region, then the verbs group by
group, and the guards last so they are born green. Reading them in order is
considerably easier than reading the squashed diff.

Two things are worth a reviewer's attention. The `--json` key sets are pinned
against goldens captured before any verb moved, so the machine contract is
checked rather than asserted. And terminal behavior is covered by a pty lane
that drives scripted runs against a stub runtime; it needs a real tty, so it
runs as its own CI lane rather than in the unit lane.

## How it hangs together

```text
   osprey <verb>                       library / service code
        |                                       |
        | report  note  section  table          | logger.info(...)
        | warn    fail  report_fact             |
        v                                       v
  +---------------------+           +--------------------------+
  |    cli/output.py    |           |     cli/altitude.py      |
  |   six primitives    |           |   gate on the handler    |
  +---------------------+           |   -v lifts it            |
        |                           +--------------------------+
        |                              |                    |
        |                      blocked |                    | passed
        |                              v                    v
        |                      file / aggregation       RichHandler
        |                      sinks (always)               |
        v                                                   |
  +----------------------------------------+                |
  |        _target_console(err=...)        | <--------------+
  |  machine_mode wins over everything     |
  +----------------------------------------+
        |                             |
  --json|                             | normal
        v                             v
  human text -> stderr        installed reporter's console
  stdout = one JSON doc         (built by cli/styles.py)
                                      |
                              tty     |      no tty
                          +-----------+-----------+
                          v                       v
                 +-------------------+   +---------------------+
                 |  live_render.py   |   |  plain phase lines  |
                 |  region owns the  |   |  + ~30s heartbeat   |
                 |  single stream    |   +---------------------+
                 +-------------------+
                          |
              while mounted, the region borrows the trouble
              line as well, so no write can land inside a
              repaint and weld a dead spinner to it
```
