### PR TITLE
feat(cli): promote deploy facts and warnings into the output hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Deploy output keeps one shape from start to finish. Facts a deploy used to
+  print as paragraphs between phases (minted tokens, generated certificates, a
+  renamed secrets file) are now one short line each in the step column, with
+  the details collected into a "This deploy wrote" block after the closing
+  summary. Warnings an operator must see print in the same indented `⚠` shape
+  instead of as timestamped log blocks, and raw log warnings stay in the
+  transcript (`-v`, file sinks) while a lifecycle command is drawing its
+  progress. `osprey init --reset` now reports what the reset removed and kept
+  as steps of its own phase; the full destruction plan remains what standalone
+  `osprey reset` shows before asking for confirmation.
+
 - What the CLI prints is now a progress report rather than a log. A verb prints
   the phase it is in, the steps under it, and a summary at the end; the
   timestamped `INFO` records that used to scroll past no longer reach the

--- a/src/osprey/cli/altitude.py
+++ b/src/osprey/cli/altitude.py
@@ -12,7 +12,10 @@ record is still emitted, still reaches ``caplog``, and still reaches any other
 handler or sink on the root logger. Nothing is lost — it is only not painted.
 
 ``-v``/``--verbose`` lifts the gate and restores the full transcript. Levels are
-never remapped; the gate reads a record's level and nothing else.
+never remapped; the gate reads a record's level, plus one bit of CLI state —
+whether a lifecycle reporter currently owns the terminal, which is what tells a
+WARNING record it must arrive promoted (:func:`osprey.cli.output.warn_fact`)
+rather than as a raw transcript block through a phase column.
 """
 
 import logging
@@ -23,18 +26,44 @@ __all__ = ["gate_installed", "install_gate", "lift_gate"]
 
 
 class _AltitudeGate(logging.Filter):
-    """Drop INFO-and-below records at the handler; pass WARNING and above.
+    """Drop INFO-and-below records at the handler; pass WARNING and above —
+    except while a lifecycle reporter owns the terminal, where WARNING is
+    dropped too and only ERROR and above still paint.
 
     The policy is deliberately level-based. Records emitted through
     :class:`~osprey.utils.logger.ComponentLogger` also carry an
     ``osprey_intent`` attribute naming the method that emitted them, but the
     shipped policy does not read it — INFO-family intents are separated by
     rewriting their call sites as report lines, not by filtering on intent.
+
+    The lifecycle exception is the renderer's single-voice rule. While a phase
+    record is being drawn, a raw WARNING painted by the handler arrives as a
+    timestamped, hard-wrapped transcript block in the middle of a column of
+    phase lines — the one shape the output hierarchy exists to prevent. So a
+    warning an operator must read during a lifecycle verb is *promoted* at its
+    call site (:func:`osprey.cli.output.warn_fact`), exactly as INFO-family
+    facts already are, and the un-promoted rest stays where it always was: in
+    the emitted record, for ``caplog``, file sinks, and ``-v``. ERROR keeps
+    painting unconditionally — a failure outranks the column's tidiness.
+
+    "A lifecycle reporter owns the terminal" is read off the installed reporter
+    per record, through the same predicate ``lifecycle_reporter`` uses to
+    decide ownership: the quiet ``NullReporter`` default means no lifecycle
+    verb is running, and every other reporter means one is.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Return True when this record should be rendered."""
-        return record.levelno >= logging.WARNING
+        if record.levelno >= logging.ERROR:
+            return True
+        if record.levelno < logging.WARNING:
+            return False
+        from osprey.cli.phase_reporter import NullReporter, current_reporter
+
+        # Either NullReporter shape means no phase column is being drawn: the
+        # quiet default because no lifecycle verb is running, the verbose one
+        # because ``-v`` streams the transcript instead of drawing one.
+        return isinstance(current_reporter(), NullReporter)
 
 
 def _root_rich_handler() -> RichHandler | None:

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2119,10 +2119,12 @@ def _build_repo(
         # Outside every phase, on purpose. The next thing this build opens is
         # `Preparing the project environment`, the long pole: hung under a
         # phase this identity would arrive minutes after the wait it labels,
-        # and as a step it would vanish entirely (no phase is open here).
+        # and as a step it would vanish entirely (no phase is open here). A
+        # note rather than a report line: it is context for the phases that
+        # follow, not something the operator ran the verb to find out.
         from . import output
 
-        output.report(
+        output.note(
             f"profile {build_profile.name} (bundle {build_profile.data_bundle}, "
             f"tier {build_profile.resolved_tier()})"
         )

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1130,18 +1130,17 @@ def init(
         if reset:
             # Imported here, not at module scope: this command is lazy-loaded,
             # and `reset` pulls in the whole deployment stack.
-            from osprey.deployment.reset import reset_deployment
+            from osprey.deployment.reset import ResetOutcome, reset_for_reinit
 
-            # `output.report`, and NOT a logger call: the destruction plan is
-            # this verb's own output, not a transcript line. Routed through the
-            # logger it is an INFO record, which the altitude gate drops on a
-            # normal run -- so `osprey init --reset` used to destroy a
-            # deployment without ever showing the operator the list of what it
-            # was about to take, while `osprey reset` printed the same plan in
-            # full. One printer for both call sites is what keeps the two paths
-            # line-identical rather than merely similar.
-            with reporter.phase(f"Discarding the previous {target.name}"):
-                reset_deployment(target, assume_yes=True, emit=output.report)
+            # The condensed form, not `reset_deployment`: the full destruction
+            # plan is the text a standalone `osprey reset` asks an operator to
+            # confirm against, and nothing is being confirmed here. The chained
+            # reset reports what it removed and what it kept as steps of this
+            # phase, and a reset with nothing to do closes the phase saying so
+            # instead of printing an empty plan.
+            with reporter.phase(f"Discarding the previous {target.name}") as phase:
+                if reset_for_reinit(target) is ResetOutcome.NOTHING_TO_DO:
+                    phase.done("nothing from a previous run to remove")
 
             # `reset` removes only what carries this checkout's repo-id label,
             # so a deployment predating that label survives it — correctly, since

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -277,6 +277,12 @@ def lifecycle_reporter() -> Iterator["PhaseReporter"]:
     ctx = click.get_current_context(silent=True)
     verbose = bool(ctx.find_root().params.get("verbose")) if ctx is not None else False
     reporter: PhaseReporter = NullReporter(verbose=True) if verbose else _tty_aware_reporter()
+    # The ledger is process-scoped and the outermost verb owns the flush, so
+    # the outermost install is where rows a failed earlier run never flushed
+    # get dropped -- otherwise they would print under this run's card.
+    from .output import clear_ledger
+
+    clear_ledger()
     previous = install_reporter(reporter)
     try:
         reporter.start_rendering()

--- a/src/osprey/cli/output.py
+++ b/src/osprey/cli/output.py
@@ -38,7 +38,9 @@ if TYPE_CHECKING:
     from osprey_connectors.logger import ComponentLogger
 
 __all__ = [
+    "clear_ledger",
     "fail",
+    "flush_ledger",
     "machine_mode",
     "machine_mode_active",
     "note",
@@ -47,6 +49,7 @@ __all__ = [
     "section",
     "table",
     "warn",
+    "warn_fact",
 ]
 
 #: The one indentation step. Everything subordinate -- a note, a section's rows
@@ -77,10 +80,26 @@ _WARN_GLYPH = "⚠"
 #: scrollback full of causes.
 _REMEDY_GLYPH = "→"
 
+#: What opens a fact line -- the same mark the phase record's ``  · name`` steps
+#: wear, so a fact reads as part of the run it happened in rather than as a
+#: paragraph interrupting it. A fact is not a step: it never touches the phase's
+#: lap clock and never carries a duration.
+_FACT_GLYPH = "·"
+
 #: True for as long as a :func:`machine_mode` block is open. Process-scoped
 #: rather than task- or thread-scoped: the CLI is single-threaded at these call
 #: sites, and a ``--json`` verb wraps its whole body in one block.
 _machine_mode = False
+
+#: The run ledger: the ``(label, value)`` rows :func:`report_fact` collected for
+#: the closing "what this run wrote" block. Process-scoped for the same reason
+#: the reporter is a module singleton -- the facts are minted by helpers deep in
+#: the call stack, and the verb that owns the run flushes them once at its end.
+_ledger: list[tuple[str, str]] = []
+
+#: The heading the flushed ledger prints under. One spelling, here, so the
+#: closing block reads identically whichever verb flushes it.
+_LEDGER_TITLE = "This deploy wrote"
 
 
 def _region_is_mounted() -> bool:
@@ -199,31 +218,109 @@ def report(text: str, /, *, style: str | None = None) -> None:
     _echo(Text(text, style=style or ""))
 
 
-def report_fact(logger: ComponentLogger, message: str) -> None:
-    """Print an operator-critical fact, and keep its record for the log sinks.
+def report_fact(
+    logger: ComponentLogger, message: str, /, *, wrote: tuple[str, object] | None = None
+) -> None:
+    """Print an operator-critical fact in the run's own step column, and keep it.
 
     The promotion contract, spelled once for every module that carries facts a
     person running the verb has to read: credentials a deploy minted, secret
-    files it wrote or renamed, host state it changed, a posture it chose. All of
-    them printed through ``logger.key_info`` alone, which the CLI's altitude
-    gate drops at the handler on a normal run, so the fact never reached the
-    terminal at all.
+    files it wrote or renamed, host state it changed, a posture it chose. The
+    fact prints as ONE short line in the same indented shape the phase record's
+    steps use, so a run reads as one column rather than as steps interrupted by
+    paragraphs. The line goes through ``logger.key_info`` too, so file and
+    aggregation sinks keep the transcript they always kept; under ``-v`` it
+    appears twice, once as the verb's own output and once in the transcript
+    that flag asked for.
 
-    :func:`report` puts the fact in the default view, where the person running
-    the verb reads it. The log record stays at the level it always had, so file
-    and aggregation sinks keep the transcript they always kept. On a normal run
-    the gate drops the record at the handler and the fact reaches the terminal
-    once; under ``-v`` the gate is lifted and it appears twice, once as the
-    verb's own output and once in the transcript that flag asked for.
+    ``wrote`` is the fact's second altitude: a ``(label, value)`` row for the
+    closing ledger the owning verb flushes after its summary card (see
+    :func:`flush_ledger`). The inline line says THAT it happened, in passing;
+    the ledger row says exactly what, with the variable names and caveats an
+    operator acts on later. Give a row to anything someone will need after the
+    run has scrolled by; skip it for postures the inline line already states in
+    full. Ledger rows travel in a keyword and a variable, so the copy-style
+    guard never reads them; their prose keeps the house rules by review.
 
     :param logger: The calling module's logger, passed in rather than made here,
         so the record still names the module that holds the fact.
-    :param message: The finished line. The caller builds it, because every one
-        of these facts names a value only the caller holds: a path, a variable
-        name, a count.
+    :param message: The finished inline line, short enough to sit in the step
+        column. Positional-ONLY, as for :func:`report`: the copy guard reads
+        prose out of positional arguments.
+    :param wrote: The ledger row, or ``None`` for an inline-only fact. The value
+        is rendered with :func:`str`, like a :func:`section` value.
     """
-    report(message)
+    _echo(Text(f"{_INDENT}{_FACT_GLYPH} {message}"))
     logger.key_info(message)
+    if wrote is not None:
+        label, value = wrote
+        _ledger.append((label, str(value)))
+        logger.key_info(f"{label}: {value}")
+
+
+def warn_fact(
+    logger: ComponentLogger, summary: str, detail: str | None = None, remedy: str | None = None, /
+) -> None:
+    """Print a warning in the run's own column, and keep its record for the sinks.
+
+    :func:`warn`'s counterpart to :func:`report_fact`, for the warnings an
+    operator must read while a lifecycle verb runs: the deploy posture that
+    changed, the configuration that disagrees with itself. The block is the
+    trouble shape -- marked summary, indented body, ``→ remedy`` -- indented one
+    step so it reads as part of the run it happened in, and the record goes to
+    ``logger.warning`` for the file and aggregation sinks.
+
+    While a lifecycle reporter is installed, the altitude gate keeps raw WARNING
+    records off the terminal (see :mod:`osprey.cli.altitude`), so this function
+    is how a warning reaches the operator at all; under ``-v`` the gate is
+    lifted and the warning appears in both shapes, exactly as a promoted fact
+    does.
+
+    :param logger: The calling module's logger, as for :func:`report_fact`.
+    :param summary: What went sideways, in one line and without the glyph.
+        Positional-ONLY, as for :func:`warn`: the copy guard reads prose out of
+        positional arguments.
+    :param detail: What an operator needs in order to judge it. Printed indented
+        under the summary, line by line. Positional-only for the same reason.
+    :param remedy: The one thing to do about it, printed as ``→ remedy`` under
+        the detail. Omit it when there is nothing honest to suggest.
+    """
+    _echo(Text(f"{_INDENT}{_WARN_GLYPH} {summary}", style=Styles.WARNING), err=True)
+    body = list(detail.splitlines()) if detail else []
+    if remedy:
+        body.append(f"{_REMEDY_GLYPH} {remedy}")
+    for line in body:
+        _echo(Text(f"{_INDENT}{_INDENT}{line}"), err=True)
+    logger.warning(" ".join(part for part in (summary, detail, remedy) if part))
+
+
+def flush_ledger() -> None:
+    """Print the collected ledger rows as one closing block, and empty the ledger.
+
+    Called by the verb that owns the run, after its summary card -- and, on the
+    attached ``up`` path, immediately before the reporter's hand-off, because a
+    process about to replace itself with compose has exactly one last chance to
+    say what it wrote. A run that collected nothing prints nothing.
+
+    Rows print in the order they were collected, which is the order the run did
+    the writing -- :func:`section` keeps sequence order for exactly this caller.
+    """
+    if not _ledger:
+        return
+    rows, _ledger[:] = list(_ledger), []
+    report("")
+    section(_LEDGER_TITLE, rows)
+
+
+def clear_ledger() -> None:
+    """Drop any rows a previous run left uncollected.
+
+    The verb that installs the lifecycle reporter calls this at entry: the
+    ledger is process-scoped, and a run that failed before its flush must not
+    donate its rows to the next run in the same process (the test suite runs
+    the CLI many times in one process).
+    """
+    _ledger.clear()
 
 
 def note(text: str, /) -> None:

--- a/src/osprey/cli/summary_card.py
+++ b/src/osprey/cli/summary_card.py
@@ -138,6 +138,12 @@ def print_summary_card(repo_root: Path | str, state: str) -> None:
         title, rows = _card_parts(repo_root, state)
     except Exception as exc:
         logger.debug("Summary card skipped: %s", exc)
+        # The ledger still flushes: what the run wrote is a fact about the
+        # operator's disk whether or not the card could be derived.
+        output.flush_ledger()
         return
     output.report("")
     output.section(title, rows)
+    # After the card, so the endpoints an operator acts on stay the first thing
+    # under the ✓ line, and the written-files block reads as the appendix it is.
+    output.flush_ledger()

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -1944,7 +1944,7 @@ def prepare_compose_files(config_path, dev_mode=False, expose_network=False, out
         )
     elif "bind_address" not in config.get("deployment", {}):
         config["deployment"]["bind_address"] = "127.0.0.1"
-        _report_fact("Services will bind to localhost only (127.0.0.1) for security")
+        _report_fact("services bound to localhost only (127.0.0.1)")
 
     # Get deployed services list
     deployed_services = config.get("deployed_services", [])

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -260,16 +260,32 @@ _QSERVER_ZMQ_PRIVATE_KEY_VAR = "BLUESKY_QSERVER_ZMQ_PRIVATE_KEY"
 _QSERVER_ZMQ_PUBLIC_KEY_VAR = "BLUESKY_QSERVER_ZMQ_PUBLIC_KEY"
 
 
-def _report_fact(message: str) -> None:
+def _report_fact(message: str, /, *, wrote: tuple[str, object] | None = None) -> None:
     """Report ``message`` under this module's logger.
 
     The promotion contract lives in :func:`osprey.cli.output.report_fact`; this
     binds it to the lifecycle logger so call sites pass the line alone.
 
     Args:
-        message: The finished line, built by the caller.
+        message: The finished inline line, built by the caller.
+        wrote: The closing-ledger row, passed through as
+            :func:`osprey.cli.output.report_fact` documents it.
     """
-    output.report_fact(logger, message)
+    output.report_fact(logger, message, wrote=wrote)
+
+
+def _warn_fact(summary: str, detail: str | None = None, remedy: str | None = None, /) -> None:
+    """Warn under this module's logger, in the run's own column.
+
+    The promotion contract lives in :func:`osprey.cli.output.warn_fact`; this
+    binds it to the lifecycle logger so call sites pass the words alone.
+
+    Args:
+        summary: What went sideways, in one line.
+        detail: What an operator needs in order to judge it.
+        remedy: The one thing to do about it, if there is an honest one.
+    """
+    output.warn_fact(logger, summary, detail, remedy)
 
 
 #: What the knob diff below is a diff of. Named once because both halves of the
@@ -485,10 +501,14 @@ def _ensure_service_tokens(
                 "Auto-generated service auth tokens (osprey deploy up)",
                 generated,
             )
-            # Report the path and which keys — NEVER the values.
+            # Report the count inline and the key names in the ledger — NEVER
+            # the values.
             _report_fact(
-                f"Generated auth token(s) {', '.join(generated)} in "
-                f"{env_path.resolve()} (gitignored). Keep them secret."
+                f"minted {len(generated)} service auth token(s) → .env",
+                wrote=(
+                    ".env",
+                    f"{', '.join(generated)} (gitignored; keep them secret)",
+                ),
             )
 
             # A mint is the moment the volume-initialized vars become a hazard:
@@ -952,8 +972,11 @@ def _ensure_bluesky_substrate_env(config: dict, env_path: Path | None = None) ->
         generated,
     )
     _report_fact(
-        f"Auto-configured bluesky bridge scan devices {', '.join(generated)} in "
-        f"{env_path.resolve()} from the project's own channel_limits.json"
+        "bluesky scan devices auto-configured → .env",
+        wrote=(
+            ".env",
+            f"{', '.join(generated)} from the project's channel_limits.json",
+        ),
     )
 
 
@@ -1068,11 +1091,17 @@ def _ensure_bluesky_document_plane_certs(config: dict, env_path: Path | None = N
         return
 
     _report_fact(
-        f"Generated bluesky document-plane CURVE certificates under "
-        f"{paths['bridge'].parent} (gitignored, like the project .env). Both containers "
-        "read them at startup, so certificates written or replaced while the stack is "
-        "running take effect only after the bridge and queueserver containers are "
-        "recreated."
+        f"bluesky CURVE certificates → {_BLUESKY_CURVE_DIR}/",
+        wrote=(
+            f"{_BLUESKY_CURVE_DIR}/",
+            "document-plane certificates (gitignored); containers read them at "
+            "startup, so replacements need the bridge and queueserver recreated",
+        ),
+    )
+    # The transcript keeps the resolved location: a log read away from the
+    # project needs the absolute path the relative line cannot carry.
+    logger.key_info(
+        f"Bluesky document-plane CURVE certificates live under {paths['bridge'].parent}"
     )
 
 
@@ -1269,10 +1298,8 @@ def _ensure_bluesky_control_plane_keys(config: dict, env_path: Path | None = Non
         # comes from the same source, and nothing on disk can go stale.
         os.environ.update(generated)
         _report_fact(
-            f"Derived {', '.join(generated)} from the {_QSERVER_ZMQ_PRIVATE_KEY_VAR} in "
-            f"this environment for this deploy only; not written to {env_path.resolve()}, "
-            "since the private half is not there either and a lone public key on disk "
-            "would fail the next deploy from a clean shell."
+            f"derived {', '.join(generated)} from this shell's "
+            f"{_QSERVER_ZMQ_PRIVATE_KEY_VAR} for this deploy only (not written to .env)"
         )
         return
 
@@ -1286,9 +1313,12 @@ def _ensure_bluesky_control_plane_keys(config: dict, env_path: Path | None = Non
     # material here). Matches _ensure_service_tokens' "log which keys, never
     # what they are" convention.
     _report_fact(
-        f"Generated bluesky RE manager control-socket keypair {', '.join(generated)} in "
-        f"{env_path.resolve()} (gitignored). Treat both values as secrets. The public "
-        "half alone is enough to reach the manager's control socket."
+        "bluesky control-socket keypair minted → .env",
+        wrote=(
+            ".env",
+            f"{', '.join(generated)} (gitignored); treat both halves as secrets, since "
+            "the public half alone reaches the manager's control socket",
+        ),
     )
 
 
@@ -2338,19 +2368,19 @@ def _preflight_env_shadowing(
             "reaches nothing."
         )
         remedy = (
-            f"To change what starts: edit the chain — an export cannot reach this stack. "
+            f"To change what starts: edit the chain; an export cannot reach this stack. "
             f"To stop the disagreement: unset {' '.join(shadowed)}."
         )
     elif provider is ComposeProvider.DOCKER_V2:
         mechanics = (
-            "Docker Compose substitutes the EXPORTED value into the compose files — "
-            "--env-file is its lower-precedence source — so the stack starts on the "
+            "Docker Compose substitutes the EXPORTED value into the compose files "
+            "(--env-file is its lower-precedence source), so the stack starts on the "
             "shell's value while the chain keeps the one its volumes were initialized "
             "with."
         )
         remedy = (
             f"To start on the chain's value: unset {' '.join(shadowed)}. To adopt the "
-            f"exported one: edit the chain to match — but a volume that already exists "
+            f"exported one: edit the chain to match; a volume that already exists "
             f"keeps the credential it was created with, whichever value the container is "
             f"handed."
         )
@@ -2363,14 +2393,10 @@ def _preflight_env_shadowing(
         )
         remedy = f"Either way, to leave the chain as the only source: unset {' '.join(shadowed)}."
 
-    logger.warning(
-        "Shell export disagrees with this deployment's env chain: %s\n"
-        "  Exported here with a value that differs from the one the chain resolves to "
-        "(%s). %s Values are never printed.\n"
-        "  %s",
-        ", ".join(shadowed),
-        " + ".join(str(path) for path in chain),
-        mechanics,
+    _warn_fact(
+        f"shell export disagrees with this deployment's env chain: {', '.join(shadowed)}",
+        f"exported here with a value that differs from the one the chain resolves to "
+        f"({' + '.join(str(path) for path in chain)}). {mechanics} Values are never printed.",
         remedy,
     )
     return shadowed
@@ -3532,7 +3558,7 @@ def _start_stack(
     env = {**os.environ, **dotenv_shell_overrides()}
     if dev_mode:
         env["DEV_MODE"] = "true"
-        _report_fact("Development mode: DEV_MODE environment variable set for containers")
+        _report_fact("dev mode: DEV_MODE set for the containers")
 
     # Fail-fast web-terminal preflight (persona render + credential gate)
     # BEFORE the minutes-long image build below: a deploy that is doomed to
@@ -3679,7 +3705,11 @@ def _start_stack(
         # this path — has to be committed as a permanent line while there is
         # still a process to write it. Unconditional: a no-op on a reporter
         # with nothing to hand over, and inside the phase because a hand-off
-        # after it would find nothing left to commit.
+        # after it would find nothing left to commit. The ledger flushes first
+        # for the same reason: no summary card ever prints on this path, and
+        # what this run wrote to disk has to be said by the process that wrote
+        # it.
+        output.flush_ledger()
         current_reporter().hand_off()
         os.execvpe(cmd[0], cmd, run_env)
 
@@ -3896,10 +3926,10 @@ def _reconcile_exposure(config: dict, compose_files: list[str]) -> bool:
         reasons.append(f"{service} runs on the host network and {where}")
 
     if reasons:
-        logger.warning(
-            "This deployment is reachable from the network (%s). Starting it under "
-            "the fail-closed service-token rules that reachability calls for.",
-            "; ".join(reasons),
+        _warn_fact(
+            "this deployment is reachable from the network",
+            f"{'; '.join(reasons)}; starting under the fail-closed service-token rules "
+            "that reachability calls for",
         )
 
     return bool(reasons)
@@ -4153,6 +4183,7 @@ def _start_as_built(
     :func:`~osprey.utils.config.config_anchored_at`.
     """
     with config_anchored_at(as_built_config_path(repo_root)):
+        _warn_on_timezone_drift(config)
         _start_stack(
             config,
             compose_files,
@@ -4170,6 +4201,32 @@ def _start_as_built(
             keep_archiver_base=keep_archiver_base,
             reuse_stores=reuse_stores,
         )
+
+
+def _warn_on_timezone_drift(config: dict) -> None:
+    """Promote a host-vs-facility timezone divergence at the start of an up.
+
+    The same divergence :func:`osprey_connectors.config._warn_on_tz_drift`
+    records when a timestamp is first stamped — but that record is a library
+    warning the altitude gate keeps off the terminal while a lifecycle verb
+    runs, and it fires minutes into the start, wherever the first timestamp
+    happens to be minted. The operator-facing copy of it belongs to the verb:
+    stated once, up front, from the same two values.
+
+    Only an explicit ``system.timezone`` counts, for the connectors check's
+    reason: the implicit UTC default would make every host with ``$TZ`` set
+    look divergent.
+    """
+    configured = (config.get("system") or {}).get("timezone")
+    host_tz = os.environ.get("TZ")
+    if not configured or not host_tz or host_tz == configured:
+        return
+    _warn_fact(
+        "host timezone differs from the facility setting",
+        f"$TZ={host_tz} but system.timezone={configured}; OS-level log timestamps "
+        "will differ from the times the agent reports",
+        "set both to the same zone (system.timezone is what the agent reports)",
+    )
 
 
 def _repo_label_filter(repo_root: Path) -> str:
@@ -4236,20 +4293,26 @@ def _down_by_label(config: dict | None, repo_root: Path) -> None:
     container_ids = listing.stdout.split()
     if not container_ids:
         _report_fact(
-            f"Nothing to stop. There are no compose files in {repo_root / BUILD_DIRNAME} "
-            f"to run a `down` from, and no container is labelled "
-            f"{label_filter.removeprefix('label=')} for this repo. Containers get that "
-            "label when they are CREATED, so a stack started before this repo's "
-            "containers were labelled is not visible here and may still be running. "
-            "`osprey build` restores build/, after which `osprey down` works normally."
+            f"nothing to stop: no compose files in {BUILD_DIRNAME}/ and no containers "
+            "labelled for this repo"
+        )
+        # The caveat stays in the transcript at the level it always had: the
+        # label is applied at CREATE time, so a stack started before this
+        # repo's containers were labelled is invisible to the sweep above.
+        logger.key_info(
+            f"There are no compose files in {repo_root / BUILD_DIRNAME} to run a "
+            f"`down` from, and no container carries "
+            f"{label_filter.removeprefix('label=')}. Containers get that label when "
+            "they are created, so a stack started before this repo's containers were "
+            "labelled is not visible here and may still be running. `osprey build` "
+            "restores build/, after which `osprey down` works normally."
         )
         return
 
     _report_fact(
-        f"No compose files in {repo_root / BUILD_DIRNAME}. Stopping the "
-        f"{len(container_ids)} container(s) labelled "
-        f"{label_filter.removeprefix('label=')} instead. Volumes are kept, as they are "
-        "by a compose `down`; the compose network is not labelled and stays."
+        f"no compose files in {BUILD_DIRNAME}/; stopping the {len(container_ids)} "
+        "container(s) labelled for this repo instead (volumes and the compose "
+        "network are kept)"
     )
 
     # stop, then rm: the same two steps, in the same order, that `compose down`

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -1518,6 +1518,97 @@ def reset_deployment(
     return ResetOutcome.COMPLETED
 
 
+def reset_for_reinit(repo_root: Path | str, *, probe: RuntimeProbe | None = None) -> ResetOutcome:
+    """The condensed reset ``osprey init --reset`` chains, reported as phase steps.
+
+    The same plan and the same execution as :func:`reset_deployment` with
+    ``assume_yes`` — the removal set comes from :func:`plan_reset` and runs
+    through :func:`execute_reset`, so nothing here can remove anything the
+    standalone verb would not. What differs is the reporting contract: the
+    caller has this reset inside an open phase of a larger run, so the outcome
+    is a handful of ``report_step`` lines in that phase's own column, not the
+    full destruction plan. The full plan stays what it is — the text an
+    operator confirms a standalone ``osprey reset`` against — and is not
+    printed here, where nothing is being confirmed.
+
+    A plan that removes nothing does nothing and says nothing: the caller reads
+    ``NOTHING_TO_DO`` and closes its phase with that as the note.
+
+    Args:
+        repo_root: The deployment repo.
+        probe: The runtime seam, as for :func:`reset_deployment`.
+
+    Returns:
+        ``NOTHING_TO_DO``, ``COMPLETED``, or ``COMPLETED_WITH_FAILURES``.
+
+    Raises:
+        ForeignCheckoutError: Same-name resources belong to another checkout.
+        RuntimeError: The container runtime is unreachable, or the ``down``
+            failed. Nothing is removed on either path.
+    """
+    # Imported here rather than at module scope, mirroring the CLI's own lazy
+    # imports: this module is loaded by library callers that never print.
+    from osprey.cli.output import warn
+    from osprey.cli.phase_reporter import report_step
+
+    repo_root = Path(repo_root)
+    if probe is None:
+        probe = _default_probe(repo_root)
+
+    plan = plan_reset(repo_root, probe=probe)
+    if not plan.removes_anything:
+        return ResetOutcome.NOTHING_TO_DO
+
+    execute_reset(plan, probe=probe)
+    for line in _condensed_outcome_lines(plan):
+        report_step(line)
+
+    if probe.failures:
+        warn(
+            f"{len(probe.failures)} resource(s) on the reset plan could not be removed",
+            "\n".join(f"{subject}: {reason}" for subject, reason in probe.failures)
+            + "\nre-run `osprey reset` after clearing whatever is holding them",
+        )
+        return ResetOutcome.COMPLETED_WITH_FAILURES
+    return ResetOutcome.COMPLETED
+
+
+def _condensed_outcome_lines(plan: ResetPlan) -> list[str]:
+    """The executed plan as step lines: what went, then what stayed.
+
+    Counts and names only — the chained reset runs unconfirmed inside ``init
+    --reset``, so these lines report what WAS removed, in the same column as
+    the steps around them. Skips every category the plan held nothing of.
+    """
+    lines: list[str] = []
+    counted = ", ".join(
+        f"{count} {noun}{'' if count == 1 else 's'}"
+        for count, noun in (
+            (len(plan.containers), "container"),
+            (len(plan.volumes), "volume"),
+            (len(plan.images), "image"),
+        )
+        if count
+    )
+    if counted:
+        lines.append(f"removed {counted}")
+    if plan.paths:
+        cleared = ", ".join(_relative_to(path, plan.repo_root) for path in plan.paths)
+        lines.append(f"cleared {cleared}")
+    if plan.env_blocks:
+        minted = sum(len(block.keys) for block in plan.env_blocks)
+        lines.append(
+            f"stripped {minted} minted value{'' if minted == 1 else 's'} "
+            f"from {COMPOSE_ENV_FILENAME}"
+        )
+    lines.append(
+        f"kept the audit log, {COMPOSE_ENV_FILENAME} provider keys "
+        f"({len(plan.env_kept_keys)} entr{'y' if len(plan.env_kept_keys) == 1 else 'ies'}) "
+        "and the files you edit"
+    )
+    return lines
+
+
 def _default_probe(repo_root: Path) -> RuntimeProbe:
     """The real runtime seam, refusing early when the daemon is unreachable.
 

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -81,8 +81,8 @@ def migrate_users_env(project_root: str | Path) -> Path | None:
         legacy_path.unlink()
         report_fact(
             logger,
-            f"Removed {legacy_path}: {users_path} is the current name for the web "
-            "terminals' runtime secrets and already exists, so the older file was a leftover.",
+            f"removed leftover {LEGACY_USERS_ENV_FILENAME} ({USERS_ENV_FILENAME} is the "
+            "current name and already exists)",
         )
         return users_path
 
@@ -96,8 +96,12 @@ def migrate_users_env(project_root: str | Path) -> Path | None:
     os.chmod(users_path, 0o600)
     report_fact(
         logger,
-        f"Renamed {legacy_path} to {users_path}: the web terminals' runtime secrets "
-        "now live under the current name.",
+        f"{LEGACY_USERS_ENV_FILENAME} renamed → {USERS_ENV_FILENAME}",
+        wrote=(
+            USERS_ENV_FILENAME,
+            f"renamed from {LEGACY_USERS_ENV_FILENAME}; the web terminals' runtime "
+            "secrets live under this name now",
+        ),
     )
     return users_path
 

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import yaml
 
-from osprey.cli.output import report_fact
+from osprey.cli.output import report_fact, warn_fact
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.build_progress import with_plain_build_progress
 from osprey.deployment.compose_generator import (
@@ -270,16 +270,15 @@ def _report_unshown_mints(credentials: AuthCredentialsResult) -> None:
     if not credentials.minted or _stdout_is_a_terminal():
         return
     users = ", ".join(sorted(credentials.minted))
-    logger.warning(
-        "Minted a login password for web-terminal user(s) %s and did NOT print it: stdout "
-        "is not a terminal here, and this output can be retained (a CI job log is readable "
-        "by everyone with access to the project). The plaintext is gone, and only the hash "
-        "is stored in %s. Set a password you choose with `osprey users passwd <user>`, or "
-        "put "
-        "OSPREY_AUTH_PW_<USER> in .env before the first deploy and it will be hashed in "
-        "instead of a random one being minted.",
-        users,
-        credentials.env_auth_path,
+    warn_fact(
+        logger,
+        f"Minted a login password for web-terminal user(s) {users} and did NOT print it",
+        "stdout is not a terminal here, and this output can be retained (a CI job log "
+        "is readable by everyone with access to the project); the plaintext is gone, "
+        f"and only the hash is stored in {credentials.env_auth_path}",
+        "set a password you choose with `osprey users passwd <user>`, or put "
+        "OSPREY_AUTH_PW_<USER> in .env before the first deploy and it will be hashed "
+        "in instead of a random one being minted",
     )
 
 

--- a/src/osprey/deployment/wheel_build.py
+++ b/src/osprey/deployment/wheel_build.py
@@ -295,7 +295,11 @@ def _build_dev_wheel_cached(osprey_source_root):
                         _wheel_cache_cleanup_registered = True
                 cached_wheel = Path(_wheel_cache_dir) / wheel_files[0].name
                 shutil.copy2(wheel_files[0], cached_wheel)
-                report_step("built osprey wheel from the local checkout")
+                # Named per distribution: this builds both the framework wheel
+                # and the connectors wheel in one deploy, and two steps wearing
+                # one label read as a stutter.
+                distribution = cached_wheel.name.split("-", 1)[0].replace("_", "-")
+                report_step(f"built the {distribution} wheel from the local checkout")
 
     _wheel_build_cache[key] = cached_wheel
     return cached_wheel

--- a/tests/cli/test_altitude_gate.py
+++ b/tests/cli/test_altitude_gate.py
@@ -64,7 +64,12 @@ def _capture_renders(buffer: StringIO) -> RichHandler:
 
 
 class TestGateFilter:
-    """The filter itself: level-based, nothing else."""
+    """The filter itself: the record's level, plus one bit of reporter state.
+
+    These direct tests run under the quiet ``NullReporter`` default, which is
+    the no-lifecycle-verb state: WARNING and above pass. The lifecycle state is
+    ``TestSingleVoiceDuringLifecycleVerbs``' subject.
+    """
 
     @pytest.mark.parametrize(
         ("level", "passes"),
@@ -91,6 +96,53 @@ class TestGateFilter:
         gated = logging.LogRecord("osprey.test", logging.INFO, __file__, 1, "msg", None, None)
         gated.osprey_intent = "key_info"  # type: ignore[attr-defined]
         assert _AltitudeGate().filter(gated) is False
+
+
+class TestSingleVoiceDuringLifecycleVerbs:
+    """While a reporter owns the terminal, a WARNING arrives promoted or not at all.
+
+    A raw WARNING painted through a phase column is the timestamped transcript
+    block the output hierarchy exists to prevent, so the gate drops it there —
+    the operator-facing copy comes from ``osprey.cli.output.warn_fact`` at the
+    call sites that owe one. ERROR outranks the column and always paints.
+    """
+
+    @pytest.fixture
+    def lifecycle_reporter_installed(self):
+        from osprey.cli.phase_reporter import PhaseReporter, current_reporter, install_reporter
+
+        previous = current_reporter()
+        install_reporter(PhaseReporter(color=False))
+        yield
+        install_reporter(previous)
+
+    def _record(self, level: int) -> logging.LogRecord:
+        return logging.LogRecord("osprey.test", level, __file__, 1, "msg", None, None)
+
+    def test_warning_is_dropped_while_a_reporter_is_installed(self, lifecycle_reporter_installed):
+        assert _AltitudeGate().filter(self._record(logging.WARNING)) is False
+
+    def test_error_still_paints_while_a_reporter_is_installed(self, lifecycle_reporter_installed):
+        assert _AltitudeGate().filter(self._record(logging.ERROR)) is True
+
+    def test_warning_paints_again_once_the_reporter_is_gone(self):
+        """The uninstall on the verb's way out is what restores the old policy."""
+        assert _AltitudeGate().filter(self._record(logging.WARNING)) is True
+
+    def test_the_verbose_null_reporter_counts_as_no_lifecycle_rendering(self):
+        """Under ``-v`` nothing draws a phase column, so nothing needs protecting.
+
+        The gate is normally not even installed under ``-v``; this pins the
+        harmless answer for the state where one is.
+        """
+        from osprey.cli.phase_reporter import NullReporter, current_reporter, install_reporter
+
+        previous = current_reporter()
+        install_reporter(NullReporter(verbose=True))
+        try:
+            assert _AltitudeGate().filter(self._record(logging.WARNING)) is True
+        finally:
+            install_reporter(previous)
 
 
 class TestNormalRun:

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -1000,6 +1000,13 @@ def test_importing_the_module_stays_off_the_heavy_chain() -> None:
     assert completed.stdout.split() == ["False", "False"]
 
 
+def _completed_reset(repo_root, **kw):
+    """A reset that ran and removed what it planned, without a runtime."""
+    from osprey.deployment.reset import ResetOutcome
+
+    return ResetOutcome.COMPLETED
+
+
 class TestResetFlag:
     """``--reset`` — starting over on a name that has been used before.
 
@@ -1011,20 +1018,28 @@ class TestResetFlag:
     runtime state with it", in the one command that would otherwise walk
     straight into that.
 
-    Delegated to ``reset_deployment`` (imported at call time, so these patch
-    it on its own module) rather than reimplemented: it already owns
-    the label-scoped plan, the foreign-checkout refusal, and the
-    one-resource-at-a-time removals. By the time this runs the repo has been
-    materialized, so that machinery has the repo root it needs.
+    ``_completed_reset`` below is the shared stub: a reset that ran and
+    removed what it planned, without touching a runtime.
+
+    Delegated to ``reset_for_reinit`` (imported at call time, so these patch
+    it on its own module) rather than reimplemented: it runs the same
+    label-scoped plan, foreign-checkout refusal, and one-resource-at-a-time
+    removals as ``reset_deployment``, reported as phase steps instead of as
+    the standalone verb's confirmation document. By the time this runs the
+    repo has been written out, so that machinery has the repo root it needs.
     """
 
     def test_it_discards_the_previous_deployments_runtime_state(
         self, runner, tmp_path, monkeypatch
     ):
+        from osprey.deployment.reset import ResetOutcome
+
         calls: list[dict] = []
         monkeypatch.setattr(
-            "osprey.deployment.reset.reset_deployment",
-            lambda repo_root, **kw: calls.append({"repo_root": Path(repo_root), **kw}) or True,
+            "osprey.deployment.reset.reset_for_reinit",
+            lambda repo_root, **kw: (
+                calls.append({"repo_root": Path(repo_root), **kw}) or ResetOutcome.COMPLETED
+            ),
         )
 
         result = runner.invoke(
@@ -1035,21 +1050,20 @@ class TestResetFlag:
         assert result.exit_code == 0, result.output
         assert len(calls) == 1, "expected exactly one reset of the target repo"
         assert calls[0]["repo_root"] == tmp_path / "demo"
-        # No prompt: the operator already said so on the command line, and the
-        # point of the flag is a one-line re-create that runs unattended.
-        assert calls[0]["assume_yes"] is True
 
     def test_it_runs_after_the_repo_exists(self, runner, tmp_path, monkeypatch):
-        """``reset_deployment`` reads the repo it is pointed at, so order matters.
+        """``reset_for_reinit`` reads the repo it is pointed at, so order matters.
 
-        Called before materialization it would be handed a directory with no
+        Called before the repo is written it would be handed a directory with no
         profile.yml, and would resolve the project name from a repo not yet there.
         """
+        from osprey.deployment.reset import ResetOutcome
+
         seen: list[bool] = []
         monkeypatch.setattr(
-            "osprey.deployment.reset.reset_deployment",
+            "osprey.deployment.reset.reset_for_reinit",
             lambda repo_root, **kw: (
-                seen.append((Path(repo_root) / "profile.yml").is_file()) or True
+                seen.append((Path(repo_root) / "profile.yml").is_file()) or ResetOutcome.COMPLETED
             ),
         )
 
@@ -1073,9 +1087,7 @@ class TestResetFlag:
         remedy is `osprey reset`: the exact thing that just declined. Naming the
         real cause here is the difference between a dead end and a fix.
         """
-        monkeypatch.setattr(
-            "osprey.deployment.reset.reset_deployment", lambda repo_root, **kw: True
-        )
+        monkeypatch.setattr("osprey.deployment.reset.reset_for_reinit", _completed_reset)
         monkeypatch.setattr(
             "osprey.cli.init_cmd._surviving_project_resources",
             lambda target: ["container old-thing", "volume old-thing_data"],
@@ -1091,9 +1103,7 @@ class TestResetFlag:
         assert "com.osprey.repo-id" in result.output
 
     def test_it_proceeds_when_the_sweep_was_complete(self, runner, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "osprey.deployment.reset.reset_deployment", lambda repo_root, **kw: True
-        )
+        monkeypatch.setattr("osprey.deployment.reset.reset_for_reinit", _completed_reset)
         monkeypatch.setattr("osprey.cli.init_cmd._surviving_project_resources", lambda target: [])
 
         result = runner.invoke(
@@ -1121,9 +1131,7 @@ class TestResetFlag:
         code. The provider keys in ``.env`` are the ones that matter here — the
         reason to converge a repo in place rather than delete and re-create it.
         """
-        monkeypatch.setattr(
-            "osprey.deployment.reset.reset_deployment", lambda repo_root, **kw: True
-        )
+        monkeypatch.setattr("osprey.deployment.reset.reset_for_reinit", _completed_reset)
         stale_marker = "STALE-FROM-THE-LAST-DEPLOYMENT"
         (exemplar_repo / "profile.yml").write_text(f"name: {stale_marker}\n", encoding="utf-8")
         (exemplar_repo / "data" / "orphan.json").write_text("{}\n", encoding="utf-8")
@@ -1155,8 +1163,8 @@ class TestResetFlag:
         """The default must never destroy a volume — that is what the flag is for."""
         calls: list = []
         monkeypatch.setattr(
-            "osprey.deployment.reset.reset_deployment",
-            lambda repo_root, **kw: calls.append(repo_root) or True,
+            "osprey.deployment.reset.reset_for_reinit",
+            lambda repo_root, **kw: calls.append(repo_root) or _completed_reset(repo_root),
         )
 
         result = runner.invoke(

--- a/tests/cli/test_lifecycle_promotions.py
+++ b/tests/cli/test_lifecycle_promotions.py
@@ -18,10 +18,11 @@ Every absence assertion here carries an armed witness (see
 Tasks 3.3, 3.4 and 3.7 append their own sections below; the fixtures and
 helpers above the first section marker are shared.
 
-A WARNING is a third case, and it belongs to neither half: the altitude gate
-passes it, so it stays on the *painted* side. The needle for one of those
-(Task 3.3's unshown-mint warning) asserts presence in ``rendered_text``, which
-is the opposite of what ``assert_promoted`` asks.
+A WARNING is a third case with two states. With no reporter installed the
+altitude gate passes it and it stays on the *painted* side; while a reporter
+owns the terminal the gate drops it there too, and anything an operator must
+read arrives promoted through ``warn_fact`` instead — the unshown-mint warning
+below is pinned in both states.
 """
 
 from __future__ import annotations
@@ -40,7 +41,7 @@ import pytest
 from click.testing import CliRunner
 from rich.console import Console
 
-from osprey.cli import build_cmd, build_persistence, deploy_cmd
+from osprey.cli import build_cmd, build_persistence, deploy_cmd, output
 from osprey.cli.build_persistence import _apply_conventions
 from osprey.cli.main import cli
 from osprey.cli.phase_reporter import PhaseReporter, install_reporter
@@ -57,9 +58,11 @@ from osprey.deployment.web_terminals import (
 from osprey.simulation import apply
 from tests.cli.conftest import TerminalProbe
 
-# The witness logger and its marker. A WARNING is above the altitude gate, so
-# it MUST reach the probe console; if it does not, the console is not armed and
-# nothing else this module asserts about absence means anything.
+# The witness logger and its marker. An ERROR is above the altitude gate on
+# every path -- WARNING no longer is while a reporter is installed, which these
+# tests' capture reporter counts as -- so it MUST reach the probe console; if
+# it does not, the console is not armed and nothing else this module asserts
+# about absence means anything.
 _WITNESS_LOGGER = "osprey.lifecycle_promotion_witness"
 _WITNESS = "PROMOTIONWITNESSMARKER"
 
@@ -170,10 +173,10 @@ def assert_promoted(probe: TerminalProbe, printed: Printed, fragment: str) -> No
         f"no record kept for: {fragment!r}"
     )
 
-    # Armed witness, in the same test: a WARNING is above the gate, so its
-    # absence would mean the probe console was never reachable and the
-    # absence assertion above proved nothing.
-    logging.getLogger(_WITNESS_LOGGER).warning(_WITNESS)
+    # Armed witness, in the same test: an ERROR is above the gate on every
+    # path, so its absence would mean the probe console was never reachable
+    # and the absence assertion above proved nothing.
+    logging.getLogger(_WITNESS_LOGGER).error(_WITNESS)
     assert _WITNESS in probe.rendered_text, "the probe console is not armed"
 
 
@@ -217,9 +220,10 @@ class TestMintedSecretsAreReported:
             {"deployed_services": ["event_dispatcher"]}, False, project
         )
 
-        assert_promoted(default_altitude, printed, "Generated auth token(s)")
+        assert_promoted(default_altitude, printed, "minted 2 service auth token(s)")
+        output.flush_ledger()
         assert "EVENT_DISPATCHER_TOKEN" in printed.flowed
-        assert "Keep them secret." in printed.flowed
+        assert "keep them secret" in printed.flowed
 
     def test_an_adopted_volume_credential_names_the_variables_never_the_values(
         self, default_altitude, printed, project
@@ -247,10 +251,9 @@ class TestMintedSecretsAreReported:
             {"deployed_services": ["bluesky"]}, project
         )
 
-        assert_promoted(
-            default_altitude, printed, "Generated bluesky RE manager control-socket keypair"
-        )
-        assert "Treat both values as secrets." in printed.flowed
+        assert_promoted(default_altitude, printed, "bluesky control-socket keypair minted")
+        output.flush_ledger()
+        assert "treat both halves as secrets" in printed.flowed
 
     def test_a_derived_public_half_says_it_was_not_written_to_disk(
         self, default_altitude, printed, project, monkeypatch
@@ -280,10 +283,9 @@ class TestMintedSecretsAreReported:
             {"deployed_services": ["bluesky"]}, project
         )
 
-        assert_promoted(
-            default_altitude, printed, "Generated bluesky document-plane CURVE certificates"
-        )
-        assert "containers are recreated" in printed.flowed
+        assert_promoted(default_altitude, printed, "bluesky CURVE certificates")
+        output.flush_ledger()
+        assert "bridge and queueserver recreated" in printed.flowed
 
 
 class TestDegradationsAreReported:
@@ -338,8 +340,10 @@ class TestAutonomousHostChangesAreReported:
             {**BLUESKY_VA, "control_system": {"type": "virtual_accelerator"}}, project
         )
 
-        assert_promoted(default_altitude, printed, "Auto-configured bluesky bridge scan devices")
+        assert_promoted(default_altitude, printed, "bluesky scan devices auto-configured")
+        output.flush_ledger()
         assert "channel_limits.json" in printed.flowed
+        assert "BLUESKY_EPICS_MOTORS" in printed.flowed
 
     def test_a_local_env_override_is_reported_by_name(self, default_altitude, printed, tmp_path):
         from osprey.utils.dotenv import ENV_SHARED_FILENAME
@@ -363,7 +367,7 @@ class TestAutonomousHostChangesAreReported:
                 {"deployed_services": ["event_dispatcher"]}, [], tmp_path, dev_mode=True
             )
 
-        assert_promoted(default_altitude, printed, "Development mode: DEV_MODE")
+        assert_promoted(default_altitude, printed, "dev mode: DEV_MODE")
 
 
 class TestDestructiveActionsAreReported:
@@ -388,8 +392,8 @@ class TestDestructiveActionsAreReported:
 
         container_lifecycle._down_by_label({}, tmp_path)
 
-        assert_promoted(default_altitude, printed, "Stopping the 2 container(s) labelled")
-        assert "Volumes are kept" in printed.flowed
+        assert_promoted(default_altitude, printed, "stopping the 2 container(s) labelled")
+        assert "volumes and the compose network are kept" in printed.flowed
 
     def test_finding_nothing_to_stop_states_the_limit_of_the_sweep(
         self, default_altitude, printed, tmp_path, monkeypatch
@@ -398,8 +402,13 @@ class TestDestructiveActionsAreReported:
 
         container_lifecycle._down_by_label({}, tmp_path)
 
-        assert_promoted(default_altitude, printed, "Nothing to stop.")
-        assert "may still be running" in printed.flowed
+        assert_promoted(default_altitude, printed, "nothing to stop")
+        # The sweep's limit is a caveat for the transcript, not the phase
+        # column: the record is kept, the default view stays one line.
+        assert any("may still be running" in message for message in default_altitude.messages), (
+            "the log sinks lost the sweep's limit"
+        )
+        assert "may still be running" not in printed.flowed
 
 
 class TestSubStepRows:
@@ -915,7 +924,7 @@ class TestSubStepRowsOnTheMiscDeployPath:
 
         assert wheel_build._build_dev_wheel_cached(tmp_path) is not None
 
-        assert_sub_step(printed, "built osprey wheel from the local checkout")
+        assert_sub_step(printed, "built the osprey wheel from the local checkout")
 
     def test_seeding_a_profile_context_dir_is_a_step(self, printed, tmp_path):
         """Row 36: the build wrote into the operator's profile, outside build/."""
@@ -969,8 +978,8 @@ class TestTheBuildsIdentityLine:
         A security posture the build chose on the operator's behalf, so it is
         printed rather than logged. The record is kept for the sinks.
         """
-        assert "bind to localhost only" in built_exemplar.flowed
-        assert any("bind to localhost only" in m for m in built_exemplar.records(logging.INFO))
+        assert "bound to localhost only" in built_exemplar.flowed
+        assert any("bound to localhost only" in m for m in built_exemplar.records(logging.INFO))
 
 
 class TestAbsorbedRowsSayNothingOfTheirOwn:
@@ -1411,7 +1420,7 @@ class TestWebTerminalSecretsAreReported:
 
         assert env_production.migrate_users_env(tmp_path) == tmp_path / ".env.users"
 
-        assert_promoted(default_altitude, printed, "now live under the current name")
+        assert_promoted(default_altitude, printed, ".env.production renamed")
         assert env_production.LEGACY_USERS_ENV_FILENAME in printed.flowed
         assert ".env.users" in printed.flowed
 
@@ -1424,7 +1433,7 @@ class TestWebTerminalSecretsAreReported:
 
         assert env_production.migrate_users_env(tmp_path) == tmp_path / ".env.users"
 
-        assert_promoted(default_altitude, printed, "the older file was a leftover")
+        assert_promoted(default_altitude, printed, "removed leftover .env.production")
         assert not (tmp_path / env_production.LEGACY_USERS_ENV_FILENAME).exists()
 
 
@@ -1470,12 +1479,13 @@ class TestWebTerminalHostChangesAreReported:
 
 
 class TestTheUnshownMintWarningStillReachesTheTerminal:
-    """The pinned minted-password warning, re-pinned to its reworded copy.
+    """The pinned minted-password warning, re-pinned to its promoted form.
 
-    It is a WARNING, so the altitude gate passes it: this one is painted by the
-    log handler rather than printed by the renderer, and that is the whole
-    claim. The fragments are the ones ``tests/deployment/test_up_as_built.py``
-    pins, asserted here against what a default-altitude terminal shows.
+    It is promoted through ``warn_fact``: the renderer prints the ``⚠`` block
+    (the altitude gate keeps the raw WARNING record off the terminal while a
+    reporter is installed), and the record stays for the sinks. The fragments
+    are the ones ``tests/deployment/test_up_as_built.py`` pins, asserted here
+    against what a default-altitude run keeps in its records.
     """
 
     def test_the_pinned_fragments_survive_at_the_default_altitude(self, default_altitude, tmp_path):
@@ -1491,8 +1501,11 @@ class TestTheUnshownMintWarningStillReachesTheTerminal:
             "OSPREY_AUTH_PW_<USER>",
         ):
             assert fragment in painted, fragment
+            assert any(fragment in message for message in default_altitude.messages), fragment
 
-    def test_the_password_itself_is_in_neither_stream(self, default_altitude, printed, tmp_path):
+    def test_the_password_itself_is_in_neither_stream(
+        self, default_altitude, printed, tmp_path, capsys
+    ):
         """The point of the warning: the plaintext went nowhere, and is gone."""
         shown: list[str] = []
         result = auth_credentials.ensure_auth_credentials(["alice"], tmp_path, echo=shown.append)
@@ -1500,8 +1513,13 @@ class TestTheUnshownMintWarningStillReachesTheTerminal:
         provision._report_unshown_mints(result)
 
         assert result.minted == ("alice",)
-        assert "alice" in " ".join(default_altitude.rendered_text.split())
+        # With a reporter installed the promoted block is the warning's only
+        # terminal form, on the trouble stream; the record is for the sinks.
+        promoted = " ".join(capsys.readouterr().err.split())
+        assert "alice" in promoted
+        assert any("alice" in message for message in default_altitude.messages)
         for line in shown:
+            assert line not in promoted
             assert line not in printed.text
             assert line not in default_altitude.rendered_text
 
@@ -1891,7 +1909,7 @@ class TestTheArchiveKnobDiff:
         assert any("retention_days: 5 -> 7" in message for message in default_altitude.messages), (
             "the log sinks lost the diff"
         )
-        logging.getLogger(_WITNESS_LOGGER).warning(_WITNESS)
+        logging.getLogger(_WITNESS_LOGGER).error(_WITNESS)
         assert _WITNESS in default_altitude.rendered_text, "the probe console is not armed"
 
     def test_a_matching_fingerprint_prints_no_diff(

--- a/tests/cli/test_output_primitives.py
+++ b/tests/cli/test_output_primitives.py
@@ -895,3 +895,184 @@ def test_machine_mode_output_is_plain_off_a_terminal(capsys):
         note("resolved from OSPREY_PROFILE")
         section("endpoints", {"web": "http://localhost:8080"})
     assert "\x1b" not in capsys.readouterr().err
+
+
+# -- report_fact and the run ledger ------------------------------------------
+
+
+class _RecordingLogger:
+    """The two methods the fact primitives call, recording what they were told."""
+
+    def __init__(self) -> None:
+        self.key_info_messages: list[str] = []
+        self.warnings: list[str] = []
+
+    def key_info(self, message: str) -> None:
+        self.key_info_messages.append(message)
+
+    def warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+
+@pytest.fixture(autouse=True)
+def empty_ledger():
+    """Start and leave every test with no collected rows."""
+    output.clear_ledger()
+    yield
+    output.clear_ledger()
+
+
+def test_report_fact_prints_one_line_in_the_step_column(capsys):
+    """A fact wears the phase record's own ``  · `` shape, not a paragraph's."""
+    install_reporter(PhaseReporter(color=False))
+    logger = _RecordingLogger()
+    output.report_fact(logger, "minted 2 service auth token(s) → .env")
+    assert visible(capsys.readouterr().out) == ["  · minted 2 service auth token(s) → .env"]
+    assert logger.key_info_messages == ["minted 2 service auth token(s) → .env"]
+
+
+def test_report_fact_prints_under_null_reporter(capsys):
+    """Echo class: ``-v`` keeps the facts with the rest of the verb's output."""
+    install_reporter(NullReporter(verbose=True))
+    output.report_fact(_RecordingLogger(), "dev mode: DEV_MODE set for the containers")
+    assert visible(capsys.readouterr().out) == ["  · dev mode: DEV_MODE set for the containers"]
+
+
+def test_report_fact_takes_its_prose_positionally():
+    with pytest.raises(TypeError):
+        output.report_fact(_RecordingLogger(), message="minted a token")  # type: ignore[call-arg]
+
+
+def test_a_wrote_row_waits_for_the_flush(capsys):
+    """The inline line prints now; the row prints once, at the flush, aligned."""
+    install_reporter(PhaseReporter(color=False))
+    logger = _RecordingLogger()
+    output.report_fact(
+        logger,
+        "minted 2 service auth token(s) → .env",
+        wrote=(".env", "TOKEN_A, TOKEN_B (gitignored; keep them secret)"),
+    )
+    before_flush = capsys.readouterr().out
+    assert "TOKEN_A" not in before_flush
+
+    output.flush_ledger()
+    assert visible(capsys.readouterr().out) == [
+        "This deploy wrote",
+        "  .env   TOKEN_A, TOKEN_B (gitignored; keep them secret)",
+    ]
+    # The row reached the log sinks at collection time, not at the flush.
+    assert any("TOKEN_A" in message for message in logger.key_info_messages)
+
+
+def test_the_flush_empties_the_ledger(capsys):
+    install_reporter(PhaseReporter(color=False))
+    output.report_fact(_RecordingLogger(), "wrote a file", wrote=("file", "what it holds"))
+    output.flush_ledger()
+    capsys.readouterr()
+    output.flush_ledger()
+    assert capsys.readouterr().out == ""
+
+
+def test_a_flush_with_nothing_collected_prints_nothing(capsys):
+    install_reporter(PhaseReporter(color=False))
+    output.flush_ledger()
+    assert capsys.readouterr().out == ""
+
+
+def test_clear_ledger_drops_rows_without_printing_them(capsys):
+    """The next run must not inherit rows a failed run never flushed."""
+    install_reporter(PhaseReporter(color=False))
+    output.report_fact(_RecordingLogger(), "wrote a file", wrote=("file", "what it holds"))
+    capsys.readouterr()
+    output.clear_ledger()
+    output.flush_ledger()
+    assert capsys.readouterr().out == ""
+
+
+def test_ledger_rows_keep_their_collection_order(capsys):
+    install_reporter(PhaseReporter(color=False))
+    logger = _RecordingLogger()
+    output.report_fact(logger, "first", wrote=("b-label", "second row"))
+    output.report_fact(logger, "second", wrote=("a-label", "first row"))
+    capsys.readouterr()
+    output.flush_ledger()
+    lines = visible(capsys.readouterr().out)
+    assert lines[1].startswith("  b-label")
+    assert lines[2].startswith("  a-label")
+
+
+def test_report_fact_honors_machine_mode(capsys):
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        output.report_fact(_RecordingLogger(), "minted a token", wrote=(".env", "TOKEN"))
+        output.flush_ledger()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "minted a token" in captured.err
+    assert "TOKEN" in captured.err
+
+
+# -- warn_fact ----------------------------------------------------------------
+
+
+def test_warn_fact_prints_the_indented_trouble_shape(capsys):
+    """Summary one step in, body one step under it, remedy marked ``→``."""
+    install_reporter(PhaseReporter(color=False))
+    logger = _RecordingLogger()
+    output.warn_fact(
+        logger,
+        "host timezone differs from the facility setting",
+        "$TZ=US/Pacific but system.timezone=UTC",
+        "set both to the same zone",
+    )
+    captured = capsys.readouterr()
+    assert visible(captured.err) == [
+        "  ⚠ host timezone differs from the facility setting",
+        "    $TZ=US/Pacific but system.timezone=UTC",
+        "    → set both to the same zone",
+    ]
+    assert captured.out == ""
+    # One record for the sinks, carrying all three parts.
+    assert logger.warnings == [
+        "host timezone differs from the facility setting "
+        "$TZ=US/Pacific but system.timezone=UTC set both to the same zone"
+    ]
+
+
+def test_warn_fact_without_detail_or_remedy_is_the_summary_alone(capsys):
+    install_reporter(PhaseReporter(color=False))
+    output.warn_fact(_RecordingLogger(), "this deployment is reachable from the network")
+    assert visible(capsys.readouterr().err) == ["  ⚠ this deployment is reachable from the network"]
+
+
+def test_warn_fact_prints_under_null_reporter(capsys):
+    """Echo class, like every promoted fact: ``-v`` never swallows it."""
+    install_reporter(NullReporter(verbose=True))
+    output.warn_fact(_RecordingLogger(), "this deployment is reachable from the network")
+    assert visible(capsys.readouterr().err) == ["  ⚠ this deployment is reachable from the network"]
+
+
+def test_warn_fact_takes_its_prose_positionally():
+    with pytest.raises(TypeError):
+        output.warn_fact(_RecordingLogger(), summary="reachable")  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        output.warn_fact(_RecordingLogger(), "reachable", detail="why")  # type: ignore[call-arg]
+
+
+def test_warn_fact_honors_machine_mode(capsys):
+    install_reporter(PhaseReporter(color=False))
+    with machine_mode():
+        output.warn_fact(_RecordingLogger(), "this deployment is reachable from the network")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "reachable from the network" in captured.err
+
+
+def test_warn_fact_lands_above_a_mounted_region(live, err_buffer, capsys):
+    """Promoted trouble takes the same region-aware seam as ``warn``."""
+    reporter, buffer = live
+    output.warn_fact(_RecordingLogger(), "this deployment is reachable from the network")
+    assert "⚠ this deployment is reachable from the network" in _ANSI.sub("", buffer.getvalue())
+    assert err_buffer.getvalue() == ""
+    assert capsys.readouterr().err == ""
+    assert reporter.is_rendering() is True

--- a/tests/cli/test_printed_copy_style.py
+++ b/tests/cli/test_printed_copy_style.py
@@ -67,6 +67,8 @@ _PRINTERS = frozenset(
         "_abort",
         "_report_fact",
         "report_fact",
+        "_warn_fact",
+        "warn_fact",
     }
 )
 

--- a/tests/cli/test_reset_plan_parity.py
+++ b/tests/cli/test_reset_plan_parity.py
@@ -1,26 +1,25 @@
-"""The destruction plan reads the same whichever verb is about to destroy.
+"""One removal set, two verbs — and a report shaped for each verb's reader.
 
-``osprey reset`` and ``osprey init --reset`` run the same wipe through the same
-``reset_deployment`` call, but until now they handed it two different printers:
-``reset`` passed the CLI's echo path, ``init`` passed ``logger.key_info``. An
-INFO record is what the altitude gate drops on a normal run, so the plan
-listing every container, volume and file about to go simply did not appear on
-the ``init --reset`` path -- on the one command in OSPREY that destroys data
-without asking, because ``--reset`` means unattended.
+``osprey reset`` and ``osprey init --reset`` run the same wipe: both plan with
+``plan_reset`` and remove with ``execute_reset``, so neither can touch anything
+the other would not. What differs — deliberately, and pinned here — is the
+report. Standalone ``reset`` is a confirmed destruction: it prints the full
+plan (WILL BE REMOVED / WILL BE KEPT) because that text is what the operator
+types the confirmation against. Chained ``init --reset`` runs unconfirmed
+inside another verb's phase record, so it reports the executed outcome as
+condensed phase steps — what was removed, what was kept — and never pastes a
+confirmation document into the middle of a run.
 
-Both call sites now pass :func:`osprey.cli.output.report`, and this file pins
-that as an equality rather than as two separate presence checks: the same lines
-in the same order, sliced out of each path's stdout by the SAME rule. A
-transport that re-wrapped at the console width, swallowed a blank separator or
-dropped the trailing summary would satisfy every substring assertion ever
-written about a plan and fail the comparison below.
+The equality that used to be asserted line-by-line on the printed plan is now
+asserted where it actually lives: on the planned removal set both paths hand to
+``execute_reset``. A transport cannot re-wrap or truncate an object.
 
 Nothing here reaches a container runtime, and nothing here removes anything:
 the runtime is the recording fake ``tests/deployment/test_reset_scoping``
 already specifies, and ``execute_reset`` is stubbed out. That is not only for
-speed -- it is what lets both halves plan against a repo in *identical* state,
-which is the precondition that makes line-identity a claim about the transport
-rather than about two different deployments.
+speed — it is what lets both halves plan against a repo in *identical* state,
+which is the precondition that makes removal-set equality a claim about the
+verbs rather than about two different deployments.
 """
 
 from __future__ import annotations
@@ -35,7 +34,7 @@ from osprey.cli import init_cmd
 from osprey.cli.main import cli
 from osprey.deployment import reset as reset_mod
 from osprey.deployment.compose_generator import REPO_ID_LABEL, repo_identity
-from osprey.deployment.reset import RuntimeProbe, confirmation_token
+from osprey.deployment.reset import ResetPlan, RuntimeProbe, confirmation_token
 from tests.deployment import test_reset_scoping as scoping
 
 FakeRuntime = scoping.FakeRuntime
@@ -46,14 +45,14 @@ FakeRuntime = scoping.FakeRuntime
 #: same project, and the plan's header line matches on both.
 PROJECT = "demo"
 
-#: The first line of every rendered plan, and the last. The slice between them
-#: is the plan; everything outside it belongs to whichever verb was running.
+#: The first line of every rendered full plan, and the last. Their presence is
+#: what marks the standalone verb's output; their absence is what marks the
+#: chained verb's.
 PLAN_OPENS_WITH = "osprey reset "
 PLAN_CLOSES_WITH = "Reset complete."
 
-#: A line deep inside the plan body, used where the question is presence rather
-#: than equality. It is a heading rather than a resource name, so it is there in
-#: every plan this file drives.
+#: A heading deep inside the full plan body. It is a heading rather than a
+#: resource name, so it is there in every full plan this file drives.
 PLAN_HEADING = "WILL BE REMOVED"
 
 
@@ -69,6 +68,21 @@ def ours(repo_root: Path) -> dict[str, str]:
     }
 
 
+def removal_set(plan: ResetPlan) -> dict[str, list[str]]:
+    """The plan's removal set, as comparable names.
+
+    What ``execute_reset`` iterates, reduced to the identity of each entry:
+    equality of two of these is equality of what the two verbs would remove.
+    """
+    return {
+        "containers": sorted(r.name for r in plan.containers),
+        "volumes": sorted(r.name for r in plan.volumes),
+        "images": sorted(r.name for r in plan.images),
+        "paths": sorted(str(p) for p in plan.paths),
+        "env_keys": sorted(key for block in plan.env_blocks for key in block.keys),
+    }
+
+
 @pytest.fixture
 def target(tmp_path: Path) -> Path:
     """Where the deployment goes. It must not exist yet -- ``init`` creates it."""
@@ -79,9 +93,10 @@ def target(tmp_path: Path) -> Path:
 def runtime(target: Path, monkeypatch: pytest.MonkeyPatch) -> FakeRuntime:
     """A runtime holding one container and one volume labelled for ``target``.
 
-    A plan with nothing on it returns early with "nothing to reset" and would
-    make the comparison below pass on an empty removal list, so the fake is
-    stocked: the plan under test has resources, files and a kept section.
+    A plan with nothing on it takes the nothing-to-do path on both verbs and
+    would make every comparison below pass on an empty removal list, so the
+    fake is stocked: the plan under test has resources, files and a kept
+    section.
     """
     fake = FakeRuntime(
         containers={f"{PROJECT}-dispatch": ours(target)},
@@ -92,17 +107,17 @@ def runtime(target: Path, monkeypatch: pytest.MonkeyPatch) -> FakeRuntime:
 
 
 @pytest.fixture
-def no_destruction(monkeypatch: pytest.MonkeyPatch) -> list[object]:
-    """Stub the removals, and record that they were reached.
+def no_destruction(monkeypatch: pytest.MonkeyPatch) -> list[ResetPlan]:
+    """Stub the removals, and record the plan each verb was about to run.
 
-    The recorder is what makes "the gate held" observable: a declined reset must
-    leave this list empty. Stubbing here rather than at the runtime is also what
-    keeps the repo's files where they are, so the second path plans the same
-    deployment the first one did.
+    The recorder is what makes both "the gate held" (an empty list) and "the
+    two verbs remove the same things" (recorded plans) observable. Stubbing
+    here rather than at the runtime is also what keeps the repo's files where
+    they are, so the second path plans the same deployment the first one did.
     """
-    reached: list[object] = []
+    reached: list[ResetPlan] = []
 
-    def record(plan: object, **kwargs: object) -> None:
+    def record(plan: ResetPlan, **kwargs: object) -> None:
         reached.append(plan)
 
     monkeypatch.setattr(reset_mod, "execute_reset", record)
@@ -120,22 +135,6 @@ def no_survivor_check(monkeypatch: pytest.MonkeyPatch) -> None:
     it is not this file's subject.
     """
     monkeypatch.setattr(init_cmd, "_surviving_project_resources", lambda repo_root: [])
-
-
-def plan_lines(stdout: str) -> list[str]:
-    """The rendered destruction plan, sliced out of a verb's whole output.
-
-    The same rule is applied to both paths -- open at the header line, close at
-    the completion line, keep everything between. Anything the plan lost in
-    transport is lost from the slice too, which is the point: the slice is not
-    allowed to be a filter that agrees with itself.
-    """
-    lines = stdout.splitlines()
-    opens = [i for i, line in enumerate(lines) if line.startswith(PLAN_OPENS_WITH)]
-    closes = [i for i, line in enumerate(lines) if line.startswith(PLAN_CLOSES_WITH)]
-    assert opens, f"no plan header in:\n{stdout}"
-    assert closes, f"no plan completion line in:\n{stdout}"
-    return lines[opens[0] : closes[-1] + 1]
 
 
 def run_init_reset(target: Path) -> Result:
@@ -160,19 +159,20 @@ def run_reset(repo_root: Path, *args: str) -> Result:
 
 
 # ---------------------------------------------------------------------------
-# FR4: one plan, two verbs
+# One removal set, two verbs
 # ---------------------------------------------------------------------------
 
 
-def test_the_plan_is_line_identical_on_both_paths(
+def test_both_verbs_execute_the_same_removal_set(
     target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check
 ) -> None:
-    """The two verbs print the same plan, line for line and in the same order.
+    """The two verbs hand ``execute_reset`` the same plan, entry for entry.
 
     Ordering matters: ``init --reset`` runs first and leaves the repo it just
     created, and because nothing was actually removed the ``reset`` below plans
     that same repo in that same state. Equality is therefore a statement about
-    the printer, which is the only thing that differs between the two calls.
+    the two verbs' planning, which is the only thing that differs between the
+    calls.
     """
     from_init = run_init_reset(target)
     assert from_init.exit_code == 0, from_init.output
@@ -180,77 +180,106 @@ def test_the_plan_is_line_identical_on_both_paths(
     from_reset = run_reset(target, "-y")
     assert from_reset.exit_code == 0, from_reset.output
 
-    init_plan = plan_lines(from_init.stdout)
-    reset_plan = plan_lines(from_reset.stdout)
-
-    assert init_plan == reset_plan
-    # Guard on the guard. A plan of two lines, or one whose longest line is
-    # comfortably inside a console width, would let a truncating or re-wrapping
-    # transport through the equality above without anyone noticing.
-    assert len(init_plan) > 20
-    assert max(len(line) for line in init_plan) > 100
+    assert len(no_destruction) == 2
+    init_removals, reset_removals = (removal_set(plan) for plan in no_destruction)
+    assert init_removals == reset_removals
+    # Guard on the guard: an empty removal set would make the equality above
+    # a comparison of two empty lists.
+    assert init_removals["containers"] and init_removals["volumes"]
 
 
-def test_the_reset_verbs_whole_output_is_the_plan(
+def test_the_standalone_verb_still_prints_the_full_plan(
     target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check
 ) -> None:
-    """The slice is not dropping anything on the side where it can be checked.
+    """``osprey reset`` keeps the confirmation document, whole.
 
-    ``osprey reset`` prints its plan and nothing else, so on that path the
-    sliced plan must be the entire stdout. That is what stops
-    :func:`plan_lines` from quietly becoming a filter that makes any two
-    outputs agree.
+    The full plan is what an operator confirms a destruction against, so the
+    standalone verb opens with the header, carries the removal heading, and
+    closes with the completion line.
     """
     run_init_reset(target)
 
     result = run_reset(target, "-y")
 
     assert result.exit_code == 0, result.output
-    assert "".join(f"{line}\n" for line in plan_lines(result.stdout)) == result.stdout
+    assert PLAN_OPENS_WITH in result.stdout
+    assert PLAN_HEADING in result.stdout
+    assert PLAN_CLOSES_WITH in result.stdout
 
 
-def test_the_plan_is_printed_on_the_default_init_reset_view(
-    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check, terminal_probe
+def test_init_reset_reports_condensed_steps_not_the_plan(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check
 ) -> None:
-    """The bug: on a normal run the plan reached the operator on neither channel.
+    """The chained reset is phase steps: what went, what stayed — no document.
 
-    Routed through ``logger.key_info`` the plan was an INFO record, which the
-    altitude gate drops -- so the destructive verb that never asks also never
-    said what it was taking. Both halves are asserted, because either alone
-    passes for the wrong reason: the plan is on stdout NOW, and it is no longer
-    a log record at all (an absence the gate would have faked either way, so it
-    is checked against ``records``, which the gate never touches).
+    The full plan is a confirmation surface, and nothing is being confirmed
+    inside ``init --reset``; pasting it into the phase record is exactly the
+    clutter the condensed form replaces.
     """
     result = run_init_reset(target)
 
     assert result.exit_code == 0, result.output
-    assert PLAN_HEADING in result.stdout
-    assert not any(PLAN_HEADING in message for message in terminal_probe.messages)
+    assert PLAN_HEADING not in result.stdout
+    assert PLAN_OPENS_WITH not in result.stdout
+    flowed = " ".join(result.stdout.split())
+    assert "removed 1 container, 1 volume" in flowed
+    assert "kept the audit log" in flowed
+
+
+def test_the_condensed_steps_are_on_the_default_view_not_the_log(
+    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check, terminal_probe
+) -> None:
+    """The historical bug, re-pinned against the condensed form.
+
+    Routed through ``logger.key_info`` the old plan was an INFO record, which
+    the altitude gate drops — so the destructive verb that never asks also
+    never said what it was taking. The condensed outcome is phase record now:
+    on stdout, and not painted by the log handler.
+    """
+    result = run_init_reset(target)
+
+    assert result.exit_code == 0, result.output
+    assert "removed 1 container, 1 volume" in " ".join(result.stdout.split())
+    assert "removed 1 container" not in terminal_probe.rendered_text
     # Witness: the record sink is live, so the absence above is an observation
     # rather than an empty buffer agreeing with everything.
     logging.getLogger("osprey.test.reset_plan_parity").info("plan parity witness")
     assert any("plan parity witness" in message for message in terminal_probe.messages)
 
 
-def test_the_plan_survives_the_verbose_reporter_on_both_paths(
-    target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check
+def test_an_empty_plan_reports_nothing_to_do_and_removes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, no_destruction
 ) -> None:
-    """``-v`` installs the NullReporter, which swallows the phase record only.
+    """``reset_for_reinit`` on a repo with nothing to take does not execute.
 
-    The plan is echo-class on both paths now, so the flag that turns the run
-    into a transcript must not be the flag that loses the destruction list.
+    A fresh ``init`` always leaves *something* on the plan (the state
+    directories it just made), so this is the direct contract test for the
+    branch — the phase note it feeds is pinned on the CLI below.
     """
-    from_init = CliRunner().invoke(
-        cli,
-        ["-v", "init", str(target), "--preset", "hello-world", "--no-git", "--reset"],
-        catch_exceptions=False,
+    repo = tmp_path / PROJECT
+    repo.mkdir()
+    fake = FakeRuntime()
+
+    outcome = reset_mod.reset_for_reinit(repo, probe=RuntimeProbe("docker", run=fake))
+
+    assert outcome is reset_mod.ResetOutcome.NOTHING_TO_DO
+    assert no_destruction == []
+
+
+def test_a_reset_with_nothing_to_remove_says_so_on_the_phase_line(
+    target: Path, monkeypatch: pytest.MonkeyPatch, no_survivor_check
+) -> None:
+    """An empty plan closes the phase with its note instead of printing a plan."""
+    monkeypatch.setattr(
+        reset_mod, "reset_for_reinit", lambda repo_root, **kw: reset_mod.ResetOutcome.NOTHING_TO_DO
     )
-    assert from_init.exit_code == 0, from_init.output
 
-    from_reset = run_reset(target, "-y")
+    result = run_init_reset(target)
 
-    assert PLAN_HEADING in from_init.stdout
-    assert plan_lines(from_init.stdout) == plan_lines(from_reset.stdout)
+    assert result.exit_code == 0, result.output
+    flowed = " ".join(result.stdout.split())
+    assert "nothing from a previous run to remove" in flowed
+    assert PLAN_HEADING not in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -290,7 +319,7 @@ def test_the_typed_gate_still_accepts_the_token(
 def test_init_reset_waives_the_prompt_rather_than_answering_it(
     target: Path, runtime: FakeRuntime, no_destruction, no_survivor_check, monkeypatch
 ) -> None:
-    """``--reset`` is the unattended path: it passes ``assume_yes``, so nothing asks.
+    """``--reset`` is the unattended path: nothing may ask.
 
     Worth pinning next to the two above: the gate is *waived* here, by a flag
     the operator typed, and not silently answered on their behalf somewhere in

--- a/tests/deployment/test_deploy_summary.py
+++ b/tests/deployment/test_deploy_summary.py
@@ -207,7 +207,9 @@ def probe(restore_root_logging):
 def test_the_endpoint_summary_is_in_the_default_view(probe, compose_file):
     """The needle: printed on a normal run, no longer painted by the logger."""
     deploy_summary.log_endpoint_summary({"project_name": "demo"}, [compose_file])
-    logging.getLogger("deployment.summary").warning("armed witness")
+    # ERROR, not WARNING: the gate keeps WARNING off the terminal while a
+    # reporter is installed, and this fixture installs one.
+    logging.getLogger("deployment.summary").error("armed witness")
 
     # Echoed: what the operator ran the verb to find out.
     assert "Service endpoints (demo):" in probe.printed

--- a/tests/deployment/test_down_restart_gates.py
+++ b/tests/deployment/test_down_restart_gates.py
@@ -364,7 +364,7 @@ def test_finding_no_labelled_container_does_not_claim_the_stack_is_down(
     text = caplog.text
     assert str(lifecycle_repo / "build") in text
     assert REPO_ID_LABEL in text
-    assert "CREATED" in text
+    assert "label when they are created" in text
     assert "may still be running" in text
     assert "osprey build" in text
 

--- a/tests/deployment/test_up_as_built.py
+++ b/tests/deployment/test_up_as_built.py
@@ -1059,7 +1059,9 @@ def test_the_up_path_reaches_the_sink_aware_mint(lifecycle_repo, started, monkey
 
     assert result.exit_code == 0, result.output
     assert sinks and all(sink is not print for sink in sinks)
-    assert "Minted a login password" not in result.output
+    # The fact still reaches the operator — as the renderer's promoted block,
+    # not as a password printed through the unguarded sink.
+    assert "⚠ Minted a login password" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/web_terminals/test_env_users_rename.py
+++ b/tests/deployment/web_terminals/test_env_users_rename.py
@@ -60,11 +60,13 @@ def test_migration_moves_the_old_file_onto_the_new_name(tmp_path, caplog):
     # no downstream check catches.
     assert stat.S_IMODE(users_path.stat().st_mode) == 0o600
 
-    # One line, naming both paths, so an operator reading the deploy output can
-    # see where their secrets went without diffing the directory.
+    # The record names both filenames, so an operator reading the deploy
+    # output can see where their secrets went without diffing the directory.
     migration_lines = [rec.message for rec in caplog.records if USERS_ENV_FILENAME in rec.message]
-    assert len(migration_lines) == 1
-    assert str(legacy) in migration_lines[0] and str(users_path) in migration_lines[0]
+    assert migration_lines, "the migration left no record"
+    assert any(
+        LEGACY_USERS_ENV_FILENAME in line and USERS_ENV_FILENAME in line for line in migration_lines
+    )
 
 
 def test_both_files_present_keeps_the_new_one_and_deletes_the_leftover(tmp_path, caplog):
@@ -89,7 +91,7 @@ def test_both_files_present_keeps_the_new_one_and_deletes_the_leftover(tmp_path,
 
     removal_lines = [rec.message for rec in caplog.records if USERS_ENV_FILENAME in rec.message]
     assert len(removal_lines) == 1
-    assert str(legacy) in removal_lines[0] and str(users_path) in removal_lines[0]
+    assert LEGACY_USERS_ENV_FILENAME in removal_lines[0]
 
 
 def test_no_old_file_is_a_silent_no_op(tmp_path, caplog):

--- a/tests/pty/test_live_region_real_terminal.py
+++ b/tests/pty/test_live_region_real_terminal.py
@@ -738,7 +738,7 @@ def test_two_paints_of_the_region_differ_only_by_the_clock(
 def test_a_warning_lands_intact_above_a_mounted_region(
     startable_repo: Path, pty_env: dict[str, str], unhurried_runtime: None
 ) -> None:
-    """A real WARNING from the start path, on a real terminal, above the region.
+    """A real warning from the start path, on a real terminal, above the region.
 
     Provoked rather than injected: the start path compares the shell's exports
     against the deployment's env chain and warns when an exported value
@@ -748,9 +748,13 @@ def test_a_warning_lands_intact_above_a_mounted_region(
     it produces it in the middle of the start phase, with the region mounted
     and the monitor thread repainting.
 
-    Intact means: the record's own lines are consecutive on the final screen,
-    with the ``RichHandler`` level column at its usual width, and no region
-    frame anywhere between them.
+    The call site is promoted (:func:`osprey.cli.output.warn_fact`), so what
+    must land is the renderer's trouble shape — marked summary, indented body —
+    and NOT a ``RichHandler`` record: while the reporter owns the terminal the
+    altitude gate keeps raw WARNING records off it, and this scenario is where
+    that pair of facts is read off a real screen. Intact means: the block's
+    lines are consecutive on the final screen with no region frame anywhere
+    between them.
     """
     env_path = startable_repo / ".env"
     env_path.write_text(
@@ -765,26 +769,41 @@ def test_a_warning_lands_intact_above_a_mounted_region(
     assert_screen_is_intact(run)
 
     screen = run.screen
-    heads = [index for index, line in enumerate(screen) if re.search(r"\bWARNING {2}\S", line)]
-    assert len(heads) == 1, f"expected exactly one WARNING record\n{run.describe()}"
+    heads = [
+        index
+        for index, line in enumerate(screen)
+        if "shell export disagrees with this deployment's env chain" in line
+    ]
+    assert len(heads) == 1, f"expected exactly one promoted warning\n{run.describe()}"
     head = heads[0]
-    assert "Shell export disagrees with this deployment's env chain" in screen[head], run.describe()
-    assert_region_was_mounted_when(run, "Shell export disagrees")
+    assert screen[head].lstrip().startswith("⚠"), (
+        f"the warning did not render as the renderer's warn shape: {screen[head]!r}\n"
+        f"{run.describe()}"
+    )
+    # The summary names what diverged; the promotion must not have lost that.
+    assert "ZO_ROOT_USER_PASSWORD" in screen[head], run.describe()
+    assert_region_was_mounted_when(run, "shell export disagrees")
 
-    # The record wraps at the terminal's width, so "intact" is about the block:
-    # every line of it is consecutive, the variable it names is in there, and
-    # no region frame is drawn between any two of its lines.
+    # The gate's half of the contract: the record this warning also files must
+    # NOT have painted as a RichHandler block — the promoted shape is the one
+    # voice this warning gets on the terminal.
+    assert not any(re.search(r"\bWARNING {2}\S", line) for line in screen), (
+        f"a raw WARNING record reached the terminal past the altitude gate\n{run.describe()}"
+    )
+
+    # The block wraps at the terminal's width, so "intact" is about the block:
+    # every line of it is consecutive and no region frame is drawn between any
+    # two of its lines.
     body = screen[head : head + 6]
-    assert "ZO_ROOT_USER_PASSWORD" in "".join(body), run.describe()
     assert all(not any(glyph in line for glyph in SPINNER_FRAMES) for line in body), (
-        "a region frame is interleaved with the record:\n" + "\n".join(body)
+        "a region frame is interleaved with the warning block:\n" + "\n".join(body)
     )
 
     # And it is above the region, not inside it: the phase the region was
-    # drawing for closes after the record.
+    # drawing for closes after the block.
     closing = [index for index, line in enumerate(screen) if "✓ Starting" in line]
     assert closing and closing[0] > head, (
-        f"the record did not land above the open phase's region\n{run.describe()}"
+        f"the warning did not land above the open phase's region\n{run.describe()}"
     )
 
 
@@ -1054,12 +1073,18 @@ def test_a_warn_from_inside_a_mounted_phase_does_not_take_the_screen_with_it(
 #: measured. Riding the step call reaches it on purpose, so the scenario asserts
 #: a property of the code rather than of the scheduler.
 HAZARD_BOOTSTRAP = """
+import atexit
+import pathlib
 import sys
 
 from osprey.cli import output, phase_reporter
 
 _real_step = phase_reporter.Phase.step
 _issued = []
+
+atexit.register(
+    lambda: pathlib.Path("probe-step-receipt").write_text(str(len(_issued)), encoding="utf-8")
+)
 
 
 def _step(self, name):
@@ -1153,15 +1178,25 @@ def probe_warning_lines(run: PtyRun) -> list[str]:
     return [run.screen[row] for row in probe_warning_rows(run)]
 
 
-def sub_step_lines(run: PtyRun) -> list[str]:
-    """Every sub-step line the deploy printed under an open phase.
+def issued_step_count(repo: Path) -> int:
+    """How many ``Phase.step`` calls the hazard bootstrap rode, from its receipt.
 
-    The two bootstraps that ride ``Phase.step`` issue exactly one line per
-    sub-step, so this is what their count is checked against — a scenario that
-    hardcoded "two warnings" would go quietly vacuous the day the start path
-    gains or loses a step.
+    The bootstraps that ride ``Phase.step`` issue exactly one warning per
+    sub-step, so this is what their warning count is checked against — a
+    scenario that hardcoded "two warnings" would go quietly vacuous the day the
+    start path gains or loses a step. The count comes from the bootstrap's own
+    receipt file rather than from counting ``·`` lines on the screen: promoted
+    facts (:func:`osprey.cli.output.report_fact`) share that grammar on
+    purpose, so the screen cannot tell a sub-step from a fact — and a proxy
+    that miscounts would fail these scenarios for a reason that has nothing to
+    do with how trouble is routed.
     """
-    return [line for line in run.screen if re.match(r"\s*· \S", line)]
+    receipt = repo / "probe-step-receipt"
+    assert receipt.exists(), (
+        "the hazard bootstrap never wrote its step receipt, so the warning count "
+        "has nothing sound to be checked against"
+    )
+    return int(receipt.read_text(encoding="utf-8"))
 
 
 def test_a_warn_issued_from_inside_an_open_phase_lands_above_the_region(
@@ -1188,10 +1223,10 @@ def test_a_warn_issued_from_inside_an_open_phase_lands_above_the_region(
 
     assert run.exit_code == 0, run.describe()
     warnings = probe_warning_lines(run)
-    steps = sub_step_lines(run)
-    assert steps, f"the deploy printed no sub-step to ride\n{run.describe()}"
-    assert len(warnings) == len(steps), (
-        f"one warning per sub-step was issued but {len(warnings)} of {len(steps)} reached the "
+    issued = issued_step_count(startable_repo)
+    assert issued, f"the deploy ran no sub-step to ride\n{run.describe()}"
+    assert len(warnings) == issued, (
+        f"one warning per sub-step was issued but {len(warnings)} of {issued} reached the "
         f"screen\n{run.describe()}"
     )
     # The set asserted on below is pinned by an anchored pattern, so a warning
@@ -1249,11 +1284,11 @@ def test_control_the_same_line_through_the_reporter_console_never_welds(
 
     assert run.exit_code == 0, run.describe()
     lines = probe_warning_lines(run)
-    steps = sub_step_lines(run)
-    assert steps, f"the deploy printed no sub-step to ride\n{run.describe()}"
-    assert len(lines) == len(steps), (
+    issued = issued_step_count(startable_repo)
+    assert issued, f"the deploy ran no sub-step to ride\n{run.describe()}"
+    assert len(lines) == issued, (
         f"the control must issue the same number of lines as the finding does, or the two "
-        f"runs are not comparable: {len(lines)} of {len(steps)}\n{run.describe()}"
+        f"runs are not comparable: {len(lines)} of {issued}\n{run.describe()}"
     )
     for index, line in enumerate(lines):
         assert line.strip() == f"probe warning {index}", (

--- a/tests/pty/test_piped_parity.py
+++ b/tests/pty/test_piped_parity.py
@@ -40,11 +40,12 @@ normalised, each for a measured reason:
 
 * **The width.** Rich takes a pipe's width from ``COLUMNS`` and falls back to 80;
   a terminal's comes from the pty, which this harness fixes at
-  :data:`~tests.pty.test_live_region_real_terminal.TERMINAL_COLUMNS`. Measured
-  without the pin: the wrapped WARNING record comes out 18 lines on the pipe
-  against 15 on the terminal, and the subtraction fails on wrapping alone. So the
-  piped run is told the terminal's width, and the two runs wrap alike.
-* **The clock.** A ``RichHandler`` record is stamped with the wall clock and a
+  :data:`~tests.pty.test_live_region_real_terminal.TERMINAL_COLUMNS`. The echo
+  path itself never wraps, but anything rendered through a width-aware rich
+  surface (a table, a record under ``-v``) would wrap differently without the
+  pin — so the piped run is told the terminal's width, and the two runs wrap
+  alike.
+* **The clock.** A rendered log record is stamped with the wall clock and a
   phase line carries its own elapsed. Both are normalised to placeholders.
 * **Sub-second laps.** A lap under 50 ms prints with no duration at all
   (``phase_reporter.Phase.step``), so against the instant stub the *presence* of a
@@ -58,10 +59,12 @@ normalised, each for a measured reason:
 **The stderr side is armed on purpose.** The scripted deploy is quiet on stderr,
 and a subtraction with nothing to subtract would pass for no reason. So the run
 provokes the env-chain disagreement warning the way scenario 3 does — a real
-WARNING from the start path, not an injected line — and it is a 15-line wrapped
-record, which is the strongest shape available: every one of those lines has to
-appear on the terminal and be struck off, and any drift in how a redirect wraps
-or splits the record shows up as a leftover.
+warning from the start path, not an injected line. Its call site is promoted
+(:func:`osprey.cli.output.warn_fact`), so what lands on stderr is the renderer's
+trouble block: a summary line, a wrapped multi-line detail and a remedy, which is
+the strongest shape available — every one of those lines has to appear on the
+terminal and be struck off, and any drift in how a redirect wraps or splits the
+block shows up as a leftover.
 
 POSIX only, like the rest of this directory.
 """
@@ -108,18 +111,22 @@ pytestmark = [
 #: move where the record wraps.
 TIMESTAMP = re.compile(r"\[\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\]")
 
-#: What that column reads as once normalised. Spelled once and used both by
-#: :func:`normalised` and by :data:`RECORD_HEAD`, so the pattern that finds a
-#: record's first line cannot drift from the placeholder that produces it.
+#: What that column reads as once normalised. A rendered log record can still
+#: reach stderr outside a reporter's tenure (and always under ``-v``), so the
+#: normalisation keeps handling the stamp even though the armed warning no
+#: longer carries one.
 TIME_PLACEHOLDER = "[<time>]"
 
-#: The first line of a rendered log record, after normalisation: the timestamp
-#: column and the level. Wrap-immune by construction — the column is fixed width
-#: and the level is one word — which is what makes it a safe anchor for finding
-#: where a record starts. The record's head *phrase* is not safe for that: it is
-#: long enough to wrap, and matching it line by line reports a wrapping
+#: The first line of the armed warning's block. The call site is promoted
+#: (:func:`osprey.cli.output.warn_fact`), so the shape on stderr is the
+#: renderer's trouble block — ``⚠ summary`` over an indented body — rather than
+#: a ``RichHandler`` record: while the reporter owns the run the altitude gate
+#: keeps raw WARNING records off the terminal, and the promoted block is the
+#: warning's one rendered voice. The anchor is the glyph and the phrase's first
+#: words only — short enough that no width this suite runs at can wrap it —
+#: because matching the whole head phrase line by line would report a wrapping
 #: difference as a missing warning.
-RECORD_HEAD = re.compile(rf"^{re.escape(TIME_PLACEHOLDER)}\s+WARNING\b")
+RECORD_HEAD = re.compile(r"^\s*⚠ shell export disagrees\b")
 
 #: A phase line's or a sub-step's trailing duration, in both shapes
 #: :func:`osprey.cli.phase_reporter.format_elapsed` produces.
@@ -143,7 +150,7 @@ EXPORTED_VALUE = "Exp0rted!Value"
 #: phrase is long enough to wrap, and a width the run did not expect would then
 #: fail the arming check and report a lost warning instead of the wrapping
 #: difference that is the actual finding.
-ARMED_WARNING_HEAD = "Shell export disagrees with this deployment's env chain"
+ARMED_WARNING_HEAD = "shell export disagrees with this deployment's env chain"
 
 #: How many lines that record is expected to occupy, as a floor — and it is the
 #: **record's** size, not the capture's. A floor over the whole of stderr would
@@ -153,10 +160,13 @@ ARMED_WARNING_HEAD = "Shell export disagrees with this deployment's env chain"
 #: have to be one set.
 #:
 #: Pinned as a floor rather than exactly, because what matters is that the
-#: subtraction has a substantial, wrapped, multi-line record to work on and the
-#: copy is free to grow. One line would satisfy "non-empty" while testing almost
-#: nothing.
-ARMED_WARNING_MINIMUM_LINES = 10
+#: subtraction has the whole block to work on and the copy is free to grow. One
+#: line would satisfy "non-empty" while testing almost nothing. The echo path
+#: never wraps — a pipe carries each of the block's lines whole, and the
+#: harness's scrollback reassembles a terminal's wrapped rows back into them —
+#: so the floor is the promoted block's three logical lines: the summary, the
+#: detail and the remedy.
+ARMED_WARNING_MINIMUM_LINES = 3
 
 
 @dataclass


### PR DESCRIPTION
## Summary

During a lifecycle verb (`up`, `down`, `init --reset`, `build`), the terminal carried two interleaved voices: the phase reporter's structured output, and stray facts and warnings escaping as column-zero paragraphs or timestamped log records — some of them welding onto the live region's row when they arrived mid-repaint. The operator had no single place to read what a deploy did or what went sideways while it ran.

The reporter is now the single voice on the terminal for the duration of a verb:

- Facts an operator should see print in the phase grammar (`· minted 1 service auth token(s) → .env`) via a `report_fact` primitive that also keeps the log record for sinks.
- Warnings an operator must read mid-run print the trouble shape (`⚠ summary` / indented detail / `→ remedy`) via `warn_fact`, on stderr, with the record kept.
- Durable outputs (tokens, certificates, rewritten env files) collect into a process-scoped ledger, flushed as one aligned **This deploy wrote** block after the summary card — and before the reporter hand-off on attached `up`.
- While a reporter is installed, raw WARNING records stay off the terminal (ERROR+ always paints; `-v` lifts the gate). Every record still reaches file sinks, `-v`, and `caplog` unchanged.

Builds on #603.

## Changes

- New primitives in `osprey.cli.output`: `report_fact`, `warn_fact`, `flush_ledger`, `clear_ledger`; the WARNING gate in `osprey.cli.altitude`.
- Promoted call sites: service-token mint, bluesky scan devices, control-socket keypair, CURVE certificates, `.env.production` → `.env.users` rename, dev mode, localhost binding, network reachability, the down-path "nothing to stop" report, timezone drift, and the env-chain shell-export warning.
- `init --reset` reports its chained reset as condensed phase steps (`reset_for_reinit`), collapsing to one line when there is nothing to remove; standalone `osprey reset` keeps its full confirmation plan.
- The real-terminal (pty) suites pin the new contract: the promoted block above a mounted region, no raw WARNING record past the gate, warning-per-step counts checked against the bootstrap's own step receipt, and piped/terminal parity measured on the promoted block.

## Test plan

- Unit tests for each primitive, the ledger lifecycle, and the gate's reporter-aware behavior (`tests/cli/test_output_primitives.py`, `test_altitude_gate.py`, `test_lifecycle_promotions.py`).
- Reset parity pinned at the plan-object level plus both report shapes (`test_reset_plan_parity.py`).
- Real-terminal behavior verified on a pty: live-region integrity, warning placement, piped parity (`tests/pty/`).
- Env-chain warning copy and names-only guarantees unchanged across all providers (`tests/deployment/test_env_shadow_preflight.py`).

## How it hangs together

```text
  CALL SITES (deploy path)      cli/output.py            OPERATOR'S TERMINAL
  ─────────────────────────     ─────────────            ───────────────────
  container_lifecycle.py                                ┌──────────────────────────┐
  provision.py            ──▶ report_fact() ─┐          │ → Starting exemplar      │
  env_production.py           · fact line    │          │   · minted 1 token → .env│
  wheel_build.py              + ledger row   │          │   · containers started   │
                                             ├─▶ phase  │   ⚠ shell export         │
  (same call sites)       ──▶ warn_fact() ───┘ reporter │     disagrees with the   │
                          ⚠ summary / detail / → remedy │     env chain            │
                                                        │     → unset the export   │
  raw logger.warning()    ──╳ altitude gate             │   ✓ Starting (3.1s)      │
    ERROR+ always paints · -v lifts the gate            ├──────────────────────────┤
                                                        │   summary card           │
  flush_ledger() ──────────────────────────────────────▶│ This deploy wrote        │
  every log record ──▶ file sinks · -v · caplog         │   .env   service tokens  │
    (the gate only mutes the terminal)                  └──────────────────────────┘

  init --reset ──▶ reset_for_reinit() — the same plan/execute machinery as
     standalone `osprey reset`, reported as condensed "·" steps
```
