### PR TITLE
feat(cli): theme the lifecycle output and group deploy steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Lifecycle output now carries the CLI's theme. Phase openers anchor in the
+  theme's primary color with a blank line before each phase, finished phases
+  and durations dim so the open phase stays prominent, promoted facts and
+  remedy arrows use the accent, and the closing "This deploy wrote" block
+  styles its heading and file paths like the rest of the CLI. Long phases
+  group their steps under quiet per-service headers (`archiver`, `ariel`,
+  `personas`, `services`, …) so a busy `osprey up` reads as sections instead
+  of one flat column. Piped output is unchanged apart from the new blank
+  lines and group headers — color never reaches a pipe.
 - Deploy output keeps one shape from start to finish. Facts a deploy used to
   print as paragraphs between phases (minted tokens, generated certificates, a
   renamed secrets file) are now one short line each in the step column, with

--- a/src/osprey/cli/output.py
+++ b/src/osprey/cli/output.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from contextlib import contextmanager
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 
 from rich.text import Text
@@ -250,7 +251,9 @@ def report_fact(
     :param wrote: The ledger row, or ``None`` for an inline-only fact. The value
         is rendered with :func:`str`, like a :func:`section` value.
     """
-    _echo(Text(f"{_INDENT}{_FACT_GLYPH} {message}"))
+    line = Text(f"{_INDENT}{_FACT_GLYPH} ", style=Styles.ACCENT)
+    line.append(message)
+    _echo(line)
     logger.key_info(message)
     if wrote is not None:
         label, value = wrote
@@ -290,7 +293,7 @@ def warn_fact(
     if remedy:
         body.append(f"{_REMEDY_GLYPH} {remedy}")
     for line in body:
-        _echo(Text(f"{_INDENT}{_INDENT}{line}"), err=True)
+        _echo(_body_text(f"{_INDENT}{_INDENT}", line), err=True)
     logger.warning(" ".join(part for part in (summary, detail, remedy) if part))
 
 
@@ -309,7 +312,7 @@ def flush_ledger() -> None:
         return
     rows, _ledger[:] = list(_ledger), []
     report("")
-    section(_LEDGER_TITLE, rows)
+    section(_LEDGER_TITLE, rows, label_style=Styles.PATH)
 
 
 def clear_ledger() -> None:
@@ -337,14 +340,23 @@ def note(text: str, /) -> None:
     _echo(Text(f"{_INDENT}{text}", style=Styles.DIM))
 
 
-def section(title: str, items: Mapping[str, object] | Sequence[tuple[str, object]], /) -> None:
+def section(
+    title: str,
+    items: Mapping[str, object] | Sequence[tuple[str, object]],
+    /,
+    *,
+    label_style: str = Styles.LABEL,
+) -> None:
     """Print a key/value block: ``title``, then one indented row per item.
 
     The one shape for "here are the facts about this thing" -- an endpoint
     list, a summary card's rows, a config dump. Labels are padded to a common
     width so the values line up as a column; values are rendered with
     :func:`str`, so a caller may hand over paths, ports and booleans as they
-    are.
+    are. The title carries the theme's header token, the same anchor color the
+    phase record's arrows use, and a value handed over as a
+    :class:`~pathlib.PurePath` renders in the path token -- semantic styling
+    by TYPE, never by guessing at strings.
 
     An empty ``items`` prints the title alone, and an empty ``title`` prints
     the rows alone -- a section that continues the line above it.
@@ -354,16 +366,21 @@ def section(title: str, items: Mapping[str, object] | Sequence[tuple[str, object
     :param items: The rows, as a mapping or as an ordered sequence of
         ``(label, value)`` pairs. A sequence when the order is meaningful and
         labels may repeat; either way the rows print in iteration order.
+    :param label_style: The style token for the label column. The default is
+        the bold label; :func:`flush_ledger` passes the path token because its
+        labels ARE paths by :func:`report_fact`'s ``wrote`` contract.
+        Keyword-only: it is not prose, and the copy guard reads prose out of
+        the positional arguments.
     """
     rows = list(items.items()) if isinstance(items, Mapping) else list(items)
     if title:
-        _echo(Text(title, style=Styles.BOLD))
+        _echo(Text(title, style=Styles.HEADER))
     width = max((len(label) for label, _ in rows), default=0)
     for label, value in rows:
         line = Text(_INDENT)
-        line.append(label.ljust(width), style=Styles.LABEL)
+        line.append(label.ljust(width), style=label_style)
         line.append(_GUTTER)
-        line.append(str(value))
+        line.append(str(value), style=Styles.PATH if isinstance(value, PurePath) else "")
         _echo(line)
 
 
@@ -397,6 +414,24 @@ def table(renderable: RenderableType, /) -> None:
     _echo(renderable)
 
 
+def _body_text(indent: str, line: str) -> Text:
+    """Build one indented body line, with a remedy's arrow in the accent.
+
+    The arrow is the one glyph in a trouble body that is an instruction rather
+    than evidence, and the accent is what lets the eye find it without reading
+    the block. The words are untouched: off a terminal the line prints exactly
+    as composed.
+    """
+    text = Text(indent)
+    remedy_head = f"{_REMEDY_GLYPH} "
+    if line.startswith(remedy_head):
+        text.append(remedy_head, style=Styles.ACCENT)
+        text.append(line[len(remedy_head) :])
+    else:
+        text.append(line)
+    return text
+
+
 def _trouble(glyph: str, style: str, summary: str, body: Sequence[str]) -> None:
     """Print one trouble event: a marked summary line, then its indented body.
 
@@ -424,7 +459,7 @@ def _trouble(glyph: str, style: str, summary: str, body: Sequence[str]) -> None:
     """
     _echo(Text(f"{glyph} {summary}" if glyph else summary, style=style), err=True)
     for line in body:
-        _echo(Text(f"{_INDENT}{line}"), err=True)
+        _echo(_body_text(_INDENT, line), err=True)
 
 
 def warn(summary: str, detail: str | None = None, /) -> None:

--- a/src/osprey/cli/phase_reporter.py
+++ b/src/osprey/cli/phase_reporter.py
@@ -3,8 +3,18 @@
 Lifecycle verbs (``init``, ``build``, ``up``, ``restart``, ``down``, ``reset``)
 report progress as a short sequence of phases rendered as plain sequential
 lines on stdout: ``→ title`` when a phase starts, ``  ✓ title (elapsed)`` when
-it ends, ``  · name`` for sub-steps. Those lines are the permanent record on
-every path, terminal or not, and nothing rewrites them once printed.
+it ends, ``  · name`` for sub-steps, with an optional ``  group`` header line
+opening a named run of steps (which then sit one step deeper). Those lines are
+the permanent record on every path, terminal or not, and nothing rewrites them
+once printed.
+
+On a terminal the lines carry the CLI's theme, assigned by role rather than
+per line: the phase arrow anchors in the theme's primary, group headers in its
+subheader, and everything that is *over* — durations, closed ``✓`` lines —
+drops to dim, so the open phase and any warning are the brightest things on
+screen. The words never change: styles ride on text segments
+(:meth:`PhaseReporter.emit_segments`), and off a terminal the segments print
+unstyled, byte-identical to what these lines have always been.
 
 On a terminal :class:`LiveReporter` adds a live region *underneath* that record:
 the open phase repainted with a spinner and a ticking elapsed, and a row per
@@ -42,7 +52,7 @@ from .live_render import render_live_region
 from .styles import Styles, console
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
     from rich.console import Console
 
@@ -96,6 +106,7 @@ class Phase:
         self._start = time.monotonic()
         self._lap = self._start
         self._closed = False
+        self._group: str | None = None
 
     @property
     def elapsed(self) -> float:
@@ -116,6 +127,22 @@ class Phase:
         """Record the spool file the phase is currently writing to."""
         self.spool = path
 
+    def group(self, name: str | None) -> None:
+        """Open a named group of steps, printing its header line once.
+
+        A long phase's steps arrive in contiguous runs — one service brought
+        up, then the next — and the header is what lets a reader hold those
+        runs apart in the scrollback. Steps reported while a group is open sit
+        one step deeper than the header. Re-declaring the open group is a
+        no-op (a loop may declare per iteration); ``None`` closes the group
+        without printing anything.
+        """
+        if name == self._group:
+            return
+        self._group = name
+        if name is not None:
+            self._reporter.emit_segments((("  ", None), (name, Styles.SUBHEADER)))
+
     def step(self, name: str) -> None:
         """Print a sub-line under this phase.
 
@@ -125,17 +152,28 @@ class Phase:
         """
         now = time.monotonic()
         lap, self._lap = now - self._lap, now
-        suffix = f" ({format_elapsed(lap)})" if lap >= 0.05 else ""
-        self._reporter.emit(f"  · {name}{suffix}")
+        indent = "    " if self._group is not None else "  "
+        segments: list[tuple[str, str | None]] = [(f"{indent}· ", Styles.DIM), (name, None)]
+        if lap >= 0.05:
+            segments.append((f" ({format_elapsed(lap)})", Styles.DIM))
+        self._reporter.emit_segments(segments)
 
     def done(self, note: str = "") -> None:
-        """Print the success line for this phase."""
+        """Print the success line for this phase.
+
+        The ``✓`` keeps the success color; the rest of the line is dim. A
+        closed phase is over, and the record of it must recede so the open
+        one stays the brightest thing on screen.
+        """
         if self._closed:
             return
         self._closed = True
         suffix = f" — {note}" if note else ""
-        self._reporter.emit(
-            f"  ✓ {self.title} ({format_elapsed(self.elapsed)}){suffix}", style=Styles.SUCCESS
+        self._reporter.emit_segments(
+            (
+                ("  ✓ ", Styles.SUCCESS),
+                (f"{self.title} ({format_elapsed(self.elapsed)}){suffix}", Styles.DIM),
+            )
         )
 
     def fail(self, replay: Path | None = None) -> None:
@@ -253,6 +291,26 @@ class PhaseReporter:
             soft_wrap=True,
         )
 
+    def emit_segments(self, segments: Sequence[tuple[str, str | None]]) -> None:
+        """Print one line assembled from ``(text, style)`` segments.
+
+        How a phase line carries more than one style — a dim glyph in front of
+        default text, a dim duration behind it. With color off the segments ARE
+        their joined text, so the line goes through :meth:`emit` — which keeps
+        every subclass that intercepts ``emit`` (the ``--verbose`` swallower,
+        the tests' recorders) seeing one seam, and keeps the bytes a pipe reads
+        exactly what they always were. With color on, the styles ride on the
+        Text's own spans — never on a ``style=`` argument, which Rich would
+        apply to a mounted live region repainted in the same call.
+        """
+        if not self.color:
+            self.emit("".join(part for part, _ in segments))
+            return
+        text = Text()
+        for part, style in segments:
+            text.append(part, style=style or "")
+        self.out().print(text, soft_wrap=True)
+
     def echo(self, text: str) -> None:
         """Print one line of a verb's OWN output, rather than of the phase record.
 
@@ -272,8 +330,16 @@ class PhaseReporter:
         self.out().print(text, markup=False, highlight=False, soft_wrap=True)
 
     def phase(self, title: str) -> Phase:
-        """Start a phase, printing its opening line."""
-        self.emit(f"→ {title}", style=Styles.BOLD)
+        """Start a phase, printing a blank line and its opening line.
+
+        The blank line is the record's vertical rhythm: phases are the units
+        an operator scans for, and the gap is what makes the boundary findable
+        in a wall of steps. Structure rather than color, so it survives a pipe.
+        The arrow anchors in the theme's primary — the one saturated mark on a
+        healthy run, which is what makes it the eye's landing point.
+        """
+        self.emit("")
+        self.emit_segments((("→ ", Styles.HEADER), (title, Styles.BOLD)))
         self._phase = Phase(self, title)
         return self._phase
 
@@ -620,6 +686,9 @@ def _heartbeat_line(row: BuildRow, now: float) -> str:
     surface already speaks -- ``  · step (lap)``, ``  ✓ title (elapsed)``. A
     reader who has seen one line of this output has already learned where to
     look for a time, and this line says only that the time is still running.
+
+    A plain string, not styled segments: heartbeats print where no live region
+    does — off a terminal, where the color gate strips styles anyway.
     """
     parts = (row.service, row.step, _clip(row.caption))
     head = " ".join(part for part in parts if part)
@@ -771,7 +840,13 @@ class LiveReporter(PhaseReporter):
         phase = self._phase
         if phase is None:
             return
-        self.emit(f"  · {phase.title} (running {format_elapsed(phase.elapsed)})")
+        self.emit_segments(
+            (
+                ("  · ", Styles.DIM),
+                (phase.title, None),
+                (f" (running {format_elapsed(phase.elapsed)})", Styles.DIM),
+            )
+        )
 
     def refresh_live(self) -> bool:
         """Repaint the region from one clock reading; True while it is mounted.
@@ -941,3 +1016,17 @@ def report_step(name: str) -> None:
     phase = current_reporter().current_phase
     if phase is not None:
         phase.step(name)
+
+
+def report_group(name: str | None) -> None:
+    """Open a named group of steps under the open phase, if there is one.
+
+    :func:`report_step`'s counterpart for the header line: a deploy site that
+    is about to report a contiguous run of steps for one service declares the
+    group once, and the steps that follow nest under it. Conditional on an
+    open phase for the same reason :func:`report_step` is, and idempotent per
+    group so a loop may declare each iteration. ``None`` closes the group.
+    """
+    phase = current_reporter().current_phase
+    if phase is not None:
+        phase.group(name)

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -24,6 +24,7 @@ import yaml
 
 from osprey.cli import output
 from osprey.cli.phase_reporter import current_reporter
+from osprey.cli.phase_reporter import report_group as _report_group
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.build_progress import BuildModel, with_plain_build_progress
 from osprey.deployment.compose_generator import (
@@ -1701,6 +1702,7 @@ def _build_project_image(
         logger.debug("Running command:\n    %s", " ".join(cmd))
         # Watched for the duration of the build and no longer; the step line
         # below is what reports the finished image.
+        _report_group("images")
         with (report := single_image_build_reporter(project_image)):
             run_captured(
                 cmd,
@@ -2919,6 +2921,7 @@ def _stage_archiver_store(
         provider,
     )
 
+    _report_group("archiver")
     up_cmd = base_cmd + ["up", "-d", _ARCHIVER_STORE_SERVICE]
     logger.debug(f"Running command:\n    {' '.join(up_cmd)}")
     run_captured(up_cmd, env=run_env, spool_name="archiver-store-up", repo_root=project_dir)
@@ -3161,6 +3164,7 @@ def _stage_ariel_store(config, compose_files, env, project_dir, *, provider=None
         provider,
     )
 
+    _report_group("ariel")
     up_cmd = base_cmd + ["up", "-d", _ARIEL_STORE_SERVICE]
     logger.debug(f"Running command:\n    {' '.join(up_cmd)}")
     run_captured(up_cmd, env=run_env, spool_name="ariel-store-up", repo_root=project_dir)
@@ -3649,6 +3653,7 @@ def _start_stack(
     # there is nothing stopped), so a healthy stack's reconcile stays
     # zero-churn. Volumes are never touched — destroying state stays the job
     # of clean/rebuild. Best-effort: if it fails, `up` surfaces the real error.
+    _report_group("services")
     rm_cmd = base_cmd + ["rm", "-f"]
     logger.debug(f"Running command:\n    {' '.join(rm_cmd)}")
     run_captured(rm_cmd, env=run_env, spool_name="compose-rm", repo_root=repo_root, check=False)

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import cast
 
 from osprey.build.claude_code_resolver import load_provider_spec
+from osprey.cli.phase_reporter import report_group as _report_group
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.build_progress import with_plain_build_progress
 from osprey.deployment.compose_generator import (
@@ -739,7 +740,9 @@ def build_persona_images(
             from osprey.deployment.container_lifecycle import single_image_build_reporter
 
             # Watched for the duration of the build and no longer; the step line
-            # below is what reports the finished image.
+            # below is what reports the finished image. The group declaration is
+            # idempotent, so the per-persona loop declares it each pass.
+            _report_group("personas")
             with (report := single_image_build_reporter(image_tag)):
                 run_captured(
                     cmd,

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import yaml
 
 from osprey.cli.output import report_fact, warn_fact
+from osprey.cli.phase_reporter import report_group as _report_group
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.build_progress import with_plain_build_progress
 from osprey.deployment.compose_generator import (
@@ -1105,6 +1106,7 @@ def deploy_up_web_terminals(
         # anywhere on this path: both invocations share one
         # COMPOSE_PROJECT_NAME, so orphan-removal in either would destroy the
         # OTHER stack's containers as "orphans" of the shared project.
+        _report_group("services")
         services_rm = services_base + ["rm", "-f"]
         logger.debug(f"Running command:\n    {' '.join(services_rm)}")
         run_captured(
@@ -1158,6 +1160,7 @@ def deploy_up_web_terminals(
 
     # Same stale-container preflight as the services stack above (and same
     # no-`--remove-orphans` constraint — see that comment).
+    _report_group("web terminals")
     web_rm = web_cmd + ["rm", "-f"]
     logger.debug(f"Running command:\n    {' '.join(web_rm)}")
     run_captured(web_rm, env=run_env, spool_name="compose-web-rm", repo_root=repo_root, check=False)

--- a/tests/cli/test_output_primitives.py
+++ b/tests/cli/test_output_primitives.py
@@ -474,12 +474,15 @@ def test_fail_only_prints(capsys):
     assert visible(captured.out) == ["and the verb decided what to do about it"]
 
 
-def test_fail_is_colored_on_a_terminal_and_only_on_its_summary(recording_err):
+def test_fail_is_colored_on_a_terminal_summary_and_remedy_arrow_only(recording_err):
     fail("could not start the web service", "port 8080 is already bound", "free the port")
     lines = recording_err.getvalue().splitlines()
     assert "\x1b[" in lines[0]
     assert "\x1b[" not in lines[1]
-    assert "\x1b[" not in lines[2]
+    # The remedy line's ARROW carries the accent; its prose stays uncolored.
+    arrow, _, prose = lines[2].partition("→ ")
+    assert "\x1b[" in arrow
+    assert "\x1b[" not in prose.replace("\x1b[0m", "")
     assert _ANSI.sub("", recording_err.getvalue()).splitlines() == [
         "✗ could not start the web service",
         "  port 8080 is already bound",

--- a/tests/cli/test_phase_reporter_watchers.py
+++ b/tests/cli/test_phase_reporter_watchers.py
@@ -226,7 +226,8 @@ def test_phase_lines_are_untouched_when_no_build_is_watched(sink, fake_clock):
 
     Off a TTY the contract is that nothing about today's output changes except
     the heartbeats that were not there before -- so with no build registered,
-    a phase's lines are byte-for-byte what they have always been.
+    a phase's lines are byte-for-byte what the reporter always prints (the
+    blank line is the phase opener's own rhythm, not a build artifact).
     """
     fake_clock(0.0, 12.0, 90.0)
 
@@ -235,7 +236,7 @@ def test_phase_lines_are_untouched_when_no_build_is_watched(sink, fake_clock):
         phase.step("web-terminal")
 
     assert sink.getvalue() == (
-        "→ Building images\n  · web-terminal (12.0s)\n  ✓ Building images (1m30s)\n"
+        "\n→ Building images\n  · web-terminal (12.0s)\n  ✓ Building images (1m30s)\n"
     )
 
 

--- a/tests/deployment/test_lifecycle_capture.py
+++ b/tests/deployment/test_lifecycle_capture.py
@@ -64,9 +64,15 @@ class RecordingReporter(PhaseReporter):
 
     @property
     def steps(self) -> list[str]:
-        """Just the sub-step names, with the bullet and any duration stripped."""
+        """Just the sub-step names, with the bullet and any duration stripped.
+
+        Matched on the bullet after the indent, not on a fixed column: a step
+        under a group header sits one step deeper than an ungrouped one.
+        """
         return [
-            _DURATION.sub("", line.strip()[2:]) for line in self.lines if line.startswith("  ·")
+            _DURATION.sub("", line.strip()[2:])
+            for line in self.lines
+            if line.lstrip().startswith("·")
         ]
 
 
@@ -213,9 +219,9 @@ def test_the_image_step_is_reported_after_the_build(reporter, image_build_stubs,
 
     container_lifecycle._build_project_image(_image_config(), False, {}, None)
 
-    marks = [line for line in reporter.lines if line == "<<ran>>" or line.startswith("  ·")]
+    marks = [line for line in reporter.lines if line == "<<ran>>" or line.lstrip().startswith("·")]
     assert marks[0] == "<<ran>>", "the step line was reported before the build it times"
-    assert marks[1].startswith("  · project image proj:local")
+    assert marks[1].lstrip().startswith("· project image proj:local")
 
 
 def test_the_image_build_is_skipped_without_a_dispatch_worker(captured, reporter):

--- a/tests/deployment/test_web_terminals_capture.py
+++ b/tests/deployment/test_web_terminals_capture.py
@@ -52,8 +52,14 @@ class RecordingReporter(PhaseReporter):
 
     @property
     def steps(self) -> list[str]:
-        """Just the sub-step lines, stripped of their `  · ` prefix and lap."""
-        return [line[4:].split(" (")[0] for line in self.lines if line.startswith("  · ")]
+        """Just the sub-step lines, stripped of their `· ` prefix, indent and lap.
+
+        Matched on the bullet after the indent, not on a fixed column: a step
+        under a group header sits one step deeper than an ungrouped one.
+        """
+        return [
+            line.strip()[2:].split(" (")[0] for line in self.lines if line.lstrip().startswith("· ")
+        ]
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

Applies the CLI's existing theme to the lifecycle output hierarchy, and groups a long phase's steps under per-service headers.

- **Phase openers** anchor in the theme's primary color (`→`), with a blank line before each phase for vertical rhythm.
- **Finished work recedes**: closed `✓` lines and all durations render dim, so the open phase and any warning are the brightest things on screen.
- **Promoted facts** wear an accent bullet; **remedy arrows** (`→ do this`) in warn/fail blocks carry the accent so the action is findable without reading the block.
- **Section headings** ("This deploy wrote", summary cards) use the header token; ledger labels and `Path` values render in the path token — styling by type, never by string-guessing.
- **Step groups**: deploy sites declare the service stretch they report (`archiver`, `ariel`, `personas`, `services`, `web terminals`), printed once as a quiet subheader with that stretch's steps nested one level deeper.

## Mechanics

Styles ride on text segments behind the reporter's existing color gate (`PhaseReporter.emit_segments`); with color off the segments collapse to their joined text through the same `emit` seam subclasses already intercept. Piped output changes only by the blank separator lines and the group header lines — color never reaches a pipe.

## Tests

- `tests/cli` (4146), `tests/deployment` (2818), and the real-terminal `tests/pty` lane all green locally.
- Re-pinned: the fail-block color contract (remedy arrow now styled), the byte-exact no-build phase output (leading blank line), and the capture-suite step parsers (bullet matched after indent, not at a fixed column).