### PR TITLE
fix(deploy): eight honesty fixes on the deploy path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,8 @@ src/osprey/_version.py
 
 # Process scaffolding — never committed (specs/plans live here uncommitted)
 docs/superpowers/
+
+# Locally scaffolded deployment project. Carries a real .env, build output and
+# run data; belongs to the working copy, never to the repo. Anchored to the root
+# so the pattern cannot swallow a same-named path elsewhere in the tree.
+/my-control-assistant/

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -290,7 +290,6 @@ compose template per service directory, rendered by the build.
        labels:
          osprey.project.name: "{{ osprey_labels.project_name }}"
          osprey.project.root: "{{ osprey_labels.project_root }}"
-         osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
        restart: unless-stopped
        ports:
          - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services['facility-mcp'] | default({})).port | default(8200) }}:8200/tcp"

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -290,6 +290,11 @@ compose template per service directory, rendered by the build.
        labels:
          osprey.project.name: "{{ osprey_labels.project_name }}"
          osprey.project.root: "{{ osprey_labels.project_root }}"
+         # Content hashes of the env chain and the rendered config this service
+         # reads. They are what makes an edit to either file restart this
+         # container; see the service-template section of deploy-project.
+         osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
+         osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
        restart: unless-stopped
        ports:
          - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services['facility-mcp'] | default({})).port | default(8200) }}:8200/tcp"

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -309,7 +309,6 @@ engine-injected values:
        labels:
          osprey.project.name: "{{osprey_labels.project_name}}"
          osprey.project.root: "{{osprey_labels.project_root}}"
-         osprey.deployed.at: "{{osprey_labels.deployed_at}}"
        ports:
          - "{{deployment.bind_address}}:{{services.postgresql.port_host}}:5432"
        environment:
@@ -320,7 +319,18 @@ engine-injected values:
 Common access patterns: ``{{services.<name>.<key>}}``,
 ``{{file_paths.<key>}}``, ``{{system.<key>}}``, ``{{project_root}}``,
 ``{{deployment.bind_address}}``, and ``{{osprey_labels.project_name}}`` /
-``project_root`` / ``deployed_at`` (injected by the deploy engine).
+``project_root`` (injected by the deploy engine).
+
+The engine deliberately injects no deploy timestamp. Everything a template
+renders comes from the project's configuration, so building the same project
+twice produces the same files — which is what lets you diff a rebuilt
+``build/`` directory and see only your own changes. A timestamp would also
+make every container look changed to the container runtime on each ``osprey
+up``, restarting the whole stack for nothing. If you need to know when a
+container was started, ask the runtime: ``docker inspect`` reports it as
+``.Created``. Earlier versions of these templates carried an
+``osprey.deployed.at`` label; a template you have customized that still sets it
+keeps building, and the label just renders empty, but you should drop the line.
 
 Service Template Ownership
 ==========================

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -332,6 +332,23 @@ container was started, ask the runtime: ``docker inspect`` reports it as
 ``osprey.deployed.at`` label; a template you have customized that still sets it
 keeps building, and the label just renders empty, but you should drop the line.
 
+What that timestamp was doing by accident, two labels now do on purpose::
+
+      osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
+
+Your service reads its settings from files — the env chain, and the
+``config.yml`` mounted into the container — and the container runtime decides
+whether to restart a container by comparing the compose document, which names
+neither file's *contents*. So editing ``.env`` or running ``osprey set`` would
+leave the running container on the values it started with. Each label carries a
+hash of one of those files, which turns such an edit into a document change and
+restarts exactly the containers that read it. ``osprey up`` sets both variables
+for you; they interpolate to empty if you run ``docker compose`` by hand. **A
+service template you wrote yourself should carry both lines** — without them
+your service keeps serving its old settings after a change, with nothing to say
+so.
+
 Service Template Ownership
 ==========================
 

--- a/src/osprey/build/claude_code_telemetry.py
+++ b/src/osprey/build/claude_code_telemetry.py
@@ -86,6 +86,22 @@ class TelemetryConfigError(ValueError):
     """
 
 
+class ObservabilityCredentialError(TelemetryConfigError):
+    """The observability backend's credentials are missing or unresolved.
+
+    The narrow case of a telemetry misconfiguration whose remedy is a
+    credential in the deployment's own secret store — never a model, a
+    provider, or an endpoint. Callers that resolve a provider spec catch
+    broad error types and phrase their own remedy from what they caught, so
+    without this distinction a missing observability password is reported as
+    a bad model or an unreadable provider, sending the operator to fix
+    something that was never wrong.
+
+    Subclasses :class:`TelemetryConfigError` (and through it ``ValueError``),
+    so every existing handler keeps catching it exactly as before.
+    """
+
+
 def _running_in_container() -> bool:
     """Best-effort detection of whether this process runs inside a container.
 
@@ -240,17 +256,19 @@ def _openobserve_auth_header(
         a credential is deferred.
 
     Raises:
-        ValueError: If either credential is missing or blank — an
-            unauthenticated exporter to an auth-gated store would silently drop
-            every span, so refuse to emit one — or if either credential still
-            carries a literal ``${VAR}`` (an unresolved placeholder whose env
-            var is unset) and ``defer_unresolved`` is False.
+        ObservabilityCredentialError: If either credential is missing or blank
+            — an unauthenticated exporter to an auth-gated store would silently
+            drop every span, so refuse to emit one — or if either credential
+            still carries a literal ``${VAR}`` (an unresolved placeholder whose
+            env var is unset) and ``defer_unresolved`` is False. Both cases are
+            fixed in the deployment's secret store, which is why they carry
+            their own type rather than the general telemetry one.
     """
     oo = telemetry_cfg.get("openobserve") or {}
     user = oo.get("user")
     password = oo.get("password")
     if not user or not password:
-        raise TelemetryConfigError(
+        raise ObservabilityCredentialError(
             "claude_code.telemetry.backend is 'openobserve' but "
             "openobserve.user / openobserve.password are missing or blank; "
             "refusing to emit an unauthenticated OTLP exporter to an "
@@ -270,7 +288,7 @@ def _openobserve_auth_header(
                     stacklevel=2,
                 )
                 return None
-            raise TelemetryConfigError(
+            raise ObservabilityCredentialError(
                 f"{field_name} still contains an unresolved '${{VAR}}': {cred!r}. "
                 "The referenced environment variable is unset — refusing to "
                 "encode a literal placeholder into the OpenObserve auth header."
@@ -308,9 +326,11 @@ def _build_telemetry_env(
         are a subset of :data:`TELEMETRY_ENV_VARS`.
 
     Raises:
-        ValueError: On an unresolvable endpoint, ``protocol: grpc`` against an
-            auto-derived (HTTP-only) OpenObserve endpoint, a leaked ``${VAR}`` in
-            the endpoint, or an ``openobserve`` backend with missing/blank creds.
+        TelemetryConfigError: On an unresolvable endpoint, ``protocol: grpc``
+            against an auto-derived (HTTP-only) OpenObserve endpoint, or a
+            leaked ``${VAR}`` in the endpoint.
+        ObservabilityCredentialError: On an ``openobserve`` backend whose
+            credentials are missing, blank, or an unresolved ``${VAR}``.
     """
     if not telemetry_cfg or not telemetry_cfg.get("enabled"):
         return {}

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1351,6 +1351,14 @@ def _render_project(
             "Agent tool/permission drift detected:\n  " + "\n  ".join(validation_errors)
         )
     try:
+        # Reachability: with defer_unresolved_telemetry_creds=True, an
+        # unresolved "${VAR}" in an openobserve credential (user/password) no
+        # longer raises here — _openobserve_auth_header
+        # (claude_code_telemetry.py) warns and omits the auth header instead.
+        # Only the missing/blank-credential arm of that same check still
+        # raises ObservabilityCredentialError into this ValueError catch.
+        # Pinned by test_deferred_var_credential_warns_not_raises_through_resolve
+        # in tests/cli/test_telemetry_env.py.
         load_provider_spec(render_dir, defer_unresolved_telemetry_creds=True)
     except ValueError as e:
         raise BuildProfileError(str(e)) from e

--- a/src/osprey/cli/build_environment.py
+++ b/src/osprey/cli/build_environment.py
@@ -780,8 +780,13 @@ def _create_project_venv(project_path: Path, profile: Any) -> list[str]:
     if base_python is not None:
         logger.debug("  Base interpreter: %s", base_python)
     if uv_path:
+        # `--clear` because a rebuild is the ordinary case, not the exception:
+        # without it uv refuses a directory that already holds a venv, so the
+        # second build of an unchanged tree would fail where the first
+        # succeeded. The stdlib branch below already replaces what it finds, so
+        # this is also what keeps the two branches behaving alike.
         result = subprocess.run(
-            [uv_path, "venv", str(venv_path), "--python", base_python_arg, "--quiet"],
+            [uv_path, "venv", str(venv_path), "--python", base_python_arg, "--quiet", "--clear"],
             capture_output=True,
             text=True,
             timeout=60,

--- a/src/osprey/cli/deploy_scaffold.py
+++ b/src/osprey/cli/deploy_scaffold.py
@@ -222,8 +222,10 @@ def _load_deploy_profile(profile_file: Path) -> tuple[dict[str, Any], Path, Depl
     if deploy is None:
         raise ConfigurationError(
             f"{profile_file} declares no 'deploy:' block, so there are no "
-            f"deployment coordinates to render a pipeline from. Add one naming "
-            f"the CI platform, the registry and the deploy host."
+            f"deployment coordinates to render a pipeline from. An emitted "
+            f"profile carries a commented 'deploy:' example among the commented "
+            f"blocks at the end of the file — uncomment it, fill in the CI "
+            f"platform, the registry and the deploy host, then re-run."
         )
     return document.raw, document.root_dir, deploy
 

--- a/src/osprey/cli/profile_conventions.py
+++ b/src/osprey/cli/profile_conventions.py
@@ -581,12 +581,50 @@ def _validate_directory_dir(convention: ConventionDir, root: Path) -> list[str]:
             continue
         if not entry.is_dir():
             errors.append(
-                f"{convention.source}/{entry.name} is a file: {convention.source}/ "
-                f"holds one directory per {convention.entry_noun}.\n"
-                f"  Move it into {convention.source}/{entry.stem}/ "
-                f"(the whole directory is copied as a unit)."
+                _per_user_file_error(convention, entry)
+                if convention.per_user
+                else (
+                    f"{convention.source}/{entry.name} is a file: {convention.source}/ "
+                    f"holds one directory per {convention.entry_noun}.\n"
+                    f"  Move it into {convention.source}/{entry.stem}/ "
+                    f"(the whole directory is copied as a unit)."
+                )
             )
     return errors
+
+
+def _per_user_file_error(convention: ConventionDir, entry: Path) -> str:
+    """Report a loose file in a per-user convention directory.
+
+    A per-user directory's names are not free-form: the build matches every one
+    of them against the resolved roster, and a directory naming nobody on it is
+    skipped (:func:`partition_context_users`). "Move it into ``<stem>/``" — the
+    advice every other directory-shaped convention gets — would therefore tell
+    an operator to invent a user, and their file would quietly stop being read
+    on the next build. So the rule is stated instead, and the file is pointed at
+    a route that carries it: a named user's directory, or, for the shared
+    baseline, the ``project/`` mirror.
+    """
+    header = (
+        f"{convention.source}/{entry.name} is a file: {convention.source}/ holds one "
+        f"directory per {convention.entry_noun}, and each one is named for a user on "
+        f"the resolved roster. A directory named anything else is skipped as a user "
+        f"who has left, so a directory invented to hold this file would not be read."
+    )
+    if entry.name == "base.md":
+        return (
+            f"{header}\n"
+            f"  base.md is the baseline every seeded user starts from, not one user's "
+            f"context, so it has no directory here. Carry it through the "
+            f"{PROJECT_MIRROR_DIR}/ mirror instead: put it at "
+            f"{PROJECT_MIRROR_DIR}/{convention.destination}/base.md, which lands on "
+            f"the same file the build installs."
+        )
+    return (
+        f"{header}\n"
+        f"  Move it into the directory of the user it belongs to "
+        f"({convention.source}/<user>/{entry.name}), naming a user the build resolves."
+    )
 
 
 def validate_convention_sources(profile_dir: Path) -> None:

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -303,8 +303,17 @@ def _probe_auth_secret(build_dir: Path, repo_root: Path) -> tuple[list[str], lis
     malformed config.yml, or an unknown provider name, is left for Probe 3 (or
     the launch itself) to report — this probe just skips quietly rather than
     duplicating that diagnosis.
+
+    The one exception is
+    :class:`~osprey.build.claude_code_telemetry.ObservabilityCredentialError`:
+    nothing else in pre-flight resolves telemetry credentials, so a quiet skip
+    there leaves the operator with an empty report and no reason for it. That
+    case returns a warning naming what stopped the read, which keeps the launch
+    going (telemetry credentials are orthogonal to whether the terminal can
+    authenticate) while saying why the auth check never ran.
     """
     from osprey.build.claude_code_resolver import load_provider_spec
+    from osprey.build.claude_code_telemetry import ObservabilityCredentialError
 
     try:
         # The provider is declared in the render and its ``${VAR}`` references
@@ -314,6 +323,18 @@ def _probe_auth_secret(build_dir: Path, repo_root: Path) -> tuple[list[str], lis
         # lives in ``.env`` resolves to a literal placeholder and the probe
         # reports on a provider the launch will not use.
         spec = load_provider_spec(build_dir, env_dir=repo_root)
+    except ObservabilityCredentialError as exc:
+        # Must come BEFORE the ValueError arm: this type subclasses
+        # TelemetryConfigError, which subclasses ValueError, so the broad arm
+        # would swallow it and the operator would see an empty pre-flight with
+        # no reason for it. The provider was never read, so there is nothing to
+        # say about auth; report what stopped the read instead of nothing. Only
+        # names reach the message, never a credential's value.
+        return [], [
+            "provider auth check skipped: the telemetry credentials in this "
+            "deployment could not be resolved, so the provider was never read.\n"
+            f"  {exc}"
+        ]
     except (OSError, ValueError):
         return [], []
     if spec is None or not spec.auth_secret_env:

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -739,8 +739,6 @@ def _inject_project_metadata(config):
     :return: Configuration with added osprey_labels section
     :rtype: dict
     """
-    import datetime
-
     project_name = resolve_project_name(config)
 
     # Resolve the running framework version so service Dockerfiles can pin the
@@ -767,7 +765,18 @@ def _inject_project_metadata(config):
     config_with_labels["osprey_labels"] = {
         "project_name": project_name,
         "project_root": config.get("project_root", os.getcwd()),
-        "deployed_at": datetime.datetime.now().isoformat(),
+        # Deliberately NO deploy timestamp. A wall-clock value here made the
+        # rendered compose documents differ on every build for no reader:
+        # nothing in the framework ever read the label back, and a container's
+        # creation time is already reported natively by the runtime
+        # (`docker inspect` exposes it as `.Created`). Keeping it would have
+        # meant a build/ tree whose bytes are not a function of its inputs.
+        #
+        # A deploy-time `${VAR}` was considered and rejected for the same
+        # reason in a different place: a wall-clock value in the interpolation
+        # seam changes the compose document on every `osprey up` and so
+        # recreates every container for a label nobody reads.
+        #
         # Which CHECKOUT this is (:func:`repo_identity`). Baked in as a literal
         # at render time rather than left as a `${VAR}` for compose to
         # interpolate: the label has to be trustworthy for a verb that reads it

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -65,6 +65,8 @@ from osprey.deployment.service_tokens import (
     _effective_value,
     _generate_openobserve_password,  # noqa: F401  (re-exported for tests)
     _generate_token,
+    _is_forbidden_value,
+    _raise_forbidden_var,
     _raise_invalid_var,
     _validate_openobserve_password,  # noqa: F401  (re-exported for tests)
     _validate_var,
@@ -376,20 +378,64 @@ def _ensure_service_tokens(
     ``.env``" is about the file the caller named.
 
     For any token var (per ``_SERVICE_TOKEN_VARS``, keyed by the deployed
-    services present) unset in BOTH the process env and that ``.env``,
+    services present) unset — or present with an empty value — in BOTH the
+    process env and that ``.env``,
     generate a strong random value (``_generate_token``: ``token_urlsafe(32)``
     unless the var registers a different alphabet in ``_VAR_GENERATORS``) and
     append it to ``.env``
-    (``chmod 0o600``, matching the build-time convention). Existing values are
-    never overwritten, so re-running ``osprey up`` is idempotent. No-op unless
-    a token-requiring service is actually deployed.
+    (``chmod 0o600``, matching the build-time convention). Existing non-empty
+    values are never overwritten, so re-running ``osprey up`` is idempotent.
+    No-op unless a token-requiring service is actually deployed.
 
-    A token that is *present but explicitly empty* (e.g. ``TOKEN=`` exported in
-    the shell) is left untouched — generating would silently override a
-    deliberate value. For a loopback deploy the server simply fails closed; for
-    a deployment the build rendered as reachable off-host (a wildcard bind, or
-    the host-networked web-terminal stack) we refuse rather than bind a
-    fail-open-at-bind server to all interfaces.
+    **An empty value is not a decision here.** Osprey's general rule is that an
+    explicitly empty variable is the operator saying *leave this alone* — a
+    blank ``NO_PROXY=`` is a real setting, and a missing line is not the same
+    thing. These vars are the deliberate exception, because every name this loop
+    can reach is a machine-generated secret with no meaningful empty state. An
+    empty one does not switch a service's authentication off; it runs the
+    service with no authentication at all, and for the three store passwords it
+    hands the container back the published default its compose template
+    interpolates with ``:-``. Nothing is expressible as ``TOKEN=`` that leaving
+    the var unset does not express better, so the operator gives up nothing and
+    a deploy stops coming up unauthenticated with nobody told. The same
+    judgement is already made one function over, for the RE manager's
+    control-socket keys — see ``_is_set`` inside
+    :func:`_ensure_bluesky_qserver_zmq_keys`, which spells out that an empty
+    value is not honoured there either. This brings the token path into
+    agreement with it rather than adding a third convention.
+
+    The exception is bounded by ``required_vars``, and that bound is what makes
+    it safe: it is exactly ``_SERVICE_TOKEN_VARS`` filtered by
+    ``deployed_services`` membership (built below, from a module constant no
+    runtime path mutates), so the only names whose empty spelling is overridden
+    are the machine-minted secrets that map declares. Nothing else travelling in
+    this ``.env`` can reach the predicate — the proxy settings (``HTTP_PROXY``,
+    ``NO_PROXY``), where a blank value *is* the setting, belong to neither
+    ``_SERVICE_TOKEN_VARS`` nor ``_VALIDATE_ONLY_VARS``, and the validate-only
+    loop below never mints anything at all.
+
+    Whatever a value's origin, it is then checked at the boundary: one that
+    matches a compose template's published default is refused by name
+    (``_is_forbidden_value``), and one that fails a registered format constraint
+    is refused too. A minted value satisfies both by construction, so either
+    finding is always about a value an operator supplied.
+
+    Minting over a blank also rewrites this process's copy of it. The deploy
+    loads the project ``.env`` over its own environment before reaching here, so
+    a blank line in that file leaves a stale empty variable behind that would
+    outrank the newly appended line for compose's interpolation. The file is the
+    source of truth and the environment is its mirror, so both are updated
+    together; a name that was never in the environment stays out of it.
+
+    One empty spelling is still left alone, because minting cannot repair it: a
+    var the ``.env`` does not carry at all, exported empty in the deploying
+    shell. That export is the operator's own, it outranks any ``--env-file``
+    line a mint would write, and overwriting a shell the deploy does not own is
+    not this function's business — so writing one would report a mint that
+    changes nothing. It keeps the older treatment: on a loopback deploy the service
+    fails closed on its own; on a deployment the build rendered as reachable
+    off-host (a wildcard bind, or the host-networked web-terminal stack) we
+    refuse rather than bind a fail-open-at-bind server to all interfaces.
 
     Minting is unconditional for every var a deployed service declares: these
     tokens authenticate *network callers* to a service's own HTTP boundary and
@@ -491,9 +537,23 @@ def _ensure_service_tokens(
         generated: dict[str, str] = {}
         for name in required_vars:
             # Process env wins over .env (matches docker compose --env-file).
-            present = name in os.environ or name in existing
+            # "Present" means present with a NON-EMPTY value: for these vars an
+            # empty spelling is a blank, not a decision (see the docstring).
+            #
+            # The second clause is not the presence rule — it is the one empty
+            # spelling a mint cannot repair. A name absent from the `.env` but
+            # exported empty in the deploying shell came from the shell alone,
+            # and that export outranks the `--env-file` line this would append
+            # for compose's interpolation, so minting would report a token no
+            # container ever receives. Left alone, and caught below instead.
+            # (A name the `.env` *does* carry is a different case: the deploy
+            # has already loaded that file over this process's environment, so
+            # the empty copy sitting in `os.environ` is the file's own value
+            # mirrored, not a second opinion — see the write-back below.)
+            exported_only = name in os.environ and name not in existing
+            present = bool(_effective_value(name, existing).strip()) or exported_only
             if present:
-                continue  # keep the user's value (even an empty one — see docstring)
+                continue  # keep the operator's value
             generated[name] = _generate_token(name)
 
         if generated:
@@ -502,6 +562,18 @@ def _ensure_service_tokens(
                 "Auto-generated service auth tokens (osprey deploy up)",
                 generated,
             )
+            # Only the names minted OVER an empty `.env` entry are in the
+            # environment already: the deploy loads the project `.env` over this
+            # process before it gets here, so the blank line just replaced left a
+            # stale empty copy behind. That copy would outrank the file for
+            # compose's interpolation and for the validation below — a token
+            # minted, reported, and then not delivered. Replace it, so the file
+            # and its in-process mirror say the same thing. Names absent from
+            # the environment stay absent; they reach the containers through
+            # `--env-file` as they always have.
+            for name, value in generated.items():
+                if name in os.environ:
+                    os.environ[name] = value
             # Report the count inline and the key names in the ledger — NEVER
             # the values.
             _report_fact(
@@ -533,11 +605,29 @@ def _ensure_service_tokens(
     post = parse_dotenv_file(env_path) if env_path.is_file() else {}
     for name in required_vars:
         effective = _effective_value(name, post)
+        # Still reachable, and now for exactly one shape. A blank carried by the
+        # `.env` was minted over above, so an empty effective value at this
+        # point means the var is exported empty in a shell whose `.env` never
+        # mentions it — the one spelling the mint deliberately leaves alone. The
+        # remedy therefore names the environment, not `.env`: adding a line to
+        # the file would not change what compose resolves while that export
+        # stands.
         if expose_network and not effective.strip():
             raise RuntimeError(
                 f"{name} is empty; refusing to start a deployment that is reachable "
-                f"off-host with an empty token. Set {name} in .env to a strong secret."
+                f"off-host with an empty token. Unset {name} in the environment and let "
+                f"`osprey up` mint one, or export a strong secret."
             )
+        # Ahead of the format check so the more specific diagnosis wins. A
+        # registered forbidden value is well-formed by construction — that is
+        # exactly why no validator can catch it — but a var could later register
+        # one that is not, and "your password is public" is the finding an
+        # operator needs first either way. Narrow by construction: a var reaches
+        # here holding either a value minted moments ago or one an operator
+        # supplied, so a match means the operator pinned the template's published
+        # default as their real password.
+        if effective and _is_forbidden_value(name, effective):
+            _raise_forbidden_var(name)
         if effective and not _validate_var(name, effective):
             _raise_invalid_var(name, effective)
 
@@ -558,8 +648,9 @@ def _ensure_service_tokens(
 def _volume_initialized_vars_that_would_be_minted(config: dict, env_path: Path) -> set[str]:
     """Which store credentials a mint on this config *would* generate.
 
-    The same rule ``_ensure_service_tokens`` mints by — absent from both the
-    process env and the ``.env`` — evaluated without writing anything. It exists
+    The same rule ``_ensure_service_tokens`` mints by — no non-empty value in
+    either the process env or the ``.env``, and not left alone as an export the
+    mint cannot reach — evaluated without writing anything. It exists
     for ``restart``, which has to run the stale-volume check BEFORE its ``down``:
     the ``down`` removes the store containers, and with them the only host-side
     copy of the credential each surviving volume was initialized with. Asking
@@ -569,10 +660,19 @@ def _volume_initialized_vars_that_would_be_minted(config: dict, env_path: Path) 
 
     services = {str(s) for s in (config.get("deployed_services") or [])}
     on_disk = parse_dotenv_file(env_path) if env_path.is_file() else {}
+
+    def _would_mint(var: str) -> bool:
+        # Kept in step with the predicate in _ensure_service_tokens: a blank
+        # entry in the .env is minted over, so predicting "not minted" for one
+        # would let restart skip the very store whose credential is about to
+        # change. The export carve-out is mirrored for the same reason.
+        exported_only = var in os.environ and var not in on_disk
+        return not exported_only and not _effective_value(var, on_disk).strip()
+
     return {
         var
         for var, store in _VOLUME_INITIALIZED_VARS.items()
-        if store.service in services and var not in os.environ and var not in on_disk
+        if store.service in services and _would_mint(var)
     }
 
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -3788,9 +3788,9 @@ def _start_stack(
     # or it would refuse what the deploy is about to provide. Two of those are
     # load-bearing here — `_ensure_service_tokens` and the bluesky key material
     # mint `.env` on a fresh repo (a deploy that has no `.env` at all has one by
-    # now), and `migrate_users_env` carries a pre-rename `.env.production` onto
-    # `.env.users`, whose own comment names the web-terminal preflight as that
-    # file's first reader. This pass now reads it one step earlier, so it
+    # now), and `migrate_users_env` carries a pre-rename deployment's secrets
+    # onto `.env.users`, whose own comment names the web-terminal preflight as
+    # that file's first reader. This pass now reads it one step earlier, so it
     # inherits the same constraint.
     #
     # Below: it must precede the first minutes-long step, which is the project

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -1673,6 +1673,69 @@ def _worker_image_target(config: dict, env: dict) -> str:
     return f"{resolve_project_name(config)}:local"
 
 
+def _project_image_build_target(config: dict, env: dict) -> str | None:
+    """The image tag :func:`_build_project_image` will build, or ``None``.
+
+    The gate in front of that build, split out so a caller can ask whether the
+    build will happen at all without running it. Two ways it does not: this
+    deployment does not deploy the dispatch worker, or the worker's effective
+    image (:func:`_worker_image_target`) is a prebuilt one rather than this
+    project's own ``<project>:local`` tag.
+
+    That question is the difference between a definite refusal and a
+    hypothetical one for anything the build itself would raise. The
+    unreleased-pin refusal is the case in point: it is a fact about a build that
+    is going to happen, and reporting it for a deployment that builds nothing
+    would send the operator to fix something that was never going to run.
+
+    :param config: Raw deploy config.
+    :param env: Environment the build would run with, read for
+        ``OSPREY_WORKER_IMAGE``.
+    :return: The ``<project>:local`` tag, or ``None`` when nothing is built.
+    """
+    services = {str(s) for s in (config.get("deployed_services") or [])}
+    if "dispatch_worker" not in services:
+        return None
+    project_image = f"{resolve_project_name(config)}:local"
+    if _worker_image_target(config, env) != project_image:
+        return None
+    return project_image
+
+
+def _unreleased_pin_problem(config: dict, env: dict, dev_mode: bool) -> tuple[str, str] | None:
+    """Whether the project-image build would refuse over an unreleased pin.
+
+    :func:`_resolve_pip_spec` asked as a question, behind
+    :func:`_project_image_build_target` so it is only asked about a build this
+    deployment will actually make.
+
+    Only the DEFINITE case is reported. Under ``--dev`` the spec is inert when a
+    wheel is staged and live when the staging fails, and which of those happens
+    is not knowable from here — so a ``--dev`` start is left to the build's own
+    refusal rather than pre-judged, which would refuse the very workflow the
+    error recommends. An ``OSPREY_PIP_SPEC`` export answers the question outright
+    and is honoured here exactly as the build honours it.
+
+    Pure: it reads the process environment and this build's version metadata.
+
+    :param config: Raw deploy config.
+    :param env: Environment the build would run with.
+    :param dev_mode: Whether ``--dev`` was passed.
+    :return: The refusal as a ``(problem, remedy)`` pair — the one probed
+        refusal that already carries its two halves apart, so the collected
+        report can keep them apart too — or ``None``.
+    """
+    if dev_mode or _project_image_build_target(config, env) is None:
+        return None
+    from osprey.deployment.errors import UnreleasedVersionPinError
+
+    try:
+        _resolve_pip_spec(dev_mode=False)
+    except UnreleasedVersionPinError as exc:
+        return (f"{exc.summary}: {exc.reason}", exc.remedy)
+    return None
+
+
 def _project_image_build_cmd(
     config: dict, runtime: str, project_root: str, dev_mode: bool = False
 ) -> list[str]:
@@ -1757,17 +1820,19 @@ def _build_project_image(
         an image whose every recorded path — ``project_root``, and the
         ``OSPREY_CONFIG`` each MCP server is handed — names this machine.
     """
-    services = {str(s) for s in (config.get("deployed_services") or [])}
-    if "dispatch_worker" not in services:
-        return
-
-    target = _worker_image_target(config, env)
-    project_image = f"{resolve_project_name(config)}:local"
-    if target != project_image:
-        _report_fact(
-            f"Dispatch worker uses image {target!r} (OSPREY_WORKER_IMAGE / pinned "
-            f"services.dispatch_worker.image). Skipping the {project_image} build."
-        )
+    project_image = _project_image_build_target(config, env)
+    if project_image is None:
+        # Only ONE of the two no-op cases is worth a line. A deployment without
+        # the dispatch worker was never going to build this image and has
+        # nothing to explain; a deployment that has the worker but points it at
+        # another image took a decision the operator should see reflected back.
+        services = {str(s) for s in (config.get("deployed_services") or [])}
+        if "dispatch_worker" in services:
+            _report_fact(
+                f"Dispatch worker uses image {_worker_image_target(config, env)!r} "
+                f"(OSPREY_WORKER_IMAGE / pinned services.dispatch_worker.image). "
+                f"Skipping the {resolve_project_name(config)}:local build."
+            )
         return
 
     runtime = get_runtime_command(config)[0]
@@ -3479,6 +3544,57 @@ def single_image_build_reporter(image_tag: str) -> BuildProgressReporter:
     return BuildProgressReporter(image_tag, step_prefix=None)
 
 
+def _collect_unmet_preconditions(
+    config: dict,
+    repo_root: Path | str,
+    env: dict,
+    *,
+    dev_mode: bool,
+    web_terminals_enabled: bool,
+) -> None:
+    """Probe every cheaply checkable start precondition, and report them all.
+
+    A start has several preconditions that are answerable from this
+    deployment's own files, before anything is built or started. Raised one at a
+    time, they cost the operator a whole deploy attempt per finding: refuse on
+    the first, fix it, re-run, wait, meet the second. This asks all of them and
+    raises once, so a deployment with four problems is described in one refusal.
+
+    Every probe is pure — it reads files and this build's version metadata,
+    writes nothing, starts no process, and asks the container runtime nothing.
+    That is not a stylistic preference at this position in the sequence: the
+    steps around it provision credentials and are ordered against each other, so
+    a probe with a side effect would silently be a step in that order.
+
+    The refusals stay where they are. Each probe's raising counterpart runs
+    later, unchanged, and would refuse the same start on its own — this is a
+    reporting pass in front of them, not a replacement for them.
+
+    Args:
+        config: Raw deploy config.
+        repo_root: The deployment repo whose renders and secret files are read.
+        env: The environment the project-image build would run with.
+        dev_mode: Whether ``--dev`` was passed.
+        web_terminals_enabled: Whether the web tier is part of this deploy;
+            three of the probes are about artifacts only it has.
+
+    Raises:
+        UnmetPreconditionsError: One or more probes reported a problem. Nothing
+            has been built or started.
+    """
+    from osprey.deployment.errors import UnmetPreconditionsError
+    from osprey.deployment.web_terminals.provision import web_terminal_preflight_problems
+
+    findings: list[tuple[str, str]] = []
+    if web_terminals_enabled:
+        findings.extend(web_terminal_preflight_problems(config, repo_root=repo_root))
+    if (pin := _unreleased_pin_problem(config, env, dev_mode)) is not None:
+        findings.append(pin)
+
+    if findings:
+        raise UnmetPreconditionsError(findings)
+
+
 def _start_stack(
     config: dict,
     compose_files: list[str],
@@ -3663,6 +3779,42 @@ def _start_stack(
     if dev_mode:
         env["DEV_MODE"] = "true"
         _report_fact("dev mode: DEV_MODE set for the containers")
+
+    # Report every remaining precondition this deployment's own files can
+    # answer, in one refusal rather than one deploy attempt each. The position
+    # is pinned from both sides.
+    #
+    # Above: it must follow every provisioner that WRITES what the probes read,
+    # or it would refuse what the deploy is about to provide. Two of those are
+    # load-bearing here — `_ensure_service_tokens` and the bluesky key material
+    # mint `.env` on a fresh repo (a deploy that has no `.env` at all has one by
+    # now), and `migrate_users_env` carries a pre-rename `.env.production` onto
+    # `.env.users`, whose own comment names the web-terminal preflight as that
+    # file's first reader. This pass now reads it one step earlier, so it
+    # inherits the same constraint.
+    #
+    # Below: it must precede the first minutes-long step, which is the project
+    # image build. Reporting in seconds is the whole point.
+    #
+    # Deliberately OUTSIDE the pass, and left to raise on their own:
+    #  * everything `_ensure_service_tokens` refuses upstream — the
+    #    forbidden-published-default credential and the `expose_network`
+    #    empty-token raise — because that step MINTS. It cannot be probed
+    #    without either duplicating the mint's rules or moving the mint, and it
+    #    has already run by the time control reaches here.
+    #  * the `--dev` failed-staging case. Whether a wheel stages is not knowable
+    #    without staging it, and the staging is paired with its cleanup inside
+    #    `_build_project_image`'s try/finally — hoisting it out to get a definite
+    #    answer would leave a staged wheel behind on a refusal.
+    #  * `preflight_web_terminals`' minting half (`_provision_auth_secrets`) and
+    #    the auth-sidecar image check ordered against it, for the same reason.
+    _collect_unmet_preconditions(
+        config,
+        repo_root,
+        env,
+        dev_mode=dev_mode,
+        web_terminals_enabled=web_terminals_enabled,
+    )
 
     # Fail-fast web-terminal preflight (persona render + credential gate)
     # BEFORE the minutes-long image build below: a deploy that is doomed to

--- a/src/osprey/deployment/errors.py
+++ b/src/osprey/deployment/errors.py
@@ -147,6 +147,58 @@ class NoRenderedBuildError(DeploymentPreconditionError):
     summary = "No rendered build to start from"
 
 
+class UnmetPreconditionsError(DeploymentPreconditionError):
+    """Every cheaply checkable precondition a start failed, reported at once.
+
+    The other subclasses each describe ONE thing that is not true, because each
+    is raised the moment its own check fails. That is the right shape for a
+    check that can only be made once the step before it has run — but most of a
+    start's preconditions are answerable from this deployment's own files,
+    before anything is built or started, and reporting those one at a time costs
+    the operator a full deploy attempt per finding: fix, re-run, wait, discover
+    the next one.
+
+    So the collectable ones are probed together and land here. ``summary`` is
+    the count, and ``reason`` is the findings enumerated in the order the deploy
+    would have hit them, each followed by its own remedy line. There is no
+    top-level ``remedy``: with more than one thing to fix there is no single
+    ``→`` line that is honest, and naming one of several would read as *the* way
+    through. This is the convention ``gate_start_from_build`` already follows
+    for its two-exits refusal — the alternatives go in the cause as an aligned
+    block, and the operator picks. It holds at a count of one too, where the
+    finding's own remedy line is the whole answer and a duplicate of it at the
+    bottom would be noise.
+
+    Raised for **one** finding as well as for many, deliberately. A start that
+    refuses over a single precondition then reads the same as one that refuses
+    over four: the same frame, the same enumeration, the same place to look for
+    the remedy. The alternative — a bare message below some threshold and a
+    structured one above it — would make the common case the unfamiliar one.
+
+    Args:
+        findings: ``(problem, remedy)`` pairs, in the order the deploy would
+            have reached them. ``remedy`` may be empty for a problem whose own
+            text already says what to do about it, which is the shape of the
+            refusals that carry their fix in prose.
+    """
+
+    def __init__(self, findings: Sequence[tuple[str, str]]) -> None:
+        self.findings = [(str(problem), str(remedy)) for problem, remedy in findings]
+        count = len(self.findings)
+        noun = "precondition" if count == 1 else "preconditions"
+        # Instance attribute shadowing the class one: the lead-in is a fact
+        # about THIS refusal (how many things are wrong), not about the type.
+        self.summary = f"{count} unmet {noun} on this deployment"
+        blocks = []
+        for index, (problem, remedy) in enumerate(self.findings, start=1):
+            text = f"{problem}\n{remedy}" if remedy else problem
+            head, *rest = text.splitlines() or [""]
+            # Continuation lines are indented under the number so a multi-line
+            # finding reads as one item rather than as several.
+            blocks.append("\n".join([f"{index}. {head}", *(f"   {line}" for line in rest)]))
+        super().__init__("\n\n".join(blocks), "")
+
+
 class NoComposeFilesError(DeploymentPreconditionError):
     """A read verb needs the compose files a build rendered, and there are none.
 

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -110,7 +110,10 @@ from osprey.deployment.container_lifecycle import as_built_config_path, down_dep
 from osprey.deployment.runtime_helper import get_runtime_command, runtime_env
 from osprey.deployment.staleness import BUILD_DIRNAME
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
-from osprey.deployment.web_terminals.env_production import USERS_ENV_FILENAME
+from osprey.deployment.web_terminals.env_production import (
+    SUPERSEDED_USERS_ENV_FILENAME,
+    USERS_ENV_FILENAME,
+)
 from osprey.deployment.web_terminals.lifecycle import confirm_destroy
 from osprey.utils.dotenv import parse_dotenv_text
 from osprey.utils.logger import get_logger
@@ -130,17 +133,18 @@ COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
 #: is verified against before removal — exactly as ``nuke`` verifies it.
 OSPREY_PROJECT_LABEL = "com.osprey.project"
 
-#: The web tier's two credential files, as ``(filename, what it holds, how it is
-#: refreshed)``. Both are write-once — a deploy creates each when it is absent
-#: and never rewrites an existing one — and reset removes neither, which is why
-#: they are disclosed (:meth:`ResetPlan._kept_lines`) rather than left for an
+#: The web tier's credential files, as ``(filename, what it holds, how it is
+#: refreshed)``. Each is written once — a deploy creates it when it is absent
+#: and never rewrites an existing one — and reset removes none of them, which is
+#: why they are disclosed (:meth:`ResetPlan._kept_lines`) rather than left for an
 #: operator to discover after wiping the deployment they belong to.
 #:
-#: The refresh clauses are per-file because the two do NOT behave alike: the
-#: same removal that gets one re-derived costs every user their password in the
-#: other, and stops a registry-mode deploy outright. Both spellings come from
-#: the modules that write them, so neither disclosure can name a file this
-#: system stopped producing.
+#: The refresh clauses are per-file because these do NOT behave alike: the same
+#: removal that gets the first re-derived (and stops a registry-mode deploy
+#: outright) costs every user their password in the second, while the third is
+#: a superseded copy nothing refreshes at all and the operator is free to drop.
+#: Every spelling comes from the module that writes it, so no disclosure here
+#: can name a file this system stopped producing.
 WEB_CREDENTIAL_FILES: tuple[tuple[str, str, str], ...] = (
     (
         USERS_ENV_FILENAME,
@@ -153,6 +157,12 @@ WEB_CREDENTIAL_FILES: tuple[tuple[str, str, str], ...] = (
         "the web terminals' password hashes and cookie-signing secrets",
         "Remove it and the next deploy mints a NEW password for every user; "
         "`osprey users decommission` is what drops one departed user's entries.",
+    ),
+    (
+        SUPERSEDED_USERS_ENV_FILENAME,
+        "a pre-rename copy of the runtime secrets, set aside by a deploy",
+        f"Nothing reads it and no deploy refreshes it: {USERS_ENV_FILENAME} is the live "
+        f"file. Delete it yourself once you have confirmed {USERS_ENV_FILENAME} is good.",
     ),
 )
 
@@ -748,7 +758,7 @@ class ResetPlan:
         for filename, holds, refresh in WEB_CREDENTIAL_FILES:
             if (self.repo_root / filename).is_file():
                 kept.append(
-                    f"    {filename}  {holds} — operator-owned and written once, so a "
+                    f"    {filename}  {holds} — written once and never rewritten, so a "
                     "reset leaves it exactly as it is."
                 )
                 kept.append(f"      {refresh}")

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -352,6 +352,11 @@ def detect_compose_provider(
 #: contract and is spelled here once for every producer and consumer of it.
 ENV_DIGEST_VAR = "OSPREY_ENV_DIGEST"
 
+#: The same contract as :data:`ENV_DIGEST_VAR`, for the other file a container
+#: reads its settings out of: the rendered config the build decided on. Carried
+#: into an ``osprey.config.digest`` label by every service template.
+CONFIG_DIGEST_VAR = "OSPREY_CONFIG_DIGEST"
+
 
 def env_chain_digest(repo_root: Path | str) -> str:
     """Fingerprint of the env chain's *contents* under ``repo_root``.
@@ -391,6 +396,44 @@ def env_chain_digest(repo_root: Path | str) -> str:
     for path in paths:
         digest.update(path.read_bytes())
     return digest.hexdigest()
+
+
+def as_built_config_digest(repo_root: Path | str) -> str:
+    """Fingerprint of the *contents* of the config this repo's build decided on.
+
+    :func:`env_chain_digest`'s twin, for the other file whose contents reach a
+    container without passing through the compose document. Every service
+    directory receives the rendered project configuration as its own
+    ``config.yml`` and mounts it, so ``osprey set`` changes a FILE — and compose
+    decides whether to recreate a container by comparing service definitions,
+    which such a change leaves identical. Without a label carrying this, the
+    container keeps serving the configuration it parsed at startup, and ``set``
+    -> ``build`` -> ``up`` reports success having changed nothing an operator
+    can observe.
+
+    Hashes ``<repo_root>/build/config.yml`` — the single as-built config
+    (:func:`osprey.deployment.container_lifecycle.as_built_config_path`), which
+    is what ``up`` starts from and what every per-service copy is rendered from.
+    One file rather than the copies: they are one document, and hashing the
+    source keeps this answer independent of how many services a deployment has.
+
+    Raw bytes, like the env chain, and for the same reason — parsing would be a
+    second, subtly different answer to "did the config change?". A **comment**
+    edit therefore moves the digest and recreates containers. That is the honest
+    trade: the alternative is a semantic diff that has to stay in step with
+    every reader of the file, and a spurious recreate costs a restart while a
+    missed one leaves a container lying about its own configuration.
+
+    :param repo_root: The deployment repo root (the compose project directory).
+    :return: Hex sha256 of the as-built config, or ``""`` when the repo has no
+        rendered build yet — a valid state for every verb that runs before one.
+    """
+    from osprey.deployment.container_lifecycle import as_built_config_path
+
+    path = as_built_config_path(repo_root)
+    if not path.is_file():
+        return ""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def runtime_env(
@@ -471,7 +514,13 @@ def runtime_env(
     env["COMPOSE_PROJECT_NAME"] = resolve_project_name(config or {})
     # Derived from the repo compose_base_cmd pins as --project-directory, so the
     # digest covers the same chain files compose itself resolves ./.env* against.
-    env[ENV_DIGEST_VAR] = env_chain_digest(resolve_repo_root(config))
+    repo_root = resolve_repo_root(config)
+    env[ENV_DIGEST_VAR] = env_chain_digest(repo_root)
+    # Unconditional for the same reason the env digest is: the value only works
+    # as a recreate trigger if every invocation that can reach `up` computes the
+    # same one, and a call site that skipped it would interpolate the label to
+    # empty, read as a document change, and recreate the whole stack for nothing.
+    env[CONFIG_DIGEST_VAR] = as_built_config_digest(repo_root)
     if ignore_orphans:
         env["COMPOSE_IGNORE_ORPHANS"] = "1"
     return env

--- a/src/osprey/deployment/service_tokens.py
+++ b/src/osprey/deployment/service_tokens.py
@@ -247,6 +247,50 @@ _VAR_VALIDATOR_DESCRIPTIONS: dict[str, str] = {
 }
 
 
+# Values a var must never hold, whatever its format says. Keyed and opted into
+# exactly like ``_VAR_VALIDATORS``: a var absent here has no forbidden value and
+# ``_is_forbidden_value`` returns False for it.
+#
+# A separate map rather than another validator, because it answers a different
+# question. The openobserve compose template's fallback satisfies
+# ``_validate_openobserve_password`` completely — it carries all four required
+# character classes — so no *format* rule can ever catch it. What disqualifies
+# it is that it is published: it ships in the template every rendered project
+# carries, which makes it a shared password rather than a secret, guarding a
+# store that holds full agent conversation transcripts.
+#
+# Deliberately narrow, and there is no build-time twin of this check. On a fresh
+# repo the template default is what the ``${VAR:-default}`` form resolves to
+# transiently, and the very next step mints a real value — refusing there would
+# fire on the ordinary first deploy. By the time this map is consulted (the
+# post-mint validation loop in ``_ensure_service_tokens``) the effective value is
+# either something just minted or something an operator supplied, so a match
+# means the operator pinned the published default as their actual password.
+_VAR_FORBIDDEN_VALUES: dict[str, frozenset[str]] = {
+    # The ``${ZO_ROOT_USER_PASSWORD:-…}`` fallback in
+    # ``osprey/templates/services/openobserve/docker-compose.yml.j2``.
+    "ZO_ROOT_USER_PASSWORD": frozenset({"Complexpass#123"}),
+}
+
+# The ``_VAR_VALIDATOR_DESCRIPTIONS`` twin for _VAR_FORBIDDEN_VALUES: the
+# operator-facing constraint text shown in the RuntimeError
+# ``_ensure_service_tokens`` raises on a forbidden value — never the value
+# itself. Two maps rather than one because a var can fail either way and the two
+# failures have different fixes; sharing one entry would send an operator
+# reading about character classes when the problem is that their password is
+# public. A var with a forbidden value but no entry here falls back to a generic
+# description.
+_VAR_FORBIDDEN_DESCRIPTIONS: dict[str, str] = {
+    "ZO_ROOT_USER_PASSWORD": (
+        "must not be the default published in the openobserve compose template — "
+        "that value ships in every rendered project, so it is a shared password "
+        "rather than a secret, and this store holds full agent conversation "
+        "transcripts; remove the line from .env (and unset any shell export of the "
+        "same name) so the next run mints a per-deploy value"
+    ),
+}
+
+
 def _effective_value(var: str, dotenv: dict[str, str]) -> str:
     """The value ``_ensure_service_tokens`` treats as authoritative for ``var``.
 
@@ -284,6 +328,31 @@ def _validate_var(var: str, value: str) -> bool:
     if validator is None:
         return True
     return validator(value)
+
+
+def _is_forbidden_value(var: str, value: str) -> bool:
+    """True if ``value`` is one of ``var``'s registered forbidden values.
+
+    Kept out of :func:`_validate_var` on purpose. That function answers "is this
+    value *well-formed* for its consumer?", and every value registered in
+    ``_VAR_FORBIDDEN_VALUES`` is — the published openobserve default would start
+    the container quite happily. This asks a second question, "is this value
+    *anyone's* secret?", which only the deploy boundary is in a position to ask.
+    """
+    return value in _VAR_FORBIDDEN_VALUES.get(var, frozenset())
+
+
+def _raise_forbidden_var(var: str) -> None:
+    """Raise the standard "forbidden value" RuntimeError, never the value.
+
+    The twin of :func:`_raise_invalid_var` for the other refusal, in the same
+    shape and with the same rule: the message names the VARIABLE and how to fix
+    it, and never echoes the offending value back — a published default is still
+    the password some deployment is currently running on, and error text travels
+    into terminals, transcripts and CI logs.
+    """
+    constraint = _VAR_FORBIDDEN_DESCRIPTIONS.get(var, "must not be its published template default")
+    raise RuntimeError(f"{var} is invalid: {constraint}. Refusing to deploy. (Value not shown.)")
 
 
 def _raise_invalid_var(var: str, value: str = "") -> None:

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -749,6 +749,56 @@ def _artifact_drift(repo_root, build_dir, config):
             logger.debug("Artifact dry run said: %s", chatter.getvalue().strip())
 
 
+# Environment variable names whose VALUE is a credential rather than configuration.
+#
+# The agent section prints the settings.json env block key AND value, because
+# that is what it is for: the OTLP endpoint, the exporters, the model IDs and
+# the content-capture gates are exactly the facts an operator opens ``osprey
+# status`` to read, and a blanket mask over the block would leave the section
+# with nothing to say. One entry is different — the OTLP headers block carries
+# the observability store's authorization header, a directly decodable
+# credential — and a status report is read on a shared terminal and pasted into
+# tickets.
+#
+# Two rules rather than one literal comparison, so the next secret-bearing
+# variable is covered by the policy instead of by someone remembering to add a
+# second special case: any name carrying a conventional secret word is masked,
+# and this set holds the ones whose name does not advertise what they hold.
+_SECRET_ENV_VARS: frozenset[str] = frozenset({"OTEL_EXPORTER_OTLP_HEADERS"})
+
+_SECRET_ENV_NAME_MARKERS: tuple[str, ...] = (
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "API_KEY",
+    "CREDENTIAL",
+)
+
+#: What a masked value is printed as. Deliberately not a partial reveal: a
+#: trailing "last four characters" of a base64 credential is a leak with an
+#: extra step, and of a short one it is most of the secret.
+_MASKED_ENV_VALUE = "*** (value not shown)"
+
+
+def _display_env_value(name: str, value: object) -> object:
+    """The value to print for environment variable *name*, masked if it is a secret.
+
+    Masks the whole value, and makes no assumption about its shape. The OTLP
+    headers value happens to be a comma-joined ``name=value`` map whose names
+    (``Authorization``) are not themselves secret, so its header names could in
+    principle be shown with only the values masked. That is not worth what it
+    costs: the split would have to run over any value this rule ever masks, and
+    a value that is *not* a ``name=value`` map — a bare token under some future
+    ``..._TOKEN`` variable — would be parsed into a "name" and printed verbatim.
+    The variable's own name already says which credential is configured, which
+    is the fact the row exists to carry.
+    """
+    upper = str(name).upper()
+    if upper in _SECRET_ENV_VARS or any(marker in upper for marker in _SECRET_ENV_NAME_MARKERS):
+        return _MASKED_ENV_VALUE
+    return value
+
+
 def _print_agent_section(repo_root, build_dir, config, *, show_agents):
     """Print how the agent in this deployment is configured, and whether it is in sync.
 
@@ -849,7 +899,9 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
 
             if spec.env_block:
                 rows.append(("environment", "rendered into settings.json"))
-                rows.extend((key, value) for key, value in spec.env_block.items())
+                rows.extend(
+                    (key, _display_env_value(key, value)) for key, value in spec.env_block.items()
+                )
 
             rows.append(("model tiers", ""))
             model_overrides = claude_code.get("models") or {}
@@ -869,8 +921,12 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
 
             conflicts = spec.detect_env_conflicts(dict(os.environ))
             if conflicts:
+                # Masked on the same rule as the block above: this is the second
+                # printer of the same values, and a secret that the env row
+                # withholds must not come back out of the conflict line beside it.
                 detail = [
-                    f"{var}: shell {shell_val} / build {settings_val}"
+                    f"{var}: shell {_display_env_value(var, shell_val)} "
+                    f"/ build {_display_env_value(var, settings_val)}"
                     for var, (shell_val, settings_val) in sorted(conflicts.items())
                 ]
                 detail.append("`osprey chat` resolves these in favour of the build.")

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -768,6 +768,7 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
     import os
 
     from osprey.build.claude_code_resolver import AGENT_DEFAULT_TIERS, load_provider_spec
+    from osprey.build.claude_code_telemetry import ObservabilityCredentialError
 
     rows: list[tuple[str, object]] = []
     notes: list[str] = []
@@ -791,6 +792,28 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
             # ``_auth_availability`` below, which already looks for the
             # credential in ``repo_root/.env``.
             spec = load_provider_spec(build_dir, env_dir=repo_root)
+        except ObservabilityCredentialError:
+            # Ahead of the broad handler on purpose, and load-bearing: resolving
+            # the provider also resolves the telemetry block, so a missing
+            # observability credential arrives here as a failure to read the
+            # provider. Reported as one, an operator goes and checks a provider
+            # that was never wrong. Behind the ``except Exception`` below this
+            # branch would never run while still reading as if it did.
+            #
+            # Names only — the exception text can carry the credential field's
+            # value, and a status report is printed to a shared terminal and
+            # pasted into tickets. The remedy is the name of the setting and
+            # the file it belongs in.
+            spec = None
+            troubles.append(
+                (
+                    "telemetry: the observability backend's credentials are missing or "
+                    "unresolved, so the provider could not be resolved",
+                    "Set claude_code.telemetry.openobserve.user and .password — or the "
+                    f"environment variables they reference — in {repo_root / '.env'}, "
+                    "then rerun. The provider configuration itself is not the problem.",
+                )
+            )
         except Exception as exc:
             spec = None
             troubles.append(

--- a/src/osprey/deployment/web_terminals/artifacts.py
+++ b/src/osprey/deployment/web_terminals/artifacts.py
@@ -170,10 +170,37 @@ def check_bash_launch_token_conflict(config: Any, project_root: Path | str) -> s
             ``.claude/settings.json`` that does not deny ``Bash``.
     """
     launch_token_personas = personas_needing_launch_token(config, project_root)
-    offenders = launch_token_personas & personas_not_denying_bash(config, project_root)
-    if offenders:
+    if offenders := bash_launch_token_offenders(config, project_root):
         raise BashLaunchTokenConflictError(offenders)
     return launch_token_personas
+
+
+def bash_launch_token_offenders(config: Any, project_root: Path | str) -> set[str]:
+    """The personas in conflict, computed without refusing anything.
+
+    The same intersection :func:`check_bash_launch_token_conflict` refuses on,
+    split out so the collect-all preflight can ASK the question without raising
+    on the answer. The raising wrapper stays exactly as it was for its three
+    call sites — this is a second reader of one predicate, never a second
+    definition of what a conflict is.
+
+    Reads two rendered directories and nothing else: no file is written, no
+    process is started, and nothing about the deployment changes. That purity is
+    what licenses calling it from the middle of a start sequence, before any
+    provisioning step has been skipped or repeated.
+
+    Args:
+        config: The parsed deploy config.
+        project_root: Deploy project root; relative ``project_path`` values
+            resolve against it.
+
+    Returns:
+        Every persona both entitled to ``BLUESKY_LAUNCH_TOKEN`` and shipping
+        settings that do not deny ``Bash``. Empty when there is no conflict.
+    """
+    return personas_needing_launch_token(config, project_root) & personas_not_denying_bash(
+        config, project_root
+    )
 
 
 def web_artifacts_dir(repo_root: Path | str) -> Path:

--- a/src/osprey/deployment/web_terminals/auth_credentials.py
+++ b/src/osprey/deployment/web_terminals/auth_credentials.py
@@ -434,10 +434,10 @@ def ensure_auth_session_secrets(project_root: str | Path) -> AuthSecretsResult:
     invalidate every live session. The one exception is a present-but-empty (or
     whitespace-only) value, which is re-minted: the sidecar strips and rejects
     such a value as missing configuration and answers every request with 503,
-    so preserving it would keep the whole deployment locked out. This is the
-    deliberate opposite of ``_ensure_service_tokens``' "an explicitly empty
-    token is a decision, leave it" rule, which holds there because an empty
-    service token fails only its own service closed.
+    so preserving it would keep the whole deployment locked out. That is the
+    same judgement ``_ensure_service_tokens`` makes about the tokens it mints —
+    a machine-generated secret has no meaningful empty state, so a blank is a
+    blank rather than a decision to honour.
 
     A write failure is reported through ``missing`` rather than raised, matching
     :func:`ensure_auth_credentials` so the deploy gate owns the abort.

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -8,6 +8,7 @@ exists-check it (CI is expected to have produced it). Called from
 """
 
 import os
+import re
 from pathlib import Path
 
 import yaml
@@ -106,6 +107,192 @@ def migrate_users_env(project_root: str | Path) -> Path | None:
     return users_path
 
 
+#: The two forms a config value may use to reference an env var: ``${NAME}``
+#: and ``${NAME:-default}``. Anchored, because the values this module reads are
+#: reference LITERALS — a whole config value that is nothing but the reference —
+#: and a partial match would report a variable the reader never actually
+#: depends on. The unbraced ``$NAME`` spelling is deliberately NOT matched:
+#: nothing this module reads is written that way, and treating it as a
+#: reference would make any value containing a bare ``$`` look like one.
+_ENV_REFERENCE_RE = re.compile(r"\A\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}\Z")
+
+#: Where a project's telemetry credentials live in its own ``config.yml``.
+_TELEMETRY_CONFIG_PATH = ("claude_code", "telemetry", "openobserve")
+
+#: The observability store's account NAME — an email address, not a secret.
+#: A fixed name rather than a config-declared one, like ``TZ`` and
+#: ``ARIEL_DSN``: the shipped configs reference it under this spelling and
+#: ``osprey up`` writes it into the deploy env chain under it too.
+_TELEMETRY_USER_ENV_VAR = "ZO_ROOT_USER_EMAIL"
+
+
+def _env_reference(value: object) -> tuple[str, bool] | None:
+    """Read a config value that IS an env-var reference.
+
+    The telemetry credential keys hold the reference itself (``user:
+    ${ZO_ROOT_USER_EMAIL:-root@example.com}``) rather than the *name* of a
+    variable the way ``llm.api_key_env_var`` does, so telling a reference from
+    a plain literal — and a bare reference from one carrying its own default —
+    takes reading the value, which is what this does.
+
+    The distinction matters because the two forms fail differently in a
+    container: a reference with a default quietly falls back to it when the
+    variable is unset, while a bare one is left in the config verbatim (see
+    :func:`osprey_connectors.config.resolve_env_vars`) and reaches the store as
+    a literal ``${...}`` string.
+
+    :param value: A raw config value; anything that is not a string, and any
+        string that is not exactly one reference, reads as a plain literal.
+    :return: ``(var_name, has_default)``, or ``None`` for a plain literal.
+    """
+    if not isinstance(value, str):
+        return None
+    match = _ENV_REFERENCE_RE.match(value)
+    if match is None:
+        return None
+    return match.group(1), match.group(2) is not None
+
+
+def _telemetry_credentials(cfg: dict) -> dict:
+    """The ``claude_code.telemetry.openobserve`` block of one project's config."""
+    node: object = cfg
+    for key in _TELEMETRY_CONFIG_PATH:
+        if not isinstance(node, dict):
+            return {}
+        node = node.get(key)
+    return node if isinstance(node, dict) else {}
+
+
+def _referenced_persona_names(config: dict) -> list[str]:
+    """Every persona name this roster runs: the default plus each user's own.
+
+    Sorted, so everything derived from the roster reports in a stable order.
+    Names are taken as written; whether the catalog knows one is a separate
+    question (see :func:`_referenced_persona_entries`).
+    """
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    referenced: set[str] = set()
+    default_persona = web_terminals.get("default_persona")
+    if isinstance(default_persona, str) and default_persona:
+        referenced.add(default_persona)
+    users = web_terminals.get("users")
+    for user in users if isinstance(users, list) else []:
+        if isinstance(user, dict) and isinstance(user.get("persona"), str) and user["persona"]:
+            referenced.add(user["persona"])
+    return sorted(referenced)
+
+
+def _referenced_persona_entries(config: dict) -> list[tuple[str, dict]]:
+    """``(persona_name, catalog entry)`` for every persona this roster runs.
+
+    Referenced names resolved against ``modules.web_terminals.personas``; a
+    name with no catalog entry contributes nothing here.
+    """
+    catalog = ((config.get("modules") or {}).get("web_terminals") or {}).get("personas")
+    catalog = catalog if isinstance(catalog, dict) else {}
+    entries: list[tuple[str, dict]] = []
+    for persona_name in _referenced_persona_names(config):
+        entry = catalog.get(persona_name)
+        if isinstance(entry, dict):
+            entries.append((persona_name, entry))
+    return entries
+
+
+def _persona_config_yml(project_root: Path, entry: dict) -> Path | None:
+    """Where a catalog entry's rendered ``config.yml`` would be.
+
+    Path join: an absolute ``project_path`` stands on its own; a relative one
+    resolves against the deploy project root, same as every other cwd-relative
+    assumption on this path. An entry naming no project has no config to read.
+    """
+    project_path_raw = entry.get("project_path")
+    if not isinstance(project_path_raw, str) or not project_path_raw:
+        return None
+    return Path(project_root, project_path_raw) / "config.yml"
+
+
+def _load_config_yml(path: Path) -> dict | None:
+    """Load a rendered ``config.yml``; ``None`` when it cannot be read as one."""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            loaded = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _telemetry_credential_references(
+    config: dict, project_root: Path, field: str, *, bare_only: bool
+) -> dict[str, str]:
+    """``{var: origin}`` for one telemetry credential key across every config in play.
+
+    The deploy config and each referenced persona project's rendered
+    ``config.yml`` are read the same way :func:`_claude_code_auth_secret_vars`
+    reads them, since a per-user container runs its persona's project and it is
+    that project's telemetry block which decides what the agent inside presents
+    to the observability store.
+
+    :param field: Key under ``claude_code.telemetry.openobserve`` to read.
+    :param bare_only: When true, report only references with no ``:-default``
+        of their own — the ones that cannot resolve to anything on their own.
+    """
+    references: dict[str, str] = {}
+
+    def _record(cfg: dict, source: str) -> None:
+        reference = _env_reference(_telemetry_credentials(cfg).get(field))
+        if reference is None:
+            return
+        var, has_default = reference
+        if bare_only and has_default:
+            return
+        references.setdefault(var, f"claude_code.telemetry.openobserve.{field} {source}")
+
+    for persona_name, entry in _referenced_persona_entries(config):
+        config_yml = _persona_config_yml(project_root, entry)
+        if config_yml is None or not config_yml.is_file():
+            # Silent, unlike _claude_code_auth_secret_vars: that function warns
+            # about the same unreadable project already, and saying it twice
+            # per deploy would read as two separate problems.
+            continue
+        persona_config = _load_config_yml(config_yml)
+        if persona_config is None:
+            continue
+        _record(persona_config, f"(persona {persona_name!r})")
+
+    _record(config, "(deploy config)")
+    return references
+
+
+def _telemetry_credential_requirements(config: dict, project_root: Path) -> dict[str, str]:
+    """``{var: origin}`` for telemetry passwords a config REQUIRES from the env chain.
+
+    A bare ``${VAR}`` password reference — no ``:-default`` — is a config
+    asserting that the variable is set: unset, it is left in the rendered
+    config verbatim and the agent authenticates to the observability store with
+    a literal ``${VAR}`` string. This reports those variables so
+    :func:`ensure_env_production` can refuse a deploy that would ship one,
+    exactly as it refuses a missing provider auth secret.
+
+    The result feeds the missing-variable gate ONLY. It must never reach
+    :func:`_build_env_production_subset`: the store password is the store's
+    single admin credential, and ``.env.users`` is handed to every persona
+    alike, so copying it there would grant every read-only terminal admin read
+    of every transcript in the store.
+    """
+    return _telemetry_credential_references(config, project_root, "password", bare_only=True)
+
+
+def _telemetry_user_references(config: dict, project_root: Path) -> dict[str, str]:
+    """``{var: origin}`` for the telemetry account-name variables a config references.
+
+    Both reference forms count here, unlike
+    :func:`_telemetry_credential_requirements`: a defaulted reference resolves
+    to the shipped placeholder address, which is the wrong account whenever the
+    deploy configured the store under a different one.
+    """
+    return _telemetry_credential_references(config, project_root, "user", bare_only=False)
+
+
 def _copy_named_env_var(var_name: str | None, source: dict[str, str], dest: dict[str, str]) -> None:
     """Copy ``source[var_name]`` into ``dest[var_name]`` iff both are present.
 
@@ -171,33 +358,18 @@ def _claude_code_auth_secret_vars(
             api_providers = None
         return provider, provider_auth_secret_env(provider, api_providers)
 
-    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
-    catalog = web_terminals.get("personas")
+    catalog = ((config.get("modules") or {}).get("web_terminals") or {}).get("personas")
     catalog = catalog if isinstance(catalog, dict) else {}
-
-    referenced: set[str] = set()
-    default_persona = web_terminals.get("default_persona")
-    if isinstance(default_persona, str) and default_persona:
-        referenced.add(default_persona)
-    users = web_terminals.get("users")
-    for user in users if isinstance(users, list) else []:
-        if isinstance(user, dict) and isinstance(user.get("persona"), str) and user["persona"]:
-            referenced.add(user["persona"])
+    referenced = _referenced_persona_names(config)
+    entries = _referenced_persona_entries(config)
 
     required: dict[str, str] = {}
     extra: dict[str, str] = {}
 
-    for persona_name in sorted(referenced):
-        entry = catalog.get(persona_name)
-        if not isinstance(entry, dict):
+    for persona_name, entry in entries:
+        config_yml = _persona_config_yml(project_root, entry)
+        if config_yml is None:
             continue
-        project_path_raw = entry.get("project_path")
-        if not isinstance(project_path_raw, str) or not project_path_raw:
-            continue
-        # Path join: an absolute project_path stands on its own; a relative
-        # one resolves against the deploy project root, same as every other
-        # cwd-relative assumption on this path.
-        config_yml = Path(project_root, project_path_raw) / "config.yml"
         if not config_yml.is_file():
             # Said out loud rather than skipped: a persona whose project cannot
             # be found contributes no auth secret, so its terminals come up
@@ -212,12 +384,8 @@ def _claude_code_auth_secret_vars(
                 config_yml,
             )
             continue
-        try:
-            with config_yml.open("r", encoding="utf-8") as fh:
-                persona_config = yaml.safe_load(fh)
-        except (OSError, yaml.YAMLError):
-            continue
-        if not isinstance(persona_config, dict):
+        persona_config = _load_config_yml(config_yml)
+        if persona_config is None:
             continue
         resolved = _provider_var(persona_config)
         if resolved is None:
@@ -271,8 +439,25 @@ def _build_env_production_subset(
       ``modules.ariel.dsn`` directly. Unlike every entry above this is read
       from ``config``, not ``dotenv``: the DSN is itself a literal config
       value, not the *name* of an env var holding one.
+    - ``ZO_ROOT_USER_EMAIL`` — the observability store's account NAME, copied
+      when the chain sets it and silently skipped otherwise. A fixed key rather
+      than a config-declared one, like the two entries below: the shipped
+      telemetry block references it under this spelling and ``osprey up``
+      writes it into the deploy env chain under it too. An account name is not
+      a secret; it is here because a terminal that emits telemetry has to name
+      the same account the store was configured with, and the reference's own
+      fallback address is the wrong one on any deploy that set this.
     - ``TZ`` — always, from ``facility.timezone`` (default ``"UTC"``, matching
       the schema's own documented default), likewise a literal config value.
+
+    The store's PASSWORD is deliberately not here beside its account name.
+    ``ZO_ROOT_USER_PASSWORD`` is the observability store's single admin
+    credential — the same value the store container itself is configured with —
+    so a copy in this rosterwide file would grant every persona, read-only ones
+    included, admin read of every transcript the store holds. It stays out for
+    the same reason the service tokens do (see below), and
+    :func:`_telemetry_credential_requirements` exists to REPORT a config that
+    depends on it rather than to satisfy one.
 
     NEVER included, by construction (this function never reads them at all):
     build-time credentials — the CI provider token, the container-registry
@@ -368,10 +553,136 @@ def _build_env_production_subset(
         if dsn:
             subset["ARIEL_DSN"] = str(dsn)
 
+    # Fixed key, chain-presence rule: the store's account name crosses, its
+    # admin password never does (see the security spec above).
+    _copy_named_env_var(_TELEMETRY_USER_ENV_VAR, dotenv, subset)
+
     facility = config.get("facility") or {}
     subset["TZ"] = str(facility.get("timezone") or "UTC")
 
     return subset
+
+
+def users_env_generation_problem(config: dict, project_root: str | Path) -> str | None:
+    """Whether generating ``.env.users`` would leave web terminals unauthenticated.
+
+    The gate :func:`ensure_env_production` raises on, expressed as a question so
+    it can also be ASKED — by the collect-all preflight, which reports every
+    cheaply checkable refusal at once instead of costing the operator a deploy
+    attempt per finding. One function rather than two, so the probe and the
+    writer can never disagree about which variables are required or about how
+    the refusal is worded.
+
+    Answers ``None`` — nothing to report — for the three cases that are not this
+    refusal, in the order :func:`ensure_env_production` settles them:
+
+    * ``.env.users`` already on disk. An existing file is never regenerated, so
+      there is no generation to have a problem with (whether its CONTENTS are
+      adequate is :func:`_warn_if_env_production_lacks_credentials`' warning,
+      not a refusal).
+    * Registry mode. Nothing is generated there at all.
+    * No env-chain file. There is nothing to generate FROM, which is its own
+      refusal with its own remedy and not this one.
+
+    Pure: it parses the env chain and each referenced persona's rendered
+    ``config.yml``, and writes nothing anywhere. The ambient environment is read
+    only for the presence check behind the shell hint — never for a value, and
+    never as a source (see :func:`ensure_env_production` on why the chain on
+    disk is the whole source).
+
+    :param config: Raw deploy config.
+    :param project_root: Project root; ``.env.users`` and the env-chain files
+        are resolved relative to it.
+    :return: The refusal sentence, or ``None`` when generation would succeed.
+    """
+    root = Path(project_root)
+    users_env_path = root / USERS_ENV_FILENAME
+    if users_env_path.is_file():
+        return None
+
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    if effective_image_source(web_terminals) != "local":
+        return None
+
+    sources = chain_files(root)
+    if not sources:
+        return None
+    sources_desc = " + ".join(str(path) for path in sources)
+    env_path = root / ENV_LOCAL_FILENAME
+
+    dotenv = merge_chain(root)
+    required_cc_vars, _extra_cc_vars = _claude_code_auth_secret_vars(config, root)
+    # Reported, never copied: these are variables a telemetry block depends on
+    # that this file is not allowed to carry, so they join the gate below and
+    # nothing else. Keeping them out of the {**required, **extra} pair handed to
+    # _build_env_production_subset is what stops the store's admin password from
+    # being written into a file every persona reads.
+    telemetry_vars = _telemetry_credential_requirements(config, root)
+
+    # "Missing" means missing from the MERGED chain: a var only .env.shared
+    # sets is set.
+    missing = {
+        var: origin
+        for var, origin in {**telemetry_vars, **required_cc_vars}.items()
+        if var not in dotenv
+    }
+    if not missing:
+        return None
+
+    needs = "; ".join(f"{origin} needs {var}" for var, origin in missing.items())
+    # The chain on disk stays the only SOURCE (see ensure_env_production's
+    # determinism note) — but when a missing var is sitting right there in the
+    # shell, say so and hand over the exact copy-in command instead of leaving
+    # the operator to discover the .env-only rule by archaeology. Presence
+    # check only; the value itself is never read into the message.
+    exported = [var for var in missing if os.environ.get(var)]
+    shell_hint = ""
+    if exported:
+        # One store, one command. ``env_path`` is the deployment repo's own
+        # ``.env`` at the repo root — source, not render — so appending to
+        # it IS the durable write; there is no second, profile-side copy to
+        # name and no rebuild needed to carry the value anywhere. (This
+        # replaced a two-.env model where the project's ``.env`` was
+        # derived from the profile's and a write to the wrong one was
+        # dropped by the next build. Under the four-zone layout the
+        # profile and the secret store share a root, so that distinction no
+        # longer exists — and telling an operator their write will be
+        # dropped would now be false.)
+        names = ", ".join(exported)
+        verb = "are" if len(exported) > 1 else "is"
+        copy_cmds = " && ".join(f'echo "{var}=${var}" >> {env_path}' for var in exported)
+        shell_hint = (
+            f" Note: {names} {verb} exported in the current shell, but this "
+            f"deploy reads only the env chain on disk ({sources_desc}) "
+            "(generation never reads the ambient environment). Copy it in "
+            f"with: {copy_cmds}"
+        )
+    # Named separately because the remedy is only half the usual one: the
+    # chain is where these belong, but this file will still not carry them,
+    # so an operator who adds one and expects it to reach the terminals has
+    # to be told what actually happens instead.
+    telemetry_missing = [var for var in missing if var in telemetry_vars]
+    telemetry_note = ""
+    if telemetry_missing:
+        telemetry_names = ", ".join(telemetry_missing)
+        telemetry_verb = "are" if len(telemetry_missing) > 1 else "is"
+        telemetry_note = (
+            f" Note: {telemetry_names} {telemetry_verb} the observability store's single admin "
+            "credential, so this file never carries it — one .env.users is "
+            "handed to every persona alike, read-only ones included, and admin "
+            "access to that store reads every transcript in it. Setting it in "
+            "the chain configures the store itself; a scoped ingest credential "
+            "is what will let a terminal authenticate to the store. A telemetry "
+            "block that names its own fallback (${VAR:-default}) is not asked "
+            "for here at all."
+        )
+    return (
+        f"Generating {users_env_path} from {sources_desc} would leave web "
+        f"terminals unauthenticated: {needs}, set in none of them. Add the "
+        f"missing variable(s) to {env_path}, or author .env.users "
+        "yourself (an existing file is never regenerated) if this deploy "
+        f"authenticates another way.{telemetry_note}{shell_hint}"
+    )
 
 
 def ensure_env_production(config: dict, project_root: str | Path) -> Path:
@@ -408,7 +719,10 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
       of generating: the resulting file would produce healthy-looking terminals
       that fail authentication on their first prompt (authoring
       ``.env.users`` directly remains the bypass for deploys that
-      authenticate another way).
+      authenticate another way). A telemetry password reference that carries no
+      default of its own (see :func:`_telemetry_credential_requirements`) joins
+      the same gate: the variable it names is reported when the chain does not
+      set it, and is never written into the generated file either way.
     - **Local mode, absent, the whole chain absent too**: raises, before any
       compose invocation — there is nothing to generate from and no file to
       fall back on.
@@ -464,7 +778,6 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
     # web terminal as one the host-local .env carries, and .env still wins on
     # any key both set. With no .env.shared on disk the chain is [.env] and
     # the merge is that file's own parse, byte for byte.
-    env_path = root / ENV_LOCAL_FILENAME
     sources = chain_files(root)
     if not sources:
         chain_names = ", ".join(ENV_CHAIN_FILENAMES)
@@ -484,45 +797,13 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
     # see _copy_named_env_var), a missing claude_code auth secret means some
     # web container comes up healthy and fails authentication on its first
     # prompt, with nothing in the deploy output to say why. Fail HERE, before
-    # any compose invocation, naming the exact var and both remedies. "Missing"
-    # means missing from the MERGED chain: a var only .env.shared sets is set.
-    missing = {var: origin for var, origin in required_cc_vars.items() if var not in dotenv}
-    if missing:
-        needs = "; ".join(f"{origin} needs {var}" for var, origin in missing.items())
-        # The chain on disk stays the only SOURCE (see the determinism note
-        # above) — but when a missing var is sitting right there in the shell,
-        # say so and hand over the exact copy-in command instead of leaving
-        # the operator to discover the .env-only rule by archaeology. Presence
-        # check only; the value itself is never read into the message.
-        exported = [var for var in missing if os.environ.get(var)]
-        shell_hint = ""
-        if exported:
-            # One store, one command. ``env_path`` is the deployment repo's own
-            # ``.env`` at the repo root — source, not render — so appending to
-            # it IS the durable write; there is no second, profile-side copy to
-            # name and no rebuild needed to carry the value anywhere. (This
-            # replaced a two-.env model where the project's ``.env`` was
-            # derived from the profile's and a write to the wrong one was
-            # dropped by the next build. Under the four-zone layout the
-            # profile and the secret store share a root, so that distinction no
-            # longer exists — and telling an operator their write will be
-            # dropped would now be false.)
-            names = ", ".join(exported)
-            verb = "are" if len(exported) > 1 else "is"
-            copy_cmds = " && ".join(f'echo "{var}=${var}" >> {env_path}' for var in exported)
-            shell_hint = (
-                f" Note: {names} {verb} exported in the current shell, but this "
-                f"deploy reads only the env chain on disk ({sources_desc}) "
-                "(generation never reads the ambient environment). Copy it in "
-                f"with: {copy_cmds}"
-            )
-        raise RuntimeError(
-            f"Generating {users_env_path} from {sources_desc} would leave web "
-            f"terminals unauthenticated: {needs}, set in none of them. Add the "
-            f"missing variable(s) to {env_path}, or author .env.users "
-            "yourself (an existing file is never regenerated) if this deploy "
-            f"authenticates another way.{shell_hint}"
-        )
+    # any compose invocation, naming the exact var and both remedies. The
+    # question and the sentence answering it both live in
+    # users_env_generation_problem, so the collect-all preflight asks exactly
+    # what this raises on rather than a second approximation of it.
+    problem = users_env_generation_problem(config, root)
+    if problem is not None:
+        raise RuntimeError(problem)
 
     subset = _build_env_production_subset(config, dotenv, {**required_cc_vars, **extra_cc_vars})
 
@@ -568,7 +849,7 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
 def _warn_if_env_production_lacks_credentials(
     config: dict, project_root: Path, users_env_path: Path
 ) -> None:
-    """Warn when an existing ``.env.users`` carries no LLM credential.
+    """Warn when an existing ``.env.users`` is missing credentials the config names.
 
     The never-clobber rule (see :func:`ensure_env_production`) means a file
     generated before a provider change — or before the generator knew about
@@ -578,7 +859,22 @@ def _warn_if_env_production_lacks_credentials(
     authentication on their first prompt; this warning is the only breadcrumb.
     Advisory by design: an operator-authored file may authenticate another
     way, so nothing here blocks the deploy or touches the file.
+
+    Two arms, evaluated independently — either can fire on its own, and a file
+    that satisfies one says nothing about the other:
+
+    - The LLM arm is all-or-nothing on purpose: a file carrying ANY of the
+      provider secrets in play is a file someone is maintaining, and naming the
+      rest of them would fire on every deploy that authenticates a subset of
+      its personas another way.
+    - The telemetry arm asks about one variable at a time, because the
+      observability account name has no such alternative: a file that omits it
+      leaves the terminals naming the reference's own fallback address, which
+      is the wrong account on any deploy that configured the store under a
+      different one.
     """
+    _warn_if_telemetry_account_absent(config, project_root, users_env_path)
+
     required_cc_vars, extra_cc_vars = _claude_code_auth_secret_vars(config, project_root)
     expected: dict[str, str] = dict(extra_cc_vars)
     expected.update(required_cc_vars)
@@ -600,4 +896,42 @@ def _warn_if_env_production_lacks_credentials(
         "terminals will fail authentication unless this deploy authenticates "
         "another way. Delete the file to regenerate it from the env chain, or "
         "add the variable(s) to it directly."
+    )
+
+
+def _warn_if_telemetry_account_absent(
+    config: dict, project_root: Path, users_env_path: Path
+) -> None:
+    """Warn when an existing ``.env.users`` omits the telemetry account name.
+
+    The second, independently-evaluated arm of
+    :func:`_warn_if_env_production_lacks_credentials` — a file that carries an
+    LLM credential and therefore satisfies the arm above can still omit this
+    one, which is the common shape for a file written before the generator
+    copied it at all.
+
+    Names only, never values: the advisory says which variable is missing and
+    where the config asks for it, and reads nothing out of either file beyond
+    whether the key is present.
+    """
+    expected = _telemetry_user_references(config, project_root)
+    if not expected:
+        return
+    try:
+        present = parse_dotenv_file(users_env_path)
+    except OSError:
+        return  # unreadable file surfaces as compose's own env_file error
+    absent = {var: origin for var, origin in expected.items() if var not in present}
+    if not absent:
+        return
+    expectations = "; ".join(f"{var} ({origin})" for var, origin in absent.items())
+    logger.warning(
+        f"{users_env_path} exists but does not set the observability account "
+        f"name(s) this config's telemetry references: {expectations}. Web "
+        "terminals emitting telemetry will name whatever that reference "
+        "resolves to inside the container — its own fallback address, or the "
+        "placeholder verbatim when it has none — so the store rejects their "
+        "records unless its account happens to match. Delete the file to "
+        "regenerate it from the env chain, or add the variable(s) to it "
+        "directly."
     )

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -39,6 +39,16 @@ USERS_ENV_FILENAME = ".env.users"
 #: nothing ever writes it again.
 LEGACY_USERS_ENV_FILENAME = ".env.production"
 
+#: Where :func:`migrate_users_env` sets a leftover legacy file aside when the
+#: current name is already taken: the legacy spelling plus a ``.superseded``
+#: suffix. Derived rather than spelled out, so the two names cannot drift apart.
+#:
+#: A fixed literal and not a timestamp, deliberately: a repeated ``osprey up``
+#: must not be able to accumulate an unbounded pile of files holding live
+#: secrets. That is the whole reason the collision rule is "keep the earlier
+#: copy, skip the rename" rather than "overwrite".
+SUPERSEDED_USERS_ENV_FILENAME = f"{LEGACY_USERS_ENV_FILENAME}.superseded"
+
 
 def migrate_users_env(project_root: str | Path) -> Path | None:
     """Move a leftover ``.env.production`` onto :data:`USERS_ENV_FILENAME`.
@@ -55,16 +65,39 @@ def migrate_users_env(project_root: str | Path) -> Path | None:
     guess: registry-mode CI renders a fresh ``.env.users`` on the host just
     before ``osprey up``, while the old file — gitignored, so untouched by the
     ``git reset --hard`` that precedes a CI checkout — survives from an earlier
-    pipeline. The new file is therefore always kept, and the leftover is
-    deleted rather than left to look like a second source of truth. Either way
-    the operator gets one line naming both paths.
+    pipeline. The new file is therefore always kept, and the leftover must stop
+    looking like a second source of truth. Either way the operator gets one
+    line naming both paths.
+
+    Getting there costs a rename, not a delete. The reasoning above is about
+    OSPREY's OWN artifact, and it is sound about one — but this function
+    identifies that artifact by filename alone, and a file at that name need
+    never have been OSPREY's: another tool on the host may keep its own secrets
+    under the same spelling, on a deployment that never had a pre-rename
+    ``.env.users`` at all. A delete cannot tell the two cases apart, so on the
+    second one it destroys the operator's only copy on the strength of a
+    filename match, during an ``osprey up`` that asked nothing and warned about
+    nothing. Moving the leftover to :data:`SUPERSEDED_USERS_ENV_FILENAME` buys
+    the whole of what the delete bought — nothing is left at the old name for a
+    later reader to mistake for the live file — and costs an operator one
+    ``rm`` instead of a restore from backup.
+
+    The set-aside name is fixed rather than timestamped (see
+    :data:`SUPERSEDED_USERS_ENV_FILENAME`), so a copy may already be sitting
+    there from an earlier deploy. When one is, the EARLIER copy is kept
+    untouched and the rename is skipped: it is the copy closer to the last
+    deployment that worked, and overwriting it would lose exactly what this
+    branch exists to preserve. The leftover stays where it is, and the one
+    reported line names both paths.
 
     A moved file lands at mode ``0600`` whatever it carried before, matching
-    every other write of this artifact.
+    every other write of this artifact — the set-aside copy included, since it
+    still holds live secrets and a rename would otherwise carry a
+    world-readable mode along with it.
 
     :param project_root: Project root directory holding both files.
-    :return: Path to ``.env.users`` when a file was moved or a leftover
-        removed, ``None`` when there was no old file to act on.
+    :return: Path to ``.env.users`` when a file was moved or a leftover set
+        aside, ``None`` when there was no old file to act on.
     :raises OSError: When something that is not a regular file already occupies
         the new name; the old file is left where it is.
     """
@@ -74,16 +107,35 @@ def migrate_users_env(project_root: str | Path) -> Path | None:
     if not legacy_path.is_file():
         return None
 
-    # is_file, not exists: deleting the operator's only copy of the web tier's
-    # secrets is justified by a real file standing in its place and by nothing
-    # else. Anything else at that name (a directory, a dangling symlink) falls
-    # through to os.replace below, which fails loudly with the leftover intact.
+    # is_file, not exists: setting the operator's only copy of the web tier's
+    # secrets aside is justified by a real file standing in its place and by
+    # nothing else. Anything else at that name (a directory, a dangling symlink)
+    # falls through to os.replace below, which fails loudly with the leftover
+    # intact.
     if users_path.is_file():
-        legacy_path.unlink()
+        superseded_path = root / SUPERSEDED_USERS_ENV_FILENAME
+        if superseded_path.exists():
+            report_fact(
+                logger,
+                f"{LEGACY_USERS_ENV_FILENAME} left in place: {SUPERSEDED_USERS_ENV_FILENAME} "
+                "from an earlier deploy is kept rather than overwritten",
+            )
+            return users_path
+        # Same atomic same-directory rename as the migrate branch below, and the
+        # same explicit mode after it: this copy carries the same live secrets
+        # the file it came from did.
+        os.replace(legacy_path, superseded_path)
+        os.chmod(superseded_path, 0o600)
         report_fact(
             logger,
-            f"removed leftover {LEGACY_USERS_ENV_FILENAME} ({USERS_ENV_FILENAME} is the "
-            "current name and already exists)",
+            f"{LEGACY_USERS_ENV_FILENAME} set aside as {SUPERSEDED_USERS_ENV_FILENAME} "
+            f"({USERS_ENV_FILENAME} is the current name and already exists)",
+            wrote=(
+                SUPERSEDED_USERS_ENV_FILENAME,
+                f"the leftover {LEGACY_USERS_ENV_FILENAME} this deploy set aside, at mode "
+                f"0600; nothing reads it — delete it once {USERS_ENV_FILENAME} is confirmed "
+                "good",
+            ),
         )
         return users_path
 

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -12,10 +12,12 @@ registry-mode deploys never enter this module.
 
 import os
 import posixpath
+import re
 from pathlib import Path
 from typing import cast
 
 from osprey.build.claude_code_resolver import load_provider_spec
+from osprey.build.claude_code_telemetry import ObservabilityCredentialError
 from osprey.cli.phase_reporter import report_group as _report_group
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.build_progress import with_plain_build_progress
@@ -29,11 +31,18 @@ from osprey.deployment.subprocess_capture import run_captured
 from osprey.deployment.web_terminals.personas import effective_image_source
 from osprey.deployment.wheel_build import _staged_dev_artifact_paths
 from osprey.utils.config import ConfigBuilder
+from osprey.utils.dotenv import ENV_LOCAL_FILENAME
 from osprey.utils.log_filter import quiet_logger
 from osprey.utils.logger import get_logger
 from osprey.utils.workspace import BUILD_DIR_NAME, IMAGE_DIR_NAME
 
 logger = get_logger("deployment.lifecycle")
+
+#: Environment-variable names quoted inside an unresolved-placeholder message,
+#: with any ``:-default`` suffix dropped. The credential check reports the
+#: literal ``${VAR}`` it refused to encode, which is the only place the name of
+#: the variable an operator has to set is available to this module.
+_PLACEHOLDER_NAME_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)[^}]*\}")
 
 
 def _persona_image_context(project_path: str | Path) -> Path:
@@ -493,6 +502,14 @@ def _check_existing_render(persona_name: str, project_path: Path, repo_root: Pat
     ``default_model: ${OPS_MODEL}`` as a literal placeholder and refuse a
     persona the deployment can in fact serve.
 
+    That same resolve also reads the persona's telemetry block, so a missing or
+    unresolved observability credential surfaces here too — and it is reported
+    as the credential problem it is. The remedy for a model the provider cannot
+    serve is an edit to the profile; the remedy for an unset observability
+    credential is a variable in the deployment's own ``.env``, and an operator
+    handed the wrong one of those goes and changes something that was never
+    wrong.
+
     Args:
         persona_name: The persona whose render is being checked.
         project_path: Its rendered project directory under ``build/``.
@@ -524,6 +541,34 @@ def _check_existing_render(persona_name: str, project_path: Path, repo_root: Pat
 
     try:
         load_provider_spec(project_path, env_dir=repo_root)
+    except ObservabilityCredentialError as e:
+        # Ahead of the ValueError arm below on purpose: this IS a ValueError,
+        # so the broad handler would otherwise claim a credential the profile
+        # never names is a bad model, and send the operator to edit profile.yml
+        # over a variable that belongs in the deployment's secret store. Only
+        # the credential failures land here — an unusable endpoint stays a
+        # general telemetry misconfiguration and keeps the broad frame.
+        env_path = repo_root / ENV_LOCAL_FILENAME
+        names = sorted(set(_PLACEHOLDER_NAME_RE.findall(str(e))))
+        if names:
+            # Names only, never values: a placeholder is unresolved precisely
+            # because nothing on this host holds the value to print.
+            fix = " && ".join(f'echo "{var}=<value>" >> {env_path}' for var in names)
+            remedy = f"Set {', '.join(names)} in {env_path} — {fix} — "
+        else:
+            remedy = (
+                "Give the telemetry block's openobserve.user and "
+                f"openobserve.password real values, via {env_path} — "
+            )
+        raise ValueError(
+            f"Persona {persona_name!r} render at {project_path} names "
+            f"observability credentials this deployment cannot resolve:\n  {e}\n"
+            f"{remedy}then re-render with `osprey build`. The model "
+            "configuration is not what is wrong here. Note that `osprey up` "
+            "mints the observability store's own ZO_ROOT_USER_PASSWORD into "
+            "that file when it starts the store, so a deployment that has "
+            "never been started will not have one there yet."
+        ) from e
     except ValueError as e:
         raise ValueError(
             f"Persona {persona_name!r} render at {project_path} has a "

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -45,6 +45,8 @@ from osprey.deployment.runtime_helper import (
 )
 from osprey.deployment.subprocess_capture import run_captured
 from osprey.deployment.web_terminals.artifacts import (
+    BashLaunchTokenConflictError,
+    bash_launch_token_offenders,
     check_bash_launch_token_conflict,
     web_compose_file,
     write_web_terminal_artifacts,
@@ -57,7 +59,10 @@ from osprey.deployment.web_terminals.auth_credentials import (
     ensure_auth_session_secrets,
     raise_if_env_auth_would_be_interpolated,
 )
-from osprey.deployment.web_terminals.env_production import ensure_env_production
+from osprey.deployment.web_terminals.env_production import (
+    ensure_env_production,
+    users_env_generation_problem,
+)
 from osprey.deployment.web_terminals.persona_images import (
     build_persona_images,
     verify_persona_renders,
@@ -144,6 +149,86 @@ def preflight_web_terminals(config: dict, *, repo_root: Path | str | None = None
     # below _provision_auth_secrets silently loses that property.
     _require_auth_sidecar_image(web_terminals)
     _provision_auth_secrets(web_terminals, str(root))
+
+
+def persona_render_problem(config: dict, repo_root: Path | str) -> str | None:
+    """Whether any referenced persona's rendered project would refuse this start.
+
+    :func:`verify_persona_renders` asked as a question. It walks the same set
+    :func:`preflight_web_terminals` walks, in the same mode gate, and reports
+    what that call would have raised — a persona with no render, a partial one,
+    a model its provider cannot serve, or a telemetry block naming an
+    observability credential this deployment cannot resolve.
+
+    Pure: every step reads. ``resolve_personas`` parses the catalog,
+    ``verify_persona_renders`` stats rendered directories and parses their
+    ``config.yml`` (expanding ``${VAR}`` against the repo root's ``.env``), and
+    neither writes a file, starts a process, or touches the container runtime.
+
+    Registry-mode deploys answer ``None`` unconditionally: nothing on this host
+    renders their persona projects, so there is no render to have a problem
+    with — the same gate :func:`preflight_web_terminals` applies.
+
+    :param config: Raw deploy config.
+    :param repo_root: The deployment repo whose ``build/`` holds the renders.
+    :return: The refusal sentence, or ``None`` when every persona is usable.
+    """
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    if effective_image_source(web_terminals) != "local":
+        return None
+    facility_prefix = (config.get("facility") or {}).get("prefix") or ""
+    registry_cfg = config.get("registry") or {}
+    try:
+        resolved_users = resolve_personas(web_terminals, registry_cfg, facility_prefix, strict=True)
+        verify_persona_renders(config, resolved_users, repo_root=Path(repo_root))
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def web_terminal_preflight_problems(
+    config: dict, *, repo_root: Path | str | None = None
+) -> list[tuple[str, str]]:
+    """Every :func:`preflight_web_terminals` refusal that can be probed instead.
+
+    The collectable subset of the fail-fast gate, in the gate's own order, so an
+    operator reading the collected report meets the findings where the deploy
+    would have hit them. Each entry is a ``(problem, remedy)`` pair; these three
+    refusals all carry their fix inside their own prose, so the remedy half is
+    empty and the enumeration prints one block per finding.
+
+    Deliberately NOT the whole of :func:`preflight_web_terminals`:
+
+    * The registry-mode and absent-chain arms of :func:`ensure_env_production`
+      stay behind. Both are refusals about a file that does not exist rather
+      than about its contents, and the gate reports them unchanged.
+    * :func:`_require_auth_sidecar_image` and :func:`_provision_auth_secrets`
+      stay behind because the second of them MINTS — it establishes credentials
+      and prints them once. A probe that could write is not a probe, and the
+      pair are ordered against each other for exactly that reason.
+
+    Nothing here writes, so calling it costs the deploy only the file reads and
+    leaves the gate itself to run afterwards, unchanged and idempotent.
+
+    :param config: Raw deploy config.
+    :param repo_root: The deployment repo the renders and secret files are read
+        from. Defaults to the one resolved from ``config``, as the gate does.
+    :return: The findings, empty when nothing is wrong.
+    """
+    root = _resolved_repo_root(config, repo_root)
+    findings: list[tuple[str, str]] = []
+
+    if (problem := persona_render_problem(config, root)) is not None:
+        findings.append((problem, ""))
+    # Same position as in the gate: ahead of the .env.users question, because a
+    # persona that may arm hardware from a shell is the more serious of the two
+    # and an operator reading top-down should meet it first.
+    if offenders := bash_launch_token_offenders(config, root):
+        findings.append((str(BashLaunchTokenConflictError(offenders)), ""))
+    if (problem := users_env_generation_problem(config, root)) is not None:
+        findings.append((problem, ""))
+
+    return findings
 
 
 def _provision_auth_secrets(web_terminals: dict, repo_root: str) -> None:

--- a/src/osprey/health/core/channel_finder.py
+++ b/src/osprey/health/core/channel_finder.py
@@ -152,13 +152,20 @@ def _database_row(db_path: Path | None) -> CheckResult:
     ``error`` when a path is configured but the file is missing or empty (the
     data bundle should have materialized it); ``warning`` when no path is
     configured at all; ``ok`` otherwise, with the file size as ``value``.
+
+    Every message names *the active pipeline's* ``database.path`` file, because
+    that one file is all this row stats. A deployment can hold more than one
+    channel database — the middle-layer DuckDB that ``channel_finder_channels``
+    reports on separately is a different file, under a different key — so a row
+    saying "the channel database" would be vouching for artifacts it never
+    looked at.
     """
     if db_path is None:
         return CheckResult(
             "channel_finder_database",
             CATEGORY,
             Status.WARNING,
-            "No channel database path configured",
+            "No database.path configured for the active pipeline",
             details="Set the pipeline's database.path in config.yml.",
         )
 
@@ -169,7 +176,7 @@ def _database_row(db_path: Path | None) -> CheckResult:
             "channel_finder_database",
             CATEGORY,
             Status.ERROR,
-            f"Channel database missing at {db_path}",
+            f"Active pipeline's channel database file missing at {db_path}",
             details="The data bundle materializes this file — rebuild it, or fix database.path.",
         )
 
@@ -178,21 +185,25 @@ def _database_row(db_path: Path | None) -> CheckResult:
             "channel_finder_database",
             CATEGORY,
             Status.ERROR,
-            f"Channel database is empty ({db_path})",
-            details="The file exists but has zero bytes — rebuild the channel database.",
+            f"Active pipeline's channel database file is empty ({db_path})",
+            details="The file exists but has zero bytes — rebuild it, or fix database.path.",
         )
 
     return CheckResult(
         "channel_finder_database",
         CATEGORY,
         Status.OK,
-        "Channel database present",
+        "Active pipeline's channel database file present",
         value=_humanize_size(size),
     )
 
 
 def _freshness_row(db_path: Path) -> CheckResult:
-    """Report the database file's modification age (always informational)."""
+    """Report the ``database.path`` file's modification age (informational).
+
+    Named as narrowly as :func:`_database_row`, and for the same reason: this
+    is the age of one file, not of every channel database the deployment holds.
+    """
     try:
         mtime = db_path.stat().st_mtime
     except OSError:
@@ -200,13 +211,13 @@ def _freshness_row(db_path: Path) -> CheckResult:
             "channel_finder_freshness",
             CATEGORY,
             Status.OK,
-            "Database build age is unavailable",
+            "Build age of the active pipeline's channel database file is unavailable",
         )
     return CheckResult(
         "channel_finder_freshness",
         CATEGORY,
         Status.OK,
-        "Channel database build age",
+        "Active pipeline's channel database file build age",
         value=f"built {_humanize_age(datetime.fromtimestamp(mtime))}",
     )
 

--- a/src/osprey/templates/services/archiver_recorder/docker-compose.yml.j2
+++ b/src/osprey/templates/services/archiver_recorder/docker-compose.yml.j2
@@ -50,7 +50,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     # No `ports:` and no `healthcheck:` — deliberately. This service opens no
     # listening socket, so it has nothing to publish and nothing an HTTP or TCP

--- a/src/osprey/templates/services/archiver_recorder/docker-compose.yml.j2
+++ b/src/osprey/templates/services/archiver_recorder/docker-compose.yml.j2
@@ -50,6 +50,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # No `ports:` and no `healthcheck:` — deliberately. This service opens no
     # listening socket, so it has nothing to publish and nothing an HTTP or TCP

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -71,6 +71,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.bluesky.port | default(8090) }}:{{ services.bluesky.port | default(8090) }}"
@@ -341,6 +350,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # No `ports:` — deliberately. Publishing the control socket would put a
     # second route to plan execution next to the bridge's launch-token gate,

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -71,7 +71,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.bluesky.port | default(8090) }}:{{ services.bluesky.port | default(8090) }}"
@@ -342,7 +341,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     # No `ports:` — deliberately. Publishing the control socket would put a
     # second route to plan execution next to the bridge's launch-token gate,

--- a/src/osprey/templates/services/bluesky_panels/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky_panels/docker-compose.yml.j2
@@ -52,6 +52,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.bluesky_panels.port | default(8095) }}:{{ services.bluesky_panels.port | default(8095) }}"

--- a/src/osprey/templates/services/bluesky_panels/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky_panels/docker-compose.yml.j2
@@ -52,7 +52,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.bluesky_panels.port | default(8095) }}:{{ services.bluesky_panels.port | default(8095) }}"

--- a/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
+++ b/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
@@ -61,7 +61,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
+++ b/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
@@ -61,6 +61,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/src/osprey/templates/services/event_dispatcher/docker-compose.yml.j2
+++ b/src/osprey/templates/services/event_dispatcher/docker-compose.yml.j2
@@ -48,6 +48,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
 {#- Fingerprint of the env chain (`.env.shared` then `.env`) this deploy read,
     interpolated at compose time from the variable `runtime_env` injects. The
     container runtime does not diff a running container's environment against

--- a/src/osprey/templates/services/event_dispatcher/docker-compose.yml.j2
+++ b/src/osprey/templates/services/event_dispatcher/docker-compose.yml.j2
@@ -48,7 +48,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
 {#- Fingerprint of the env chain (`.env.shared` then `.env`) this deploy read,
     interpolated at compose time from the variable `runtime_env` injects. The
     container runtime does not diff a running container's environment against

--- a/src/osprey/templates/services/gchat_bridge/docker-compose.yml.j2
+++ b/src/osprey/templates/services/gchat_bridge/docker-compose.yml.j2
@@ -91,6 +91,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/src/osprey/templates/services/gchat_bridge/docker-compose.yml.j2
+++ b/src/osprey/templates/services/gchat_bridge/docker-compose.yml.j2
@@ -91,7 +91,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/src/osprey/templates/services/mongodb/docker-compose.yml.j2
+++ b/src/osprey/templates/services/mongodb/docker-compose.yml.j2
@@ -31,7 +31,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     # Block compression for every collection this server creates. It is set on
     # the SERVER, not per-collection, precisely because the seeder creates the

--- a/src/osprey/templates/services/mongodb/docker-compose.yml.j2
+++ b/src/osprey/templates/services/mongodb/docker-compose.yml.j2
@@ -31,6 +31,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # Block compression for every collection this server creates. It is set on
     # the SERVER, not per-collection, precisely because the seeder creates the

--- a/src/osprey/templates/services/nextcloud_bridge/docker-compose.yml.j2
+++ b/src/osprey/templates/services/nextcloud_bridge/docker-compose.yml.j2
@@ -91,6 +91,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/src/osprey/templates/services/nextcloud_bridge/docker-compose.yml.j2
+++ b/src/osprey/templates/services/nextcloud_bridge/docker-compose.yml.j2
@@ -91,7 +91,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/src/osprey/templates/services/openobserve/docker-compose.yml.j2
+++ b/src/osprey/templates/services/openobserve/docker-compose.yml.j2
@@ -32,6 +32,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services.openobserve | default({})).port | default(5080) }}:5080/tcp"

--- a/src/osprey/templates/services/openobserve/docker-compose.yml.j2
+++ b/src/osprey/templates/services/openobserve/docker-compose.yml.j2
@@ -32,7 +32,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services.openobserve | default({})).port | default(5080) }}:5080/tcp"

--- a/src/osprey/templates/services/postgresql/docker-compose.yml.j2
+++ b/src/osprey/templates/services/postgresql/docker-compose.yml.j2
@@ -15,7 +15,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.postgresql.port_host }}:5432"

--- a/src/osprey/templates/services/postgresql/docker-compose.yml.j2
+++ b/src/osprey/templates/services/postgresql/docker-compose.yml.j2
@@ -15,6 +15,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ services.postgresql.port_host }}:5432"

--- a/src/osprey/templates/services/qmd/docker-compose.yml.j2
+++ b/src/osprey/templates/services/qmd/docker-compose.yml.j2
@@ -63,6 +63,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
     restart: unless-stopped
 {#- Published ports, suppressed under `host`, where the container shares the

--- a/src/osprey/templates/services/qmd/docker-compose.yml.j2
+++ b/src/osprey/templates/services/qmd/docker-compose.yml.j2
@@ -63,7 +63,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
       osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
     restart: unless-stopped
 {#- Published ports, suppressed under `host`, where the container shares the

--- a/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
+++ b/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
@@ -55,6 +55,15 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services.virtual_accelerator | default({})).port | default(5064) }}:{{ (services.virtual_accelerator | default({})).port | default(5064) }}/tcp"

--- a/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
+++ b/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
@@ -55,7 +55,6 @@ services:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       com.osprey.repo-id: "{{ osprey_labels.repo_id }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services.virtual_accelerator | default({})).port | default(5064) }}:{{ (services.virtual_accelerator | default({})).port | default(5064) }}/tcp"

--- a/tests/cli/test_bluesky_compose_render.py
+++ b/tests/cli/test_bluesky_compose_render.py
@@ -52,7 +52,6 @@ def _render(
         "osprey_labels": {
             "project_name": "proj",
             "project_root": "/tmp/proj",
-            "deployed_at": "2026-08-07T00:00:00Z",
         },
         "osprey_version": "2026.8.1",
         "system": {"timezone": "UTC"},
@@ -585,7 +584,6 @@ def test_redis_image_honours_a_config_override() -> None:
                 "osprey_labels": {
                     "project_name": "proj",
                     "project_root": "/tmp/proj",
-                    "deployed_at": "x",
                 },
                 "system": {"timezone": "UTC"},
                 "deployment": {},
@@ -731,7 +729,6 @@ def test_dev_guard_keys_on_the_build_arg_the_compose_template_passes() -> None:
                 "osprey_labels": {
                     "project_name": "proj",
                     "project_root": "/tmp/proj",
-                    "deployed_at": "x",
                 },
                 "system": {"timezone": "UTC"},
                 "deployment": {},
@@ -755,7 +752,6 @@ def test_dev_guard_keys_on_the_build_arg_the_compose_template_passes() -> None:
                 "osprey_labels": {
                     "project_name": "proj",
                     "project_root": "/tmp/proj",
-                    "deployed_at": "x",
                 },
                 "system": {"timezone": "UTC"},
                 "deployment": {},

--- a/tests/cli/test_bluesky_service_registration.py
+++ b/tests/cli/test_bluesky_service_registration.py
@@ -139,7 +139,6 @@ def _render_copied_compose(project_path: Path, config: dict) -> dict:
         "osprey_labels": {
             "project_name": "p",
             "project_root": str(project_path),
-            "deployed_at": "x",
         },
         "osprey_version": "",
         "system": {"timezone": "UTC"},

--- a/tests/cli/test_lifecycle_promotions.py
+++ b/tests/cli/test_lifecycle_promotions.py
@@ -1424,17 +1424,24 @@ class TestWebTerminalSecretsAreReported:
         assert env_production.LEGACY_USERS_ENV_FILENAME in printed.flowed
         assert ".env.users" in printed.flowed
 
-    def test_a_deleted_leftover_secrets_file_says_which_one_it_removed(
+    def test_a_superseded_leftover_secrets_file_says_where_it_went(
         self, default_altitude, printed, tmp_path
     ):
-        """The other half of the migration: a delete, of a file holding secrets."""
+        """The other half of the migration: a leftover secrets file set aside.
+
+        Set aside rather than deleted, so the line names the path the operator
+        can go and read -- and the promotion is what tells them a second
+        secret-bearing file is now sitting in the repo root.
+        """
         (tmp_path / env_production.LEGACY_USERS_ENV_FILENAME).write_text("A=1\n", encoding="utf-8")
         (tmp_path / ".env.users").write_text("B=2\n", encoding="utf-8")
 
         assert env_production.migrate_users_env(tmp_path) == tmp_path / ".env.users"
 
-        assert_promoted(default_altitude, printed, "removed leftover .env.production")
+        assert_promoted(default_altitude, printed, ".env.production set aside as")
+        assert env_production.SUPERSEDED_USERS_ENV_FILENAME in printed.flowed
         assert not (tmp_path / env_production.LEGACY_USERS_ENV_FILENAME).exists()
+        assert (tmp_path / env_production.SUPERSEDED_USERS_ENV_FILENAME).is_file()
 
 
 class TestWebTerminalHostChangesAreReported:

--- a/tests/cli/test_profile_conventions.py
+++ b/tests/cli/test_profile_conventions.py
@@ -22,6 +22,7 @@ from osprey.cli.profile_conventions import (
     CONVENTION_DIRS,
     CONVENTION_SOURCES,
     KNOWN_ROOT_ENTRIES,
+    PER_USER_CONTEXT_DIRNAME,
     PROJECT_MIRROR_DIR,
     RESERVED_PROJECT_PATHS,
     STATE_DIR,
@@ -385,6 +386,65 @@ def test_loose_file_in_a_directory_shaped_convention_is_rejected(profile_dir: Pa
     message = str(excinfo.value)
     assert "skills/orbit-check.md" in message
     assert "one directory per skill" in message
+
+
+def test_loose_file_in_the_per_user_convention_states_the_roster_rule(profile_dir: Path):
+    """The generic "move it into ``<stem>/``" advice manufactures a phantom user.
+
+    Directory names under the per-user convention are matched against the
+    resolved roster, so a directory invented to hold a loose file names nobody:
+    the build skips it as departed, and the operator's file stops being read
+    while they believe they followed the instructions. The message has to name
+    the rule, and must not offer the move that breaks it.
+    """
+    _write(profile_dir / PER_USER_CONTEXT_DIRNAME / "shift-notes.md")
+
+    with pytest.raises(BuildProfileError) as excinfo:
+        validate_convention_sources(profile_dir)
+
+    message = str(excinfo.value)
+    assert f"{PER_USER_CONTEXT_DIRNAME}/shift-notes.md is a file" in message
+    assert "named for a user on the resolved roster" in message
+    assert "skipped as a user who has left" in message
+    assert f"{PER_USER_CONTEXT_DIRNAME}/<user>/shift-notes.md" in message
+    # The advice that would quietly stop the file being read.
+    assert f"Move it into {PER_USER_CONTEXT_DIRNAME}/shift-notes/" not in message
+
+
+def test_base_md_in_the_per_user_convention_is_sent_through_the_mirror(profile_dir: Path):
+    """``base.md`` is nobody's context, so no per-user directory can hold it.
+
+    It is the baseline every seeded user starts from, installed by the build at
+    one path. The only route a profile has to that path today is the
+    ``project/`` mirror, so the refusal names it rather than leaving the
+    operator to guess at a user directory that would never be read.
+    """
+    _write(profile_dir / PER_USER_CONTEXT_DIRNAME / "base.md")
+
+    with pytest.raises(BuildProfileError) as excinfo:
+        validate_convention_sources(profile_dir)
+
+    message = str(excinfo.value)
+    assert f"{PROJECT_MIRROR_DIR}/docker/web-terminal-context/base.md" in message
+    assert "the baseline every seeded user starts from" in message
+    assert f"Move it into {PER_USER_CONTEXT_DIRNAME}/base/" not in message
+
+
+def test_the_other_directory_conventions_keep_their_move_advice(profile_dir: Path):
+    """Only the per-user convention constrains its directory names.
+
+    A skill directory is free-form, so ``skills/<stem>/`` is exactly the right
+    move there — the per-user wording must not have spread to the conventions
+    it does not describe.
+    """
+    _write(profile_dir / "skills" / "orbit-check.md")
+
+    with pytest.raises(BuildProfileError) as excinfo:
+        validate_convention_sources(profile_dir)
+
+    message = str(excinfo.value)
+    assert "Move it into skills/orbit-check/" in message
+    assert "roster" not in message
 
 
 def test_hidden_entries_do_not_trip_source_validation(profile_dir: Path):

--- a/tests/cli/test_scaffold_ci.py
+++ b/tests/cli/test_scaffold_ci.py
@@ -274,6 +274,28 @@ def test_a_profile_without_coordinates_is_refused_cleanly(
     assert not (bare / CI_PATH).exists()
 
 
+def test_the_refusal_points_at_the_commented_block_the_profile_already_carries(
+    tmp_path: Path,
+) -> None:
+    """ "Add one naming the CI platform" reads as authoring a block from scratch.
+
+    Every emitted profile already ends with a commented ``deploy:`` example, so
+    the operator's work is uncommenting and filling in — a smaller, different
+    task than the one the old wording described, and one they can only find if
+    the refusal says where to look.
+    """
+    bare = build_exemplar_repo(tmp_path / "no-coordinates", with_ci=False)
+
+    with pytest.raises(ConfigurationError) as caught:
+        scaffold_deploy_files(bare)
+
+    message = " ".join(str(caught.value).split())
+    assert "commented 'deploy:' example" in message
+    assert "at the end of the file" in message
+    assert "uncomment it" in message
+    assert "the CI platform, the registry and the deploy host" in message
+
+
 def test_the_engines_missing_profile_message_names_this_verb(tmp_path: Path) -> None:
     """The one refusal the resolver cannot pre-empt still points somewhere.
 

--- a/tests/cli/test_telemetry_env.py
+++ b/tests/cli/test_telemetry_env.py
@@ -20,6 +20,7 @@ from osprey.build.claude_code_resolver import (
 )
 from osprey.build.claude_code_telemetry import (
     TELEMETRY_ENV_VARS,
+    ObservabilityCredentialError,
     TelemetryConfigError,
     _build_telemetry_env,
     _gate_is_on,
@@ -658,3 +659,129 @@ def test_telemetry_misconfig_raises_telemetry_config_error():
         )
     with pytest.raises(TelemetryConfigError):
         _build_telemetry_env({"enabled": True})
+
+
+# ── observability-credential error type ──────────────────────────
+
+
+def test_credential_error_subclass_chain():
+    """The credential type nests inside the general one, which nests inside ValueError.
+
+    Every existing handler catches one of the two outer types, so the narrower
+    type must stay a subclass of both or those handlers stop seeing the failure
+    they already handle today.
+    """
+    assert issubclass(ObservabilityCredentialError, TelemetryConfigError)
+    assert issubclass(ObservabilityCredentialError, ValueError)
+
+
+@pytest.mark.parametrize(
+    "openobserve",
+    [
+        {"user": "u"},
+        {"password": "p"},
+        {},
+        {"user": "", "password": ""},
+    ],
+    ids=["password-absent", "user-absent", "block-empty", "both-blank"],
+)
+def test_missing_or_blank_credential_raises_the_credential_type(openobserve):
+    """A credential the operator has to supply reports itself as a credential fault."""
+    with pytest.raises(ObservabilityCredentialError):
+        _build_telemetry_env(
+            {"enabled": True, "backend": "openobserve", "openobserve": openobserve}
+        )
+
+
+@pytest.mark.parametrize(
+    "openobserve",
+    [
+        {"user": "${STORE_USER}", "password": "p"},
+        {"user": "u", "password": "${STORE_PASSWORD}"},
+    ],
+    ids=["user-unresolved", "password-unresolved"],
+)
+def test_unresolved_credential_var_raises_the_credential_type(openobserve):
+    """An unresolved ${VAR} credential is the same kind of fault as a blank one.
+
+    Both are fixed by putting a value in the deployment's secret store, so both
+    carry the type whose remedy says so.
+    """
+    with pytest.raises(ObservabilityCredentialError):
+        _build_telemetry_env(
+            {"enabled": True, "backend": "openobserve", "openobserve": openobserve}
+        )
+
+
+def test_deferred_credential_still_raises_the_credential_type_when_absent():
+    """Deferral covers an unresolved ${VAR}; an absent credential keeps its type."""
+    with pytest.raises(ObservabilityCredentialError):
+        _build_telemetry_env(
+            {"enabled": True, "backend": "openobserve", "openobserve": {"user": "u"}},
+            defer_unresolved_creds=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "telemetry",
+    [
+        {"enabled": True, "backend": "jaeger"},
+        {"enabled": True},
+        {"enabled": True, "endpoint": "http://${COLLECTOR_HOST}:4318"},
+        {
+            "enabled": True,
+            "backend": "openobserve",
+            "protocol": "grpc",
+            "openobserve": {"user": "u", "password": "p"},
+        },
+    ],
+    ids=["no-endpoint-other-backend", "no-endpoint-no-backend", "unresolved-var", "grpc-derived"],
+)
+def test_endpoint_faults_keep_the_general_telemetry_type(telemetry):
+    """An endpoint fault is not a credential fault, and must not borrow its type.
+
+    A handler that offers a credential remedy would send the operator to the
+    secret store for a problem that lives in the endpoint config.
+    """
+    with pytest.raises(TelemetryConfigError) as caught:
+        _build_telemetry_env(telemetry)
+    assert not isinstance(caught.value, ObservabilityCredentialError)
+
+
+def test_existing_broad_handlers_still_catch_a_credential_fault():
+    """The callers that catch TelemetryConfigError or ValueError keep working."""
+    cfg = {"enabled": True, "backend": "openobserve", "openobserve": {"user": "u"}}
+    with pytest.raises(TelemetryConfigError):
+        _build_telemetry_env(cfg)
+    with pytest.raises(ValueError):
+        _build_telemetry_env(cfg)
+
+
+def test_deferred_var_credential_warns_not_raises_through_resolve(monkeypatch, recwarn):
+    """Pins the build-time catch site's reachability contract through resolve().
+
+    ``build_cmd.py``'s render call sets ``defer_unresolved_telemetry_creds=True``
+    around ``load_provider_spec()`` and catches ``ValueError``. An unresolved
+    ``${VAR}`` credential must warn rather than raise all the way through
+    ``resolve()`` — not just at the ``_build_telemetry_env``/
+    ``_openobserve_auth_header`` leaf — or the comment at that catch site goes
+    stale silently. A missing/blank credential is a separate arm (see
+    ``test_deferred_credential_still_raises_the_credential_type_when_absent``)
+    and keeps raising even when deferred.
+    """
+    monkeypatch.setattr(resolver, "_running_in_container", lambda: False)
+    spec = ClaudeCodeModelResolver.resolve(
+        {
+            "provider": "anthropic",
+            "telemetry": {
+                "enabled": True,
+                "backend": "openobserve",
+                "openobserve": {"user": "${STORE_USER}", "password": "p"},
+            },
+        },
+        defer_unresolved_telemetry_creds=True,
+    )
+    assert spec is not None
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in spec.env_block
+    assert spec.env_block["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert any("unresolved" in str(w.message) for w in recwarn)

--- a/tests/cli/test_users_group.py
+++ b/tests/cli/test_users_group.py
@@ -1099,6 +1099,30 @@ class TestUsersEnv:
         assert result.exit_code == 0
         assert "STALE" not in (repo_root / "out.env").read_text(encoding="utf-8")
 
+    def test_the_observability_account_name_crosses_but_its_password_does_not(
+        self, cli_runner, tmp_path, monkeypatch
+    ):
+        """The render and a deploy share one builder, so what the deploy copies
+        this verb copies too — no rule of its own on either side. Pinned on the
+        pair that must not travel together: the store's account name is not a
+        secret and reaches the terminals, while its admin password is a single
+        credential for a store holding every transcript and never does."""
+        repo_root = _make_repo(tmp_path, USERS_ENV_CONFIG)
+        (repo_root / ".env").write_text(
+            "CBORG_API_KEY=llm-secret\n"
+            "ZO_ROOT_USER_EMAIL=store-account@example.org\n"
+            "ZO_ROOT_USER_PASSWORD=store-admin-secret\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(repo_root)
+
+        result = cli_runner.invoke(users, ["env"])
+
+        assert result.exit_code == 0
+        assert "ZO_ROOT_USER_EMAIL=store-account@example.org" in result.stdout.splitlines()
+        assert "ZO_ROOT_USER_PASSWORD" not in result.stdout
+        assert "store-admin-secret" not in result.stdout
+
     def test_a_missing_secrets_file_aborts(self, cli_runner, tmp_path, monkeypatch):
         repo_root = _make_repo(tmp_path, USERS_ENV_CONFIG)
         monkeypatch.chdir(repo_root)

--- a/tests/cli/test_web_cmd.py
+++ b/tests/cli/test_web_cmd.py
@@ -968,6 +968,64 @@ class TestPreflightAuthSecret:
 
         assert result.exit_code == 0
 
+    def test_credential_error_reported_not_hidden(self, runner, monkeypatch, deployment):
+        """A telemetry-credential failure explains itself instead of vanishing.
+
+        `ObservabilityCredentialError` subclasses `ValueError`, so the broad
+        skip below would swallow it and leave pre-flight silent about a read
+        that never happened. The launch still proceeds: telemetry credentials
+        say nothing about whether the terminal can authenticate.
+        """
+        from osprey.build.claude_code_telemetry import ObservabilityCredentialError
+
+        self._stub_launch(monkeypatch)
+        self._stub_clean_ports(monkeypatch)
+
+        def _raise(*_a, **_kw):
+            raise ObservabilityCredentialError(
+                "openobserve.user / openobserve.password are missing or blank"
+            )
+
+        monkeypatch.setattr("osprey.build.claude_code_resolver.load_provider_spec", _raise)
+        own_port = _free_port()
+
+        result = runner.invoke(
+            web,
+            ["--repo", str(deployment), "--port", str(own_port), "--shell", "true"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "⚠" in result.stderr
+        assert "provider auth check skipped" in result.stderr
+        assert "openobserve.password" in result.stderr
+
+    def test_unrelated_value_error_still_skips_quietly(self, runner, monkeypatch, deployment):
+        """The narrow arm must not widen the catch it sits in front of.
+
+        An unknown provider name (or any other plain `ValueError`) is Probe 3's
+        diagnosis to make, so Probe 2 keeps saying nothing about it.
+        """
+        self._stub_launch(monkeypatch)
+        self._stub_clean_ports(monkeypatch)
+
+        def _raise(*_a, **_kw):
+            raise ValueError("unknown provider 'nowhere'")
+
+        monkeypatch.setattr("osprey.build.claude_code_resolver.load_provider_spec", _raise)
+        own_port = _free_port()
+
+        result = runner.invoke(
+            web,
+            ["--repo", str(deployment), "--port", str(own_port), "--shell", "true"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "provider auth check skipped" not in result.output
+        assert "provider auth check skipped" not in result.stderr
+        assert "nowhere" not in result.output
+
 
 class TestPreflightConfigValidity:
     """Probe 3: config.yml and .claude/settings.json must at least parse."""

--- a/tests/deployment/goldens/exemplar-profile/services/facility-mcp/docker-compose.yml.j2
+++ b/tests/deployment/goldens/exemplar-profile/services/facility-mcp/docker-compose.yml.j2
@@ -22,6 +22,15 @@ services:
     labels:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services['facility-mcp'] | default({})).port | default(8200) }}:8200/tcp"

--- a/tests/deployment/goldens/exemplar-profile/services/facility-mcp/docker-compose.yml.j2
+++ b/tests/deployment/goldens/exemplar-profile/services/facility-mcp/docker-compose.yml.j2
@@ -22,7 +22,6 @@ services:
     labels:
       osprey.project.name: "{{ osprey_labels.project_name }}"
       osprey.project.root: "{{ osprey_labels.project_root }}"
-      osprey.deployed.at: "{{ osprey_labels.deployed_at }}"
     restart: unless-stopped
     ports:
       - "{{ deployment.bind_address | default('127.0.0.1') }}:{{ (services['facility-mcp'] | default({})).port | default(8200) }}:8200/tcp"

--- a/tests/deployment/test_bluesky_token_mint.py
+++ b/tests/deployment/test_bluesky_token_mint.py
@@ -133,15 +133,45 @@ def test_bluesky_process_env_token_not_written_to_dotenv(captured_argv, monkeypa
     assert "BLUESKY_LAUNCH_TOKEN" not in env
 
 
-def test_an_exposed_bluesky_deploy_refuses_an_empty_token(captured_argv, monkeypatch, tmp_path):
-    # A token explicitly set empty must not be auto-overwritten, and a deployment
-    # reachable off-host must refuse rather than bind a fail-open server to it.
+def test_an_empty_dotenv_token_is_minted_on_the_default_loopback_deploy(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
+):
+    """``BLUESKY_LAUNCH_TOKEN=`` in ``.env`` is a blank the mint fills in.
+
+    The off-host refusal below is the only guard that ever caught this, and a
+    default deploy publishes on loopback — so before the mint reached empty
+    values, a bare ``VAR=`` line brought the bridge up with no launch token and
+    nothing said so.
+    """
+    (tmp_path / ".env").write_text("BLUESKY_LAUNCH_TOKEN=\n", encoding="utf-8")
+    # The deploy loads that .env over the process environment before it mints,
+    # so this is the state the predicate sees. Set through monkeypatch so the
+    # minted value does not outlive the test.
     monkeypatch.setenv("BLUESKY_LAUNCH_TOKEN", "")
 
-    with pytest.raises(RuntimeError, match="reachable off-host with an empty token"):
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert env["BLUESKY_LAUNCH_TOKEN"], "the empty launch token was left empty"
+    assert env["BLUESKY_TILED_API_KEY"].isalnum()
+
+
+def test_an_exposed_bluesky_deploy_refuses_an_empty_exported_token(
+    captured_argv, monkeypatch, tmp_path
+):
+    # An *exported* empty token is the one spelling a mint cannot repair: the
+    # export shadows the .env line minting would write, so nothing is generated
+    # and a deployment reachable off-host refuses rather than bind a fail-open
+    # server to it. The remedy names the environment, since editing .env would
+    # not change what compose resolves while the export stands.
+    monkeypatch.setenv("BLUESKY_LAUNCH_TOKEN", "")
+
+    with pytest.raises(RuntimeError, match="reachable off-host with an empty token") as exc_info:
         container_lifecycle.deploy_up(
             str(tmp_path / "config.yml"), detached=True, expose_network=True
         )
+
+    assert "Unset BLUESKY_LAUNCH_TOKEN in the environment" in str(exc_info.value)
 
 
 def test_bluesky_alongside_dispatch_mints_both_independently(

--- a/tests/deployment/test_collect_all_preflight.py
+++ b/tests/deployment/test_collect_all_preflight.py
@@ -1,0 +1,428 @@
+"""The collect-all precondition pass: probe everything cheap, refuse once.
+
+A start has several preconditions answerable from the deployment's own files
+before anything is built. Raised one at a time they cost the operator a whole
+deploy attempt per finding. These tests pin the three properties that make the
+pass worth having and safe to run where it runs:
+
+* it reports every finding in ONE refusal, in the order the deploy would have
+  met them;
+* it sits BELOW every step that writes what it reads, so it never refuses what
+  the deploy is about to provide;
+* it sits ABOVE the first minutes-long step.
+
+The probes' own answers are pinned by the suites of the checks they mirror
+(``test_provision.py``, ``test_artifacts.py``, ``test_env_production.py``);
+what is tested here is the collecting, the placement, and the frame.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from osprey.deployment import container_lifecycle
+from osprey.deployment.errors import DeploymentPreconditionError, UnmetPreconditionsError
+from osprey.deployment.runtime_helper import ComposeProvider
+from osprey.deployment.web_terminals import provision
+
+# ---------------------------------------------------------------------------
+# The frame
+# ---------------------------------------------------------------------------
+
+
+def test_the_frame_enumerates_every_finding_under_a_counted_summary():
+    exc = UnmetPreconditionsError(
+        [
+            ("the render is missing", "run `osprey build`"),
+            ("the token conflicts with a shell", ""),
+        ]
+    )
+
+    assert exc.summary == "2 unmet preconditions on this deployment"
+    assert exc.reason == (
+        "1. the render is missing\n   run `osprey build`\n\n2. the token conflicts with a shell"
+    )
+
+
+def test_a_multi_line_finding_stays_one_numbered_item():
+    """Continuation lines indent under the number, or a finding that wraps
+    reads as two separate problems in the rendered block."""
+    exc = UnmetPreconditionsError([("first line\nsecond line", "")])
+
+    assert exc.reason == "1. first line\n   second line"
+
+
+def test_a_single_finding_gets_the_same_structured_frame():
+    """N >= 1, deliberately: a start that refuses over one precondition reads
+    exactly like one that refuses over four, so the common case is not also the
+    unfamiliar one."""
+    exc = UnmetPreconditionsError([("the render is missing", "run `osprey build`")])
+
+    assert exc.summary == "1 unmet precondition on this deployment"
+    assert exc.reason == "1. the render is missing\n   run `osprey build`"
+
+
+def test_the_frame_carries_no_top_level_remedy():
+    """With several things to fix there is no single `→` line that is honest,
+    so each finding carries its own and the aggregate carries none -- the
+    convention `gate_start_from_build` already follows for its two exits."""
+    exc = UnmetPreconditionsError([("a", "fix a"), ("b", "fix b")])
+
+    assert exc.remedy == ""
+
+
+def test_the_aggregate_reaches_the_one_precondition_handler():
+    """It has to be a DeploymentPreconditionError, or the start verbs' single
+    `except` clause renders it as a crash instead of a refusal."""
+    exc = UnmetPreconditionsError([("a", "")])
+
+    assert isinstance(exc, DeploymentPreconditionError)
+    assert str(exc) == f"{exc.summary}: {exc.reason}"
+
+
+def test_the_cli_renders_the_aggregate_through_the_shared_refusal_shape(capsys):
+    """No new handler: the aggregate lands on the one renderer every unmet
+    precondition already goes through, and its three fields fill the same three
+    slots."""
+    import click
+
+    from osprey.cli import deploy_cmd
+
+    exc = UnmetPreconditionsError([("the render is missing", "run `osprey build`"), ("b", "")])
+
+    with pytest.raises(click.Abort):
+        deploy_cmd._abort_unmet_precondition(exc, nothing_done="Nothing was deployed.")
+
+    rendered = capsys.readouterr().err
+    assert "2 unmet preconditions on this deployment" in rendered
+    assert "1. the render is missing" in rendered
+    assert "2. b" in rendered
+    assert "Nothing was deployed." in rendered
+    # No `→` line: every remedy here belongs to one finding, and a trailing
+    # arrow would name one of them as THE way through.
+    assert "→" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Collecting: three problems, one refusal
+# ---------------------------------------------------------------------------
+
+
+def _persona_project(root: Path, name: str, *, writes: bool, denies_bash: bool) -> str:
+    """Write a persona project under *root*; return its relative project_path."""
+    project_dir = root / "profiles" / name
+    (project_dir / ".claude").mkdir(parents=True)
+    (project_dir / "config.yml").write_text(
+        yaml.safe_dump({"project_name": name, "control_system": {"writes_enabled": writes}}),
+        encoding="utf-8",
+    )
+    deny = ["Bash", "Edit"] if denies_bash else ["Edit"]
+    (project_dir / ".claude" / "settings.json").write_text(
+        json.dumps({"permissions": {"deny": deny}}), encoding="utf-8"
+    )
+    return f"profiles/{name}"
+
+
+def _three_problem_config(root: Path) -> dict:
+    """One deployment carrying one of each collectable problem.
+
+    Two personas, because the render problem and the shell/token conflict
+    cannot both be true of the same one: a persona with no render contributes
+    nothing to the launch-token set, so the conflict needs a persona whose
+    render is there and wrong.
+    """
+    return {
+        "deployed_services": [],
+        "facility": {"prefix": "test"},
+        "registry": {"url": "registry.example.org/test"},
+        "claude_code": {"telemetry": {"openobserve": {"password": "${OBS_PASSWORD}"}}},
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "image_source": "local",
+                "auth": {"method": "none"},
+                "default_persona": "readwrite",
+                "users": [
+                    {"name": "alice", "index": 0, "persona": "unrendered"},
+                    {"name": "bob", "index": 1, "persona": "readwrite"},
+                ],
+                "personas": {
+                    "unrendered": {"project": "unrendered", "project_path": "build/nowhere"},
+                    "readwrite": {
+                        "project": "rw",
+                        "project_path": _persona_project(
+                            root, "readwrite", writes=True, denies_bash=False
+                        ),
+                    },
+                },
+            }
+        },
+    }
+
+
+def test_three_unmet_preconditions_are_reported_in_one_refusal(tmp_path):
+    """The whole point of the pass. Serially, this deployment costs three
+    deploy attempts to diagnose; here it costs one."""
+    # A chain that is present but does not carry the telemetry password the
+    # config demands -- the third problem.
+    (tmp_path / ".env").write_text("FOO=bar\n", encoding="utf-8")
+
+    with pytest.raises(UnmetPreconditionsError) as excinfo:
+        container_lifecycle._collect_unmet_preconditions(
+            _three_problem_config(tmp_path),
+            tmp_path,
+            {},
+            dev_mode=False,
+            web_terminals_enabled=True,
+        )
+
+    exc = excinfo.value
+    assert exc.summary == "3 unmet preconditions on this deployment"
+    problems = [problem for problem, _remedy in exc.findings]
+    assert "unrendered" in problems[0]
+    assert "readwrite" in problems[1]
+    assert "OBS_PASSWORD" in problems[2]
+
+
+def test_a_clean_deployment_collects_nothing(tmp_path, monkeypatch):
+    """The negative control: the same shape with each problem fixed collects
+    nothing, so the pass cannot be green by refusing everything.
+
+    The render probe is inert here — a complete persona render is a fixture in
+    its own right and `test_persona_images.py` owns that question. What this
+    asserts is that the two probes reading files the fixture DOES write both
+    answer "no problem" when the files are right."""
+    monkeypatch.setattr(
+        provision, "verify_persona_renders", lambda config, resolved_users, repo_root=None: None
+    )
+    (tmp_path / ".env").write_text("OBS_PASSWORD=set\n", encoding="utf-8")
+    config = _three_problem_config(tmp_path)
+    web_terminals = config["modules"]["web_terminals"]
+    # One persona, rendered, denying the shell.
+    web_terminals["default_persona"] = "safe"
+    web_terminals["users"] = [{"name": "bob", "index": 0, "persona": "safe"}]
+    web_terminals["personas"] = {
+        "safe": {
+            "project": "safe",
+            "project_path": _persona_project(tmp_path, "safe", writes=True, denies_bash=True),
+        }
+    }
+
+    container_lifecycle._collect_unmet_preconditions(
+        config, tmp_path, {}, dev_mode=False, web_terminals_enabled=True
+    )
+
+
+def test_a_deploy_without_web_terminals_asks_none_of_the_web_questions(tmp_path):
+    """The three web probes read artifacts only the web tier has. A plain
+    services deploy has none of them, and must not be asked about them."""
+    container_lifecycle._collect_unmet_preconditions(
+        _three_problem_config(tmp_path),
+        tmp_path,
+        {},
+        dev_mode=False,
+        web_terminals_enabled=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The unreleased-pin probe: only about a build that will happen
+# ---------------------------------------------------------------------------
+
+
+def _worker_config() -> dict:
+    return {"deployed_services": ["dispatch_worker"], "project_name": "proj"}
+
+
+def test_the_pin_is_probed_only_for_a_build_this_deploy_will_make(monkeypatch):
+    """The refusal belongs to the project-image build. A deployment that
+    builds nothing must not be sent to fix a pin that was never going to be
+    used -- both no-op cases of that build answer "nothing to report"."""
+    monkeypatch.delenv("OSPREY_PIP_SPEC", raising=False)
+    monkeypatch.setattr("osprey.version.is_release", lambda: False)
+
+    # No dispatch worker at all.
+    assert container_lifecycle._unreleased_pin_problem({"deployed_services": []}, {}, False) is None
+    # A worker pinned to a prebuilt image.
+    assert (
+        container_lifecycle._unreleased_pin_problem(
+            _worker_config(), {"OSPREY_WORKER_IMAGE": "registry.example.org/prebuilt:1"}, False
+        )
+        is None
+    )
+
+
+def test_a_definite_unreleased_pin_is_reported_with_its_own_remedy(monkeypatch):
+    monkeypatch.delenv("OSPREY_PIP_SPEC", raising=False)
+    monkeypatch.setattr("osprey.version.is_release", lambda: False)
+
+    finding = container_lifecycle._unreleased_pin_problem(_worker_config(), {}, False)
+
+    assert finding is not None
+    problem, remedy = finding
+    assert "Cannot pin osprey-framework" in problem
+    assert "--dev" in remedy
+
+
+def test_dev_mode_is_left_to_the_build_to_answer(monkeypatch):
+    """Under --dev the pin is inert when the wheel stages and live when it does
+    not, and which happens is not knowable without staging it. Pre-judging it
+    here would refuse the very workflow the refusal recommends."""
+    monkeypatch.delenv("OSPREY_PIP_SPEC", raising=False)
+    monkeypatch.setattr("osprey.version.is_release", lambda: False)
+
+    assert container_lifecycle._unreleased_pin_problem(_worker_config(), {}, True) is None
+
+
+def test_an_operator_pin_answers_the_question_outright(monkeypatch):
+    monkeypatch.setenv("OSPREY_PIP_SPEC", "git+https://example.invalid/osprey@abc123")
+    monkeypatch.setattr("osprey.version.is_release", lambda: False)
+
+    assert container_lifecycle._unreleased_pin_problem(_worker_config(), {}, False) is None
+
+
+def test_the_build_target_is_the_gate_the_build_itself_uses(monkeypatch):
+    """5a's extraction has to answer the same question `_build_project_image`
+    asks, or the probe and the build disagree about whether a build happens."""
+    assert container_lifecycle._project_image_build_target({"deployed_services": []}, {}) is None
+    assert (
+        container_lifecycle._project_image_build_target(
+            _worker_config(), {"OSPREY_WORKER_IMAGE": "prebuilt:1"}
+        )
+        is None
+    )
+    assert container_lifecycle._project_image_build_target(_worker_config(), {}) == "proj:local"
+
+
+# ---------------------------------------------------------------------------
+# Placement: below every provisioner that writes what the pass reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stubbed_start(monkeypatch):
+    """Reduce ``_start_stack`` to the pass and the step after it.
+
+    Everything that touches a host or a container runtime is inert; the two
+    collaborators these tests re-patch are the ones whose ordering against the
+    pass is the subject.
+    """
+    reached: list[str] = []
+    for name in (
+        "_check_shared_disk_preflight",
+        "_preflight_host_ports",
+        "_preflight_archiver_pymongo",
+        "_preflight_stale_store_volumes",
+        "_ensure_bluesky_substrate_env",
+        "_ensure_bluesky_control_plane_keys",
+        "_ensure_bluesky_document_plane_certs",
+        "_preflight_env_chain_drift",
+        "_preflight_env_shadowing",
+        "preflight_web_terminals",
+        "deploy_up_web_terminals",
+        "log_endpoint_summary",
+    ):
+        monkeypatch.setattr(container_lifecycle, name, lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_build_project_image",
+        lambda *a, **k: reached.append("build_image"),
+    )
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(args=[], returncode=0),
+    )
+    # The persona-render probe has its own suite; kept inert so these tests are
+    # about placement rather than about any repo's rendered state.
+    monkeypatch.setattr(
+        provision, "verify_persona_renders", lambda config, resolved_users, repo_root=None: None
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "_compose_provider", lambda config: ComposeProvider.DOCKER_V2
+    )
+    return reached
+
+
+def _mint_dependent_config() -> dict:
+    """A deployment whose only unmet precondition is one the mint resolves."""
+    return {
+        "deployed_services": ["osprey-mcp"],
+        "facility": {"prefix": "test"},
+        "claude_code": {"telemetry": {"openobserve": {"password": "${OBS_PASSWORD}"}}},
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "image_source": "local",
+                "default_persona": "ops",
+                "personas": {"ops": {"project": "ops-app", "project_path": "build/ops-app"}},
+            }
+        },
+    }
+
+
+def test_a_fresh_repo_with_no_env_file_is_not_refused_over_what_the_mint_writes(
+    tmp_path, stubbed_start, monkeypatch
+):
+    """THE property the pass's position exists for.
+
+    A fresh repo has committed defaults and no ``.env`` at all; the deploy's own
+    token mint writes that file, and the pass runs below it. So the variable
+    this config demands is there by the time the pass looks, and the start is
+    not refused over a file the deploy just created.
+
+    The counterfactual is the test below: the same repo and the same config,
+    with nothing minted, IS refused. A pass hoisted above the mint would take
+    that second outcome on the first repo too, and refuse every fresh deploy.
+    """
+    (tmp_path / ".env.shared").write_text("SHARED_DEFAULT=1\n", encoding="utf-8")
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_ensure_service_tokens",
+        lambda *a, **k: (tmp_path / ".env").write_text("OBS_PASSWORD=minted\n", encoding="utf-8"),
+    )
+
+    container_lifecycle._start_stack(_mint_dependent_config(), [], tmp_path, detached=True)
+
+    assert stubbed_start == ["build_image"]
+
+
+def test_the_same_repo_is_refused_when_nothing_provides_the_variable(
+    tmp_path, stubbed_start, monkeypatch
+):
+    """The counterfactual that gives the test above its meaning: with the mint
+    writing nothing, the identical start refuses. So the first test is passing
+    because of WHERE the pass sits, not because the probe is inert."""
+    (tmp_path / ".env.shared").write_text("SHARED_DEFAULT=1\n", encoding="utf-8")
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+
+    with pytest.raises(UnmetPreconditionsError, match="OBS_PASSWORD"):
+        container_lifecycle._start_stack(_mint_dependent_config(), [], tmp_path, detached=True)
+
+    assert stubbed_start == []  # nothing was built
+
+
+def test_a_pre_rename_secrets_file_is_migrated_before_the_pass_reads_it(
+    tmp_path, stubbed_start, monkeypatch
+):
+    """The pass's other upper constraint. ``migrate_users_env`` carries a
+    pre-rename ``.env.production`` onto ``.env.users``; the pass reads that file
+    one step later, so a repo whose secrets are sitting there under the old name
+    is not refused for not having them."""
+    (tmp_path / ".env.shared").write_text("SHARED_DEFAULT=1\n", encoding="utf-8")
+    (tmp_path / ".env.production").write_text("OBS_PASSWORD=carried\n", encoding="utf-8")
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+
+    container_lifecycle._start_stack(_mint_dependent_config(), [], tmp_path, detached=True)
+
+    assert stubbed_start == ["build_image"]
+    assert (tmp_path / ".env.users").is_file()

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -5360,6 +5360,25 @@ _DIGEST_LABEL_LINE = '      osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"\n'
 #: :func:`test_render_carries_no_deploy_timestamp`.
 _DEPLOYED_AT_LABEL_LINE = '      osprey.deployed.at: ""\n'
 
+#: The config-digest label and the comment that carries its reasoning, as the
+#: committed side does not render them yet while this addition is uncommitted.
+#: The mirror image of :data:`_DEPLOYED_AT_LABEL_LINE` — one delta is a removal
+#: and this one an addition, and both have to be nameable for the comparison
+#: below to survive its own commit. Includes the comment because the delta IS
+#: the whole block: stripping the label alone would leave the comment as an
+#: unexplained difference and fail for the wrong reason.
+_CONFIG_DIGEST_BLOCK = (
+    "      # Content fingerprint of the rendered config this deploy built\n"
+    "      # (runtime_helper's as_built_config_digest, carried in by\n"
+    "      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for\n"
+    "      # the other file a container reads its settings from: this service mounts\n"
+    "      # the rendered config.yml, so `osprey set` changes a file the compose\n"
+    "      # document never mentions and compose would leave the container running on\n"
+    "      # the settings it parsed at startup. Empty when the invocation did not set\n"
+    "      # the variable (a hand-run `docker compose up`).\n"
+    '      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"\n'
+)
+
 
 def _head_dispatcher_render() -> str:
     """Render the dispatcher template as of ``HEAD`` in the same Environment.
@@ -5402,7 +5421,7 @@ def _head_dispatcher_render() -> str:
 
 
 def test_dispatcher_default_render_matches_the_committed_one_but_for_the_digest_label() -> None:
-    """One enumerated delta, byte for byte, and nothing else.
+    """The enumerated deltas, byte for byte, and nothing else.
 
     Asserted on raw text rather than parsed YAML: the macros' whole whitespace
     contract is that a default render moves no byte, and a parsed comparison
@@ -5413,11 +5432,16 @@ def test_dispatcher_default_render_matches_the_committed_one_but_for_the_digest_
     """
 
     def _normalized(text: str) -> str:
-        return text.replace(_DIGEST_LABEL_LINE, "", 1).replace(_DEPLOYED_AT_LABEL_LINE, "", 1)
+        return (
+            text.replace(_DIGEST_LABEL_LINE, "", 1)
+            .replace(_DEPLOYED_AT_LABEL_LINE, "", 1)
+            .replace(_CONFIG_DIGEST_BLOCK, "", 1)
+        )
 
     rendered = _render_dispatcher_template()
 
     assert rendered.count(_DIGEST_LABEL_LINE) == 1, "the digest label renders exactly once"
+    assert rendered.count(_CONFIG_DIGEST_BLOCK) == 1, "the config digest renders exactly once"
     assert _normalized(rendered) == _normalized(_head_dispatcher_render())
 
 

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -219,7 +219,7 @@ def _dispatcher_context(**service_overrides: object) -> dict:
         "services": {"event_dispatcher": dict(service_overrides)},
         "deployment": {},
         "system": {"timezone": "UTC"},
-        "osprey_labels": {"project_name": "p", "project_root": "/r", "deployed_at": "now"},
+        "osprey_labels": {"project_name": "p", "project_root": "/r"},
         "osprey_version": "",
     }
 
@@ -1033,6 +1033,39 @@ def test_worker_carries_the_env_digest_label(network: str | None) -> None:
     assert _worker_service(rendered)["labels"]["osprey.env.digest"] == "${OSPREY_ENV_DIGEST:-}"
 
 
+def test_render_carries_no_deploy_timestamp() -> None:
+    """No label records when the render happened, and none is offered to one.
+
+    The counterpart to the digest label above, and its opposite: a digest is a
+    function of the deployment's inputs, so it belongs in the document; a wall
+    clock is not, so it does not. A timestamp here would change every rendered
+    compose document on every build — and, because compose recreates a
+    container whose definition moved, would churn the whole stack for a value
+    nothing reads. Container creation time is already reported natively by the
+    runtime.
+
+    Both halves are asserted: the rendered document, and the injected context
+    behind it. Checking only the render would pass on a context that still
+    carried the value for the next template author to reach for.
+    """
+    from osprey.deployment.compose_generator import _inject_project_metadata
+
+    rendered = _render_worker_template(env_present=True)
+    assert "osprey.deployed.at" not in rendered
+    assert "deployed_at" not in rendered
+
+    injected = _inject_project_metadata(
+        {
+            "project_name": _WORKER_PROJECT_NAME,
+            "project_root": f"/r/{_WORKER_PROJECT_NAME}",
+            "services": {"dispatch_worker": {}},
+            "system": {"timezone": "UTC"},
+            "deployed_services": [],
+        }
+    )
+    assert "deployed_at" not in injected["osprey_labels"]
+
+
 def test_worker_env_file_lists_the_whole_chain_in_precedence_order() -> None:
     """Both chain files are delivered, lowest precedence first.
 
@@ -1116,7 +1149,7 @@ def _render_bluesky_template(
         "deployment": {},
         "system": {"timezone": "UTC"},
         "deployed_services": deployed,
-        "osprey_labels": {"project_name": "p", "project_root": "/r", "deployed_at": "now"},
+        "osprey_labels": {"project_name": "p", "project_root": "/r"},
         "osprey_version": "",
     }
     # Task 3.2: control_system is omitted by default (matching every
@@ -1938,7 +1971,6 @@ def _render_postgres_template(project_name: str) -> str:
         osprey_labels={
             "project_name": project_name,
             "project_root": f"/r/{project_name}",
-            "deployed_at": "now",
         },
         osprey_version="",
     )
@@ -1998,7 +2030,7 @@ def test_postgres_image_follows_env_config_default_chain() -> None:
         services={"postgresql": {"port_host": 5432, "image": "registry.local/pg:custom"}},
         deployment={},
         system={"timezone": "UTC"},
-        osprey_labels={"project_name": "p", "project_root": "/r/p", "deployed_at": "now"},
+        osprey_labels={"project_name": "p", "project_root": "/r/p"},
         osprey_version="",
     )
     svc = yaml.safe_load(rendered)["services"]["postgresql"]
@@ -2039,7 +2071,6 @@ def _render_mongodb_template(project_name: str = "proj-a", **mongodb_config: obj
         osprey_labels={
             "project_name": project_name,
             "project_root": f"/r/{project_name}",
-            "deployed_at": "now",
         },
         osprey_version="",
     )
@@ -2403,7 +2434,6 @@ def _render_service_template(rel_path: str, project_name: str, **overrides: obje
         "osprey_labels": {
             "project_name": project_name,
             "project_root": f"/r/{project_name}",
-            "deployed_at": "now",
         },
         "osprey_version": "",
         "osprey_env_present": False,
@@ -3512,7 +3542,6 @@ def _render_nextcloud_bridge_template(
         osprey_labels={
             "project_name": project_name,
             "project_root": f"/r/{project_name}",
-            "deployed_at": "now",
         },
         osprey_version="",
         osprey_env_present=env_present,
@@ -4181,7 +4210,6 @@ def _render_gchat_bridge_template(
         osprey_labels={
             "project_name": project_name,
             "project_root": f"/r/{project_name}",
-            "deployed_at": "now",
         },
         osprey_version="",
         osprey_env_present=env_present,
@@ -5322,6 +5350,16 @@ def test_bridge_still_requires_both_addresses_when_the_pair_is_external(
 #: The label line the dispatcher gained, exactly as it must render.
 _DIGEST_LABEL_LINE = '      osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"\n'
 
+#: The deploy-timestamp label the templates no longer carry, as the committed
+#: side still renders it while this removal is uncommitted. Normalized away on
+#: both sides for the same reason the digest label is: the comparison below is
+#: "these two renders differ only by the deltas named here", and a delta that
+#: is being REMOVED has to be nameable too or the check cannot survive its own
+#: commit. Once committed neither side emits it and both replacements are
+#: no-ops; that the label is gone for good is pinned directly by
+#: :func:`test_render_carries_no_deploy_timestamp`.
+_DEPLOYED_AT_LABEL_LINE = '      osprey.deployed.at: ""\n'
+
 
 def _head_dispatcher_render() -> str:
     """Render the dispatcher template as of ``HEAD`` in the same Environment.
@@ -5368,17 +5406,19 @@ def test_dispatcher_default_render_matches_the_committed_one_but_for_the_digest_
 
     Asserted on raw text rather than parsed YAML: the macros' whole whitespace
     contract is that a default render moves no byte, and a parsed comparison
-    would pass on a render that gained or lost a blank line. The label is
-    removed from BOTH sides so the check keeps its meaning once the template is
-    committed — what it pins is "the digest label is the only difference",
-    which stays true either way.
+    would pass on a render that gained or lost a blank line. The enumerated
+    labels are removed from BOTH sides so the check keeps its meaning once the
+    templates are committed — what it pins is "these labels are the only
+    differences", which stays true either way.
     """
+
+    def _normalized(text: str) -> str:
+        return text.replace(_DIGEST_LABEL_LINE, "", 1).replace(_DEPLOYED_AT_LABEL_LINE, "", 1)
+
     rendered = _render_dispatcher_template()
 
     assert rendered.count(_DIGEST_LABEL_LINE) == 1, "the digest label renders exactly once"
-    assert rendered.replace(_DIGEST_LABEL_LINE, "", 1) == _head_dispatcher_render().replace(
-        _DIGEST_LABEL_LINE, "", 1
-    )
+    assert _normalized(rendered) == _normalized(_head_dispatcher_render())
 
 
 @pytest.mark.parametrize("network", [None, "bridge", "host"], ids=["unset", "bridge", "host"])

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from osprey.deployment import container_lifecycle
+from osprey.deployment.errors import UnmetPreconditionsError
 from osprey.deployment.web_terminals import postup_hooks, provision
 
 
@@ -792,14 +793,18 @@ def test_local_mode_unresolvable_persona_raises_before_any_compose_call(
     """A user referencing a persona absent from the catalog must raise via
     resolve_personas(strict=True) before build_persona_images or any compose
     call -- surfacing actionably instead of an opaque unbuilt-tag failure at
-    `compose up` (the reviewer integration note from task 3.2)."""
+    `compose up` (the reviewer integration note from task 3.2).
+
+    The collect-all pass now asks this question one step ahead of the
+    preflight that used to raise it, so the refusal arrives in the aggregate
+    frame. The persona is still named, which is the property that matters."""
     (tmp_path / ".env").write_text("FOO=bar\n", encoding="utf-8")
     config = _web_terminals_config(
         "local", users=[{"name": "alice", "index": 0, "persona": "no-such-persona"}]
     )
     monkeypatch.setattr(container_lifecycle, "prepare_compose_files", lambda *a, **k: (config, []))
 
-    with pytest.raises(ValueError, match="no-such-persona"):
+    with pytest.raises(UnmetPreconditionsError, match="no-such-persona"):
         container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=False)
 
     assert _mode_wiring_collab == []  # no compose subprocess ever ran
@@ -815,7 +820,13 @@ def test_local_mode_verifies_renders_then_ensure_env_production_then_build_then_
     missing one has to be refused before that sweep runs (and long before any
     compose call). A spy on verify_persona_renders (overriding the fixture's
     inert stub) proves the wiring line actually runs it -- and runs it BEFORE
-    build_persona_images, which needs the rendered context to exist."""
+    build_persona_images, which needs the rendered context to exist.
+
+    The collect-all pass asks the same render question once more, ahead of the
+    preflight, which is why the spy sees a third call. It only reads, so the
+    extra call changes nothing about the deployment -- and the preflight below
+    it still runs unchanged, which is the property the rest of this order
+    pins."""
     order: list[str] = []
     config = _web_terminals_config("local")
     monkeypatch.setattr(container_lifecycle, "prepare_compose_files", lambda *a, **k: (config, []))
@@ -842,13 +853,16 @@ def test_local_mode_verifies_renders_then_ensure_env_production_then_build_then_
 
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=False)
 
-    # The fail-fast deploy_up preflight runs the persona check +
+    # The collect-all pass reads the renders first (and nothing else -- it
+    # probes .env.users generation rather than calling ensure_env_production).
+    # The fail-fast deploy_up preflight then runs the persona check +
     # ensure_env_production once BEFORE the image-build stage, and
     # deploy_up_web_terminals re-runs the same (idempotent) pair; then exactly
     # three compose calls (the stale-container `rm -f` preflight, the web
     # `up -d`, then the advisory nginx config reload; no deployed_services, no
     # pull in local mode).
     assert order == [
+        "verify_persona_renders",
         "verify_persona_renders",
         "ensure_env_production",
         "verify_persona_renders",
@@ -1877,6 +1891,14 @@ def test_deploy_up_runs_web_terminal_preflight_before_image_build(monkeypatch, t
     monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
     monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda *a, **k: None)
     monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    # The collect-all pass sits ahead of the preflight and probes the same
+    # config; recorded rather than answered, so this test stays about ordering
+    # and is not also asserting on the (empty) roster it declares.
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_collect_unmet_preconditions",
+        lambda *a, **k: order.append("collect"),
+    )
     monkeypatch.setattr(
         container_lifecycle,
         "preflight_web_terminals",
@@ -1896,7 +1918,7 @@ def test_deploy_up_runs_web_terminal_preflight_before_image_build(monkeypatch, t
 
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
 
-    assert order == ["preflight", "build_image", "web_up"]
+    assert order == ["collect", "preflight", "build_image", "web_up"]
 
 
 def test_deploy_up_no_web_terminals_skips_preflight(monkeypatch, tmp_path):

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -2695,3 +2695,220 @@ def test_the_auth_grace_sits_between_the_healthcheck_and_the_reachability_budget
         f"reachability budget ({container_lifecycle._ARCHIVER_HEALTH_TIMEOUT_S}s), or a stale "
         "volume burns the whole budget before saying so"
     )
+
+
+# ---------------------------------------------------------------------------
+# The shared half of the env chain, at the deploy path's other two read sites
+# ---------------------------------------------------------------------------
+# The deployment's environment is a two-file chain at the repo root —
+# ``.env.shared`` (committed defaults) below ``.env`` (host-local secrets).
+# Neither of the two provisioners below opens the first of those files: both
+# call ``parse_dotenv_file(env_path)``, which names the LOCAL one, and read
+# ``os.environ`` for everything else. So a value living only in the shared half
+# reaches them by one indirect route — the CLI entry point loads the whole chain
+# over ``os.environ`` before any deploy code runs.
+#
+# Each site gets both cells: the value in the shared file alone, and the same
+# value once that entry-point load has happened. The pair is the measurement.
+# What it records is pinned as observed, including where the observation is that
+# the shared half is not seen at all.
+
+#: Obviously-fake stand-ins throughout this section. None is a credential.
+SHARED_HALF_CREDENTIAL = "shared-half-fixture-credential"
+VOLUME_BORN_WITH = "the-credential-the-volume-was-born-with"
+CHAIN_PROJECT = "demo-deployment"
+
+
+def _write_shared_half(repo: Path, text: str) -> Path:
+    """Lay down the chain's committed-defaults file beside the local one."""
+    from osprey.utils.dotenv import ENV_SHARED_FILENAME
+
+    path = repo / ENV_SHARED_FILENAME
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _load_the_entry_point_chain(monkeypatch, repo: Path) -> None:
+    """Run the load ``osprey <verb>`` performs before it reaches any deploy code.
+
+    ``osprey.cli.main`` calls this first thing, cwd-rooted, with override
+    semantics, so by the time a provisioner runs ``os.environ`` carries the
+    merged chain. Reproduced verbatim rather than simulated with ``setenv``,
+    because what is being measured IS that this step is what makes the shared
+    half visible downstream.
+    """
+    import osprey.utils.config as config
+
+    monkeypatch.setattr(config, "_dotenv_shell_overrides", {})
+    monkeypatch.chdir(repo)
+    config.load_project_dotenv()
+
+
+class _StoreRuntime:
+    """Answers the two argv shapes the stale-volume preflight builds.
+
+    Argv-shaped rather than a mock of the probe: the subject is which questions
+    the deploy asks the runtime, so a stand-in that accepted anything would pass
+    while the real command was wrong.
+    """
+
+    def __init__(self, volumes: list[str], container_env: dict[str, dict[str, str]]):
+        self.volumes = volumes
+        self.container_env = container_env
+
+    def __call__(self, cmd, **kwargs):
+        argv = list(cmd)[1:]  # drop the runtime binary
+        if argv[:2] == ["volume", "ls"]:
+            return subprocess.CompletedProcess(list(cmd), 0, stdout="\n".join(self.volumes))
+        if argv[:2] == ["container", "inspect"]:
+            env = self.container_env.get(argv[2])
+            if env is None:
+                return subprocess.CompletedProcess(list(cmd), 1, stdout="")
+            lines = "\n".join(f"{k}={v}" for k, v in env.items())
+            return subprocess.CompletedProcess(list(cmd), 0, stdout=lines)
+        return subprocess.CompletedProcess(list(cmd), 0, stdout="")
+
+
+@pytest.fixture
+def store_preflight(monkeypatch, tmp_path):
+    """One store, one surviving volume whose container holds a different value.
+
+    The mismatch is the setup, not the assertion: whether the preflight *sees*
+    it is what each test below records.
+    """
+    monkeypatch.delenv("MONGO_ROOT_PASSWORD", raising=False)
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "run",
+        _StoreRuntime(
+            volumes=[f"{CHAIN_PROJECT}_archiver_mongodb_data"],
+            container_env={
+                f"{CHAIN_PROJECT}-archiver-mongodb": {
+                    "MONGO_INITDB_ROOT_PASSWORD": VOLUME_BORN_WITH
+                }
+            },
+        ),
+    )
+
+    def _run(repo: Path):
+        config = {"deployed_services": ["mongodb"], "project_name": CHAIN_PROJECT}
+        container_lifecycle._preflight_stale_store_volumes(config, set(), repo / ".env")
+
+    return _run
+
+
+def test_a_shared_only_store_credential_that_the_volume_rejects_is_not_caught(
+    store_preflight, tmp_path
+):
+    """The preflight's disagreement rule cannot see a shared-half credential.
+
+    ``.env.shared`` names a credential the surviving volume was never
+    initialized with, which is exactly the state this check exists to refuse.
+    It does not refuse it: the effective value it computes is empty (it parsed
+    the local ``.env``, which does not exist), and an empty value never
+    disagrees with anything. The deploy proceeds and the store's own
+    authentication failure arrives minutes later instead.
+
+    Pinned as it behaves. A change that makes this raise is a change in which
+    file the preflight reads — the signal, not a break.
+    """
+    _write_shared_half(tmp_path, f"MONGO_ROOT_PASSWORD={SHARED_HALF_CREDENTIAL}\n")
+
+    store_preflight(tmp_path)  # no refusal
+
+
+def test_the_same_shared_only_credential_is_refused_after_the_entry_point_chain_load(
+    store_preflight, monkeypatch, tmp_path
+):
+    """The route by which the shared half reaches the preflight at all.
+
+    Same files, same runtime answers, with the one step a real ``osprey up``
+    takes first. The chain load puts the shared value in ``os.environ``, the
+    effective value stops being empty, and the disagreement with the container
+    is found before anything starts.
+    """
+    _write_shared_half(tmp_path, f"MONGO_ROOT_PASSWORD={SHARED_HALF_CREDENTIAL}\n")
+
+    _load_the_entry_point_chain(monkeypatch, tmp_path)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        store_preflight(tmp_path)
+    message = str(excinfo.value)
+    assert "archiver_mongodb_data" in message
+    # The report names the store and the file, never either credential.
+    assert SHARED_HALF_CREDENTIAL not in message
+    assert VOLUME_BORN_WITH not in message
+
+
+#: A minimal machine whose channel names yield one corrector pair and one BPM —
+#: the least the substrate derivation accepts.
+_SUBSTRATE_LIMITS = {
+    "SR:MAG:HCM:01:CURRENT:SP": {"min": -10, "max": 10},
+    "SR:MAG:HCM:01:CURRENT:RB": {"min": -10, "max": 10},
+    "SR:DIAG:BPM:01:POSITION:X": {"min": -5, "max": 5},
+    "SR:DIAG:BPM:01:POSITION:Y": {"min": -5, "max": 5},
+}
+
+_SUBSTRATE_CONFIG = {
+    "deployed_services": ["bluesky", "virtual_accelerator"],
+    "control_system": {"type": "virtual_accelerator"},
+}
+
+
+@pytest.fixture
+def substrate_project(monkeypatch, tmp_path):
+    """A built project the substrate derivation can read devices out of."""
+    for var in ("BLUESKY_EPICS_SUBSTRATE", "BLUESKY_EPICS_MOTORS", "BLUESKY_EPICS_DETECTORS"):
+        monkeypatch.delenv(var, raising=False)
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "channel_limits.json").write_text(
+        json.dumps(_SUBSTRATE_LIMITS), encoding="utf-8"
+    )
+    return tmp_path / ".env"
+
+
+def _dotenv(path: Path) -> dict:
+    from osprey.utils.dotenv import parse_dotenv_file
+
+    return parse_dotenv_file(path) if path.is_file() else {}
+
+
+def test_a_substrate_var_only_the_shared_half_sets_is_derived_over(substrate_project, tmp_path):
+    """The "already set is left untouched" promise is scoped to the local file.
+
+    The docstring's promise is "in the process env or an existing ``.env``",
+    and that is literally what the code checks — so a device list an operator
+    committed to ``.env.shared`` is not seen, a derived one is appended to
+    ``.env``, and the appended line outranks the committed one in the chain.
+    The operator's setting is still in the file they put it in, and no longer
+    the value the bridge resolves.
+    """
+    _write_shared_half(tmp_path, "BLUESKY_EPICS_MOTORS=shared-half-device-list\n")
+
+    container_lifecycle._ensure_bluesky_substrate_env(_SUBSTRATE_CONFIG, env_path=substrate_project)
+
+    local = _dotenv(substrate_project)
+    assert local["BLUESKY_EPICS_MOTORS"], "the shared-only value did not reach the predicate"
+    assert local["BLUESKY_EPICS_MOTORS"] != "shared-half-device-list"
+
+
+def test_the_same_substrate_var_is_left_alone_after_the_entry_point_chain_load(
+    substrate_project, monkeypatch, tmp_path
+):
+    """The route again: the process-env mirror is what preserves the setting.
+
+    With the chain loaded, the committed device list is in ``os.environ``, the
+    ``k not in os.environ`` guard holds, and only the keys the operator did not
+    set are appended.
+    """
+    _write_shared_half(tmp_path, "BLUESKY_EPICS_MOTORS=shared-half-device-list\n")
+
+    _load_the_entry_point_chain(monkeypatch, tmp_path)
+    container_lifecycle._ensure_bluesky_substrate_env(_SUBSTRATE_CONFIG, env_path=substrate_project)
+
+    local = _dotenv(substrate_project)
+    assert "BLUESKY_EPICS_MOTORS" not in local
+    assert local.get("BLUESKY_EPICS_DETECTORS")

--- a/tests/deployment/test_env_chain_matrix.py
+++ b/tests/deployment/test_env_chain_matrix.py
@@ -406,6 +406,37 @@ def resolve_via_health_loader(repo: Path, monkeypatch: pytest.MonkeyPatch) -> di
     return chain_keys_of(os.environ)
 
 
+def resolve_via_service_token_read_path(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, str]:
+    """The deploy's token mint — ``_effective_value``, asked the way it is asked.
+
+    The only row whose answer depends on a step another component took.
+    ``_ensure_service_tokens`` parses the LOCAL file alone
+    (``parse_dotenv_file(env_path)``) and hands that mapping to
+    ``_effective_value``, which reads ``os.environ`` ahead of it — so the shared
+    half reaches the mint by exactly one route: the CLI entry point loads the
+    whole chain over ``os.environ`` before any deploy code runs. Both reads are
+    reproduced here, in that order, because either one alone would answer a
+    question the deploy never asks.
+
+    A future delivery that stops mirroring the chain into ``os.environ`` fails
+    this row on the shared-only cell while every other row stays green, which is
+    the finding: the mint would resolve a credential from a different file than
+    it does today, and would mint over the shared half rather than honour it.
+    """
+    import osprey.utils.config as config
+    from osprey.deployment.service_tokens import _effective_value
+
+    monkeypatch.setattr(config, "_dotenv_shell_overrides", {})
+    monkeypatch.chdir(repo)
+    config.load_project_dotenv()
+
+    env_path = repo / ENV_LOCAL_FILENAME
+    on_disk = parse_dotenv_file(env_path) if env_path.is_file() else {}
+    return {key: value for key in CHAIN_KEYS if (value := _effective_value(key, on_disk))}
+
+
 LOADERS = [
     pytest.param(resolve_via_load_project_dotenv, id="load_project_dotenv"),
     pytest.param(resolve_via_chat_overlay, id="chat-overlay"),
@@ -418,6 +449,7 @@ LOADERS = [
     pytest.param(resolve_via_users_cli, id="users-env-cli"),
     pytest.param(resolve_via_health_cli, id="health-cli-cross-cwd"),
     pytest.param(resolve_via_health_loader, id="health-loader"),
+    pytest.param(resolve_via_service_token_read_path, id="service-token-mint-read-path"),
 ]
 
 

--- a/tests/deployment/test_env_shadow_preflight.py
+++ b/tests/deployment/test_env_shadow_preflight.py
@@ -310,12 +310,14 @@ def test_an_export_the_store_does_not_pin_is_not_a_divergence(tmp_path, caplog):
     assert caplog.text == ""
 
 
-def test_an_export_over_a_deliberately_empty_pin_is_reported(tmp_path, caplog):
-    """``TOKEN=`` in the store means "no token" — a deliberate fail-closed setting.
+def test_an_export_over_an_empty_pin_is_reported(tmp_path, caplog):
+    """``TOKEN=`` in the store and a different value exported over it diverge.
 
-    The deploy layer treats an empty value as a setting rather than a blank (it
-    declines to mint over one), so an export that re-arms the service behind the
-    operator's back is exactly the divergence worth naming.
+    What this preflight reports is the divergence itself, whatever either side
+    holds — it reads the files as they are and does not model the mint (which
+    treats a blank service token as a blank and fills it in). An export that
+    silently decides what a service authenticates with is worth naming either
+    way.
     """
     repo = _repo(
         tmp_path,

--- a/tests/deployment/test_openobserve_token_mint.py
+++ b/tests/deployment/test_openobserve_token_mint.py
@@ -12,16 +12,23 @@ this entry different from every other minted token and are pinned here:
   (the same failure shape as ``BLUESKY_TILED_API_KEY``/Tiled).
 * Its compose template carries an insecure ``:-Complexpass#123`` default, so the
   motivation is not fail-closed arming (as with dispatch/bluesky) but replacing a
-  shared, transcript-guarding default with a per-deploy secret.
+  shared, transcript-guarding default with a per-deploy secret. That same
+  published default is refused outright when an operator sets it — the one
+  failure no format rule can express, since the value satisfies OpenObserve's
+  policy in full (see ``TestPublishedDefaultIsRefused``).
 """
 
 from __future__ import annotations
 
 import base64
+import re
+from pathlib import Path
 
 import pytest
 
 from osprey.deployment import container_lifecycle
+from osprey.deployment.service_tokens import _VAR_FORBIDDEN_VALUES
+from osprey.utils.dotenv import format_env_line
 
 _MINT_SAMPLES = 200
 
@@ -217,6 +224,160 @@ def test_ensure_service_tokens_accepts_a_strong_operator_password(tmp_path, monk
 def test_service_token_vars_map_includes_openobserve():
     """Lock in the map shape: only the password, not the email."""
     assert container_lifecycle._SERVICE_TOKEN_VARS["openobserve"] == ("ZO_ROOT_USER_PASSWORD",)
+
+
+# ---------------------------------------------------------------------------
+# The published compose default is refused outright — the one failure no format
+# rule can express, because that value satisfies OpenObserve's policy in full.
+# ---------------------------------------------------------------------------
+
+
+class TestPublishedDefaultIsRefused:
+    """A password that is public is not a password, however well-formed.
+
+    ``ZO_ROOT_USER_PASSWORD`` is interpolated in the compose template with a
+    ``:-`` fallback, so a project that never sets it still starts — on a value
+    printed in every rendered copy of the template, guarding a store that holds
+    full agent conversation transcripts. The mint exists to replace that value,
+    but nothing stopped an operator from writing it back into ``.env`` by hand,
+    and it passes every character-class check there is.
+
+    The refusal is deliberately narrow. It reads the *effective* value at the
+    deploy boundary, after the mint, so it can only fire on a value an operator
+    supplied — never on the fresh-repo path, where the template default resolves
+    transiently and the mint replaces it before this check ever runs.
+    """
+
+    def test_the_registered_default_is_the_one_the_template_ships(self):
+        """The declaration must track the template, or the refusal guards nothing.
+
+        Parse the fallback out of the shipped compose template rather than
+        restating it: a template edit that changes the published default while
+        this map keeps the old one would leave the new default accepted, and
+        nothing else in the suite would notice.
+        """
+        import osprey.templates
+
+        template = (
+            Path(osprey.templates.__file__).parent
+            / "services"
+            / "openobserve"
+            / "docker-compose.yml.j2"
+        )
+        shipped = re.search(
+            r"\$\{ZO_ROOT_USER_PASSWORD:-([^}]*)\}", template.read_text(encoding="utf-8")
+        )
+        assert shipped, f"no ${{ZO_ROOT_USER_PASSWORD:-...}} fallback found in {template}"
+
+        assert shipped.group(1) in _VAR_FORBIDDEN_VALUES["ZO_ROOT_USER_PASSWORD"]
+
+    def test_the_published_default_would_pass_every_format_check(self):
+        """Why this needs its own mechanism rather than another validator."""
+        for published in _VAR_FORBIDDEN_VALUES["ZO_ROOT_USER_PASSWORD"]:
+            assert _satisfies_openobserve_policy(published)
+            assert container_lifecycle._validate_var("ZO_ROOT_USER_PASSWORD", published)
+
+    @pytest.mark.parametrize("published", sorted(_VAR_FORBIDDEN_VALUES["ZO_ROOT_USER_PASSWORD"]))
+    def test_an_operator_supplied_default_refuses_the_deploy(
+        self, tmp_path, monkeypatch, published
+    ):
+        monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+        env_path = tmp_path / ".env"
+        env_path.write_text(format_env_line("ZO_ROOT_USER_PASSWORD", published) + "\n")
+        # The value must survive the .env round-trip, or the test would be
+        # asserting the refusal fires on something the operator never set.
+        assert _parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"] == published
+
+        with pytest.raises(RuntimeError) as exc_info:
+            container_lifecycle._ensure_service_tokens(
+                {"deployed_services": ["openobserve"]}, expose_network=False, env_path=env_path
+            )
+
+        assert str(exc_info.value) == (
+            "ZO_ROOT_USER_PASSWORD is invalid: must not be the default published in the "
+            "openobserve compose template — that value ships in every rendered project, "
+            "so it is a shared password rather than a secret, and this store holds full "
+            "agent conversation transcripts; remove the line from .env (and unset any "
+            "shell export of the same name) so the next run mints a per-deploy value. "
+            "Refusing to deploy. (Value not shown.)"
+        )
+        # Names only: the refusal must not echo the credential it rejected.
+        assert published not in str(exc_info.value)
+
+    def test_a_shell_export_of_the_default_refuses_too(self, tmp_path, monkeypatch):
+        """Process env wins over ``.env``, so it is just as much "set to the default"."""
+        published = next(iter(_VAR_FORBIDDEN_VALUES["ZO_ROOT_USER_PASSWORD"]))
+        monkeypatch.setenv("ZO_ROOT_USER_PASSWORD", published)
+
+        with pytest.raises(RuntimeError, match="ZO_ROOT_USER_PASSWORD") as exc_info:
+            container_lifecycle._ensure_service_tokens(
+                {"deployed_services": ["openobserve"]},
+                expose_network=False,
+                env_path=tmp_path / ".env",
+            )
+
+        assert published not in str(exc_info.value)
+
+    def test_a_fresh_repo_mints_and_does_not_refuse(self, tmp_path, monkeypatch):
+        """The narrowness this check is designed around.
+
+        Nothing in the process env, nothing on disk — the state every first
+        deploy starts from, and the state in which the template's ``:-``
+        fallback is what the value *would* resolve to. The mint runs first, so
+        the effective value is a per-deploy secret and the deploy proceeds. A
+        build-time twin of this refusal would fire here, on every new project,
+        which is why there is none.
+        """
+        monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+        env_path = tmp_path / ".env"
+        assert not env_path.exists()
+
+        minted = container_lifecycle._ensure_service_tokens(
+            {"deployed_services": ["openobserve"]}, expose_network=False, env_path=env_path
+        )
+
+        assert minted == {"ZO_ROOT_USER_PASSWORD"}
+        assert (
+            _parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"]
+            not in _VAR_FORBIDDEN_VALUES["ZO_ROOT_USER_PASSWORD"]
+        )
+
+    def test_a_second_run_over_a_minted_value_still_does_not_refuse(self, tmp_path, monkeypatch):
+        """Idempotence survives the new check: a minted value is not forbidden."""
+        monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+        env_path = tmp_path / ".env"
+        config = {"deployed_services": ["openobserve"]}
+
+        container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+        minted = _parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"]
+        container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+
+        assert _parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"] == minted
+
+    def test_the_generator_can_never_mint_a_forbidden_value(self):
+        """The mint and the refusal must not be able to disagree."""
+        for _ in range(_MINT_SAMPLES):
+            assert not container_lifecycle._is_forbidden_value(
+                "ZO_ROOT_USER_PASSWORD", container_lifecycle._generate_openobserve_password()
+            )
+
+    def test_only_the_registered_var_has_a_forbidden_value(self, tmp_path, monkeypatch):
+        """Opt-in per var, exactly like ``_VAR_VALIDATORS``.
+
+        The same string set on an unregistered var is nobody's published
+        default, so it passes — the check is a named-value refusal, not a
+        password-strength opinion applied everywhere.
+        """
+        published = next(iter(_VAR_FORBIDDEN_VALUES["ZO_ROOT_USER_PASSWORD"]))
+        assert not container_lifecycle._is_forbidden_value("EVENT_DISPATCHER_TOKEN", published)
+
+        monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", published)
+        monkeypatch.setenv("DISPATCH_WORKER_TOKEN", published)
+        container_lifecycle._ensure_service_tokens(
+            {"deployed_services": ["event_dispatcher"]},
+            expose_network=False,
+            env_path=tmp_path / ".env",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_runtime_env_digest.py
+++ b/tests/deployment/test_runtime_env_digest.py
@@ -1,11 +1,16 @@
-"""Tests for the ``OSPREY_ENV_DIGEST`` fingerprint ``runtime_env`` injects.
+"""Tests for the content fingerprints ``runtime_env`` injects.
 
 The rendered compose templates carry an ``osprey.env.digest`` label
-interpolated from this variable, which is what makes an edit to the env chain
-recreate the containers that read it. podman-compose does not diff a running
-container's environment against the env files it was built from, so without a
-label that moves with the chain's contents, ``osprey up`` after an edit to
-``.env`` leaves the old values running.
+interpolated from ``OSPREY_ENV_DIGEST``, which is what makes an edit to the env
+chain recreate the containers that read it. podman-compose does not diff a
+running container's environment against the env files it was built from, so
+without a label that moves with the chain's contents, ``osprey up`` after an edit
+to ``.env`` leaves the old values running.
+
+``OSPREY_CONFIG_DIGEST`` and ``osprey.config.digest`` are the same mechanism for
+the other file a container reads settings out of: the rendered ``config.yml``
+each service mounts. Neither file is named by the compose document, which is the
+only thing compose compares, so both need a label to be seen at all.
 
 Two properties are load-bearing and tested separately here:
 
@@ -28,7 +33,13 @@ from pathlib import Path
 
 import pytest
 
-from osprey.deployment.runtime_helper import ENV_DIGEST_VAR, env_chain_digest, runtime_env
+from osprey.deployment.runtime_helper import (
+    CONFIG_DIGEST_VAR,
+    ENV_DIGEST_VAR,
+    as_built_config_digest,
+    env_chain_digest,
+    runtime_env,
+)
 
 # ---------------------------------------------------------------------------
 # The recipe.
@@ -176,6 +187,116 @@ def test_runtime_env_digest_does_not_leak_into_the_caller_env(tmp_path: Path) ->
     runtime_env({"project_root": str(tmp_path)}, base_env=base, ignore_orphans=True)
 
     assert base == {}
+
+
+# ---------------------------------------------------------------------------
+# The same contract for the as-built config.
+#
+# A service mounts the rendered config.yml, so a setting an operator changes
+# lands in a file the compose document never mentions -- and compose recreates
+# on a changed DEFINITION. Everything below is the env-chain recipe applied to
+# that file: hash its raw bytes, empty when there is no build yet, and carried by
+# every runtime_env call site so the label moves exactly when the config does.
+# ---------------------------------------------------------------------------
+
+
+def _write_as_built(repo_root: Path, text: str) -> Path:
+    """Lay down the one as-built config a build leaves behind."""
+    build_dir = repo_root / "build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    path = build_dir / "config.yml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_config_digest_is_empty_before_a_build_has_rendered_one(tmp_path: Path) -> None:
+    """Every verb that runs before a build sees no config, which is not an error."""
+    assert as_built_config_digest(tmp_path) == ""
+
+
+def test_config_digest_hashes_the_as_built_config_bytes(tmp_path: Path) -> None:
+    """The recipe, so a second reproducer of it cannot disagree."""
+    _write_as_built(tmp_path, "connector: virtual_accelerator\n")
+
+    expected = hashlib.sha256(b"connector: virtual_accelerator\n").hexdigest()
+    assert as_built_config_digest(tmp_path) == expected
+
+
+def test_config_digest_is_stable_across_rewrites_of_identical_bytes(tmp_path: Path) -> None:
+    """Rebuilding an unchanged deployment must not restart it.
+
+    The property the removed deploy timestamp destroyed: it differed on every
+    render, so every ``up`` recreated every container.
+    """
+    _write_as_built(tmp_path, "connector: virtual_accelerator\n")
+    before = as_built_config_digest(tmp_path)
+
+    _write_as_built(tmp_path, "connector: virtual_accelerator\n")
+
+    assert as_built_config_digest(tmp_path) == before
+
+
+def test_config_digest_moves_when_a_setting_changes(tmp_path: Path) -> None:
+    """The whole point, in the shape the operator hits it.
+
+    ``osprey set connector=mock`` rewrites the config and the next ``up`` has to
+    recreate the containers that mount it -- otherwise the deployment keeps
+    answering with the connector it started on, and the flip silently did
+    nothing.
+    """
+    _write_as_built(tmp_path, "connector: virtual_accelerator\n")
+    before = as_built_config_digest(tmp_path)
+
+    _write_as_built(tmp_path, "connector: mock\n")
+
+    assert as_built_config_digest(tmp_path) != before
+
+
+def test_runtime_env_carries_the_config_digest_of_the_configured_repo(tmp_path: Path) -> None:
+    """The value in the env is the build under the repo compose is pinned to."""
+    _write_as_built(tmp_path, "connector: mock\n")
+    config = {"project_name": "proj-a", "project_root": str(tmp_path)}
+
+    env = runtime_env(config, base_env={})
+
+    assert env[CONFIG_DIGEST_VAR] == hashlib.sha256(b"connector: mock\n").hexdigest()
+
+
+def test_runtime_env_config_digest_is_empty_without_a_build(tmp_path: Path) -> None:
+    """Set-but-empty, like the env digest, so callers can rely on the key."""
+    config = {"project_name": "proj-a", "project_root": str(tmp_path)}
+
+    assert runtime_env(config, base_env={})[CONFIG_DIGEST_VAR] == ""
+
+
+def test_runtime_env_recomputes_rather_than_inheriting_a_stale_config_digest(
+    tmp_path: Path,
+) -> None:
+    """A value left in an outer shell must never pin the label."""
+    _write_as_built(tmp_path, "connector: mock\n")
+    config = {"project_name": "proj-a", "project_root": str(tmp_path)}
+
+    env = runtime_env(config, base_env={CONFIG_DIGEST_VAR: "stale-from-an-outer-shell"})
+
+    assert env[CONFIG_DIGEST_VAR] == hashlib.sha256(b"connector: mock\n").hexdigest()
+
+
+def test_the_two_digests_are_independent(tmp_path: Path) -> None:
+    """An env-chain edit must not move the config digest, or the reverse.
+
+    They answer different questions about different files, and a deployment that
+    edited only one of them should recreate for that reason alone.
+    """
+    (tmp_path / ".env").write_text("LOCAL=2\n", encoding="utf-8")
+    _write_as_built(tmp_path, "connector: mock\n")
+    config = {"project_name": "proj-a", "project_root": str(tmp_path)}
+    first = runtime_env(config, base_env={})
+
+    (tmp_path / ".env").write_text("LOCAL=3\n", encoding="utf-8")
+    second = runtime_env(config, base_env={})
+
+    assert second[ENV_DIGEST_VAR] != first[ENV_DIGEST_VAR]
+    assert second[CONFIG_DIGEST_VAR] == first[CONFIG_DIGEST_VAR]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_service_token_unconditional_mint.py
+++ b/tests/deployment/test_service_token_unconditional_mint.py
@@ -420,3 +420,181 @@ def test_an_exported_empty_value_is_left_alone_because_a_mint_cannot_reach_it(
     assert "BLUESKY_LAUNCH_TOKEN" not in env
     # The var beside it still mints — the carve-out is per var, not per deploy.
     assert env.get("BLUESKY_TILED_API_KEY")
+
+
+# ---------------------------------------------------------------------------
+# The shared half of the chain: what this function's own read can and cannot see
+# ---------------------------------------------------------------------------
+# The deployment's environment is a two-file chain at the repo root —
+# ``.env.shared`` (committed defaults) below ``.env`` (host-local secrets). This
+# function reads exactly one of those files: ``parse_dotenv_file(env_path)``
+# names the LOCAL one, and ``_effective_value`` consults ``os.environ`` ahead of
+# it. So the shared half reaches the mint by a single indirect route — the CLI
+# entry point loads the whole chain over ``os.environ`` before any deploy code
+# runs, and the mint reads that mirror rather than the file.
+#
+# Both halves of that are pinned below, as observed rather than as wished for:
+# what the function makes of a shared-only value on its own, and what it makes
+# of the same value once the entry-point load has happened. The pair is the
+# measurement — the second test is what says the mint's answer depends on a step
+# some other component took.
+
+#: Obviously-fake stand-ins. Every value in this section is a fixture, never a
+#: credential recipe, and none of them is ever asserted against a minted value
+#: except to show the two differ.
+SHARED_HALF_TOKEN = "shared-half-fixture-token-not-a-secret"
+
+
+def _write_shared_half(tmp_path, text: str):
+    """Lay down the chain's committed-defaults file beside the local one."""
+    from osprey.utils.dotenv import ENV_SHARED_FILENAME
+
+    path = tmp_path / ENV_SHARED_FILENAME
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _load_the_entry_point_chain(monkeypatch, repo):
+    """Run the load ``osprey <verb>`` performs before it reaches any deploy code.
+
+    ``osprey.cli.main`` calls this first thing, cwd-rooted, with override
+    semantics — so by the time the mint runs, ``os.environ`` carries the merged
+    chain. Reproduced here verbatim rather than simulated with ``setenv``,
+    because the thing being measured IS that this step is what makes the shared
+    half visible.
+    """
+    import osprey.utils.config as config
+
+    monkeypatch.setattr(config, "_dotenv_shell_overrides", {})
+    monkeypatch.chdir(repo)
+    config.load_project_dotenv()
+
+
+def test_a_token_only_the_shared_half_carries_is_minted_over(_clean_token_env, tmp_path):
+    """``.env.shared`` alone is invisible to the mint, so the var reads as absent.
+
+    Pinned as it behaves, not as it ought to: the function's file read names the
+    local ``.env``, and a value the operator committed to the shared half is not
+    one this predicate can see. It therefore mints — and the minted line lands
+    in ``.env``, which outranks ``.env.shared`` everywhere in the chain, so the
+    operator's committed value stops being the one the deployment resolves.
+
+    The shared file itself is left untouched, which is the only part of this a
+    reader would have guessed.
+    """
+    _write_shared_half(tmp_path, f"BLUESKY_LAUNCH_TOKEN={SHARED_HALF_TOKEN}\n")
+    env_path = tmp_path / ".env"
+
+    container_lifecycle._ensure_service_tokens(_config(), expose_network=False, env_path=env_path)
+
+    local = _parse_dotenv(env_path)
+    assert local["BLUESKY_LAUNCH_TOKEN"], "the shared-only value did not even reach the predicate"
+    assert local["BLUESKY_LAUNCH_TOKEN"] != SHARED_HALF_TOKEN
+    from osprey.utils.dotenv import ENV_SHARED_FILENAME
+
+    assert _parse_dotenv(tmp_path / ENV_SHARED_FILENAME)["BLUESKY_LAUNCH_TOKEN"] == (
+        SHARED_HALF_TOKEN
+    )
+
+
+def test_the_shared_half_is_honoured_once_the_entry_point_chain_load_has_run(
+    _clean_token_env, monkeypatch, tmp_path
+):
+    """The route that makes the shared half visible: the process-env mirror.
+
+    Same fixture as the test above, with the one step a real ``osprey up``
+    takes first. The chain load puts the shared value in ``os.environ``,
+    ``_effective_value`` reads that ahead of the ``.env`` mapping, and the var
+    is left alone. Nothing else changed — so if this ever disagrees with the
+    test above again, the delivery of the environment moved, not the mint.
+    """
+    _write_shared_half(tmp_path, f"BLUESKY_LAUNCH_TOKEN={SHARED_HALF_TOKEN}\n")
+    env_path = tmp_path / ".env"
+
+    _load_the_entry_point_chain(monkeypatch, tmp_path)
+    container_lifecycle._ensure_service_tokens(_config(), expose_network=False, env_path=env_path)
+
+    local = _parse_dotenv(env_path)
+    assert "BLUESKY_LAUNCH_TOKEN" not in local
+    assert os.environ["BLUESKY_LAUNCH_TOKEN"] == SHARED_HALF_TOKEN
+    # Per var, as everywhere else here: the one the shared half does not carry
+    # still mints.
+    assert local.get("BLUESKY_TILED_API_KEY")
+
+
+class TestEffectiveValueWithAllThreeSourcesDisagreeing:
+    """The conflict configuration: shell, ``.env`` and ``.env.shared`` differ.
+
+    ``_effective_value`` is a two-argument function — process env, then the
+    mapping the caller passes — and its docstring makes a claim about a THIRD
+    thing, the deploy path it sits on: that the ``.env`` has already been loaded
+    over the process env, so a shell export is only visible when the file does
+    not carry the key. The first test below pins the function's own mechanics;
+    the second pins the composed behaviour the docstring describes, with all
+    three sources set to different values so no two of them can be confused.
+    """
+
+    VAR = "BLUESKY_LAUNCH_TOKEN"
+
+    def _effective_value(self):
+        from osprey.deployment.service_tokens import _effective_value
+
+        return _effective_value
+
+    def test_the_process_env_outranks_the_mapping_the_caller_passes(
+        self, _clean_token_env, monkeypatch
+    ):
+        """The mechanic, in isolation: ``os.environ`` first, mapping second, ``""``.
+
+        Called with a mapping the process env contradicts, which on the deploy
+        path never happens by accident — the loader put the file's value there.
+        """
+        effective_value = self._effective_value()
+        monkeypatch.setenv(self.VAR, "value-from-the-shell")
+
+        assert effective_value(self.VAR, {self.VAR: "value-from-the-local-file"}) == (
+            "value-from-the-shell"
+        )
+        monkeypatch.delenv(self.VAR)
+        assert effective_value(self.VAR, {self.VAR: "value-from-the-local-file"}) == (
+            "value-from-the-local-file"
+        )
+        assert effective_value(self.VAR, {}) == ""
+
+    def test_on_the_deploy_path_the_local_file_wins_and_the_shell_loses(
+        self, _clean_token_env, monkeypatch, tmp_path
+    ):
+        """The composed answer, with every source of the chain disagreeing.
+
+        Order observed: ``.env`` beats ``.env.shared`` beats the shell export.
+        The shell losing is not ``_effective_value``'s doing — it reads the
+        process env first — but the entry-point load overwrote that export with
+        the chain's value, which is exactly what the docstring says: the derived
+        file, not the ambient shell, decides a present key's value.
+        """
+        effective_value = self._effective_value()
+        _write_shared_half(tmp_path, f"{self.VAR}=value-from-the-shared-file\n")
+        (tmp_path / ".env").write_text(f"{self.VAR}=value-from-the-local-file\n", encoding="utf-8")
+        monkeypatch.setenv(self.VAR, "value-from-the-shell")
+
+        _load_the_entry_point_chain(monkeypatch, tmp_path)
+        on_disk = _parse_dotenv(tmp_path / ".env")
+
+        assert effective_value(self.VAR, on_disk) == "value-from-the-local-file"
+
+    def test_a_key_only_the_shared_file_sets_outranks_the_shell_too(
+        self, _clean_token_env, monkeypatch, tmp_path
+    ):
+        """The middle rank, which the two-file case cannot show on its own.
+
+        With no local line for the key, the winner is the committed default
+        rather than the operator's export — the chain load overrides both files
+        over the process env, and the shared half is a member of that chain.
+        """
+        effective_value = self._effective_value()
+        _write_shared_half(tmp_path, f"{self.VAR}=value-from-the-shared-file\n")
+        monkeypatch.setenv(self.VAR, "value-from-the-shell")
+
+        _load_the_entry_point_chain(monkeypatch, tmp_path)
+
+        assert effective_value(self.VAR, {}) == "value-from-the-shared-file"

--- a/tests/deployment/test_service_token_unconditional_mint.py
+++ b/tests/deployment/test_service_token_unconditional_mint.py
@@ -28,6 +28,7 @@ sections say — including when they are absent entirely.
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 
 import pytest
@@ -356,17 +357,23 @@ def test_existing_env_value_is_never_overwritten(
     assert env.get("BLUESKY_TILED_API_KEY")
 
 
-def test_explicitly_empty_value_is_left_empty_not_minted(
+def test_an_explicitly_empty_dotenv_value_is_minted_over(
     captured_argv, _clean_token_env, monkeypatch, tmp_path
 ):
-    """``TOKEN=`` is a deliberate value: the operator is choosing a fail-closed bridge.
+    """``TOKEN=`` in ``.env`` is a blank, not a decision — the mint fills it.
 
-    Minting over it would override that choice. On a loopback deploy the
-    service simply fails closed on its own; only a deployment the build
-    rendered as reachable off-host refuses (covered in
-    ``test_bluesky_token_mint.py``).
+    This replaces the opposite expectation. A minted service token has no
+    meaningful empty state: an empty ``BLUESKY_LAUNCH_TOKEN`` does not choose a
+    fail-closed bridge, it starts one with no authentication and says nothing
+    about it, on the default loopback deploy where no other guard is watching.
+    The narrow carve-out — an empty value exported in a shell whose ``.env``
+    never mentions the var — is pinned separately below.
     """
     (tmp_path / ".env").write_text("BLUESKY_LAUNCH_TOKEN=\n", encoding="utf-8")
+    # The deploy loads that .env over the process environment before it mints,
+    # so this is the state the predicate actually sees. Set it through
+    # monkeypatch so the minted value does not outlive the test.
+    monkeypatch.setenv("BLUESKY_LAUNCH_TOKEN", "")
     config = _config(
         control_system={"writes_enabled": True},
         execution={"execution_method": "local"},
@@ -376,5 +383,40 @@ def test_explicitly_empty_value_is_left_empty_not_minted(
     container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
 
     env = _parse_env(tmp_path)
-    assert env["BLUESKY_LAUNCH_TOKEN"] == ""
+    minted = env["BLUESKY_LAUNCH_TOKEN"]
+    assert minted, "an empty launch token was left empty on a loopback deploy"
+    assert env.get("BLUESKY_TILED_API_KEY")
+    assert minted != env["BLUESKY_TILED_API_KEY"]
+    # The appended line is what the deploy resolves: parse order is last-wins,
+    # the same rule compose applies to a repeated key in an --env-file.
+    assert (tmp_path / ".env").read_text().index(f"BLUESKY_LAUNCH_TOKEN={minted}") > 0
+    # And the stale empty copy the .env load left in this process is replaced,
+    # so compose resolves the minted value rather than being shadowed by it.
+    assert os.environ["BLUESKY_LAUNCH_TOKEN"] == minted
+
+
+def test_an_exported_empty_value_is_left_alone_because_a_mint_cannot_reach_it(
+    captured_argv, _clean_token_env, monkeypatch, tmp_path
+):
+    """The bound on the exception above: an export the ``.env`` cannot outrank.
+
+    The ``.env`` here does not carry the var at all, so the empty value is the
+    shell's own rather than that file's mirrored back. An export wins over
+    ``--env-file`` for compose's interpolation, so a mint appended to ``.env``
+    would be a token reported and never delivered. Nothing is written, and a
+    deployment the build rendered as reachable off-host refuses instead (covered
+    in ``test_bluesky_token_mint.py``).
+    """
+    monkeypatch.setenv("BLUESKY_LAUNCH_TOKEN", "")
+    config = _config(
+        control_system={"writes_enabled": True},
+        execution={"execution_method": "local"},
+    )
+    _patch_prepare_compose_files(monkeypatch, config)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    env = _parse_env(tmp_path)
+    assert "BLUESKY_LAUNCH_TOKEN" not in env
+    # The var beside it still mints — the carve-out is per var, not per deploy.
     assert env.get("BLUESKY_TILED_API_KEY")

--- a/tests/deployment/test_status_sections.py
+++ b/tests/deployment/test_status_sections.py
@@ -27,6 +27,7 @@ this deployment's containers or at nothing at all.
 
 from __future__ import annotations
 
+import base64
 import json
 import subprocess
 from pathlib import Path
@@ -480,6 +481,94 @@ def test_a_telemetry_endpoint_failure_still_reads_as_a_provider_problem(
 
     assert "could not be read from the build" in text
     assert "credentials are missing or unresolved" not in text
+
+
+#: A telemetry block whose credentials actually resolve, so the provider spec
+#: comes back with a populated env block — including the OTLP headers, which is
+#: where the observability store's authorization header ends up.
+_WORKING_TELEMETRY = (
+    "  telemetry:\n"
+    "    enabled: true\n"
+    "    backend: openobserve\n"
+    "    openobserve:\n"
+    "      user: observability-user\n"
+    "      password: not-a-real-password\n"
+)
+
+
+def _telemetry_report(repo: Path, monkeypatch) -> str:
+    """``osprey status`` for a repo whose agent has working telemetry configured."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OSPREY_IN_CONTAINER", raising=False)
+    monkeypatch.delenv("OSPREY_OTEL_OPENOBSERVE_HOST", raising=False)
+    render_build(repo, config=_config_with_telemetry(_WORKING_TELEMETRY))
+    return report(repo)
+
+
+def test_the_observability_authorization_header_is_never_printed(
+    lifecycle_repo, runtime, monkeypatch
+):
+    """The env block is printed key AND value, and one of those values is a credential.
+
+    ``OTEL_EXPORTER_OTLP_HEADERS`` carries HTTP Basic auth for the observability
+    store — base64 of ``user:password``, decodable by anyone who reads the
+    terminal. Neither the credentials nor the encoding of them may appear.
+    """
+    text = _telemetry_report(lifecycle_repo, monkeypatch)
+
+    token = base64.b64encode(b"observability-user:not-a-real-password").decode()
+    assert token not in text
+    assert "not-a-real-password" not in text
+    assert "Basic " not in text
+
+
+def test_the_headers_variable_is_still_reported_as_configured(lifecycle_repo, runtime, monkeypatch):
+    """Masking the value must not delete the row.
+
+    Whether the exporter is authenticated at all is a fact an operator came to
+    this section for; only the credential itself is withheld.
+    """
+    text = _telemetry_report(lifecycle_repo, monkeypatch)
+
+    assert "OTEL_EXPORTER_OTLP_HEADERS" in text
+    assert "value not shown" in text
+
+
+def test_the_rest_of_the_telemetry_block_still_shows_its_values(
+    lifecycle_repo, runtime, monkeypatch
+):
+    """Only the credential-bearing variable is masked, not the block around it.
+
+    Ten of the eleven telemetry variables are ordinary configuration, and a mask
+    broad enough to cover them would leave the section unable to answer where
+    the agent ships its metrics — which is what the section is for.
+    """
+    text = _telemetry_report(lifecycle_repo, monkeypatch)
+
+    assert ":5080/api/default" in text
+    assert "value not shown" not in text.split("OTEL_EXPORTER_OTLP_ENDPOINT")[1].splitlines()[0]
+
+
+@pytest.mark.parametrize(
+    ("name", "masked"),
+    [
+        ("OTEL_EXPORTER_OTLP_HEADERS", True),
+        ("SOME_SERVICE_TOKEN", True),
+        ("WEBHOOK_SIGNING_SECRET", True),
+        ("OTEL_EXPORTER_OTLP_ENDPOINT", False),
+        ("ANTHROPIC_MODEL", False),
+    ],
+)
+def test_the_mask_is_a_rule_and_not_one_remembered_variable(name, masked):
+    """A variable named after a credential is withheld even if nobody listed it.
+
+    The leak this closes was one variable, but a mask spelled as one literal
+    comparison would let the next secret added to the env block out unnoticed
+    while looking like a finished fix.
+    """
+    shown = status_display._display_env_value(name, "the-value")
+
+    assert (shown != "the-value") is masked
 
 
 def test_the_artifact_check_mirrors_the_arguments_the_build_renders_with(

--- a/tests/deployment/test_status_sections.py
+++ b/tests/deployment/test_status_sections.py
@@ -387,6 +387,101 @@ def test_a_credential_that_is_nowhere_is_reported_missing(lifecycle_repo, runtim
     assert "not found in this shell" in text
 
 
+def _config_with_telemetry(block: str) -> str:
+    """The rendered config, plus a ``claude_code.telemetry`` block under it.
+
+    Resolving the provider also resolves telemetry, so what a broken telemetry
+    block does to the *provider* line is a property of the status report and
+    testable from the config alone — no stub in front of the resolver, which is
+    the piece whose behaviour is under test.
+    """
+    return _RENDERED_CONFIG + block
+
+
+def test_a_missing_observability_credential_is_not_blamed_on_the_provider(
+    lifecycle_repo, runtime, monkeypatch
+):
+    """The provider is fine; the observability backend has no password.
+
+    Telemetry resolves as part of the provider spec, so a missing observability
+    credential surfaces as a failure to read the provider. Reported that way, an
+    operator goes and audits a provider configuration that was never wrong.
+    """
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    render_build(
+        lifecycle_repo,
+        config=_config_with_telemetry(
+            "  telemetry:\n"
+            "    enabled: true\n"
+            "    backend: openobserve\n"
+            "    openobserve:\n"
+            '      user: ""\n'
+            "      password: not-a-real-password\n"
+        ),
+    )
+
+    text = report(lifecycle_repo)
+
+    assert "telemetry" in text
+    assert "credentials are missing or unresolved" in text
+    assert "openobserve.user" in text
+    assert ".env" in text
+    # The old framing sent the operator to the wrong subsystem.
+    assert "could not be read from the build" not in text
+    # A status report is read on a shared terminal and pasted into tickets.
+    assert "not-a-real-password" not in text
+
+
+def test_an_unresolved_observability_credential_reports_names_not_the_raw_error(
+    lifecycle_repo, runtime, monkeypatch
+):
+    """The credential's own text never reaches the report.
+
+    The resolver phrases its refusal with the offending value in it, which is
+    exactly what must not be printed. The trouble line is written from the
+    setting names and the file that holds them instead.
+    """
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    render_build(
+        lifecycle_repo,
+        config=_config_with_telemetry(
+            "  telemetry:\n"
+            "    enabled: true\n"
+            "    backend: openobserve\n"
+            "    openobserve:\n"
+            "      user: observability-user\n"
+            "      password: ${OSPREY_STATUS_TEST_UNSET_PASSWORD}\n"
+        ),
+    )
+
+    text = report(lifecycle_repo)
+
+    assert "credentials are missing or unresolved" in text
+    assert "OSPREY_STATUS_TEST_UNSET_PASSWORD" not in text
+    assert "refusing to encode" not in text
+
+
+def test_a_telemetry_endpoint_failure_still_reads_as_a_provider_problem(
+    lifecycle_repo, runtime, monkeypatch
+):
+    """Only the credential case is re-framed.
+
+    An enabled telemetry block with no reachable endpoint is not a secret-store
+    problem, and the credential remedy would be the wrong advice. It stays on
+    the general handler, which names the provider and quotes the resolver.
+    """
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    render_build(
+        lifecycle_repo,
+        config=_config_with_telemetry("  telemetry:\n    enabled: true\n    backend: nowhere\n"),
+    )
+
+    text = report(lifecycle_repo)
+
+    assert "could not be read from the build" in text
+    assert "credentials are missing or unresolved" not in text
+
+
 def test_the_artifact_check_mirrors_the_arguments_the_build_renders_with(
     lifecycle_repo, runtime, monkeypatch
 ):

--- a/tests/deployment/test_up_as_built.py
+++ b/tests/deployment/test_up_as_built.py
@@ -783,12 +783,14 @@ def test_a_wildcard_build_is_treated_as_exposed_without_the_flag(
     There is no start-time flag to arm or disarm the empty-token guard: a build
     that publishes on a wildcard address gets the fail-closed rules because of
     what it publishes.
+
+    The token is emptied by an export alone, with no line for it in the ``.env``
+    — the one empty spelling the mint leaves alone, and so the one that still
+    reaches the guard. A blank line in the file is minted over instead.
     """
     monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "")
     monkeypatch.delenv("DISPATCH_WORKER_TOKEN", raising=False)
-    (lifecycle_repo / ".env").write_text(
-        "ANTHROPIC_API_KEY=x\nEVENT_DISPATCHER_TOKEN=\n", encoding="utf-8"
-    )
+    (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=x\n", encoding="utf-8")
     render_build(lifecycle_repo, bind_address="0.0.0.0")
 
     result = run_up(lifecycle_repo, "-d")

--- a/tests/deployment/web_terminals/test_env_production.py
+++ b/tests/deployment/web_terminals/test_env_production.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 
 import pytest
+import yaml
 
 from osprey.deployment.web_terminals import env_production
 
@@ -640,3 +641,272 @@ def test_env_production_quotes_a_value_that_would_not_survive_a_re_read(tmp_path
 
     assert 'CBORG_API_KEY="  padded-secret  "' in result.read_text(encoding="utf-8")
     assert env_production.parse_dotenv_file(result)["CBORG_API_KEY"] == "  padded-secret  "
+
+
+# ---------------------------------------------------------------------------
+# Observability-store credentials. The store's account NAME crosses into
+# .env.users; its admin PASSWORD never does, because one file is handed to
+# every persona alike and admin access reads every transcript in the store.
+# ---------------------------------------------------------------------------
+
+
+#: How the shipped telemetry block spells its two credentials: reference
+#: literals carrying their own fallbacks, not env-var NAMES the way
+#: ``llm.api_key_env_var`` does.
+_SHIPPED_STORE_USER = "${ZO_ROOT_USER_EMAIL:-root@example.com}"
+_SHIPPED_STORE_PASSWORD = "${ZO_ROOT_USER_PASSWORD:-Complexpass#123}"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("${ZO_ROOT_USER_PASSWORD}", ("ZO_ROOT_USER_PASSWORD", False)),
+        (_SHIPPED_STORE_PASSWORD, ("ZO_ROOT_USER_PASSWORD", True)),
+        (_SHIPPED_STORE_USER, ("ZO_ROOT_USER_EMAIL", True)),
+        ("root@example.com", None),  # a plain literal references nothing
+        ("$ZO_ROOT_USER_PASSWORD", None),  # unbraced: outside the dialect
+        ("", None),
+        (None, None),
+        (5080, None),
+    ],
+)
+def test_env_reference_tells_the_two_reference_forms_from_a_literal(value, expected):
+    """The whole point of the matcher: a bare reference and a defaulted one
+    fail differently in a container, and neither looks like a plain value."""
+    assert env_production._env_reference(value) == expected
+
+
+def _write_telemetry_persona(
+    tmp_path, name="operator-proj", *, provider="anthropic", **credentials
+):
+    """Write a rendered persona project carrying a telemetry block.
+
+    ``credentials`` are placed under ``claude_code.telemetry.openobserve``
+    verbatim, so a test can spell each one the way a real config would.
+    """
+    project_dir = tmp_path / name
+    project_dir.mkdir()
+    (project_dir / "config.yml").write_text(
+        yaml.safe_dump(
+            {
+                "project_name": name,
+                "claude_code": {
+                    "provider": provider,
+                    "telemetry": {
+                        "enabled": True,
+                        "backend": "openobserve",
+                        "openobserve": {"org": "default", **credentials},
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return name  # catalog project_path, relative to the deploy project root
+
+
+def _catalog_config(project_path, persona="operator"):
+    """A local-mode deploy config whose roster runs one catalogued persona."""
+    return {
+        "facility": {"timezone": "UTC"},
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "image_source": "local",
+                "default_persona": persona,
+                "personas": {persona: {"project": project_path, "project_path": project_path}},
+                "users": [{"name": "alice", "index": 0, "persona": persona}],
+            },
+        },
+    }
+
+
+def test_env_production_never_carries_the_store_admin_password(tmp_path):
+    """The security decision this category exists to make.
+
+    ZO_ROOT_USER_PASSWORD is the observability store's single admin credential,
+    and .env.users is handed to every persona alike -- a copy here would grant
+    every read-only terminal admin read of every transcript in the store. The
+    account NAME is not a secret and does cross, which is what makes the
+    omission of the password a decision rather than an oversight.
+    """
+    _write_dotenv(
+        tmp_path / ".env",
+        {
+            "ANTHROPIC_API_KEY": "cc-secret",
+            "ZO_ROOT_USER_EMAIL": "store-account@example.org",
+            "ZO_ROOT_USER_PASSWORD": "store-admin-secret",
+        },
+    )
+    config = _catalog_config(
+        _write_telemetry_persona(
+            tmp_path, user=_SHIPPED_STORE_USER, password=_SHIPPED_STORE_PASSWORD
+        )
+    )
+
+    result = env_production.ensure_env_production(config, tmp_path)
+
+    generated = env_production.parse_dotenv_file(result)
+    raw_text = result.read_text(encoding="utf-8")
+    assert generated["ZO_ROOT_USER_EMAIL"] == "store-account@example.org"
+    assert "ZO_ROOT_USER_PASSWORD" not in generated
+    assert "ZO_ROOT_USER_PASSWORD" not in raw_text
+    assert "store-admin-secret" not in raw_text
+
+
+def test_env_production_omits_the_store_password_a_config_declares_it_needs(tmp_path):
+    """Even a config asserting the variable is set -- a bare reference, with no
+    fallback of its own -- and a chain that sets it: the requirement is
+    REPORTED, never satisfied by copying the credential into this file."""
+    _write_dotenv(
+        tmp_path / ".env",
+        {
+            "ANTHROPIC_API_KEY": "cc-secret",
+            "ZO_ROOT_USER_PASSWORD": "store-admin-secret",
+        },
+    )
+    config = _catalog_config(
+        _write_telemetry_persona(tmp_path, password="${ZO_ROOT_USER_PASSWORD}")
+    )
+
+    result = env_production.ensure_env_production(config, tmp_path)
+
+    raw_text = result.read_text(encoding="utf-8")
+    assert "ZO_ROOT_USER_PASSWORD" not in raw_text
+    assert "store-admin-secret" not in raw_text
+
+
+def test_env_production_copies_the_store_account_name_when_the_chain_sets_it(tmp_path):
+    """A fixed-key enumerated category, like TZ and ARIEL_DSN: present in the
+    chain, copied; absent, silently skipped."""
+    _write_dotenv(
+        tmp_path / ".env",
+        {**_INCLUDED_ENV, "ZO_ROOT_USER_EMAIL": "store-account@example.org"},
+    )
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(_FULL_CONFIG, tmp_path)
+    )
+
+    assert generated["ZO_ROOT_USER_EMAIL"] == "store-account@example.org"
+
+
+def test_env_production_omits_the_store_account_name_when_the_chain_lacks_it(tmp_path):
+    _write_dotenv(tmp_path / ".env", _INCLUDED_ENV)
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(_FULL_CONFIG, tmp_path)
+    )
+
+    assert "ZO_ROOT_USER_EMAIL" not in generated
+
+
+def test_env_production_bare_telemetry_password_absent_from_the_chain_refuses(tmp_path):
+    """A bare reference resolves to nothing at all inside the container -- the
+    placeholder reaches the store verbatim -- so the deploy is refused rather
+    than generated, naming the variable, where it is asked for, and why this
+    file will not be carrying it either way."""
+    _write_dotenv(tmp_path / ".env", {"ANTHROPIC_API_KEY": "cc-secret"})
+    config = _catalog_config(
+        _write_telemetry_persona(tmp_path, password="${ZO_ROOT_USER_PASSWORD}")
+    )
+
+    with pytest.raises(RuntimeError, match="ZO_ROOT_USER_PASSWORD") as excinfo:
+        env_production.ensure_env_production(config, tmp_path)
+
+    message = str(excinfo.value)
+    assert "claude_code.telemetry.openobserve.password" in message
+    assert "operator" in message
+    assert "single admin credential" in message
+    assert not (tmp_path / ".env.users").exists()
+
+
+def test_env_production_bare_telemetry_password_in_the_deploy_config_refuses_too(tmp_path):
+    """The deploy config is read the same way a persona project is: on the
+    zero-migration path it IS the project the web image runs."""
+    _write_dotenv(tmp_path / ".env", {"ANTHROPIC_API_KEY": "cc-secret"})
+    config = {
+        "facility": {},
+        "claude_code": {
+            "provider": "anthropic",
+            "telemetry": {"openobserve": {"password": "${ZO_ROOT_USER_PASSWORD}"}},
+        },
+        "modules": {"web_terminals": {"image_source": "local"}},
+    }
+
+    with pytest.raises(RuntimeError, match="ZO_ROOT_USER_PASSWORD") as excinfo:
+        env_production.ensure_env_production(config, tmp_path)
+
+    assert "deploy config" in str(excinfo.value)
+
+
+def test_env_production_defaulted_telemetry_password_is_not_required(tmp_path):
+    """The shipped spelling carries its own fallback, so it asks nothing of the
+    env chain and must not turn a working deploy into a refusal."""
+    _write_dotenv(tmp_path / ".env", {"ANTHROPIC_API_KEY": "cc-secret"})
+    config = _catalog_config(_write_telemetry_persona(tmp_path, password=_SHIPPED_STORE_PASSWORD))
+
+    result = env_production.ensure_env_production(config, tmp_path)
+
+    assert result.is_file()
+
+
+def test_env_production_a_literal_telemetry_password_asks_nothing_of_the_chain(tmp_path):
+    """A hand-written password is a value, not a reference: nothing to require,
+    and nothing this file copies either."""
+    _write_dotenv(tmp_path / ".env", {"ANTHROPIC_API_KEY": "cc-secret"})
+    config = _catalog_config(_write_telemetry_persona(tmp_path, password="hand-written"))
+
+    result = env_production.ensure_env_production(config, tmp_path)
+
+    assert "hand-written" not in result.read_text(encoding="utf-8")
+
+
+def test_env_production_existing_file_without_the_store_account_name_warns(tmp_path, caplog):
+    """The advisory arm for the never-clobbered file: it names the variable the
+    config's telemetry references and nothing about any value."""
+    (tmp_path / ".env.users").write_text("ANTHROPIC_API_KEY=ok\nTZ=UTC\n", encoding="utf-8")
+    config = _catalog_config(_write_telemetry_persona(tmp_path, user=_SHIPPED_STORE_USER))
+
+    with caplog.at_level("WARNING"):
+        env_production.ensure_env_production(config, tmp_path)
+
+    assert "ZO_ROOT_USER_EMAIL" in caplog.text
+    assert "claude_code.telemetry.openobserve.user" in caplog.text
+
+
+def test_env_production_the_two_advisory_arms_are_evaluated_independently(tmp_path, caplog):
+    """A file carrying the LLM credential satisfies the all-or-nothing arm and
+    still gets the telemetry advisory; the LLM arm stays silent."""
+    (tmp_path / ".env.users").write_text("ANTHROPIC_API_KEY=ok\n", encoding="utf-8")
+    config = _catalog_config(_write_telemetry_persona(tmp_path, user=_SHIPPED_STORE_USER))
+
+    with caplog.at_level("WARNING"):
+        env_production.ensure_env_production(config, tmp_path)
+
+    assert "none of the LLM credential" not in caplog.text
+    assert "ZO_ROOT_USER_EMAIL" in caplog.text
+
+
+def test_env_production_existing_file_with_the_store_account_name_does_not_warn(tmp_path, caplog):
+    (tmp_path / ".env.users").write_text(
+        "ANTHROPIC_API_KEY=ok\nZO_ROOT_USER_EMAIL=store-account@example.org\n",
+        encoding="utf-8",
+    )
+    config = _catalog_config(_write_telemetry_persona(tmp_path, user=_SHIPPED_STORE_USER))
+
+    with caplog.at_level("WARNING"):
+        env_production.ensure_env_production(config, tmp_path)
+
+    assert "ZO_ROOT_USER_EMAIL" not in caplog.text
+
+
+def test_env_production_no_telemetry_block_means_no_telemetry_advisory(tmp_path, caplog):
+    """A config that references no store account gets no advisory about one."""
+    (tmp_path / ".env.users").write_text("ANTHROPIC_API_KEY=ok\n", encoding="utf-8")
+    config = _catalog_config(_write_telemetry_persona(tmp_path))
+
+    with caplog.at_level("WARNING"):
+        env_production.ensure_env_production(config, tmp_path)
+
+    assert "observability account" not in caplog.text

--- a/tests/deployment/web_terminals/test_env_users_rename.py
+++ b/tests/deployment/web_terminals/test_env_users_rename.py
@@ -6,7 +6,11 @@ refusals name that name, and ``osprey reset`` discloses that name. Second, a
 deployment carrying the pre-rename ``.env.production`` is carried onto the new
 name by ``osprey up`` rather than being told its secrets are missing: the file
 is gitignored and never regenerated once present, so on a host that deployed
-successfully yesterday it is the operator's only copy.
+successfully yesterday it is the operator's only copy. That second half is
+pinned as a NON-destructive migration throughout — a leftover the current file
+already stands in for is set aside under a name of its own, never deleted,
+because ``up`` recognizes it by filename alone and a file at that name need
+never have been this system's to remove.
 """
 
 from __future__ import annotations
@@ -21,6 +25,7 @@ from osprey.deployment import container_lifecycle
 from osprey.deployment.reset import WEB_CREDENTIAL_FILES
 from osprey.deployment.web_terminals.env_production import (
     LEGACY_USERS_ENV_FILENAME,
+    SUPERSEDED_USERS_ENV_FILENAME,
     USERS_ENV_FILENAME,
     ensure_env_production,
     migrate_users_env,
@@ -36,7 +41,7 @@ _LOCAL_CONFIG = {
 
 
 # ---------------------------------------------------------------------------
-# migrate_users_env -- the three states a project root can be in.
+# migrate_users_env -- the states a project root can be in.
 # ---------------------------------------------------------------------------
 
 
@@ -69,16 +74,24 @@ def test_migration_moves_the_old_file_onto_the_new_name(tmp_path, caplog):
     )
 
 
-def test_both_files_present_keeps_the_new_one_and_deletes_the_leftover(tmp_path, caplog):
+def test_both_files_present_keeps_the_new_one_and_sets_the_leftover_aside(tmp_path, caplog):
     """Registry-mode CI's fresh render wins over a survivor of an earlier pipeline.
 
     CI writes ``.env.users`` on the host just before ``osprey up``, while the
     gitignored old file survives the ``git reset --hard`` that precedes the
-    checkout. The fresh file is authoritative; the leftover is deleted rather
-    than left looking like a second source of truth.
+    checkout. The fresh file is authoritative and the leftover stops sitting
+    under a name a later reader could mistake for the live file.
+
+    It gets there by a rename and NOT by a delete, which is what this pins:
+    ``osprey up`` identifies the leftover by filename alone, so a file that was
+    never OSPREY's — another tool's secrets under the same spelling — reaches
+    this branch too, and a delete would destroy the operator's only copy of it
+    without asking. The superseded copy is still secret-bearing, so it lands at
+    0600 like every other write of this artifact.
     """
     legacy = tmp_path / LEGACY_USERS_ENV_FILENAME
     legacy.write_text("CBORG_API_KEY=stale\n", encoding="utf-8")
+    os.chmod(legacy, 0o644)
     users_path = tmp_path / USERS_ENV_FILENAME
     users_path.write_text("CBORG_API_KEY=fresh\n", encoding="utf-8")
 
@@ -89,9 +102,53 @@ def test_both_files_present_keeps_the_new_one_and_deletes_the_leftover(tmp_path,
     assert not legacy.exists()
     assert users_path.read_text(encoding="utf-8") == "CBORG_API_KEY=fresh\n"
 
-    removal_lines = [rec.message for rec in caplog.records if USERS_ENV_FILENAME in rec.message]
-    assert len(removal_lines) == 1
-    assert LEGACY_USERS_ENV_FILENAME in removal_lines[0]
+    # The leftover was moved, not destroyed: same bytes, under the set-aside
+    # name, at the mode a secrets file is entitled to rather than the one it
+    # happened to carry.
+    superseded = tmp_path / SUPERSEDED_USERS_ENV_FILENAME
+    assert superseded.read_text(encoding="utf-8") == "CBORG_API_KEY=stale\n"
+    assert stat.S_IMODE(superseded.stat().st_mode) == 0o600
+
+    supersede_lines = [rec.message for rec in caplog.records if USERS_ENV_FILENAME in rec.message]
+    assert supersede_lines, "the supersede left no record"
+    # Both paths in one line, so the operator can find the copy without diffing
+    # the directory -- and nothing anywhere claiming a removal that no longer
+    # happens.
+    assert any(
+        LEGACY_USERS_ENV_FILENAME in line and SUPERSEDED_USERS_ENV_FILENAME in line
+        for line in supersede_lines
+    )
+    assert not any("removed" in line for line in supersede_lines)
+
+
+def test_a_second_supersede_keeps_the_earlier_copy_and_skips_the_rename(tmp_path, caplog):
+    """The set-aside name is fixed, so a repeated ``up`` must not overwrite it.
+
+    A timestamped name would pile up copies of a secrets file, so there is one;
+    the price is that a second deploy in this state finds it taken. The earlier
+    copy is the one closer to the deployment that last worked, so it wins, the
+    leftover stays where it is, and nothing is destroyed on either side.
+    """
+    legacy = tmp_path / LEGACY_USERS_ENV_FILENAME
+    legacy.write_text("CBORG_API_KEY=second\n", encoding="utf-8")
+    superseded = tmp_path / SUPERSEDED_USERS_ENV_FILENAME
+    superseded.write_text("CBORG_API_KEY=first\n", encoding="utf-8")
+    users_path = tmp_path / USERS_ENV_FILENAME
+    users_path.write_text("CBORG_API_KEY=fresh\n", encoding="utf-8")
+
+    with caplog.at_level("INFO"):
+        result = migrate_users_env(tmp_path)
+
+    assert result == users_path
+    assert superseded.read_text(encoding="utf-8") == "CBORG_API_KEY=first\n"
+    assert legacy.read_text(encoding="utf-8") == "CBORG_API_KEY=second\n"
+    assert users_path.read_text(encoding="utf-8") == "CBORG_API_KEY=fresh\n"
+
+    # One line, naming both paths: which file was left alone and which copy it
+    # was left alone for.
+    skip_lines = [rec.message for rec in caplog.records if LEGACY_USERS_ENV_FILENAME in rec.message]
+    assert len(skip_lines) == 1
+    assert SUPERSEDED_USERS_ENV_FILENAME in skip_lines[0]
 
 
 def test_no_old_file_is_a_silent_no_op(tmp_path, caplog):
@@ -121,12 +178,13 @@ def test_a_directory_named_like_the_old_file_is_not_migrated(tmp_path):
     assert not (tmp_path / USERS_ENV_FILENAME).exists()
 
 
-def test_a_directory_at_the_new_name_never_deletes_the_old_file(tmp_path):
-    """The delete branch needs a real file standing in, not merely something.
+def test_a_directory_at_the_new_name_never_moves_the_old_file(tmp_path):
+    """The supersede branch needs a real file standing in, not merely something.
 
     A directory at the new name is not a copy of anything, so treating it as
-    one would delete the operator's only copy of the web tier's secrets. The
-    migration fails loudly instead, with the old file where it was.
+    one would move the operator's only copy of the web tier's secrets out from
+    under the deploy that is about to read it. The migration fails loudly
+    instead, with the old file where it was and nothing set aside.
     """
     legacy = tmp_path / LEGACY_USERS_ENV_FILENAME
     legacy.write_text("CBORG_API_KEY=carried\n", encoding="utf-8")
@@ -136,6 +194,7 @@ def test_a_directory_at_the_new_name_never_deletes_the_old_file(tmp_path):
         migrate_users_env(tmp_path)
 
     assert legacy.read_text(encoding="utf-8") == "CBORG_API_KEY=carried\n"
+    assert not (tmp_path / SUPERSEDED_USERS_ENV_FILENAME).exists()
 
 
 def test_a_world_readable_old_file_is_migrated_to_0600(tmp_path):
@@ -199,6 +258,10 @@ def test_reset_discloses_the_kept_file_under_the_new_name():
     disclosed = [entry[0] for entry in WEB_CREDENTIAL_FILES]
     assert USERS_ENV_FILENAME in disclosed
     assert LEGACY_USERS_ENV_FILENAME not in disclosed
+    # The set-aside copy is disclosed too, for the reason every entry in that
+    # list is: it survives a reset, it holds live secrets, and an operator who
+    # is not told it is there has no way to know they can drop it.
+    assert SUPERSEDED_USERS_ENV_FILENAME in disclosed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/web_terminals/test_persona_images.py
+++ b/tests/deployment/web_terminals/test_persona_images.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from osprey.build.claude_code_telemetry import ObservabilityCredentialError
 from osprey.deployment.errors import CapturedProcessError
 from osprey.deployment.web_terminals import persona_images
 
@@ -680,6 +681,106 @@ def test_a_persona_placeholder_resolves_from_the_repo_env(tmp_path, calls, monke
 
     persona_images.verify_persona_renders(_persona_config(repo), _PERSONA_USERS, repo_root=repo)
 
+    assert calls == []
+
+
+def _telemetry_render(repo: Path, password_line: str) -> Path:
+    """A complete render whose model is fine and whose telemetry block varies.
+
+    The model is deliberately servable in every one of these: the point is what
+    the refusal says when the ONLY thing wrong is an observability credential.
+    """
+    project_path = _render(repo)
+    (project_path / "config.yml").write_text(
+        "project_name: ops-app\n"
+        "claude_code:\n"
+        "  provider: anthropic\n"
+        "  default_model: sonnet\n"
+        "  telemetry:\n"
+        "    enabled: true\n"
+        "    backend: openobserve\n" + password_line,
+        encoding="utf-8",
+    )
+    return project_path
+
+
+def test_unresolved_observability_credential_is_not_a_model_problem(tmp_path, calls, monkeypatch):
+    """An observability credential nothing on the host resolves is reported as
+    a credential, with the file it belongs in.
+
+    Both failures come out of the same resolve and the credential one is a
+    ValueError too, so the general frame would otherwise tell an operator whose
+    store password is unset to go and fix their model — an edit to a profile
+    that was never wrong, leaving the actual gap in place.
+    """
+    monkeypatch.delenv("OBSERVABILITY_PASSWORD", raising=False)
+    repo = _repo(tmp_path, "ops")
+    project_path = _telemetry_render(
+        repo,
+        "    openobserve:\n"
+        "      user: operator@example.com\n"
+        "      password: ${OBSERVABILITY_PASSWORD}\n",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        persona_images.verify_persona_renders(_persona_config(repo), _PERSONA_USERS, repo_root=repo)
+
+    message = str(excinfo.value)
+    assert "observability credentials this deployment cannot resolve" in message
+    assert str(project_path) in message
+    # The variable to set, and the one file that will be read for it -- a name,
+    # never a value, since an unresolved placeholder has none to print.
+    assert "OBSERVABILITY_PASSWORD" in message
+    assert f'echo "OBSERVABILITY_PASSWORD=<value>" >> {repo / ".env"}' in message
+    assert "`osprey up` mints" in message
+    # And emphatically not the other remedy.
+    assert "Fix the model in this deployment's profile" not in message
+    assert isinstance(excinfo.value.__cause__, ObservabilityCredentialError)
+    assert calls == []
+
+
+def test_a_blank_observability_credential_names_the_config_keys(tmp_path, calls):
+    """Nothing declared at all: there is no variable name to hand back, so the
+    remedy names the config keys instead of inventing one."""
+    repo = _repo(tmp_path, "ops")
+    _telemetry_render(repo, "    openobserve:\n      org: default\n")
+
+    with pytest.raises(ValueError) as excinfo:
+        persona_images.verify_persona_renders(_persona_config(repo), _PERSONA_USERS, repo_root=repo)
+
+    message = str(excinfo.value)
+    assert "openobserve.user" in message and "openobserve.password" in message
+    assert str(repo / ".env") in message
+    assert "Fix the model in this deployment's profile" not in message
+    assert calls == []
+
+
+def test_an_unservable_model_still_gets_the_model_remedy(tmp_path, calls):
+    """The converse, and the reason arm order matters: the credential arm sits
+    ahead of the general one and must not swallow a genuine model failure."""
+    repo = _repo(tmp_path, "ops")
+    project_path = _render(repo)
+    (project_path / "config.yml").write_text(
+        "project_name: ops-app\n"
+        "claude_code:\n"
+        "  provider: anthropic\n"
+        "  default_model: anthropic/claude-opus\n"
+        "  telemetry:\n"
+        "    enabled: true\n"
+        "    backend: openobserve\n"
+        "    openobserve:\n"
+        "      user: operator@example.com\n"
+        "      password: not-a-placeholder\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        persona_images.verify_persona_renders(_persona_config(repo), _PERSONA_USERS, repo_root=repo)
+
+    message = str(excinfo.value)
+    assert "model configuration its provider cannot serve" in message
+    assert "Fix the model in this deployment's profile" in message
+    assert "observability" not in message
     assert calls == []
 
 

--- a/tests/health/core/test_channel_finder.py
+++ b/tests/health/core/test_channel_finder.py
@@ -145,6 +145,39 @@ async def test_no_database_path_configured_warns() -> None:
     assert by_name["channel_finder_database"].status is Status.WARNING
 
 
+async def test_every_database_row_names_the_one_file_it_stats(tmp_path) -> None:
+    """The row stats ``database.path`` and nothing else, so it must say so.
+
+    A middle-layer deployment holds a second channel database — the DuckDB
+    ``channel_finder_channels`` reports on — and a row saying "channel database
+    present" while stat-ing only the pipeline's own file reads as a verdict on
+    both. It would be vouching for an artifact it never opened, next to a row
+    correctly reporting that artifact absent.
+    """
+    present = tmp_path / "hierarchical.json"
+    _write_json_db(present, '{"SR": {}}')
+    empty = tmp_path / "empty.json"
+    empty.write_bytes(b"")
+    missing = tmp_path / "nope.json"
+
+    ok = (await _run(_cf(path=str(present))))["channel_finder_database"]
+    assert ok.message == "Active pipeline's channel database file present"
+
+    fresh = (await _run(_cf(path=str(present))))["channel_finder_freshness"]
+    assert fresh.message == "Active pipeline's channel database file build age"
+
+    assert (await _run(_cf(path=str(empty))))[
+        "channel_finder_database"
+    ].message == f"Active pipeline's channel database file is empty ({empty})"
+
+    assert (await _run(_cf(path=str(missing))))[
+        "channel_finder_database"
+    ].message == f"Active pipeline's channel database file missing at {missing}"
+
+    unset = (await _run(_cf(path=None)))["channel_finder_database"]
+    assert unset.message == "No database.path configured for the active pipeline"
+
+
 async def test_relative_database_path_resolved_against_cwd(tmp_path) -> None:
     rel = "data/channel_databases/hierarchical.json"
     _write_json_db(tmp_path / rel, '{"SR": {}}')

--- a/tests/interfaces/test_logbook_composition_provider.py
+++ b/tests/interfaces/test_logbook_composition_provider.py
@@ -184,7 +184,7 @@ _CTX = {
     "enable_hierarchical": False,
     "enable_middle_layer": False,
     "system": {"timezone": "UTC"},
-    "osprey_labels": {"project_name": "demo", "project_root": "/tmp/demo", "deployed_at": "now"},
+    "osprey_labels": {"project_name": "demo", "project_root": "/tmp/demo"},
 }
 
 _TEMPLATES_WITH_LOGBOOK = [

--- a/tests/templates/render_axis_shapes/bridge-on-host/gchat_bridge.yml
+++ b/tests/templates/render_axis_shapes/bridge-on-host/gchat_bridge.yml
@@ -45,6 +45,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/tests/templates/render_axis_shapes/bridge-on-host/gchat_bridge.yml
+++ b/tests/templates/render_axis_shapes/bridge-on-host/gchat_bridge.yml
@@ -45,7 +45,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/tests/templates/render_axis_shapes/bridge-on-host/nextcloud_bridge.yml
+++ b/tests/templates/render_axis_shapes/bridge-on-host/nextcloud_bridge.yml
@@ -45,6 +45,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/tests/templates/render_axis_shapes/bridge-on-host/nextcloud_bridge.yml
+++ b/tests/templates/render_axis_shapes/bridge-on-host/nextcloud_bridge.yml
@@ -45,7 +45,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/tests/templates/render_axis_shapes/env-shared-chain/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/env-shared-chain/dispatch_worker.yml
@@ -34,6 +34,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/tests/templates/render_axis_shapes/env-shared-chain/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/env-shared-chain/dispatch_worker.yml
@@ -34,7 +34,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/tests/templates/render_axis_shapes/pair-on-host/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/pair-on-host/dispatch_worker.yml
@@ -34,6 +34,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/tests/templates/render_axis_shapes/pair-on-host/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/pair-on-host/dispatch_worker.yml
@@ -34,7 +34,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/tests/templates/render_axis_shapes/pair-on-host/event_dispatcher.yml
+++ b/tests/templates/render_axis_shapes/pair-on-host/event_dispatcher.yml
@@ -34,7 +34,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
       osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
     restart: unless-stopped
     environment:

--- a/tests/templates/render_axis_shapes/pair-on-host/event_dispatcher.yml
+++ b/tests/templates/render_axis_shapes/pair-on-host/event_dispatcher.yml
@@ -34,6 +34,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
     restart: unless-stopped
     environment:

--- a/tests/templates/render_axis_shapes/two-workers-on-host/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/two-workers-on-host/dispatch_worker.yml
@@ -34,7 +34,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document
@@ -166,7 +165,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/tests/templates/render_axis_shapes/two-workers-on-host/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/two-workers-on-host/dispatch_worker.yml
@@ -34,6 +34,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document
@@ -165,6 +174,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/tests/templates/render_defaults/archiver_recorder.yml
+++ b/tests/templates/render_defaults/archiver_recorder.yml
@@ -45,6 +45,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # No `ports:` and no `healthcheck:` — deliberately. This service opens no
     # listening socket, so it has nothing to publish and nothing an HTTP or TCP

--- a/tests/templates/render_defaults/archiver_recorder.yml
+++ b/tests/templates/render_defaults/archiver_recorder.yml
@@ -45,7 +45,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     # No `ports:` and no `healthcheck:` — deliberately. This service opens no
     # listening socket, so it has nothing to publish and nothing an HTTP or TCP

--- a/tests/templates/render_defaults/bluesky.yml
+++ b/tests/templates/render_defaults/bluesky.yml
@@ -61,6 +61,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "127.0.0.1:8090:8090"
@@ -259,6 +268,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # No `ports:` — deliberately. Publishing the control socket would put a
     # second route to plan execution next to the bridge's launch-token gate,

--- a/tests/templates/render_defaults/bluesky.yml
+++ b/tests/templates/render_defaults/bluesky.yml
@@ -61,7 +61,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     ports:
       - "127.0.0.1:8090:8090"
@@ -260,7 +259,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     # No `ports:` — deliberately. Publishing the control socket would put a
     # second route to plan execution next to the bridge's launch-token gate,

--- a/tests/templates/render_defaults/bluesky_panels.yml
+++ b/tests/templates/render_defaults/bluesky_panels.yml
@@ -41,6 +41,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "127.0.0.1:8095:8095"

--- a/tests/templates/render_defaults/bluesky_panels.yml
+++ b/tests/templates/render_defaults/bluesky_panels.yml
@@ -41,7 +41,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     ports:
       - "127.0.0.1:8095:8095"

--- a/tests/templates/render_defaults/dispatch_worker.yml
+++ b/tests/templates/render_defaults/dispatch_worker.yml
@@ -34,6 +34,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/tests/templates/render_defaults/dispatch_worker.yml
+++ b/tests/templates/render_defaults/dispatch_worker.yml
@@ -34,7 +34,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
       # Content fingerprint of the env chain this deploy read (runtime_helper's
       # env_chain_digest, carried in by OSPREY_ENV_DIGEST). It is a label, not
       # documentation: compose recreates a container when the compose document

--- a/tests/templates/render_defaults/event_dispatcher.yml
+++ b/tests/templates/render_defaults/event_dispatcher.yml
@@ -34,6 +34,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
     restart: unless-stopped
     ports:

--- a/tests/templates/render_defaults/event_dispatcher.yml
+++ b/tests/templates/render_defaults/event_dispatcher.yml
@@ -34,7 +34,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
       osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
     restart: unless-stopped
     ports:

--- a/tests/templates/render_defaults/gchat_bridge.yml
+++ b/tests/templates/render_defaults/gchat_bridge.yml
@@ -35,6 +35,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/tests/templates/render_defaults/gchat_bridge.yml
+++ b/tests/templates/render_defaults/gchat_bridge.yml
@@ -35,7 +35,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/tests/templates/render_defaults/mongodb.yml
+++ b/tests/templates/render_defaults/mongodb.yml
@@ -31,7 +31,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     # Block compression for every collection this server creates. It is set on
     # the SERVER, not per-collection, precisely because the seeder creates the

--- a/tests/templates/render_defaults/mongodb.yml
+++ b/tests/templates/render_defaults/mongodb.yml
@@ -31,6 +31,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # Block compression for every collection this server creates. It is set on
     # the SERVER, not per-collection, precisely because the seeder creates the

--- a/tests/templates/render_defaults/nextcloud_bridge.yml
+++ b/tests/templates/render_defaults/nextcloud_bridge.yml
@@ -35,6 +35,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/tests/templates/render_defaults/nextcloud_bridge.yml
+++ b/tests/templates/render_defaults/nextcloud_bridge.yml
@@ -35,7 +35,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     # Deliberately NO bulk .env passthrough. The project .env carries the
     # provider keys the dispatch worker needs (CBORG/OpenAI/...), and this

--- a/tests/templates/render_defaults/openobserve.yml
+++ b/tests/templates/render_defaults/openobserve.yml
@@ -32,7 +32,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     ports:
       - "127.0.0.1:5080:5080/tcp"

--- a/tests/templates/render_defaults/openobserve.yml
+++ b/tests/templates/render_defaults/openobserve.yml
@@ -32,6 +32,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "127.0.0.1:5080:5080/tcp"

--- a/tests/templates/render_defaults/postgresql.yml
+++ b/tests/templates/render_defaults/postgresql.yml
@@ -15,7 +15,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     ports:
       - "127.0.0.1::5432"

--- a/tests/templates/render_defaults/postgresql.yml
+++ b/tests/templates/render_defaults/postgresql.yml
@@ -15,6 +15,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "127.0.0.1::5432"

--- a/tests/templates/render_defaults/qmd.yml
+++ b/tests/templates/render_defaults/qmd.yml
@@ -44,6 +44,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
       osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
     restart: unless-stopped
     ports:

--- a/tests/templates/render_defaults/qmd.yml
+++ b/tests/templates/render_defaults/qmd.yml
@@ -44,7 +44,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
       osprey.env.digest: "${OSPREY_ENV_DIGEST:-}"
     restart: unless-stopped
     ports:

--- a/tests/templates/render_defaults/virtual_accelerator.yml
+++ b/tests/templates/render_defaults/virtual_accelerator.yml
@@ -53,7 +53,6 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
-      osprey.deployed.at: "2026-01-01T00:00:00"
     restart: unless-stopped
     ports:
       - "127.0.0.1:5064:5064/tcp"

--- a/tests/templates/render_defaults/virtual_accelerator.yml
+++ b/tests/templates/render_defaults/virtual_accelerator.yml
@@ -53,6 +53,15 @@ services:
       osprey.project.name: "golden-project"
       com.osprey.repo-id: "0123456789ab"
       osprey.project.root: "/deploy/golden-project"
+      # Content fingerprint of the rendered config this deploy built
+      # (runtime_helper's as_built_config_digest, carried in by
+      # OSPREY_CONFIG_DIGEST). The same recreate trigger as the env digest, for
+      # the other file a container reads its settings from: this service mounts
+      # the rendered config.yml, so `osprey set` changes a file the compose
+      # document never mentions and compose would leave the container running on
+      # the settings it parsed at startup. Empty when the invocation did not set
+      # the variable (a hand-run `docker compose up`).
+      osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"
     restart: unless-stopped
     ports:
       - "127.0.0.1:5064:5064/tcp"

--- a/tests/templates/test_render_defaults_golden.py
+++ b/tests/templates/test_render_defaults_golden.py
@@ -280,6 +280,33 @@ def test_goldens_pin_the_env_chain_deltas() -> None:
     assert "./.env.shared" not in worker, "the default shape has no shared chain file"
 
 
+def test_every_labelled_golden_carries_the_config_digest() -> None:
+    """A service that mounts the rendered config must be recreated when it moves.
+
+    Enumerated across the whole baseline rather than spot-checked on one service,
+    because the failure is silent per service: a template without this label
+    renders, deploys and comes up healthy, and simply keeps serving the settings
+    it parsed the first time — so ``osprey set`` reports success and changes
+    nothing an operator can see.
+
+    Keyed on carrying the project labels at all: the services-root template
+    declares only the shared network and has no container to label.
+    """
+    missing = []
+    for name in sorted(path.name for path in _GOLDEN_DIR.glob("*.yml")):
+        text = (_GOLDEN_DIR / name).read_text(encoding="utf-8")
+        if "osprey.project.name:" not in text:
+            continue
+        if 'osprey.config.digest: "${OSPREY_CONFIG_DIGEST:-}"' not in text:
+            missing.append(name)
+
+    assert not missing, (
+        f"these rendered services carry container labels but no config digest: {missing}. "
+        "A service that mounts the rendered config.yml needs it, or a config change "
+        "never reaches the running container."
+    )
+
+
 def _regenerate() -> None:
     """Overwrite every golden from today's templates. See the update discipline."""
     _GOLDEN_DIR.mkdir(parents=True, exist_ok=True)

--- a/tests/templates/test_render_defaults_golden.py
+++ b/tests/templates/test_render_defaults_golden.py
@@ -37,12 +37,15 @@ quietly drops them.
   template edit you just made. A byte you cannot account for is the bug this
   suite exists to catch.
 
-The three render-time values that differ per checkout and per run — the deploy
-timestamp, the repo-identity hash, and the running framework version — are
-pinned to fixed literals in the context (see the ``_PINNED_*`` constants) rather
-than substituted at comparison time, so the goldens stay literal, readable
-files. What derives those values in production is covered by the generator's
-own tests; what this suite covers is what the templates do with them.
+The render-time values that differ per checkout — the deployment repo's path,
+its identity hash, and the running framework version — are pinned to fixed
+literals in the context (see the ``_PINNED_*`` constants) rather than
+substituted at comparison time, so the goldens stay literal, readable files.
+What derives those values in production is covered by the generator's own
+tests; what this suite covers is what the templates do with them.
+
+Nothing here is pinned per *run*: a render is a function of its context alone,
+which is what :mod:`test_render_reproducible` asserts directly.
 """
 
 from __future__ import annotations
@@ -62,12 +65,11 @@ _GOLDEN_DIR = Path(__file__).parent / "render_defaults"
 #: — it lands in image tags, container names and mount paths throughout.
 _PROJECT_NAME = "golden-project"
 
-#: The render-time values that would otherwise differ on every run and every
-#: machine. Pinned into the context after injection so the committed files are
-#: literal: the deploy clock, the hash of the deployment repo's resolved path,
-#: and the framework version the renderer happens to be running.
+#: The render-time values that would otherwise differ from one machine to the
+#: next. Pinned into the context after injection so the committed files are
+#: literal: the deployment repo's resolved path, the hash of that path, and the
+#: framework version the renderer happens to be running.
 _PINNED_PROJECT_ROOT = f"/deploy/{_PROJECT_NAME}"
-_PINNED_DEPLOYED_AT = "2026-01-01T00:00:00"
 _PINNED_REPO_ID = "0123456789ab"
 _PINNED_OSPREY_VERSION = "0.0.0"
 
@@ -137,8 +139,8 @@ def _pinned_context(config: dict) -> dict:
 
     The injection is ``_inject_project_metadata`` — the same call
     ``render_template`` makes — so what a golden pins is the generator's own
-    context, not one the test assembled. Only the four values that would
-    otherwise differ per run and per machine are overwritten afterwards.
+    context, not one the test assembled. Only the three values that would
+    otherwise differ from one checkout to the next are overwritten afterwards.
 
     Shared with the axis-shape suite (``test_render_axis_shapes.py``), which
     hands in the same raw config with a per-scenario overlay applied: one
@@ -153,29 +155,36 @@ def _pinned_context(config: dict) -> dict:
     config["osprey_labels"] = {
         **config["osprey_labels"],
         "project_root": _PINNED_PROJECT_ROOT,
-        "deployed_at": _PINNED_DEPLOYED_AT,
         "repo_id": _PINNED_REPO_ID,
     }
     return config
 
 
-def _default_context(repo_root: Path) -> dict:
-    """The production render context for a deployment with every axis unset.
+def _raw_default_config(repo_root: Path) -> dict:
+    """The un-injected config a deployment with every axis unset renders from.
 
     The per-service blocks are empty dicts: that is how a deployment which never
     heard of the network axis renders, and spelling defaults here would prove
     only that the test and the template agree on a value the test supplied.
+
+    Split out from :func:`_default_context` so the reproducibility suite
+    (``test_render_reproducible.py``) can inject it itself, unpinned — what it
+    asserts is a property of the production injection, which a pinned context
+    would hide.
     """
-    return _pinned_context(
-        {
-            "project_name": _PROJECT_NAME,
-            "project_root": str(repo_root),
-            "services": {key: {} for key in _service_keys()},
-            "deployment": {},
-            "system": {"timezone": "UTC"},
-            "deployed_services": [],
-        }
-    )
+    return {
+        "project_name": _PROJECT_NAME,
+        "project_root": str(repo_root),
+        "services": {key: {} for key in _service_keys()},
+        "deployment": {},
+        "system": {"timezone": "UTC"},
+        "deployed_services": [],
+    }
+
+
+def _default_context(repo_root: Path) -> dict:
+    """The production render context for a deployment with every axis unset."""
+    return _pinned_context(_raw_default_config(repo_root))
 
 
 def _render_templates(context: dict, rel_paths: Iterable[str]) -> dict[str, str]:

--- a/tests/templates/test_render_reproducible.py
+++ b/tests/templates/test_render_reproducible.py
@@ -1,0 +1,106 @@
+"""A compose render is a function of its inputs and nothing else.
+
+The golden suites beside this one pin *what* every bundled template renders.
+This one pins something they structurally cannot: that rendering the same
+deployment twice produces the same bytes. A golden suite compares one render
+against a committed file, so a value that is fresh on every render is invisible
+to it the moment the harness pins that value into the context — which is
+exactly how a wall-clock deploy timestamp survived in the rendered documents
+while every golden stayed green.
+
+Why the property matters beyond tidiness: compose decides whether to recreate a
+container by diffing its service definition, so any per-run value in a rendered
+document makes ``osprey up`` tear down and rebuild the whole stack on a build
+that changed nothing. A build directory whose bytes move on their own is also
+undiffable — an operator cannot tell a real configuration change from noise.
+
+The context is built by the production injection
+(``_inject_project_metadata``), twice, from one unchanged config — not built
+once and rendered twice, which would only prove that Jinja is deterministic.
+The two injections are deliberately separated by a real clock tick, so a
+timestamp reintroduced into the context is caught here rather than passing by
+landing inside the same microsecond.
+"""
+
+from __future__ import annotations
+
+import datetime
+import tempfile
+from pathlib import Path
+
+# Imported by bare module name for the same reason the axis-shape suite does it:
+# this directory carries no ``__init__.py``, so pytest names the module by its
+# basename.
+from test_render_defaults_golden import (
+    TEMPLATES,
+    _raw_default_config,
+    _render_templates,
+)
+
+
+def _await_clock_tick() -> None:
+    """Block until the system clock reports a different instant.
+
+    Cheap — the resolution of ``datetime.now()`` is microseconds — and it is
+    what gives the comparison below its teeth: two renders that happened to
+    share a timestamp would agree even with a timestamp in the document.
+    """
+    start = datetime.datetime.now()
+    while datetime.datetime.now() == start:
+        pass
+
+
+def _render_everything(config: dict) -> dict[str, str]:
+    """Inject *config* the way production does, then render every template."""
+    from osprey.deployment.compose_generator import _inject_project_metadata
+
+    return _render_templates(_inject_project_metadata(dict(config)), TEMPLATES)
+
+
+def test_rendering_the_same_deployment_twice_is_byte_identical() -> None:
+    """Every bundled template renders the same bytes on a second pass.
+
+    Asserted per document rather than on the two mappings at once, so a failure
+    names the template that moved instead of dumping every rendered file.
+    """
+    with tempfile.TemporaryDirectory() as directory:
+        repo_root = Path(directory)
+        (repo_root / ".env").write_text("OSPREY_GOLDEN_FIXTURE=1\n", encoding="utf-8")
+        config = _raw_default_config(repo_root)
+
+        first = _render_everything(config)
+        _await_clock_tick()
+        second = _render_everything(config)
+
+    assert first.keys() == second.keys()
+    assert first, "no bundled templates were rendered — the discovery glob found nothing"
+
+    for name in sorted(first):
+        assert first[name] == second[name], (
+            f"{name} renders differently on a second pass from an unchanged "
+            "deployment. Something in the render context varies per run — a "
+            "clock, a random value, or an unordered iteration. A compose "
+            "document must be a function of its inputs alone."
+        )
+
+
+def test_the_injected_context_carries_no_per_run_values() -> None:
+    """The context itself is stable, not merely the templates' use of it.
+
+    The render check above only catches a volatile value that some template
+    happens to emit. This catches one sitting in the context unused, waiting for
+    the next template author to reach for it.
+    """
+    from osprey.deployment.compose_generator import _inject_project_metadata
+
+    with tempfile.TemporaryDirectory() as directory:
+        repo_root = Path(directory)
+        (repo_root / ".env").write_text("OSPREY_GOLDEN_FIXTURE=1\n", encoding="utf-8")
+        config = _raw_default_config(repo_root)
+
+        first = _inject_project_metadata(dict(config))
+        _await_clock_tick()
+        second = _inject_project_metadata(dict(config))
+
+    assert first["osprey_labels"] == second["osprey_labels"]
+    assert first == second

--- a/tests/templates/test_telemetry_optin_templates.py
+++ b/tests/templates/test_telemetry_optin_templates.py
@@ -35,7 +35,7 @@ _CTX = {
     "enable_hierarchical": False,
     "enable_middle_layer": False,
     "system": {"timezone": "UTC"},
-    "osprey_labels": {"project_name": "demo", "project_root": "/tmp/demo", "deployed_at": "now"},
+    "osprey_labels": {"project_name": "demo", "project_root": "/tmp/demo"},
 }
 
 _PROJECT = "project/config.yml.j2"


### PR DESCRIPTION
Eight independent fixes to the deploy path, each one a case of the tooling
telling an operator something that was not true — or not telling them at all.

**The observability store's credentials were diagnosed as something else.** A
missing or unresolved OpenObserve credential raised the same error type as a bad
endpoint, and every caller that resolves a provider spec catches broadly and
phrases its own remedy from what it caught. An unset store password was
therefore reported as a bad model, as an unreadable provider, or as nothing at
all. The credential failures now carry their own type, caught ahead of the broad
arms at the four places that report on a resolve.

**The same store accepted values that are not secrets.** Its compose template
interpolates a published default, which passes every format rule because it is
well formed; an operator who pinned it ran the transcript store on a value that
ships in every rendered project. An empty service token was honoured as a
deliberate fail-closed setting, which is not a setting a machine-minted secret
has — an empty one starts the service with no authentication at all. The mint now
fills a blank, and refuses the published default by name.

**`osprey status` printed the store's Authorization header** — base64 of
user:password — on a report that goes to shared terminals and into tickets.
Masking is a rule now, not a comparison against one remembered variable.

**Renders were not a function of their inputs.** Every bundled service template
stamped a wall-clock deploy timestamp, so the same project built twice produced
different bytes, and the runtime treated every container as changed on each
`osprey up` — recreating the whole stack for a label nothing read back.

**A start refused one precondition at a time.** Most are answerable from the
deployment's own files before anything is built, so an operator with four
problems paid four deploy attempts. The collectable ones are now probed together
and reported in one structured refusal.

**The users-env migration deleted a leftover secrets file** identified by
filename alone. Another tool on the host may keep its own secrets under that
spelling; a delete cannot tell the two cases apart. It is set aside at 0600 now,
and `osprey reset` discloses it.

Plus a generated `.env.users` that never carried the observability account name,
and four unrelated operator-facing defects (a second `uv venv` build that failed
where the first succeeded, a scaffold refusal that did not mention the commented
example already in the file, two health rows vouching for artifacts they never
stat, and convention advice that told an operator to invent a user).

## What a reviewer should push back on

Two deliberate behaviour changes, stated plainly:

- **A telemetry block naming a bare `${VAR}` password is now refused** when the
  env chain does not set it. Previously that reference reached the container
  verbatim and the agent authenticated with a literal `${...}` string. A
  reference that carries its own `:-default` is not asked for at all, so stock
  templates keep today's behaviour — the generated file still never carries the
  store's admin password, because one `.env.users` is handed to every persona
  alike and admin access to that store reads every transcript in it. Terminals
  will not authenticate to the store until a scoped ingest credential exists;
  this PR makes that gap visible rather than closing it.
- **The aggregate refusal fires at a count of one**, not only for several. A
  start refusing over a single precondition now reads like one refusing over
  four. The alternative — a bare message below some threshold, a structured one
  above it — would make the common case the unfamiliar one.

The last commit is tests only. It pins how a value living in the chain's shared
half reaches two provisioners that never open that file, before anything
refactors them.
