### PR TITLE
fix(cli): surface the deploy problems the operator never saw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Fixed
+
+- A deploy whose web terminals are unreachable now says so on the terminal. The
+  warning naming the Docker Desktop remedy was emitted with `logger.warning`,
+  which the altitude gate drops while a lifecycle verb owns the terminal, and
+  the root logger carries no other handler. So on the one path that mattered,
+  a self-heal bounce that did not help, the run printed "bounced the web
+  stack ..." and then went straight to the endpoint table, which reads as
+  success. It is promoted through `warn_fact` now.
+
+### Added
+
+- The post-up reachability warning now separates a forwarder that is switched
+  off from a port registration the running forwarder missed. A definite "off"
+  skips the self-heal restart, which cannot help, and states the cause; an
+  unreadable setting keeps bouncing first and then names the setting as
+  something to check.
+
 ### Changed
 
 - Lifecycle output now carries the CLI's theme. Phase openers anchor in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The same-name-different-checkout refusal leads with its conclusion. It used
+  to open with the count and the identity hashes, print one line per resource,
+  and only then explain that a worktree or a second clone shares its parent
+  directory's name. On a real deployment that put the explanation and the way
+  out about thirty lines below the top, where nobody reads them. Now the
+  finding, the other copy's path and the remedy come first, each path is listed
+  once instead of once per resource, and the per-resource evidence prints under
+  `--verbose`. No claim changed: it still says only what the labels prove.
+
 - A deploy whose web terminals are unreachable now says so on the terminal. The
   warning naming the Docker Desktop remedy was emitted with `logger.warning`,
   which the altitude gate drops while a lifecycle verb owns the terminal, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- `osprey init --reset` no longer crashes with a Python traceback when the
+  containers it would remove belong to another copy of this repo. `osprey
+  reset` has always caught that refusal and rendered it; this path never did,
+  so the same deliberate guard looked like a bug in OSPREY depending on which
+  verb you typed. It is a refusal now, and it says what is on disk afterwards.
 - The same-name-different-checkout refusal leads with its conclusion. It used
   to open with the count and the identity hashes, print one line per resource,
   and only then explain that a worktree or a second clone shares its parent
@@ -21,7 +26,10 @@ Compatibility is documented in release notes, not encoded in the version string.
   finding, the other copy's path and the remedy come first, each path is listed
   once instead of once per resource, and the per-resource evidence prints under
   `--verbose`. No claim changed: it still says only what the labels prove.
-
+- `osprey init --reset` also offers the way out that destroys nothing. `reset`
+  can only suggest going and wiping the other deployment; whoever ran `init`
+  asked to create something, so deploying this copy under its own name is
+  named too.
 - A deploy whose web terminals are unreachable now says so on the terminal. The
   warning naming the Docker Desktop remedy was emitted with `logger.warning`,
   which the altitude gate drops while a lifecycle verb owns the terminal, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- `osprey up` and `osprey restart` warn in Preflight when Docker Desktop's
+  "Enable host networking" is off and the deployment has web terminals. The
+  post-up probe already caught this, but only after every image was built and
+  every container was up, which on a first deploy is a quarter of an hour after
+  the operator could have fixed it. Read from Docker Desktop's own settings
+  (its backend API, falling back to the persisted settings store), so the
+  warning names the cause instead of listing suspects. A setting that cannot be
+  read stays silent and leaves the post-up probe to speak.
 - The post-up reachability warning now separates a forwarder that is switched
   off from a port registration the running forwarder missed. A definite "off"
   skips the self-heal restart, which cannot help, and states the cause; an

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -43,6 +43,18 @@ def _report_fact(message: str) -> None:
     output.report_fact(logger, message)
 
 
+def _warn_fact(summary: str, detail: str | None = None, remedy: str | None = None) -> None:
+    """Warn under this module's logger, in the run's own column.
+
+    The promotion contract lives in :func:`osprey.cli.output.warn_fact`; this
+    binds it to the deploy logger so call sites pass the copy alone. Promotion is
+    not optional for a warning raised during a lifecycle verb: the altitude gate
+    drops raw WARNING records while a reporter owns the terminal, so
+    ``logger.warning`` here would reach nobody.
+    """
+    output.warn_fact(logger, summary, detail, remedy)
+
+
 # ---------------------------------------------------------------------------
 # osprey up — the four-zone start verb
 # ---------------------------------------------------------------------------
@@ -362,14 +374,71 @@ def ensure_repo_env(repo_root: Path, config: dict[str, Any], *, mark: bool = Tru
     )
 
 
-def _preflight(repo_root: Path, reporter: PhaseReporter, *, nothing_done: str) -> None:
-    """Check the two things a start verb needs before it starts anything.
+def _warn_if_host_networking_is_off(config: dict) -> None:
+    """Say up front when Docker Desktop cannot forward the web terminals' port.
 
-    Reported as one phase because it is one question to the operator — can this
-    deployment start at all? — answered by two facts: a ``build/`` to start, and
-    the secret store every compose invocation is pointed at. Both refusals name
-    the same remedies they always did; the phase only adds a ✗ line naming the
+    :func:`~osprey.deployment.web_terminals.postup_hooks.warn_if_web_stack_unreachable`
+    stays the authority on whether the web tier is actually reachable, because it
+    tests the thing itself rather than a setting. The one thing it cannot be is
+    early: it runs after the images are built and the containers are up, which on
+    a first deploy is a quarter of an hour after the operator could have fixed
+    this with one checkbox. So this is the same finding, stated before any of that
+    work is done.
+
+    Only a definite "off" earns a word here. A setting that reads as on, a host
+    that cannot be asked, a deployment with no web terminals: all silent, and
+    left to the post-up probe. A preflight that warned on suspicion would fire on
+    every deployment whose web tier is perfectly fine, and an operator who is
+    warned about nothing stops reading warnings.
+
+    Advisory, like the probe it front-runs. The backend services do not care
+    about this setting, so refusing a deploy over it would be deciding for an
+    operator that they wanted the web terminals more than they wanted their
+    services running.
+
+    :param config: The as-built deploy config, already loaded by the caller.
+    """
+    from osprey.deployment.docker_desktop import (
+        HOST_NETWORKING_REMEDY,
+        host_networking_enabled,
+        on_docker_desktop,
+    )
+
+    # The same reading of "this deployment has web terminals" the post-up probe
+    # uses: a rendered nginx port is what the module's presence amounts to here.
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    nginx_port = web_terminals.get("nginx_port")
+    if not isinstance(nginx_port, int):
+        return
+    if not on_docker_desktop(config):
+        return
+    if host_networking_enabled() is not False:
+        return
+
+    _warn_fact(
+        "Docker Desktop will not be able to reach the web terminals",
+        f"host networking is turned off in Docker Desktop, so the web terminal on port "
+        f"{nginx_port} binds inside the Docker Linux VM and stays unreachable from this "
+        "machine. The containers will start and report themselves healthy either way, "
+        "and http://127.0.0.1:"
+        f"{nginx_port}/ will not load in a browser. Everything else in this deployment "
+        "publishes its ports normally and is unaffected.",
+        f"{HOST_NETWORKING_REMEDY}, and run this again",
+    )
+
+
+def _preflight(repo_root: Path, reporter: PhaseReporter, *, nothing_done: str) -> None:
+    """Check what a start verb needs before it starts anything.
+
+    Reported as one phase because it is one question to the operator: can this
+    deployment start at all? Two facts answer it, a ``build/`` to start and the
+    secret store every compose invocation is pointed at, and both refusals name
+    the same remedies they always did. The phase only adds a ✗ line naming the
     step that stopped.
+
+    One thing here refuses nothing and is reported anyway:
+    :func:`_warn_if_host_networking_is_off`. It belongs to this phase rather than
+    to the start because its whole value is arriving before the images are built.
 
     Args:
         repo_root: The deployment repo.
@@ -394,9 +463,12 @@ def _preflight(repo_root: Path, reporter: PhaseReporter, *, nothing_done: str) -
                 "run `osprey build` to render it",
                 mark=False,
             )
-        ensure_repo_env(
-            repo_root, load_project_config(str(config_path), wrap_errors=True), mark=False
-        )
+        config = load_project_config(str(config_path), wrap_errors=True)
+        ensure_repo_env(repo_root, config, mark=False)
+        # Last, so a refusal above still leaves through the phase rather than
+        # being preceded by a warning about a deployment that is not going to
+        # start at all.
+        _warn_if_host_networking_is_off(config)
         phase.done("build/ and .env are in place")
 
 

--- a/src/osprey/cli/foreign_refusal.py
+++ b/src/osprey/cli/foreign_refusal.py
@@ -1,0 +1,56 @@
+"""How the CLI shows a same-name-different-checkout refusal.
+
+One renderer, shared by ``osprey reset`` and ``osprey init --reset``, because
+the two verbs meet the identical guard and an operator who has read one refusal
+should recognise the other. What differs between them is the verb in the opening
+line and whether there is a second way out, so both are arguments.
+
+The split between what prints and what does not is the point of this module.
+:attr:`~osprey.deployment.reset.ForeignCheckoutError.inventory` is the evidence,
+one line per resource, and on a real deployment it is dozens of lines that repeat
+one path between them. Printed by default it pushes the sentence that explains
+the refusal below the fold, which is how a guard doing exactly its job reads as a
+crash. So the conclusion, the path and the way out print always, and the evidence
+prints under ``--verbose`` with a line saying it is there.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from osprey.cli import output
+from osprey.cli.phase_reporter import is_verbose
+
+if TYPE_CHECKING:
+    from osprey.deployment.reset import ForeignCheckoutError
+
+__all__ = ["render_foreign_refusal"]
+
+
+def render_foreign_refusal(
+    error: ForeignCheckoutError, actor: str, *, extra_remedy: str | None = None, mark: bool = True
+) -> None:
+    """Print ``error`` as a refusal, with its evidence only where it was asked for.
+
+    :param error: The refusal, in parts.
+    :param actor: The verb the operator typed, for the opening line. ``reset``
+        and ``--reset`` are the two, and each names itself so neither reports
+        the other's verb at somebody who did not run it.
+    :param extra_remedy: A second way out this verb can offer and the other
+        cannot. Printed under the shared one, because the shared one is the
+        destructive option and an operator should read the alternative before
+        acting on it.
+    :param mark: Passed to :func:`osprey.cli.output.fail`. ``False`` where a
+        phase has already printed the ✗ this refusal leaves through.
+    """
+    cause = error.cause
+    if error.inventory:
+        cause += (
+            f"\n\nRun again with --verbose to list all {len(error.inventory)} of them."
+            if not is_verbose()
+            else "\n\nRead off the resources' own labels, none of it inferred:\n"
+            + "\n".join(error.inventory)
+        )
+    output.fail(error.summary(actor), cause, error.remedy, mark=mark)
+    if extra_remedy:
+        output.note(f"or {extra_remedy}")

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -52,6 +52,8 @@ if TYPE_CHECKING:
     # Annotation only — both modules are imported lazily inside the command
     # body to keep `osprey --help` off the build-profile import chain (the
     # lazy-import budget test in tests/cli/test_main.py pins this).
+    from osprey.deployment.reset import ForeignCheckoutError
+
     from .deploy_scaffold import ScaffoldedFile
     from .profile_cmd import _MaterializedProfile
 
@@ -1130,7 +1132,13 @@ def init(
         if reset:
             # Imported here, not at module scope: this command is lazy-loaded,
             # and `reset` pulls in the whole deployment stack.
-            from osprey.deployment.reset import ResetOutcome, reset_for_reinit
+            from osprey.deployment.reset import (
+                ForeignCheckoutError,
+                ResetOutcome,
+                reset_for_reinit,
+            )
+
+            from .foreign_refusal import render_foreign_refusal
 
             # The condensed form, not `reset_deployment`: the full destruction
             # plan is the text a standalone `osprey reset` asks an operator to
@@ -1138,9 +1146,18 @@ def init(
             # reset reports what it removed and what it kept as steps of this
             # phase, and a reset with nothing to do closes the phase saying so
             # instead of printing an empty plan.
-            with reporter.phase(f"Discarding the previous {target.name}") as phase:
-                if reset_for_reinit(target) is ResetOutcome.NOTHING_TO_DO:
-                    phase.done("nothing from a previous run to remove")
+            try:
+                with reporter.phase(f"Discarding the previous {target.name}") as phase:
+                    if reset_for_reinit(target) is ResetOutcome.NOTHING_TO_DO:
+                        phase.done("nothing from a previous run to remove")
+            except ForeignCheckoutError as e:
+                # `osprey reset` has always caught this and rendered it; this
+                # path never did, so the same deliberate guard reached click as
+                # a traceback here and as a refusal there. A traceback is the
+                # loudest way the CLI can say "this is a bug in OSPREY", which
+                # is the opposite of what happened: nothing was touched, on
+                # purpose, and the operator has two ways forward.
+                _abort_foreign_reset(target, e, render_foreign_refusal)
 
             # `reset` removes only what carries this checkout's repo-id label,
             # so a deployment predating that label survives it — correctly, since
@@ -1191,6 +1208,42 @@ def _surviving_project_resources(target: Path) -> list[str]:
         ]
     except Exception:  # noqa: BLE001 — see docstring: never mask the real failure
         return []
+
+
+def _abort_foreign_reset(
+    target: Path,
+    error: ForeignCheckoutError,
+    render: Callable[..., None],
+) -> None:
+    """Stop a ``--reset`` that met another checkout's resources, and say why.
+
+    The refusal itself belongs to ``reset`` and is rendered by its shared
+    renderer, unchanged. What this verb adds is the second way out: whoever ran
+    ``osprey reset`` asked to destroy something and has one option, to go and do
+    it where it lives, but whoever ran ``osprey init`` asked to CREATE something
+    and has another. Deploying this copy under a name of its own leaves the
+    other deployment alone and is the option a second checkout usually wants, so
+    it is named rather than left for the operator to think of.
+
+    ``mark=False``: the phase this left through has printed its own ✗ already,
+    and a second one reads as a second failure.
+    """
+    render(
+        error,
+        "--reset",
+        extra_remedy=(
+            f"deploy this copy under a name of its own, which leaves that one alone: "
+            f"`osprey init {target.name}-2 ...`"
+        ),
+        mark=False,
+    )
+    # Not a repeat of the refusal's own "nothing was stopped or removed": that
+    # is about the OTHER deployment's containers, and this is about this one.
+    # The scaffold above did get written, so saying nothing at all here would
+    # leave an operator guessing what is now on disk.
+    output.report("")
+    output.report(f"{target.name}/ was created. Nothing was built and nothing was started.")
+    raise click.Abort()
 
 
 def _abort_incomplete_reset(target: Path, survivors: list[str]) -> None:

--- a/src/osprey/cli/reset_cmd.py
+++ b/src/osprey/cli/reset_cmd.py
@@ -100,6 +100,7 @@ def reset(repo: Path | None, dry_run: bool, assume_yes: bool, purge_audit: bool)
         reset_deployment,
     )
 
+    from .foreign_refusal import render_foreign_refusal
     from .main import lifecycle_reporter
 
     repo_root = find_repo_root(repo)
@@ -139,11 +140,16 @@ def reset(repo: Path | None, dry_run: bool, assume_yes: bool, purge_audit: bool)
                     emit=output.report,
                 )
         except ForeignCheckoutError as e:
-            # Shown verbatim rather than summarized: the message is already the
-            # whole explanation, and it is carefully scoped to what the labels
-            # actually prove. Rewording it here would be how a claim it does not
-            # make gets reintroduced.
-            raise click.ClickException(str(e)) from None
+            # Rendered through the shared refusal shape, not reworded: the parts
+            # are carefully scoped to what the labels actually prove, and
+            # rewriting them here would be how a claim they do not make gets
+            # reintroduced. What this decides is only how much to show, and it
+            # shows the evidence to whoever asked for it.
+            render_foreign_refusal(e, "reset")
+            # Exit rather than ClickException: the block above is already the
+            # whole explanation, and ClickException would restate a summary of
+            # it under an "Error:" prefix. Same exit code either way.
+            raise click.exceptions.Exit(1) from None
         except KeyboardInterrupt:
             # An interrupt AT THE PROMPT is handled inside reset_deployment, which
             # can prove nothing ran and says so. Reaching here means the interrupt

--- a/src/osprey/deployment/docker_desktop.py
+++ b/src/osprey/deployment/docker_desktop.py
@@ -1,0 +1,215 @@
+"""What Docker Desktop's own settings say about this host's networking.
+
+Docker Desktop runs containers inside a Linux VM, so ``network_mode: host``
+binds a port on *that* VM and not on the machine the operator is sitting at. The
+port reaches the real machine only through Docker Desktop's host-network
+forwarder, which is off unless "Enable host networking" is turned on (Docker
+Desktop 4.34 and later). With it off, a host-networked container starts, passes
+every healthcheck it runs on itself, and is unreachable from any browser on the
+host. OSPREY's web-terminal tier is exactly that shape, which is why this module
+exists: it is the difference between telling an operator their deploy "is not
+reachable" and telling them which checkbox to click.
+
+The read is a question about Docker Desktop, not about OSPREY, so it is
+deliberately advisory: every failure path returns ``None`` ("cannot tell") rather
+than raising or guessing. A caller that gets ``None`` must keep whatever hedged
+wording it had, because a confident wrong diagnosis is worse than an honest
+vague one.
+
+Two sources, most authoritative first.
+
+1. Docker Desktop's backend API over its own Unix socket. This is the live
+   setting, it always carries the key, and it agrees with what the Settings
+   window shows. Preferred for that reason.
+2. The persisted settings store on disk, as a fallback for the hosts where the
+   socket is not reachable (Windows, where the backend listens on a named pipe
+   rather than a Unix socket). This source is weaker in one specific way, and
+   the weakness is the whole reason source 1 comes first: the store persists
+   only settings that differ from their default, so a host that has never
+   touched host networking has no key at all. Absent therefore means "cannot
+   tell", NOT "disabled" -- reading it as "disabled" would blame this setting on
+   every Windows host whose web tier is dark for some unrelated reason.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import socket
+import sys
+from pathlib import Path
+from typing import Any
+
+from osprey.deployment.runtime_helper import get_runtime_command
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.docker_desktop")
+
+#: What an operator does about a disabled forwarder, in the words the Docker
+#: Desktop UI uses for each step. Shared so the preflight refusal and the
+#: post-up warning cannot drift apart into two different sets of directions.
+HOST_NETWORKING_REMEDY = (
+    "in Docker Desktop, turn on Settings -> Resources -> Network -> "
+    "'Enable host networking', then Apply & restart"
+)
+
+#: Seconds to wait on the backend socket. Generous enough for a busy Docker
+#: Desktop and short enough that a wedged one cannot hold up a deploy: the
+#: answer is advisory, so giving up is a valid outcome.
+_SOCKET_TIMEOUT = 3.0
+
+#: The settings endpoint on Docker Desktop's backend API.
+_SETTINGS_PATH = "/app/settings"
+
+#: The key in the persisted store, which spells it in PascalCase where the API
+#: spells it in camelCase.
+_STORE_KEY = "HostNetworkingEnabled"
+
+
+class _UnixHTTPConnection(http.client.HTTPConnection):
+    """``HTTPConnection`` that dials a Unix socket instead of a TCP port.
+
+    The standard library has no HTTP-over-Unix-socket client, and Docker
+    Desktop's backend speaks ordinary HTTP/1.1 over ``AF_UNIX``. Overriding
+    :meth:`connect` is the whole adaptation: everything above the socket --
+    request framing, chunked bodies, the response parser -- is unchanged.
+    """
+
+    def __init__(self, socket_path: str, timeout: float) -> None:
+        # The Host header has to be *something* and is never read by a backend
+        # that only ever hears from this machine.
+        super().__init__("localhost", timeout=timeout)
+        self._socket_path = socket_path
+
+    def connect(self) -> None:
+        """Open the ``AF_UNIX`` stream this connection will speak HTTP over."""
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        sock.connect(self._socket_path)
+        self.sock = sock
+
+
+def backend_socket_path() -> Path | None:
+    """Docker Desktop's backend socket for this platform, or ``None``.
+
+    ``None`` on Windows on purpose: the backend there listens on a named pipe,
+    which this client cannot dial, so those hosts fall through to the persisted
+    store. Returned rather than read from a constant so tests can point the
+    reader at a socket they control.
+    """
+    if sys.platform == "darwin":
+        return Path.home() / "Library/Containers/com.docker.docker/Data/backend.sock"
+    if sys.platform.startswith("linux"):
+        return Path.home() / ".docker/desktop/backend.sock"
+    return None
+
+
+def settings_store_paths() -> tuple[Path, ...]:
+    """The persisted settings files to try, in order, for this platform.
+
+    Both spellings are listed because Docker Desktop renamed the file:
+    ``settings.json`` up to 4.34, ``settings-store.json`` after it. Trying both
+    costs one ``is_file`` call and keeps the fallback working across the
+    versions an operator might actually be running.
+    """
+    if sys.platform == "darwin":
+        base = Path.home() / "Library/Group Containers/group.com.docker"
+    elif sys.platform == "win32":
+        appdata = Path.home() / "AppData/Roaming"
+        base = appdata / "Docker"
+    else:
+        base = Path.home() / ".docker/desktop"
+    return (base / "settings-store.json", base / "settings.json")
+
+
+def _unwrap(value: Any) -> bool | None:
+    """The boolean in ``value``, however Docker Desktop wrapped it.
+
+    The settings API returns some fields bare (``false``) and others wrapped
+    with their lock state (``{"locked": false, "value": false}``). Which
+    treatment a given field gets has changed between versions, so read both
+    shapes rather than pinning today's.
+    """
+    if isinstance(value, dict):
+        value = value.get("value")
+    return value if isinstance(value, bool) else None
+
+
+def _from_backend_socket() -> bool | None:
+    """Ask the running Docker Desktop, or ``None`` if it cannot be asked."""
+    socket_path = backend_socket_path()
+    if socket_path is None or not socket_path.exists():
+        return None
+
+    conn = _UnixHTTPConnection(str(socket_path), timeout=_SOCKET_TIMEOUT)
+    try:
+        conn.request("GET", _SETTINGS_PATH)
+        response = conn.getresponse()
+        if response.status != 200:
+            logger.debug(f"Docker Desktop settings API answered {response.status}.")
+            return None
+        payload = json.loads(response.read())
+    except (OSError, http.client.HTTPException, ValueError) as exc:
+        # Every way this can fail is a reason to stay quiet rather than to fail
+        # a deploy: Desktop not running, socket moved, an API that no longer
+        # answers this path, a body that is not the JSON this expects.
+        logger.debug(f"Could not read the Docker Desktop settings API: {exc}")
+        return None
+    finally:
+        conn.close()
+
+    if not isinstance(payload, dict):
+        return None
+    network = (payload.get("vm") or {}).get("network") or {}
+    if not isinstance(network, dict):
+        return None
+    return _unwrap(network.get("hostNetworkingEnabled"))
+
+
+def _from_settings_store() -> bool | None:
+    """Read the persisted store, or ``None`` when it does not say.
+
+    Only an explicit key counts. See this module's docstring for why a missing
+    key is "cannot tell" rather than "disabled".
+    """
+    for path in settings_store_paths():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(payload, dict) and _STORE_KEY in payload:
+            return _unwrap(payload[_STORE_KEY])
+    return None
+
+
+def host_networking_enabled() -> bool | None:
+    """Whether Docker Desktop will forward a host-networked port to this machine.
+
+    :return: ``True`` or ``False`` when Docker Desktop says so, ``None`` when
+        this host cannot be asked. Callers must treat ``None`` as "no new
+        information" and keep their existing wording.
+    """
+    from_api = _from_backend_socket()
+    if from_api is not None:
+        return from_api
+    return _from_settings_store()
+
+
+def on_docker_desktop(config: dict) -> bool:
+    """Whether this deployment's containers run under Docker Desktop.
+
+    Docker Desktop is the macOS and Windows product, so the platform check is
+    what distinguishes it from a Linux host running the engine directly -- where
+    ``network_mode: host`` binds on the machine itself and none of this applies.
+    Podman on macOS runs its own machine with its own port handling and is not
+    Docker Desktop, hence the runtime check as well.
+
+    The platform is read first so that a Linux host never invokes the runtime
+    resolver at all, which is what keeps this cheap on the hosts where the
+    answer is structurally ``False``.
+
+    :param config: Raw deploy config, read only for which runtime it selects.
+    """
+    if sys.platform not in ("darwin", "win32"):
+        return False
+    return get_runtime_command(config)[0] == "docker"

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -94,6 +94,7 @@ import json
 import os
 import shutil
 import subprocess
+import textwrap
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
@@ -281,17 +282,71 @@ PARTIAL_RESET_EXIT_CODE = EXIT_CODES[ResetOutcome.COMPLETED_WITH_FAILURES]
 class ForeignCheckoutError(RuntimeError):
     """Same-named resources were created from a different repo path — nothing was touched.
 
-    Carries the offending resources so a caller can render them its own way. The
-    string form is already operator-facing and names each resource, the identity
-    it carries, and the path that identity was recorded against *when one of the
-    path-evidence labels supplies it* — a volume with no such label leaves the
-    path genuinely unknown, and the message says that rather than filling it in.
+    Carried in parts rather than as one block of text, because the two verbs
+    that meet this refusal have different room for it and different advice to
+    give. A verb renders :attr:`summary`, :attr:`cause` and :attr:`remedy`
+    through :func:`osprey.cli.output.fail` and shows :attr:`inventory` only
+    under ``--verbose``: the inventory is the evidence, and on a real deployment
+    it runs to dozens of lines that repeat one path between them, which is how
+    an operator ends up reading past the sentence that would have explained it.
+
+    The parts claim exactly as much as the labels support, which is the property
+    the split has to preserve. :attr:`cause` names a path only when a
+    path-evidence label supplies one, and says the path is unknown when none
+    does, because a foreign checkout's path is not derivable from its identity
+    hash and inventing one would be worse than admitting it is unknown.
+
+    ``str(e)`` remains the whole refusal, evidence included. That is what a log
+    record and a ``--verbose`` run keep, and what a caller that has no renderer
+    still gets by printing the exception.
     """
 
-    def __init__(self, message: str, *, resources: Sequence[Resource]) -> None:
-        super().__init__(message)
+    #: The refusal's opening line, minus the verb that provoked it. Held apart
+    #: so ``reset`` and ``init --reset`` name themselves in their own summary
+    #: rather than one of them reporting the other's verb.
+    SUMMARY_TAIL = "will not remove containers and volumes from another copy of this repo"
+
+    def __init__(
+        self,
+        *,
+        project: str,
+        identity: str,
+        resources: Sequence[Resource],
+        cause: str,
+        remedy: str | None,
+        inventory: Sequence[str],
+    ) -> None:
+        #: The compose project name both copies claim.
+        self.project = project
+        #: This repo's identity, the one the foreign resources do not carry.
+        self.identity = identity
         #: The foreign resources, in discovery order.
         self.resources = list(resources)
+        #: Why, in full sentences: what was found, where it came from, and why
+        #: refusing is the right answer. Multi-line.
+        self.cause = cause
+        #: The one thing to do about it, or ``None`` where nothing honest fits.
+        self.remedy = remedy
+        #: One line per foreign resource, read off its own labels.
+        self.inventory = list(inventory)
+        super().__init__(self.full_text())
+
+    def summary(self, actor: str = "reset") -> str:
+        """The opening line, named for the verb the operator actually typed."""
+        return f"{actor} {self.SUMMARY_TAIL}"
+
+    def full_text(self, actor: str = "reset") -> str:
+        """Every part, evidence included: the record, and the ``--verbose`` view."""
+        parts = [self.summary(actor), "", self.cause]
+        if self.inventory:
+            parts += [
+                "",
+                "Read off the resources' own labels, none of it inferred:",
+                *self.inventory,
+            ]
+        if self.remedy:
+            parts += ["", f"-> {self.remedy}"]
+        return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -1183,9 +1238,7 @@ def plan_reset(repo_root: Path, *, probe: RuntimeProbe, purge_audit: bool = Fals
 
     foreign = [*containers.foreign, *volumes.foreign]
     if foreign:
-        raise ForeignCheckoutError(
-            _foreign_refusal(repo_root, project, identity, foreign), resources=foreign
-        )
+        raise _foreign_refusal(repo_root, project, identity, foreign)
 
     images = [
         image
@@ -1229,55 +1282,153 @@ def plan_reset(repo_root: Path, *, probe: RuntimeProbe, purge_audit: bool = Fals
 
 def _foreign_refusal(
     repo_root: Path, project: str, identity: str, foreign: Sequence[Resource]
-) -> str:
-    """The refusal text, claiming exactly as much as the labels support.
+) -> ForeignCheckoutError:
+    """Build the refusal, claiming exactly as much as the labels support.
 
-    An operator who sees this is in one of three situations, and the message has
+    An operator who sees this is in one of three situations, and the parts have
     to serve all of them without deciding between them: they are standing in the
     wrong directory, two checkouts of one deployment are genuinely sharing a
     host, or they renamed or moved *this* directory and are meeting their own
-    resources under the old path. The recorded path is what tells them which —
-    so it is quoted from the resource rather than reconstructed, and when no
+    resources under the old path. The recorded path is what tells them which, so
+    it is quoted from the resource rather than reconstructed, and when no
     resource carries one, the message says so instead of guessing.
+
+    Neutral about WHICH of the three it is; not neutral about ORDER. The
+    conclusion, the path and the way out come first, and the per-resource
+    evidence goes to :attr:`ForeignCheckoutError.inventory` for a verb to show
+    under ``--verbose``. That ordering claims nothing extra: a refusal whose
+    explanation sits below thirty lines of hashes is one an operator stops
+    reading before they reach it, which is how a careful guard comes across as a
+    crash.
 
     What is a *label* fact and what is a *filesystem* fact are kept apart on
     purpose: the path is reported as recorded, and whether it still exists is
     added separately by :func:`_path_liveness_note`. The remedy then branches on
     that (:func:`_foreign_remedies`), because "go and reset it over there" is
     wrong advice for a directory that is no longer on the host.
-    """
-    lines = [
-        f"Refusing to reset {repo_root}: {len(foreign)} container(s)/volume(s) carrying this "
-        f"deployment's project name ({project!r})",
-        "were created from a DIFFERENT repo path.",
-        "",
-        f"This repo is {REPO_ID_LABEL}={identity}. These are not. Every line below is read off "
-        "the resource's own",
-        "labels — none of it is inferred:",
-    ]
-    for resource in foreign:
-        note = _path_liveness_note(resource.recorded_path)
-        lines.append(f"  {resource.kind} {resource.name}  — {resource.describe_origin()}{note}")
 
-    lines.extend(
-        [
-            "",
-            "A compose project name is the repo's DIRECTORY name, so two clones or worktrees "
-            "of one deployment share",
-            "it — and would share a volume namespace. The identity is a hash of that path, so "
-            "a directory you RENAMED",
-            "or MOVED also reads as a different repo from here: if that is what happened, "
-            "these are your own resources",
-            "under their old path, and reset still will not remove them, because from here it "
-            "cannot tell them apart",
-            "from a colleague's.",
-            "",
-            "Nothing has been stopped, removed, or written.",
-            "",
-        ]
+    :param repo_root: The repo that refused. Not quoted into the text: the verb
+        that raises this already names it, and repeating it beside the foreign
+        paths invites reading it as one of them.
+    """
+    inventory = [
+        f"  {resource.kind} {resource.name}  — {resource.describe_origin()}"
+        f"{_path_liveness_note(resource.recorded_path)}"
+        for resource in foreign
+    ]
+    return ForeignCheckoutError(
+        project=project,
+        identity=identity,
+        resources=foreign,
+        cause=_foreign_cause(project, identity, foreign),
+        remedy=_foreign_remedy(foreign),
+        inventory=inventory,
     )
-    lines.extend(_foreign_remedies(foreign))
+
+
+def _distinct(values: Iterable[str]) -> list[str]:
+    """``values`` without repeats, in first-seen order."""
+    seen: dict[str, None] = {}
+    for value in values:
+        seen.setdefault(value, None)
+    return list(seen)
+
+
+def _foreign_cause(project: str, identity: str, foreign: Sequence[Resource]) -> str:
+    """Why this refused, in the order the reader needs it.
+
+    Every path is listed once rather than once per resource. Fifteen containers
+    of one deployment record one directory between them, and printing it fifteen
+    times says nothing the first line did not while burying what follows.
+
+    Wrapped here rather than left to the renderer:
+    :func:`osprey.cli.output.fail` prints each cause line as given, on the rule
+    that a caller passes lines already the shape it wants them. So this is where
+    the shape is decided.
+    """
+    recorded = _distinct(path for resource in foreign if (path := resource.recorded_path))
+    theirs = _distinct(repo_id for resource in foreign if (repo_id := resource.repo_id))
+    ids = f"{identity} here" + (f", {', '.join(theirs)} on those" if theirs else "")
+
+    lines = _wrap(
+        f"{len(foreign)} container(s) and volume(s) are named {project!r}, but they were "
+        "created from a different copy of this repo:"
+    )
+    lines.append("")
+    if recorded:
+        lines += [f"    {path}  ({_path_state(path)})" for path in recorded]
+    else:
+        lines += _wrap(
+            "the path is unknown: none of them carries a label recording it, and a repo path "
+            "cannot be derived back out of the identity hash",
+            indent="    ",
+        )
+    lines.append("")
+    lines += _wrap(
+        "Compose names a project after its directory, so a second clone, a worktree, or a "
+        "directory you renamed or moved claims the same name as the first, and would share "
+        f"its volumes. The repo ids say they are not the same repo ({ids}). Removing them "
+        "from here would mean taking resources this repo cannot prove are its own, which is "
+        "what keeps one checkout from destroying another's, so it stopped."
+    )
+    lines.append("")
+    lines += _wrap(
+        "If you renamed or moved this directory, these are your own resources under its old "
+        "path. Reset still will not take them: from here they cannot be told apart from a "
+        "colleague's."
+    )
+    lines += ["", "Nothing has been stopped, removed, or written."]
     return "\n".join(lines)
+
+
+#: Where the refusal's prose wraps. Narrow enough that the renderer's indent
+#: still leaves it inside a default terminal, since nothing downstream will
+#: re-wrap it.
+_WRAP_WIDTH = 88
+
+
+def _wrap(paragraph: str, *, indent: str = "") -> list[str]:
+    """``paragraph`` as terminal-width lines, each carrying ``indent``."""
+    return textwrap.wrap(
+        paragraph,
+        width=_WRAP_WIDTH,
+        initial_indent=indent,
+        subsequent_indent=indent,
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+
+
+def _path_state(path: str) -> str:
+    """Whether ``path`` is on this host now, as the filesystem answers it."""
+    return "still on disk" if Path(path).is_dir() else "no such directory on this host now"
+
+
+def _foreign_remedy(foreign: Sequence[Resource]) -> str:
+    """The way out, branched on what the refusal actually knows.
+
+    Three states, because the honest advice differs and one line covering all of
+    them would be wrong in two: a recorded path that still exists can be reset
+    from; one that no longer exists cannot, and naming it as a remedy would send
+    the operator to a directory that is not there; and with no path recorded at
+    all there is nowhere to send them, which has to be said rather than papered
+    over with generic advice.
+    """
+    recorded = [path for resource in foreign if (path := resource.recorded_path)]
+    live = [path for path in recorded if Path(path).is_dir()]
+
+    if live:
+        return f"reset that deployment where it lives: `osprey reset --repo {live[0]}`"
+    if recorded:
+        return (
+            "these are leftovers from a deployment whose repo is gone, and the identity they "
+            "carry is tied to that path rather than to this one, so check them and remove "
+            "them by hand"
+        )
+    return (
+        "this refusal cannot point you at the repo they came from; run `osprey reset` there "
+        "if you know which one it is, and otherwise inspect them and remove them by hand"
+    )
 
 
 def _path_liveness_note(path: str | None) -> str:
@@ -1291,41 +1442,6 @@ def _path_liveness_note(path: str | None) -> str:
     if path is None:
         return ""
     return "" if Path(path).is_dir() else "  (no such directory on this host now)"
-
-
-def _foreign_remedies(foreign: Sequence[Resource]) -> list[str]:
-    """The way out, branched on what the refusal actually knows.
-
-    Three states, because the honest advice differs and a single paragraph
-    covering all of them would be wrong in two: a recorded path that still
-    exists can be reset from; one that no longer exists cannot, and naming it as
-    a remedy would send the operator to a directory that is not there; and with
-    no path recorded at all there is nowhere to send them, which has to be said
-    rather than papered over with generic advice.
-    """
-    recorded = [path for resource in foreign if (path := resource.recorded_path)]
-    live = [path for path in recorded if Path(path).is_dir()]
-
-    if live:
-        return [
-            f"That repo is still here. Run `osprey reset` from {live[0]} (or "
-            "`osprey reset --repo <path>`) if that",
-            "is the deployment you meant to wipe.",
-        ]
-    if recorded:
-        return [
-            "None of the paths above exist on this host any more, so these are leftovers from "
-            "a deployment whose repo",
-            "is gone. Reset will not remove them from here: the identity they carry is tied to "
-            "that path, not to this",
-            "one. Check them yourself and remove them by hand.",
-        ]
-    return [
-        "No path is recorded on any of them, so this refusal cannot point you at the repo they "
-        "came from. If you",
-        "know which one it is, run `osprey reset` from there. Otherwise inspect them and remove "
-        "them by hand.",
-    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/deployment/web_terminals/postup_hooks.py
+++ b/src/osprey/deployment/web_terminals/postup_hooks.py
@@ -10,15 +10,19 @@ it never fails the deploy. Called from
 import getpass
 import shutil
 import subprocess
-import sys
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 
-from osprey.cli.output import report_fact
+from osprey.cli.output import report_fact, warn_fact
 from osprey.cli.phase_reporter import report_step as _report_step
 from osprey.deployment.compose_generator import resolve_repo_root
+from osprey.deployment.docker_desktop import (
+    HOST_NETWORKING_REMEDY,
+    host_networking_enabled,
+    on_docker_desktop,
+)
 from osprey.deployment.runtime_helper import get_runtime_command
 from osprey.deployment.subprocess_capture import run_captured
 from osprey.utils.logger import get_logger
@@ -235,27 +239,38 @@ def warn_if_web_stack_unreachable(
     This probe is the only signal that distinguishes that state from a
     working deploy.
 
-    SELF-HEAL, and why it comes before the settings hint. That forwarder
-    registers a VM-side socket by *watching* for the listen event. A
-    container that came back up under ``restart: unless-stopped`` while
-    Docker Desktop was still starting — after an update, a reboot, or the
-    Apply & Restart that enabling the setting itself performs — opens its
-    socket unobserved and stays invisible to the host indefinitely. Nothing
-    about its compose definition changed, so every subsequent ``up -d``
-    leaves it ``Running``, reconciles nothing, and reports the same failure
-    forever. Bouncing the container re-opens the socket while the forwarder
-    is watching, which fixes it. Because that state is indistinguishable
-    from "the setting is off" without a second experiment, and because the
-    restart is cheap and repairs the far more common cause, this tries the
-    restart first and only blames the setting if the port is *still* dark
-    afterwards. Gated to Docker Desktop: on Linux the port is bound on the
-    machine directly, so an unreachable one means something else entirely
-    and a blind restart would be noise.
+    TWO CAUSES, told apart by asking Docker Desktop. A dark host port on
+    Docker Desktop is either a forwarder that is switched off, or a socket the
+    running forwarder never saw. The second is real and common: the forwarder
+    registers a VM-side socket by *watching* for the listen event, so a
+    container that came back up under ``restart: unless-stopped`` while Docker
+    Desktop was still starting (after an update, a reboot, or the Apply &
+    restart that enabling the setting itself performs) opens its socket
+    unobserved and stays invisible to the host indefinitely. Nothing about its
+    compose definition changed, so every subsequent ``up -d`` leaves it
+    ``Running``, reconciles nothing, and reports the same failure forever.
+    Bouncing the container re-opens the socket while the forwarder is watching,
+    which fixes it.
+
+    :func:`~osprey.deployment.docker_desktop.host_networking_enabled` is what
+    separates the two, so the bounce is no longer attempted blind: a definite
+    "off" skips it (no restart can conjure a forwarder that is not running) and
+    the warning names the checkbox as the cause. An unreadable setting keeps the
+    old order, bouncing first and then naming the setting as a thing to check,
+    because on a host that cannot be asked the repairable cause is still the
+    likelier one. All of it is gated to Docker Desktop: on Linux the port is
+    bound on the machine directly, so an unreachable one means something else
+    entirely and a blind restart would be noise.
 
     Advisory like :func:`run_verify_script`: the containers themselves are
     healthy, so an unreachable host port warns loudly (with the Docker
     Desktop remedy where that's the likely cause) but never fails a deploy
-    that did, in fact, reconcile.
+    that did, in fact, reconcile. The warning goes out through
+    :func:`~osprey.cli.output.warn_fact` rather than ``logger.warning``, which
+    is not a style choice: the altitude gate drops raw WARNING records while a
+    lifecycle reporter owns the terminal (see :mod:`osprey.cli.altitude`), and
+    the root logger carries no other handler, so a warning emitted the raw way
+    here reaches nobody at all.
 
     :param web_cmd: The web stack's compose argv (from
         :func:`provision.web_stack_compose_cmd`), used for the self-heal
@@ -273,11 +288,19 @@ def warn_if_web_stack_unreachable(
     if _host_port_answers(url, attempts, delay):
         return
 
-    on_docker_desktop = (
-        sys.platform in ("darwin", "win32") and get_runtime_command(config)[0] == "docker"
-    )
+    desktop = on_docker_desktop(config)
+    # Asked once, up front, because it decides two separate things below: whether
+    # the self-heal bounce is worth attempting at all, and how confidently the
+    # warning at the end is allowed to speak. ``None`` means this host could not
+    # be asked, which is not the same as enabled and is not reported as either.
+    forwarder = host_networking_enabled() if desktop else None
 
-    if on_docker_desktop and web_cmd:
+    # A bounce re-registers a socket the forwarder missed. It cannot conjure a
+    # forwarder that is switched off, so a definite ``False`` skips it: the
+    # restart would cost an operator ten seconds and then tell them the same
+    # thing. ``None`` keeps the bounce, because an unknown host is exactly the
+    # one where the far more common stale registration is still worth repairing.
+    if desktop and web_cmd and forwarder is not False:
         restart_cmd = web_cmd + ["restart"]
         report_fact(
             logger,
@@ -288,8 +311,8 @@ def warn_if_web_stack_unreachable(
         try:
             # Spooled, not inherited: the restart's compose chatter would bury
             # the warning above, which is the part the operator has to act on.
-            # check=False keeps this advisory — a failed restart falls through
-            # to the settings hint below, exactly as before.
+            # check=False keeps this advisory: a failed restart falls through
+            # to the warning below, exactly as before.
             run_captured(
                 restart_cmd,
                 env=run_env,
@@ -307,23 +330,34 @@ def warn_if_web_stack_unreachable(
                 _report_step("web endpoint reachable")
                 return
 
-    hint = ""
-    if on_docker_desktop:
-        hint = (
-            " On Docker Desktop the web stack's network_mode: host binds "
-            "inside the Docker Linux VM and reaches this machine only through "
-            "Docker Desktop's host-network forwarder"
-            + (
-                ", and restarting the stack did not re-register it. Check that host "
-                "networking is enabled"
-                if web_cmd
-                else ", which is off unless host networking is enabled"
-            )
-            + ": Docker Desktop -> Settings -> Resources -> Network -> 'Enable "
-            "host networking', then Apply & Restart and re-run `osprey up`."
+    summary = "the web terminals are running but not reachable from this host"
+    if desktop and forwarder is False:
+        # Docker Desktop was asked and said no. Nothing here is a guess, so the
+        # copy states the cause and names the checkbox instead of hedging.
+        detail = (
+            f"every container is healthy and nginx is listening on port {nginx_port}, but it "
+            "is listening inside the Docker Desktop Linux VM. Host networking is turned off "
+            f"in Docker Desktop, so {url} never reaches this machine and the landing page "
+            "will not load in a browser."
         )
-    logger.warning(
-        f"Web-terminal containers are up, but {url} is not reachable from "
-        f"this host after {attempts} probes -- the landing page will not "
-        f"load in a browser.{hint}"
-    )
+        remedy = f"{HOST_NETWORKING_REMEDY}, and re-run `osprey up`"
+    elif desktop:
+        # Docker Desktop, but the setting could not be read. Same suspect, stated
+        # as a thing to check rather than as a finding.
+        bounced = " Restarting the stack did not re-register it." if web_cmd else ""
+        detail = (
+            f"{url} did not answer after {attempts} probes, so the landing page will not "
+            "load in a browser. On Docker Desktop the web stack binds its port inside the "
+            "Docker Linux VM and reaches this machine only through the host-network "
+            f"forwarder, which is off unless host networking is enabled.{bounced}"
+        )
+        remedy = f"check that host networking is on: {HOST_NETWORKING_REMEDY}"
+    else:
+        # Not Docker Desktop, so the port is bound on the machine itself and this
+        # is some other problem. Saying which one would be a guess.
+        detail = (
+            f"{url} did not answer after {attempts} probes, so the landing page will not "
+            f"load in a browser, even though nginx reports itself healthy on port {nginx_port}."
+        )
+        remedy = None
+    warn_fact(logger, summary, detail, remedy)

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -1054,6 +1054,132 @@ class TestResetFlag:
         assert len(calls) == 1, "expected exactly one reset of the target repo"
         assert calls[0]["repo_root"] == tmp_path / "demo"
 
+    def _refuse(self, monkeypatch, tmp_path, resources=2):
+        """Make the chained reset meet another checkout's resources.
+
+        The other checkout is a directory that really exists, because that is
+        the branch an operator in a worktree hits and the only one whose remedy
+        can name a repo to go and reset.
+        """
+        from osprey.deployment.compose_generator import REPO_ID_LABEL
+        from osprey.deployment.reset import Resource, _foreign_refusal
+
+        other = tmp_path / "other-checkout" / "demo"
+        other.mkdir(parents=True)
+        foreign = [
+            Resource(
+                "container",
+                f"demo-svc-{index}",
+                {
+                    REPO_ID_LABEL: "cafebabe1234",
+                    "com.docker.compose.project.working_dir": str(other),
+                },
+            )
+            for index in range(resources)
+        ]
+        error = _foreign_refusal(tmp_path / "demo", "demo", "0123456789ab", foreign)
+
+        def _raise(repo_root, **kw):
+            raise error
+
+        monkeypatch.setattr("osprey.deployment.reset.reset_for_reinit", _raise)
+        return other
+
+    def test_another_checkouts_resources_are_refused_not_crashed_into(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """The regression: `osprey reset` has always caught this and rendered it,
+        and this path never did, so the same deliberate guard came out of `init`
+        as a Python traceback. A traceback is how the CLI says "this is a bug in
+        OSPREY", and nothing here is a bug: nothing was touched, on purpose."""
+        self._refuse(monkeypatch, tmp_path)
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        assert result.exit_code != 0
+        assert result.exception is None or isinstance(result.exception, SystemExit), (
+            f"the refusal escaped as an exception: {result.exception!r}"
+        )
+        assert "Traceback" not in result.output
+
+    def test_the_refusal_leads_with_what_happened_and_where(self, runner, tmp_path, monkeypatch):
+        """Conclusion, path, way out. All of it above the evidence, because an
+        operator who has to read thirty lines of hashes to reach the sentence
+        that explains the refusal does not reach it."""
+        other = self._refuse(monkeypatch, tmp_path)
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        flowed = " ".join(result.output.split())
+        assert "--reset will not remove containers and volumes" in flowed
+        assert str(other) in flowed
+        assert f"osprey reset --repo {other}" in flowed
+
+    def test_the_refusal_offers_the_way_out_that_destroys_nothing(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """`osprey reset` knows one way out: go and wipe the other deployment.
+        Whoever typed `init` asked to CREATE something, and giving this copy its
+        own name leaves the other one alone. `reset` cannot offer that, so it is
+        this verb's to add."""
+        self._refuse(monkeypatch, tmp_path)
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        flowed = " ".join(result.output.split())
+        assert "deploy this copy under a name of its own" in flowed
+        assert "osprey init demo-2" in flowed
+
+    def test_the_evidence_waits_for_verbose(self, runner, tmp_path, monkeypatch):
+        """Every resource, one line each, is what buried the explanation. It is
+        still there for whoever wants it, and the refusal says so."""
+        self._refuse(monkeypatch, tmp_path, resources=2)
+
+        quiet = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "a"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+        loud = runner.invoke(
+            cli,
+            [
+                "--verbose",
+                "init",
+                str(tmp_path / "b"),
+                "--preset",
+                "hello-world",
+                "--no-git",
+                "--reset",
+            ],
+        )
+
+        assert "container demo-svc-0" not in quiet.output
+        assert "--verbose to list all 2 of them" in " ".join(quiet.output.split())
+        assert "container demo-svc-0" in loud.output
+
+    def test_it_says_what_is_on_disk_afterwards(self, runner, tmp_path, monkeypatch):
+        """The scaffold was written before the reset ran, so "nothing happened"
+        would be false. What did not happen is the build and the start."""
+        self._refuse(monkeypatch, tmp_path)
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        flowed = " ".join(result.output.split())
+        assert "demo/ was created" in flowed
+        assert "Nothing was built and nothing was started" in flowed
+        assert (tmp_path / "demo" / "profile.yml").is_file()
+
     def test_it_runs_after_the_repo_exists(self, runner, tmp_path, monkeypatch):
         """``reset_for_reinit`` reads the repo it is pointed at, so order matters.
 

--- a/tests/cli/test_lifecycle_promotions.py
+++ b/tests/cli/test_lifecycle_promotions.py
@@ -180,6 +180,33 @@ def assert_promoted(probe: TerminalProbe, printed: Printed, fragment: str) -> No
     assert _WITNESS in probe.rendered_text, "the probe console is not armed"
 
 
+def assert_warned(probe: TerminalProbe, promoted: str, fragment: str) -> None:
+    """The warning needle: the ``warn_fact`` counterpart to :func:`assert_promoted`.
+
+    A promoted FACT goes through the reporter, so its needle is the reporter's
+    buffer. A promoted WARNING goes to the trouble stream instead, so reading
+    ``printed`` for one would pass vacuously against an empty buffer. Everything
+    else is the same three halves plus the witness.
+
+    Args:
+        probe: The terminal probe, armed by ``default_altitude``.
+        promoted: The run's stderr, from ``capsys``.
+        fragment: A distinctive piece of the warning, short enough to survive
+            the console's wrapping once whitespace is collapsed.
+    """
+    flowed = " ".join(promoted.split())
+    assert fragment in flowed, f"not in the promoted block: {fragment!r}\n{flowed}"
+    assert fragment not in probe.rendered_text, f"still painted by the log handler: {fragment!r}"
+    assert any(fragment in message for message in probe.messages), (
+        f"no record kept for: {fragment!r}"
+    )
+
+    # Armed witness, as in assert_promoted: without it the absence assertion
+    # above would also pass on a probe console nothing could ever reach.
+    logging.getLogger(_WITNESS_LOGGER).error(_WITNESS)
+    assert _WITNESS in probe.rendered_text, "the probe console is not armed"
+
+
 def assert_sub_step(printed: Printed, name: str) -> None:
     """A ``sub-step`` row's needle: the phase record carries ``· name``."""
     assert re.search(rf"·\s+{re.escape(name)}", printed.flowed), (
@@ -1473,6 +1500,65 @@ class TestWebTerminalHostChangesAreReported:
         assert_promoted(default_altitude, printed, "is not reachable from this host yet")
         assert "docker compose -f web.yml restart" in printed.flowed
 
+    def test_a_bounce_that_did_not_help_still_reaches_the_operator(
+        self, default_altitude, printed, monkeypatch, tmp_path, capsys
+    ):
+        """The regression this class exists for, on the one path that had no test.
+
+        A deploy whose bounce fixed nothing used to end its run with
+        ``logger.warning``. The altitude gate drops WARNING while a lifecycle
+        reporter owns the terminal, and the root logger carries no other handler,
+        so the only text that named the remedy was emitted and then discarded.
+        The operator saw ``bounced the web stack ...`` and then the endpoint
+        table, which reads as success. Both stubbed probes fail, which is the
+        shape of a bounce that changed nothing.
+        """
+        _stub_the_host_port_bounce(monkeypatch, tmp_path, answers=[False, False])
+
+        postup_hooks.warn_if_web_stack_unreachable(
+            {"modules": {"web_terminals": {"nginx_port": 8080}}},
+            attempts=1,
+            delay=0,
+            web_cmd=["docker", "compose", "-f", "web.yml"],
+            run_env={},
+        )
+
+        promoted = capsys.readouterr().err
+        assert_warned(default_altitude, promoted, "not reachable from this host")
+        assert "Enable host networking" in " ".join(promoted.split())
+        # The bounce's success step is the only other thing that could have
+        # spoken, and it must not have: the endpoint is still dark.
+        assert "web endpoint reachable" not in printed.flowed
+
+    def test_a_disabled_forwarder_is_named_as_the_cause_and_skips_the_bounce(
+        self, default_altitude, monkeypatch, tmp_path, capsys
+    ):
+        """Docker Desktop was asked and said no, so nothing here is a guess.
+
+        The bounce is skipped because no restart can re-register a port through
+        a forwarder that is switched off, and the copy states the cause rather
+        than asking the operator to go and check it.
+        """
+        _stub_the_host_port_bounce(monkeypatch, tmp_path, answers=[False])
+        monkeypatch.setattr(postup_hooks, "host_networking_enabled", lambda: False)
+        restarts: list[list[str]] = []
+        monkeypatch.setattr(
+            postup_hooks, "run_captured", lambda cmd, **kwargs: restarts.append(cmd)
+        )
+
+        postup_hooks.warn_if_web_stack_unreachable(
+            {"modules": {"web_terminals": {"nginx_port": 8080}}},
+            attempts=1,
+            delay=0,
+            web_cmd=["docker", "compose", "-f", "web.yml"],
+            run_env={},
+        )
+
+        assert restarts == [], f"a bounce that cannot help was attempted anyway: {restarts}"
+        promoted = capsys.readouterr().err
+        assert_warned(default_altitude, promoted, "Host networking is turned off")
+        assert "Enable host networking" in " ".join(promoted.split())
+
     def test_a_pinned_sidecar_image_reports_the_build_it_skipped(
         self, default_altitude, printed, tmp_path, monkeypatch
     ):
@@ -1790,8 +1876,10 @@ def _stub_the_host_port_bounce(
 ) -> None:
     """A Docker Desktop host whose port answers only after the bounce."""
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: True)
+    # None is "could not read the setting", which is the state that keeps the
+    # self-heal bounce these tests are about. A definite False would skip it.
+    monkeypatch.setattr(postup_hooks, "host_networking_enabled", lambda: None)
     replies = iter(answers)
     monkeypatch.setattr(
         postup_hooks, "_host_port_answers", lambda url, attempts, delay: next(replies)

--- a/tests/cli/test_preflight_host_networking.py
+++ b/tests/cli/test_preflight_host_networking.py
@@ -1,0 +1,151 @@
+"""The preflight word about a Docker Desktop that cannot forward a host port.
+
+Why this check exists at all is a timing argument, not a correctness one. The
+post-up probe in ``web_terminals/postup_hooks.py`` already finds this state, and
+finds it by testing the port rather than a setting, so it is the authority. What
+it cannot be is early: it runs after every image is built and every container is
+up. On a first deploy that is a quarter of an hour spent building images for a
+web tier that was never going to be reachable, when the operator could have
+fixed it with one checkbox beforehand.
+
+So what is pinned here is the discipline that makes an early warning bearable:
+it speaks only when Docker Desktop has been asked and has said no, and it never
+refuses a deploy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.cli import deploy_cmd
+from osprey.deployment import docker_desktop
+
+pytestmark = pytest.mark.unit
+
+#: A config with web terminals rendered, which is what a deployment that owns a
+#: reachable landing page looks like.
+_WITH_WEB_TERMINALS = {"modules": {"web_terminals": {"nginx_port": 9080}}}
+
+
+@pytest.fixture
+def warned(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str | None, str | None]]:
+    """Collect the promoted warning instead of printing it."""
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    def record(summary: str, detail: str | None = None, remedy: str | None = None) -> None:
+        calls.append((summary, detail, remedy))
+
+    monkeypatch.setattr(deploy_cmd, "_warn_fact", record)
+    return calls
+
+
+@pytest.fixture
+def on_desktop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A macOS/Windows host running Docker Desktop."""
+    monkeypatch.setattr(docker_desktop, "on_docker_desktop", lambda config: True)
+
+
+def _setting(monkeypatch: pytest.MonkeyPatch, value: bool | None) -> None:
+    """What Docker Desktop reports, including "cannot tell"."""
+    monkeypatch.setattr(docker_desktop, "host_networking_enabled", lambda: value)
+
+
+class TestWhenItSpeaks:
+    def test_a_disabled_forwarder_is_reported_before_anything_is_built(
+        self, monkeypatch, warned, on_desktop
+    ):
+        """The whole point: the operator hears this while it is still cheap."""
+        _setting(monkeypatch, False)
+
+        deploy_cmd._warn_if_host_networking_is_off(_WITH_WEB_TERMINALS)
+
+        assert len(warned) == 1
+        summary, detail, remedy = warned[0]
+        assert "web terminals" in summary
+        assert "9080" in detail
+        assert "Enable host networking" in remedy
+
+    def test_the_warning_says_the_rest_of_the_deployment_is_fine(
+        self, monkeypatch, warned, on_desktop
+    ):
+        """Only the host-networked tier is affected. Everything else publishes
+        its ports and works, and an operator deciding whether to stop and fix
+        this now needs to know that."""
+        _setting(monkeypatch, False)
+
+        deploy_cmd._warn_if_host_networking_is_off(_WITH_WEB_TERMINALS)
+
+        assert "unaffected" in warned[0][1]
+
+
+class TestWhenItStaysQuiet:
+    def test_an_enabled_forwarder_says_nothing(self, monkeypatch, warned, on_desktop):
+        _setting(monkeypatch, True)
+
+        deploy_cmd._warn_if_host_networking_is_off(_WITH_WEB_TERMINALS)
+
+        assert warned == []
+
+    def test_a_setting_that_cannot_be_read_says_nothing(self, monkeypatch, warned, on_desktop):
+        """The discipline that keeps this warning worth reading. Guessing here
+        would warn on every host this reader cannot interrogate, and the post-up
+        probe still catches the real thing by testing the port."""
+        _setting(monkeypatch, None)
+
+        deploy_cmd._warn_if_host_networking_is_off(_WITH_WEB_TERMINALS)
+
+        assert warned == []
+
+    def test_a_host_that_is_not_docker_desktop_says_nothing(self, monkeypatch, warned):
+        """On Linux the port is bound on the machine itself and this setting does
+        not exist."""
+        monkeypatch.setattr(docker_desktop, "on_docker_desktop", lambda config: False)
+        _setting(monkeypatch, False)
+
+        deploy_cmd._warn_if_host_networking_is_off(_WITH_WEB_TERMINALS)
+
+        assert warned == []
+
+    def test_docker_desktop_is_not_even_asked_off_desktop(self, monkeypatch, warned):
+        """The read dials a socket, so it is not work a Linux host should do."""
+        monkeypatch.setattr(docker_desktop, "on_docker_desktop", lambda config: False)
+
+        def fail() -> bool:
+            raise AssertionError("the setting was read on a host it cannot apply to")
+
+        monkeypatch.setattr(docker_desktop, "host_networking_enabled", fail)
+
+        deploy_cmd._warn_if_host_networking_is_off(_WITH_WEB_TERMINALS)
+
+        assert warned == []
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            pytest.param({}, id="no-modules"),
+            pytest.param({"modules": {}}, id="no-web-terminals"),
+            pytest.param({"modules": {"web_terminals": {}}}, id="no-nginx-port"),
+            pytest.param({"modules": None}, id="null-modules"),
+        ],
+    )
+    def test_a_deployment_without_web_terminals_says_nothing(
+        self, monkeypatch, warned, on_desktop, config
+    ):
+        """Nothing in such a deployment binds a host-networked port, so the
+        setting cannot affect it."""
+        _setting(monkeypatch, False)
+
+        deploy_cmd._warn_if_host_networking_is_off(config)
+
+        assert warned == []
+
+
+class TestItRefusesNothing:
+    def test_the_check_returns_rather_than_raising(self, monkeypatch, warned, on_desktop):
+        """An operator who wants the backend services has a working deploy even
+        with the web terminals dark, so this is advisory like the probe it
+        front-runs. Pinned because turning a warning into a refusal is a
+        one-word change that would strand exactly those operators."""
+        _setting(monkeypatch, False)
+
+        assert deploy_cmd._warn_if_host_networking_is_off(_WITH_WEB_TERMINALS) is None

--- a/tests/deployment/test_docker_desktop.py
+++ b/tests/deployment/test_docker_desktop.py
@@ -1,0 +1,280 @@
+"""Reading Docker Desktop's host-networking setting, and refusing to guess.
+
+The behaviour under test is a three-valued answer: enabled, disabled, or "cannot
+tell". The third value is the one worth tests, because it is what keeps a
+hedged-but-honest warning from being replaced by a confident wrong one on a host
+this reader cannot interrogate.
+
+The backend-API tests speak real HTTP over a real ``AF_UNIX`` socket rather than
+stubbing the connection out. The adaptation being tested IS the socket dial, so a
+test that stubbed it would assert nothing about the only part that can break.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import tempfile
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment import docker_desktop
+
+pytestmark = pytest.mark.unit
+
+
+#: A settings payload shaped like the real one, trimmed to the read path.
+def _settings(host_networking: object) -> dict:
+    return {
+        "desktop": {"enhancedContainerIsolation": {"locked": False, "value": False}},
+        "vm": {
+            "network": {
+                "defaultNetworkingMode": {"locked": False, "value": "ipv4only"},
+                "hostNetworkingEnabled": host_networking,
+            }
+        },
+    }
+
+
+@pytest.fixture
+def socket_dir() -> Iterator[Path]:
+    """A directory short enough to hold an ``AF_UNIX`` path.
+
+    Not ``tmp_path``: macOS caps a Unix socket path near 104 bytes, and pytest's
+    per-test temp directories under ``/var/folders`` are long enough that
+    appending a filename can cross it. A ``/tmp`` child keeps the whole path
+    comfortably short.
+    """
+    if not hasattr(socket, "AF_UNIX"):  # pragma: no cover - POSIX-only test
+        pytest.skip("AF_UNIX sockets are unavailable on this platform")
+    with tempfile.TemporaryDirectory(dir="/tmp", prefix="osprey-dd-") as tmp:
+        yield Path(tmp)
+
+
+def _serve_once(socket_path: Path, status: str, body: str) -> threading.Thread:
+    """Answer exactly one HTTP request on ``socket_path``, then close.
+
+    One request is all :func:`host_networking_enabled` makes, so a one-shot
+    server needs no shutdown handshake: the thread is done when the read is.
+    """
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(socket_path))
+    server.listen(1)
+
+    def serve() -> None:
+        try:
+            conn, _ = server.accept()
+            with conn:
+                conn.recv(65536)  # the request line and headers, which we ignore
+                payload = body.encode("utf-8")
+                conn.sendall(
+                    f"HTTP/1.1 {status}\r\n"
+                    "Content-Type: application/json\r\n"
+                    f"Content-Length: {len(payload)}\r\n"
+                    "Connection: close\r\n\r\n".encode()
+                    + payload
+                )
+        except OSError:  # pragma: no cover - only on a torn-down test socket
+            pass
+        finally:
+            server.close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    return thread
+
+
+@pytest.fixture
+def no_settings_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the on-disk fallback at nothing, isolating the source under test.
+
+    Without this the reader would fall through to the developer's own Docker
+    Desktop settings and the test would assert on the machine it runs on.
+    """
+    monkeypatch.setattr(docker_desktop, "settings_store_paths", lambda: (tmp_path / "absent.json",))
+
+
+@pytest.fixture
+def no_backend_socket(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the API source at nothing, so only the on-disk source can answer."""
+    monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: tmp_path / "absent.sock")
+
+
+class TestTheBackendApiSource:
+    """The live setting, read from the running Docker Desktop."""
+
+    @pytest.mark.parametrize("enabled", [False, True])
+    def test_it_reports_what_docker_desktop_says(
+        self, socket_dir, monkeypatch, no_settings_store, enabled
+    ):
+        """The load-bearing case: a disabled forwarder is reported as disabled,
+        which is what lets a warning name the checkbox instead of hedging."""
+        sock = socket_dir / "backend.sock"
+        _serve_once(sock, "200 OK", json.dumps(_settings(enabled)))
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: sock)
+
+        assert docker_desktop.host_networking_enabled() is enabled
+
+    def test_it_reads_a_value_wrapped_with_its_lock_state(
+        self, socket_dir, monkeypatch, no_settings_store
+    ):
+        """Docker Desktop wraps some settings as ``{"locked", "value"}`` and
+        leaves others bare, and which is which has moved between versions."""
+        sock = socket_dir / "backend.sock"
+        _serve_once(sock, "200 OK", json.dumps(_settings({"locked": False, "value": True})))
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: sock)
+
+        assert docker_desktop.host_networking_enabled() is True
+
+    def test_an_api_that_does_not_answer_this_path_tells_us_nothing(
+        self, socket_dir, monkeypatch, no_settings_store
+    ):
+        """A future Desktop that moves the endpoint must not read as disabled."""
+        sock = socket_dir / "backend.sock"
+        _serve_once(sock, "404 Not Found", "{}")
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: sock)
+
+        assert docker_desktop.host_networking_enabled() is None
+
+    def test_a_body_that_is_not_the_expected_json_tells_us_nothing(
+        self, socket_dir, monkeypatch, no_settings_store
+    ):
+        sock = socket_dir / "backend.sock"
+        _serve_once(sock, "200 OK", "not json at all")
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: sock)
+
+        assert docker_desktop.host_networking_enabled() is None
+
+    def test_a_payload_without_the_key_tells_us_nothing(
+        self, socket_dir, monkeypatch, no_settings_store
+    ):
+        """Absent from the API is still absent: no key, no claim."""
+        sock = socket_dir / "backend.sock"
+        _serve_once(sock, "200 OK", json.dumps({"vm": {"network": {}}}))
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: sock)
+
+        assert docker_desktop.host_networking_enabled() is None
+
+    def test_a_socket_nobody_is_listening_on_tells_us_nothing(
+        self, socket_dir, monkeypatch, no_settings_store
+    ):
+        """Docker Desktop stopped between the deploy starting and this read."""
+        sock = socket_dir / "backend.sock"
+        sock.write_bytes(b"")  # a plain file where a socket should be
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: sock)
+
+        assert docker_desktop.host_networking_enabled() is None
+
+    def test_no_socket_at_all_tells_us_nothing(self, monkeypatch, tmp_path, no_settings_store):
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: None)
+
+        assert docker_desktop.host_networking_enabled() is None
+
+
+class TestThePersistedStoreFallback:
+    """The on-disk source, for the hosts whose backend cannot be dialled."""
+
+    def test_an_explicit_setting_is_read(self, monkeypatch, tmp_path, no_backend_socket):
+        store = tmp_path / "settings-store.json"
+        store.write_text(json.dumps({"HostNetworkingEnabled": False}), encoding="utf-8")
+        monkeypatch.setattr(docker_desktop, "settings_store_paths", lambda: (store,))
+
+        assert docker_desktop.host_networking_enabled() is False
+
+    def test_a_store_without_the_key_tells_us_nothing(
+        self, monkeypatch, tmp_path, no_backend_socket
+    ):
+        """The case that makes this source the weaker one, and the reason it is
+        second: the store persists only non-default settings, so a host that has
+        never touched host networking has no key. This is what a fresh Docker
+        Desktop install looks like, and reading it as "disabled" would blame
+        this setting for every unrelated failure on such a host."""
+        store = tmp_path / "settings-store.json"
+        store.write_text(json.dumps({"AutoStart": False, "SettingsVersion": 44}), encoding="utf-8")
+        monkeypatch.setattr(docker_desktop, "settings_store_paths", lambda: (store,))
+
+        assert docker_desktop.host_networking_enabled() is None
+
+    def test_the_older_filename_is_still_read(self, monkeypatch, tmp_path, no_backend_socket):
+        """Docker Desktop renamed ``settings.json`` to ``settings-store.json``."""
+        legacy = tmp_path / "settings.json"
+        legacy.write_text(json.dumps({"HostNetworkingEnabled": True}), encoding="utf-8")
+        monkeypatch.setattr(
+            docker_desktop,
+            "settings_store_paths",
+            lambda: (tmp_path / "settings-store.json", legacy),
+        )
+
+        assert docker_desktop.host_networking_enabled() is True
+
+    def test_unreadable_json_tells_us_nothing(self, monkeypatch, tmp_path, no_backend_socket):
+        store = tmp_path / "settings-store.json"
+        store.write_text("{ truncated", encoding="utf-8")
+        monkeypatch.setattr(docker_desktop, "settings_store_paths", lambda: (store,))
+
+        assert docker_desktop.host_networking_enabled() is None
+
+
+class TestSourcePrecedence:
+    """The live setting wins over whatever was last persisted."""
+
+    def test_the_api_answer_beats_a_stale_store(self, socket_dir, monkeypatch, tmp_path):
+        """A store written before the operator last toggled the setting must not
+        override what the running Docker Desktop reports now."""
+        sock = socket_dir / "backend.sock"
+        _serve_once(sock, "200 OK", json.dumps(_settings(True)))
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: sock)
+        store = tmp_path / "settings-store.json"
+        store.write_text(json.dumps({"HostNetworkingEnabled": False}), encoding="utf-8")
+        monkeypatch.setattr(docker_desktop, "settings_store_paths", lambda: (store,))
+
+        assert docker_desktop.host_networking_enabled() is True
+
+    def test_the_store_answers_when_the_api_cannot(self, monkeypatch, tmp_path):
+        """The Windows path: no dialable socket, so the store is all there is."""
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: None)
+        store = tmp_path / "settings-store.json"
+        store.write_text(json.dumps({"HostNetworkingEnabled": False}), encoding="utf-8")
+        monkeypatch.setattr(docker_desktop, "settings_store_paths", lambda: (store,))
+
+        assert docker_desktop.host_networking_enabled() is False
+
+
+class TestTheDockerDesktopPredicate:
+    """Which hosts this whole module applies to."""
+
+    def test_docker_on_macos_is_docker_desktop(self, monkeypatch):
+        monkeypatch.setattr(docker_desktop.sys, "platform", "darwin")
+        monkeypatch.setattr(docker_desktop, "get_runtime_command", lambda config: ["docker"])
+
+        assert docker_desktop.on_docker_desktop({}) is True
+
+    def test_a_linux_host_is_not(self, monkeypatch):
+        """There ``network_mode: host`` binds on the machine itself, so an
+        unreachable port means something else entirely."""
+        monkeypatch.setattr(docker_desktop.sys, "platform", "linux")
+
+        assert docker_desktop.on_docker_desktop({}) is False
+
+    def test_the_runtime_is_not_resolved_on_a_linux_host(self, monkeypatch):
+        """The platform is checked first so the cheap answer stays cheap."""
+        monkeypatch.setattr(docker_desktop.sys, "platform", "linux")
+
+        def fail(config: dict) -> list[str]:
+            raise AssertionError("the runtime should not be resolved on Linux")
+
+        monkeypatch.setattr(docker_desktop, "get_runtime_command", fail)
+
+        assert docker_desktop.on_docker_desktop({}) is False
+
+    def test_podman_on_macos_is_not_docker_desktop(self, monkeypatch):
+        """Podman runs its own machine with its own port handling."""
+        monkeypatch.setattr(docker_desktop.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            docker_desktop, "get_runtime_command", lambda config: ["podman", "compose"]
+        )
+
+        assert docker_desktop.on_docker_desktop({}) is False

--- a/tests/deployment/test_reset_scoping.py
+++ b/tests/deployment/test_reset_scoping.py
@@ -247,6 +247,17 @@ def test_a_resource_labelled_for_this_checkout_is_removed(repo, no_down):
     ]
 
 
+def _flowed(message: str) -> str:
+    """``message`` with every run of whitespace collapsed to one space.
+
+    The refusal wraps its prose itself, because the renderer prints cause lines
+    exactly as given. So a multi-word phrase in it is split at whatever column
+    the wrap fell on, and only a flowed view can assert on the words rather than
+    on the line breaks.
+    """
+    return " ".join(message.split())
+
+
 def test_a_same_named_resource_from_another_checkout_refuses(repo):
     fake = FakeRuntime(volumes={"als-exemplar_dispatch_workspace": theirs()})
 
@@ -385,7 +396,7 @@ def test_the_refusal_points_at_a_recorded_path_that_really_is_there(repo, tmp_pa
         plan_reset(repo, probe=make_probe(fake))
 
     message = str(excinfo.value)
-    assert f"Run `osprey reset` from {other}" in message
+    assert f"osprey reset --repo {other}" in message
     assert "no such directory on this host now" not in message
 
 
@@ -403,10 +414,15 @@ def test_the_refusal_does_not_claim_a_different_checkout_only_a_different_path(r
     with pytest.raises(ForeignCheckoutError) as excinfo:
         plan_reset(repo, probe=make_probe(fake))
 
-    message = str(excinfo.value)
-    assert "created from a DIFFERENT repo path" in message
-    assert "RENAMED" in message and "MOVED" in message
-    assert "these are your own resources" in message
+    # Flowed, because the refusal wraps its own prose to a terminal width: a
+    # phrase assertion against the raw text is an assertion about where the
+    # wrap happened to fall.
+    message = _flowed(str(excinfo.value))
+    assert "created from a different copy of this repo" in message
+    assert "renamed or moved" in message
+    assert "these are your own resources under its old path" in message
+    # The claim it must never make, however the sentence is reworded.
+    assert "belong to a different checkout" not in message
 
 
 def test_the_refusal_is_precise_about_what_it_scanned(repo):
@@ -416,7 +432,7 @@ def test_the_refusal_is_precise_about_what_it_scanned(repo):
     with pytest.raises(ForeignCheckoutError) as excinfo:
         plan_reset(repo, probe=make_probe(fake))
 
-    assert "container(s)/volume(s)" in str(excinfo.value)
+    assert "container(s) and volume(s) are named" in str(excinfo.value)
     assert not [argv for argv in fake.calls if argv[1:3] == ["image", "inspect"]]
 
 

--- a/tests/deployment/test_web_terminals_capture.py
+++ b/tests/deployment/test_web_terminals_capture.py
@@ -624,8 +624,10 @@ def test_host_port_self_heal_restart_is_captured(monkeypatch, tmp_path, reporter
     under, so it spools; advisory as before (check=False), and it reports the
     bounce as a step."""
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: True)
+    # None is "could not read the setting", which is the state that keeps the
+    # self-heal bounce these tests are about. A definite False would skip it.
+    monkeypatch.setattr(postup_hooks, "host_networking_enabled", lambda: None)
     monkeypatch.setattr(postup_hooks, "_host_port_answers", lambda url, attempts, delay: False)
     recorder = RunRecorder()
     monkeypatch.setattr(postup_hooks, "run_captured", recorder)
@@ -654,8 +656,10 @@ def test_a_bounce_that_worked_reports_the_endpoint_as_reachable(monkeypatch, tmp
     stale port registration.
     """
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: True)
+    # None is "could not read the setting", which is the state that keeps the
+    # self-heal bounce these tests are about. A definite False would skip it.
+    monkeypatch.setattr(postup_hooks, "host_networking_enabled", lambda: None)
     answers = iter([False, True])
     monkeypatch.setattr(
         postup_hooks, "_host_port_answers", lambda url, attempts, delay: next(answers)

--- a/tests/deployment/web_terminals/test_postup_hooks.py
+++ b/tests/deployment/web_terminals/test_postup_hooks.py
@@ -216,8 +216,11 @@ def test_web_stack_unreachable_warns_with_docker_desktop_hint(monkeypatch, caplo
         raise OSError("connection refused")
 
     monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refuse)
-    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: True)
+    # None is "the setting could not be read", which is what keeps the bounce and
+    # the hedged wording. Stubbed rather than left alone so these tests do not
+    # read the Docker Desktop settings of whatever machine runs them.
+    monkeypatch.setattr(postup_hooks, "host_networking_enabled", lambda: None)
 
     with caplog.at_level("WARNING"):
         postup_hooks.warn_if_web_stack_unreachable(_PROBE_CONFIG, attempts=2, delay=0)
@@ -231,8 +234,7 @@ def test_web_stack_unreachable_on_linux_warns_without_desktop_hint(monkeypatch, 
         raise OSError("connection refused")
 
     monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refuse)
-    monkeypatch.setattr(postup_hooks.sys, "platform", "linux")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: False)
 
     with caplog.at_level("WARNING"):
         postup_hooks.warn_if_web_stack_unreachable(_PROBE_CONFIG, attempts=2, delay=0)
@@ -279,8 +281,11 @@ def test_docker_desktop_unreachable_self_heals_via_restart(monkeypatch, caplog):
     """A stale forwarder registration is repaired by a restart, with no warning."""
     probes: list[int] = []
     monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refusing_urlopen(2, probes))
-    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: True)
+    # None is "the setting could not be read", which is what keeps the bounce and
+    # the hedged wording. Stubbed rather than left alone so these tests do not
+    # read the Docker Desktop settings of whatever machine runs them.
+    monkeypatch.setattr(postup_hooks, "host_networking_enabled", lambda: None)
 
     ran: list[list[str]] = []
     # The self-heal restart is a captured run: patching the helper (rather than
@@ -310,8 +315,11 @@ def test_docker_desktop_warns_only_after_restart_fails_to_help(monkeypatch, capl
     """When the bounce does not help, the setting really is the likely cause."""
     probes: list[int] = []
     monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refusing_urlopen(999, probes))
-    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: True)
+    # None is "the setting could not be read", which is what keeps the bounce and
+    # the hedged wording. Stubbed rather than left alone so these tests do not
+    # read the Docker Desktop settings of whatever machine runs them.
+    monkeypatch.setattr(postup_hooks, "host_networking_enabled", lambda: None)
 
     ran: list[list[str]] = []
     # The self-heal restart is a captured run: patching the helper (rather than
@@ -336,8 +344,7 @@ def test_docker_desktop_warns_only_after_restart_fails_to_help(monkeypatch, capl
 def test_self_heal_never_fires_on_linux(monkeypatch, caplog):
     """Linux host networking is real -- an unreachable port means something else."""
     monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refusing_urlopen(999, []))
-    monkeypatch.setattr(postup_hooks.sys, "platform", "linux")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: False)
 
     ran: list[list[str]] = []
     # The self-heal restart is a captured run: patching the helper (rather than
@@ -361,8 +368,11 @@ def test_self_heal_never_fires_on_linux(monkeypatch, caplog):
 def test_self_heal_skipped_when_caller_supplies_no_compose_cmd(monkeypatch, caplog):
     """Lifecycle callers that never had a web_cmd keep the old warn-only behaviour."""
     monkeypatch.setattr(postup_hooks.urllib.request, "urlopen", _refusing_urlopen(999, []))
-    monkeypatch.setattr(postup_hooks.sys, "platform", "darwin")
-    monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(postup_hooks, "on_docker_desktop", lambda config: True)
+    # None is "the setting could not be read", which is what keeps the bounce and
+    # the hedged wording. Stubbed rather than left alone so these tests do not
+    # read the Docker Desktop settings of whatever machine runs them.
+    monkeypatch.setattr(postup_hooks, "host_networking_enabled", lambda: None)
 
     ran: list[list[str]] = []
     # The self-heal restart is a captured run: patching the helper (rather than


### PR DESCRIPTION
Two deploy-time guards already knew something was wrong and failed to say so where
the operator would read it.

Docker Desktop's "Enable host networking" has to be on for web terminals to be
reachable. A post-up probe already detected this, but only after every image was
built and every container was up — a quarter of an hour into a first deploy, long
after the operator could have fixed it in one click. The probe's remedy line also
went out through `logger.warning`, which the altitude gate drops while a lifecycle
verb owns the terminal, and no other handler is attached to the root logger. On the
path that mattered most, a self-heal bounce that did not help, the run printed
"bounced the web stack" and then the endpoint table, which reads as success.

`osprey up` and `osprey restart` now read the setting from Docker Desktop itself
during Preflight and warn there. The post-up warning is promoted through `warn_fact`
so it survives the gate, and it separates a forwarder that is switched off from a
port registration the running forwarder missed: a definite "off" skips the self-heal
restart, which cannot help.

The second guard refuses to remove containers that belong to another copy of this
repo. `osprey reset` caught that refusal and rendered it; `osprey init --reset`
called the same function with no handler, so the identical deliberate guard escaped
as a Python traceback — the loudest way the CLI can claim a bug in OSPREY, for one
of the few cases that is not one. The refusal also buried its own conclusion: it
opened with the resource count and identity hashes, printed one line per resource,
and reached the explanation and the remedy about thirty lines down.

The refusal now leads with the finding, the other copy's path, and the remedy; lists
each path once rather than once per resource; and keeps the per-resource evidence
behind `--verbose`. `init --reset` additionally names the non-destructive way out —
deploying this copy under a name of its own — which `reset` structurally cannot
offer.

Two things worth disagreeing with. Reading a vendor's settings store is brittle by
nature: the backend API is tried first, the persisted settings file is the fallback,
and a setting that cannot be read stays silent rather than guessing, leaving the
post-up probe to speak. And `str(e)` on the refusal is unchanged — it still carries
the full evidence, so log records and any caller that merely prints the exception
lose nothing; only the rendering decides how much to show.

## How it hangs together

The host-networking path, from the new Preflight read to the post-up probe it
front-runs:

```text
  osprey up / osprey restart
      │
      ├─ Preflight ──▶ docker_desktop.host_networking_enabled()
      │                   ├─ Docker Desktop backend API      ─┐
      │                   └─ persisted settings store (fallback) ─┴─▶ on │ off │ unknown
      │                                │
      │                     off + deployment has web terminals
      │                                │
      │                                └──▶ warn_fact  ◀── NEW: seconds in, one click to fix
      │
      ├─ build images        ─┐
      ├─ compose up           ─┴─ ~15 min on a first deploy
      │
      └─ post-up reachability probe ──▶ web terminal unreachable?
                   │
                   ├─ setting reads "off"      ──▶ state the cause, skip the self-heal bounce
                   └─ setting unreadable       ──▶ bounce the web stack, then name the setting
                                │
                                └──▶ warn_fact  ◀── was logger.warning, dropped by the gate
```

The foreign-checkout refusal is a rendering change on an existing guard and has no
flow of its own: `reset_for_reinit()` raises `ForeignCheckoutError` as it always
did, and both `reset_cmd` and — now — `init_cmd` catch and render it.
