### PR TITLE
chore: ignore the whole feature-scaffolding log directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,8 +191,7 @@ node_modules/
 src/osprey/_version.py
 
 # feature-scaffolding logs (not committed)
-.claude/.logs/.state/
-.claude/.logs/*.jsonl
+.claude/.logs/
 
 # Process scaffolding — never committed (specs/plans live here uncommitted)
 docs/superpowers/


### PR DESCRIPTION
`.claude/.logs/` held two ignore rules — `.state/` and `*.jsonl` — so any other file the log tooling wrote there showed up as untracked noise in `git status`.

Nothing under that directory is tracked, so collapsing the two rules into the directory itself hides nothing that was being kept.