### PR TITLE
feat(build): give profiles a first-class web-terminal-context/base.md slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Added
+
+- Build profiles can now author the shared web-terminal context baseline at
+  `web-terminal-context/base.md`, overriding the framework's copy. `osprey
+  init` materializes it from the preset (the control assistant ships its own
+  text), so the context every seeded user starts from is visible and editable
+  in the deployment repo instead of hidden in the installed package.
+
 ### Fixed
 
 - `osprey init --reset` no longer crashes with a Python traceback when the

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -98,7 +98,8 @@ What ``osprey init`` writes
      README.md       explains the layout, for whoever opens the repository next
      triggers.yml    the events the agent runs on (dispatch profiles only)
      personas/       one delta per web-terminal persona (persona presets only)
-     web-terminal-context/  one seeded directory per operator on the roster
+     web-terminal-context/  the shared base.md baseline, plus one seeded
+                     directory per operator on the roster
      ci-extra.yml    the facility's own CI jobs; never regenerated
      .gitignore      keeps build/, var/ and .env out of version control
      build/          rendered by `osprey build`; disposable
@@ -151,7 +152,7 @@ name *is* the declaration, and where each one lands is fixed.
      - a script, usually ``.py``
    * - ``web-terminal-context/``
      - ``docker/web-terminal-context/``
-     - a directory named for one operator
+     - a directory named for one operator, plus one shared ``base.md``
    * - ``mcp_servers/``
      - ``_mcp_servers/``
      - a directory per server

--- a/docs/source/how-to/multi-user.rst
+++ b/docs/source/how-to/multi-user.rst
@@ -205,6 +205,13 @@ The config block
       ``web-terminal-context/<user>/`` slot for each new operator, which is
       where their per-user context goes.
 
+      Beside those slots sits ``web-terminal-context/base.md`` — the shared
+      baseline every seeded user's ``CLAUDE.md`` starts from. ``osprey init``
+      materializes it from the preset so the text is visible and editable in
+      your repo; edit it there and rebuild, and every terminal picks up the
+      change. A profile without one falls back to a generic framework
+      baseline.
+
       .. list-table::
          :header-rows: 1
          :widths: 34 66

--- a/src/osprey/cli/audit_prompts.py
+++ b/src/osprey/cli/audit_prompts.py
@@ -73,8 +73,8 @@ examine file contents. Focus on:
 4. **Convention directories** — A profile carries its artifacts in named \
 directories at its root, each with one fixed destination: `rules/`, `skills/`, \
 `agents/`, `commands/`, `output-styles/` land under `.claude/`; \
-`web-terminal-context/<user>/`, `mcp_servers/<name>/` and `services/<name>/` \
-land in their own trees; `project/` mirrors verbatim onto the project root. \
+`web-terminal-context/<user>/` (plus its shared `base.md` baseline), \
+`mcp_servers/<name>/` and `services/<name>/` land in their own trees; `project/` mirrors verbatim onto the project root. \
 Does anything there shadow a safety-critical framework artifact? Does the \
 `project/` mirror target a build-owned path — `config.yml`, `.mcp.json`, \
 `.claude/settings.json`, `CLAUDE.md`, `.env`, `.env.example`, \

--- a/src/osprey/cli/build_persistence.py
+++ b/src/osprey/cli/build_persistence.py
@@ -147,9 +147,10 @@ def _artifact_name(copy: ConventionCopy) -> str:
     if canonical is not None:
         return canonical
     # What is left is the classes outside the ownership system — MCP servers
-    # and per-user context — and both are whole-directory copies, so the only
-    # thing separating name from destination is the source directory's own
-    # spelling (``mcp_servers/`` for ``_mcp_servers/``).
+    # and per-user context (directories per user, plus the base.md baseline as
+    # the one file copy) — so the only thing separating name from destination
+    # is the source directory's own spelling (``mcp_servers/`` for
+    # ``_mcp_servers/``).
     convention = convention_for(copy.category)
     assert convention is not None  # planned copies always come from the table
     rel = PurePosixPath(copy.destination).relative_to(convention.destination).as_posix()
@@ -164,8 +165,12 @@ def ownership_canonical(copy: ConventionCopy) -> str | None:
     is owned, because that is the tree a later render could rewrite or prune.
     ``services/`` directories are owned for the same reason. Everything else
     is outside the ownership system: MCP servers register through
-    ``claude_code.servers``, per-user context is roster-derived, and mirror
-    files landing outside ``.claude/`` have no render that could contest them.
+    ``claude_code.servers``, per-user context (its ``base.md`` baseline
+    included) is re-copied from the profile on every build after the framework
+    installs its fallback, and mirror files landing outside ``.claude/`` are
+    likewise final once the copy loop has run — no post-build render rewrites
+    or prunes anything outside ``.claude/``, so there is nothing there for
+    ownership to defend.
 
     This function answers only *whether* a copy is owned; how the name is
     spelled is :func:`~osprey.cli.profile_conventions.ownership_name`, the

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -34,7 +34,11 @@ from osprey.errors import BuildProfileError
 from osprey.utils.logger import get_logger
 
 from .output import report
-from .profile_conventions import BUILD_OUTPUT_DIR, PER_USER_CONTEXT_DIRNAME
+from .profile_conventions import (
+    BUILD_OUTPUT_DIR,
+    CONTEXT_BASELINE_FILENAME,
+    PER_USER_CONTEXT_DIRNAME,
+)
 
 if TYPE_CHECKING:
     # Annotation only — the profile model is imported lazily inside the command
@@ -741,6 +745,27 @@ def _cleanup(target: Path) -> str:
     return "Nothing was materialized."
 
 
+def _context_baseline_source(manager: TemplateManager, data_bundle: str) -> Path:
+    """The ``base.md`` text a new profile's context baseline starts from.
+
+    Bundle first: an app template that ships its own
+    ``web-terminal-context/base.md`` (the control assistant does — its text
+    describes that family's personas) seeds the profile with it. Any other
+    bundle falls back to the framework's generic baseline, the same file
+    ``osprey build`` installs into every render — so the materialized slot
+    starts byte-identical to what the build would have used anyway, and every
+    edit to it from then on is visible in the operator's own repo.
+    """
+    bundle = (
+        manager.template_root / "apps" / data_bundle / PER_USER_CONTEXT_DIRNAME
+    ) / CONTEXT_BASELINE_FILENAME
+    if bundle.is_file():
+        return bundle
+    return (
+        manager.template_root / "claude_code" / PER_USER_CONTEXT_DIRNAME
+    ) / CONTEXT_BASELINE_FILENAME
+
+
 def _packaged_data_source(manager: TemplateManager, data_bundle: str) -> Path:
     """The packaged ``data/`` tree this command copies verbatim.
 
@@ -974,9 +999,19 @@ def _materialize_profile_directory(
             user_dir.mkdir(parents=True, exist_ok=True)
             (user_dir / ".gitkeep").touch()
         if roster:
+            # The shared baseline, beside the slots — the one seeded entry that
+            # carries content, because it IS content the deployment ships: the
+            # build copies this file over the framework's fallback, so the text
+            # every seeded user starts from lives in the operator's repo where
+            # they can read and edit it.
+            shutil.copy2(
+                _context_baseline_source(manager, resolved.data_bundle),
+                target / _CONTEXT_CONVENTION_DIRNAME / CONTEXT_BASELINE_FILENAME,
+            )
             logger.debug(
-                "  Per-user context: %s",
+                "  Per-user context: %s (+ shared %s)",
                 ", ".join(f"{_CONTEXT_CONVENTION_DIRNAME}/{user}/" for user in roster),
+                CONTEXT_BASELINE_FILENAME,
             )
 
         if persona_texts:

--- a/src/osprey/cli/profile_conventions.py
+++ b/src/osprey/cli/profile_conventions.py
@@ -134,7 +134,7 @@ CONVENTION_DIRS: tuple[ConventionDir, ...] = (
         destination="docker/web-terminal-context",
         shape=EntryShape.DIRECTORY,
         entry_noun="web-terminal user",
-        description="Per-user web-terminal context (one directory per user)",
+        description="Per-user web-terminal context (one directory per user, plus a shared base.md)",
         per_user=True,
     ),
     ConventionDir(
@@ -168,6 +168,15 @@ _PER_USER_CONVENTION: ConventionDir = next(c for c in CONVENTION_DIRS if c.per_u
 #: user. Public because ``osprey init`` seeds those subdirectories from
 #: the roster and must name the same directory this table maps.
 PER_USER_CONTEXT_DIRNAME: str = _PER_USER_CONVENTION.source
+
+#: The one loose file the per-user convention directory accepts: the shared
+#: baseline every seeded user's ``CLAUDE.md`` starts from. It rides the same
+#: channel as the per-user directories (landing beside them at the convention's
+#: destination) but is roster-independent — a profile that ships it overrides
+#: the framework's fallback for every user at once. Public because ``osprey
+#: init`` materializes it and seeding documents it, and all three must spell
+#: the same filename.
+CONTEXT_BASELINE_FILENAME: str = "base.md"
 
 CONVENTION_SOURCES: tuple[str, ...] = tuple(c.source for c in CONVENTION_DIRS)
 
@@ -258,6 +267,11 @@ RESERVED_PROJECT_PATHS: tuple[ReservedPath, ...] = (
     ReservedPath("CLAUDE.md", "the profile's `claude_md_template:` key"),
     ReservedPath("data/simulation/channel_manifest.json", "the profile's `data/` directory"),
     ReservedPath("data/simulation/channel_limits.json", "the profile's `data/` directory"),
+    ReservedPath(
+        "docker/web-terminal-context/base.md",
+        "the profile's `web-terminal-context/base.md` slot — the shared baseline "
+        "sits beside the per-user directories, not in the mirror",
+    ),
 )
 
 #: The table indexed by path — the exact reservations mapped to the channel
@@ -579,6 +593,10 @@ def _validate_directory_dir(convention: ConventionDir, root: Path) -> list[str]:
     for entry in sorted(root.iterdir(), key=lambda p: p.name):
         if entry.name.startswith("."):
             continue
+        if convention.per_user and entry.name == CONTEXT_BASELINE_FILENAME and entry.is_file():
+            # The shared baseline, not a user: it has its own slot at the
+            # convention root and is planned as a file copy.
+            continue
         if not entry.is_dir():
             errors.append(
                 _per_user_file_error(convention, entry)
@@ -602,24 +620,18 @@ def _per_user_file_error(convention: ConventionDir, entry: Path) -> str:
     advice every other directory-shaped convention gets — would therefore tell
     an operator to invent a user, and their file would quietly stop being read
     on the next build. So the rule is stated instead, and the file is pointed at
-    a route that carries it: a named user's directory, or, for the shared
-    baseline, the ``project/`` mirror.
+    the routes that carry it: a named user's directory, or — for the shared
+    baseline — the :data:`CONTEXT_BASELINE_FILENAME` slot at the convention
+    root, which the validator has already accepted by the time this error fires
+    for anything else.
     """
     header = (
         f"{convention.source}/{entry.name} is a file: {convention.source}/ holds one "
-        f"directory per {convention.entry_noun}, and each one is named for a user on "
+        f"directory per {convention.entry_noun} (plus the shared "
+        f"{CONTEXT_BASELINE_FILENAME} baseline), and each one is named for a user on "
         f"the resolved roster. A directory named anything else is skipped as a user "
         f"who has left, so a directory invented to hold this file would not be read."
     )
-    if entry.name == "base.md":
-        return (
-            f"{header}\n"
-            f"  base.md is the baseline every seeded user starts from, not one user's "
-            f"context, so it has no directory here. Carry it through the "
-            f"{PROJECT_MIRROR_DIR}/ mirror instead: put it at "
-            f"{PROJECT_MIRROR_DIR}/{convention.destination}/base.md, which lands on "
-            f"the same file the build installs."
-        )
     return (
         f"{header}\n"
         f"  Move it into the directory of the user it belongs to "
@@ -746,6 +758,23 @@ def plan_convention_copies(
             continue
 
         if convention.shape is EntryShape.DIRECTORY:
+            if convention.per_user:
+                baseline = root / CONTEXT_BASELINE_FILENAME
+                if baseline.is_file():
+                    # Roster-independent by design: the baseline overrides the
+                    # framework's fallback for every seeded user at once, so it
+                    # copies even on a build with no roster (a persona render),
+                    # like every other convention artifact.
+                    copies.append(
+                        ConventionCopy(
+                            category=convention.source,
+                            source=baseline,
+                            destination=destination_for(
+                                f"{convention.source}/{CONTEXT_BASELINE_FILENAME}"
+                            ),
+                            is_directory=False,
+                        )
+                    )
             for entry in root.iterdir():
                 if not entry.is_dir() or entry.name.startswith("."):
                     continue

--- a/src/osprey/cli/templates/manager.py
+++ b/src/osprey/cli/templates/manager.py
@@ -350,9 +350,11 @@ class TemplateManager:
             shutil.copytree(machine_data_src, machine_data_dst, dirs_exist_ok=True)
             logger.debug("Copied machine data to %s", machine_data_dst)
 
-        # 6a'. Install the web-terminal persona baseline. base.md is
-        # framework-layer, not bundle-layer: seeding requires it for ANY
-        # project that seeds a user, so every bundle gets it. Per-user
+        # 6a'. Install the web-terminal context baseline. This base.md is the
+        # framework FALLBACK: seeding hard-requires one for any project that
+        # seeds a user, so every bundle gets a generic copy — and a profile
+        # that ships its own `web-terminal-context/base.md` overrides it when
+        # the convention copies apply after this render. Per-user
         # extra.md/skills stay user-authored under the same tree.
         context_src = self.template_root / "claude_code" / "web-terminal-context"
         context_dst = project_dir / "docker" / "web-terminal-context"

--- a/src/osprey/deployment/web_terminals/seeding.py
+++ b/src/osprey/deployment/web_terminals/seeding.py
@@ -52,9 +52,10 @@ logger = get_logger("deployment.web_terminals.seeding")
 # Overlay tree root, relative to the RENDERED PROJECT — i.e. to `build/` in a
 # deployment repo, not to the repo root and not to the source-zone
 # `web-terminal-context/` a profile authors. The tree is build output: every
-# `osprey build` installs the framework's base.md here
-# (templates/manager.py) and copies each roster user's authored directory in
-# below it (profile_conventions.py's `web-terminal-context` convention, whose
+# `osprey build` installs the framework's fallback base.md here
+# (templates/manager.py), lets a profile's own `web-terminal-context/base.md`
+# replace it, and copies each roster user's authored directory in below it
+# (profile_conventions.py's `web-terminal-context` convention, whose
 # destination is this same project-relative path). Seeding reads what the build
 # produced, so it resolves against the same zone.
 _CONTEXT_RELPATH = Path("docker/web-terminal-context")

--- a/src/osprey/templates/apps/control_assistant/web-terminal-context/base.md
+++ b/src/osprey/templates/apps/control_assistant/web-terminal-context/base.md
@@ -1,0 +1,25 @@
+# Control Assistant — Web Terminal Context
+
+You are the OSPREY control-room assistant for this facility. This context is
+seeded into every web-terminal user's session; per-user additions live in
+`docker/web-terminal-context/<user>/extra.md` alongside this file.
+
+## Ground rules
+
+- Hardware writes always require explicit human approval — never assume a
+  write is pre-approved, and never work around the approval flow.
+- If a capability is not available in your session (for example plan
+  tooling), say so plainly rather than improvising an alternative path.
+- When the control system is the mock backend, channel values are
+  synthesized: fine for browsing and demos, but say so if a user asks
+  whether readings are real.
+
+## Personas
+
+Each user's terminal runs a persona-specific project with its own capability
+set. The control-room personas monitor, diagnose, and author and validate
+plans (orbit response matrix, n-dimensional grid scan); only the read-write
+persona can execute writes — setpoint changes and plan runs. A terminal can
+also host a different product entirely, such as the ARIEL logbook research
+assistant, which carries no control-system tools at all. Capabilities are
+enforced per project — what you can do is defined by the session you are in.

--- a/src/osprey/templates/claude_code/web-terminal-context/base.md
+++ b/src/osprey/templates/claude_code/web-terminal-context/base.md
@@ -1,6 +1,6 @@
-# Control Assistant — Web Terminal Context
+# Web Terminal Context
 
-You are the OSPREY control-room assistant for this facility. This context is
+You are an OSPREY web-terminal assistant for this facility. This context is
 seeded into every web-terminal user's session; per-user additions live in
 `docker/web-terminal-context/<user>/extra.md` alongside this file.
 
@@ -8,16 +8,8 @@ seeded into every web-terminal user's session; per-user additions live in
 
 - Hardware writes always require explicit human approval — never assume a
   write is pre-approved, and never work around the approval flow.
-- If a capability is not available in your session (for example plan
-  tooling), say so plainly rather than improvising an alternative path.
+- If a capability is not available in your session, say so plainly rather
+  than improvising an alternative path.
 - When the control system is the mock backend, channel values are
   synthesized: fine for browsing and demos, but say so if a user asks
   whether readings are real.
-
-## Personas
-
-Each user's terminal runs a persona-specific project with its own capability
-set. Both personas monitor, diagnose, and author and validate plans
-(orbit response matrix, n-dimensional grid scan); only the read-write persona
-can execute writes — setpoint changes and plan runs. Capabilities are
-enforced per project — what you can do is defined by the session you are in.

--- a/tests/cli/test_build_context_guard.py
+++ b/tests/cli/test_build_context_guard.py
@@ -1,11 +1,12 @@
-"""Profile context artifacts must not delete the web-terminal persona baseline.
+"""Profile context artifacts must not delete the web-terminal context baseline.
 
-Every build installs the framework's ``docker/web-terminal-context/base.md``.
-The profile's ``web-terminal-context/`` convention directory copies one whole
-directory per user *below* that path, so the baseline survives by construction —
-these tests pin that, and pin the error a profile gets when it puts a loose file
-where a per-user directory belongs (the shape that could otherwise replace the
-context root wholesale).
+Every build installs the framework's fallback ``docker/web-terminal-context/
+base.md``; a profile that ships ``web-terminal-context/base.md`` replaces it
+through the convention's first-class slot. Per-user directories copy *below*
+that path, so the baseline survives them by construction — these tests pin
+that, pin the slot's override precedence (which otherwise rests on nothing but
+build-step ordering), and pin the error a profile gets when it puts any other
+loose file where a per-user directory belongs.
 """
 
 from __future__ import annotations
@@ -49,6 +50,24 @@ def test_per_user_context_keeps_baseline_and_seeds_user(tmp_path: Path) -> None:
     base_md = project_path / CONTEXT_DIR / "base.md"
     assert base_md.is_file()
     assert base_md.read_text(encoding="utf-8").strip() != ""
+    assert (project_path / CONTEXT_DIR / "alice" / "extra.md").is_file()
+
+
+def test_profile_base_md_overrides_the_framework_fallback(tmp_path: Path) -> None:
+    """The slot's whole point: the profile's baseline text wins over the
+    framework's, and the precedence is pinned here rather than left to the
+    accident that the framework install runs before the convention copies."""
+    project_path = _built_project(tmp_path, "context-base-override")
+    profile_dir = _profile_with_user_dir(tmp_path, "alice")
+    authored = "# Facility baseline\n\nOur own ground rules.\n"
+    (profile_dir / "web-terminal-context" / "base.md").write_text(authored, encoding="utf-8")
+
+    framework_text = (project_path / CONTEXT_DIR / "base.md").read_text(encoding="utf-8")
+    assert framework_text != authored  # the override must be observable
+
+    _apply_conventions(profile_dir, project_path, ["alice"])
+
+    assert (project_path / CONTEXT_DIR / "base.md").read_text(encoding="utf-8") == authored
     assert (project_path / CONTEXT_DIR / "alice" / "extra.md").is_file()
 
 

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -447,10 +447,11 @@ class TestControlAssistantPersonas:
 class TestWebTerminalContextShipped:
     """Every built project — not just the ``control_assistant`` bundle —
     carries the ``docker/web-terminal-context/base.md`` that seeding
-    requires. base.md is framework-layer: any project that seeds a web
-    terminal user needs it, so it ships from the framework template root
-    rather than from one bundle. Without it, ``osprey up`` brings up the whole
-    stack and then aborts at the seed step.
+    requires. The framework ships a generic FALLBACK from its template root:
+    ``modules.web_terminals.enabled`` is a config key any profile can turn
+    on, so any bundle may end up seeding a user, and without a baseline
+    ``osprey up`` brings up the whole stack and then aborts at the seed step.
+    A profile's own ``web-terminal-context/base.md`` overrides the fallback.
 
     The path is PROJECT-relative (``seeding._CONTEXT_RELPATH``), and in a
     deployment repo the rendered project is the ``build/`` zone — which is why

--- a/tests/cli/test_profile_conventions.py
+++ b/tests/cli/test_profile_conventions.py
@@ -19,6 +19,7 @@ import pytest
 
 from osprey.cli.profile_conventions import (
     BUILD_OUTPUT_DIR,
+    CONTEXT_BASELINE_FILENAME,
     CONVENTION_DIRS,
     CONVENTION_SOURCES,
     KNOWN_ROOT_ENTRIES,
@@ -152,6 +153,7 @@ def test_destination_for_rejects_a_non_convention_root():
         ("CLAUDE.md", "claude_md_template"),
         ("data/simulation/channel_manifest.json", "`data/`"),
         ("data/simulation/channel_limits.json", "`data/`"),
+        ("docker/web-terminal-context/base.md", "`web-terminal-context/base.md`"),
     ],
 )
 def test_reserved_path_names_its_channel(reserved: str, channel_hint: str):
@@ -411,23 +413,51 @@ def test_loose_file_in_the_per_user_convention_states_the_roster_rule(profile_di
     assert f"Move it into {PER_USER_CONTEXT_DIRNAME}/shift-notes/" not in message
 
 
-def test_base_md_in_the_per_user_convention_is_sent_through_the_mirror(profile_dir: Path):
-    """``base.md`` is nobody's context, so no per-user directory can hold it.
+def test_base_md_at_the_convention_root_is_accepted_and_planned(profile_dir: Path):
+    """``base.md`` is the per-user convention's one loose file: the shared
+    baseline every seeded user starts from, overriding the framework's
+    fallback at the same destination."""
+    _write(profile_dir / PER_USER_CONTEXT_DIRNAME / CONTEXT_BASELINE_FILENAME, "# baseline\n")
 
-    It is the baseline every seeded user starts from, installed by the build at
-    one path. The only route a profile has to that path today is the
-    ``project/`` mirror, so the refusal names it rather than leaving the
-    operator to guess at a user directory that would never be read.
-    """
-    _write(profile_dir / PER_USER_CONTEXT_DIRNAME / "base.md")
+    validate_convention_sources(profile_dir)
+
+    copies = plan_convention_copies(profile_dir, context_users=["alice"])
+    baselines = [c for c in copies if c.destination == "docker/web-terminal-context/base.md"]
+    assert len(baselines) == 1
+    assert not baselines[0].is_directory
+    assert baselines[0].category == PER_USER_CONTEXT_DIRNAME
+
+
+def test_base_md_copies_even_without_a_roster(profile_dir: Path):
+    """The baseline is roster-independent: a persona render (no roster) still
+    carries the profile's text, like every other convention artifact."""
+    _write(profile_dir / PER_USER_CONTEXT_DIRNAME / CONTEXT_BASELINE_FILENAME, "# baseline\n")
+
+    copies = plan_convention_copies(profile_dir, context_users=None)
+    assert any(c.destination == "docker/web-terminal-context/base.md" for c in copies)
+
+
+def test_a_base_md_directory_is_not_read_as_the_baseline(profile_dir: Path):
+    """Only the FILE is the baseline slot — a directory named ``base.md`` is
+    just a user directory naming nobody on the roster, skipped like any
+    other departed user."""
+    (profile_dir / PER_USER_CONTEXT_DIRNAME / CONTEXT_BASELINE_FILENAME).mkdir(parents=True)
+
+    validate_convention_sources(profile_dir)
+    copies = plan_convention_copies(profile_dir, context_users=["alice"])
+    assert not any(c.destination == "docker/web-terminal-context/base.md" for c in copies)
+
+
+def test_mirrored_base_md_is_rejected_naming_the_slot(profile_dir: Path):
+    """The mirror may not write the baseline's destination: the slot is its one
+    channel, so two writers can never race on build ordering."""
+    _write(profile_dir / PROJECT_MIRROR_DIR / "docker" / "web-terminal-context" / "base.md")
 
     with pytest.raises(BuildProfileError) as excinfo:
-        validate_convention_sources(profile_dir)
+        validate_project_mirror(profile_dir / PROJECT_MIRROR_DIR)
 
     message = str(excinfo.value)
-    assert f"{PROJECT_MIRROR_DIR}/docker/web-terminal-context/base.md" in message
-    assert "the baseline every seeded user starts from" in message
-    assert f"Move it into {PER_USER_CONTEXT_DIRNAME}/base/" not in message
+    assert f"`{PER_USER_CONTEXT_DIRNAME}/{CONTEXT_BASELINE_FILENAME}` slot" in message
 
 
 def test_the_other_directory_conventions_keep_their_move_advice(profile_dir: Path):

--- a/tests/cli/test_source_zone_materialization.py
+++ b/tests/cli/test_source_zone_materialization.py
@@ -257,21 +257,59 @@ def test_per_user_context_directories_are_seeded_from_the_roster(
     assert _new(runner, target, preset).exit_code == 0
 
     context_dir = target / "web-terminal-context"
-    assert sorted(p.name for p in context_dir.iterdir()) == sorted(expected)
+    assert sorted(p.name for p in context_dir.iterdir()) == sorted([*expected, "base.md"])
     for user in expected:
         assert (context_dir / user).is_dir()
 
 
 def test_seeded_context_directories_carry_no_content(runner: CliRunner, tmp_path: Path) -> None:
-    """Slots, not literals. Anything written here would become context the
-    agent reads, and would freeze at materialization time — the build derives
-    what to copy from the roster it resolves then."""
+    """Per-user slots, not literals: what goes in them is the facility's. The
+    one seeded entry that does carry content is the shared ``base.md``
+    baseline — that IS content the deployment ships, and materializing it is
+    what makes the text every seeded user starts from visible in the repo."""
     target = tmp_path / "my-facility"
 
     assert _new(runner, target, "control-assistant").exit_code == 0
 
     for user_dir in (target / "web-terminal-context").iterdir():
+        if user_dir.is_file():
+            continue
         assert [p.name for p in user_dir.iterdir()] == [".gitkeep"]
+
+
+def test_context_baseline_is_materialized_from_the_bundle(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """The control-assistant bundle ships its own baseline text (it describes
+    that family's personas), and the profile starts from a byte-identical
+    copy — visible and editable where the operator works."""
+    from osprey.cli.templates.manager import TemplateManager
+
+    target = tmp_path / "my-facility"
+    assert _new(runner, target, "control-assistant").exit_code == 0
+
+    materialized = target / "web-terminal-context" / "base.md"
+    bundle = (
+        TemplateManager().template_root
+        / "apps"
+        / "control_assistant"
+        / "web-terminal-context"
+        / "base.md"
+    )
+    assert materialized.read_bytes() == bundle.read_bytes()
+
+
+def test_context_baseline_falls_back_to_the_framework_text() -> None:
+    """A bundle with no baseline of its own seeds the framework's generic
+    fallback — the same file every build installs, so the materialized slot
+    starts byte-identical to what the build would have used anyway."""
+    from osprey.cli.profile_cmd import _context_baseline_source
+    from osprey.cli.templates.manager import TemplateManager
+
+    manager = TemplateManager()
+    source = _context_baseline_source(manager, "hello_world")
+    assert source == (manager.template_root / "claude_code" / "web-terminal-context" / "base.md")
+    assert source.is_file()
 
 
 def test_profile_without_a_web_terminal_module_seeds_no_context(


### PR DESCRIPTION
The text every web-terminal agent starts its session on lived only inside the
installed framework package. An operator opening `web-terminal-context/` in
their own repo saw three empty per-user directories and reasonably concluded
the feature was unconfigured — while every terminal in the deployment was in
fact running on a framework-authored file they had never seen.

That file also described the wrong thing. It named the control-room personas
and their plan tooling, yet the render copies it into every project
unconditionally, so a hello-world deployment and an ARIEL logbook terminal both
inherited a brief written for a control room.

`web-terminal-context/base.md` is now a convention slot like any other: the
build copies it over the framework's file, and `osprey init` materializes the
preset's text into it, so what every seeded user reads is visible and editable
where the operator works. The control-room prose moves to the control-assistant
bundle. What stays in the framework is the part true of any terminal —
approval-gated writes, don't improvise an unavailable capability, mock readings
are synthetic — and it stays as a fallback, because seeding hard-aborts without
a baseline and `modules.web_terminals.enabled` is a config key any profile can
turn on.

The `project/` mirror route to the same destination is now reserved, so the slot
is the single writer. A profile could previously reach that path through the
mirror and win only by build-step ordering; nothing tested that ordering, and
the validator's error message steered operators to it deliberately.

## How it hangs together

```text
FRAMEWORK PACKAGE (installed, invisible to the operator)
┌────────────────────────┐ ┌─────────────────────────┐
│ templates/apps/        │ │ templates/claude_code/  │
│ control_assistant/     │ │ web-terminal-context/   │
│ web-terminal-context/  │ │  base.md                │
│  base.md   ◀ NEW       │ │ (generic fallback:      │
│ (control-room persona, │ │  approval-gated writes, │
│  moved out of generic) │ │  mock == synthetic)     │
└────────────────────────┘ └─────────────────────────┘
  ▼                          ▼
    osprey init                installed into every build
    --preset control-assistant

┌───────────────────────┐  ┌──────────────────────┐  ┌──────────────────────┐
│ ZONE 1 - SOURCE       │  │ ZONE 2 - BUILD       │  │ ZONE 3 - CONTAINER   │
│ (operator repo)       │  │ (disposable build/)  │  │ (per web-term user)  │
│                       │  │                      │  │                      │
│ web-terminal-context/ │  │ docker/…-context/    │  │ /data/claude-config/ │
│  base.md      ◀ NEW   │═►│  base.md  (fallback, │─►│  CLAUDE.md =         │
│  alice/ bob/ ariel/   │  │   then overwritten   │  │   base.md +          │
│   (extra.md each)     │  │   by profile ◀ NEW)  │  │   <user>/extra.md    │
│                       │  │  alice/ bob/ ariel/  │  │                      │
└───────────────────────┘  └──────────────────────┘  └──────────────────────┘

legend:  ◀ NEW = added here    ═► = profile's base.md WINS    ─► = copy/seed
```
