### PR TITLE
test(e2e): drop each deployment's named volumes at final teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,8 +191,7 @@ node_modules/
 src/osprey/_version.py
 
 # feature-scaffolding logs (not committed)
-.claude/.logs/.state/
-.claude/.logs/*.jsonl
+.claude/.logs/
 
 # Process scaffolding — never committed (specs/plans live here uncommitted)
 docs/superpowers/

--- a/tests/e2e/_volumes.py
+++ b/tests/e2e/_volumes.py
@@ -1,0 +1,109 @@
+"""Named-volume teardown hygiene for the deploy-backed e2e suites.
+
+``osprey down`` keeps named volumes by design: stopping a deployment must never
+destroy its data, and the destructive verb is ``osprey reset``. For a TEST
+deployment that durability inverts into a liability: a volume left behind by
+one attempt survives into the next -- ``pytest.mark.flaky`` reruns included --
+carrying whatever state the earlier attempt wrote into it. Stale queue
+contents, store credentials from a previous init, an agent-data tree owned by
+the wrong user: each of these has produced a failure that pointed at the code
+under test when the actual cause was inherited disk state.
+
+So every deploy fixture removes its own volumes in the same ``finally`` that
+runs ``osprey down`` -- the teardown of the attempt that created them, which is
+the only place cleanup is guaranteed to know the volumes are no longer wanted.
+A pre-flight in the NEXT attempt is not equivalent: it cannot tell a leftover
+from a deployment someone wants to keep, which is exactly the judgment
+``osprey reset`` refuses to automate.
+
+The removal is scoped the way the shipped destructive verb scopes it (see
+``osprey.deployment.reset``): volumes are LISTED via compose's own project
+stamp -- the ``com.docker.compose.project`` label, valued with the
+``COMPOSE_PROJECT_NAME`` the deploy path pins -- then removed one exact name at
+a time. Never a prune, never ``-a``/``--all``, never a name glob: any volume
+of any other compose project on the host is invisible to the listing. External
+(host-global) volumes a deployment merely mounts carry no project stamp and
+are equally invisible, so a suite that manages one (e.g. the OpenObserve data
+volume) still handles it explicitly.
+
+Do NOT call this around a mid-test ``down`` whose point is that data survives
+it -- ``test_deploy_writeback_e2e`` proves precisely that guarantee.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+#: The label compose stamps on every volume (and container) it creates, valued
+#: with the compose project name. Spelled the same way as
+#: ``osprey.deployment.reset.COMPOSE_PROJECT_LABEL``; duplicated here so the
+#: e2e helper stays importable without the deployment package on the path.
+COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
+
+
+def remove_project_volumes(project: str, *, runtime: str = "docker") -> None:
+    """Remove every named volume compose created for ``project``, if any.
+
+    Best-effort by construction: this runs inside teardown ``finally`` blocks,
+    after the test verdict exists, and must never replace that verdict with a
+    cleanup error. Problems are printed (landing in the CI log next to the
+    ``osprey down`` output the same blocks already surface) rather than raised.
+    A volume still held by a container is left in place and reported; a volume
+    already gone is a success.
+
+    :param project: The RESOLVED compose project name -- the value
+        ``resolve_project_name`` returns and the deploy pins as
+        ``COMPOSE_PROJECT_NAME`` (``_orm_stack.project_prefix`` for the suites
+        that already derive it there).
+    :param runtime: Container CLI to drive, for the suites that run under a
+        detected ``docker``/``podman`` runtime.
+    """
+    if not project:
+        # An empty value would still be a syntactically valid label filter --
+        # one that no longer says "this deployment's volumes". Refuse loudly:
+        # only a caller bug can produce it.
+        raise ValueError("remove_project_volumes needs a non-empty project name")
+
+    try:
+        listed = subprocess.run(
+            [
+                runtime,
+                "volume",
+                "ls",
+                "--filter",
+                f"label={COMPOSE_PROJECT_LABEL}={project}",
+                "--format",
+                "{{.Name}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"could not list {project!r} volumes for teardown: {exc}")  # noqa: T201
+        return
+    if listed.returncode != 0:
+        print(  # noqa: T201
+            f"could not list {project!r} volumes for teardown: "
+            f"`{runtime} volume ls` rc={listed.returncode} {(listed.stderr or '').strip()}"
+        )
+        return
+
+    for name in (line.strip() for line in listed.stdout.splitlines()):
+        if not name:
+            continue
+        try:
+            removed = subprocess.run(
+                [runtime, "volume", "rm", "-f", name],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            print(f"volume {name!r} not removed at teardown: {exc}")  # noqa: T201
+            continue
+        if removed.returncode != 0:
+            print(  # noqa: T201
+                f"volume {name!r} not removed at teardown: "
+                f"rc={removed.returncode} {(removed.stderr or '').strip()}"
+            )

--- a/tests/e2e/test_bluesky_catalog_e2e.py
+++ b/tests/e2e/test_bluesky_catalog_e2e.py
@@ -34,7 +34,9 @@ refuses to hold work it could never run.
 Container safety: every docker invocation below names an exact
 container/image -- never a wildcard, never ``system prune``/``--volumes``.
 Teardown goes through ``osprey down``, matching every other e2e in
-this directory.
+this directory, followed by exact-named removal of this project's own volumes
+(``tests/e2e/_volumes.py``): ``down`` keeps them by design, and a rerun must
+not inherit their state.
 
 Gating: needs Docker. Much lighter than the VA-backed e2e (no amd64
 emulation) -- comparable to ``test_bluesky_deploy.py``'s build+deploy time.
@@ -76,6 +78,7 @@ from osprey.services.bluesky_bridge.queue_backend import (
     REASON_BROWSE_ONLY_CONNECTOR,
 )
 from tests.e2e import _orm_stack
+from tests.e2e._volumes import remove_project_volumes
 
 # Every word the pre-flight is allowed to answer with. Imported rather than
 # spelled, because the approval prompt branches on these exact literals.
@@ -397,6 +400,9 @@ def deployed_catalog_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(_orm_stack.project_prefix(PROJECT_NAME))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_bluesky_deploy.py
+++ b/tests/e2e/test_bluesky_deploy.py
@@ -51,7 +51,9 @@ Asserts, against the REAL deployed containers:
 CONTAINER SAFETY: every docker/podman invocation below names an exact
 container/image — never a wildcard, never ``system prune``/``--volumes``.
 Teardown goes through ``osprey down`` (the shipped compose teardown path), not
-a raw ``docker rm``/``rmi`` sweep.
+a raw ``docker rm``/``rmi`` sweep, followed by exact-named removal of this
+project's own volumes (``tests/e2e/_volumes.py``): ``down`` keeps them by
+design, and a rerun must not inherit their state.
 
 Gating: needs Docker. Skipped entirely if unavailable. Lives in ``tests/e2e/``
 (not ``tests/integration/``) so the fast lane (``pytest tests/ --ignore=tests/e2e``,
@@ -82,6 +84,7 @@ from osprey.services.bluesky_bridge.queue_backend import (
     FLIP_COMMAND,
     REASON_BROWSE_ONLY_CONNECTOR,
 )
+from tests.e2e._volumes import remove_project_volumes
 
 # Deliberately NOT the bluesky-bridge default (8090): this is a shared dev
 # machine with other long-running services, and 8090 was observed colliding
@@ -257,6 +260,9 @@ def deployed_bridge(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(resolve_project_name({"project_name": PROJECT_NAME}))
 
 
 def _wait_for_health(url: str, timeout: float) -> None:

--- a/tests/e2e/test_bluesky_panels_deploy.py
+++ b/tests/e2e/test_bluesky_panels_deploy.py
@@ -57,7 +57,9 @@ resource (``<project>-bluesky-bridge``, ``<project>-virtual-accelerator``,
 ``<project>-bluesky-panels``, images ``<project>-bluesky-bridge:local``/
 ``<project>-va:local``/``<project>-bluesky-panels:local``) -- never ``system prune``,
 never ``--volumes``, never a wildcard ``docker rm``/``rmi``. Teardown goes
-through ``osprey down`` (the shipped compose path).
+through ``osprey down`` (the shipped compose path), followed by exact-named
+removal of this project's own volumes (``tests/e2e/_volumes.py``): ``down``
+keeps them by design, and a rerun must not inherit their state.
 
 Gating: needs Docker; the VA image builds natively for the host arch (PyAT/
 softioc compile from source on Apple Silicon -- slow on a cold image cache).
@@ -85,6 +87,7 @@ import pytest
 
 from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import queue_stack_logs
+from tests.e2e._volumes import remove_project_volumes
 
 # Distinct from every sibling e2e module's pinned bridge port (_orm_stack.py's
 # 18102, test_bluesky_deploy.py's 18090, test_va_substrate_equivalence.py's
@@ -505,6 +508,9 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(_orm_stack.project_prefix(PROJECT_NAME))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_bluesky_queue_e2e.py
+++ b/tests/e2e/test_bluesky_queue_e2e.py
@@ -91,8 +91,10 @@ a log line.
 
 CONTAINER SAFETY: every docker invocation below names an EXACT container,
 image, or network belonging to this test's own project. Never a wildcard,
-never ``system prune``, never ``volume rm``. Teardown goes through the shipped
-``osprey down``.
+never ``system prune``. Teardown goes through the shipped ``osprey down``,
+followed by exact-named removal of this project's own volumes
+(``tests/e2e/_volumes.py``): ``down`` keeps them by design, and a rerun must
+not inherit their state -- the queue itself lives in a Redis named volume.
 
 Gating: needs Docker. Lives in ``tests/e2e/`` so the fast lane
 (``pytest tests/ --ignore=tests/e2e``) never collects this ~20-minute
@@ -131,6 +133,7 @@ from osprey.services.bluesky_bridge.queue_backend import (
 )
 from osprey.services.bluesky_bridge.session_upload import REASON_UNVALIDATED
 from tests.e2e import _orm_stack
+from tests.e2e._volumes import remove_project_volumes
 
 # The nine keys every pre-flight answer carries, success or not: the approval
 # gate reads `ok` and never a status code, so the shape cannot vary with the
@@ -852,6 +855,9 @@ def stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[QueueStack]:
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(_orm_stack.project_prefix(PROJECT_NAME))
 
 
 # ===========================================================================

--- a/tests/e2e/test_bluesky_sandbox_escape_e2e.py
+++ b/tests/e2e/test_bluesky_sandbox_escape_e2e.py
@@ -47,7 +47,9 @@ actually guarantees.
 Container safety: every docker invocation here names an exact
 container/image -- never a wildcard, never ``system prune``/``--volumes``.
 Teardown goes through ``osprey down``, matching every other e2e in
-this directory. ``BRIDGE_PORT`` below is distinct from every sibling e2e
+this directory, followed by exact-named removal of this project's own volumes
+(``tests/e2e/_volumes.py``): ``down`` keeps them by design, and a rerun must
+not inherit their state. ``BRIDGE_PORT`` below is distinct from every sibling e2e
 module's pinned port; the VA's Channel Access port is NOT freely overridable
 (see ``_orm_stack.VA_CA_PORT``'s docstring) so this test shares that fixed
 port with ``test_orm_roundtrip.py``/``test_va_substrate_equivalence.py`` --
@@ -93,6 +95,7 @@ import pytest
 
 from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import queue_stack_logs
+from tests.e2e._volumes import remove_project_volumes
 
 pytestmark = [
     pytest.mark.e2e,
@@ -550,6 +553,9 @@ def deployed_sandbox_stack(
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(_orm_stack.project_prefix(PROJECT_NAME))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_dispatch_deploy.py
+++ b/tests/e2e/test_dispatch_deploy.py
@@ -68,7 +68,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-from osprey.deployment.compose_generator import resolve_project_name, resolve_user_volume_names
+from osprey.deployment.compose_generator import resolve_project_name
+from tests.e2e._volumes import remove_project_volumes
 
 DISPATCHER_URL = "http://localhost:8020"
 TOKEN = "dev-token"  # matches the .env tokens written below
@@ -323,10 +324,12 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
         # `osprey down` tears down the services stack AND the web stack
         # (deploy_down_web_terminals); the exact-named sweeps after it are
         # belt-and-suspenders for a down that failed midway. Volumes are
-        # deliberately kept by `down`, so the per-user volumes this run created
-        # are removed by exact name; the persona image tags are namespaced by
-        # this repo's name (see COEXISTENCE), so removing them cannot untag a
-        # real deployment's images.
+        # deliberately kept by `down`, so this project's own — the per-user
+        # terminal volumes and the dispatch workspace alike — are removed
+        # exact-named via the shared label-scoped sweep (tests/e2e/_volumes.py);
+        # the persona image tags are namespaced by this repo's name (see
+        # COEXISTENCE), so removing them cannot untag a real deployment's
+        # images.
         down = _run([str(osprey_bin), "down"], cwd=repo, timeout=300)
         if down.returncode != 0:
             print(  # noqa: T201 - surface teardown issues in CI logs
@@ -336,8 +339,7 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
             subprocess.run(
                 ["docker", "rm", "-f", _web_container(user)], capture_output=True, text=True
             )
-            for volume in resolve_user_volume_names({"project_name": PROJECT_NAME}, user):
-                subprocess.run(["docker", "volume", "rm", volume], capture_output=True, text=True)
+        remove_project_volumes(resolve_project_name({"project_name": PROJECT_NAME}))
         subprocess.run(["docker", "rm", "-f", NGINX_CONTAINER], capture_output=True, text=True)
         for image in (READONLY_IMAGE, READWRITE_IMAGE):
             subprocess.run(["docker", "rmi", "-f", image], capture_output=True, text=True)

--- a/tests/e2e/test_dispatch_overlay_visibility.py
+++ b/tests/e2e/test_dispatch_overlay_visibility.py
@@ -62,6 +62,7 @@ import pytest
 import yaml
 
 from osprey.deployment.compose_generator import resolve_project_name
+from tests.e2e._volumes import remove_project_volumes
 
 DISPATCHER_URL = "http://localhost:8020"
 TOKEN = "dev-token"  # matches the .env tokens written below
@@ -88,22 +89,6 @@ WORKER_AGENT_DATA = f"{WORKER_PROJECT_DIR}/var/agent_data"
 WORKER_ARTIFACT_DIR = f"{WORKER_AGENT_DATA}/artifacts"
 # The worker persists each completed run (full result incl. tool_calls) here.
 WORKER_DISPATCH_DIR = f"{WORKER_AGENT_DATA}/dispatch"
-
-# The named volume the worker mounts at WORKER_AGENT_DATA. Its name is
-# ``<compose-project>_<volume>_<replica>`` = ``services`` (the compose files live
-# under ``build/services/``) + ``dispatch_workspace`` + ``_1`` (one worker).
-#
-# ``osprey down`` does NOT remove named volumes, so a volume left by a prior
-# deployment survives. The worker runs as a NON-ROOT user and relies on a FRESH
-# volume inheriting the image's ``osprey``-owned agent-data tree (see
-# ``docker-compose.yml.j2``: the image ``chown``s the tree before ``USER
-# osprey``, and Docker copies that ownership into a volume only on first
-# population). A volume left root-owned by an older root-writing deployment makes
-# the worker's ``_persist_run`` fail with ``PermissionError`` — the run still
-# completes, but its per-run JSON never lands, so this test would read an empty
-# record and mis-report the agent as having taken no actions. Removing the volume
-# before deploy restores the documented fresh-volume precondition.
-WORKER_WORKSPACE_VOLUME = "services_dispatch_workspace_1"
 
 # Custom trigger + the observable tokens the overlay skill is instructed to emit.
 OVERLAY_TRIGGER = "overlay-visibility"
@@ -217,21 +202,28 @@ _OVERLAY_TRIGGER_ENTRY = {
 }
 
 
-def _remove_worker_workspace_volume() -> None:
-    """Remove the worker's persisted agent-data named volume, if present.
+def _drop_project_volumes() -> None:
+    """Remove this project's named volumes, the worker workspace included.
 
-    Guarantees the fresh-volume precondition the non-root worker relies on to own
-    (and write) its agent-data tree (see ``WORKER_WORKSPACE_VOLUME``). ``rm -f``
-    tolerates an absent volume; it only fails if a live container still holds the
-    volume, in which case the post-deploy checks surface the stale-ownership
-    symptom with a clear diagnostic rather than the misleading "no tool_calls".
+    Guarantees the fresh-volume precondition the non-root worker relies on to
+    own (and write) its agent-data tree: the worker mounts a NAMED volume at
+    ``WORKER_AGENT_DATA`` (``<project>_dispatch_workspace_1`` — the deploy path
+    pins ``COMPOSE_PROJECT_NAME`` to ``resolve_project_name``), and it inherits
+    the image's ``osprey``-owned tree only on FIRST population (see
+    ``docker-compose.yml.j2``: the image ``chown``s the tree before ``USER
+    osprey``). A volume left root-owned by an older root-writing deployment
+    makes the worker's ``_persist_run`` fail with ``PermissionError`` — the run
+    still completes, but its per-run JSON never lands, so this test would read
+    an empty record and mis-report the agent as having taken no actions.
+
+    Listing by compose's project label rather than a predicted name is the
+    point: a hardcoded name here once encoded the pre-pin ``services_*``
+    namespace and silently removed nothing. Removal is best-effort; a volume a
+    live container still holds stays put, and the post-deploy checks surface
+    the stale-ownership symptom with a clear diagnostic rather than the
+    misleading "no tool_calls".
     """
-    subprocess.run(
-        ["docker", "volume", "rm", "-f", WORKER_WORKSPACE_VOLUME],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    remove_project_volumes(resolve_project_name({"project_name": PROJECT_NAME}))
 
 
 def _mutate_source(repo: Path) -> None:
@@ -369,11 +361,11 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
         ["docker", "rmi", "-f", f"{project}-dispatch:local"], capture_output=True, text=True
     )
 
-    # Drop any stale worker workspace volume so the fresh deploy repopulates it
-    # from the image (osprey-owned agent-data tree). Without this, a volume left
-    # root-owned by an older deployment makes the non-root worker unable to
-    # persist run records (see WORKER_WORKSPACE_VOLUME).
-    _remove_worker_workspace_volume()
+    # Drop any stale project volumes so the fresh deploy repopulates the worker
+    # workspace from the image (osprey-owned agent-data tree). Without this, a
+    # volume left root-owned by an older deployment makes the non-root worker
+    # unable to persist run records (see _drop_project_volumes).
+    _drop_project_volumes()
 
     try:
         up = _run(
@@ -394,9 +386,9 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
-        # Leave no stale workspace volume behind so the next local run starts
-        # from the documented fresh-volume state (see WORKER_WORKSPACE_VOLUME).
-        _remove_worker_workspace_volume()
+        # Leave no stale volumes behind so the next local run starts from the
+        # documented fresh-volume state (see _drop_project_volumes).
+        _drop_project_volumes()
 
 
 def _wait_for_health(url: str, timeout: float) -> None:
@@ -733,9 +725,9 @@ def test_overlay_skill_and_data_visible_in_worker(deployed_stack: Path) -> None:
             f"run {run_id!r} completed with tool_count={run.get('tool_count')!r} in "
             f"the dispatcher feed, but its persisted record at {WORKER_DISPATCH_DIR} "
             "has no tool_calls: the worker failed to PERSIST the run (typically a "
-            f"PermissionError writing {WORKER_DISPATCH_DIR} because the "
-            f"{WORKER_WORKSPACE_VOLUME} volume was left root-owned by a prior "
-            "deployment). The agent acted; the record is the problem — check the "
+            f"PermissionError writing {WORKER_DISPATCH_DIR} because the worker "
+            "workspace volume was left root-owned by a prior deployment). The "
+            "agent acted; the record is the problem — check the "
             f"worker logs for 'Failed to persist run'.\n{diag}"
         )
     assert tool_calls, (

--- a/tests/e2e/test_grid_scan_roundtrip.py
+++ b/tests/e2e/test_grid_scan_roundtrip.py
@@ -36,7 +36,9 @@ logic.
 Container safety: every docker invocation below names an exact
 container/image -- never a wildcard, never ``system prune``/``--volumes``.
 Teardown goes through ``osprey down``, matching every other e2e in
-this directory.
+this directory, followed by exact-named removal of this project's own volumes
+(``tests/e2e/_volumes.py``): ``down`` keeps them by design, and a rerun must
+not inherit their state.
 
 Gating: needs Docker; the VA image builds natively for the host arch, so on
 Apple Silicon PyAT/softioc compile from source (no prebuilt aarch64 wheels) --
@@ -61,6 +63,7 @@ import pytest
 from osprey.services.bluesky_bridge.figure import rows_from_columnar
 from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import queue_stack_logs
+from tests.e2e._volumes import remove_project_volumes
 
 pytestmark = [
     pytest.mark.e2e,
@@ -205,6 +208,9 @@ def deployed_grid_scan_stack(
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(_orm_stack.project_prefix(PROJECT_NAME))
 
 
 @pytest.mark.flaky(reruns=1, only_rerun=["AssertionError"])

--- a/tests/e2e/test_openobserve_telemetry.py
+++ b/tests/e2e/test_openobserve_telemetry.py
@@ -17,7 +17,10 @@ appended and ``skipif``-gated on a provider key for when one is present.
 
 CONTAINER SAFETY: every docker/podman invocation names an EXACT container/image
 — never a wildcard, never ``system prune``/``--volumes``. Teardown goes through
-``osprey down`` (the shipped compose teardown), not a raw ``docker rm`` sweep.
+``osprey down`` (the shipped compose teardown), not a raw ``docker rm`` sweep,
+followed by exact-named removal of this project's own volumes
+(``tests/e2e/_volumes.py``): ``down`` keeps them by design, and a rerun must
+not inherit their state.
 
 Gating: needs Docker; skipped entirely if unavailable. Lives in ``tests/e2e/``
 so the fast lane never collects this real-container build+deploy; run via
@@ -42,6 +45,7 @@ import pytest
 import yaml
 
 from osprey.build.claude_code_telemetry import _build_telemetry_env
+from tests.e2e._volumes import remove_project_volumes
 
 # Deliberately NOT OpenObserve's 5080 default: this is a shared dev machine and
 # 5080 can collide with an unrelated process. Pinned through the SOURCE zone at
@@ -66,10 +70,11 @@ OO_CONTAINER = f"{OO_PROJECT}-openobserve"  # matches the rendered container_nam
 # fixture's own reruns included — ``osprey down`` keeps volumes) would pin
 # whatever creds that attempt initialized with. The fixture removes it before
 # deploy and on teardown so the store always initializes with THIS test's
-# credentials. The pre-project-pinning deploys derived the compose project from
-# the compose files' directory (``services``), so the legacy host-global name
-# is removed too — a dev machine can still carry one.
-OO_DATA_VOLUME = f"{OO_PROJECT}_openobserve_data"
+# credentials. The project-named volume is removed by the shared label-scoped
+# sweep (``tests/e2e/_volumes.py``); the pre-project-pinning deploys derived
+# the compose project from the compose files' directory (``services``), so
+# that legacy host-global name is removed by exact name too — a dev machine
+# can still carry one, and it carries no project label the sweep could find.
 OO_LEGACY_DATA_VOLUME = "services_openobserve_data"
 OO_ORG = "default"
 
@@ -131,25 +136,25 @@ def _run(cmd: list[str], cwd: Path, timeout: int) -> subprocess.CompletedProcess
     )
 
 
-def _remove_oo_data_volume() -> None:
-    """Remove this project's OpenObserve data volume by EXACT name, if present.
+def _remove_oo_data_volumes() -> None:
+    """Remove this project's volumes, the OpenObserve data volume included.
 
     OpenObserve pins its root credentials on the volume's first init, so a volume
     left behind by an earlier deploy (including this fixture's own prior rerun
     attempt) would reject this test's credentials (401). Removing it guarantees a
     clean init. Exact-named and failure-tolerant — never a wildcard, never a
     prune; a missing/in-use volume is a no-op. The legacy directory-derived name
-    is removed alongside for dev machines that predate project-pinned compose
-    namespacing.
+    is removed by exact name for dev machines that predate project-pinned compose
+    namespacing — it carries no project label, so the shared sweep cannot see it.
     """
-    for volume in (OO_DATA_VOLUME, OO_LEGACY_DATA_VOLUME):
-        subprocess.run(
-            ["docker", "volume", "rm", volume],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
+    remove_project_volumes(OO_PROJECT)
+    subprocess.run(
+        ["docker", "volume", "rm", OO_LEGACY_DATA_VOLUME],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
 
 
 def _write_port_override(base: Path) -> Path:
@@ -253,11 +258,11 @@ def deployed_openobserve(tmp_path_factory: pytest.TempPathFactory) -> Iterator[P
     # before the deploy — compose interpolates it at up time.
     _write_credentials(repo)
 
-    # Guarantee a clean store: the data volume is host-global (see OO_DATA_VOLUME),
-    # so a volume left by another deployment's openobserve — common because
-    # telemetry is on by default — would pin foreign credentials and 401 this test.
-    # Remove it before deploy so OpenObserve initializes with THIS test's credentials.
-    _remove_oo_data_volume()
+    # Guarantee a clean store: a volume left by an earlier deploy under this
+    # project name (or the legacy ``services`` namespace) would pin foreign
+    # credentials and 401 this test. Remove them before deploy so OpenObserve
+    # initializes with THIS test's credentials (see _remove_oo_data_volumes).
+    _remove_oo_data_volumes()
 
     try:
         up = _run(
@@ -278,9 +283,10 @@ def deployed_openobserve(tmp_path_factory: pytest.TempPathFactory) -> Iterator[P
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
-        # ``osprey down`` keeps volumes; drop the host-global data volume so this
-        # test never leaves foreign credentials pinned for a later deploy.
-        _remove_oo_data_volume()
+        # ``osprey down`` keeps volumes; drop this project's own (legacy name
+        # included) so this test never leaves foreign credentials pinned for a
+        # later deploy (see _remove_oo_data_volumes).
+        _remove_oo_data_volumes()
 
 
 def _container_cred_diagnosis() -> str:

--- a/tests/e2e/test_orm_roundtrip.py
+++ b/tests/e2e/test_orm_roundtrip.py
@@ -49,7 +49,9 @@ Container safety: every docker invocation below names an exact
 container/image -- never a wildcard, never ``system prune``/``--volumes``.
 The one restart names a single compose service inside this deployment's own
 project. Teardown goes through ``osprey down``, matching every other e2e in
-this directory.
+this directory, followed by exact-named removal of this project's own volumes
+(``tests/e2e/_volumes.py``): ``down`` keeps them by design, and a rerun must
+not inherit their state.
 
 Gating: needs Docker; the VA image builds natively for the host arch, so on
 Apple Silicon PyAT/softioc compile from source (no prebuilt aarch64 wheels) --
@@ -79,6 +81,7 @@ from osprey.services.bluesky_bridge.figure import rows_from_columnar
 from osprey.services.bluesky_bridge.orm_analysis import build_response_matrix
 from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import dead_container_logs, queue_stack_logs
+from tests.e2e._volumes import remove_project_volumes
 
 pytestmark = [
     pytest.mark.e2e,
@@ -259,6 +262,9 @@ def deployed_orm_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Dep
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(_orm_stack.project_prefix(PROJECT_NAME))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_plan_stack_agentic.py
+++ b/tests/e2e/test_plan_stack_agentic.py
@@ -124,6 +124,7 @@ from osprey.deployment.compose_generator import resolve_project_name
 from osprey.services.bluesky_bridge.queue_backend import is_queue_active
 from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import dead_container_logs, queue_stack_logs
+from tests.e2e._volumes import remove_project_volumes
 from tests.e2e.judge import LLMJudge, WorkflowResult
 from tests.e2e.sdk_helpers import (
     HAS_SDK,
@@ -1842,8 +1843,10 @@ async def test_judge_rejects_a_failing_grid_scan_conclusion(control: str) -> Non
 #
 # CONTAINER SAFETY: every docker invocation below names an EXACT image
 # (``<project>-bluesky-bridge:local`` / ``-va:local`` / ``-bluesky-panels:local``,
-# all derived from ``PROJECT_NAME``) — never a wildcard, never a prune, never a
-# volume operation. Teardown goes through ``osprey down``.
+# all derived from ``PROJECT_NAME``) — never a wildcard, never a prune. Teardown
+# goes through ``osprey down``, followed by exact-named removal of this
+# project's own volumes (``tests/e2e/_volumes.py``): ``down`` keeps them by
+# design, and a rerun must not inherit their state.
 # ===========================================================================
 
 BUILD_TIMEOUT_SEC = _orm_stack.BUILD_TIMEOUT_SEC
@@ -2116,6 +2119,9 @@ def deployed_scan_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[De
                 f"osprey down could not complete ({type(exc).__name__}: {exc}) -- "
                 f"containers of project {PROJECT_NAME!r} may still be running"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(_orm_stack.project_prefix(PROJECT_NAME))
 
 
 def _queue_snapshot() -> dict[str, Any]:
@@ -2158,11 +2164,11 @@ def clean_queue(request: pytest.FixtureRequest) -> None:
     runs. ``getfixturevalue`` is what deploys the stack on the first live test.
 
     Why per-test rather than once per module. The queue is Redis-backed and
-    that Redis lives in a compose NAMED VOLUME keyed on the project name, which
-    ``osprey down`` does NOT remove — so a rerun inherits whatever the
-    previous attempt left queued. And these tests are agentic: a rerun (each
-    live test carries ``flaky``) follows an attempt that may have left a run
-    mid-flight. An agent that then queues its own work and arms the queue would
+    that Redis lives in a compose NAMED VOLUME keyed on the project name that
+    outlives every test in this module (the deploy fixture drops it only at
+    module teardown) — so a rerun inherits whatever the previous attempt left
+    queued. And these tests are agentic: a rerun (each live test carries
+    ``flaky``) follows an attempt that may have left a run mid-flight. An agent that then queues its own work and arms the queue would
     put the PREVIOUS attempt's plan on the hardware too, and read back a run it
     never launched — a floor satisfied by someone else's run.
 

--- a/tests/e2e/test_plan_stack_agentic.py
+++ b/tests/e2e/test_plan_stack_agentic.py
@@ -2168,9 +2168,10 @@ def clean_queue(request: pytest.FixtureRequest) -> None:
     outlives every test in this module (the deploy fixture drops it only at
     module teardown) — so a rerun inherits whatever the previous attempt left
     queued. And these tests are agentic: a rerun (each live test carries
-    ``flaky``) follows an attempt that may have left a run mid-flight. An agent that then queues its own work and arms the queue would
-    put the PREVIOUS attempt's plan on the hardware too, and read back a run it
-    never launched — a floor satisfied by someone else's run.
+    ``flaky``) follows an attempt that may have left a run mid-flight. An agent
+    that then queues its own work and arms the queue would put the PREVIOUS
+    attempt's plan on the hardware too, and read back a run it never launched —
+    a floor satisfied by someone else's run.
 
     The three steps, and why each is needed:
 

--- a/tests/e2e/test_tiled_roundtrip.py
+++ b/tests/e2e/test_tiled_roundtrip.py
@@ -43,7 +43,9 @@ swept into a lenient rerun. Keep it that way if the two ever diverge.
 
 Container safety: every docker invocation below names an exact container or
 image -- never a wildcard, never ``system prune``/``--volumes``. Teardown
-goes through ``osprey down``, never a raw ``docker rm`` sweep. The restart step
+goes through ``osprey down``, never a raw ``docker rm`` sweep, followed by
+exact-named removal of this project's own volumes (``tests/e2e/_volumes.py``):
+``down`` keeps them by design, and a rerun must not inherit their state. The restart step
 names the ``<project>-bluesky-bridge`` container only; ``osprey restart`` is
 never used here because it bounces every service, including Tiled and the RE
 manager, which would defeat the whole proof.
@@ -73,6 +75,7 @@ import pytest
 from osprey.deployment.compose_generator import resolve_project_name
 from tests.e2e import _queue_drive
 from tests.e2e._deploy_diagnostics import queue_stack_logs
+from tests.e2e._volumes import remove_project_volumes
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -323,6 +326,9 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(resolve_project_name({"project_name": PROJECT_NAME}))
 
 
 def _seed_repo_env(repo: Path) -> None:

--- a/tests/e2e/test_va_substrate_equivalence.py
+++ b/tests/e2e/test_va_substrate_equivalence.py
@@ -38,7 +38,10 @@ Container safety: every docker invocation below names an exact container/image
 — never a wildcard, never ``system prune``/``--volumes``. The one forced
 ``docker rmi -f <image>`` (below) names an exact image, matching
 ``test_bluesky_deploy.py``'s precedent for forcing a fresh ``--dev`` build.
-Teardown goes through ``osprey down``, never a raw ``docker rm`` sweep.
+Teardown goes through ``osprey down``, never a raw ``docker rm`` sweep,
+followed by exact-named removal of this project's own volumes
+(``tests/e2e/_volumes.py``): ``down`` keeps them by design, and a rerun must
+not inherit their state.
 
 Gating: needs Docker; the VA image builds natively for the host arch, so on
 Apple Silicon PyAT/softioc compile from source (no prebuilt aarch64 wheels) —
@@ -72,6 +75,7 @@ import pytest
 from osprey.deployment.compose_generator import resolve_project_name
 from tests.e2e import _orm_stack, _queue_drive
 from tests.e2e._deploy_diagnostics import dead_container_logs, queue_stack_logs
+from tests.e2e._volumes import remove_project_volumes
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SWEEP_SCRIPT = REPO_ROOT / "scripts" / "va" / "sweep_check.py"
@@ -411,6 +415,9 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
             print(  # noqa: T201 - surface teardown issues in CI logs
                 f"osprey down rc={down.returncode}\n{down.stdout}\n{down.stderr}"
             )
+        # `osprey down` keeps volumes by design; drop this project's own so a
+        # rerun cannot inherit their state (see tests/e2e/_volumes.py).
+        remove_project_volumes(_orm_stack.project_prefix(PROJECT_NAME))
 
 
 def _dead_container_logs() -> str:

--- a/tests/e2e/web_terminals/test_auth_perimeter.py
+++ b/tests/e2e/web_terminals/test_auth_perimeter.py
@@ -101,6 +101,8 @@ from typing import Any
 import pytest
 import yaml
 
+from tests.e2e._volumes import remove_project_volumes
+
 # ``dockerbuild`` is load-bearing, not descriptive: a guard in
 # tests/deployment/test_ci_workflow_wiring.py requires every file carrying it to
 # be --ignore'd in the shared e2e-tests lane AND given its own job. Without the
@@ -432,12 +434,18 @@ def _make_repo(tmp_path: Path, osprey_bin: Path) -> Path:
 
 
 def _teardown() -> None:
-    """Exact-named sweep; failures swallowed (a safety net, never an assertion)."""
+    """Exact-named sweep; failures swallowed (a safety net, never an assertion).
+
+    The volume sweep is what keeps reruns honest: ``compose down`` (like
+    ``osprey down``) keeps named volumes, and a rerun inheriting a previous
+    attempt's per-user volumes would start from that attempt's state.
+    """
     for user in USERS:
         _runtime_cli("rm", "-f", _web_container(user))
     _runtime_cli("rm", "-f", AUTH_C)
     _runtime_cli("rm", "-f", NGINX_C)
     _runtime_cli("compose", "-p", PROJECT_NAME, "down", timeout=60)
+    remove_project_volumes(PROJECT_NAME, runtime=RUNTIME)
     for tag in (AUTH_IMAGE_TAG, PERSONA_IMAGE_TAG):
         _runtime_cli("rmi", "-f", tag, timeout=60)
 


### PR DESCRIPTION
## Why

`osprey down` keeps named volumes by design (`reset` is the destructive verb). For a test deployment that durability inverts into a liability: a rerun inherits whatever the previous attempt left on disk — a root-owned worker workspace that makes `_persist_run` fail, store credentials pinned by a failed attempt (OpenObserve 401s), leftover queue contents. The dispatch-overlay failure that motivated this had a second layer: its targeted cleanup removed `services_dispatch_workspace_1`, a volume name from the pre-`COMPOSE_PROJECT_NAME`-pin era, so it silently removed nothing.

## What

- **`tests/e2e/_volumes.py`** — one shared, best-effort helper: list volumes by compose's own `com.docker.compose.project` label (the same listing `osprey.deployment.reset` uses), then remove them one exact name at a time. Never a prune, never `-a`/`--all`, never a name glob; external/host-global volumes carry no project label and are invisible to it.
- Called from every deploy fixture's **final** teardown (13 files), right after `osprey down`; module CONTAINER SAFETY docstrings updated to match.
- `test_dispatch_overlay_visibility.py`: the stale hardcoded volume name is gone; both the pre-up fresh-volume guard and the teardown now go through the sweep.
- `test_openobserve_telemetry.py`: keeps its exact-named removal only for the legacy `services_openobserve_data` namespace, which carries no project label.
- `test_dispatch_deploy.py`: the per-user volume loop is subsumed by the sweep, which also covers the dispatch workspace volume the loop missed.

## Deliberately untouched

- `test_deploy_writeback_e2e.py:633` — the one mid-test `down` whose point is that volumes **survive** it (down → rebuild → up → witness row still readable).
- `test_deploy_lifecycle.py`, `test_deploy_writeback_e2e.py`'s teardown, `test_archiver_world_e2e.py`, `test_two_shape_boot.py` — already remove their volumes by exact pinned name, complete today (and the podman lanes keep their proven cleanup paths).

Also carries a small `.gitignore` cleanup commit so it rides this PR's CI.