### PR TITLE
CI flake ranking tool + fix for the top-ranked e2e flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- `scripts/ci/flake_report.py` ranks flaky CI tests from GitHub Actions re-run
+  history. A test counts as flaky only when it failed and then passed on the
+  identical commit; failures that never went green are listed separately so a
+  branch bug is never filed as a flake.
 - `osprey up` and `osprey restart` warn in Preflight when Docker Desktop's
   "Enable host networking" is off and the deployment has web terminals. The
   post-up probe already caught this, but only after every image was built and

--- a/scripts/ci/flake_report.py
+++ b/scripts/ci/flake_report.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Find flaky CI tests from GitHub Actions re-run history.
+
+A flake here is proven, not guessed. When a job fails on one attempt of a
+workflow run and succeeds on a later attempt, both attempts ran identical
+code against an identical commit -- the only thing that changed is luck.
+Failures that never flipped to green are reported separately as persistent
+failures, because those are branch bugs and hiding them among the flakes
+would be worse than not running this at all.
+
+Reads only. Never writes to GitHub.
+
+Usage:
+    python scripts/ci/flake_report.py --days 30
+    python scripts/ci/flake_report.py --days 7 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+# The aggregator gate fails whenever anything else does, so it carries no
+# information of its own and would otherwise top every ranking.
+AGGREGATOR_JOB = "All CI Checks Passed"
+
+MAX_WORKERS = 12
+
+# Below this many failures from one file in one job, treat them as individual
+# test failures. At or above it, a shared fixture almost certainly broke.
+FIXTURE_GROUP_THRESHOLD = 3
+
+# Constant, so repeat collection failures aggregate rather than splitting on
+# however many modules each one happened to take down.
+COLLECTION_ERROR_LABEL = "[collection error: modules failed to import]"
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# pytest prints "FAILED <nodeid> - <message>" in its summary and
+# "[gw1] [ 43%] FAILED <nodeid>" under xdist. A parametrised node ID can
+# contain spaces inside its brackets, so the ID is matched as "everything up
+# to whitespace or an opening bracket" plus an optional bracketed suffix --
+# which stops cleanly before the " - <message>" tail.
+FAILURE_RE = re.compile(r"(?:FAILED|ERROR)\s+((?:tests|src)/[^\s\[]+(?:\[[^\]]*\])?)")
+
+
+# --------------------------------------------------------------------------
+# Pure functions -- these are what the tests cover.
+# --------------------------------------------------------------------------
+
+
+def strip_ansi(text: str) -> str:
+    """Remove SGR colour escapes so log lines can be matched literally."""
+    return ANSI_RE.sub("", text)
+
+
+def iter_json_documents(raw: str):
+    """Yield each JSON document from a concatenated stream.
+
+    ``gh api --paginate`` writes one JSON body per page back to back with no
+    separator between them -- not newline-delimited, not wrapped in an array.
+    A plain ``json.loads`` on the whole buffer raises "Extra data", and
+    splitting on newlines finds nothing because there are none.
+    """
+    decoder = json.JSONDecoder()
+    index, end = 0, len(raw)
+    while index < end:
+        while index < end and raw[index].isspace():
+            index += 1
+        if index >= end:
+            return
+        try:
+            document, index = decoder.raw_decode(raw, index)
+        except json.JSONDecodeError:
+            return
+        yield document
+
+
+def parse_test_failures(log_text: str) -> list[str]:
+    """Extract failing pytest node IDs from one job's log.
+
+    Returns them sorted and de-duplicated: the same failure appears in both
+    the xdist progress stream and the final summary.
+    """
+    found: set[str] = set()
+    for raw_line in strip_ansi(log_text).splitlines():
+        match = FAILURE_RE.search(raw_line.rstrip())
+        if match:
+            found.add(match.group(1).strip())
+    return sorted(found)
+
+
+def split_flakes_and_persistent(runs):
+    """Split early-attempt job failures by whether they later went green.
+
+    ``runs`` is an iterable of dicts with keys ``run_id``, ``branch``,
+    ``attempts`` (mapping attempt number -> list of ``(job_id, job_name,
+    conclusion)``) and ``final_attempt``.
+
+    Returns ``(flakes, persistent)``, each a list of job-failure dicts. A
+    failure is a flake only when the same-named job succeeded on the final
+    attempt -- same commit, opposite outcome.
+    """
+    flakes, persistent = [], []
+    for run in runs:
+        final_jobs = {
+            name: conclusion
+            for _job_id, name, conclusion in run["attempts"].get(run["final_attempt"], [])
+        }
+        for attempt, jobs in sorted(run["attempts"].items()):
+            if attempt >= run["final_attempt"]:
+                continue
+            for job_id, name, conclusion in jobs:
+                if conclusion != "failure" or name == AGGREGATOR_JOB:
+                    continue
+                record = {
+                    "run_id": run["run_id"],
+                    "branch": run["branch"],
+                    "attempt": attempt,
+                    "job_id": job_id,
+                    "job_name": name,
+                    "created_at": run.get("created_at", ""),
+                }
+                if final_jobs.get(name) == "success":
+                    flakes.append(record)
+                else:
+                    persistent.append(record)
+    return flakes, persistent
+
+
+def group_fixture_failures(node_ids: list[str]) -> list[str]:
+    """Collapse bursts of related failures so one incident occupies one row.
+
+    Two bursts matter, and both come from a single root cause:
+
+    * A broken shared fixture fails every test it feeds, at setup. Those are
+      collapsed per file.
+    * A failed import fails whole modules at collection time, which pytest
+      reports as bare paths with no ``::`` node. One bad import can name a
+      hundred files, which would otherwise bury the real ranking.
+
+    The collection label is deliberately constant so that recurring collection
+    failures aggregate across runs instead of splitting on the file count.
+    """
+    with_test, bare = [], []
+    for node_id in node_ids:
+        (with_test if "::" in node_id else bare).append(node_id)
+
+    grouped: list[str] = []
+
+    if len(bare) >= FIXTURE_GROUP_THRESHOLD:
+        grouped.append(COLLECTION_ERROR_LABEL)
+    else:
+        grouped.extend(bare)
+
+    by_file: dict[str, list[str]] = defaultdict(list)
+    for node_id in with_test:
+        by_file[node_id.split("::", 1)[0]].append(node_id)
+    for path, ids in by_file.items():
+        if len(ids) >= FIXTURE_GROUP_THRESHOLD:
+            grouped.append(f"{path} [fixture: {len(ids)} tests]")
+        else:
+            grouped.extend(ids)
+
+    return sorted(grouped)
+
+
+def rank_failures(records) -> list[dict]:
+    """Rank test entries by distinct runs blocked, then distinct branches.
+
+    Branch spread is the confidence signal: the same test failing across many
+    unrelated branches cannot be any one branch's bug.
+
+    Each entry also carries ``last_seen``, without which a flake fixed weeks
+    ago is indistinguishable from one that bit this morning.
+    """
+    runs_by_test: dict[str, set] = defaultdict(set)
+    branches_by_test: dict[str, set] = defaultdict(set)
+    jobs_by_test: dict[str, set] = defaultdict(set)
+    last_seen_by_test: dict[str, str] = defaultdict(str)
+
+    for record in records:
+        for node_id in record["tests"]:
+            runs_by_test[node_id].add(record["run_id"])
+            branches_by_test[node_id].add(record["branch"])
+            jobs_by_test[node_id].add(record["job_name"])
+            created = record.get("created_at", "")
+            if created > last_seen_by_test[node_id]:
+                last_seen_by_test[node_id] = created
+
+    ranked = [
+        {
+            "test": node_id,
+            "runs": len(run_ids),
+            "branches": len(branches_by_test[node_id]),
+            "last_seen": last_seen_by_test[node_id][:10],
+            "jobs": sorted(jobs_by_test[node_id]),
+        }
+        for node_id, run_ids in runs_by_test.items()
+    ]
+    ranked.sort(key=lambda row: (-row["runs"], -row["branches"], row["test"]))
+    return ranked
+
+
+# --------------------------------------------------------------------------
+# GitHub access
+# --------------------------------------------------------------------------
+
+
+def gh_api(path: str, paginate: bool = False) -> str:
+    """Call ``gh api`` and return stdout, or "" when the resource is gone.
+
+    Expired logs and deleted runs are normal in a 90-day window, so a failed
+    call is data rather than an error.
+    """
+    cmd = ["gh", "api"]
+    if paginate:
+        cmd.append("--paginate")
+    cmd.append(path)
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=180)
+    except subprocess.TimeoutExpired:
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.decode("utf-8", errors="replace")
+
+
+def cache_dir(repo: str) -> Path:
+    root = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    # Keyed outside the repo so every worktree shares one cache.
+    path = Path(root) / "osprey-flake-report" / repo.replace("/", "_")
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def cached_json(cache: Path | None, key: str, produce):
+    """Memoise an immutable API result on disk.
+
+    Completed job logs and attempt job lists never change, so caching them
+    turns a repeat scan from minutes into seconds.
+    """
+    if cache is None:
+        return produce()
+    entry = cache / f"{key}.json"
+    if entry.exists():
+        try:
+            return json.loads(entry.read_text())
+        except (OSError, json.JSONDecodeError):
+            pass
+    value = produce()
+    try:
+        entry.write_text(json.dumps(value))
+    except OSError:
+        pass
+    return value
+
+
+def list_rerun_runs(repo: str, workflow: str, since: str) -> list[dict]:
+    """Return completed runs in the window that someone re-ran."""
+    raw = gh_api(
+        f"repos/{repo}/actions/workflows/{workflow}/runs?per_page=100&created=%3E%3D{since}",
+        paginate=True,
+    )
+    runs = []
+    for payload in iter_json_documents(raw):
+        for run in payload.get("workflow_runs", []):
+            if run.get("run_attempt", 1) > 1 and run.get("status") == "completed":
+                runs.append(
+                    {
+                        "run_id": run["id"],
+                        "branch": run.get("head_branch") or "?",
+                        "final_attempt": run["run_attempt"],
+                        "created_at": run.get("created_at", ""),
+                    }
+                )
+    return runs
+
+
+def fetch_attempt_jobs(repo: str, run_id: int, attempt: int, cache: Path | None):
+    def produce():
+        raw = gh_api(f"repos/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs?per_page=100")
+        if not raw:
+            return []
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+        return [[j["id"], j["name"], j.get("conclusion")] for j in payload.get("jobs", [])]
+
+    rows = cached_json(cache, f"jobs_{run_id}_{attempt}", produce)
+    return [tuple(row) for row in rows]
+
+
+def fetch_job_failures(repo: str, job_id: int, cache: Path | None) -> list[str]:
+    def produce():
+        return parse_test_failures(gh_api(f"repos/{repo}/actions/jobs/{job_id}/logs"))
+
+    return cached_json(cache, f"log_{job_id}", produce)
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+
+def render_table(ranked: list[dict], limit: int) -> str:
+    if not ranked:
+        return "  (none)"
+    rows = ranked[:limit]
+    width = min(max(len(r["test"]) for r in rows), 100)
+    lines = [
+        f"  {'runs':>4}  {'brs':>4}  {'last seen':>10}  test",
+        f"  {'-' * 4}  {'-' * 4}  {'-' * 10}  {'-' * width}",
+    ]
+    for row in rows:
+        lines.append(
+            f"  {row['runs']:>4}  {row['branches']:>4}  {row['last_seen']:>10}  {row['test']}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Find proven flaky CI tests from GitHub Actions re-run history.",
+    )
+    parser.add_argument("--days", type=int, default=30, help="lookback window (default: 30)")
+    parser.add_argument("--repo", default="als-apg/osprey")
+    parser.add_argument("--workflow", default="ci.yml")
+    parser.add_argument("--limit", type=int, default=25, help="rows to show (default: 25)")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    parser.add_argument("--no-cache", action="store_true", help="bypass the on-disk log cache")
+    args = parser.parse_args(argv)
+
+    cache = None if args.no_cache else cache_dir(args.repo)
+    since = (datetime.now(UTC) - timedelta(days=args.days)).strftime("%Y-%m-%d")
+
+    def note(message: str) -> None:
+        if not args.json:
+            print(message, file=sys.stderr)
+
+    note(f"Scanning {args.repo} {args.workflow} since {since} ...")
+    runs = list_rerun_runs(args.repo, args.workflow, since)
+    note(f"  {len(runs)} completed runs were re-run at least once")
+    if not runs:
+        print("No re-run runs in window -- nothing to analyse.")
+        return 0
+
+    # Every attempt of every re-run run, fetched concurrently: serially this
+    # takes minutes and times out interactive shells.
+    tasks = [(run, a) for run in runs for a in range(1, run["final_attempt"] + 1)]
+
+    def load_attempt(task):
+        run, attempt = task
+        return (
+            run["run_id"],
+            attempt,
+            fetch_attempt_jobs(args.repo, run["run_id"], attempt, cache),
+        )
+
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        results = list(pool.map(load_attempt, tasks))
+
+    attempts_by_run: dict[int, dict[int, list]] = defaultdict(dict)
+    for run_id, attempt, jobs in results:
+        attempts_by_run[run_id][attempt] = jobs
+    for run in runs:
+        run["attempts"] = attempts_by_run.get(run["run_id"], {})
+
+    flakes, persistent = split_flakes_and_persistent(runs)
+    note(f"  {len(flakes)} proven flakes, {len(persistent)} persistent failures")
+
+    if not flakes:
+        print("No proven flakes in window.")
+        return 0
+
+    note(f"  fetching logs for {len(flakes)} flaky jobs ...")
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        node_id_lists = list(
+            pool.map(lambda f: fetch_job_failures(args.repo, f["job_id"], cache), flakes)
+        )
+
+    infra: list[dict] = []
+    enriched: list[dict] = []
+    for record, node_ids in zip(flakes, node_id_lists, strict=True):
+        if node_ids:
+            enriched.append({**record, "tests": group_fixture_failures(node_ids)})
+        else:
+            infra.append(record)
+
+    ranked = rank_failures(enriched)
+    persistent_jobs = sorted({p["job_name"] for p in persistent})
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "repo": args.repo,
+                    "since": since,
+                    "runs_rerun": len(runs),
+                    "flaky_job_instances": len(flakes),
+                    "persistent_job_instances": len(persistent),
+                    "flakes": ranked,
+                    "infra_flakes": [
+                        {"job_name": r["job_name"], "run_id": r["run_id"], "branch": r["branch"]}
+                        for r in infra
+                    ],
+                    "persistent_failure_jobs": persistent_jobs,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    print()
+    print(f"PROVEN FLAKES -- failed then passed on the same commit ({args.days}d)")
+    print(render_table(ranked, args.limit))
+    if len(ranked) > args.limit:
+        print(f"  ... {len(ranked) - args.limit} more (raise --limit to see them)")
+
+    if infra:
+        print()
+        print(f"INFRA FLAKES -- job flipped green with no test-level failure ({len(infra)})")
+        counts: dict[str, int] = defaultdict(int)
+        for record in infra:
+            counts[record["job_name"]] += 1
+        for name, count in sorted(counts.items(), key=lambda kv: -kv[1]):
+            print(f"  {count:>4}  {name}")
+
+    if persistent_jobs:
+        print()
+        print(
+            f"NOT FLAKES -- never went green, these are real failures ({len(persistent)} instances)"
+        )
+        for name in persistent_jobs:
+            print(f"        {name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -561,6 +561,7 @@ async def run_dispatch(
         # ``__anext__`` is bounded by the inactivity watchdog. A full-window
         # silence means the provider never responded — fail fast with a clear
         # message instead of stalling to the worker's outer DISPATCH_TIMEOUT_SEC.
+        first_message_seen = False
         while True:
             try:
                 message = await asyncio.wait_for(agen.__anext__(), timeout=_INACTIVITY_TIMEOUT_SEC)
@@ -572,15 +573,34 @@ async def run_dispatch(
                 except Exception:
                     logger.debug("agen.aclose() raised after inactivity timeout", exc_info=True)
                 duration_sec = time.monotonic() - t0
-                msg = (
-                    f"No response from the model provider for "
-                    f"{_INACTIVITY_TIMEOUT_SEC:.0f}s — dispatch aborted. This usually "
-                    "means an invalid or expired provider credential, or an "
-                    "unreachable provider base URL."
-                )
+                if first_message_seen:
+                    msg = (
+                        f"No response from the model provider for "
+                        f"{_INACTIVITY_TIMEOUT_SEC:.0f}s — dispatch aborted. This usually "
+                        "means an invalid or expired provider credential, or an "
+                        "unreachable provider base URL."
+                    )
+                else:
+                    # The first window is NOT pure provider time: it also spans
+                    # SDK startup, the CLI spawn, and the MCP-ready barrier — so
+                    # on a cold or overloaded host it can expire without any
+                    # provider traffic having been attempted. Name both causes
+                    # rather than blaming the credential unconditionally.
+                    msg = (
+                        f"No response from the model provider within the first "
+                        f"{_INACTIVITY_TIMEOUT_SEC:.0f}s — dispatch aborted before any "
+                        "message arrived. This can mean an invalid or expired provider "
+                        "credential or an unreachable provider base URL — but this first "
+                        "window also covers local agent-runtime startup (SDK, CLI spawn, "
+                        "MCP servers), so a cold or overloaded host can exhaust it "
+                        "without any provider fault."
+                    )
                 logger.error("Dispatch aborted after %.1fs: %s", duration_sec, msg)
                 await _push({"type": "error", "message": msg})
-                # No bytes from the provider within the window — a provider fault.
+                # Nothing arrived within the window. Classified as a provider
+                # failure either way: mid-stream that is certain, and on the
+                # first window it remains the best single guess — the message
+                # above is what carries the cold-start caveat.
                 return failure_class._stamp(
                     _finalize(
                         {
@@ -598,6 +618,8 @@ async def run_dispatch(
                     failure_class.FAILURE_PROVIDER,
                     _num_calls(),
                 )
+
+            first_message_seen = True
 
             # Tool RESULTS arrive as ToolResultBlock inside UserMessage (the
             # SDK's message_parser wraps tool_result content that way), while

--- a/tests/e2e/_queue_drive.py
+++ b/tests/e2e/_queue_drive.py
@@ -120,25 +120,54 @@ def wait_for_worker_environment(
     on it would be very nearly vacuous. ``worker_environment_exists`` is the
     one field that separates the two.
 
+    ``worker_environment_exists`` alone is necessary but NOT sufficient: it
+    flips true the moment the worker process is up, while ``plans_allowed``
+    is filled in on a separate, later path -- the manager notices the open
+    environment on a poll, downloads the worker's plan and device lists, and
+    only then recomputes what is allowed. An enqueue landing in that window
+    is refused with exactly the 409 this gate exists to prevent. So a second
+    phase polls ``GET /devices`` until it is non-empty: the manager assigns
+    its allowed-plans and allowed-devices lists in one synchronous body
+    (plans first), so a non-empty device list proves ``plans_allowed`` has
+    already landed. Every substrate ships at least one device, so "non-empty"
+    is the right bar.
+
     Returns the manager status document that satisfied the wait. Raises
-    ``AssertionError`` naming the last status seen -- a failure here says the
-    worker environment never came up, which points at the queueserver rather
-    than at the plan the caller was about to run.
+    ``AssertionError`` naming the last thing seen -- a failure here says the
+    worker environment (or its plan list) never came up, which points at the
+    queueserver rather than at the plan the caller was about to run.
     """
     deadline = time.monotonic() + timeout
     last: Any = "(no answer yet)"
+    status_doc: dict[str, Any] | None = None
     while time.monotonic() < deadline:
         http_status, body = request(base_url, "/queue", "GET")
         if http_status == 200 and isinstance(body, dict):
             last = body.get("status") or {}
             if isinstance(last, dict) and last.get("worker_environment_exists"):
-                return dict(last)
+                status_doc = dict(last)
+                break
         else:
             last = body
         time.sleep(poll)
+    if status_doc is None:
+        raise AssertionError(
+            f"the RE worker environment never opened within {timeout:.0f}s -- the queue "
+            f"cannot accept plans until it does (last manager status: {last!r})"
+        )
+    # Phase 2, on the same deadline: the environment is open, but the manager
+    # may not have downloaded the worker's plan list yet (see docstring).
+    last = "(no answer yet)"
+    while time.monotonic() < deadline:
+        http_status, body = request(base_url, "/devices", "GET")
+        if http_status == 200 and isinstance(body, list) and body:
+            return status_doc
+        last = body
+        time.sleep(poll)
     raise AssertionError(
-        f"the RE worker environment never opened within {timeout:.0f}s -- the queue "
-        f"cannot accept plans until it does (last manager status: {last!r})"
+        f"the RE worker environment opened but the manager never published its "
+        f"device list within {timeout:.0f}s -- plans_allowed is filled on the same "
+        f"path, so an enqueue now would be refused 409 (last GET /devices: {last!r})"
     )
 
 

--- a/tests/e2e/test_dispatch_deploy.py
+++ b/tests/e2e/test_dispatch_deploy.py
@@ -538,7 +538,15 @@ def _runs_by_trigger() -> dict[str, dict]:
     by_trigger: dict[str, dict] = {}
     for run in runs:
         name = run.get("trigger_name")
-        if name:
+        if not name:
+            continue
+        # Latest wins by created_at, explicitly. The feed arrives newest-first,
+        # so a plain overwrite would keep the OLDEST run per trigger -- and on a
+        # flaky() rerun (module fixture not torn down) the poll loop would
+        # instantly re-read attempt 1's failed run instead of tracking the run
+        # this attempt just fired, making the retry vacuous.
+        held = by_trigger.get(name)
+        if held is None or (run.get("created_at") or 0) > (held.get("created_at") or 0):
             by_trigger[name] = run
     return by_trigger
 

--- a/tests/interfaces/web_terminal/test_panels_collab_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_collab_browser.py
@@ -191,9 +191,52 @@ def _new_page(browser) -> Page:
     return page
 
 
+# Passive in-flight counter around window.fetch, installed before the app
+# boots. The panel write helpers (panel-commands.js) are fire-and-forget by
+# design: a click resolves in the DOM via the server's SSE echo, so the browser
+# can still have focus/visibility POSTs in flight after every DOM- and
+# server-side wait has converged. A test that then issues its own write from
+# the pytest process races those stragglers on unrelated connections — this
+# counter is what lets it wait for the browser's writes to actually settle.
+# `.then(settle, settle)` fires when headers arrive, which is after the server
+# has processed the POST — exactly the ordering the barrier needs.
+_FETCH_COUNTER_JS = r"""(() => {
+  window.__ospreyFetchInflight = 0;
+  const orig = window.fetch.bind(window);
+  window.fetch = (...args) => {
+    window.__ospreyFetchInflight += 1;
+    const settle = () => { window.__ospreyFetchInflight -= 1; };
+    const p = orig(...args);
+    p.then(settle, settle);
+    return p;
+  };
+})();"""
+
+
+def _wait_for_fetch_quiescence(page: Page, *, timeout: float = 10.0) -> None:
+    """Block until the page has had no fetch in flight for 3 consecutive reads.
+
+    A single zero-read is not enough: the SSE echo of a write can itself
+    trigger the next write (a dock change schedules an open-tiles report), so
+    the counter can pass through zero between links of a chain. Three reads
+    50ms apart require a genuine quiet period, not an instant between requests.
+    """
+    deadline = time.monotonic() + timeout
+    streak = 0
+    inflight = None
+    while time.monotonic() < deadline:
+        inflight = page.evaluate("window.__ospreyFetchInflight ?? 0")
+        streak = streak + 1 if inflight == 0 else 0
+        if streak >= 3:
+            return
+        page.wait_for_timeout(50)
+    raise AssertionError(f"browser fetches never went quiet ({inflight} still in flight)")
+
+
 def _open_page(browser, base_url: str) -> Page:
     """Open a page and wait for the rail and the dock grid to be up."""
     page = _new_page(browser)
+    page.add_init_script(_FETCH_COUNTER_JS)
     page.goto(base_url, wait_until="domcontentloaded")
     expect(page.locator('button.panel-rail-button[data-panel-id="artifacts"]')).to_be_attached(
         timeout=15_000
@@ -775,11 +818,17 @@ def test_preset_click_and_agent_preset_call_are_the_same_operation(tmp_path, chr
             page.locator('button.panel-rail-button[data-panel-id="scope"]').click()
             _wait_for_client_tiles(page, ["scope"])
             _wait_for_active(base_url, "scope")
+            # _wait_for_active proves A focus write landed, not the LAST one:
+            # the click's POSTs are fire-and-forget, so a straggler can arrive
+            # AFTER the arrangement below, hit the membership-adding branch
+            # (the arrange just pruned scope), and resurrect the pruned panel —
+            # diverging tiles, rail, and active all at once. Quiesce first.
+            _wait_for_fetch_quiescence(page)
 
             page_action(page, base_url)
 
             _wait_for_client_tiles(page, ["data-viz", "artifacts"])
-            page.wait_for_timeout(800)
+            _wait_for_fetch_quiescence(page)
             signature = _workspace_signature(page)
             server = _wait_for_open_tiles(base_url, ["data-viz", "artifacts"])
             signature["server_open_tiles"] = server["open_tiles"]

--- a/tests/scripts/test_flake_report.py
+++ b/tests/scripts/test_flake_report.py
@@ -1,0 +1,307 @@
+"""Tests for the CI flake report's pure analysis functions.
+
+The GitHub-facing layer is deliberately untested: it is a thin `gh api`
+wrapper, and mocking it would only assert that the mock was called. The
+logic worth protecting is the parsing, the flip rule, and the ranking --
+all of which run on recorded log text.
+
+Log excerpts below are verbatim from als-apg/osprey CI, ANSI codes and all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "flake_report.py"
+_spec = importlib.util.spec_from_file_location("flake_report", _MODULE_PATH)
+flake_report = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(flake_report)
+
+
+class TestParseTestFailures:
+    def test_xdist_progress_and_summary_lines_dedupe_to_one_node_id(self):
+        """The same failure is printed twice; it must count once."""
+        log = (
+            "2026-08-16T05:29:33.0016730Z \x1b[31m[gw3] [ 43%] FAILED\x1b[0m "
+            "tests/cli/test_phase_reporter_live.py::test_a_styled_line \n"
+            "2026-08-16T05:35:12.7100440Z === short test summary info ===\n"
+            "2026-08-16T05:35:13.1239170Z FAILED "
+            "tests/cli/test_phase_reporter_live.py::test_a_styled_line - AssertionError: assert 1\n"
+        )
+        assert flake_report.parse_test_failures(log) == [
+            "tests/cli/test_phase_reporter_live.py::test_a_styled_line"
+        ]
+
+    def test_assertion_message_is_not_captured_into_the_node_id(self):
+        """A greedy match here would make every failure look unique."""
+        log = (
+            "2026-08-16T05:35:13Z FAILED tests/dispatch_worker/test_retention.py"
+            "::test_retention_loop_runs_one_iteration - assert [123.0, 0.1] == [123.0]\n"
+        )
+        assert flake_report.parse_test_failures(log) == [
+            "tests/dispatch_worker/test_retention.py::test_retention_loop_runs_one_iteration"
+        ]
+
+    def test_parametrised_id_containing_spaces_is_captured_whole(self):
+        log = (
+            "2026-08-16T05:35:13Z FAILED tests/cli/test_lifecycle_invariants.py"
+            "::test_no_shipped_text[the quick brown] - AssertionError\n"
+        )
+        assert flake_report.parse_test_failures(log) == [
+            "tests/cli/test_lifecycle_invariants.py::test_no_shipped_text[the quick brown]"
+        ]
+
+    def test_setup_error_and_collection_error_are_both_captured(self):
+        log = (
+            "2026-08-03T08:07:37Z \x1b[31mERROR\x1b[0m "
+            "tests/integration/test_build_boot.py::test_build_paths[hello-world]\n"
+            "2026-08-03T08:07:38Z ERROR tests/va/test_record_factory.py\n"
+        )
+        assert flake_report.parse_test_failures(log) == [
+            "tests/integration/test_build_boot.py::test_build_paths[hello-world]",
+            "tests/va/test_record_factory.py",
+        ]
+
+    def test_prose_mentioning_error_is_not_a_test_failure(self):
+        """Only paths under tests/ or src/ count, so log chatter is ignored."""
+        log = (
+            "2026-08-17T22:49:28Z echo ERROR ALS-APG endpoint probe failed\n"
+            "2026-08-17T23:05:15Z ##[error]Process completed with exit code 1.\n"
+            "2026-08-16T05:27:40Z [gw2] [ 11%] PASSED tests/services/test_database.py::test_up\n"
+        )
+        assert flake_report.parse_test_failures(log) == []
+
+
+class TestSplitFlakesAndPersistent:
+    @staticmethod
+    def _run(attempts, final_attempt=2, run_id=1, branch="feature/x"):
+        return {
+            "run_id": run_id,
+            "branch": branch,
+            "final_attempt": final_attempt,
+            "attempts": attempts,
+        }
+
+    def test_failure_that_later_passes_is_a_flake(self):
+        run = self._run({1: [(10, "E2E Tests", "failure")], 2: [(11, "E2E Tests", "success")]})
+        flakes, persistent = flake_report.split_flakes_and_persistent([run])
+        assert [f["job_id"] for f in flakes] == [10]
+        assert persistent == []
+
+    def test_failure_that_never_passes_is_not_a_flake(self):
+        """This is the distinction that keeps real branch bugs out of the table."""
+        run = self._run({1: [(10, "E2E Tests", "failure")], 2: [(11, "E2E Tests", "failure")]})
+        flakes, persistent = flake_report.split_flakes_and_persistent([run])
+        assert flakes == []
+        assert [p["job_id"] for p in persistent] == [10]
+
+    def test_aggregator_job_is_ignored(self):
+        """It fails whenever anything else does, so it would top every ranking."""
+        run = self._run(
+            {
+                1: [(10, flake_report.AGGREGATOR_JOB, "failure")],
+                2: [(11, flake_report.AGGREGATOR_JOB, "success")],
+            }
+        )
+        assert flake_report.split_flakes_and_persistent([run]) == ([], [])
+
+    def test_final_attempt_failures_are_not_counted_as_flakes(self):
+        """A failure on the last attempt has no later attempt to prove it flaky."""
+        run = self._run(
+            {1: [(10, "E2E", "success")], 2: [(11, "E2E", "failure")]},
+            final_attempt=2,
+        )
+        flakes, persistent = flake_report.split_flakes_and_persistent([run])
+        assert flakes == []
+        assert persistent == []
+
+    def test_three_attempt_run_counts_both_early_failures(self):
+        run = self._run(
+            {
+                1: [(10, "E2E", "failure")],
+                2: [(11, "E2E", "failure")],
+                3: [(12, "E2E", "success")],
+            },
+            final_attempt=3,
+        )
+        flakes, _ = flake_report.split_flakes_and_persistent([run])
+        assert sorted(f["job_id"] for f in flakes) == [10, 11]
+
+    def test_job_absent_from_final_attempt_is_not_a_flake(self):
+        """A skipped or removed job never proved it can pass."""
+        run = self._run({1: [(10, "Removed Job", "failure")], 2: []})
+        flakes, persistent = flake_report.split_flakes_and_persistent([run])
+        assert flakes == []
+        assert len(persistent) == 1
+
+
+class TestGroupFixtureFailures:
+    def test_three_or_more_from_one_file_collapse_to_a_fixture_entry(self):
+        """test_build_boot.py produced 6 node IDs from one uv timeout."""
+        node_ids = [
+            "tests/integration/test_build_boot.py::test_a[hello-world]",
+            "tests/integration/test_build_boot.py::test_a[control-assistant]",
+            "tests/integration/test_build_boot.py::test_b[hello-world]",
+        ]
+        assert flake_report.group_fixture_failures(node_ids) == [
+            "tests/integration/test_build_boot.py [fixture: 3 tests]"
+        ]
+
+    def test_two_from_one_file_stay_individual(self):
+        node_ids = [
+            "tests/e2e/test_scan.py::test_one",
+            "tests/e2e/test_scan.py::test_two",
+        ]
+        assert flake_report.group_fixture_failures(node_ids) == node_ids
+
+    def test_many_collection_errors_collapse_to_one_row(self):
+        """One bad import names ~100 modules; that must not bury the ranking."""
+        node_ids = [f"tests/agent_runner/test_{n}.py" for n in ("a", "b", "c", "d")]
+        assert flake_report.group_fixture_failures(node_ids) == [
+            flake_report.COLLECTION_ERROR_LABEL
+        ]
+
+    def test_collection_label_is_independent_of_file_count(self):
+        """A constant label lets recurring collection failures aggregate."""
+        few = flake_report.group_fixture_failures([f"tests/x/t{n}.py" for n in range(3)])
+        many = flake_report.group_fixture_failures([f"tests/y/t{n}.py" for n in range(40)])
+        assert few == many == [flake_report.COLLECTION_ERROR_LABEL]
+
+    def test_isolated_collection_error_keeps_its_filename(self):
+        """A single module failing to import is a real, nameable signal."""
+        assert flake_report.group_fixture_failures(["tests/va/test_record_factory.py"]) == [
+            "tests/va/test_record_factory.py"
+        ]
+
+    def test_collection_errors_and_test_failures_coexist(self):
+        node_ids = [
+            "tests/a/t1.py",
+            "tests/a/t2.py",
+            "tests/a/t3.py",
+            "tests/e2e/test_scan.py::test_one",
+        ]
+        assert flake_report.group_fixture_failures(node_ids) == [
+            flake_report.COLLECTION_ERROR_LABEL,
+            "tests/e2e/test_scan.py::test_one",
+        ]
+
+    def test_files_are_grouped_independently(self):
+        node_ids = [
+            "tests/a.py::t1",
+            "tests/a.py::t2",
+            "tests/a.py::t3",
+            "tests/b.py::t1",
+        ]
+        assert flake_report.group_fixture_failures(node_ids) == [
+            "tests/a.py [fixture: 3 tests]",
+            "tests/b.py::t1",
+        ]
+
+
+class TestRankFailures:
+    def test_ranked_by_distinct_runs_then_branches(self):
+        records = [
+            {"run_id": 1, "branch": "a", "job_name": "J", "tests": ["t_hot"]},
+            {"run_id": 2, "branch": "b", "job_name": "J", "tests": ["t_hot", "t_cold"]},
+            {"run_id": 3, "branch": "c", "job_name": "J", "tests": ["t_hot"]},
+        ]
+        ranked = flake_report.rank_failures(records)
+        assert [r["test"] for r in ranked] == ["t_hot", "t_cold"]
+        assert ranked[0] == {
+            "test": "t_hot",
+            "runs": 3,
+            "branches": 3,
+            "last_seen": "",
+            "jobs": ["J"],
+        }
+
+    def test_last_seen_is_the_most_recent_occurrence(self):
+        """Without this, a flake fixed weeks ago looks identical to a live one."""
+        records = [
+            {
+                "run_id": 1,
+                "branch": "a",
+                "job_name": "J",
+                "created_at": "2026-08-01T10:00:00Z",
+                "tests": ["t"],
+            },
+            {
+                "run_id": 2,
+                "branch": "b",
+                "job_name": "J",
+                "created_at": "2026-08-16T09:00:00Z",
+                "tests": ["t"],
+            },
+            {
+                "run_id": 3,
+                "branch": "c",
+                "job_name": "J",
+                "created_at": "2026-08-09T09:00:00Z",
+                "tests": ["t"],
+            },
+        ]
+        assert flake_report.rank_failures(records)[0]["last_seen"] == "2026-08-16"
+
+    def test_same_test_twice_in_one_run_counts_as_one_run(self):
+        """Two attempts of the same run are not two independent data points."""
+        records = [
+            {"run_id": 7, "branch": "a", "job_name": "J", "tests": ["t"]},
+            {"run_id": 7, "branch": "a", "job_name": "J", "tests": ["t"]},
+        ]
+        ranked = flake_report.rank_failures(records)
+        assert ranked[0]["runs"] == 1
+        assert ranked[0]["branches"] == 1
+
+    def test_branch_spread_breaks_ties_on_run_count(self):
+        """Wider branch spread means less chance it is one branch's bug."""
+        records = [
+            {"run_id": 1, "branch": "a", "job_name": "J", "tests": ["spread", "narrow"]},
+            {"run_id": 2, "branch": "b", "job_name": "J", "tests": ["spread"]},
+            {"run_id": 3, "branch": "a", "job_name": "J", "tests": ["narrow"]},
+        ]
+        ranked = flake_report.rank_failures(records)
+        assert [r["test"] for r in ranked] == ["spread", "narrow"]
+        assert ranked[0]["branches"] == 2
+        assert ranked[1]["branches"] == 1
+
+
+class TestIterJsonDocuments:
+    def test_concatenated_pages_are_all_yielded(self):
+        """`gh api --paginate` writes pages back to back with no separator."""
+        raw = '{"total_count":2,"workflow_runs":[{"id":1}]}{"total_count":2,"workflow_runs":[{"id":2}]}'
+        ids = [
+            r["id"] for doc in flake_report.iter_json_documents(raw) for r in doc["workflow_runs"]
+        ]
+        assert ids == [1, 2]
+
+    def test_single_page_still_works(self):
+        raw = '{"workflow_runs":[{"id":9}]}'
+        assert [d["workflow_runs"][0]["id"] for d in flake_report.iter_json_documents(raw)] == [9]
+
+    def test_whitespace_between_documents_is_tolerated(self):
+        raw = '{"a":1}\n  {"a":2}\n'
+        assert [d["a"] for d in flake_report.iter_json_documents(raw)] == [1, 2]
+
+    def test_empty_input_yields_nothing(self):
+        assert list(flake_report.iter_json_documents("")) == []
+
+    def test_truncated_trailing_document_stops_cleanly(self):
+        """A cut-off response should surrender the good pages, not raise."""
+        raw = '{"a":1}{"a":'
+        assert [d["a"] for d in flake_report.iter_json_documents(raw)] == [1]
+
+
+class TestStripAnsi:
+    def test_removes_colour_codes_and_keeps_text(self):
+        assert flake_report.strip_ansi("\x1b[31mFAILED\x1b[0m x") == "FAILED x"
+
+    def test_leaves_plain_text_untouched(self):
+        assert flake_report.strip_ansi("no codes here") == "no codes here"
+
+
+@pytest.mark.parametrize("empty", ["", "\n", "   \n\n"])
+def test_empty_log_yields_no_failures(empty):
+    assert flake_report.parse_test_failures(empty) == []


### PR DESCRIPTION
## What

Two things, from the same investigation:

1. **`scripts/ci/flake_report.py`** — ranks flaky tests from GitHub Actions re-run history. A test counts as a proven flake only when the same commit failed and then passed on a re-run (the flip rule), so the report can never blame a genuinely broken branch. Output is ranked by branch spread: a test flipping on many unrelated branches is infrastructure noise, not any one branch's bug. Covered by unit tests; runs in ~14 s warm against the last 60 days of history.

2. **A fix for the top-ranked flake it found** (5 re-run cycles across 5 unrelated branches): the shared e2e readiness gate in `tests/e2e/_queue_drive.py` returned as soon as `worker_environment_exists` flipped true, but `plans_allowed` is populated on a later async path — the manager notices the open environment on a poll, downloads the worker's plan/device lists over 0MQ, then recomputes what is allowed. An enqueue landing in that window is refused 409 "not in the list of allowed plans", which is exactly the failure the gate's docstring says it exists to prevent.

## Fix

`wait_for_worker_environment` gains a second phase on the same deadline: poll `GET /devices` until non-empty. This is a sound proxy because the queueserver manager assigns `_allowed_plans` and `_allowed_devices` in one synchronous body (plans first), so a non-empty device list proves the plan list has already landed.

Test-only change; no assertion weakened. Eight e2e modules share this gate, so this closes the same race everywhere it was being masked by `flaky` reruns.

## Numbers behind it

60 days of CI history: 80 proven flake instances; 12% of all runs needed a re-run. Three past flakes were eventually fixed, but only after burning 7–9 re-run cycles each — this tool exists to shorten that loop.

## Also folded in: the other two live flakes

- **`test_full_stack_dispatch`** — the run-feed snapshot kept the *oldest* run per trigger (plain overwrite over a newest-first feed), so a `flaky()` rerun instantly re-read the previous attempt's failed run and the retry was vacuous. Now picks by `created_at` explicitly. Companion product fix: the dispatch inactivity watchdog's first window also spans local runtime startup (SDK, CLI spawn, MCP-ready), so its error no longer unconditionally blames the provider credential before any message has arrived.
- **`test_preset_click_and_agent_preset_call_are_the_same_operation`** — the browser's panel focus writes are fire-and-forget, so a straggler POST could arrive after the test's arrangement and resurrect the panel the arrange just pruned. The test now installs an in-flight fetch counter before the app boots and waits for genuine request quiescence (three consecutive quiet reads) before arranging and before capturing the signature, replacing the blind 800 ms settle. The underlying product-side write-ordering hazard is filed as #632.
