### PR TITLE
feat(deploy): ship control-assistant web terminals with password login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- Web-terminal roster entries can opt out of the login wall with `login:
+  false` — the entry is served without authentication while every other
+  terminal stays gated, and no password is provisioned for it. Meant for
+  entries that front a public read-only service, like the ARIEL card.
+- Profile `env.defaults` values are now seeded into the repository's `.env` by
+  `osprey init` (append-only; a value already set wins), so a preset can ship
+  working starting values.
+- The `control-assistant` preset now deploys its web terminals with password
+  login on: Alice and Bob log in with demo passwords seeded into `.env`
+  (`alice`/`alice`, `bob`/`bob` — edit there, or rotate with `osprey users
+  passwd`), while the ARIEL terminal stays open via `login: false`.
+
 - Build profiles can now author the shared web-terminal context baseline at
   `web-terminal-context/base.md`, overriding the framework's copy. `osprey
   init` materializes it from the preset (the control assistant ships its own

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -1032,9 +1032,9 @@ resolve to the project's own Python.
 Environment variables
 =====================
 
-The ``env`` section declares what the deployment needs. It documents variables;
-it does not carry values — values live in the repository's ``.env.shared`` and
-``.env`` (see :ref:`profile-secrets`).
+The ``env`` section declares what the deployment needs. ``required`` documents
+variables the operator must supply; secrets live in the repository's ``.env``
+and never in the profile (see :ref:`profile-secrets`).
 
 .. code-block:: yaml
 
@@ -1049,9 +1049,15 @@ Both lists are rendered into the repository's ``.env.example``, so an operator
 opening that file sees them alongside every other variable. Required names must
 match ``^[A-Z_][A-Z0-9_]*$``.
 
-Non-secret values the whole site should start from do not belong here either.
-Put them in ``.env.shared``, which is committed with the repository and read by
-every host (see :ref:`deployment-env-chain`).
+``defaults`` values are additionally seeded into the repository's ``.env`` by
+``osprey init``, under their own section banner, so a deployment created from
+the profile starts with them in force. Seeding is append-only: a value already
+in the file — set by the operator, or minted by a deploy — always wins, and
+later ``init`` runs never rewrite one. Declare a default only for a value the
+profile's author can honestly choose for every deployment (the
+``control-assistant`` preset's demo login passwords, say); values a *site*
+should share across hosts belong in ``.env.shared``, which is committed with
+the repository and read by every host (see :ref:`deployment-env-chain`).
 
 
 Dependencies

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -159,6 +159,15 @@ and this list is what ``osprey up`` reads.
 (``demo-nginx``, ``demo-web-alice``), so keep it short and distinct from the
 project name.
 
+While you are in the ``modules.web_terminals:`` block, note the ``auth:``
+stanza the preset ships: the terminals ask for a login, with demo passwords
+that ``osprey init`` seeded into this repository's ``.env``
+(``alice``/``alice``, ``bob``/``bob``) and ``allow_insecure_http: true``
+keeping the login flow on plain HTTP. That is a demo posture. For a facility
+host, set real passwords in ``.env`` (or rotate with ``osprey users passwd``)
+and serve TLS — :doc:`multi-user` walks through both, and through single
+sign-on if your site runs one.
+
 Then confirm the persona catalog, further down the same ``config:`` block
 under ``modules.web_terminals:``. ``osprey init`` derived these names from the
 repository name, so after Step 2's trim the block already reads:

--- a/docs/source/how-to/multi-user.rst
+++ b/docs/source/how-to/multi-user.rst
@@ -429,14 +429,19 @@ warm, and returning to the same user reconnects to it.
 Require a login
 ===============
 
-Out of the box the stack asks for no credentials and speaks plain HTTP:
-clicking a card on the landing page opens that terminal, and anyone who can
-reach the nginx port can click any card. That posture suits a **single trusted
-host** — a workstation or control-room machine you already trust — and nothing
-beyond it. It is the walkthrough's choice, not a limit of the stack: it keeps
-one ``osprey up`` on a laptop free of certificates and identity
-providers. No preset ships with login enabled, so this is something you turn on
-deliberately.
+With no ``auth`` stanza the stack asks for no credentials and speaks plain
+HTTP: clicking a card on the landing page opens that terminal, and anyone who
+can reach the nginx port can click any card. That posture suits a **single
+trusted host** — a workstation or control-room machine you already trust — and
+nothing beyond it.
+
+The ``control-assistant`` preset ships with password login switched on, in its
+demo posture: each roster user's password is seeded into the repository's
+``.env`` by ``osprey init`` (``alice``/``alice``, ``bob``/``bob`` — change them
+there, or rotate with ``osprey users passwd``), the ARIEL entry stays public
+via ``login: false`` (see below), and ``allow_insecure_http: true`` keeps the
+demo on plain HTTP. Those passwords authenticate a demo, not a facility: for
+any reachable host, set real passwords and serve TLS as described here.
 
 Set ``auth.method`` and every request under ``/u/<name>/`` — pages, APIs and
 the terminal's live connection alike — is refused unless the browser holds a
@@ -546,6 +551,36 @@ The service listens on ``127.0.0.1`` on the deploy host itself (the web stack
 uses host networking), so nginx reaches it and nothing off-host does. It is not
 published as a container port, and anyone with a shell on the deploy host can
 reach it — the same as every per-user terminal.
+
+Leave one entry public
+----------------------
+
+Not every card on the landing page is a person's terminal. A roster entry that
+fronts a read-only service — the preset's ARIEL logbook assistant, say — can
+opt out of the login wall:
+
+.. code-block:: yaml
+
+   users:
+     - name: ariel
+       index: 2
+       persona: ariel
+       login: false
+
+With authentication on, that entry is served exactly as the whole deployment is
+with authentication off: no login, no session, open to anyone who can reach the
+nginx port. No password is provisioned for it (``osprey users passwd`` refuses
+the name and says why), and nginx never asks the authentication service about
+it. Session cookies still never reach its container.
+
+Only the literal ``false`` opts an entry out. Absence, ``true``, and any typo
+all mean "login required" — a misspelling can lock an entry down, never open it
+up — and lint reports a non-boolean value. The key is inert while
+``auth.method`` is ``none``, which lint points out as well.
+
+Opting out is for entries whose *content* is public by design. Anything that
+can reach a control system, write anywhere, or spend provider tokens belongs
+behind the wall.
 
 Serve it over HTTPS
 -------------------

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1375,16 +1375,25 @@ def _entry_list(target: Path, materialized: _MaterializedProfile) -> list[str]:
 def _env_note(target: Path, materialized: _MaterializedProfile) -> str:
     """What happened to the secrets file, in one clause.
 
-    Three outcomes, and the remedy differs: keys were taken from the shell,
-    nothing was exported at all, or what was exported belongs to providers this
-    assistant does not use.
+    Three outcomes, and the remedy differs: keys were seeded (from the shell
+    and/or the profile's own ``env.defaults`` — the file's section banners say
+    which is which), nothing was exported at all, or what was exported belongs
+    to providers this assistant does not use.
     """
     from osprey.utils.dotenv import parse_dotenv_file
 
+    from .templates.scaffolding import provider_api_key_entries
+
     env_path = target / ".env"
     if env_path.is_file():
-        taken = ", ".join(sorted(parse_dotenv_file(env_path)))
-        return f"from your shell: {taken}. Not in git"
+        keys = sorted(parse_dotenv_file(env_path))
+        taken = ", ".join(keys)
+        # A .env holding only profile-declared defaults is seeded but not yet
+        # usable: the provider key is still the operator's to add, and that
+        # remedy must not disappear just because the file exists now.
+        if not {entry["var"] for entry in provider_api_key_entries()}.intersection(keys):
+            return f"seeded: {taken}. Add your API key; not in git"
+        return f"seeded: {taken}. Not in git"
     if materialized.skipped_shell_keys:
         return "empty; no key for the providers this assistant uses"
     return "empty; copy .env.example and add your API key"

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -147,6 +147,13 @@ _ENV_EXAMPLE_TEMPLATE = "project/env.example.j2"
 # attribution at all (SC-8).
 REPO_SEEDED_ENV_BANNER = "# ── Seeded by `osprey init` from your shell ──"
 
+# Section header for values the profile itself declares under `env.defaults`.
+# A third origin, and a third banner for the same reason the two above are
+# distinct: these came from the preset's author, not from this operator's shell
+# and not from a deploy mint, and the reader deciding whether a value is safe
+# to change needs to know that.
+PROFILE_DEFAULTS_ENV_BANNER = "# ── Declared by this profile (env.defaults) — edit freely ──"
+
 #: Source-zone entries a repo-root materialization owns, and therefore the exact
 #: set a re-materialization is allowed to replace. Everything else in a
 #: deployment repo — ``.git``, ``.env``, ``var/``, ``build/``, ``ci-extra.yml``,
@@ -514,9 +521,18 @@ def _write_secret_channel(
     ``.env.example`` is always written, and comes from the project template
     (:data:`_ENV_EXAMPLE_TEMPLATE`) rather than from prose of its own — one
     template documents the variable set wherever it is rendered. ``.env`` is
-    written ONLY when ``exported`` is non-empty: an empty secrets file reads as
-    a configured one, and ``cp .env.example .env`` is the honest starting point
-    when there is nothing to seed.
+    written ONLY when there is something to seed it with — shell-exported
+    provider keys (``exported``) and/or the profile's own ``env.defaults``
+    values: an empty secrets file reads as a configured one, and ``cp
+    .env.example .env`` is the honest starting point when there is nothing to
+    seed.
+
+    ``env.defaults`` values are seeded as real starting values, under their own
+    banner (:data:`PROFILE_DEFAULTS_ENV_BANNER`), because a preset declares one
+    for exactly the deployments that should come up working without a hand
+    edit — a demo login password, say. The append-only writer keeps every
+    later authority intact: a value the operator has already set (or that
+    ``osprey up`` minted) always wins over the declared default.
 
     Args:
         target: The profile directory, already created.
@@ -550,8 +566,9 @@ def _write_secret_channel(
                 if entry["provider"] in providers
             ],
             "service_token_vars": service_token_var_entries(),
-            # The profile's `env:` block is documentation, not values — the
-            # same two keys `osprey build` feeds this template.
+            # The profile's `env:` block, for the example's documentation —
+            # the same two keys `osprey build` feeds this template. The
+            # `env.defaults` VALUES are additionally seeded into `.env` below.
             "env_required": list(resolved.env.required or []),
             "env_defaults": dict(resolved.env.defaults or {}),
             # No project exists yet; the key is a commented hint either way.
@@ -567,6 +584,14 @@ def _write_secret_channel(
         # profile `.env` rather than a second one that only new profiles get.
         append_profile_env(target / _PROFILE_ENV_FILENAME, exported, REPO_SEEDED_ENV_BANNER)
         written.append(_PROFILE_ENV_FILENAME)
+
+    defaults = dict(resolved.env.defaults or {})
+    if defaults:
+        # Same writer, own banner: a declared default an operator has already
+        # overridden (or that a mint got to first) is never rewritten.
+        append_profile_env(target / _PROFILE_ENV_FILENAME, defaults, PROFILE_DEFAULTS_ENV_BANNER)
+        if _PROFILE_ENV_FILENAME not in written:
+            written.append(_PROFILE_ENV_FILENAME)
 
     return written
 

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -108,6 +108,7 @@ from osprey.deployment.web_terminals.naming import web_container_name, web_conta
 from osprey.deployment.web_terminals.personas import (
     as_dict,
     effective_image_source,
+    entry_requires_login,
     env_var_suffix,
     freeze_user_indices,
     normalize_users,
@@ -915,9 +916,19 @@ def rotate_user_password(config_path: str | Path, user: str, password: str) -> N
             "there; nothing was modified."
         )
 
-    if not any(entry["name"] == user for entry in normalize_users(web_terminals.get("users"))):
+    roster = normalize_users(web_terminals.get("users"))
+    if not any(entry["name"] == user for entry in roster):
         raise ValueError(
             f"User {user!r} is not present in modules.web_terminals.users; no password was changed."
+        )
+    # On the roster, but outside the login wall: no gate ever consults a hash
+    # for this entry, so "changing its password" would store a credential
+    # nothing checks while telling the operator it took effect.
+    if not any(entry["name"] == user and entry_requires_login(entry) for entry in roster):
+        raise ValueError(
+            f"User {user!r} has 'login: false' in modules.web_terminals.users, so its "
+            "terminal is served without authentication and has no password to change. "
+            "Remove that key to put the entry behind the login wall; nothing was modified."
         )
 
     _require_running_runtime(config)

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -114,6 +114,7 @@ def lint_web_terminals(config: Any, *, rendered_project: bool = True) -> list[Fi
     findings.extend(_check_username_charset(users))
     findings.extend(_check_display_name(users))
     findings.extend(_check_user_theme(users))
+    findings.extend(_check_user_login(web_terminals, users))
     findings.extend(_check_invalid_index(users))
     findings.extend(_check_duplicate_index(users))
     findings.extend(_check_bare_list_port_drift_risk(users))
@@ -138,7 +139,7 @@ def lint_web_terminals(config: Any, *, rendered_project: bool = True) -> list[Fi
     findings.extend(_check_unknown_mcp_topology(web_terminals))
     findings.extend(_check_nginx_image(web_terminals))
     findings.extend(_check_auth_method(web_terminals))
-    findings.extend(_check_auth_transport(web_terminals))
+    findings.extend(_check_auth_transport(root, web_terminals))
     findings.extend(_check_auth_oidc(root, web_terminals))
     findings.extend(_check_auth_credential_collisions(web_terminals, users))
     return findings
@@ -365,6 +366,60 @@ def _check_user_theme(users: list[Any]) -> list[Finding]:
                     f"modules.web_terminals.users entry {name!r} has a non-string "
                     f"theme {theme!r}; theme must be a string (a theme family such "
                     f"as 'desy', or a concrete id such as 'desy-light')"
+                ),
+            )
+        )
+    return findings
+
+
+def _check_user_login(web_terminals: dict[str, Any], users: list[Any]) -> list[Finding]:
+    """An object-form entry's optional ``login`` must be a boolean, and only
+    does anything while authentication is on.
+
+    Two findings, for the two ways the key can lie:
+
+    * A non-boolean ``login`` is an ERROR. The normalizer reads anything but
+      the literal ``false`` as "login required" — deliberately fail-closed —
+      so the typo can never open an entry to the world, but the author who
+      wrote ``login: no-thanks`` believes the opposite of what deploys.
+    * ``login: false`` with ``auth.method: none`` is a WARN. The key is inert
+      (there is no login wall to be exempt from), so the config claims a
+      distinction the deployment does not have.
+    """
+    findings: list[Finding] = []
+    login_declared = False
+    for user in users:
+        if not isinstance(user, dict) or "login" not in user:
+            continue
+        login = user.get("login")
+        if isinstance(login, bool):
+            login_declared = login_declared or login is False
+            continue
+        name = user.get("name", user)
+        findings.append(
+            Finding(
+                severity="error",
+                code="web_terminals.invalid_user_login",
+                message=(
+                    f"modules.web_terminals.users entry {name!r} has a non-boolean "
+                    f"login {login!r}; login must be true (default: this entry "
+                    f"requires a login) or false (served without authentication). "
+                    f"Anything else deploys as 'login required'"
+                ),
+            )
+        )
+
+    context = _auth_context(web_terminals)
+    auth_off = context is None or context["auth_method"] == "none"
+    if login_declared and auth_off:
+        findings.append(
+            Finding(
+                severity="warn",
+                code="web_terminals.user_login_inert",
+                message=(
+                    "a modules.web_terminals.users entry sets login: false, but "
+                    "auth.method is 'none' so no entry has a login to be exempt "
+                    "from; the key changes nothing until authentication is enabled"
                 ),
             )
         )
@@ -1408,7 +1463,7 @@ def _check_auth_method(web_terminals: dict[str, Any]) -> list[Finding]:
     ]
 
 
-def _check_auth_transport(web_terminals: dict[str, Any]) -> list[Finding]:
+def _check_auth_transport(root: dict[str, Any], web_terminals: dict[str, Any]) -> list[Finding]:
     """Authentication over cleartext HTTP: an ERROR, or a WARN once accepted.
 
     A session cookie is a bearer credential. Served over plain HTTP it is
@@ -1419,7 +1474,12 @@ def _check_auth_transport(web_terminals: dict[str, Any]) -> list[Finding]:
     WARN when the escape hatch is what's keeping the config renderable, so the
     risk is restated at every lint rather than only in the commit that took it.
 
-    With TLS on, ``allow_insecure_http`` is inert and nothing is reported.
+    With TLS on, ``allow_insecure_http`` is inert and nothing is reported. The
+    WARN is also withheld when ``deploy.fqdn`` names loopback: the deployment
+    advertises itself as same-host-only, so its cookies cross no network path —
+    the exact case the escape hatch exists for, and the posture the
+    control-assistant preset ships in. Pointing ``fqdn`` at a real host brings
+    the WARN back with the config change that creates the exposure.
     """
     context = _auth_context(web_terminals)
     if context is None or context["auth_method"] == "none":
@@ -1427,6 +1487,9 @@ def _check_auth_transport(web_terminals: dict[str, Any]) -> list[Finding]:
     if context["tls_enabled"]:
         return []
     if context["auth_allow_insecure_http"]:
+        fqdn = str(as_dict(root.get("deploy")).get("fqdn") or "").strip()
+        if fqdn in ("127.0.0.1", "localhost", "::1"):
+            return []
         return [
             Finding(
                 severity="warn",

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -326,6 +326,15 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
     *non-secret* side of the mapping ever lives in config.yml; password hashes
     never do (they live in ``.env.auth``, keyed by :func:`env_var_suffix`).
 
+    An object entry's optional ``login`` (whether this entry sits behind the
+    deployment's login wall when authentication is enabled) is carried through
+    only when it is the literal boolean ``False`` — the one value that changes
+    anything. ``true``, absence, and every malformed spelling all mean "login
+    required", so dropping them is both the fail-closed reading and what keeps
+    a config typo from silently opening an entry to the world (lint reports
+    the typo separately). See :func:`entry_requires_login` for the single
+    consumer-side reading of the carried key.
+
     Malformed entries — anything that isn't a string, and any dict missing a
     string ``name`` or an int ``index`` — are dropped rather than raising
     (well-formedness is lint.py's job). ``bool`` is a subclass of ``int`` in
@@ -342,9 +351,10 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
 
     Returns:
         New ``{"name": str, "index": int}`` dicts (plus optional
-        ``"display_name"``, ``"theme"`` and ``"oidc_subject"`` string keys when
-        the entry carried them) in config-declaration order. Input dicts are
-        never mutated or returned by reference.
+        ``"display_name"``, ``"theme"`` and ``"oidc_subject"`` string keys and
+        a ``"login": False`` marker when the entry carried them) in
+        config-declaration order. Input dicts are never mutated or returned by
+        reference.
     """
     if not isinstance(users_raw, list):
         return []
@@ -366,8 +376,34 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
                 oidc_subject = entry.get("oidc_subject")
                 if isinstance(oidc_subject, str) and oidc_subject:
                     normalized_entry["oidc_subject"] = oidc_subject
+                # Only the literal boolean False is carried: absent or True both
+                # mean "login required", and any other value is a config typo
+                # (reported by lint) whose safe reading is the same. Carrying
+                # only the exempting value keeps the gate fail-closed — a typo
+                # can never open an entry to the world.
+                if entry.get("login") is False:
+                    normalized_entry["login"] = False
                 normalized.append(normalized_entry)
     return normalized
+
+
+def entry_requires_login(entry: dict[str, Any]) -> bool:
+    """Whether this normalized roster entry sits behind the login wall.
+
+    ``login: false`` on a roster entry opts it out of authentication: with
+    ``auth.method`` enabled, nginx still gates every other entry but proxies
+    this one without an ``auth_request``, and no password is provisioned for
+    it. The single reading of that key, shared by the render (which decides
+    whether to emit the gate), credential provisioning (which decides whether a
+    password exists) and the ``users passwd`` verb (which refuses to rotate a
+    password that cannot exist) — three call sites that must never disagree
+    about who has a login.
+
+    Reads the *normalized* entry, so only the literal ``False``
+    :func:`normalize_users` carries through exempts; every malformed spelling
+    already normalized back to "login required".
+    """
+    return entry.get("login") is not False
 
 
 def freeze_user_indices(users_raw: Any) -> list[dict[str, Any]]:
@@ -645,7 +681,9 @@ def resolve_personas(
         existed. An optional ``"oidc_subject"`` key rides through on the same
         terms, so the auth sidecar's roster→identity mapping is read off the same
         resolved entry as everything else rather than re-derived from the raw
-        roster. An optional ``"landing_group"`` key — the catalog entry's own
+        roster. An optional ``"login": False`` marker rides through likewise —
+        present only when the roster entry opted out of the login wall (see
+        :func:`entry_requires_login`). An optional ``"landing_group"`` key — the catalog entry's own
         ``landing_group``, present only for a non-empty string — names the
         landing-page section this entry's card belongs in; it is read by
         :func:`osprey.deployment.web_terminals.render._build_groups` and affects
@@ -698,6 +736,10 @@ def resolve_personas(
             value = source.get(field)
             if isinstance(value, str) and value:
                 entry[field] = value
+        # `login: False` rides through on the same present-only-when-set terms;
+        # normalize_users already reduced every other spelling to absence.
+        if source.get("login") is False:
+            entry["login"] = False
         return entry
 
     def _zero_migration_entry(

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -69,6 +69,7 @@ from osprey.deployment.web_terminals.persona_images import (
 )
 from osprey.deployment.web_terminals.personas import (
     effective_image_source,
+    entry_requires_login,
     normalize_users,
     resolve_personas,
 )
@@ -292,7 +293,15 @@ def _provision_auth_secrets(web_terminals: dict, repo_root: str) -> None:
 
     credentials = None
     if auth_method == "password":
-        usernames = [entry["name"] for entry in normalize_users(web_terminals.get("users"))]
+        # `login: false` entries are left out on purpose: no gate ever asks the
+        # sidecar about them, so a hash here would be a credential nothing
+        # checks — and a minted password printed for an entry that has no login
+        # would tell the operator the opposite of the truth.
+        usernames = [
+            entry["name"]
+            for entry in normalize_users(web_terminals.get("users"))
+            if entry_requires_login(entry)
+        ]
         credentials = ensure_auth_credentials(usernames, repo_root, echo=_mint_echo())
         _report_unshown_mints(credentials)
     session_secrets = ensure_auth_session_secrets(repo_root)

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -31,6 +31,7 @@ from osprey.deployment.web_terminals.personas import (
     config_needs_facility_bundle,
     config_needs_launch_token,
     effective_image_source,
+    entry_requires_login,
     env_var_suffix,
     env_var_suffix_collisions,
     resolve_personas,
@@ -360,6 +361,12 @@ def render_web_terminals(
                 # would render no subject mapping at all and every IdP identity
                 # would be unmappable.
                 "oidc_subject": entry.get("oidc_subject"),
+                # Whether this entry opted out of the login wall (`login:
+                # false` on the roster entry). Read through the shared
+                # predicate rather than off the raw key so the template's gate
+                # and credential provisioning can never disagree about who has
+                # a login. With auth off the template never consults it.
+                "login_exempt": not entry_requires_login(entry),
                 # The env-var name that subject is emitted under, resolved HERE
                 # through env_var_suffix() — the single definition of the
                 # username->env-var mapping, shared with credential

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -184,6 +184,13 @@ config:
     lattice_base_port: 9491       # first per-user lattice-dashboard port
     channel_finder_base_port: 9591  # first per-user channel-finder panel port
     default_persona: readonly   # used for any user below with no persona
+    # Every terminal below asks for a login (user alice: password alice, and
+    # so on — set in this repo's .env; rotate with `osprey users passwd`).
+    auth:
+      method: password
+      # Accepts login over plain HTTP, which fits 127.0.0.1 and nothing else.
+      # For any reachable host, delete this line and configure tls instead.
+      allow_insecure_http: true
     # How the landing page is laid out. Omit this whole block and you get one
     # section holding every entry below, headed "Terminals".
     landing:
@@ -213,6 +220,8 @@ config:
         index: 2
         persona: ariel
         display_name: "ARIEL Logbook Research"
+        # Read-only research service, open without a login on purpose.
+        login: false
     personas:
       # `osprey build` builds one of these per file in personas/, into build/.
       # `osprey up` builds nothing: if one is missing it stops and says so.
@@ -253,3 +262,8 @@ env:
   required:
     - EVENT_DISPATCHER_TOKEN
     - DISPATCH_WORKER_TOKEN
+  # Demo login passwords for the terminals above, written into this repo's
+  # .env by `osprey init`. Edit them there — these are not secrets.
+  defaults:
+    OSPREY_AUTH_PW_ALICE: alice
+    OSPREY_AUTH_PW_BOB: bob

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -39,6 +39,11 @@
       location each of them subrequests, and the public `/auth/` surface the
       sidecar serves the login flow from. When "none", nothing auth-related is
       emitted and the plain proxy config below is the whole render.
+      Per-service exception: a svc with `login_exempt: true` (the roster
+      entry declared `login: false`) gets NO auth_request and NO internal
+      verify target — it is served publicly even while auth is on. The
+      cookie strip in its location is kept: public or not, a per-user
+      container must never receive the origin-wide session cookie jar.
     auth_port: int, required when auth_method != "none" (defaults to 9070)
       The loopback port the auth sidecar listens on. Reached at bind_host, the
       same way every per-user app is: the sidecar shares the host network
@@ -131,7 +136,9 @@
     authorized is structural — a request cannot influence which user it is
     checked against. The public `/auth/` prefix (login page, credential POST,
     OIDC callback, logout) stays outside `auth_request`, as does the landing
-    page at `= /`; everything else under a user prefix is gated.
+    page at `= /`; everything else under a user prefix is gated — except a
+    svc whose roster entry declared `login: false` (`svc.login_exempt`),
+    which is served ungated on purpose and gets no verify target either.
 
   Fail-closed is the invariant that survives every partial state: a sidecar
   that is down, unconfigured, or answering 503 denies the subrequest, and
@@ -267,7 +274,13 @@ server {
     # location and proxy_pass target strip /u/{{ svc.user }} before the
     # request reaches the upstream.
     location /u/{{ svc.user }}/ {
-{% if auth_method != "none" %}
+{% if auth_method != "none" and svc.login_exempt %}
+        # Authentication is on, but this roster entry declared `login: false`:
+        # it is served to anyone who can reach this nginx, exactly as the whole
+        # deployment is when auth is off. The cookie strip below still applies —
+        # a public container must never see another user's session cookie.
+{% endif -%}
+{% if auth_method != "none" and not svc.login_exempt %}
         # Authentication is on (web_terminals.auth.method is "{{ auth_method }}"):
         # every request that reaches this location — page load, panel API call,
         # WebSocket handshake, SSE stream — is authorized first by the internal
@@ -322,7 +335,7 @@ server {
     location = /u/{{ svc.user }} {
         return 301 /u/{{ svc.user }}/;
     }
-{% if auth_method != "none" %}
+{% if auth_method != "none" and not svc.login_exempt %}
 
     # {{ svc.user }}'s own auth target — the only thing the `auth_request` above
     # can reach. There is one of these per roster user, and the `?user=` it asks

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -591,10 +591,19 @@ def test_force_replaces_the_source_zone_and_nothing_else(
     result = init_exemplar(runner, exemplar_repo, "--force")
 
     assert result.exit_code == 0, result.output
+    # `.env` is held to survival-of-content rather than byte-identity: the
+    # profile's `env.defaults` seeding is append-only (missing keys join the
+    # file; nothing present is ever rewritten), so a re-init may grow the file
+    # — what it can never do is cost the operator a line they wrote.
     destroyed = sorted(
         entry
         for entry, survivor in survivors.items()
-        if not survivor.is_file() or survivor.read_text(encoding="utf-8") != SENTINEL
+        if not survivor.is_file()
+        or (
+            SENTINEL not in survivor.read_text(encoding="utf-8")
+            if entry == ".env"
+            else survivor.read_text(encoding="utf-8") != SENTINEL
+        )
     )
     assert destroyed == []
     # …and the source zone really was re-materialized, so the test cannot pass
@@ -688,9 +697,16 @@ def test_env_is_seeded_from_the_shell(
     assert stat.S_IMODE((target / ".env").stat().st_mode) == 0o600
 
 
-def test_a_shell_with_no_keys_writes_no_env(exemplar_repo: Path) -> None:
-    """An empty secrets file reads as a configured one. Absence is the honest state."""
-    assert not (exemplar_repo / ".env").exists()
+def test_a_shell_with_no_keys_seeds_only_the_profiles_declared_defaults(
+    exemplar_repo: Path,
+) -> None:
+    """With nothing exported, the ``.env`` that appears carries exactly the
+    preset's own ``env.defaults`` (the demo login passwords) — no provider key
+    is invented, and the example file still documents the full variable set."""
+    env_text = (exemplar_repo / ".env").read_text(encoding="utf-8")
+    assert "OSPREY_AUTH_PW_ALICE=alice" in env_text
+    assert "OSPREY_AUTH_PW_BOB=bob" in env_text
+    assert "ANTHROPIC_API_KEY" not in env_text
     assert (exemplar_repo / ".env.example").is_file()
 
 
@@ -732,7 +748,7 @@ EXEMPLAR_REPORT = f"""\
   profile.yml   your assistant's settings; edit this
   data/         channel lists and facility docs; edit these
   personas/     one per web login: ariel, readonly, readwrite
-  .env          empty; copy .env.example and add your API key
+  .env          seeded: OSPREY_AUTH_PW_ALICE, OSPREY_AUTH_PW_BOB. Add your API key; not in git
   .env.shared   settings shared by every host; your .env wins
   README.md     what everything here does
 

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -224,6 +224,9 @@ class TestControlAssistantWebTier:
         assert wt["image_source"] == "local"
         assert wt["default_persona"] == "readonly"
         assert wt["nginx_port"] == 9080
+        # Password login ships ON, in the demo posture: plain HTTP is only
+        # acceptable because the preset's fqdn is loopback.
+        assert wt["auth"] == {"method": "password", "allow_insecure_http": True}
 
         assert wt["users"][0] == {
             "name": "alice",
@@ -237,11 +240,14 @@ class TestControlAssistantWebTier:
             "persona": "readonly",
             "display_name": "Read-Only View (Bob)",
         }
+        # The standalone research tier is public by design: `login: false`
+        # keeps its card outside the login wall the preset ships enabled.
         assert wt["users"][2] == {
             "name": "ariel",
             "index": 2,
             "persona": "ariel",
             "display_name": "ARIEL Logbook Research",
+            "login": False,
         }
 
         personas = wt["personas"]

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -36,15 +36,18 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # health check or a skill directory — and in either case the deploy-side
     # staleness advisory firing on already-deployed projects is the correct
     # signal, not noise.
-    "control-assistant": "sha256:7f34fdf03e254c29b56a50197c3145fad0e3696fc6aba1158389c68d6449772e",
+    # Moved when the control-assistant preset turned password login on for its
+    # web terminals (auth stanza, ariel's `login: false`, demo passwords under
+    # `env.defaults`). All four moved together, as the note above predicts.
+    "control-assistant": "sha256:71f3f6e282f6e9c64d76d933310b973fda3dff3f9ba891cfb2f3aac5682d3cfb",
     "control-assistant-ariel": (
-        "sha256:a19f94f08707b1ae31ee8b552c7b5ae1d64da7a2408c59fc820af89cdaca37ba"
+        "sha256:fbf54b9933426ceeac2e4a5e018422fcfcc777f7e6f8eaa6c6475eed704f0877"
     ),
     "control-assistant-readonly": (
-        "sha256:f382bdcd0c14db5a6a6885a3df8af598998a510d6fa28be18608cdd4f2587dd5"
+        "sha256:479a6dc1652f3b7ff8866d62dcef6f7e4fdb147f912f2966dea6fa85f2a1d921"
     ),
     "control-assistant-readwrite": (
-        "sha256:c1abf15d10e77b4cb9b63bd8641cb14d578328558f2b9f3b1b94411711eb7e87"
+        "sha256:7633397e5dfbe696da4a3298ff2511201f64bd8e22b68ecadfcd502aa5a1f77d"
     ),
     # Moved when the onboarding rewrite dropped the `facility` rule. The
     # wholesale comment rewrite that shipped alongside it contributed nothing:

--- a/tests/cli/test_source_zone_materialization.py
+++ b/tests/cli/test_source_zone_materialization.py
@@ -517,8 +517,9 @@ def test_env_example_documents_the_whole_variable_set(
 def test_env_example_documents_the_profiles_own_env_block(
     runner: CliRunner, tmp_path: Path, no_provider_keys: None
 ) -> None:
-    """The `env:` block is documentation, not values — required vars arrive
-    bare, declared defaults arrive with theirs."""
+    """The example documents the `env:` block — required vars arrive bare,
+    declared defaults arrive with theirs (the defaults are *also* seeded into
+    `.env`; the test below pins that)."""
     target = tmp_path / "my-facility"
 
     result = _new(
@@ -535,6 +536,31 @@ def test_env_example_documents_the_profiles_own_env_block(
     lines = (target / ".env.example").read_text(encoding="utf-8").splitlines()
     assert "FACILITY_ENDPOINT=" in lines
     assert "LOG_LEVEL=info" in lines
+
+
+def test_env_defaults_are_seeded_into_env_as_starting_values(
+    runner: CliRunner, tmp_path: Path, no_provider_keys: None
+) -> None:
+    """Declared `env.defaults` become real starting values: seeded into `.env`
+    under their own banner, so a deployment created from the profile comes up
+    with them in force — even when the shell exported nothing."""
+    from osprey.cli.profile_cmd import PROFILE_DEFAULTS_ENV_BANNER
+
+    target = tmp_path / "my-facility"
+
+    result = _new(
+        runner,
+        target,
+        "hello-world",
+        "--set",
+        "env.defaults={OSPREY_AUTH_PW_ALICE: alice}",
+    )
+
+    assert result.exit_code == 0, result.output
+    content = (target / ".env").read_text(encoding="utf-8")
+    assert "OSPREY_AUTH_PW_ALICE=alice" in content
+    assert PROFILE_DEFAULTS_ENV_BANNER in content
+    assert (target / ".env").stat().st_mode & 0o777 == 0o600
 
 
 def test_summary_names_the_secret_files_it_wrote(

--- a/tests/deployment/web_terminals/test_auth_tls_seams.py
+++ b/tests/deployment/web_terminals/test_auth_tls_seams.py
@@ -164,6 +164,57 @@ def test_seam_auth_method_set_gates_every_user_behind_its_own_internal_target() 
     assert "location = /_osprey_auth {" not in nginx_conf
 
 
+def test_seam_login_false_entry_is_served_ungated_while_the_rest_stay_gated() -> None:
+    """SEAM 1 (deliberate exemption): a roster entry with `login: false` renders
+    with no `auth_request` and no internal verify target, while every other
+    entry keeps both — and the exempt location still strips the origin's cookie
+    jar before proxying, since a public container must never see another user's
+    session cookie."""
+    # Arrange
+    config = _auth_config(
+        [
+            {"name": "alice", "index": 0},
+            {"name": "ariel", "index": 1, "login": False},
+        ]
+    )
+
+    # Act
+    nginx_conf = _render_nginx(config)
+    directives = _directives(nginx_conf)
+
+    # Assert — exactly one gate, and it is alice's
+    assert directives.count("auth_request ") == 1
+    assert "auth_request /_osprey_auth/alice;" in _location_body(nginx_conf, "location /u/alice/")
+    assert "location = /_osprey_auth/alice {" in nginx_conf
+
+    # Assert — ariel is proxied with no gate and no verify target at all
+    ariel_body = _location_body(nginx_conf, "location /u/ariel/")
+    assert "auth_request" not in _directives(ariel_body)
+    assert "location = /_osprey_auth/ariel" not in nginx_conf
+
+    # Assert — the cookie strip survives the exemption
+    assert 'proxy_set_header Cookie "";' in ariel_body
+
+
+def test_seam_login_exemption_is_fail_closed_against_typos() -> None:
+    """SEAM 1 (fail-closed): only the literal boolean `false` opts an entry
+    out. A string spelling — the classic YAML quoting accident — deploys as
+    "login required", so a typo can never open a terminal to the world."""
+    # Arrange
+    config = _auth_config(
+        [
+            {"name": "alice", "index": 0, "login": "false"},
+            {"name": "bob", "index": 1, "login": True},
+        ]
+    )
+
+    # Act
+    directives = _directives(_render_nginx(config))
+
+    # Assert — both entries stay gated
+    assert directives.count("auth_request ") == 2
+
+
 def test_seam_auth_target_asks_the_sidecar_about_a_render_time_username() -> None:
     """SEAM 1 (identity is structural): each internal target's `?user=` is a
     render-time literal from the roster, so no part of a client's request

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -1491,6 +1491,22 @@ def test_passwd_refuses_an_off_roster_user(tmp_path, monkeypatch, fake_runtime):
     assert fake_runtime == []
 
 
+def test_passwd_refuses_a_login_false_user(tmp_path, monkeypatch, fake_runtime):
+    """On the roster, but outside the login wall: no gate ever consults a hash
+    for a `login: false` entry, so "changing its password" would store a
+    credential nothing checks over a success message."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(
+        tmp_path, _auth_config(["alice", {"name": "ariel", "index": 1, "login": False}])
+    )
+
+    with pytest.raises(ValueError, match="login: false"):
+        lifecycle.rotate_user_password(str(config_path), "ariel", "some-password")
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+    assert fake_runtime == []
+
+
 def test_passwd_refuses_before_writing_when_the_runtime_is_down(tmp_path, monkeypatch):
     """Gate on the runtime BEFORE the write: otherwise the operator is handed a
     password the deployment was never told about."""

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -436,6 +436,57 @@ def test_lint_string_display_name_reports_no_error() -> None:
     assert not any(f.code == "web_terminals.invalid_display_name" for f in findings)
 
 
+def test_lint_non_boolean_user_login_is_an_error() -> None:
+    """A non-boolean `login` deploys fail-closed as "login required", which is
+    the opposite of what the author who wrote it believes — so the typo is an
+    ERROR here rather than a silent lock-out."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "login": "false"}
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.invalid_user_login" for f in _errors(findings))
+
+
+def test_lint_login_false_without_auth_is_an_inert_key_warning() -> None:
+    """`login: false` with `auth.method: none` changes nothing — there is no
+    login wall to be exempt from — and the config should not claim otherwise."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0, "login": False}]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.user_login_inert" for f in _warnings(findings))
+
+
+def test_lint_login_false_with_auth_on_reports_nothing() -> None:
+    """The intended use — a public entry in an authenticated deployment — is
+    clean; and explicit `login: true` is a well-formed (default) spelling."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    web_terminals = config["modules"]["web_terminals"]
+    web_terminals["auth"] = {"method": "password", "allow_insecure_http": True}
+    web_terminals["users"] = [
+        {"name": "thellert", "index": 0, "login": True},
+        {"name": "ariel", "index": 1, "login": False},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.invalid_user_login" for f in findings)
+    assert not any(f.code == "web_terminals.user_login_inert" for f in findings)
+
+
 def test_lint_non_string_user_theme_is_an_error() -> None:
     """A non-string `theme` (a config typo) is rejected — the renderer would
     otherwise drop it silently."""
@@ -2080,6 +2131,24 @@ def test_lint_auth_without_tls_and_allow_insecure_http_is_a_warning() -> None:
 
     # Assert
     assert any(f.code == "web_terminals.auth_insecure_http" for f in _warnings(findings))
+    assert not any(f.code == "web_terminals.auth_requires_tls" for f in _errors(findings))
+
+
+def test_lint_auth_insecure_http_warning_is_withheld_on_loopback() -> None:
+    """With `deploy.fqdn` naming loopback the deployment advertises itself as
+    same-host-only, so its cookies cross no network path — the exact case the
+    escape hatch exists for (and the control-assistant preset's demo posture).
+    A real hostname brings the warning back with the exposure."""
+    # Arrange
+    config = _auth_config(
+        {"method": "password", "allow_insecure_http": True}, tls=False, fqdn="127.0.0.1"
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.auth_insecure_http" for f in _warnings(findings))
     assert not any(f.code == "web_terminals.auth_requires_tls" for f in _errors(findings))
 
 

--- a/tests/deployment/web_terminals/test_personas.py
+++ b/tests/deployment/web_terminals/test_personas.py
@@ -13,6 +13,7 @@ from osprey.deployment.web_terminals.personas import (
     config_needs_ariel_password,
     config_needs_dispatcher_token,
     config_needs_launch_token,
+    entry_requires_login,
     env_var_suffix,
     env_var_suffix_collisions,
     freeze_user_indices,
@@ -1115,6 +1116,56 @@ def test_normalize_users_oidc_subject_is_independent_of_the_cosmetic_fields() ->
             "oidc_subject": "alice@example.org",
         }
     ]
+
+
+def test_normalize_users_carries_login_false_through() -> None:
+    """`login: false` — the one value that changes anything — rides onto the
+    normalized entry."""
+    # Act
+    result = normalize_users([{"name": "ariel", "index": 2, "login": False}])
+
+    # Assert
+    assert result == [{"name": "ariel", "index": 2, "login": False}]
+
+
+def test_normalize_users_drops_every_other_login_spelling() -> None:
+    """`true`, absence, and every malformed spelling all normalize to "login
+    required" — a typo can lock an entry down, never open it up."""
+    # Act / Assert — explicit true and non-boolean spellings alike leave the
+    # plain two-key shape, so downstream reads them all as gated
+    for spelling in (True, "false", "no", 0, None, ["false"]):
+        result = normalize_users([{"name": "ariel", "index": 2, "login": spelling}])
+        assert result == [{"name": "ariel", "index": 2}], repr(spelling)
+
+
+def test_entry_requires_login_reads_only_the_literal_false() -> None:
+    """The shared predicate: one reading of the key for render, provisioning,
+    and the `users passwd` refusal."""
+    assert entry_requires_login({"name": "alice", "index": 0}) is True
+    assert entry_requires_login({"name": "ariel", "index": 2, "login": False}) is False
+
+
+def test_resolve_personas_threads_login_false_through_both_branches() -> None:
+    """The exemption survives resolution on the zero-migration path and the
+    persona-catalog path alike, and stays absent when never declared."""
+    # Act
+    zero_migration = resolve_personas(
+        {"users": [{"name": "ariel", "index": 0, "login": False}]}, _REGISTRY, "als"
+    )
+    persona_branch = resolve_personas(
+        {
+            "users": [{"name": "ariel", "index": 0, "persona": "gui", "login": False}],
+            "personas": {"gui": {"project": "als-gui"}},
+        },
+        _REGISTRY,
+        "als",
+    )
+    undeclared = resolve_personas({"users": ["alice"]}, _REGISTRY, "als")
+
+    # Assert
+    assert zero_migration[0]["login"] is False
+    assert persona_branch[0]["login"] is False
+    assert "login" not in undeclared[0]
 
 
 def test_resolve_personas_exposes_oidc_subject_when_set() -> None:

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -388,6 +388,36 @@ def test_preflight_mints_credentials_then_secrets_for_the_roster(
     assert calls[1][1] == str(tmp_path)
 
 
+def test_preflight_mints_no_credential_for_a_login_false_entry(monkeypatch, tmp_path):
+    """A roster entry with `login: false` is left out of the password mint: no
+    gate ever asks the sidecar about it, so a hash for it would be a credential
+    nothing checks — and a minted password printed for it would tell the
+    operator the opposite of the truth."""
+    calls: list[list[str]] = []
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+
+    def _fake_credentials(usernames, project_root, **kwargs):
+        calls.append(list(usernames))
+        return _credentials_result(env_auth, users=usernames)
+
+    monkeypatch.setattr(provision, "ensure_auth_credentials", _fake_credentials)
+    monkeypatch.setattr(
+        provision, "ensure_auth_session_secrets", lambda root: _secrets_result(env_auth)
+    )
+
+    config = _auth_config(
+        "password",
+        users=[
+            "alice",
+            {"name": "ariel", "index": 1, "login": False},
+            {"name": "bob", "index": 2, "login": True},
+        ],
+    )
+    _run_preflight(monkeypatch, tmp_path, config)
+
+    assert calls == [["alice", "bob"]]
+
+
 def test_preflight_with_auth_none_touches_no_credential_state(monkeypatch, tmp_path, caplog):
     """`auth.method: none` (the default) must behave exactly as it did before
     authentication existed: nothing minted, no .env.auth, no gitignore warning

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -305,6 +305,13 @@ config:
     lattice_base_port: 9491       # first per-user lattice-dashboard port
     channel_finder_base_port: 9591  # first per-user channel-finder panel port
     default_persona: readonly   # used for any user below with no persona
+    # Every terminal below asks for a login (user alice: password alice, and
+    # so on — set in this repo's .env; rotate with `osprey users passwd`).
+    auth:
+      method: password
+      # Accepts login over plain HTTP, which fits 127.0.0.1 and nothing else.
+      # For any reachable host, delete this line and configure tls instead.
+      allow_insecure_http: true
     # How the landing page is laid out. Omit this whole block and you get one
     # section holding every entry below, headed "Terminals".
     landing:
@@ -334,6 +341,8 @@ config:
         index: 2
         persona: ariel
         display_name: "ARIEL Logbook Research"
+        # Read-only research service, open without a login on purpose.
+        login: false
     personas:
       # `osprey build` builds one of these per file in personas/, into build/.
       # `osprey up` builds nothing: if one is missing it stops and says so.
@@ -374,6 +383,11 @@ env:
   required:
     - EVENT_DISPATCHER_TOKEN
     - DISPATCH_WORKER_TOKEN
+  # Demo login passwords for the terminals above, written into this repo's
+  # .env by `osprey init`. Edit them there — these are not secrets.
+  defaults:
+    OSPREY_AUTH_PW_ALICE: alice
+    OSPREY_AUTH_PW_BOB: bob
 data: data
 # Minimum OSPREY release that understands this profile's keys. Builds below it abort.
 requires_osprey_version: '>=2026.9.0'
@@ -911,6 +925,11 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 # cannot run without them.
 EVENT_DISPATCHER_TOKEN=
 DISPATCH_WORKER_TOKEN=
+
+# Declared by this profile with a default (`env.defaults`). Override only if
+# your facility needs a different value.
+OSPREY_AUTH_PW_ALICE=alice
+OSPREY_AUTH_PW_BOB=bob
 
 # Runtime overrides (optional - for advanced use cases)
 #LOCAL_PYTHON_VENV=/path/to/your/venv/bin/python


### PR DESCRIPTION
## Summary

The `control-assistant` preset now deploys its multi-user web tier with password login switched on, in a demo posture:

- **Alice and Bob log in** with short demo passwords (`alice`/`alice`, `bob`/`bob`), seeded into the repo's `.env` by `osprey init` and hashed at deploy — edit them there or rotate with `osprey users passwd`.
- **The ARIEL card stays public**: a new per-roster-entry key `login: false` opts an entry out of the login wall. nginx emits no `auth_request` for it, no password is provisioned, and `users passwd` refuses the name with an explanation. Fail-closed: only the literal boolean `false` exempts — any typo deploys as "login required" (lint reports it).
- `allow_insecure_http: true` keeps the demo on plain HTTP at 127.0.0.1; lint's cleartext-cookie WARN is now withheld when `deploy.fqdn` is loopback and returns with a real hostname.
- Profile `env.defaults` values are now seeded into the repository's `.env` at init (append-only; an existing value always wins), which is the mechanism carrying the demo passwords.

## Changes

- `personas.py`: `login` passthrough (literal `False` only) + shared `entry_requires_login()` predicate
- `render.py`/`nginx.conf.j2`: per-service `login_exempt` — no auth gate, no verify target; cookie strip kept
- `provision.py`: exempt users excluded from the password mint
- `lifecycle.py`: `users passwd` refuses an exempt user
- `lint.py`: non-boolean `login` is an ERROR; inert `login: false` (auth off) is a WARN; loopback fqdn suppresses the cleartext WARN
- `profile_cmd.py`/`init_cmd.py`: `env.defaults` → `.env` seeding under its own banner; init report names seeded keys
- Preset, docs (multi-user, deploy-a-facility, build-profiles), exemplar fixture, preset hash pins, CHANGELOG

## Testing

- Full unit suite (minus e2e/browser): 20,894 passed
- New tests: normalize/resolve passthrough, nginx seam (exempt entry ungated + fail-closed typo), mint-roster exclusion, passwd refusal, lint findings, init seeding
- Golden nginx renders byte-identical for non-exempt configs; docs build clean