### PR TITLE
Polish batch (staging)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2051,10 +2051,7 @@ jobs:
       uses: docker/setup-compose-action@v2
 
     - name: Install osprey
-      # archiver-mongodb: the staged bring-up preflights pymongo before any
-      # image build, so without the extra this lane aborts in seconds with an
-      # install hint rather than running.
-      run: uv sync --extra dev --extra archiver-mongodb
+      run: uv sync --extra dev
 
     - name: Run archiver world E2E
       # Step cap under the job cap so a hang fails THIS step, leaving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,22 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- `osprey up` now writes the OpenObserve account name `ZO_ROOT_USER_EMAIL` into
+  `.env` alongside the minted password, so both halves of the telemetry login
+  are in one findable place. Previously only the password was written and the
+  email existed solely as a default inside the templates. The value is
+  unchanged (`root@example.com`), and a value you already set is never
+  overwritten.
+- The minted `ZO_ROOT_USER_PASSWORD` is now 12 characters instead of 48, drawn
+  from an alphabet without the easily-misread `l I 1 O 0` — you read this one
+  off a terminal and type it into a browser login. Existing projects keep the
+  password already in their `.env`.
+- Deploying with `--expose` now refuses to start while `ZO_ROOT_USER_PASSWORD`
+  is under 20 characters, naming the variable. The minted password is sized for
+  a store on `localhost`, and nothing re-mints it when a project is later
+  published on all interfaces — set a strong one before exposing a store that
+  holds full agent conversation transcripts.
+
 - `pymongo` is now a core dependency instead of the `archiver-mongodb` extra.
   The `control-assistant` preset deploys a MongoDB archive, so a plain `pip
   install osprey-framework` has to be able to run it. The extra is gone —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,10 @@ Compatibility is documented in release notes, not encoded in the version string.
   major is a client rewrite, so adopting it should be a deliberate change
   rather than something a lock refresh picks up on its own.
 
+- In the bluesky panel's web-terminal tile bar, the plan filter now sits to
+  the left of the Plans / Queue / Results switcher rather than to its right,
+  matching the artifacts gallery.
+
 ### Added
 
 - The `control-assistant` preset now stands up a third web terminal beside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,11 +117,6 @@ Compatibility is documented in release notes, not encoded in the version string.
   from an alphabet without the easily-misread `l I 1 O 0` — you read this one
   off a terminal and type it into a browser login. Existing projects keep the
   password already in their `.env`.
-- Deploying with `--expose` now refuses to start while `ZO_ROOT_USER_PASSWORD`
-  is under 20 characters, naming the variable. The minted password is sized for
-  a store on `localhost`, and nothing re-mints it when a project is later
-  published on all interfaces — set a strong one before exposing a store that
-  holds full agent conversation transcripts.
 
 - `pymongo` is now a core dependency instead of the `archiver-mongodb` extra.
   The `control-assistant` preset deploys a MongoDB archive, so a plain `pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- `osprey up` now refuses as a precondition, rather than failing with a generic
+  "Deployment failed", when a project deploys the archiver store and pymongo is
+  missing. The refusal names the interpreter it is missing from — OSPREY seeds
+  the store from the process running the CLI, not from the project's
+  `build/.venv` — so a `dependencies:` entry in the build profile is visibly
+  the wrong lever.
 - `osprey init --reset` no longer crashes with a Python traceback when the
   containers it would remove belong to another copy of this repo. `osprey
   reset` has always caught that refusal and rendered it; this path never did,
@@ -80,6 +86,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- `pymongo` is now a core dependency instead of the `archiver-mongodb` extra.
+  The `control-assistant` preset deploys a MongoDB archive, so a plain `pip
+  install osprey-framework` has to be able to run it. The extra is gone —
+  drop it from any install command, since pip only warns about an unknown
+  extra rather than failing. The preset no longer lists `pymongo` under
+  `dependencies:`, which moves its profile hash: rebuilt projects will report
+  staleness once, then match.
 - The browser-facing bluesky sidecar is now the `bluesky-web` service (was
   `bluesky-panels`): it is named for its role — the web half of the bluesky
   stack, beside `bluesky-bridge` — rather than for the one panel it serves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Compatibility is documented in release notes, not encoded in the version string.
   handler that turns an error into a `✗` line with a cause and a remedy, so
   every failure no verb caught reached the terminal as a stack trace ending in
   installed-package paths. Affects every verb.
+- `osprey init --reset` and `osprey init --up` now check for a running
+  container runtime before they create anything. Both need one — `--reset` to
+  read what the previous deployment owns, `--up` to start the new one — but the
+  check ran after the repo had been written, git-initialized and committed, so
+  a stopped Docker left a repo behind that nobody asked for.
 - `osprey init --reset` no longer crashes with a Python traceback when the
   containers it would remove belong to another copy of this repo. `osprey
   reset` has always caught that refusal and rendered it; this path never did,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The `osprey` command no longer prints a Python traceback when something goes
+  wrong. Its console script was wired straight to the Click group, past the
+  handler that turns an error into a `✗` line with a cause and a remedy, so
+  every failure no verb caught reached the terminal as a stack trace ending in
+  installed-package paths. Affects every verb.
 - `osprey init --reset` no longer crashes with a Python traceback when the
   containers it would remove belong to another copy of this repo. `osprey
   reset` has always caught that refusal and rendered it; this path never did,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   read what the previous deployment owns, `--up` to start the new one — but the
   check ran after the repo had been written, git-initialized and committed, so
   a stopped Docker left a repo behind that nobody asked for.
+- `osprey init --provider cborg` (and `--model`, `--connector`,
+  `--channel-finder-mode`) now say which spelling works — `--set
+  provider=cborg` — instead of suggesting the unrelated `--override`.
 - `osprey init --reset` no longer crashes with a Python traceback when the
   containers it would remove belong to another copy of this repo. `osprey
   reset` has always caught that refusal and rendered it; this path never did,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,9 +268,16 @@ Compatibility is documented in release notes, not encoded in the version string.
   major is a client rewrite, so adopting it should be a deliberate change
   rather than something a lock refresh picks up on its own.
 
-- In the bluesky panel's web-terminal tile bar, the plan filter now sits to
-  the left of the Plans / Queue / Results switcher rather than to its right,
-  matching the artifacts gallery.
+- Controls no longer slide out from under the pointer when a neighbouring
+  control appears, disappears, or changes its label. Fixed across the web
+  interfaces: the bluesky panel's Plans / Queue / Results switcher (the plan
+  filter now opens to its left), the operator chat's Send button (Stop now
+  opens inboard of it, so Send never lands where Stop was), the ARIEL entry
+  pager (Previous and Next stay put and grey out at the ends instead of
+  vanishing), the channel finder's feedback toolbar (Clear All now opens
+  left of Add/Export instead of shoving them), and the confirm step on the
+  bluesky emergency abort and the lattice dashboard's Baseline button, whose
+  armed labels no longer widen the button and shove the control beside it.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Artifacts built from a dev checkout report the right version again. A release
+  tag cut for the workspace sibling (`osprey-connectors-v0.1.0`) matched the
+  build backend's default tag glob, so every wheel, editable install and
+  container built off `main` since 2026-08-15 was stamped `0.1.0.postN` while
+  `osprey --version` said `2026.6.2.postN`. The build now describes against the
+  same `v[0-9]*` tags the runtime always has, the commit hash is pinned to one
+  width instead of varying with clone size, and a test holds the two
+  derivations byte-identical.
 - `osprey init --reset` no longer crashes with a Python traceback when the
   containers it would remove belong to another copy of this repo. `osprey
   reset` has always caught that refusal and rendered it; this path never did,

--- a/docs/source/how-to/add-connector.rst
+++ b/docs/source/how-to/add-connector.rst
@@ -22,7 +22,7 @@ The Control System Integration system provides a **two-layer abstraction** for w
 - **virtual_accelerator**: the PyAT Virtual Accelerator's EPICS soft-IOC — behaves
   like ``epics`` but tracks setpoints through the simulated machine, so plans
   actually run (the mock connector can't do that); see :doc:`use-virtual-accelerator`
-- **mongodb_archiver**: MongoDB time-series archiver (optional, ``pip install "osprey-framework[archiver-mongodb]"``)
+- **mongodb_archiver**: MongoDB time-series archiver
 - **doocs** / **doocs_archiver**: DOOCS properties and DOOCS local histories
   (DESY, European XFEL). Both require ``doocs4py``, which is supplied by the
   DOOCS environment rather than installed from PyPI — the import is deferred to
@@ -131,12 +131,8 @@ value2, ...}``. A query matches any document that carries **at least one** of th
 requested PVs (an ``$or`` across per-PV ``$exists`` checks) -- documents do not need
 to carry every requested PV together, so channels archived at different cadences, or
 written into separate documents by different collectors, are still returned
-correctly, each on its own timestamp series. The connector requires the optional
-``archiver-mongodb`` extra:
-
-.. code-block:: bash
-
-   pip install "osprey-framework[archiver-mongodb]"
+correctly, each on its own timestamp series. The connector's MongoDB client ships
+with OSPREY, so there is nothing extra to install.
 
 Production Mode (DOOCS)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/how-to/monitor-agent.rst
+++ b/docs/source/how-to/monitor-agent.rst
@@ -139,8 +139,9 @@ there. So the answer to "what do I log in with" is always ``.env``:
 
 The minted password is short on purpose: you read it off a terminal and type it
 into a browser login form, so it is 12 characters drawn from an alphabet with
-the easily-misread characters (``l I 1 O 0``) removed. That is sized for a
-store published on ``localhost``.
+the easily-misread characters (``l I 1 O 0``) removed. Every character still
+comes from a cryptographic random source, so it is short to type without being
+easy to guess.
 
 Set the two variables yourself (in the profile's ``.env``) if you want specific
 values — the same pair configures the container **and** authenticates the
@@ -154,13 +155,13 @@ agent's OTLP push, one source of truth:
 
 .. important::
 
-   **Deploying with** ``--expose`` **requires a password you set yourself.** A
-   deployment published on all interfaces refuses to start while
-   ``ZO_ROOT_USER_PASSWORD`` is under 20 characters, which includes the minted
-   demo-sized value. Nothing re-mints it for you: the password minted during a
-   localhost deploy is still in ``.env`` when the project is later brought up
-   with ``--expose``, so choose a strong one there before exposing a store that
-   holds full agent conversation transcripts.
+   **Publishing this store beyond** ``localhost`` **exposes agent transcripts.**
+   It holds full agent conversation transcripts, and the same credentials serve
+   both its browser login and the agent's OTLP push. Reach it over an SSH
+   tunnel, or put it behind TLS, rather than binding it to every interface. The
+   minted password is a per-deploy random value, so it stays usable wherever the
+   store is published — what exposure changes is who can reach the login, not
+   how strong the password is.
 
 3. Deploy it
 ------------

--- a/docs/source/how-to/monitor-agent.rst
+++ b/docs/source/how-to/monitor-agent.rst
@@ -128,17 +128,39 @@ default. If your project removed it, restore it:
 ---------------------------------------
 
 The OpenObserve root account doubles as the OTLP ingest credential. You do not
-have to set it yourself: the first ``osprey up`` mints a strong
-``ZO_ROOT_USER_PASSWORD`` into the profile's ``.env`` automatically, and the
-project's ``.env`` is derived from there. Set the two variables yourself (in the
-profile's ``.env``) only if you want specific values — the same pair configures
-the container **and** authenticates the agent's OTLP push, one source of truth:
+have to set it yourself: the first ``osprey up`` writes **both halves of the
+login** into the profile's ``.env`` — a minted ``ZO_ROOT_USER_PASSWORD`` and the
+account name ``ZO_ROOT_USER_EMAIL`` — and the project's ``.env`` is derived from
+there. So the answer to "what do I log in with" is always ``.env``:
+
+.. code-block:: bash
+
+   grep ZO_ROOT_USER ~/my-project/.env
+
+The minted password is short on purpose: you read it off a terminal and type it
+into a browser login form, so it is 12 characters drawn from an alphabet with
+the easily-misread characters (``l I 1 O 0``) removed. That is sized for a
+store published on ``localhost``.
+
+Set the two variables yourself (in the profile's ``.env``) if you want specific
+values — the same pair configures the container **and** authenticates the
+agent's OTLP push, one source of truth:
 
 .. code-block:: bash
 
    # .env
    ZO_ROOT_USER_EMAIL=you@example.com
    ZO_ROOT_USER_PASSWORD=choose-a-strong-password
+
+.. important::
+
+   **Deploying with** ``--expose`` **requires a password you set yourself.** A
+   deployment published on all interfaces refuses to start while
+   ``ZO_ROOT_USER_PASSWORD`` is under 20 characters, which includes the minted
+   demo-sized value. Nothing re-mints it for you: the password minted during a
+   localhost deploy is still in ``.env`` when the project is later brought up
+   with ``--expose``, so choose a strong one there before exposing a store that
+   holds full agent conversation transcripts.
 
 3. Deploy it
 ------------

--- a/packages/osprey-connectors/README.md
+++ b/packages/osprey-connectors/README.md
@@ -62,8 +62,9 @@ importing `osprey_connectors` never requires them:
   Install `epicscorelibs` (or otherwise make a per-architecture `libca`
   available) if you use `EPICSConnector` or `EPICSArchiverConnector` against a
   live control system; `PYEPICS_LIBCA` can also point at one explicitly.
-- **`pymongo`** — required by `MongoDBArchiverConnector`. Install with
-  `pip install pymongo` if you archive to MongoDB.
+- **`pymongo`** — required by `MongoDBArchiverConnector`. Installed with this
+  package; the connector imports it inside `connect()` so registration stays
+  cheap, not because it is optional.
 - **`doocs4py`** — required by `DOOCSConnector` and `DOOCSArchiverConnector`.
   Install separately (it is not on PyPI in all environments) if you connect
   to a DOOCS control system.

--- a/packages/osprey-connectors/pyproject.toml
+++ b/packages/osprey-connectors/pyproject.toml
@@ -17,6 +17,10 @@ dependencies = [
     "pandas>=2.2.3",
     "python-dateutil>=2.9.0",
     "pyepics",
+    # MongoDB client for MongoDBArchiverConnector. Declared even though the
+    # connector imports it inside connect(): the deferred import exists so
+    # registration stays cheap, not to make the dependency optional.
+    "pymongo>=4.17.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/osprey-connectors/src/osprey_connectors/archiver/mongodb_archiver_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/archiver/mongodb_archiver_connector.py
@@ -30,11 +30,15 @@ logger = get_logger("mongodb_archiver_connector")
 # the only one, since a facility MongoDB may be administered elsewhere.
 DEPLOY_HINT = "If this project deploys its own MongoDB, run 'osprey up' to start it."
 
-# Names the optional dependency the way it is actually installed, so the message
-# works whether or not the reader knows pymongo is what backs this connector.
+# pymongo is a dependency of this package, so reaching this message means an
+# incomplete environment rather than an unselected option. It names the package
+# to reinstall, not an extra to add -- there is no longer an extra to select --
+# and it names pymongo too, so the message works whether or not the reader knows
+# what backs this connector.
 PYMONGO_INSTALL_HINT = (
-    "pymongo is required for the MongoDB archiver. "
-    "Install it with: pip install 'osprey-framework[archiver-mongodb]'"
+    "pymongo is required for the MongoDB archiver. It is a dependency of "
+    "osprey-connectors, so this environment is incomplete. "
+    "Reinstall it with: pip install --upgrade osprey-connectors"
 )
 
 #: Environment overrides for the two connection keys whose configured value is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ docs = [
 # Development and testing
 dev = [
     "pytest",
+    "setuptools-scm",  # The build backend under hatch-vcs, called directly by the version-parity test
     "pytest-asyncio",
     "pytest-cov",  # Code coverage reporting
     "pytest-order",  # Run flaky/in-debug e2e tests first via @pytest.mark.order
@@ -415,7 +416,15 @@ exclude-newer-package = { lume-pyat = "2026-08-06T00:00:00Z", lume-pva-apg = "20
 # predict its own next number, so guessing is worse than not guessing.
 [tool.hatch.version]
 source = "vcs"
-raw-options = { version_scheme = "post-release" }
+# `git_describe_command` exists because the backend's default tag glob (*[0-9]*)
+# matches every tag containing a digit: the workspace sibling's release tag
+# osprey-connectors-v0.1.0 (which rebased every dev build to 0.1.0.postN the day
+# it was cut) and the checkpoint-* tags (which do not parse as versions at all).
+# The runtime probe in src/osprey/version.py has always filtered to v[0-9]*; this
+# makes the build stamp read the same tags, and --abbrev=40 hands the backend a
+# full node to slice to its fixed width. Pinned to the runtime derivation by
+# tests/test_version.py::TestBuildStampParity.
+raw-options = { version_scheme = "post-release", git_describe_command = "git describe --dirty --tags --long --abbrev=40 --match v[0-9]*" }
 
 # Stamps the resolved version into the built artifact, which is the only way a wheel
 # (and any container built from one) can report its version without git present.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,15 @@ dependencies = [
     # PostgreSQL (required for native logbook_search capability and checkpointing)
     "psycopg[binary,pool]>=3.3.4,<4.0.0",
     "psycopg-pool>=3.3.1,<4.0.0",
+    # MongoDB client for the stored archive: the `mongodb_archiver` connector
+    # reads it, the deploy-time seeder writes it, and the recorder keeps it
+    # current. Core rather than an extra because the shipped `control-assistant`
+    # preset deploys that store, and `osprey up` preflights this import before it
+    # builds anything -- so an install that lacked it could not run the preset at
+    # all. Declared here as well as in osprey-connectors: three framework modules
+    # (simulation.apply, deployment.container_lifecycle, services.archiver_recorder)
+    # import pymongo directly rather than through a connector.
+    "pymongo>=4.17.0",
     # ARIEL proxy support for HTTP ingestion through SOCKS tunnels
     "aiohttp-socks>=0.8.0",
     # File system monitoring for web terminal
@@ -210,7 +219,7 @@ dev = [
     # disagree about what "formatted" means.
     "ruff>=0.16.2,<0.17",
     "testcontainers[postgres]>=4.15.0",  # Real PostgreSQL for integration tests
-    "testcontainers[mongodb]>=4.15.0",  # MongoDB for archiver-mongodb integration tests
+    "testcontainers[mongodb]>=4.15.0",  # Real MongoDB for archiver integration tests
     "docker>=7.2.0",  # Docker SDK for testcontainers availability check
     "psycopg[binary,pool]>=3.3.4,<4.0.0",  # ARIEL search integration tests
     "psycopg-pool>=3.3.1,<4.0.0",  # ARIEL search integration tests
@@ -233,11 +242,6 @@ ariel-proxy = [
 # Google Sheets database backend for channel finder
 sheets = [
     "gspread>=6.2.1",
-]
-
-# MongoDB archiver connector backend
-archiver-mongodb = [
-    "pymongo>=4.17.0",
 ]
 
 # Google Chat bridge (osprey.bridges.google_chat): Pub/Sub event ingestion,
@@ -273,11 +277,12 @@ screen-capture-linux = [
 # `osprey-framework[virtual-accelerator]` keeps resolving for every existing
 # reference to it (CI `uv sync --extra`, both VA images).
 #
-# The last two entries are the recorder's, not the IOC's. The recorder
+# The `aioca` entry is the recorder's, not the IOC's. The recorder
 # (osprey.services.archiver_recorder) ships as a compose-template-only service
 # that runs this image with a different command -- deliberately, so it adds no
 # image build to any deploy or to the seven VA-stack CI lanes -- which makes its
-# two dependencies part of what this extra has to deliver:
+# dependencies part of what this extra has to deliver. Its other one, pymongo, is
+# a core dependency and reaches the image without being named here:
 #
 #   * aioca is its Channel Access CLIENT. The serving stack below is a CA
 #     *server* and ships no client, and while `ophyd-async[ca]` (a core
@@ -285,10 +290,6 @@ screen-capture-linux = [
 #     another package's extra, not a declaration -- and the recorder imports
 #     aioca directly. Declared here so it stays installed if ophyd-async ever
 #     changes backends.
-#   * pymongo arrives through the `archiver-mongodb` extra rather than a second
-#     `pymongo>=4.0` line, so the floor keeps exactly one definition and cannot
-#     drift between the connector's extra and this one. Same self-referencing
-#     form the `all` extra uses.
 #
 # lume-pva-apg is the serving package `serving/runner.py` subclasses. Its `ca`
 # and `pva` extras are what put the two transports on the wire -- pcaspy for
@@ -353,12 +354,11 @@ virtual-accelerator = [
     # everywhere, so marking them would only make the recorder's dependencies
     # silently absent on a developer's machine.
     "aioca>=1.7",
-    "osprey-framework[archiver-mongodb]",
 ]
 
 # All optional dependencies for complete installation
 all = [
-    "osprey-framework[docs,dev,ariel,sheets,screen-capture-linux,archiver-mongodb,knowledge,gchat]"
+    "osprey-framework[docs,dev,ariel,sheets,screen-capture-linux,knowledge,gchat]"
 ]
 
 [tool.uv.workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,8 +377,11 @@ Changelog = "https://github.com/als-apg/osprey/blob/main/CHANGELOG.md"
 
 # Define console scripts for CLI entry points
 [project.scripts]
-# Main CLI entry point (Click group with subcommands)
-osprey = "osprey.cli.main:cli"
+# Main CLI entry point. Points at `main`, NOT at the `cli` group it wraps:
+# `main` is where the last-resort handlers live, and an entry point naming the
+# bare group routes every uncaught exception past them into a traceback on an
+# operator's terminal. Pinned by tests/cli/test_main.py::TestConsoleScriptWiring.
+osprey = "osprey.cli.main:main"
 
 # Built-in trigger sources for the event dispatcher, discovered by
 # osprey.dispatch.source_registry.SourceRegistry at startup.

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1004,6 +1004,56 @@ def _list_presets_callback(ctx: click.Context, param: click.Parameter, value: bo
     ctx.exit(0)
 
 
+def _point_at_set(ctx: click.Context, param: click.Parameter, value: str | None) -> None:
+    """Answer a profile shorthand typed as a flag with the spelling that works.
+
+    ``--provider cborg`` is the natural guess and is not an option: the
+    shorthands are values baked into the emitted profile, so they are written
+    ``--set provider=cborg``. Click answers an unknown option with the nearest
+    one it has by edit distance, which for ``--provider`` is ``--override`` —
+    a different feature, taking a file. Left to that, the first thing an
+    operator meets is a suggestion that would not have worked either.
+
+    Registered as hidden options rather than checked after parsing, because
+    Click rejects an unknown option before any callback of ours runs.
+
+    Raises:
+        click.UsageError: Whenever the flag was given at all.
+    """
+    if value is None or ctx.resilient_parsing:
+        return None
+    raise click.UsageError(
+        f"There is no --{param.name.replace('_', '-')} option. {param.name} is a "
+        f"profile setting, so it is baked in with --set: --set {param.name}={value}"
+    )
+
+
+#: The ``--set`` shorthand keys that get typed as flags, and are refused as
+#: flags with the spelling that works. Spelled out rather than imported from
+#: :data:`~.build_profile_resolve.SHORTHAND_OVERRIDE_KEYS`, which is where they
+#: are defined: options are declared at decoration time, so importing them
+#: there would put the whole build-profile chain on this module's import — the
+#: one thing ``test_importing_the_module_stays_off_the_heavy_chain`` exists to
+#: prevent. The copy is held to the original by
+#: ``test_the_refused_flags_are_the_documented_shorthands``, so a shorthand
+#: added there and not here fails a test rather than going quietly uncaught.
+_SHORTHAND_FLAG_KEYS = ("provider", "model", "channel_finder_mode", "connector")
+
+
+def _reject_shorthand_flags(command: Callable) -> Callable:
+    """Add one hidden, always-refusing option per ``--set`` shorthand key."""
+    for key in _SHORTHAND_FLAG_KEYS:
+        command = click.option(
+            f"--{key.replace('_', '-')}",
+            key,
+            hidden=True,
+            expose_value=False,
+            metavar="VALUE",
+            callback=_point_at_set,
+        )(command)
+    return command
+
+
 @click.command()
 @click.argument("directory", required=False, type=click.Path(path_type=Path))
 @click.option(
@@ -1065,6 +1115,7 @@ def _list_presets_callback(ctx: click.Context, param: click.Parameter, value: bo
 @click.option("--up", "start", is_flag=True, help="Build the deployment and start it.")
 @click.option("-d", "--detach", "detached", is_flag=True, help="With --up: run in the background.")
 @click.option("--dev", is_flag=True, help="With --up: start in development mode.")
+@_reject_shorthand_flags
 @click.pass_context
 def init(
     ctx: click.Context,

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -491,6 +491,71 @@ def _resolve_target(directory: Path | None) -> Path:
     return here
 
 
+def _refuse_without_a_container_runtime(target: Path, *, reset: bool, start: bool) -> None:
+    """Refuse --reset or --up up front when no container runtime answers.
+
+    Both flags need one for certain: ``--reset`` reads the containers and
+    volumes the previous deployment owns in order to know what to remove, and
+    ``--up`` starts them. Neither can be satisfied against a runtime that is
+    not running, and both are known from the command line — so the check
+    belongs here, with the other refusals, rather than after the repo has been
+    written, git-initialized and committed. Asked later it is still correct and
+    still refuses, but it refuses about a directory that now exists, and the
+    operator's next move is deleting a repo they were never given a reason to
+    want. Nothing this function refuses has created anything.
+
+    The probe inside the reset itself stays where it is: a runtime can go down
+    between here and there, and it is what proves an EMPTY listing means empty
+    rather than unreachable. This one is about what gets written to disk.
+
+    An ``init`` that neither resets nor starts anything writes files and stops,
+    and is not asked — preparing a deployment repo on a machine with no
+    container runtime is a thing people do.
+
+    Raises:
+        click.exceptions.Exit: With status 1, after printing the refusal.
+    """
+    if not (reset or start):
+        return
+
+    from osprey.deployment.reset import runtime_selection_config
+    from osprey.deployment.runtime_helper import verify_runtime_is_running
+
+    from .output import fail
+
+    is_running, error = verify_runtime_is_running(runtime_selection_config(target))
+    if is_running:
+        return
+
+    # The runtime messages are written as a headline and the steps that fix it,
+    # which is `fail`'s summary and cause already -- so they are split rather
+    # than reworded. Rewriting them here would mean maintaining a second copy of
+    # every platform's remedy, and this is not the place that knows them.
+    headline, _, detail = error.partition("\n")
+    flags = " and ".join(flag for flag, given in (("--reset", reset), ("--up", start)) if given)
+    # Named per flag rather than as one sentence about "the flags you gave":
+    # what an operator has to decide is whether they still want the flag, and
+    # that reads off the thing it was going to do.
+    why = {
+        "--reset": "--reset reads the containers and volumes the previous deployment "
+        "left, to know what to remove.",
+        "--up": "--up builds the deployment and starts its containers.",
+        "--reset and --up": "--reset reads the containers and volumes the previous "
+        "deployment left, to know what to remove, and --up then starts the new ones.",
+    }[flags]
+    cause = f"{why} Nothing was created."
+    if detail.strip():
+        cause += f"\n\n{detail.strip()}"
+
+    # No remedy argument: the runtime messages ARE remedies -- numbered steps
+    # for a daemon that is down, install links for one that is absent -- and
+    # they are already in the cause. An arrow line restating "try again" would
+    # be true for one of those cases and wrong for the other, which is worse
+    # than leaving the arrow off.
+    fail(headline, cause)
+    raise click.exceptions.Exit(1)
+
+
 def _refuse_enclosing_repo(target: Path) -> None:
     """Refuse a target that would nest one deployment repo inside another.
 
@@ -1056,6 +1121,10 @@ def init(
 
     target = _resolve_target(directory)
     _refuse_enclosing_repo(target)
+    # Before `_prepare_repo_root` below writes anything: --reset and --up are
+    # both preconditions on a running container runtime, and a run that cannot
+    # honor them should not leave a repo behind to be cleaned up by hand.
+    _refuse_without_a_container_runtime(target, reset=reset, start=start)
     # Before anything is decided: a repo whose last `--force` run was killed
     # mid-replacement is a whole repo again, so the refusals below judge the
     # deployment the operator has rather than the wreck of one.

--- a/src/osprey/cli/main.py
+++ b/src/osprey/cli/main.py
@@ -326,7 +326,21 @@ def main():
     except Exception as e:
         from .output import fail
 
-        fail(str(e))
+        # Split at the first newline rather than handed over whole. What
+        # reaches here is overwhelmingly a refusal written for an operator to
+        # read -- the container-runtime checks are the loudest of them -- and
+        # those are a headline followed by the steps that fix it. `fail` paints
+        # its first argument in the error style and documents it as one line,
+        # so the undivided block prints as a red paragraph with a numbered list
+        # inside it. The headline stays the summary and the rest becomes the
+        # indented cause, which is the shape every deliberately-rendered
+        # refusal in the CLI already wears.
+        summary, _, cause = str(e).partition("\n")
+        if not summary.strip():
+            # A raise with no message at all. The type is the only thing left
+            # that says anything, and is what a bug report needs to name.
+            summary = type(e).__name__
+        fail(summary, cause.strip("\n") or None)
         sys.exit(1)
 
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -67,6 +67,7 @@ from osprey.deployment.service_tokens import (
     _generate_openobserve_password,  # noqa: F401  (re-exported for tests)
     _generate_token,
     _is_forbidden_value,
+    _is_too_weak_when_exposed,
     _raise_forbidden_var,
     _raise_invalid_var,
     _validate_openobserve_password,  # noqa: F401  (re-exported for tests)
@@ -159,6 +160,33 @@ _SERVICE_TOKEN_VARS: dict[str, tuple[str, ...]] = {
     "openobserve": ("ZO_ROOT_USER_PASSWORD",),
     "postgresql": ("ARIEL_DB_PASSWORD",),
     "mongodb": ("MONGO_ROOT_PASSWORD",),
+}
+
+# Non-secret settings written into ``.env`` for a deployed service, as
+# ``service -> ((var, default), ...)``. Keyed by ``deployed_services`` membership
+# exactly like ``_SERVICE_TOKEN_VARS``, and never overwriting a value that is
+# already there — but a DIFFERENT concern, which is why it is a different map.
+#
+# ``_SERVICE_TOKEN_VARS`` declares machine-generated secrets, and every name it
+# reaches is minted through ``_VAR_GENERATORS`` under that module's CSPRNG bar.
+# A constant is not a secret and has no recipe, so registering one there would
+# mean writing a generator that returns a fixed string — a value the bar has no
+# meaning for, sitting in the map an operator reads to learn what osprey
+# considers secret.
+#
+# The reason to write a default down at all is discoverability. Both halves of
+# the OpenObserve login are needed to reach the store, and the email previously
+# existed only as a ``:-`` fallback inline in the compose template and the
+# rendered config.yml. An operator looking for their credentials found a
+# password in ``.env``, no email anywhere, and nothing naming the file that
+# would have told them. Writing the default makes ``.env`` the whole answer,
+# and — because it is the same value the ``:-`` fallback resolves to — records
+# the login rather than changing it.
+_SERVICE_DEFAULT_VARS: dict[str, tuple[tuple[str, str], ...]] = {
+    # Must stay equal to the ``${ZO_ROOT_USER_EMAIL:-…}`` fallback in
+    # ``osprey/templates/services/openobserve/docker-compose.yml.j2``; the mint
+    # tests parse the template and pin the two together.
+    "openobserve": (("ZO_ROOT_USER_EMAIL", "root@example.com"),),
 }
 
 # Vars checked against their _VAR_VALIDATORS constraint when present, but
@@ -596,6 +624,54 @@ def _ensure_service_tokens(
                 name for name in generated if name in _VOLUME_INITIALIZED_VARS
             }
 
+    # Write the non-secret service settings (_SERVICE_DEFAULT_VARS) for every
+    # deployed service that declares one. Its OWN block, outside `if
+    # required_vars:` and outside `if generated:`, and that placement is the
+    # whole upgrade path: the mint is idempotent, so a project deployed before
+    # this existed has a `.env` carrying a password and no email, generates
+    # nothing on its next deploy, and would never receive the line if this rode
+    # along with the minted block. Exactly the deployments that need it are the
+    # ones with nothing left to mint.
+    #
+    # Presence is read the same way the mint reads it — process env over `.env`,
+    # non-empty — so an operator's value is never overwritten and a re-run
+    # appends nothing. Reported separately from the token ledger, and the VALUE
+    # is shown: these are account names, not secrets, and an operator who cannot
+    # see what was written is back where they started.
+    defaults: dict[str, str] = {}
+    existing_defaults = parse_dotenv_file(env_path) if env_path.is_file() else {}
+    for svc_name, var_defaults in _SERVICE_DEFAULT_VARS.items():
+        if svc_name not in services:
+            continue
+        for var, default in var_defaults:
+            if _effective_value(var, existing_defaults).strip():
+                continue  # keep the operator's value
+            defaults[var] = default
+
+    if defaults:
+        _append_env_block(
+            env_path,
+            "Service account names (osprey up) — not secrets",
+            defaults,
+        )
+        # Same repair the mint makes, for the same reason: the deploy loaded
+        # this `.env` over the process environment before we got here, so a name
+        # the file spelled EMPTY left an empty copy in `os.environ` that
+        # outranks the `--env-file` line for compose's interpolation. Without
+        # this the container receives the blank while `.env` shows the default —
+        # written down and not delivered. Names absent from the environment stay
+        # absent and reach the containers through `--env-file` as usual.
+        for var, value in defaults.items():
+            if var in os.environ:
+                os.environ[var] = value
+        _report_fact(
+            f"wrote {len(defaults)} service account name(s) → .env",
+            wrote=(
+                ".env",
+                ", ".join(f"{var}={value}" for var, value in defaults.items()),
+            ),
+        )
+
     # Validate the effective value of every required var — whichever of
     # process env, an existing .env, or a value just minted above the caller
     # actually sees — against its registered _VAR_VALIDATORS constraint (if
@@ -618,6 +694,25 @@ def _ensure_service_tokens(
                 f"{name} is empty; refusing to start a deployment that is reachable "
                 f"off-host with an empty token. Unset {name} in the environment and let "
                 f"`osprey up` mint one, or export a strong secret."
+            )
+        # The length floor, for the same exposure and one step past empty. Only
+        # ZO_ROOT_USER_PASSWORD registers one, because only its recipe mints
+        # deliberately short — short enough for a person to read off a terminal
+        # and type into the OpenObserve login form during a demo. That trade is
+        # sound on the loopback deploy it was chosen for and not sound here, and
+        # the mint's idempotence is what makes the check necessary rather than
+        # decorative: the demo password is still in `.env` when this project is
+        # later brought up with `--expose`, so nothing re-mints it and only a
+        # read of the effective value can catch it. Applies whatever the origin,
+        # which also covers an operator who simply chose a short password.
+        if expose_network and _is_too_weak_when_exposed(name, effective):
+            raise RuntimeError(
+                f"{name} is too short for a deployment that is reachable off-host. "
+                f"The value osprey mints is sized to be typed at a demo login on "
+                f"localhost, not to guard a store other hosts can reach — and this "
+                f"one holds full agent conversation transcripts. Set a strong "
+                f"{name} in .env before deploying with --expose. "
+                f"Refusing to deploy. (Value not shown.)"
             )
         # Ahead of the format check so the more specific diagnosis wins. A
         # registered forbidden value is well-formed by construction — that is

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -41,6 +41,7 @@ from osprey.deployment.compose_generator import (
 )
 from osprey.deployment.deploy_summary import log_endpoint_summary
 from osprey.deployment.errors import (
+    ArchiverClientMissingError,
     ComposeInterpolationError,
     DevModeUnavailableError,
     NoRenderedBuildError,
@@ -2684,10 +2685,11 @@ _ARCHIVER_STORE_SERVICE = "mongodb"
 _ARCHIVER_RECORDER_SERVICE = "archiver-recorder"
 _ARCHIVER_RECORDER_DEPLOY_NAME = "archiver_recorder"
 
-# The install target every archiver error names. pymongo is an optional extra,
-# and a deploy that hits the seeder without it must say what to install rather
-# than surfacing a bare ImportError.
-_ARCHIVER_EXTRA = "osprey-framework[archiver-mongodb]"
+# The install target every archiver error names. pymongo is a core dependency,
+# so a deploy that hits the seeder without it is running from an incomplete
+# environment -- which is worth saying plainly rather than surfacing a bare
+# ImportError, or pointing at an extra that no longer exists.
+_ARCHIVER_INSTALL_TARGET = "osprey-framework"
 
 # How long the staged store gets to start answering before the deploy gives up.
 # Generous because the very first start of a fresh volume creates the admin user
@@ -2736,23 +2738,39 @@ def _archiver_store_deployed(config: dict) -> bool:
 def _preflight_archiver_pymongo(config: dict) -> None:
     """Abort a store-deploying run that cannot talk to the store it deploys.
 
-    pymongo is an optional extra, and without it the seeder cannot run — but the
-    only place that becomes visible is minutes later, after the project image has
-    been built and the store container is already up. Checking here, beside the
-    token mint, turns that into an immediate error naming the install.
+    pymongo is a core dependency, but an environment can still be missing it —
+    a partial install, a stale venv — and without it the seeder cannot run. The
+    only place that would otherwise become visible is minutes later, after the
+    project image has been built and the store container is already up. Checking
+    here, beside the token mint, turns that into an immediate error naming the
+    install.
+
+    The reason names ``sys.executable`` rather than only the package, because
+    the environment is the whole confusion: see
+    :class:`~osprey.deployment.errors.ArchiverClientMissingError`.
 
     :param config: Raw deploy config.
-    :raises RuntimeError: if the store is deployed and pymongo is absent.
+    :raises ArchiverClientMissingError: if the store is deployed and pymongo is
+        absent from the interpreter running this process.
     """
     if not _archiver_store_deployed(config):
         return
     try:
         import pymongo  # noqa: F401
     except ImportError as exc:
-        raise RuntimeError(
-            "This project deploys the archiver store (services.mongodb), and seeding "
-            "its history needs pymongo, which is not installed.\n"
-            f"Install it with: pip install '{_ARCHIVER_EXTRA}'"
+        raise ArchiverClientMissingError(
+            reason=(
+                "This project deploys the archiver store (services.mongodb), and "
+                "OSPREY seeds its history from this process — "
+                f"{sys.executable} — not from the project's build/.venv and not "
+                "in the project image. pymongo is not importable there. A "
+                "`dependencies:` entry in the build profile installs it into "
+                "those, not into this interpreter."
+            ),
+            remedy=(
+                "Reinstall osprey where the CLI runs:\n"
+                f"    pip install --upgrade {_ARCHIVER_INSTALL_TARGET}"
+            ),
         ) from exc
 
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -67,7 +67,6 @@ from osprey.deployment.service_tokens import (
     _generate_openobserve_password,  # noqa: F401  (re-exported for tests)
     _generate_token,
     _is_forbidden_value,
-    _is_too_weak_when_exposed,
     _raise_forbidden_var,
     _raise_invalid_var,
     _validate_openobserve_password,  # noqa: F401  (re-exported for tests)
@@ -694,25 +693,6 @@ def _ensure_service_tokens(
                 f"{name} is empty; refusing to start a deployment that is reachable "
                 f"off-host with an empty token. Unset {name} in the environment and let "
                 f"`osprey up` mint one, or export a strong secret."
-            )
-        # The length floor, for the same exposure and one step past empty. Only
-        # ZO_ROOT_USER_PASSWORD registers one, because only its recipe mints
-        # deliberately short — short enough for a person to read off a terminal
-        # and type into the OpenObserve login form during a demo. That trade is
-        # sound on the loopback deploy it was chosen for and not sound here, and
-        # the mint's idempotence is what makes the check necessary rather than
-        # decorative: the demo password is still in `.env` when this project is
-        # later brought up with `--expose`, so nothing re-mints it and only a
-        # read of the effective value can catch it. Applies whatever the origin,
-        # which also covers an operator who simply chose a short password.
-        if expose_network and _is_too_weak_when_exposed(name, effective):
-            raise RuntimeError(
-                f"{name} is too short for a deployment that is reachable off-host. "
-                f"The value osprey mints is sized to be typed at a demo login on "
-                f"localhost, not to guard a store other hosts can reach — and this "
-                f"one holds full agent conversation transcripts. Set a strong "
-                f"{name} in .env before deploying with --expose. "
-                f"Refusing to deploy. (Value not shown.)"
             )
         # Ahead of the format check so the more specific diagnosis wins. A
         # registered forbidden value is well-formed by construction — that is

--- a/src/osprey/deployment/errors.py
+++ b/src/osprey/deployment/errors.py
@@ -199,6 +199,27 @@ class UnmetPreconditionsError(DeploymentPreconditionError):
         super().__init__("\n\n".join(blocks), "")
 
 
+class ArchiverClientMissingError(DeploymentPreconditionError):
+    """A deploy would seed an archiver store, but pymongo is not importable here.
+
+    "Here" is the load-bearing word, and it is why this carries its own type
+    rather than a bare :class:`RuntimeError`. OSPREY seeds the store *in the
+    process running the CLI*, not in the project's ``build/.venv`` and not in
+    the project image — so the one lever an operator reaches for first, a
+    ``dependencies:`` entry in the build profile, cannot satisfy it. That entry
+    is real and does install pymongo, into all three of the environments the
+    project owns; none of them is this one. An operator who has declared it and
+    still sees a refusal is owed that sentence explicitly, so ``reason`` names
+    the interpreter instead of only naming the package.
+
+    pymongo is a core dependency, so reaching this at all means an incomplete
+    environment — a partial install, a stale venv, a wheel built from a narrower
+    dependency set — rather than an unselected option.
+    """
+
+    summary = "The archiver store cannot be seeded"
+
+
 class NoComposeFilesError(DeploymentPreconditionError):
     """A read verb needs the compose files a build rendered, and there are none.
 

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -1735,6 +1735,27 @@ def _condensed_outcome_lines(plan: ResetPlan) -> list[str]:
     return lines
 
 
+def runtime_selection_config(repo_root: Path) -> dict | None:
+    """The as-built config, where this repo has one, for choosing the runtime.
+
+    Only ever used to decide docker vs podman: a deployment that pins one is
+    entitled to have every check made against that one, and a probe that
+    defaulted to detection would report the wrong daemon's absence at an
+    operator running the other. ``None`` when there is nothing built yet or the
+    file will not load — a fresh repo has no as-built config by definition, and
+    detection is the right answer there rather than a failure.
+    """
+    config_path = as_built_config_path(repo_root)
+    if not config_path.is_file():
+        return None
+    try:
+        from osprey.utils.config import load_project_config
+
+        return load_project_config(str(config_path), wrap_errors=True)
+    except Exception:  # noqa: BLE001 - runtime selection falls back to detection
+        return None
+
+
 def _default_probe(repo_root: Path) -> RuntimeProbe:
     """The real runtime seam, refusing early when the daemon is unreachable.
 
@@ -1746,16 +1767,7 @@ def _default_probe(repo_root: Path) -> RuntimeProbe:
     """
     from osprey.deployment.runtime_helper import verify_runtime_is_running
 
-    config_path = as_built_config_path(repo_root)
-    config: dict | None = None
-    if config_path.is_file():
-        try:
-            from osprey.utils.config import load_project_config
-
-            config = load_project_config(str(config_path), wrap_errors=True)
-        except Exception:  # noqa: BLE001 - runtime selection falls back to detection
-            config = None
-
+    config = runtime_selection_config(repo_root)
     is_running, error = verify_runtime_is_running(config)
     if not is_running:
         raise RuntimeError(

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -201,6 +201,18 @@ MINTED_ENV_BANNERS: tuple[str, ...] = (
     "Auto-configured bluesky bridge plan devices (osprey deploy up)",
     "Auto-generated bluesky RE manager control-socket keypair (osprey deploy up)",
     "Credentials adopted from pre-existing data volumes (osprey --reuse-stores)",
+    # Not a secret — service account names, written so an operator can find the
+    # whole login in one place. Listed here for the same reason as the rest:
+    # every block the deploy writes is one the deploy can write again, so
+    # leaving it behind would strand a name beside credentials that are gone.
+    #
+    # Names the current command, unlike the older banners above, which still
+    # carry the retired command spelling they were written under — this tuple is
+    # a data format and never rewrites an entry. A NEW banner has no `.env` on
+    # disk to stay compatible with, so it uses the command that actually exists.
+    # test_lifecycle_invariants' retired-spelling scan grandfathers exactly the
+    # older three and nothing else, which is what keeps this from drifting back.
+    "Service account names (osprey up) — not secrets",
 )
 
 

--- a/src/osprey/deployment/service_tokens.py
+++ b/src/osprey/deployment/service_tokens.py
@@ -22,6 +22,17 @@ def _default_token() -> str:
     return secrets.token_urlsafe(32)
 
 
+# Characters excluded from the OpenObserve password alphabet because a human
+# reads this one off a screen: ``l``/``I``/``1`` and ``O``/``0`` are the pairs
+# people transcribe wrongly, and a rejected OpenObserve login says nothing about
+# which character was misread.
+_AMBIGUOUS_CHARS = "lI1O0"
+
+#: Length of a minted ``ZO_ROOT_USER_PASSWORD``. See
+#: :func:`_generate_openobserve_password` for why this one credential is short.
+_OPENOBSERVE_PASSWORD_LENGTH = 12
+
+
 def _generate_openobserve_password() -> str:
     """Mint a ``ZO_ROOT_USER_PASSWORD`` that satisfies OpenObserve's policy.
 
@@ -35,23 +46,39 @@ def _generate_openobserve_password() -> str:
     constraint (see ``_VAR_GENERATORS`` below).
 
     Build a value that guarantees all four required classes instead, drawing
-    every character from ``secrets`` (never ``random``): a 44-char alphanumeric
-    core (>=256 bits of entropy on its own, meeting the module's CSPRNG bar)
-    plus one guaranteed member of each class, then shuffled so the class
-    positions are not fixed. The special is drawn from ``@%*^`` — punctuation
-    every reasonable policy counts as "special", and each of which is safe both
-    in a ``.env`` value (unlike ``#``, ``$``, quotes, backslash, ``=`` or a
-    space, which break dotenv parsing) and in the base64 Basic-auth header the
-    resolver computes from it.
+    every character from ``secrets`` (never ``random``), then shuffling so the
+    class positions are not fixed. The special is drawn from ``@%*^`` —
+    punctuation every reasonable policy counts as "special", and each of which
+    is safe both in a ``.env`` value (unlike ``#``, ``$``, quotes, backslash,
+    ``=`` or a space, which break dotenv parsing) and in the base64 Basic-auth
+    header the resolver computes from it.
+
+    **Why this recipe is deliberately short.** It is the one minted credential
+    with a human in the loop: every other secret in ``_VAR_GENERATORS`` travels
+    machine-to-machine, but this one is read off a terminal and typed into a
+    browser login form, often on a projector during a demo. At 12 characters
+    from an alphabet with the easily-misread characters removed it carries ~65
+    bits — under the module's 256-bit default bar, and that is the point, not
+    an oversight. Two things bound the exception: the store publishes on
+    loopback by default, and an off-host deploy refuses this length outright
+    (``_VAR_EXPOSED_MIN_LENGTH``), so the weaker value cannot silently follow a
+    demo project into a reachable deployment.
     """
-    alphabet = string.ascii_letters + string.digits
-    chars = [secrets.choice(alphabet) for _ in range(44)]
-    chars += [
-        secrets.choice(string.ascii_lowercase),
-        secrets.choice(string.ascii_uppercase),
-        secrets.choice(string.digits),
-        secrets.choice("@%*^"),
+    lower = "".join(c for c in string.ascii_lowercase if c not in _AMBIGUOUS_CHARS)
+    upper = "".join(c for c in string.ascii_uppercase if c not in _AMBIGUOUS_CHARS)
+    digits = "".join(c for c in string.digits if c not in _AMBIGUOUS_CHARS)
+    specials = "@%*^"
+
+    # One guaranteed member of each required class, then fill to length from the
+    # union so the class counts are not themselves a fixed pattern.
+    chars = [
+        secrets.choice(lower),
+        secrets.choice(upper),
+        secrets.choice(digits),
+        secrets.choice(specials),
     ]
+    pool = lower + upper + digits + specials
+    chars += [secrets.choice(pool) for _ in range(_OPENOBSERVE_PASSWORD_LENGTH - len(chars))]
     secrets.SystemRandom().shuffle(chars)
     return "".join(chars)
 
@@ -59,12 +86,23 @@ def _generate_openobserve_password() -> str:
 # Per-variable overrides of the default recipe. A var absent here gets
 # ``_default_token``.
 #
-# CSPRNG bar: any recipe registered here MUST draw from ``secrets`` (never
-# ``random``, a hashed timestamp, or any other non-cryptographic source) and
-# MUST yield at least 256 bits of entropy — the same bar ``_default_token``'s
-# ``token_urlsafe(32)`` meets. A registered recipe exists to change the
-# *alphabet* for a downstream consumer's parsing rules (see
-# BLUESKY_TILED_API_KEY below), never to weaken the randomness.
+# CSPRNG bar: every recipe registered here MUST draw from ``secrets`` (never
+# ``random``, a hashed timestamp, or any other non-cryptographic source). That
+# half is absolute and has no exceptions.
+#
+# Entropy bar: a recipe SHOULD yield at least 256 bits — the same bar
+# ``_default_token``'s ``token_urlsafe(32)`` meets. Ordinarily a registered
+# recipe exists to change the *alphabet* for a downstream consumer's parsing
+# rules (see BLUESKY_TILED_API_KEY below), never to weaken the randomness.
+#
+# ONE exception is allowed, and only on this ground: a credential a HUMAN types
+# into a login form may trade entropy for legibility, because a password nobody
+# can transcribe is a password that gets pasted into a chat window or replaced
+# with something worse. A recipe claiming the exception must say so in its
+# docstring and must be bounded by an entry in ``_VAR_EXPOSED_MIN_LENGTH``, so
+# the weaker value cannot follow the deployment off-host. ZO_ROOT_USER_PASSWORD
+# is the only var that qualifies today: the Tiled key, both dispatch tokens, and
+# the Postgres/Mongo passwords are read by processes, never by people.
 #
 # BLUESKY_TILED_API_KEY: Tiled validates its ``--api-key`` during server startup
 # and raises ``ValueError("The API key must only contain alphanumeric
@@ -289,6 +327,36 @@ _VAR_FORBIDDEN_DESCRIPTIONS: dict[str, str] = {
         "same name) so the next run mints a per-deploy value"
     ),
 }
+
+# Minimum length a var's effective value must have when the deployment is
+# published on all interfaces. Checked ONLY under ``expose_network``; a loopback
+# deploy has no opinion about length, which is what lets the OpenObserve mint be
+# short enough to type (see ``_generate_openobserve_password``).
+#
+# Why a length floor and not a strength *recipe* applied at mint time: minting
+# is idempotent, so a password minted during a loopback demo is still sitting in
+# ``.env`` when someone later runs ``osprey up --expose``. Choosing the recipe
+# by ``expose_network`` would mint strong on an exposed FIRST deploy and change
+# nothing for the far more common case of a demo project that grows up — false
+# comfort. Reading the effective value on every exposed deploy catches both that
+# path and an operator who simply typed a short password, whatever its origin.
+#
+# Opt-in per var, exactly like ``_VAR_VALIDATORS`` and ``_VAR_FORBIDDEN_VALUES``:
+# a var absent here has no length opinion at any exposure. Only the credential
+# whose recipe claims the human-legibility exception needs one, because only
+# that recipe deliberately mints below the module's entropy bar.
+_VAR_EXPOSED_MIN_LENGTH: dict[str, int] = {
+    "ZO_ROOT_USER_PASSWORD": 20,
+}
+
+
+def _is_too_weak_when_exposed(var: str, value: str) -> bool:
+    """True if ``value`` is below ``var``'s registered off-host length floor.
+
+    Fail-open for an unregistered var, matching every other per-var map here.
+    """
+    minimum = _VAR_EXPOSED_MIN_LENGTH.get(var)
+    return minimum is not None and len(value) < minimum
 
 
 def _effective_value(var: str, dotenv: dict[str, str]) -> str:

--- a/src/osprey/deployment/service_tokens.py
+++ b/src/osprey/deployment/service_tokens.py
@@ -59,10 +59,15 @@ def _generate_openobserve_password() -> str:
     browser login form, often on a projector during a demo. At 12 characters
     from an alphabet with the easily-misread characters removed it carries ~65
     bits — under the module's 256-bit default bar, and that is the point, not
-    an oversight. Two things bound the exception: the store publishes on
-    loopback by default, and an off-host deploy refuses this length outright
-    (``_VAR_EXPOSED_MIN_LENGTH``), so the weaker value cannot silently follow a
-    demo project into a reachable deployment.
+    an oversight. That bar is sized for secrets an attacker can attack offline;
+    the only attack this one faces is online guessing against an HTTP login
+    form, where 65 bits of CSPRNG entropy is many orders of magnitude out of
+    reach. A character count is the wrong instrument here in any case — it
+    would reject this value while admitting a longer, guessable one an operator
+    typed. What actually disqualifies a password is being absent or being
+    public, and both are refused on their own terms: the empty-value check in
+    ``_ensure_service_tokens`` under exposure, and ``_VAR_FORBIDDEN_VALUES``
+    for the template's published default.
     """
     lower = "".join(c for c in string.ascii_lowercase if c not in _AMBIGUOUS_CHARS)
     upper = "".join(c for c in string.ascii_uppercase if c not in _AMBIGUOUS_CHARS)
@@ -99,10 +104,10 @@ def _generate_openobserve_password() -> str:
 # into a login form may trade entropy for legibility, because a password nobody
 # can transcribe is a password that gets pasted into a chat window or replaced
 # with something worse. A recipe claiming the exception must say so in its
-# docstring and must be bounded by an entry in ``_VAR_EXPOSED_MIN_LENGTH``, so
-# the weaker value cannot follow the deployment off-host. ZO_ROOT_USER_PASSWORD
-# is the only var that qualifies today: the Tiled key, both dispatch tokens, and
-# the Postgres/Mongo passwords are read by processes, never by people.
+# docstring and must still draw every character from ``secrets``: legibility
+# buys a shorter value, never a weaker source. ZO_ROOT_USER_PASSWORD is the only
+# var that qualifies today: the Tiled key, both dispatch tokens, and the
+# Postgres/Mongo passwords are read by processes, never by people.
 #
 # BLUESKY_TILED_API_KEY: Tiled validates its ``--api-key`` during server startup
 # and raises ``ValueError("The API key must only contain alphanumeric
@@ -327,36 +332,6 @@ _VAR_FORBIDDEN_DESCRIPTIONS: dict[str, str] = {
         "same name) so the next run mints a per-deploy value"
     ),
 }
-
-# Minimum length a var's effective value must have when the deployment is
-# published on all interfaces. Checked ONLY under ``expose_network``; a loopback
-# deploy has no opinion about length, which is what lets the OpenObserve mint be
-# short enough to type (see ``_generate_openobserve_password``).
-#
-# Why a length floor and not a strength *recipe* applied at mint time: minting
-# is idempotent, so a password minted during a loopback demo is still sitting in
-# ``.env`` when someone later runs ``osprey up --expose``. Choosing the recipe
-# by ``expose_network`` would mint strong on an exposed FIRST deploy and change
-# nothing for the far more common case of a demo project that grows up — false
-# comfort. Reading the effective value on every exposed deploy catches both that
-# path and an operator who simply typed a short password, whatever its origin.
-#
-# Opt-in per var, exactly like ``_VAR_VALIDATORS`` and ``_VAR_FORBIDDEN_VALUES``:
-# a var absent here has no length opinion at any exposure. Only the credential
-# whose recipe claims the human-legibility exception needs one, because only
-# that recipe deliberately mints below the module's entropy bar.
-_VAR_EXPOSED_MIN_LENGTH: dict[str, int] = {
-    "ZO_ROOT_USER_PASSWORD": 20,
-}
-
-
-def _is_too_weak_when_exposed(var: str, value: str) -> bool:
-    """True if ``value`` is below ``var``'s registered off-host length floor.
-
-    Fail-open for an unregistered var, matching every other per-var map here.
-    """
-    minimum = _VAR_EXPOSED_MIN_LENGTH.get(var)
-    return minimum is not None and len(value) < minimum
 
 
 def _effective_value(var: str, dotenv: dict[str, str]) -> str:

--- a/src/osprey/interfaces/ariel/static/js/entries.js
+++ b/src/osprey/interfaces/ariel/static/js/entries.js
@@ -168,20 +168,27 @@ function renderEntriesList(container, result) {
  * @returns {string} HTML string
  */
 function renderPagination(currentPage, totalPages) {
-  let html = '<div class="pagination" style="display: flex; justify-content: center; gap: 8px; margin-top: 24px;">';
-
-  if (currentPage > 1) {
-    html += `<button class="btn btn-secondary btn-sm" data-page="${currentPage - 1}">Previous</button>`;
-  }
-
-  html += `<span class="text-muted" style="padding: 8px;">Page ${currentPage} of ${totalPages}</span>`;
-
-  if (currentPage < totalPages) {
-    html += `<button class="btn btn-secondary btn-sm" data-page="${currentPage + 1}">Next</button>`;
-  }
-
-  html += '</div>';
-  return html;
+  // Both buttons ALWAYS render; the ends of the range disable them rather than
+  // dropping them from the DOM. The row is centred, so a member coming and
+  // going re-centres the whole row and moves every OTHER member by half the
+  // delta — and the first click of "Next" is exactly what brings "Previous"
+  // into existence, so Next would slide out from under the cursor on the one
+  // gesture people repeat to page through a list. Disabled buttons hold the
+  // geometry still for the whole run. (artifacts/js/timeseries.js pages its
+  // table the same way, for the same reason.)
+  //
+  // Residual, deliberately left: the page readout still widens when the counts
+  // cross a digit (Page 9 of 9 -> Page 10 of 12), which nudges both buttons by
+  // about half a character. Same class, two orders of magnitude smaller.
+  const atStart = currentPage <= 1;
+  const atEnd = currentPage >= totalPages;
+  return (
+    '<div class="pagination" style="display: flex; justify-content: center; gap: 8px; margin-top: 24px;">' +
+    `<button class="btn btn-secondary btn-sm" data-page="${currentPage - 1}"${atStart ? ' disabled' : ''}>Previous</button>` +
+    `<span class="text-muted" style="padding: 8px;">Page ${currentPage} of ${totalPages}</span>` +
+    `<button class="btn btn-secondary btn-sm" data-page="${currentPage + 1}"${atEnd ? ' disabled' : ''}>Next</button>` +
+    '</div>'
+  );
 }
 
 export default {

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.css
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.css
@@ -145,6 +145,32 @@ html:not([data-ui-mode="simple"]) body.embedded .panel-tabs { display: none; }
 }
 .status-strip-spacer { flex: 1 1 auto; }
 
+/* WIDTH FLOORS on the two halt buttons. The strip is a right-anchored cluster
+ * (leading spacer), so a member's position depends only on the widths of the
+ * members AFTER it — which makes the rightmost button, Abort, the thing that
+ * positions Stop. Both buttons swap labels at runtime (arming, and the
+ * stop-pending withdrawal), and every one of those swaps used to drag Stop
+ * sideways under the operator's cursor at the exact moment they are choosing
+ * between the two halts. Worse, the armed Abort then covered most of the
+ * pixels Stop had just vacated, so a click aimed at Stop committed the abort —
+ * the confirm gate defeating itself geometrically.
+ *
+ * Only ABORT needs the floor. Stop is inboard of it, so Stop's own label swaps
+ * (the stop-pending withdrawal, and its confirm) move Stop's left edge into
+ * the spacer and nothing else — which is why those labels are left long and
+ * explicit. Abort is the one whose width is load-bearing for a neighbour.
+ *
+ * The floor is one `ch` per character of the resting label. `ch` is the "0"
+ * advance, comfortably wider than the mean glyph advance of this Latin string
+ * in a proportional face, so the floor clears the resting text without anyone
+ * measuring a pixel — slack in the box rather than a number that goes stale
+ * when the type changes. The armed label is kept SHORTER than the resting one
+ * (queue-client.js), so the box never changes size in either direction. */
+#abort-btn {
+  box-sizing: content-box;
+  min-width: 18ch; /* 'Abort running plan' — the resting label */
+}
+
 /* `body.embedded` zeroes the body padding so the scrolling views can meet the
    tile edges — but this strip is a fixed header band, not scrolling content,
    and it had no inset of its own: standalone, the body padding was quietly

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.js
@@ -222,16 +222,23 @@ function resultsHaveUnwatchedActivity() {
 function publishContribution() {
   /** @type {import('/design-system/js/header-contrib.js').HeaderItem[]} */
   const items = [];
-  // ORDER IS THE LAYOUT. The hub right-anchors every interactive item into one
-  // cluster and lays it out in contribution order, so the filter comes FIRST to
-  // sit left of the view switcher — the arrangement the Artifacts gallery
-  // already uses for its own filter/switcher pair. Reordering this array is the
-  // only way to move them; there is no side or slot to ask the hub for.
+  // ORDER IS THE LAYOUT (see header-contrib.js): the hub right-anchors every
+  // interactive item into one cluster against the close button, so an item's
+  // arrival or departure moves everything contributed BEFORE it and nothing
+  // after it.
   //
-  // The filter belongs to the Plans view, so it is contributed only while that
-  // view is showing — and never in Simple mode, where the hub collapses the
-  // tile bar and Simple deliberately ENLARGES a search box rather than hiding
-  // it. In both excluded cases the in-body search box is the one on screen.
+  // The filter is the conditional item here — it belongs to the Plans view, so
+  // it is contributed only while that view is showing, and never in Simple
+  // mode, where the hub collapses the tile bar and Simple deliberately
+  // ENLARGES a search box rather than hiding it (in both excluded cases the
+  // in-body box is the one on screen). The view switcher is the item an
+  // operator aims at over and over. So the filter goes FIRST and the switcher
+  // LAST: the switcher stays pinned to the close button and the filter appears
+  // and disappears to its left, in the slack.
+  //
+  // The other order would put the tab strip on the moving side of its own
+  // effect — clicking away from Plans drops the filter, and the strip you just
+  // clicked slides right by the filter's whole width. Do not swap these.
   if (activeView === 'plans' && !isSimpleMode()) {
     items.push({ kind: 'search', id: FILTER_ITEM_ID, placeholder: 'Filter plans…' });
   }

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.js
@@ -221,20 +221,13 @@ function resultsHaveUnwatchedActivity() {
  */
 function publishContribution() {
   /** @type {import('/design-system/js/header-contrib.js').HeaderItem[]} */
-  const items = [
-    {
-      kind: 'nav',
-      id: VIEW_ITEM_ID,
-      items: VIEWS.map((entry) => ({
-        id: entry.id,
-        label:
-          entry.id === 'results' && resultsHaveUnwatchedActivity()
-            ? `${entry.label}${ACTIVITY_MARKER}`
-            : entry.label,
-        active: entry.id === activeView,
-      })),
-    },
-  ];
+  const items = [];
+  // ORDER IS THE LAYOUT. The hub right-anchors every interactive item into one
+  // cluster and lays it out in contribution order, so the filter comes FIRST to
+  // sit left of the view switcher — the arrangement the Artifacts gallery
+  // already uses for its own filter/switcher pair. Reordering this array is the
+  // only way to move them; there is no side or slot to ask the hub for.
+  //
   // The filter belongs to the Plans view, so it is contributed only while that
   // view is showing — and never in Simple mode, where the hub collapses the
   // tile bar and Simple deliberately ENLARGES a search box rather than hiding
@@ -242,6 +235,18 @@ function publishContribution() {
   if (activeView === 'plans' && !isSimpleMode()) {
     items.push({ kind: 'search', id: FILTER_ITEM_ID, placeholder: 'Filter plans…' });
   }
+  items.push({
+    kind: 'nav',
+    id: VIEW_ITEM_ID,
+    items: VIEWS.map((entry) => ({
+      id: entry.id,
+      label:
+        entry.id === 'results' && resultsHaveUnwatchedActivity()
+          ? `${entry.label}${ACTIVITY_MARKER}`
+          : entry.label,
+      active: entry.id === activeView,
+    })),
+  });
   contributeHeader(items);
 }
 

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/queue-client.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/queue-client.js
@@ -56,7 +56,16 @@ export const CONFIRM_WITHDRAW_STOP_LABEL = 'Confirm — the queue keeps draining
 // has a Stop and the two must not read as degrees of the same thing: this one
 // throws away the rest of the running plan.
 export const ABORT_LABEL = 'Abort running plan';
-export const CONFIRM_ABORT_LABEL = 'Confirm — abort now, hardware stays put';
+// SHORTER than the resting label, deliberately, and panel.css pins the button
+// at its resting width. This button is the LAST item in the status strip's
+// right-anchored cluster, so its own width is what positions the plain Stop
+// beside it: a label that grew on arming dragged Stop ~150px left at the exact
+// moment an operator is choosing between the two halts — and the armed Abort
+// then covered most of the pixels Stop had just vacated, so a click aimed at
+// Stop committed the abort. The confirm gate defeated itself geometrically.
+// What the second click does is said in #abort-note (see abortControl), which
+// already renders on arm and says it better than a button label can.
+export const CONFIRM_ABORT_LABEL = 'Confirm abort';
 
 /** @typedef {Record<string, unknown>} QueueStatus */
 /** @typedef {Record<string, any>} QueueItem */

--- a/src/osprey/interfaces/channel_finder/static/js/feedback.js
+++ b/src/osprey/interfaces/channel_finder/static/js/feedback.js
@@ -110,9 +110,15 @@ async function _renderList() {
         </div>
       </div>
       <div class="fb-toolbar-right">
+        <!-- ORDER IS THE LAYOUT. space-between pins this cluster's right edge,
+             so a member's arrival moves everything BEFORE it and nothing after
+             it. Clear All is the conditional member (it exists only while
+             there are entries), so it goes FIRST: it appears on the very
+             action that creates the first entry, and the other order shoved
+             the persistent Add/Export pair sideways on that click. -->
+        ${entries.length > 0 ? '<button class="btn btn-danger btn-sm" id="fb-clear-btn">Clear All</button>' : ''}
         <button class="btn btn-secondary btn-sm" id="fb-add-btn">+ Add Entry</button>
         <button class="btn btn-secondary btn-sm" id="fb-export-btn">Export</button>
-        ${entries.length > 0 ? '<button class="btn btn-danger btn-sm" id="fb-clear-btn">Clear All</button>' : ''}
       </div>
     </div>
   `;

--- a/src/osprey/interfaces/design_system/static/js/header-contrib.js
+++ b/src/osprey/interfaces/design_system/static/js/header-contrib.js
@@ -34,10 +34,40 @@
  * what keeps a panel and a hub of different vintages compatible — there is no
  * negotiation beyond that.
  *
+ * ORDER IS THE LAYOUT, AND THE RIGHT EDGE IS THE ANCHOR. The hub gathers every
+ * INTERACTIVE item into one cluster pinned against the tile's close button — a
+ * flexible spacer takes all the slack to its left — and lays that cluster out
+ * in contribution order. (`text` items are outside it: they are the tile's
+ * subtitle, left-anchored beside the name, and their width costs the spacer,
+ * not a neighbour.) Right-anchoring makes change ASYMMETRIC: when an item
+ * appears, disappears, or changes width, everything contributed BEFORE it
+ * slides sideways and everything after it does not move at all.
+ *
+ * So order the array by how STABLE each item is, least stable first:
+ *
+ *   1. items contributed CONDITIONALLY — only in one view, only outside
+ *      Simple, only while something is running;
+ *   2. items whose label CHANGES WIDTH at runtime — an arming button's
+ *      "Confirm?", a count, an activity marker;
+ *   3. the control the operator aims at repeatedly — the view switcher, the
+ *      primary action — LAST, hard against the close button.
+ *
+ * Put a conditional item after a persistent one and the persistent one moves
+ * every time the conditional comes and goes — usually as a direct result of
+ * clicking that persistent control, which is the worst case there is: the
+ * target slides out from under the cursor that just hit it. Reordering the
+ * array is a panel's ONLY control over this; there is no side or slot to ask
+ * the hub for.
+ *
  * Every item may carry `priority` (number, default 0): in a narrow tile the
  * hub hides lowest-priority items first (text truncates before anything
- * hides). Both helpers are strict no-ops outside an embedded frame, so panels
- * call them unconditionally.
+ * hides). That is a SEPARATE axis from order — it decides what survives a
+ * narrow tile, not where anything sits — and the two may legitimately
+ * disagree. Note the coupling, though: a re-contribution that widens a label
+ * can itself make the bar crowded, so an item that both grows and carries the
+ * lowest priority can fold ITSELF into the ⋯ menu at the moment it grows.
+ * Both helpers are strict no-ops outside an embedded frame, so panels call
+ * them unconditionally.
  *
  * SIMPLE MODE: the hub collapses a service tile's whole bar to zero height in
  * Simple mode, so anything contributed is invisible there. That suits chrome

--- a/src/osprey/interfaces/lattice_dashboard/static/js/header.js
+++ b/src/osprey/interfaces/lattice_dashboard/static/js/header.js
@@ -66,7 +66,15 @@ export function createHeader(callbacks) {
       {
         kind: 'button',
         id: 'baseline',
-        label: armed ? 'Confirm baseline?' : 'Baseline',
+        // Same character count as the resting label, deliberately. This button
+        // is not last in either rendering — the theme switcher follows it in
+        // the standalone topbar, Refresh/Verify precede it in both — and every
+        // one of those is a persistent control that a growing label shoves
+        // sideways on the very click that arms this one. `Confirm baseline?`
+        // was 9 characters longer — in the topbar's monospace face, a ~60px
+        // shove of Refresh and Verify. What the second click does is in the
+        // title, where it does not cost layout.
+        label: armed ? 'Confirm?' : 'Baseline',
         title: armed ? 'Click again to overwrite the baseline' : 'Set current as baseline',
         tone: armed ? 'accent' : 'default',
         disabled: !hasLattice,
@@ -82,7 +90,8 @@ export function createHeader(callbacks) {
     btn.classList.toggle('action-btn--armed', armed);
     btn.title = armed ? 'Click again to overwrite the baseline' : 'Set current as baseline';
     const label = btn.querySelector('.baseline-label');
-    if (label) label.textContent = armed ? 'Confirm baseline?' : 'Baseline';
+    // Same length as the resting label — see publishContribution for why.
+    if (label) label.textContent = armed ? 'Confirm?' : 'Baseline';
   }
 
   function render() {

--- a/src/osprey/interfaces/web_terminal/static/js/chat.js
+++ b/src/osprey/interfaces/web_terminal/static/js/chat.js
@@ -61,8 +61,18 @@ function buildConsole() {
   stopBtn.type = 'button';
   stopBtn.hidden = true;
 
+  // ORDER IS THE LAYOUT. The textarea takes all the slack (`flex: 1`), so this
+  // cluster is pinned to the row's right edge and a member's arrival moves
+  // everything BEFORE it and nothing after it. Stop is the conditional one —
+  // it exists only while a turn streams — so it goes FIRST and Send stays put.
+  //
+  // The other order is a control-substitution hazard, not just a jump: Stop
+  // hides and Send re-enables in the same statement block (see setStreaming),
+  // so Send would slide into the exact pixels Stop had occupied at the moment
+  // it becomes clickable again — a hand already moving toward Stop as the turn
+  // ends lands on Send instead.
   const controls = elem('div', 'op-input-controls');
-  controls.append(sendBtn, stopBtn);
+  controls.append(stopBtn, sendBtn);
 
   const inputArea = elem('div', 'op-input-area');
   inputArea.append(elem('span', 'op-prompt-char', '›'), textarea, controls);

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -25,11 +25,6 @@ model: haiku   # tier (haiku/sonnet/opus), or a model ID the provider serves
 # also accepts in_context or middle_layer.
 channel_finder_mode: hierarchical
 
-# Extra Python packages your agent needs. pymongo is required by the stored
-# archive declared under `va_archiver:` below.
-dependencies:
-  - pymongo>=4.0
-
 # ── What the agent can do ────────────────────────────────────────────────────
 # Each entry is a name from the OSPREY artifact library. Delete what you do not
 # need; add your own through an overlay.

--- a/src/osprey/simulation/apply.py
+++ b/src/osprey/simulation/apply.py
@@ -478,7 +478,8 @@ def _require_pymongo() -> None:
     except ImportError as exc:
         raise RuntimeError(
             "Rewriting the archive needs pymongo, which is not installed. "
-            "Install it with: pip install 'osprey-framework[archiver-mongodb]'"
+            "It is a core dependency, so this environment is incomplete. "
+            "Reinstall it with: pip install --upgrade osprey-framework"
         ) from exc
 
 

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -493,9 +493,8 @@ archiver:
     url: https://archiver.als.lbl.gov:8443
     timeout: 60              # Timeout for archiver requests in seconds
 
-  # MongoDB archiver — needs the archiver-mongodb extra:
-  #   pip install 'osprey-framework[archiver-mongodb]'
-  # Every key here except port and timeout is required; the connector raises on
+  # MongoDB archiver. Its client ships with OSPREY, so there is nothing extra to
+  # install. Every key here except port and timeout is required; the connector raises on
   # the first one missing. The password itself is never stored here — it is read
   # at connect time from the environment variable named by password_env, which
   # `osprey up` mints into the project's .env.

--- a/src/osprey/templates/services/virtual_accelerator/Dockerfile
+++ b/src/osprey/templates/services/virtual_accelerator/Dockerfile
@@ -14,8 +14,9 @@
 #     on dev builds. Its build cache is shared across projects and only
 #     rebuilds when the staged manifest changes. The extra is what carries the
 #     serving stack (`lume-pva-apg[ca,pva]`, PyAT) and the archiver recorder's
-#     client-side deps (a CA client, pymongo) — deliberately, so this file
-#     cannot pin a dependency that pyproject.toml disagrees with. The recorder
+#     CA client — deliberately, so this file cannot pin a dependency that
+#     pyproject.toml disagrees with. The recorder's other client-side dep,
+#     pymongo, is core and arrives with the base install. The recorder
 #     runs THIS image with a different command (compose template only, no
 #     Dockerfile of its own), which is why its deps ride along here.
 #   * wheel layer — when `osprey up --dev` stages a locally-built wheel

--- a/src/osprey/version.py
+++ b/src/osprey/version.py
@@ -112,7 +112,9 @@ def _pep440_from_describe(described: str) -> str | None:
     if distance == "0" and not dirty:
         return base
 
-    local = f"g{remainder}"
+    # setuptools-scm slices every node to a fixed width ("g" + 9 hex); mirror
+    # it, or the build stamp and this string disagree on hash length alone.
+    local = f"g{remainder[:9]}"
     if dirty:
         from datetime import date
 
@@ -135,6 +137,10 @@ def _version_from_git() -> str | None:
                 "--tags",
                 "--long",
                 "--dirty",
+                # Full node, sliced below. git's default abbreviation width
+                # scales with the size of the clone, so left to it the same
+                # commit reports g1234567a here and g1234567ab elsewhere.
+                "--abbrev=40",
                 "--match",
                 "v[0-9]*",
             ],

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -1433,3 +1433,67 @@ class TestContainerRuntimePreflight:
         assert result.exit_code == 0, result.output
         assert asked == []
         assert (target / "profile.yml").is_file()
+
+
+class TestSetShorthandMistakenForAFlag:
+    """`--provider cborg` is a natural guess, and it is not an option.
+
+    The profile's own shorthands are spelled `--set provider=cborg`, and Click
+    answers an unknown option by naming the closest one it has by edit
+    distance — which for `--provider` is `--override`, a different feature with
+    a different argument. So the operator's first contact with the verb is a
+    suggestion that would not have worked either. These four keys are the ones
+    `--set` documents, so they are the ones worth catching by name.
+    """
+
+    @staticmethod
+    def _flat(output: str) -> str:
+        """One line, so an assertion is not a hostage to where Rich wrapped."""
+        return " ".join(output.split())
+
+    @pytest.mark.parametrize(
+        ("flag", "value", "key"),
+        [
+            ("--provider", "cborg", "provider"),
+            ("--model", "haiku", "model"),
+            ("--connector", "epics", "connector"),
+            ("--channel-finder-mode", "hybrid", "channel_finder_mode"),
+        ],
+    )
+    def test_it_names_the_set_spelling_that_works(self, runner, tmp_path, flag, value, key):
+        target = tmp_path / "demo"
+
+        result = runner.invoke(
+            cli, ["init", str(target), "--preset", "hello-world", "--no-git", flag, value]
+        )
+
+        assert result.exit_code == 2, result.output
+        assert f"--set {key}={value}" in self._flat(result.output)
+        assert not target.exists()
+
+    def test_the_refused_flags_are_the_documented_shorthands(self):
+        """The local copy against the definition it was copied from.
+
+        `init_cmd` declares these as options at decoration time and may not
+        import the build-profile chain to get them (TR-2, pinned by
+        `test_importing_the_module_stays_off_the_heavy_chain`), so the list is
+        spelled out there. This is what stops the copy from drifting: a
+        shorthand added to `--set` and not to the guard fails here instead of
+        quietly going back to `Did you mean --override?`.
+        """
+        from osprey.cli.build_profile_resolve import SHORTHAND_OVERRIDE_KEYS
+        from osprey.cli.init_cmd import _SHORTHAND_FLAG_KEYS
+
+        assert set(_SHORTHAND_FLAG_KEYS) == set(SHORTHAND_OVERRIDE_KEYS)
+
+    def test_the_real_spelling_still_works(self, runner, tmp_path):
+        """The guard is about the flag form; the documented one is untouched."""
+        target = tmp_path / "demo"
+
+        result = runner.invoke(
+            cli,
+            ["init", str(target), "--preset", "hello-world", "--no-git", "--set", "model=haiku"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert yaml.safe_load((target / "profile.yml").read_text())["model"] == "haiku"

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -65,6 +65,29 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture(autouse=True)
+def _container_runtime_is_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer ``init``'s runtime preflight without consulting the host.
+
+    ``--reset`` and ``--up`` are refused up front when no container runtime
+    answers, which is the right behaviour and the wrong dependency for a unit
+    test: left unstubbed these tests pass on a developer's machine with Docker
+    Desktop open and fail on a CI runner that has no daemon, which is a
+    property of the runner rather than of the verb.
+
+    Patched on ``runtime_helper`` itself because that is where the preflight
+    reads it from, at call time. The other callers of this function bind it at
+    import into their own modules, so this reaches exactly the one check these
+    tests need to get past and none of theirs.
+    ``TestContainerRuntimePreflight`` patches it back down, in the test body,
+    where it wins over this.
+    """
+    monkeypatch.setattr(
+        "osprey.deployment.runtime_helper.verify_runtime_is_running",
+        lambda config=None: (True, ""),
+    )
+
+
+@pytest.fixture(autouse=True)
 def _no_harvested_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep the developer's own exported API keys out of every repo these tests make.
 
@@ -1318,3 +1341,95 @@ class TestResetFlag:
 
         assert result.exit_code == 0, result.output
         assert calls == []
+
+
+class TestContainerRuntimePreflight:
+    """`--reset` and `--up` are checked against a reachable runtime FIRST.
+
+    Both flags need a container runtime for certain — `--reset` reads the
+    containers and volumes the previous deployment owns to know what to remove,
+    `--up` starts them — and neither can be satisfied without one. Asking after
+    the repo is materialized, git-initialized and committed is how a foreseeable
+    precondition turns into wreckage: the operator is left with a directory to
+    delete, and (since git objects are written read-only) an `rm -r` that stops
+    to ask about every one of them.
+
+    So the check moves to the front, next to the other refusals, and the
+    contract these tests pin is "nothing was created". The probe inside
+    `reset_for_reinit` stays where it is — the runtime can go down between the
+    two — but by then it is a guard, not the first news.
+    """
+
+    @staticmethod
+    def _runtime_down(monkeypatch, message="Docker Desktop is not running.\n\nTo fix this:\n1. x"):
+        monkeypatch.setattr(
+            "osprey.deployment.runtime_helper.verify_runtime_is_running",
+            lambda config=None: (False, message),
+        )
+
+    def test_reset_refuses_before_creating_anything(self, runner, tmp_path, monkeypatch):
+        self._runtime_down(monkeypatch)
+        target = tmp_path / "demo"
+
+        result = runner.invoke(
+            cli, ["init", str(target), "--preset", "hello-world", "--no-git", "--reset"]
+        )
+
+        assert result.exit_code != 0
+        assert not target.exists(), "the repo was created by a run that could not finish"
+        assert "Docker Desktop is not running." in result.output
+
+    def test_up_refuses_before_creating_anything(self, runner, tmp_path, monkeypatch):
+        self._runtime_down(monkeypatch)
+        target = tmp_path / "demo"
+
+        result = runner.invoke(
+            cli, ["init", str(target), "--preset", "hello-world", "--no-git", "--up", "-d"]
+        )
+
+        assert result.exit_code != 0
+        assert not target.exists()
+
+    def test_the_refusal_names_the_flag_that_needed_the_runtime(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """Otherwise the operator reads a Docker complaint out of a verb whose
+        job is writing files, with nothing connecting the two."""
+        self._runtime_down(monkeypatch)
+
+        result = runner.invoke(
+            cli, ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"]
+        )
+
+        assert "--reset" in result.output
+        assert "Nothing was created" in result.output
+
+    def test_it_escapes_as_a_refusal_not_a_traceback(self, runner, tmp_path, monkeypatch):
+        self._runtime_down(monkeypatch)
+
+        result = runner.invoke(
+            cli, ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"]
+        )
+
+        assert result.exception is None or isinstance(result.exception, SystemExit), (
+            f"the refusal escaped as an exception: {result.exception!r}"
+        )
+
+    def test_a_plain_init_never_asks_about_the_runtime(self, runner, tmp_path, monkeypatch):
+        """An init that neither resets nor starts anything writes files and
+        stops. Making it depend on a running Docker would be a precondition it
+        has no use for — and would take `osprey init` away from anyone
+        preparing a deployment repo on a machine that does not run containers.
+        """
+        asked: list[object] = []
+        monkeypatch.setattr(
+            "osprey.deployment.runtime_helper.verify_runtime_is_running",
+            lambda config=None: (asked.append(config), (False, "should not be consulted"))[1],
+        )
+        target = tmp_path / "demo"
+
+        result = runner.invoke(cli, ["init", str(target), "--preset", "hello-world", "--no-git"])
+
+        assert result.exit_code == 0, result.output
+        assert asked == []
+        assert (target / "profile.yml").is_file()

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -56,6 +56,29 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def _container_runtime_is_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer ``init``'s runtime preflight without consulting the host.
+
+    ``--reset`` and ``--up`` are refused up front when no container runtime
+    answers, which is the right behaviour and the wrong dependency for a unit
+    test: left unstubbed these tests pass on a developer's machine with Docker
+    Desktop open and fail on a CI runner that has no daemon, which is a
+    property of the runner rather than of the verb.
+
+    Patched on ``runtime_helper`` itself because that is where the preflight
+    reads it from, at call time. The other callers of this function bind it at
+    import into their own modules, so this reaches exactly the one check these
+    tests need to get past and none of theirs.
+    ``TestContainerRuntimePreflight`` patches it back down, in the test body,
+    where it wins over this.
+    """
+    monkeypatch.setattr(
+        "osprey.deployment.runtime_helper.verify_runtime_is_running",
+        lambda config=None: (True, ""),
+    )
+
+
 @pytest.fixture
 def recorder():
     """Pre-install a recording reporter, as an outer verb would have.

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -3,6 +3,11 @@
 Tests the main CLI group and lazy command loading mechanism.
 """
 
+import importlib
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -329,3 +334,141 @@ class TestEdgeCases:
 
         assert result.exit_code == 0
         assert "Usage: cli health" in result.output
+
+
+def _console_script_target() -> tuple[str, str]:
+    """The ``module``, ``attribute`` the ``osprey`` console script is wired to.
+
+    Read out of ``pyproject.toml`` rather than out of installed metadata: the
+    metadata of an editable install is written once, at install time, so it
+    answers with the wiring of whenever the developer last ran `uv sync` and
+    would keep a fixed entry point looking broken (or a broken one looking
+    fixed). The manifest is what actually ships.
+    """
+    import tomllib
+
+    root = Path(__file__).resolve().parents[2]
+    with (root / "pyproject.toml").open("rb") as handle:
+        target = tomllib.load(handle)["project"]["scripts"]["osprey"]
+    module, _, attribute = target.partition(":")
+    return module, attribute
+
+
+class TestConsoleScriptWiring:
+    """What `osprey` on an operator's PATH actually calls.
+
+    :class:`TestMainFunction` above proves :func:`~osprey.cli.main.main`
+    handles a failure well. It cannot prove anything about whether that
+    function is reached: it imports the symbol directly, so it stayed green
+    through the entire period the console script was wired past it, straight to
+    the bare Click group. Every uncaught exception in every verb reached
+    operators as a traceback the whole time. These tests enter the CLI the way
+    the shell does — through whatever `[project.scripts]` names — so the wiring
+    is what is under test, not the handler alone.
+    """
+
+    def test_the_console_script_target_handles_an_uncaught_failure(self, capsys):
+        """The entry point is a handler, not the raw Click group.
+
+        Asserted on behavior rather than on the target's name so the pin is
+        about what an operator sees, not about which function happens to
+        provide it.
+        """
+        module, attribute = _console_script_target()
+
+        entry = getattr(importlib.import_module(module), attribute)
+        with mock.patch(f"{module}.cli", side_effect=RuntimeError("Docker is not running")):
+            with pytest.raises(SystemExit) as exc_info:
+                entry()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "✗" in captured.err
+        assert "Docker is not running" in captured.err
+
+    def test_the_console_script_target_handles_an_interrupt(self, capsys):
+        """Ctrl+C through the shipped entry point is a goodbye, not a stack."""
+        module, attribute = _console_script_target()
+
+        entry = getattr(importlib.import_module(module), attribute)
+        with mock.patch(f"{module}.cli", side_effect=KeyboardInterrupt()):
+            with pytest.raises(SystemExit) as exc_info:
+                entry()
+
+        assert exc_info.value.code == 130
+        assert "⚠" in capsys.readouterr().err
+
+    def test_a_verb_that_raises_prints_no_traceback(self):
+        """End to end, in the shape the console script runs: no stack, exit 1.
+
+        A subprocess because that is the only place the whole path exists at
+        once — the entry point resolved from the manifest, Click's own
+        dispatch, and the process exiting. The failing verb is injected rather
+        than borrowed from the real command set: the assertion is about what
+        the CLI does with an exception no one caught, and pinning it to a verb
+        that happens to raise today would make this test a hostage to that
+        verb's error handling improving.
+        """
+        module, attribute = _console_script_target()
+        program = textwrap.dedent(
+            f"""
+            import importlib
+            import sys
+            import click
+            from {module} import {attribute} as entry
+
+            main_module = importlib.import_module("osprey.cli.main")
+
+            @click.command("boom")
+            def boom():
+                raise RuntimeError("Container runtime installed but not running")
+
+            # LazyGroup resolves verbs from a fixed table and returns None for
+            # anything else, so the failing verb is spliced into that lookup.
+            original = main_module.LazyGroup.get_command
+            main_module.LazyGroup.get_command = (
+                lambda self, ctx, name: boom if name == "boom" else original(self, ctx, name)
+            )
+            sys.exit(entry())
+            """
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", program, "boom"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert "Traceback (most recent call last)" not in result.stderr
+        assert "Container runtime installed but not running" in result.stderr
+        assert result.returncode == 1
+
+    def test_a_multi_line_failure_keeps_its_headline_on_the_summary_line(self, capsys):
+        """A raised message with detail arrives as summary + indented cause.
+
+        Nearly every failure that reaches this handler is a refusal written for
+        an operator to read — the container-runtime checks are the loudest of
+        them — and those arrive as a headline followed by the steps that fix
+        it. :func:`osprey.cli.output.fail` documents its first argument as one
+        line and paints it in the error style, so handing it the whole block
+        prints a numbered list in red with no structure. The split is what
+        makes the last-resort path wear the same shape as the refusals the
+        verbs render deliberately.
+        """
+        module, attribute = _console_script_target()
+        message = (
+            "Docker Desktop is not running.\n"
+            "\n"
+            "To fix this:\n"
+            "1. Open Docker Desktop from Applications"
+        )
+
+        entry = getattr(importlib.import_module(module), attribute)
+        with mock.patch(f"{module}.cli", side_effect=RuntimeError(message)):
+            with pytest.raises(SystemExit):
+                entry()
+
+        lines = capsys.readouterr().err.splitlines()
+        assert lines[0] == "✗ Docker Desktop is not running."
+        assert "  To fix this:" in lines
+        assert "  1. Open Docker Desktop from Applications" in lines

--- a/tests/cli/test_preset_dependency_pin.py
+++ b/tests/cli/test_preset_dependency_pin.py
@@ -1,0 +1,121 @@
+"""Pin: a bundled preset must not need a profile ``dependencies:`` entry.
+
+A profile's ``dependencies:`` list reaches exactly three places, all of them the
+*deployed project's*: the project venv at ``build/.venv``, the ``pyproject.toml``
+recorded beside it, and the install line of the project image. It never reaches
+the interpreter running the ``osprey`` CLI — and some of what a deploy does runs
+there, in-process, notably the archiver store's seeding (see
+``container_lifecycle._stage_archiver_store``).
+
+That gap is why the ``control-assistant`` preset once carried
+``dependencies: [pymongo>=4.0]`` and ``osprey up`` still refused: the entry was
+real, it did install pymongo into all three project environments, and none of
+them was the one doing the seeding. The declaration looked like the fix, which
+is what kept the actual problem — a framework dependency filed as an optional
+extra — out of sight.
+
+So the rule pinned here is the one that was violated, not the symptom: a preset
+OSPREY ships must be deployable from a plain ``pip install osprey-framework``. A
+non-empty entry below is a claim that a package OSPREY does not ship is
+nonetheless required by a preset OSPREY does ship. That is a legitimate thing to
+want — a facility toolkit the agent imports inside the Python executor is
+project business, not framework business — but it is worth stopping over,
+because the same line is indistinguishable from the mistake above. Add the entry
+knowingly, with the reason beside it.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from osprey.cli.build_profile import _load_preset_raw, list_presets
+
+#: preset name -> the ``dependencies:`` it declares in its own file.
+#:
+#: Raw rather than resolved, deliberately: this pins what an author edits. A
+#: value inherited through ``extends:`` shows up on the base that declares it,
+#: which is where the decision was made.
+PINNED_PRESET_DEPENDENCIES: dict[str, list[str]] = {
+    "ariel-standalone": [],
+    "channel-finder-standalone": [],
+    # Emptied when pymongo became a core OSPREY dependency. Before that this
+    # read ``[pymongo>=4.0]`` — see the module docstring.
+    "control-assistant": [],
+    "control-assistant-ariel": [],
+    "control-assistant-readonly": [],
+    "control-assistant-readwrite": [],
+    "hello-world": [],
+}
+
+#: Packages a deploy imports in the CLI's own process, which therefore cannot be
+#: supplied by any profile. Each must be a core dependency of the framework.
+HOST_SIDE_PACKAGES = {
+    # container_lifecycle._preflight_archiver_pymongo and, behind it,
+    # _stage_archiver_store -> simulation.apply.archiver_collection.
+    "pymongo",
+}
+
+
+def _distribution_name(spec: str) -> str:
+    """The bare distribution name from a requirement string."""
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+
+    return canonicalize_name(Requirement(spec).name)
+
+
+def _framework_pyproject() -> dict:
+    root = Path(__file__).resolve().parents[2]
+    return tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def test_bundled_preset_set_is_pinned():
+    """A new preset must be classified here before it ships.
+
+    Without this the comparison below would silently skip an unpinned preset,
+    and the pin would degrade as presets are added.
+    """
+    assert list_presets() == sorted(PINNED_PRESET_DEPENDENCIES)
+
+
+def test_every_bundled_preset_declares_the_dependencies_it_is_pinned_to():
+    """No bundled preset asks for a package OSPREY does not already ship."""
+    actual = {
+        name: list(_load_preset_raw(name)[0].get("dependencies", []) or [])
+        for name in list_presets()
+    }
+    assert actual == PINNED_PRESET_DEPENDENCIES
+
+
+def test_host_side_packages_are_core_dependencies():
+    """A package the CLI imports during a deploy cannot live behind an extra.
+
+    This is the check that would have caught the original mistake at the commit
+    that made it, rather than at a deploy months later: pymongo was reachable
+    only through the ``archiver-mongodb`` extra while a shipped preset's deploy
+    path imported it unconditionally.
+    """
+    core = {_distribution_name(spec) for spec in _framework_pyproject()["project"]["dependencies"]}
+    missing = sorted(HOST_SIDE_PACKAGES - core)
+    assert not missing, (
+        f"{missing} are imported by the deploy path in the CLI's own process, "
+        "so they must be core dependencies — no profile can supply them"
+    )
+
+
+def test_host_side_packages_are_not_also_optional():
+    """An extra that re-declares a core dependency invites the floor to drift.
+
+    It also leaves an install command in circulation that reads as necessary and
+    is not: pip only *warns* about an extra that does not exist, so a stale hint
+    sends the reader to install nothing and hit the same failure again.
+    """
+    extras = _framework_pyproject()["project"].get("optional-dependencies", {})
+    offenders = {
+        f"{extra}: {spec}"
+        for extra, specs in extras.items()
+        for spec in specs
+        if _distribution_name(spec) in HOST_SIDE_PACKAGES
+    }
+    assert not offenders, sorted(offenders)

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -39,15 +39,20 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved when the control-assistant preset turned password login on for its
     # web terminals (auth stanza, ariel's `login: false`, demo passwords under
     # `env.defaults`). All four moved together, as the note above predicts.
-    "control-assistant": "sha256:71f3f6e282f6e9c64d76d933310b973fda3dff3f9ba891cfb2f3aac5682d3cfb",
+    # Moved again when pymongo became a core OSPREY dependency and the preset
+    # dropped its `dependencies: [pymongo>=4.0]` line. Behavior-neutral for a
+    # rebuilt project — pymongo still lands in its venv, now from the base
+    # install rather than the profile — but the generated pyproject.toml no
+    # longer names it, so the advisory firing is correct.
+    "control-assistant": "sha256:7410d74d603fefa04d8ad79e042782da32b01a9acb0ca8871786e93ad3d65f13",
     "control-assistant-ariel": (
-        "sha256:fbf54b9933426ceeac2e4a5e018422fcfcc777f7e6f8eaa6c6475eed704f0877"
+        "sha256:9e71eaa1c45afcf201a12a1722fab5b80ffcb059ff45b0d602785c7e37a1cea5"
     ),
     "control-assistant-readonly": (
-        "sha256:479a6dc1652f3b7ff8866d62dcef6f7e4fdb147f912f2966dea6fa85f2a1d921"
+        "sha256:8a304867bb0f9d2aab63d6ebd3490780d6e720780d01562a72c92ce62ddc46f5"
     ),
     "control-assistant-readwrite": (
-        "sha256:7633397e5dfbe696da4a3298ff2511201f64bd8e22b68ecadfcd502aa5a1f77d"
+        "sha256:2a9af46cc9affb350db60b7df30ebc58f51d3ce19634ae05292e67d40bad60e2"
     ),
     # Moved when the onboarding rewrite dropped the `facility` rule. The
     # wholesale comment rewrite that shipped alongside it contributed nothing:

--- a/tests/cli/test_reset_plan_parity.py
+++ b/tests/cli/test_reset_plan_parity.py
@@ -106,6 +106,22 @@ def runtime(target: Path, monkeypatch: pytest.MonkeyPatch) -> FakeRuntime:
     return fake
 
 
+@pytest.fixture(autouse=True)
+def container_runtime_is_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Get ``init --reset`` past its up-front runtime check.
+
+    That check reads the real daemon on purpose — it is what stops the verb
+    from creating a repo it cannot finish — and it is upstream of the
+    ``_default_probe`` seam the ``runtime`` fixture injects at, so without this
+    the file's subject would depend on whether the host running it has Docker
+    open.
+    """
+    monkeypatch.setattr(
+        "osprey.deployment.runtime_helper.verify_runtime_is_running",
+        lambda config=None: (True, ""),
+    )
+
+
 @pytest.fixture
 def no_destruction(monkeypatch: pytest.MonkeyPatch) -> list[ResetPlan]:
     """Stub the removals, and record the plan each verb was about to run.

--- a/tests/cli/test_summary_card.py
+++ b/tests/cli/test_summary_card.py
@@ -83,6 +83,29 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def _container_runtime_is_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer ``init``'s runtime preflight without consulting the host.
+
+    ``--reset`` and ``--up`` are refused up front when no container runtime
+    answers, which is the right behaviour and the wrong dependency for a unit
+    test: left unstubbed these tests pass on a developer's machine with Docker
+    Desktop open and fail on a CI runner that has no daemon, which is a
+    property of the runner rather than of the verb.
+
+    Patched on ``runtime_helper`` itself because that is where the preflight
+    reads it from, at call time. The other callers of this function bind it at
+    import into their own modules, so this reaches exactly the one check these
+    tests need to get past and none of theirs.
+    ``TestContainerRuntimePreflight`` patches it back down, in the test body,
+    where it wins over this.
+    """
+    monkeypatch.setattr(
+        "osprey.deployment.runtime_helper.verify_runtime_is_running",
+        lambda config=None: (True, ""),
+    )
+
+
 @pytest.fixture
 def recorder():
     """Install a recording reporter for the duration of one test."""

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -557,11 +557,18 @@ class TestControlAssistantMongoDBTemplate:
         return path.read_text(encoding="utf-8")
 
     def test_template_documents_mongodb_option(self):
-        """The options comment must list mongodb_archiver and name the extra."""
+        """The options comment must list mongodb_archiver, and must not send the
+        reader after an install that no longer exists.
+
+        pymongo is a core dependency; the ``archiver-mongodb`` extra is gone, and
+        pip accepts an unknown extra with a warning rather than an error — so a
+        stale hint here would have a reader install nothing and hit the same
+        failure again.
+        """
         template = self._template_text()
 
         assert "#   - mongodb_archiver:" in template
-        assert "archiver-mongodb" in template
+        assert "archiver-mongodb" not in template
 
     def test_template_shows_required_mongodb_keys(self):
         """A LIVE block covers every key the connector refuses to default.

--- a/tests/connectors/conftest.py
+++ b/tests/connectors/conftest.py
@@ -20,8 +20,7 @@ def mongodb_container():
     """Start a MongoDB container for the test session.
 
     Yields a dict with connection parameters. Skips the entire chain
-    of dependent tests if Docker isn't available or pymongo isn't
-    installed (i.e., the ``archiver-mongodb`` extra wasn't selected).
+    of dependent tests if Docker isn't available.
     """
     if not is_docker_available():
         pytest.skip(

--- a/tests/connectors/test_mongodb_archiver_connector.py
+++ b/tests/connectors/test_mongodb_archiver_connector.py
@@ -199,10 +199,13 @@ class TestImportErrorHandling:
             with pytest.raises(ImportError) as exc_info:
                 await connector.connect(mongodb_config)
 
-            # Naming the extra, not the bare package: that is how a user of
-            # this framework actually installs the dependency.
+            # pymongo is a declared dependency of osprey-connectors, so the
+            # message must name the package to reinstall — not an extra to
+            # select, which would send the reader after one that no longer
+            # exists.
             assert "pymongo is required" in str(exc_info.value)
-            assert "osprey-framework[archiver-mongodb]" in str(exc_info.value)
+            assert "osprey-connectors" in str(exc_info.value)
+            assert "archiver-mongodb" not in str(exc_info.value)
 
 
 @pytest.mark.integration

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -2476,23 +2476,22 @@ def test_archiver_world_job_has_no_llm_secret__mutation_adds_secret() -> None:
         assert not _job_declares_secret(mutated, ARCHIVER_JOB, SECRET_TOKEN)
 
 
-def test_archiver_world_job_installs_the_pymongo_extra(workflow: dict[str, Any]) -> None:
-    """The staged bring-up preflights pymongo before any image build, so without
-    the extra this lane aborts in seconds with an install hint instead of running
-    — a green-looking job that tested nothing."""
+def test_archiver_world_job_installs_osprey(workflow: dict[str, Any]) -> None:
+    """The staged bring-up preflights pymongo before any image build, so a lane
+    that never installed osprey would abort in seconds with an install hint
+    instead of running — a green-looking job that tested nothing. pymongo is a
+    core dependency, so a plain sync is enough; there is no extra to select."""
     installed = json.dumps(_jobs(workflow)[ARCHIVER_JOB])
-    assert "archiver-mongodb" in installed, (
-        f"the '{ARCHIVER_JOB}' lane must `uv sync` the archiver-mongodb extra"
-    )
+    assert "uv sync" in installed, f"the '{ARCHIVER_JOB}' lane must install osprey"
 
 
-def test_archiver_world_job_installs_the_pymongo_extra__mutation_drops_extra() -> None:
+def test_archiver_world_job_installs_osprey__mutation_drops_sync() -> None:
     mutated = copy.deepcopy(_load_workflow())
     mutated["jobs"][ARCHIVER_JOB] = json.loads(
-        json.dumps(mutated["jobs"][ARCHIVER_JOB]).replace(" --extra archiver-mongodb", "")
+        json.dumps(mutated["jobs"][ARCHIVER_JOB]).replace("uv sync", "true")
     )
     with pytest.raises(AssertionError):
-        test_archiver_world_job_installs_the_pymongo_extra(mutated)
+        test_archiver_world_job_installs_osprey(mutated)
 
 
 def test_archiver_world_job_runs_pytest_unbuffered(workflow: dict[str, Any]) -> None:

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -18,7 +18,11 @@ from pathlib import Path
 import pytest
 
 from osprey.deployment import container_lifecycle
-from osprey.deployment.errors import UnmetPreconditionsError
+from osprey.deployment.errors import (
+    ArchiverClientMissingError,
+    DeploymentPreconditionError,
+    UnmetPreconditionsError,
+)
 from osprey.deployment.web_terminals import postup_hooks, provision
 
 
@@ -2325,7 +2329,7 @@ def test_deploy_without_the_store_service_stages_nothing(captured_argv, monkeypa
 
 
 def test_pymongo_preflight_aborts_before_any_container_work(monkeypatch, tmp_path):
-    """Naming the extra in seconds beats an ImportError after a minutes-long
+    """Naming the install in seconds beats an ImportError after a minutes-long
     image build, so the check sits beside the token mint, not at the seeder."""
     import sys
 
@@ -2344,14 +2348,49 @@ def test_pymongo_preflight_aborts_before_any_container_work(monkeypatch, tmp_pat
     monkeypatch.setattr(
         container_lifecycle.subprocess, "run", lambda *a, **k: ran.append("compose")
     )
-    # A None entry in sys.modules is what an absent optional extra looks like to
+    # A None entry in sys.modules is what an incomplete environment looks like to
     # `import pymongo` — the import machinery raises ImportError without touching
     # the installed package.
     monkeypatch.setitem(sys.modules, "pymongo", None)
 
-    with pytest.raises(RuntimeError, match=r"osprey-framework\[archiver-mongodb\]"):
+    with pytest.raises(ArchiverClientMissingError) as exc_info:
         container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
     assert ran == []
+    assert "pip install --upgrade osprey-framework" in exc_info.value.remedy
+
+
+def test_pymongo_preflight_refusal_names_the_interpreter(monkeypatch):
+    """The refusal has to say WHICH environment is missing pymongo.
+
+    A `dependencies:` entry in the build profile installs into the project's
+    `build/.venv`, its recorded pyproject.toml and its image — never into the
+    interpreter running the CLI, which is where the seeder runs. An operator who
+    has declared pymongo and still sees this refusal has already tried the
+    obvious lever, so the reason names `sys.executable` and says that entry is
+    not the one, rather than repeating "pymongo is not installed" at them.
+    """
+    import sys
+
+    monkeypatch.setitem(sys.modules, "pymongo", None)
+
+    with pytest.raises(ArchiverClientMissingError) as exc_info:
+        container_lifecycle._preflight_archiver_pymongo(dict(ARCHIVER_CONFIG))
+
+    reason = exc_info.value.reason
+    assert sys.executable in reason
+    assert "build/.venv" in reason
+    assert "dependencies:" in reason
+
+
+def test_pymongo_preflight_refusal_is_a_precondition_not_a_bug():
+    """It must leave `up` through the precondition handler, not the catch-all.
+
+    `deploy_cmd.up_verb` renders `DeploymentPreconditionError` as a refusal with
+    a remedy and renders everything else as "Deployment failed". A bare
+    RuntimeError here would be indistinguishable from a genuine bug — which is
+    exactly what DeploymentPreconditionError's own docstring forbids.
+    """
+    assert issubclass(ArchiverClientMissingError, DeploymentPreconditionError)
 
 
 def test_pymongo_preflight_is_silent_without_the_store_service():

--- a/tests/deployment/test_openobserve_token_mint.py
+++ b/tests/deployment/test_openobserve_token_mint.py
@@ -360,7 +360,8 @@ def test_writing_the_email_is_idempotent(tmp_path, monkeypatch):
 # Password SHAPE. This store is a localhost demo backend whose password a human
 # reads off a terminal and types into a browser login form — the only minted
 # credential in the system with a human in the loop. The length is chosen for
-# that, and bounded by the expose-time refusal below.
+# that; every character still comes from ``secrets``, so the value is short
+# without being guessable.
 # ---------------------------------------------------------------------------
 
 
@@ -382,15 +383,26 @@ def test_minted_password_avoids_visually_ambiguous_characters():
 
 
 # ---------------------------------------------------------------------------
-# Off-host exposure raises the bar. Minting is idempotent, so a short password
-# minted on a loopback deploy SURVIVES a later `osprey up --expose` — scoping
-# the recipe to expose_network at mint time would be false comfort. The refusal
-# is what makes the short mint safe: it reads the effective value on every
-# exposed deploy, whatever its origin.
+# Off-host exposure does NOT impose a length bar. A character count is the wrong
+# instrument for this credential: it would reject the CSPRNG-minted value while
+# admitting a longer, guessable one an operator typed. The only attack this
+# password faces is online guessing against an HTTP login form, where ~65 bits
+# is many orders of magnitude out of reach. What an exposed deploy still
+# refuses is a password that is ABSENT (the empty-token rule, covered in
+# test_container_lifecycle) or PUBLIC (the published compose default, below) —
+# the two failures a length has no opinion about.
 # ---------------------------------------------------------------------------
 
 
-def test_an_exposed_deploy_refuses_the_short_demo_password(tmp_path, monkeypatch):
+def test_an_exposed_deploy_accepts_the_minted_demo_password(tmp_path, monkeypatch):
+    """osprey must never refuse a value it minted itself.
+
+    Minting is idempotent, so the password from a loopback demo is still in
+    ``.env`` when the project is later brought up exposed. That is not an edge
+    case: every deployment carrying web terminals counts as exposed, which is
+    the ordinary shape of a shipped preset, so a self-refusal here would break
+    the first ``osprey up`` on a project whose operator did nothing wrong.
+    """
     monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
     monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
     env_path = tmp_path / ".env"
@@ -399,11 +411,9 @@ def test_an_exposed_deploy_refuses_the_short_demo_password(tmp_path, monkeypatch
     container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
     minted = _parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"]
 
-    with pytest.raises(RuntimeError, match="ZO_ROOT_USER_PASSWORD") as exc_info:
-        container_lifecycle._ensure_service_tokens(config, expose_network=True, env_path=env_path)
+    container_lifecycle._ensure_service_tokens(config, expose_network=True, env_path=env_path)
 
-    assert minted not in str(exc_info.value)
-    assert "reachable off-host" in str(exc_info.value)
+    assert _parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"] == minted
 
 
 def test_an_exposed_deploy_accepts_a_long_operator_password(tmp_path, monkeypatch):
@@ -421,7 +431,6 @@ def test_an_exposed_deploy_accepts_a_long_operator_password(tmp_path, monkeypatc
 
 
 def test_a_loopback_deploy_accepts_the_short_demo_password(tmp_path, monkeypatch):
-    """The refusal must not fire on the ordinary demo deploy it exists to allow."""
     monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
     monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
     env_path = tmp_path / ".env"
@@ -431,22 +440,6 @@ def test_a_loopback_deploy_accepts_the_short_demo_password(tmp_path, monkeypatch
     container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
 
     assert len(_parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"]) == 12
-
-
-def test_the_exposure_bar_is_opt_in_per_var(tmp_path, monkeypatch):
-    """A short token on an unregistered var is not this rule's business.
-
-    The dispatch tokens are machine-to-machine and carry their own recipes; the
-    length bar exists for the one credential a human shortened on purpose.
-    """
-    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "short1")
-    monkeypatch.setenv("DISPATCH_WORKER_TOKEN", "short2")
-
-    container_lifecycle._ensure_service_tokens(
-        {"deployed_services": ["event_dispatcher"]},
-        expose_network=True,
-        env_path=tmp_path / ".env",
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_openobserve_token_mint.py
+++ b/tests/deployment/test_openobserve_token_mint.py
@@ -21,6 +21,7 @@ this entry different from every other minted token and are pinned here:
 from __future__ import annotations
 
 import base64
+import os
 import re
 from pathlib import Path
 
@@ -64,7 +65,11 @@ def test_openobserve_password_generator_always_satisfies_policy():
     )
     # Its own validator must agree with the policy check on every mint.
     assert all(container_lifecycle._validate_openobserve_password(p) for p in pws)
-    # Strong + random: >=256 bits of entropy means unique values across the sample.
+    # Random, not patterned. This recipe mints deliberately short (see the
+    # human-legibility exception in _VAR_GENERATORS), so the bar here is
+    # per-deploy uniqueness rather than the module's 256-bit default: ~65 bits
+    # over this sample makes a collision astronomically unlikely, and a repeat
+    # would mean the recipe is drawing from something other than `secrets`.
     assert len(set(pws)) == _MINT_SAMPLES, "generator is not random"
 
 
@@ -106,9 +111,15 @@ def test_deploying_openobserve_mints_a_policy_valid_password_every_time(tmp_path
         assert _satisfies_openobserve_policy(pw), f"mint {i} would crash-loop OpenObserve: {pw!r}"
 
 
-def test_openobserve_mint_does_not_mint_the_email(tmp_path, monkeypatch):
-    """Only the password is a secret; the email is a username with a non-secret
-    default, so it is never fabricated into .env."""
+def test_openobserve_mint_writes_both_halves_of_the_login(tmp_path, monkeypatch):
+    """The password is minted; the account email is written at its default.
+
+    Not because the email is a secret — it is a username — but because a login
+    nobody can find is a login nobody can use. Before this, the email existed
+    only as a ``:-`` fallback inline in two templates, so an operator grepping
+    ``.env`` for their credentials found half a login and no hint where the
+    other half lived.
+    """
     monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
     monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
     config = {"deployed_services": ["openobserve"]}
@@ -118,7 +129,7 @@ def test_openobserve_mint_does_not_mint_the_email(tmp_path, monkeypatch):
 
     env = _parse_dotenv(env_path)
     assert env.get("ZO_ROOT_USER_PASSWORD")
-    assert "ZO_ROOT_USER_EMAIL" not in env
+    assert env.get("ZO_ROOT_USER_EMAIL") == "root@example.com"
 
 
 def test_openobserve_mint_is_idempotent(tmp_path, monkeypatch):
@@ -224,6 +235,218 @@ def test_ensure_service_tokens_accepts_a_strong_operator_password(tmp_path, monk
 def test_service_token_vars_map_includes_openobserve():
     """Lock in the map shape: only the password, not the email."""
     assert container_lifecycle._SERVICE_TOKEN_VARS["openobserve"] == ("ZO_ROOT_USER_PASSWORD",)
+
+
+# ---------------------------------------------------------------------------
+# The account email — a NON-SECRET written for discoverability, which is why it
+# lives in its own map rather than in _SERVICE_TOKEN_VARS. That map's contract
+# is "machine-generated secret, minted through _VAR_GENERATORS"; a constant
+# email registered there would have to declare a generator, and every generator
+# is bound by the module's CSPRNG bar. Two concerns, two maps.
+# ---------------------------------------------------------------------------
+
+
+def test_the_written_email_matches_the_fallback_the_template_ships():
+    """The default written to ``.env`` must be the value the container would
+    otherwise have used, or writing it down CHANGES the login instead of
+    recording it.
+
+    Parsed out of the shipped template rather than restated, for the same reason
+    ``TestPublishedDefaultIsRefused`` parses the password fallback: a template
+    edit that moves the default while this map keeps the old one would silently
+    hand operators an email their store does not know.
+    """
+    import osprey.templates
+
+    template = (
+        Path(osprey.templates.__file__).parent
+        / "services"
+        / "openobserve"
+        / "docker-compose.yml.j2"
+    )
+    shipped = re.search(r"\$\{ZO_ROOT_USER_EMAIL:-([^}]*)\}", template.read_text(encoding="utf-8"))
+    assert shipped, f"no ${{ZO_ROOT_USER_EMAIL:-...}} fallback found in {template}"
+
+    written = dict(container_lifecycle._SERVICE_DEFAULT_VARS["openobserve"])
+    assert written["ZO_ROOT_USER_EMAIL"] == shipped.group(1)
+
+
+def test_an_operator_email_is_never_overwritten(tmp_path, monkeypatch):
+    monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+    monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
+    env_path = tmp_path / ".env"
+    env_path.write_text("ZO_ROOT_USER_EMAIL=ops@facility.example\n", encoding="utf-8")
+
+    container_lifecycle._ensure_service_tokens(
+        {"deployed_services": ["openobserve"]}, expose_network=False, env_path=env_path
+    )
+
+    assert _parse_dotenv(env_path)["ZO_ROOT_USER_EMAIL"] == "ops@facility.example"
+    assert env_path.read_text().count("ZO_ROOT_USER_EMAIL=") == 1
+
+
+def test_a_stale_empty_export_does_not_outrank_the_written_email(tmp_path, monkeypatch):
+    """Writing the line is not enough if the process still says otherwise.
+
+    The deploy loads the project ``.env`` over its own environment before
+    reaching here, so a name the file spells empty leaves an empty copy in
+    ``os.environ``. That copy outranks the ``--env-file`` line for compose's
+    interpolation, so the container would receive the empty value while ``.env``
+    shows the default — the account name written down and not delivered. The
+    mint repairs exactly this for the secrets it generates; the defaults block
+    has to repair it too or it is only half a fix.
+    """
+    monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+    monkeypatch.setenv("ZO_ROOT_USER_EMAIL", "")
+    env_path = tmp_path / ".env"
+    env_path.write_text("ZO_ROOT_USER_EMAIL=\n", encoding="utf-8")
+
+    container_lifecycle._ensure_service_tokens(
+        {"deployed_services": ["openobserve"]}, expose_network=False, env_path=env_path
+    )
+
+    assert _parse_dotenv(env_path)["ZO_ROOT_USER_EMAIL"] == "root@example.com"
+    assert os.environ["ZO_ROOT_USER_EMAIL"] == "root@example.com"
+
+
+def test_the_email_is_written_even_when_the_password_already_exists(tmp_path, monkeypatch):
+    """The upgrade path, and the reason this cannot ride along with the mint.
+
+    Every project deployed before the email was written has a ``.env`` carrying
+    a password and no email. The mint is idempotent, so it generates nothing on
+    that project's next deploy — if writing the email were folded into the
+    minted block it would never run, and exactly the deployments that need the
+    line would be the ones that never get it.
+    """
+    monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+    monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
+    env_path = tmp_path / ".env"
+    env_path.write_text("ZO_ROOT_USER_PASSWORD=MyStr0ng#Facility@Pass\n", encoding="utf-8")
+
+    container_lifecycle._ensure_service_tokens(
+        {"deployed_services": ["openobserve"]}, expose_network=False, env_path=env_path
+    )
+
+    assert _parse_dotenv(env_path)["ZO_ROOT_USER_EMAIL"] == "root@example.com"
+
+
+def test_no_email_is_written_when_openobserve_is_not_deployed(tmp_path, monkeypatch):
+    """Keyed by deployed service, exactly like the token map."""
+    monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
+    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "a" * 40)
+    monkeypatch.setenv("DISPATCH_WORKER_TOKEN", "b" * 40)
+    env_path = tmp_path / ".env"
+
+    container_lifecycle._ensure_service_tokens(
+        {"deployed_services": ["event_dispatcher"]}, expose_network=False, env_path=env_path
+    )
+
+    assert "ZO_ROOT_USER_EMAIL" not in _parse_dotenv(env_path)
+
+
+def test_writing_the_email_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+    monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
+    env_path = tmp_path / ".env"
+    config = {"deployed_services": ["openobserve"]}
+
+    container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+    container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+
+    assert env_path.read_text().count("ZO_ROOT_USER_EMAIL=") == 1
+
+
+# ---------------------------------------------------------------------------
+# Password SHAPE. This store is a localhost demo backend whose password a human
+# reads off a terminal and types into a browser login form — the only minted
+# credential in the system with a human in the loop. The length is chosen for
+# that, and bounded by the expose-time refusal below.
+# ---------------------------------------------------------------------------
+
+
+def test_minted_password_is_short_enough_to_type():
+    for _ in range(_MINT_SAMPLES):
+        assert len(container_lifecycle._generate_openobserve_password()) == 12
+
+
+def test_minted_password_avoids_visually_ambiguous_characters():
+    """``l I 1 O 0`` are the characters people transcribe wrongly off a screen.
+
+    A password you cannot read back is as bad as one you cannot type, and a
+    failed OpenObserve login says nothing about which character was misread.
+    """
+    ambiguous = set("lI1O0")
+    for _ in range(_MINT_SAMPLES):
+        pw = container_lifecycle._generate_openobserve_password()
+        assert not (set(pw) & ambiguous), f"minted an easily-misread password: {pw!r}"
+
+
+# ---------------------------------------------------------------------------
+# Off-host exposure raises the bar. Minting is idempotent, so a short password
+# minted on a loopback deploy SURVIVES a later `osprey up --expose` — scoping
+# the recipe to expose_network at mint time would be false comfort. The refusal
+# is what makes the short mint safe: it reads the effective value on every
+# exposed deploy, whatever its origin.
+# ---------------------------------------------------------------------------
+
+
+def test_an_exposed_deploy_refuses_the_short_demo_password(tmp_path, monkeypatch):
+    monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+    monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
+    env_path = tmp_path / ".env"
+    config = {"deployed_services": ["openobserve"]}
+    # Mint on loopback, the way a demo deploy does.
+    container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+    minted = _parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"]
+
+    with pytest.raises(RuntimeError, match="ZO_ROOT_USER_PASSWORD") as exc_info:
+        container_lifecycle._ensure_service_tokens(config, expose_network=True, env_path=env_path)
+
+    assert minted not in str(exc_info.value)
+    assert "reachable off-host" in str(exc_info.value)
+
+
+def test_an_exposed_deploy_accepts_a_long_operator_password(tmp_path, monkeypatch):
+    monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+    monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
+    env_path = tmp_path / ".env"
+    strong = "Str0ng@Facility%Password%ForRealDeployments"
+    env_path.write_text(f"ZO_ROOT_USER_PASSWORD={strong}\n", encoding="utf-8")
+
+    container_lifecycle._ensure_service_tokens(
+        {"deployed_services": ["openobserve"]}, expose_network=True, env_path=env_path
+    )
+
+    assert _parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"] == strong
+
+
+def test_a_loopback_deploy_accepts_the_short_demo_password(tmp_path, monkeypatch):
+    """The refusal must not fire on the ordinary demo deploy it exists to allow."""
+    monkeypatch.delenv("ZO_ROOT_USER_PASSWORD", raising=False)
+    monkeypatch.delenv("ZO_ROOT_USER_EMAIL", raising=False)
+    env_path = tmp_path / ".env"
+    config = {"deployed_services": ["openobserve"]}
+
+    container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+    container_lifecycle._ensure_service_tokens(config, expose_network=False, env_path=env_path)
+
+    assert len(_parse_dotenv(env_path)["ZO_ROOT_USER_PASSWORD"]) == 12
+
+
+def test_the_exposure_bar_is_opt_in_per_var(tmp_path, monkeypatch):
+    """A short token on an unregistered var is not this rule's business.
+
+    The dispatch tokens are machine-to-machine and carry their own recipes; the
+    length bar exists for the one credential a human shortened on purpose.
+    """
+    monkeypatch.setenv("EVENT_DISPATCHER_TOKEN", "short1")
+    monkeypatch.setenv("DISPATCH_WORKER_TOKEN", "short2")
+
+    container_lifecycle._ensure_service_tokens(
+        {"deployed_services": ["event_dispatcher"]},
+        expose_network=True,
+        env_path=tmp_path / ".env",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -148,11 +148,6 @@ model: haiku   # tier (haiku/sonnet/opus), or a model ID the provider serves
 # also accepts in_context or middle_layer.
 channel_finder_mode: hierarchical
 
-# Extra Python packages your agent needs. pymongo is required by the stored
-# archive declared under `va_archiver:` below.
-dependencies:
-  - pymongo>=4.0
-
 # ── What the agent can do ────────────────────────────────────────────────────
 # Each entry is a name from the OSPREY artifact library. Delete what you do not
 # need; add your own through an overlay.

--- a/tests/interfaces/ariel/render-xss.test.mjs
+++ b/tests/interfaces/ariel/render-xss.test.mjs
@@ -325,6 +325,43 @@ describe('pagination (entries.js renderPagination, via delegated click)', () => 
     await vi.waitFor(() => expect(entriesApi.list).toHaveBeenCalledTimes(2));
     expect(vi.mocked(entriesApi.list).mock.calls[1][0]).toMatchObject({ page: 2 });
   });
+
+  test('both pager buttons always render; the ends disable them instead of removing them', async () => {
+    // The pager row is centred, so a button coming and going re-centres the
+    // whole row and moves every other member by half the delta — and the first
+    // click of Next is exactly what brings Previous into existence, sliding
+    // Next out from under the cursor on the one gesture people repeat to page
+    // through a list. Disabled-at-the-ends keeps the geometry constant for the
+    // whole run; this asserts the DOM contract that guarantees it.
+    const entry = {
+      entry_id: 'e1',
+      timestamp: '2026-01-01T00:00:00Z',
+      author: 'a',
+      source_system: 's',
+      raw_text: 'body',
+      score: null,
+      attachments: [],
+      keywords: [],
+      highlights: [],
+    };
+    const list = /** @type {HTMLElement} */ (document.getElementById('entries-list'));
+
+    // First page: Previous exists but is disabled, Next is live.
+    vi.mocked(entriesApi.list).mockResolvedValueOnce({ entries: [entry], total: 60, page: 1, total_pages: 3 });
+    await loadEntries();
+    let buttons = list.querySelectorAll('.pagination [data-page]');
+    expect(buttons.length, 'both buttons render on the first page').toBe(2);
+    expect(/** @type {HTMLButtonElement} */ (buttons[0]).disabled, 'Previous disabled at the start').toBe(true);
+    expect(/** @type {HTMLButtonElement} */ (buttons[1]).disabled, 'Next live at the start').toBe(false);
+
+    // Last page: the mirror image.
+    vi.mocked(entriesApi.list).mockResolvedValueOnce({ entries: [entry], total: 60, page: 3, total_pages: 3 });
+    await loadEntries({ page: 3 });
+    buttons = list.querySelectorAll('.pagination [data-page]');
+    expect(buttons.length, 'both buttons render on the last page').toBe(2);
+    expect(/** @type {HTMLButtonElement} */ (buttons[0]).disabled, 'Previous live at the end').toBe(false);
+    expect(/** @type {HTMLButtonElement} */ (buttons[1]).disabled, 'Next disabled at the end').toBe(true);
+  });
 });
 
 describe('cited-source link (components.js renderAnswerBox, via performSearch + delegated click)', () => {

--- a/tests/interfaces/bluesky_web/bluesky-panel.test.mjs
+++ b/tests/interfaces/bluesky_web/bluesky-panel.test.mjs
@@ -1642,10 +1642,29 @@ describe('abortControl', () => {
 });
 
 describe('abort button label and class', () => {
-  test('two steps, and the second states what it does', () => {
+  test('two steps, and the armed one names the act', () => {
     expect(abortButtonLabel(false)).toBe(ABORT_LABEL);
     expect(abortButtonLabel(true)).toBe(CONFIRM_ABORT_LABEL);
-    expect(CONFIRM_ABORT_LABEL).toContain('hardware stays put');
+    expect(CONFIRM_ABORT_LABEL.toLowerCase()).toContain('abort');
+  });
+
+  test('the armed label never outgrows the resting one, so Stop cannot move', () => {
+    // The status strip is a right-anchored cluster, so a member's position
+    // depends only on the widths of the members AFTER it — which makes Abort,
+    // the rightmost, the thing that positions the plain Stop beside it.
+    // panel.css floors #abort-btn at its resting label width; the floor only
+    // holds while every other label this button can show is shorter. A longer
+    // one pushes the box past its floor and drags Stop sideways at the moment
+    // an operator is choosing between the two halts — and the widened Abort
+    // lands on the pixels Stop just vacated, so a click meant for Stop commits
+    // the abort. That is the defect the two-step confirm exists to prevent, so
+    // the confirm must not reintroduce it.
+    //
+    // Asserted on the constants, not rendered geometry: the CSS floor is safe
+    // by construction (1ch per resting character), the copy is what drifts.
+    // Stop's own labels are deliberately NOT constrained — it is inboard of
+    // Abort, so its width moves nothing but itself.
+    expect(CONFIRM_ABORT_LABEL.length).toBeLessThanOrEqual(ABORT_LABEL.length);
   });
 
   test('the caution class is on the armed step only', () => {
@@ -2464,12 +2483,17 @@ describe('the merged panel shell', () => {
     expect(search.placeholder).toContain('Filter plans');
   });
 
-  test('the filter is contributed before the view switcher, so it renders left of it', async () => {
-    // The hub right-anchors every interactive item into ONE cluster and lays
-    // it out in contribution order (dockview-overrides.css gives them all the
-    // same flex `order`), so this array IS the left-to-right arrangement in
-    // the tile bar. Filter first, switcher second — the same pairing the
-    // Artifacts gallery contributes.
+  test('the view switcher is contributed last, so the conditional filter cannot move it', async () => {
+    // The hub right-anchors the interactive items into ONE cluster against the
+    // close button and lays it out in contribution order, so an item's arrival
+    // or departure moves everything BEFORE it and nothing after it. The filter
+    // is conditional (Plans view, Expert only); the switcher is what an
+    // operator aims at repeatedly. Switcher last therefore keeps the tab strip
+    // still, and the filter comes and goes in the slack to its left.
+    //
+    // Swap these and the strip jumps right by the filter's whole width the
+    // moment you click away from Plans — the target sliding out from under the
+    // cursor that just hit it.
     mount();
     await import(`${BUNDLE}panel.js`);
 

--- a/tests/interfaces/bluesky_web/bluesky-panel.test.mjs
+++ b/tests/interfaces/bluesky_web/bluesky-panel.test.mjs
@@ -2464,6 +2464,18 @@ describe('the merged panel shell', () => {
     expect(search.placeholder).toContain('Filter plans');
   });
 
+  test('the filter is contributed before the view switcher, so it renders left of it', async () => {
+    // The hub right-anchors every interactive item into ONE cluster and lays
+    // it out in contribution order (dockview-overrides.css gives them all the
+    // same flex `order`), so this array IS the left-to-right arrangement in
+    // the tile bar. Filter first, switcher second — the same pairing the
+    // Artifacts gallery contributes.
+    mount();
+    await import(`${BUNDLE}panel.js`);
+
+    expect(lastContribution().map((entry) => entry.kind)).toEqual(['search', 'nav']);
+  });
+
   test('Simple mode contributes no search — the hub collapses the bar there', async () => {
     // Simple deliberately ENLARGES a search box; the tile bar it would live in
     // is zero-height. The in-body one is the one on screen.

--- a/tests/interfaces/channel_finder/feedback-toolbar-order.test.mjs
+++ b/tests/interfaces/channel_finder/feedback-toolbar-order.test.mjs
@@ -1,0 +1,81 @@
+// @ts-check
+/**
+ * Regression for the feedback toolbar's button order (feedback.js _renderList).
+ *
+ * `.fb-toolbar` lays its right cluster out against the toolbar's right edge
+ * (space-between), so a member's arrival moves everything BEFORE it and
+ * nothing after it. Clear All is the conditional member — it renders only
+ * while entries exist — and it used to come LAST, which shoved the persistent
+ * `+ Add Entry` / `Export` pair sideways on the very click that created the
+ * first entry. It must be contributed FIRST, so it comes and goes in the
+ * slack to the pair's left.
+ *
+ *   npx vitest run tests/interfaces/channel_finder/feedback-toolbar-order.test.mjs
+ */
+
+import { test, expect, vi, afterEach } from 'vitest';
+
+import { mountFeedback, unmountFeedback } from '../../../src/osprey/interfaces/channel_finder/static/js/feedback.js';
+
+afterEach(() => {
+  unmountFeedback();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = '';
+});
+
+/**
+ * Stub global fetch to serve the endpoints _renderList touches.
+ * @param {any[]} entries
+ */
+function stubFeedbackApi(entries) {
+  /** @type {Record<string, any>} */
+  const routes = {
+    '/api/feedback/status': { available: true },
+    '/api/feedback': { entries },
+    '/api/pending-reviews/status': { available: false },
+  };
+  vi.stubGlobal('fetch', vi.fn(async (/** @type {string} */ url) => {
+    const payload = routes[url];
+    if (payload === undefined) throw new Error(`unstubbed fetch: ${url}`);
+    return { ok: true, json: async () => payload };
+  }));
+}
+
+/** @param {HTMLElement} container */
+async function mountAndSettle(container) {
+  mountFeedback(container);
+  await vi.waitFor(() => {
+    expect(container.querySelector('#fb-add-btn'), 'toolbar rendered').not.toBeNull();
+  });
+}
+
+test('with entries, Clear All renders BEFORE the persistent Add/Export pair', async () => {
+  document.body.innerHTML = '<div id="fb-root"></div>';
+  const container = /** @type {HTMLElement} */ (document.getElementById('fb-root'));
+
+  stubFeedbackApi([
+    { key: 'k1', query: 'q', facility: 'als', success_count: 1, failure_count: 0, last_activity: '2026-01-01T00:00:00Z' },
+  ]);
+  await mountAndSettle(container);
+
+  const cluster = /** @type {HTMLElement} */ (container.querySelector('.fb-toolbar-right'));
+  const ids = Array.from(cluster.querySelectorAll('button')).map((b) => b.id);
+  expect(ids).toEqual(['fb-clear-btn', 'fb-add-btn', 'fb-export-btn']);
+});
+
+test('with no entries, Add/Export sit exactly where they sit with entries', async () => {
+  // The invariant behind the order: the persistent pair's position in the
+  // cluster must not depend on whether the conditional member exists. Child
+  // order is the mechanism; this asserts the consequence — the pair is the
+  // cluster's tail in both states.
+  document.body.innerHTML = '<div id="fb-root"></div>';
+  const container = /** @type {HTMLElement} */ (document.getElementById('fb-root'));
+
+  stubFeedbackApi([]);
+  await mountAndSettle(container);
+
+  const cluster = /** @type {HTMLElement} */ (container.querySelector('.fb-toolbar-right'));
+  const ids = Array.from(cluster.querySelectorAll('button')).map((b) => b.id);
+  expect(ids).toEqual(['fb-add-btn', 'fb-export-btn']);
+  expect(container.querySelector('#fb-clear-btn')).toBeNull();
+});

--- a/tests/interfaces/lattice_dashboard/header.test.mjs
+++ b/tests/interfaces/lattice_dashboard/header.test.mjs
@@ -102,7 +102,7 @@ describe('baseline arming', () => {
     byId('btn-baseline').click();
 
     expect(cb.onBaseline).not.toHaveBeenCalled();
-    expect(qs(byId('btn-baseline'), '.baseline-label').textContent).toBe('Confirm baseline?');
+    expect(qs(byId('btn-baseline'), '.baseline-label').textContent).toBe('Confirm?');
     expect(byId('btn-baseline').classList.contains('action-btn--armed')).toBe(true);
   });
 
@@ -129,7 +129,7 @@ describe('baseline arming', () => {
 
     byId('btn-baseline').click();
     expect(cb.onBaseline).not.toHaveBeenCalled();
-    expect(qs(byId('btn-baseline'), '.baseline-label').textContent).toBe('Confirm baseline?');
+    expect(qs(byId('btn-baseline'), '.baseline-label').textContent).toBe('Confirm?');
   });
 
   test('one state machine drives both renderings', () => {
@@ -138,9 +138,9 @@ describe('baseline arming', () => {
 
     // Armed from the tile bar, confirmed from the standalone button
     headerAction('baseline');
-    expect(contributedItem('baseline').label).toBe('Confirm baseline?');
+    expect(contributedItem('baseline').label).toBe('Confirm?');
     expect(contributedItem('baseline').tone).toBe('accent');
-    expect(qs(byId('btn-baseline'), '.baseline-label').textContent).toBe('Confirm baseline?');
+    expect(qs(byId('btn-baseline'), '.baseline-label').textContent).toBe('Confirm?');
 
     byId('btn-baseline').click();
     expect(cb.onBaseline).toHaveBeenCalledTimes(1);
@@ -174,6 +174,30 @@ describe('contribution', () => {
     expect(contributedItem('lattice-name').text).toBe('AR_full.mat');
     expect(contributedItem('refresh').disabled).toBe(false);
     expect(contributedItem('baseline').disabled).toBe(false);
+  });
+
+  test('the armed label matches the resting one in length, so neighbours hold still', () => {
+    // Baseline is not the last item in either rendering: the standalone topbar
+    // puts the theme switcher after it, and Refresh/Verify sit before it in
+    // both. A label that grows on arming therefore shoves a persistent control
+    // sideways on the very click that arms this one — exactly the class of
+    // jump the two-step confirm is supposed to protect against, reintroduced
+    // by the confirm itself.
+    //
+    // Equal CHARACTER count is exact in the topbar (.action-btn is monospace)
+    // and near-exact in the tile bar (--font-display is proportional), which
+    // is the best a contributed item can do: the hub owns that button's box
+    // and a panel has no way to ask it for a width.
+    const header = createHeader(makeCallbacks());
+    header.init();
+    header.syncState({ base_lattice: '/fake.mat' });
+
+    const resting = contributedItem('baseline').label;
+    byId('btn-baseline').click();
+    const armed = contributedItem('baseline').label;
+
+    expect(armed).not.toBe(resting);
+    expect(armed.length).toBe(resting.length);
   });
 
   test('unloading the lattice cancels a pending confirm', () => {

--- a/tests/interfaces/web_terminal/test_chat_browser.py
+++ b/tests/interfaces/web_terminal/test_chat_browser.py
@@ -450,6 +450,56 @@ def test_stop_mid_stream_reenables_and_next_prompt_works(tmp_path, chromium_brow
 
 
 # ---------------------------------------------------------------------------
+# 4b. Send holds its position while Stop comes and goes
+# ---------------------------------------------------------------------------
+
+
+def test_send_button_does_not_move_when_stop_appears_and_leaves(tmp_path, chromium_browser):
+    """Send is pinned to the composer's right edge; only Stop moves, inboard of it.
+
+    The textarea takes all the slack (``flex: 1``), so the button cluster is
+    anchored to the row's right edge and a member's arrival shifts everything
+    BEFORE it and nothing after it. Stop is the conditional member, so it has to
+    come FIRST in the cluster or Send slides sideways on every turn.
+
+    The end of a turn is what makes this worth a browser test rather than a
+    child-order assertion: ``setStreaming(false)`` hides Stop and re-enables Send
+    in the same statement block, so the wrong order drops a live Send onto the
+    exact pixels a hand was already moving toward for Stop. Asserted on real
+    geometry, because the invariant is "the operator's target does not move" —
+    a future layout change could honour the child order and still break it.
+    """
+    with _live_chat_server(tmp_path) as (base_url, _app):
+        _PLANS["long task"] = [("text", "starting…"), ("await_interrupt",), ("result",)]
+        page = _open_chat_page(chromium_browser, base_url)
+
+        send_btn = page.locator(f"{_OP} .op-send-btn")
+        stop_btn = page.locator(f"{_OP} .op-stop-btn")
+        expect(send_btn).to_be_visible()
+        idle_x = send_btn.bounding_box()["x"]
+
+        _send(page, "long task")
+        expect(stop_btn).to_be_visible(timeout=10_000)
+        streaming_x = send_btn.bounding_box()["x"]
+
+        stop_btn.click()
+        expect(stop_btn).to_be_hidden(timeout=10_000)
+        _wait_chat_idle(base_url)
+        settled_x = send_btn.bounding_box()["x"]
+
+        assert streaming_x == pytest.approx(idle_x, abs=1.0), (
+            "Send moved when Stop appeared — Stop must be the first child of "
+            ".op-input-controls so it opens inboard of Send"
+        )
+        assert settled_x == pytest.approx(idle_x, abs=1.0), (
+            "Send moved back when Stop went away, landing on the pixels Stop had "
+            "occupied at the moment Send became clickable again"
+        )
+
+        page.close()
+
+
+# ---------------------------------------------------------------------------
 # 5. Mode flip swaps chat card ↔ xterm live, both directions, no reload
 # ---------------------------------------------------------------------------
 

--- a/tests/simulation/test_archiver_seed.py
+++ b/tests/simulation/test_archiver_seed.py
@@ -642,11 +642,13 @@ def _epoch(moment: datetime) -> float:
 
 
 def test_the_module_never_imports_pymongo():
-    """An optional dependency has to stay optional.
+    """A deferred import has to stay deferred.
 
-    The seeder is imported by deployment code that runs on hosts where the
-    ``archiver-mongodb`` extra was never selected — the fingerprint check has to
-    be able to say "no store here" without one.
+    The seeder is imported by deployment code on every deploy, archiver or not,
+    and the fingerprint check has to be able to say "no store here" without
+    paying for a MongoDB client. pymongo being a core dependency now makes this
+    cheaper to get wrong, not less important: nothing would fail loudly if the
+    import were hoisted to module scope, it would only get slower.
     """
     import subprocess
     import sys

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,7 @@
 """Unit tests for the version resolution chain in osprey.version."""
 
 import subprocess
+import tomllib
 
 import pytest
 
@@ -53,6 +54,16 @@ class TestDescribeParsing:
         parsed = version_module._pep440_from_describe("v2026.6.2-0-g1234567-dirty")
         assert parsed is not None
         assert parsed.startswith("2026.6.2.post0+g1234567.d")
+
+    def test_a_full_width_node_is_sliced_to_the_build_stamps_width(self):
+        # The describe the runtime runs pins --abbrev=40; the parse trims to the
+        # 9 hex the build backend stamps, so clone size cannot change the string.
+        assert (
+            version_module._pep440_from_describe(
+                "v2026.6.2-783-g0123456789abcdef0123456789abcdef01234567"
+            )
+            == "2026.6.2.post783+g012345678"
+        )
 
     def test_unparseable_output_returns_none(self):
         assert version_module._pep440_from_describe("not-a-describe") is None
@@ -190,3 +201,34 @@ class TestLiveCheckout:
             pytest.skip("no reachable v* tag in this checkout")
 
         assert get_release_version() == described.stdout.strip().removeprefix("v")
+
+
+class TestBuildStampParity:
+    """The build stamp and the runtime derivation are the same string.
+
+    Two independent implementations derive a version from this repo's git
+    state: the build backend at build time, configured by
+    ``[tool.hatch.version].raw-options``, and ``_version_from_git`` at runtime.
+    They agreed until the sibling release tag ``osprey-connectors-v0.1.0``
+    matched the backend's default tag glob — any tag containing a digit — and
+    silently rebased every dev build to ``0.1.0.postN``. Byte-parity here means
+    the next sibling tag fails a test instead of shipping.
+    """
+
+    def test_the_build_backend_and_the_runtime_derive_the_same_version(self):
+        setuptools_scm = pytest.importorskip("setuptools_scm")
+
+        runtime = version_module._version_from_git()
+        if runtime is None:
+            pytest.skip("no reachable v* tag in this checkout")
+
+        pyproject = version_module._SOURCE_ROOT / "pyproject.toml"
+        with pyproject.open("rb") as handle:
+            raw_options = tomllib.load(handle)["tool"]["hatch"]["version"]["raw-options"]
+        # The half of the fix that lives in pyproject: left to its default
+        # describe, the backend reads every tag with a digit in it, sibling
+        # release tags included.
+        assert "--match v[0-9]*" in raw_options.get("git_describe_command", "")
+
+        stamped = setuptools_scm.get_version(root=str(version_module._SOURCE_ROOT), **raw_options)
+        assert stamped == runtime

--- a/uv.lock
+++ b/uv.lock
@@ -4502,6 +4502,7 @@ all = [
     { name = "python-xlib" },
     { name = "rdflib" },
     { name = "ruff" },
+    { name = "setuptools-scm" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-autobuild" },
@@ -4536,6 +4537,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "setuptools-scm" },
     { name = "testcontainers", extra = ["mongodb"] },
 ]
 docs = [
@@ -4694,6 +4696,8 @@ requires-dist = [
     { name = "scikit-learn" },
     { name = "scipy", specifier = ">=1.17.1" },
     { name = "seaborn" },
+    { name = "setuptools-scm", marker = "extra == 'all'" },
+    { name = "setuptools-scm", marker = "extra == 'dev'" },
     { name = "sphinx", marker = "extra == 'all'", specifier = ">=9.0.4" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=9.0.4" },
     { name = "sphinx-autobuild", marker = "extra == 'all'" },
@@ -6742,6 +6746,20 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools-scm"
+version = "10.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "vcs-versioning" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/b1/d0b97ffd2856a7d19c63024a89fb84813cb9d2ed7fa8fdbedf9e2f13a9ab/setuptools_scm-10.2.1.tar.gz", hash = "sha256:4fa7dd82cf8c800df59c9a288c90299b1657ff1ecfc3f5cc00287c5dbf5e27a9", size = 154237, upload-time = "2026-07-21T08:08:04.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/b4/02ac1d9833b882c87b3a4e82703e70eac4ab33d0d15fb123e60bb01f3bc1/setuptools_scm-10.2.1-py3-none-any.whl", hash = "sha256:b7c82f4102d389ee57dc66ccdb4f9b4bca3c40ba83b43f1f63d68ccd72db2580", size = 29078, upload-time = "2026-07-21T08:08:03.293Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -7478,6 +7496,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "vcs-versioning"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/95/c95bb74950763a163defcf4cedf6c5edfca1d623fd5031b76516ece85076/vcs_versioning-2.2.2.tar.gz", hash = "sha256:4ac4ded78720cdb4d0291ae58ace87e1e9201912e1023f3029c6cce5c9152cfb", size = 143135, upload-time = "2026-06-29T13:26:06.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/9e/1f06f4ddc3a74ccfe0877490caaf4a5233e65401160afc8cb13207815f5e/vcs_versioning-2.2.2-py3-none-any.whl", hash = "sha256:fe7fb216f8780a5516e7864a9333aacb1b70015b087a9be3918da76ef2760808", size = 108014, upload-time = "2026-06-29T13:26:05.367Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4385,6 +4385,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pyepics" },
+    { name = "pymongo" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -4396,6 +4397,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pyepics" },
+    { name = "pymongo", specifier = ">=4.17.0" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -4451,6 +4453,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "psycopg-pool" },
     { name = "pyepics" },
+    { name = "pymongo" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -4490,7 +4493,6 @@ all = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "psycopg-pool" },
     { name = "pydata-sphinx-theme" },
-    { name = "pymongo" },
     { name = "pysocks" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -4510,9 +4512,6 @@ all = [
     { name = "sphinxcontrib-jsmath" },
     { name = "sphinxcontrib-mermaid" },
     { name = "testcontainers", extra = ["mongodb"] },
-]
-archiver-mongodb = [
-    { name = "pymongo" },
 ]
 ariel = [
     { name = "psycopg", extra = ["pool"] },
@@ -4571,7 +4570,6 @@ virtual-accelerator = [
     { name = "aioca" },
     { name = "lume-pva-apg", extra = ["ca", "pva"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pcaspy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pymongo" },
 ]
 
 [package.metadata]
@@ -4658,9 +4656,7 @@ requires-dist = [
     { name = "pydata-sphinx-theme", marker = "extra == 'all'" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'" },
     { name = "pyepics" },
-    { name = "pymongo", marker = "extra == 'all'", specifier = ">=4.17.0" },
-    { name = "pymongo", marker = "extra == 'archiver-mongodb'", specifier = ">=4.17.0" },
-    { name = "pymongo", marker = "extra == 'virtual-accelerator'", specifier = ">=4.17.0" },
+    { name = "pymongo", specifier = ">=4.17.0" },
     { name = "pysocks", marker = "extra == 'all'", specifier = ">=1.7" },
     { name = "pysocks", marker = "extra == 'gchat'", specifier = ">=1.7" },
     { name = "pytest", marker = "extra == 'all'" },
@@ -4719,7 +4715,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "websocket-client", specifier = ">=1.7.0" },
 ]
-provides-extras = ["all", "archiver-mongodb", "ariel", "ariel-proxy", "dev", "docs", "gchat", "knowledge", "screen-capture-linux", "sheets", "virtual-accelerator"]
+provides-extras = ["all", "ariel", "ariel-proxy", "dev", "docs", "gchat", "knowledge", "screen-capture-linux", "sheets", "virtual-accelerator"]
 
 [[package]]
 name = "p4p"


### PR DESCRIPTION
Rolling integration branch for the small polish branches, batched so CI runs
once over the set instead of once per branch. Branched from `main` at
80b391614.

Open early and left open on purpose: a branch push runs no CI in this repo, so
this PR is what gives the batch a continuous signal against `main` while
commits keep landing on `staging/polish`.

Kept as a draft until the batch converges — `gh pr ready` when it is time to
merge.

## Landed so far

- `feat(deps): make pymongo a core dependency`
- `fix(bluesky): put the plan filter left of the view switcher`
- `feat(deploy): make the OpenObserve login findable and typeable`
- `fix(cli): route the console script through the error handler`
- `fix(init): check for a container runtime before creating anything`
- `fix(init): point profile shorthands typed as flags at --set`
- `fix(build): stop sibling release tags from setting the framework version`

More will be appended; expect this list to grow rather than the branch to be
re-cut.
