### PR TITLE
fix: queue routing guidance, stale panel-focus stragglers, unit-lane timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,13 @@ jobs:
         # minutes later in an unrelated test and EPICS' signal handling turns
         # it into a silent wedge rather than a death. A live CA client/server
         # pair is only safe in a process of its own.
-        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -m "not pty" -v --tb=short -n 4 --dist loadgroup $COV_ARGS
+        #
+        # --durations=50: the ubuntu cells run ~2x the macOS wall clock and the
+        # gap is undiagnosed. A per-cell slow-test ranking in every run is what
+        # tells "one group of tests got expensive" apart from "the whole suite
+        # is uniformly slower on this runner" — remove once the unit lane's
+        # runtime question is settled.
+        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -m "not pty" -v --tb=short --durations=50 -n 4 --dist loadgroup $COV_ARGS
 
     # The two steps below are the reason the step above has its own timeout.
     # They run on success too: on a green lane the summary is one line, and on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Agents now route a measurement that needs more than one setting through the
+  Bluesky queue instead of stepping a setpoint with repeated `channel_write`
+  calls. The `operating-bluesky-plans` skill also triggers on requests phrased
+  as physics ("step a corrector across a few settings and record the beam")
+  rather than only on the words *plan*, *run*, *queue* and *start*, and the
+  control-system safety rule states the routing directly. Hand-stepping cost
+  the operator one approval per write instead of one per measurement and left
+  no run behind.
 - `osprey up` now refuses as a precondition, rather than failing with a generic
   "Deployment failed", when a project deploys the archiver store and pymongo is
   missing. The refusal names the interpreter it is missing from — OSPREY seeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Compatibility is documented in release notes, not encoded in the version string.
   control-system safety rule states the routing directly. Hand-stepping cost
   the operator one approval per write instead of one per measurement and left
   no run behind.
+- A panel closed by an agent workspace arrange no longer pops back open when a
+  browser's tab-switch report, sent before the arrange, arrives after it. The
+  server drops the stale report instead of re-adding the panel to every
+  client's rail and stealing the active tab.
 - `osprey up` now refuses as a precondition, rather than failing with a generic
   "Deployment failed", when a project deploys the archiver store and pymongo is
   missing. The refusal names the interpreter it is missing from — OSPREY seeds

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -395,17 +395,21 @@ async def set_panel_focus(body: PanelFocusRequest, request: Request):
     lands inside the user's own mount; an already-absolute URL is left
     untouched.
 
-    Focusing a panel that is **not** in the launcher rail also adds it there,
-    emitting a ``panel_visibility`` frame *before* the focus frame. An agent's
-    ``open_panel`` may name a panel the operator took off the rail; without the
-    membership update the rail entry would exist only on the client that
-    happened to apply the focus, so ``list_panels`` would keep reporting the
-    panel invisible, a reload would drop both the entry and the agent-opened
-    tile, and a late-connecting client would never see it at all. Ordering is
-    deliberate: clients add the rail entry, then apply focus to it.
+    An **agent** focus on a panel that is **not** in the launcher rail also
+    adds it there, emitting a ``panel_visibility`` frame *before* the focus
+    frame. An agent's ``open_panel`` may name a panel the operator took off
+    the rail; without the membership update the rail entry would exist only on
+    the client that happened to apply the focus, so ``list_panels`` would keep
+    reporting the panel invisible, a reload would drop both the entry and the
+    agent-opened tile, and a late-connecting client would never see it at all.
+    Ordering is deliberate: clients add the rail entry, then apply focus to it.
 
     A panel already in the rail — which is the only kind a human can click —
-    changes nothing and emits no visibility frame.
+    changes nothing and emits no visibility frame. A **source-less** focus on
+    a non-member is dropped whole: a human can only gesture at a panel already
+    on the rail, so such a report is always a fire-and-forget straggler that a
+    concurrent arrange overtook, and applying it would resurrect the panel the
+    arrange just pruned.
 
     An agent switch is also mirrored into the activity history ring as one
     ``open_panel`` row. When the open additionally adds rail membership,
@@ -435,6 +439,16 @@ async def set_panel_focus(body: PanelFocusRequest, request: Request):
     else:
         visible_panels = list(stored_visible)
     adds_membership = body.panel not in visible_panels
+    if adds_membership and body.source != "agent":
+        # A source-less focus is a human gesture report, and a human can only
+        # gesture at a panel already on the rail — new membership arrives via
+        # ``/api/panels/register`` or an agent ``open_panel``, never a human
+        # focus. A source-less report naming a non-member is therefore a
+        # fire-and-forget straggler that a concurrent arrange overtook;
+        # applying it would resurrect the pruned panel on every client's rail
+        # and steal the active slot, so the whole write is dropped.
+        active = getattr(request.app.state, "active_panel", None)
+        return {"status": "ok", "active_panel": active}
     if adds_membership:
         visible_panels.append(body.panel)
         request.app.state.visible_panels = visible_panels

--- a/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
+++ b/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
@@ -93,6 +93,24 @@ with `execution_mode: "write"` —
 the `execute` tool defaults to readonly mode, which blocks write operations.
 {% if "bluesky" in enabled_servers | default([]) %}
 
+## Measurements Go Through the Queue, Not Through Repeated Writes
+
+A request that needs the machine set to **more than one value** is a plan, and
+plans run through the Bluesky queue. This holds however the request was worded:
+"step a corrector across a few settings and record where the beam sits",
+"sweep this setpoint and read the response back", and "run a scan" are the same
+operation, and none of them is a loop of `channel_write` calls.
+
+Stepping a setpoint by hand instead costs the operator one approval for every
+write rather than one for the whole measurement, produces no run — so nothing
+reaches the queue panel, the data store, or `get_run_data` — and parks the
+setpoint wherever the last accepted write left it if the sequence stops part
+way. Use the `operating-bluesky-plans` skill; it owns this path.
+
+`channel_read` is unrestricted, and a single `channel_write` the operator asked
+for by name is a legitimate operation. It is a *sequence* of writes standing in
+for a plan that is not.
+
 ## Starting a Bluesky Queue
 
 Starting a queue moves accelerator hardware. Arming a start needs

--- a/src/osprey/templates/claude_code/claude/skills/operating-bluesky-plans/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/operating-bluesky-plans/SKILL.md
@@ -5,7 +5,12 @@ description: >
   the plan/queue panels: stage the complete configuration in one set_draft,
   let the human review it live in the plan panel, add that pinned revision to
   the queue, start the queue, and watch the run. Use when asked to run, queue,
-  or start a plan that already exists. NOT for authoring a new plan file (use
+  or start a plan that already exists, AND whenever a measurement is asked for
+  in prose that never says "plan": step or sweep a setpoint across a range and
+  record a readback, take readings at several settings, vary a corrector and
+  watch the orbit, characterise how one channel responds to another. Any
+  measurement that needs more than one setting goes through the queue, never
+  through repeated channel_write. NOT for authoring a new plan file (use
   writing-bluesky-plans first).
 summary: Stage, queue, start, and watch a registered plan through the shared draft
 ---
@@ -22,6 +27,40 @@ never a hidden, agent-only path to hardware.
 This skill operates plans that already exist. To author a brand-new plan
 file, use the `writing-bluesky-plans` skill first, then come back here to run
 it.
+
+---
+
+## A multi-point measurement is a plan, whatever the operator called it
+
+Operators ask for measurements in physics prose, not in tool names. "Step one
+of the correctors across a few settings inside its allowed range and record
+where the beam sits", "sweep this setpoint and read the response back", "take
+a few readings at different settings" — none of those sentences contains the
+word *plan*, *scan* or *queue*, and every one of them is this skill's job.
+
+**The rule: if reaching the answer needs more than one setting, it goes through
+the queue.** Stage it in the draft, add it, start it. The alternative — a run
+of `channel_write` calls stepping the setpoint by hand, with reads in between —
+is the wrong path for three reasons, and none of them is a matter of taste:
+
+- **It costs the operator one approval per write instead of one per
+  measurement.** A ten-point sweep becomes ten consent prompts, and consent
+  asked ten times is consent nobody reads.
+- **It leaves no run.** There is no `run_id`, so nothing lands in the queue
+  panel, nothing reaches the data store, and `get_run_data` / `get_run_figure`
+  have nothing to read. The numbers exist only in the transcript.
+- **It leaves the machine wherever the last write put it.** A plan restores
+  what it moved and records what it did; a hand-stepped loop that stops
+  half-way — refused, errored, interrupted — simply stops, with the setpoint
+  parked at whatever the last accepted write set it to.
+
+`channel_read` is fine at any time, and a **single** deliberate `channel_write`
+that the operator asked for by name is fine too. What does not belong here is a
+*sequence* of writes standing in for a plan.
+
+If no registered plan fits the measurement, that is a `list_plans()` finding to
+report — and possibly a job for `writing-bluesky-plans` — not a licence to
+hand-step. Say which plan you are using and why, or say that none fits.
 
 ---
 
@@ -447,6 +486,10 @@ know why it was requested.
 
 ## Anti-patterns
 
+- **Never** hand-step a measurement with repeated `channel_write` because the
+  request was phrased as physics rather than as a plan — more than one setting
+  means the queue, which costs one approval instead of one per write and leaves
+  a run behind.
 - **Never** stage a plan across multiple `set_draft` calls that each leave an
   incomplete draft in front of the human's Add-to-queue button — assemble the
   full `plan_args` and stage it in one call.

--- a/tests/interfaces/web_terminal/test_panels_routes.py
+++ b/tests/interfaces/web_terminal/test_panels_routes.py
@@ -284,15 +284,48 @@ def test_focus_without_explicit_membership_treats_enabled_as_the_rail():
     assert not hasattr(app.state, "visible_panels")
 
 
-def test_focus_without_explicit_membership_still_adds_a_custom_non_member():
-    """A custom panel is not in the enabled set, so it is a genuine non-member."""
+def test_focus_without_explicit_membership_drops_a_source_less_non_member():
+    """A custom panel outside the enabled fallback is a non-member too."""
     app = _make_focus_app(visible=None)
     with TestClient(app) as client:
         client.post("/api/panel-focus", json={"panel": "grafana"})
-    # Membership is shared state, so the visibility frame broadcasts even for a
-    # human gesture; the focus itself stays a local matter.
-    assert [f["type"] for f in _frames(app)] == ["panel_visibility"]
-    assert "grafana" in app.state.visible_panels
+    # A source-less focus can only be a human gesture, and a human can only
+    # gesture at a panel already on the rail — so this is a straggler report
+    # and must not create membership.
+    assert _frames(app) == []
+    assert not hasattr(app.state, "visible_panels")
+
+
+# ---- A stale human focus must not resurrect a pruned panel ---- #
+#
+# Every source-less focus POST is a human gesture REPORT (panel-commands.js),
+# and a human can only gesture at a panel already on screen. New membership
+# arrives through /api/panels/register or an agent ``open_panel``, never
+# through a human focus. So a source-less focus naming a non-member is always
+# a straggler that a concurrent arrange overtook: the fire-and-forget report
+# was issued before the arrange pruned the panel and arrived after. Applying
+# it would resurrect the pruned panel on every client's rail and steal the
+# active slot, so the whole write is dropped.
+
+
+def test_stale_human_focus_does_not_resurrect_a_pruned_panel():
+    """Source-less focus on a non-member: no membership add, no broadcast."""
+    app = _make_focus_app(visible=["ariel"])  # an arrange just pruned grafana
+    with TestClient(app) as client:
+        resp = client.post("/api/panel-focus", json={"panel": "grafana"})
+    assert resp.status_code == 200
+    assert app.state.visible_panels == ["ariel"]
+    app.state.broadcaster.broadcast.assert_not_called()
+
+
+def test_stale_human_focus_does_not_steal_the_active_slot():
+    """The dropped straggler must leave ``active_panel`` untouched too."""
+    app = _make_focus_app(visible=["ariel"])
+    app.state.active_panel = "ariel"
+    with TestClient(app) as client:
+        resp = client.post("/api/panel-focus", json={"panel": "grafana"})
+    assert resp.json() == {"status": "ok", "active_panel": "ariel"}
+    assert app.state.active_panel == "ariel"
 
 
 def test_focus_on_unknown_panel_changes_nothing():


### PR DESCRIPTION
Three polish fixes bundled to keep CI/rebase churn down: the queue-routing
guidance fix (#619), the panel-focus straggler fix (#632), and the unit-lane
timing diagnostic from #582.

Closes #619. Closes #632.

---

## 1. Route multi-point measurements to the queue (#619)

### What was wrong

`test_starting_a_queued_scan_costs_one_operator_approval` intermittently
failed with the agent reaching for `mcp__controls__channel_write` to hand-step
a corrector instead of staging a queued plan — the exact substitution the
test's approval policy refuses.

The cause is guidance coverage, not model randomness. The prompt asks for a
measurement in physics prose:

> step one of the steering correctors across a few settings inside the range it
> is allowed and record where the beam sits at each step

`operating-bluesky-plans` described itself as *"Use when asked to run, queue,
or start a plan that already exists."* None of *plan*, *run*, *queue* or
*start* appears in that sentence, so the skill never loaded and the agent
reasoned from tool names alone — where `channel_write` and `channel_limits` are
the literal match for "step" and "the range it is allowed".

The two sibling tests that pass both name a plan class ("run an orbit-response
measurement", "a grid of settings"), which is why they route correctly unaided.

### What changed

This is option 1 from the issue — the substantive fix. The test's prompt is
untouched, so the routing signal it carries is preserved.

- **`operating-bluesky-plans` trigger surface.** The description now also fires
  on measurement and sweep phrasing: stepping or sweeping a setpoint across a
  range and recording a readback, taking readings at several settings, varying
  a corrector and watching the orbit.
- **The rule, stated in the skill body.** A new section says a measurement
  needing more than one setting goes through the queue, with the three reasons
  hand-stepping is wrong: one approval per write instead of one per
  measurement, no `run_id` so nothing reaches the queue panel or the data
  store, and a setpoint left wherever the last write parked it if the sequence
  stops part way. A matching anti-pattern bullet makes it greppable.
- **The rule, stated in the always-loaded controls guidance.**
  `control-system-safety.md.j2` gains the same routing statement inside its
  `bluesky` block, so it applies whether or not the skill fires. A single
  `channel_write` the operator asked for by name stays legitimate; a *sequence*
  of them standing in for a plan does not.

### Why this matters beyond the test

The test's subject is how many human consents it takes to reach hardware. In a
deployment where `channel_write` sits on `permissions.ask`, an agent that
hand-steps prompts the operator once per write instead of once per scan —
consent asked ten times is consent nobody reads. That is the regression this
test guards after #594 removed the second confirmation.

## 2. Drop stale panel-focus reports (#632)

The issue sketches a monotonic-revision protocol as one possible direction.
It turns out the message's own shape already carries the ordering
information, so a ~10-line server-only guard closes the hazard:

- `activateTab`'s contract is "focus an already-visible panel", and both
  source-less `setPanelFocus` call sites (`dock-sync.js`,
  `panel-manager.js`) fire only for a panel the human has on screen.
- New rail membership arrives via `POST /api/panels/register` (which adds to
  `visible_panels` itself) or an agent `open_panel` — never a human focus.

So a **source-less focus naming a non-member has no legitimate fresh path**:
it is always a fire-and-forget straggler that a concurrent arrange overtook.
The route now drops that write whole — no membership add, no
`panel_visibility` broadcast, and no `active_panel` change (the straggler
used to steal the active slot too, which was one of the three diverging
fields in the flaky test that surfaced this). The agent `open_panel`
contract is untouched.

Three new route tests pin the straggler-drop contract;
`test_focus_without_explicit_membership_still_adds_a_custom_non_member` was
rewritten to the new contract (its scenario — unset `visible_panels` plus a
custom panel — cannot occur in production, where startup always seeds the
list).

The revision protocol remains available if an agent-vs-agent interleaving
ever surfaces, but nothing observed so far needs it.

## 3. Unit-lane timing diagnostic (#582, not closed)

Adds `--durations=50` to the unit lane — the issue's own suggested first
step — so every run carries the per-cell slow-test ranking that tells "one
group of tests got expensive" apart from "the whole suite is uniformly
slower on ubuntu". Two corrections to the issue's zmq lead, verified against
the installed versions:

- The `zmq.auth` threads are **daemon** (`AuthenticationThread.__init__` →
  `super().__init__(daemon=True)`, pyzmq 27.1.0), so they do not keep a
  worker alive past its session — that premise doesn't hold.
- The thread leak is real but **upstream**: `bluesky.callbacks.zmq.
  configure_server_socket` builds its `ThreadAuthenticator` as a local and
  drops the reference, so `DocumentPlane.stop()` has nothing it could stop.
  Scope is one daemon thread per document-plane test (~23 max) — not a
  10-minute runtime story.

The lane's measurement has to come before any fix, so #582 stays open.

## Verification

- Full `tests/interfaces/web_terminal/` suite: 1093 passed, 1 skipped; the
  one failure (`test_contract_params`, a server-boot port timeout under
  full-suite load) passes in isolation.
- `tests/deployment/test_ci_workflow_wiring.py` green — the `--durations=50`
  placement keeps the `-n 4 --dist loadgroup` pins and their mutation probes
  intact.
- For #619: `tests/templates/`, `tests/cli/test_claude_code_integration.py`,
  `tests/cli/test_operating_bluesky_plans_skill_install.py`,
  `tests/cli/test_artifact_library.py`,
  `tests/services/bluesky_bridge/test_contract_guards.py` — 481 + 115 passed.
- Ruff clean. The scan-stack lane is PR-only and needs `ALS_APG_API_KEY`, so
  the live confirmation for #619 is this PR's Scan Stack Agentic E2E run.
