### PR TITLE
fix: limits database anchoring (#636) and sash-resize panel freeze (#638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ Compatibility is documented in release notes, not encoded in the version string.
   browser's tab-switch report, sent before the arrange, arrives after it. The
   server drops the stale report instead of re-adding the panel to every
   client's rail and stealing the active tab.
+- A relative `control_system.limits_checking.database_path` now anchors on the
+  directory of the config actually loaded, so the limits gate finds the render's
+  database regardless of how the process was launched. Previously a Claude Code
+  hook running without `CONFIG_FILE` resolved it against the repo root and the
+  empty-database failsafe denied every write (#636).
+- The limits failsafe now refuses with "limits database unavailable" instead of
+  reporting every channel as "not in limits database", so a load failure is no
+  longer mistaken for a data problem (#636).
 - `osprey up` now refuses as a precondition, rather than failing with a generic
   "Deployment failed", when a project deploys the archiver store and pymongo is
   missing. The refusal names the interpreter it is missing from — OSPREY seeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 - The limits failsafe now refuses with "limits database unavailable" instead of
   reporting every channel as "not in limits database", so a load failure is no
   longer mistaken for a data problem (#636).
+- Resizing a web-terminal pane no longer freezes the other panels until a
+  browser refresh: the adapter's sash shield poisoned dockview's own
+  pointer-events snapshot and is removed — dockview shields iframes during
+  sash drags itself (#638).
 - `osprey up` now refuses as a precondition, rather than failing with a generic
   "Deployment failed", when a project deploys the archiver store and pymongo is
   missing. The refusal names the interpreter it is missing from — OSPREY seeds

--- a/packages/osprey-connectors/src/osprey_connectors/config.py
+++ b/packages/osprey-connectors/src/osprey_connectors/config.py
@@ -851,6 +851,23 @@ def get_config_builder(
     return _get_config(config_path, set_as_default)
 
 
+def default_config_path() -> str | None:
+    """Path of the config file the default singleton actually loaded, if any.
+
+    This answers "which config is this process's unqualified lookups reading
+    from" — the CONFIG_FILE target, the cwd fallback, or a
+    :func:`config_anchored_at` anchor, whichever produced the singleton.
+    Callers that resolve paths *relative to the config in use* (e.g.
+    ``LimitsValidator.resolve_database_path``) anchor on this rather than
+    re-deriving the location from the environment, which can disagree with
+    what was actually loaded.
+
+    Side-effect free: no singleton is created and no ``.env`` chain is loaded.
+    Returns ``None`` until something initializes the default configuration.
+    """
+    return str(_default_config.config_path) if _default_config is not None else None
+
+
 @contextmanager
 def config_anchored_at(config_path: str | Path) -> "Iterator[None]":
     """Answer this process's unqualified config lookups from *config_path*.

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
@@ -42,41 +42,49 @@ class LimitsValidator:
         limits_database: dict[str, ChannelLimitsConfig],
         policy_config: dict,
         raw_db: dict = None,
+        failsafe_reason: str | None = None,
     ):
         self.limits = limits_database
         self.policy = policy_config
         self._raw_db = raw_db  # Keep raw database for verification config access
+        # Set only by the empty-DB failsafe paths in from_config: the database
+        # could not be loaded, so every write is blocked. validate() uses it to
+        # refuse with a load-failure message instead of the unlisted-channel
+        # one — the two conditions need different operator responses.
+        self.failsafe_reason = failsafe_reason
 
     @staticmethod
-    def resolve_database_path(db_path: str, project_root: str | None) -> str:
+    def resolve_database_path(
+        db_path: str, project_root: str | None, config_path: str | None = None
+    ) -> str:
         """Resolve a relative ``database_path`` the same way for every caller.
 
-        The base is the directory holding the config that is actually in use:
-        ``Path(CONFIG_FILE).parent`` when ``CONFIG_FILE`` is set, and the
-        config's own ``project_root`` key otherwise.
+        A relative ``database_path`` is written alongside the config it appears
+        in, so the anchor is the directory of the config that is actually in
+        use: *config_path*, when the caller can name the file it loaded (see
+        :func:`osprey_connectors.config.default_config_path`). This is what
+        makes the resolution independent of how the process was launched — a
+        Claude Code hook, an MCP server, and a host verb anchored via
+        ``config_anchored_at`` all load the render's config and find the
+        ``data/`` tree the build copied next to it.
 
-        CONFIG_FILE wins because a relative ``database_path`` is written
-        alongside the config it appears in, and that config is the RENDER. A
-        build copies the profile's ``data/`` tree into the same directory it
-        writes ``config.yml`` (``<repo>/build/``), so ``data/channel_limits.json``
-        resolves there; in a container deploy CONFIG_FILE names the config
-        mounted inside the container while ``project_root`` may record a host
-        path the container does not have.
+        Fallbacks, for callers that cannot name the loaded config:
+        ``Path(CONFIG_FILE).parent`` when that variable is set (a container
+        deploy names the config mounted inside the container while
+        ``project_root`` may record a host path the container does not have),
+        else the config's own ``project_root`` key. Note that under the
+        four-zone repo layout the render lives at ``<repo>/build/config.yml``
+        while ``project_root`` names ``<repo>`` — the project_root branch is a
+        last resort, not an equivalent spelling.
 
-        These two bases are NOT the same directory. Under the four-zone repo
-        layout the rendered config lives at ``<repo>/build/config.yml`` while
-        ``project_root`` names ``<repo>`` — so the CONFIG_FILE branch is a real
-        choice of the build zone over the repo root, not the no-op it was back
-        when ``config.yml`` sat at the project root. Which root a relative
-        ``database_path`` *ought* to anchor on is a separate question from what
-        this function does today; nothing here decides it.
-
-        Returns ``db_path`` unchanged if it is already absolute, or if
-        neither ``CONFIG_FILE`` nor ``project_root`` is available.
+        Returns ``db_path`` unchanged if it is already absolute, or if no base
+        is available.
         """
         db_path_obj = Path(db_path)
         if db_path_obj.is_absolute():
             return db_path
+        if config_path:
+            return str(Path(config_path).parent / db_path)
         config_file = os.environ.get("CONFIG_FILE")
         if config_file:
             return str(Path(config_file).parent / db_path)
@@ -92,7 +100,7 @@ class LimitsValidator:
         This allows connectors to work in test environments without config files.
         """
         try:
-            from osprey_connectors.config import get_config_value
+            from osprey_connectors.config import default_config_path, get_config_value
 
             enabled = get_config_value("control_system.limits_checking.enabled", False)
             if not enabled:
@@ -104,17 +112,22 @@ class LimitsValidator:
                 logger.warning(
                     "Limits checking enabled but no database path configured - blocking all writes"
                 )
-                return cls({}, {}, {})  # Empty DB = blocks all (failsafe)
+                return cls(
+                    {},
+                    {},
+                    {},
+                    failsafe_reason=(
+                        "limits checking is enabled but "
+                        "control_system.limits_checking.database_path is not configured"
+                    ),
+                )  # Empty DB = blocks all (failsafe)
 
             project_root = get_config_value("project_root", None)
-            resolved_path = cls.resolve_database_path(db_path, project_root)
+            resolved_path = cls.resolve_database_path(
+                db_path, project_root, config_path=default_config_path()
+            )
             if resolved_path != db_path:
-                if os.environ.get("CONFIG_FILE"):
-                    logger.debug(
-                        f"Resolved limits database path (via CONFIG_FILE): {resolved_path}"
-                    )
-                else:
-                    logger.debug(f"Resolved limits database path: {resolved_path}")
+                logger.debug(f"Resolved limits database path: {resolved_path}")
             db_path = resolved_path
 
             try:
@@ -129,7 +142,14 @@ class LimitsValidator:
                     f"Limits checking enabled but the database at {db_path} could not "
                     f"be read or parsed - blocking all writes. {e}"
                 )
-                return cls({}, {}, {})  # Empty DB = blocks all (failsafe)
+                return cls(
+                    {},
+                    {},
+                    {},
+                    failsafe_reason=(
+                        f"the limits database at {db_path} could not be read or parsed"
+                    ),
+                )  # Empty DB = blocks all (failsafe)
             logger.debug(f"Loaded limits database with {len(limits_db)} channels")
 
             policy = {
@@ -425,6 +445,24 @@ class LimitsValidator:
         channel_config = self.limits.get(channel_address)
 
         if channel_config is None:
+            # A database that failed to load blocks everything — say so, rather
+            # than refusing with the unlisted-channel message: "not in limits
+            # database" sends the operator chasing a data problem when the
+            # actual failure is that no database was loaded at all.
+            if self.failsafe_reason:
+                logger.warning(
+                    f"Blocked write (limits database unavailable): {channel_address}={value}"
+                )
+                raise ChannelLimitsViolationError(
+                    channel_address=channel_address,
+                    value=value,
+                    violation_type="LIMITS_DATABASE_UNAVAILABLE",
+                    violation_reason=(
+                        f"Limits database unavailable — all writes are blocked as a "
+                        f"failsafe ({self.failsafe_reason}). This is not a statement "
+                        f"about channel '{channel_address}'."
+                    ),
+                )
             # Unlisted channel - check policy
             if self.policy.get("allow_unlisted_channels", False):
                 return  # Allow unlisted channel

--- a/src/osprey/interfaces/web_terminal/static/js/dock-iframe.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-iframe.js
@@ -130,7 +130,6 @@ function ensureDock() {
         api.onDidActivePanelChange(trackActiveServiceGroup),
       );
       wireDragShield(api);
-      wireSashShield();
       window.addEventListener('resize', syncGeometry);
       // After a default-layout rebuild (reset / restore-fallback) the grid holds
       // only the terminal — re-dock every visible managed panel's placeholder so
@@ -177,6 +176,17 @@ export function setIframePointerShield(on) {
 /**
  * Re-apply dock-workspace.js's pointer shield to the overlay iframes across
  * every dockview-initiated drag gesture (start → any natural terminator).
+ *
+ * SASH drags need no shield here — and must not get one. dockview-core's own
+ * sash handling already disables pointer-events on every iframe in the
+ * document for the whole gesture (disableIframePointEvents in its splitview),
+ * by SNAPSHOTTING each iframe's inline pointer-events value on sash
+ * pointerdown and restoring the snapshot on pointerup. A second, adapter-side
+ * shield running in the capture phase sets 'none' before dockview snapshots,
+ * so dockview records 'none' as the "original" value and its restore
+ * re-freezes every overlay iframe after the drag — permanently, since each
+ * further drag re-snapshots the poisoned value. That was the issue-638
+ * panel freeze; dock-iframe.test.mjs pins the gesture contract.
  * @param {any} api
  */
 function wireDragShield(api) {
@@ -184,29 +194,6 @@ function wireDragShield(api) {
     onStart: () => setIframePointerShield(true),
     onEnd: () => setIframePointerShield(false),
   }));
-}
-
-/**
- * Same shield for SASH drags. A live resize now follows the pointer frame-by-
- * frame (see the content-container ResizeObserver), so the pointer can cross an
- * overlay iframe mid-drag — a separate browsing context that would swallow the
- * pointermove events dockview's sash handler needs. Neutralize the iframes for
- * the whole gesture (sash pointerdown → pointerup/cancel), exactly as the old
- * hand-rolled splitter did with `body.resizing iframe { pointer-events:none }`.
- * Capture-phase so it runs regardless of dockview's own sash handling.
- */
-function wireSashShield() {
-  document.addEventListener('pointerdown', (e) => {
-    if (!(e.target instanceof Element) || !e.target.closest('.dv-sash')) return;
-    for (const entry of managed.values()) entry.iframe.style.pointerEvents = 'none';
-    const end = () => {
-      document.removeEventListener('pointerup', end, true);
-      document.removeEventListener('pointercancel', end, true);
-      for (const entry of managed.values()) entry.iframe.style.pointerEvents = 'auto';
-    };
-    document.addEventListener('pointerup', end, true);
-    document.addEventListener('pointercancel', end, true);
-  }, true);
 }
 
 /** @param {HTMLIFrameElement} iframe */

--- a/src/osprey/services/bluesky_bridge/validation.py
+++ b/src/osprey/services/bluesky_bridge/validation.py
@@ -63,11 +63,12 @@ def _assert_limits_readable_if_writable() -> None:
     begins.
 
     Mirrors `LimitsValidator.from_config`'s ``database_path`` resolution
-    (a relative path resolved against the ``CONFIG_FILE`` env var's directory
-    when set, falling back to ``project_root`` otherwise — container-correct,
-    since the deploy flattens ``project_root`` in as the HOST build path,
-    while ``CONFIG_FILE`` points at the config actually mounted in-container),
-    but probes readability via `LimitsValidator._load_limits_database`
+    (a relative path anchors on the directory of the config actually loaded,
+    falling back to the ``CONFIG_FILE`` env var's directory and then
+    ``project_root`` — container-correct, since the deploy flattens
+    ``project_root`` in as the HOST build path while the loaded config is the
+    one mounted in-container), but probes readability via
+    `LimitsValidator._load_limits_database`
     directly rather than calling `from_config` — `from_config` swallows every
     load failure to `None`, which would hide the exact failure this guard
     must detect and raise on.
@@ -108,7 +109,11 @@ def _assert_limits_readable_if_writable() -> None:
     from osprey.connectors.control_system.limits_validator import LimitsValidator
 
     # Same relative-path resolution as `LimitsValidator.from_config`.
-    db_path = LimitsValidator.resolve_database_path(db_path, project_root)
+    from osprey.utils.config import default_config_path
+
+    db_path = LimitsValidator.resolve_database_path(
+        db_path, project_root, config_path=default_config_path()
+    )
 
     try:
         LimitsValidator._load_limits_database(db_path)

--- a/tests/connectors/test_limits_validator.py
+++ b/tests/connectors/test_limits_validator.py
@@ -166,14 +166,45 @@ class TestResolveDatabasePath:
 
         assert LimitsValidator.resolve_database_path("limits.json", None) == "limits.json"
 
+    def test_loaded_config_directory_beats_env_and_project_root(self, monkeypatch):
+        """The config actually loaded is the anchor, ahead of CONFIG_FILE and project_root."""
+        monkeypatch.setenv("CONFIG_FILE", "/somewhere/else/config.yml")
+
+        resolved = LimitsValidator.resolve_database_path(
+            "data/limits.json", "/repo", config_path="/repo/build/config.yml"
+        )
+
+        assert resolved == str(Path("/repo/build/data/limits.json"))
+
+    def test_loaded_config_anchor_ignores_absolute_paths(self, monkeypatch):
+        monkeypatch.delenv("CONFIG_FILE", raising=False)
+        abs_path = str(Path("/etc/osprey/limits.json"))
+
+        resolved = LimitsValidator.resolve_database_path(
+            abs_path, "/repo", config_path="/repo/build/config.yml"
+        )
+
+        assert resolved == abs_path
+
 
 # ---------------------------------------------------------------------------
 # from_config
 # ---------------------------------------------------------------------------
 
 
-def _patch_config(monkeypatch, values: dict, raise_exc: Exception | None = None):
-    """Patch get_config_value with a key->value map (default fallback otherwise)."""
+def _patch_config(
+    monkeypatch,
+    values: dict,
+    raise_exc: Exception | None = None,
+    config_path: str | None = None,
+):
+    """Patch get_config_value with a key->value map (default fallback otherwise).
+
+    ``config_path`` stands in for ``default_config_path()`` — the path of the
+    config the singleton actually loaded. ``None`` (the default) models a
+    process whose config came from somewhere the singleton can't name, which
+    keeps the env-var/project_root fallback branches testable in isolation.
+    """
 
     def fake_get_config_value(key, default=None):
         if raise_exc is not None:
@@ -181,6 +212,7 @@ def _patch_config(monkeypatch, values: dict, raise_exc: Exception | None = None)
         return values.get(key, default)
 
     monkeypatch.setattr("osprey.utils.config.get_config_value", fake_get_config_value)
+    monkeypatch.setattr("osprey.utils.config.default_config_path", lambda: config_path)
 
 
 class TestFromConfig:
@@ -190,7 +222,12 @@ class TestFromConfig:
         assert LimitsValidator.from_config() is None
 
     def test_missing_db_path_yields_blocking_failsafe_validator(self, monkeypatch):
-        """Enabled but no database path -> an empty validator that blocks all writes."""
+        """Enabled but no database path -> an empty validator that blocks all writes.
+
+        The refusal must say the database is unavailable, not that the channel
+        is unlisted — an agent reading "not in limits database" narrates a data
+        problem when the actual failure is configuration (#636).
+        """
         _patch_config(
             monkeypatch,
             {
@@ -202,9 +239,49 @@ class TestFromConfig:
         validator = LimitsValidator.from_config()
 
         assert isinstance(validator, LimitsValidator)
-        # Empty DB is a failsafe: every channel is unlisted and therefore blocked.
         with pytest.raises(ChannelLimitsViolationError) as exc:
             validator.validate("ANY:CHANNEL", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+        assert "failsafe" in exc.value.violation_reason
+
+    def test_unreadable_db_failsafe_is_distinguishable_from_unlisted_channel(
+        self, monkeypatch, tmp_path
+    ):
+        """A database that fails to load blocks with a load-failure refusal (#636)."""
+        db_file = tmp_path / "limits.json"
+        db_file.write_text("{not valid json")
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system.limits_checking.enabled": True,
+                "control_system.limits_checking.database_path": str(db_file),
+            },
+        )
+
+        validator = LimitsValidator.from_config()
+
+        assert isinstance(validator, LimitsValidator)
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("ANY:CHANNEL", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+        assert "not in limits database" not in exc.value.violation_reason
+
+    def test_genuinely_unlisted_channel_keeps_the_unlisted_refusal(self, monkeypatch, tmp_path):
+        """A loaded database still refuses unlisted channels with the unlisted message."""
+        db_file = tmp_path / "limits.json"
+        db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system.limits_checking.enabled": True,
+                "control_system.limits_checking.database_path": str(db_file),
+            },
+        )
+
+        validator = LimitsValidator.from_config()
+
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:LISTED", 1.0)
         assert exc.value.violation_type == "UNLISTED_CHANNEL"
 
     def test_loads_absolute_database(self, monkeypatch, tmp_path):
@@ -265,6 +342,37 @@ class TestFromConfig:
         _patch_config(monkeypatch, {}, raise_exc=RuntimeError("no config"))
 
         assert LimitsValidator.from_config() is None
+
+    def test_four_zone_hook_resolves_database_beside_loaded_config(self, monkeypatch, tmp_path):
+        """Regression (#636): a relative database_path anchors on the config actually loaded.
+
+        The four-zone hook scenario: the render lives at <repo>/build (config +
+        data/ side by side), the config's ``project_root`` names <repo>, and the
+        hook process has no CONFIG_FILE in its environment. The database must be
+        found next to the loaded config — not resolved against project_root,
+        where it does not exist and every write would hit the empty-DB failsafe.
+        """
+        monkeypatch.delenv("CONFIG_FILE", raising=False)
+        build = tmp_path / "build"
+        (build / "data").mkdir(parents=True)
+        (build / "data" / "channel_limits.json").write_text(
+            json.dumps({"SR:C1:HCM:SP": {"min_value": -1.0, "max_value": 1.0}})
+        )
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system.limits_checking.enabled": True,
+                "control_system.limits_checking.database_path": "data/channel_limits.json",
+                "project_root": str(tmp_path),
+                "control_system.limits_checking.allow_unlisted_channels": False,
+            },
+            config_path=str(build / "config.yml"),
+        )
+
+        validator = LimitsValidator.from_config()
+
+        assert "SR:C1:HCM:SP" in validator.limits
+        validator.validate("SR:C1:HCM:SP", 0.5)  # listed and in range: allowed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/interfaces/web_terminal/dock-iframe.test.mjs
+++ b/tests/interfaces/web_terminal/dock-iframe.test.mjs
@@ -325,3 +325,60 @@ describe('pruning — placeholders of server-closed panels', () => {
     expect(api.getPanel('iframe:lattice')).not.toBeNull();
   });
 });
+
+describe('sash drags — dockview owns the iframe shield (#638)', () => {
+  /**
+   * dockview-core 7.x shields iframes during sash drags itself
+   * (disableIframePointEvents in its splitview): on sash pointerdown it
+   * SNAPSHOTS each iframe's inline pointer-events into a WeakMap and sets
+   * 'none'; its document-level, bubble-phase pointerup handler restores the
+   * snapshot. The adapter must not touch pointer-events around that gesture:
+   * an adapter shield running in the capture phase sets 'none' BEFORE dockview
+   * snapshots, so dockview records 'none' as the original value and its
+   * restore re-freezes every overlay iframe after the drag — permanently,
+   * since each further drag re-snapshots the poisoned value (the #638 freeze).
+   * This test emulates dockview's exact contract and pins that a full sash
+   * gesture ends with the managed iframe interactive.
+   */
+  test('a full sash gesture leaves managed overlay iframes interactive', async () => {
+    const api = makeApi();
+    addTerminal(api);
+    const mod = await freshAdapter(api);
+    const iframe = makeIframe();
+    mod.adoptIframe('artifacts', iframe, { title: 'WORKSPACE' });
+    expect(iframe.style.pointerEvents).toBe('auto');
+
+    const sash = document.createElement('div');
+    sash.className = 'dv-sash';
+    document.body.appendChild(sash);
+
+    // dockview's splitview sash handling, verbatim contract: target-phase
+    // pointerdown snapshot, bubble-phase document pointerup restore.
+    const snapshot = new WeakMap();
+    sash.addEventListener('pointerdown', () => {
+      for (const f of document.querySelectorAll('iframe')) {
+        snapshot.set(f, f.style.pointerEvents);
+        f.style.pointerEvents = 'none';
+      }
+      const release = () => {
+        document.removeEventListener('pointerup', release);
+        for (const f of document.querySelectorAll('iframe')) {
+          f.style.pointerEvents = snapshot.get(f) ?? 'auto';
+        }
+      };
+      document.addEventListener('pointerup', release);
+    });
+
+    sash.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    document.dispatchEvent(new Event('pointerup', { bubbles: true }));
+
+    expect(iframe.style.pointerEvents).toBe('auto');
+
+    // A second gesture must also end interactive (the old shield could never
+    // self-heal: every drag re-snapshotted the poisoned 'none').
+    sash.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    document.dispatchEvent(new Event('pointerup', { bubbles: true }));
+
+    expect(iframe.style.pointerEvents).toBe('auto');
+  });
+});


### PR DESCRIPTION
Bundles the two mechanical fixes from this week's field reports.

## #636 — limits hook denies every write under the four-zone layout

**Root cause** (differs from the issue's framing): the hook *does* load the correct config — `ConfigBuilder`'s cwd fallback finds `build/config.yml` — but `LimitsValidator.resolve_database_path` then ignored which config was loaded and guessed the anchor from the `CONFIG_FILE` env var, falling back to `project_root` (the repo root). The database was resolved one zone too high, and the empty-DB failsafe denied everything.

**Fix**: a relative `database_path` now anchors on the directory of the config actually loaded (new side-effect-free `default_config_path()` accessor; `CONFIG_FILE`/`project_root` remain as fallbacks). The bluesky-bridge startup guard mirrors the same resolution.

Deliberately **not** the issue's suggested fix (injecting `CONFIG_FILE` into the rendered hook commands): `resolve_config_path()` documents why `CONFIG_FILE` is not honored framework-wide, rendered `settings.json` is user-owned and skipped on regen so deployed facilities would never receive a launcher-side fix, and the validator-side fix ships in the wheel and covers every launch path at once. The field workaround (`CONFIG_FILE` in the deployment repo's `.env`) can be deleted after upgrading.

Also lands the issue's secondary finding: the failsafe now refuses with `LIMITS_DATABASE_UNAVAILABLE` ("limits database unavailable — all writes are blocked as a failsafe (…)") instead of the unlisted-channel message, so a load failure is no longer narrated as a data problem.

## #638 — sash resize freezes all other panels

**Root cause** (both mechanisms proposed in the issue are refuted): a double-shield clobber. dockview-core 7.0.2 (the pinned vendor version; verified against the manifest's exact sha256) already disables pointer-events on every iframe for the whole sash gesture — by *snapshotting* each iframe's inline value on sash pointerdown and restoring the snapshot on pointerup (bubble phase). The adapter's capture-phase `wireSashShield()` set `none` before that snapshot, so dockview recorded `none` as the original value and its restore re-froze every overlay iframe after each drag. Each further drag re-snapshotted the poisoned value, which is why the freeze never self-healed short of a refresh.

**Fix**: delete `wireSashShield()` — it is fully redundant for the pinned dockview version. `wireDragShield`/`setIframePointerShield` stay: the tab/group and rail drag paths cannot poison dockview's snapshot (`onWillDragPanel` never fires in the 7.0.2 bundle; `onWillDragGroup` fires only after dockview's own snapshot), and rail drags start outside dockview entirely.

## Verification

- New regression tests, written first and observed red: the four-zone hook scenario for #636, and a jsdom test emulating dockview's exact snapshot/restore sash contract for #638 (it reproduced the permanent `pointer-events: none`).
- Failsafe-vs-unlisted refusals covered both ways.
- `quick_check` green (the one design-hygiene failure was the scanner reading `#638` in a comment as a hex color — reworded); JS typecheck + eslint green; pre-existing mypy findings in `limits_validator.py` unchanged from baseline.

Closes #636. Closes #638.