### PR TITLE
feat(web-terminal): reach panel actions from a menu and the palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1273,6 +1273,34 @@ Compatibility is documented in release notes, not encoded in the version string.
   sweeps move below the fit into a collapsed section that shows one corrector
   at a time; when the fit is skipped they stay inline.
 
+### Added
+
+- The web terminal's command palette keeps a Recent section listing the
+  commands you last ran.
+- The command palette can open a panel in a new window or in a new tile — the
+  same two verbs the right-click menu offers. The new-window rows include the
+  panel you are looking at, which is the one most often wanted in its own tab.
+  The new-tile rows are absent in simple mode, whose layout holds one service
+  tile.
+
+### Changed
+
+- Panel actions in the web terminal now live in a right-click menu, on the
+  panel's rail entry and on its tile header alike: focus the panel, open it in
+  a new tile, open it in a new window, remove it from the rail. It replaces the
+  ↗ and ⊞ corner glyphs, which appeared only on hover and only on the rail. The
+  menu also opens from the keyboard — the menu key or Shift+F10 on a focused
+  rail entry.
+
+### Fixed
+
+- The command palette takes typing straight away. The search box was focused
+  before the overlay was made visible, which does nothing, so the first
+  keystrokes after Cmd/Ctrl+K were dropped and you had to click the box first.
+- Palette search answers to the words operators actually reach for: a panel's
+  domain vocabulary ("logbook" finds ARIEL, "pv" finds Channel Finder) and the
+  verbs' synonyms ("window", "popout", "tile", "split").
+
 ## [2026.8.0]
 
 ### Removed

--- a/src/osprey/interfaces/web_terminal/static/css/palette.css
+++ b/src/osprey/interfaces/web_terminal/static/css/palette.css
@@ -109,14 +109,21 @@
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
+  /* visibility is a discrete property: while it TRANSITIONS the computed value
+   * stays `hidden` through the whole opening frame, which turns openPalette's
+   * same-frame `inputEl.focus()` into a spec'd no-op on the first open. So the
+   * flip is never animated — on close it is merely DELAYED past the opacity
+   * fade (this rule), and on open it applies instantly (.visible below). */
   transition: opacity var(--wt-transition-fast),
-              visibility var(--wt-transition-fast);
+              visibility 0s linear var(--duration-instant);
 }
 
 .command-palette-overlay.visible {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
+  transition: opacity var(--wt-transition-fast),
+              visibility 0s;
 }
 
 /* ---- Dialog panel ---- */
@@ -175,7 +182,10 @@
   flex: 1;
 }
 
-/* ---- Group heading (Settings / Panels / Layouts / Actions) ---- */
+/* ---- Group heading (Recent / Settings / Panels / Layouts / Actions) ----
+   "Recent" is not a registry group — palette.js builds that section at
+   render time when the query is empty — but it is a heading over rows like
+   any other, so it borrows this style rather than introducing its own. */
 .command-palette-group-heading {
   padding: var(--space-2) var(--space-2) var(--space-1);
   font-family: var(--font-mono);

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -688,20 +688,22 @@ html[data-ui-mode="simple"] .session-selector {
   box-sizing: border-box;
 }
 
-/* Per-entry corner affordances — decorative, revealed on hover. The rail owns
-   a panel's MEMBERSHIP lifecycle: close "×" (remove from rail, top-left),
-   popout "↗" (top-right), and open-beside "⊞" (open as a new tile,
-   bottom-right); closing an OPEN tile is the tile header's own "×". The
-   corners sit clear of the centred icon + label stack. */
-.panel-rail-close,
-.panel-rail-popout,
-.panel-rail-beside {
+/* The entry's one corner affordance — decorative, revealed on hover. The rail
+   owns a panel's MEMBERSHIP lifecycle, and the close "×" (top-left) is what is
+   left of that in the corners: "open in a new tile" and "open in a new window"
+   now live in the right-click context menu, spelled out as words instead of
+   glyphs. Closing an OPEN tile remains the tile header's own "×". The corner
+   sits clear of the centred icon + label stack. */
+.panel-rail-close {
   position: absolute;
+  top: 4px;
+  left: 4px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 14px;
   height: 14px;
+  font-size: var(--text-lg);
   border-radius: var(--radius-xs);
   line-height: var(--leading-none);
   color: var(--text-muted);
@@ -711,34 +713,9 @@ html[data-ui-mode="simple"] .session-selector {
     background var(--wt-transition-fast);
 }
 
-.panel-rail-close {
-  top: 4px;
-  left: 4px;
-  font-size: var(--text-lg);
-}
-
-/* The arrow is a smaller glyph than the "×" at the same nominal size, so it
-   rides one step up the scale to read as the "×"'s equal weight. */
-.panel-rail-popout {
-  top: 4px;
-  right: 4px;
-  font-size: var(--text-base);
-}
-
-/* Open-beside takes the bottom-right corner, below the popout: both "take
-   this panel somewhere" verbs share the right edge, membership removal keeps
-   the left. Same step-up sizing rationale as the popout glyph. */
-.panel-rail-beside {
-  bottom: 4px;
-  right: 4px;
-  font-size: var(--text-base);
-}
-
 /* Revealed on hover only — the active cell stays clean (close via hover or the
    keyboard Delete/Backspace shortcut). */
-.panel-rail-button:hover .panel-rail-close,
-.panel-rail-button:hover .panel-rail-popout,
-.panel-rail-button:hover .panel-rail-beside { opacity: 0.7; }
+.panel-rail-button:hover .panel-rail-close { opacity: 0.7; }
 
 .panel-rail-close:hover {
   opacity: 1;
@@ -746,27 +723,10 @@ html[data-ui-mode="simple"] .session-selector {
   background: var(--accent-tint-08);
 }
 
-/* Popout and open-beside are non-destructive, so they light accent rather
-   than the close's error red — the colour is the cue distinguishing the
-   corners on hover. */
-.panel-rail-popout:hover,
-.panel-rail-beside:hover {
-  opacity: 1;
-  color: var(--color-accent-light);
-  background: var(--accent-tint-08);
-}
-
 /* The drag source dims while its ghost travels, so "this entry is being
    dragged" reads at a glance. */
 .panel-rail-button.dragging {
   opacity: 0.4;
-}
-
-/* Simple mode is a locked layout: growing it is not a simple-mode gesture, so
-   the open-beside corner disappears entirely (rail-drag.js cancels the drag
-   half in JS — CSS cannot suppress draggable). */
-html[data-ui-mode="simple"] .panel-rail-beside {
-  display: none;
 }
 
 /* The design system's `.agent-attention` badge is pinned to the same top-right
@@ -786,22 +746,11 @@ html[data-ui-mode="simple"] .panel-rail-beside {
   opacity: 0.6;
 }
 
-/* Popout and open-beside are the opposite case: a panel whose backend has not
-   come up has nothing useful to open, so the affordances are hidden rather
-   than offered as a dead click (the JS handlers guard regardless). */
-.panel-rail-button.disabled .panel-rail-popout,
-.panel-rail-button.disabled .panel-rail-beside {
-  display: none;
-}
-
 /* The SESSION (terminal) entry is the rail's permanent anchor: it never has a
    membership "×" — its tile is closed/reopened through its own header bar and
    the Delete-key shortcut instead (dock-workspace.js guards the JS paths too).
-   It has no standalone page either, so no "↗"; its tile reopens via a plain
-   click, so no "⊞" (and panel-manager cancels its drag). */
-.panel-rail-button[data-panel-id="terminal"] .panel-rail-close,
-.panel-rail-button[data-panel-id="terminal"] .panel-rail-popout,
-.panel-rail-button[data-panel-id="terminal"] .panel-rail-beside {
+   Its context menu carries terminal verbs rather than the panel ones. */
+.panel-rail-button[data-panel-id="terminal"] .panel-rail-close {
   display: none;
 }
 
@@ -944,6 +893,103 @@ html[data-ui-mode="simple"] .panel-rail-beside {
 .panel-add-submit:hover { background: var(--color-accent-light); color: var(--bg-primary); }
 .panel-add-submit:disabled { opacity: 0.5; cursor: default; }
 
+/* ---- Rail / tile-header context menu ---- */
+
+/* The right-click popover that replaced the "↗" and "⊞" corners: the same
+   verbs, spelled out. Styled as the "+" popover's sibling (same surface,
+   border, shadow and row rhythm) so the two read as one menu family, but
+   positioned `fixed` rather than absolute — panel-context-menu.js appends it
+   to <body> at the cursor and clamps it into the viewport, so it has no
+   layout parent to hang off and needs no data-rail-position variants. */
+.rail-context-menu {
+  position: fixed;
+  min-width: 200px;
+  max-width: 280px;
+  padding: var(--space-1);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-dropdown);
+  z-index: var(--z-dropdown);
+}
+
+/* Verb on the left, its rail glyph trailing right — the glyph is the bridge
+   back to the iconography operators already learned. */
+.rail-context-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  color: var(--text-primary);
+  background: none;
+  border: none;
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: color var(--wt-transition-fast), background var(--wt-transition-fast);
+}
+
+.rail-context-item:hover,
+.rail-context-item:focus {
+  background: var(--bg-elevated);
+  outline: none;
+}
+
+/* A server-supplied panel label rides inside the verb, so it must be able to
+   truncate rather than widen the popover past its max. */
+.rail-context-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rail-context-glyph {
+  flex-shrink: 0;
+  font-size: var(--text-base);
+  line-height: var(--leading-none);
+  color: var(--text-muted);
+}
+
+/* The hovered row's glyph joins its text colour — on the danger row that is
+   how the "×" turns red with "Remove from rail". */
+.rail-context-item:hover .rail-context-glyph,
+.rail-context-item:focus .rail-context-glyph {
+  color: inherit;
+}
+
+/* Destructive verb: neutral at rest like every other row, error-red the
+   moment it is the one about to run. */
+.rail-context-item.danger:hover,
+.rail-context-item.danger:focus {
+  color: var(--color-error);
+  background: var(--error-tint-10);
+}
+
+/* An unavailable verb (a panel whose standalone URL has not resolved yet) is
+   shown so the menu's shape stays stable, but reads and behaves as inert:
+   muted, no pointer, and no hover response of any kind. */
+.rail-context-item[aria-disabled="true"] {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.rail-context-item[aria-disabled="true"]:hover,
+.rail-context-item[aria-disabled="true"]:focus {
+  color: var(--text-muted);
+  background: none;
+}
+
+.rail-context-divider {
+  height: 1px;
+  margin: var(--space-1) 0;
+  background: var(--border-default);
+}
+
 /* ============================================================
    Rail position: top — the same rail DOM rendered as a horizontal
    strip under the header, echoing the pre-redesign tab bar. Gated
@@ -1004,24 +1050,11 @@ html[data-rail-position="top"] .panel-rail-label {
   font-family: var(--font-display);
 }
 
-/* Pinned children: the LED keeps its top-right corner; close and popout tuck
-   tighter into their top corners so they clear the now-centered icon. */
-html[data-rail-position="top"] .panel-rail-close,
-html[data-rail-position="top"] .panel-rail-popout {
-  top: 2px;
-}
-
+/* Pinned children: the LED keeps its top-right corner; the close "×" tucks
+   tighter into its top-left corner so it clears the now-centered icon. */
 html[data-rail-position="top"] .panel-rail-close {
+  top: 2px;
   left: 2px;
-}
-
-html[data-rail-position="top"] .panel-rail-beside {
-  bottom: 2px;
-  right: 2px;
-}
-
-html[data-rail-position="top"] .panel-rail-popout {
-  right: 2px;
 }
 
 html[data-rail-position="top"] .panel-add {

--- a/src/osprey/interfaces/web_terminal/static/js/dock-tab.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-tab.js
@@ -20,6 +20,10 @@
  * Registered via dockview's createTabComponent/defaultTabComponent
  * (dock-workspace.js), which keeps dockview's native tab DnD, drop
  * hit-testing and close plumbing intact — the bar IS the drag handle.
+ *
+ * Both bar kinds are also a right-click surface: the tile header opens the
+ * same verb menu as the panel's rail entry (panel-context-menu.js), routed
+ * through the setTileContextMenuHandler registration seam below.
  */
 
 import { TERMINAL_RAIL_ID } from './panel-catalog.js';
@@ -58,11 +62,12 @@ let terminalHeaderEl = null;
 /**
  * Registers the live `.terminal-header` node. Called once by dock-workspace.js
  * before the terminal panel is added to dockview (see initDockWorkspace).
- * Also wires the interactive-children pointerdown guard directly on the node,
- * here rather than in the TileTab constructor: the header node is long-lived
- * across close/reopen/mode-switch, but a TileTab is rebuilt on every one of
- * those, so attaching in the constructor would stack a new listener on the
- * same node each time. Registration happens exactly once per node.
+ * Also wires the interactive-children pointerdown guard and the header's
+ * contextmenu route directly on the node, here rather than in the TileTab
+ * constructor: the header node is long-lived across close/reopen/mode-switch,
+ * but a TileTab is rebuilt on every one of those, so attaching in the
+ * constructor would stack a new listener on the same node each time.
+ * Registration happens exactly once per node.
  * @param {HTMLElement} el
  */
 export function setTerminalHeaderSource(el) {
@@ -75,6 +80,10 @@ export function setTerminalHeaderSource(el) {
       e.stopPropagation();
     }
   });
+  // The terminal bar's right-click surface is the adopted header itself, not
+  // the tab root: the header fills the bar, and listening on the root as well
+  // would run the handler twice for one press.
+  wireTileContextMenu(el, TERMINAL_RAIL_ID);
 }
 
 /** @returns {HTMLElement | null} */
@@ -84,6 +93,58 @@ function terminalHeader() {
 
 /** Matches the interactive children of the adopted terminal header. */
 const INTERACTIVE = 'button, select, input, a, [role="button"]';
+
+/**
+ * Handler a tile-header right-click is routed to, registered by
+ * panel-manager.js at init — it owns the whole menu policy (which verbs, and
+ * whether the surface has a menu at all), exactly as it does for the rail.
+ *
+ * A registration seam rather than an import, mirroring dock-sync's
+ * setTileCloseHandler: panel-manager imports dock-workspace, which imports
+ * this module, so importing panel-manager back would close a cycle.
+ * @type {((id: string, opts: TileMenuRequest) => boolean) | null}
+ */
+let tileContextMenuHandler = null;
+
+/**
+ * Where the menu should appear and what it belongs to. `anchorEl` is the
+ * header bar: the menu scopes its scroll dismissal to it, so a panel
+ * scrolling its own content underneath leaves the menu standing.
+ * @typedef {{ x: number, y: number, anchorEl: HTMLElement }} TileMenuRequest
+ */
+
+/**
+ * Registers the tile-header context-menu handler. Called once by
+ * panel-manager.js at init. The handler returns true when it opened a menu.
+ * @param {((id: string, opts: TileMenuRequest) => boolean) | null} fn
+ */
+export function setTileContextMenuHandler(fn) {
+  tileContextMenuHandler = fn;
+}
+
+/**
+ * Route right-clicks on a header bar to the registered handler.
+ *
+ * Declining is doing NOTHING — no menu and no preventDefault — so the browser
+ * shows its own menu instead. That happens on interactive header children
+ * (right-clicking inside a contributed search input must still offer
+ * copy/paste) and whenever the handler itself declines, e.g. the terminal in
+ * simple mode, where every terminal verb acts on a surface the operator
+ * cannot see.
+ * @param {HTMLElement} el  the header surface, and the menu's anchor
+ * @param {string} id  the panel id the menu's verbs act on
+ */
+function wireTileContextMenu(el, id) {
+  el.addEventListener('contextmenu', (e) => {
+    if (e.target instanceof Element && e.target.closest(INTERACTIVE)) return;
+    const opened = tileContextMenuHandler?.(id, {
+      x: e.clientX,
+      y: e.clientY,
+      anchorEl: el,
+    });
+    if (opened) e.preventDefault();
+  });
+}
 
 /**
  * The tile-tab renderer (dockview ITabRenderer: element / init / dispose).
@@ -147,6 +208,10 @@ class TileTab {
         ? id.slice(PLACEHOLDER_PREFIX.length)
         : id;
       registerContribHost(this._servicePanelId, contrib);
+      // The bar is the panel's second home for its verbs, alongside the rail
+      // entry. Wired per construction because a service tab's root IS rebuilt
+      // with the tab — unlike the terminal's long-lived adopted header.
+      wireTileContextMenu(root, this._servicePanelId);
     }
 
     const actions = document.createElement('div');

--- a/src/osprey/interfaces/web_terminal/static/js/palette-boot.js
+++ b/src/osprey/interfaces/web_terminal/static/js/palette-boot.js
@@ -12,11 +12,12 @@
  * the action cluster never shifts under an operator on an Expert/Simple flip.
  * What changes is the REGISTRY, not the entry points: simple mode hides the
  * terminal (the operator console takes its place) and locks the dock to a
- * single service tile, so `buildPaletteDeps` drops the terminal/session actions
- * and the Layouts group there rather than offering picks that would silently do
- * nothing. Everything simple mode can honour — settings search, the panel
- * show/focus verbs the rail already exposes, rail placement, the drawer tabs,
- * the safety reference — stays.
+ * single service tile, so `buildPaletteDeps` drops the terminal/session actions,
+ * the Layouts group and the "Open … in a new tile" rows there rather than
+ * offering picks that would silently do nothing. Everything simple mode can
+ * honour — settings search, the panel show/focus verbs the rail already
+ * exposes, popping a panel out to its own browser tab, rail placement, the
+ * drawer tabs, the safety reference — stays.
  */
 
 import { restartTerminal, startTerminal } from './terminal.js';
@@ -24,11 +25,14 @@ import { withPrefix } from './api.js';
 import {
   getHiddenPanels,
   getVisiblePanels,
+  getPopoutPanels,
   getPresets,
   showPanel,
   activateTab,
   applyMenuPreset,
+  popoutPanel,
 } from './panel-manager.js';
+import { openPanelBeside } from './panel-placement.js';
 import { openDrawerTab, revealSetting } from './settings.js';
 import { startNewSession } from './sessions.js';
 import { setRailPosition } from './rail-position.js';
@@ -53,7 +57,11 @@ function currentUiMode() {
  * boot state. The action closures are the vetted mechanisms (paired restart,
  * gated drawer tabs, new-tab safety nav) — do not collapse or reorder them
  * casually.
- * @returns {import('./palette.js').OpenDeps}
+ *
+ * Typed against the REGISTRY's dep bundle rather than palette.js's OpenDeps:
+ * everything assembled here exists to reach `buildRegistry`, and PaletteDeps is
+ * the declaration site for the panel-verb deps. openPalette accepts it as-is.
+ * @returns {import('./palette-registry.js').PaletteDeps}
  */
 function buildPaletteDeps() {
   const simple = currentUiMode() === 'simple';
@@ -95,7 +103,7 @@ function buildPaletteDeps() {
     actions.push({ label: 'Log out', run: () => document.getElementById('logout-btn')?.click() });
   }
 
-  /** @type {import('./palette.js').OpenDeps} */
+  /** @type {import('./palette-registry.js').PaletteDeps} */
   const deps = {
     // Panel show/focus is exactly what a rail click does, and the rail is
     // present in both modes — in simple the show path takes over the single
@@ -105,14 +113,24 @@ function buildPaletteDeps() {
     showPanel,
     // "Focus" reports as a user-initiated activation so the server sees it.
     focusPanel: (id) => activateTab(id, { userInitiated: true }),
+    // Popping out is a browser-tab action, so it survives simple mode's locked
+    // layout untouched. getPopoutPanels is already narrowed to rail members
+    // whose standalone URL resolved, and INCLUDES the active panel — the
+    // context menu's "Open in a new window" reads the same way.
+    getPopoutPanels,
+    popoutPanel,
     revealSetting,
     actions,
   };
 
-  // Layouts restore a multi-tile arrangement; simple mode's locked layout holds
-  // exactly one service tile, so a preset there could not be honoured. Omitting
-  // the getter drops the whole group from the registry.
+  // Both of the below place a SECOND service tile, which simple mode's locked
+  // layout cannot hold — omitting the dep is what drops the rows.
   if (!simple) {
+    // "Open … in a new tile" shares getVisiblePanels with the Focus rows, so
+    // withholding the closure is the only thing that can separate the two.
+    deps.openPanelBeside = openPanelBeside;
+    // Layouts restore a multi-tile arrangement; omitting the getter drops the
+    // whole group from the registry.
     deps.getPresets = getPresets;
     deps.applyPreset = applyMenuPreset;
   }

--- a/src/osprey/interfaces/web_terminal/static/js/palette-registry.js
+++ b/src/osprey/interfaces/web_terminal/static/js/palette-registry.js
@@ -48,14 +48,57 @@
  *   ),
  *   getHiddenPanels?: () => Array<{ id: string, label: string }>,
  *   getVisiblePanels?: () => Array<{ id: string, label: string }>,
+ *   getPopoutPanels?: () => Array<{ id: string, label: string }>,
  *   getPresets?: () => Array<{ name: string, panels: string[] }>,
  *   actions?: Array<{ label: string, detail?: string, run: () => void }>,
  *   showPanel?: (id: string) => void,
  *   focusPanel?: (id: string) => void,
+ *   popoutPanel?: (id: string) => void,
+ *   openPanelBeside?: (id: string) => void,
  *   applyPreset?: (name: string) => void,
  *   revealSetting?: (dotKey: string) => void,
  * }} PaletteDeps
  */
+
+/**
+ * Domain vocabulary for the built-in panels — the words an operator reaches
+ * for when they do not have the catalog label in mind ("logbook" for ARIEL,
+ * "pv" for Channel Finder). Folded into the searchText of EVERY row for that
+ * panel, so any of its verbs is reachable by the domain word. Keyed by catalog
+ * panel id; ids absent here (custom facility panels) contribute no aliases.
+ * @type {Record<string, string>}
+ */
+const PANEL_SYNONYMS = {
+  ariel: 'logbook elog',
+  'channel-finder': 'pv channels',
+  artifacts: 'gallery files',
+  lattice: 'optics',
+  okf: 'knowledge docs',
+  'system-health': 'status monitoring',
+};
+
+/** Verb vocabulary for "Open … in a new window" rows. */
+const POPOUT_ALIASES = 'window popout standalone tab';
+
+/** Verb vocabulary for "Open … in a new tile" rows. */
+const BESIDE_ALIASES = 'tile beside split';
+
+/**
+ * searchText for a panel row: the verb, the panel's own label and id, the
+ * verb's aliases, then the panel's domain aliases. Only searchText is scored
+ * by the matcher (labels are not), so every alias a row should answer to has
+ * to be present here.
+ *
+ * @param {string} verb
+ * @param {{ id: string, label: string }} panel
+ * @param {string} [verbAliases]
+ * @returns {string}
+ */
+function panelSearchText(verb, panel, verbAliases) {
+  return [verb, panel.label, panel.id, verbAliases, PANEL_SYNONYMS[panel.id]]
+    .filter(Boolean)
+    .join(' ');
+}
 
 /**
  * Invoke an optional getter defensively, always returning an array. Absent or
@@ -144,8 +187,23 @@ function buildSettings(deps) {
 }
 
 /**
- * Build the Panels group: a "Show <label>" item per hidden panel, then a
- * "Focus <label>" item per visible (non-active) panel.
+ * Build the Panels group: a "Show <label>" item per hidden panel, a
+ * "Focus <label>" item per visible (non-active) panel, an "Open <label> in a
+ * new window" item per pop-out-able panel, and an "Open <label> in a new tile"
+ * item per visible (non-active) panel.
+ *
+ * The two "Open" verbs draw on DIFFERENT sources on purpose, and the
+ * difference is the whole point of FR8:
+ *
+ *   - new window ← `getPopoutPanels`, which INCLUDES the active panel (popping
+ *     out the panel you are looking at is the verb's commonest use) and is
+ *     already filtered to members whose standalone URL has resolved.
+ *   - new tile ← `getVisiblePanels`, which EXCLUDES the active panel (opening
+ *     it beside itself is a guaranteed no-op), and carries no URL gate — the
+ *     rail corner this verb replaces never had one.
+ *
+ * The new-tile rows are dropped wholesale when `openPanelBeside` is absent,
+ * which is how simple mode (locked to one service tile) omits them.
  *
  * @param {PaletteDeps} deps
  * @returns {Item[]}
@@ -153,6 +211,8 @@ function buildSettings(deps) {
 function buildPanels(deps) {
   const showPanel = deps.showPanel;
   const focusPanel = deps.focusPanel;
+  const popoutPanel = deps.popoutPanel;
+  const openPanelBeside = deps.openPanelBeside;
 
   /** @type {Item[]} */
   const items = [];
@@ -162,7 +222,7 @@ function buildPanels(deps) {
     items.push({
       group: 'Panels',
       label: `Show ${panel.label}`,
-      searchText: `show ${panel.label} ${id}`,
+      searchText: panelSearchText('show', panel),
       run: () => {
         if (typeof showPanel === 'function') {
           showPanel(id);
@@ -176,13 +236,41 @@ function buildPanels(deps) {
     items.push({
       group: 'Panels',
       label: `Focus ${panel.label}`,
-      searchText: `focus ${panel.label} ${id}`,
+      searchText: panelSearchText('focus', panel),
       run: () => {
         if (typeof focusPanel === 'function') {
           focusPanel(id);
         }
       },
     });
+  }
+
+  for (const panel of safeList(deps.getPopoutPanels)) {
+    const id = panel.id;
+    items.push({
+      group: 'Panels',
+      label: `Open ${panel.label} in a new window`,
+      searchText: panelSearchText('open', panel, POPOUT_ALIASES),
+      run: () => {
+        if (typeof popoutPanel === 'function') {
+          popoutPanel(id);
+        }
+      },
+    });
+  }
+
+  if (typeof openPanelBeside === 'function') {
+    for (const panel of safeList(deps.getVisiblePanels)) {
+      const id = panel.id;
+      items.push({
+        group: 'Panels',
+        label: `Open ${panel.label} in a new tile`,
+        searchText: panelSearchText('open', panel, BESIDE_ALIASES),
+        run: () => {
+          openPanelBeside(id);
+        },
+      });
+    }
   }
 
   return items;

--- a/src/osprey/interfaces/web_terminal/static/js/palette.js
+++ b/src/osprey/interfaces/web_terminal/static/js/palette.js
@@ -19,6 +19,17 @@
  * The keydown handler is installed on the document in CAPTURE phase and calls
  * stopPropagation for the keys it owns, so palette Escape/arrows never reach
  * osprey-drawer's Escape-closes-drawers handler or the terminal underneath.
+ *
+ * Recent commands are a PRESENTATION-level section, not a registry group: the
+ * last few executed items are stored in localStorage by their `itemKey()` and
+ * re-resolved against the live registry each render, so the Item group union
+ * and GROUP_ORDER never learn about them and a stored key that no longer
+ * matches anything (a mode-dependent row, a renamed setting) is skipped
+ * silently. Because a Recent row duplicates a row that also appears in its
+ * home group, its NAVIGATION key is namespaced (`recent\x1f` + itemKey) so the
+ * active-row restore across the mid-open config-fetch re-render can never snap
+ * from the home-group row to its Recent twin; recording always stores the
+ * plain underlying key, from whichever copy was executed.
  */
 
 import { fuzzyMatch } from './fuzzy.js';
@@ -47,9 +58,12 @@ import { el } from '/design-system/js/dom.js';
  * @typedef {{
  *   getHiddenPanels?: () => Array<{ id: string, label: string }>,
  *   getVisiblePanels?: () => Array<{ id: string, label: string }>,
+ *   getPopoutPanels?: () => Array<{ id: string, label: string }>,
  *   getPresets?: () => Array<{ name: string, panels: string[] }>,
  *   showPanel?: (id: string) => void,
  *   focusPanel?: (id: string) => void,
+ *   popoutPanel?: (id: string) => void,
+ *   openPanelBeside?: (id: string) => void,
  *   applyPreset?: (name: string) => void,
  *   revealSetting?: (dotKey: string) => void,
  *   actions?: Array<{ label: string, detail?: string, run: () => void }>,
@@ -61,6 +75,13 @@ import { el } from '/design-system/js/dom.js';
 
 /** Fixed outer group order — matches the registry and the stylesheet. */
 const GROUP_ORDER = /** @type {const} */ (['Settings', 'Panels', 'Layouts', 'Actions']);
+
+/** localStorage key + cap for the most-recently-executed item keys. */
+const RECENT_STORAGE_KEY = 'osprey-palette-recent-v1';
+const RECENT_LIMIT = 5;
+
+/** Namespace prefix keeping a Recent row's nav key distinct from its original. */
+const RECENT_KEY_PREFIX = 'recent\x1f';
 
 /** The module's ONLY network call: fetch the config snapshot. */
 const defaultFetchConfig = () => fetchJSON('/api/config');
@@ -105,6 +126,58 @@ function isWelcomeVisible() {
  */
 function itemKey(/** @type {NavItem} */ item) {
   return `${item.group}\x1f${item.label}`;
+}
+
+/**
+ * Read the stored recent-item keys, most-recent first. Anything unreadable or
+ * malformed (storage blocked in private mode, hand-edited value) yields an
+ * empty list, which turns the feature off silently rather than breaking the
+ * render.
+ * @returns {string[]}
+ */
+function readRecent() {
+  let raw = null;
+  try {
+    raw = localStorage.getItem(RECENT_STORAGE_KEY);
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((k) => typeof k === 'string').slice(0, RECENT_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Move `key` to the front of the recent list, capped at RECENT_LIMIT. Storage
+ * failures are swallowed: Recent is a convenience, never a precondition for
+ * running a command.
+ * @param {string} key
+ */
+function recordRecent(key) {
+  const next = [key, ...readRecent().filter((k) => k !== key)].slice(0, RECENT_LIMIT);
+  try {
+    localStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(next));
+  } catch { /* storage blocked — Recent stays empty, execution is unaffected */ }
+}
+
+/**
+ * Wrap an item's `run` so executing it from EITHER path (Enter or click) and
+ * from EITHER copy (home group or Recent) records the same plain item key.
+ * @param {NavItem} item
+ * @returns {() => void}
+ */
+function makeExecutor(item) {
+  const key = itemKey(item);
+  const run = item.run;
+  return () => {
+    recordRecent(key);
+    run();
+  };
 }
 
 /** Lazily create the single reused overlay node and (re)attach it to <body>. */
@@ -159,9 +232,12 @@ function rebuildRegistry() {
     config: configState,
     getHiddenPanels: currentDeps.getHiddenPanels,
     getVisiblePanels: currentDeps.getVisiblePanels,
+    getPopoutPanels: currentDeps.getPopoutPanels,
     getPresets: currentDeps.getPresets,
     showPanel: currentDeps.showPanel,
     focusPanel: currentDeps.focusPanel,
+    popoutPanel: currentDeps.popoutPanel,
+    openPanelBeside: currentDeps.openPanelBeside,
     applyPreset: currentDeps.applyPreset,
     revealSetting: currentDeps.revealSetting,
     actions: currentDeps.actions,
@@ -199,9 +275,10 @@ function appendHighlighted(container, text, query) {
  * @param {NavItem} item
  * @param {string} id
  * @param {string} query
+ * @param {() => void} run  the recording executor, shared with the Enter path
  * @returns {HTMLElement}
  */
-function buildItemRow(item, id, query) {
+function buildItemRow(item, id, query, run) {
   const row = el('div', 'command-palette-item');
   row.id = id;
   row.setAttribute('role', 'option');
@@ -217,7 +294,6 @@ function buildItemRow(item, id, query) {
     row.appendChild(detail);
   }
 
-  const run = item.run;
   row.addEventListener('click', () => {
     closePalette();
     run();
@@ -230,9 +306,45 @@ function buildItemRow(item, id, query) {
 }
 
 /**
+ * Append the "Recent" section — the stored keys resolved against the CURRENT
+ * registry, most-recent first — and register its rows for navigation. Keys
+ * with no live match are skipped, so a row that disappears with a mode switch
+ * costs nothing and heals itself on the next execution. Nothing renders (not
+ * even the heading) when no stored key resolves.
+ * @param {() => string} nextId  shared option-id sequence, so ids stay unique
+ */
+function renderRecentSection(nextId) {
+  if (!listEl) return;
+  /** @type {Map<string, NavItem>} */
+  const byKey = new Map();
+  for (const item of registryItems) {
+    if (!('status' in item)) byKey.set(itemKey(item), item);
+  }
+
+  /** @type {NavItem[]} */
+  const items = [];
+  for (const key of readRecent()) {
+    const item = byKey.get(key);
+    if (item) items.push(item);
+  }
+  if (items.length === 0) return;
+
+  const heading = el('div', 'command-palette-group-heading');
+  heading.textContent = 'Recent';
+  listEl.appendChild(heading);
+  for (const item of items) {
+    const run = makeExecutor(item);
+    const node = buildItemRow(item, nextId(), '', run);
+    listEl.appendChild(node);
+    navItems.push({ key: RECENT_KEY_PREFIX + itemKey(item), run, el: node });
+  }
+}
+
+/**
  * Recompute the filtered/sorted results for the current query and repaint the
- * list. Group order (Settings → Panels → Layouts → Actions) is the outer
- * ordering; within each group navigable items sort by descending score. Status
+ * list. With an empty query the Recent section renders first; group order
+ * (Settings → Panels → Layouts → Actions) is the outer ordering after it, and
+ * within each group navigable items sort by descending score. Status
  * decorations always render under Settings but are excluded from navigation.
  */
 function render() {
@@ -241,7 +353,10 @@ function render() {
   navItems = [];
   const q = currentQuery.trim();
   let optSeq = 0;
+  const nextId = () => `command-palette-opt-${optSeq++}`;
   let renderedStatus = false;
+
+  if (!q) renderRecentSection(nextId);
 
   for (const group of GROUP_ORDER) {
     /** @type {Array<{ node: HTMLElement, nav?: { key: string, run: () => void } }>} */
@@ -264,8 +379,8 @@ function render() {
 
     matches.sort((a, b) => b.score - a.score);
     for (const { item } of matches) {
-      const id = `command-palette-opt-${optSeq++}`;
-      rows.push({ node: buildItemRow(item, id, q), nav: { key: itemKey(item), run: item.run } });
+      const run = makeExecutor(item);
+      rows.push({ node: buildItemRow(item, nextId(), q, run), nav: { key: itemKey(item), run } });
     }
 
     if (rows.length === 0) continue;
@@ -411,9 +526,16 @@ export function openPalette(deps) {
 
   buildDialog();
   const root = ensureOverlay();
-  requestAnimationFrame(() => root.classList.add('visible'));
+  // Focus has to land in the same frame that reveals the overlay: focusing an
+  // element inside a `visibility: hidden` subtree is a spec'd no-op. The guard
+  // drops a stale callback left by a fast open -> close, which would otherwise
+  // re-show the overlay and steal focus.
+  requestAnimationFrame(() => {
+    if (!opened) return;
+    root.classList.add('visible');
+    if (inputEl) inputEl.focus();
+  });
   document.addEventListener('keydown', onKeydown, true);
-  if (inputEl) inputEl.focus();
 
   rebuildRegistry();
   render();

--- a/src/osprey/interfaces/web_terminal/static/js/panel-context-menu.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-context-menu.js
@@ -1,0 +1,265 @@
+// @ts-check
+/* OSPREY Web Terminal — Rail Context Menu
+ *
+ * A small cursor-anchored popover listing a rail entry's verbs in words —
+ * the legible home for the panel actions that used to be hover-revealed
+ * corner glyphs ("open in a new tile" ⊞, "open in a new window" ↗). Opened
+ * by panel-manager from a rail entry's or tile header's contextmenu event.
+ *
+ * The keyboard path is NOT the browser's: macOS fires no `contextmenu` event
+ * from the menu key or Shift+F10, so panel-rail handles those keydowns itself
+ * and calls the same opener with the entry's rect. (Windows/Firefox DO fire a
+ * native `contextmenu` from that keydown, which is why the rail cancels the
+ * keydown's default action — otherwise one keypress would open two menus.)
+ *
+ * Purely presentational, like panel-add-menu: it owns the popover DOM,
+ * open/close, dismissal, focus bookkeeping, and viewport clamping. It holds
+ * no panel state and issues no fetches — the caller passes fully-bound `run`
+ * closures, so this module never knows what the verbs do. One menu at a time:
+ * opening replaces any open menu.
+ *
+ * Dismissal contract — the menu closes on:
+ *   - pointerdown outside it (capture phase, so the press dismisses first),
+ *   - Escape or Tab,
+ *   - running an item (the menu closes BEFORE the action),
+ *   - window `blur` — a click into a panel iframe never reaches this document,
+ *   - window `resize`,
+ *   - a scroll that actually moves the anchor: capture-phase `scroll` whose
+ *     target is the document or an ancestor of `anchorEl`. Scoping matters —
+ *     an unscoped listener would dismiss on xterm's own viewport scrolls, i.e.
+ *     every time the terminal streams output.
+ *
+ * Focus contract — `openContextMenu` records `document.activeElement` as
+ * `previousFocus` and focuses the first enabled row. That focus is handed back
+ * only on the KEYBOARD dismissals (Escape/Tab) and on close-before-run, where
+ * it is restored before the action runs so an action that moves focus itself
+ * (window.open, docking a tile) still wins. Pointer/blur/scroll/resize
+ * dismissals never move focus: blur in particular fires AFTER focus entered
+ * the clicked iframe, and restoring would yank it straight back out.
+ * `previousFocus` rather than "the invoking element" because tile headers are
+ * non-focusable divs — there is nothing else to hand focus back to.
+ *
+ * DOM contract (the browser suite selects on it):
+ *
+ *   <div class="rail-context-menu" role="menu" aria-label="ARIEL actions">
+ *     <button class="rail-context-item" role="menuitem" type="button">
+ *       <span class="rail-context-label">Open in a new window</span>
+ *       <span class="rail-context-glyph" aria-hidden="true">↗</span>
+ *     </button>
+ *     <div class="rail-context-divider" role="separator"></div>
+ *     <button class="rail-context-item danger" ...>
+ *   </div>
+ */
+
+/**
+ * One menu row. A `divider: true` entry renders a separator instead of a
+ * button (its other fields are ignored).
+ * @typedef {object} MenuItem
+ * @property {boolean} [divider]  - render a separator, not a button
+ * @property {string} [label]     - the verb, in words
+ * @property {string} [glyph]     - trailing glyph tying the row to rail iconography
+ * @property {boolean} [disabled] - render the row inert (aria-disabled, no run)
+ * @property {boolean} [danger]   - destructive verb — hover styles error-red
+ * @property {() => void} [run]   - the caller-bound action; the menu closes first
+ */
+
+/** @type {HTMLElement | null} the single open menu, or null */
+let menuEl = null;
+
+/** @type {HTMLElement | null} the surface the menu belongs to (scroll scoping) */
+let anchorEl = null;
+
+/** @type {HTMLElement | null} what had focus when the menu opened */
+let previousFocus = null;
+
+/** @param {MouseEvent} e */
+function onDocPointerDown(e) {
+  if (menuEl && e.target instanceof Node && !menuEl.contains(e.target)) dismiss(false);
+}
+
+/** @param {KeyboardEvent} e */
+function onDocKeydown(e) {
+  if (!menuEl) return;
+  // Escape and Tab both leave the menu by keyboard, so both hand focus back.
+  // Tab's default is cancelled: the operator resumes tabbing from where they
+  // were, not from wherever a removed menu row left the sequence.
+  if (e.key === 'Escape' || e.key === 'Tab') {
+    e.preventDefault();
+    e.stopPropagation();
+    dismiss(true);
+    return;
+  }
+  // Arrow navigation over the enabled rows — the menu's only focusables.
+  if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    e.preventDefault();
+    e.stopPropagation();
+    const rows = /** @type {HTMLElement[]} */ (
+      [...menuEl.querySelectorAll('.rail-context-item:not([aria-disabled="true"])')]
+    );
+    if (!rows.length) return;
+    const idx = rows.indexOf(/** @type {HTMLElement} */ (document.activeElement));
+    const next = e.key === 'ArrowDown'
+      ? rows[(idx + 1 + rows.length) % rows.length]
+      : rows[(idx - 1 + rows.length) % rows.length];
+    next.focus();
+  }
+}
+
+/** The window lost focus — usually a click landing inside a panel iframe. */
+function onWindowBlur() {
+  dismiss(false);
+}
+
+/** A resize moves every anchor; a cursor-anchored popover cannot follow. */
+function onWindowResize() {
+  dismiss(false);
+}
+
+/**
+ * Close only when the scroll actually moved the menu's anchor: the document
+ * scrolled, or a container holding the anchor did. A panel's own scroller —
+ * the terminal viewport above all — leaves the menu alone.
+ * @param {Event} e
+ */
+function onDocScroll(e) {
+  if (!menuEl) return;
+  if (e.target === document) {
+    dismiss(false);
+    return;
+  }
+  if (anchorEl && e.target instanceof Node && e.target.contains(anchorEl)) dismiss(false);
+}
+
+/**
+ * Tear down the open menu, optionally handing focus back to whatever held it
+ * when the menu opened.
+ * @param {boolean} restoreFocus
+ */
+function dismiss(restoreFocus) {
+  if (!menuEl) return;
+  menuEl.remove();
+  menuEl = null;
+  anchorEl = null;
+  const restoreTo = previousFocus;
+  previousFocus = null;
+  document.removeEventListener('pointerdown', onDocPointerDown, true);
+  document.removeEventListener('keydown', onDocKeydown, true);
+  document.removeEventListener('scroll', onDocScroll, true);
+  window.removeEventListener('blur', onWindowBlur);
+  window.removeEventListener('resize', onWindowResize);
+  if (restoreFocus && restoreTo && restoreTo.isConnected) restoreTo.focus();
+}
+
+/**
+ * Close the open context menu, if any, leaving focus where it is. Safe to
+ * call when none is open.
+ */
+export function closeContextMenu() {
+  dismiss(false);
+}
+
+/**
+ * Open the context menu at a viewport position, replacing any open menu.
+ *
+ * All children are assembled via DOM APIs (never innerHTML) because labels can
+ * carry server-supplied panel labels. After insertion the menu is clamped so
+ * it never overflows the viewport (opened near an edge it flips inward), and
+ * the first enabled row takes focus for keyboard users.
+ *
+ * @param {{
+ *   x: number,
+ *   y: number,
+ *   anchorEl?: HTMLElement | null,
+ *   ariaLabel: string,
+ *   items: MenuItem[],
+ * }} opts  - `anchorEl` is the rail entry or tile header the menu belongs to;
+ *   it scopes the scroll dismissal (omitting it leaves only document scrolls).
+ */
+export function openContextMenu(opts) {
+  const { x, y, ariaLabel, items } = opts;
+  // Capture the focus to hand back BEFORE tearing down any open menu — when
+  // one menu replaces another the active element is the old menu's row, so
+  // the earlier capture is the one worth keeping.
+  const active = document.activeElement;
+  const held = menuEl && active instanceof Node && menuEl.contains(active) ? previousFocus : active;
+  dismiss(false);
+  previousFocus = held instanceof HTMLElement ? held : null;
+  anchorEl = opts.anchorEl ?? null;
+
+  const menu = document.createElement('div');
+  menu.className = 'rail-context-menu';
+  menu.setAttribute('role', 'menu');
+  menu.setAttribute('aria-label', ariaLabel);
+  // A right-click on the popover itself (or the menu key on a focused row)
+  // must not stack the browser's native menu on top of this one.
+  menu.addEventListener('contextmenu', (e) => e.preventDefault());
+
+  for (const item of items) {
+    if (item.divider) {
+      const hr = document.createElement('div');
+      hr.className = 'rail-context-divider';
+      hr.setAttribute('role', 'separator');
+      menu.appendChild(hr);
+      continue;
+    }
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'rail-context-item' + (item.danger ? ' danger' : '');
+    btn.setAttribute('role', 'menuitem');
+    const label = document.createElement('span');
+    label.className = 'rail-context-label';
+    label.textContent = item.label ?? '';
+    btn.appendChild(label);
+    if (item.glyph) {
+      const glyph = document.createElement('span');
+      glyph.className = 'rail-context-glyph';
+      glyph.setAttribute('aria-hidden', 'true');
+      glyph.textContent = item.glyph;
+      btn.appendChild(glyph);
+    }
+    if (item.disabled) {
+      btn.setAttribute('aria-disabled', 'true');
+    } else {
+      const run = item.run;
+      // Close BEFORE running, matching the palette's Enter path — an action
+      // that moves focus (window.open, dock changes) must not race dismissal.
+      // Focus goes back first for the same reason: whatever the action does
+      // with focus lands last and therefore wins.
+      btn.addEventListener('click', () => {
+        dismiss(true);
+        run?.();
+      });
+    }
+    menu.appendChild(btn);
+  }
+
+  menu.style.left = `${x}px`;
+  menu.style.top = `${y}px`;
+  document.body.appendChild(menu);
+  menuEl = menu;
+
+  // Clamp into the viewport: near the right/bottom edge the menu flips to
+  // sit on the cursor's other side rather than overflowing.
+  const rect = menu.getBoundingClientRect();
+  if (rect.right > window.innerWidth) menu.style.left = `${Math.max(0, x - rect.width)}px`;
+  if (rect.bottom > window.innerHeight) menu.style.top = `${Math.max(0, y - rect.height)}px`;
+
+  // Capture-phase pointerdown (not click) so a drag started outside also
+  // dismisses, and before the outside target acts on the press. Scroll is
+  // capture-phase because element scrolls do not bubble.
+  document.addEventListener('pointerdown', onDocPointerDown, true);
+  document.addEventListener('keydown', onDocKeydown, true);
+  document.addEventListener('scroll', onDocScroll, true);
+  window.addEventListener('blur', onWindowBlur);
+  window.addEventListener('resize', onWindowResize);
+
+  const first = /** @type {HTMLElement | null} */ (
+    menu.querySelector('.rail-context-item:not([aria-disabled="true"])')
+  );
+  first?.focus();
+}
+
+/** @returns {boolean} whether a context menu is currently open (test hook). */
+export function isContextMenuOpen() {
+  return menuEl !== null;
+}

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -18,6 +18,11 @@
  * focus/visibility/registration, iframe lifecycle) and drives the
  * rail's DOM through panel-rail.js's imperative API — it never touches rail
  * markup itself.
+ *
+ * What a GESTURE on a rail entry or a tile header does is panel-menu-policy.js
+ * (entry closures, both context menus) and where a panel LANDS is
+ * panel-placement.js; both read this module's private state through deps
+ * registered at init, so neither imports it back.
  */
 
 import { fetchJSON, createEventSource } from './api.js';
@@ -31,18 +36,22 @@ import {
   setKnownServicePanels, setServerVisiblePanels, glowPanel,
 } from './dock-iframe.js';
 import {
-  initPanelPlacement, openPanelBeside, dropPanelAt, applyAgentSwitch, applyArrange,
+  initPanelPlacement, dropPanelAt, applyAgentSwitch, applyArrange,
 } from './panel-placement.js';
 import { createPanelIframe } from './panel-iframe-factory.js';
 import {
   PANELS, TERMINAL_RAIL_ID, TERMINAL_RAIL_LABEL, DEFAULT_PANEL_FALLBACK,
 } from './panel-catalog.js';
 import { initDockSync, withEchoSuppressed, setTileCloseHandler, setTileFocusHandler } from './dock-sync.js';
-import { initRailDrag, railDragStart, railDragEnd } from './rail-drag.js';
+import { setTileContextMenuHandler } from './dock-tab.js';
+import { initRailDrag } from './rail-drag.js';
 import { startHealthPolling as startPolling } from './panel-health.js';
 import { updateStatusBar } from './panel-status-bar.js';
 import { openTerminalPanel, closeTerminalPanel } from './dock-workspace.js';
 import { initRailThemeCoupling } from './rail-position.js';
+import {
+  initMenuPolicy, railOptions, openTileContextMenu, RAIL_MENU_HINT,
+} from './panel-menu-policy.js';
 import {
   createRail, addEntry, removeEntry, setActive, setEntryEnabled,
 } from './panel-rail.js';
@@ -228,6 +237,16 @@ export async function initPanelManager(panelId) {
     openTerminal: openTerminalPanel,
   });
 
+  // Hand the menu policy (the rail's interaction closures and both context
+  // menus) the same live view of this module's private state. Rendered rows and
+  // gates are decided per gesture, so these must be closures, not values.
+  initMenuPolicy({
+    getRailEl: () => railEl,
+    isMember: (id) => visiblePanels.has(id),
+    getActiveTabId: () => activeTabId,
+    activateTab, showPanel, retireTile, labelOf, getPanelStandaloneUrl, popoutPanel,
+  });
+
   // Rail drag-and-drop: a rail entry dropped on a tile edge opens (or moves)
   // that panel as a new tile at the drop position, then reveals it through the
   // same activate/show tail every other open path uses. Wires lazily like
@@ -322,6 +341,11 @@ export async function initPanelManager(panelId) {
   // and the server does not echo human focus back, so this registration is the
   // only thing that keeps the gesturing client's own rail in step.
   setTileFocusHandler(activateTab);
+
+  // A tile header is the panel's second right-click surface, offering the same
+  // verbs as its rail entry. dock-tab cannot import this module (cycle via
+  // dock-workspace), so the policy arrives by registration.
+  setTileContextMenuHandler(openTileContextMenu);
 
   // Hand the adapter a live reference to the visible set (it prunes restored
   // placeholders of server-closed panels), then finalize the registry — the
@@ -622,58 +646,28 @@ async function resyncPanelState() {
 // ---- Rail Rendering ----
 
 /**
- * Interaction closures handed to every rail render/append call. Routing
- * activation and close through here keeps a human click/"×" and an agent MCP
- * call indistinguishable downstream (both hit activateTab /
- * setPanelVisibility).
- *
- * Every entry is a member, so a click is always an activation: show this panel
- * in the main tile, taking it over from its current occupant (one panel per
- * tile; the rail IS the workspace's tab system). The take-over happens in the
- * dock adapter's placement logic and is purely local — the evicted panel keeps
- * its entry. "×" removes the panel from the rail (membership, a server
- * change). The terminal entry routes to the dock instead (its open/closed
- * state is layout state, not membership — see TERMINAL_RAIL_ID).
+ * Open a panel in a new browser tab at its standalone (non-embedded) URL.
+ * The target of the context menu's "Open in a new window" row and the
+ * palette's "Open <label> in a new window" action — both go through here so
+ * the two surfaces cannot drift. No-op until the panel's config fetch has
+ * resolved a URL (callers gate on that too).
+ * @param {string} id
  */
-function railOptions() {
-  return {
-    onActivate: (/** @type {string} */ id) => {
-      if (id === TERMINAL_RAIL_ID) { openTerminalPanel(); return; }
-      // Clicking the entry whose tile is ALREADY surfaced retires that tile —
-      // a toggle shortcut equivalent to the tile header's own "×". It stays a
-      // LOCAL layout change: rail membership survives, so a second click
-      // brings the tile back. Membership removal remains the separate "×"
-      // corner.
-      if (visiblePanels.has(id)) {
-        if (activeTabId === id) { retireTile(id); return; }
-        activateTab(id, { userInitiated: true });
-      } else showPanel(id);
-    },
-    onClose: (/** @type {string} */ id) => {
-      if (id === TERMINAL_RAIL_ID) { closeTerminalPanel(); return; }
-      setPanelVisibility(id, false);
-    },
-    // Popout stays rail-only (a tile has no standalone-URL affordance).
-    // No-ops before the panel's config fetch has resolved a URL; the rail
-    // also hides the affordance while the entry is `.disabled`, so this
-    // guard is the backstop, not the only gate.
-    onPopout: (/** @type {string} */ id) => {
-      if (id === TERMINAL_RAIL_ID) return;
-      const url = getPanelStandaloneUrl(id);
-      if (url) window.open(url, '_blank', 'noopener');
-    },
-    // "⊞" — open this panel as a NEW tile beside the active one, the
-    // discoverable half of the open-beside verb (rail drag is the precise
-    // half). The terminal entry routes to its own reopen path; CSS hides its
-    // corner regardless.
-    onOpenBeside: (/** @type {string} */ id) => openPanelBeside(id),
-    // Rail drag source: the terminal entry never drags (its tile moves by its
-    // own header bar); everything else defers to rail-drag's policy (simple
-    // mode and fallback mode cancel there).
-    onDragStart: (/** @type {string} */ id, /** @type {DataTransfer | null} */ dt) =>
-      id === TERMINAL_RAIL_ID ? false : railDragStart(id, dt),
-    onDragEnd: () => railDragEnd(),
-  };
+export function popoutPanel(id) {
+  const url = getPanelStandaloneUrl(id);
+  if (url) window.open(url, '_blank', 'noopener');
+}
+
+/**
+ * Rail-member panels that can pop out (standalone URL resolved), in catalog
+ * order. Unlike getVisiblePanels this INCLUDES the active panel — popping out
+ * the panel you are looking at is the verb's most common use.
+ * @returns {Array<{id: string, label: string}>}
+ */
+export function getPopoutPanels() {
+  return PANELS
+    .filter((p) => visiblePanels.has(p.id) && getPanelStandaloneUrl(p.id) !== null)
+    .map((p) => ({ id: p.id, label: p.label }));
 }
 
 /** The catalog label for a panel id (falls back to the id itself).
@@ -694,7 +688,9 @@ function renderRail() {
     railEl,
     [
       { id: TERMINAL_RAIL_ID, label: TERMINAL_RAIL_LABEL },
-      ...PANELS.filter((p) => visiblePanels.has(p.id)).map((p) => ({ id: p.id, label: p.label })),
+      ...PANELS.filter((p) => visiblePanels.has(p.id)).map(
+        (p) => ({ id: p.id, label: p.label, hint: RAIL_MENU_HINT })
+      ),
     ],
     railOptions(),
   );
@@ -765,7 +761,7 @@ function ensureRailMembership(panelId) {
   visiblePanels.add(panelId);
   const spec = PANELS.find((p) => p.id === panelId);
   if (!spec) return;
-  addEntry(railEl, { id: spec.id, label: spec.label }, railOptions());
+  addEntry(railEl, { id: spec.id, label: spec.label, hint: RAIL_MENU_HINT }, railOptions());
   applyEntryState(panelId);
 }
 
@@ -803,7 +799,7 @@ function addPanel(spec) {
   // Append exactly one entry. addEntry is non-destructive — never a full
   // re-render — so every live entry keeps its active/disabled/LED state, and it
   // is idempotent by id, which also guards the re-register path.
-  addEntry(railEl, { id: normalized.id, label: normalized.label }, railOptions());
+  addEntry(railEl, { id: normalized.id, label: normalized.label, hint: RAIL_MENU_HINT }, railOptions());
 
   // Seed url and health, mirroring the custom-panel block in initPanelManager
   if (spec.url) {
@@ -1118,8 +1114,8 @@ export function getVisiblePanels() { return visiblePanelsExcept(PANELS, visibleP
 export function getPresets() { return panelPresets; }
 
 /**
- * Standalone (non-embedded) URL for a service panel — the target of the rail
- * entry's popout corner (railOptions' onPopout). state.url is the
+ * Standalone (non-embedded) URL for a service panel — the target of the
+ * context menu's and palette's "Open in a new window". state.url is the
  * already-proxied root-relative base; the optional catalog path suffixes custom
  * panels' UI root. Null until the panel's config fetch has resolved a URL.
  * @param {string} panelId

--- a/src/osprey/interfaces/web_terminal/static/js/panel-menu-policy.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-menu-policy.js
@@ -1,0 +1,269 @@
+// @ts-check
+/* OSPREY Web Terminal — Panel Menu Policy
+ *
+ * WHAT a gesture on a panel surface does. panel-manager.js owns the panel state
+ * machine (health, membership, iframes, SSE dispatch) and panel-placement.js
+ * owns tile geometry; this module owns the policy layer in between — the
+ * closures a rail entry is rendered with, and the context menus a rail entry or
+ * a tile header opens.
+ *
+ * It is the counterpart of panel-context-menu.js, which is purely
+ * presentational (popover DOM, dismissal, focus bookkeeping) and never knows
+ * what a verb does. Every decision lives here instead: which menu a surface
+ * gets, whether it gets one at all, which rows the current ui mode allows, and
+ * which closure each row runs. The rows bind the SAME closures the rail
+ * corners, the rail drag and the agent MCP tools use, so a menu pick is
+ * indistinguishable downstream from any other path to the verb.
+ *
+ * Leaf modules are imported directly; everything that lives in panel-manager's
+ * private state arrives as injected deps registered once at init
+ * ({@link initMenuPolicy}) — the same seam pattern panel-placement.js, the
+ * iframe adapter and the tile-close handler use. That injection is what keeps
+ * this module out of an import cycle: panel-manager imports it, never the
+ * reverse.
+ *
+ * TWO SURFACES, ONE VERB SET
+ * --------------------------
+ * A panel's rail entry and its tile header offer identical rows, built by the
+ * same {@link buildServiceMenuItems} / {@link buildTerminalMenuItems}, so the
+ * two can never drift apart. They differ in exactly one place, deliberately:
+ * the rail applies an enabled gate (see openRailContextMenu) and the tile
+ * header does not.
+ *
+ * DECLINE BY EMPTY LIST
+ * ---------------------
+ * Both openers return a boolean their caller turns into `preventDefault()`:
+ * true when a menu opened, false to leave the event alone so the browser's own
+ * menu still shows. A builder returning NO rows is that decline — the case is
+ * the terminal in simple mode, where the xterm card is replaced by the operator
+ * console and every terminal verb would act on a surface the operator cannot
+ * see.
+ */
+
+import { openContextMenu } from './panel-context-menu.js';
+import { TERMINAL_RAIL_ID, TERMINAL_RAIL_LABEL } from './panel-catalog.js';
+import { setPanelVisibility } from './panel-commands.js';
+import { openPanelBeside } from './panel-placement.js';
+import { openTerminalPanel, closeTerminalPanel } from './dock-workspace.js';
+import { restartTerminal, startTerminal } from './terminal.js';
+import { startNewSession } from './sessions.js';
+import { railDragStart, railDragEnd } from './rail-drag.js';
+import { getEntry } from './panel-rail.js';
+
+/**
+ * The panel-manager state and actions this module's closures act through. Every
+ * entry is a live closure over panel-manager's private state — never a
+ * snapshot, so a menu built now reads the rail and health of this moment.
+ * @typedef {object} MenuPolicyDeps
+ * @property {() => HTMLElement} getRailEl - the rail nav the entries live in
+ * @property {(id: string) => boolean} isMember - the panel has rail membership
+ * @property {() => string | null} getActiveTabId - the locally surfaced panel id
+ * @property {(id: string, options?: {userInitiated?: boolean, auto?: boolean}) => void} activateTab
+ * @property {(id: string) => void} showPanel - reveal a NON-member through the visibility POST path
+ * @property {(id: string) => void} retireTile - vacate a surfaced tile LOCALLY (membership survives)
+ * @property {(id: string) => string} labelOf - the panel's catalog label
+ * @property {(id: string) => string | null} getPanelStandaloneUrl - null until the config fetch resolves
+ * @property {(id: string) => void} popoutPanel - open the standalone url in a new browser tab
+ */
+
+/** @type {MenuPolicyDeps | null} */
+let deps = null;
+
+/**
+ * Register the panel-manager state every closure here reads. Called once from
+ * initPanelManager, before the rail is rendered.
+ * @param {MenuPolicyDeps} menuPolicyDeps
+ */
+export function initMenuPolicy(menuPolicyDeps) {
+  deps = menuPolicyDeps;
+}
+
+/**
+ * The registered deps, or a hard failure. A gesture before init is a wiring
+ * bug, not a runtime condition to degrade around — panel-manager registers in
+ * the same init that mounts the rail.
+ * @returns {MenuPolicyDeps}
+ */
+function ctx() {
+  if (!deps) throw new Error('panel-menu-policy: initMenuPolicy() has not run');
+  return deps;
+}
+
+/**
+ * Interaction closures handed to every rail render/append call. Routing
+ * activation and close through here keeps a human click/"×" and an agent MCP
+ * call indistinguishable downstream (both hit activateTab /
+ * setPanelVisibility).
+ *
+ * Every entry is a member, so a click is always an activation: show this panel
+ * in the main tile, taking it over from its current occupant (one panel per
+ * tile; the rail IS the workspace's tab system). The take-over happens in the
+ * dock adapter's placement logic and is purely local — the evicted panel keeps
+ * its entry. "×" removes the panel from the rail (membership, a server
+ * change). The terminal entry routes to the dock instead (its open/closed
+ * state is layout state, not membership — see TERMINAL_RAIL_ID).
+ */
+export function railOptions() {
+  return {
+    onActivate: (/** @type {string} */ id) => {
+      if (id === TERMINAL_RAIL_ID) { openTerminalPanel(); return; }
+      // Clicking the entry whose tile is ALREADY surfaced retires that tile —
+      // a toggle shortcut equivalent to the tile header's own "×". It stays a
+      // LOCAL layout change: rail membership survives, so a second click
+      // brings the tile back. Membership removal remains the separate "×"
+      // corner.
+      if (ctx().isMember(id)) {
+        if (ctx().getActiveTabId() === id) { ctx().retireTile(id); return; }
+        ctx().activateTab(id, { userInitiated: true });
+      } else ctx().showPanel(id);
+    },
+    onClose: (/** @type {string} */ id) => {
+      if (id === TERMINAL_RAIL_ID) { closeTerminalPanel(); return; }
+      setPanelVisibility(id, false);
+    },
+    // Right-click — or the menu key / Shift+F10, which the rail forwards
+    // through this same closure — opens the entry's verbs in words
+    // (panel-context-menu.js). openRailContextMenu owns the whole policy
+    // (which menu, and whether there is one at all) and reports back with the
+    // boolean the rail uses to decide whether to suppress the browser's menu.
+    onContextMenu: (/** @type {string} */ id, /** @type {MouseEvent} */ e) =>
+      openRailContextMenu(id, e.clientX, e.clientY),
+    // Rail drag source: the terminal entry never drags (its tile moves by its
+    // own header bar); everything else defers to rail-drag's policy (simple
+    // mode and fallback mode cancel there).
+    onDragStart: (/** @type {string} */ id, /** @type {DataTransfer | null} */ dt) =>
+      id === TERMINAL_RAIL_ID ? false : railDragStart(id, dt),
+    onDragEnd: () => railDragEnd(),
+  };
+}
+
+// Tooltip suffix advertising the context menu on every service entry. The
+// terminal entry gets none: its menu exists only in expert mode, so a tooltip
+// promising actions would misinform every simple-mode operator.
+export const RAIL_MENU_HINT = 'right-click for actions';
+
+/**
+ * Simple mode locks the workspace to a single service tile and replaces the
+ * xterm card with the operator console — the two facts every menu-policy gate
+ * below turns on.
+ * @returns {boolean}
+ */
+function isSimpleMode() {
+  return document.documentElement.getAttribute('data-ui-mode') === 'simple';
+}
+
+/**
+ * Open a rail entry's context menu at a viewport position, and report whether
+ * one was opened — the boolean the rail uses to decide whether to suppress the
+ * browser's native menu, on the right-click and keyboard routes alike (FR5).
+ *
+ * The enabled gate lives HERE rather than in the rail CSS. `pointer-events:
+ * none` on a disabled entry stops a right-click landing on the entry itself,
+ * but it does not stop a menu request fired from the KEYBOARD on that focused
+ * button, and it does not cover the offline entry's still-live "×" corner,
+ * which stays interactive by design. Both routes would otherwise reach a menu
+ * whose verbs act on a panel that has never answered.
+ *
+ * @param {string} id  @param {number} x  @param {number} y
+ * @returns {boolean} true when a menu was opened
+ */
+export function openRailContextMenu(id, x, y) {
+  const entry = getEntry(ctx().getRailEl(), id);
+  if (!entry || entry.classList.contains('disabled')) return false;
+  // The entry is the anchor: it scopes the menu's scroll dismissal, so the
+  // menu survives a panel scrolling its own content underneath it.
+  return openSurfaceMenu(id, x, y, entry);
+}
+
+/**
+ * The tile-header counterpart of openRailContextMenu, registered into
+ * dock-tab.js at init. Same verb sets, so a panel's two surfaces cannot offer
+ * different actions, and the same decline-by-empty-list contract: the terminal
+ * header in simple mode reports false and keeps the browser's native menu.
+ *
+ * The rail's enabled gate has no counterpart here on purpose. It exists so a
+ * panel that has never answered cannot be acted on from an offline entry; a
+ * tile header only exists for a panel already occupying a tile, and its verbs
+ * (focus it, pop it out, drop it from the rail) stay meaningful even if health
+ * polling has since gone quiet.
+ *
+ * @param {string} id  service panel id, or TERMINAL_RAIL_ID
+ * @param {{x: number, y: number, anchorEl: HTMLElement}} opts
+ * @returns {boolean} true when a menu was opened
+ */
+export function openTileContextMenu(id, opts) {
+  // The header bar is the anchor — the menu rides out the panel's own scrolls,
+  // including the terminal streaming output underneath it.
+  return openSurfaceMenu(id, opts.x, opts.y, opts.anchorEl);
+}
+
+/**
+ * The shared tail of both surface openers: build the id's verb rows, decline
+ * by empty list, and open the popover. Items, label and the decline signal
+ * live in this one place, so the two-surfaces-one-verb-set contract is
+ * mechanical rather than maintained in parallel.
+ * @param {string} id  service panel id, or TERMINAL_RAIL_ID
+ * @param {number} x  @param {number} y
+ * @param {HTMLElement} anchorEl  scopes the menu's scroll dismissal
+ * @returns {boolean} true when a menu was opened
+ */
+function openSurfaceMenu(id, x, y, anchorEl) {
+  const items = id === TERMINAL_RAIL_ID ? buildTerminalMenuItems() : buildServiceMenuItems(id);
+  // No rows is a decline, never an empty popover — simple mode's terminal.
+  if (!items.length) return false;
+  const label = id === TERMINAL_RAIL_ID ? TERMINAL_RAIL_LABEL : ctx().labelOf(id);
+  openContextMenu({ x, y, anchorEl, ariaLabel: `${label} actions`, items });
+  return true;
+}
+
+/**
+ * A service panel's menu rows, bound to the SAME closures the rail, the rail
+ * drag and the agent MCP tools use — a menu pick is indistinguishable
+ * downstream from any other path to the verb. Shared by the rail entry and the
+ * panel's tile header so the two surfaces cannot drift apart.
+ *
+ * Policy carried over from the retired corner glyphs: "Open in a new tile" is
+ * not a simple-mode gesture (the layout is locked to one service tile), and
+ * "Open in a new window" stays inert until the panel's standalone URL
+ * resolves.
+ * @param {string} id
+ * @returns {import('./panel-context-menu.js').MenuItem[]}
+ */
+export function buildServiceMenuItems(id) {
+  const label = ctx().labelOf(id);
+  return [
+    // Focus is the ACTIVATION half of the entry click only. A click on the
+    // entry whose tile is already surfaced retires that tile; a row that says
+    // "Focus" and made the panel disappear would say the opposite of what it
+    // does, so on the already-active panel this row is deliberately a no-op.
+    { label: `Focus ${label}`, run: () => { if (ctx().isMember(id)) ctx().activateTab(id, { userInitiated: true }); else ctx().showPanel(id); } },
+    ...(isSimpleMode() ? [] : [{ label: 'Open in a new tile', glyph: '⊞', run: () => openPanelBeside(id) }]),
+    { label: 'Open in a new window', glyph: '↗', disabled: ctx().getPanelStandaloneUrl(id) === null, run: () => ctx().popoutPanel(id) },
+    { divider: true },
+    // The one server-side membership change in the menu — same POST as the "×".
+    { label: 'Remove from rail', glyph: '×', danger: true, run: () => setPanelVisibility(id, false) },
+  ];
+}
+
+/**
+ * The terminal surfaces' menu rows — the SESSION rail entry and the terminal
+ * tile header, which share one verb set.
+ *
+ * Empty in simple mode, and that emptiness IS the callers' decline signal:
+ * there the terminal card is replaced by the operator console and
+ * closeTerminalPanel no-ops, so every row would act on a surface the operator
+ * cannot see. (The palette drops the same actions there, for the same reason.)
+ * @returns {import('./panel-context-menu.js').MenuItem[]}
+ */
+export function buildTerminalMenuItems() {
+  if (isSimpleMode()) return [];
+  return [
+    // restartTerminal tears the PTY down but does NOT reconnect — pairing it
+    // with startTerminal is what keeps the card from being left stranded. The
+    // palette's "Restart terminal" runs the identical pair.
+    { label: 'Restart terminal', run: async () => { await restartTerminal(); startTerminal(); } },
+    { label: 'New session', run: () => { startNewSession(); } },
+    { divider: true },
+    { label: 'Close terminal tile', glyph: '×', danger: true, run: () => closeTerminalPanel() },
+  ];
+}

--- a/src/osprey/interfaces/web_terminal/static/js/panel-rail.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-rail.js
@@ -3,7 +3,7 @@
  *
  * A pure DOM-rendering module for the 74px left icon rail that replaces the
  * horizontal header tab strip. It builds one entry per rail MEMBER (icon,
- * label, active accent, hover corners, drag source) and exposes small
+ * label, active accent, close corner, drag source) and exposes small
  * imperative mutators — set active, enable, attention, append, remove — so
  * `panel-manager.js`'s state machine can drive the rail without owning any DOM
  * specifics. (The `＋` add control is NOT the rail's: the template supplies it
@@ -34,14 +34,30 @@
  *   <nav class="panel-rail" role="tablist">
  *     <button class="panel-rail-button disabled" data-panel-id="artifacts"
  *             type="button" role="tab" aria-selected="false" title="WORKSPACE"
+ *             aria-label="WORKSPACE"                (title gains " · hint" when panel.hint is given)
  *             draggable="true">                                       (only when onDragStart given)
  *       <span class="panel-rail-icon" data-icon="artifacts" aria-hidden="true"></span>
  *       <span class="panel-rail-label">WORKSPACE</span>
  *       <span class="panel-rail-close" aria-hidden="true">×</span>    (only when onClose given)
- *       <span class="panel-rail-popout" aria-hidden="true">↗</span>   (only when onPopout given)
- *       <span class="panel-rail-beside" aria-hidden="true">⊞</span>   (only when onOpenBeside given)
  *     </button>
  *   </nav>
+ *
+ * Beyond activate/close, an entry's verbs (open beside, open standalone,
+ * remove) live in the caller's right-click context menu — the rail only
+ * forwards the contextmenu event through `onContextMenu` and suppresses the
+ * browser menu when the caller reports it handled. A caller-supplied
+ * `panel.hint` is appended to the tooltip so the menu is advertised where the
+ * corner glyphs used to be.
+ *
+ * That menu is reachable from the keyboard, and explicitly so: a focused entry
+ * handles the `ContextMenu` key and Shift+F10 itself and asks the caller to
+ * open the menu centred on the entry's own rect. macOS fires no `contextmenu`
+ * event from the keyboard at all, so leaving this to the platform would strand
+ * those operators; on the platforms that DO fire one (Windows menu key,
+ * Firefox Shift+F10) it is that keydown's default action, and suppressing the
+ * default is what stops a single keypress opening two menus. The suppression
+ * follows the same boolean contract as the right-click path, so an entry the
+ * caller declines keeps its native behaviour on every input route.
  *
  * State classes on an entry: `.active` (surfaced panel), `.disabled` (backend
  * not healthy yet), `.agent-attention` (badge). A badged entry also carries a
@@ -61,20 +77,26 @@ import { flashElement } from '/design-system/js/highlight.js';
  * @typedef {object} RailPanel
  * @property {string} id
  * @property {string} label
+ * @property {string} [hint] - tooltip suffix advertising the context menu
+ *   (rendered as "LABEL · hint"; aria-label stays the bare label)
  */
 
 /**
  * Interaction closures injected by the caller so the rail stays a dumb view.
- * Every callback is optional: omit `onClose` / `onPopout` / `onOpenBeside` to
- * render no such per-entry corner affordance, omit `onDragStart` to render
- * non-draggable entries. `onDragStart` may return false to cancel the drag for
- * that entry (the caller's policy — e.g. the terminal entry, simple mode);
- * this module stays policy-free.
+ * Every callback is optional: omit `onClose` to render no close corner, omit
+ * `onDragStart` to render non-draggable entries. `onDragStart` may return
+ * false to cancel the drag for that entry, and `onContextMenu` false to let
+ * the browser's native menu through (the caller's policy — e.g. the terminal
+ * entry, simple mode); this module stays policy-free.
  * @typedef {object} RailOptions
  * @property {(id: string) => void} [onActivate]   - an entry was clicked
  * @property {(id: string) => void} [onClose]      - the entry's close "×" was clicked
- * @property {(id: string) => void} [onPopout]     - the entry's popout "↗" was clicked
- * @property {(id: string) => void} [onOpenBeside] - the entry's "⊞" (open in a new tile) was clicked
+ * @property {(id: string, e: MouseEvent) => boolean} [onContextMenu]
+ *   - an entry was right-clicked, or asked for its menu from the keyboard
+ *     (`ContextMenu` / Shift+F10, where `e` is a synthetic contextmenu event
+ *     positioned at the entry's rect); return true if a menu was opened
+ *     (suppresses the browser menu), false to decline and let the native menu
+ *     show
  * @property {(id: string, dataTransfer: DataTransfer | null) => boolean} [onDragStart]
  *   - a drag left an entry; return false to cancel it
  * @property {(id: string) => void} [onDragEnd]    - the entry's drag gesture ended (any outcome)
@@ -112,7 +134,10 @@ function buildRailButton(panel, options = {}) {
   btn.setAttribute('data-panel-id', panel.id);
   btn.setAttribute('role', 'tab');
   btn.setAttribute('aria-selected', 'false');
-  btn.title = panel.label;
+  // The tooltip advertises the context menu (the entry's non-corner verbs have
+  // no visible affordance); aria-label stays the bare label — assistive tech
+  // reaches the menu itself via the menu key / Shift+F10.
+  btn.title = panel.hint ? `${panel.label} · ${panel.hint}` : panel.label;
   btn.setAttribute('aria-label', panel.label);
 
   const icon = document.createElement('span');
@@ -131,29 +156,45 @@ function buildRailButton(panel, options = {}) {
     btn.addEventListener('click', () => onActivate(panel.id));
   }
 
-  // Per-entry corner affordances — the rail owns a panel's MEMBERSHIP
-  // lifecycle (remove from rail, pop out, open as a new tile). Rendered only
-  // when the caller wants them; close takes the top-left corner, popout the
-  // mirrored top-right, open-beside the bottom-right. (Closing an OPEN tile
-  // is the tile header's own "×" — a layout gesture, not a membership one.)
+  // The one corner affordance — close "×", the frequent membership verb that
+  // must stay reachable even on a disabled (offline) entry. The rest of the
+  // entry's verbs (open beside, open standalone, remove) live in the caller's
+  // context menu. (Closing an OPEN tile is the tile header's own "×" — a
+  // layout gesture, not a membership one.)
   if (options.onClose) {
     btn.appendChild(
       buildCornerAffordance('panel-rail-close', '×', `Close ${panel.label}`, panel.id, options.onClose)
     );
   }
-  if (options.onPopout) {
-    btn.appendChild(
-      buildCornerAffordance(
-        'panel-rail-popout', '↗', `Open ${panel.label} in a new window`, panel.id, options.onPopout
-      )
-    );
-  }
-  if (options.onOpenBeside) {
-    btn.appendChild(
-      buildCornerAffordance(
-        'panel-rail-beside', '⊞', `Open ${panel.label} in a new tile`, panel.id, options.onOpenBeside
-      )
-    );
+
+  // Right-click → the caller's context menu. The caller decides per-entry
+  // whether a menu exists (returns true); declining (false — e.g. the
+  // terminal entry) leaves the event alone so the browser menu shows.
+  if (options.onContextMenu) {
+    const onContextMenu = options.onContextMenu;
+    btn.addEventListener('contextmenu', (e) => {
+      if (onContextMenu(panel.id, e)) e.preventDefault();
+    });
+
+    // The keyboard route to the same menu, opened by this module rather than
+    // by the platform: macOS synthesises no `contextmenu` event from the menu
+    // key, so a native-only path would have no keyboard route at all there.
+    // The synthetic event is handed straight to the caller and never
+    // dispatched, so the listener above cannot also fire for one keypress.
+    btn.addEventListener('keydown', (e) => {
+      if (e.key !== 'ContextMenu' && !(e.key === 'F10' && e.shiftKey)) return;
+      const rect = btn.getBoundingClientRect();
+      const synthetic = new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      });
+      // Preventing the default is what keeps Windows/Firefox — where the
+      // native menu IS this keydown's default action — from stacking a second
+      // menu on the one just opened; a declined entry keeps that default.
+      if (onContextMenu(panel.id, synthetic)) e.preventDefault();
+    });
   }
 
   // Drag source: dragging an entry into the workspace opens the panel as a
@@ -181,10 +222,11 @@ function buildRailButton(panel, options = {}) {
 }
 
 /**
- * One hover-revealed corner glyph on a rail entry. Decorative (aria-hidden) so
- * it is not a control nested inside the entry button — assistive tech reaches
- * the same actions through the command palette. The click stops propagation so
- * acting on the corner does not also activate the entry underneath it.
+ * The entry's one hover-revealed corner glyph — the close "×". Decorative
+ * (aria-hidden) so it is not a control nested inside the entry button;
+ * assistive tech reaches the same action through the entry's context menu and
+ * the command palette. The click stops propagation so acting on the corner
+ * does not also activate the entry underneath it.
  *
  * @param {string} className
  * @param {string} glyph

--- a/tests/interfaces/web_terminal/palette-registry.test.mjs
+++ b/tests/interfaces/web_terminal/palette-registry.test.mjs
@@ -9,6 +9,10 @@
  *   - config ok flattens a NESTED sections tree into leaf dot-keys, and each
  *     item's run calls the injected revealSetting with its dot-key
  *   - Panels emit Show/Focus items wired to showPanel/focusPanel by id
+ *   - Panels emit "Open … in a new window" rows from getPopoutPanels (active
+ *     panel INCLUDED) and "Open … in a new tile" rows from getVisiblePanels
+ *     (active panel EXCLUDED, dropped entirely without openPanelBeside)
+ *   - panel rows carry domain + verb synonyms in searchText
  *   - Layouts emit items wired to applyPreset with the preset's NAME
  *   - Actions are wrapped in order with run passed through
  *   - missing optional deps never throw and contribute nothing
@@ -132,6 +136,167 @@ describe('buildRegistry', () => {
     panels[1].run();
     expect(shown).toEqual(['ariel']);
     expect(focused).toEqual(['okf']);
+  });
+
+  it('FR8 ACTIVE PANEL: the active panel gets a new-window row but NO new-tile row', () => {
+    // ARIEL is the active panel, so panel-manager's getVisiblePanels (which
+    // filters the active id out) omits it while getPopoutPanels keeps it.
+    const items = buildRegistry({
+      getVisiblePanels: () => [{ id: 'okf', label: 'Facility' }],
+      getPopoutPanels: () => [
+        { id: 'ariel', label: 'ARIEL' },
+        { id: 'okf', label: 'Facility' },
+      ],
+      focusPanel: () => {},
+      popoutPanel: () => {},
+      openPanelBeside: () => {},
+    });
+
+    const labels = inGroup(items, 'Panels').map((it) => it.label);
+    expect(labels).toContain('Open ARIEL in a new window');
+    // Opening the active panel beside itself is a no-op, so the row is absent.
+    expect(labels).not.toContain('Open ARIEL in a new tile');
+    // A non-active member gets both verbs.
+    expect(labels).toContain('Open Facility in a new window');
+    expect(labels).toContain('Open Facility in a new tile');
+  });
+
+  it('FR8 NON-ACTIVE PANEL: with ARIEL not active, ARIEL gets both Open rows', () => {
+    const items = buildRegistry({
+      getVisiblePanels: () => [{ id: 'ariel', label: 'ARIEL' }],
+      getPopoutPanels: () => [{ id: 'ariel', label: 'ARIEL' }],
+      focusPanel: () => {},
+      popoutPanel: () => {},
+      openPanelBeside: () => {},
+    });
+
+    const labels = inGroup(items, 'Panels').map((it) => it.label);
+    expect(labels).toEqual([
+      'Focus ARIEL',
+      'Open ARIEL in a new window',
+      'Open ARIEL in a new tile',
+    ]);
+  });
+
+  it('OPEN ROWS: run calls popoutPanel / openPanelBeside with the panel id', () => {
+    /** @type {string[]} */
+    const poppedOut = [];
+    /** @type {string[]} */
+    const besided = [];
+    const items = buildRegistry({
+      getVisiblePanels: () => [{ id: 'okf', label: 'Facility' }],
+      getPopoutPanels: () => [{ id: 'okf', label: 'Facility' }],
+      popoutPanel: (id) => poppedOut.push(id),
+      openPanelBeside: (id) => besided.push(id),
+    });
+
+    const byLabel = (/** @type {string} */ label) => inGroup(items, 'Panels').find((it) => it.label === label);
+    byLabel('Open Facility in a new window').run();
+    byLabel('Open Facility in a new tile').run();
+    expect(poppedOut).toEqual(['okf']);
+    expect(besided).toEqual(['okf']);
+  });
+
+  it('SIMPLE MODE: omitting openPanelBeside drops every new-tile row, Focus rows stay', () => {
+    // Simple mode's layout is locked to one service tile, so palette-boot
+    // withholds the closure — the rows come off the SAME getter as Focus, so
+    // this is the only thing that can distinguish them.
+    const items = buildRegistry({
+      getVisiblePanels: () => [{ id: 'okf', label: 'Facility' }],
+      getPopoutPanels: () => [{ id: 'okf', label: 'Facility' }],
+      focusPanel: () => {},
+      popoutPanel: () => {},
+    });
+
+    const labels = inGroup(items, 'Panels').map((it) => it.label);
+    expect(labels).toEqual(['Focus Facility', 'Open Facility in a new window']);
+  });
+
+  it('NO POPOUT GETTER: omitting getPopoutPanels drops every new-window row', () => {
+    const items = buildRegistry({
+      getVisiblePanels: () => [{ id: 'okf', label: 'Facility' }],
+      openPanelBeside: () => {},
+    });
+
+    const labels = inGroup(items, 'Panels').map((it) => it.label);
+    expect(labels).toEqual(['Focus Facility', 'Open Facility in a new tile']);
+  });
+
+  it('SYNONYMS: a panel domain alias matches EVERY row for that panel', () => {
+    const items = buildRegistry({
+      getHiddenPanels: () => [{ id: 'ariel', label: 'ARIEL' }],
+      getVisiblePanels: () => [{ id: 'ariel', label: 'ARIEL' }],
+      getPopoutPanels: () => [{ id: 'ariel', label: 'ARIEL' }],
+      openPanelBeside: () => {},
+    });
+
+    const panels = inGroup(items, 'Panels');
+    expect(panels).toHaveLength(4);
+    for (const row of panels) {
+      // Only searchText is scored by the matcher, so the alias has to live there.
+      expect(row.searchText).toContain('logbook');
+      expect(row.searchText).toContain('elog');
+      // The label and id stay searchable alongside the aliases.
+      expect(row.searchText).toContain('ARIEL');
+      expect(row.searchText).toContain('ariel');
+    }
+  });
+
+  it('SYNONYMS: every built-in panel id carries its domain aliases', () => {
+    const expected = {
+      ariel: ['logbook', 'elog'],
+      'channel-finder': ['pv', 'channels'],
+      artifacts: ['gallery', 'files'],
+      lattice: ['optics'],
+      okf: ['knowledge', 'docs'],
+      'system-health': ['status', 'monitoring'],
+    };
+    const ids = Object.keys(expected);
+    const items = buildRegistry({
+      getVisiblePanels: () => ids.map((id) => ({ id, label: id.toUpperCase() })),
+      focusPanel: () => {},
+    });
+
+    const panels = inGroup(items, 'Panels');
+    for (const [id, aliases] of Object.entries(expected)) {
+      const row = panels.find((it) => it.label === `Focus ${id.toUpperCase()}`);
+      for (const alias of aliases) {
+        expect(row.searchText).toContain(alias);
+      }
+    }
+  });
+
+  it('SYNONYMS: verb aliases ride the Open rows, not Show/Focus', () => {
+    const items = buildRegistry({
+      getHiddenPanels: () => [{ id: 'okf', label: 'Facility' }],
+      getVisiblePanels: () => [{ id: 'okf', label: 'Facility' }],
+      getPopoutPanels: () => [{ id: 'okf', label: 'Facility' }],
+      openPanelBeside: () => {},
+    });
+
+    const byLabel = (/** @type {string} */ label) => inGroup(items, 'Panels').find((it) => it.label === label);
+    const popout = byLabel('Open Facility in a new window').searchText;
+    for (const token of ['window', 'popout', 'standalone', 'tab']) {
+      expect(popout).toContain(token);
+    }
+    const beside = byLabel('Open Facility in a new tile').searchText;
+    for (const token of ['tile', 'beside', 'split']) {
+      expect(beside).toContain(token);
+    }
+    // The verb vocabularies do not bleed into each other or onto Show/Focus.
+    expect(popout).not.toContain('beside');
+    expect(beside).not.toContain('popout');
+    expect(byLabel('Show Facility').searchText).not.toContain('popout');
+    expect(byLabel('Focus Facility').searchText).not.toContain('beside');
+  });
+
+  it('SYNONYMS: an unknown (facility-custom) panel id contributes no aliases', () => {
+    const items = buildRegistry({
+      getVisiblePanels: () => [{ id: 'custom-thing', label: 'Custom Thing' }],
+      focusPanel: () => {},
+    });
+    const [row] = inGroup(items, 'Panels');
+    expect(row.searchText).toBe('focus Custom Thing custom-thing');
   });
 
   it('LAYOUTS: preset run applies the preset BY NAME', () => {

--- a/tests/interfaces/web_terminal/palette.test.mjs
+++ b/tests/interfaces/web_terminal/palette.test.mjs
@@ -4,7 +4,9 @@
  *   npx vitest run tests/interfaces/web_terminal/palette.test.mjs
  *
  * happy-dom weakly supports scrollIntoView/focus, so these tests assert only
- * CLASS/ATTRIBUTE state — never scroll position or document.activeElement.
+ * CLASS/ATTRIBUTE state and never scroll position. document.activeElement is
+ * asserted in one place only — the focus-on-open block, which checks WHEN
+ * focus() is called relative to the reveal frame, not browser focus fidelity.
  * scrollIntoView is stubbed to a no-op and a fake `fetchConfig` is injected so
  * no real network is hit.
  *
@@ -80,15 +82,51 @@ function pressKey(key) {
   input().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
 }
 
+/**
+ * Recent commands need a working `localStorage`. Node defines a `localStorage`
+ * global that stays undefined unless the process was started with
+ * `--localstorage-file`, and on Node versions that ship it that definition
+ * shadows the one happy-dom installs — so the Recent code path would be
+ * exercised against nothing on such a host. Give the global a real happy-dom
+ * Storage when it is missing; a working one is left untouched.
+ */
+if (!globalThis.localStorage) {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: new Storage(),
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** localStorage key holding the Recent list (mirrors palette.js). */
+const RECENT_KEY = 'osprey-palette-recent-v1';
+
+/** @returns {string[]} the stored Recent keys, most-recent first. */
+function storedRecent() {
+  return JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+}
+
+/** @returns {string[]} the visible section headings, in DOM order. */
+function headings() {
+  return [...document.querySelectorAll('.command-palette-group-heading')].map((h) => h.textContent);
+}
+
+/** @returns {string[]} the visible row labels, in DOM order. */
+function rowLabels() {
+  return [...document.querySelectorAll('.command-palette-item-label')].map((l) => l.textContent);
+}
+
 beforeEach(() => {
   closePalette();
   document.body.innerHTML = '';
+  localStorage.clear();
   // happy-dom does not implement scrollIntoView — stub to a no-op.
   Element.prototype.scrollIntoView = () => {};
 });
 
 afterEach(() => {
   closePalette();
+  vi.restoreAllMocks();
 });
 
 describe('open / close lifecycle', () => {
@@ -258,5 +296,197 @@ describe('welcome-overlay guard', () => {
 
     openPalette(makeDeps());
     expect(isOpen()).toBe(true);
+  });
+});
+
+describe('focus on open', () => {
+  test('the search input is focused once the overlay becomes visible', async () => {
+    openPalette(makeDeps());
+    // Focus is deferred to the reveal frame: a real browser makes focus() a
+    // no-op while the overlay subtree is still `visibility: hidden`.
+    expect(document.activeElement).not.toBe(input());
+
+    await flushRaf();
+
+    expect(overlay().classList.contains('visible')).toBe(true);
+    expect(document.activeElement).toBe(input());
+  });
+
+  test('open then close within one frame leaves the overlay hidden and focus put', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    openPalette(makeDeps());
+    closePalette();
+    await flushRaf();
+
+    expect(isOpen()).toBe(false);
+    expect(overlay().classList.contains('visible')).toBe(false);
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+
+describe('recent commands', () => {
+  /** The stable keys of two fixture rows (group + label, \x1f-joined). */
+  const RESTART = 'Actions\x1fRestart terminal';
+  const SHOW_ARIEL = 'Panels\x1fShow ARIEL';
+
+  /** Click the row whose label reads exactly `label`.
+   * @param {string} label */
+  function clickRow(label) {
+    const row = [...document.querySelectorAll('.command-palette-item')].find(
+      (r) => r.querySelector('.command-palette-item-label')?.textContent === label,
+    );
+    if (!row) throw new Error(`no palette row labelled "${label}"`);
+    /** @type {HTMLElement} */ (row).click();
+  }
+
+  /** Seed the stored Recent list directly.
+   * @param {string[]} keys */
+  function seedRecent(keys) {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(keys));
+  }
+
+  test('the Enter path records the executed item key', async () => {
+    openPalette(makeDeps());
+    await flushMicro();
+    typeQuery('restart terminal');
+    pressKey('Enter');
+    expect(storedRecent()).toEqual([RESTART]);
+  });
+
+  test('the click path records the same plain key', async () => {
+    openPalette(makeDeps());
+    await flushMicro();
+    typeQuery('show ariel');
+    clickRow('Show ARIEL');
+    expect(storedRecent()).toEqual([SHOW_ARIEL]);
+  });
+
+  test('the list is capped at 5, most-recent first', async () => {
+    seedRecent(['k1', 'k2', 'k3', 'k4', 'k5']);
+    openPalette(makeDeps());
+    await flushMicro();
+    typeQuery('restart terminal');
+    pressKey('Enter');
+    expect(storedRecent()).toEqual([RESTART, 'k1', 'k2', 'k3', 'k4']);
+  });
+
+  test('re-executing an item moves it to the front instead of duplicating it', async () => {
+    seedRecent(['k1', RESTART, 'k2']);
+    openPalette(makeDeps());
+    await flushMicro();
+    typeQuery('restart terminal');
+    pressKey('Enter');
+    expect(storedRecent()).toEqual([RESTART, 'k1', 'k2']);
+  });
+
+  test('an empty query renders Recent first, in stored order', async () => {
+    seedRecent([RESTART, SHOW_ARIEL]);
+    openPalette(makeDeps());
+    await flushMicro();
+    typeQuery('');
+
+    expect(headings()).toEqual(['Recent', 'Settings', 'Panels', 'Layouts', 'Actions']);
+    expect(rowLabels().slice(0, 2)).toEqual(['Restart terminal', 'Show ARIEL']);
+  });
+
+  test('Recent is hidden as soon as the query is non-empty', async () => {
+    seedRecent([RESTART]);
+    openPalette(makeDeps());
+    await flushMicro();
+    typeQuery('restart');
+    expect(headings()).not.toContain('Recent');
+  });
+
+  test('stored keys with no live registry match are skipped silently', async () => {
+    seedRecent(['Panels\x1fShow GONE', RESTART]);
+    openPalette(makeDeps());
+    await flushMicro();
+    typeQuery('');
+
+    expect(headings()[0]).toBe('Recent');
+    // Only the surviving key renders, so the label appears exactly twice: once
+    // in Recent, once in its home group.
+    expect(rowLabels()[0]).toBe('Restart terminal');
+    expect(rowLabels().filter((l) => l === 'Restart terminal').length).toBe(2);
+  });
+
+  test('an all-stale list renders no Recent section at all', async () => {
+    seedRecent(['Panels\x1fShow GONE', 'Actions\x1fVanished']);
+    openPalette(makeDeps());
+    await flushMicro();
+    typeQuery('');
+    expect(headings()).toEqual(['Settings', 'Panels', 'Layouts', 'Actions']);
+  });
+
+  test('selection stays on the home-group row when Recent duplicates it', async () => {
+    seedRecent([RESTART]);
+    /** @type {(value: any) => void} */
+    let resolveConfig = () => {};
+    const pending = new Promise((r) => {
+      resolveConfig = r;
+    });
+    openPalette(makeDeps({ fetchConfig: () => pending }));
+    typeQuery('');
+
+    const options = () => [...document.querySelectorAll('[role="option"]')];
+    const activeIdx = () => options().findIndex(
+      (o) => o.classList.contains('command-palette-item--active'),
+    );
+
+    // Wrap backwards from the first row onto the LAST one — the Actions group's
+    // own "Restart terminal", the twin of the Recent row at index 0.
+    pressKey('ArrowUp');
+    expect(activeIdx()).toBe(options().length - 1);
+
+    resolveConfig({ sections: SECTIONS });
+    await flushMicro();
+
+    // The mid-open re-render must not snap the selection up to the Recent
+    // duplicate: namespaced nav keys keep the two rows distinct.
+    expect(activeIdx()).toBe(options().length - 1);
+    expect(activeIdx()).not.toBe(0);
+    const active = options()[activeIdx()];
+    expect(active.querySelector('.command-palette-item-label')?.textContent).toBe(
+      'Restart terminal',
+    );
+  });
+
+  test('blocked storage disables Recent without breaking execution', async () => {
+    // A private-mode-style storage that throws on every access. Swapping the
+    // global (rather than spying on Storage.prototype, which happy-dom's
+    // instances bypass) is what actually reaches the module's bare
+    // `localStorage` reference.
+    const blocked = {
+      getItem() {
+        throw new Error('storage blocked');
+      },
+      setItem() {
+        throw new Error('storage blocked');
+      },
+    };
+    const real = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: blocked,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const run = vi.fn();
+      openPalette(makeDeps({ actions: [{ label: 'Restart terminal', run }] }));
+      await flushMicro();
+      typeQuery('');
+      expect(headings()).toEqual(['Settings', 'Panels', 'Layouts', 'Actions']);
+
+      typeQuery('restart terminal');
+      pressKey('Enter');
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(isOpen()).toBe(false);
+    } finally {
+      if (real) Object.defineProperty(globalThis, 'localStorage', real);
+    }
   });
 });

--- a/tests/interfaces/web_terminal/panel-context-menu.test.mjs
+++ b/tests/interfaces/web_terminal/panel-context-menu.test.mjs
@@ -1,0 +1,424 @@
+/**
+ * Unit tests for the rail/tile context-menu popover (panel-context-menu.js).
+ *
+ *   npx vitest run tests/interfaces/web_terminal/panel-context-menu.test.mjs
+ *
+ * The module is purely presentational, so everything it owns is testable here:
+ * the DOM contract, the dismissal paths (pointerdown, Escape, Tab, run, window
+ * blur/resize, anchor-scoped scroll), and the focus hand-back rules. happy-dom
+ * implements focus/activeElement well enough for the focus assertions; layout
+ * is faked where clamping is under test, since happy-dom reports zero rects.
+ *
+ * Imported by RELATIVE path — this module lives under web_terminal, so the
+ * /design-system/js/* alias does not apply.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  openContextMenu,
+  closeContextMenu,
+  isContextMenuOpen,
+} from '../../../src/osprey/interfaces/web_terminal/static/js/panel-context-menu.js';
+
+/** The open menu element, or null. @returns {HTMLElement | null} */
+function menu() {
+  return /** @type {HTMLElement | null} */ (document.querySelector('.rail-context-menu'));
+}
+
+/** The menu's rows, dividers excluded. @returns {HTMLElement[]} */
+function rows() {
+  return /** @type {HTMLElement[]} */ ([...document.querySelectorAll('.rail-context-item')]);
+}
+
+/** The rendered label text of every row, in order. @returns {string[]} */
+function rowLabels() {
+  return rows().map((r) => /** @type {string} */ (r.querySelector('.rail-context-label')?.textContent));
+}
+
+/**
+ * A rail entry inside a scrollable rail, plus an unrelated scroller standing in
+ * for the terminal's xterm viewport.
+ * @returns {{entry: HTMLButtonElement, rail: HTMLElement, viewport: HTMLElement}}
+ */
+function mountSurfaces() {
+  document.body.innerHTML = `
+    <div id="rail"><button id="entry" type="button">ARIEL</button></div>
+    <div id="xterm-viewport"></div>`;
+  return {
+    entry: /** @type {HTMLButtonElement} */ (document.getElementById('entry')),
+    rail: /** @type {HTMLElement} */ (document.getElementById('rail')),
+    viewport: /** @type {HTMLElement} */ (document.getElementById('xterm-viewport')),
+  };
+}
+
+/** Open a three-row service menu at the cursor. @param {object} [over] */
+function openServiceMenu(over = {}) {
+  const items = [
+    { label: 'Focus ARIEL' },
+    { label: 'Open in a new tile', glyph: '⊞' },
+    { divider: true },
+    { label: 'Remove from rail', glyph: '×', danger: true },
+  ].map((i) => ({ run: () => {}, ...i }));
+  openContextMenu({ x: 10, y: 20, ariaLabel: 'ARIEL actions', items, ...over });
+}
+
+/** @param {string} key */
+function pressKey(key) {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  closeContextMenu();
+  vi.restoreAllMocks();
+});
+
+describe('openContextMenu — DOM contract', () => {
+  test('renders rows, glyphs, dividers and danger styling', () => {
+    openServiceMenu();
+
+    const el = /** @type {HTMLElement} */ (menu());
+    expect(el).not.toBeNull();
+    expect(el.getAttribute('role')).toBe('menu');
+    expect(el.getAttribute('aria-label')).toBe('ARIEL actions');
+    expect(rowLabels()).toEqual(['Focus ARIEL', 'Open in a new tile', 'Remove from rail']);
+    expect(rows().every((r) => r.getAttribute('role') === 'menuitem')).toBe(true);
+    expect(rows()[2].classList.contains('danger')).toBe(true);
+
+    const glyph = rows()[1].querySelector('.rail-context-glyph');
+    expect(glyph?.textContent).toBe('⊞');
+    expect(glyph?.getAttribute('aria-hidden')).toBe('true');
+
+    const divider = el.querySelector('.rail-context-divider');
+    expect(divider?.getAttribute('role')).toBe('separator');
+  });
+
+  test('labels are text, never markup (panel labels are server-supplied)', () => {
+    openContextMenu({
+      x: 0,
+      y: 0,
+      ariaLabel: 'actions',
+      items: [{ label: 'Focus <img src=x onerror=boom>', run: () => {} }],
+    });
+
+    expect(rows()[0].querySelector('img')).toBeNull();
+    expect(rowLabels()[0]).toBe('Focus <img src=x onerror=boom>');
+  });
+
+  test('a disabled row is inert: aria-disabled, no run, menu stays open', () => {
+    const run = vi.fn();
+    openContextMenu({
+      x: 0,
+      y: 0,
+      ariaLabel: 'ARIEL actions',
+      items: [{ label: 'Open in a new window', glyph: '↗', disabled: true, run }],
+    });
+
+    expect(rows()[0].getAttribute('aria-disabled')).toBe('true');
+    rows()[0].click();
+    expect(run).not.toHaveBeenCalled();
+    expect(isContextMenuOpen()).toBe(true);
+  });
+
+  test('right-clicking the popover never stacks the native menu', () => {
+    openServiceMenu();
+
+    const e = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    rows()[0].dispatchEvent(e);
+
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  test('only one menu is open at a time — a second replaces the first', () => {
+    openServiceMenu();
+    openContextMenu({ x: 0, y: 0, ariaLabel: 'Lattice actions', items: [{ label: 'Focus Lattice' }] });
+
+    expect(document.querySelectorAll('.rail-context-menu')).toHaveLength(1);
+    expect(menu()?.getAttribute('aria-label')).toBe('Lattice actions');
+  });
+
+  test('clamps inward rather than overflowing the viewport', () => {
+    const width = 200;
+    const height = 150;
+    const x = window.innerWidth - 10;
+    const y = window.innerHeight - 10;
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(
+      /** @type {DOMRect} */ ({ width, height, right: x + width, bottom: y + height })
+    );
+
+    openServiceMenu({ x, y });
+
+    expect(menu()?.style.left).toBe(`${x - width}px`);
+    expect(menu()?.style.top).toBe(`${y - height}px`);
+  });
+
+  test('clamping never pushes the menu off the top-left corner', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(
+      /** @type {DOMRect} */ ({ width: 200, height: 150, right: 1e6, bottom: 1e6 })
+    );
+
+    openServiceMenu({ x: 5, y: 5 });
+
+    expect(menu()?.style.left).toBe('0px');
+    expect(menu()?.style.top).toBe('0px');
+  });
+});
+
+describe('keyboard behavior', () => {
+  test('the first enabled row takes focus on open', () => {
+    openContextMenu({
+      x: 0,
+      y: 0,
+      ariaLabel: 'ARIEL actions',
+      items: [
+        { label: 'Open in a new window', disabled: true },
+        { label: 'Focus ARIEL', run: () => {} },
+      ],
+    });
+
+    expect(document.activeElement).toBe(rows()[1]);
+  });
+
+  test('arrows walk the enabled rows and wrap, skipping disabled ones', () => {
+    openContextMenu({
+      x: 0,
+      y: 0,
+      ariaLabel: 'ARIEL actions',
+      items: [
+        { label: 'Focus ARIEL', run: () => {} },
+        { label: 'Open in a new window', disabled: true },
+        { label: 'Remove from rail', danger: true, run: () => {} },
+      ],
+    });
+
+    pressKey('ArrowDown');
+    expect(document.activeElement).toBe(rows()[2]);
+    pressKey('ArrowDown');
+    expect(document.activeElement).toBe(rows()[0]);
+    pressKey('ArrowUp');
+    expect(document.activeElement).toBe(rows()[2]);
+  });
+});
+
+describe('dismissal', () => {
+  test('pointerdown outside closes; inside does not', () => {
+    const { entry } = mountSurfaces();
+    openServiceMenu({ anchorEl: entry });
+
+    rows()[0].dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(isContextMenuOpen()).toBe(true);
+
+    entry.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(isContextMenuOpen()).toBe(false);
+  });
+
+  test('Escape and Tab both close the menu', () => {
+    openServiceMenu();
+    pressKey('Escape');
+    expect(isContextMenuOpen()).toBe(false);
+
+    openServiceMenu();
+    pressKey('Tab');
+    expect(isContextMenuOpen()).toBe(false);
+  });
+
+  test('Tab does not also move focus onward — its default is cancelled', () => {
+    openServiceMenu();
+
+    const e = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    document.dispatchEvent(e);
+
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  test('window blur closes the menu (a click landing in a panel iframe)', () => {
+    openServiceMenu();
+    window.dispatchEvent(new Event('blur'));
+    expect(isContextMenuOpen()).toBe(false);
+  });
+
+  test('window resize closes the menu', () => {
+    openServiceMenu();
+    window.dispatchEvent(new Event('resize'));
+    expect(isContextMenuOpen()).toBe(false);
+  });
+
+  test('a document scroll closes the menu', () => {
+    const { entry } = mountSurfaces();
+    openServiceMenu({ anchorEl: entry });
+
+    document.dispatchEvent(new Event('scroll'));
+
+    expect(isContextMenuOpen()).toBe(false);
+  });
+
+  test('a scroll of a container holding the anchor closes the menu', () => {
+    const { entry, rail } = mountSurfaces();
+    openServiceMenu({ anchorEl: entry });
+
+    rail.dispatchEvent(new Event('scroll'));
+
+    expect(isContextMenuOpen()).toBe(false);
+  });
+
+  test('an unrelated scroller — xterm streaming output — never dismisses', () => {
+    const { entry, viewport } = mountSurfaces();
+    openServiceMenu({ anchorEl: entry });
+
+    viewport.dispatchEvent(new Event('scroll'));
+
+    expect(isContextMenuOpen()).toBe(true);
+  });
+
+  test('without an anchor only document scrolls dismiss', () => {
+    const { viewport } = mountSurfaces();
+    openServiceMenu();
+
+    viewport.dispatchEvent(new Event('scroll'));
+    expect(isContextMenuOpen()).toBe(true);
+
+    document.dispatchEvent(new Event('scroll'));
+    expect(isContextMenuOpen()).toBe(false);
+  });
+
+  test('closing detaches every listener', () => {
+    const { entry } = mountSurfaces();
+    entry.focus();
+    openServiceMenu({ anchorEl: entry });
+    pressKey('Escape');
+
+    // Nothing left listening: these would each close or restore focus if the
+    // teardown had missed a handler.
+    const other = document.createElement('button');
+    document.body.appendChild(other);
+    other.focus();
+    pressKey('Escape');
+    window.dispatchEvent(new Event('blur'));
+    window.dispatchEvent(new Event('resize'));
+    document.dispatchEvent(new Event('scroll'));
+
+    expect(document.activeElement).toBe(other);
+  });
+
+  test('closeContextMenu is safe with no menu open', () => {
+    expect(() => closeContextMenu()).not.toThrow();
+    expect(isContextMenuOpen()).toBe(false);
+  });
+});
+
+describe('focus hand-back', () => {
+  test('Escape returns focus to whatever held it at open', () => {
+    const { entry } = mountSurfaces();
+    entry.focus();
+    openServiceMenu({ anchorEl: entry });
+    expect(document.activeElement).toBe(rows()[0]);
+
+    pressKey('Escape');
+
+    expect(document.activeElement).toBe(entry);
+  });
+
+  test('Tab returns focus to whatever held it at open', () => {
+    const { entry } = mountSurfaces();
+    entry.focus();
+    openServiceMenu({ anchorEl: entry });
+
+    pressKey('Tab');
+
+    expect(document.activeElement).toBe(entry);
+  });
+
+  test('replacing a menu keeps the ORIGINAL previous focus', () => {
+    const { entry } = mountSurfaces();
+    entry.focus();
+    openServiceMenu({ anchorEl: entry });
+    // Second menu opens while a row of the first holds focus — the row is not
+    // somewhere focus can be handed back to.
+    openServiceMenu({ anchorEl: entry });
+
+    pressKey('Escape');
+
+    expect(document.activeElement).toBe(entry);
+  });
+
+  test('pointer, blur, scroll and resize dismissals leave focus alone', () => {
+    const { entry, rail } = mountSurfaces();
+
+    for (const dismissBy of [
+      () => entry.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true })),
+      () => window.dispatchEvent(new Event('blur')),
+      () => window.dispatchEvent(new Event('resize')),
+      () => rail.dispatchEvent(new Event('scroll')),
+    ]) {
+      entry.focus();
+      openServiceMenu({ anchorEl: entry });
+      const rowEl = rows()[0];
+      expect(document.activeElement).toBe(rowEl);
+
+      dismissBy();
+
+      expect(isContextMenuOpen()).toBe(false);
+      // Focus stayed with the removed row rather than being yanked back — in a
+      // real browser it has already moved on (the iframe, the clicked target).
+      expect(document.activeElement).not.toBe(entry);
+    }
+  });
+
+  test('closeContextMenu() does not move focus', () => {
+    const { entry } = mountSurfaces();
+    entry.focus();
+    openServiceMenu({ anchorEl: entry });
+
+    closeContextMenu();
+
+    expect(document.activeElement).not.toBe(entry);
+  });
+});
+
+describe('running an item', () => {
+  test('the menu is gone and focus is back before the action runs', () => {
+    const { entry } = mountSurfaces();
+    entry.focus();
+    const seen = /** @type {{open: boolean, focus: Element | null}[]} */ ([]);
+    openContextMenu({
+      x: 0,
+      y: 0,
+      anchorEl: entry,
+      ariaLabel: 'ARIEL actions',
+      items: [{ label: 'Focus ARIEL', run: () => seen.push({ open: isContextMenuOpen(), focus: document.activeElement }) }],
+    });
+
+    rows()[0].click();
+
+    expect(seen).toEqual([{ open: false, focus: entry }]);
+  });
+
+  test('an action that moves focus itself wins', () => {
+    const { entry } = mountSurfaces();
+    const target = document.createElement('button');
+    document.body.appendChild(target);
+    entry.focus();
+    openContextMenu({
+      x: 0,
+      y: 0,
+      anchorEl: entry,
+      ariaLabel: 'ARIEL actions',
+      items: [{ label: 'Open in a new tile', run: () => target.focus() }],
+    });
+
+    rows()[0].click();
+
+    expect(document.activeElement).toBe(target);
+  });
+
+  test('a row with no run closes the menu without throwing', () => {
+    openContextMenu({ x: 0, y: 0, ariaLabel: 'ARIEL actions', items: [{ label: 'Focus ARIEL' }] });
+
+    expect(() => rows()[0].click()).not.toThrow();
+    expect(isContextMenuOpen()).toBe(false);
+  });
+});

--- a/tests/interfaces/web_terminal/panel-manager.test.mjs
+++ b/tests/interfaces/web_terminal/panel-manager.test.mjs
@@ -59,6 +59,35 @@ vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
   onDragGesture: () => [],
 }));
 
+// The terminal verbs the context menu binds live outside panel-manager's own
+// state machine (a PTY socket and the session list). Stub both modules at the
+// boundary so a menu pick can be asserted as the call it makes — the restart
+// PAIR above all, which is a correctness contract, not a detail: restartTerminal
+// tears the PTY down without reconnecting.
+// Only the three verbs are replaced: terminal.js is already on the import
+// chain (panel-iframe-sync reads the live session id from it), so a whole-module
+// stub would strand that reader — these are partial mocks, registered per
+// import next to the dock-iframe one below for the same freshness reason.
+const TERMINAL_PATH = '../../../src/osprey/interfaces/web_terminal/static/js/terminal.js';
+const SESSIONS_PATH = '../../../src/osprey/interfaces/web_terminal/static/js/sessions.js';
+const { restartTerminal, startTerminal, startNewSession } = vi.hoisted(() => ({
+  restartTerminal: vi.fn(async () => {}),
+  startTerminal: vi.fn(),
+  startNewSession: vi.fn(),
+}));
+
+/** @param {() => Promise<unknown>} importOriginal */
+async function terminalWithVerbSpies(importOriginal) {
+  const actual = /** @type {Record<string, unknown>} */ (await importOriginal());
+  return { ...actual, restartTerminal, startTerminal };
+}
+
+/** @param {() => Promise<unknown>} importOriginal */
+async function sessionsWithVerbSpies(importOriginal) {
+  const actual = /** @type {Record<string, unknown>} */ (await importOriginal());
+  return { ...actual, startNewSession };
+}
+
 // dock-iframe.js keeps its REAL placement engine — only the tile-glow entry
 // point is spied on. What the glow looks like (an overlay rectangle measured a
 // frame later) is dock-glow.test.mjs's and the browser suite's contract; what
@@ -135,6 +164,8 @@ function stubEventSource() {
 async function freshImport() {
   vi.resetModules();
   vi.doMock(DOCK_IFRAME_PATH, dockIframeWithGlowSpy);
+  vi.doMock(TERMINAL_PATH, terminalWithVerbSpies);
+  vi.doMock(SESSIONS_PATH, sessionsWithVerbSpies);
   return import('../../../src/osprey/interfaces/web_terminal/static/js/panel-manager.js');
 }
 
@@ -611,7 +642,7 @@ describe('simple-UX chat-only first boot (workspace suppression)', () => {
   });
 });
 
-describe('getPanelStandaloneUrl — the rail popout corner\'s target (railOptions onPopout)', () => {
+describe('getPanelStandaloneUrl — the "Open in a new window" target (context menu + palette)', () => {
   test('is null before config resolves a url, then the resolved url once it has', async () => {
     window.__OSPREY_PREFIX__ = '';
     renderContainer();
@@ -953,6 +984,55 @@ const dockedTiles = (/** @type {any} */ api) =>
   api.panels
     .filter((/** @type {any} */ p) => p.id.startsWith('iframe:'))
     .map((/** @type {any} */ p) => p.id.slice('iframe:'.length));
+
+/** The open context-menu popover, or null when none is open. */
+const contextMenu = () =>
+  /** @type {HTMLElement | null} */ (document.querySelector('.rail-context-menu'));
+
+/** Every menu row's visible verb, in order (dividers carry no label). */
+const menuLabels = () =>
+  [...document.querySelectorAll('.rail-context-label')].map((el) => el.textContent);
+
+/**
+ * The menu row reading exactly `label`, or undefined when the menu omits it.
+ * @param {string} label
+ * @returns {HTMLElement | undefined}
+ */
+const menuRow = (label) =>
+  /** @type {HTMLElement | undefined} */ (
+    [...document.querySelectorAll('.rail-context-item')].find(
+      (el) => el.querySelector('.rail-context-label')?.textContent === label
+    )
+  );
+
+/**
+ * Right-click a rail surface the way the browser does — on the entry button or
+ * on a child of it (the "×" corner), letting the event bubble. The returned
+ * event's `defaultPrevented` is the visible half of the handler's boolean:
+ * true means a menu was claimed and the browser's native menu is suppressed.
+ * @param {Element} el
+ * @returns {MouseEvent}
+ */
+function rightClick(el) {
+  const ev = new MouseEvent('contextmenu', {
+    bubbles: true, cancelable: true, clientX: 40, clientY: 60,
+  });
+  el.dispatchEvent(ev);
+  return ev;
+}
+
+/**
+ * Ask a focused entry for its menu from the keyboard (the ContextMenu key),
+ * the route the rail synthesises itself because macOS fires no `contextmenu`
+ * event from the keyboard at all.
+ * @param {Element} el
+ * @returns {KeyboardEvent}
+ */
+function menuKey(el) {
+  const ev = new KeyboardEvent('keydown', { key: 'ContextMenu', bubbles: true, cancelable: true });
+  el.dispatchEvent(ev);
+  return ev;
+}
 
 /**
  * Boot the manager against a live dock shell. Every listed panel is enabled and
@@ -1339,17 +1419,20 @@ describe('panel_arrange — the declarative whole-workspace rebuild', () => {
   });
 
   test('a tile still on screen is never painted over as an empty workspace', async () => {
-    // The one reachable route to "docked but UNHEALTHY": the rail's ⊞ corner
-    // docks a tile regardless of health (its activation then refuses), which is
-    // the state the rebuild deliberately leaves on screen.
+    // The reachable route to "docked but UNHEALTHY": "Open in a new tile" docks
+    // a tile regardless of health (its activation then refuses), which is the
+    // state the rebuild deliberately leaves on screen.
     const { api, emit } = await bootWorkspace({
       panels: ['artifacts', 'ariel'],
       unhealthy: ['ariel'],
     });
-    const beside = /** @type {HTMLElement} */ (
-      document.querySelector('[data-panel-id="ariel"] .panel-rail-beside')
-    );
-    beside.click();
+    // A panel that is unhealthy from boot never had its entry enabled, and the
+    // menu declines a disabled entry. Clear the class by hand to stand in for
+    // the production sequence this state comes from: healthy long enough to
+    // enable the entry, then gone dark — the manager never re-disables one.
+    entry('ariel')?.classList.remove('disabled');
+    rightClick(/** @type {Element} */ (entry('ariel')));
+    /** @type {HTMLElement} */ (menuRow('Open in a new tile')).click();
     expect(dockedTiles(api).sort()).toEqual(['ariel', 'artifacts']);
     expect(activeStamp()).toBe('artifacts'); // the unhealthy panel took no focus
 
@@ -1804,5 +1887,211 @@ describe('agent-attention badges survive a reload — acknowledged by server ts'
     open();
 
     await vi.waitFor(() => expect(badged('artifacts')).toBe(true));
+  });
+});
+
+
+describe('rail context menu — the entry’s verbs in words (railOptions onContextMenu)', () => {
+  const entry = (/** @type {string} */ id) =>
+    /** @type {HTMLElement} */ (document.querySelector(`.panel-rail-button[data-panel-id="${id}"]`));
+  const activeStamp = () => document.getElementById('panel-manager')?.dataset.activePanel ?? null;
+
+  afterEach(() => {
+    // Dismiss whatever a test left open — an undismissed popover keeps
+    // document-level listeners alive across the module reset.
+    document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    document.documentElement.removeAttribute('data-ui-mode');
+  });
+
+  test('a healthy service entry opens the full verb list and suppresses the native menu', async () => {
+    await bootWorkspace();
+
+    const ev = rightClick(entry('ariel'));
+
+    expect(ev.defaultPrevented).toBe(true);
+    expect(menuLabels()).toEqual([
+      'Focus ARIEL', 'Open in a new tile', 'Open in a new window', 'Remove from rail',
+    ]);
+    expect(contextMenu()?.getAttribute('aria-label')).toBe('ARIEL actions');
+  });
+
+  test('the entry is the menu’s anchor, so a panel scrolling its own content leaves it open', async () => {
+    await bootWorkspace();
+    rightClick(entry('ariel'));
+
+    // A scroll inside some other subtree — xterm streaming output is the case
+    // that matters — is not a scroll of the anchor and must not dismiss.
+    const other = document.createElement('div');
+    document.body.appendChild(other);
+    other.dispatchEvent(new Event('scroll', { bubbles: false }));
+    expect(contextMenu()).not.toBeNull();
+
+    // The rail scrolling DOES move the anchor.
+    document.getElementById('panel-rail')?.dispatchEvent(new Event('scroll'));
+    expect(contextMenu()).toBeNull();
+  });
+
+  test('"Open in a new tile" docks a NEW tile beside the active one', async () => {
+    const { api } = await bootWorkspace();
+    const artifactsGroup = api.getPanel('iframe:artifacts').group;
+
+    rightClick(entry('ariel'));
+    /** @type {HTMLElement} */ (menuRow('Open in a new tile')).click();
+
+    expect(dockedTiles(api).sort()).toEqual(['ariel', 'artifacts']);
+    expect(api.getPanel('iframe:ariel').group).not.toBe(artifactsGroup);
+    // Running a row closes the menu before the action — never after it.
+    expect(contextMenu()).toBeNull();
+  });
+
+  test('"Open in a new window" opens the panel’s standalone url in a new tab', async () => {
+    const { mod } = await bootWorkspace();
+    const open = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    rightClick(entry('ariel'));
+    /** @type {HTMLElement} */ (menuRow('Open in a new window')).click();
+
+    expect(open).toHaveBeenCalledWith(mod.getPanelStandaloneUrl('ariel'), '_blank', 'noopener');
+    open.mockRestore();
+  });
+
+  test('"Remove from rail" POSTs the same membership change the "×" does', async () => {
+    const { calls } = await bootWorkspace();
+
+    rightClick(entry('ariel'));
+    /** @type {HTMLElement} */ (menuRow('Remove from rail')).click();
+
+    const post = /** @type {{url: string, opts: any}} */ (
+      calls.find((c) => c.url === '/api/panel-visibility')
+    );
+    expect(post).toBeDefined();
+    expect(JSON.parse(post.opts.body)).toEqual({ panel: 'ariel', visible: false });
+  });
+
+  test('Focus on the ALREADY-active panel is a no-op — never the entry click’s retire branch', async () => {
+    const { api } = await bootWorkspace();
+    expect(activeStamp()).toBe('artifacts');
+
+    rightClick(entry('artifacts'));
+    /** @type {HTMLElement} */ (menuRow('Focus WORKSPACE')).click();
+
+    expect(dockedTiles(api)).toContain('artifacts');
+    expect(activeStamp()).toBe('artifacts');
+
+    // The contrast that makes the row’s wording true: clicking the entry
+    // itself toggles, and DOES retire the tile it is already showing.
+    entry('artifacts').click();
+    expect(dockedTiles(api)).not.toContain('artifacts');
+  });
+
+  test('Focus surfaces a member that holds no tile', async () => {
+    const { api } = await bootWorkspace();
+
+    rightClick(entry('ariel'));
+    /** @type {HTMLElement} */ (menuRow('Focus ARIEL')).click();
+
+    expect(dockedTiles(api)).toContain('ariel');
+    expect(activeStamp()).toBe('ariel');
+  });
+
+  test('simple mode drops the new-tile row — its layout is one service tile', async () => {
+    await bootWorkspace({ mode: 'simple' });
+
+    rightClick(entry('ariel'));
+
+    expect(menuLabels()).toEqual(['Focus ARIEL', 'Open in a new window', 'Remove from rail']);
+  });
+
+  test('an entry with no standalone url yet renders the popout row inert', async () => {
+    await bootWorkspace({ panels: ['artifacts', 'ariel'], unhealthy: ['ariel'] });
+    // Stand-in for the production state: enabled by an earlier healthy settle,
+    // url since gone (the manager never re-disables an entry).
+    entry('ariel').classList.remove('disabled');
+
+    rightClick(entry('ariel'));
+
+    const row = /** @type {HTMLElement} */ (menuRow('Open in a new window'));
+    expect(row.getAttribute('aria-disabled')).toBe('true');
+    // Inert, not merely dimmed: the row carries no action at all.
+    const open = vi.spyOn(window, 'open').mockReturnValue(null);
+    row.click();
+    expect(open).not.toHaveBeenCalled();
+    expect(contextMenu()).not.toBeNull();
+    open.mockRestore();
+  });
+
+  test('a disabled entry gets no menu — not by right-click, not through its still-live "×"', async () => {
+    await bootWorkspace({ panels: ['artifacts', 'ariel'], unhealthy: ['ariel'] });
+    expect(entry('ariel').classList.contains('disabled')).toBe(true);
+
+    // The gate is the handler’s, not the CSS’s: happy-dom applies no
+    // pointer-events, so these dispatches are exactly the two routes that get
+    // past `pointer-events: none` in a real browser.
+    const onEntry = rightClick(entry('ariel'));
+    expect(contextMenu()).toBeNull();
+    // Declining leaves the event alone, so the browser’s own menu still shows.
+    expect(onEntry.defaultPrevented).toBe(false);
+
+    const close = /** @type {Element} */ (entry('ariel').querySelector('.panel-rail-close'));
+    const onClose = rightClick(close);
+    expect(contextMenu()).toBeNull();
+    expect(onClose.defaultPrevented).toBe(false);
+  });
+
+  test('the keyboard route obeys the same gate', async () => {
+    await bootWorkspace({ panels: ['artifacts', 'ariel'], unhealthy: ['ariel'] });
+
+    const declined = menuKey(entry('ariel'));
+    expect(contextMenu()).toBeNull();
+    // Not cancelled: on the platforms that fire a native contextmenu from this
+    // keydown, the declined entry keeps it.
+    expect(declined.defaultPrevented).toBe(false);
+
+    const opened = menuKey(entry('artifacts'));
+    expect(contextMenu()).not.toBeNull();
+    // Cancelled, so one keypress cannot also stack the platform’s own menu.
+    expect(opened.defaultPrevented).toBe(true);
+  });
+
+  test('the terminal entry offers the session verbs, and pairs restart with reconnect', async () => {
+    await bootWorkspace();
+
+    const ev = rightClick(entry('terminal'));
+
+    expect(ev.defaultPrevented).toBe(true);
+    expect(menuLabels()).toEqual(['Restart terminal', 'New session', 'Close terminal tile']);
+    expect(contextMenu()?.getAttribute('aria-label')).toBe('SESSION actions');
+
+    /** @type {HTMLElement} */ (menuRow('Restart terminal')).click();
+    await vi.waitFor(() => expect(startTerminal).toHaveBeenCalled());
+    // restartTerminal tears the PTY down without reconnecting — unpaired it
+    // would leave the card stranded.
+    expect(restartTerminal).toHaveBeenCalled();
+    expect(restartTerminal.mock.invocationCallOrder[0])
+      .toBeLessThan(startTerminal.mock.invocationCallOrder[0]);
+  });
+
+  test('the terminal entry’s other verbs reach the session list and the dock', async () => {
+    await bootWorkspace();
+
+    rightClick(entry('terminal'));
+    /** @type {HTMLElement} */ (menuRow('New session')).click();
+    expect(startNewSession).toHaveBeenCalled();
+
+    rightClick(entry('terminal'));
+    /** @type {HTMLElement} */ (menuRow('Close terminal tile')).click();
+    expect(closeTerminalPanel).toHaveBeenCalled();
+  });
+
+  test('simple mode declines the terminal menu entirely', async () => {
+    await bootWorkspace({ mode: 'simple' });
+
+    // The terminal is replaced by the operator console there and
+    // closeTerminalPanel no-ops, so every row would act on an invisible
+    // surface — the native menu falls through instead.
+    const ev = rightClick(entry('terminal'));
+
+    expect(contextMenu()).toBeNull();
+    expect(ev.defaultPrevented).toBe(false);
   });
 });

--- a/tests/interfaces/web_terminal/panel-rail.test.mjs
+++ b/tests/interfaces/web_terminal/panel-rail.test.mjs
@@ -93,6 +93,16 @@ describe('createRail', () => {
     expect(first?.getAttribute('title')).toBe('WORKSPACE');
   });
 
+  test('a hint is appended to the tooltip, never to the accessible name', () => {
+    // The context menu has no visible affordance, so the tooltip is where it
+    // is advertised; aria-label stays the panel's identity so a screen reader
+    // does not read the advertisement on every entry.
+    createRail(rail, [{ id: 'ariel', label: 'ARIEL', hint: 'right-click for actions' }]);
+    const entry = getEntry(rail, 'ariel');
+    expect(entry?.getAttribute('title')).toBe('ARIEL · right-click for actions');
+    expect(entry?.getAttribute('aria-label')).toBe('ARIEL');
+  });
+
   test('entries never render the retired closed/dimmed state', () => {
     createRail(rail, PANELS);
     expect(rail.querySelector('.panel-rail-closed')).toBeNull();
@@ -159,63 +169,171 @@ describe('entry interactions', () => {
     expect(activated).toEqual([]);
   });
 
-  test('popout affordance renders only when onPopout is provided', () => {
-    createRail(rail, PANELS);
-    expect(getEntry(rail, 'artifacts')?.querySelector('.panel-rail-popout')).toBeNull();
-
-    rail = freshRail();
-    createRail(rail, PANELS, { onPopout: () => {} });
-    expect(getEntry(rail, 'artifacts')?.querySelector('.panel-rail-popout')?.textContent).toBe('↗');
-  });
-
-  test('clicking popout invokes onPopout without activating the entry', () => {
-    /** @type {string[]} */
-    const activated = [];
-    /** @type {string[]} */
-    const popped = [];
+  test('right-click forwards (id, event) to onContextMenu and suppresses the browser menu', () => {
+    /** @type {any[]} */
+    const calls = [];
     createRail(rail, PANELS, {
-      onActivate: (id) => activated.push(id),
-      onPopout: (id) => popped.push(id),
+      onContextMenu: (id, e) => {
+        calls.push([id, e]);
+        return true;
+      },
     });
-    /** @type {HTMLElement} */ (
-      /** @type {HTMLElement} */ (getEntry(rail, 'ariel')).querySelector('.panel-rail-popout')
-    ).click();
-    expect(popped).toEqual(['ariel']);
-    expect(activated).toEqual([]);
-  });
-
-  test('close and popout occupy opposite corners of the same entry', () => {
-    createRail(rail, PANELS, { onClose: () => {}, onPopout: () => {} });
     const entry = /** @type {HTMLElement} */ (getEntry(rail, 'ariel'));
-    expect(entry.querySelector('.panel-rail-close')).toBeTruthy();
-    expect(entry.querySelector('.panel-rail-popout')).toBeTruthy();
-  });
-
-  test('open-beside affordance renders only when onOpenBeside is provided', () => {
-    createRail(rail, PANELS);
-    expect(getEntry(rail, 'artifacts')?.querySelector('.panel-rail-beside')).toBeNull();
-
-    rail = freshRail();
-    createRail(rail, PANELS, { onOpenBeside: () => {} });
-    expect(getEntry(rail, 'artifacts')?.querySelector('.panel-rail-beside')?.textContent).toBe('⊞');
-  });
-
-  test('clicking open-beside invokes onOpenBeside without activating the entry', () => {
-    /** @type {string[]} */
-    const activated = [];
-    /** @type {string[]} */
-    const beside = [];
-    createRail(rail, PANELS, {
-      onActivate: (id) => activated.push(id),
-      onOpenBeside: (id) => beside.push(id),
+    const ev = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 12,
+      clientY: 34,
     });
-    /** @type {HTMLElement} */ (
-      /** @type {HTMLElement} */ (getEntry(rail, 'ariel')).querySelector('.panel-rail-beside')
-    ).click();
-    expect(beside).toEqual(['ariel']);
-    expect(activated).toEqual([]);
+    entry.dispatchEvent(ev);
+
+    expect(calls).toEqual([['ariel', ev]]);
+    expect(ev.defaultPrevented).toBe(true);
   });
 
+  test('a declined right-click keeps the native browser menu', () => {
+    // The caller's policy — a disabled entry, the terminal in simple mode —
+    // is expressed as `false`, and the rail must then leave the event alone.
+    createRail(rail, PANELS, { onContextMenu: () => false });
+    const ev = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    /** @type {HTMLElement} */ (getEntry(rail, 'ariel')).dispatchEvent(ev);
+
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  test('no onContextMenu leaves right-click entirely to the browser', () => {
+    createRail(rail, PANELS);
+    const ev = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    /** @type {HTMLElement} */ (getEntry(rail, 'ariel')).dispatchEvent(ev);
+
+    expect(ev.defaultPrevented).toBe(false);
+  });
+});
+
+/**
+ * The keyboard route to the context menu. The rail opens the menu itself
+ * rather than waiting for the platform: macOS fires no `contextmenu` event
+ * from the keyboard at all. Where the platform DOES fire one (Windows menu
+ * key, Firefox Shift+F10) it is the keydown's default action, so the same
+ * boolean contract as right-click decides whether that default is suppressed
+ * — the difference between one menu and two.
+ */
+describe('keyboard route to the context menu', () => {
+  /** @type {HTMLElement} */
+  let rail;
+
+  // happy-dom reports an all-zero rect, so the entry's geometry is stubbed:
+  // the assertion is about WHERE the menu is asked to open, not about layout.
+  const RECT = /** @type {DOMRect} */ (
+    /** @type {unknown} */ ({
+      x: 10,
+      y: 40,
+      left: 10,
+      top: 40,
+      width: 74,
+      height: 60,
+      right: 84,
+      bottom: 100,
+      toJSON: () => ({}),
+    })
+  );
+  const CENTER_X = 47; // 10 + 74 / 2
+  const CENTER_Y = 70; // 40 + 60 / 2
+
+  /** @param {string} key @param {boolean} [shiftKey] */
+  function keyEvent(key, shiftKey = false) {
+    return new KeyboardEvent('keydown', { key, shiftKey, bubbles: true, cancelable: true });
+  }
+
+  /** @param {HTMLElement} entry */
+  function stubRect(entry) {
+    vi.spyOn(entry, 'getBoundingClientRect').mockReturnValue(RECT);
+  }
+
+  /** Wire a rail whose onContextMenu records its calls and reports `handled`.
+   *  @param {boolean} handled @returns {any[]} */
+  function railWithMenu(handled) {
+    /** @type {any[]} */
+    const calls = [];
+    createRail(rail, PANELS, {
+      onContextMenu: (id, e) => {
+        calls.push([id, e]);
+        return handled;
+      },
+    });
+    return calls;
+  }
+
+  beforeEach(() => {
+    rail = freshRail();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('the ContextMenu key opens the menu centred on the entry rect', () => {
+    const calls = railWithMenu(true);
+    const entry = /** @type {HTMLElement} */ (getEntry(rail, 'ariel'));
+    stubRect(entry);
+
+    const ev = keyEvent('ContextMenu');
+    entry.dispatchEvent(ev);
+
+    // Exactly one open: the synthetic event is handed to the caller, never
+    // dispatched, so the entry's own contextmenu listener cannot also fire.
+    expect(calls.length).toBe(1);
+    const [id, menuEvent] = calls[0];
+    expect(id).toBe('ariel');
+    expect(menuEvent.type).toBe('contextmenu');
+    expect(menuEvent.clientX).toBe(CENTER_X);
+    expect(menuEvent.clientY).toBe(CENTER_Y);
+    // Windows/Firefox would otherwise open a second, native menu on this key.
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  test('Shift+F10 opens the same menu at the same point', () => {
+    const calls = railWithMenu(true);
+    const entry = /** @type {HTMLElement} */ (getEntry(rail, 'ariel'));
+    stubRect(entry);
+
+    const ev = keyEvent('F10', true);
+    entry.dispatchEvent(ev);
+
+    expect(calls.length).toBe(1);
+    expect(calls[0][0]).toBe('ariel');
+    expect(calls[0][1].clientX).toBe(CENTER_X);
+    expect(calls[0][1].clientY).toBe(CENTER_Y);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  test('a declined entry keeps the platform default on the keyboard too', () => {
+    const calls = railWithMenu(false);
+    /** @type {HTMLElement} */ (getEntry(rail, 'ariel')).dispatchEvent(keyEvent('ContextMenu'));
+
+    expect(calls.length).toBe(1);
+    // No menu was opened, so whatever the platform does with this key stands.
+    expect(calls[0][1].defaultPrevented).toBe(false);
+  });
+
+  test('F10 without Shift, and ordinary keys, are left alone', () => {
+    const calls = railWithMenu(true);
+    const entry = /** @type {HTMLElement} */ (getEntry(rail, 'ariel'));
+
+    for (const ev of [keyEvent('F10'), keyEvent('Enter'), keyEvent('m', true)]) {
+      entry.dispatchEvent(ev);
+      expect(ev.defaultPrevented).toBe(false);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  test('no onContextMenu means no keyboard menu at all', () => {
+    createRail(rail, PANELS);
+    const ev = keyEvent('ContextMenu');
+    /** @type {HTMLElement} */ (getEntry(rail, 'ariel')).dispatchEvent(ev);
+
+    expect(ev.defaultPrevented).toBe(false);
+  });
 });
 
 describe('drag from the rail (onDragStart / onDragEnd)', () => {
@@ -629,6 +747,21 @@ describe('setEntryAttention tooltip time', () => {
       setEntryAttention(rail, 'ariel', true, bad);
       expect(getEntry(rail, 'ariel')?.title).toBe('ARIEL');
     }
+  });
+
+  test('the badge borrows and returns a hinted tooltip intact', () => {
+    // The stash is what the badge restores; a rail entry advertising its menu
+    // must get that advertisement back, not just the bare label.
+    rail = freshRail();
+    createRail(rail, [{ id: 'ariel', label: 'ARIEL', hint: 'right-click for actions' }]);
+
+    setEntryAttention(rail, 'ariel', true, TS);
+    expect(getEntry(rail, 'ariel')?.title).toBe(
+      `ARIEL · right-click for actions · agent touched ${expectedTime(TS)}`
+    );
+
+    setEntryAttention(rail, 'ariel', false);
+    expect(getEntry(rail, 'ariel')?.title).toBe('ARIEL · right-click for actions');
   });
 
   test('the suffix never reaches the accessible name', () => {

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -9,8 +9,9 @@ parts the FastAPI TestClient cannot reach.
 
 One panel per tile is a workspace invariant: the rail is the tab system, so an
 activation REPLACES the focused service tile's panel (the evicted panel closes
-server-side and dims on the rail), the "+" add menu is the verb that opens a
-NEW tile beside the current one, and no drop geometry may stack tabs.
+server-side and dims on the rail), the "+" add menu and the rail entry's
+"Open in a new tile" are the verbs that open a NEW tile beside the current one,
+and no drop geometry may stack tabs.
 
 What is proven here, grouped:
 
@@ -34,6 +35,19 @@ What is proven here, grouped:
   * The "+" add menu: unclipped geometry beside the rail, URL-row gating, reveal a
     hidden panel INTO A NEW TILE beside the active one, register from URL, and
     inline register errors.
+  * Tile header-bar contributions (the embed contract): a panel's own nav, search
+    and overflow items render in ITS bar only, actions round-trip into the iframe,
+    and the bar's drag ghost keeps its icons bar-sized.
+  * The right-click context menu (``panel-context-menu.js``), the only home left
+    for the open-beside and pop-out verbs: the rows a rail entry and a tile header
+    offer, the surfaces that DECLINE (an offline entry by mouse or keyboard, a
+    contributed header input, the terminal in simple mode), and the dismissals
+    that need real focus and real event targets — a click into a panel iframe,
+    and the scroll scoping that leaves the menu standing while xterm scrolls.
+  * The command palette: it opens with the input focused and typing filters
+    immediately, its Panels rows cover the ACTIVE panel and answer domain
+    synonyms, a pop-out row really opens the proxied panel URL, and executed
+    items come back under "Recent" on an empty query.
 
 Each test launches a real uvicorn server in a background thread, drives events
 through the REST API, and asserts the DOM via Playwright auto-waiting.
@@ -390,18 +404,70 @@ def _command_posts(posts: list[str]) -> list[str]:
     return [p for p in posts if p != "panel-layout"]
 
 
+# ---------------------------------------------------------------------------
+# Context-menu helpers
+# ---------------------------------------------------------------------------
+#
+# The rail's ⊞ and ↗ corner glyphs are gone: "open in a new tile" and "open in
+# a new window" live only in the right-click context menu
+# (panel-context-menu.js), a body-level popover carrying one .rail-context-item
+# per verb. Every gesture that used to click a corner goes through the menu
+# now, so these helpers are the one place that knows the popover's DOM.
+
+_RAIL_MENU = ".rail-context-menu"
+_RAIL_MENU_ITEM = ".rail-context-item"
+
+#: Row labels of the open context menu, in render order. Read from the label
+#: span rather than the row so the trailing glyph never joins the text.
+_MENU_LABELS_JS = (
+    "() => [...document.querySelectorAll('.rail-context-menu .rail-context-label')]"
+    ".map(e => e.textContent)"
+)
+
+
+def _rail_entry(page: Page, panel_id: str):
+    return page.locator(f'button.panel-rail-button[data-panel-id="{panel_id}"]')
+
+
+def _context_menu(page: Page):
+    return page.locator(_RAIL_MENU)
+
+
+def _menu_labels(page: Page) -> list[str]:
+    return page.evaluate(_MENU_LABELS_JS)
+
+
+def _menu_row(page: Page, label: str):
+    """The menu row whose label contains ``label``."""
+    return page.locator(_RAIL_MENU_ITEM).filter(has_text=label)
+
+
+def _open_rail_menu(page: Page, panel_id: str):
+    """Right-click a rail entry and wait for its context menu to render.
+
+    The entry is the click target rather than one of its corners: a disabled
+    entry is ``pointer-events: none``, so Playwright's actionability check also
+    waits out the boot window in which the panel has not yet reported healthy —
+    the same implicit wait the hover-corner gesture used to provide.
+    """
+    _rail_entry(page, panel_id).click(button="right")
+    menu = _context_menu(page)
+    expect(menu).to_have_count(1, timeout=5_000)
+    return menu
+
+
 def _open_second_tile(page: Page, base_url: str, panel_id: str, label: str) -> None:
-    """Open ``panel_id`` as a SECOND tile beside the current one via the rail's ⊞.
+    """Open ``panel_id`` as a SECOND tile beside the current one from its menu.
 
     A rail click would REPLACE the focused tile's panel (one panel per tile), so
-    tests that need two service tiles side by side use the entry's hover ⊞
-    ("open in a new tile") corner — the open-beside verb. ``base_url`` is
-    unused (kept so call sites read uniformly with the old add-menu dance).
+    tests that need two service tiles side by side use the entry's context-menu
+    row "Open in a new tile" — the open-beside verb, whose hover ⊞ corner is
+    gone. ``base_url`` is unused (kept so call sites read uniformly with the old
+    add-menu dance).
     """
-    del base_url  # the ⊞ path is purely client-side
-    entry = page.locator(f'button.panel-rail-button[data-panel-id="{panel_id}"]')
-    entry.hover()
-    entry.locator(".panel-rail-beside").click()
+    del base_url  # the menu path is purely client-side
+    _open_rail_menu(page, panel_id)
+    _menu_row(page, "Open in a new tile").click()
     expect(_service_tab(page, label)).to_have_count(1, timeout=5_000)
 
 
@@ -834,7 +900,7 @@ def test_service_tile_close_button_is_local_vacate(tmp_path, chromium_browser):
 
 
 def test_open_beside_moves_docked_panel_instead_of_duplicating(tmp_path, chromium_browser):
-    """⊞ on an ALREADY-OPEN panel moves its tile beside the active one.
+    """The new-tile verb on an ALREADY-OPEN panel moves its tile beside the active one.
 
     The old dance (remove from rail, re-add via "+") is gone: dockPanelAt's
     move semantics relocate the existing placeholder, so the panel never
@@ -858,10 +924,9 @@ def test_open_beside_moves_docked_panel_instead_of_duplicating(tmp_path, chromiu
         ).to_have_count(1, timeout=5_000)
         groups_before = len(_dock_groups(page))
 
-        # Act — ⊞ on the already-open data-viz entry.
-        entry = page.locator('button.panel-rail-button[data-panel-id="data-viz"]')
-        entry.hover()
-        entry.locator(".panel-rail-beside").click()
+        # Act — "Open in a new tile" on the already-open data-viz entry.
+        _open_rail_menu(page, "data-viz")
+        _menu_row(page, "Open in a new tile").click()
 
         # Still exactly one data-viz tab, and the tile count is unchanged —
         # the tile MOVED (beside artifacts), it was not duplicated.
@@ -2252,6 +2317,14 @@ def test_header_contribution_renders_and_round_trips(tmp_path, chromium_browser)
             workspace,
             enabled_panels={"artifacts"},
             custom_panels=[custom],
+            # The premise below is that artifacts contributes NOTHING, which
+            # only holds while its iframe fails to load. The default fallback
+            # URL is the artifacts server's standard port, so a real artifacts
+            # server running on this host (a live web terminal, a demo stack)
+            # would load for real and contribute its own nav items — turning
+            # that assertion into a report about the machine. A free port keeps
+            # the panel dead by construction.
+            artifact_url=f"http://127.0.0.1:{_free_port()}",
         ) as (base_url, _app):
             page = _open_page(chromium_browser, base_url)
             _open_second_tile(page, base_url, "contrib-demo", "CONTRIB")
@@ -2546,3 +2619,747 @@ def test_tile_bar_drag_ghost_keeps_icons_bar_sized(tmp_path, chromium_browser):
             assert probe["ghostClose"] == probe["liveClose"], probe
 
             page.close()
+
+
+# ===========================================================================
+# Group 9 — The rail / tile-header context menu (FR1-FR6)
+# ===========================================================================
+#
+# The panel verbs that used to be hover-revealed corner glyphs now live in a
+# right-click menu, and only there. What only a real browser can settle:
+#
+#   * FR1 - a right-click on a healthy rail entry really renders the popover,
+#     with every verb in words, and its rows really drive the panel.
+#   * FR3/FR5 - the surfaces that must DECLINE: a disabled entry (mouse on its
+#     still-live "×" and keyboard alike) and a contributed header input, where
+#     the browser's own text menu has to survive. No test can see that native
+#     menu; what it can hold the app to is that the app's own popover stays
+#     away and the event is left to the browser.
+#   * FR4 - the dismissals that depend on real focus and real event targets: a
+#     click landing inside a panel iframe (which never reaches this document —
+#     only `window` blur does), and the scroll scoping that keeps the menu
+#     standing while the terminal streams output.
+#   * FR5 - the keyboard route, opened by the app rather than the platform.
+
+
+def test_rail_context_menu_lists_every_panel_verb(tmp_path, chromium_browser):
+    """Right-clicking a healthy rail entry opens the menu with all four verbs.
+
+    The popover is body-level and viewport-positioned (it has to escape the
+    rail's own overflow), names the panel in its accessible name, and carries
+    the verbs in words with the rail's glyphs kept as trailing decoration. The
+    membership verb is the only destructive one and is styled apart.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_CUSTOM_DATA_VIZ],
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=10_000)
+
+        menu = _open_rail_menu(page, "data-viz")
+
+        assert _menu_labels(page) == [
+            "Focus DATA VIZ",
+            "Open in a new tile",
+            "Open in a new window",
+            "Remove from rail",
+        ], _menu_labels(page)
+        expect(menu).to_have_attribute("role", "menu")
+        expect(menu).to_have_attribute("aria-label", "DATA VIZ actions")
+        expect(menu.locator(".rail-context-divider")).to_have_count(1)
+        expect(menu.locator(".rail-context-glyph")).to_have_count(3)
+        expect(menu.locator(f"{_RAIL_MENU_ITEM}.danger")).to_have_text(
+            re.compile(r"Remove from rail")
+        )
+        # data-viz's URL resolved at boot, so the popout row is live.
+        expect(menu.locator(f'{_RAIL_MENU_ITEM}[aria-disabled="true"]')).to_have_count(0)
+
+        placement = page.evaluate(
+            "() => { const m = document.querySelector('.rail-context-menu');"
+            " return { parent: m.parentElement.tagName,"
+            " position: getComputedStyle(m).position }; }"
+        )
+        assert placement == {"parent": "BODY", "position": "fixed"}, placement
+
+        page.close()
+
+
+def test_rail_context_menu_keyboard_open_and_escape_restores_focus(tmp_path, chromium_browser):
+    """Shift+F10 on a focused entry opens ONE menu; Escape hands focus back.
+
+    macOS synthesises no `contextmenu` event from the keyboard, so the rail
+    opens the menu itself — and cancels the keydown's default action, which on
+    the platforms that DO synthesise one is what keeps a single keypress from
+    stacking a second, native menu. Escape is a keyboard dismissal, so focus
+    returns to whatever held it when the menu opened.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_CUSTOM_DATA_VIZ],
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(_service_tab(page, "WORKSPACE")).to_have_count(1, timeout=10_000)
+        # The entry has to be enabled before the keyboard route is allowed —
+        # the same gate the mouse route passes through.
+        expect(_rail_entry(page, "data-viz")).not_to_have_class(
+            re.compile(r"\bdisabled\b"), timeout=10_000
+        )
+
+        _rail_entry(page, "data-viz").focus()
+        page.keyboard.press("Shift+F10")
+
+        # Exactly one popover, and the keyboard user lands on its first row.
+        expect(_context_menu(page)).to_have_count(1, timeout=5_000)
+        assert page.evaluate("() => document.activeElement?.textContent ?? ''").startswith(
+            "Focus DATA VIZ"
+        )
+
+        page.keyboard.press("Escape")
+        expect(_context_menu(page)).to_have_count(0, timeout=5_000)
+        focused = page.evaluate("() => document.activeElement?.getAttribute('data-panel-id') ?? ''")
+        assert focused == "data-viz", focused
+
+        page.close()
+
+
+def test_rail_context_menu_remove_from_rail_drops_membership(tmp_path, chromium_browser):
+    """The menu's "Remove from rail" runs the same membership POST the "×" does.
+
+    Like the corner it replaces, this is a SERVER change applied through the
+    panel_visibility echo, so the wait spans a full click → POST → broadcast →
+    handler round trip (see the rail "×" test for why the budget is 10s).
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        custom_panels=[_CUSTOM_DATA_VIZ],
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        _focus_service_panel(page, "data-viz", "DATA VIZ")
+
+        _open_rail_menu(page, "data-viz")
+        _menu_row(page, "Remove from rail").click()
+
+        # The menu closes before the action runs, and the panel loses both its
+        # rail entry (membership) and its tile.
+        expect(_context_menu(page)).to_have_count(0, timeout=5_000)
+        expect(_rail_entry(page, "data-viz")).to_have_count(0, timeout=10_000)
+        expect(_service_tab(page, "DATA VIZ")).to_have_count(0, timeout=10_000)
+
+        page.close()
+
+
+def test_rail_context_menu_popout_row_inert_until_url_resolves(tmp_path, chromium_browser):
+    """The new-window row renders inert while the panel has no standalone URL.
+
+    A panel's URL and its health arrive together at boot (one with no URL never
+    polls, so it never enables), which is why the entry is force-enabled here:
+    the menu's enabled gate is a DOM-class question, and taking the class off is
+    the only way to reach an entry that HAS a menu while its popout target is
+    still unresolved — the state an operator meets when a companion server is
+    slow to answer.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        artifact_url=None,
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        entry = _rail_entry(page, "artifacts")
+        expect(entry).to_have_class(re.compile(r"\bdisabled\b"), timeout=10_000)
+        page.evaluate(
+            "() => document.querySelector('button.panel-rail-button"
+            "[data-panel-id=\"artifacts\"]').classList.remove('disabled')"
+        )
+
+        menu = _open_rail_menu(page, "artifacts")
+        popout = _menu_row(page, "Open in a new window")
+        expect(popout).to_have_attribute("aria-disabled", "true")
+        # Every other row stays live — the gate is per-verb, not per-menu.
+        expect(menu.locator(f'{_RAIL_MENU_ITEM}[aria-disabled="true"]')).to_have_count(1)
+
+        pages_before = len(page.context.pages)
+        # Forced, because Playwright reads `aria-disabled` on a menuitem as
+        # "not enabled" and would otherwise refuse the press outright — which
+        # is itself half the assertion. The press is still delivered, so the
+        # row is held to doing nothing rather than merely looking inert.
+        popout.click(force=True)
+        page.wait_for_timeout(500)
+        assert len(page.context.pages) == pages_before, "an inert row opened a window"
+        # An inert row is not a dismissal either: the press landed inside the
+        # menu, so the menu is still standing.
+        expect(_context_menu(page)).to_have_count(1)
+
+        page.close()
+
+
+def test_disabled_rail_entry_has_no_context_menu(tmp_path, chromium_browser):
+    """An offline panel's entry offers no menu — not by its "×", not by keyboard.
+
+    The gate is in the handler rather than the rail's CSS on purpose: the
+    disabled entry's "×" keeps `pointer-events: auto` so a dead panel can always
+    be dismissed, and a keyboard menu request never consults CSS at all. Both
+    routes are driven here; neither may reach a menu whose verbs act on a panel
+    that has never answered. Declining leaves the event untouched, so what an
+    operator gets on those presses is the browser's own menu.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        artifact_url=None,
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        entry = _rail_entry(page, "artifacts")
+        expect(entry).to_have_class(re.compile(r"\bdisabled\b"), timeout=10_000)
+
+        # The still-live corner: a right-click on it lands on the entry.
+        entry.locator(".panel-rail-close").click(button="right")
+        page.wait_for_timeout(500)
+        expect(_context_menu(page)).to_have_count(0)
+
+        # The keyboard route bypasses `pointer-events` entirely.
+        entry.focus()
+        page.keyboard.press("Shift+F10")
+        page.wait_for_timeout(500)
+        expect(_context_menu(page)).to_have_count(0)
+
+        page.close()
+
+
+def test_simple_mode_drops_new_tile_row_and_terminal_menu(tmp_path, chromium_browser):
+    """Simple mode: no new-tile row, and the terminal surfaces decline outright.
+
+    The layout is locked to a single service tile there, so the open-beside verb
+    has nowhere to go; and the xterm card is replaced by the operator console,
+    so every terminal verb would act on a surface the operator cannot see — the
+    same reason the palette drops those actions in simple mode.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+    # Non-empty workspace — see test_simple_mode_locks_layout_and_hides_close_controls.
+    (workspace / "seed_artifact.txt").write_text("seed\n")
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+        ui_mode="simple",
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(page.locator("html")).to_have_attribute("data-ui-mode", "simple")
+
+        _open_rail_menu(page, "artifacts")
+        assert _menu_labels(page) == [
+            "Focus WORKSPACE",
+            "Open in a new window",
+            "Remove from rail",
+        ], _menu_labels(page)
+
+        page.keyboard.press("Escape")
+        expect(_context_menu(page)).to_have_count(0, timeout=5_000)
+
+        # The SESSION entry declines: no rows means no menu at all, never an
+        # empty popover.
+        _rail_entry(page, "terminal").click(button="right")
+        page.wait_for_timeout(500)
+        expect(_context_menu(page)).to_have_count(0)
+
+        page.close()
+
+
+def test_terminal_context_menu_survives_streaming_output(tmp_path, chromium_browser):
+    """The terminal's menu stays open while xterm scrolls its own viewport.
+
+    Scroll dismissal is scoped to the menu's anchor: only a scroll of the
+    document, or of a container that HOLDS the anchor, may close the menu. An
+    unscoped listener would close it on xterm's viewport scroll — which fires on
+    every streamed line, i.e. the terminal's normal state, making the menu
+    unusable exactly where it is most useful.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _live_server(
+        workspace,
+        enabled_panels={"artifacts"},
+    ) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        expect(page.locator(".xterm-viewport")).to_have_count(1, timeout=10_000)
+
+        _open_rail_menu(page, "terminal")
+        assert _menu_labels(page) == [
+            "Restart terminal",
+            "New session",
+            "Close terminal tile",
+        ], _menu_labels(page)
+
+        # The event xterm emits from its viewport on every streamed line. It
+        # does not bubble, which is why the module listens in the capture phase
+        # — and why it has to tell this target apart from the document.
+        page.evaluate(
+            "() => document.querySelector('.xterm-viewport').dispatchEvent(new Event('scroll'))"
+        )
+        page.wait_for_timeout(300)
+        expect(_context_menu(page)).to_have_count(1)
+
+        # A document scroll DOES move the anchor, so it dismisses — the contrast
+        # that keeps the assertion above from passing on a missing listener.
+        page.evaluate("() => document.dispatchEvent(new Event('scroll'))")
+        expect(_context_menu(page)).to_have_count(0, timeout=5_000)
+
+        page.close()
+
+
+def test_tile_header_menu_yields_to_contributed_search_input(tmp_path, chromium_browser):
+    """A right-click inside a contributed header input keeps the browser's menu.
+
+    The tile bar owns a menu of the panel's verbs, but its interactive children
+    do not: right-clicking a contributed search box has to leave copy/paste and
+    the spell-check entries alone (dock-tab.js's INTERACTIVE guard). The title
+    beside it is the contrast — the same press there does open the panel's menu.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _search_menu_panel_backend() as stub_url:
+        custom = {
+            "id": "search-demo",
+            "label": "SEARCHY",
+            "url": stub_url,
+            "healthEndpoint": None,
+            "path": "/",
+        }
+        with _live_server(
+            workspace,
+            enabled_panels={"artifacts"},
+            custom_panels=[custom],
+        ) as (base_url, _app):
+            page = _open_page(chromium_browser, base_url)
+            _open_second_tile(page, base_url, "search-demo", "SEARCHY")
+
+            tab = _service_tab(page, "SEARCHY")
+            search = tab.locator(".contrib-search-input")
+            expect(search).to_have_attribute("placeholder", "Filter things…", timeout=10_000)
+
+            search.click(button="right")
+            page.wait_for_timeout(500)
+            expect(_context_menu(page)).to_have_count(0)
+
+            # The bar itself is a menu surface, with the same verbs the rail
+            # entry offers.
+            tab.locator(".tile-tab-title").click(button="right")
+            menu = _context_menu(page)
+            expect(menu).to_have_count(1, timeout=5_000)
+            expect(menu).to_have_attribute("aria-label", "SEARCHY actions")
+            assert _menu_labels(page) == [
+                "Focus SEARCHY",
+                "Open in a new tile",
+                "Open in a new window",
+                "Remove from rail",
+            ], _menu_labels(page)
+
+            page.close()
+
+
+def test_context_menu_closes_when_a_click_lands_in_a_panel_iframe(tmp_path, chromium_browser):
+    """A click inside a panel iframe closes the menu — without stealing focus back.
+
+    A press inside an overlay iframe never reaches this document, so the outside
+    pointerdown listener cannot see it; `window` blur is the only signal, and it
+    arrives AFTER focus has entered the iframe. Restoring focus on that path
+    would yank it straight back out of the panel the operator just clicked into,
+    so this dismissal deliberately leaves focus alone.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _stub_backend() as stub_url:
+        custom = {
+            "id": "data-viz",
+            "label": "DATA VIZ",
+            "url": stub_url,
+            "healthEndpoint": None,
+            "path": "/",
+        }
+        with _live_server(
+            workspace,
+            enabled_panels={"artifacts"},
+            custom_panels=[custom],
+        ) as (base_url, _app):
+            page = _open_page(chromium_browser, base_url)
+            _focus_service_panel(page, "data-viz", "DATA VIZ")
+            expect(_overlay_iframe(page, "data-viz")).to_be_visible(timeout=10_000)
+
+            _open_rail_menu(page, "data-viz")
+
+            # A real click in the panel's own document (the stub answers the
+            # proxied /panel/data-viz, so the iframe is same-origin and has a
+            # body to click).
+            page.frame_locator('.dock-iframe-overlay iframe[data-panel-id="data-viz"]').locator(
+                "body"
+            ).click()
+
+            expect(_context_menu(page)).to_have_count(0, timeout=5_000)
+            # Focus stayed where the operator put it: inside the iframe, not
+            # back on the rail entry the menu was opened from.
+            focused = page.evaluate("() => document.activeElement?.tagName ?? ''")
+            assert focused == "IFRAME", focused
+
+            page.close()
+
+
+# ---------------------------------------------------------------------------
+# Command palette (FR7-FR9)
+# ---------------------------------------------------------------------------
+#
+# What only a real browser can settle about the palette:
+#
+#   * FR7 - focus. The input is focused inside the same rAF that reveals the
+#     overlay, because focusing a node in a `visibility: hidden` subtree is a
+#     spec'd no-op. happy-dom has no visibility model, so it cannot tell a
+#     working focus call from the broken one; a real keystroke landing in the
+#     input is the only proof.
+#   * FR8 - the Panels rows. The registry unit tests prove the row set from
+#     injected getters; these prove the LIVE getters produce it: ARIEL's
+#     standalone URL really resolved through /api/ariel-server, and the active
+#     panel really is included in the popout source and excluded from the
+#     new-tile source.
+#   * FR8 - the popout verb end to end: `window.open` opens a real page on the
+#     proxied, same-origin /panel/<id> URL.
+#   * FR9 - Recent. Real localStorage, and the section really renders first on
+#     an empty query and survives a reload.
+#
+# ARIEL is the panel under test because it is the one the synonym table has
+# domain vocabulary for ("logbook"/"elog"). It is enabled as a built-in panel
+# with its companion server URL published post-startup - the catalog entry
+# carries no healthEndpoint, so it is healthy the moment its config fetch
+# resolves, and the stub backend behind it lets the proxied /panel/ariel URL
+# answer for real when a popout navigates to it.
+
+_PALETTE_OVERLAY = ".command-palette-overlay.visible"
+_PALETTE_INPUT = ".command-palette-input"
+_PALETTE_ITEM = ".command-palette-item"
+
+#: The same platform split palette-boot.js applies to the hotkey: Cmd+K on
+#: macOS, Ctrl+K everywhere else. Read from the browser rather than from the
+#: host's ``sys.platform`` so the test follows the page's own decision.
+_IS_MAC_JS = r"""() => {
+  const nav = navigator;
+  const platform = (nav.userAgentData && nav.userAgentData.platform) || nav.platform || '';
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}"""
+
+#: The palette list's group headings, in render order. "Recent" is a
+#: presentation-level section, so it shows up here as a heading like any group.
+_PALETTE_HEADINGS_JS = (
+    "() => [...document.querySelectorAll('.command-palette-group-heading')].map(h => h.textContent)"
+)
+
+#: Row texts of the "Recent" section only - the nodes between the Recent
+#: heading and the next heading. Returns None when no Recent section rendered,
+#: which distinguishes "the section is absent" from "the section is empty".
+_PALETTE_RECENT_ROWS_JS = r"""() => {
+  const list = document.querySelector('.command-palette-list');
+  if (!list) return null;
+  const rows = [];
+  let inRecent = false;
+  for (const node of list.children) {
+    if (node.classList.contains('command-palette-group-heading')) {
+      if (inRecent) break;
+      if (node.textContent === 'Recent') inRecent = true;
+      continue;
+    }
+    if (inRecent) rows.push(node.textContent);
+  }
+  return inRecent ? rows : null;
+}"""
+
+
+@contextmanager
+def _palette_live_server(workspace):
+    """A live server whose ARIEL panel is a rail member with a resolved URL.
+
+    ``_launch_panel_server`` is stubbed to publish only the gallery URL, so
+    ARIEL's is set here - after startup, before any page load, which is when
+    the browser first fetches /api/ariel-server. It points at the always-200
+    stub so the proxied ``/panel/ariel`` a popout navigates to answers for real
+    instead of erroring behind the proxy.
+
+    Yields:
+        (base_url, app) - as ``_live_server``.
+    """
+    with _stub_backend() as stub_url:
+        with _live_server(
+            workspace,
+            enabled_panels={"artifacts", "ariel"},
+        ) as (base_url, app):
+            app.state.ariel_server_url = stub_url
+            yield base_url, app
+
+
+def _palette_input(page: Page):
+    return page.locator(_PALETTE_INPUT)
+
+
+def _palette_row(page: Page, label: str):
+    """Palette rows whose text contains ``label`` (substring, case-insensitive).
+
+    A row's label is split across highlight spans when the query matched it, so
+    the text is read from the row rather than from a single text node.
+    """
+    return page.locator(_PALETTE_ITEM).filter(has_text=label)
+
+
+def _open_palette(page: Page, *, hotkey: bool = False) -> None:
+    """Open the command palette and wait for the revealed overlay.
+
+    The default entry point is the header trigger; ``hotkey=True`` drives the
+    Cmd/Ctrl+K path instead. Either way this returns only once the overlay
+    carries ``.visible`` - the class the focus call shares a frame with, so a
+    caller may type immediately afterwards without a further wait.
+
+    The hotkey path first focuses a rail entry: off macOS the shortcut
+    deliberately yields to readline's Ctrl+K while focus is inside the
+    terminal, so the gesture has to start where the operator's would.
+    """
+    if hotkey:
+        page.locator('button.panel-rail-button[data-panel-id="artifacts"]').focus()
+        page.keyboard.press("Meta+k" if page.evaluate(_IS_MAC_JS) else "Control+k")
+    else:
+        page.locator("#command-palette-btn").click()
+    expect(page.locator(_PALETTE_OVERLAY)).to_be_visible(timeout=5_000)
+
+
+def _palette_query(page: Page, query: str) -> None:
+    """Put ``query`` in the search box and let the list re-render.
+
+    Typed rather than pressed: whether the open FOCUSED the box is FR7's
+    question, and exactly one test above owns it. Every other palette test is
+    about what the list then contains, so they set the query outright instead of
+    inheriting a focus dependency and failing for someone else's reason.
+    """
+    _palette_input(page).fill(query)
+    expect(_palette_input(page)).to_have_value(query)
+
+
+def _palette_reload(page: Page) -> None:
+    """Reload the page and wait for the same steady state ``_open_page`` does.
+
+    The welcome overlay ships in the served HTML and only self-dismisses once
+    the operator clicks through it (which stores the server session id), so a
+    reload brings it back and it has to be removed again - it intercepts
+    pointer events over the whole viewport, the palette trigger included.
+    """
+    page.reload(wait_until="domcontentloaded")
+    expect(page.locator('button.panel-rail-button[data-panel-id="artifacts"]')).to_be_attached(
+        timeout=10_000
+    )
+    expect(page.locator(".dv-groupview").first).to_be_visible(timeout=10_000)
+    page.evaluate("document.getElementById('welcome-overlay')?.remove()")
+
+
+def test_palette_hotkey_opens_with_input_focused_and_types_immediately(tmp_path, chromium_browser):
+    """FR7: Cmd/Ctrl+K opens the palette focused - the next keystroke filters.
+
+    The regression this guards is silent: ``inputEl.focus()`` ran while the
+    overlay was still ``visibility: hidden``, which the spec makes a no-op, so
+    the palette opened looking usable and swallowed everything the operator
+    typed. Nothing here clicks the input - the characters are pressed straight
+    at the document, so they can only reach the input if the open really moved
+    focus there.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _palette_live_server(workspace) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+
+        _open_palette(page, hotkey=True)
+
+        # Real focus, not merely a rendered overlay. The diagnostic carries the
+        # computed visibility because that is the whole story when this fails:
+        # a `visible` class on the overlay is not the same as a computed
+        # `visibility: visible` the browser will focus into.
+        state = page.evaluate(
+            """() => {
+  const overlay = document.querySelector('.command-palette-overlay');
+  const active = document.activeElement;
+  return {
+    focused: !!active && active.classList.contains('command-palette-input'),
+    active: active ? active.tagName + '.' + active.className : null,
+    overlayClass: overlay ? overlay.className : null,
+    overlayVisibility: overlay ? getComputedStyle(overlay).visibility : null,
+  };
+}"""
+        )
+        assert state["focused"] is True, f"palette opened without the search input focused: {state}"
+
+        # Act - type without touching the input first.
+        page.keyboard.type("ariel")
+
+        # Assert - the keystrokes landed AND re-filtered the list.
+        expect(_palette_input(page)).to_have_value("ariel")
+        expect(_palette_row(page, "Open ARIEL in a new window")).to_have_count(1, timeout=5_000)
+        expect(_palette_row(page, "Open Settings")).to_have_count(0)
+
+        page.close()
+
+
+def test_palette_query_ariel_offers_popout_of_the_active_panel(tmp_path, chromium_browser):
+    """FR8: with ARIEL active, "ariel" finds its popout row but no new-tile row.
+
+    The two "Open ..." verbs draw on different sources, and the live getters
+    are what this proves: ``getPopoutPanels`` includes the ACTIVE panel
+    (popping out what you are looking at is the verb's commonest use, and it
+    needed ARIEL's standalone URL to have resolved through /api/ariel-server),
+    while ``getVisiblePanels`` - the new-tile source - excludes it, because
+    opening a panel beside itself is a no-op. The second query proves the
+    new-tile verb is present in this (expert) mode at all, so ARIEL's missing
+    row is the active-panel exclusion rather than a whole verb going absent.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _palette_live_server(workspace) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+        _focus_service_panel(page, "ariel", "ARIEL")
+
+        _open_palette(page)
+        _palette_query(page, "ariel")
+
+        expect(_palette_row(page, "Open ARIEL in a new window")).to_have_count(1, timeout=5_000)
+        # The query really narrowed the list, so the absences below mean the
+        # rows do not exist rather than that everything is still on screen.
+        expect(_palette_row(page, "Open Settings")).to_have_count(0)
+        expect(_palette_row(page, "Open ARIEL in a new tile")).to_have_count(0)
+        # Focus is the same story as the new tile: the active panel is not
+        # offered a verb that would do nothing.
+        expect(_palette_row(page, "Focus ARIEL")).to_have_count(0)
+
+        # The new-tile verb itself is alive here - it just skips the active panel.
+        _palette_query(page, "tile")
+        expect(_palette_row(page, "Open WORKSPACE in a new tile")).to_have_count(1, timeout=5_000)
+        expect(_palette_row(page, "Open ARIEL in a new tile")).to_have_count(0)
+
+        page.close()
+
+
+def test_palette_logbook_synonym_matches_ariel(tmp_path, chromium_browser):
+    """FR8: "logbook" - the domain word, not the label - finds the ARIEL rows.
+
+    ARIEL's rail label says nothing about logbooks, so an operator who types
+    what the panel IS gets nothing unless the synonym tokens really reach the
+    live rows' searchText.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _palette_live_server(workspace) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+
+        _open_palette(page)
+        _palette_query(page, "logbook")
+
+        expect(_palette_row(page, "Open ARIEL in a new window")).to_have_count(1, timeout=5_000)
+        # A word ARIEL's own rows are the only ones carrying: WORKSPACE, the
+        # other rail member, is filtered out entirely.
+        expect(_palette_row(page, "WORKSPACE")).to_have_count(0)
+
+        page.close()
+
+
+def test_palette_popout_row_opens_the_proxied_panel_url(tmp_path, chromium_browser):
+    """FR8: running the popout row opens a real page on same-origin /panel/ariel.
+
+    happy-dom can only prove ``window.open`` was called with some string. What
+    matters to the operator is the page that opens: the proxied, root-relative
+    standalone URL resolved against the terminal's own origin - never the
+    panel's internal address, which the browser cannot reach.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _palette_live_server(workspace) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+
+        _open_palette(page)
+        _palette_query(page, "ariel window")
+        row = _palette_row(page, "Open ARIEL in a new window")
+        expect(row).to_have_count(1, timeout=5_000)
+
+        with page.context.expect_page() as popup_info:
+            row.click()
+        popup = popup_info.value
+        popup.wait_for_url(re.compile(r"/panel/ariel$"), timeout=10_000)
+
+        assert popup.url == f"{base_url}/panel/ariel", popup.url
+
+        popup.close()
+        page.close()
+
+
+def test_palette_recent_section_leads_the_empty_query_after_an_execution(
+    tmp_path, chromium_browser
+):
+    """FR9: an executed item comes back first under "Recent", and survives reload.
+
+    Recent is a presentation-level section rebuilt from localStorage keys that
+    are re-resolved against the live registry on each render, so this drives
+    the whole loop through a real browser store: execute, reopen on an empty
+    query, reload, reopen again. "Move panel rail to left" is the item because
+    it is offered in every mode and is a no-op at the default rail position, so
+    the proof does not hinge on the workspace being left in some other state.
+    """
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+
+    with _palette_live_server(workspace) as (base_url, _app):
+        page = _open_page(chromium_browser, base_url)
+
+        # No history yet: an empty query renders no Recent section at all.
+        _open_palette(page)
+        assert page.evaluate(_PALETTE_RECENT_ROWS_JS) is None
+        page.keyboard.press("Escape")
+        expect(page.locator(_PALETTE_OVERLAY)).to_have_count(0, timeout=5_000)
+
+        # Act - run one item.
+        _open_palette(page)
+        _palette_query(page, "rail to left")
+        row = _palette_row(page, "Move panel rail to left")
+        expect(row).to_have_count(1, timeout=5_000)
+        row.click()
+        expect(page.locator(_PALETTE_OVERLAY)).to_have_count(0, timeout=5_000)
+
+        # Assert - it leads the empty-query render, ahead of every group.
+        _open_palette(page)
+        headings = page.evaluate(_PALETTE_HEADINGS_JS)
+        assert headings and headings[0] == "Recent", headings
+        assert page.evaluate(_PALETTE_RECENT_ROWS_JS) == ["Move panel rail to left"]
+        # The normal groups still render underneath - Recent never replaces them.
+        assert "Panels" in headings, headings
+        page.keyboard.press("Escape")
+        expect(page.locator(_PALETTE_OVERLAY)).to_have_count(0, timeout=5_000)
+
+        # Assert - the history lives in the browser store, not in module memory.
+        _palette_reload(page)
+        _open_palette(page)
+        assert page.evaluate(_PALETTE_RECENT_ROWS_JS) == ["Move panel rail to left"]
+
+        page.close()

--- a/tests/interfaces/web_terminal/test_panels_collab_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_collab_browser.py
@@ -344,15 +344,18 @@ def _active_rail_id(page: Page) -> str | None:
 
 
 def _open_beside(page: Page, panel_id: str) -> None:
-    """Open ``panel_id`` as a NEW tile beside the active one via the rail's ⊞.
+    """Open ``panel_id`` as a NEW tile beside the active one from its menu.
 
     A plain rail click REPLACES the focused tile's panel (one panel per tile),
     so every test here that needs side-by-side tiles grows the layout through
-    the entry's hover ⊞ corner — the human open-beside verb.
+    the entry's right-click menu: "Open in a new tile" is the human open-beside
+    verb now that the hover ⊞ corner is gone (panel-context-menu.js).
     """
     entry = page.locator(f'button.panel-rail-button[data-panel-id="{panel_id}"]')
-    entry.hover()
-    entry.locator(".panel-rail-beside").click()
+    entry.click(button="right")
+    menu = page.locator(".rail-context-menu")
+    expect(menu).to_have_count(1, timeout=5_000)
+    menu.locator(".rail-context-item", has_text="Open in a new tile").click()
     expect(_service_tab(page, _LABELS[panel_id])).to_have_count(1, timeout=5_000)
 
 

--- a/tests/interfaces/web_terminal/tile-tab.test.mjs
+++ b/tests/interfaces/web_terminal/tile-tab.test.mjs
@@ -208,3 +208,199 @@ describe('tile-tab renderer', () => {
     });
   });
 });
+
+/**
+ * The tile header is a panel's second right-click surface: the same verb menu
+ * its rail entry offers. dock-tab holds no policy — it forwards the press
+ * through the setTileContextMenuHandler seam (panel-manager registers into it,
+ * and cannot be imported here: dock-workspace already imports this module) and
+ * suppresses the browser's own menu ONLY when the handler reports it opened
+ * one. Declining is doing nothing at all, which is what leaves copy/paste
+ * working inside a contributed search input.
+ */
+describe('tile header context menu', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  /** A right-click, cancelable so defaultPrevented is observable. */
+  function rightClick(x = 40, y = 12) {
+    return new MouseEvent('contextmenu', {
+      bubbles: true, cancelable: true, clientX: x, clientY: y,
+    });
+  }
+
+  /**
+   * The (id, opts) pair a handler mock was called with. Named here because a
+   * `vi.fn(() => true)` carries a zero-argument signature, so its recorded
+   * call tuple is not indexable without saying what it holds.
+   * @param {any} handler
+   * @returns {{id: string, opts: {x: number, y: number, anchorEl: HTMLElement}}}
+   */
+  function firstCall(handler) {
+    const [id, opts] = handler.mock.calls[0];
+    return { id, opts };
+  }
+
+  /** The detached terminal card fixture, as the terminal-tab suite builds it. */
+  function terminalHeaderFixture() {
+    const card = document.createElement('div');
+    card.className = 'terminal-card';
+    const header = document.createElement('div');
+    header.className = 'terminal-header';
+    const sel = document.createElement('select');
+    sel.id = 'session-selector';
+    header.appendChild(sel);
+    card.appendChild(header);
+    return header;
+  }
+
+  test('a service bar forwards the press with the SERVICE id, the bar as anchor, and the cursor position', async () => {
+    const { createTileTab, setTileContextMenuHandler } = await import(MOD);
+    const handler = vi.fn(() => true);
+    setTileContextMenuHandler(handler);
+    const tab = createTileTab('iframe:ariel');
+    tab.init({ title: 'ARIEL', params: {}, api: fakeApi() });
+    document.body.appendChild(tab.element);
+
+    const ev = rightClick(120, 30);
+    tab.element.dispatchEvent(ev);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const { id, opts } = firstCall(handler);
+    // The dockview placeholder prefix never leaves this module — the handler
+    // speaks the same panel ids the rail does.
+    expect(id).toBe('ariel');
+    expect(opts.anchorEl).toBe(tab.element);
+    expect(opts.x).toBe(120);
+    expect(opts.y).toBe(30);
+    // The menu owns this press: no native menu on top of it.
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  test('a declined press keeps the browser default (nothing is prevented)', async () => {
+    const { createTileTab, setTileContextMenuHandler } = await import(MOD);
+    // What simple mode's terminal reports: no menu opened, so the native one
+    // must still appear.
+    setTileContextMenuHandler(vi.fn(() => false));
+    const tab = createTileTab('iframe:ariel');
+    tab.init({ title: 'ARIEL', params: {}, api: fakeApi() });
+    document.body.appendChild(tab.element);
+
+    const ev = rightClick();
+    tab.element.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  test('with no handler registered the bar is inert — no throw, no suppression', async () => {
+    const { createTileTab } = await import(MOD);
+    const tab = createTileTab('iframe:ariel');
+    tab.init({ title: 'ARIEL', params: {}, api: fakeApi() });
+    document.body.appendChild(tab.element);
+
+    const ev = rightClick();
+    expect(() => tab.element.dispatchEvent(ev)).not.toThrow();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  test('interactive bar children are excluded — their native menu survives', async () => {
+    const { createTileTab, setTileContextMenuHandler } = await import(MOD);
+    const handler = vi.fn(() => true);
+    setTileContextMenuHandler(handler);
+    const tab = createTileTab('iframe:ariel');
+    tab.init({ title: 'ARIEL', params: {}, api: fakeApi() });
+    document.body.appendChild(tab.element);
+
+    // A contributed control standing in for the panel search inputs that make
+    // this exclusion matter: right-clicking one must still offer copy/paste.
+    const input = document.createElement('input');
+    /** @type {HTMLElement} */ (tab.element.querySelector('.tile-tab-contrib')).appendChild(input);
+
+    const onInput = rightClick();
+    input.dispatchEvent(onInput);
+    expect(handler).not.toHaveBeenCalled();
+    expect(onInput.defaultPrevented).toBe(false);
+
+    // The close button is interactive too, by the same rule.
+    const onClose = rightClick();
+    /** @type {HTMLElement} */ (tab.element.querySelector('.tile-tab-close')).dispatchEvent(onClose);
+    expect(handler).not.toHaveBeenCalled();
+    expect(onClose.defaultPrevented).toBe(false);
+
+    // Plain bar surface still opens the menu.
+    /** @type {HTMLElement} */ (tab.element.querySelector('.tile-tab-title'))
+      .dispatchEvent(rightClick());
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('the terminal bar forwards the terminal id once, anchored to its adopted header', async () => {
+    const { createTileTab, setTerminalHeaderSource, setTileContextMenuHandler } = await import(MOD);
+    const header = terminalHeaderFixture();
+    setTerminalHeaderSource(header);
+    const handler = vi.fn(() => true);
+    setTileContextMenuHandler(handler);
+    const tab = createTileTab('terminal');
+    tab.init({ title: 'SESSION', params: {}, api: fakeApi() });
+    document.body.appendChild(tab.element);
+
+    const ev = rightClick(8, 4);
+    /** @type {HTMLElement} */ (tab.element.querySelector('.terminal-header')).dispatchEvent(ev);
+
+    // Exactly once: the header fills the terminal bar, so listening on the tab
+    // root as well would run the handler twice for one press.
+    expect(handler).toHaveBeenCalledTimes(1);
+    const { id, opts } = firstCall(handler);
+    expect(id).toBe('terminal');
+    expect(opts.anchorEl).toBe(header);
+    expect(opts.x).toBe(8);
+    expect(opts.y).toBe(4);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  test('the terminal header keeps ONE contextmenu listener across tab rebuilds', async () => {
+    const { createTileTab, setTerminalHeaderSource, setTileContextMenuHandler } = await import(MOD);
+    const header = terminalHeaderFixture();
+    // Registration is per NODE, not per tab: close→reopen rebuilds the tab but
+    // re-adopts the same header, so a per-construction wiring would stack up.
+    setTerminalHeaderSource(header);
+    const handler = vi.fn(() => true);
+    setTileContextMenuHandler(handler);
+
+    const first = createTileTab('terminal');
+    first.init({ title: 'SESSION', params: {}, api: fakeApi() });
+    first.element.remove();
+    const second = createTileTab('terminal');
+    second.init({ title: 'SESSION', params: {}, api: fakeApi() });
+    document.body.appendChild(second.element);
+
+    /** @type {HTMLElement} */ (second.element.querySelector('.terminal-header'))
+      .dispatchEvent(rightClick());
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("the terminal header's interactive children are excluded too", async () => {
+    const { createTileTab, setTerminalHeaderSource, setTileContextMenuHandler } = await import(MOD);
+    const header = terminalHeaderFixture();
+    setTerminalHeaderSource(header);
+    const handler = vi.fn(() => true);
+    setTileContextMenuHandler(handler);
+    const tab = createTileTab('terminal');
+    tab.init({ title: 'SESSION', params: {}, api: fakeApi() });
+    document.body.appendChild(tab.element);
+
+    const ev = rightClick();
+    /** @type {HTMLElement} */ (tab.element.querySelector('#session-selector')).dispatchEvent(ev);
+    expect(handler).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  test('the verbs live in the menu, not on the bar — still no popout control', async () => {
+    const { createTileTab, setTileContextMenuHandler } = await import(MOD);
+    setTileContextMenuHandler(vi.fn(() => true));
+    const tab = createTileTab('iframe:ariel');
+    tab.init({ title: 'ARIEL', params: {}, api: fakeApi() });
+    expect(tab.element.querySelector('.tile-tab-popout')).toBeNull();
+  });
+});


### PR DESCRIPTION
The web terminal's panel verbs — open a panel in a new window, open it as a
tile, remove it from the rail — lived only as hover-revealed corner glyphs on
rail entries. They were invisible until pointed at, absent from tile headers
entirely, and unreachable from the keyboard on macOS. The operator who
motivated this could not find the pop-out at all. Their policy was enforced
only by CSS `pointer-events`, which a keyboard-fired `contextmenu` and the
offline entry's still-live `×` both bypass.

The command palette had the same discoverability gap from the other side.
Searching it for a panel matched only that panel's settings keys: no row
opened a panel in a window or a tile, the active panel was excluded from the
rows entirely, and domain vocabulary ("logbook", "pv") matched nothing. The
palette also opened unusable — `focus()` ran inside a `visibility:hidden`
subtree, which the spec defines as a no-op, and the overlay's visibility
transition kept the computed value hidden through the revealing frame, so the
first keystrokes after Cmd/Ctrl+K were dropped.

Both surfaces now carry the verbs in words. Presentation is separate from
policy: `panel-context-menu.js` renders, positions, and dismisses the menu,
while `panel-menu-policy.js` decides the row set, gates disabled entries, and
declines in simple mode so the native browser menu falls through. Tile headers
reach the menu through a registration seam rather than an import, because
`dock-tab.js` cannot import `panel-manager.js` without closing a cycle through
`dock-workspace.js`. The keyboard path is explicit rather than native: the
ContextMenu key and Shift+F10 open the menu and cancel the platform's own
`contextmenu` default, so one keypress cannot open two menus.

No new verb, URL, or endpoint is introduced. Every surface binds the same
closures the rail corners and the agent MCP tools already used, so a menu
pick, a palette run, and an agent call stay indistinguishable downstream — the
reason the `↗` and `⊞` corners could simply be deleted (`×` stays).

Worth disagreeing with: the palette's Recent section is a presentation-level
block built inside `render()` rather than a registry group, so its rows
duplicate live registry items and are namespaced for navigation only. The
alternative — a real group — would have meant touching the `Item` group union
and `GROUP_ORDER` for something that is not a source of items.

## How it hangs together

```text
      right-click / ContextMenu key                     Cmd/Ctrl+K
   ┌───────────────┬─────────────────┐                      │
   │  rail entry   │   tile header   │                 palette.js
   │ panel-rail.js │   dock-tab.js   │                      │
   └───────┬───────┴────────┬────────┘                      ▼
           │                │                      palette-registry.js
           │      setTileContextMenuHandler()      (Panels rows, synonyms,
           │      registered by panel-manager       Recent section)
           │      — dock-tab must not import                 │
           │        panel-manager (import cycle)             │
           └───────┬────────┘                                │
                   ▼                                         │
         panel-context-menu.js                               │
       (render · position · focus ·                          │
        arrow keys · dismissal)                              │
                   │                                         │
                   ▼                                         │
         panel-menu-policy.js                                │
       (row set · disabled gates ·                           │
        simple-mode decline)                                 │
                   │                                         │
                   └────────────────┬────────────────────────┘
                                    ▼
                            panel-manager.js
           activateTab · showPanel · openPanelBeside · popoutPanel
                                    │
                                    ▼
                            panel-commands.js
          POST /api/panel-focus        POST /api/panel-visibility
```

A non-member panel is always revealed through `showPanel`, which POSTs
visibility before focus — never through a direct `activateTab`, which the
focus route now drops for a source-less report naming a non-member.
