### PR TITLE
feat(bluesky): assert bump closure at monitor BPMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- The `orbit_bump_sweep` plan can now assert bump closure at its monitor BPMs:
+  an optional `leakage_tolerance` band judges every `readbacks` BPM against the
+  reference orbit at each settled step, failing the run (or recording the miss
+  under `best_effort`) when the bump leaks beyond it. Unset, monitors stay
+  recorded-only as before.
 - Web-terminal roster entries can opt out of the login wall with `login:
   false` — the entry is served without authentication while every other
   terminal stays gated, and no password is provisioned for it. Meant for

--- a/src/osprey/services/bluesky_bridge/bump_analysis.py
+++ b/src/osprey/services/bluesky_bridge/bump_analysis.py
@@ -22,6 +22,7 @@ measurement step:
 - `demand_is_negligible`: the run-level gate deciding whether anything is
   actually being asked for, before any solve is attempted.
 - `band_converged`: whether the machine landed inside the tolerance band.
+- `band_violations`: which rows landed outside it -- the leakage check's form.
 - `noise_floor_violations`: whether the requested band is measurable at all.
 
 Everything here is expressed *relative to the measured reference orbit*: a
@@ -352,6 +353,57 @@ def demand_is_negligible(
     return bool(np.all(np.abs(demand) <= band))
 
 
+def band_violations(measured: np.ndarray, desired: np.ndarray, tolerance: float) -> list[int]:
+    """Indices of rows sitting outside the `±tolerance` band around *desired*.
+
+    The elementwise form of `band_converged`: a row is flagged when
+    `|measured - desired| > tolerance`, with both vectors expressed relative
+    to the measured reference orbit. `band_converged` answers "is every row
+    in?"; this answers "which rows are out?", which is what an error message
+    that names the offending BPMs needs. The leakage check runs it with an
+    all-zero *desired* -- a monitor BPM is asked for nothing, so any offset
+    beyond the band is leakage.
+
+    Equality at the boundary is inside the band, exactly as `band_converged`
+    counts it -- the two must agree row by row, since `band_converged` is
+    implemented on top of this.
+
+    Anything unreadable -- mismatched shapes, a non-finite reading, a
+    non-positive tolerance -- flags *every* row rather than raising or
+    returning none. Conservative in the same direction as `band_converged`'s
+    `False` and `noise_floor_violations`' all-indices answer: a judgment that
+    cannot be established must never read as "all clear".
+
+    Args:
+        measured: `[n_rows]` measured offsets, relative to the reference.
+        desired: `[n_rows]` wanted offsets, relative to the reference.
+        tolerance: The band's half-width, in BPM units.
+
+    Returns:
+        The offending indices into *measured*, ascending; empty when every row
+        is inside the band.
+    """
+    got = np.asarray(measured, dtype=float)
+    want = np.asarray(desired, dtype=float)
+
+    if got.ndim != 1 or got.shape != want.shape:
+        # "Every row" of a mis-shaped input is ill-defined, so flag row 0:
+        # the answer must be non-empty for the caller's violation branch to
+        # run, and there is no honest list of indices to hand it.
+        return [0]
+    if not np.isfinite(tolerance) or tolerance <= 0.0:
+        # A band nothing can satisfy: every row is out, and even an empty
+        # input flags row 0 -- vacuous convergence into an invalid band is
+        # still a claim nobody could check.
+        return list(range(got.size)) if got.size else [0]
+
+    unreadable = ~(np.isfinite(got) & np.isfinite(want))
+    outside = np.zeros(got.shape, dtype=bool)
+    finite = ~unreadable
+    outside[finite] = np.abs(got[finite] - want[finite]) > tolerance
+    return [int(index) for index in np.flatnonzero(unreadable | outside)]
+
+
 def band_converged(measured: np.ndarray, desired: np.ndarray, tolerance: float) -> bool:
     """Did the machine land inside the tolerance band at every constraint row?
 
@@ -380,18 +432,16 @@ def band_converged(measured: np.ndarray, desired: np.ndarray, tolerance: float) 
     for a step whose outcome cannot be established: it trims, and if trimming
     cannot fix it the run stops or records a best-effort miss, either of which
     is visible. `True` would silently bank an unverified bump.
+
+    Implemented as "no `band_violations`", so the two can never disagree about
+    a row.
     """
     got = np.asarray(measured, dtype=float)
     want = np.asarray(desired, dtype=float)
-
     if got.ndim != 1 or got.shape != want.shape:
         return False
-    if not (np.all(np.isfinite(got)) and np.all(np.isfinite(want))):
-        return False
-    if not np.isfinite(tolerance) or tolerance <= 0.0:
-        return False
 
-    return bool(np.all(np.abs(got - want) <= tolerance))
+    return not band_violations(measured, desired, tolerance)
 
 
 def noise_floor_violations(sigma: np.ndarray, tolerance: float) -> list[int]:

--- a/src/osprey/services/bluesky_bridge/plans_core/orbit_bump_sweep.py
+++ b/src/osprey/services/bluesky_bridge/plans_core/orbit_bump_sweep.py
@@ -62,6 +62,7 @@ from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_va
 # load time and quarantines the plan.
 from osprey.services.bluesky_bridge.bump_analysis import (
     band_converged,
+    band_violations,
     demand_is_negligible,
     fit_probe_response,
     noise_floor_violations,
@@ -128,6 +129,13 @@ class PARAMS(BaseModel):
     do it. ``readbacks`` and ``monitors`` are recorded at every point without
     taking part in the solve, so a run carries the surrounding orbit and any
     other instrument the operator wants alongside it.
+
+    With ``leakage_tolerance`` set, the monitor BPMs are additionally *judged*:
+    a step that moves any of them further than that band from the reference
+    orbit is a leaking bump, surfaced exactly like a convergence miss. They
+    still take no part in the solve — they are watched, not asked for — so a
+    leak is a finding about the bump's constraint set, not something a trim
+    pass could remove.
 
     ``mode`` reads the target values either as a displacement *from the orbit
     the machine is already on* (``relative``) or as an absolute orbit position
@@ -253,6 +261,15 @@ class PARAMS(BaseModel):
             "at one amplitude before the plan gives up on that point."
         ),
     )
+    leakage_tolerance: Annotated[float, Field(gt=0, allow_inf_nan=False)] | None = Field(
+        default=None,
+        title="Leakage tolerance",
+        description=(
+            "Band, in BPM units, the monitor BPMs must stay inside relative "
+            "to the reference orbit at every step. Unset, they are recorded "
+            "but never judged."
+        ),
+    )
     best_effort: bool = Field(
         default=False,
         title="Best effort",
@@ -341,6 +358,28 @@ class PARAMS(BaseModel):
                 f"underdetermined bump: {rows} orbit constraint(s) "
                 f"(targets + closure_readbacks) for {len(self.correctors)} correctors; "
                 "add closure BPMs or drop a corrector"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _leakage_check_has_monitors_to_judge(self) -> PARAMS:
+        """Reject a leakage band with no BPM it could apply to.
+
+        The leakage check judges the monitor BPMs (``readbacks``) that are not
+        already constraint rows — a target or closure BPM is asserted more
+        strictly by the solve's own band. A ``leakage_tolerance`` whose every
+        candidate is already constrained (or that has no ``readbacks`` at all)
+        would be a guard that is on while judging nothing, the same inert-guard
+        state the beam-current pairing below refuses.
+        """
+        if self.leakage_tolerance is None:
+            return self
+        constrained = {target.readback for target in self.targets} | set(self.closure_readbacks)
+        if not (set(self.readbacks) - constrained):
+            raise ValueError(
+                "leakage_tolerance needs at least one readbacks BPM that is "
+                "not already a target or closure BPM — there is nothing else "
+                "for it to judge"
             )
         return self
 
@@ -556,7 +595,11 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
        the residual, re-apply, re-check — at most ``max_trim_iterations``
        times; a step that still misses raises (the ``finally`` below
        restores) unless ``best_effort`` is set, in which case the achieved
-       orbit is recorded and the sweep continues. Every step then emits
+       orbit is recorded and the sweep continues. With ``leakage_tolerance``
+       set, each settled step is then also judged at the monitor BPMs — the
+       ``readbacks`` not already constrained — against ``±leakage_tolerance``
+       around the reference orbit, with the same miss handling; no trim, since
+       the monitors are not in the solve. Every step then emits
        exactly one data row, so a run's rows are ``baseline_reads`` baseline
        rows followed by one row per scale, in profile order.
     4. **Terminal step.** The last step of the profile is scale ``0``, and it
@@ -611,8 +654,10 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
             BPM.
         RuntimeError: The beam current fell below ``min_beam_current`` before
             a write batch; a step could not be trimmed inside ``tolerance``
-            (with ``best_effort`` unset); or, on an otherwise clean run, a
-            corrector could not be restored to its working point.
+            (with ``best_effort`` unset); a settled step moved a monitor BPM
+            outside ``±leakage_tolerance`` (with ``best_effort`` unset); or,
+            on an otherwise clean run, a corrector could not be restored to
+            its working point.
         DegenerateBumpError: The measured machine cannot answer the bump asked
             of it — see ``bump_analysis``.
     """
@@ -642,6 +687,13 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
     ]
     fit_devices = [devices[name] for name in fit_names]
     constrained_devices = [devices[name] for name in constrained_names]
+    # The leakage-judged BPMs: the monitor readbacks that are not already
+    # constraint rows (a constrained BPM is asserted more strictly by the
+    # solve's own band; the PARAMS validator guarantees this set is non-empty
+    # whenever the band is set). `fit_names` is constrained + the rest of
+    # `readbacks`, so this is exactly its tail.
+    leak_names = fit_names[len(constrained_names) :] if params.leakage_tolerance is not None else []
+    leak_devices = [devices[name] for name in leak_names]
     beam_device = (
         devices[params.beam_current_readback] if params.beam_current_readback is not None else None
     )
@@ -674,20 +726,19 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
             pairs.extend((corrector, working_point if solution is None else working_point + offset))
         yield from bps.mv(*pairs)
 
-    def _measure_offsets(reference: dict[str, float]) -> Any:
-        """The constrained orbit relative to *reference*: the mean of two reads.
+    def _measure_offsets(
+        devices_to_read: list[Any], names: list[str], reference: dict[str, float], context: str
+    ) -> Any:
+        """*names*' orbit relative to *reference*: the mean of two reads.
 
-        Two reads because the band check compares a mean against ``tolerance``
-        with no noise term of its own — see ``band_converged`` on why σ/√2 is
-        part of that band's honesty.
+        Two reads because both band checks compare a mean against their band
+        with no noise term of their own — see ``band_converged`` on why σ/√2
+        is part of that band's honesty. The convergence check runs this over
+        the constrained BPMs, the leakage check over the monitor BPMs.
         """
-        first = yield from _snapshot_values(
-            constrained_devices, constrained_names, "a convergence check"
-        )
-        second = yield from _snapshot_values(
-            constrained_devices, constrained_names, "a convergence check"
-        )
-        return [(first[name] + second[name]) / 2.0 - reference[name] for name in constrained_names]
+        first = yield from _snapshot_values(devices_to_read, names, context)
+        second = yield from _snapshot_values(devices_to_read, names, context)
+        return [(first[name] + second[name]) / 2.0 - reference[name] for name in names]
 
     @bpp.stage_decorator(all_devices)
     @bpp.run_decorator(md=run_md)
@@ -710,9 +761,11 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
                 readings = yield from bps.trigger_and_read(all_devices)
                 baseline_rows.append(_finite_values(readings, fit_names, "the baseline"))
 
+            # The reference covers the leakage-judged BPMs too (`fit_names` is
+            # the constrained rows plus the remaining monitors), so both band
+            # checks measure against the same baseline.
             reference = {
-                name: statistics.fmean(row[name] for row in baseline_rows)
-                for name in constrained_names
+                name: statistics.fmean(row[name] for row in baseline_rows) for name in fit_names
             }
             sigma = [
                 statistics.stdev([row[name] for row in baseline_rows]) for name in constrained_names
@@ -726,6 +779,22 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
                     "falls outside of by chance alone cannot be converged into; widen the "
                     "tolerance or fix the BPM(s)"
                 )
+            if params.leakage_tolerance is not None:
+                # The leakage band is held to the same standard as the
+                # convergence band, for the same reason: a monitor whose noise
+                # exceeds it would read as leaking by chance alone.
+                leak_sigma = [
+                    statistics.stdev([row[name] for row in baseline_rows]) for name in leak_names
+                ]
+                leak_floor = noise_floor_violations(leak_sigma, params.leakage_tolerance)
+                if leak_floor:
+                    offenders = [leak_names[index] for index in leak_floor]
+                    raise ValueError(
+                        f"orbit_bump_sweep plan: leakage_tolerance {params.leakage_tolerance} "
+                        f"is narrower than twice the measured baseline noise at {offenders} — "
+                        "a leakage band the orbit falls outside of by chance alone cannot be "
+                        "certified; widen it or fix the BPM(s)"
+                    )
 
             # The run-level demand, as reference-relative offsets over the
             # constraint rows. `absolute` targets are converted exactly once,
@@ -778,7 +847,9 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
                 yield from _guard(step_label)
                 yield from _apply(working_points, None if terminal else solution)
                 yield from bps.sleep(params.settle_s)
-                measured = yield from _measure_offsets(reference)
+                measured = yield from _measure_offsets(
+                    constrained_devices, constrained_names, reference, "a convergence check"
+                )
                 converged = band_converged(measured, desired_step, params.tolerance)
 
                 # Trim only where a solve is allowed: never on the terminal
@@ -797,7 +868,9 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
                         ]
                         yield from _apply(working_points, solution)
                         yield from bps.sleep(params.settle_s)
-                        measured = yield from _measure_offsets(reference)
+                        measured = yield from _measure_offsets(
+                            constrained_devices, constrained_names, reference, "a convergence check"
+                        )
                         converged = band_converged(measured, desired_step, params.tolerance)
                         if converged:
                             break
@@ -825,6 +898,46 @@ def build_plan(devices: dict[str, Any], params: PARAMS) -> Any:
                                 else f" after {params.max_trim_iterations} trim pass(es)"
                             )
                         )
+
+                # The leakage check: after the constrained rows have settled
+                # (post-trim), the monitor BPMs must still be on the reference
+                # orbit. Measured the same way the convergence band is (the
+                # mean of two reads), judged after the trim loop because a
+                # trim moves the correctors and so moves the leakage too.
+                if params.leakage_tolerance is not None:
+                    leak_measured = yield from _measure_offsets(
+                        leak_devices, leak_names, reference, "a leakage check"
+                    )
+                    leaks = band_violations(
+                        leak_measured, [0.0] * len(leak_names), params.leakage_tolerance
+                    )
+                    if leaks:
+                        offenders = ", ".join(
+                            f"{leak_names[index]} ({leak_measured[index]:+.4g})" for index in leaks
+                        )
+                        if params.best_effort:
+                            logger.warning(
+                                "orbit_bump_sweep plan: %s leaked outside ±%g BPM units at "
+                                "monitor BPM(s) %s relative to the reference orbit; "
+                                "best_effort is set, recording the step and continuing",
+                                step_label,
+                                params.leakage_tolerance,
+                                offenders,
+                            )
+                        else:
+                            raise RuntimeError(
+                                f"orbit_bump_sweep plan: {step_label} leaked outside "
+                                f"±{params.leakage_tolerance:g} BPM units at monitor BPM(s) "
+                                f"{offenders} relative to the reference orbit"
+                                + (
+                                    " at the terminal working-point step — the machine did "
+                                    "not come back to its reference orbit"
+                                    if terminal
+                                    else " — the monitors are watched, not solved for, so a "
+                                    "trim cannot remove this; add them as closure BPMs to "
+                                    "constrain them"
+                                )
+                            )
 
                 yield from bps.trigger_and_read(all_devices)
         except BaseException:
@@ -1110,12 +1223,19 @@ def _orbit_shift_panel(sweep: _Sweep, params: PARAMS) -> Panel | None:
 
     targets = [sweep.bpm_order.index(target.readback) + 1 for target in params.targets]
     closure = [sweep.bpm_order.index(name) + 1 for name in params.closure_readbacks]
+    beyond = (
+        "anything beyond them is recorded, not constrained."
+        if params.leakage_tolerance is None
+        else (
+            f"the remaining monitor BPMs are held inside ±{params.leakage_tolerance:g} "
+            "BPM units of the reference — the leakage band — without joining the solve."
+        )
+    )
     annotations = [
         "Each line is one amplitude step's orbit, measured against the "
         "baseline reference orbit. A closed bump is displaced across the "
         f"target BPMs (index {_index_list(targets)}) and back on the reference "
-        f"orbit at the closure BPMs (index {_index_list(closure)}); anything "
-        "beyond them is recorded, not constrained.",
+        f"orbit at the closure BPMs (index {_index_list(closure)}); {beyond}",
         "BPMs are in the order they were requested, which is not their order "
         "around the ring — this plan carries no lattice positions.",
     ]

--- a/tests/services/bluesky_bridge/test_builtin_plans.py
+++ b/tests/services/bluesky_bridge/test_builtin_plans.py
@@ -740,8 +740,31 @@ def test_bump_params_accepts_a_complete_beam_current_guard() -> None:
     assert params.min_beam_current == 50.0
 
 
+def test_bump_params_leakage_band_defaults_off_and_accepts_a_free_monitor() -> None:
+    """Unset, the monitors stay recorded-only; set, the payload's `bpm4` — a
+    readback that is neither target nor closure — is what the band judges."""
+    assert BumpParams(**_bump_payload()).leakage_tolerance is None
+    assert BumpParams(**_bump_payload(leakage_tolerance=0.002)).leakage_tolerance == 0.002
+
+
+@pytest.mark.parametrize(
+    "readbacks",
+    [[], ["bpm2"]],
+    ids=["no-monitors", "all-already-constrained"],
+)
+def test_bump_params_rejects_a_leakage_band_with_nothing_to_judge(readbacks: list[str]) -> None:
+    """A leakage band whose every candidate is already a constraint row (or
+    that has no monitors at all) is a guard that is on while judging nothing —
+    the same inert state the half-a-beam-guard case refuses."""
+    with pytest.raises(ValidationError, match="nothing else"):
+        BumpParams(**_bump_payload(leakage_tolerance=0.002, readbacks=readbacks))
+
+
 @pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
-@pytest.mark.parametrize("field", ["probe_amplitude", "tolerance", "settle_s", "min_beam_current"])
+@pytest.mark.parametrize(
+    "field",
+    ["probe_amplitude", "tolerance", "settle_s", "min_beam_current", "leakage_tolerance"],
+)
 def test_bump_params_rejects_a_non_finite_float(field: str, value: float) -> None:
     """A non-finite demand cannot be refused by a limits check (`nan < low` and
     `nan > high` are both false), so it would reach the machine and fail only
@@ -809,6 +832,7 @@ def test_bump_params_rejects_too_few_baseline_reads() -> None:
         ("tolerance", 0.0),
         ("settle_s", -0.1),
         ("max_trim_iterations", 0),
+        ("leakage_tolerance", 0.0),
     ],
 )
 def test_bump_params_rejects_a_non_positive_bound(field: str, value: float) -> None:
@@ -1443,3 +1467,98 @@ def test_bump_plan_does_not_trim_the_terminal_restore_step() -> None:
     assert after_arming[-3:] == _bump_restore_writes()
     for name, working_point in _BUMP_WORKING_POINTS.items():
         assert asyncio.run(devices[name].readback.get_value()) == working_point
+
+
+def _arm_after_baseline(bpm: _ArmableBpm, baseline_reads: int) -> Callable[[Any], None]:
+    """A `msg_hook` arming *bpm* the moment the baseline's last row is saved,
+    so the first off-reference reading lands in the first amplitude step."""
+    saves: list[int] = []
+
+    def _hook(msg: Any) -> None:
+        if msg.command == "save":
+            saves.append(1)
+            bpm.armed = len(saves) >= baseline_reads
+
+    return _hook
+
+
+def test_bump_plan_leakage_violation_aborts_and_restores() -> None:
+    """With `leakage_tolerance` set, a monitor BPM knocked off the reference
+    orbit fails the step — naming the BPM — and the correctors come back.
+
+    `bpm4` is the payload's one free monitor: recorded at every point, never a
+    solve row. Without the band this run completes and the excursion is only
+    visible in the data; the band is what turns it into a finding. It is armed
+    after the baseline, so the reference is clean and the first step is the
+    first to see the leak.
+    """
+    bpm4 = _ArmableBpm("bpm4", initial_value=_BUMP_BPM_VALUE, armed_value=_BUMP_BPM_VALUE + 5.0)
+    devices = _bump_devices(bpm4=bpm4)
+    params = _bump_run_params(leakage_tolerance=0.01)
+
+    commands: list[tuple[str, float]] = []
+    record = _record_writes(commands)
+    arm = _arm_after_baseline(bpm4, params.baseline_reads)
+
+    def _hook(msg: Any) -> None:
+        record(msg)
+        arm(msg)
+
+    RE = RunEngine(context_managers=[])
+    RE.msg_hook = _hook
+    with pytest.raises(RuntimeError, match="leaked outside") as excinfo:
+        RE(bump_plan(devices, params))
+
+    assert "bpm4" in str(excinfo.value)
+    assert "closure" in str(excinfo.value)  # the remedy: constrain the monitor
+    assert commands[-3:] == _bump_restore_writes()
+    for name, working_point in _BUMP_WORKING_POINTS.items():
+        assert asyncio.run(devices[name].readback.get_value()) == working_point
+
+
+def test_bump_plan_leakage_violation_under_best_effort_warns_and_completes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`best_effort` gives leakage the same treatment as a convergence miss:
+    the step is recorded, the sweep continues to its full row layout, and the
+    finding lands in the log instead of ending the run."""
+    bpm4 = _ArmableBpm("bpm4", initial_value=_BUMP_BPM_VALUE, armed_value=_BUMP_BPM_VALUE + 5.0)
+    devices = _bump_devices(bpm4=bpm4)
+    params = _bump_run_params(leakage_tolerance=0.01, best_effort=True)
+
+    rows: list[str] = []
+    RE = RunEngine(context_managers=[])
+    RE.msg_hook = _arm_after_baseline(bpm4, params.baseline_reads)
+    with caplog.at_level(logging.WARNING, logger=_BUMP_LOGGER):
+        RE(
+            bump_plan(devices, params),
+            lambda name, doc: rows.append(name) if name == "event" else None,
+        )
+
+    assert "leaked outside" in caplog.text
+    assert "bpm4" in caplog.text
+    assert len(rows) == params.baseline_reads + 2 * params.num
+    for name, working_point in _BUMP_WORKING_POINTS.items():
+        assert asyncio.run(devices[name].readback.get_value()) == working_point
+
+
+def test_bump_plan_fail_fast_refuses_a_leakage_band_below_the_monitor_noise() -> None:
+    """A leakage band narrower than twice a monitor's baseline noise fails the
+    run before the first probe write, exactly as the convergence band does at
+    the constrained BPMs — a monitor that leaves it by chance alone would read
+    as a leak the machine never had.
+
+    Only `bpm4` counts: the constrained BPMs stay quiet, so the run passes the
+    convergence-band floor and the refusal below is the leakage floor's own.
+    """
+    devices = _bump_devices(bpm4=MockReadable("bpm4"))
+    params = _bump_run_params(leakage_tolerance=0.01)
+
+    commands: list[tuple[str, float]] = []
+    RE = RunEngine(context_managers=[])
+    RE.msg_hook = _record_writes(commands)
+    with pytest.raises(ValueError, match="leakage_tolerance") as excinfo:
+        RE(bump_plan(devices, params))
+
+    assert "bpm4" in str(excinfo.value)
+    assert commands == _bump_restore_writes()

--- a/tests/services/bluesky_bridge/test_bump_analysis.py
+++ b/tests/services/bluesky_bridge/test_bump_analysis.py
@@ -11,6 +11,7 @@ import pytest
 from osprey.services.bluesky_bridge.bump_analysis import (
     DegenerateBumpError,
     band_converged,
+    band_violations,
     demand_is_negligible,
     fit_probe_response,
     noise_floor_violations,
@@ -423,6 +424,63 @@ def test_band_is_not_converged_when_the_outcome_cannot_be_established(
     measured: np.ndarray, desired: np.ndarray, tolerance: float
 ) -> None:
     assert not band_converged(measured, desired, tolerance)
+
+
+def test_band_violations_is_empty_inside_the_band_including_the_boundary() -> None:
+    """The elementwise form keeps `band_converged`'s boundary convention:
+    exactly `tolerance` away is inside."""
+    desired = np.zeros(4)
+    measured = np.array([TOLERANCE, -TOLERANCE, 5e-5, 0.0])
+
+    assert band_violations(measured, desired, TOLERANCE) == []
+
+
+def test_band_violations_names_only_the_offending_rows_ascending() -> None:
+    """The leakage form: an all-zero desired, and the answer is which monitor
+    BPMs moved -- the indices an error message turns into names."""
+    desired = np.zeros(5)
+    measured = np.array([0.0, 3e-4, 5e-5, -2e-4, 1e-5])
+
+    assert band_violations(measured, desired, TOLERANCE) == [1, 3]
+
+
+def test_band_violations_flags_an_unreadable_row_alongside_a_miss() -> None:
+    """A NaN reading is a row whose membership cannot be established, so it is
+    flagged -- individually, not by failing the whole vector, because the
+    message should still name the finite miss next to it."""
+    desired = np.zeros(4)
+    measured = np.array([0.0, np.nan, 5e-5, 2e-4])
+
+    assert band_violations(measured, desired, TOLERANCE) == [1, 3]
+
+
+@pytest.mark.parametrize(
+    ("measured", "desired", "tolerance", "expected"),
+    [
+        (np.zeros(3), np.zeros(2), TOLERANCE, [0]),
+        (np.zeros(3), np.zeros(3), 0.0, [0, 1, 2]),
+        (np.zeros(3), np.zeros(3), float("nan"), [0, 1, 2]),
+        (np.zeros(0), np.zeros(0), 0.0, [0]),
+    ],
+    ids=["shape-mismatch", "zero-tolerance", "nan-tolerance", "empty-and-invalid"],
+)
+def test_band_violations_is_never_empty_when_the_judgment_is_unsupportable(
+    measured: np.ndarray, desired: np.ndarray, tolerance: float, expected: list[int]
+) -> None:
+    assert band_violations(measured, desired, tolerance) == expected
+
+
+def test_band_violations_and_band_converged_agree_row_for_row() -> None:
+    """`band_converged` is implemented on top of `band_violations`, and this is
+    the observable contract: converged exactly when no row is flagged."""
+    desired = np.array([2e-4, 0.0, -3e-4, 1e-4])
+    inside = desired + np.array([1e-5, -4e-5, 2e-5, 0.0])
+    outside = desired + np.array([1e-5, -4e-5, 2e-5, 1.5e-4])
+
+    assert band_converged(inside, desired, TOLERANCE)
+    assert band_violations(inside, desired, TOLERANCE) == []
+    assert not band_converged(outside, desired, TOLERANCE)
+    assert band_violations(outside, desired, TOLERANCE) == [3]
 
 
 def test_band_noise_floor_is_empty_when_every_bpm_is_quiet_enough() -> None:


### PR DESCRIPTION
`orbit_bump_sweep` recorded its monitor BPMs but never judged them. Only the closure BPMs were held to the reference orbit, so a bump that leaked past its closure set finished green — every other BPM in `readbacks` was data nobody checked, and the plan's own orbit-shift panel said so ("recorded, not constrained").

An optional `leakage_tolerance` bands those monitors around the reference orbit and judges them at every settled step. Three choices worth disagreeing with:

- **Judged after the trim loop, not before.** A trim moves the correctors, so it moves the leakage; checking earlier would judge an orbit the run does not keep.
- **No trim on a leak.** The monitors are not constraint rows, so the solve has no lever that targets them. The error says as much and points at the fix — promote the monitor to a closure BPM. Under `best_effort` it warns and the sweep continues.
- **The noise floor gate extends to the monitors.** A leakage band narrower than 2σ of the monitor's own baseline noise would read as leaking by chance, so the run fails before any write rather than mid-sweep.

Measurement matches the convergence band exactly — the mean of two off-record reads against the same baseline reference — so the two bands are comparable and a `leakage_tolerance` means the same thing as a `tolerance`.

A validator refuses a band with no free monitor to judge, matching how the beam-current guard refuses to be half-configured. Unset, behavior is byte-for-byte what it is today.

`band_violations` is the elementwise form of `band_converged` — it reports which rows are out, so the error message can name the BPMs. `band_converged` is reimplemented as "no violations" so the two can never disagree about a row.