### PR TITLE
Deployment hardening: proxy-bridged builds, distro Node, prebuilt images, qmd prefetched models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2582,6 +2582,169 @@ jobs:
         # secret is ever absent, so this stays advisory and self-gating.
         ALS_APG_API_KEY: ${{ secrets.ALS_APG_API_KEY }}
       run: uv run pytest tests/e2e/test_dockerfile_e2e.py -v --tb=short
+
+    # ── the proxied build ────────────────────────────────────────────────────
+    # Every template Dockerfile opens each apt-using RUN with
+    #   export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" …
+    # because apt reads only the lowercase names, while a facility hands its
+    # proxy to a build as the uppercase ones. The steps below are the
+    # empirical proof that this bridge works, and what they assert is the
+    # PROXY'S ACCESS LOG, never the build's exit status: this runner has open
+    # egress, so a build whose bridge was deleted would quietly fetch straight
+    # past the proxy and still exit 0.
+    #
+    # `set -euo pipefail` is spelled out in every step: GitHub's default shell
+    # is `bash -e`, without pipefail, so a masked failure inside a pipeline
+    # would report the last command's status and green the lane.
+    - name: Start a logging forward proxy (tinyproxy)
+      # No Allow/Deny lines: with no ACL at all tinyproxy accepts every client,
+      # which is what a single-use proxy on an ephemeral runner wants and keeps
+      # a CIDR out of the parse path. No Listen either — the default is every
+      # interface. `LogLevel Info` is load-bearing rather than chatty: the
+      # request line that names the TARGET host ("Request (fd N): CONNECT
+      # deb.debian.org:443") is logged at Info, and the assertion below reads
+      # exactly that. The log file is pre-created by this (unprivileged) user
+      # so the root process inside the container appends to a file the later
+      # grep can still read.
+      run: |
+        set -euo pipefail
+        rm -rf /tmp/osprey-proxy
+        mkdir -p /tmp/osprey-proxy
+        cat > /tmp/osprey-proxy/tinyproxy.conf <<'CONF'
+        Port 8888
+        Timeout 600
+        MaxClients 100
+        LogLevel Info
+        LogFile "/proxy/access.log"
+        CONF
+        : > /tmp/osprey-proxy/access.log
+        chmod 666 /tmp/osprey-proxy/access.log
+        docker run -d --name osprey-ci-proxy --network host \
+          -v /tmp/osprey-proxy:/proxy debian:bookworm-slim \
+          sh -c 'apt-get update -qq \
+                 && apt-get install -y -qq --no-install-recommends tinyproxy \
+                 && exec tinyproxy -d -c /proxy/tinyproxy.conf'
+        # Readiness is a bare TCP connect, deliberately: a probe that FETCHED
+        # anything through the proxy would write that host into the access log
+        # the assertion step reads, and could satisfy it on its own.
+        for _ in $(seq 60); do
+          if (exec 3<>/dev/tcp/127.0.0.1/8888) 2>/dev/null; then
+            echo "✅ tinyproxy is listening on 127.0.0.1:8888"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "❌ tinyproxy never came up on 127.0.0.1:8888"
+        docker logs osprey-ci-proxy || true
+        exit 1
+
+    - name: Assert the uppercase-only proxy contract reaches the build
+      # The bridge is only worth proving on a runtime that does NOT already
+      # hand the RUN step a lowercase copy of its own. Docker's BuildKit does
+      # exactly that — measured: `--build-arg HTTP_PROXY=…` arrives inside RUN
+      # as BOTH `HTTP_PROXY` and `http_proxy` — so a docker build would satisfy
+      # the log assertion below with the bridge deleted. Podman (buildah)
+      # passes the names it is given, which is why the build step uses podman;
+      # this probe pins that property on the runner instead of trusting it. If
+      # a future podman starts duplicating the case, the lane fails HERE rather
+      # than greening over a proof that no longer proves anything.
+      #
+      # The probe Dockerfile deliberately declares no ARG: the proxy names are
+      # predeclared build args, and that is the shape the real Dockerfile
+      # relies on. Its base image is fully qualified so nothing here depends on
+      # podman's short-name resolution.
+      run: |
+        set -euo pipefail
+        rm -rf /tmp/osprey-proxy-probe
+        mkdir -p /tmp/osprey-proxy-probe
+        cat > /tmp/osprey-proxy-probe/Dockerfile <<'PROBE'
+        FROM docker.io/library/busybox
+        RUN env | sort | grep -i proxy || echo "NO-PROXY-ENV"
+        PROBE
+        out="$(podman build --no-cache --http-proxy=false \
+          --build-arg HTTP_PROXY=http://127.0.0.1:8888 \
+          --build-arg HTTPS_PROXY=http://127.0.0.1:8888 \
+          /tmp/osprey-proxy-probe 2>&1)"
+        printf '%s\n' "$out"
+        if ! grep -q 'HTTP_PROXY=http://127.0.0.1:8888' <<<"$out"; then
+          echo "❌ the uppercase HTTP_PROXY build-arg never reached the RUN environment"
+          exit 1
+        fi
+        if grep -q 'http_proxy=' <<<"$out"; then
+          echo "❌ this build runtime injects a lowercase proxy variable of its own —"
+          echo "   the access-log assertion would then pass with the Dockerfile's"
+          echo "   lowercase bridge deleted, i.e. it would prove nothing."
+          exit 1
+        fi
+        echo "✅ uppercase in, uppercase only — the bridge is the sole path to apt"
+
+    - name: Build the web-terminal auth sidecar through the proxy
+      # A staged copy of the template directory, not the directory in place:
+      # `osprey up --dev` stages an `osprey-local-requirements.txt` beside the
+      # Dockerfile and the COPY that picks it up is an optional glob. Staging an
+      # empty one keeps that glob's cross-runtime behaviour out of this lane, so
+      # the proxy bridge stays the only thing that can fail here.
+      #
+      # OSPREY_VERSION is required by the Dockerfile (it exits non-zero when
+      # empty) and OSPREY_DEV=1 is what lets a branch version that is not on
+      # PyPI fall back to an unpinned prime — the same pair `osprey up --dev`
+      # passes. Either way pip talks to PyPI, which is the second half of the
+      # assertion below.
+      #
+      # `--http-proxy=false` turns off buildah's copy of the HOST's proxy
+      # variables, so the two build-args are the only proxy values in the
+      # build. That, and their case, is the contract under test.
+      timeout-minutes: 15
+      run: |
+        set -euo pipefail
+        version="$(uv run --no-sync python -c 'import osprey; print(osprey.__version__)')"
+        echo "OSPREY_VERSION=$version"
+        rm -rf /tmp/osprey-sidecar-ctx
+        mkdir -p /tmp/osprey-sidecar-ctx
+        cp -a src/osprey/templates/modules/web_terminals/auth_sidecar/. /tmp/osprey-sidecar-ctx/
+        : > /tmp/osprey-sidecar-ctx/osprey-local-requirements.txt
+        podman build --no-cache --network=host --http-proxy=false \
+          --build-arg HTTP_PROXY=http://127.0.0.1:8888 \
+          --build-arg HTTPS_PROXY=http://127.0.0.1:8888 \
+          --build-arg OSPREY_VERSION="$version" \
+          --build-arg OSPREY_DEV=1 \
+          --tag osprey-auth-sidecar:proxied-ci \
+          /tmp/osprey-sidecar-ctx
+
+    - name: Assert apt and pip traffic went through the proxy
+      # The point of the whole sequence. Two host classes, checked separately
+      # because they prove different things: the apt host proves the lowercase
+      # bridge (apt reads no uppercase name, so its traffic can only be proxied
+      # via the export), and the pip host proves the proxy was engaged for the
+      # framework install as well. Matched lines are printed for the job log.
+      # Every grep is a plain file read into a variable — no pipelines whose
+      # status could be swallowed, and no `head` downstream of a producer.
+      run: |
+        set -euo pipefail
+        log=/tmp/osprey-proxy/access.log
+        if [ ! -s "$log" ]; then
+          echo "❌ proxy access log missing or empty at $log — nothing was proxied at all"
+          docker logs osprey-ci-proxy || true
+          exit 1
+        fi
+        apt_hits="$(grep -F 'deb.debian.org' "$log" || true)"
+        pip_hits="$(grep -E 'pypi\.org|files\.pythonhosted\.org' "$log" || true)"
+        echo "── apt traffic seen by the proxy ──────────────────────────────"
+        head -n 20 <<<"${apt_hits:-<none>}"
+        echo "── pip traffic seen by the proxy ──────────────────────────────"
+        head -n 20 <<<"${pip_hits:-<none>}"
+        if [ -z "$apt_hits" ]; then
+          echo "❌ no deb.debian.org request reached the proxy: the lowercase-proxy"
+          echo "   bridge in the auth-sidecar Dockerfile is not doing its job."
+          exit 1
+        fi
+        if [ -z "$pip_hits" ]; then
+          echo "❌ no pypi.org / files.pythonhosted.org request reached the proxy:"
+          echo "   the framework install bypassed it."
+          exit 1
+        fi
+        echo "✅ both apt and pip traffic went through the proxy"
+
     # On failure only: container logs, exit codes, `OOMKilled`, and runner
     # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
     - name: Capture failure diagnostics
@@ -2590,6 +2753,24 @@ jobs:
       with:
         name: dockerfile-e2e
         engine: docker
+
+    - name: Stop the forward proxy
+      # `always()`: the proxy is a fixed-name container on a shared runner, and
+      # a failed assertion above must not leave it holding port 8888 for
+      # whatever runs next. The log tail is printed here because it is the one
+      # diagnostic that explains any failure in this sequence.
+      #
+      # Last, deliberately — AFTER the capture step above. Teardown removes the
+      # container whose logs that step exists to collect, so the order is the
+      # difference between a diagnosable red lane and an empty artifact.
+      if: always()
+      run: |
+        set -euo pipefail
+        if [ -f /tmp/osprey-proxy/access.log ]; then
+          echo "── last 40 proxy access-log lines ─────────────────────────────"
+          tail -n 40 /tmp/osprey-proxy/access.log || true
+        fi
+        docker rm -f osprey-ci-proxy > /dev/null 2>&1 || true
 
 
   execution-environment-parity-e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3510,6 +3510,37 @@ jobs:
         OSPREY_QMD_IMAGE: osprey-qmd:ci
       run: uv run pytest tests/e2e/test_deploy_lifecycle.py -m qmd -v --tb=short
 
+    - name: Build the sidecar image with the model fetches skipped
+      # The image an air-gapped build host produces: same Dockerfile, same
+      # digest pins, but `services.qmd.models_dir` set means the three GGUFs
+      # arrive at runtime over a read-only bind mount instead of being baked in.
+      # It is the only image the mounted-delivery path can be tested against —
+      # a baked image already has the models, so it can never exercise the
+      # check — and it is cheap for exactly the reason the path exists: the
+      # 2.1 GB of downloads is what the build arg skips.
+      #
+      # `cache-from` only. Exporting a second cache here would race the rotated
+      # entry above and evict the model layers, which are the expensive half.
+      run: |
+        set -euo pipefail
+        docker buildx build \
+          --build-arg OSPREY_QMD_MODELS_MOUNTED=1 \
+          --tag osprey-qmd:ci-mounted \
+          --load \
+          --cache-from type=local,src=/tmp/qmd-buildx-cache \
+          src/osprey/templates/services/qmd
+
+    - name: Run the mounted-models E2E
+      # Named by path, not by marker: this module is the whole subject, and a
+      # path that stops existing exits pytest 4 and reds the step, whereas a
+      # renamed marker would silently select nothing. The module is collected by
+      # the sidecar step above too, where it skips — the variable below is what
+      # says the skip-ARG image exists, and it is set on this step alone.
+      timeout-minutes: 10
+      env:
+        OSPREY_QMD_MOUNTED_IMAGE: osprey-qmd:ci-mounted
+      run: uv run pytest tests/integration/test_qmd_models_mount.py -v --tb=short
+
     # On failure only: container logs, exit codes, `OOMKilled`, and runner
     # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
     - name: Capture failure diagnostics
@@ -3536,12 +3567,13 @@ jobs:
         docker rm -f osprey-e2e-mus-p3-registry || true
         docker compose -p osprey-e2e-mus-p3 down || true
 
-    - name: Clean up the sidecar image
-      # Exact tag only — never a prune, an -a/--all, or a wildcard, matching
+    - name: Clean up the sidecar images
+      # Exact tags only — never a prune, an -a/--all, or a wildcard, matching
       # the container-ops guardrail every other lane here observes.
       if: always()
       run: |
         docker rmi -f osprey-qmd:ci || true
+        docker rmi -f osprey-qmd:ci-mounted || true
 
   all-checks-passed:
     name: All CI Checks Passed

--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,13 @@ tests/e2e/claude_code/benchmark_results/
 # or the build — see also the hatch exclude in pyproject.toml)
 src/osprey/templates/apps/control_assistant/data/benchmarks/results/
 
+# Model files staged by hand for hosts that cannot reach the model host. They
+# reach the qmd sidecar over the read-only mount `services.qmd.models_dir`
+# names, never through a build context — but the staging directory itself can
+# sit anywhere, this tree included. Gigabytes of GGUF, never source — keep them
+# out of git and out of the build (see also the hatch exclude in pyproject.toml)
+**/prefetched-models/
+
 # Playwright MCP browser-session cache (page snapshots, console logs)
 .playwright-mcp/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,32 @@ Compatibility is documented in release notes, not encoded in the version string.
   text), so the context every seeded user starts from is visible and editable
   in the deployment repo instead of hidden in the installed package.
 
+- A host that cannot build images can now skip the dev-mode image build, with
+  `prebuilt_images: true` in `config.yml` or `OSPREY_PREBUILT_IMAGES=1` for one
+  shell. `osprey up --dev` then starts the containers from the image tags
+  already on the host.
+- The qmd search sidecar can take its three model files from a host directory
+  instead of downloading them during the image build. Point
+  `services.qmd.models_dir` at a directory holding the staged files: the build
+  skips the downloads and the directory is mounted read-only into the
+  container, with the same SHA256 check moved to container start. For build
+  hosts with no route to the model host.
+
 ### Fixed
 
+- Container builds now hand apt the proxy settings they were given. A facility
+  proxy arrives as `HTTP_PROXY`/`HTTPS_PROXY`, which apt does not read, so on a
+  network with no direct egress every image build stalled in its first package
+  install.
+- The project and dispatch images install Node and npm from the base image's
+  own Debian release instead of a third-party apt repository. That repository's
+  setup step had stopped configuring anything on current base images, leaving
+  them without npm and without a working agent launch path.
+- Model files staged inside the project tree no longer end up in the built
+  wheel, which they had been inflating to several gigabytes.
+- The qmd sidecar now finds its own daemon on hosts where `localhost` resolves
+  to IPv4. It previously probed only the IPv6 loopback, and where that was the
+  wrong one the container crash-looped while the deploy still reported success.
 - Agents now route a measurement that needs more than one setting through the
   Bluesky queue instead of stepping a setpoint with repeated `channel_write`
   calls. The `operating-bluesky-plans` skill also triggers on requests phrased

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -36,20 +36,21 @@ Claude Code requires `Node.js <https://nodejs.org/>`_ 18+.
 
       .. code-block:: bash
 
-         # Ubuntu/Debian
-         curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-         sudo apt-get install -y nodejs
+         # Debian/Ubuntu — npm is a separate package here, and Claude Code needs it
+         sudo apt-get install -y nodejs npm
 
-         # Or use your distribution's package manager
+      Your distribution's own packages are the simplest route and the one the
+      OSPREY container images take. Check what yours ships (``node --version``):
+      a few older releases package a Node below the 18 floor, and there the
+      cleanest fix is a current Node from `nvm <https://github.com/nvm-sh/nvm>`_.
 
    .. tab-item:: Windows (WSL2)
 
-      Install Node.js inside your WSL2 environment:
+      Install Node.js inside your WSL2 environment, the same way as on Linux:
 
       .. code-block:: bash
 
-         curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-         sudo apt-get install -y nodejs
+         sudo apt-get install -y nodejs npm
 
 Verify:
 

--- a/docs/source/how-to/containerize-project.rst
+++ b/docs/source/how-to/containerize-project.rst
@@ -13,7 +13,7 @@ every project.
    - How to keep a customized Dockerfile across rebuilds
    - Building and running the image (ports, secrets, volumes)
    - The three build-arg extension points for site-specific installs
-   - Building behind a proxy
+   - Building behind a proxy, and staging model files for the search sidecar
    - Path relocation with ``osprey build --runtime-root``
    - Air-gapped images, the non-root requirement, and Kubernetes notes
 
@@ -162,6 +162,71 @@ dependency layer the bridge runs first and the existing
 ``NO_PROXY="$PIP_NO_PROXY"`` export follows it, so a site that needs an
 exemption there sets ``PIP_NO_PROXY`` exactly as before while ``http_proxy`` and
 ``https_proxy`` are bridged normally.
+
+Prefetched Models for the Search Sidecar
+========================================
+
+A deployment that includes the qmd search sidecar builds a second image, and
+that one downloads three model files from ``huggingface.co`` during its build.
+On a network with no route there, stage the files on the host once and name that
+directory of prefetched models in the project's ``config.yml``:
+
+.. code-block:: yaml
+
+   services:
+     qmd:
+       models_dir: /srv/osprey/qmd-models   # absolute host path
+
+That one key does both halves of the job: the build skips the downloads, and the
+directory is bind-mounted read-only into the container at the location the image
+looks for models. The container-side path is fixed by the image and is not
+configurable.
+
+Staging the files
+-----------------
+
+The three files must sit in that directory under exactly these names:
+
+.. code-block:: text
+
+   hf_ggml-org_embeddinggemma-300M-Q8_0.gguf
+   hf_ggml-org_qwen3-reranker-0.6b-q8_0.gguf
+   hf_tobil_qmd-query-expansion-1.7B-q4_k_m.gguf
+
+These are cache names, not the names the files download under. The model loader
+recognizes a staged file only in this form; under any other name it reads as
+**absent**, and the sidecar tries to fetch it again — into a read-only mount, on
+a network that cannot reach the model host.
+
+Copy the files from a machine that can reach ``huggingface.co`` (or from the
+model cache of one that has already built the sidecar image), rename them, and
+check them before setting the key:
+
+.. code-block:: bash
+
+   sha256sum /srv/osprey/qmd-models/*.gguf
+
+Compare the three digests against the pins in the qmd service's Dockerfile
+(``services/qmd/Dockerfile`` in the rendered deployment), which carries both the
+source URL and the expected SHA256 of each file.
+
+What gets checked
+-----------------
+
+- **Before anything starts.** If ``services.qmd.models_dir`` is set but the
+  directory is missing, or a model is absent, misnamed, or zero bytes, the
+  deploy refuses up front and prints the expected filenames along with the
+  staging steps. Nothing has been started at that point.
+- **At container start.** The entrypoint verifies all three SHA256 digests
+  against the pins the image was built with, every time, and fails with a clear
+  message rather than letting the sidecar crash-loop unnoticed. A stamp file
+  records what it already verified, so ordinary restarts stay fast.
+
+Leaving ``models_dir`` unset keeps the default: the models are baked into the
+image at build time, which needs a build host that can reach ``huggingface.co``.
+Those downloads use ``curl``, which reads the uppercase ``HTTPS_PROXY``
+directly, so an online build behind a proxy needs nothing beyond the build
+arguments described above.
 
 Path Relocation
 ===============

--- a/docs/source/how-to/containerize-project.rst
+++ b/docs/source/how-to/containerize-project.rst
@@ -13,6 +13,7 @@ every project.
    - How to keep a customized Dockerfile across rebuilds
    - Building and running the image (ports, secrets, volumes)
    - The three build-arg extension points for site-specific installs
+   - Building behind a proxy
    - Path relocation with ``osprey build --runtime-root``
    - Air-gapped images, the non-root requirement, and Kubernetes notes
 
@@ -122,6 +123,45 @@ vendored assets for an air-gapped host:
    distribute — prefer `Docker build secrets
    <https://docs.docker.com/build/building/secrets/>`_ or a credential-free
    internal mirror.
+
+Building Behind a Proxy
+-----------------------
+
+Two things have to line up for a build on a proxied network: the proxy values
+have to reach the build, and the tools inside it have to find them under the
+names they actually read.
+
+**Getting the values in.** Docker takes them as build arguments —
+``docker build --build-arg HTTP_PROXY=... --build-arg HTTPS_PROXY=...``. The
+uppercase spellings are predeclared by the builder, so no ``ARG`` line is needed
+for them. Podman does this for you: it forwards the host's proxy environment
+into every build unless you pass ``--http-proxy=false``.
+
+**Finding them inside a build step.** ``apt`` and ``pip`` read only the
+lowercase ``http_proxy`` / ``https_proxy`` / ``no_proxy``, and an uppercase
+build argument does not answer to a lowercase name. So every ``RUN`` that
+reaches the network in a generated Dockerfile opens with a bridge line:
+
+.. code-block:: dockerfile
+
+   RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" \
+              https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" \
+              no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+       apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates
+
+Each expansion prefers a lowercase value that is already set, falls back to the
+uppercase one, and otherwise defaults to empty — so a build with no proxy
+exports three empty variables and behaves exactly as it did before.
+
+The two mechanisms answer different questions and work together: the build
+arguments (or Podman's forwarding) deliver the values, and the bridge closes the
+upper/lowercase gap inside the step. ``PIP_NO_PROXY`` remains the knob for the
+other half — which hosts to *skip* the proxy for. In the project image's
+dependency layer the bridge runs first and the existing
+``NO_PROXY="$PIP_NO_PROXY"`` export follows it, so a site that needs an
+exemption there sets ``PIP_NO_PROXY`` exactly as before while ``http_proxy`` and
+``https_proxy`` are bridged normally.
 
 Path Relocation
 ===============

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -427,6 +427,37 @@ default:
 Point either layer at an internal registry mirror or a pinned digest when
 your deployment host cannot (or should not) pull public images.
 
+Deploying Prebuilt Images
+=========================
+
+Some hosts cannot build images at all — no build tooling, no registry in
+reach — and run instead on images built elsewhere and loaded from a tarball.
+There, the image build that a :ref:`dev-mode <development-mode>` deploy
+normally runs is not merely slow but impossible. The top-level
+``prebuilt_images`` key skips it, so ``osprey up --dev`` starts the containers
+from the tags already on the host:
+
+.. code-block:: yaml
+
+   # config.yml
+   prebuilt_images: true
+
+.. code-block:: bash
+
+   # or, for one shell
+   OSPREY_PREBUILT_IMAGES=1 osprey up --dev
+
+``1``, ``true``, ``yes`` and ``on`` turn the switch on; ``0``, ``false``,
+``no`` and ``off`` turn it off — case does not matter. The variable wins over
+the config key in both directions, so ``OSPREY_PREBUILT_IMAGES=0`` forces a
+build for one shell even on a host whose ``config.yml`` pins the key. With
+neither set, deploys build as they always have.
+
+The deploy reports ``skipped image build (prebuilt images)`` where it would
+otherwise have built. Nothing checks up front that the tags are really
+present — a missing one surfaces as compose's own ``No such image`` error,
+which names the image to load.
+
 .. _qmd-search-sidecar:
 
 The Search Sidecar (``qmd``)
@@ -848,6 +879,8 @@ are.
    from ``services.postgresql`` — keeps such deployments working. To adopt
    the minted password, remove the ``ariel_postgres_data`` volume and redeploy
    (this deletes the stored logbook data — re-ingest afterwards).
+
+.. _development-mode:
 
 Development Mode
 ================

--- a/docs/source/how-to/deploy-project.rst
+++ b/docs/source/how-to/deploy-project.rst
@@ -614,9 +614,9 @@ Where the sidecar listens
 
 The sidecar publishes port **8180**. qmd's own daemon runs on **8181** on the
 container's internal loopback and is fronted by a small forwarder. That split is
-not cosmetic: qmd hardcodes a loopback-only, IPv6-only bind with no option to
-change it, which makes it unreachable from any other container. Only the
-forwarder owns a routable port.
+not cosmetic: qmd hardcodes a loopback-only bind with no option to change it,
+which makes it unreachable from any other container. Only the forwarder owns a
+routable port.
 
 .. warning::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -435,10 +435,18 @@ raw-options = { version_scheme = "post-release", git_describe_command = "git des
 version-file = "src/osprey/_version.py"
 
 [tool.hatch.build]
-# Never package benchmark results produced by running the channel-finder
-# benchmark from inside the template tree (untracked in git, but hatchling
-# packages the working tree — see the matching .gitignore entry).
-exclude = ["src/osprey/templates/apps/control_assistant/data/benchmarks/results"]
+# Directories a working tree can hold but a distribution must never carry.
+# Hatchling packages the working tree, so each entry here is half a pair: the
+# exclude keeps the files out of the sdist/wheel, a matching .gitignore entry
+# keeps them out of git. Add one, add the other — tests/cli/test_dockerfile_template.py
+# fails if the pair comes apart.
+#
+# - benchmarks/results: written by running the channel-finder benchmark from
+#   inside the packaged template tree.
+# - prefetched-models: GGUF model files staged on disk where the model host is
+#   unreachable, for the qmd sidecar to load over a read-only mount. Gigabytes
+#   each — unexcluded they turn a small wheel into an unusable one.
+exclude = ["src/osprey/templates/apps/control_assistant/data/benchmarks/results", "**/prefetched-models"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/osprey"]

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -130,6 +130,20 @@ keys:
       Fallback corpus-sweep period, not the freshness lag — `.qmd-touch` is the
       primary trigger. Default 30 s; a no-op sweep costs ~12.5 s at 135k
       documents, so a large corpus should raise it.
+  services.qmd.models_dir:
+    rendered: false
+    evidence: '_absolute_path\(block\.get\("models_dir"\)'
+    note: >-
+      Hidden key, unset in all five templates. Names a host directory holding
+      the three GGUF models the sidecar image otherwise downloads at build
+      time; setting it skips the downloads and delivers them over a read-only
+      mount instead, which is what makes the sidecar buildable on a network
+      with no route to huggingface.co. Subject-named after what the directory
+      holds, like `path`/`mirror_path`, not after the mount that carries it.
+      `preflight_qmd_models_dir` refuses the deploy when the directory is
+      missing or lacks a model under its exact `hf_<org>_<basename>` cache
+      name — the one operator error that would otherwise surface only as an
+      unhealthy container an hour later.
   # `services.qmd.bind_address` is deliberately absent: the sidecar publishes on
   # the project-wide `deployment.bind_address` like every other service. See
   # deployment/qmd_service.py for why a per-service key would be a hazard.

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -51,6 +51,7 @@ from osprey.deployment.host_ports import (
     format_conflict_report,
     parse_host_port_bindings,
 )
+from osprey.deployment.qmd_service import preflight_qmd_models_dir
 from osprey.deployment.runtime_helper import (
     ComposeProvider,
     UnsupportedComposeProviderError,
@@ -3795,6 +3796,14 @@ def _start_stack(
     # plain services branch further down rather than duplicating the check
     # in each.
     _check_shared_disk_preflight(config)
+
+    # Same shape, for the other configured host path: when services.qmd.models_dir
+    # is set, the sidecar's models come from that directory over a read-only mount
+    # instead of from the image. A missing or mis-named file there does not fail
+    # the deploy — it makes the sidecar try to download the model it cannot find,
+    # on a host that was configured this way because it has no route out. Checked
+    # here, before the build the setting is meant to shorten.
+    preflight_qmd_models_dir(config)
 
     # Verify container runtime is actually running
     is_running, error_msg = verify_runtime_is_running(config)

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -1730,6 +1730,38 @@ def _resolve_pip_spec(dev_mode: bool = False) -> str:
     return f"osprey-framework=={get_release_version()}"
 
 
+#: Env-var spellings for "on" and "off", matching the other framework switches.
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+
+def _resolve_prebuilt_images(config: dict) -> bool:
+    """Whether this host already has the images and must not build them.
+
+    Some deployment hosts cannot build at all — no build tooling, no registry
+    reachable, images side-loaded from a tarball instead. There the dev-mode
+    compose build is not slow but impossible, and the only thing that can run
+    is ``up`` against tags that are already present.
+
+    Resolution order:
+      1. ``OSPREY_PREBUILT_IMAGES`` environment variable (truthy: 1/true/yes/on;
+         falsy: 0/false/no/off)
+      2. Top-level ``prebuilt_images`` key in the deploy config
+      3. Default: false — deploys build as they always have
+
+    Env var wins in both directions, so a host whose config pins the switch can
+    still be made to build for one shell, and vice versa.
+
+    :param config: Loaded deploy config.
+    """
+    env = os.environ.get("OSPREY_PREBUILT_IMAGES", "").strip().lower()
+    if env in _TRUTHY:
+        return True
+    if env in _FALSY:
+        return False
+    return bool(config.get("prebuilt_images", False))
+
+
 def _worker_image_target(config: dict, env: dict) -> str:
     """The image the dispatch worker will actually run.
 
@@ -4004,7 +4036,14 @@ def _start_stack(
     run_captured(rm_cmd, env=run_env, spool_name="compose-rm", repo_root=repo_root, check=False)
     _report_step("cleared stopped containers")
 
-    if dev_mode:
+    if dev_mode and _resolve_prebuilt_images(config):
+        # Nothing to build: the tags are expected to be on the host already, and
+        # the `up --no-build` below runs against them. A tag that is in fact
+        # missing surfaces as compose's own "No such image", which names the
+        # image that has to be loaded — better than anything a preflight here
+        # could say.
+        _report_step("skipped image build (prebuilt images)")
+    elif dev_mode:
         # `osprey up --dev` re-bakes the local osprey checkout into a fresh
         # wheel on every run, but compose reuses the cached image tag (e.g.
         # <project>-dispatch:local) unless it is rebuilt — so a dev deploy must build.

--- a/src/osprey/deployment/qmd_service.py
+++ b/src/osprey/deployment/qmd_service.py
@@ -13,6 +13,14 @@ Config shape, as it appears in a project's ``config.yml``::
         path: ./services/qmd
         port: 8180
         interval: 30
+        models_dir: /srv/osprey/qmd-models   # optional; see below
+
+``models_dir`` is the one key that changes how the sidecar is *built*. By
+default the image bakes its three GGUF models in at build time, which needs
+build-host access to huggingface.co. On a network that has none, an operator
+stages the same three files once on the host and names the directory here; the
+build then skips the downloads and the models arrive at runtime over a
+read-only bind mount instead. Default unset — behaviour is unchanged.
 
 ``bind_address`` is deliberately NOT a per-service key. Every deployed service
 publishes on the project-wide ``deployment.bind_address`` (default
@@ -36,14 +44,17 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
+from osprey.deployment.errors import DeploymentPreconditionError
+
 #: Host port the sidecar publishes. Deliberately NOT qmd's own default of
-#: 8181: the daemon binds IPv6 loopback only (``[::1]:8181``, hardcoded, no
-#: ``--host`` flag), so the container's entrypoint runs qmd on the internal
-#: 8181 and fronts it with a forwarder that owns the routable port. Keeping the
-#: two numbers distinct means "8181" always names the private daemon and this
-#: port always names the endpoint clients talk to.
+#: 8181: the daemon binds loopback only (``listen(port, "localhost")``,
+#: hardcoded, no ``--host`` flag), so the container's entrypoint runs qmd on the
+#: internal 8181 and fronts it with a forwarder that owns the routable port.
+#: Keeping the two numbers distinct means "8181" always names the private
+#: daemon and this port always names the endpoint clients talk to.
 DEFAULT_PORT = 8180
 
 #: Interface every deployed service publishes on when ``deployment`` is absent.
@@ -67,6 +78,30 @@ DEFAULT_INTERVAL_SECONDS = 30
 #: so the deploy-time port-conflict remedy and the schema cannot drift apart.
 PORT_CONFIG_KEY = "services.qmd.port"
 
+#: Config key naming a host directory of pre-staged GGUF model files. Spelled
+#: once so the schema, the deploy-time preflight and its refusal text agree.
+MODELS_DIR_CONFIG_KEY = "services.qmd.models_dir"
+
+#: The exact filenames the three models must carry, in the order the sidecar
+#: loads them: embedding, reranker, query expansion.
+#:
+#: These are not the huggingface filenames. node-llama-cpp — which qmd loads
+#: its models through — caches a repo file as ``hf_<org>_<basename>``, and that
+#: cached name is the *only* one it recognises as "already present". A file
+#: under any other name, including the bare huggingface basename, leaves qmd
+#: believing the model is absent, and it re-downloads: on a locked-down network
+#: that hangs, and into a read-only mount it fails outright. Hence a preflight
+#: that checks names rather than merely counting files.
+#:
+#: Kept in step with the model URIs pinned in
+#: ``src/osprey/templates/services/qmd/Dockerfile`` — the same three files it
+#: fetches and SHA256-verifies at build time.
+MODEL_FILENAMES = (
+    "hf_ggml-org_embeddinggemma-300M-Q8_0.gguf",
+    "hf_ggml-org_qwen3-reranker-0.6b-q8_0.gguf",
+    "hf_tobil_qmd-query-expansion-1.7B-q4_k_m.gguf",
+)
+
 
 @dataclass(frozen=True)
 class QMDServiceConfig:
@@ -78,11 +113,16 @@ class QMDServiceConfig:
             project-wide ``deployment.bind_address``.
         interval_seconds: Fallback corpus-sweep period for the sidecar's
             update loop.
+        models_dir: Absolute host directory holding the pre-staged GGUF models,
+            or ``None`` (the default) to bake them into the image at build
+            time. Validated for shape here and for contents by
+            :func:`preflight_qmd_models_dir` at deploy time.
     """
 
     port: int = DEFAULT_PORT
     bind_address: str = DEFAULT_BIND_ADDRESS
     interval_seconds: int = DEFAULT_INTERVAL_SECONDS
+    models_dir: str | None = None
 
     @property
     def base_url(self) -> str:
@@ -112,9 +152,10 @@ def resolve_qmd_service_config(config: Mapping[str, Any] | None) -> QMDServiceCo
 
     Raises:
         ValueError: If ``port`` or ``interval`` is present but not a positive
-            integer. A silently-defaulted typo would point the client at the
-            wrong endpoint or stall the update loop, which is far harder to
-            diagnose than a refusal at resolution time.
+            integer, or if ``models_dir`` is present but not an absolute path.
+            A silently-defaulted typo would point the client at the wrong
+            endpoint or stall the update loop, which is far harder to diagnose
+            than a refusal at resolution time.
     """
     if not config:
         return None
@@ -130,6 +171,7 @@ def resolve_qmd_service_config(config: Mapping[str, Any] | None) -> QMDServiceCo
         interval_seconds=_positive_int(
             block.get("interval"), DEFAULT_INTERVAL_SECONDS, "services.qmd.interval"
         ),
+        models_dir=_absolute_path(block.get("models_dir"), MODELS_DIR_CONFIG_KEY),
     )
 
 
@@ -154,6 +196,102 @@ def resolve_bind_address(config: Mapping[str, Any] | None) -> str:
     return address.strip()
 
 
+def preflight_qmd_models_dir(config: Mapping[str, Any] | None) -> None:
+    """Refuse a deploy whose pre-staged model directory would not satisfy qmd.
+
+    Runs only when ``services.qmd.models_dir`` is set; an unset key means the
+    image bakes its own models and there is nothing to check.
+
+    What this catches is a *silent* failure, which is why it refuses rather
+    than warns. The mount is read-only and the models are absent, so the
+    sidecar starts, decides it must download them, and cannot — on a host
+    configured this way because it has no route to huggingface.co, that is a
+    hang rather than an error. The container's health check allows an hour of
+    start-up for the model load it normally does, so the first honest signal an
+    operator gets is an unhealthy container an hour later, with the cause an
+    hour behind it. Checking three filenames on the host beforehand costs
+    nothing and turns that into an immediate refusal naming the fix.
+
+    Args:
+        config: A loaded project config mapping, or ``None``.
+
+    Raises:
+        DeploymentPreconditionError: If the key is set and the directory is
+            missing, or does not hold all three models under the exact names
+            qmd recognises. Nothing has been started when this raises.
+        ValueError: Propagated from :func:`resolve_qmd_service_config` for a
+            malformed ``services.qmd`` block.
+    """
+    resolved = resolve_qmd_service_config(config)
+    if resolved is None or resolved.models_dir is None:
+        return
+
+    directory = Path(resolved.models_dir)
+    if not directory.is_dir():
+        raise DeploymentPreconditionError(
+            reason=(
+                f"{MODELS_DIR_CONFIG_KEY} names a host directory that does not "
+                f"exist: {directory}. Setting it says the qmd sidecar's models are "
+                "staged on this host instead of downloaded during the image build, "
+                "so there is nothing for the build to skip and nothing for the "
+                "container to load."
+            ),
+            remedy=_models_staging_remedy(directory),
+        )
+
+    missing = [name for name in MODEL_FILENAMES if not _staged(directory / name)]
+    if missing:
+        raise DeploymentPreconditionError(
+            reason=(
+                f"{MODELS_DIR_CONFIG_KEY} is set to {directory}, but "
+                f"{len(missing)} of the sidecar's {len(MODEL_FILENAMES)} models are "
+                "not staged there under the names qmd looks for (missing, or present "
+                "but empty):\n"
+                + "\n".join(f"    {name}" for name in missing)
+                + "\n\nqmd loads models through node-llama-cpp, which recognises a "
+                "staged model only by its `hf_<org>_<basename>` cache name. Under any "
+                "other name — the bare download name included — the file reads as "
+                "absent and the sidecar tries to fetch it into a read-only mount, on "
+                "a host configured this way precisely because it cannot reach "
+                "huggingface.co."
+            ),
+            remedy=_models_staging_remedy(directory),
+        )
+
+
+def _models_staging_remedy(directory: Path) -> str:
+    """The staging instructions both model-directory refusals end on.
+
+    Args:
+        directory: The configured host directory, named so the operator does
+            not have to re-read config.yml to act on the message.
+
+    Returns:
+        A multi-line remedy listing all three filenames verbatim.
+    """
+    listing = "\n".join(f"    {name}" for name in MODEL_FILENAMES)
+    return (
+        f"Stage all three model files in {directory}, named exactly:\n"
+        f"{listing}\n"
+        "Copy them from a host that can reach huggingface.co, or from the qmd model\n"
+        "cache of a machine that has already built the sidecar image; the source URLs\n"
+        "and their SHA256 pins are in the qmd service's Dockerfile. Rename each to the\n"
+        "`hf_<org>_<basename>` form above — the download names differ — then re-run\n"
+        "the deploy.\n"
+        f"To go back to build-time downloads, remove {MODELS_DIR_CONFIG_KEY} from "
+        "config.yml."
+    )
+
+
+def _staged(path: Path) -> bool:
+    """True when ``path`` is a non-empty regular file.
+
+    Emptiness counts as absence: an interrupted copy leaves a zero-byte file
+    that would otherwise pass a bare existence check and fail in the container.
+    """
+    return path.is_file() and path.stat().st_size > 0
+
+
 def _positive_int(value: Any, default: int, key: str) -> int:
     """Coerce a config value to a positive int, or fall back to ``default``.
 
@@ -175,3 +313,35 @@ def _positive_int(value: Any, default: int, key: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise ValueError(f"{key} must be a positive integer, got {value!r}")
     return int(value)
+
+
+def _absolute_path(value: Any, key: str) -> str | None:
+    """Coerce a config value to an absolute host path, or ``None`` when unset.
+
+    Args:
+        value: The raw value read from config, possibly ``None``.
+        key: Dotted config key, named in the error message.
+
+    Returns:
+        ``None`` when ``value`` is ``None``, otherwise the stripped path.
+
+    Raises:
+        ValueError: If ``value`` is present but not a non-empty absolute path.
+            Absoluteness is required rather than resolved-for: a relative path
+            means one directory to this process and another to the container
+            runtime, which resolves it against the compose file instead, and
+            neither of them expands ``~``. Accepting one would let the check
+            below pass against a directory the mount never sees.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty absolute host path, got {value!r}")
+    path = value.strip()
+    if not Path(path).is_absolute():
+        raise ValueError(
+            f"{key} must be an absolute host path, got {path!r}. A relative path "
+            "resolves differently here than in the container runtime, and neither "
+            "expands '~'."
+        )
+    return path

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -1211,17 +1211,25 @@ def deploy_up_web_terminals(
             check=False,
         )
         _report_step("cleared stale service containers")
-        if dev_mode:
+        # Function-level import, like `_env_file_args` below: container_lifecycle
+        # imports this module at its own top level, so the favour cannot be
+        # returned there.
+        from osprey.deployment.container_lifecycle import (
+            _resolve_prebuilt_images,
+            compose_build_step_reporter,
+        )
+
+        if dev_mode and _resolve_prebuilt_images(config):
+            # Same bargain as the plain path (see _start_stack): the service tags
+            # are already on the host, `up --no-build` runs against them, and a
+            # missing one surfaces as compose's own "No such image".
+            _report_step("skipped image build (prebuilt images)")
+        elif dev_mode:
             # Mirrors the plain non-web path's dev-mode build (see deploy_up):
             # without a rebuild, a co-deployed service's cached image tag keeps
             # running the stale code from its first build. Build in its own step,
             # then `up --no-build`, to dodge the `up --build` containerd
             # image-store race.
-            # Function-level import, like `_env_file_args` below:
-            # container_lifecycle imports this module at its own top level, so
-            # the favour cannot be returned there.
-            from osprey.deployment.container_lifecycle import compose_build_step_reporter
-
             services_build = services_base + ["build"]
             logger.debug(f"Running command:\n    {' '.join(services_build)}")
             # Watched only for as long as the build runs — same scope as the

--- a/src/osprey/health/core/claude_cli.py
+++ b/src/osprey/health/core/claude_cli.py
@@ -176,7 +176,10 @@ async def _check_claude_cli_pinned(pinned: str | None) -> list[CheckResult]:
                 category=_CATEGORY_PINNED,
                 status=Status.ERROR,
                 message="npx not found in PATH",
-                details="Install Node.js (which ships npx) to use claude_code.cli_version pinning.",
+                details=(
+                    "Install the nodejs and npm packages (npx ships with npm) "
+                    "to use claude_code.cli_version pinning."
+                ),
             )
         ]
     except TimeoutError:

--- a/src/osprey/templates/modules/web_terminals/auth_sidecar/Dockerfile
+++ b/src/osprey/templates/modules/web_terminals/auth_sidecar/Dockerfile
@@ -38,7 +38,8 @@ WORKDIR /app
 # broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
 # bounded apt retries with backoff so a transient network blip mid-build does
 # not fail the whole image.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
@@ -56,7 +57,8 @@ RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
 ARG OSPREY_VERSION=""
 ARG OSPREY_DEV=""
 COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
-RUN [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
     && apt-get update \
     && apt-get install -y --no-install-recommends build-essential python3-dev \
     && { pip install --no-cache-dir "osprey-framework==$OSPREY_VERSION" \

--- a/src/osprey/templates/project/Dockerfile.j2
+++ b/src/osprey/templates/project/Dockerfile.j2
@@ -43,13 +43,19 @@ RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_prox
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
+# Tools the agent's shell reaches for at runtime (curl, git, procps) and Node
+# for the Claude Code CLI installed below. Node comes from the base image's own
+# Debian release rather than a third-party apt repo, so the image has a single
+# package provenance and needs no network beyond the Debian mirror to build. The
+# CLI's engines floor is node >= 18, which every Debian release the slim bases
+# resolve to satisfies.
+#
+# npm is a runtime dependency, not a build-time convenience: the agent is
+# launched as `npx -y @anthropic-ai/claude-code@<version>` (claude_launcher.py),
+# so npm must remain in the final image.
 RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
     apt-get update \
- && apt-get install -y --no-install-recommends curl git procps ca-certificates gnupg \
- && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
- && apt-get purge -y gnupg \
- && apt-get autoremove -y \
+ && apt-get install -y --no-install-recommends curl git procps ca-certificates nodejs npm \
  && rm -rf /var/lib/apt/lists/*
 
 # Claude Code CLI, pinned via CLAUDE_CLI_VERSION (npm global install) so an

--- a/src/osprey/templates/project/Dockerfile.j2
+++ b/src/osprey/templates/project/Dockerfile.j2
@@ -38,11 +38,13 @@ ARG OSPREY_OFFLINE="0"
 # broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
 # bounded apt retries with backoff so a transient network blip mid-build does
 # not fail the whole image.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
-RUN apt-get update \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    apt-get update \
  && apt-get install -y --no-install-recommends curl git procps ca-certificates gnupg \
  && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
@@ -53,7 +55,8 @@ RUN apt-get update \
 # Claude Code CLI, pinned via CLAUDE_CLI_VERSION (npm global install) so an
 # upstream release cannot silently change agent behavior between image
 # builds — mirrors the dispatch-worker image's pinned install.
-RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
 
 # OSPREY + profile dependencies (deps layer). A C toolchain (build-essential +
 # python3-dev) is needed at install time to compile native deps (e.g.
@@ -79,7 +82,8 @@ COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
 # reaches pip's isolated build environments, where a plain requirement pin
 # would not. Drop the constraint once a fixed setuptools or setuptools_dso
 # release is out.
-RUN export NO_PROXY="$PIP_NO_PROXY" no_proxy="$PIP_NO_PROXY" \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    export NO_PROXY="$PIP_NO_PROXY" no_proxy="$PIP_NO_PROXY" \
     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt \
     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt \
     && apt-get update \

--- a/src/osprey/templates/project/dockerignore
+++ b/src/osprey/templates/project/dockerignore
@@ -58,3 +58,15 @@ CLAUDE.local.md
 # NOT excluded — the wheel layer's `COPY .dockerignore *.wh[l]` relies on it as a
 # guaranteed-present sibling so the COPY never fails when no wheel is staged.
 Dockerfile
+
+# Model files an operator stages by hand where the model host is unreachable.
+# They belong to the qmd sidecar, which loads them over a read-only mount and
+# never from an image — gigabytes of GGUF that this image would carry for no
+# reader.
+#
+# The one `**/`-anchored entry in this file, deliberately: the staged directory
+# sits beside the qmd service's Dockerfile deep in the render, not at the
+# project root, so the root-anchored spelling the rest of the list uses would
+# match nothing here. The derivation described above prefixes another `**/`,
+# which is redundant but harmless.
+**/prefetched-models/

--- a/src/osprey/templates/services/bluesky/Dockerfile
+++ b/src/osprey/templates/services/bluesky/Dockerfile
@@ -27,7 +27,8 @@ WORKDIR /app
 # broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
 # bounded apt retries with backoff so a transient network blip mid-build does
 # not fail the whole image.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
@@ -73,7 +74,8 @@ COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
 # fails sdist compiles of the EPICS toolchain (pvxslibs/epicscorelibs/softioc)
 # where no binary wheel exists (notably linux/arm64); PIP_CONSTRAINT reaches
 # pip's isolated build environments. Drop once a fixed release is out.
-RUN [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt \
     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt \
     && apt-get update \

--- a/src/osprey/templates/services/bluesky_web/Dockerfile
+++ b/src/osprey/templates/services/bluesky_web/Dockerfile
@@ -23,7 +23,8 @@ WORKDIR /app
 # broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
 # bounded apt retries with backoff so a transient network blip mid-build does
 # not fail the whole image.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
@@ -45,7 +46,8 @@ COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
 # fails sdist compiles of the EPICS toolchain (pvxslibs/epicscorelibs/softioc)
 # where no binary wheel exists (notably linux/arm64); PIP_CONSTRAINT reaches
 # pip's isolated build environments. Drop once a fixed release is out.
-RUN [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt \
     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt \
     && apt-get update \

--- a/src/osprey/templates/services/event_dispatcher/Dockerfile
+++ b/src/osprey/templates/services/event_dispatcher/Dockerfile
@@ -28,18 +28,22 @@ RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_prox
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
-# Node.js 20 + the Claude Code CLI (the dispatch-worker shells out to `claude`).
+# Node + the Claude Code CLI (the dispatch-worker shells out to `claude`).
+# Node comes from the base image's own Debian release rather than a third-party
+# apt repo, so the image has a single package provenance and needs no network
+# beyond the Debian mirror to build. The CLI's engines floor is node >= 18,
+# which every Debian release the slim bases resolve to satisfies.
+#
+# npm is a runtime dependency, not a build-time convenience: the agent is
+# launched as `npx -y @anthropic-ai/claude-code@<version>` (claude_launcher.py),
+# so npm must remain in the final image.
 RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
     apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get install -y --no-install-recommends ca-certificates nodejs npm \
     # Pin the Claude Code CLI so an upstream release cannot silently change the
     # headless agent's behavior between image builds (matches the cli_version
     # OSPREY documents in config.yml). Bump deliberately.
     && npm install -g @anthropic-ai/claude-code@2.1.146 \
-    && apt-get purge -y curl gnupg \
-    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/src/osprey/templates/services/event_dispatcher/Dockerfile
+++ b/src/osprey/templates/services/event_dispatcher/Dockerfile
@@ -23,12 +23,14 @@ FROM python:3.11-slim
 # broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
 # bounded apt retries with backoff so a transient network blip mid-build does
 # not fail the whole image.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
 # Node.js 20 + the Claude Code CLI (the dispatch-worker shells out to `claude`).
-RUN apt-get update \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -60,7 +62,8 @@ COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
 # fails sdist compiles of the EPICS toolchain (pvxslibs/epicscorelibs/softioc)
 # where no binary wheel exists (notably linux/arm64); PIP_CONSTRAINT reaches
 # pip's isolated build environments. Drop once a fixed release is out.
-RUN [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt \
     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt \
     && apt-get update \

--- a/src/osprey/templates/services/gchat_bridge/Dockerfile
+++ b/src/osprey/templates/services/gchat_bridge/Dockerfile
@@ -23,7 +23,8 @@ WORKDIR /app
 # broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
 # bounded apt retries with backoff so a transient network blip mid-build does
 # not fail the whole image.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
@@ -47,7 +48,8 @@ COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
 # fails sdist compiles of the EPICS toolchain (pvxslibs/epicscorelibs/softioc)
 # where no binary wheel exists (notably linux/arm64); PIP_CONSTRAINT reaches
 # pip's isolated build environments. Drop once a fixed release is out.
-RUN [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt \
     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt \
     && apt-get update \

--- a/src/osprey/templates/services/nextcloud_bridge/Dockerfile
+++ b/src/osprey/templates/services/nextcloud_bridge/Dockerfile
@@ -22,7 +22,8 @@ WORKDIR /app
 # broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
 # bounded apt retries with backoff so a transient network blip mid-build does
 # not fail the whole image.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
@@ -44,7 +45,8 @@ COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
 # fails sdist compiles of the EPICS toolchain (pvxslibs/epicscorelibs/softioc)
 # where no binary wheel exists (notably linux/arm64); PIP_CONSTRAINT reaches
 # pip's isolated build environments. Drop once a fixed release is out.
-RUN [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt \
     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt \
     && apt-get update \

--- a/src/osprey/templates/services/qmd/.dockerignore
+++ b/src/osprey/templates/services/qmd/.dockerignore
@@ -3,10 +3,14 @@
 # The build context is the rendered service directory. The Dockerfile needs
 # exactly one file from it — entrypoint.sh — plus this file, which doubles as
 # the guaranteed COPY sibling that keeps the optional `entrypoint.s[h]` glob
-# matching. Everything else is a deploy artifact or a runtime bind-mount and
-# must not be baked into the image.
+# matching. Nothing else in the directory is an image input, so every rule
+# below is defensive: it keeps a file that shows up next to a rendered service
+# — a deploy artifact, a bind-mount target, or a volume someone materialised by
+# hand — from being uploaded as build context.
+# Byte-code left behind by anything run inside the service directory.
 **/__pycache__/
 *.pyc
+# History and secrets, neither of which belong in an image.
 .git/
 .env
 # Compose files + templates are runtime/deploy artifacts, not image inputs.
@@ -20,4 +24,9 @@ corpus/
 index/
 *.db
 *.sqlite*
-*.gguf
+# Model files reach the container either from the pinned fetches in the
+# Dockerfile or over the read-only mount `services.qmd.models_dir` configures —
+# never through the build context. `**/` because the bare `*.gguf` this
+# replaces matched only the context root, leaving a subdirectory of models
+# (2.1 GB of them) free to be uploaded.
+**/*.gguf

--- a/src/osprey/templates/services/qmd/Dockerfile
+++ b/src/osprey/templates/services/qmd/Dockerfile
@@ -30,11 +30,13 @@ RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_prox
 #
 # curl  — build-time model fetch; the slim base has no curl either.
 # socat — runtime port forwarder. qmd hardcodes `httpServer.listen(port,
-#         "localhost")` and resolves that to IPv6 loopback only, with no --host
-#         flag and no env override, so the daemon is unreachable from outside
-#         its own network namespace. The entrypoint runs qmd on internal
-#         [::1]:<internal port> and forwards the routable port to it. This keeps
-#         the security posture: qmd itself never listens on a routable address.
+#         "localhost")`, with no --host flag and no env override, so the daemon
+#         only ever answers on a loopback address — unreachable from outside its
+#         own network namespace — and which loopback family "localhost" resolves
+#         to depends on the host. The entrypoint runs qmd on the internal port,
+#         probes both families for the one that answers, and forwards the
+#         routable port to it. This keeps the security posture: qmd itself never
+#         listens on a routable address.
 RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
     find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \

--- a/src/osprey/templates/services/qmd/Dockerfile
+++ b/src/osprey/templates/services/qmd/Dockerfile
@@ -1,9 +1,15 @@
 # qmd search sidecar image.
 #
 # Runs `@tobilu/qmd` as a long-lived indexer + MCP search server next to the
-# OSPREY agent. The image is self-contained and works offline: the qmd CLI and
-# all three GGUF models it can load are baked in at build time, so a cold
-# container never reaches out to huggingface.co on a user's first query.
+# OSPREY agent. The running container works offline: the qmd CLI and all three
+# GGUF models it can load are in place before it starts, so a cold container
+# never reaches out to huggingface.co on a user's first query.
+#
+# The models get there one of two ways. By default they are baked in at build
+# time, which needs a build host that can reach huggingface.co. A build host
+# that cannot is told so with OSPREY_QMD_MODELS_MOUNTED (see below): the
+# fetches are skipped and the same three files arrive at runtime over the
+# read-only bind mount that `services.qmd.models_dir` configures.
 #
 # Node 22 is the floor, not a preference: @tobilu/qmd declares
 # `"engines": {"node": ">=22.0.0"}` and refuses to run on Node 20.
@@ -88,6 +94,37 @@ ENV QMD_EMBED_MODEL=hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_
     QMD_RERANK_MODEL=hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf \
     QMD_GENERATE_MODEL=hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf
 
+# ── model pins ───────────────────────────────────────────────────────────────
+# The SHA256 of each of the three model files, written once here and read by
+# everything downstream: the fetch steps below, the identity file, and (via the
+# ENV promotion) the entrypoint's check of the mounted files. The
+# `com.osprey.qmd.*_sha256` labels are the one deliberate second copy — see the
+# comment on the LABEL block for why they cannot reference these.
+#
+# Declared here rather than at the top of the file so that bumping a pin
+# invalidates only the model layers below it, not the apt and npm layers above.
+# A bumped value does change the text of the RUN that reads it, which is what
+# makes the layer miss (and what CI's pin-keyed layer cache assumes).
+ARG OSPREY_QMD_EMBED_SHA256=b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63
+ARG OSPREY_QMD_RERANK_SHA256=22c9979ce4fbcdc5acdc310c6641c32797eff1aa980b8f7a2db8a8ea23429a48
+ARG OSPREY_QMD_GENERATE_SHA256=000dfb1c06efa6a049e9f64ba921c3740e2454f62abab6fa10e77bd30bb2bcc0
+
+# Set to any non-empty value — the compose fragment passes "1" — to declare
+# that the models will be supplied at runtime by the read-only bind mount
+# `services.qmd.models_dir` configures. The three fetches below then do
+# nothing, so the image builds on a host with no route to huggingface.co. The
+# pins above still travel with the image: skipping the *download* does not skip
+# verification, it moves it to container startup, where the entrypoint checks
+# the mounted files against them before qmd is allowed to load one.
+ARG OSPREY_QMD_MODELS_MOUNTED=""
+
+# Promote the pins to ENV so the entrypoint reads exactly what the build used.
+# The ENV shadows the ARG of the same name for every instruction below, at the
+# same value — including a value passed with --build-arg.
+ENV OSPREY_QMD_EMBED_SHA256=${OSPREY_QMD_EMBED_SHA256} \
+    OSPREY_QMD_RERANK_SHA256=${OSPREY_QMD_RERANK_SHA256} \
+    OSPREY_QMD_GENERATE_SHA256=${OSPREY_QMD_GENERATE_SHA256}
+
 # ── models ───────────────────────────────────────────────────────────────────
 # Fetched from pinned HuggingFace *commit* revisions (not `main`, which moves)
 # and SHA256-verified; a mismatch fails the build rather than baking an
@@ -95,7 +132,8 @@ ENV QMD_EMBED_MODEL=hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_
 #
 # The on-disk names are node-llama-cpp's cache naming for an `hf:` URI —
 # `hf_<org>_<basename>`. They must match exactly or qmd treats the model as
-# absent and re-downloads it on first use.
+# absent and re-downloads it on first use — which is also why the runtime mount
+# has to carry these same three names.
 #
 # One RUN per model so a network failure on the 1.2 GB file does not discard the
 # two already-verified layers.
@@ -103,8 +141,11 @@ ENV QMD_EMBED_MODEL=hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_
 # Embeddings (318 MB). Needed to BUILD an index — the fail-closed startup pass
 # in the entrypoint depends on this one.
 RUN set -eu; \
+    if [ -n "${OSPREY_QMD_MODELS_MOUNTED:-}" ]; then \
+      echo "models arrive by runtime mount; skipping embed model fetch"; exit 0; \
+    fi; \
     dest="$OSPREY_QMD_MODEL_DIR/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf"; \
-    want=b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63; \
+    want="$OSPREY_QMD_EMBED_SHA256"; \
     curl -fSL --retry 5 --retry-delay 5 --retry-connrefused -o "$dest" \
       "https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/0f741b5a6585bd53aeb15cd1372c56f2a0f65e12/embeddinggemma-300M-Q8_0.gguf"; \
     got="$(sha256sum "$dest" | cut -d' ' -f1)"; \
@@ -113,8 +154,11 @@ RUN set -eu; \
 
 # Reranking (610 MB). Loaded on first query, not on index build.
 RUN set -eu; \
+    if [ -n "${OSPREY_QMD_MODELS_MOUNTED:-}" ]; then \
+      echo "models arrive by runtime mount; skipping rerank model fetch"; exit 0; \
+    fi; \
     dest="$OSPREY_QMD_MODEL_DIR/hf_ggml-org_qwen3-reranker-0.6b-q8_0.gguf"; \
-    want=22c9979ce4fbcdc5acdc310c6641c32797eff1aa980b8f7a2db8a8ea23429a48; \
+    want="$OSPREY_QMD_RERANK_SHA256"; \
     curl -fSL --retry 5 --retry-delay 5 --retry-connrefused -o "$dest" \
       "https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/a02f48bb4f057028298c21fa033da2b30d7742d5/qwen3-reranker-0.6b-q8_0.gguf"; \
     got="$(sha256sum "$dest" | cut -d' ' -f1)"; \
@@ -123,8 +167,11 @@ RUN set -eu; \
 
 # Query expansion / HyDE (1.2 GB). Loaded on first `hyde` search.
 RUN set -eu; \
+    if [ -n "${OSPREY_QMD_MODELS_MOUNTED:-}" ]; then \
+      echo "models arrive by runtime mount; skipping generate model fetch"; exit 0; \
+    fi; \
     dest="$OSPREY_QMD_MODEL_DIR/hf_tobil_qmd-query-expansion-1.7B-q4_k_m.gguf"; \
-    want=000dfb1c06efa6a049e9f64ba921c3740e2454f62abab6fa10e77bd30bb2bcc0; \
+    want="$OSPREY_QMD_GENERATE_SHA256"; \
     curl -fSL --retry 5 --retry-delay 5 --retry-connrefused -o "$dest" \
       "https://huggingface.co/tobil/qmd-query-expansion-1.7B-gguf/resolve/7816de0b72572c6c860ca1eddf97ba9e7fb8cc65/qmd-query-expansion-1.7B-q4_k_m.gguf"; \
     got="$(sha256sum "$dest" | cut -d' ' -f1)"; \
@@ -143,16 +190,35 @@ ENV OSPREY_QMD_MODEL_IDENTITY_FILE=/opt/qmd/model-identity.env
 RUN printf '%s\n' \
     'OSPREY_QMD_EMBED_MODEL_URI=hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf' \
     'OSPREY_QMD_EMBED_MODEL_FILE=hf_ggml-org_embeddinggemma-300M-Q8_0.gguf' \
-    'OSPREY_QMD_EMBED_MODEL_SHA256=b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63' \
-    'OSPREY_QMD_EMBED_MODEL_ID=hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf@sha256:b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63' \
+    "OSPREY_QMD_EMBED_MODEL_SHA256=${OSPREY_QMD_EMBED_SHA256}" \
+    "OSPREY_QMD_EMBED_MODEL_ID=hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf@sha256:${OSPREY_QMD_EMBED_SHA256}" \
     "OSPREY_QMD_VERSION=${QMD_VERSION}" \
     > "$OSPREY_QMD_MODEL_IDENTITY_FILE"
 
+# The pins name the models this image REQUIRES: the ones it baked in on an
+# online build, and the ones it will insist on seeing — same names, same
+# digests — on the runtime mount when the fetches were skipped.
+#
+# The three `*_sha256` values are spelled out here instead of referencing the
+# ARGs above because CI reads them straight out of this file, before any build,
+# to key the layer cache on the pins (`.github/workflows/ci.yml`, "Derive the
+# model-pin cache key"); it greps for exactly three 64-hex literals and fails
+# the job if it finds any other number. A unit test asserts these three match
+# the ARG defaults, so the copy cannot drift unnoticed.
+#
+# `model_delivery` records which of the two paths this image took, as "baked"
+# or "mounted", for `docker inspect` and for the entrypoint (which reads the
+# ENV of the same name). `:+` turns any non-empty OSPREY_QMD_MODELS_MOUNTED
+# into "mounted" and the `:-` supplies the other half. It carries no digest, so
+# it stays clear of the cache-key grep.
+ARG OSPREY_QMD_MODEL_DELIVERY="${OSPREY_QMD_MODELS_MOUNTED:+mounted}"
+ENV OSPREY_QMD_MODEL_DELIVERY=${OSPREY_QMD_MODEL_DELIVERY:-baked}
 LABEL com.osprey.qmd.version="2.5.3" \
       com.osprey.qmd.embed_model="hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf" \
       com.osprey.qmd.embed_sha256="b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63" \
       com.osprey.qmd.rerank_sha256="22c9979ce4fbcdc5acdc310c6641c32797eff1aa980b8f7a2db8a8ea23429a48" \
-      com.osprey.qmd.generate_sha256="000dfb1c06efa6a049e9f64ba921c3740e2454f62abab6fa10e77bd30bb2bcc0"
+      com.osprey.qmd.generate_sha256="000dfb1c06efa6a049e9f64ba921c3740e2454f62abab6fa10e77bd30bb2bcc0" \
+      com.osprey.qmd.model_delivery="${OSPREY_QMD_MODEL_DELIVERY}"
 
 # ── entrypoint ───────────────────────────────────────────────────────────────
 # `entrypoint.sh` is a sibling of this Dockerfile in the rendered service

--- a/src/osprey/templates/services/qmd/Dockerfile
+++ b/src/osprey/templates/services/qmd/Dockerfile
@@ -18,7 +18,8 @@ FROM node:22-bookworm-slim
 # with no ca-certificates at all, so this first fetch has to go over plain HTTP
 # — switching the mirror to HTTPS before the CA bundle exists fails apt with
 # "certificate issuer is unknown".
-RUN printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries \
  && apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates \
  && rm -rf /var/lib/apt/lists/*
@@ -34,7 +35,8 @@ RUN printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries \
 #         its own network namespace. The entrypoint runs qmd on internal
 #         [::1]:<internal port> and forwards the routable port to it. This keeps
 #         the security posture: qmd itself never listens on a routable address.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && apt-get update \
  && apt-get install -y --no-install-recommends curl socat \
@@ -52,7 +54,8 @@ RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
 # so it does not bloat the image. This also means the image is architecture-
 # specific: build it for the architecture it will run on.
 ARG QMD_VERSION=2.5.3
-RUN apt-get update \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    apt-get update \
  && apt-get install -y --no-install-recommends build-essential python3 \
  && npm install -g "@tobilu/qmd@${QMD_VERSION}" \
  && npm cache clean --force \

--- a/src/osprey/templates/services/qmd/docker-compose.yml.j2
+++ b/src/osprey/templates/services/qmd/docker-compose.yml.j2
@@ -25,12 +25,16 @@
 # never race to tag one shared image. To use a prebuilt/published image instead,
 # set OSPREY_QMD_IMAGE (e.g. OSPREY_QMD_IMAGE=my-registry/osprey-qmd:2.5.3).
 #
-# PORT SPLIT. qmd's daemon hardcodes `httpServer.listen(port, "localhost")`,
-# which resolves to IPv6 loopback only — there is no --host flag and no env
-# override — so it is unreachable from any other container. The entrypoint runs
-# it on the container's internal 8181 and fronts it with a socat forwarder that
-# owns the port published below, which is the one clients talk to. The security
-# posture is the point: qmd itself never listens on a routable address.
+# PORT SPLIT. qmd's daemon hardcodes `httpServer.listen(port, "localhost")` —
+# there is no --host flag and no env override — so it answers only on a loopback
+# address inside the container, unreachable from any other container. WHICH
+# loopback family "localhost" lands on is not fixed: Node resolves it to [::1]
+# on some image/host combinations and to 127.0.0.1 on others (observed under
+# rootless podman on RHEL-family hosts). So the entrypoint runs the daemon on
+# the container's internal 8181, probes BOTH families for /health, and points a
+# socat forwarder at whichever one answered. The forwarder owns the port
+# published below, which is the one clients talk to. The security posture is the
+# point: qmd itself never listens on a routable address, on either family.
 #
 # The endpoint carries no token, no TLS and no per-caller identity — it answers
 # any request that reaches it. That is safe exactly as long as only this host

--- a/src/osprey/templates/services/qmd/docker-compose.yml.j2
+++ b/src/osprey/templates/services/qmd/docker-compose.yml.j2
@@ -58,6 +58,22 @@ services:
       dockerfile: Dockerfile
       args:
         OSPREY_PROJECT_NAME: "{{ osprey_labels.project_name }}"
+{%- if services.qmd.models_dir %}
+        # Pre-staged models: the operator named a host directory that already
+        # holds the three GGUF files, so the build must not fetch them. Without
+        # this the image build reaches huggingface.co — the one step in it that
+        # needs egress — and on a network that has none it hangs there. The
+        # value is truthy-only ("1"); the Dockerfile tests it with `-n`, and the
+        # model SHA pins still travel with the image, so verification moves to
+        # container startup rather than being skipped.
+        #
+        # Gated at RENDER time off the config key, never with a `${VAR}`
+        # default at compose time: a config-keyed conditional produces static
+        # YAML that docker compose and podman-compose read identically, whereas
+        # interpolation-driven conditionality is exactly where those two
+        # disagree.
+        OSPREY_QMD_MODELS_MOUNTED: "1"
+{%- endif %}
     # container_name is a HOST-GLOBAL docker identifier: namespace it per-project
     # so two OSPREY projects can deploy a sidecar on one host without colliding
     # on one name. In-network consumers reach this service by its compose
@@ -110,6 +126,29 @@ services:
       # container recreate.
       - qmd_index:{{ state_dir }}
       - ./build/services/qmd/index.yml:{{ index_config }}:ro
+{%- if services.qmd.models_dir %}
+      # The three pre-staged GGUF model files, supplied at runtime because the
+      # build skipped their download (same config key drives the build arg
+      # above — set one without the other and the container starts with no
+      # models at all). The host path is `services.qmd.models_dir`, guaranteed
+      # absolute by the schema and checked for the three expected filenames by
+      # the deploy-time preflight before compose ever runs.
+      #
+      # The container target is the LITERAL value of the image's
+      # OSPREY_QMD_MODEL_DIR, not `$OSPREY_QMD_MODEL_DIR`: that name exists only
+      # as an ENV inside the image, while compose expands `${...}` against the
+      # HOST environment, where it is unset — which would mount the models at
+      # the container root and leave qmd's cache empty. The two spellings are
+      # held together by a test, not by expansion.
+      #
+      # Only the models leaf is read-only. qmd owns the cache tree above it
+      # (/opt/qmd/.cache) and writes there; mounting the whole tree read-only
+      # would break it.
+      # `| trim` mirrors the stripping the schema does when it resolves and
+      # validates this key, so the bind spec names the same directory the
+      # preflight checked.
+      - {{ services.qmd.models_dir | trim }}:/opt/qmd/.cache/qmd/models:ro
+{%- endif %}
 {#- One read-only mount per configured corpus. The list is resolved in
     compose_generator._resolve_qmd_corpora, which the collection config below
     is rendered from as well, so a corpus cannot end up mounted without a

--- a/src/osprey/templates/services/qmd/entrypoint.sh
+++ b/src/osprey/templates/services/qmd/entrypoint.sh
@@ -42,11 +42,12 @@ INDEX_CONFIG="${OSPREY_QMD_INDEX_CONFIG:-/etc/qmd/index.yml}"
 # supported here; use the rendered config for those.
 COLLECTIONS_SPEC="${OSPREY_QMD_COLLECTIONS:-}"
 
-# Port split. qmd hardcodes `httpServer.listen(port, "localhost")`, which
-# resolves to IPv6 loopback only -- there is no --host flag and no env
-# override, so the daemon is unreachable from outside its own network
-# namespace. INTERNAL_PORT is where the daemon actually listens; PORT is the
-# routable port the forwarder owns and clients connect to.
+# Port split. qmd hardcodes `httpServer.listen(port, "localhost")` -- there is
+# no --host flag and no env override -- so the daemon only ever answers on a
+# loopback address inside the container, and which family "localhost" resolves
+# to depends on the environment. Either way it is unreachable from outside its
+# own network namespace. INTERNAL_PORT is where the daemon actually listens;
+# PORT is the routable port the forwarder owns and clients connect to.
 PORT="${OSPREY_QMD_PORT:-8180}"
 INTERNAL_PORT="${OSPREY_QMD_INTERNAL_PORT:-8181}"
 
@@ -365,34 +366,49 @@ assert_index_populated() {
 # ── phase 2: serve ───────────────────────────────────────────────────────────
 
 start_daemon() {
-    log "starting qmd MCP daemon on internal [::1]:$INTERNAL_PORT"
+    log "starting qmd MCP daemon on internal loopback:$INTERNAL_PORT"
     qmd mcp --http --port "$INTERNAL_PORT" &
     QMD_PID=$!
 
+    # qmd hardcodes listen(port, "localhost"), and which loopback family that
+    # binds is environment-dependent: Node resolves localhost to ::1 on some
+    # images/hosts and to 127.0.0.1 on others (observed: 127.0.0.1 under
+    # rootless podman on RHEL-family hosts, where the [::1]-only probe made
+    # the sidecar die at HEALTH_TIMEOUT and crash-loop the container). Probe
+    # both families and remember the one that answers for the forwarder.
+    DAEMON_TARGET=""
     _waited=0
     while :; do
         if ! kill -0 "$QMD_PID" 2>/dev/null; then
             QMD_PID=""
             die "qmd daemon exited during startup; see its output above"
         fi
-        if curl -fsS -o /dev/null --max-time 5 "http://[::1]:$INTERNAL_PORT/health" 2>/dev/null; then
-            log "daemon healthy after ${_waited}s"
-            return 0
-        fi
+        for _a in "[::1]" "127.0.0.1"; do
+            if curl -fsS -o /dev/null --max-time 5 "http://$_a:$INTERNAL_PORT/health" 2>/dev/null; then
+                DAEMON_TARGET="$_a"
+                log "daemon healthy after ${_waited}s on $_a"
+                return 0
+            fi
+        done
         [ "$_waited" -lt "$HEALTH_TIMEOUT" ] \
-            || die "qmd daemon did not answer /health within ${HEALTH_TIMEOUT}s"
+            || die "qmd daemon did not answer /health on [::1] or 127.0.0.1 within ${HEALTH_TIMEOUT}s"
         sleep 1
         _waited=$((_waited + 1))
     done
 }
 
 start_forwarder() {
-    # qmd binds IPv6 loopback only, which is unreachable from any other
-    # container. socat owns the routable port and forwards to it. The security
-    # posture is unchanged -- qmd itself still never listens on a routable
-    # address; only this forwarder does, inside the container.
-    log "publishing MCP endpoint on 0.0.0.0:$PORT (POST /mcp, GET /health)"
-    socat "TCP4-LISTEN:$PORT,fork,reuseaddr" "TCP6:[::1]:$INTERNAL_PORT" &
+    # qmd answers on the container's loopback only, which is unreachable from
+    # any other container. socat owns the routable port and forwards to the
+    # loopback family the health probe found answering. The security posture is
+    # unchanged -- qmd itself still never listens on a routable address; only
+    # this forwarder does, inside the container.
+    log "publishing MCP endpoint on 0.0.0.0:$PORT (POST /mcp, GET /health) -> $DAEMON_TARGET:$INTERNAL_PORT"
+    if [ "$DAEMON_TARGET" = "127.0.0.1" ]; then
+        socat "TCP4-LISTEN:$PORT,fork,reuseaddr" "TCP4:127.0.0.1:$INTERNAL_PORT" &
+    else
+        socat "TCP4-LISTEN:$PORT,fork,reuseaddr" "TCP6:[::1]:$INTERNAL_PORT" &
+    fi
     SOCAT_PID=$!
 }
 
@@ -537,7 +553,7 @@ main() {
     # and are safe.
 
     command -v qmd > /dev/null 2>&1 || die "qmd is not on PATH"
-    command -v socat > /dev/null 2>&1 || die "socat is not installed; the IPv6-loopback forwarder cannot start"
+    command -v socat > /dev/null 2>&1 || die "socat is not installed; the loopback forwarder cannot start"
 
     prepare_state
     run_startup_pass

--- a/src/osprey/templates/services/qmd/entrypoint.sh
+++ b/src/osprey/templates/services/qmd/entrypoint.sh
@@ -17,6 +17,9 @@
 # The ordering is the safety property: nothing outside the container can reach
 # a half-built index, because the port that reaches it does not exist yet.
 #
+# Ahead of all three, the model files are checked against the digests this image
+# was built with -- see "model verification".
+#
 # POSIX sh on purpose -- this runs as PID 1 in a slim image and has no bash.
 set -eu
 
@@ -31,6 +34,19 @@ set -eu
 # separate from the model cache so that persisting the index does not shadow
 # the 2.1 GB of baked models.
 STATE_DIR="${OSPREY_QMD_STATE_DIR:-/var/lib/qmd}"
+
+# Where the three model files live, and how they got there ("baked" into the
+# image, or "mounted" from the host at runtime). Both come from the image; an
+# unset MODEL_DIR is an error rather than a guess, because guessing wrong here
+# would report every model as missing.
+MODEL_DIR="${OSPREY_QMD_MODEL_DIR:-}"
+MODEL_DELIVERY="${OSPREY_QMD_MODEL_DELIVERY:-baked}"
+
+# The names node-llama-cpp resolves an `hf:` URI to. A model under any other
+# name reads as absent, so these are exact, not conventional.
+MODEL_FILES="hf_ggml-org_embeddinggemma-300M-Q8_0.gguf
+hf_ggml-org_qwen3-reranker-0.6b-q8_0.gguf
+hf_tobil_qmd-query-expansion-1.7B-q4_k_m.gguf"
 
 # Rendered collection config, mounted read-only by the deployment. Copied into
 # place on every start, so editing the deployment's config and restarting is
@@ -75,6 +91,7 @@ FORCE_REINDEX="${OSPREY_QMD_FORCE_REINDEX:-0}"
 CONFIG_FILE="$STATE_DIR/.qmd/index.yml"
 DB_FILE="$STATE_DIR/.qmd/index.sqlite"
 IDENTITY_STAMP="$STATE_DIR/.qmd/osprey-embed-identity"
+MODEL_STAMP="$STATE_DIR/.qmd/osprey-model-digests"
 
 QMD_PID=""
 SOCAT_PID=""
@@ -202,6 +219,89 @@ corpus_roots() {
             if (length($0) > 0) print
         }
     ' "$CONFIG_FILE"
+}
+
+# ── model verification ───────────────────────────────────────────────────────
+# Unconditional, for both delivery modes. qmd's own reaction to a model file it
+# cannot make sense of -- missing, truncated, or not the file the image expects
+# -- is to download a replacement, which stalls on a network with no route to
+# huggingface.co and cannot write into a read-only mount either way. Under the
+# compose healthcheck's hour-long start_period that failure is invisible: the
+# container just sits there. Checking first turns it into one loud refusal.
+#
+# It runs for baked images too, because the mismatches worth catching are the
+# ones the deployment cannot see: a `mounted` image whose bind mount was removed
+# again, a stale image left behind by a toggled build, or a prebuilt image
+# substituted through OSPREY_QMD_IMAGE that baked different models.
+
+# The digest this image expects for one model file.
+expected_digest() {
+    case "$1" in
+        *embeddinggemma*) printf '%s' "${OSPREY_QMD_EMBED_SHA256:-}" ;;
+        *reranker*) printf '%s' "${OSPREY_QMD_RERANK_SHA256:-}" ;;
+        *query-expansion*) printf '%s' "${OSPREY_QMD_GENERATE_SHA256:-}" ;;
+    esac
+}
+
+# Refuse to start, saying what is wrong with which file and what to do about it.
+model_refusal() {
+    # No half-written stamp left behind in the state volume.
+    rm -f "$MODEL_STAMP.new"
+    log "FATAL: model file '$1' cannot be used: $2"
+    log "  Not starting qmd: it would read this model as absent and try to"
+    log "  download a replacement, which is exactly what this deployment cannot"
+    log "  do. Stage all three model files in $MODEL_DIR, named exactly:"
+    for _mr_name in $MODEL_FILES; do
+        log "    $_mr_name"
+    done
+    if [ "$MODEL_DELIVERY" = mounted ]; then
+        log "  This image expects the models at runtime, so stage them under those"
+        log "  names in the host directory bind-mounted at $MODEL_DIR."
+    else
+        log "  This image baked its models in, so seeing this means the image is"
+        log "  stale or a substituted one carries different models; rebuild the"
+        log "  qmd service image."
+    fi
+    exit 1
+}
+
+# Compare every model against its baked-in digest before the startup pass.
+#
+# Hashing 2.1 GB costs about half a minute, which is fine once and wasteful on
+# every restart -- so a stamp file in the state volume records `name size mtime
+# sha256` per verified file, and a file whose size and mtime are unchanged is
+# accepted from it. The recorded digest is still compared against the expected
+# one, so an image that changes a pin without changing the file is caught.
+verify_models() {
+    [ -n "$MODEL_DIR" ] || die "OSPREY_QMD_MODEL_DIR is unset; cannot tell where the models should be"
+
+    _vm_new="$MODEL_STAMP.new"
+    : > "$_vm_new"
+
+    for _vm_name in $MODEL_FILES; do
+        _vm_path="$MODEL_DIR/$_vm_name"
+        _vm_want=$(expected_digest "$_vm_name")
+        [ -n "$_vm_want" ] || model_refusal "$_vm_name" \
+            "this image records no expected SHA256 for it"
+        _vm_size=$(stat -c %s "$_vm_path" 2>/dev/null || printf '')
+        [ -n "$_vm_size" ] || model_refusal "$_vm_name" "no such file in $MODEL_DIR"
+        [ "$_vm_size" -gt 0 ] || model_refusal "$_vm_name" "the file is empty (0 bytes)"
+        _vm_mtime=$(stat -c %Y "$_vm_path")
+
+        _vm_got=$(awk -v n="$_vm_name" -v s="$_vm_size" -v m="$_vm_mtime" \
+            '$1 == n && $2 == s && $3 == m { print $4; exit }' "$MODEL_STAMP" 2>/dev/null || printf '')
+        if [ -z "$_vm_got" ]; then
+            log "hashing $_vm_name ($_vm_size bytes)"
+            _vm_got=$(sha256sum "$_vm_path" | cut -d' ' -f1)
+        fi
+        [ "$_vm_got" = "$_vm_want" ] || model_refusal "$_vm_name" \
+            "SHA256 mismatch: this image expects $_vm_want, the file on disk is $_vm_got"
+
+        printf '%s %s %s %s\n' "$_vm_name" "$_vm_size" "$_vm_mtime" "$_vm_got" >> "$_vm_new"
+    done
+
+    mv "$_vm_new" "$MODEL_STAMP"
+    log "models verified against the digests this image was built with ($MODEL_DELIVERY delivery)"
 }
 
 # ── phase 1: startup pass ────────────────────────────────────────────────────
@@ -556,6 +656,7 @@ main() {
     command -v socat > /dev/null 2>&1 || die "socat is not installed; the loopback forwarder cannot start"
 
     prepare_state
+    verify_models
     run_startup_pass
     seed_markers
     start_daemon

--- a/src/osprey/templates/services/virtual_accelerator/Dockerfile
+++ b/src/osprey/templates/services/virtual_accelerator/Dockerfile
@@ -69,7 +69,8 @@ RUN arch="$(dpkg --print-architecture)"; [ "$arch" = "amd64" ] \
 # broken by middleboxes on some networks; deb.debian.org supports HTTPS), and
 # bounded apt retries with backoff so a transient network blip mid-build does
 # not fail the whole image.
-RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
     -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
  && printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-osprey-retries
 
@@ -100,7 +101,8 @@ RUN find /etc/apt \( -name '*.sources' -o -name '*.list' \) \
 ARG OSPREY_VERSION=""
 ARG OSPREY_DEV=""
 COPY .dockerignore osprey-local-requirements.tx[t] /tmp/deps-ctx/
-RUN [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
+RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_proxy:-${HTTPS_PROXY:-}}" no_proxy="${no_proxy:-${NO_PROXY:-}}"; \
+    [ -n "$OSPREY_VERSION" ] || { echo "ERROR: OSPREY_VERSION build-arg is required" >&2; exit 1; } \
     && printf 'setuptools<84\n' > /tmp/deps-ctx/pip-constraints.txt \
     && export PIP_CONSTRAINT=/tmp/deps-ctx/pip-constraints.txt \
     && apt-get update \

--- a/tests/cli/test_dockerfile_template.py
+++ b/tests/cli/test_dockerfile_template.py
@@ -27,6 +27,7 @@ import pytest
 from click.testing import CliRunner
 
 from osprey.cli.main import cli
+from tests.deployment._proxy_idiom import assert_apt_runs_carry_proxy_idiom
 
 # The site-extension contract: exactly these quoted build ARGs, with these
 # defaults. (CLAUDE_CLI_VERSION is rendered without quotes and is not captured.)
@@ -98,6 +99,18 @@ class TestDockerfileContent:
             text = (hello_project / name).read_text()
             assert "{{" not in text, f"unrendered Jinja in {name}"
             assert "{%" not in text, f"unrendered Jinja in {name}"
+
+    def test_apt_runs_deliver_the_proxy_settings(self, hello_project):
+        """Every apt-using RUN hands apt the proxy settings before it fetches.
+
+        The rendered project image is the ninth recipe under the same rule as
+        the eight on-disk ones in
+        :mod:`tests.deployment.test_service_dockerfiles`; the idiom itself is
+        spelled once, in :mod:`tests.deployment._proxy_idiom`.
+        """
+        assert_apt_runs_carry_proxy_idiom(
+            (hello_project / "Dockerfile").read_text(), "rendered project template"
+        )
 
     @classmethod
     def _deps_run_body(cls, text: str) -> str:

--- a/tests/cli/test_dockerfile_template.py
+++ b/tests/cli/test_dockerfile_template.py
@@ -6,6 +6,8 @@
 - content invariants (base image, port, project path, the 3-ARG site
   extension contract),
 - the security-critical .dockerignore entries (secrets never enter the image),
+- the pairing between the repo's hatch exclude list and its .gitignore (what
+  must not ship has to be kept out of both),
 - that a Claude Code regeneration never touches the Dockerfile (it is
   rendered by `osprey build` and owned by the user in between), and
 - the anti-drift guard: every `osprey <cmd>` invocation inside the rendered
@@ -21,6 +23,7 @@ import pathlib
 import re
 import shlex
 import subprocess
+import tomllib
 
 import click
 import pytest
@@ -516,6 +519,67 @@ class TestDockerignore:
         assert ".dockerignore" not in entries, (
             ".dockerignore must not self-exclude — the wheel-staging COPY relies on it"
         )
+
+    def test_staged_models_excluded(self, hello_project):
+        """Model files staged by hand are qmd build inputs, not image content.
+
+        Pinned with its ``**/`` prefix, which is the one deviation from the
+        root-anchored spelling the rest of the list uses: the staged directory
+        sits beside the qmd service's Dockerfile inside the render, so a
+        root-anchored pattern would name nothing and gigabytes of GGUF would
+        ride into the project image.
+        """
+        assert "**/prefetched-models/" in self._entries(hello_project)
+
+
+class TestPackagingExcludePairing:
+    """The hatch exclude list and .gitignore are one list, spelled twice.
+
+    Hatchling packages the working tree rather than what git tracks, so a
+    directory that must never ship needs both halves: the
+    ``[tool.hatch.build]`` exclude keeps it out of the sdist and wheel, the
+    ``.gitignore`` entry keeps it out of the repo. Either half alone leaves a
+    way in, and the failure is quiet at the moment it is introduced — a staged
+    model directory that was gitignored but not excluded produced a
+    multi-gigabyte wheel, and nothing said so until someone installed it.
+
+    Asserted as a pairing over the whole list rather than entry by entry, so a
+    future exclude added with no ``.gitignore`` sibling fails here too.
+    """
+
+    @staticmethod
+    def _repo_root() -> pathlib.Path:
+        return pathlib.Path(__file__).resolve().parents[2]
+
+    @classmethod
+    def _hatch_excludes(cls) -> list[str]:
+        with (cls._repo_root() / "pyproject.toml").open("rb") as handle:
+            return tomllib.load(handle)["tool"]["hatch"]["build"]["exclude"]
+
+    @classmethod
+    def _gitignore_entries(cls) -> set[str]:
+        text = (cls._repo_root() / ".gitignore").read_text(encoding="utf-8")
+        return {
+            line.strip().rstrip("/")
+            for line in text.splitlines()
+            if line.strip() and not line.startswith("#")
+        }
+
+    def test_every_hatch_exclude_is_gitignored(self):
+        # Compared with the trailing slash normalized away: .gitignore spells a
+        # directory `foo/` and hatch spells it `foo`, and the pairing is about
+        # the path, not the punctuation.
+        gitignored = self._gitignore_entries()
+        for pattern in self._hatch_excludes():
+            assert pattern.rstrip("/") in gitignored, (
+                f"{pattern} is excluded from the build but not gitignored — "
+                "add the matching .gitignore entry"
+            )
+
+    def test_staged_models_are_excluded_from_the_distribution(self):
+        """Named guard for the pair that motivated the rule."""
+        assert "**/prefetched-models" in self._hatch_excludes()
+        assert "**/prefetched-models" in self._gitignore_entries()
 
 
 class TestRegenOwnership:

--- a/tests/cli/test_dockerfile_template.py
+++ b/tests/cli/test_dockerfile_template.py
@@ -100,6 +100,60 @@ class TestDockerfileContent:
             assert "{{" not in text, f"unrendered Jinja in {name}"
             assert "{%" not in text, f"unrendered Jinja in {name}"
 
+    @classmethod
+    def _node_run_body(cls, text: str) -> str:
+        """The single apt RUN that installs Node."""
+        bodies = [b for b in cls._run_command_bodies(text) if "nodejs" in b]
+        assert len(bodies) == 1, f"expected exactly one node-install RUN, got {len(bodies)}"
+        return bodies[0]
+
+    def test_node_comes_from_the_base_image_distro(self, hello_project):
+        """Node and npm are Debian packages, installed in the same apt RUN as the
+        agent's shell tools — one package provenance, and no network beyond the
+        Debian mirror. The list is this image's own (curl/git/procps are runtime
+        tools the agent's shell reaches for); the dispatch image installs a
+        smaller one, so the two are deliberately not asserted as a shared list.
+        """
+        node = self._node_run_body((hello_project / "Dockerfile").read_text())
+        assert (
+            "apt-get install -y --no-install-recommends "
+            "curl git procps ca-certificates nodejs npm" in node
+        ), node
+        assert "rm -rf /var/lib/apt/lists/*" in node
+
+    def test_no_third_party_node_apt_repo(self, hello_project):
+        """No third-party apt repo, and none of the machinery one needs.
+
+        Fetching a vendor's setup script and piping it to a shell adds a second
+        package source to the image, a key to trust, and a network dependency
+        that fails the build wherever that host is unreachable. Asserted over
+        the whole file as an absence, because that is the shape of the
+        regression: any of these tokens reappearing means the pipeline came
+        back.
+        """
+        text = (hello_project / "Dockerfile").read_text()
+        for token in ("nodesource", "gnupg", "setup_20.x", "apt-key"):
+            assert token not in text, f"{token} is back in the Dockerfile — third-party Node repo"
+        node = self._node_run_body(text)
+        assert "| bash" not in node and "| sh" not in node, (
+            "the node layer pipes a downloaded script into a shell"
+        )
+
+    def test_npm_survives_into_the_final_image(self, hello_project):
+        """npm is a runtime dependency, not a build-time convenience.
+
+        The agent is launched as ``npx -y @anthropic-ai/claude-code@<version>``
+        (claude_launcher.py), so an apt cleanup that treats npm as build-only
+        breaks the agent at run time, not at build time. The reason is pinned
+        alongside the absence of any purge in this layer, so a future edit has
+        to confront it.
+        """
+        text = (hello_project / "Dockerfile").read_text()
+        node = self._node_run_body(text)
+        assert "apt-get purge" not in node, "the node layer purges packages"
+        assert "autoremove" not in node, "the node layer autoremoves packages"
+        assert "npm is a runtime dependency, not a build-time convenience" in text
+
     def test_apt_runs_deliver_the_proxy_settings(self, hello_project):
         """Every apt-using RUN hands apt the proxy settings before it fetches.
 
@@ -111,6 +165,19 @@ class TestDockerfileContent:
         assert_apt_runs_carry_proxy_idiom(
             (hello_project / "Dockerfile").read_text(), "rendered project template"
         )
+
+    def test_cli_pin_is_its_own_layer(self, hello_project):
+        """The pinned CLI install stays a separate RUN from the apt layer, so
+        bumping ``CLAUDE_CLI_VERSION`` does not re-run apt."""
+        text = (hello_project / "Dockerfile").read_text()
+        cli_bodies = [
+            b
+            for b in self._run_command_bodies(text)
+            if "npm install -g" in b and "@anthropic-ai/claude-code" in b
+        ]
+        assert len(cli_bodies) == 1, f"expected exactly one CLI-install RUN, got {len(cli_bodies)}"
+        assert 'npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"' in cli_bodies[0]
+        assert "nodejs" not in cli_bodies[0], "the CLI pin shares a RUN with the apt install"
 
     @classmethod
     def _deps_run_body(cls, text: str) -> str:

--- a/tests/deployment/_proxy_idiom.py
+++ b/tests/deployment/_proxy_idiom.py
@@ -1,0 +1,113 @@
+"""The one place the shipped Dockerfiles' proxy-delivery idiom is spelled.
+
+Every OSPREY image installs Debian packages, and on a site network that apt
+traffic has to go through a proxy. Operators configure the proxy with the
+uppercase spellings (``HTTP_PROXY``/``HTTPS_PROXY``/``NO_PROXY``, the names
+``.env.shared`` documents and the ones a container runtime forwards into the
+build), while apt itself reads the lowercase ones — so every layer that runs
+``apt-get`` bridges the two before it does anything else:
+
+``export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" ...``
+
+which fills each lowercase name from its uppercase counterpart while leaving an
+explicitly-set lowercase value alone, and expands to the empty string (not an
+unbound-variable error) when neither is set.
+
+:func:`assert_apt_runs_carry_proxy_idiom` is that rule as an assertion, applied
+to every shipped recipe from :mod:`tests.deployment.test_service_dockerfiles`
+(the on-disk service and module Dockerfiles) and
+:mod:`tests.cli.test_dockerfile_template` (the rendered project template). It is
+deliberately the *only* place the export string appears in the test suite: a
+future move to a different single idiom edits this module, not an assertion in
+each of the nine recipes.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: The canonical bridge, keyed on its first assignment. An apt-using RUN opens
+#: with this and may follow it with further exports (see :data:`_ARG_EXPORT`).
+PROXY_EXPORT_BRIDGE = 'export http_proxy="${http_proxy:-${HTTP_PROXY:-}}"'
+
+#: The alternative accepted idiom: an opening export that delivers the proxy
+#: settings from a declared build ARG rather than from the ambient environment
+#: — ``export NO_PROXY="$PIP_NO_PROXY" no_proxy="$PIP_NO_PROXY"`` and kin.
+_ARG_EXPORT = re.compile(
+    r"^export\s+(?:[A-Za-z_]+=\S+\s+)*"
+    r"(?:http_proxy|https_proxy|no_proxy|HTTP_PROXY|HTTPS_PROXY|NO_PROXY)="
+    r'"?\$\{?[A-Za-z_][A-Za-z0-9_]*'
+)
+
+#: Statement separators. The bridge is one simple command, so the text before
+#: the first of these is the RUN's opening statement.
+_STATEMENT_BREAK = re.compile(r";|&&|\|\|")
+
+
+def run_instructions(text: str) -> list[str]:
+    """Every ``RUN`` instruction in *text*, reconstructed as Docker runs it.
+
+    Line continuations are joined, and a comment line *inside* a continuation
+    is dropped rather than folded into the body — which is how Docker treats
+    it, and the difference matters: a naive join turns everything after such a
+    comment into inert shell comment text, hiding the commands that actually
+    run.
+    """
+    blocks: list[list[str]] = []
+    current: list[str] | None = None
+    for line in text.splitlines():
+        if current is None and not line.startswith("RUN "):
+            continue
+        if current is not None and line.strip().startswith("#"):
+            continue
+        current = [line] if current is None else [*current, line]
+        if not line.rstrip().endswith("\\"):
+            blocks.append(current)
+            current = None
+    if current:
+        blocks.append(current)
+    return [re.sub(r"\\\n\s*", " ", "\n".join(block)) for block in blocks]
+
+
+def apt_run_instructions(text: str) -> list[str]:
+    """The apt-using ``RUN`` instructions in *text*.
+
+    An **apt-using RUN** is a RUN whose reconstructed instruction (see
+    :func:`run_instructions`) invokes ``apt-get`` anywhere in its body — the
+    install itself, but equally a ``purge``/``autoremove`` cleanup, since those
+    reach the network too. A RUN that only edits apt's *configuration* (mirror
+    rewrites, retry settings) does not qualify; it needs no proxy to succeed.
+    """
+    return [instr for instr in run_instructions(text) if "apt-get" in instr]
+
+
+def _opening_statement(instruction: str) -> str:
+    """The first shell statement of a reconstructed ``RUN`` instruction."""
+    body = instruction[len("RUN ") :] if instruction.startswith("RUN ") else instruction
+    return _STATEMENT_BREAK.split(body, maxsplit=1)[0].strip()
+
+
+def carries_proxy_idiom(instruction: str) -> bool:
+    """Whether a reconstructed RUN opens with a proxy-delivery idiom."""
+    opening = _opening_statement(instruction)
+    return opening.startswith(PROXY_EXPORT_BRIDGE) or bool(_ARG_EXPORT.match(opening))
+
+
+def assert_apt_runs_carry_proxy_idiom(text: str, label: str) -> None:
+    """Assert every apt-using RUN in *text* delivers the proxy settings.
+
+    *label* names the recipe in failure messages (e.g. ``"qmd"``). The recipe
+    must contain at least one apt-using RUN: a file this is called on with
+    nothing to check is a parse failure, not a pass.
+    """
+    apt_runs = apt_run_instructions(text)
+    assert apt_runs, (
+        f"{label}: no apt-using RUN found — either the recipe stopped installing "
+        f"packages, or the RUN parser no longer matches how it is written"
+    )
+    for instruction in apt_runs:
+        assert carries_proxy_idiom(instruction), (
+            f"{label}: an apt-using RUN does not open with the proxy-delivery "
+            f"idiom, so an apt fetch behind a site proxy hangs at build time:\n"
+            f"{instruction}"
+        )

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -3834,3 +3834,307 @@ def test_parse_only_step_proves_the_env_chain_interpolates__mutation_drops_a_sen
     assert "local-wins" in step["run"]  # the other sentinel survives
     with pytest.raises(AssertionError, match="shared-loses"):
         test_parse_only_step_proves_the_env_chain_interpolates(mutated)
+
+
+# ---------------------------------------------------------------------------
+# The proxied build inside dockerfile-e2e
+# ---------------------------------------------------------------------------
+#
+# The nine template Dockerfiles bridge the uppercase proxy variables a facility
+# hands a build into the lowercase ones apt reads. Nothing about that bridge is
+# observable from a build's exit status on a runner with open egress: delete
+# the export and apt simply fetches directly, and the build still succeeds. The
+# lane therefore routes a real build through a tinyproxy and asserts on the
+# PROXY'S ACCESS LOG, and what is pinned here is that it keeps doing exactly
+# that — the failure mode these guards exist for is a sequence that survives as
+# a green step while proving nothing.
+
+DOCKERFILE_E2E_JOB = "dockerfile-e2e"
+PROXY_START_STEP = "Start a logging forward proxy (tinyproxy)"
+PROXY_CONTRACT_STEP = "Assert the uppercase-only proxy contract reaches the build"
+PROXY_BUILD_STEP = "Build the web-terminal auth sidecar through the proxy"
+PROXY_ASSERT_STEP = "Assert apt and pip traffic went through the proxy"
+PROXY_STOP_STEP = "Stop the forward proxy"
+PROXY_SEQUENCE = (
+    PROXY_START_STEP,
+    PROXY_CONTRACT_STEP,
+    PROXY_BUILD_STEP,
+    PROXY_ASSERT_STEP,
+    PROXY_STOP_STEP,
+)
+#: The host-side path the proxy's access log is mounted to and read back from.
+PROXY_ACCESS_LOG = "/tmp/osprey-proxy/access.log"
+#: The apt mirror the template Dockerfiles rewrite their sources to. This is
+#: the half that proves the BRIDGE: apt reads no uppercase proxy variable, so
+#: its traffic can only reach the proxy through the Dockerfile's export.
+PROXY_APT_HOST = "deb.debian.org"
+#: The pip side — either host is enough to show the framework install was
+#: proxied too.
+PROXY_PIP_HOSTS = ("pypi.org", "files.pythonhosted.org")
+#: The build context: small, and it uses both apt and pip.
+PROXIED_BUILD_TARGET = "src/osprey/templates/modules/web_terminals/auth_sidecar"
+_UPPERCASE_PROXY_ARG_RE = re.compile(r"--build-arg\s+(HTTP_PROXY|HTTPS_PROXY)=")
+_LOWERCASE_PROXY_ARG_RE = re.compile(r"--build-arg\s+(http_proxy|https_proxy)=")
+
+
+def _proxy_step_run(wf: dict[str, Any], step_name: str) -> str:
+    return _find_named_step(wf, DOCKERFILE_E2E_JOB, step_name)["run"]
+
+
+def test_dockerfile_e2e_carries_the_whole_proxied_sequence(workflow: dict[str, Any]) -> None:
+    """All five steps, checked by name. They are one proof split across steps
+    for readability, and each is independently droppable in a way that leaves
+    the lane green: without the start step the build is unproxied, without the
+    contract probe the log assertion can be satisfied by a runtime rather than
+    by the Dockerfile, without the assertion the build's exit status is all
+    that is left, and without the teardown a fixed-name container keeps port
+    8888 on a shared runner."""
+    for step_name in PROXY_SEQUENCE:
+        _find_named_step(workflow, DOCKERFILE_E2E_JOB, step_name)
+
+
+@pytest.mark.parametrize("dropped", PROXY_SEQUENCE)
+def test_dockerfile_e2e_carries_the_whole_proxied_sequence__mutation_drops_one(
+    dropped: str,
+) -> None:
+    """Dropping any single step must fail — otherwise the check is satisfied
+    by the other four and the sequence can be dismantled one step at a time."""
+    mutated = copy.deepcopy(_load_workflow())
+    steps = _jobs(mutated)[DOCKERFILE_E2E_JOB]["steps"]
+    steps.remove(_find_named_step(mutated, DOCKERFILE_E2E_JOB, dropped))
+    with pytest.raises(AssertionError, match=re.escape(dropped)):
+        test_dockerfile_e2e_carries_the_whole_proxied_sequence(mutated)
+
+
+def test_proxy_assertion_reads_the_access_log(workflow: dict[str, Any]) -> None:
+    """The assertion must be about LOG CONTENT. On this runner the internet is
+    directly reachable, so a build whose bridge was deleted exits 0 all the
+    same: an exit-status check would be a green step over a broken bridge.
+    Both host classes are required, and separately — apt proves the lowercase
+    bridge, pip proves the proxy was engaged for the framework install."""
+    run_text = _proxy_step_run(workflow, PROXY_ASSERT_STEP)
+    assert PROXY_ACCESS_LOG in run_text, (
+        f"'{PROXY_ASSERT_STEP}' must read the proxy's access log at {PROXY_ACCESS_LOG}"
+    )
+    assert PROXY_APT_HOST in run_text, (
+        f"'{PROXY_ASSERT_STEP}' must assert that {PROXY_APT_HOST} traffic reached the proxy"
+    )
+    assert any(host in run_text for host in PROXY_PIP_HOSTS), (
+        f"'{PROXY_ASSERT_STEP}' must assert that pip traffic ({' or '.join(PROXY_PIP_HOSTS)}) "
+        f"reached the proxy"
+    )
+
+
+def test_proxy_assertion_reads_the_access_log__mutation_checks_exit_status_instead() -> None:
+    """The shape this guard exists for: an assertion step reduced to "the build
+    exited 0", which on an open-egress runner is true whether or not anything
+    was proxied."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_ASSERT_STEP)
+    step["run"] = 'set -euo pipefail\necho "✅ the proxied build exited 0"\n'
+    with pytest.raises(AssertionError, match="access log"):
+        test_proxy_assertion_reads_the_access_log(mutated)
+
+
+def test_proxy_assertion_reads_the_access_log__mutation_drops_only_the_apt_host() -> None:
+    """Losing the apt half must fail on its own. It is the half that proves the
+    bridge — pip honours the uppercase names unaided, so a pip-only assertion
+    would stay green with every `export http_proxy=…` line deleted."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_ASSERT_STEP)
+    original = step["run"]
+    step["run"] = original.replace(PROXY_APT_HOST, "example.invalid")
+    assert step["run"] != original, f"no {PROXY_APT_HOST} in the step — mutation is stale"
+    assert any(host in step["run"] for host in PROXY_PIP_HOSTS)  # the pip half survives
+    with pytest.raises(AssertionError, match=PROXY_APT_HOST):
+        test_proxy_assertion_reads_the_access_log(mutated)
+
+
+def test_proxy_assertion_reads_the_access_log__mutation_drops_only_the_pip_hosts() -> None:
+    """And losing the pip half must fail too, so the two are independent."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_ASSERT_STEP)
+    original = step["run"]
+    for host in PROXY_PIP_HOSTS:
+        step["run"] = step["run"].replace(host, "example.invalid")
+    assert step["run"] != original, "no pip host in the step — mutation is stale"
+    assert PROXY_APT_HOST in step["run"]  # the apt half survives
+    with pytest.raises(AssertionError, match="pip traffic"):
+        test_proxy_assertion_reads_the_access_log(mutated)
+
+
+def test_proxied_build_passes_only_uppercase_proxy_build_args(workflow: dict[str, Any]) -> None:
+    """Uppercase in, and nothing else. The lowercase spelling is what the
+    Dockerfile itself is supposed to derive; handing it to the build directly
+    would satisfy apt without the export ever running, which is the same
+    vacuous green as asserting on exit status."""
+    run_text = _proxy_step_run(workflow, PROXY_BUILD_STEP)
+    passed = {match.group(1) for match in _UPPERCASE_PROXY_ARG_RE.finditer(run_text)}
+    assert passed == {"HTTP_PROXY", "HTTPS_PROXY"}, (
+        f"'{PROXY_BUILD_STEP}' must pass both uppercase proxy build-args; got {sorted(passed)}"
+    )
+    lowercase = _LOWERCASE_PROXY_ARG_RE.search(run_text)
+    assert lowercase is None, (
+        f"'{PROXY_BUILD_STEP}' passes a lowercase proxy build-arg "
+        f"({lowercase.group(1) if lowercase else ''}) — the Dockerfile's bridge must be the "
+        f"only source of it, or the lane proves nothing"
+    )
+
+
+def test_proxied_build_passes_only_uppercase_proxy_build_args__mutation_drops_https() -> None:
+    """Dropping either uppercase arg must fail: pip and apt both reach their
+    hosts over HTTPS, so HTTP_PROXY alone routes neither."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_BUILD_STEP)
+    original = step["run"]
+    step["run"] = re.sub(r"\s*--build-arg\s+HTTPS_PROXY=\S+\s*\\\n", "\n", original)
+    assert step["run"] != original, "HTTPS_PROXY build-arg not found — mutation is stale"
+    with pytest.raises(AssertionError, match="both uppercase proxy build-args"):
+        test_proxied_build_passes_only_uppercase_proxy_build_args(mutated)
+
+
+def test_proxied_build_passes_only_uppercase_proxy_build_args__mutation_adds_lowercase() -> None:
+    """Adding the lowercase spelling alongside is the plausible "just make the
+    build work" edit, and it silently retires the thing under test."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_BUILD_STEP)
+    original = step["run"]
+    step["run"] = original.replace(
+        "--build-arg HTTP_PROXY=",
+        "--build-arg http_proxy=http://127.0.0.1:8888 \\\n  --build-arg HTTP_PROXY=",
+    )
+    assert step["run"] != original, "HTTP_PROXY build-arg not found — mutation is stale"
+    with pytest.raises(AssertionError, match="lowercase proxy build-arg"):
+        test_proxied_build_passes_only_uppercase_proxy_build_args(mutated)
+
+
+def test_proxied_build_uses_a_case_preserving_runtime(workflow: dict[str, Any]) -> None:
+    """Measured, not assumed: docker's BuildKit expands `--build-arg
+    HTTP_PROXY=…` into BOTH `HTTP_PROXY` and `http_proxy` inside RUN, so a
+    docker build would satisfy the access-log assertion with the Dockerfile's
+    bridge deleted. podman (buildah) passes the names it is given. The runtime
+    is therefore part of the proof, and the contract probe step re-checks it on
+    the runner every run."""
+    run_text = _proxy_step_run(workflow, PROXY_BUILD_STEP)
+    assert "podman build" in run_text, (
+        f"'{PROXY_BUILD_STEP}' must build with podman — see the docstring"
+    )
+    assert "docker build" not in run_text, (
+        f"'{PROXY_BUILD_STEP}' must not build with docker: BuildKit supplies the lowercase "
+        f"proxy variables itself, which is precisely what the Dockerfile bridge is for"
+    )
+
+
+def test_proxied_build_uses_a_case_preserving_runtime__mutation_switches_to_docker() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_BUILD_STEP)
+    original = step["run"]
+    step["run"] = original.replace("podman build", "docker build")
+    assert step["run"] != original, "no podman build in the step — mutation is stale"
+    with pytest.raises(AssertionError):
+        test_proxied_build_uses_a_case_preserving_runtime(mutated)
+
+
+def test_contract_probe_rejects_a_runtime_that_injects_lowercase(workflow: dict[str, Any]) -> None:
+    """The probe is what keeps the whole sequence honest across runtime
+    upgrades, so its two halves are pinned: the uppercase value must be seen to
+    arrive, and a lowercase one must be seen NOT to. A probe that only checked
+    the first would go on passing on a runtime that supplies both."""
+    run_text = _proxy_step_run(workflow, PROXY_CONTRACT_STEP)
+    assert "HTTP_PROXY=" in run_text, (
+        f"'{PROXY_CONTRACT_STEP}' must assert the uppercase value reaches the RUN environment"
+    )
+    assert "http_proxy=" in run_text, (
+        f"'{PROXY_CONTRACT_STEP}' must fail when the runtime injects a lowercase proxy "
+        f"variable of its own — without that half the log assertion can be satisfied by "
+        f"the build runtime instead of by the Dockerfile"
+    )
+
+
+def test_contract_probe_rejects_a_runtime_that_injects_lowercase__mutation_drops_the_half() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_CONTRACT_STEP)
+    original = step["run"]
+    step["run"] = "\n".join(line for line in original.splitlines() if "http_proxy=" not in line)
+    assert step["run"] != original, "no lowercase check in the probe — mutation is stale"
+    assert "HTTP_PROXY=" in step["run"]  # the uppercase half survives
+    with pytest.raises(AssertionError, match="lowercase proxy"):
+        test_contract_probe_rejects_a_runtime_that_injects_lowercase(mutated)
+
+
+def test_proxied_build_threads_the_version_args(workflow: dict[str, Any]) -> None:
+    """The sidecar Dockerfile exits non-zero on an empty ``OSPREY_VERSION``,
+    and a branch version is usually not on PyPI — ``OSPREY_DEV=1`` is what
+    turns that pin miss into an unpinned prime. Both are threaded explicitly so
+    the proxy bridge stays the only thing that can fail in this build."""
+    run_text = _proxy_step_run(workflow, PROXY_BUILD_STEP)
+    assert "--build-arg OSPREY_VERSION=" in run_text, (
+        f"'{PROXY_BUILD_STEP}' must pass OSPREY_VERSION; the Dockerfile requires it"
+    )
+    assert "--build-arg OSPREY_DEV=1" in run_text, (
+        f"'{PROXY_BUILD_STEP}' must pass OSPREY_DEV=1 so an unreleased pin falls back "
+        f"to an unpinned prime instead of failing the build"
+    )
+    assert PROXIED_BUILD_TARGET in run_text, (
+        f"'{PROXY_BUILD_STEP}' must build from {PROXIED_BUILD_TARGET}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("dropped", "message"),
+    [
+        ("--build-arg OSPREY_DEV=1", "OSPREY_DEV=1"),
+        ("--build-arg OSPREY_VERSION=", "OSPREY_VERSION"),
+    ],
+)
+def test_proxied_build_threads_the_version_args__mutation_drops_one(
+    dropped: str, message: str
+) -> None:
+    """Either one missing turns a bridge failure and a version failure into the
+    same red step, which is the reading problem this threading exists to avoid."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_BUILD_STEP)
+    original = step["run"]
+    step["run"] = original.replace(dropped, "--build-arg UNRELATED=")
+    assert step["run"] != original, f"{dropped!r} not found — mutation is stale"
+    with pytest.raises(AssertionError, match=message):
+        test_proxied_build_threads_the_version_args(mutated)
+
+
+def test_every_proxied_step_sets_pipefail(workflow: dict[str, Any]) -> None:
+    """GitHub's default shell is ``bash -e`` WITHOUT pipefail, so a pipeline
+    reports its last command's status. These steps grep for evidence of
+    absence, which is exactly the shape a swallowed status turns into a silent
+    pass."""
+    for step_name in PROXY_SEQUENCE:
+        run_text = _proxy_step_run(workflow, step_name)
+        assert "set -euo pipefail" in run_text, f"'{step_name}' must open with `set -euo pipefail`"
+
+
+def test_every_proxied_step_sets_pipefail__mutation_drops_it_from_one() -> None:
+    """One step losing it is enough to fail — the guard must not be satisfied
+    by its neighbours."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_ASSERT_STEP)
+    original = step["run"]
+    step["run"] = original.replace("set -euo pipefail", "set -e")
+    assert step["run"] != original, "no pipefail in the step — mutation is stale"
+    with pytest.raises(AssertionError, match=re.escape(PROXY_ASSERT_STEP)):
+        test_every_proxied_step_sets_pipefail(mutated)
+
+
+def test_proxy_teardown_runs_even_when_the_assertion_fails(workflow: dict[str, Any]) -> None:
+    """The proxy is a fixed-name container holding a fixed port on a runner
+    other steps share. A teardown that only runs on success leaves it behind
+    for precisely the run that failed."""
+    step = _find_named_step(workflow, DOCKERFILE_E2E_JOB, PROXY_STOP_STEP)
+    assert step.get("if") == "always()", (
+        f"'{PROXY_STOP_STEP}' must carry `if: always()`; got {step.get('if')!r}"
+    )
+
+
+def test_proxy_teardown_runs_even_when_the_assertion_fails__mutation_drops_the_condition() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    del _find_named_step(mutated, DOCKERFILE_E2E_JOB, PROXY_STOP_STEP)["if"]
+    with pytest.raises(AssertionError, match="always"):
+        test_proxy_teardown_runs_even_when_the_assertion_fails(mutated)

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -63,6 +63,9 @@ def captured_argv(monkeypatch, tmp_path):
     captured: dict = {}
 
     monkeypatch.chdir(tmp_path)
+    # An operator shell that exported the prebuilt-images switch would delete
+    # the dev-mode build from every deploy driven here (see the switch tests).
+    monkeypatch.delenv("OSPREY_PREBUILT_IMAGES", raising=False)
     monkeypatch.setattr(
         container_lifecycle,
         "prepare_compose_files",
@@ -457,6 +460,9 @@ def captured_combined_runs(monkeypatch, tmp_path):
     token_calls: list[dict] = []
 
     monkeypatch.chdir(tmp_path)
+    # Same hygiene as captured_argv: the switch tests set this deliberately, and
+    # an exported one would otherwise remove the build these tests count.
+    monkeypatch.delenv("OSPREY_PREBUILT_IMAGES", raising=False)
     # Registry mode (default) -- pre-write .env.users so
     # ensure_env_production's exists-check passes (see captured_web_runs).
     (tmp_path / ".env.users").write_text("", encoding="utf-8")
@@ -2034,6 +2040,198 @@ class TestResolvePipSpec:
 
         with pytest.raises(UnreleasedVersionPinError):
             container_lifecycle._resolve_pip_spec(dev_mode=False)
+
+
+class TestResolvePrebuiltImages:
+    """Some deployment hosts cannot build images at all.
+
+    No build tooling, no reachable registry, images side-loaded from a tarball
+    instead. There a dev deploy's ``compose build`` is not slow but impossible,
+    and the only thing that can run is an ``up`` against tags already present.
+    """
+
+    def test_the_default_is_to_build(self, monkeypatch):
+        monkeypatch.delenv("OSPREY_PREBUILT_IMAGES", raising=False)
+        assert container_lifecycle._resolve_prebuilt_images({}) is False
+
+    @pytest.mark.parametrize("value", sorted(container_lifecycle._TRUTHY))
+    def test_every_on_spelling_is_accepted(self, monkeypatch, value):
+        """Operators reach for whichever word the rest of the framework took.
+
+        A spelling that parsed as "off" would start a build on a host that
+        cannot run one, and the failure would name compose rather than the
+        variable that was misread.
+        """
+        monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", value)
+        assert container_lifecycle._resolve_prebuilt_images({}) is True
+
+    @pytest.mark.parametrize("value", sorted(container_lifecycle._FALSY))
+    def test_every_off_spelling_overrides_a_config_that_says_prebuilt(self, monkeypatch, value):
+        """The env var wins in both directions, not just when it says "on".
+
+        A one-way override would leave a config-pinned host unable to prove its
+        build works again without an edit someone has to remember to revert.
+        """
+        monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", value)
+        assert container_lifecycle._resolve_prebuilt_images({"prebuilt_images": True}) is False
+
+    @pytest.mark.parametrize("value", [" true ", "TRUE", "\tYes\n", "On"])
+    def test_case_and_surrounding_whitespace_do_not_change_the_answer(self, monkeypatch, value):
+        """A value pasted out of a shell script keeps its padding."""
+        monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", value)
+        assert container_lifecycle._resolve_prebuilt_images({}) is True
+
+    def test_the_config_key_turns_the_switch_on(self, monkeypatch):
+        monkeypatch.delenv("OSPREY_PREBUILT_IMAGES", raising=False)
+        assert container_lifecycle._resolve_prebuilt_images({"prebuilt_images": True}) is True
+
+    def test_the_config_key_can_also_spell_out_the_default(self, monkeypatch):
+        monkeypatch.delenv("OSPREY_PREBUILT_IMAGES", raising=False)
+        assert container_lifecycle._resolve_prebuilt_images({"prebuilt_images": False}) is False
+
+    def test_env_on_overrides_a_config_that_says_build(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "yes")
+        assert container_lifecycle._resolve_prebuilt_images({"prebuilt_images": False}) is True
+
+    @pytest.mark.parametrize("value", ["", "   ", "maybe", "2", "yes please"])
+    def test_an_unreadable_value_defers_to_the_config(self, monkeypatch, value):
+        """An empty or unrecognized export must not silently mean "off".
+
+        Reading it as a decision would let a stray ``OSPREY_PREBUILT_IMAGES=``
+        in an env file quietly re-enable building on a host whose config
+        already said it cannot build.
+        """
+        monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", value)
+        assert container_lifecycle._resolve_prebuilt_images({"prebuilt_images": True}) is True
+        assert container_lifecycle._resolve_prebuilt_images({}) is False
+
+
+# ---------------------------------------------------------------------------
+# The prebuilt-images switch at the two dev-mode build sites
+# ---------------------------------------------------------------------------
+
+
+def _dev_deploy_cmds(monkeypatch, tmp_path, config_extra: dict | None = None) -> list[list[str]]:
+    """Every argv a ``--dev`` deploy runs down the plain (no web) path."""
+    cmds: list[list[str]] = []
+    config = {"deployed_services": ["event_dispatcher"], **(config_extra or {})}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (config, ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    # The project image is built by its own helper, outside the compose build
+    # this switch gates; leaving it live would add argv that says nothing about
+    # which branch ran.
+    monkeypatch.setattr(container_lifecycle, "_build_project_image", lambda *a, **k: None)
+
+    def _fake_run(cmd, env=None, check=False, **kwargs):
+        cmds.append(list(cmd))
+        return _FakeCompletedProcess(returncode=0)
+
+    monkeypatch.setattr(container_lifecycle.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        container_lifecycle.subprocess,
+        "Popen",
+        _fake_popen(lambda cmd, env: cmds.append(list(cmd))),
+    )
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True, dev_mode=True)
+    return cmds
+
+
+def _compose_builds(cmds: list[list[str]]) -> list[list[str]]:
+    return [cmd for cmd in cmds if cmd[-1] == "build" and _addresses(cmd, "docker-compose.yml")]
+
+
+def test_a_dev_deploy_builds_the_service_images_by_default(monkeypatch, tmp_path):
+    """The baseline the switch has to leave alone."""
+    monkeypatch.delenv("OSPREY_PREBUILT_IMAGES", raising=False)
+
+    cmds = _dev_deploy_cmds(monkeypatch, tmp_path)
+
+    assert len(_compose_builds(cmds)) == 1
+
+
+def test_the_switch_removes_the_services_build_from_a_dev_deploy(monkeypatch, tmp_path):
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "1")
+
+    cmds = _dev_deploy_cmds(monkeypatch, tmp_path)
+
+    assert _compose_builds(cmds) == []
+
+
+def test_the_config_key_removes_it_too(monkeypatch, tmp_path):
+    monkeypatch.delenv("OSPREY_PREBUILT_IMAGES", raising=False)
+
+    cmds = _dev_deploy_cmds(monkeypatch, tmp_path, {"prebuilt_images": True})
+
+    assert _compose_builds(cmds) == []
+
+
+def test_env_off_restores_the_build_a_prebuilt_config_would_have_skipped(monkeypatch, tmp_path):
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "false")
+
+    cmds = _dev_deploy_cmds(monkeypatch, tmp_path, {"prebuilt_images": True})
+
+    assert len(_compose_builds(cmds)) == 1
+
+
+def test_the_up_still_carries_no_build_when_the_build_was_skipped(monkeypatch, tmp_path):
+    """``up --no-build`` is what makes the skip safe on a host that cannot build.
+
+    Without it compose would build on ``up`` instead, moving the failure rather
+    than removing it.
+    """
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "1")
+
+    cmds = _dev_deploy_cmds(monkeypatch, tmp_path)
+
+    up = next(cmd for cmd in cmds if "up" in cmd)
+    assert "--no-build" in up
+    assert "--build" not in up
+
+
+def test_the_web_terminals_path_skips_its_services_build_too(
+    captured_combined_runs, monkeypatch, tmp_path
+):
+    """A web-terminals deploy builds the backend services on its own path.
+
+    That second build site is the one a web-terminals host actually hits, so a
+    switch wired only into the plain path would look correct in tests and still
+    fail the deployment it was written for.
+    """
+    steps: list[str] = []
+    monkeypatch.setattr(provision, "_report_step", steps.append)
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "1")
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=False, dev_mode=True)
+
+    cmds = [c["cmd"] for c in captured_combined_runs["calls"]]
+    assert _compose_builds(cmds) == []
+    assert "skipped image build (prebuilt images)" in steps
+    assert "built service images" not in steps
+
+
+def test_the_web_terminals_path_builds_when_the_switch_is_off(
+    captured_combined_runs, monkeypatch, tmp_path
+):
+    steps: list[str] = []
+    monkeypatch.setattr(provision, "_report_step", steps.append)
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "off")
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=False, dev_mode=True)
+
+    cmds = [c["cmd"] for c in captured_combined_runs["calls"]]
+    assert len(_compose_builds(cmds)) == 1
+    assert "built service images" in steps
+    assert "skipped image build (prebuilt images)" not in steps
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_lifecycle_capture.py
+++ b/tests/deployment/test_lifecycle_capture.py
@@ -395,6 +395,10 @@ def _repo(tmp_path: Path) -> Path:
 @pytest.fixture
 def start_stack_stubs(monkeypatch):
     """The host-touching preflights ``_start_stack`` runs before its compose calls."""
+    # An operator who exported the prebuilt-images switch in their shell would
+    # otherwise silently delete `compose build` from every start sequence below,
+    # reddening tests that are about spooling and have no stake in the switch.
+    monkeypatch.delenv("OSPREY_PREBUILT_IMAGES", raising=False)
     monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
     monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda config, files: None)
     # Asks the runtime which of this project's data volumes exist. Stubbed for
@@ -412,9 +416,15 @@ def start_stack_stubs(monkeypatch):
     )
 
 
-def _start(repo: Path, *, dev_mode: bool = False, detached: bool = True) -> None:
+def _start(
+    repo: Path,
+    *,
+    dev_mode: bool = False,
+    detached: bool = True,
+    config_extra: dict | None = None,
+) -> None:
     container_lifecycle._start_stack(
-        {"project_name": "proj", "deployed_services": ["postgresql"]},
+        {"project_name": "proj", "deployed_services": ["postgresql"], **(config_extra or {})},
         ["build/services/docker-compose.0.yml"],
         repo,
         detached=detached,
@@ -467,6 +477,93 @@ def test_a_non_dev_deploy_does_not_build(captured, reporter, start_stack_stubs, 
 
     assert captured.spool_names == ["compose-rm", "compose-up"]
     assert "service images built" not in reporter.steps
+
+
+def test_prebuilt_images_replace_the_build_with_a_step_that_says_so(
+    captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path, monkeypatch
+):
+    """A host with the tags already loaded runs the same sequence minus the build.
+
+    The step line is the whole point of skipping in place rather than silently:
+    a deploy that prints nothing where the longest step used to be reads as a
+    build that finished suspiciously fast, and the operator has no way to tell
+    whether the images running are the ones they loaded.
+    """
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "1")
+    repo = _repo(tmp_path)
+
+    _start(repo, dev_mode=True)
+
+    assert captured.spool_names == ["compose-rm", "compose-up"]
+    assert reporter.steps == [
+        "cleared stopped containers",
+        "skipped image build (prebuilt images)",
+        "containers started",
+    ]
+
+
+def test_prebuilt_images_leave_the_up_asking_not_to_build(
+    captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path, monkeypatch
+):
+    """``--no-build`` has to survive the skip.
+
+    Dropping it here would hand the build back to compose's implicit
+    build-on-up — on the one kind of host that cannot build — and the deploy
+    would fail at the step the switch exists to remove.
+    """
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "1")
+
+    _start(_repo(tmp_path), dev_mode=True)
+
+    assert "--no-build" in captured.call("compose-up")["cmd"]
+
+
+def test_the_config_key_skips_the_build_without_an_env_var(
+    captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path
+):
+    """The switch has to be a property of the deployment, not of one shell.
+
+    A host that can never build should say so once in its config rather than
+    relying on every operator exporting the variable before every deploy.
+    """
+    _start(_repo(tmp_path), dev_mode=True, config_extra={"prebuilt_images": True})
+
+    assert captured.spool_names == ["compose-rm", "compose-up"]
+    assert "skipped image build (prebuilt images)" in reporter.steps
+
+
+def test_the_env_var_can_force_a_build_the_config_would_have_skipped(
+    captured, reporter, start_stack_stubs, no_bare_subprocess, tmp_path, monkeypatch
+):
+    """The override runs both ways, so a pinned host stays debuggable.
+
+    Once build tooling is available again, proving it works must not require
+    editing the deploy config — otherwise the first thing anyone tries is a
+    change they then have to remember to revert.
+    """
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "0")
+
+    _start(_repo(tmp_path), dev_mode=True, config_extra={"prebuilt_images": True})
+
+    assert captured.spool_names == ["compose-rm", "compose-build", "compose-up"]
+    assert "service images built" in reporter.steps
+    assert "skipped image build (prebuilt images)" not in reporter.steps
+
+
+def test_a_non_dev_deploy_is_unaffected_by_the_switch(
+    captured, reporter, start_stack_stubs, tmp_path, monkeypatch
+):
+    """Non-dev never ran a separate build, so there is nothing for it to skip.
+
+    Emitting the skip line here would claim a decision the switch did not make,
+    and would report it on every ordinary deploy.
+    """
+    monkeypatch.setenv("OSPREY_PREBUILT_IMAGES", "1")
+
+    _start(_repo(tmp_path))
+
+    assert captured.spool_names == ["compose-rm", "compose-up"]
+    assert "skipped image build (prebuilt images)" not in reporter.steps
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_qmd_compose_fragment.py
+++ b/tests/deployment/test_qmd_compose_fragment.py
@@ -9,23 +9,36 @@ so the agreement is asserted here rather than assumed, and both renders go
 through the production injection (``_inject_project_metadata``) so what is
 tested is the derivation a deploy actually uses.
 
-Three further properties carry the design and each has its own test:
+Four further properties carry the design and each has its own test:
 
 * **The published port is 8180, never 8181.** qmd's own daemon hardcodes
-  ``listen(port, "localhost")`` and binds ``[::1]`` only, so it is unreachable
-  from any other container; the entrypoint fronts it with a forwarder that owns
-  the routable port. Publishing 8181 would publish nothing.
+  ``listen(port, "localhost")`` — no ``--host`` flag, no env override — so it
+  answers only on a loopback address inside the container, unreachable from any
+  other container. Which loopback family that is depends on the host: Node
+  resolves ``localhost`` to ``[::1]`` on some image/host combinations and to
+  ``127.0.0.1`` on others. So the entrypoint runs the daemon on an internal
+  port, probes both families for ``/health``, and points a socat forwarder at
+  whichever one answered; the forwarder owns the published port. Publishing
+  8181 would publish nothing.
 * **The publish interface is project-wide.** ``deployment.bind_address``
   decides it, and a per-service ``bind_address`` is deliberately inert — the
   endpoint is unauthenticated, so it must not be possible to expose it on an
   interface the rest of the stack is not on.
 * **The index survives a recreate.** It is a named volume, not a bind and not
   container-local: rebuilding it costs ~41 minutes at ALS scale.
+* **Pre-staged models are two edits or none.** ``services.qmd.models_dir`` gates
+  a build arg (which tells the image build to skip the 2.1 GB of downloads) and
+  a read-only bind mount (which supplies those same files at runtime). One
+  without the other is the silent no-models failure: an image built with nothing
+  baked in and nothing mounted. The last two sections assert that the two sites
+  fire together, and that the literal strings they share with the image's
+  Dockerfile still agree with it.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import shutil
 
 import pytest
@@ -112,6 +125,20 @@ def compose_service(**kwargs) -> dict:
     return yaml.safe_load(render_compose(**kwargs))["services"]["qmd"]
 
 
+def _packaged_text(rel_path: str) -> str:
+    """Read a packaged sidecar file that is NOT a template.
+
+    The Dockerfile and the entrypoint carry no Jinja — they are copied into the
+    build context verbatim — so the tests that pair the fragment with them read
+    the shipped bytes rather than a render.
+    """
+    from importlib import resources
+
+    import osprey
+
+    return resources.files(osprey).joinpath("templates", rel_path).read_text()
+
+
 #: The two corpora a fully-configured deployment mounts, as they appear in
 #: config. Spelled once so every test that needs "both corpora" agrees.
 BOTH_CORPORA = {
@@ -130,9 +157,10 @@ BOTH_CORPORA = {
 def test_publishes_8180_not_qmds_own_8181():
     """8180 is the forwarder's port; 8181 is the unreachable daemon's.
 
-    qmd binds IPv6 loopback only and offers no ``--host`` flag, so a fragment
-    that published 8181 would publish a port nothing outside the container's own
-    namespace can reach.
+    qmd binds a loopback address — whichever family the host resolves
+    ``localhost`` to — and offers no ``--host`` flag, so a fragment that
+    published 8181 would publish a port nothing outside the container's own
+    namespace can reach on either family.
     """
     service = compose_service()
 
@@ -544,3 +572,253 @@ def test_setup_build_dir_produces_both_of_the_sidecars_artifacts(tmp_path, monke
     assert index["collections"]["okf"]["path"] == "/corpus/okf"
     # The templates themselves must never land in a build context.
     assert not list(out.glob("*.j2"))
+
+
+# ---------------------------------------------------------------------------
+# Pre-staged models
+# ---------------------------------------------------------------------------
+
+#: A host directory of pre-staged GGUF files, as an operator would configure it.
+MODELS_DIR = "/srv/osprey/qmd-models"
+
+#: Where the image looks for them. Spelled here and checked against the
+#: Dockerfile's ``OSPREY_QMD_MODEL_DIR`` in the drift section below — compose
+#: cannot expand the image's own ENV, so the fragment has to carry the literal.
+MODELS_TARGET = "/opt/qmd/.cache/qmd/models"
+
+#: Build arg that tells the image build the models arrive at runtime. Same
+#: pairing: the name is a literal on both sides, drift-checked below.
+MODELS_BUILD_ARG = "OSPREY_QMD_MODELS_MOUNTED"
+
+
+def _build_args(service: dict) -> dict:
+    return service["build"]["args"]
+
+
+def _models_mounts(service: dict) -> list[str]:
+    return [v for v in service["volumes"] if MODELS_TARGET in v]
+
+
+def test_no_models_dir_renders_neither_the_build_arg_nor_the_mount():
+    service = compose_service()
+
+    assert MODELS_BUILD_ARG not in _build_args(service)
+    assert _models_mounts(service) == []
+
+
+def test_no_models_dir_leaves_the_fragment_exactly_as_it_was():
+    """The unset state is the default, so it has to render the pre-change shape.
+
+    Asserted as whole collections rather than as absences: an extra build arg or
+    an extra volume that happened not to mention the model directory would slip
+    past a negative check, and both are things a deployment acts on.
+    """
+    service = compose_service()
+
+    assert _build_args(service) == {"OSPREY_PROJECT_NAME": "demo"}
+    assert service["volumes"] == [
+        "qmd_index:/var/lib/qmd",
+        "./build/services/qmd/index.yml:/etc/qmd/index.yml:ro",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("qmd", "expected"),
+    [({}, False), ({"models_dir": MODELS_DIR}, True)],
+    ids=["unset", "set"],
+)
+def test_the_build_arg_and_the_mount_fire_together(qmd, expected):
+    """One config key drives both sites, and neither may render without the other.
+
+    The build arg alone builds an image with no models baked in and nothing
+    mounted to supply them; the mount alone mounts three files over models the
+    image already has. The first is the silent failure this pairing exists to
+    prevent — the container starts, finds no model, and tries to download one on
+    a host that was configured this way precisely because it cannot.
+    """
+    service = compose_service(qmd=qmd)
+
+    fired = (MODELS_BUILD_ARG in _build_args(service), bool(_models_mounts(service)))
+    assert fired == (expected, expected)
+
+
+def test_models_dir_mounts_the_staged_directory_read_only():
+    service = compose_service(qmd={"models_dir": MODELS_DIR})
+
+    assert _models_mounts(service) == [f"{MODELS_DIR}:{MODELS_TARGET}:ro"]
+
+
+def test_the_build_arg_is_truthy_only_and_carries_no_path():
+    """The Dockerfile tests it with ``-n``. The host path is a HOST path — it
+    means nothing inside the build, and passing it would bake an operator's
+    directory layout into the image for no reader."""
+    args = _build_args(compose_service(qmd={"models_dir": MODELS_DIR}))
+
+    assert args[MODELS_BUILD_ARG] == "1"
+    assert MODELS_DIR not in yaml.safe_dump(args)
+
+
+def test_the_mount_source_is_trimmed_like_the_schema_trims_it():
+    """The preflight checks the stripped path; a bind spec that kept the padding
+    would name a different directory than the one that was checked."""
+    service = compose_service(qmd={"models_dir": f"  {MODELS_DIR}  "})
+
+    assert _models_mounts(service) == [f"{MODELS_DIR}:{MODELS_TARGET}:ro"]
+
+
+def test_a_relative_models_dir_refuses_the_render():
+    """Rendering resolves the block through the schema, so a relative path is
+    refused here rather than mounted: the runtime would resolve it against the
+    compose project directory, not against the directory the operator meant."""
+    with pytest.raises(ValueError, match=r"services\.qmd\.models_dir"):
+        compose_service(qmd={"models_dir": "qmd-models"})
+
+
+def test_the_models_mount_precedes_the_corpus_mounts():
+    """Position is not cosmetic: the corpus mounts are emitted by a Jinja loop,
+    and a models mount rendered inside that loop would repeat per corpus."""
+    volumes = compose_service(qmd={"models_dir": MODELS_DIR}, **BOTH_CORPORA)["volumes"]
+
+    models = volumes.index(f"{MODELS_DIR}:{MODELS_TARGET}:ro")
+    corpora = [i for i, v in enumerate(volumes) if ":/corpus/" in v]
+    assert volumes.index("./build/services/qmd/index.yml:/etc/qmd/index.yml:ro") < models
+    assert models < min(corpora)
+
+
+def test_the_models_mount_survives_host_networking():
+    """The network axis suppresses ports and the network stanza. It must not
+    take an unrelated volume with it."""
+    service = yaml.safe_load(render_compose(qmd={"network": "host", "models_dir": MODELS_DIR}))[
+        "services"
+    ]["qmd"]
+
+    assert _models_mounts(service) == [f"{MODELS_DIR}:{MODELS_TARGET}:ro"]
+
+
+# ---------------------------------------------------------------------------
+# The fragment against the image it configures
+# ---------------------------------------------------------------------------
+# Two literal strings cross from the Dockerfile into the compose fragment — the
+# directory the models are mounted at and the name of the build arg that gates
+# the fetches. Neither can be expanded at render or at compose time: the ENV and
+# the ARG exist only inside the image, while `${...}` in a compose file expands
+# against the HOST environment, where both are unset. So they are spelled twice
+# on purpose, and held together here.
+
+
+def _dockerfile() -> str:
+    return _packaged_text("services/qmd/Dockerfile")
+
+
+def _entrypoint() -> str:
+    return _packaged_text("services/qmd/entrypoint.sh")
+
+
+def _dockerfile_env(name: str) -> str:
+    """The value of one ``ENV NAME=value`` assignment.
+
+    Matches the assignment at the start of a line (``ENV`` blocks continue with
+    a backslash, so most assignments carry no keyword of their own) and so does
+    not match a ``$NAME`` reference further along a ``RUN``.
+    """
+    match = re.search(rf"^[ \t]*(?:ENV[ \t]+)?{re.escape(name)}=(\S+)", _dockerfile(), re.MULTILINE)
+    assert match is not None, f"the Dockerfile no longer sets ENV {name}"
+    return match.group(1)
+
+
+def _dockerfile_arg_default(name: str) -> str:
+    match = re.search(rf"^ARG\s+{re.escape(name)}=(.*)$", _dockerfile(), re.MULTILINE)
+    assert match is not None, f"the Dockerfile no longer declares ARG {name}"
+    return match.group(1).strip().strip('"')
+
+
+def _dockerfile_label_pins() -> dict[str, str]:
+    """The ``com.osprey.qmd.<kind>_sha256`` label literals, by kind."""
+    return dict(re.findall(r'com\.osprey\.qmd\.([a-z]+)_sha256="([0-9a-f]{64})"', _dockerfile()))
+
+
+def test_the_mount_target_is_the_images_model_directory():
+    assert MODELS_TARGET == _dockerfile_env("OSPREY_QMD_MODEL_DIR")
+
+
+def test_the_build_arg_name_is_the_one_the_dockerfile_declares():
+    assert _dockerfile_arg_default(MODELS_BUILD_ARG) == ""
+
+
+def test_only_the_models_leaf_is_read_only_never_qmds_writable_cache():
+    """qmd owns the cache tree above the models directory and writes into it.
+    Mounting the tree read-only instead of the leaf would break the daemon on a
+    write it makes for reasons that have nothing to do with models."""
+    cache_home = _dockerfile_env("XDG_CACHE_HOME")
+    service = compose_service(qmd={"models_dir": MODELS_DIR})
+
+    assert MODELS_TARGET.startswith(f"{cache_home}/")
+    assert MODELS_TARGET != cache_home
+    assert [v for v in service["volumes"] if v.endswith(f":{cache_home}:ro")] == []
+
+
+def test_the_writable_state_directory_is_outside_the_model_tree():
+    """Everything the sidecar writes at runtime — the index, and the digest
+    stamp the model check records — lands in the named volume. If the state
+    directory sat under the model cache, the read-only mount would turn those
+    writes into EROFS on a container that is otherwise configured correctly."""
+    cache_home = _dockerfile_env("XDG_CACHE_HOME")
+    state_dir = compose_service()["environment"]["OSPREY_QMD_STATE_DIR"]
+
+    assert not state_dir.startswith(cache_home)
+    assert 'MODEL_STAMP="$STATE_DIR/' in _entrypoint()
+
+
+#: Every qmd subcommand the entrypoint is allowed to run. The exclusion that
+#: matters is ``pull``: it HEAD-checks the model registry, treats an unreachable
+#: registry as "stale", and DELETES the model files before failing to replace
+#: them — which against a read-only mount cannot even be undone by a rebuild of
+#: the index. The rest of the CLI resolves models from the cache and reads only.
+READ_ONLY_QMD_SUBCOMMANDS = {"update", "embed", "mcp", "status", "collection"}
+
+
+def test_the_entrypoint_runs_no_qmd_command_that_writes_to_the_model_cache():
+    """The read-only mount is the last line of defence, not the first.
+
+    A runtime write into the models leaf fails with EROFS and takes the sidecar
+    down; the same command against a *baked* image silently deletes the models
+    instead. So the check is on what the entrypoint invokes rather than on what
+    the mount permits.
+
+    Comment lines and quoted strings are stripped before the scan, because the
+    file talks about qmd as well as running it: the paragraph explaining why
+    ``qmd pull`` is never called must not read as a call, and neither must the
+    log line "qmd daemon exited".
+    """
+    body = "\n".join(
+        line for line in _entrypoint().splitlines() if not line.lstrip().startswith("#")
+    )
+    body = re.sub(r"\"[^\"]*\"|'[^']*'", " ", body)
+    invoked = set(re.findall(r"\bqmd ([a-z-]+)", body))
+
+    assert invoked <= READ_ONLY_QMD_SUBCOMMANDS, (
+        f"the entrypoint invokes qmd subcommands outside the read-only set: "
+        f"{sorted(invoked - READ_ONLY_QMD_SUBCOMMANDS)}. `qmd pull` in particular "
+        f"deletes model files it then cannot re-download."
+    )
+    # Not vacuous: the three phases each have to still be there.
+    assert {"update", "embed", "mcp"} <= invoked
+
+
+def test_the_label_pins_are_the_arg_defaults_verbatim():
+    """The labels are a deliberate second copy of the three SHA256 pins — CI
+    greps them out of this file before any build, to key the layer cache — so
+    they cannot reference the ARGs. This is what keeps the copy honest."""
+    pins = _dockerfile_label_pins()
+
+    assert set(pins) == {"embed", "rerank", "generate"}
+    assert pins == {
+        kind: _dockerfile_arg_default(f"OSPREY_QMD_{kind.upper()}_SHA256") for kind in pins
+    }
+
+
+def test_exactly_three_pin_labels_carry_a_bare_digest():
+    """CI's cache-key step fails unless it greps exactly three 64-hex label
+    literals out of the Dockerfile. A fourth — or a digest smuggled into
+    ``model_delivery`` — reds that step long after the edit that caused it."""
+    assert len(re.findall(r'com\.osprey\.qmd\.[a-z]+_sha256="[0-9a-f]{64}"', _dockerfile())) == 3

--- a/tests/deployment/test_qmd_service_config.py
+++ b/tests/deployment/test_qmd_service_config.py
@@ -1,14 +1,20 @@
 """Tests for the ``services.qmd`` config schema resolver."""
 
+from pathlib import Path
+
 import pytest
 
+from osprey.deployment.errors import DeploymentPreconditionError
 from osprey.deployment.host_ports import _SERVICE_REMEDY_KEYS
 from osprey.deployment.qmd_service import (
     DEFAULT_BIND_ADDRESS,
     DEFAULT_INTERVAL_SECONDS,
     DEFAULT_PORT,
+    MODEL_FILENAMES,
+    MODELS_DIR_CONFIG_KEY,
     PORT_CONFIG_KEY,
     QMDServiceConfig,
+    preflight_qmd_models_dir,
     resolve_bind_address,
     resolve_qmd_service_config,
 )
@@ -119,6 +125,146 @@ class TestBaseUrl:
         assert QMDServiceConfig(port=8180, bind_address="0.0.0.0").base_url == (
             "http://127.0.0.1:8180"
         )
+
+
+class TestModelsDir:
+    """The optional pre-staged-model directory, and its shape validation."""
+
+    def test_absent_by_default(self) -> None:
+        resolved = resolve_qmd_service_config({"services": {"qmd": {}}})
+        assert resolved is not None
+        assert resolved.models_dir is None
+
+    def test_absolute_path_is_kept(self) -> None:
+        resolved = resolve_qmd_service_config(
+            {"services": {"qmd": {"models_dir": " /srv/qmd-models "}}}
+        )
+        assert resolved is not None
+        assert resolved.models_dir == "/srv/qmd-models"
+
+    @pytest.mark.parametrize("bad", ["", "   ", "models", "./models", "~/models", 7, True])
+    def test_non_absolute_path_raises(self, bad: object) -> None:
+        with pytest.raises(ValueError, match=r"services\.qmd\.models_dir"):
+            resolve_qmd_service_config({"services": {"qmd": {"models_dir": bad}}})
+
+
+class TestModelsDirPreflight:
+    """A set ``models_dir`` refuses the deploy unless all three models are staged."""
+
+    @staticmethod
+    def _stage(directory: Path, names: tuple[str, ...]) -> None:
+        for name in names:
+            (directory / name).write_bytes(b"gguf")
+
+    @pytest.mark.parametrize(
+        "config",
+        [None, {}, {"services": {"qmd": {}}}, {"services": {"qmd": {"port": 9000}}}],
+        ids=["none", "empty", "no-models-dir", "other-keys-only"],
+    )
+    def test_unset_key_is_a_no_op(self, config: dict | None) -> None:
+        assert preflight_qmd_models_dir(config) is None
+
+    def test_missing_directory_refuses(self, tmp_path: Path) -> None:
+        absent = tmp_path / "nope"
+        with pytest.raises(DeploymentPreconditionError) as excinfo:
+            preflight_qmd_models_dir({"services": {"qmd": {"models_dir": str(absent)}}})
+        assert str(absent) in excinfo.value.reason
+        assert MODELS_DIR_CONFIG_KEY in excinfo.value.reason
+
+    def test_fully_staged_directory_passes(self, tmp_path: Path) -> None:
+        self._stage(tmp_path, MODEL_FILENAMES)
+        assert (
+            preflight_qmd_models_dir({"services": {"qmd": {"models_dir": str(tmp_path)}}}) is None
+        )
+
+    def test_partial_staging_names_only_what_is_missing(self, tmp_path: Path) -> None:
+        self._stage(tmp_path, MODEL_FILENAMES[:1])
+        with pytest.raises(DeploymentPreconditionError) as excinfo:
+            preflight_qmd_models_dir({"services": {"qmd": {"models_dir": str(tmp_path)}}})
+        assert MODEL_FILENAMES[0] not in excinfo.value.reason
+        assert MODEL_FILENAMES[1] in excinfo.value.reason
+        assert MODEL_FILENAMES[2] in excinfo.value.reason
+
+    def test_wrong_filename_reads_as_absent(self, tmp_path: Path) -> None:
+        """The download basename is not the cache name qmd recognises."""
+        self._stage(tmp_path, MODEL_FILENAMES[1:])
+        (tmp_path / "embeddinggemma-300M-Q8_0.gguf").write_bytes(b"gguf")
+        with pytest.raises(DeploymentPreconditionError) as excinfo:
+            preflight_qmd_models_dir({"services": {"qmd": {"models_dir": str(tmp_path)}}})
+        assert MODEL_FILENAMES[0] in excinfo.value.reason
+
+    def test_empty_file_reads_as_absent(self, tmp_path: Path) -> None:
+        """An interrupted copy leaves a zero-byte file that must not pass."""
+        self._stage(tmp_path, MODEL_FILENAMES[1:])
+        (tmp_path / MODEL_FILENAMES[0]).touch()
+        with pytest.raises(DeploymentPreconditionError) as excinfo:
+            preflight_qmd_models_dir({"services": {"qmd": {"models_dir": str(tmp_path)}}})
+        assert MODEL_FILENAMES[0] in excinfo.value.reason
+
+    def test_a_path_that_is_a_file_refuses(self, tmp_path: Path) -> None:
+        """``models_dir`` names a directory to mount, not an archive to unpack.
+
+        A file there passes the schema — it is an absolute path — and would be
+        bind-mounted over the container's model directory, hiding it behind a
+        single file. Refused with the same message a missing directory gets.
+        """
+        staged = tmp_path / "models.tar"
+        staged.write_bytes(b"not a directory")
+        with pytest.raises(DeploymentPreconditionError) as excinfo:
+            preflight_qmd_models_dir({"services": {"qmd": {"models_dir": str(staged)}}})
+        assert str(staged) in excinfo.value.reason
+
+    def test_every_refusal_lists_all_three_names_verbatim(self, tmp_path: Path) -> None:
+        """The remedy is the staging instruction, so it must be complete."""
+        for config_dir in (tmp_path / "absent", tmp_path):
+            with pytest.raises(DeploymentPreconditionError) as excinfo:
+                preflight_qmd_models_dir(
+                    {"services": {"qmd": {"models_dir": str(config_dir)}}},
+                )
+            for name in MODEL_FILENAMES:
+                assert name in excinfo.value.remedy
+
+
+def test_the_deploy_runs_the_preflight_before_it_touches_the_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unwired preflight is a preflight that never runs.
+
+    Every other assertion here calls the function directly, which proves the
+    check is correct and nothing about it being reached. This one goes in
+    through ``_start_stack``, the one sequence both ``osprey up`` paths share,
+    with a config whose model directory does not exist — and fails if the
+    runtime is probed at all, because a refusal that arrives after the runtime
+    has been touched is a refusal that arrives after work has started.
+    """
+    from osprey.deployment import container_lifecycle
+
+    def _unreachable(config: object) -> tuple[bool, str]:
+        raise AssertionError(
+            "the container runtime was probed before the models-dir preflight refused"
+        )
+
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", _unreachable)
+
+    with pytest.raises(DeploymentPreconditionError):
+        container_lifecycle._start_stack(
+            {
+                "deployed_services": ["qmd"],
+                "services": {"qmd": {"models_dir": str(tmp_path / "never-staged")}},
+            },
+            [],
+            tmp_path,
+        )
+
+
+def test_model_filenames_match_the_dockerfile_pins() -> None:
+    """The preflight checks for exactly the files the image build produces."""
+    dockerfile = (
+        Path(__file__).resolve().parents[2] / "src/osprey/templates/services/qmd/Dockerfile"
+    )
+    text = dockerfile.read_text()
+    for name in MODEL_FILENAMES:
+        assert name in text, f"{name} is not the cache name the Dockerfile writes"
 
 
 def test_port_conflict_preflight_knows_the_sidecar() -> None:

--- a/tests/deployment/test_service_dockerfiles.py
+++ b/tests/deployment/test_service_dockerfiles.py
@@ -328,6 +328,65 @@ def _probe_deps_body(body: str, tmp_path, *, with_manifest: bool):
     return result, ctx
 
 
+# ── Node provenance (event_dispatcher) ───────────────────────────────────────
+#
+# Only the dispatch image ships Node — the worker shells out to the Claude Code
+# CLI, which is a Node package. It comes from the base image's own Debian
+# release rather than a third-party apt repo, so the image has one package
+# provenance and needs no network beyond the Debian mirror to build.
+
+
+def _run_instruction_source(text: str, needle: str) -> str:
+    """The single RUN instruction containing *needle*, as Docker executes it.
+
+    :func:`_run_bodies` joins continuations naively, which folds any comment
+    line *inside* a continued RUN into the middle of the body — everything
+    after it then reads as inert shell comment, though Docker strips those
+    lines and runs what follows. This helper drops them the way Docker does:
+    a comment inside a continuation is removed entirely, and so neither ends
+    the instruction nor comments out the commands below it. The reconstruction
+    itself lives in :func:`tests.deployment._proxy_idiom.run_instructions`,
+    which the shared proxy-idiom assertion parses with too.
+    """
+    matches = [instr for instr in run_instructions(text) if needle in instr]
+    assert len(matches) == 1, f"expected exactly one RUN containing {needle!r}, got {len(matches)}"
+    return matches[0]
+
+
+def test_event_dispatcher_node_comes_from_the_base_image_distro():
+    node = _run_instruction_source(_dockerfile("event_dispatcher"), "nodejs")
+    assert "apt-get install -y --no-install-recommends ca-certificates nodejs npm" in node, node
+    # The pinned CLI install and the apt cleanup both follow an inline comment
+    # inside the continuation, so they are only reachable in the comment-
+    # stripped body above — a naive join would leave them commented out.
+    assert "npm install -g @anthropic-ai/claude-code@" in node
+    assert "rm -rf /var/lib/apt/lists/*" in node
+
+
+def test_event_dispatcher_has_no_third_party_node_apt_repo():
+    """Asserted as an absence over the whole file: any of these tokens coming
+    back means the vendor setup-script pipeline came back with them."""
+    text = _dockerfile("event_dispatcher")
+    for token in ("nodesource", "gnupg", "setup_20.x", "apt-key"):
+        assert token not in text, f"{token} is back in the Dockerfile — third-party Node repo"
+    node = _run_instruction_source(text, "nodejs")
+    assert "| bash" not in node and "| sh" not in node, (
+        "the node layer pipes a downloaded script into a shell"
+    )
+
+
+def test_event_dispatcher_keeps_npm_in_the_final_image():
+    """npm is a runtime dependency, not a build-time convenience: the worker
+    launches the agent as ``npx -y @anthropic-ai/claude-code@<version>``
+    (claude_launcher.py). The deps layer's own toolchain purge is asserted
+    elsewhere; what must not appear is a purge in *this* layer."""
+    text = _dockerfile("event_dispatcher")
+    node = _run_instruction_source(text, "nodejs")
+    assert "apt-get purge" not in node, "the node layer purges packages"
+    assert "autoremove" not in node, "the node layer autoremoves packages"
+    assert "npm is a runtime dependency, not a build-time convenience" in text
+
+
 def test_virtual_accelerator_wheel_extra_placement():
     """The VA extra is primed in the deps layer and re-resolved on the wheel
     layer's FIRST install (so a dev wheel that adds/bumps a dep inside the extra

--- a/tests/deployment/test_service_dockerfiles.py
+++ b/tests/deployment/test_service_dockerfiles.py
@@ -1,10 +1,16 @@
-"""Layer-split invariants for the four service Dockerfiles.
+"""Build invariants for the shipped service Dockerfiles.
 
-`osprey up` builds each managed service (event_dispatcher,
-virtual_accelerator, bluesky, bluesky_web) from a template Dockerfile shipped
-under ``osprey/templates/services/<name>/``. This module pins the shared layer
-contract those recipes follow so a fast per-project dev rebuild only re-runs the
-cheap wheel layer, never the expensive framework/deps install:
+`osprey up` builds each managed service from a template Dockerfile shipped
+under ``osprey/templates/services/<name>/``. Two sets of checks live here, over
+two different sets of files.
+
+The **layer-split contract**, over the four framework-primed services
+(event_dispatcher, virtual_accelerator, bluesky, bluesky_web) that
+:data:`PRIMER_SPEC` names with the exact spec their deps layer installs — those
+recipes are not only parsed but executed, so each has to be named with its spec
+rather than discovered. This module pins the shared layer contract they follow
+so a fast per-project dev rebuild only re-runs the cheap wheel layer, never the
+expensive framework/deps install:
 
 - a **deps layer** (one RUN) that primes the pinned framework release + deps,
   with a dev-gated fallback for an unreleased pin, then installs an optional
@@ -19,6 +25,11 @@ followed by a metadata-only ``ARG OSPREY_PROJECT_NAME`` / ``LABEL
 com.osprey.project`` pair kept last so a per-project value never invalidates the
 shared deps cache. Each RUN body is parsed under ``sh -n`` so a shell syntax
 error in the conditional install fails here rather than at ``docker build``.
+
+The **whole-file invariants**, over every Dockerfile shipped as a literal file —
+all seven services plus the web-terminal auth sidecar, discovered by glob rather
+than listed: the proxy-delivery idiom on every apt-using RUN, and a
+non-self-excluding ``.dockerignore`` beside every service recipe.
 """
 
 import os
@@ -29,11 +40,26 @@ import subprocess
 import pytest
 
 import osprey
+from tests.deployment._proxy_idiom import (
+    assert_apt_runs_carry_proxy_idiom,
+    carries_proxy_idiom,
+    run_instructions,
+)
 
-SERVICES_DIR = pathlib.Path(osprey.__file__).parent / "templates" / "services"
+TEMPLATES_DIR = pathlib.Path(osprey.__file__).parent / "templates"
+SERVICES_DIR = TEMPLATES_DIR / "services"
 
-# The four managed services and their pinned primer spec (what the deps layer
-# installs from PyPI). Only the virtual accelerator carries an extra.
+# Every Dockerfile shipped as a literal file — the managed services plus the
+# web-terminal auth sidecar. Discovered rather than listed, so a new service
+# recipe is covered by the shared invariants below the day it lands. The
+# project image's recipe is a Jinja template and is checked from the rendered
+# output instead (tests/cli/test_dockerfile_template.py).
+SHIPPED_DOCKERFILES = sorted(TEMPLATES_DIR.rglob("Dockerfile"))
+SHIPPED_DOCKERFILE_IDS = [str(p.parent.relative_to(TEMPLATES_DIR)) for p in SHIPPED_DOCKERFILES]
+
+# The four services whose layer split is checked here, and the pinned primer
+# spec each one's deps layer installs from PyPI. Only the virtual accelerator
+# carries an extra.
 PRIMER_SPEC = {
     "event_dispatcher": "osprey-framework==$OSPREY_VERSION",
     "virtual_accelerator": "osprey-framework[virtual-accelerator]==$OSPREY_VERSION",
@@ -332,6 +358,46 @@ def test_every_service_ships_non_self_excluding_dockerignore():
         }
         offenders = {e for e in entries if e.strip("/") == ".dockerignore"}
         assert not offenders, f"{d.name}: .dockerignore self-excludes: {offenders}"
+
+
+# ── Proxy delivery ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dockerfile", SHIPPED_DOCKERFILES, ids=SHIPPED_DOCKERFILE_IDS)
+def test_apt_runs_deliver_the_proxy_settings(dockerfile):
+    """Every apt-using RUN in every shipped recipe hands apt the proxy.
+
+    The rule, and the idiom that satisfies it, are spelled once in
+    :mod:`tests.deployment._proxy_idiom` — here and in the rendered project
+    template's copy of this test, so a change of idiom is one edit.
+    """
+    assert_apt_runs_carry_proxy_idiom(
+        dockerfile.read_text(), str(dockerfile.parent.relative_to(TEMPLATES_DIR))
+    )
+
+
+def test_shipped_dockerfiles_are_all_discovered():
+    """Floor on the discovery glob: a typo that finds nothing would make the
+    parametrization above vacuous rather than red."""
+    assert "modules/web_terminals/auth_sidecar" in SHIPPED_DOCKERFILE_IDS
+    assert {f"services/{s}" for s in SERVICES} <= set(SHIPPED_DOCKERFILE_IDS)
+
+
+def test_proxy_guard_catches_a_bare_apt_run():
+    """Meta-test: an apt RUN with no proxy delivery must fail the guard."""
+    bare = "RUN apt-get update \\\n && apt-get install -y --no-install-recommends curl\n"
+    assert not carries_proxy_idiom(run_instructions(bare)[0])
+    with pytest.raises(AssertionError, match="proxy-delivery idiom"):
+        assert_apt_runs_carry_proxy_idiom(bare, "synthetic")
+
+
+def test_proxy_guard_accepts_the_declared_arg_idiom():
+    """Meta-test: delivering the settings from a declared build ARG counts too
+    — the project template's deps layer follows its bridge with exactly this."""
+    from_arg = (
+        'RUN export NO_PROXY="$PIP_NO_PROXY" no_proxy="$PIP_NO_PROXY" \\\n && apt-get update\n'
+    )
+    assert carries_proxy_idiom(run_instructions(from_arg)[0])
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_dockerfile_e2e.py
+++ b/tests/e2e/test_dockerfile_e2e.py
@@ -30,6 +30,12 @@ the als-apg provider. This is the only test that proves the *shipped*
 entrypoint actually serves an agent — ``claude --version`` proves the binary
 launches, not that the assembled image answers a prompt.
 
+``test_node_runtime_satisfies_the_cli_engine_floor`` — the Node runtime the
+image installs from its own Debian release clears the CLI's engines floor
+(node >= 18, never an exact major), npm is present for the ``npx`` launch path,
+and the image's size is reported so a provenance change's size delta is on the
+record.
+
 Three further tests cover the fast-dev-rebuild layer split:
 
 - ``test_rebuild_without_changes_is_fully_cached`` — a no-change rebuild runs
@@ -243,6 +249,66 @@ def test_generated_dockerfile_builds_and_boots(built_image):
     assert not env_check.stdout.strip(), (
         f".env must never enter the image, found: {env_check.stdout.strip()}"
     )
+
+
+def _report_image_size(tag: str) -> int:
+    """Report the built image's size, and return it in bytes.
+
+    Node now comes from the base image's own Debian release instead of a
+    third-party apt repo, which moves the image size — the number belongs in
+    the change that moves it. The lane runs pytest without ``-s``, so stdout
+    alone would only surface on a failure; ``$GITHUB_STEP_SUMMARY`` is the
+    channel that shows it on a green run, and is simply absent locally.
+    """
+    out = subprocess.run(
+        ["docker", "image", "inspect", "--format", "{{.Size}}", tag],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert out.returncode == 0, out.stderr
+    size = int(out.stdout.strip())
+    line = f"generated image size: {size} bytes ({size / 1e9:.2f} GB)"
+    print(line)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(f"- {line}\n")
+    return size
+
+
+def test_node_runtime_satisfies_the_cli_engine_floor(built_image):
+    """Node and npm work in the image, and Node clears the CLI's engines floor.
+
+    The floor is the contract — ``@anthropic-ai/claude-code`` requires node >=
+    18 — and the version above it is whatever the base image's Debian release
+    ships. Asserting an exact major would be asserting a pin this image
+    deliberately does not have: it would fail the day the base image moves,
+    for a change that is not a regression.
+
+    npm is checked separately because it is a *runtime* dependency here: the
+    agent is launched via ``npx``, so an image with node but no npm boots and
+    then fails on the first turn.
+    """
+    tag, _repo, _project_name, _out_dir = built_image
+
+    node = _docker_run(tag, "node", "-v")
+    assert node.returncode == 0, f"node is not runnable in the image:\n{node.stderr}"
+    raw = node.stdout.strip()
+    match = re.match(r"v?(\d+)\.", raw)
+    assert match, f"unparseable `node -v` output: {raw!r}"
+    assert int(match.group(1)) >= 18, (
+        f"node {raw} is below the Claude Code CLI's engines floor (node >= 18)"
+    )
+
+    npm = _docker_run(tag, "npm", "--version")
+    assert npm.returncode == 0, (
+        f"npm is not runnable in the image — the agent is launched via `npx`, "
+        f"so this fails at the first turn, not at build time:\n{npm.stderr}"
+    )
+    assert npm.stdout.strip(), "npm --version printed nothing"
+
+    _report_image_size(tag)
 
 
 # ── The container layout contract ────────────────────────────────────────────

--- a/tests/integration/_qmd_ariel_support.py
+++ b/tests/integration/_qmd_ariel_support.py
@@ -10,9 +10,11 @@ here, so nothing has to import a conftest.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import time
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +37,43 @@ DEFAULT_QMD_SIDECAR_IMAGE = "osprey-qmd:local-validate"
 #: The deployment-wide override for the sidecar image, established by the image
 #: task and consumed by the compose ``image:`` line.
 QMD_IMAGE_ENV = "OSPREY_QMD_IMAGE"
+
+
+#: The other image this lane builds: the same Dockerfile with the three model
+#: fetches skipped (``--build-arg OSPREY_QMD_MODELS_MOUNTED=1``), which is what
+#: a build host with no route to huggingface.co produces. Cheap to build — it
+#: downloads none of the 2.1 GB — and it is the only image the mounted-delivery
+#: path can be tested against, because a baked image already has the models.
+MOUNTED_IMAGE_ENV = "OSPREY_QMD_MOUNTED_IMAGE"
+
+#: Where that image looks for its models, and therefore where the deployment's
+#: read-only bind mount lands. The literal is the image's own
+#: ``OSPREY_QMD_MODEL_DIR``; ``tests/deployment/test_qmd_compose_fragment.py``
+#: pins the compose fragment's copy of it to the Dockerfile.
+SIDECAR_MODEL_DIR = "/opt/qmd/.cache/qmd/models"
+
+#: The sidecar's writable state directory — the index, and the stamp file that
+#: records which model files were already verified. Deliberately outside the
+#: model tree, so nothing the container writes lands on the read-only mount.
+SIDECAR_STATE_DIR = "/var/lib/qmd"
+
+#: Per-model environment variable carrying the digest the image expects, keyed
+#: by the model's on-disk name. Setting these at ``docker run`` overrides the
+#: ENV the build baked in, which is what lets a kilobyte fixture stand in for a
+#: 318 MB model: the check is "this file is the file this image was built with",
+#: and both halves of that are supplied here. The identity file the entrypoint
+#: sources uses different names (``OSPREY_QMD_EMBED_MODEL_SHA256``), so it
+#: cannot clobber them.
+MODEL_DIGEST_ENV = {
+    "hf_ggml-org_embeddinggemma-300M-Q8_0.gguf": "OSPREY_QMD_EMBED_SHA256",
+    "hf_ggml-org_qwen3-reranker-0.6b-q8_0.gguf": "OSPREY_QMD_RERANK_SHA256",
+    "hf_tobil_qmd-query-expansion-1.7B-q4_k_m.gguf": "OSPREY_QMD_GENERATE_SHA256",
+}
+
+#: How long the model check gets to reach its verdict. It runs before anything
+#: slow — before the index pass, before the daemon — so this covers container
+#: start plus three sha256sums of whatever was staged.
+MODEL_VERDICT_TIMEOUT = 120.0
 
 
 def qmd_sidecar_image() -> str:
@@ -292,6 +331,180 @@ def wait_for_indexed(client, collection: str, query: str, predicate, *, what: st
         f"the sidecar never reported {what} within {SIDECAR_REINDEX_TIMEOUT:.0f}s; "
         f"last hit files: {[h.file for h in hits]}"
     )
+
+
+def require_mounted_models_image() -> str:
+    """The skip-ARG image, or the right kind of non-result.
+
+    Same split as :func:`require_sidecar_image`, for the same reason and with
+    the opposite default. The variable is set by one CI step, the one that
+    builds this image; anywhere else — a developer machine, or this lane's
+    other steps, which run before that build — its absence is honest and a skip
+    is the correct outcome. A variable that IS set and names an absent image is
+    a failed build, and skipping there would report success having proved
+    nothing about the delivery path this whole feature exists for.
+
+    Returns:
+        The image reference to run.
+
+    Raises:
+        AssertionError: If the named image is not present on this daemon.
+        Skipped: Via ``pytest.skip`` when the variable is unset.
+    """
+    image = os.environ.get(MOUNTED_IMAGE_ENV)
+    if not image:
+        pytest.skip(
+            f"{MOUNTED_IMAGE_ENV} is unset; these cases need the sidecar image built "
+            "with the model fetches skipped (--build-arg OSPREY_QMD_MODELS_MOUNTED=1), "
+            "which only the qmd sidecar CI lane builds"
+        )
+    if not is_image_present(image):
+        raise AssertionError(
+            f"{MOUNTED_IMAGE_ENV}={image!r} names an image that is not present on this "
+            "daemon. The step that sets this variable builds the image first, so this "
+            "is a failed or mis-tagged build, not a missing dependency."
+        )
+    return image
+
+
+def stage_model_fixtures(directory: Path) -> dict[str, str]:
+    """Write three stand-in model files and return their digests.
+
+    Kilobyte files, not models: the entrypoint's check is a name, a non-zero
+    size and a SHA256 comparison, and none of those care what the bytes mean.
+    Staging the real 2.1 GB in CI to assert a digest comparison would buy
+    nothing and cost the download this feature exists to avoid. The contents
+    differ per file so a check that compared the wrong file against the wrong
+    digest would fail rather than pass by coincidence.
+
+    Args:
+        directory: Host directory to stage into, mounted read-only afterwards.
+
+    Returns:
+        Mapping of ``OSPREY_QMD_*_SHA256`` variable name to the digest of the
+        file it describes, ready to pass as container environment.
+    """
+    digests = {}
+    for index, (name, variable) in enumerate(MODEL_DIGEST_ENV.items()):
+        payload = bytes([index + 1]) * 1024
+        (directory / name).write_bytes(payload)
+        digests[variable] = hashlib.sha256(payload).hexdigest()
+    return digests
+
+
+@contextmanager
+def sidecar_over_models_dir(
+    image: str,
+    models_dir: Path,
+    env: dict[str, str] | None = None,
+    state_volume: str | None = None,
+):
+    """Run the sidecar over ``models_dir``, mounted where the image looks.
+
+    Detached and unpublished: every case here is decided by what the container
+    logs before it opens a port, and both of them end with the container
+    exiting on its own — a refusal immediately, a verified start once the
+    fail-closed index gate finds nothing to serve. Neither is a container to
+    wait on with a health probe.
+
+    Args:
+        image: Image reference to run.
+        models_dir: Host directory to bind read-only at the image's model
+            directory.
+        env: Extra environment for the container.
+        state_volume: Named volume to mount as the writable state directory, for
+            the cases that need one container's state to reach the next.
+
+    Yields:
+        The started container.
+    """
+    import docker
+
+    client = docker.from_env()
+    volumes: dict[str, dict[str, str]] = {
+        str(models_dir): {"bind": SIDECAR_MODEL_DIR, "mode": "ro"}
+    }
+    if state_volume:
+        volumes[state_volume] = {"bind": SIDECAR_STATE_DIR, "mode": "rw"}
+    container = client.containers.run(
+        image,
+        detach=True,
+        environment=dict(env or {}),
+        volumes=volumes,
+    )
+    try:
+        yield container
+    finally:
+        with suppress(Exception):
+            container.remove(force=True)
+
+
+def wait_for_sidecar_log(container, needle: str, timeout: float = MODEL_VERDICT_TIMEOUT) -> str:
+    """Block until ``needle`` appears in the container's output.
+
+    A container that exits without it gets one final read before the failure,
+    because the last lines and the exit are written at the same moment.
+
+    Args:
+        container: A started container.
+        needle: Substring to wait for.
+        timeout: Seconds to wait.
+
+    Returns:
+        The full log text at the moment the needle was found.
+
+    Raises:
+        AssertionError: If the container exits or the timeout passes first. The
+            message carries the log, which is the diagnosis.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        text = _combined_logs(container)
+        if needle in text:
+            return text
+        exited = _exit_code(container) is not None
+        if exited or time.monotonic() >= deadline:
+            raise AssertionError(
+                f"the sidecar never logged {needle!r} "
+                + ("before exiting" if exited else f"within {timeout:.0f}s")
+                + f"\n--- container logs ---\n{text[-4000:]}"
+            )
+        time.sleep(0.5)
+
+
+def wait_for_sidecar_exit(container, timeout: float = MODEL_VERDICT_TIMEOUT) -> int:
+    """Return the container's exit status, waiting for it if necessary."""
+    result = container.wait(timeout=timeout)
+    return int(result.get("StatusCode", -1))
+
+
+def sidecar_logs(container) -> str:
+    """Everything the container has written so far.
+
+    Read a refusal through this only after the container has exited. A refusal
+    is several lines long — the cause, the staging instructions, the three
+    names — and a read that lands between the first line and the last returns a
+    truthfully incomplete message, which reads exactly like a message that was
+    never finished.
+    """
+    return _combined_logs(container)
+
+
+def _exit_code(container) -> int | None:
+    """The container's exit status, or ``None`` while it is still running."""
+    with suppress(Exception):
+        container.reload()
+        if container.status == "exited":
+            return int(container.attrs["State"]["ExitCode"])
+    return None
+
+
+def _combined_logs(container) -> str:
+    """Everything the container has written so far, best effort."""
+    try:
+        return container.logs().decode("utf-8", errors="replace")
+    except Exception as exc:  # pragma: no cover - diagnostic path only
+        return f"(could not read container logs: {exc})"
 
 
 def _tail_logs(container) -> str:

--- a/tests/integration/test_qmd_models_mount.py
+++ b/tests/integration/test_qmd_models_mount.py
@@ -1,0 +1,239 @@
+"""The sidecar's other model-delivery path, against a real container.
+
+By default the qmd image bakes its three GGUF models in at build time, which
+needs a build host that can reach huggingface.co. A host that cannot gets the
+other path: ``services.qmd.models_dir`` names a host directory holding the same
+three files, the build is told to skip the downloads
+(``--build-arg OSPREY_QMD_MODELS_MOUNTED=1``), and the files arrive at runtime
+over a read-only bind mount instead.
+
+That path has one failure mode worth this whole module: **the models are not
+there**. Nothing about it is loud on its own. qmd's reaction to a model file it
+cannot make sense of is to download a replacement, on a host chosen for this
+path precisely because it has no route out, under a compose health check that
+allows an hour of start-up. So the entrypoint checks the staged files against
+the digests the image was built with, before it starts anything, and refuses
+with staging instructions when they do not hold up. These cases are that
+refusal and its opposite, run for real.
+
+The image under test is the skip-ARG build, named by ``OSPREY_QMD_MOUNTED_IMAGE``
+— the *only* image the mounted path can be tested against, since a baked one
+already carries the models. It is cheap to build for exactly the reason this
+feature exists: it downloads none of the 2.1 GB.
+
+The staged files are kilobyte stand-ins. The check under test is a name, a
+non-zero size and a SHA256 comparison; the expected digests are supplied to the
+container as ``OSPREY_QMD_*_SHA256``, which is what the image's own build would
+have baked in. Staging 2.1 GB of real models in CI to assert a digest
+comparison would prove nothing extra and cost the download this path exists to
+avoid.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tests._container_support import is_docker_available
+from tests.integration._qmd_ariel_support import (
+    MODEL_DIGEST_ENV,
+    SIDECAR_MODEL_DIR,
+    require_mounted_models_image,
+    sidecar_logs,
+    sidecar_over_models_dir,
+    stage_model_fixtures,
+    wait_for_sidecar_exit,
+    wait_for_sidecar_log,
+)
+
+# xdist_group("docker") pins every container-starting module onto one worker, so
+# a run has a single testcontainers session and a single ryuk reaper.
+pytestmark = [
+    pytest.mark.dockerbuild,
+    pytest.mark.integration,
+    pytest.mark.xdist_group("docker"),
+]
+
+#: The model the entrypoint reaches first, and so the one an empty directory is
+#: reported against. Its digest variable leads ``MODEL_DIGEST_ENV`` for the same
+#: reason: the order is the load order.
+EMBED_MODEL = next(iter(MODEL_DIGEST_ENV))
+
+#: The verdict line the model check ends on when every staged file holds up.
+#: The delivery word in it is the image's own ``OSPREY_QMD_MODEL_DELIVERY``, so
+#: a baked image logging this would be reporting the wrong path.
+VERIFIED = "models verified against the digests this image was built with (mounted delivery)"
+
+#: Every line the entrypoint writes carries this tag after its timestamp.
+#: Asserting through it is what makes an indent assertion mean the indent of a
+#: message rather than of some substring inside one.
+TAG = "[qmd-sidecar] "
+
+
+def refusal_logs(container) -> str:
+    """The complete output of a container that refused to start.
+
+    Waits for the FATAL line first, so a container that hangs instead of
+    refusing fails with its own logs rather than with a bare timeout — then
+    waits for the exit before reading, because the refusal is many lines long
+    and a read taken while it is still being written returns a message that
+    looks truncated when it is only unfinished.
+    """
+    wait_for_sidecar_log(container, "FATAL: model file")
+    assert wait_for_sidecar_exit(container) != 0, "the sidecar logged a refusal and then exited 0"
+    return sidecar_logs(container)
+
+
+@pytest.fixture
+def mounted_image() -> str:
+    """The skip-ARG image, or a skip/failure per its build state."""
+    if not is_docker_available():
+        pytest.skip("docker daemon is not reachable")
+    return require_mounted_models_image()
+
+
+@pytest.fixture
+def state_volume():
+    """A named volume standing in for the deployment's ``qmd_index``.
+
+    Named uniquely per test and removed afterwards — never a prune, matching
+    the container-ops guardrail the rest of the suite observes.
+    """
+    import docker
+
+    client = docker.from_env()
+    volume = client.volumes.create(name=f"osprey-qmd-models-test-{uuid.uuid4().hex[:8]}")
+    try:
+        yield volume.name
+    finally:
+        try:
+            volume.remove(force=True)
+        except Exception:  # pragma: no cover - teardown best effort
+            pass
+
+
+def test_an_empty_mount_refuses_and_says_what_to_stage(mounted_image: str, tmp_path: Path):
+    """The whole point of the pre-start check, in the state that motivated it.
+
+    An operator who configured ``models_dir`` and never staged the files gets a
+    named file, a named cause, the directory, and the three exact names — not an
+    hour of a container that looks like it is starting.
+    """
+    with sidecar_over_models_dir(mounted_image, tmp_path) as container:
+        logs = refusal_logs(container)
+
+        assert (
+            f"FATAL: model file '{EMBED_MODEL}' cannot be used: "
+            f"no such file in {SIDECAR_MODEL_DIR}" in logs
+        )
+        assert f"Stage all three model files in {SIDECAR_MODEL_DIR}, named exactly:" in logs
+        for name in MODEL_DIGEST_ENV:
+            assert f"{TAG}    {name}" in logs
+        # The image knows its models come from the mount, so the remedy is about
+        # the host directory rather than about rebuilding the image.
+        assert "This image expects the models at runtime, so stage them under those" in logs
+        assert f"names in the host directory bind-mounted at {SIDECAR_MODEL_DIR}." in logs
+
+
+def test_staged_models_verify_against_the_digests_the_image_records(
+    mounted_image: str, tmp_path: Path
+):
+    """The path a correctly-staged host takes: three files in, verification out.
+
+    Asserted at the verification line rather than at ``/health``, because
+    everything after it — the index pass, the daemon, the forwarder — belongs to
+    the sidecar suites that already cover it over a real corpus. What is new
+    here is that a *mounted* image accepts files it did not bake.
+    """
+    digests = stage_model_fixtures(tmp_path)
+
+    with sidecar_over_models_dir(mounted_image, tmp_path, env=digests) as container:
+        before = wait_for_sidecar_log(container, VERIFIED).split(VERIFIED)[0]
+
+        # Nothing was refused on the way there. Read up to the verification line
+        # rather than over the whole log: the container carries on into the
+        # startup pass, which fails closed on an empty index because this case
+        # stages models and no corpus — a real refusal, about something else.
+        assert "FATAL" not in before
+        # Cold start: no stamp yet, so every file is actually hashed. 1024 is
+        # the fixture size, so this also proves the check read the staged file
+        # rather than something already in the image.
+        assert f"hashing {EMBED_MODEL} (1024 bytes)" in before
+
+
+def test_a_staged_file_that_is_not_the_expected_one_refuses(mounted_image: str, tmp_path: Path):
+    """Right name, wrong bytes — the case a name-only check would wave through.
+
+    A truncated copy or a file staged from a different model release reads as
+    present to everything except the digest, and qmd's own reaction to loading
+    it is a crash or a silent re-download rather than a message.
+    """
+    digests = stage_model_fixtures(tmp_path)
+    on_disk = digests[MODEL_DIGEST_ENV[EMBED_MODEL]]
+    # Point the embed model's expected digest at a different staged file, which
+    # is the shape of a mis-staged directory without needing a second fixture.
+    expected = digests["OSPREY_QMD_RERANK_SHA256"]
+    env = {**digests, MODEL_DIGEST_ENV[EMBED_MODEL]: expected}
+
+    with sidecar_over_models_dir(mounted_image, tmp_path, env=env) as container:
+        logs = refusal_logs(container)
+
+        assert (
+            f"FATAL: model file '{EMBED_MODEL}' cannot be used: SHA256 mismatch: "
+            f"this image expects {expected}, the file on disk is {on_disk}" in logs
+        )
+
+
+def test_a_restart_trusts_the_stamp_instead_of_rehashing(
+    mounted_image: str, tmp_path: Path, state_volume: str
+):
+    """Verification is once per staged file, not once per start.
+
+    Hashing 2.1 GB of real models costs about half a minute, which is fine on a
+    first start and pure delay on every restart after it. The stamp in the state
+    volume is what turns it into the former; its absence would be invisible
+    except as a container that takes longer than it should to come back.
+    """
+    digests = stage_model_fixtures(tmp_path)
+
+    with sidecar_over_models_dir(
+        mounted_image, tmp_path, env=digests, state_volume=state_volume
+    ) as first:
+        assert f"hashing {EMBED_MODEL}" in wait_for_sidecar_log(first, VERIFIED)
+
+    with sidecar_over_models_dir(
+        mounted_image, tmp_path, env=digests, state_volume=state_volume
+    ) as second:
+        logs = wait_for_sidecar_log(second, VERIFIED).split(VERIFIED)[0]
+
+    assert "hashing" not in logs, (
+        "the second start re-hashed the staged models, so the stamp written by the "
+        f"first start was not read back:\n{logs}"
+    )
+
+
+def test_the_staged_names_are_the_names_the_deploy_preflight_checks():
+    """The host-side refusal and the container-side one have to name the same
+    three files, or a deploy passes its preflight and the container refuses
+    anyway (or worse, the other way round). No container needed."""
+    from osprey.deployment.qmd_service import MODEL_FILENAMES
+
+    assert tuple(MODEL_DIGEST_ENV) == MODEL_FILENAMES
+
+
+def test_the_mount_target_is_the_directory_the_image_reads(mounted_image: str):
+    """The bind target is a literal on both sides — a rename of the image's
+    ``OSPREY_QMD_MODEL_DIR`` that missed this constant would mount the models
+    somewhere the container never looks, and the deployment would report the
+    staged files as missing."""
+    import docker
+
+    image = docker.from_env().images.get(mounted_image)
+    env = dict(item.split("=", 1) for item in image.attrs["Config"]["Env"])
+
+    assert env["OSPREY_QMD_MODEL_DIR"] == SIDECAR_MODEL_DIR
+    # And the image knows it is the mounted build, which is what selects the
+    # staging half of the refusal text asserted above.
+    assert env["OSPREY_QMD_MODEL_DELIVERY"] == "mounted"

--- a/tests/templates/render_defaults/qmd.yml
+++ b/tests/templates/render_defaults/qmd.yml
@@ -6,12 +6,16 @@
 # never race to tag one shared image. To use a prebuilt/published image instead,
 # set OSPREY_QMD_IMAGE (e.g. OSPREY_QMD_IMAGE=my-registry/osprey-qmd:2.5.3).
 #
-# PORT SPLIT. qmd's daemon hardcodes `httpServer.listen(port, "localhost")`,
-# which resolves to IPv6 loopback only — there is no --host flag and no env
-# override — so it is unreachable from any other container. The entrypoint runs
-# it on the container's internal 8181 and fronts it with a socat forwarder that
-# owns the port published below, which is the one clients talk to. The security
-# posture is the point: qmd itself never listens on a routable address.
+# PORT SPLIT. qmd's daemon hardcodes `httpServer.listen(port, "localhost")` —
+# there is no --host flag and no env override — so it answers only on a loopback
+# address inside the container, unreachable from any other container. WHICH
+# loopback family "localhost" lands on is not fixed: Node resolves it to [::1]
+# on some image/host combinations and to 127.0.0.1 on others (observed under
+# rootless podman on RHEL-family hosts). So the entrypoint runs the daemon on
+# the container's internal 8181, probes BOTH families for /health, and points a
+# socat forwarder at whichever one answered. The forwarder owns the port
+# published below, which is the one clients talk to. The security posture is the
+# point: qmd itself never listens on a routable address, on either family.
 #
 # The endpoint carries no token, no TLS and no per-caller identity — it answers
 # any request that reaches it. That is safe exactly as long as only this host


### PR DESCRIPTION
Six fixes to the deployment path, all found during a first lifecycle deployment on a locked-down facility network: a host behind a mandatory forward proxy, with no route to the model host, and unable to build some images at all. Each commit stands alone; they ship together because the same deploy has to clear all six.

## What was broken

**Proxy-bridged builds.** A facility hands a build its proxy as `HTTP_PROXY`/`HTTPS_PROXY`, the spelling docker predeclares as build args, and apt reads only the lowercase names. Every apt-using layer in all nine shipped recipes therefore stalled until it timed out. Each such RUN now exports the lowercase names from the uppercase ones, defaulting to empty so a build with no proxy behaves exactly as before.

The CI lane proving this asserts the **proxy's access log**, not the build's exit status: the runner has open egress, so a build with the bridge deleted would fetch straight past the proxy and still exit 0. It builds with **podman** because BuildKit delivers a proxy build-arg in both cases on its own, which would satisfy the assertion without the bridge doing anything; a probe step reds the lane if the runtime ever starts doing that.

**Node provenance.** `python:3.12-slim` resolves to trixie, where the NodeSource setup script exits 0 without configuring anything. The apt install that followed then took Debian's own `nodejs` package, which does not pull in `npm`, and left the images with a `claude` launch path that could not run. Both node-using images now take `nodejs` and `npm` from the base image's own release: one package provenance, no network beyond the Debian mirror. The e2e check asserts the CLI's declared engines floor (node >= 18) rather than an exact major, and the host installation guide drops its own NodeSource pipeline for the same reason.

**Packaging.** Hatchling packages the working tree rather than what git tracks, so a gitignored directory of staged model files still rode into the wheel and inflated it to several gigabytes. The hatch exclude list and `.gitignore` are now one list spelled twice, with a test asserting the pairing.

**Prebuilt images.** Some hosts cannot build at all: no build tooling, no registry in reach, images side-loaded from a tarball. `prebuilt_images` in the config, or `OSPREY_PREBUILT_IMAGES` in the environment, skips the dev-mode build and starts the containers from the tags already present. The variable wins over the config key in both directions, following `OSPREY_OFFLINE`.

**qmd loopback.** qmd hardcodes `listen(port, "localhost")`, and which loopback family that binds is environment-dependent: 127.0.0.1 under rootless podman on RHEL-family hosts, not the `::1` the sidecar assumed. The health probe then died at `HEALTH_TIMEOUT` and the container crash-looped while the deploy summary still reported success. The entrypoint now probes both families and points the forwarder at whichever answered.

**qmd prefetched models.** The sidecar build downloads three model files, the one step in it that needs egress. `services.qmd.models_dir` names a host directory that already holds them: the build skips the downloads and the directory is bind-mounted read-only where the image loads models from. Skipping the download does not skip verification, it moves it to startup, checked against the pins that travel with the image, with a stamp file so an unchanged file is not rehashed. A missing or misnamed file is refused at deploy time rather than surfacing an hour later as an unhealthy container.

## Notes for review

- **`persona_images.py` is out of scope.** It builds an image outside the template recipes and was deliberately not touched here. If it needs the same proxy treatment, that is a separate change.
- **One-time qmd layer-cache miss.** Declaring the model SHA pins as ARGs changes the text of the RUNs that read them, so the first sidecar build after this lands re-fetches the models. Later builds cache normally.
- **Image-size delta** is printed by the dockerfile-e2e lane; the measured number will be recorded here once that lane reports.
