### PR TITLE
feat(web): channel autocomplete in bluesky plan forms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,6 +773,7 @@ jobs:
             - 'src/osprey/dispatch/**'
             - 'tests/interfaces/design_system/**'
             - 'tests/interfaces/web_terminal/**'
+            - 'tests/interfaces/bluesky_web/**'
             - 'tests/interfaces/ariel/**'
             - 'tests/interfaces/conftest.py'
             - 'tests/interfaces/_browser.py'
@@ -817,6 +818,7 @@ jobs:
           tests/interfaces/web_terminal/test_contract_params.py \
           tests/interfaces/web_terminal/test_logout_resume_browser.py \
           tests/interfaces/web_terminal/test_auth_login_browser.py \
+          tests/interfaces/bluesky_web/test_channel_combobox_browser.py \
           tests/interfaces/ariel/test_embedded_nav.py \
           tests/interfaces/test_load_smokes.py -v --tb=short
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ Compatibility is documented in release notes, not encoded in the version string.
   init` materializes it from the preset (the control assistant ships its own
   text), so the context every seeded user starts from is visible and editable
   in the deployment repo instead of hidden in the installed package.
+- Channel fields in the BLUESKY panel's plan forms offer typeahead
+  suggestions drawn from the project's Channel Finder catalog, snapshotted at
+  build time. On by default when a channel database is configured;
+  `web.channel_suggestions.enabled` and `web.channel_suggestions.max_channels`
+  tune or disable it.
 
 - A host that cannot build images can now skip the dev-mode image build, with
   `prebuilt_images: true` in `config.yml` or `OSPREY_PREBUILT_IMAGES=1` for one

--- a/docs/source/how-to/web-terminal/panels.rst
+++ b/docs/source/how-to/web-terminal/panels.rst
@@ -70,6 +70,45 @@ do.
 **Results** shows the selected run's record and its live figure, with the raw
 data table collapsed underneath and a one-click CSV export.
 
+Channel suggestions in plan forms
+---------------------------------
+
+A plan-form field that asks for a channel completes what you type: a popup
+lists matching channel names — substring matches first, looser fuzzy matches
+when those run dry. Arrow keys move through the list, **Enter** takes the
+highlighted name, **Escape** dismisses it. The suggestions only suggest — a
+name typed in full is accepted whether or not it appears in the list.
+
+The names come from the project's Channel Finder catalog: ``osprey build``
+writes a snapshot of it next to the generated config, and the panel reads
+that snapshot — no control-system traffic, and nothing to keep in sync at run
+time. A project with no channel database configured shows no suggestions and
+is otherwise unchanged.
+
+The feature is on by default, tuned under ``web.channel_suggestions`` in
+``config.yml``:
+
+.. code-block:: yaml
+
+   web:
+     channel_suggestions:
+       enabled: true         # the default
+       max_channels: 50000   # the default
+
+``max_channels`` guards the browser, not the build: every panel load fetches
+the whole snapshot, so a database holding more channels than the limit is
+skipped instead of shipped — the build log names the limit it hit, and the
+form falls back to plain fields. Raise the limit to cover a larger facility,
+or set ``enabled: false`` to turn the feature off and write no snapshot at
+all. A build profile overrides these keys from its ``config:`` block in the
+dotted form, e.g. ``web.channel_suggestions.max_channels: 200000``.
+
+One staleness rule to know: editing a channel database inside the profile's
+``data/`` tree changes the build fingerprint, so ``osprey up`` refuses until
+you rebuild — the snapshot cannot silently go stale on that path. A database
+referenced from *outside* the profile tree is not fingerprinted; its snapshot
+refreshes only on the next explicit ``osprey build``.
+
 Adding your own panel
 ---------------------
 

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -527,6 +527,10 @@ keys:
   web.panels.ariel.enabled: {covered-by: web.panels.ariel}
   web.panels.channel-finder: {covered-by: web.panels}
   web.panels.channel-finder.enabled: {covered-by: web.panels.channel-finder}
+  web.channel_suggestions: {evidence: 'web\.get\("channel_suggestions"\)'}
+  web.channel_suggestions.enabled: {evidence: 'section\.get\("enabled", True\)'}
+  web.channel_suggestions.max_channels:
+    evidence: 'section\.get\("max_channels", DEFAULT_MAX_CHANNELS\)'
   cli: {evidence: 'get_config_value\("cli\.theme", "default", config_path\)'}
   cli.theme: {evidence: 'get_config_value\("cli\.theme", "default", config_path\)'}
 

--- a/src/osprey/deployment/channel_snapshot.py
+++ b/src/osprey/deployment/channel_snapshot.py
@@ -1,0 +1,217 @@
+"""Build-time channel snapshot decision for web channel suggestions.
+
+Web panels offer a typeahead over the control-system addresses a project knows
+about. The addresses come from the project's Channel Finder database, which
+lives on the build host and is not reachable from a browser, so the build emits
+a static snapshot of them next to the rendered service files instead.
+
+This module answers the single question the build needs: *should a snapshot be
+written, and what goes in it?* :func:`compute_channel_snapshot` returns one
+:class:`SnapshotDecision`; every consumer reads that object rather than
+re-deriving the predicate, so the compose fragment, the mount, and the file on
+disk can never disagree about whether a snapshot exists.
+
+The decision fails soft in every direction. A project with no Channel Finder
+database, an empty one, one too large to be useful as a typeahead, or one that
+cannot be read at all simply gets no snapshot — the build itself is never
+blocked, because a missing autocomplete list is a degraded panel, not a broken
+deployment.
+
+Working-directory precondition: a relative ``database.path`` is resolved against
+the process working directory, which the build sets to the project root before
+generating compose files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.channel_snapshot")
+
+#: Upper bound on snapshot size when the project does not set one. Well past any
+#: real facility catalog, and small enough that the browser-side typeahead stays
+#: responsive on the largest one anybody has pointed at OSPREY so far.
+DEFAULT_MAX_CHANNELS = 50000
+
+#: Named in the skip message so a project that trips the guard knows what to raise.
+MAX_CHANNELS_CONFIG_KEY = "web.channel_suggestions.max_channels"
+
+#: Named in the skip message when the feature is switched off explicitly.
+ENABLED_CONFIG_KEY = "web.channel_suggestions.enabled"
+
+
+@dataclass(frozen=True)
+class SnapshotDecision:
+    """Whether to emit a channel snapshot, and what it contains.
+
+    Attributes:
+        emit: True when a snapshot file should be written.
+        channels: Sorted, deduplicated control-system addresses. Empty unless
+            ``emit`` is True — a decision not to emit carries no payload.
+        count: How many distinct addresses the database yielded. Reported even
+            when ``emit`` is False, so a caller can say why nothing was written.
+        source_path: Resolved path of the database the addresses came from, or
+            None when no database was configured or reachable.
+    """
+
+    emit: bool
+    channels: list[str] = field(default_factory=list)
+    count: int = 0
+    source_path: Path | None = None
+
+
+def _suggestions_section(config: dict) -> dict:
+    """Read the ``web.channel_suggestions`` block, tolerating any shape.
+
+    An absent block is not an opt-out: the feature is on by default, and the
+    keys are only written explicitly by newer generated configs.
+
+    Args:
+        config: Full project configuration dictionary.
+
+    Returns:
+        The block as a dict, or an empty dict when it is absent or not a mapping.
+    """
+    web = config.get("web") or {}
+    if not isinstance(web, dict):
+        return {}
+    section = web.get("channel_suggestions") or {}
+    return section if isinstance(section, dict) else {}
+
+
+def _max_channels(section: dict) -> int:
+    """Resolve the size guard, falling back to the default on an unusable value."""
+    raw = section.get("max_channels", DEFAULT_MAX_CHANNELS)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Ignoring unusable {MAX_CHANNELS_CONFIG_KEY} value {raw!r}; "
+            f"using the default of {DEFAULT_MAX_CHANNELS}."
+        )
+        return DEFAULT_MAX_CHANNELS
+
+
+def _load_channel_records(pipeline_type: str, db_config: dict, db_path: Path) -> list[dict]:
+    """Load a channel database and return its channel records.
+
+    Constructing any of the database classes loads the file, so a bad path or
+    malformed content surfaces here as an exception for the caller to absorb.
+    The database classes are imported lazily to keep the deployment import graph
+    free of the Channel Finder service.
+
+    Args:
+        pipeline_type: Pipeline name from ``detect_pipeline_config``.
+        db_config: The pipeline's ``database`` block (``path``, and ``type`` for
+            the in-context pipeline).
+        db_path: Resolved path to the database file.
+
+    Returns:
+        Channel records, each carrying at least a ``channel`` key and usually an
+        ``address``.
+
+    Raises:
+        ValueError: If ``pipeline_type`` is not a known pipeline.
+    """
+    database: Any
+    if pipeline_type == "in_context":
+        from osprey.services.channel_finder.databases import (
+            FlatChannelDatabase,
+            TemplateChannelDatabase,
+        )
+
+        db_type = db_config.get("type", "template")
+        if db_type == "flat":
+            database = FlatChannelDatabase(str(db_path))
+        else:
+            database = TemplateChannelDatabase(str(db_path))
+    elif pipeline_type == "hierarchical":
+        from osprey.services.channel_finder.databases import HierarchicalChannelDatabase
+
+        database = HierarchicalChannelDatabase(str(db_path))
+    elif pipeline_type == "middle_layer":
+        from osprey.services.channel_finder.databases import MiddleLayerDatabase
+
+        database = MiddleLayerDatabase(str(db_path))
+    else:
+        raise ValueError(f"Unknown channel finder pipeline '{pipeline_type}'")
+
+    records: list[dict] = database.get_all_channels()
+    return records
+
+
+def compute_channel_snapshot(config: dict) -> SnapshotDecision:
+    """Decide whether the build should emit a channel snapshot, and with what.
+
+    A snapshot is emitted when the project configures a Channel Finder database,
+    ``web.channel_suggestions.enabled`` is not switched off, the database is
+    readable, and it holds at least one and at most
+    ``web.channel_suggestions.max_channels`` distinct addresses.
+
+    The addresses — not the human-facing channel names — are what a panel writes
+    into a control-system request, so those are what the snapshot carries. A
+    database whose records name both keeps its ``address``; one that names only
+    ``channel`` (the hierarchical and middle-layer pipelines synthesize an
+    address from the channel name) contributes that instead.
+
+    Args:
+        config: Full project configuration dictionary, as the build already
+            holds it.
+
+    Returns:
+        The decision. Never raises: an unreadable or malformed database is
+        logged as a warning and yields ``emit=False``.
+    """
+    section = _suggestions_section(config)
+
+    if not section.get("enabled", True):
+        logger.debug(f"{ENABLED_CONFIG_KEY} is off; not emitting a channel snapshot.")
+        return SnapshotDecision(emit=False)
+
+    from osprey.services.channel_finder.utils.detection import detect_pipeline_config
+
+    pipeline_type, db_config = detect_pipeline_config(config)
+    if not pipeline_type or not db_config:
+        logger.debug("No channel finder database is configured; not emitting a channel snapshot.")
+        return SnapshotDecision(emit=False)
+
+    db_path = Path(db_config["path"])
+    if not db_path.is_absolute():
+        db_path = Path.cwd() / db_path
+
+    try:
+        records = _load_channel_records(pipeline_type, db_config, db_path)
+        addresses = {record.get("address", record["channel"]) for record in records}
+        channels = sorted(address for address in addresses if address)
+    except Exception as e:
+        logger.warning(
+            f"Could not read the channel database at {db_path} ({e}); "
+            "not emitting a channel snapshot."
+        )
+        return SnapshotDecision(emit=False, source_path=db_path)
+
+    count = len(channels)
+
+    if count == 0:
+        # An empty snapshot is not a smaller suggestion list, it is a typeahead
+        # that never suggests anything — so there is nothing worth writing.
+        logger.debug(
+            f"The channel database at {db_path} holds no channels; not emitting a channel snapshot."
+        )
+        return SnapshotDecision(emit=False, source_path=db_path)
+
+    max_channels = _max_channels(section)
+    if count > max_channels:
+        logger.warning(
+            f"The channel database at {db_path} holds {count} channels, above the "
+            f"{MAX_CHANNELS_CONFIG_KEY} limit of {max_channels}; not emitting a channel "
+            "snapshot. Raise that limit to include it."
+        )
+        return SnapshotDecision(emit=False, count=count, source_path=db_path)
+
+    logger.debug(f"Channel snapshot: {count} channels from {db_path}.")
+    return SnapshotDecision(emit=True, channels=channels, count=count, source_path=db_path)

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -25,6 +25,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from osprey.cli import output
 from osprey.cli.phase_reporter import report_step
+from osprey.deployment.channel_snapshot import compute_channel_snapshot
 from osprey.deployment.runtime_helper import ComposeProvider, get_runtime_command, runtime_env
 from osprey.deployment.subprocess_capture import run_captured
 
@@ -1396,6 +1397,58 @@ def _ensure_agent_data_structure(config):
     logger.debug(f"Ensured agent data structure exists at: {agent_data_path}")
 
 
+#: Basename of the one service directory whose build context carries the
+#: channel snapshot: the bluesky_web sidecar's /channels route serves it.
+_CHANNEL_SNAPSHOT_SERVICE = "bluesky_web"
+
+#: Filename the sidecar's /channels route expects beside its mounted config.yml.
+CHANNEL_SNAPSHOT_FILENAME = "channels.json"
+
+
+def _stage_channel_snapshot(config, source_dir, out_dir):
+    """Write the channel snapshot into the bluesky_web build context; report success.
+
+    Only the bluesky_web sidecar serves the snapshot, so every other service
+    render skips the database load entirely and reports False. The boolean
+    return is the value the render context's ``channel_snapshot`` key carries —
+    fail-closed exactly like dev_mode's wheel gating: the compose template may
+    only mount a file that was actually written. When the decision is not to
+    emit, a snapshot left in ``out_dir`` by an earlier build is removed, so an
+    incremental rebuild (which reuses the directory) cannot keep a stale one.
+
+    :param config: Full project configuration dictionary
+    :type config: dict
+    :param source_dir: Service source directory being rendered
+    :type source_dir: str
+    :param out_dir: The service's build context directory
+    :type out_dir: str
+    :return: True iff a snapshot was successfully written into ``out_dir``
+    :rtype: bool
+    """
+    if os.path.basename(source_dir) != _CHANNEL_SNAPSHOT_SERVICE:
+        return False
+
+    snapshot_path = os.path.join(out_dir, CHANNEL_SNAPSHOT_FILENAME)
+    decision = compute_channel_snapshot(config)
+    if not decision.emit:
+        try:
+            os.remove(snapshot_path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            logger.warning(f"Could not remove the stale channel snapshot {snapshot_path}: {e}")
+        return False
+
+    try:
+        with open(snapshot_path, "w") as f:
+            json.dump(decision.channels, f)
+    except OSError as e:
+        logger.warning(f"Could not write the channel snapshot to {snapshot_path}: {e}")
+        return False
+    logger.debug(f"Wrote channel snapshot ({decision.count} channels) to {snapshot_path}")
+    return True
+
+
 def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
     """Create complete build environment for service deployment.
 
@@ -1543,7 +1596,13 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
     # (e.g. OSPREY_DEV) exactly when `osprey up --dev` runs AND the
     # local wheel actually landed in this context — never when staging failed
     # (fail-closed: the Dockerfile then keeps its fail-loud pinned install).
-    render_config = {**config, "dev_mode": dev_mode and wheel_staged}
+    # channel_snapshot is gated the same way: True only when the snapshot file
+    # actually landed in this context, so the mount and the file cannot disagree.
+    render_config = {
+        **config,
+        "dev_mode": dev_mode and wheel_staged,
+        "channel_snapshot": _stage_channel_snapshot(config, source_dir, out_dir),
+    }
     compose_filepath = render_template(template_path, render_config, out_dir)
 
     if source_dir != SERVICES_DIR:  # ignore the top level dir
@@ -1722,9 +1781,13 @@ def _incremental_setup_build_dir(template_path, config, service_config, out_dir,
 
         wheel_staged = _stage_dev_wheel_for_context(out_dir, dev_mode)
 
-    # Create/update the docker compose file from the template (dev_mode gated
-    # on staging success, exactly as in setup_build_dir).
-    render_config = {**config, "dev_mode": dev_mode and wheel_staged}
+    # Create/update the docker compose file from the template (dev_mode and
+    # channel_snapshot gated on staging success, exactly as in setup_build_dir).
+    render_config = {
+        **config,
+        "dev_mode": dev_mode and wheel_staged,
+        "channel_snapshot": _stage_channel_snapshot(config, source_dir, out_dir),
+    }
     compose_filepath = render_template(template_path, render_config, out_dir)
 
     # Same rendered-config step as the full path (see setup_build_dir): a

--- a/src/osprey/interfaces/bluesky_web/app.py
+++ b/src/osprey/interfaces/bluesky_web/app.py
@@ -1,14 +1,17 @@
 """The bluesky-web sidecar's FastAPI app: the operator panel bundles plus a
 shared HTTP client onto the Bluesky bridge.
 
-What the app owns is serving and plumbing: its container healthcheck, a blanket
-no-cache header on everything it serves, one ``httpx.AsyncClient`` and resolved
+What the app owns is serving and plumbing: its container healthcheck, a default
+no-cache header on everything that does not set one itself, one
+``httpx.AsyncClient`` and resolved
 bridge URL published on ``app.state`` for every router to use, and the static
 mounts for the panel bundles plus the shared design-system assets.
 
-What it does NOT own is policy. The routers it composes — the read proxy, the
-plan-draft relay and the plan-queue relay — relay to the bridge verbatim, body
-and status code alike; the bridge decides what a request is allowed to do.
+What it does NOT own is policy. The bridge-facing routers it composes — the read
+proxy, the plan-draft relay and the plan-queue relay — relay to the bridge
+verbatim, body and status code alike; the bridge decides what a request is
+allowed to do. The one router that reaches no bridge is the channel catalog,
+which serves the build-time ``channels.json`` mounted beside the config.
 
 Panel mounts (panel bundles must agree with this mapping — see
 ``_PANEL_MOUNTS`` below):
@@ -32,7 +35,7 @@ from starlette.staticfiles import StaticFiles
 
 from osprey.bluesky_bridge_connection import resolve_bridge_url
 from osprey.interfaces._app_setup import configure_interface_app
-from osprey.interfaces.bluesky_web import draft_relay, queue_relay, read_proxy
+from osprey.interfaces.bluesky_web import channels, draft_relay, queue_relay, read_proxy
 
 # Panel bundle directories (relative to this module's directory) and the mount
 # path each is served under. Directories are created on startup if absent, so
@@ -83,9 +86,14 @@ async def _no_cache(request, call_next):  # type: ignore[no-untyped-def]
     uncached branch (that middleware's path rules are interface-app specific
     — ``/static/``, ``/api/`` — and match nothing this sidecar mounts, hence
     the blanket rule; on a loopback service re-fetching is free).
+
+    Filled in with ``setdefault``, never overridden, mirroring the web-terminal
+    hub proxy's convention: a route that made its own caching decision (e.g. a
+    revalidated ETag response) keeps it, and every route that made none still
+    gets the full no-store string.
     """
     response = await call_next(request)
-    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    response.headers.setdefault("Cache-Control", "no-cache, no-store, must-revalidate")
     return response
 
 
@@ -101,6 +109,9 @@ def health() -> dict:
 app.include_router(read_proxy.router)
 app.include_router(draft_relay.router)
 app.include_router(queue_relay.router)
+# The channel catalog is the one router that talks to no bridge at all — it
+# serves the build-time channels.json mounted beside the container's config.
+app.include_router(channels.router)
 
 
 for _mount_path, _panel_name in _PANEL_MOUNTS:

--- a/src/osprey/interfaces/bluesky_web/channels.py
+++ b/src/osprey/interfaces/bluesky_web/channels.py
@@ -1,0 +1,69 @@
+"""Serves the build-time channel catalog to the operator panels.
+
+``osprey build`` writes a ``channels.json`` catalog (a sorted array of channel
+addresses) next to the config the sidecar container is handed, and the compose
+template mounts it read-only as a sibling of ``config.yml``. This router hands
+that file to the browser so the plan form's channel fields can offer
+autocomplete without a round trip to the control system.
+
+The file is located relative to ``CONFIG_FILE`` -- the environment variable the
+compose template already sets to ``/app/project/config.yml``, whose directory is
+where the catalog is mounted. This is deliberately NOT
+``osprey_connectors.workspace``'s config resolution: that resolver ignores
+``CONFIG_FILE`` by design, and what this route needs is precisely the mounted
+sibling, not whichever config the process would otherwise load. A direct dev run
+(no ``CONFIG_FILE`` set) falls back to ``./config.yml``'s directory, i.e. the
+working directory.
+
+The catalog is the one thing this sidecar serves that is worth caching, so this
+route opts out of the blanket no-store rule in
+``osprey.interfaces.bluesky_web.app`` (which fills its header in with
+``setdefault``, yielding to a route that made its own decision). ``no-cache``
+means "revalidate every time, but a 304 is fine" -- paired with a strong ETag
+over the file bytes, a panel reload costs one empty 304 instead of re-shipping
+a catalog that only changes on a rebuild.
+
+An absent catalog answers 404, not an empty list: the file is only mounted when
+the build produced one, so its absence is the honest "this deployment has no
+catalog" signal. Panels treat that identically to an empty catalog -- no
+autocomplete, every other field unaffected.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request, Response
+
+router = APIRouter()
+
+
+def _catalog_path() -> Path:
+    """Locate ``channels.json`` beside the config named by ``CONFIG_FILE``."""
+    return Path(os.environ.get("CONFIG_FILE", "config.yml")).parent / "channels.json"
+
+
+@router.get("/channels")
+async def get_channels(request: Request) -> Response:
+    """Serve the channel catalog, revalidated against a strong ETag.
+
+    The file is read on every request rather than cached in process: it is a
+    small read-only bind mount, and re-reading keeps the ETag honest if the
+    mount is swapped underneath a running container.
+    """
+    path = _catalog_path()
+
+    try:
+        payload = path.read_bytes()
+    except OSError:
+        raise HTTPException(status_code=404, detail="channel catalog not available") from None
+
+    etag = f'"{hashlib.sha256(payload).hexdigest()}"'
+    headers = {"Cache-Control": "no-cache", "ETag": etag}
+
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+
+    return Response(content=payload, media_type="application/json", headers=headers)

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.js
@@ -46,6 +46,7 @@ import { contributeHeader, isSimpleMode, onHeaderAction } from '/design-system/j
 import { createPlansView } from './plans-view.js';
 import { createQueueView } from './queue-view.js';
 import { createResultsView } from './results-view.js';
+import { setChannelCatalog } from './schema-form.js';
 
 /** @typedef {'plans'|'queue'|'results'} ViewId */
 
@@ -311,3 +312,30 @@ if (initialRunId) {
 } else {
   publishContribution();
 }
+
+/**
+ * Fetch the deployment's channel catalog — once per panel load — and hand it
+ * to the schema-form module, so plan forms rendered from then on offer
+ * suggestions on channel-tagged fields. The endpoint is optional: a 404 (no
+ * catalog deployed), a network failure, a malformed payload, and an empty
+ * list all mean the same thing — no suggestions, forms exactly as they always
+ * were — so none of them is worth a console line.
+ */
+async function loadChannelCatalog() {
+  try {
+    const response = await fetch(api('/channels'));
+    if (!response.ok) return;
+    const channels = await response.json();
+    if (
+      Array.isArray(channels) &&
+      channels.length > 0 &&
+      channels.every((entry) => typeof entry === 'string')
+    ) {
+      setChannelCatalog(channels);
+    }
+  } catch {
+    // Optional endpoint: absence is a normal deployment state, not an error.
+  }
+}
+
+loadChannelCatalog();

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/schema-form.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/schema-form.js
@@ -62,6 +62,8 @@
  * @module schema-form
  */
 
+import { attachChannelCombobox } from '/design-system/js/channel-combobox.js';
+
 import { h } from './hyperscript.js';
 
 /**
@@ -93,7 +95,45 @@ export const OMIT = Symbol('omit');
  * @property {number} [exclusiveMaximum]
  * @property {number} [minItems]
  * @property {string} [x-widget]
+ * @property {string} [x-channel-role]
  */
+
+/**
+ * Channel-address catalog backing the suggestion comboboxes, or ``null`` while
+ * none is loaded. Installed at most once per panel load via
+ * ``setChannelCatalog``; forms rendered while this is ``null`` build exactly
+ * the DOM they always did, and are not retrofitted when the catalog arrives —
+ * only fields (including dynamically added list rows / table cells) built
+ * after it is set get a combobox.
+ *
+ * @type {string[]|null}
+ */
+let channelCatalog = null;
+
+/**
+ * Install the channel catalog for suggestion comboboxes. The panel bootstrap
+ * calls this once after a successful ``/channels`` fetch; an empty list is
+ * stored as "no catalog" so the feature stays entirely invisible.
+ *
+ * @param {string[]} channels
+ */
+export function setChannelCatalog(channels) {
+  channelCatalog = Array.isArray(channels) && channels.length > 0 ? channels : null;
+}
+
+/**
+ * The catalog a field should offer suggestions from, or ``null`` when the
+ * field is not channel-tagged or no catalog is loaded. Mirrors the
+ * ``x-widget`` convention: any truthy ``x-channel-role`` (Pydantic
+ * ``json_schema_extra``) tags the field as holding a channel address — the
+ * role's *value* only says why, it never filters the suggestions.
+ *
+ * @param {JsonSchemaNode} node A resolved node.
+ * @returns {string[]|null}
+ */
+function channelSuggestionsFor(node) {
+  return node['x-channel-role'] && channelCatalog ? channelCatalog : null;
+}
 
 /**
  * @typedef {object} Field
@@ -387,8 +427,20 @@ function buildString(node, seed) {
       value: seed === undefined || seed === null ? '' : String(seed),
     })
   );
+  // A channel-tagged field gets a suggestion combobox. The combobox wraps the
+  // input in place, which needs the input parented *now* — buildString's
+  // input is otherwise mounted later by its caller (a labeled row, a table
+  // cell) — so the tagged variant mounts via a plain host div. The untagged
+  // variant returns the bare input, byte-identical to before.
+  const catalog = channelSuggestionsFor(node);
+  /** @type {HTMLElement} */
+  let el = input;
+  if (catalog) {
+    el = h('div', undefined, input);
+    attachChannelCombobox(input, catalog);
+  }
   return {
-    el: input,
+    el,
     collect: () => (input.value === '' ? OMIT : input.value),
     setValue: (value) => {
       input.value = value === undefined || value === null ? '' : String(value);
@@ -603,6 +655,29 @@ function buildChips(node, itemSchema, seed) {
   );
   const el = h('div', { class: 'chips' }, input);
 
+  // Channel-tagged chip wells get a suggestion combobox on the add-input.
+  // Attached BEFORE buildCommitList wires its own keydown handler, so on an
+  // arrow-armed Enter the combobox (registered first) writes the accepted
+  // suggestion into the input and the commit handler then commits that value
+  // — not the half-typed text it would otherwise see.
+  const catalog = channelSuggestionsFor(node);
+  /**
+   * The node re-appended after the chips on every render: the bare input, or
+   * — once the combobox wraps it — the wrapper, so a re-render doesn't pull
+   * the input back out of its popup anchor. The wrapper also takes over the
+   * input's role as the chip row's growing flex item.
+   *
+   * @type {HTMLElement}
+   */
+  let inputMount = input;
+  if (catalog) {
+    attachChannelCombobox(input, catalog);
+    inputMount = /** @type {HTMLElement} */ (input.parentElement);
+    inputMount.style.flex = '1';
+    inputMount.style.minWidth = '110px';
+    input.style.width = '100%';
+  }
+
   // Paint `values` into the chip well — a removable chip each, add-input last —
   // rebuilding the whole well every call.
   /** @param {unknown[]} values */
@@ -622,7 +697,7 @@ function buildChips(node, itemSchema, seed) {
       });
       el.appendChild(h('span', { class: 'chip' }, h('span', { text: String(value) }), remove));
     });
-    el.appendChild(input);
+    el.appendChild(inputMount);
   }
 
   // Clicking anywhere in the chip well focuses the input, like a real tag box.
@@ -693,6 +768,13 @@ function buildChannelList(node, itemSchema, seed) {
     const n = values.length;
     count.textContent = `${n} channel${n === 1 ? '' : 's'}`;
   }
+
+  // Same ordering rationale as buildChips: attach before buildCommitList so
+  // an armed Enter commits the accepted suggestion, not the half-typed text.
+  // No mount juggling here — render only rebuilds the <ul>, so the wrapper
+  // simply takes the add-input's slot in the column flex and stays put.
+  const catalog = channelSuggestionsFor(node);
+  if (catalog) attachChannelCombobox(input, catalog);
 
   return buildCommitList(itemSchema, seed, input, el, render);
 }

--- a/src/osprey/interfaces/design_system/static/js/channel-combobox.js
+++ b/src/osprey/interfaces/design_system/static/js/channel-combobox.js
@@ -1,0 +1,435 @@
+// @ts-check
+/**
+ * Channel typeahead combobox for plan-form channel fields.
+ *
+ * DOM-touching companion to the pure channel-matcher module: it owns the
+ * anchored suggestion popover (position:relative wrapper, `.open` class,
+ * capture-phase document listener installed on open / removed on close) and
+ * the ARIA combobox contract, while all ranking stays in channel-matcher.
+ * Suggestions never block free-form entry — a value outside the catalog is
+ * typed exactly as into a bare input. Hand-written ES module (mirrors
+ * theme-manager.js) with JSDoc types so it type-checks under
+ * `tsc --noEmit --strict`.
+ *
+ * Selection semantics (load-bearing, pinned by the tests):
+ *   - no default highlight; aria-activedescendant moves only via
+ *     ArrowUp/ArrowDown (wrapping), hover is visual-only + click-select
+ *   - option rows preventDefault() on mousedown so the input keeps focus
+ *   - Enter accepts only an arrow-armed item (then stops propagation);
+ *     unarmed Enter closes the popup and propagates so the form's own
+ *     Enter handling still runs
+ *   - Escape closes; input re-queries the matcher behind a debounce
+ *
+ * @module channel-combobox
+ */
+
+import { matchChannels } from '/design-system/js/channel-matcher.js';
+import { el, debounce } from '/design-system/js/dom.js';
+
+/**
+ * Trailing-edge delay between the last keystroke and a matcher query.
+ * Exported so tests advance fake timers by exactly this amount.
+ *
+ * @type {number}
+ */
+export const DEFAULT_DEBOUNCE_MS = 150;
+
+/**
+ * Monotonic source for per-instance listbox/option ids, so several
+ * comboboxes on one form never collide on aria-controls targets.
+ *
+ * @type {number}
+ */
+let comboboxSeq = 0;
+
+/**
+ * @typedef {Object} ChannelComboboxOptions
+ * @property {number} [debounceMs] - override for DEFAULT_DEBOUNCE_MS
+ * @property {(value: string) => void} [onSelect] - called after a suggestion
+ *   is accepted (click or armed Enter), once the input value is updated
+ */
+
+/**
+ * @typedef {Object} ChannelComboboxHandle
+ * @property {() => void} close - close the popup (cancels any pending query)
+ * @property {() => boolean} isOpen - whether the popup is currently open
+ * @property {() => void} destroy - close, detach all listeners, unwrap the
+ *   input back to its original parent and drop the combobox DOM
+ */
+
+/**
+ * Append `text` to `container` with highlight spans over the matched ranges.
+ * Built from text nodes + span elements (never innerHTML) so catalog values
+ * containing markup render as literal text — the escapeHtml helper is
+ * HTML-context-safe only, and building nodes sidesteps escaping entirely.
+ *
+ * @param {HTMLElement} container
+ * @param {string} text
+ * @param {Array<[number, number]>} spans - merged half-open [start,end) pairs
+ * @returns {void}
+ */
+function appendHighlighted(container, text, spans) {
+  let cursor = 0;
+  for (const [start, end] of spans) {
+    if (start > cursor) container.appendChild(document.createTextNode(text.slice(cursor, start)));
+    const mark = el('span', 'channel-combobox-match');
+    mark.style.color = 'var(--color-accent)';
+    mark.style.fontWeight = '600';
+    mark.textContent = text.slice(start, end);
+    container.appendChild(mark);
+    cursor = end;
+  }
+  if (cursor < text.length) container.appendChild(document.createTextNode(text.slice(cursor)));
+}
+
+/**
+ * Attach a channel-suggestion combobox to a text input.
+ *
+ * Wraps the input in a position:relative `.channel-combobox` container and
+ * anchors a listbox popover under it. The component only ever *suggests*:
+ * it rewrites `input.value` solely when the user accepts a suggestion, and a
+ * programmatic accept re-dispatches a bubbling `input` event so form-level
+ * listeners (e.g. schema-form model sync) observe the new value.
+ *
+ * Styling note: the design system has dropdown *tokens* but no shared
+ * dropdown component classes, so the popover carries minimal inline styles
+ * built from tokens (`--bg-elevated`, `--border-default`,
+ * `--shadow-dropdown`, `--z-dropdown`, ...). The class hooks
+ * (`channel-combobox`, `-list`, `-item`, `-match`, `-more`, `.open`) exist
+ * for future promotion into a stylesheet.
+ *
+ * @param {HTMLInputElement} input - must already be in the DOM
+ * @param {string[] | (() => string[])} catalog - channel address strings, or
+ *   a getter re-read on every query so late-loading catalogs stay live
+ * @param {ChannelComboboxOptions} [opts]
+ * @returns {ChannelComboboxHandle}
+ */
+export function attachChannelCombobox(input, catalog, opts = {}) {
+  const { debounceMs = DEFAULT_DEBOUNCE_MS, onSelect } = opts;
+  const getCatalog = typeof catalog === 'function' ? catalog : () => catalog;
+
+  const host = input.parentNode;
+  if (!host) throw new Error('attachChannelCombobox: input must be attached to the DOM');
+
+  const listId = `channel-combobox-list-${++comboboxSeq}`;
+  const wrapper = el('div', 'channel-combobox');
+  wrapper.style.position = 'relative';
+  host.insertBefore(wrapper, input);
+  wrapper.appendChild(input);
+
+  const listbox = el('div', 'channel-combobox-list');
+  listbox.id = listId;
+  listbox.setAttribute('role', 'listbox');
+  Object.assign(listbox.style, {
+    display: 'none',
+    position: 'absolute',
+    top: '100%',
+    left: '0',
+    right: '0',
+    marginTop: '2px',
+    maxHeight: '240px',
+    overflowY: 'auto',
+    zIndex: 'var(--z-dropdown)',
+    background: 'var(--bg-elevated)',
+    border: '1px solid var(--border-default)',
+    borderRadius: 'var(--radius-md)',
+    boxShadow: 'var(--shadow-dropdown)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 'var(--text-sm)',
+    color: 'var(--text-primary)',
+  });
+  wrapper.appendChild(listbox);
+
+  input.setAttribute('role', 'combobox');
+  input.setAttribute('aria-expanded', 'false');
+  input.setAttribute('aria-autocomplete', 'list');
+  input.setAttribute('aria-controls', listId);
+
+  /**
+   * Currently rendered option rows in listbox order. Rebuilt on every query;
+   * the "+N more" footer is deliberately NOT in here so arrow navigation and
+   * Enter can never land on it.
+   *
+   * @type {Array<{ row: HTMLElement, value: string }>}
+   */
+  let options = [];
+  /** Index of the arrow-armed option, -1 = none (the no-default-highlight rule). */
+  let armed = -1;
+  let isOpen = false;
+  /**
+   * Bumped on every user-intent close (Escape, select, outside click, blur)
+   * so a debounced query scheduled before the close aborts instead of
+   * reopening a popup the user just dismissed.
+   */
+  let generation = 0;
+  /** True while the accept path re-dispatches its synthetic `input` event. */
+  let suppressInput = false;
+
+  /**
+   * Paint a row's hover/armed background. Inline because there is no
+   * stylesheet to hang :hover on (see the styling note above).
+   *
+   * @param {number} index
+   * @param {boolean} on
+   * @returns {void}
+   */
+  function paintRow(index, on) {
+    const opt = options[index];
+    if (opt) opt.row.style.background = on ? 'var(--bg-secondary)' : 'transparent';
+  }
+
+  /**
+   * Move the armed highlight. Owns the full contract: aria-selected +
+   * background on the rows, aria-activedescendant on the input (removed when
+   * nothing is armed), and keeping the armed row scrolled into view.
+   *
+   * @param {number} next - option index, or -1 to disarm
+   * @returns {void}
+   */
+  function setArmed(next) {
+    if (armed !== -1 && options[armed]) {
+      options[armed].row.setAttribute('aria-selected', 'false');
+      paintRow(armed, false);
+    }
+    armed = next;
+    if (armed === -1) {
+      input.removeAttribute('aria-activedescendant');
+      return;
+    }
+    const { row } = options[armed];
+    row.setAttribute('aria-selected', 'true');
+    paintRow(armed, true);
+    input.setAttribute('aria-activedescendant', row.id);
+    if (typeof row.scrollIntoView === 'function') row.scrollIntoView({ block: 'nearest' });
+  }
+
+  /**
+   * Close triggered by explicit user intent — additionally cancels any
+   * pending debounced query via the generation counter, so the popup stays
+   * dismissed even when a keystroke was still in flight.
+   *
+   * @returns {void}
+   */
+  function dismiss() {
+    generation += 1;
+    close();
+  }
+
+  /**
+   * Outside-pointer dismissal. Installed capture-phase on the document only
+   * while the popup is open, so a click anywhere (even inside widgets that
+   * stop propagation) closes it; clicks inside the wrapper are the popup's
+   * own business and are left alone.
+   *
+   * @param {MouseEvent} e
+   * @returns {void}
+   */
+  function onDocMousedown(e) {
+    if (!(e.target instanceof Node) || !wrapper.contains(e.target)) dismiss();
+  }
+
+  /** @returns {void} */
+  function open() {
+    if (isOpen) return;
+    isOpen = true;
+    wrapper.classList.add('open');
+    listbox.style.display = 'block';
+    input.setAttribute('aria-expanded', 'true');
+    document.addEventListener('mousedown', onDocMousedown, true);
+  }
+
+  /** @returns {void} */
+  function close() {
+    if (!isOpen) return;
+    isOpen = false;
+    setArmed(-1);
+    wrapper.classList.remove('open');
+    listbox.style.display = 'none';
+    input.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('mousedown', onDocMousedown, true);
+  }
+
+  /**
+   * Accept a suggestion: write it into the input, notify the outside world,
+   * and dismiss. The synthetic bubbling `input` event exists so form-level
+   * listeners see the programmatic value change exactly like a keystroke;
+   * `suppressInput` keeps the combobox's own input handler from treating it
+   * as typing and re-querying.
+   *
+   * @param {string} value
+   * @returns {void}
+   */
+  function select(value) {
+    input.value = value;
+    suppressInput = true;
+    try {
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    } finally {
+      suppressInput = false;
+    }
+    if (onSelect) onSelect(value);
+    dismiss();
+  }
+
+  /**
+   * Build one option row: highlight-rendered label, mousedown-preventDefault
+   * (keeps focus in the input), click-select, and visual-only hover — hover
+   * never touches aria-activedescendant, which is reserved for arrow keys.
+   *
+   * @param {{ value: string, spans: Array<[number, number]> }} match
+   * @param {number} index
+   * @returns {HTMLElement}
+   */
+  function buildRow(match, index) {
+    const row = el('div', 'channel-combobox-item');
+    row.id = `${listId}-opt-${index}`;
+    row.setAttribute('role', 'option');
+    row.setAttribute('aria-selected', 'false');
+    Object.assign(row.style, {
+      padding: 'var(--space-1) var(--space-2)',
+      cursor: 'pointer',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    });
+    appendHighlighted(row, match.value, match.spans);
+    row.addEventListener('mousedown', (e) => e.preventDefault());
+    row.addEventListener('click', () => select(match.value));
+    row.addEventListener('mouseenter', () => {
+      if (index !== armed) row.style.background = 'var(--bg-secondary)';
+    });
+    row.addEventListener('mouseleave', () => {
+      if (index !== armed) row.style.background = 'transparent';
+    });
+    return row;
+  }
+
+  /**
+   * Rebuild the listbox from a matcher result. Always disarms first (rows
+   * are replaced wholesale, and a fresh result list must not inherit a
+   * highlight — the no-default-highlight rule). A truncated pool gets an
+   * aria-hidden "+N more" footer that is not an option.
+   *
+   * @param {{ results: Array<{ value: string, spans: Array<[number, number]> }>, total: number }} match
+   * @returns {void}
+   */
+  function renderResults(match) {
+    setArmed(-1);
+    listbox.textContent = '';
+    options = match.results.map((result, index) => {
+      const row = buildRow(result, index);
+      listbox.appendChild(row);
+      return { row, value: result.value };
+    });
+    if (match.total > match.results.length) {
+      const more = el('div', 'channel-combobox-more');
+      more.setAttribute('aria-hidden', 'true');
+      more.textContent = `${match.total - match.results.length} more matches — keep typing to narrow`;
+      Object.assign(more.style, {
+        padding: 'var(--space-1) var(--space-2)',
+        color: 'var(--text-muted)',
+        fontSize: 'var(--text-xs)',
+      });
+      more.addEventListener('mousedown', (e) => e.preventDefault());
+      listbox.appendChild(more);
+    }
+  }
+
+  /**
+   * Run the matcher against the current input value and open/refresh or
+   * close the popup accordingly. An empty field closes rather than browsing
+   * the whole catalog: clearing a value is an edit, not a browse request.
+   *
+   * @returns {void}
+   */
+  function runQuery() {
+    const value = input.value;
+    if (value.trim() === '') {
+      close();
+      return;
+    }
+    const match = matchChannels(value, getCatalog());
+    if (match.results.length === 0) {
+      close();
+      return;
+    }
+    renderResults(match);
+    open();
+  }
+
+  const debouncedQuery = debounce(
+    /** @param {number} gen */ (gen) => {
+      if (gen === generation) runQuery();
+    },
+    debounceMs
+  );
+
+  /** @returns {void} */
+  function onInput() {
+    if (suppressInput) return;
+    debouncedQuery(generation);
+  }
+
+  /**
+   * Keyboard contract. Runs on the input itself (not the document): with the
+   * popup closed every key falls through untouched, so free-form entry and
+   * the surrounding form's own key handling are never affected.
+   *
+   * @param {KeyboardEvent} e
+   * @returns {void}
+   */
+  function onKeydown(e) {
+    if (!isOpen || e.isComposing) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setArmed(armed >= options.length - 1 ? 0 : armed + 1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setArmed(armed <= 0 ? options.length - 1 : armed - 1);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      dismiss();
+    } else if (e.key === 'Enter') {
+      if (armed !== -1 && options[armed]) {
+        e.preventDefault();
+        e.stopPropagation();
+        select(options[armed].value);
+      } else {
+        // Unarmed Enter: close, but let the event propagate so the form's
+        // own Enter handling (submit, etc.) still fires.
+        dismiss();
+      }
+    }
+  }
+
+  /** @returns {void} */
+  function onBlur() {
+    // Option mousedown preventDefault()s, so focus never leaves the input on
+    // popup clicks — a real blur means the user moved on. Close behind them.
+    dismiss();
+  }
+
+  input.addEventListener('input', onInput);
+  input.addEventListener('keydown', onKeydown);
+  input.addEventListener('blur', onBlur);
+
+  return {
+    close: dismiss,
+    isOpen: () => isOpen,
+    destroy() {
+      dismiss();
+      input.removeEventListener('input', onInput);
+      input.removeEventListener('keydown', onKeydown);
+      input.removeEventListener('blur', onBlur);
+      input.removeAttribute('role');
+      input.removeAttribute('aria-expanded');
+      input.removeAttribute('aria-autocomplete');
+      input.removeAttribute('aria-controls');
+      input.removeAttribute('aria-activedescendant');
+      const parent = wrapper.parentNode;
+      if (parent) parent.insertBefore(input, wrapper);
+      wrapper.remove();
+    },
+  };
+}

--- a/src/osprey/interfaces/design_system/static/js/channel-matcher.js
+++ b/src/osprey/interfaces/design_system/static/js/channel-matcher.js
@@ -1,0 +1,123 @@
+// @ts-check
+/**
+ * Channel-catalog matcher for the plan-form channel typeahead.
+ *
+ * Pure, DOM-free ranking core (pure modules belong in the design system
+ * because they carry no interface coupling): given a query and a catalog of
+ * channel address strings it returns the ranked suggestion pool. Hand-written
+ * ES module (mirrors theme-manager.js) with JSDoc types so it type-checks
+ * under `tsc --noEmit --strict`.
+ *
+ * Pool rule: case-insensitive substring hits form the candidate pool when
+ * there are at least MIN_POOL of them; below that threshold the pool widens
+ * to every catalog entry that fuzzyMatch accepts (subsequence matching, so
+ * "SRHCM" still finds "SR:HCM:..." with zero substring hits). Both modes
+ * rank by fuzzyMatch score — a substring is a subsequence, so every
+ * substring hit also fuzzy-matches — and `total` reports the honest pool
+ * size while `results` is capped at RENDER_CAP entries.
+ *
+ * @module channel-matcher
+ */
+
+import { fuzzyMatch } from '/design-system/js/fuzzy.js';
+
+/**
+ * Minimum number of case-insensitive substring hits required before the
+ * substring set alone is trusted as the candidate pool. Below this the
+ * matcher falls through to subsequence (fuzzy) matching over the whole
+ * catalog so terse queries like "SRHCM" still surface "SR:HCM:..." names.
+ *
+ * @type {number}
+ */
+export const MIN_POOL = 8;
+
+/**
+ * Maximum number of entries returned in `results`. The pool itself is not
+ * truncated — `total` always reports the full pool size — but rendering
+ * thousands of dropdown rows helps nobody, so the visible slice stops here.
+ *
+ * @type {number}
+ */
+export const RENDER_CAP = 50;
+
+/**
+ * @typedef {{ value: string, spans: Array<[number, number]> }} ChannelMatch
+ */
+
+/**
+ * @typedef {{ results: ChannelMatch[], total: number }} ChannelMatchResult
+ */
+
+/**
+ * Internal scored entry carried between pooling and ranking.
+ *
+ * @typedef {{ value: string, score: number, spans: Array<[number, number]> }} ScoredEntry
+ */
+
+/**
+ * Rank scored entries by fuzzy score descending, breaking ties by value
+ * ascending. The explicit tie-break exists because catalogs are full of
+ * same-shaped names that score identically; without it the order would
+ * depend on engine sort stability and tests could not pin the contract.
+ *
+ * @param {ScoredEntry[]} entries
+ * @returns {ScoredEntry[]} the same array, sorted in place
+ */
+function rank(entries) {
+  return entries.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return a.value < b.value ? -1 : a.value > b.value ? 1 : 0;
+  });
+}
+
+/**
+ * Match a query against a channel catalog and return the ranked suggestion
+ * pool. See the module header for the pool rule. An empty or whitespace-only
+ * query matches everything: the pool is the whole catalog (honest `total`)
+ * and `results` is the first RENDER_CAP entries in catalog order, because
+ * fuzzyMatch scores every candidate 0 there and catalog order is the only
+ * meaningful ranking.
+ *
+ * @param {string} query - raw user input; not trimmed by the caller
+ * @param {string[]} catalog - channel address strings (sorted upstream)
+ * @returns {ChannelMatchResult}
+ */
+export function matchChannels(query, catalog) {
+  const trimmed = query.trim();
+  if (trimmed === '') {
+    return {
+      results: catalog.slice(0, RENDER_CAP).map((value) => ({ value, spans: [] })),
+      total: catalog.length,
+    };
+  }
+
+  // Trim for the substring test so stray surrounding whitespace does not
+  // silently empty the substring set; fuzzyMatch tokenizes on whitespace and
+  // is indifferent to it.
+  const lowerQuery = trimmed.toLowerCase();
+  /** @type {string[]} */
+  const substringHits = [];
+  for (const value of catalog) {
+    if (value.toLowerCase().includes(lowerQuery)) {
+      substringHits.push(value);
+    }
+  }
+
+  const candidates = substringHits.length >= MIN_POOL ? substringHits : catalog;
+  /** @type {ScoredEntry[]} */
+  const pool = [];
+  for (const value of candidates) {
+    const hit = fuzzyMatch(query, value);
+    if (hit !== null) {
+      pool.push({ value, score: hit.score, spans: hit.spans });
+    }
+  }
+
+  rank(pool);
+  return {
+    results: pool.slice(0, RENDER_CAP).map(({ value, spans }) => ({ value, spans })),
+    total: pool.length,
+  };
+}

--- a/src/osprey/interfaces/design_system/static/js/fuzzy.js
+++ b/src/osprey/interfaces/design_system/static/js/fuzzy.js
@@ -1,14 +1,19 @@
 // @ts-check
-/* OSPREY Web Terminal — Fuzzy Match Scorer
+/**
+ * Fuzzy match scorer for query-driven suggestion lists.
  *
- * Pure, DOM-free scorer for the command palette. The query is tokenized on
- * whitespace and EVERY token must independently subsequence-match the candidate
- * (case-insensitive, in-order, gaps allowed) — an all-tokens-AND contract, so
- * "wrt vrf" matches "control_system.write_verification" via two separate tokens.
- * Each token scores boundary hits (start / after . _ - / camelCase) and
- * consecutive runs; all per-token scores sum. Matched character ranges from
- * every token are merged into sorted, non-overlapping [start, end) spans for
- * the UI to highlight. Empty query matches everything (score 0, no spans).
+ * Pure, DOM-free scorer (pure modules belong in the design system because
+ * they carry no interface coupling) shared by the command palette and the
+ * channel-catalog matcher. The query is tokenized on whitespace and EVERY
+ * token must independently subsequence-match the candidate (case-insensitive,
+ * in-order, gaps allowed) — an all-tokens-AND contract, so "wrt vrf" matches
+ * "control_system.write_verification" via two separate tokens. Each token
+ * scores boundary hits (start / after . _ - / camelCase) and consecutive
+ * runs; all per-token scores sum. Matched character ranges from every token
+ * are merged into sorted, non-overlapping [start, end) spans for the UI to
+ * highlight. Empty query matches everything (score 0, no spans).
+ *
+ * @module fuzzy
  */
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/palette.js
+++ b/src/osprey/interfaces/web_terminal/static/js/palette.js
@@ -32,9 +32,9 @@
  * plain underlying key, from whichever copy was executed.
  */
 
-import { fuzzyMatch } from './fuzzy.js';
 import { buildRegistry } from './palette-registry.js';
 import { fetchJSON } from './api.js';
+import { fuzzyMatch } from '/design-system/js/fuzzy.js';
 import { el } from '/design-system/js/dom.js';
 
 /** @typedef {import('./palette-registry.js').Item} Item */

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -1181,6 +1181,28 @@ web:
   # the `web:` level, NOT under `panels:`:
   # allow_runtime_panels: true                       # let the agent register ad-hoc URL panels at runtime
   # runtime_panel_allowlist: ["grafana.local:3000"]  # restrict registration targets to these host[:port]
+
+  # Channel-name typeahead in the web panels. `osprey build` reads this
+  # project's channel-finder database and writes the channel names it holds
+  # next to the generated config, so a form field asking for a channel can
+  # complete what an operator types. The suggestions come from that snapshot
+  # alone: no control-system traffic, no round trip to the agent, and nothing
+  # to keep in sync at run time. It is on by default because the database is
+  # already built; the snapshot is only written when a `channel_finder:`
+  # section is configured above.
+  #
+  # `max_channels` guards the browser, not the build: every panel load fetches
+  # the whole snapshot, so a database with more channels than this limit is
+  # skipped instead of shipped, the build says which limit it hit, and the
+  # panels simply offer no suggestions — fields still accept any name typed in
+  # full. Raise the limit to cover a larger facility, or set `enabled: false`
+  # to turn the feature off and write no snapshot at all. Both keys fall back
+  # to the values shown here if removed. A build profile overrides them from
+  # its `config:` block in the dotted form, e.g.
+  # `web.channel_suggestions.max_channels: 200000`.
+  channel_suggestions:
+    enabled: true
+    max_channels: 50000
 {%- if panel_presets is defined and panel_presets %}
   # Panel layouts ("Layouts"): named sets of panels a human applies in one click
   # from the web terminal "+" popover. The key is the menu label; the value is

--- a/src/osprey/templates/services/bluesky_web/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky_web/docker-compose.yml.j2
@@ -90,6 +90,14 @@ services:
       # (build/services/), not this file's own subdir — hence the
       # bluesky-web/ prefix (mirrors the bridge's config.yml:ro convention).
       - ./build/services/bluesky_web/config.yml:/app/project/config.yml:ro
+{% if channel_snapshot | default(false) %}
+      # Only when the build emitted a channel snapshot (channel_snapshot is
+      # true exactly when build/services/bluesky_web/channels.json was staged
+      # — see compose_generator._stage_channel_snapshot): an unconditional
+      # bind mount of a file the build never wrote would fail
+      # `docker compose up` on the missing source.
+      - ./build/services/bluesky_web/channels.json:/app/project/channels.json:ro
+{% endif %}
     networks:
       - osprey-network
     healthcheck:

--- a/tests/cli/test_channel_db_drift.py
+++ b/tests/cli/test_channel_db_drift.py
@@ -1,0 +1,125 @@
+"""The channel-database snapshot stays current because the build-drift gate says so.
+
+``osprey build`` snapshots the Channel Finder database into a ``channels.json``
+artifact under ``build/``. That artifact goes stale the moment a facility edits
+its channel database, and the DECISION documented here is how staleness is
+caught: the existing build-drift gate, not a regeneration hook at ``osprey up``
+time.
+
+A channel database lives under the profile's ``data:`` tree, which
+``_fold_profile_material`` folds into the profile fingerprint. Editing one moves
+``compute_profile_hash`` while ``profile.yml`` itself is byte-identical, so the
+fingerprint stamped into the build manifest no longer matches and ``osprey up``
+refuses with the rebuild remedy. No second mechanism is needed, and a
+regeneration hook would add an up-time code path that can disagree with what
+``build`` produced.
+
+The limitation this buys is deliberate: a database pointed at from OUTSIDE the
+profile's ``data:`` tree is not folded, so its edits are invisible to the gate.
+That is recorded in the proposal's Risks and is not asserted here — asserting it
+would pin behaviour we have chosen not to provide.
+
+The fold itself is pinned in ``test_profile_material_hash.py`` and
+``test_profile_hash_folding.py``; the refusal is pinned in
+``tests/deployment/test_drift_refusal.py``. This file speaks only for the
+snapshot's source.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osprey.cli.build_profile import compute_profile_hash
+
+PROFILE_YAML = "name: Facility\napp_template: hello_world\ndata: data\n"
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def profile(tmp_path):
+    """A profile whose ``data:`` tree holds the database the snapshot is taken from."""
+    root = tmp_path / "facility"
+    _write(root / "data" / "channel_databases" / "als.json", '{"channels": []}\n')
+    return _write(root / "profile.yml", PROFILE_YAML)
+
+
+def test_editing_a_channel_database_under_data_moves_the_fingerprint(profile):
+    """The whole decision rests on this: the snapshot's source is folded material.
+
+    ``profile.yml`` is untouched — only the database the snapshot was taken from
+    changed, which is exactly what a facility adding a channel does.
+    """
+    before = compute_profile_hash(profile)
+
+    _write(
+        profile.parent / "data" / "channel_databases" / "als.json",
+        '{"channels": ["SR:BPM1"]}\n',
+    )
+
+    assert compute_profile_hash(profile) != before
+
+
+def test_adding_a_channel_database_moves_the_fingerprint(profile):
+    """A new database file is new snapshot input, so it has to count as a change."""
+    before = compute_profile_hash(profile)
+
+    _write(profile.parent / "data" / "channel_databases" / "booster.json", '{"channels": []}\n')
+
+    assert compute_profile_hash(profile) != before
+
+
+def test_an_untouched_channel_database_leaves_the_fingerprint_alone(profile):
+    """Without this, every start would refuse and operators would learn to bypass."""
+    assert compute_profile_hash(profile) == compute_profile_hash(profile)
+
+
+def test_a_channel_database_edit_makes_a_built_repo_refuse_to_start(profile):
+    """End of the chain: the moved fingerprint is what ``osprey up`` acts on.
+
+    The repo below is built — a manifest stamped with the fingerprint as it was
+    when ``channels.json`` was snapshotted. Editing the database afterwards is
+    the stale-snapshot situation, and the gate has to call it drift and point at
+    a rebuild rather than start the stale build in silence.
+    """
+    from osprey.deployment import staleness
+    from osprey.deployment.staleness import DriftState
+
+    repo = profile.parent
+    _write(repo / "build" / "config.yml", "project: facility\n")
+    fingerprint = staleness.profile_fingerprint(profile)
+    assert fingerprint is not None, "fixture profile must resolve"
+    _write(
+        staleness.build_manifest_path(repo),
+        json.dumps(
+            {
+                "schema_version": "1.2.0",
+                "creation": {
+                    "template": "hello-world",
+                    "preset_hash": fingerprint.profile_hash,
+                    staleness.KEY_DIGESTS_MANIFEST_KEY: fingerprint.key_digests,
+                },
+                "build_args": {},
+            }
+        ),
+    )
+    assert staleness.check_drift(repo).state is DriftState.CLEAN
+
+    _write(
+        repo / "data" / "channel_databases" / "als.json",
+        '{"channels": ["SR:BPM1"]}\n',
+    )
+
+    report = staleness.check_drift(repo)
+
+    assert report.state is DriftState.DRIFT
+    assert report.refuses
+    assert "data/" in report.changed_keys
+    assert "osprey build" in report.remedy

--- a/tests/deployment/test_channel_snapshot.py
+++ b/tests/deployment/test_channel_snapshot.py
@@ -1,0 +1,309 @@
+"""The build-time decision about emitting a channel-suggestions snapshot.
+
+Covers every pipeline backend the Channel Finder supports, the emission
+predicate (feature switch, absent database, empty database, size guard), and the
+fail-soft behaviour that keeps an unreadable database from blocking a build.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment.channel_snapshot import (
+    DEFAULT_MAX_CHANNELS,
+    MAX_CHANNELS_CONFIG_KEY,
+    compute_channel_snapshot,
+)
+
+
+def _write_json(path: Path, data: object) -> Path:
+    """Write a database fixture and return its path."""
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _config(
+    pipeline: str,
+    db_path: Path | str,
+    *,
+    db_type: str | None = None,
+    suggestions: dict | None = None,
+) -> dict:
+    """Build the slice of project config the decision reads."""
+    database: dict = {"path": str(db_path)}
+    if db_type is not None:
+        database["type"] = db_type
+
+    config: dict = {"channel_finder": {"pipelines": {pipeline: {"database": database}}}}
+    if suggestions is not None:
+        config["web"] = {"channel_suggestions": suggestions}
+    return config
+
+
+@pytest.fixture
+def flat_database(tmp_path):
+    """An in-context database whose channel names differ from their addresses."""
+    return _write_json(
+        tmp_path / "flat.json",
+        [
+            {
+                "channel": "BoosterRing_BPM_02_Position_X",
+                "address": "BR:DIAG:BPM:02:POSITION:X",
+                "description": "Booster BPM 2 horizontal position",
+            },
+            {
+                "channel": "BoosterRing_BPM_01_Position_X",
+                "address": "BR:DIAG:BPM:01:POSITION:X",
+                "description": "Booster BPM 1 horizontal position",
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def hierarchical_database(tmp_path):
+    """A two-level hierarchical database expanding to three channels."""
+    return _write_json(
+        tmp_path / "hierarchical.json",
+        {
+            "hierarchy": {
+                "levels": [
+                    {"name": "system", "type": "tree"},
+                    {"name": "field", "type": "tree"},
+                ],
+                "naming_pattern": "{system}:{field}",
+            },
+            "tree": {
+                "SR": {
+                    "_description": "Storage ring",
+                    "CURRENT": {"_description": "Beam current"},
+                    "LIFETIME": {"_description": "Beam lifetime"},
+                },
+                "BR": {
+                    "_description": "Booster ring",
+                    "CURRENT": {"_description": "Beam current"},
+                },
+            },
+        },
+    )
+
+
+@pytest.fixture
+def middle_layer_database(tmp_path):
+    """A Middle Layer export: System -> Family -> Field -> ChannelNames."""
+    return _write_json(
+        tmp_path / "middle_layer.json",
+        {
+            "BPM": {
+                "x": {
+                    "Monitor": {
+                        # MML exports pad names, and the same address can appear
+                        # under more than one field.
+                        "ChannelNames": ["SR:BPM:02:X ", " SR:BPM:01:X"],
+                        "Units": "mm",
+                    },
+                    "Setpoint": {"ChannelNames": ["SR:BPM:01:X"]},
+                }
+            }
+        },
+    )
+
+
+class TestPipelineBackends:
+    """Every configured backend yields the same shape of address list."""
+
+    def test_a_flat_in_context_database_contributes_its_addresses(self, flat_database):
+        decision = compute_channel_snapshot(_config("in_context", flat_database, db_type="flat"))
+
+        assert decision.emit is True
+        assert decision.channels == [
+            "BR:DIAG:BPM:01:POSITION:X",
+            "BR:DIAG:BPM:02:POSITION:X",
+        ]
+        assert decision.count == 2
+        assert decision.source_path == flat_database
+
+    def test_an_in_context_database_defaults_to_the_template_backend(self, flat_database):
+        # No `type` key: detection defaults to 'template', which reads plain
+        # records verbatim alongside any template entries.
+        decision = compute_channel_snapshot(_config("in_context", flat_database))
+
+        assert decision.emit is True
+        assert decision.channels == [
+            "BR:DIAG:BPM:01:POSITION:X",
+            "BR:DIAG:BPM:02:POSITION:X",
+        ]
+
+    def test_a_hierarchical_database_contributes_its_expanded_channels(self, hierarchical_database):
+        decision = compute_channel_snapshot(_config("hierarchical", hierarchical_database))
+
+        assert decision.emit is True
+        # The hierarchical backend has no separate address field — it synthesizes
+        # one from the expanded channel name, so both are the same string here.
+        assert decision.channels == ["BR:CURRENT", "SR:CURRENT", "SR:LIFETIME"]
+        assert decision.count == 3
+
+    def test_a_middle_layer_database_contributes_its_channel_names(self, middle_layer_database):
+        decision = compute_channel_snapshot(_config("middle_layer", middle_layer_database))
+
+        assert decision.emit is True
+        assert decision.channels == ["SR:BPM:01:X", "SR:BPM:02:X"]
+
+    def test_the_address_wins_where_it_differs_from_the_channel_name(self, flat_database):
+        decision = compute_channel_snapshot(_config("in_context", flat_database, db_type="flat"))
+
+        # Panels write addresses, not the human-facing catalog names.
+        assert all(channel.startswith("BR:DIAG:") for channel in decision.channels)
+        assert not any("BoosterRing" in channel for channel in decision.channels)
+
+    def test_addresses_are_sorted_and_deduplicated(self, tmp_path):
+        db_path = _write_json(
+            tmp_path / "duplicates.json",
+            [
+                {"channel": "Zed", "address": "SR:Z"},
+                {"channel": "Alpha", "address": "SR:A"},
+                {"channel": "AlphaAlias", "address": "SR:A"},
+            ],
+        )
+
+        decision = compute_channel_snapshot(_config("in_context", db_path, db_type="flat"))
+
+        assert decision.channels == ["SR:A", "SR:Z"]
+        assert decision.count == 2
+
+    def test_a_record_without_an_address_falls_back_to_its_channel_name(self, tmp_path):
+        db_path = _write_json(tmp_path / "no_address.json", [{"channel": "SR:PLAIN"}])
+
+        decision = compute_channel_snapshot(_config("in_context", db_path, db_type="flat"))
+
+        assert decision.channels == ["SR:PLAIN"]
+
+
+class TestEmissionPredicate:
+    """When a snapshot is worth writing at all."""
+
+    def test_a_project_without_a_channel_finder_emits_nothing(self):
+        decision = compute_channel_snapshot({"web": {"panels": {}}})
+
+        assert decision.emit is False
+        assert decision.channels == []
+        assert decision.count == 0
+        assert decision.source_path is None
+
+    def test_an_absent_channel_suggestions_block_still_emits(self, flat_database):
+        # The feature is default-on: older configs predate the keys entirely.
+        config = _config("in_context", flat_database, db_type="flat")
+        assert "web" not in config
+
+        assert compute_channel_snapshot(config).emit is True
+
+    def test_switching_the_feature_off_emits_nothing(self, flat_database):
+        config = _config(
+            "in_context", flat_database, db_type="flat", suggestions={"enabled": False}
+        )
+
+        decision = compute_channel_snapshot(config)
+
+        assert decision.emit is False
+        assert decision.channels == []
+
+    def test_an_empty_database_emits_nothing(self, tmp_path):
+        # An empty snapshot is not a shorter suggestion list, it is a typeahead
+        # that never suggests anything — so nothing is written.
+        db_path = _write_json(tmp_path / "empty.json", [])
+
+        decision = compute_channel_snapshot(_config("in_context", db_path, db_type="flat"))
+
+        assert decision.emit is False
+        assert decision.count == 0
+        assert decision.channels == []
+
+    def test_a_database_above_the_size_guard_emits_nothing_and_names_the_key(
+        self, flat_database, caplog
+    ):
+        config = _config(
+            "in_context", flat_database, db_type="flat", suggestions={"max_channels": 1}
+        )
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(config)
+
+        assert decision.emit is False
+        assert decision.channels == []
+        # The count survives so the build can say how far over the limit it was.
+        assert decision.count == 2
+        assert MAX_CHANNELS_CONFIG_KEY in caplog.text
+        assert "2" in caplog.text
+
+    def test_a_database_at_the_size_guard_still_emits(self, flat_database):
+        config = _config(
+            "in_context", flat_database, db_type="flat", suggestions={"max_channels": 2}
+        )
+
+        assert compute_channel_snapshot(config).emit is True
+
+    def test_an_unusable_size_guard_falls_back_to_the_default(self, flat_database, caplog):
+        config = _config(
+            "in_context", flat_database, db_type="flat", suggestions={"max_channels": "lots"}
+        )
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(config)
+
+        assert decision.emit is True
+        assert str(DEFAULT_MAX_CHANNELS) in caplog.text
+
+
+class TestFailSoft:
+    """An unreadable database degrades the panel, never the build."""
+
+    def test_a_missing_database_file_warns_and_emits_nothing(self, tmp_path, caplog):
+        missing = tmp_path / "gone.json"
+        config = _config("in_context", missing, db_type="flat")
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(config)
+
+        assert decision.emit is False
+        assert str(missing) in caplog.text
+        assert "No such file" in caplog.text
+
+    def test_malformed_json_warns_with_the_path_and_the_error(self, tmp_path, caplog):
+        db_path = tmp_path / "malformed.json"
+        db_path.write_text("this is not json")
+        config = _config("in_context", db_path, db_type="flat")
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(config)
+
+        assert decision.emit is False
+        assert decision.channels == []
+        assert str(db_path) in caplog.text
+        assert "Expecting value" in caplog.text
+
+    def test_a_malformed_hierarchical_database_warns_rather_than_raising(self, tmp_path, caplog):
+        # Valid JSON, invalid schema: the hierarchical loader raises on its own.
+        db_path = _write_json(tmp_path / "no_hierarchy.json", {"tree": {"SR": {}}})
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(_config("hierarchical", db_path))
+
+        assert decision.emit is False
+        assert str(db_path) in caplog.text
+
+    def test_a_relative_database_path_resolves_against_the_working_directory(
+        self, tmp_path, monkeypatch
+    ):
+        data_dir = tmp_path / "data" / "channel_databases"
+        data_dir.mkdir(parents=True)
+        _write_json(data_dir / "als.json", [{"channel": "SR:CURRENT", "address": "SR:CURRENT"}])
+        monkeypatch.chdir(tmp_path)
+
+        config = _config("in_context", "data/channel_databases/als.json", db_type="flat")
+        decision = compute_channel_snapshot(config)
+
+        assert decision.emit is True
+        assert decision.source_path == tmp_path / "data" / "channel_databases" / "als.json"

--- a/tests/deployment/test_channel_snapshot_render.py
+++ b/tests/deployment/test_channel_snapshot_render.py
@@ -1,0 +1,210 @@
+"""Channel-snapshot injection into the compose render paths.
+
+The compose render must hand every consumer one decision: the
+``channel_snapshot`` render-context key, the ``channels.json`` artifact in the
+bluesky_web build context, and (Task 2.2) the compose fragment's conditional
+mount all derive from a single :func:`compute_channel_snapshot` call. These
+tests pin the full (:func:`setup_build_dir`) and incremental
+(:func:`_incremental_setup_build_dir`) paths to identical behaviour — same
+context value, same artifact bytes, same absence.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from importlib import resources
+from pathlib import Path
+
+import pytest
+import yaml
+
+BLUESKY_WEB_TEMPLATE = "services/bluesky_web/docker-compose.yml.j2"
+OUT_DIR = Path("build") / "services" / "bluesky_web"
+SNAPSHOT = OUT_DIR / "channels.json"
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """A minimal deployment repo holding the packaged bluesky_web service.
+
+    The render helpers resolve every path against the working directory by
+    contract (the build runs them from the repo root), so the fixture chdirs in.
+    """
+    import osprey
+
+    repo = tmp_path / "repo"
+    packaged = resources.files(osprey).joinpath("templates", "services")
+    shutil.copytree(str(packaged / "bluesky_web"), repo / "services" / "bluesky_web")
+    monkeypatch.chdir(repo)
+    return repo
+
+
+@pytest.fixture
+def rendered_contexts(monkeypatch):
+    """Record the context dict each render_template call receives.
+
+    Observing the context directly pins the injection itself, independent of
+    what the template does with it; the mount tests below parse the rendered
+    YAML instead.
+    """
+    from osprey.deployment import compose_generator
+
+    contexts: list[dict] = []
+    real = compose_generator.render_template
+
+    def recording(template_path, config, out_dir):
+        contexts.append(config)
+        return real(template_path, config, out_dir)
+
+    monkeypatch.setattr(compose_generator, "render_template", recording)
+    return contexts
+
+
+def _database(repo: Path) -> Path:
+    """Write a small flat channel database into the repo."""
+    path = repo / "channels_db.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"channel": "StorageRing_BPM_02_X", "address": "SR:BPM:02:X"},
+                {"channel": "StorageRing_BPM_01_X", "address": "SR:BPM:01:X"},
+            ]
+        )
+    )
+    return path
+
+
+def _config(repo: Path, db_path: Path | None = None) -> dict:
+    """The slice of project config the render paths and the decision read."""
+    config: dict = {
+        "project_name": "demo",
+        "project_root": str(repo),
+        "build_dir": "./build",
+        "services": {"bluesky_web": {}, "bluesky": {}},
+        "deployment": {},
+        "system": {"timezone": "UTC"},
+        "deployed_services": [],
+    }
+    if db_path is not None:
+        config["channel_finder"] = {
+            "pipelines": {"in_context": {"database": {"path": str(db_path), "type": "flat"}}}
+        }
+    return config
+
+
+def _run_full(config: dict) -> None:
+    from osprey.deployment.compose_generator import setup_build_dir
+
+    setup_build_dir(BLUESKY_WEB_TEMPLATE, config, {})
+
+
+def _run_incremental(config: dict) -> None:
+    from osprey.deployment.compose_generator import _incremental_setup_build_dir
+
+    _incremental_setup_build_dir(BLUESKY_WEB_TEMPLATE, config, {}, str(OUT_DIR))
+
+
+def test_paths_agree_when_the_database_emits(repo, rendered_contexts):
+    """Full and incremental renders inject the same flag and identical bytes."""
+    config = _config(repo, _database(repo))
+
+    _run_full(config)
+    assert rendered_contexts[0]["channel_snapshot"] is True
+    full_bytes = SNAPSHOT.read_bytes()
+
+    shutil.rmtree("build")
+    _run_incremental(config)
+    assert rendered_contexts[1]["channel_snapshot"] is True
+    assert SNAPSHOT.read_bytes() == full_bytes
+
+    # The artifact is what the sidecar's /channels route serves: the sorted
+    # addresses, not the human-facing channel names.
+    assert json.loads(full_bytes) == ["SR:BPM:01:X", "SR:BPM:02:X"]
+
+
+def test_paths_agree_when_no_database_is_configured(repo, rendered_contexts):
+    """Without a channel database, both paths render exactly as today."""
+    config = _config(repo)
+
+    _run_full(config)
+    assert rendered_contexts[0]["channel_snapshot"] is False
+    assert not SNAPSHOT.exists()
+
+    shutil.rmtree("build")
+    _run_incremental(config)
+    assert rendered_contexts[1]["channel_snapshot"] is False
+    assert not SNAPSHOT.exists()
+
+
+def test_incremental_rebuild_drops_a_stale_snapshot(repo, rendered_contexts):
+    """A reused build directory cannot keep a snapshot the decision revoked."""
+    OUT_DIR.mkdir(parents=True)
+    SNAPSHOT.write_text('["SR:OLD:CHANNEL"]')
+
+    _run_incremental(_config(repo))
+
+    assert rendered_contexts[0]["channel_snapshot"] is False
+    assert not SNAPSHOT.exists()
+
+
+def test_other_services_never_compute_the_snapshot(repo, rendered_contexts, monkeypatch):
+    """Only the bluesky_web render pays for the database load."""
+    from osprey.deployment import compose_generator
+
+    def unexpected(config):
+        raise AssertionError("compute_channel_snapshot ran for a non-bluesky_web service")
+
+    monkeypatch.setattr(compose_generator, "compute_channel_snapshot", unexpected)
+
+    other = repo / "services" / "other"
+    other.mkdir()
+    (other / "docker-compose.yml.j2").write_text("services: {}\n")
+
+    from osprey.deployment.compose_generator import setup_build_dir
+
+    setup_build_dir("services/other/docker-compose.yml.j2", _config(repo, _database(repo)), {})
+
+    assert rendered_contexts[0]["channel_snapshot"] is False
+    assert not (Path("build") / "services" / "other" / "channels.json").exists()
+
+
+RENDERED_COMPOSE = OUT_DIR / "docker-compose.yml"
+CONFIG_MOUNT = "./build/services/bluesky_web/config.yml:/app/project/config.yml:ro"
+SNAPSHOT_MOUNT = "./build/services/bluesky_web/channels.json:/app/project/channels.json:ro"
+
+
+def _rendered_volumes() -> list[str]:
+    """The bluesky-web service's volumes list in the rendered compose file."""
+    document = yaml.safe_load(RENDERED_COMPOSE.read_text())
+    return document["services"]["bluesky-web"]["volumes"]
+
+
+def test_mount_present_when_the_snapshot_emits(repo):
+    """An emitted snapshot gets its read-only bind mount beside config.yml."""
+    _run_full(_config(repo, _database(repo)))
+
+    volumes = _rendered_volumes()
+    assert SNAPSHOT_MOUNT in volumes
+    assert CONFIG_MOUNT in volumes
+
+
+@pytest.mark.parametrize(
+    ("web_block", "with_database"),
+    [
+        pytest.param({"channel_suggestions": {"enabled": False}}, True, id="disabled"),
+        pytest.param({"channel_suggestions": {"max_channels": 1}}, True, id="over-guard"),
+        pytest.param(None, False, id="no-database"),
+    ],
+)
+def test_mount_absent_when_the_decision_is_false(repo, web_block, with_database):
+    """Every non-emitting branch renders valid YAML without the snapshot mount."""
+    config = _config(repo, _database(repo) if with_database else None)
+    if web_block is not None:
+        config["web"] = web_block
+
+    _run_full(config)
+
+    volumes = _rendered_volumes()
+    assert not any("channels.json" in volume for volume in volumes)
+    assert CONFIG_MOUNT in volumes

--- a/tests/deployment/test_channel_suggestions_config.py
+++ b/tests/deployment/test_channel_suggestions_config.py
@@ -1,0 +1,128 @@
+"""The channel-suggestion keys a generated ``config.yml`` must actually carry.
+
+Channel typeahead is on by default, which only means anything if the keys that
+control it are written into every project's config where an operator can see
+and change them. The assertion here is therefore on *resolution*, not on text:
+the packaged template is rendered and the result handed to ``ConfigBuilder``,
+because config.yml is never flattened — a dotted key written into the template
+by mistake would still appear in a text search while reading as nothing at all.
+
+The block also has to survive every branch of the template. ``web:`` is full of
+conditionals (builtin panels selected or not, panel presets defined or not), so
+each render below exercises a different combination and expects the same two
+values out of all of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _packaged_template(rel_path: str):
+    """Compile a packaged template, addressed from the templates root.
+
+    Rooted at the packaged ``templates/`` directory rather than compiled as a
+    bare ``jinja2.Template`` so relative loads resolve the way they do under
+    ``osprey build``, and left in the default Undefined mode so ``| default()``
+    chains behave as they do in production.
+    """
+    from importlib import resources
+
+    from jinja2 import Environment, FileSystemLoader
+
+    import osprey
+
+    templates_root = resources.files(osprey).joinpath("templates")
+    env = Environment(loader=FileSystemLoader(str(templates_root)), autoescape=False)
+    return env.get_template(rel_path)
+
+
+def _render(project_root: str, **overrides) -> str:
+    """Render the control-assistant config with a minimal realistic context.
+
+    Only the variables the template dereferences unconditionally are supplied;
+    everything else is left undefined so the ``| default(...)`` and
+    ``is defined`` guards run as they do for a project that selected nothing.
+    """
+    context = {
+        "project_name": "demo",
+        "project_root": project_root,
+        "builtin_panels": ["ariel", "channel-finder"],
+        "selected_web_panels": ["ariel", "channel-finder"],
+        "channel_finder_mode": "in_context",
+        "default_pipeline": "in_context",
+        "default_provider": "anthropic",
+        "default_model": "sonnet",
+        "enable_in_context": True,
+        **overrides,
+    }
+    return _packaged_template("apps/control_assistant/config.yml.j2").render(**context)
+
+
+def _resolved(tmp_path, **overrides):
+    """Render, write, and load through the production config reader."""
+    from osprey_connectors.config import ConfigBuilder
+
+    config_path = tmp_path / "config.yml"
+    rendered = _render(str(tmp_path), **overrides)
+    config_path.write_text(rendered)
+
+    # A malformed render would surface as a resolution miss below rather than
+    # as a parse error, so the YAML is checked on its own first.
+    assert yaml.safe_load(rendered) is not None
+
+    return ConfigBuilder(str(config_path))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestChannelSuggestionKeys:
+    """The keys resolve from a rendered config, in every template branch."""
+
+    def test_generated_config_turns_channel_suggestions_on(self, tmp_path):
+        builder = _resolved(tmp_path)
+
+        assert builder.get("web.channel_suggestions.enabled") is True
+
+    def test_generated_config_caps_the_snapshot_at_fifty_thousand_channels(self, tmp_path):
+        builder = _resolved(tmp_path)
+
+        assert builder.get("web.channel_suggestions.max_channels") == 50000
+
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            pytest.param({"selected_web_panels": []}, id="no-builtin-panels"),
+            pytest.param({"default_panel": "artifacts"}, id="default-panel-set"),
+            pytest.param(
+                {"panel_presets": {"Machine setup": ["channel-finder", "artifacts"]}},
+                id="panel-presets-defined",
+            ),
+        ],
+    )
+    def test_keys_are_written_whatever_else_the_web_section_renders(self, tmp_path, branch):
+        builder = _resolved(tmp_path, **branch)
+
+        assert builder.get("web.channel_suggestions.enabled") is True
+        assert builder.get("web.channel_suggestions.max_channels") == 50000
+
+    def test_the_keys_are_nested_not_dotted(self, tmp_path):
+        """A dotted key would be stored verbatim and read by nothing.
+
+        ``ConfigBuilder.get`` walks the mapping, so a top-level
+        ``"web.channel_suggestions.enabled"`` string key resolves to nothing
+        while still matching a text search for the dotted spelling.
+        """
+        rendered = _render(str(tmp_path))
+        loaded = yaml.safe_load(rendered)
+
+        assert "channel_suggestions" in loaded["web"]
+        assert not any(key.startswith("web.") for key in loaded)

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -2115,6 +2115,40 @@ def test_browser_lane_is_triggered_by_the_perimeter__mutation_drops_the_sidecar_
 
 
 # ---------------------------------------------------------------------------
+# (h2) channel-combobox browser test: same vacuous-green shape as (h) — the
+# lane runs an explicit file list and a paths filter, and a suite missing
+# from either silently never runs
+# ---------------------------------------------------------------------------
+
+COMBOBOX_BROWSER_TEST_FILE = "tests/interfaces/bluesky_web/test_channel_combobox_browser.py"
+COMBOBOX_TESTS_FILTER_PATH = "tests/interfaces/bluesky_web/**"
+
+
+def test_channel_combobox_browser_test_runs_in_the_browser_lane(
+    workflow: dict[str, Any],
+) -> None:
+    """The combobox suite has to be NAMED in the lane's pytest invocation —
+    the unit lane skips browser-marked files, so this lane is the only place
+    it is ever collected."""
+    assert COMBOBOX_BROWSER_TEST_FILE in _browser_lane_files(workflow)
+
+
+def test_channel_combobox_browser_test_runs_in_the_browser_lane__mutation_drops_the_file() -> None:
+    """Removing the file from the invocation must fail the guard."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, BROWSER_JOB, BROWSER_RUN_STEP)
+    step["run"] = step["run"].replace(f"{COMBOBOX_BROWSER_TEST_FILE} \\\n", "")
+    assert COMBOBOX_BROWSER_TEST_FILE not in _browser_lane_files(mutated)
+
+
+def test_browser_lane_is_triggered_by_the_bluesky_web_tests(workflow: dict[str, Any]) -> None:
+    """The suite's own directory must arm the lane: the filter covers
+    ``src/osprey/interfaces/**`` already, but a PR that only edits the tests
+    (fixtures, assertions) would otherwise green-skip the job."""
+    assert COMBOBOX_TESTS_FILTER_PATH in _browser_lane_filter_paths(workflow)
+
+
+# ---------------------------------------------------------------------------
 # (i) bluesky-queue-e2e: the queue stack's own lane, secret-free
 # ---------------------------------------------------------------------------
 

--- a/tests/interfaces/bluesky_web/conftest.py
+++ b/tests/interfaces/bluesky_web/conftest.py
@@ -1,0 +1,232 @@
+"""Shared fixtures for the bluesky-web sidecar suite: a live uvicorn server.
+
+The per-module suites in this directory exercise the composed app in-process
+through ``TestClient``. The ``bluesky_live_server`` fixture below instead runs
+the very same app object on a real localhost port, for tests that need actual
+HTTP: the fixture's own smoke test (``test_browser_fixture_smoke.py``) and the
+real-browser Playwright suites (``-m browser``) that navigate to
+``{base_url}/bluesky/`` and type into the plan form's channel fields.
+
+Two things make this fixture more than ``run_app_server(app)``:
+
+- **A stand-in project directory.** The ``/channels`` route resolves the
+  channel catalog as a sibling of the config named by ``CONFIG_FILE`` at
+  request time, so the fixture writes a temp ``config.yml`` + ``channels.json``
+  and points ``CONFIG_FILE`` at it — the deployed container layout, exactly as
+  ``test_channels_route.py``'s ``project_dir`` reproduces it. Launching with
+  ``catalog=None`` writes no catalog, which is the "this deployment has no
+  catalog" 404 path.
+- **A stubbed bridge.** The panel boots by fetching ``/plans``, ``/devices``,
+  ``/bridge/health``, ``/draft``, ``/queue``, ``/runs`` and the two SSE relays
+  through the sidecar's proxy routers, all of which read
+  ``request.app.state.client``/``bridge_url`` at request time. After the
+  server has started (the real ``_lifespan`` has run), the fixture swaps in an
+  ``httpx.MockTransport`` client — the ``test_app_integration.py`` seam — whose
+  ``/plans`` answer carries one plan with role-tagged channel fields
+  (``x-channel-role``, plus ``x-widget: channel-list`` on the list field), so
+  the rendered form exposes both the single-channel and channel-list controls
+  the autocomplete tests exercise. The lifespan closes its own local client
+  reference on shutdown, never ``app.state.client``, so the swap leaks no
+  double-close.
+
+The app is a module-level singleton (no ``create_app()``), so the swapped
+state persists on the object between tests in a worker. The fixture is
+therefore function-scoped and re-sets both attributes on every launch rather
+than trying to restore them; env vars go through ``monkeypatch``, and the root
+conftest's ``restore_environ`` clears ``CONFIG_FILE`` around every test, so
+nothing leaks sideways either.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from osprey.interfaces._serving import run_app_server as _run_app_server
+from osprey.interfaces.bluesky_web.app import app
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Stub data: the channel catalog and the bridge's plan catalog
+# ---------------------------------------------------------------------------
+
+# Default build-time catalog served at /channels — sorted, like `osprey build`
+# writes it, with enough prefix variety for autocomplete tests to get
+# distinguishable matches out of a fuzzy filter.
+DEFAULT_CHANNEL_CATALOG: list[str] = [
+    "BR:DIAG:BPM:01:POSITION:X",
+    "BR:DIAG:BPM:01:POSITION:Y",
+    "BR:DIAG:BPM:02:POSITION:X",
+    "BR:MAG:HCM:01:CURRENT:SP",
+    "BR:MAG:VCM:01:CURRENT:SP",
+    "SR:DIAG:BPM:07:POSITION:Y",
+    "SR:MAG:QF:03:CURRENT:SP",
+    "SR:VAC:ION:12:PRESSURE",
+]
+
+STUB_BRIDGE_URL = "http://bridge.test"
+
+STUB_PLAN_NAME = "channel_probe"
+
+# One plan schema shaped like the bridge's own `PARAMS.model_json_schema()`
+# output for a role-typed model (see `bluesky_bridge.plan_fields`): the role
+# annotation sits on the FIELD, beside `type`/`items`, and the presentation
+# hint rides alongside it. `target` is the plain-string channel field
+# (schema-form's `buildString`); `monitors` is the channel-list field
+# (`x-widget: channel-list` -> `buildChannelList`); `setpoint` pins that
+# non-channel fields render untouched next to them.
+STUB_PLAN_SCHEMA: dict = {
+    "title": "PARAMS",
+    "type": "object",
+    "properties": {
+        "target": {
+            "title": "Target",
+            "type": "string",
+            "x-channel-role": "movable",
+        },
+        "monitors": {
+            "title": "Monitors",
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "x-channel-role": "readable",
+            "x-widget": "channel-list",
+        },
+        "setpoint": {"title": "Setpoint", "type": "number", "default": 0.0},
+    },
+    "required": ["target", "monitors"],
+}
+
+# The bridge's `GET /plans` catalog-entry shape, as pinned by
+# `tests/integration/test_bluesky_queue_contract.py`: exactly
+# {name, description, schema, metadata, provenance}, with metadata carrying
+# the three authoring-declared fields.
+STUB_PLANS: list[dict] = [
+    {
+        "name": STUB_PLAN_NAME,
+        "description": "Stub plan exercising role-tagged channel fields.",
+        "schema": STUB_PLAN_SCHEMA,
+        "metadata": {
+            "name": STUB_PLAN_NAME,
+            "description": "Stub plan exercising role-tagged channel fields.",
+            "writes": True,
+        },
+        "provenance": "shipped",
+    }
+]
+
+
+def _stub_bridge(request: httpx.Request) -> httpx.Response:
+    """Answer the read endpoints the panel touches on boot, harmlessly.
+
+    Only ``/plans`` carries content the tests assert on; everything else
+    returns the smallest body of the real endpoint's shape so the panel's boot
+    fetches succeed without a bridge. The SSE relays get an immediately-ended
+    empty stream — the panel's reconnect logic tolerates that, and nothing in
+    these tests consumes events.
+    """
+    path = request.url.path
+    if path == "/plans":
+        return httpx.Response(200, json=STUB_PLANS)
+    if path == f"/plans/{STUB_PLAN_NAME}/source":
+        return httpx.Response(
+            200, json={"name": STUB_PLAN_NAME, "source": "def channel_probe(): ..."}
+        )
+    if path == "/health":
+        # The sidecar's /bridge/health relays the bridge's /health, capability
+        # record and all. can_execute=True keeps the panel free of the
+        # browse-only banner — one less overlay for browser tests.
+        return httpx.Response(
+            200,
+            json={
+                "status": "ok",
+                "capability": {"can_execute": True, "reason": None, "detail": None},
+            },
+        )
+    if path in ("/devices", "/runs"):
+        return httpx.Response(200, json=[])
+    if path == "/draft":
+        return httpx.Response(200, json={"draft": None, "revision": 0})
+    if path == "/queue":
+        return httpx.Response(
+            200,
+            json={"status": {"available": True}, "items": [], "running_item": None},
+        )
+    if path in ("/draft/events", "/queue/events"):
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=b"")
+    return httpx.Response(404, json={"detail": f"stub bridge has no {path}"})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ambient_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Mirrors the per-module isolation fixtures in this directory: point config
+    # resolution at a config.yml that does not exist, so ambient repo/user
+    # config can never leak a real launch token (or bridge URL) into the
+    # lifespan's resolve_bridge_url() during server startup. Harmlessly
+    # duplicates the module-level fixtures where both apply.
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "does-not-exist.yml"))
+    monkeypatch.delenv("BLUESKY_LAUNCH_TOKEN", raising=False)
+
+
+@pytest.fixture
+def bluesky_live_server(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Callable[..., AbstractContextManager[str]]:
+    """Factory: launch the composed sidecar app on a free port, bridge stubbed.
+
+    Returns a context manager factory::
+
+        def test_something(bluesky_live_server):
+            with bluesky_live_server() as base_url:
+                ...  # httpx / page.goto against base_url
+
+    Args (of the returned callable):
+        catalog: Channel addresses to serve at ``/channels``
+            (``DEFAULT_CHANNEL_CATALOG`` by default), or ``None`` to serve no
+            ``channels.json`` at all — the 404 "deployment has no catalog"
+            variant.
+
+    Yields (inside the ``with``):
+        The server's base URL, e.g. ``"http://127.0.0.1:54321"``.
+    """
+
+    @contextmanager
+    def _launch(catalog: list[str] | None = DEFAULT_CHANNEL_CATALOG) -> Iterator[str]:
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+        (project / "config.yml").write_text("connector:\n  type: mock\n")
+        catalog_file = project / "channels.json"
+        if catalog is None:
+            # A relaunch within one test may leave a previous catalog behind;
+            # absent must mean absent.
+            catalog_file.unlink(missing_ok=True)
+        else:
+            catalog_file.write_text(json.dumps(catalog))
+        # /channels resolves the catalog beside CONFIG_FILE at request time,
+        # so this only has to be set before the first request — but setting it
+        # before startup matches the deployed container's environment.
+        monkeypatch.setenv("CONFIG_FILE", str(project / "config.yml"))
+
+        with _run_app_server(app) as base_url:
+            # The lifespan has run: swap the bridge client out from under the
+            # served app (routers read app.state per request). The lifespan
+            # still closes the ORIGINAL client it created — it holds a local
+            # reference — so nothing double-closes.
+            app.state.client = httpx.AsyncClient(transport=httpx.MockTransport(_stub_bridge))
+            app.state.bridge_url = STUB_BRIDGE_URL
+            yield base_url
+
+    return _launch

--- a/tests/interfaces/bluesky_web/test_browser_fixture_smoke.py
+++ b/tests/interfaces/bluesky_web/test_browser_fixture_smoke.py
@@ -1,0 +1,88 @@
+"""Smoke tests for ``conftest.py``'s ``bluesky_live_server`` fixture.
+
+The fixture exists for the real-browser Playwright suites, but its own
+contract — the server boots, the temp channel catalog is served, the
+no-catalog variant 404s, the bridge stub answers through the proxy, and the
+panel bundle is actually mounted — is pinned here with plain HTTP, so it runs
+in the ordinary unit lane and a broken fixture fails fast instead of as an
+opaque browser-test timeout.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from tests.interfaces.bluesky_web.conftest import (
+    DEFAULT_CHANNEL_CATALOG,
+    STUB_PLAN_NAME,
+)
+
+
+def test_fixture_boots_and_answers_the_healthcheck(bluesky_live_server) -> None:
+    with bluesky_live_server() as base_url:
+        response = httpx.get(f"{base_url}/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_channels_serves_the_temp_catalog_with_an_etag(bluesky_live_server) -> None:
+    """The default launch serves the fixture's catalog under the real caching contract."""
+    with bluesky_live_server() as base_url:
+        response = httpx.get(f"{base_url}/channels")
+
+    assert response.status_code == 200
+    assert response.json() == DEFAULT_CHANNEL_CATALOG
+    assert response.headers["etag"].startswith('"')
+    assert response.headers["cache-control"] == "no-cache"
+
+
+def test_an_explicit_catalog_replaces_the_default(bluesky_live_server) -> None:
+    catalog = ["LINAC:GUN:PHASE:SP", "LINAC:GUN:PHASE:RB"]
+
+    with bluesky_live_server(catalog=catalog) as base_url:
+        response = httpx.get(f"{base_url}/channels")
+
+    assert response.status_code == 200
+    assert response.json() == catalog
+
+
+def test_no_catalog_variant_404s(bluesky_live_server) -> None:
+    """``catalog=None`` is the "this deployment has no catalog" path."""
+    with bluesky_live_server(catalog=None) as base_url:
+        response = httpx.get(f"{base_url}/channels")
+
+    assert response.status_code == 404
+
+
+def test_bridge_stub_serves_role_tagged_plans_through_the_proxy(bluesky_live_server) -> None:
+    """The stubbed ``/plans`` answer reaches the browser side of the proxy.
+
+    This is what the browser suites' plan form is built from, so the two
+    field shapes they exercise are pinned: a plain string channel field and a
+    channel-list field, each carrying ``x-channel-role`` on the field itself.
+    """
+    with bluesky_live_server() as base_url:
+        response = httpx.get(f"{base_url}/plans")
+
+    assert response.status_code == 200
+    plans = response.json()
+    assert [plan["name"] for plan in plans] == [STUB_PLAN_NAME]
+
+    properties = plans[0]["schema"]["properties"]
+    assert properties["target"]["x-channel-role"] == "movable"
+    assert properties["monitors"]["x-channel-role"] == "readable"
+    assert properties["monitors"]["x-widget"] == "channel-list"
+
+
+def test_panel_bundle_is_served(bluesky_live_server) -> None:
+    """The real panel bundle (not a stub) is mounted at /bluesky/.
+
+    The browser suites navigate here; a fixture that served an empty
+    directory would let them fail with an unhelpful blank page.
+    """
+    with bluesky_live_server() as base_url:
+        response = httpx.get(f"{base_url}/bluesky/")
+
+    assert response.status_code == 200
+    assert "<html" in response.text.lower()

--- a/tests/interfaces/bluesky_web/test_channel_combobox_browser.py
+++ b/tests/interfaces/bluesky_web/test_channel_combobox_browser.py
@@ -1,0 +1,454 @@
+"""Real-browser tests for the plan form's channel-suggestion combobox.
+
+Runs the composed bluesky-web sidecar for real (``bluesky_live_server``, bridge
+stubbed) and drives headless Chromium against ``/bluesky/``, where the plans
+view auto-selects the stub plan and renders its form: a channel-tagged string
+field (``Target``, ``buildString``), a channel-list field (``Monitors``,
+``buildChannelList``), and an untagged number (``Setpoint``). The vitest suites
+pin the combobox and schema-form contracts unit-by-unit; this suite pins what
+only a real browser exercises end to end — genuine focus/hover/keyboard event
+ordering across the combobox listener and the commit-list listener on the same
+input, and the real ``/channels`` fetch feeding the module-global catalog:
+
+- arrow keys arm and wrap, Escape closes, focus never leaves the input
+- a *hovered* popup item never arms: with the pointer parked on the open popup,
+  a single unarmed Enter commits the typed text exactly (pinned by typing a
+  lowercase exact address and asserting the hovered uppercase catalog entry
+  does not replace it)
+- prefix + click commits only the clicked address — mousedown-preventDefault
+  keeps focus in the add-input, so no blur ever commits the half-typed prefix
+- an arrow-armed Enter flows through both buildChannelList (accept + commit as
+  one keystroke) and a table cell's channel-tagged input
+- a value outside the catalog is never blocked: no popup, and it submits/
+  commits exactly as typed
+- the no-catalog deployment (``/channels`` 404) renders channel-tagged fields
+  identical in shape to untagged ones, with zero console errors
+
+The stub plan has no array-of-objects field, so the table-cell case cannot be
+reached through the served plan form; that one test bootstraps a second form on
+the same page via the panel's own ``renderSchemaForm`` export (same module
+instance, so the catalog installed by the panel's boot ``/channels`` fetch is
+live in it).
+
+Run:
+    .venv/bin/pytest tests/interfaces/bluesky_web/test_channel_combobox_browser.py -m browser -v
+
+Skips cleanly when the chromium headless binary is not installed.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.interfaces.bluesky_web.conftest import DEFAULT_CHANNEL_CATALOG
+
+try:
+    from playwright.sync_api import expect
+
+    _PLAYWRIGHT_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PLAYWRIGHT_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from playwright.sync_api import Browser, Locator, Page
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+# Addresses the tests type against, pinned to the fixture catalog here so a
+# future catalog edit fails with a clear message instead of a popup timeout.
+HCM_ADDRESS = "BR:MAG:HCM:01:CURRENT:SP"
+QF_ADDRESS = "SR:MAG:QF:03:CURRENT:SP"
+assert HCM_ADDRESS in DEFAULT_CHANNEL_CATALOG
+assert QF_ADDRESS in DEFAULT_CHANNEL_CATALOG
+
+# Comfortably longer than the combobox's DEFAULT_DEBOUNCE_MS (150 ms). Positive
+# popup assertions poll via expect(); only the negative "the popup never
+# opened" assertions need to outwait the debounced query like this.
+_DEBOUNCE_SETTLE_MS = 400
+
+_FORM_TIMEOUT_MS = 15_000
+
+TARGET = '#param-form input[aria-label="Target"]'
+CHANNEL_ADD = "#param-form .channel-list input.channel-add"
+CHANNEL_ROWS = "#param-form .channel-items li"
+
+# Bootstrap for the table-cell case (see module docstring): render an
+# array-of-flat-objects field — schema-form's buildTable — whose string column
+# is channel-tagged, through the same schema-form module the panel already
+# loaded (absolute URL == panel.js's resolved './schema-form.js', so the
+# dynamic import returns the instance holding the booted channel catalog).
+_TABLE_BOOTSTRAP = """
+async () => {
+  const mod = await import('/bluesky/schema-form.js');
+  const form = document.createElement('form');
+  form.id = 'table-probe';
+  form.addEventListener('submit', (event) => event.preventDefault());
+  document.body.appendChild(form);
+  mod.renderSchemaForm(form, {
+    title: 'PARAMS',
+    type: 'object',
+    properties: {
+      taps: {
+        title: 'Taps',
+        type: 'array',
+        items: {
+          title: 'Tap',
+          type: 'object',
+          properties: {
+            channel: { title: 'Channel', type: 'string', 'x-channel-role': 'readable' },
+            gain: { title: 'Gain', type: 'number' },
+          },
+        },
+      },
+    },
+  });
+}
+"""
+
+
+@contextmanager
+def _panel_page(browser: Browser, base_url: str) -> Iterator[Page]:
+    """Open ``/bluesky/`` in a fresh page; assert no uncaught JS errors on exit.
+
+    The pageerror listener attaches before navigation so boot-time exceptions
+    are never missed. The trailing assertion only runs when the test body
+    succeeded — a failing body propagates its own, more specific failure.
+    """
+    page = browser.new_page()
+    pageerrors: list[str] = []
+    page.on("pageerror", lambda err: pageerrors.append(str(err)))
+    try:
+        page.goto(f"{base_url}/bluesky/", wait_until="load")
+        yield page
+    finally:
+        page.close()
+    assert pageerrors == []
+
+
+def _plan_form_target(page: Page) -> Locator:
+    """Wait for the auto-selected stub plan's form and return the Target input."""
+    target = page.locator(TARGET)
+    expect(target).to_be_visible(timeout=_FORM_TIMEOUT_MS)
+    return target
+
+
+def _listbox_for(page: Page, input_locator: Locator) -> Locator:
+    """Resolve an input's own popup listbox via its aria-controls id."""
+    list_id = input_locator.get_attribute("aria-controls")
+    assert list_id, "input carries no aria-controls — combobox not attached"
+    return page.locator(f"#{list_id}")
+
+
+# ---------------------------------------------------------------------------
+# 1. Keyboard navigation
+# ---------------------------------------------------------------------------
+
+
+def test_arrow_keys_wrap_escape_closes_and_focus_stays(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    with bluesky_live_server() as base_url, _panel_page(chromium_browser, base_url) as page:
+        target = _plan_form_target(page)
+        target.fill("BPM")
+
+        listbox = _listbox_for(page, target)
+        expect(listbox).to_be_visible()
+        expect(target).to_have_attribute("aria-expanded", "true")
+
+        items = listbox.locator(".channel-combobox-item")
+        count = items.count()
+        assert count >= 2, "need at least two suggestions for wrap-around to mean anything"
+        for i in range(count):
+            assert "BPM" in (items.nth(i).text_content() or "")
+
+        # No default highlight: nothing is armed until an arrow key.
+        assert target.get_attribute("aria-activedescendant") is None
+
+        first_id = items.nth(0).get_attribute("id")
+        last_id = items.nth(count - 1).get_attribute("id")
+        assert first_id and last_id
+
+        target.press("ArrowDown")
+        expect(target).to_have_attribute("aria-activedescendant", first_id)
+        expect(items.nth(0)).to_have_attribute("aria-selected", "true")
+
+        target.press("ArrowUp")  # wraps: first -> last
+        expect(target).to_have_attribute("aria-activedescendant", last_id)
+        expect(items.nth(0)).to_have_attribute("aria-selected", "false")
+        expect(items.nth(count - 1)).to_have_attribute("aria-selected", "true")
+
+        target.press("ArrowDown")  # wraps: last -> first
+        expect(target).to_have_attribute("aria-activedescendant", first_id)
+
+        expect(target).to_be_focused()
+
+        target.press("Escape")
+        expect(listbox).to_be_hidden()
+        expect(target).to_have_attribute("aria-expanded", "false")
+        assert page.locator(".channel-combobox.open").count() == 0
+        expect(target).to_be_focused()
+        expect(target).to_have_value("BPM")  # Escape dismisses the popup, not the text
+
+
+# ---------------------------------------------------------------------------
+# 2. Hover never arms: unarmed Enter commits the typed text exactly
+# ---------------------------------------------------------------------------
+
+
+def test_hovered_item_never_steals_the_unarmed_enter(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    """Pointer parked on the open popup + single Enter = the typed value, unmodified.
+
+    Typed lowercase, the case-insensitive matcher still offers the uppercase
+    catalog entry — so if hovering armed the item (or Enter honored the
+    hovered row), the committed value would flip to uppercase. It must not.
+    """
+    typed = HCM_ADDRESS.lower()
+    with bluesky_live_server() as base_url, _panel_page(chromium_browser, base_url) as page:
+        target = _plan_form_target(page)
+        target.fill(typed)
+
+        listbox = _listbox_for(page, target)
+        expect(listbox).to_be_visible()
+        item = listbox.locator(".channel-combobox-item", has_text=HCM_ADDRESS)
+        expect(item).to_be_visible()
+
+        item.hover()  # park the pointer on the suggestion and leave it there
+        assert target.get_attribute("aria-activedescendant") is None
+        expect(item).to_have_attribute("aria-selected", "false")
+
+        target.press("Enter")  # single, unarmed Enter
+
+        expect(listbox).to_be_hidden()
+        expect(target).to_have_value(typed)  # NOT the hovered item's casing
+        expect(target).to_be_focused()
+
+
+# ---------------------------------------------------------------------------
+# 3. Prefix + click commits only the clicked address
+# ---------------------------------------------------------------------------
+
+
+def test_prefix_plus_click_commits_only_the_clicked_address(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    with bluesky_live_server() as base_url, _panel_page(chromium_browser, base_url) as page:
+        _plan_form_target(page)
+
+        # Channel-list add-input: the click must not blur-commit the prefix.
+        add = page.locator(CHANNEL_ADD)
+        add.fill("BPM")
+        listbox = _listbox_for(page, add)
+        expect(listbox).to_be_visible()
+        clicked = listbox.locator(".channel-combobox-item").nth(0).text_content()
+        assert clicked in DEFAULT_CHANNEL_CATALOG
+
+        listbox.locator(".channel-combobox-item").nth(0).click()
+
+        rows = page.locator(CHANNEL_ROWS)
+        expect(rows).to_have_count(0)  # no partial-text "BPM" row snuck in
+        expect(add).to_have_value(clicked)  # half-typed prefix fully replaced
+        expect(add).to_be_focused()  # mousedown preventDefault kept focus here
+        expect(listbox).to_be_hidden()
+
+        add.press("Enter")
+        expect(rows).to_have_count(1)
+        expect(rows.nth(0).locator(".channel-name")).to_have_text(clicked)
+        expect(add).to_have_value("")
+
+        # Same shape on the single-channel buildString field.
+        target = page.locator(TARGET)
+        target.fill("QF")
+        target_listbox = _listbox_for(page, target)
+        expect(target_listbox).to_be_visible()
+        option = target_listbox.locator(".channel-combobox-item").nth(0)
+        expect(option).to_have_text(QF_ADDRESS)
+        option.click()
+        expect(target).to_have_value(QF_ADDRESS)
+        expect(target_listbox).to_be_hidden()
+
+
+# ---------------------------------------------------------------------------
+# 4. Armed-Enter flows: channel list and table cell
+# ---------------------------------------------------------------------------
+
+
+def test_armed_enter_commits_the_suggestion_in_the_channel_list(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    """One keystroke: the combobox accepts the armed value, the list commits it."""
+    with bluesky_live_server() as base_url, _panel_page(chromium_browser, base_url) as page:
+        _plan_form_target(page)
+        add = page.locator(CHANNEL_ADD)
+        add.fill("BPM")
+        listbox = _listbox_for(page, add)
+        expect(listbox).to_be_visible()
+
+        add.press("ArrowDown")
+        armed = listbox.locator(".channel-combobox-item").nth(0)
+        expect(armed).to_have_attribute("aria-selected", "true")
+        armed_value = armed.text_content()
+        assert armed_value in DEFAULT_CHANNEL_CATALOG
+
+        add.press("Enter")
+
+        rows = page.locator(CHANNEL_ROWS)
+        expect(rows).to_have_count(1)
+        expect(rows.nth(0).locator(".channel-name")).to_have_text(armed_value)
+        expect(add).to_have_value("")
+        expect(listbox).to_be_hidden()
+        expect(page.locator("#param-form .channel-count")).to_have_text("1 channel")
+
+
+def test_armed_enter_commits_the_suggestion_in_a_table_cell(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    with bluesky_live_server() as base_url, _panel_page(chromium_browser, base_url) as page:
+        _plan_form_target(page)  # panel booted: /channels catalog is installed
+        page.evaluate(_TABLE_BOOTSTRAP)
+
+        page.locator("#table-probe .table-add").click()
+        cell = page.locator('#table-probe td input[aria-label="Channel"]')
+        expect(cell).to_be_visible()
+
+        cell.fill("BPM")
+        listbox = _listbox_for(page, cell)
+        expect(listbox).to_be_visible()
+
+        cell.press("ArrowDown")
+        armed = listbox.locator(".channel-combobox-item").nth(0)
+        expect(armed).to_have_attribute("aria-selected", "true")
+        armed_value = armed.text_content()
+        assert armed_value in DEFAULT_CHANNEL_CATALOG
+
+        cell.press("Enter")
+
+        expect(cell).to_have_value(armed_value)
+        expect(listbox).to_be_hidden()
+        expect(cell).to_be_focused()
+        assert page.url.endswith("/bluesky/")  # armed Enter never submitted the form
+
+
+# ---------------------------------------------------------------------------
+# 5. Free-form non-catalog values are never blocked
+# ---------------------------------------------------------------------------
+
+
+def test_freeform_noncatalog_value_flows_as_typed(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    freeform = "ZZ:NOT:IN:CATALOG"  # no catalog entry contains a Z: zero matches
+    with bluesky_live_server() as base_url, _panel_page(chromium_browser, base_url) as page:
+        target = _plan_form_target(page)
+
+        target.fill(freeform)
+        page.wait_for_timeout(_DEBOUNCE_SETTLE_MS)
+        assert page.locator(".channel-combobox.open").count() == 0
+        expect(target).to_have_attribute("aria-expanded", "false")
+        target.press("Enter")
+        expect(target).to_have_value(freeform)
+
+        add = page.locator(CHANNEL_ADD)
+        add.fill(freeform)
+        page.wait_for_timeout(_DEBOUNCE_SETTLE_MS)
+        assert page.locator(".channel-combobox.open").count() == 0
+        add.press("Enter")
+
+        rows = page.locator(CHANNEL_ROWS)
+        expect(rows).to_have_count(1)
+        expect(rows.nth(0).locator(".channel-name")).to_have_text(freeform)
+        expect(add).to_have_value("")
+
+
+# ---------------------------------------------------------------------------
+# 6. No-catalog deployment: channel fields render as plain inputs
+# ---------------------------------------------------------------------------
+
+
+def test_no_catalog_variant_renders_baseline_dom_with_no_console_errors(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    """With /channels 404ing, channel-tagged fields match the untagged baseline.
+
+    "Identical to baseline" is asserted structurally: zero combobox artifacts
+    anywhere, none of the combobox ARIA attributes on the tagged inputs, and
+    the tagged inputs parented exactly like the untagged Setpoint input.
+    Console gating allowlists only Chromium's own resource-error line for the
+    expected /channels 404 (matched on the message's source URL).
+    """
+    with bluesky_live_server(catalog=None) as base_url:
+        page = chromium_browser.new_page()
+        pageerrors: list[str] = []
+        console_errors: list[str] = []
+
+        def _on_console(msg) -> None:  # noqa: ANN001 - Playwright ConsoleMessage
+            if msg.type != "error":
+                return
+            url = (msg.location or {}).get("url") or ""
+            if url.rstrip("/").endswith("/channels"):
+                return
+            console_errors.append(msg.text)
+
+        page.on("pageerror", lambda err: pageerrors.append(str(err)))
+        page.on("console", _on_console)
+        try:
+            page.goto(f"{base_url}/bluesky/", wait_until="load")
+            target = _plan_form_target(page)
+            add = page.locator(CHANNEL_ADD)
+
+            assert page.locator(".channel-combobox").count() == 0
+            assert page.locator(".channel-combobox-list").count() == 0
+            combobox_attrs = (
+                "role",
+                "aria-expanded",
+                "aria-autocomplete",
+                "aria-controls",
+                "aria-activedescendant",
+            )
+            for attr in combobox_attrs:
+                assert target.get_attribute(attr) is None, f"Target carries {attr}"
+                assert add.get_attribute(attr) is None, f"channel-add carries {attr}"
+
+            # Parent shape matches the untagged baseline: the tagged string
+            # input sits in its .field-control exactly like the untagged
+            # number input, and the add-input hangs directly off .channel-list.
+            shapes = page.evaluate(
+                """() => {
+                  const parentShape = (el) => ({
+                    tag: el.parentElement.tagName,
+                    cls: el.parentElement.className,
+                  });
+                  return {
+                    target: parentShape(
+                      document.querySelector('#param-form input[aria-label="Target"]')
+                    ),
+                    setpoint: parentShape(
+                      document.querySelector('#param-form input[aria-label="Setpoint"]')
+                    ),
+                    add: parentShape(document.querySelector('#param-form .channel-add')),
+                  };
+                }"""
+            )
+            assert shapes["target"] == shapes["setpoint"]
+            assert shapes["add"] == {"tag": "DIV", "cls": "channel-list"}
+
+            # Interaction stays bare-input: typing conjures no popup material.
+            target.fill("BPM")
+            add.fill("BPM")
+            page.wait_for_timeout(_DEBOUNCE_SETTLE_MS)
+            assert page.locator(".channel-combobox").count() == 0
+            expect(target).to_have_value("BPM")
+
+            add.press("Enter")
+            expect(page.locator(CHANNEL_ROWS)).to_have_count(1)
+        finally:
+            page.close()
+
+        assert pageerrors == []
+        assert console_errors == []

--- a/tests/interfaces/bluesky_web/test_channels_route.py
+++ b/tests/interfaces/bluesky_web/test_channels_route.py
@@ -1,0 +1,144 @@
+"""Tests for the bluesky-web sidecar's channel-catalog route and the caching
+contract it depends on.
+
+The sidecar's blanket ``_no_cache`` middleware fills the header in with
+``setdefault`` rather than overwriting it, so a route can make its own caching
+decision (the channel catalog revalidates with an ETag) while everything else
+keeps the full no-store string. Both halves of that contract are pinned here:
+this module owns the caching guard for a route-level decision, and
+``test_app_integration.py::test_every_response_forbids_browser_caching`` owns
+the blanket guard across representative paths.
+
+Exercises the package-level ``osprey.interfaces.bluesky_web.app:app`` -- the
+object actually served in production -- via ``TestClient(app)`` entered as a
+context manager so the real ``_lifespan`` runs, matching the house pattern in
+``test_app_integration.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.bluesky_web.app import app
+
+_NO_STORE = "no-cache, no-store, must-revalidate"
+
+
+_NO_CACHE = "no-cache"
+_CATALOG = b'["BR:DIAG:BPM:01:POSITION:X", "BR:DIAG:BPM:02:POSITION:X"]'
+
+
+# Config isolation (OSPREY_CONFIG pointed at a nonexistent file, launch token
+# cleared) comes from this directory's conftest autouse fixture.
+
+
+@pytest.fixture
+def project_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """A stand-in for the container's ``/app/project`` mount point.
+
+    The compose template hands the sidecar ``CONFIG_FILE=/app/project/config.yml``
+    and mounts the catalog as that file's sibling, which is exactly what the
+    route resolves against -- so pointing ``CONFIG_FILE`` at a temp config.yml
+    reproduces the deployed layout. The root conftest's ``restore_environ``
+    clears ``CONFIG_FILE`` around every test, so this never leaks sideways.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.yml").write_text("connector:\n  type: mock\n")
+    monkeypatch.setenv("CONFIG_FILE", str(project / "config.yml"))
+    return project
+
+
+# ---------------------------------------------------------------------------
+# Caching contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", ["/bluesky/", "/bluesky/index.html"])
+def test_panel_bundle_response_still_forbids_browser_caching(path: str) -> None:
+    """Regression guard for the ``setdefault`` middleware.
+
+    Panel bundles ship unversioned filenames (``panel.js``, not
+    ``panel-<hash>.js``), so a cached copy silently survives a container
+    rebuild and the operator keeps seeing last week's UI. The static mount sets
+    no ``Cache-Control`` of its own, so the middleware must still fill in the
+    full no-store string -- ``setdefault`` may only yield to a route that made
+    a deliberate caching decision.
+    """
+    with TestClient(app) as client:
+        response = client.get(path)
+
+    assert response.status_code == 200, path
+    assert response.headers["cache-control"] == _NO_STORE, path
+
+
+# ---------------------------------------------------------------------------
+# GET /channels
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_is_served_with_a_revalidating_etag(project_dir: Path) -> None:
+    """The catalog comes back verbatim, cacheable only against its ETag.
+
+    ``no-cache`` (not ``no-store``) is the point: the browser must ask every
+    time, but the ETag lets the answer be an empty 304 for a catalog that only
+    changes on a rebuild.
+    """
+    (project_dir / "channels.json").write_bytes(_CATALOG)
+
+    with TestClient(app) as client:
+        response = client.get("/channels")
+
+    assert response.status_code == 200
+    assert response.json() == ["BR:DIAG:BPM:01:POSITION:X", "BR:DIAG:BPM:02:POSITION:X"]
+    assert response.headers["cache-control"] == _NO_CACHE
+    assert response.headers["etag"].startswith('"')
+
+
+def test_matching_if_none_match_gets_an_empty_304(project_dir: Path) -> None:
+    (project_dir / "channels.json").write_bytes(_CATALOG)
+
+    with TestClient(app) as client:
+        first = client.get("/channels")
+        etag = first.headers["etag"]
+        second = client.get("/channels", headers={"If-None-Match": etag})
+
+    assert second.status_code == 304
+    assert second.content == b""
+    assert second.headers["etag"] == etag
+    assert second.headers["cache-control"] == _NO_CACHE
+
+
+def test_rebuilt_catalog_invalidates_a_stale_etag(project_dir: Path) -> None:
+    """A rebuild that changes the catalog must not be served from cache."""
+    catalog = project_dir / "channels.json"
+    catalog.write_bytes(_CATALOG)
+
+    with TestClient(app) as client:
+        stale_etag = client.get("/channels").headers["etag"]
+        catalog.write_bytes(b'["SR:DIAG:BPM:07:POSITION:Y"]')
+        response = client.get("/channels", headers={"If-None-Match": stale_etag})
+
+    assert response.status_code == 200
+    assert response.json() == ["SR:DIAG:BPM:07:POSITION:Y"]
+    assert response.headers["etag"] != stale_etag
+
+
+def test_absent_catalog_is_a_404(project_dir: Path) -> None:
+    """An absent file is the "this build emitted none" signal, not an empty list.
+
+    Panels treat the 404 exactly as they treat an empty catalog -- no
+    autocomplete -- so the body shape carries no contract; only the status does.
+    The response must still not be cached, or the 404 would outlive the rebuild
+    that fixes it.
+    """
+    assert not (project_dir / "channels.json").exists()
+
+    with TestClient(app) as client:
+        response = client.get("/channels")
+
+    assert response.status_code == 404
+    assert response.headers["cache-control"] == _NO_STORE

--- a/tests/interfaces/design_system/channel-combobox.test.mjs
+++ b/tests/interfaces/design_system/channel-combobox.test.mjs
@@ -1,0 +1,418 @@
+// @ts-check
+/**
+ * Unit tests for channel-combobox.js — the anchored suggestion popover behind
+ * plan-form channel fields. Pins the selection semantics contract:
+ *
+ *   - NO default highlight: aria-activedescendant appears only after
+ *     ArrowUp/ArrowDown, which wrap; hover is visual-only + click-select
+ *   - option mousedown is preventDefault()ed so the input keeps focus
+ *   - Enter accepts only an arrow-armed item (then stops propagation);
+ *     unarmed Enter closes the popup and still propagates to the form
+ *   - Escape closes; outside mousedown closes via a capture-phase document
+ *     listener installed on open and removed on close
+ *   - input re-queries the matcher behind a trailing-edge debounce, and a
+ *     user-intent close cancels a still-pending query
+ *   - highlights are built from DOM nodes, so catalog values containing
+ *     markup render as literal text (no HTML injection)
+ *   - free-form entry is never blocked: values outside the catalog type fine
+ *
+ * Run with:
+ *   npx vitest run tests/interfaces/design_system/channel-combobox.test.mjs
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  attachChannelCombobox,
+  DEFAULT_DEBOUNCE_MS,
+} from '/design-system/js/channel-combobox.js';
+import { RENDER_CAP } from '/design-system/js/channel-matcher.js';
+
+/**
+ * Three entries match "BPM" (as substring and hence subsequence); the HCM
+ * entries contain no "b"/"p" so they cannot even fuzzy-match it. That makes
+ * the popup contents for query "BPM" exactly three rows, which the arrow
+ * wrapping tests rely on.
+ */
+const CATALOG = ['SR01:BPM:X', 'SR02:BPM:X', 'SR03:BPM:X', 'SR01:HCM:X', 'SR02:HCM:X'];
+
+/**
+ * Mount a fresh input inside a holder div and attach the combobox.
+ * @param {string[]} [catalog]
+ * @param {import('/design-system/js/channel-combobox.js').ChannelComboboxOptions} [opts]
+ * @returns {{ input: HTMLInputElement, holder: HTMLElement, handle: ReturnType<typeof attachChannelCombobox> }}
+ */
+function setup(catalog = CATALOG, opts = {}) {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+  const input = document.createElement('input');
+  holder.appendChild(input);
+  const handle = attachChannelCombobox(input, catalog, opts);
+  return { input, holder, handle };
+}
+
+/**
+ * Simulate typing: set the value, fire `input`, and run out the debounce.
+ * @param {HTMLInputElement} input
+ * @param {string} text
+ * @returns {void}
+ */
+function type(input, text) {
+  input.value = text;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
+}
+
+/**
+ * Dispatch a bubbling, cancelable keydown and return it for assertions.
+ * @param {HTMLInputElement} input
+ * @param {string} key
+ * @returns {KeyboardEvent}
+ */
+function press(input, key) {
+  const e = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  input.dispatchEvent(e);
+  return e;
+}
+
+/**
+ * The wrapper the combobox inserted around the input.
+ * @param {HTMLInputElement} input
+ * @returns {HTMLElement}
+ */
+function wrapperOf(input) {
+  const wrapper = input.parentElement;
+  if (!wrapper) throw new Error('input has no parent');
+  return wrapper;
+}
+
+/**
+ * All rendered option rows.
+ * @param {HTMLInputElement} input
+ * @returns {HTMLElement[]}
+ */
+function optionsOf(input) {
+  return Array.from(wrapperOf(input).querySelectorAll('[role="option"]'));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('attachChannelCombobox', () => {
+  it('ATTACH: wraps the input in a position:relative container with the ARIA combobox contract', () => {
+    const { input, holder } = setup();
+    const wrapper = wrapperOf(input);
+
+    expect(wrapper.classList.contains('channel-combobox')).toBe(true);
+    expect(wrapper.style.position).toBe('relative');
+    expect(wrapper.parentElement).toBe(holder);
+
+    expect(input.getAttribute('role')).toBe('combobox');
+    expect(input.getAttribute('aria-expanded')).toBe('false');
+    expect(input.getAttribute('aria-autocomplete')).toBe('list');
+
+    const listId = input.getAttribute('aria-controls');
+    expect(listId).toBeTruthy();
+    const listbox = wrapper.querySelector(`#${listId}`);
+    if (!listbox) throw new Error('listbox not found');
+    expect(listbox.getAttribute('role')).toBe('listbox');
+  });
+
+  it('OPEN: typing opens the popup (.open class, aria-expanded, option rows) after the debounce', () => {
+    const { input, handle } = setup();
+    input.value = 'BPM';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Trailing-edge debounce: nothing happens until the delay elapses.
+    expect(handle.isOpen()).toBe(false);
+    expect(wrapperOf(input).classList.contains('open')).toBe(false);
+
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
+
+    expect(handle.isOpen()).toBe(true);
+    expect(wrapperOf(input).classList.contains('open')).toBe(true);
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+    expect(optionsOf(input).length).toBe(3);
+  });
+
+  it('NO DEFAULT HIGHLIGHT: opening arms nothing — no aria-activedescendant, no aria-selected row', () => {
+    const { input } = setup();
+    type(input, 'BPM');
+
+    expect(input.hasAttribute('aria-activedescendant')).toBe(false);
+    for (const row of optionsOf(input)) {
+      expect(row.getAttribute('aria-selected')).toBe('false');
+    }
+  });
+
+  it('ARROWS: ArrowDown/ArrowUp move aria-activedescendant and wrap at both ends', () => {
+    const { input } = setup();
+    type(input, 'BPM');
+    const rows = optionsOf(input);
+
+    const down = press(input, 'ArrowDown');
+    expect(down.defaultPrevented).toBe(true);
+    expect(input.getAttribute('aria-activedescendant')).toBe(rows[0].id);
+    expect(rows[0].getAttribute('aria-selected')).toBe('true');
+
+    press(input, 'ArrowDown');
+    press(input, 'ArrowDown');
+    expect(input.getAttribute('aria-activedescendant')).toBe(rows[2].id);
+
+    // Wrap bottom -> top.
+    press(input, 'ArrowDown');
+    expect(input.getAttribute('aria-activedescendant')).toBe(rows[0].id);
+    expect(rows[2].getAttribute('aria-selected')).toBe('false');
+
+    // Wrap top -> bottom.
+    press(input, 'ArrowUp');
+    expect(input.getAttribute('aria-activedescendant')).toBe(rows[2].id);
+  });
+
+  it('ARROWS: ArrowUp from the unarmed state arms the LAST option', () => {
+    const { input } = setup();
+    type(input, 'BPM');
+    const rows = optionsOf(input);
+
+    press(input, 'ArrowUp');
+    expect(input.getAttribute('aria-activedescendant')).toBe(rows[rows.length - 1].id);
+  });
+
+  it('ENTER unarmed: closes the popup, does not consume the event, and propagates to the parent', () => {
+    const { input, holder, handle } = setup();
+    /** @type {KeyboardEvent[]} */
+    const seen = [];
+    holder.addEventListener('keydown', (e) => seen.push(e));
+    type(input, 'BPM');
+
+    const e = press(input, 'Enter');
+
+    expect(handle.isOpen()).toBe(false);
+    expect(e.defaultPrevented).toBe(false);
+    expect(seen.length).toBe(1);
+    expect(input.value).toBe('BPM');
+  });
+
+  it('ENTER armed: selects the armed value, stops propagation, and calls onSelect', () => {
+    const onSelect = vi.fn();
+    const { input, holder, handle } = setup(CATALOG, { onSelect });
+    /** @type {KeyboardEvent[]} */
+    const seen = [];
+    holder.addEventListener('keydown', (e) => seen.push(e));
+    type(input, 'BPM');
+    const armedValue = optionsOf(input)[0].textContent;
+
+    press(input, 'ArrowDown');
+    const e = press(input, 'Enter');
+
+    expect(input.value).toBe(armedValue);
+    expect(onSelect).toHaveBeenCalledWith(armedValue);
+    expect(handle.isOpen()).toBe(false);
+    expect(e.defaultPrevented).toBe(true);
+    // stopPropagation: the parent's listener never saw the armed Enter
+    // (the earlier ArrowDown was not stopped, so filter to Enter).
+    expect(seen.filter((k) => k.key === 'Enter').length).toBe(0);
+  });
+
+  it('SELECT: accepting re-dispatches a bubbling input event without re-opening the popup', () => {
+    const { input, holder, handle } = setup();
+    /** @type {string[]} */
+    const observed = [];
+    holder.addEventListener('input', () => observed.push(input.value));
+    type(input, 'BPM');
+    observed.length = 0;
+
+    press(input, 'ArrowDown');
+    press(input, 'Enter');
+
+    // Form-level listeners saw the programmatic value change...
+    expect(observed).toEqual([input.value]);
+    // ...and the synthetic event did not schedule a re-query that reopens.
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS * 2);
+    expect(handle.isOpen()).toBe(false);
+  });
+
+  it('PENDING QUERY: a select cancels an in-flight debounced query so the popup stays closed', () => {
+    const { input, handle } = setup();
+    type(input, 'BPM');
+    // New keystroke schedules a query, but the user selects before it fires.
+    input.value = 'BPM:';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    press(input, 'ArrowDown');
+    press(input, 'Enter');
+    expect(handle.isOpen()).toBe(false);
+
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS * 2);
+    expect(handle.isOpen()).toBe(false);
+  });
+
+  it('ESCAPE: closes the popup and consumes the event', () => {
+    const { input, handle } = setup();
+    type(input, 'BPM');
+    expect(handle.isOpen()).toBe(true);
+
+    const e = press(input, 'Escape');
+    expect(handle.isOpen()).toBe(false);
+    expect(input.getAttribute('aria-expanded')).toBe('false');
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it('MOUSEDOWN on an option is preventDefault()ed (input keeps focus) and does not close the popup', () => {
+    const { input, handle } = setup();
+    type(input, 'BPM');
+    const row = optionsOf(input)[0];
+
+    const e = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    row.dispatchEvent(e);
+
+    expect(e.defaultPrevented).toBe(true);
+    expect(handle.isOpen()).toBe(true);
+  });
+
+  it('CLICK on an option selects its value and closes', () => {
+    const onSelect = vi.fn();
+    const { input, handle } = setup(CATALOG, { onSelect });
+    type(input, 'BPM');
+    const row = optionsOf(input)[1];
+    const value = row.textContent;
+
+    row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(input.value).toBe(value);
+    expect(onSelect).toHaveBeenCalledWith(value);
+    expect(handle.isOpen()).toBe(false);
+  });
+
+  it('HOVER is visual-only: mouseenter never moves aria-activedescendant or aria-selected', () => {
+    const { input } = setup();
+    type(input, 'BPM');
+    const row = optionsOf(input)[1];
+
+    row.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+
+    expect(input.hasAttribute('aria-activedescendant')).toBe(false);
+    expect(row.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('OUTSIDE MOUSEDOWN: a capture-phase document listener closes the popup', () => {
+    const { input, handle } = setup();
+    type(input, 'BPM');
+    expect(handle.isOpen()).toBe(true);
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(handle.isOpen()).toBe(false);
+  });
+
+  it('LISTENER LIFECYCLE: the document mousedown listener is added (capture) on open and removed on close', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { input } = setup();
+
+    type(input, 'BPM');
+    const added = addSpy.mock.calls.filter(([name]) => name === 'mousedown');
+    expect(added.length).toBe(1);
+    expect(added[0][2]).toBe(true);
+
+    press(input, 'Escape');
+    const removed = removeSpy.mock.calls.filter(([name]) => name === 'mousedown');
+    expect(removed.length).toBe(1);
+    expect(removed[0][1]).toBe(added[0][1]);
+    expect(removed[0][2]).toBe(true);
+  });
+
+  it('BLUR: closes the popup', () => {
+    const { input, handle } = setup();
+    type(input, 'BPM');
+    expect(handle.isOpen()).toBe(true);
+
+    input.dispatchEvent(new Event('blur'));
+    expect(handle.isOpen()).toBe(false);
+  });
+
+  it('HIGHLIGHT SAFETY: a catalog value containing markup renders as literal text with match spans', () => {
+    const hostile = 'SR<b>01:BPM:X';
+    const { input } = setup([hostile, ...CATALOG]);
+    type(input, 'BPM');
+
+    const row = optionsOf(input).find((r) => r.textContent === hostile);
+    if (!row) throw new Error('hostile catalog value not rendered');
+    // No element was created from the markup...
+    expect(row.querySelector('b')).toBeNull();
+    // ...but real highlight spans wrap the matched slices. Case-insensitive:
+    // the fuzzy matcher may bind the query's "B" to the "b" inside "<b>".
+    const marks = Array.from(row.querySelectorAll('.channel-combobox-match'));
+    expect(marks.length).toBeGreaterThan(0);
+    expect(marks.map((m) => m.textContent).join('').toUpperCase()).toContain('BPM');
+  });
+
+  it('FREE-FORM: a value outside the catalog keeps the popup closed and the input untouched', () => {
+    const { input, holder, handle } = setup();
+    /** @type {KeyboardEvent[]} */
+    const seen = [];
+    holder.addEventListener('keydown', (e) => seen.push(e));
+
+    type(input, 'MY:CUSTOM:CHANNEL');
+
+    expect(handle.isOpen()).toBe(false);
+    expect(input.value).toBe('MY:CUSTOM:CHANNEL');
+    // With the popup closed the combobox never touches keys: Enter reaches
+    // the form unconsumed.
+    const e = press(input, 'Enter');
+    expect(e.defaultPrevented).toBe(false);
+    expect(seen.filter((k) => k.key === 'Enter').length).toBe(1);
+  });
+
+  it('EMPTY: clearing the field closes the popup instead of browsing the whole catalog', () => {
+    const { input, handle } = setup();
+    type(input, 'BPM');
+    expect(handle.isOpen()).toBe(true);
+
+    type(input, '');
+    expect(handle.isOpen()).toBe(false);
+  });
+
+  it('TRUNCATION: an over-cap pool renders RENDER_CAP options plus a non-option footer that arrows skip', () => {
+    const big = Array.from(
+      { length: RENDER_CAP + 10 },
+      (_, i) => `SR${String(i).padStart(3, '0')}:BPM:X`
+    );
+    const { input } = setup(big);
+    type(input, 'BPM');
+
+    const rows = optionsOf(input);
+    expect(rows.length).toBe(RENDER_CAP);
+    const footer = wrapperOf(input).querySelector('.channel-combobox-more');
+    if (!footer) throw new Error('truncation footer missing');
+    expect(footer.getAttribute('role')).toBeNull();
+    expect(footer.textContent).toContain('10 more');
+
+    // ArrowUp from unarmed lands on the last real option, not the footer.
+    press(input, 'ArrowUp');
+    expect(input.getAttribute('aria-activedescendant')).toBe(rows[rows.length - 1].id);
+  });
+
+  it('DESTROY: unwraps the input, restores its attributes, and detaches all listeners', () => {
+    const { input, holder, handle } = setup();
+    type(input, 'BPM');
+
+    handle.destroy();
+
+    expect(input.parentElement).toBe(holder);
+    expect(holder.querySelector('.channel-combobox')).toBeNull();
+    expect(input.hasAttribute('role')).toBe(false);
+    expect(input.hasAttribute('aria-expanded')).toBe(false);
+    expect(input.hasAttribute('aria-controls')).toBe(false);
+
+    // Typing after destroy is inert: no popup DOM exists to open.
+    type(input, 'BPM');
+    expect(handle.isOpen()).toBe(false);
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+  });
+});

--- a/tests/interfaces/design_system/channel-matcher.test.mjs
+++ b/tests/interfaces/design_system/channel-matcher.test.mjs
@@ -1,0 +1,158 @@
+// @ts-check
+/**
+ * Unit tests for channel-matcher.js — the pure ranking core behind the
+ * plan-form channel typeahead. Pins the load-bearing pool rule:
+ *
+ *   - case-insensitive substring hits are the candidate pool when there are
+ *     at least MIN_POOL of them; below that the pool widens to every catalog
+ *     entry fuzzyMatch accepts (subsequence matching)
+ *   - both modes rank by fuzzyMatch score (a substring is a subsequence, so
+ *     substring hits always fuzzy-match), tie-broken by value ascending
+ *   - `total` is the honest pool size; `results` is capped at RENDER_CAP
+ *   - empty/whitespace query: pool = whole catalog, first RENDER_CAP entries
+ *     in catalog order
+ *
+ * Pure module, no DOM:
+ *   npx vitest run tests/interfaces/design_system/channel-matcher.test.mjs
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  matchChannels,
+  MIN_POOL,
+  RENDER_CAP,
+} from '/design-system/js/channel-matcher.js';
+import { fuzzyMatch } from '/design-system/js/fuzzy.js';
+
+/**
+ * Build `n` distinct channel names containing `stem`, e.g. "SR01:HCM:SP".
+ * @param {number} n
+ * @param {string} stem
+ * @returns {string[]}
+ */
+function namesContaining(n, stem) {
+  return Array.from({ length: n }, (_, i) => `SR${String(i).padStart(2, '0')}:${stem}:SP`);
+}
+
+describe('matchChannels', () => {
+  it('POOL CONTAINMENT: substring mode — every result contains the query case-insensitively', () => {
+    // MIN_POOL substring hits trigger substring mode; the fuzzy-only entry
+    // (matches "HCM" only as a subsequence) must be excluded from the pool.
+    const fuzzyOnly = 'SR:H7:CTRL:M1';
+    expect(fuzzyOnly.toLowerCase().includes('hcm')).toBe(false);
+    expect(fuzzyMatch('HCM', fuzzyOnly)).not.toBeNull();
+
+    const catalog = [...namesContaining(MIN_POOL, 'HCM'), fuzzyOnly].sort();
+    const { results, total } = matchChannels('hcm', catalog);
+
+    expect(total).toBe(MIN_POOL);
+    expect(results.length).toBe(MIN_POOL);
+    for (const { value } of results) {
+      expect(value.toLowerCase()).toContain('hcm');
+    }
+  });
+
+  it('POOL CONTAINMENT: fuzzy mode — every result fuzzy-matches the query', () => {
+    // Fewer than MIN_POOL substring hits: the pool is all fuzzyMatch matches,
+    // and non-matching entries stay out.
+    const catalog = [
+      ...namesContaining(MIN_POOL - 1, 'HCM'),
+      'SR:H7:CTRL:M1', // fuzzy-only match for "hcm"
+      'SR:VBP:01:RB', // no h at all — must not appear
+    ].sort();
+    const { results, total } = matchChannels('hcm', catalog);
+
+    expect(total).toBe(MIN_POOL);
+    for (const { value } of results) {
+      expect(fuzzyMatch('hcm', value)).not.toBeNull();
+    }
+    expect(results.map((r) => r.value)).not.toContain('SR:VBP:01:RB');
+  });
+
+  it('FLIP BOUNDARY: dropping below MIN_POOL substring hits widens the pool to a superset', () => {
+    const substringHits = namesContaining(MIN_POOL, 'HCM');
+    const fuzzyOnly = 'SR:H7:CTRL:M1';
+
+    // Exactly MIN_POOL substring hits: substring mode, fuzzy-only excluded.
+    const atBoundary = matchChannels('hcm', [...substringHits, fuzzyOnly].sort());
+    expect(atBoundary.total).toBe(MIN_POOL);
+    expect(atBoundary.results.map((r) => r.value)).not.toContain(fuzzyOnly);
+
+    // Remove one hit (MIN_POOL - 1 remain): fuzzy mode. The pool must be a
+    // strict superset of the remaining substring hits — all still present,
+    // plus the fuzzy-only entry.
+    const remaining = substringHits.slice(1);
+    const below = matchChannels('hcm', [...remaining, fuzzyOnly].sort());
+    const belowValues = below.results.map((r) => r.value);
+    for (const hit of remaining) {
+      expect(belowValues).toContain(hit);
+    }
+    expect(belowValues).toContain(fuzzyOnly);
+    expect(below.total).toBe(remaining.length + 1);
+  });
+
+  it('SUBSEQUENCE FALL-THROUGH: "SRHCM" has zero substring hits but matches SR:HCM names', () => {
+    const catalog = ['SR:HCM:01:SP', 'SR:HCM:02:SP', 'SR:VCM:01:SP'];
+    for (const value of catalog) {
+      expect(value.toLowerCase().includes('srhcm')).toBe(false);
+    }
+
+    const { results, total } = matchChannels('SRHCM', catalog);
+    expect(total).toBe(2);
+    expect(results.map((r) => r.value).sort()).toEqual(['SR:HCM:01:SP', 'SR:HCM:02:SP']);
+  });
+
+  it('RENDER CAP: results capped at RENDER_CAP, total stays honest, results ⊆ pool', () => {
+    const poolSize = RENDER_CAP + 10;
+    const catalog = [...namesContaining(poolSize, 'HCM'), 'SR:VBP:01:RB'].sort();
+    const { results, total } = matchChannels('hcm', catalog);
+
+    expect(results.length).toBe(RENDER_CAP);
+    expect(total).toBe(poolSize);
+    for (const { value } of results) {
+      // Substring mode: every rendered entry is a member of the substring pool.
+      expect(value.toLowerCase()).toContain('hcm');
+    }
+  });
+
+  it('spans come from fuzzyMatch (half-open [start, end) pairs into the value)', () => {
+    const catalog = namesContaining(MIN_POOL, 'HCM');
+    const { results } = matchChannels('hcm', catalog);
+    const first = results[0];
+    if (first === undefined) throw new Error('expected at least one result');
+
+    const expected = fuzzyMatch('hcm', first.value);
+    if (expected === null) throw new Error('substring hit must fuzzy-match');
+    expect(first.spans).toEqual(expected.spans);
+  });
+
+  it('ties rank by value ascending so ordering is deterministic', () => {
+    // Identical shapes score identically; the tie-break must not depend on
+    // catalog order.
+    const catalog = ['SR02:HCM:SP', 'SR00:HCM:SP', 'SR01:HCM:SP'];
+    const scores = catalog.map((v) => {
+      const hit = fuzzyMatch('hcm', v);
+      if (hit === null) throw new Error('expected a match');
+      return hit.score;
+    });
+    expect(new Set(scores).size).toBe(1);
+
+    // 3 substring hits < MIN_POOL: fuzzy mode, same ranking rule applies.
+    const { results } = matchChannels('hcm', catalog);
+    expect(results.map((r) => r.value)).toEqual(['SR00:HCM:SP', 'SR01:HCM:SP', 'SR02:HCM:SP']);
+  });
+
+  it('empty/whitespace query: whole catalog is the pool, first RENDER_CAP in catalog order', () => {
+    const catalog = namesContaining(RENDER_CAP + 5, 'BPM');
+    for (const query of ['', '   ']) {
+      const { results, total } = matchChannels(query, catalog);
+      expect(total).toBe(catalog.length);
+      expect(results.length).toBe(RENDER_CAP);
+      expect(results.map((r) => r.value)).toEqual(catalog.slice(0, RENDER_CAP));
+      for (const { spans } of results) {
+        expect(spans).toEqual([]);
+      }
+    }
+  });
+});

--- a/tests/interfaces/design_system/fuzzy.test.mjs
+++ b/tests/interfaces/design_system/fuzzy.test.mjs
@@ -1,6 +1,7 @@
 /**
- * Unit tests for fuzzy.js — the pure command-palette scorer. Pins the
- * load-bearing contract that a naive subsequence matcher fails:
+ * Unit tests for fuzzy.js — the design system's pure fuzzy scorer (shared by
+ * the command palette and the channel-catalog matcher). Pins the load-bearing
+ * contract that a naive subsequence matcher fails:
  *
  *   - the query is tokenized on whitespace and EVERY token must independently
  *     subsequence-match the candidate (all-tokens-AND), so "wrt vrf" matches
@@ -12,12 +13,12 @@
  *     spans, and an empty query matches everything with score 0
  *
  * Pure module, no DOM:
- *   npx vitest run tests/interfaces/web_terminal/fuzzy.test.mjs
+ *   npx vitest run tests/interfaces/design_system/fuzzy.test.mjs
  */
 
 import { describe, it, expect } from 'vitest';
 
-import { fuzzyMatch } from '../../../src/osprey/interfaces/web_terminal/static/js/fuzzy.js';
+import { fuzzyMatch } from '/design-system/js/fuzzy.js';
 
 /** Reconstruct the matched substring set by slicing the candidate by spans.
  * @param {string} candidate

--- a/tests/interfaces/web_terminal/test_channels_proxy_cache.py
+++ b/tests/interfaces/web_terminal/test_channels_proxy_cache.py
@@ -1,0 +1,113 @@
+"""The channel-catalog caching contract must survive the hub's proxy hop.
+
+The bluesky panel is embedded in the web-terminal hub behind ``/panel/{id}/``,
+so the browser never talks to the sidecar directly — every ``/channels``
+request rides through the hub's generic forwarder. That forwarder applies its
+own caching default (``no-cache, no-store, must-revalidate``) via
+``setdefault``, which must yield to the route's deliberate ``no-cache`` +
+ETag decision; and the conditional-request cycle (``If-None-Match`` → empty
+``304``) must relay intact in both directions.
+
+This module pins that end to end over the real network path: a live
+``bluesky_web`` uvicorn instance on a free localhost port, proxied by the hub
+app through its real ``httpx`` client — no mocks on the wire. The route-level
+halves of the contract are pinned in
+``tests/interfaces/bluesky_web/test_channels_route.py``; this is the
+proxy-transparency half.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.interfaces._serving import run_app_server
+from osprey.interfaces.bluesky_web.app import app as bluesky_app
+from osprey.interfaces.web_terminal.app import UNIVERSAL_PANELS, create_app
+
+_CATALOG = ["BR:DIAG:BPM:01:POSITION:X", "BR:DIAG:BPM:02:POSITION:X"]
+
+# The hub proxy's own default, applied only when the upstream set no
+# Cache-Control. Appearing on /channels would mean setdefault clobbered the
+# route's decision.
+_HUB_DEFAULT = "no-cache, no-store, must-revalidate"
+
+
+def _make_client(workspace_dir, custom_panels):
+    """Create a TestClient with custom panels configured."""
+    enabled = set(UNIVERSAL_PANELS)
+    with (
+        patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value={"watch_dir": str(workspace_dir)},
+        ),
+        patch(
+            "osprey.interfaces.web_terminal.app._load_panel_config",
+            return_value=(enabled, custom_panels, None),
+        ),
+    ):
+        app = create_app(shell_command="echo")
+        with TestClient(app) as c:
+            yield app, c
+
+
+@pytest.fixture
+def bluesky_url(monkeypatch, tmp_path):
+    """A live bluesky_web server on a free port, catalog in place.
+
+    Environment isolation mirrors ``test_channels_route.py``: config
+    resolution is pointed at a nonexistent file so ambient repo/user config
+    can't leak a launch token or bridge URL into the sidecar's lifespan, and
+    ``CONFIG_FILE`` reproduces the deployed layout — the compose template
+    mounts channels.json as config.yml's sibling, which is what the /channels
+    route resolves against at request time. The root conftest's
+    ``restore_environ`` clears both around every test.
+    """
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "does-not-exist.yml"))
+    monkeypatch.delenv("BLUESKY_LAUNCH_TOKEN", raising=False)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.yml").write_text("connector:\n  type: mock\n")
+    (project / "channels.json").write_text(json.dumps(_CATALOG))
+    monkeypatch.setenv("CONFIG_FILE", str(project / "config.yml"))
+
+    with run_app_server(bluesky_app) as url:
+        yield url
+
+
+@pytest.fixture
+def hub_client(tmp_path, bluesky_url):
+    """Hub app whose ``bluesky`` custom panel points at the live sidecar."""
+    ws = tmp_path / "_agent_data"
+    ws.mkdir()
+    custom = [{"id": "bluesky", "label": "Bluesky", "url": bluesky_url}]
+    for _app, client in _make_client(ws, custom):
+        yield client
+
+
+def test_route_cache_decision_survives_the_proxy(hub_client):
+    """First fetch: 200 with the route's ``no-cache``, not the hub default."""
+    resp = hub_client.get("/panel/bluesky/channels")
+
+    assert resp.status_code == 200
+    assert resp.json() == _CATALOG
+    assert resp.headers["cache-control"] == "no-cache"
+    assert resp.headers["cache-control"] != _HUB_DEFAULT
+    assert resp.headers["etag"].startswith('"')
+
+
+def test_conditional_request_cycle_relays_through_the_proxy(hub_client):
+    """``If-None-Match`` reaches the sidecar; its empty 304 comes back intact."""
+    first = hub_client.get("/panel/bluesky/channels")
+    etag = first.headers["etag"]
+
+    second = hub_client.get("/panel/bluesky/channels", headers={"If-None-Match": etag})
+
+    assert second.status_code == 304
+    assert second.content == b""
+    assert second.headers["etag"] == etag
+    assert second.headers["cache-control"] == "no-cache"

--- a/tests/services/bluesky_bridge/test_plan_fields.py
+++ b/tests/services/bluesky_bridge/test_plan_fields.py
@@ -594,20 +594,29 @@ def test_resolve_column_accepts_a_data_row_directly() -> None:
 # --- panel tolerance --------------------------------------------------------
 
 
-def test_form_generator_never_reads_the_role_key() -> None:
-    """The panel's schema-driven form generator ignores the role extra.
+def test_form_generator_reads_the_role_key_only_to_offer_suggestions() -> None:
+    """The panel's schema-driven form generator reads the role extra at one site.
 
-    It dispatches on a fixed set of schema keys and never mentions
-    ``x-channel-role``, so the declared role is inert there -- combined with the
-    additivity test above, that is what makes adding roles to a shipped plan's
-    parameters a no-op for the operator's form.
+    The channel-suggestions feature ended the old "never reads it" rule: a
+    truthy ``x-channel-role`` now tags a field as eligible for the typeahead.
+    What survives, and what this pins, is the property the old rule existed
+    for -- the role never drives control dispatch, so adding roles to a
+    shipped plan's parameters still renders the same controls. The single
+    permitted read is ``channelSuggestionsFor``, which only decides whether a
+    field OFFERS suggestions; with no catalog loaded the rendered form is
+    byte-identical to the untagged baseline (pinned by the no-catalog case in
+    ``tests/interfaces/bluesky_web/test_channel_combobox_browser.py``).
     """
     source = _SCHEMA_FORM_JS.read_text(encoding="utf-8")
     assert "x-widget" in source, (
         f"{_SCHEMA_FORM_JS} is not the schema-driven form generator this test "
         "means to check -- it no longer reads any schema extras"
     )
-    assert CHANNEL_ROLE_KEY not in source
+    reads = [line.strip() for line in source.splitlines() if f"node['{CHANNEL_ROLE_KEY}']" in line]
+    assert len(reads) == 1, (
+        "the role key must be read at exactly one site (channelSuggestionsFor), "
+        f"never in control dispatch; found {len(reads)}: {reads}"
+    )
 
 
 # --- import cleanliness -----------------------------------------------------

--- a/tests/templates/render_defaults/bluesky_web.yml
+++ b/tests/templates/render_defaults/bluesky_web.yml
@@ -79,6 +79,7 @@ services:
       # (build/services/), not this file's own subdir — hence the
       # bluesky-web/ prefix (mirrors the bridge's config.yml:ro convention).
       - ./build/services/bluesky_web/config.yml:/app/project/config.yml:ro
+
     networks:
       - osprey-network
     healthcheck:


### PR DESCRIPTION
Channel-name inputs in the BLUESKY plan panel are free-form text with no
guidance. An operator either remembers an exact address or leaves the form to
go look it up. The project already curates the answer in its Channel Finder
database, but that catalog never reaches the browser: the bluesky container
mounts only `config.yml`.

`osprey build` now writes a `channels.json` snapshot from the configured
channel-finder pipeline and mounts it read-only into the sidecar, which serves
it with a strong ETag. The panel fetches it once per load and attaches a
suggestions popup to role-tagged fields — substring matches first, with a fuzzy
fall-through once the substring pool drops below eight hits.

Suggestions assist rather than constrain: free-form entry is never blocked, and
where no catalog exists (no channel-finder config, the flag off, an empty or
oversized database) a 404 and an empty list are treated identically, so the form
renders exactly as it does today.

Two decisions worth disagreeing with. The data path is a build-time snapshot
rather than a live query, because `get_all_channels()` is the only
pipeline-agnostic API and a per-keystroke round trip would put the control
system's channel service on the critical path of typing. Staleness then rides on
the existing build-drift gate instead of new regeneration machinery: editing a
database under the profile's `data/` tree moves the profile fingerprint, so
`osprey up` already refuses the stale build with the rebuild remedy. The gap
that buys is deliberate and recorded — a database pointed at from outside that
tree is not folded into the fingerprint, so its edits are invisible to the gate.

## How it hangs together

```text
BUILD TIME · osprey build (host)
┌────────────────────────────────────────────────────────────────────┐
│ channel_snapshot.py ──get_all_channels()──▶ channels.json          │
│      │                                      sorted, deduplicated   │
│      └─ skipped if catalog > web.channel_suggestions.max_channels  │
│         (a stale channels.json is removed rather than left behind) │
│                                                                    │
│ compose_generator._stage_channel_snapshot ─▶ docker-compose.yml.j2 │
│      └─ mounts read-only ONLY when a snapshot was actually written │
└────────────────────────────────────────────────────────────────────┘
                             │ read-only bind mount
                             ▼
CONTAINER · bluesky_web sidecar (FastAPI)
┌────────────────────────────────────────────────────────────────────┐
│ channels.py ──loads──▶ app.py  ·  GET /channels                    │
│                          └─ strong ETag + no-cache, because the    │
│                             blanket no-store middleware now yields │
│                             to the route via setdefault            │
└────────────────────────────────────────────────────────────────────┘
                             │ 304 revalidation, both directions
                             ▼
PROXY · web terminal hub · /panel/{id}/ forwards to the sidecar
                             │
                             ▼
BROWSER
┌────────────────────────────────────────────────────────────────────┐
│ panel.js · fetches the catalog once per panel load                 │
│    ├─ 200 + non-empty ─▶ install the combobox scaffolding          │
│    └─ 404 or []       ─▶ plain text input, form byte-identical     │
│                                                                    │
│ schema-form.js · setChannelCatalog() / channelSuggestionsFor()     │
│    └─ attaches to fields tagged x-channel-role                     │
│         ▼                                                          │
│ channel-combobox.js · attachChannelCombobox(input, catalog, opts)  │
│    │  role=combobox · aria-activedescendant · arrow keys arm the   │
│    │  highlight, so Enter still commits the form on first press    │
│    ▼                                                               │
│ channel-matcher.js · substring pool, fuzzy fall-through under 8    │
│    ▼                                                               │
│ fuzzy.js · /design-system/js/fuzzy.js — the shared scorer, lifted  │
│            out of the web terminal so any surface can rank matches │
└────────────────────────────────────────────────────────────────────┘
```
