### PR TITLE
feat(ariel): make the default search mode configurable, shipped as hybrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- New `ariel.default_search_mode` setting names the search module that answers
+  when a caller asks for no mode — the web interface's opening tab, `osprey
+  ariel search` without `--mode`, and the service API. The shipped templates
+  set it to `hybrid`. A name that no enabled module matches is refused at
+  startup instead of being answered by a different mode; left unset, it
+  resolves to `hybrid` where that module is enabled and `keyword` elsewhere.
+
 - The `orbit_bump_sweep` plan can now assert bump closure at its monitor BPMs:
   an optional `leakage_tolerance` band judges every `readbacks` BPM against the
   reference orbit at each settled step, failing the run (or recording the miss
@@ -54,6 +61,11 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Seeding a simulated logbook (`osprey sim apply`, and the deploy's own
+  first-bring-up seed) now writes the markdown mirror the qmd sidecar indexes.
+  Seeding skips the enhancement passes, so `hybrid` search previously searched
+  an index nothing had built and returned no hits — which reads as "the logbook
+  has nothing on that" rather than as a missing index.
 - Container builds now hand apt the proxy settings they were given. A facility
   proxy arrives as `HTTP_PROXY`/`HTTPS_PROXY`, which apt does not read, so on a
   network with no direct egress every image build stalled in its first package

--- a/docs/source/cli-reference/index.rst
+++ b/docs/source/cli-reference/index.rst
@@ -606,8 +606,9 @@ Safe to run on every build; on a fresh database, runs a full ingest.
 
 ``models`` -- List embedding models and tables.
 
-``search QUERY [--mode keyword|semantic] [--limit N] [--json]``
-   Execute a search query (default mode: ``keyword``).
+``search QUERY [--mode keyword|semantic|hybrid] [--limit N] [--json]``
+   Execute a search query. Without ``--mode``, the deployment's
+   ``ariel.default_search_mode`` decides.
 
 ``reembed --model NAME --dimension N [--batch-size N] [--force]``
    Re-embed entries with a different model.

--- a/docs/source/how-to/ariel/search-modes.rst
+++ b/docs/source/how-to/ariel/search-modes.rst
@@ -29,7 +29,7 @@ The service refuses a mode that is not registered, or is registered but disabled
 
 .. code-block:: bash
 
-   osprey ariel search "RF cavity fault"                  # default: keyword
+   osprey ariel search "RF cavity fault"                  # ariel.default_search_mode
    osprey ariel search "RF cavity fault" --mode keyword
    osprey ariel search "RF cavity fault" --mode semantic
    osprey ariel search "RF cavity fault" --mode hybrid
@@ -229,23 +229,42 @@ Modules may also export ``get_parameter_descriptors()`` to declare tunable param
    If you implement a search module that could benefit other facilities --- for example, a structured-metadata search, a time-series correlation search, or a cross-entry linking search --- we encourage you to open a pull request so it becomes natively available in Osprey.
 
 
-.. _semantic-mode-retirement:
+.. _choosing-semantic-or-hybrid:
 
-The Semantic Mode's Planned Retirement
-======================================
+Choosing Between Semantic and Hybrid
+====================================
 
-``hybrid`` covers what ``semantic`` covers and more: it is hybrid rather than
-vector-only, it needs no embedding provider and no pgvector extension, and it
-keeps its index in its own container instead of in the logbook database. The
-plan is therefore to retire the semantic leg once ``hybrid`` has been through a
-burn-in comparison against it in production.
+Both modes retrieve by meaning rather than by matching words, and a deployment
+can run either, both, or neither. They differ in what they depend on, what they
+cost per query, and how much of their ranking you can inspect.
 
-Nothing has been removed and no date has been set. ``semantic`` is fully
-supported in this release, and the burn-in is the gate --- if it does not show
-``hybrid`` matching or beating ``semantic`` on real queries, the semantic leg
-stays. Treat this as a direction to plan for, not a deprecation to act on: keep
-``semantic`` configured if you use it, and read the release notes before
-assuming otherwise.
+``hybrid`` is the stronger default for most deployments. It combines BM25 with
+vector search and an LLM reranker, and its models ship inside the qmd sidecar's
+image, so it needs no embedding provider on the host and no pgvector extension
+in the logbook database. It is also the mode the shipped templates set as
+``default_search_mode``.
+
+``semantic`` is worth keeping — or choosing — when any of the following applies:
+
+* **You want a stronger embedding model than the sidecar bakes in.** ``semantic``
+  takes its embeddings from a configured provider, so a facility with its own
+  inference endpoint can point it at a far larger model than the 300M embedder
+  qmd ships.
+* **You need the ranking to be inspectable.** ``semantic`` is cosine distance
+  over a pgvector column and nothing else --- no reranker, no query expansion.
+  Any result can be explained with a single SQL query, which matters where
+  retrieval has to be auditable.
+* **You want it composable with structured filters.** The embeddings live in
+  ``text_embeddings_*`` tables in the logbook database, so they join against
+  ordinary columns and are reachable from the ``sql_query`` tool. ``hybrid``
+  ranks a markdown mirror and post-filters instead.
+* **Query latency matters more than ranking quality.** Reranking dominates a
+  hybrid query's cost; a pure vector lookup is the fast path. (``hybrid`` can
+  also be run with ``rerank: false``.)
+
+Running both is a reasonable configuration: they are independent modules, and
+``default_search_mode`` decides only which one answers when the caller names no
+mode.
 
 
 Need behavior beyond these search modules --- multi-step reasoning, answer

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -408,6 +408,7 @@ keys:
   ariel.ingestion: {covered-by: ariel}
   ariel.ingestion.adapter: {covered-by: ariel.ingestion}
   ariel.ingestion.source_url: {evidence: 'source_url'}
+  ariel.default_search_mode: {evidence: 'default_search_mode'}
   ariel.search_modules: {evidence: 'search_modules'}
   ariel.search_modules.keyword: {covered-by: ariel.search_modules}
   ariel.search_modules.keyword.enabled: {covered-by: ariel.search_modules.keyword}

--- a/src/osprey/cli/ariel.py
+++ b/src/osprey/cli/ariel.py
@@ -448,10 +448,15 @@ def models_command() -> None:
 
 @ariel_group.command("search")
 @click.argument("query")
-@click.option("--mode", type=_SearchModeChoice(), default="keyword")
+@click.option(
+    "--mode",
+    type=_SearchModeChoice(),
+    default=None,
+    help="Search module to use. Defaults to ariel.default_search_mode.",
+)
 @click.option("--limit", type=int, default=10, help="Maximum results")
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-def search_command(query: str, mode: str, limit: int, output_json: bool) -> None:
+def search_command(query: str, mode: str | None, limit: int, output_json: bool) -> None:
     """Search the logbook.
 
     Execute a search query using the ARIEL agent.

--- a/src/osprey/interfaces/ariel/api/routes.py
+++ b/src/osprey/interfaces/ariel/api/routes.py
@@ -142,10 +142,10 @@ def _resolve_search_mode(service: ARIELSearchService, requested: str | None) -> 
     Raises:
         HTTPException: 400 if the mode is malformed, or names no enabled module.
     """
-    from osprey.services.ariel_search.models import DEFAULT_SEARCH_MODE, normalize_search_mode
+    from osprey.services.ariel_search.models import normalize_search_mode
 
     if requested is None:
-        mode = DEFAULT_SEARCH_MODE
+        mode = service.config.resolve_default_search_mode()
     else:
         try:
             mode = normalize_search_mode(requested)

--- a/src/osprey/interfaces/ariel/static/js/advanced-options.js
+++ b/src/osprey/interfaces/ariel/static/js/advanced-options.js
@@ -82,6 +82,15 @@ const FALLBACK_CAPABILITIES = {
 export function initAdvancedOptions(caps) {
   capabilities = caps || FALLBACK_CAPABILITIES;
 
+  // The deployment decides which mode a search runs in when the user picks
+  // none, so the opening tab follows ariel.default_search_mode rather than a
+  // hardcoded guess. A capabilities payload without it (or naming a mode this
+  // build does not render) leaves the module-level default in place.
+  const advertised = capabilities?.default_mode;
+  if (advertised && _modeExists(advertised)) {
+    currentMode = advertised;
+  }
+
   // Set defaults from capabilities
   resetToDefaults();
 
@@ -237,6 +246,23 @@ function selectMode(mode) {
   if (isPanelOpen) {
     renderAdvancedPanel();
   }
+}
+
+/**
+ * Whether the capabilities payload advertises a mode by this name.
+ * @param {string} modeName - Mode name
+ * @returns {boolean} True when a rendered tab exists for the mode
+ */
+function _modeExists(modeName) {
+  const categories = capabilities?.categories || {};
+  for (const cat of Object.values(categories)) {
+    for (const mode of (cat.modes || [])) {
+      if (mode.name === modeName) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/osprey/interfaces/ariel/static/js/advanced-options.js
+++ b/src/osprey/interfaces/ariel/static/js/advanced-options.js
@@ -48,6 +48,7 @@ import { escapeHtml } from '/design-system/js/dom.js';
  * @typedef {Object} Capabilities
  * @property {Object<string, AdvancedCategory>} categories
  * @property {AdvancedParam[]} [shared_parameters]
+ * @property {string} [default_mode]
  */
 
 // --- State ---

--- a/src/osprey/services/ariel_search/capabilities.py
+++ b/src/osprey/services/ariel_search/capabilities.py
@@ -78,6 +78,7 @@ def get_capabilities(config: ARIELConfig) -> dict[str, Any]:
             "categories": {
                 "direct": {"label": "Direct", "modes": [...]},
             },
+            "default_mode": "hybrid",
             "shared_parameters": [...],
         }
     """
@@ -89,6 +90,7 @@ def get_capabilities(config: ARIELConfig) -> dict[str, Any]:
 
     return {
         "categories": categories,
+        "default_mode": config.resolve_default_search_mode(),
         "shared_parameters": [p.to_dict() for p in SHARED_PARAMETERS],
     }
 

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -1014,7 +1014,7 @@ def _entry_summary(entry: dict) -> dict:
     }
 
 
-async def run_search(config_dict: dict, query: str, mode: str, limit: int) -> dict:
+async def run_search(config_dict: dict, query: str, mode: str | None, limit: int) -> dict:
     """Execute a search query and return the result as a dict.
 
     Args:
@@ -1022,7 +1022,8 @@ async def run_search(config_dict: dict, query: str, mode: str, limit: int) -> di
         query: Search query text.
         mode: Search module name, e.g. ``"keyword"``. Case and surrounding
             whitespace are normalized; whether the name is registered and
-            enabled is decided by the search service.
+            enabled is decided by the search service. ``None`` leaves the
+            choice to the deployment's ``ariel.default_search_mode``.
         limit: Maximum number of entries to return.
 
     Returns:
@@ -1036,10 +1037,12 @@ async def run_search(config_dict: dict, query: str, mode: str, limit: int) -> di
 
     config = _ariel_config(config_dict)
 
-    try:
-        search_mode = normalize_search_mode(mode)
-    except ValueError as e:
-        return {"error": str(e)}
+    search_mode: str | None = None
+    if mode is not None:
+        try:
+            search_mode = normalize_search_mode(mode)
+        except ValueError as e:
+            return {"error": str(e)}
 
     try:
         service = await create_ariel_service(config)

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .exceptions import ConfigurationError
+from .models import normalize_search_mode, resolve_implicit_search_mode
 
 logger = logging.getLogger("osprey.services.ariel_search.config")
 
@@ -366,6 +367,10 @@ class ARIELConfig:
         enhancement_modules: Enhancement module configurations by name
         ingestion: Ingestion configuration
         embedding: Embedding provider configuration
+        default_search_mode: Search module a search runs in when the caller
+            names no mode. Unset resolves to ``hybrid`` where that module is
+            enabled and ``keyword`` otherwise; a name that is set but not
+            enabled is a config error rather than a silent fallback.
 
     Documented top-level config keys read at runtime (not dataclass fields):
         entry_url_template: Optional ``str`` template for the canonical logbook
@@ -383,6 +388,7 @@ class ARIELConfig:
     enhancement_modules: dict[str, EnhancementModuleConfig] = field(default_factory=dict)
     ingestion: IngestionConfig | None = None
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    default_search_mode: str | None = None
 
     @classmethod
     def from_dict(
@@ -429,13 +435,32 @@ class ARIELConfig:
         if "embedding" in config_dict:
             embedding = EmbeddingConfig.from_dict(config_dict["embedding"])
 
+        default_search_mode = config_dict.get("default_search_mode")
+        if default_search_mode is not None:
+            default_search_mode = normalize_search_mode(default_search_mode)
+
         return cls(
             database=database,
             search_modules=search_modules,
             enhancement_modules=enhancement_modules,
             ingestion=ingestion,
             embedding=embedding,
+            default_search_mode=default_search_mode,
         )
+
+    def resolve_default_search_mode(self) -> str:
+        """Name the search module a search runs in when the caller names none.
+
+        Returns:
+            ``default_search_mode`` when the deployment sets it, else the
+            implicit answer from
+            :func:`~osprey.services.ariel_search.models.resolve_implicit_search_mode`.
+            :meth:`validate` has already refused a configured mode that names
+            no enabled module, so the returned name is routable.
+        """
+        if self.default_search_mode:
+            return self.default_search_mode
+        return resolve_implicit_search_mode(self.is_search_module_enabled)
 
     def is_search_module_enabled(self, name: str) -> bool:
         """Check if a search module is enabled.
@@ -488,6 +513,16 @@ class ARIELConfig:
         # Validate database URI
         if not self.database.uri:
             errors.append("database.uri is required")
+
+        # A configured default that names no enabled module is refused here
+        # rather than falling back: a deployment that asked for a mode and
+        # silently got a different one has no way to notice.
+        if self.default_search_mode and not self.is_search_module_enabled(self.default_search_mode):
+            enabled = ", ".join(self.get_enabled_search_modules()) or "(none)"
+            errors.append(
+                f"default_search_mode '{self.default_search_mode}' names no enabled "
+                f"search module. Enabled modules: {enabled}"
+            )
 
         # Validate semantic search requires model
         if self.is_search_module_enabled("semantic"):

--- a/src/osprey/services/ariel_search/models.py
+++ b/src/osprey/services/ariel_search/models.py
@@ -9,6 +9,7 @@ This module defines the core data models for ARIEL search service:
 
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -136,6 +137,35 @@ def enhanced_entry_from_row(row: Any) -> EnhancedLogbookEntry:
 
 
 DEFAULT_SEARCH_MODE = "keyword"
+
+PREFERRED_SEARCH_MODE = "hybrid"
+
+
+def resolve_implicit_search_mode(is_enabled: Callable[[str], bool]) -> str:
+    """Pick the mode a search runs in when the config names none.
+
+    This is the fallback for a deployment whose config predates
+    ``ariel.default_search_mode`` or deliberately leaves it unset.
+    ``hybrid`` is the preferred answer, but it only exists in deployments
+    that run the qmd sidecar, so it is preferred rather than assumed.
+    ``keyword`` needs nothing beyond the logbook database and is always the
+    safe fallback.
+
+    A deployment that sets ``ariel.default_search_mode`` never reaches this —
+    see :meth:`osprey.services.ariel_search.config.ARIELConfig
+    .resolve_default_search_mode`.
+
+    Args:
+        is_enabled: Predicate answering whether a search module name is
+            enabled in the current deployment's configuration.
+
+    Returns:
+        ``PREFERRED_SEARCH_MODE`` when that module is enabled, else
+        ``DEFAULT_SEARCH_MODE``.
+    """
+    if is_enabled(PREFERRED_SEARCH_MODE):
+        return PREFERRED_SEARCH_MODE
+    return DEFAULT_SEARCH_MODE
 
 
 def normalize_search_mode(mode: object) -> str:

--- a/src/osprey/services/ariel_search/service.py
+++ b/src/osprey/services/ariel_search/service.py
@@ -22,7 +22,6 @@ from osprey.services.ariel_search.exceptions import (
     SearchTimeoutError,
 )
 from osprey.services.ariel_search.models import (
-    DEFAULT_SEARCH_MODE,
     ARIELSearchRequest,
     ARIELSearchResult,
     ARIELStatusResult,
@@ -184,7 +183,8 @@ class ARIELSearchService:
             query: Natural language query
             max_results: Maximum results (default: ``ARIELSearchRequest``'s)
             time_range: Optional (start, end) datetime tuple
-            mode: Optional search module name (default: ``"keyword"``)
+            mode: Optional search module name. Omitted, the deployment's
+                ``ariel.default_search_mode`` decides.
             advanced_params: Mode-specific advanced parameters from the frontend
 
         Returns:
@@ -197,7 +197,7 @@ class ARIELSearchService:
                 max_results if max_results is not None else ARIELSearchRequest.max_results
             ),
             time_range=time_range,
-            modes=[mode] if mode else [DEFAULT_SEARCH_MODE],
+            modes=[mode] if mode else [self.config.resolve_default_search_mode()],
             advanced_params=advanced_params or {},
         )
 
@@ -226,7 +226,7 @@ class ARIELSearchService:
             if self.config.is_search_module_enabled("semantic"):
                 await self._validate_search_model()
 
-            mode = request.modes[0] if request.modes else DEFAULT_SEARCH_MODE
+            mode = request.modes[0] if request.modes else self.config.resolve_default_search_mode()
 
             return await self._run_module(mode, request)
 
@@ -246,7 +246,7 @@ class ARIELSearchService:
             raise
         except Exception as e:
             logger.exception(f"Search failed: {e}")
-            mode = request.modes[0] if request.modes else DEFAULT_SEARCH_MODE
+            mode = request.modes[0] if request.modes else self.config.resolve_default_search_mode()
             raise SearchExecutionError(
                 f"Search execution failed: {e}",
                 search_mode=mode,

--- a/src/osprey/simulation/apply.py
+++ b/src/osprey/simulation/apply.py
@@ -350,6 +350,31 @@ def active_logbook_entries(config: dict, project_dir: Path) -> list[EnhancedLogb
     return [_to_enhanced_entry(entry, anchor) for entry in engine.active_logbook()]
 
 
+async def _export_qmd_mirror(ariel_config: dict) -> None:
+    """Write the markdown mirror for entries that were just seeded.
+
+    Seeding upserts rows straight into the logbook and skips the enhancement
+    passes, so nothing writes the mirror the qmd sidecar indexes. Without this
+    pass a seeded deployment answers ``keyword`` searches fine while ``hybrid``
+    searches an index that was never built — the failure mode is an empty
+    result set, not an error, so it reads as "the logbook has nothing on that".
+
+    The rebuild variant is deliberate: seeding is preceded by a purge in one
+    caller and gated on an empty logbook in the other, and a full rebuild is
+    the only pass that also clears mirrored files for entries that are gone.
+
+    A deployment without the ``qmd_export`` module has no mirror to keep, and
+    :func:`~osprey.services.ariel_search.cli_operations.run_qmd_resync` makes
+    this a no-op there.
+
+    Args:
+        ariel_config: ARIEL config section with its DSN already resolved.
+    """
+    from osprey.services.ariel_search.cli_operations import run_qmd_resync
+
+    await run_qmd_resync(ariel_config, rebuild=True)
+
+
 def seed_active_logbook(config: dict, project_dir: Path, ariel_config: dict) -> int:
     """Write the active narrative into a logbook that has none. Returns entries seeded.
 
@@ -383,7 +408,9 @@ def seed_active_logbook(config: dict, project_dir: Path, ariel_config: dict) -> 
 
         if await cli_operations.logbook_entry_count(ariel_config) > 0:
             return 0
-        return await cli_operations.seed_logbook_entries(ariel_config, entries)
+        seeded = await cli_operations.seed_logbook_entries(ariel_config, entries)
+        await _export_qmd_mirror(ariel_config)
+        return seeded
 
     return _run_coro(_seed_if_empty)
 
@@ -1712,4 +1739,5 @@ async def _seed_logbook(
     await run_migrate(ariel_config)
     await execute_purge(ariel_config, embeddings_only=False)
     seeded = await seed_logbook_entries(ariel_config, entries)
+    await _export_qmd_mirror(ariel_config)
     return seeded, True

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -272,6 +272,13 @@ ariel:
     adapter: generic_json
     source_url: data/logbook_seed/demo_logbook.json
 
+  # Which module answers a search that names no mode — the web interface's
+  # opening tab, `osprey ariel search` without `--mode`, and the service API.
+  # Naming a module that is not enabled below is refused at startup rather
+  # than quietly answered by a different one. Unset, this resolves to `hybrid`
+  # where that module is enabled and `keyword` everywhere else.
+  default_search_mode: hybrid
+
   # Search modules (leaf-level search functions)
   # Both keyword and semantic are enabled out of the box.
   # If Ollama/pgvector are unavailable, ARIEL degrades gracefully to keyword-only.

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -787,19 +787,28 @@ ariel:
   #   port: 8085
   #   auto_launch: true
 
+  # Which module answers a search that names no mode — the web interface's
+  # opening tab, `osprey ariel search` without `--mode`, and the service API.
+  # Naming a module that is not enabled below is refused at startup rather
+  # than quietly answered by a different one. Unset, this resolves to `hybrid`
+  # where that module is enabled and `keyword` everywhere else.
+  default_search_mode: hybrid
+
   # Search modules (leaf-level search functions)
   # provider: references api.providers for credentials (api_key, base_url)
   # Both keyword and semantic are enabled by default.
   # If Ollama/pgvector are unavailable, ARIEL degrades gracefully to keyword-only.
-  # NOTE: entries seeded by `osprey sim apply` are keyword-only. Seeding skips
-  # the enhancement passes AND drops the embedding tables outright, so
+  # NOTE: entries seeded by `osprey sim apply` carry no embeddings. Seeding
+  # skips the enhancement passes AND drops the embedding tables outright, so
   # recovering semantic search takes two steps: `osprey ariel migrate` to
   # recreate the tables, then `osprey ariel enhance` to fill them. (`osprey
   # ariel sync` is not a shortcut here: it migrates, but then polls an
   # ingestion adapter this preset has none of, and fails before it enhances.)
   # Until then a semantic query disables itself at runtime and returns a notice
   # telling you to use keyword search — it does not silently return zero hits,
-  # and it does not run the keyword search for you.
+  # and it does not run the keyword search for you. Hybrid search is NOT
+  # affected: seeding exports the qmd markdown mirror on its way out, so the
+  # sidecar indexes the seeded narrative and `hybrid` answers immediately.
   search_modules:
     keyword:
       enabled: true

--- a/tests/interfaces/ariel/test_routes.py
+++ b/tests/interfaces/ariel/test_routes.py
@@ -679,3 +679,30 @@ def test_search_defaults_to_keyword_mode(client, mock_ariel_service):
 
     call_kwargs = mock_ariel_service.search.call_args.kwargs
     assert call_kwargs["mode"] == "keyword"
+
+
+def test_search_honors_configured_default_mode(client, mock_ariel_service):
+    """Omitting mode follows ariel.default_search_mode, not a fixed name."""
+    mock_ariel_service.config = ARIELConfig.from_dict(
+        {
+            "database": {"uri": "postgresql://localhost:5432/test"},
+            "search_modules": {
+                "keyword": {"enabled": True},
+                "semantic": {"enabled": True, "model": "test-model"},
+            },
+            "default_search_mode": "semantic",
+        }
+    )
+
+    response = client.post("/api/search", json={"query": "test", "max_results": 10})
+
+    assert response.status_code == 200
+    assert mock_ariel_service.search.call_args.kwargs["mode"] == "semantic"
+
+
+def test_capabilities_advertises_default_mode(client, mock_ariel_service):
+    """The capabilities payload carries the mode the UI should open on."""
+    response = client.get("/api/capabilities")
+
+    assert response.status_code == 200
+    assert response.json()["default_mode"] == "keyword"

--- a/tests/interfaces/bluesky_web/test_channel_combobox_browser.py
+++ b/tests/interfaces/bluesky_web/test_channel_combobox_browser.py
@@ -38,6 +38,7 @@ Skips cleanly when the chromium headless binary is not installed.
 
 from __future__ import annotations
 
+import re
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -138,7 +139,17 @@ def _plan_form_target(page: Page) -> Locator:
 
 
 def _listbox_for(page: Page, input_locator: Locator) -> Locator:
-    """Resolve an input's own popup listbox via its aria-controls id."""
+    """Resolve an input's own popup listbox via its aria-controls id.
+
+    The combobox stamps ``aria-controls`` when it attaches to an input, which
+    for a field the caller has not already waited on can land after the first
+    read. Poll for the attribute rather than sampling it once: it is removed
+    only on ``destroy()``, so an input that is genuinely never enhanced still
+    fails here, just on the timeout instead of on a race.
+    """
+    expect(input_locator).to_have_attribute(
+        "aria-controls", re.compile(r".+"), timeout=_FORM_TIMEOUT_MS
+    )
     list_id = input_locator.get_attribute("aria-controls")
     assert list_id, "input carries no aria-controls — combobox not attached"
     return page.locator(f"#{list_id}")

--- a/tests/services/ariel_search/conftest.py
+++ b/tests/services/ariel_search/conftest.py
@@ -48,6 +48,7 @@ def _build_ariel_mock_registry():
 
     # --- Search modules ---
     from osprey.services.ariel_search.search import keyword as kw_real
+    from osprey.services.ariel_search.search import qmd as qmd_real
     from osprey.services.ariel_search.search import semantic as sem_real
 
     kw_mod = types.ModuleType("keyword")
@@ -58,7 +59,11 @@ def _build_ariel_mock_registry():
     sem_mod.get_tool_descriptor = sem_real.get_tool_descriptor  # type: ignore[attr-defined]
     sem_mod.get_parameter_descriptors = getattr(sem_real, "get_parameter_descriptors", None)  # type: ignore[attr-defined]
 
-    _search_modules = {"keyword": kw_mod, "semantic": sem_mod}
+    hybrid_mod = types.ModuleType("hybrid")
+    hybrid_mod.get_tool_descriptor = qmd_real.get_tool_descriptor  # type: ignore[attr-defined]
+    hybrid_mod.get_parameter_descriptors = getattr(qmd_real, "get_parameter_descriptors", None)  # type: ignore[attr-defined]
+
+    _search_modules = {"keyword": kw_mod, "semantic": sem_mod, "hybrid": hybrid_mod}
     registry.list_ariel_search_modules.return_value = list(_search_modules)
     registry.get_ariel_search_module.side_effect = _search_modules.get
 

--- a/tests/services/ariel_search/test_capabilities.py
+++ b/tests/services/ariel_search/test_capabilities.py
@@ -222,6 +222,7 @@ class TestGetCapabilities:
     def _make_config(
         self,
         search_modules: dict | None = None,
+        default_search_mode: str | None = None,
     ) -> ARIELConfig:
         """Create an ARIELConfig for testing."""
         config_dict: dict = {
@@ -229,7 +230,24 @@ class TestGetCapabilities:
         }
         if search_modules:
             config_dict["search_modules"] = search_modules
+        if default_search_mode:
+            config_dict["default_search_mode"] = default_search_mode
         return ARIELConfig.from_dict(config_dict)
+
+    def test_advertises_the_configured_default_mode(self):
+        """The frontend's opening tab follows ariel.default_search_mode."""
+        config = self._make_config(
+            search_modules={"keyword": {"enabled": True}, "hybrid": {"enabled": True}},
+            default_search_mode="keyword",
+        )
+        assert get_capabilities(config)["default_mode"] == "keyword"
+
+    def test_advertises_the_implicit_default_mode(self):
+        """With no configured default, capabilities advertise the implicit one."""
+        config = self._make_config(
+            search_modules={"keyword": {"enabled": True}, "hybrid": {"enabled": True}}
+        )
+        assert get_capabilities(config)["default_mode"] == "hybrid"
 
     def test_returns_correct_structure(self):
         """get_capabilities returns correct top-level structure."""

--- a/tests/services/ariel_search/test_config.py
+++ b/tests/services/ariel_search/test_config.py
@@ -349,6 +349,50 @@ class TestARIELConfig:
         errors = config.validate()
         assert any("semantic.model" in e for e in errors)
 
+    def test_default_search_mode_unset_prefers_hybrid(self, minimal_config_dict: dict) -> None:
+        """With no configured default, an enabled hybrid module is preferred."""
+        minimal_config_dict["search_modules"] = {
+            "keyword": {"enabled": True},
+            "hybrid": {"enabled": True},
+        }
+        config = ARIELConfig.from_dict(minimal_config_dict)
+        assert config.default_search_mode is None
+        assert config.resolve_default_search_mode() == "hybrid"
+
+    def test_default_search_mode_unset_falls_back_to_keyword(
+        self, minimal_config_dict: dict
+    ) -> None:
+        """Without hybrid, the implicit default is the dependency-free mode."""
+        minimal_config_dict["search_modules"] = {"keyword": {"enabled": True}}
+        config = ARIELConfig.from_dict(minimal_config_dict)
+        assert config.resolve_default_search_mode() == "keyword"
+
+    def test_default_search_mode_is_normalized(self, minimal_config_dict: dict) -> None:
+        """The configured name is case- and whitespace-normalized like any mode."""
+        minimal_config_dict["search_modules"] = {"keyword": {"enabled": True}}
+        minimal_config_dict["default_search_mode"] = "  KEYWORD  "
+        config = ARIELConfig.from_dict(minimal_config_dict)
+        assert config.default_search_mode == "keyword"
+        assert config.resolve_default_search_mode() == "keyword"
+
+    def test_validate_default_search_mode_not_enabled(self, minimal_config_dict: dict) -> None:
+        """A default naming a disabled module is a config error, not a fallback."""
+        minimal_config_dict["search_modules"] = {"keyword": {"enabled": True}}
+        minimal_config_dict["default_search_mode"] = "hybrid"
+        config = ARIELConfig.from_dict(minimal_config_dict)
+        errors = config.validate()
+        assert any("default_search_mode" in e for e in errors)
+
+    def test_validate_default_search_mode_enabled(self, minimal_config_dict: dict) -> None:
+        """A default naming an enabled module validates clean."""
+        minimal_config_dict["search_modules"] = {
+            "keyword": {"enabled": True},
+            "hybrid": {"enabled": True},
+        }
+        minimal_config_dict["default_search_mode"] = "hybrid"
+        config = ARIELConfig.from_dict(minimal_config_dict)
+        assert not [e for e in config.validate() if "default_search_mode" in e]
+
     def test_validate_text_embedding_without_models(self, minimal_config_dict: dict) -> None:
         """Test validate() catches text_embedding without models."""
         minimal_config_dict["enhancement_modules"] = {"text_embedding": {"enabled": True}}

--- a/tests/services/ariel_search/test_service.py
+++ b/tests/services/ariel_search/test_service.py
@@ -221,13 +221,19 @@ class TestARIELSearchService:
 class TestServiceRouting:
     """Tests for service mode routing."""
 
-    def _create_mock_service(self, search_modules: dict | None = None) -> ARIELSearchService:
+    def _create_mock_service(
+        self,
+        search_modules: dict | None = None,
+        default_search_mode: str | None = None,
+    ) -> ARIELSearchService:
         """Create a mock service for testing."""
-        config_dict = {
+        config_dict: dict = {
             "database": {"uri": "postgresql://localhost:5432/test"},
         }
         if search_modules:
             config_dict["search_modules"] = search_modules
+        if default_search_mode:
+            config_dict["default_search_mode"] = default_search_mode
 
         config = ARIELConfig.from_dict(config_dict)
         mock_pool = MagicMock()
@@ -284,6 +290,56 @@ class TestServiceRouting:
             new=AsyncMock(return_value=[]),
         ) as keyword_search:
             result = await service.search("test query")
+
+        keyword_search.assert_called_once()
+        assert result.search_modes_used == ("keyword",)
+
+    @pytest.mark.asyncio
+    async def test_search_defaults_to_hybrid_when_enabled(self):
+        """With no configured default, an enabled hybrid module answers."""
+        service = self._create_mock_service(
+            search_modules={"keyword": {"enabled": True}, "hybrid": {"enabled": True}}
+        )
+
+        with patch(
+            "osprey.services.ariel_search.search.qmd.hybrid_search",
+            new=AsyncMock(return_value=[]),
+        ) as hybrid_search:
+            result = await service.search("test query")
+
+        hybrid_search.assert_called_once()
+        assert result.search_modes_used == ("hybrid",)
+
+    @pytest.mark.asyncio
+    async def test_configured_default_search_mode_wins(self):
+        """An explicit default_search_mode outranks the implicit preference."""
+        service = self._create_mock_service(
+            search_modules={"keyword": {"enabled": True}, "hybrid": {"enabled": True}},
+            default_search_mode="keyword",
+        )
+
+        with patch(
+            "osprey.services.ariel_search.search.keyword.keyword_search",
+            new=AsyncMock(return_value=[]),
+        ) as keyword_search:
+            result = await service.search("test query")
+
+        keyword_search.assert_called_once()
+        assert result.search_modes_used == ("keyword",)
+
+    @pytest.mark.asyncio
+    async def test_explicit_mode_outranks_the_default(self):
+        """Naming a mode still wins over the deployment's default."""
+        service = self._create_mock_service(
+            search_modules={"keyword": {"enabled": True}, "hybrid": {"enabled": True}},
+            default_search_mode="hybrid",
+        )
+
+        with patch(
+            "osprey.services.ariel_search.search.keyword.keyword_search",
+            new=AsyncMock(return_value=[]),
+        ) as keyword_search:
+            result = await service.search("test query", mode="keyword")
 
         keyword_search.assert_called_once()
         assert result.search_modes_used == ("keyword",)

--- a/tests/simulation/test_active_logbook_seed.py
+++ b/tests/simulation/test_active_logbook_seed.py
@@ -62,8 +62,8 @@ def _activate(project: Path, monkeypatch, names: list[str]) -> None:
 
 
 def _stub_ariel(monkeypatch, *, existing: int) -> dict:
-    """Stub ARIEL's two database calls; return what the seeder was asked to write."""
-    seen: dict = {"seeded": None, "counted": 0}
+    """Stub ARIEL's database calls; return what the seeder was asked to write."""
+    seen: dict = {"seeded": None, "counted": 0, "mirrored": 0}
 
     async def _count(config_dict):
         seen["counted"] += 1
@@ -73,10 +73,15 @@ def _stub_ariel(monkeypatch, *, existing: int) -> dict:
         seen["seeded"] = entries
         return len(entries)
 
+    async def _resync(config_dict, rebuild=False, page_size=None, progress=None):
+        seen["mirrored"] += 1
+        return None
+
     import osprey.services.ariel_search.cli_operations as ops
 
     monkeypatch.setattr(ops, "logbook_entry_count", _count, raising=False)
     monkeypatch.setattr(ops, "seed_logbook_entries", _seed)
+    monkeypatch.setattr(ops, "run_qmd_resync", _resync)
     return seen
 
 
@@ -111,6 +116,10 @@ def test_seed_active_logbook_writes_into_an_empty_logbook(tmp_path, monkeypatch)
     # Assert
     assert seeded == len(seen["seeded"])
     assert seeded > 0
+    # Seeding skips the enhancement passes, so nothing else would write the
+    # markdown mirror the qmd sidecar indexes -- hybrid search would answer an
+    # empty index while keyword search worked.
+    assert seen["mirrored"] == 1
 
 
 def test_seed_active_logbook_never_overwrites_an_existing_logbook(tmp_path, monkeypatch):
@@ -128,6 +137,8 @@ def test_seed_active_logbook_never_overwrites_an_existing_logbook(tmp_path, monk
     # Assert
     assert seeded == 0
     assert seen["seeded"] is None
+    # Nothing was written, so there is nothing to mirror either.
+    assert seen["mirrored"] == 0
 
 
 def test_seed_active_logbook_is_a_no_op_without_a_machine_model(tmp_path, monkeypatch):


### PR DESCRIPTION
ARIEL chose the mode for a search that named none, and that choice was not
the deployer's to make. Hybrid shipped as a module an operator had to ask
for by name every time, so the mode most deployments want was the one they
never got by default.

`ariel.default_search_mode` names the module that answers when the caller
specifies nothing: the web interface's opening tab, `osprey ariel search`
without `--mode`, and the service API. Both shipped app templates set it to
`hybrid`.

It has three states, and the middle one is the decision worth arguing with:

- Set to an enabled module — that module answers.
- Set to a module that is disabled — startup is refused, listing the modules
  that are enabled. The alternative was a silent fallback, which turns one
  typo in a config file into months of quietly wrong search results.
- Unset — resolves to `hybrid` where that module is enabled and `keyword`
  everywhere else. Existing configs and deployments with no qmd sidecar are
  untouched.

A second defect would have made the new default worthless on demo data.
`osprey sim apply` seeds a simulated logbook but skips the enhancement
passes, and it never wrote the markdown mirror the qmd sidecar indexes.
Hybrid therefore searched an index nothing had built and returned no hits,
which reads as "the logbook has nothing on that" rather than as a missing
index. Seeding and the deploy's first bring-up now export the mirror.

No fallback was added for a missing sidecar. A qmd outage still reports that
search is down, whether hybrid was requested or defaulted into.

The search-modes doc framed semantic search as on its way out. Semantic is
not deprecated and nothing here weakens it, so that section is now a
comparison instead: semantic is the mode with an operator-chosen embedding
model, ranking you can explain from one SQL query, and embeddings that join
against structured columns.
