### PR TITLE
feat(profile): make an emitted profile menu-complete and anchor the build interview on the repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- A fresh `profile.yml` now shows its whole menu: every hook, rule, skill,
+  agent, output style, and web panel you could opt into appears as a commented
+  entry with a one-line description, right in the list it belongs to.
+- `osprey profile artifacts` prints that same artifact menu from the command
+  line, grouped by kind.
+
 - The OSPREY agent now knows which Bluesky plans a deployment ships with —
   what each one does and whether it moves the machine — so it can reuse an
   existing plan instead of writing a new one. New `bluesky-plans` skill,
@@ -132,6 +138,10 @@ Compatibility is documented in release notes, not encoded in the version string.
   immediately; anything already queued or running is unaffected.
 
 ### Changed
+
+- The `osprey-build-interview` skill now creates your deployment repo up front
+  and refines it with you in place, keeps its decisions in an `INTERVIEW.md`
+  you can resume from, and reads every menu and default from the repo itself.
 
 - The bundled Claude Code CLI moved from 2.1.191 to 2.1.228, via
   `claude-agent-sdk` 0.2.136.

--- a/docs/source/cli-reference/index.rst
+++ b/docs/source/cli-reference/index.rst
@@ -214,6 +214,7 @@ source a deployment is built from — see :doc:`/how-to/build-profiles`.
 
    osprey profile validate TARGET
    osprey profile presets
+   osprey profile artifacts
 
 ``osprey profile validate TARGET``
    Check a profile without building anything. ``TARGET`` is a directory holding
@@ -226,6 +227,11 @@ source a deployment is built from — see :doc:`/how-to/build-profiles`.
 ``osprey profile presets``
    List bundled preset names, one per line. Every name printed is usable as
    ``--preset NAME`` for ``osprey init``.
+
+``osprey profile artifacts``
+   List every artifact the six profile lists can name — hooks, rules, skills,
+   agents, output styles, and web panels — with a one-line description of
+   each. The same menu appears as commented entries in an emitted profile.
 
 .. code-block:: bash
 
@@ -852,9 +858,10 @@ can be installed either globally or into a specific project's
 
    Currently supported skills:
 
-   * ``osprey-build-interview`` — guided facility-repository generation (see
-     :doc:`/getting-started/osprey-build-interview`). Typically installed globally
-     so it is available in any Osprey agent session.
+   * ``osprey-build-interview`` — set up or migrate an OSPREY deployment
+     through a guided conversation anchored on the live deployment repo (see
+     :doc:`/getting-started/osprey-build-interview`). Typically installed
+     globally so it is available in any Osprey agent session.
    * ``osprey-contribute`` — walks a contributor through the GitHub Flow
      journey from a working-tree change to a merged PR on ``main`` (branching,
      atomic commits, push, PR, rebase, merge).

--- a/docs/source/getting-started/osprey-build-interview.rst
+++ b/docs/source/getting-started/osprey-build-interview.rst
@@ -3,12 +3,12 @@ Guided Project Setup
 ====================
 
 If you're setting up OSPREY for a specific detector, beamline, or accelerator
-subsystem, the ``/osprey-build-interview`` skill walks you through a guided
-conversation that generates a ready-to-build project profile tailored to your
-system.
+subsystem, the ``/osprey-build-interview`` skill turns a guided conversation
+into a working deployment repository tailored to your system — created up
+front from a curated preset, then refined with you piece by piece.
 
-It's a short conversation — roughly five minutes, and about three rounds of
-questions.
+A minimal setup takes a few minutes; how much further you go is up to you,
+and you can stop, build, and resume at any point.
 
 .. dropdown:: **Prerequisites**
    :color: info
@@ -67,88 +67,76 @@ In the Osprey agent session, type:
 
    /osprey-build-interview
 
-There is no fixed script. The Osprey agent asks questions in whatever order the
-conversation takes, phrases them for the person in front of it, and follows up
-where an answer needs more detail. By the end of the conversation it will have
-established five things:
+The interview creates your **deployment repository first** — one ``osprey
+init`` from a working preset, in the first minutes of the conversation — and
+then refines it with you in place. There is no questionnaire to survive before
+something exists: the repo builds at every step, and you can ask to see it
+running at any point.
 
-* **What your system is** — the kind of system, a short name for the project, a
-  one-line description in plain English, and the facility it belongs to.
-* **How it connects** — simulated data to start with, which is the recommended
-  choice if you're unsure, or a live connection to your control system.
-* **Which signals matter** — the process variables the assistant will work with,
-  along with their units and typical ranges. If you don't have a list yet, a
-  rough description is enough to start from.
-* **Whether the assistant may change things, or only look** — read-only is the
-  default and the recommended starting point. If you do want it to change
-  values, you'll also be asked which signals and what range is safe for each.
-* **Which AI service you have access to** — usually whichever one your lab
-  provides. "I'm not sure" is a fine answer here too.
+Four things are always settled before the interview calls itself done:
+
+* **Which AI service answers** — usually whichever one your lab provides, and
+  a working key for it. "I'm not sure" is a fine answer; the interview helps
+  you find out.
+* **How it connects** — the built-in simulated accelerator to start with,
+  which is the recommended choice if you're unsure, or a live connection to
+  your control system.
+* **Whether the assistant may change things, or only look** — read-only is
+  the safe start. If you do want it to change values, you'll also settle
+  which channels and what range is safe for each.
+* **What the project is** — a short name, the facility it belongs to, and
+  its timezone.
+
+Everything else keeps the preset's curated defaults unless you bring it up.
+The profile the interview edits lists every optional feature — including the
+ones not switched on — as commented entries with explanations, so "what else
+could this do?" is always answerable by reading the file, with or without the
+interview.
+
+Decisions land in an ``INTERVIEW.md`` at the repository root: what was chosen,
+why, and what was deliberately deferred. Reopen the repository later and
+invoke the skill again to resume exactly where you left off.
 
 Tips during the interview
 -------------------------
 
 - If you're not sure about a question, say "I'm not sure" — it'll pick a safe default
-- If you have a spreadsheet of PV names handy, that's helpful but not required
-- You can always re-run the interview later to adjust things
+- If you have a spreadsheet of channel names handy, that's helpful but not required
+- Ask to see the assistant running whenever you're curious — the repo always builds
 
-Build your project
-==================
+Migrating an existing project
+=============================
 
-When the interview is done, the Osprey agent creates a **facility repository** —
-a git repository named after your facility, with your profile nested inside it:
+If you already have an OSPREY project — even one from the LangGraph era —
+point the interview at it. It scans the old project, salvages what carries
+over (channel databases, data files, custom code, configuration values), and
+walks you through each judgment call as a confirmation rather than a
+question. The porting decisions are recorded in ``INTERVIEW.md`` alongside
+everything else.
 
-.. code-block:: text
+Build and run
+=============
 
-   my-facility/
-     profile/       the source you own: profile.yml, data/, your secrets
-     build/         where `osprey build` renders projects (kept out of git)
-     ci-extra.yml   your own CI jobs; nothing ever regenerates this
-     .gitignore
-
-``profile/profile.yml`` records everything the interview decided. Beside it are
-a ``README.md`` explaining what was chosen and why, and — if you gave signal
-details — a channel database and the safe operating ranges that go with it.
-
-Before handing it over, the agent builds the profile itself and requires that
-build to succeed. If something doesn't render, it fixes the profile and tries
-again rather than passing you a broken one, so what you receive is known to
-build.
-
-Then:
+The interview leaves you inside a deployment repository whose
+``profile.yml`` records everything that was decided:
 
 .. code-block:: bash
 
    # skip-ci
-   cd my-facility
-   osprey build
+   cd my-project
+   osprey build     # render build/ from the profile
+   osprey web       # web dashboard on your own machine
 
-One command. OSPREY reads your profile, validates your selections, copies your
-channel database into the right place, and renders a ready-to-use project into
-``build/my-project/``. You never have to say where the output goes: a profile
-nested in a facility repository always renders into that repository's
-``build/``, from whichever directory you run the command.
-
-To start using it:
-
-.. code-block:: bash
-
-   # skip-ci
-   cd build/my-project && claude
-
-Or for the web dashboard:
-
-.. code-block:: bash
-
-   # skip-ci
-   osprey web
+Or talk to the agent directly with ``osprey chat``. Adjust anything later by
+editing ``profile.yml`` (every key carries its own explanation) and running
+``osprey build`` again.
 
 Phase 2: deploy your project
 ============================
 
 The interview settles *what* to build. Running what was built — putting it on a
 real machine and keeping it there — is the other half, and it lives in the same
-place. The facility repository is a durable, git-tracked artifact you'll
+place. The deployment repository is a durable, git-tracked artifact you'll
 redeploy from many times, and both halves of deployment live inside it.
 
 First, the deployment coordinates go in the profile itself, under a ``deploy:``

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import copy
 import io
+import re
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -426,6 +427,93 @@ _COMMENTED_TEMPLATE_ORDER: tuple[str, ...] = (
     "nextcloud_bridge",
     "gchat_bridge",
 )
+
+# The six artifact-selection lists, in profile spelling. Each gets a generated
+# "available but not selected" menu of commented entries at emit time, so the
+# emitted file shows the whole opt-in surface the same way the commented
+# templates above show the whole opt-in block surface.
+_ARTIFACT_LIST_KEYS: tuple[str, ...] = (
+    "hooks",
+    "rules",
+    "skills",
+    "agents",
+    "output_styles",
+    "web_panels",
+)
+_MENU_HEADER = "# Available — uncomment to enable:"
+
+
+def _first_sentence(text: str) -> str:
+    """First sentence of a catalog description, for a one-line menu comment."""
+    head, sep, _rest = text.partition(". ")
+    return f"{head}." if sep else head
+
+
+def artifact_menu_catalog() -> dict[str, list[tuple[str, str]]]:
+    """Selectable artifact names with one-line descriptions, per profile list key.
+
+    Names come from the same sources the profile validator trusts — the
+    artifact library for the five .claude kinds, the web-panel registry for
+    panels — so this menu can never disagree with what a profile may name.
+    Universal panels (always served) are excluded: they are not opt-ins.
+    """
+    from osprey.cli.templates.artifact_library import _TYPE_TO_SUBDIR, list_artifacts
+    from osprey.profiles.web_panels import BUILTIN_PANELS, UNIVERSAL_PANELS
+    from osprey.registry.web import FRAMEWORK_WEB_SERVERS
+    from osprey.services.build_artifacts import BuildArtifactCatalog
+
+    catalog = BuildArtifactCatalog.default()
+    menu: dict[str, list[tuple[str, str]]] = {}
+    for artifact_type, subdir in _TYPE_TO_SUBDIR.items():
+        entries: list[tuple[str, str]] = []
+        for name in list_artifacts(artifact_type):
+            artifact = catalog.get(f"{subdir}/{name}")
+            entries.append((name, _first_sentence(artifact.description) if artifact else ""))
+        menu[artifact_type] = entries
+    labels = {d.panel_id: d.name for d in FRAMEWORK_WEB_SERVERS.values()}
+    menu["web_panels"] = [
+        (panel, labels.get(panel, "")) for panel in sorted(BUILTIN_PANELS - UNIVERSAL_PANELS)
+    ]
+    return menu
+
+
+def _insert_artifact_menus(text: str) -> str:
+    """Append "available but not selected" commented entries to each artifact list.
+
+    Text-level like the commented-template append: the dumped document is
+    scanned for the six top-level list keys, each block runs until the first
+    non-indented line, and unselected artifacts are offered as comments at the
+    block's end. A name already present in the block — active or mentioned in
+    a hand-written comment — is skipped, so curated preset commentary wins.
+    """
+    menu = artifact_menu_catalog()
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        out.append(line)
+        index += 1
+        key = next((k for k in _ARTIFACT_LIST_KEYS if line.startswith(f"{k}:")), None)
+        if key is None:
+            continue
+        block: list[str] = [line]
+        while index < len(lines) and lines[index][:1] in (" ", "\t"):
+            block.append(lines[index])
+            out.append(lines[index])
+            index += 1
+        block_text = "".join(block)
+        offers = [
+            (name, description)
+            for name, description in menu.get(key, [])
+            if not re.search(rf"\b{re.escape(name)}\b", block_text)
+        ]
+        if offers:
+            out.append(f"  {_MENU_HEADER}\n")
+            for name, description in offers:
+                suffix = f"  # {description}" if description else ""
+                out.append(f"  # - {name}{suffix}\n")
+    return "".join(out)
 
 
 def _config_segments(config: Mapping[str, Any]) -> dict[str, tuple[str, ...]]:
@@ -1093,6 +1181,10 @@ def emit_standalone_profile_yaml(
         f"#   preset content hash: {preset_hash}"
     )
     text = _replace_header(text, header)
+
+    # Unselected artifacts appear as commented menu entries inside their list,
+    # so the opt-in surface of the six selection lists is visible in place.
+    text = _insert_artifact_menus(text)
 
     # Opt-in knobs the resolved profile does not carry appear as documented
     # commented templates, so no configurable surface is invisible. Look the key

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -33,7 +33,7 @@ import click
 from osprey.errors import BuildProfileError
 from osprey.utils.logger import get_logger
 
-from .output import report
+from .output import report, section
 from .profile_conventions import (
     BUILD_OUTPUT_DIR,
     CONTEXT_BASELINE_FILENAME,
@@ -77,6 +77,20 @@ def presets() -> None:
     Every name printed here is usable as 'osprey init --preset NAME'.
     """
     echo_preset_names()
+
+
+@profile.command()
+def artifacts() -> None:
+    """List every artifact the six profile lists can name.
+
+    One section per list key (hooks, rules, skills, agents, output_styles,
+    web_panels), each entry with a one-line description. The same menu
+    appears as commented entries in an emitted profile.yml.
+    """
+    from .build_profile_emit import artifact_menu_catalog
+
+    for kind, entries in artifact_menu_catalog().items():
+        section(kind, list(entries))
 
 
 @profile.command()

--- a/src/osprey/cli/skills_cmd.py
+++ b/src/osprey/cli/skills_cmd.py
@@ -59,7 +59,7 @@ def install(name: str, target: Path | None) -> None:
 
     \b
     Bundled skills:
-      osprey-build-interview  Author OSPREY build profiles (global)
+      osprey-build-interview  Set up or migrate an OSPREY deployment, interview-style (global)
       osprey-contribute       Walk a contributor through the GitHub Flow journey
       osprey-pre-commit       Run quick / ci / premerge check scripts at the right gate
       osprey-release          Cut a CalVer release: bump PR, tag, verify publish

--- a/src/osprey/templates/skills/osprey-build-interview/SKILL.md
+++ b/src/osprey/templates/skills/osprey-build-interview/SKILL.md
@@ -1,367 +1,238 @@
 ---
 name: osprey-build-interview
 description: >
-  Interactive interview to create a custom OSPREY build profile for a new accelerator, detector,
-  or beamline application. Use when someone says "interview me", "create a build profile",
-  "set up my agent", "configure my detector", "onboard me", or needs to create an OSPREY project
-  tailored to their specific control system. Also covers someone who already has something —
-  trigger on "I already have a project", "bring my existing setup forward", "my profile is in
-  the old layout", or converting an existing web-terminal variant into a persona of the
-  profile it belongs to. Also trigger when onboarding a new colleague, or when anyone needs
-  help figuring out what their OSPREY agent should look like.
+  Interactive interview that sets up a custom OSPREY deployment for a new
+  accelerator, beamline, or detector application. Use when someone says
+  "interview me", "set up my agent", "create a deployment for my system",
+  "onboard me", or needs an OSPREY project tailored to their control system.
+  Also handles migration from existing OSPREY projects (including
+  LangGraph-era projects) — trigger on "migrate my project", "I have an
+  existing project", "upgrade from old OSPREY", "bring my project forward".
+  Resume a previous interview by invoking this skill inside a deployment
+  repo that contains an INTERVIEW.md.
 ---
 
-# OSPREY Build Profile Interview
+# OSPREY Build Interview
 
-Interview someone who works on an accelerator, beamline, or detector — an operator or
-scientist, not a software engineer — and turn what they tell you into a **build profile**:
-the small set of files `osprey build` consumes to render a working OSPREY project for
-their system. Plan on roughly **three batched `AskUserQuestion` calls** — a fourth when
-the assistant is headed for a shared machine — and about **five minutes** of their time.
+You are helping someone set up an OSPREY deployment tailored to their
+facility. They may not know OSPREY at all. The outcome is a real, buildable
+deployment repo — created in the first minutes and refined iteratively —
+plus an `INTERVIEW.md` decision record inside it.
 
-## Write down only what cannot be discovered
+## The one rule: the repo is the source of truth
 
-This skill deliberately holds no catalog of OSPREY's features. Presets, providers, config
-keys, artifacts, and schemas all change from release to release, and any list copied in
-here is wrong within weeks. Whenever you need one, **discover it at runtime** — every
-command and path for that is in `references/osprey-map.md`, this skill's only reference
-file. Read the map before you generate anything, and go back to it the moment you catch
-yourself about to state a fact about OSPREY from memory.
+**Never assert anything about OSPREY that you did not just read from the
+live repo or from CLI output.** Configuration keys, available artifacts,
+defaults, valid values, directory layout — all of it comes from the
+materialized `profile.yml` (whose comments explain every key), from
+`osprey <command> --help`, and from `osprey profile artifacts`. The
+discovery commands and repo-zone map live in `references/osprey-map.md` —
+read it before generating anything. If anything in this skill contradicts
+what the repo or CLI says, the repo wins — and the discrepancy is a bug in
+this skill worth reporting.
 
-The same rule governs the past. This file carries no account of how earlier releases were
-arranged and no steps for moving off one, because a remembered layout is the one kind of
-fact you can never check. When someone arrives with an existing setup, the installed
-version and the files in front of you are the evidence; there is nothing else.
+Practical consequences:
 
-## What you produce
+- When explaining an option, quote or closely paraphrase the profile's own
+  comment for it. Do not explain from memory.
+- Before discussing any topic, re-read the relevant section of the live
+  `profile.yml` first.
+- After every edit, run `osprey validate`. It is the correctness oracle —
+  not your recollection of what keys exist.
+- Use `osprey set key=value` for scalar config edits (it preserves
+  comments); use targeted Edit calls for structural changes (list entries,
+  uncommenting blocks). Never rewrite the whole file.
 
-A **facility repo**: a git repository whose root holds the `profile.yml` (started from a bundled preset and then edited — the map has the command
-that emits one), a plain-language `README.md`, and a channel database plus channel
-limits when the person gave you signal details. One command lays the whole repo out; the
-CI pipeline is emitted once the `deploy:` block is filled in. Generation is covered in
-full further down this file.
+## Interview stance
 
-## What the interview must establish
+- **Conversational, not a form.** There is no fixed question sequence. The
+  user steers; you keep a map of what is decided and what is open.
+- **Defaults are respectable.** The preset is a curated, working
+  configuration. Anything the user does not care about stays as-is. Do not
+  walk section-by-section through the profile; do not interrogate details
+  that do not change their outcome.
+- **Depth on demand.** Go deep only where the user shows interest or where
+  a decision they made forces a follow-up (e.g. enabling writes forces the
+  limits conversation).
+- **Always shippable.** The repo builds at every point. Whenever there is a
+  natural pause, offer to show it running (`osprey build`, `osprey up -d`,
+  `osprey chat`, or the web terminal) — seeing the agent respond beats
+  another question.
+- **Use AskUserQuestion for forks**, with short ASCII previews when a
+  choice is easier shown than described.
 
-These are **goals, not a question script.** Compose questions that suit the person in
-front of you, in whatever order the conversation wants, and follow up wherever an answer
-is thin. New OSPREY capabilities should reach the interview through discovery, never
-through someone editing a question menu here.
+## Flow
 
-1. **Whether they are starting from scratch** — see below. Ask this one first; it
-   changes what the rest of the conversation is for.
-2. **What the system is** — the kind of system, a short project name (lowercase, hyphens,
-   no spaces), a one-line plain-English description, and the facility.
-3. **How it connects** — simulated data to start with (the safe default for anyone
-   unsure), or a live control-system connection. If live, collect the connection details
-   that connection needs.
-4. **Which signals** — the process variables the assistant will work with: names,
-   descriptions, units, typical ranges, and which are read-only versus writable. If they
-   have no list yet, capture the *shape* instead — signal types, rough count, naming
-   convention, a few examples — and generate a skeleton they can fill in later. Also
-   establish whether historical or archived data matters, and where it lives if so.
-5. **What privilege level** — see below.
-6. **Which AI service** — see below.
-7. **Whether it gets deployed, and where** — see below.
-8. **Who uses it, and what runs** — see below.
+### 0. Resume check
 
-### The existing-setup fork
+If the current directory (or a path the user gives) contains an
+`INTERVIEW.md`, this is a resume: read it, summarize the state in two or
+three sentences ("Decided: …; still open: …"), and continue from the Open
+section. Do not re-ask decided questions.
 
-Open with it, in one plain question: *are we starting from scratch, or do you already
-have something running?* "Something" is deliberately loose — an OSPREY project from an
-earlier release, a profile in a layout that no longer matches, hand-written instructions
-for the assistant, a tool someone wrote for it, a set of scripts, a web-terminal
-deployment built before the current arrangement existed. People rarely volunteer any of
-this, because it does not feel like part of "setting up an assistant" to them.
+### 1. Pre-init round
 
-If they are starting fresh, that is the whole of this goal. Carry on with the rest.
+One AskUserQuestion round collecting only what `osprey init` needs plus
+routing:
 
-If they already have something, the goal is **not** to run a migration procedure. It is
-to find out what exists, and then decide *with them*, item by item, what carries forward
-into the new profile and what retires. You work that out from evidence on their machine,
-not from anything remembered about how OSPREY used to be arranged.
+- **Project name** (lowercase-with-dashes; becomes the repo directory and
+  deployment name)
+- **Fresh start or migration** from an existing OSPREY/LangGraph project
+- **Facility** (free text; used for timezone/naming later)
 
-Gather the evidence first, before you ask a single migration question:
+If migration: also get the path to the old project, then follow
+`references/migration-legacy.md` for the scan before continuing — its
+findings pre-fill decisions below.
 
-- **What version is installed here** — `osprey --version`. Everything below is relative
-  to it, and it is the only version whose behaviour you can check.
-- **What a current setup looks like** — materialize a profile into a scratch directory
-  from a bundled preset (the canonical one, unless something they said points
-  elsewhere) and read what it writes. That is the shape their setup is moving towards,
-  defined by the installation in front of you rather than by memory. Delete it
-  afterwards; it exists to be read, and the real one gets materialized later.
-- **What they actually have** — open it. The old project or profile, the instructions,
-  the tools, the scripts, the deployment. Read the files rather than asking them to
-  describe the contents; they usually cannot, and it is the fastest part of this.
+### 2. Materialize the repo
 
-Now derive your own questions by comparing the two. For each thing they have, the
-question is which of three things it is: a fact that belongs in the new profile, an
-artifact that carries across as a file the profile owns, or something the framework
-does natively and that should retire. Ask one at a time, in plain language, and say what
-each answer costs them — a thing that retires is work they no longer maintain, which is
-usually welcome news once it is put that way. Where you cannot tell whether the
-framework covers something, check the installation instead of guessing; the map
-lists the commands that answer that.
-
-Two cases are common enough to name, though neither gets a procedure here:
-
-- **A deployment whose extra terminals were built as separate variants.** OSPREY's own
-  messages send people here for this one. The goal is to end with a single profile that
-  every terminal renders from, so that a change to the facility's data or conventions
-  reaches all of them at once instead of being copied around. A materialized profile
-  that configures terminals *is* the shape, and it shows you both halves: the per-terminal
-  files it writes beside `profile.yml`, and the way the profile's own terminal catalog
-  points at them. Give each existing variant that same shape, carrying over only its
-  *real* differences from the shared profile, and point the catalog at the result. If a
-  runtime message is what sent them here, it names that setting outright — take it from
-  the message or from the materialized example, never from memory.
-- **Instructions, tools, and scripts written against an older arrangement.** These are
-  usually the valuable part: they encode how the facility actually works. Move the
-  content, not the wiring — the profile's convention directories are where facility-owned
-  artifacts live, and the materialized `README.md` says which directory each kind lands
-  in on this version.
-
-**Do not write, follow, or invent a version-specific migration recipe.** No numbered
-upgrade steps, no "in the old layout, X was called Y" lore, and nothing in this file will
-ever grow into a migration guide — a recipe here would be describing a release nobody in
-front of you is running. Read what is installed, read what they have, and reason about
-the difference in the open where they can correct you.
-
-Either path ends in the same place: one facility repo, described below.
-
-### The privilege question
-
-Ask it the way an operator thinks about it: *should the assistant only look at things, or
-also change things?* Read-only is the default and the recommended starting point. Do not
-lecture them about approval flows, limit checking, or verification — the preset you
-select encodes the safety posture, and restating it here would only go stale. Your job is
-to pick the preset that delivers what they asked for.
-
-If they do want the assistant to change things, gather what the profile needs in order to
-do that safely: exactly which signals should be writable, and the safe operating range
-for each.
-
-### The provider question
-
-Ask which AI service they have access to. Most people know this as "whatever my lab gives
-me", and some genuinely do not know. Build the answer options from the **live provider
-registry** — the map points at it — never from a list written down here. Present the
-discovered names plainly, and keep an "I'm not sure" option that does not block progress.
-Model choice defaults to whatever the preset supplies; only ask about it if they raise
-it, and take the valid values from the same registry.
-
-### The deployment questions
-
-Deployment coordinates are opt-in, so the first thing to settle here is the fork: *is
-this destined for a shared machine that other people log in to, or does it run where
-you are?* A profile that only ever builds on one person's laptop needs none of what
-follows, and "not yet" is a perfectly good answer — it can be added the day a server
-appears. Do not walk someone through server details for a system that has no server.
-
-If there is a shared machine, establish how the software gets there and who meets it:
-
-- **How it is built and published** — which CI platform builds the images, where the
-  built images are kept, and how the machine running them gets hold of them: pulling
-  what CI built, or building its own on the spot. A facility whose deploy host cannot
-  reach the registry is the ordinary reason for the second answer, not an exotic case.
-- **Which machine runs it** — how to reach it, which account owns the checkout there,
-  and where on the machine that checkout lives.
-- **Anything else it pulls** — some deployments run another project's image alongside
-  their own; if theirs does, get that project's coordinates too.
-- **Who uses it** — one person, or a room of operators who each want their own
-  terminal. A multi-operator deployment needs the roster, because each person gets
-  their own workspace on the host.
-- **What actually runs** — which of the framework's optional services this deployment
-  turns on. Services nobody asked for still cost startup time and attention on the
-  host, so take the answer rather than assuming the preset's.
-
-Ask these the way you asked the rest: plainly, with defaults ready, and without a
-lecture on pipelines. The keys these answers become are not written down here — the
-deploy schema in the map is the source of truth for the block's shape, and you read it
-when you write the block, not when you ask the questions.
-
-## Running the conversation
-
-- Open with a one-line welcome and an honest estimate: a few minutes, "I'm not sure" is
-  always an acceptable answer, and everything can be changed later.
-- Ask the fresh-or-existing fork before the batches, on its own. If they already have
-  something, go and read it before you ask anything else — the batches below are worth
-  more once you know what is already there, and some of their answers will be sitting in
-  the files.
-- Batch related questions into a single `AskUserQuestion` call instead of asking one at a
-  time. Aim for three batches: what the system is; how it connects and which signals;
-  then privilege level and AI service. Add a fourth only if the deployment fork says
-  there is a shared machine — someone building on their laptop should never see it.
-- Recap in a sentence between batches — "so far I have…" — so they stay oriented and can
-  catch a misunderstanding early.
-- Explain *why* a question matters before you ask it. A question with no visible purpose
-  feels like a form.
-- Have a default ready for everything. If they hesitate, offer the simple option, say it
-  can be extended later, and move on.
-- Prefer the minimal setup. Someone starting with simulated data and their main signals
-  has a working assistant today; anything else can be layered on any time.
-- Plain language throughout. Skip the framework vocabulary; say what a thing does.
-
-## Consistency review before generating
-
-Once the goals are covered, review the collected requirements yourself — as a
-skeptic hunting for gaps and contradictions — and resolve whatever you find *with the
-person* rather than guessing. Categories worth checking:
-
-- Write access wanted, but no safe operating ranges given for the writable signals.
-- "Read-only" stated, but the work they described requires changing values.
-- A live control-system connection chosen, but the connection details are missing.
-- Historical data expected, but no archive source identified.
-- Signals implied by the use case that never made it into the list, or missing units and
-  ranges on signals they intend to analyze.
-- Scope much narrower, or much broader, than what they said they wanted.
-- A shared machine described, but no answer for how it gets the images it runs.
-- Several operators expected, but nothing said about who they are.
-- Something they already had that never got a decision — neither carried into the
-  profile nor deliberately retired. An item that quietly fell off the list is the one
-  they will miss first.
-
-## Generating the profile
-
-Pick the starting preset first. `osprey profile presets` reports what this
-installation ships; open the ones that sound close — the map says where they live — and
-take the one whose privilege level and connection mode match what the interview
-established. The `control-assistant` family is the canonical example and a
-sensible default when nothing else stands out.
-
-Then lay out the facility repo:
-
-```
-osprey init <facility-name> --preset <closest-preset>
+```bash
+osprey init --list-presets           # confirm available presets today
+osprey init <name> --preset control-assistant
 ```
 
-`--preset` is required. The command refuses to write into a directory that already holds
-a deployment, which a second pass through the interview will hit — move the old one aside
-or write into a fresh name, and tell the person which you did.
+Use the control-assistant preset unless the user's stated purpose obviously
+matches a more specific preset in the list (read the preset list output —
+do not assume the roster).
 
-What you get back is a git repository rather than a loose directory, laid out in four
-zones. The repo ROOT is the editable source: `profile.yml` sits directly at the top,
-beside its `data/` tree, its convention directories, and the CI pipeline that lands there
-once the `deploy:` block is filled in. `.env` holds the secrets — provider keys and the
-tokens `osprey up` mints — and is kept out of git alongside `build/`, which holds what
-`osprey build` renders. `var/` holds runtime state. The map records the layout and what each
-part is for. One consequence runs through everything below: every path you edit is a path
-at the repo root, and no command needs to be told where the repo is — they all find it by
-walking up from wherever you are standing.
+Then read what appeared: `profile.yml` top to bottom (it is written to be
+read), plus a quick look at the repo layout (`data/`, `personas/`, `.env`,
+`README.md` if present). This read is your knowledge base for the entire
+interview.
 
-`profile.yml` is standalone and self-documenting: the preset's full
-configuration written out explicitly — no `extends:` — with the preset's own comments,
-next to a `data/` tree copied from the preset and the convention directories its
-`README.md` walks through. Read it before you edit it. It is the current, authoritative
-statement of what a profile can say, which is exactly why no copy of it lives in this
-file.
+### 3. Coverage map
 
-Now edit **only the deltas the interview actually decided** — the project name and
-description, the connection mode, the AI service, the signals. Everything that never
-came up in the conversation already carries the preset's answer, so leave those keys as
-materialized rather than second-guessing them. Under `config:`, use dotted keys
-(`system.timezone: "America/Los_Angeles"`); nested YAML there does not merge the way
-people expect.
+Build a map from the top-level sections actually present in this
+`profile.yml` — never from a remembered list. Mark four topics as **core**
+(hardwired, must be resolved before wrap-up):
 
-If the interview established a shared machine, the deployment coordinates go in the
-profile's `deploy:` block. Its schema — the map points at it — is the source of truth
-for the block's shape, and it reports every problem in one pass, so writing the block
-and then running the profile validator is the quickest way to get it right.
+1. **Provider + credentials** — which AI provider, and is a working key in
+   `.env`?
+2. **Control system** — which connector; simulated or real hardware; if
+   real, the connection details the profile's comments ask for.
+3. **Write access & safety** — may the agent change hardware values? If
+   yes: which channels, what limits, which safety hooks stay on.
+4. **Project identity** — name, facility, timezone.
 
-One trap belongs to that block. How the machine obtains its images has two possible
-homes, and some presets already answer it under `config:` — so a profile that has never
-been touched can carry the answer, and a profile someone else wrote almost certainly
-does. The build refuses outright when both homes are filled in, because two homes for
-one fact are free to disagree, and this disagreement decides whether the host builds its
-own images or pulls them. So before you write the block, look for that existing answer
-under `config:` and remove it: the `deploy:` block is the home, and the build carries
-its value across into the rendered config for you. The refusal names the offending entry
-if you get there first.
+Everything else is **optional** and sits at its preset default until the
+user raises it. Render the map as a compact ASCII card (■ core
+resolved/pending, □ optional at default) and show it at the start, after
+each core decision, and whenever the user seems lost.
 
-Write `README.md` in the same plain language you used in the interview: what this
-profile builds, what was decided and why, what was left at preset defaults, and what to
-do next.
+### 4. Core round
 
-## The signals
+Resolve the four core topics, grounded in the live file: for each, read the
+relevant keys and comments, present the current value and what it means,
+and ask what they want. Apply edits immediately (`osprey set` / Edit),
+validate, and record in `INTERVIEW.md`.
 
-Generate the channel database and the channel limits from what they gave you — names,
-descriptions, units, ranges, and which ones are writable. Do not work from a schema
-written down anywhere in this skill. Open the two live examples the map points at (a
-channel-database template and a channel-limits file, both shipping in the wheel, both
-documenting themselves inline) and follow their shape. If they described a device family
-and a naming convention rather than listing every signal, the template shows how to
-express that without typing out hundreds of names.
+### 5. Adaptive loop
 
-Channel limits only matter when the assistant may change things. Every writable signal
-needs its safe operating range; if one is missing, go back and ask rather than inventing
-a number.
+Repeat until the user is satisfied:
 
-## Verify it builds before you hand it over
+1. Show the trimmed map; invite direction ("What would you like to change,
+   add, or see?").
+2. For an **opt-out**: the profile's own comments say what each entry does
+   and which blocks can be deleted. Delete list entries or blocks exactly
+   as instructed there.
+3. For an **opt-in of a framework artifact**: the emitted profile lists
+   available-but-unselected artifacts as commented entries, and commented
+   block templates for optional features (`mcp_servers`, `dispatch`, …).
+   Uncomment, adjust, validate. `osprey profile artifacts` gives the full
+   catalog when the user wants to browse.
+4. For **custom work** (their own MCP server, rules, skills, panel,
+   custom code): the repo's convention directories (`rules/`, `skills/`,
+   `agents/`, `mcp_servers/`, `services/`, `project/`, …) are the drop-in
+   points — the directory name is the declaration (see
+   `references/osprey-map.md`). Place ready material there, scaffold a stub
+   if that helps, and record any remaining implementation as a **Deferred**
+   entry in `INTERVIEW.md` with pointers. Do not implement custom
+   components mid-interview.
+5. After every change: `osprey validate`, then update `INTERVIEW.md`.
+6. At natural pauses, offer a live look: build and run it.
 
-Build the profile yourself before you tell anyone it works:
+### 6. Devil's advocate (mandatory before wrap-up)
 
-```
-osprey build --repo <facility-name> --skip-deps
-```
+Spawn one subagent with: the full `INTERVIEW.md`, the current
+`profile.yml`, and the latest `osprey validate` output. Its brief:
 
-Exit 0 is required. `--skip-deps` keeps it quick — you are checking that the profile
-renders, not installing anything. The render lands in the repo's `build/` zone, which is
-kept out of git, so there is nothing to clean up afterwards. `--repo` is only needed
-because you are standing outside the repo; from inside it, plain `osprey build` does the
-same thing.
+> Find gaps and inconsistencies in this OSPREY deployment setup. Check at
+> least: write access enabled without limits or with safety hooks/rules
+> removed; provider configured but no key in `.env`; a real control system
+> selected without the connection details its comments require; declared
+> feature blocks nothing reads (comments state the pairings); decisions in
+> INTERVIEW.md not reflected in profile.yml and vice versa; use cases the
+> user described that the current selection cannot serve. Classify each
+> finding CRITICAL (unsafe or broken) / RECOMMENDED / OPTIONAL. Judge only
+> against the provided artifacts, not against assumptions about OSPREY.
 
-If it exits non-zero, read the actual error, correct the profile, and run it again.
-Never hand over a profile that does not build, and never describe a failed build as a
-success. If it still fails after a few honest attempts, say plainly what the error says
-and what you tried; that is far more useful to them than a confident handover of
-something broken.
+Resolve every CRITICAL finding with the user; offer RECOMMENDED ones;
+mention OPTIONAL ones in passing.
 
-## When something does not fit
+### 7. Wrap-up
 
-**The build verification fails.** As above — read the error, fix the profile, retry, and
-be straight about it if you cannot get it green.
+- Final `osprey validate` and `osprey build`; fix anything they raise.
+- Set `INTERVIEW.md` status to `complete`; move anything unresolved to
+  Open/Deferred so it is not lost.
+- Close with next steps read from the repo itself (its README and CLI
+  help): typically `osprey up -d`, `osprey chat`, the web terminal, and
+  where to edit `profile.yml` later.
 
-**`osprey` is not on PATH.** Check this before you ask the first question. Everything
-here depends on asking a live installation what exists, so without the CLI you cannot do
-this honestly. Tell them exactly what to run — `pip install osprey-framework`, or
-whatever their facility's install instructions say — and then stop cleanly. Do not fall
-back to answering from memory and do not fabricate preset, config, or service names to
-keep the conversation moving; answering from recall is exactly how this skill goes
-stale.
+## INTERVIEW.md format
 
-**They describe an existing setup you cannot open.** It is on another machine, or behind
-a login, or they only half remember it. Say so plainly and work from what you *can* see:
-build the profile from the interview as though it were fresh, and write down in the
-README which of their existing pieces still need a decision. Do not reconstruct the old
-setup from their description plus a guess at how that release was arranged — a migration
-built on a remembered layout silently drops the parts nobody thought to mention. They can
-bring the files to the next session, and picking it up then costs almost nothing.
+Create it at the repo root right after `osprey init`, and keep it current
+throughout — it is the resume state, the decision record, and the devil's
+advocate input.
 
-**They have no signal list yet.** Do not block on it and do not emit an empty database.
-Write a skeleton in the shape they described, with placeholders that are obviously
-placeholders, and put instructions in the README for replacing them and rebuilding. They
-can come back with the real list any time.
+```markdown
+# Interview record — <deployment name>
 
-**No preset is a good fit.** Start from the closest one anyway. Record what it does not
-cover as stub files in the profile's convention directories — the materialized
-`README.md` names them and says where each one lands — and as notes in that README, so
-the gap is visible and someone can fill it in place. Authoring a profile from scratch to
-avoid an imperfect preset costs far more than it saves.
+status: in-progress   # in-progress | complete
+updated: <YYYY-MM-DD>
 
-## Handing over
+## Coverage
+core: provider ✔ · control system ✔ · writes/safety ✖ · identity ✔
+touched: <optional topics discussed>
 
-They rebuild their project from the finished profile at any time with:
+## Decided
+- <decision> — <one-line rationale> (<date>)
 
-```
-osprey build
+## Open
+- <question still unresolved, and what unblocks it>
+
+## Deferred / follow-up work
+- <custom work or later phase, with pointers>
+
+## Migration notes            # only when migrating
+- <source path, classification decisions, ported/skipped items>
 ```
 
-Run it from anywhere in the repo; the render lands in `build/` either way. Drop
-`--skip-deps` for a project that actually runs — that is the difference between the
-verification build above and a usable one.
+Commit it with the repo's other files whenever the user commits.
 
-This skill settles *what* to build. Running what was built is the CLI's own job and
-has no skill of its own: `osprey scaffold ci` emits the pipeline and health check
-from the profile's `deploy:` block, `osprey up` brings the stack up, and `osprey
-status` / `osprey logs` are where triage starts. Each verb's `--help` is the current
-catalog; do not reproduce it here.
+## Migration
+
+A migration is the same interview with pre-filled answers. Read
+`references/migration-legacy.md` for the scan patterns and the
+SALVAGE / OBSOLETE / TRANSFORM / EVALUATE classification rules (that file
+describes the frozen legacy architecture, so its hardcoded knowledge is
+safe). Then:
+
+- Channel databases and data files → the new repo's `data/` tree.
+- Config values (gateways, archiver URLs, provider) → `osprey set` into the
+  live profile, guided by the new profile's own comments.
+- Custom code (connectors, providers, rules, MCP servers) → the matching
+  convention directory; each EVALUATE item becomes a confirm-with-user
+  question and an `INTERVIEW.md` entry (ported / skipped / deferred).
+- Present findings as confirmations ("I found X — keep it?"), never
+  re-interrogation. The user already made these decisions once.
+
+## Guidelines
+
+- Explain *why* a question matters in the user's terms (safety, cost,
+  capability) — one sentence, then the question.
+- If the user is unsure, pick the safe default, say so, and record it as
+  Decided with rationale "default — revisit anytime".
+- Summarize progress briefly after each core decision, not after every
+  exchange.
+- Never edit `build/` (rendered output) or paste secrets into files other
+  than `.env`.

--- a/src/osprey/templates/skills/osprey-build-interview/references/migration-legacy.md
+++ b/src/osprey/templates/skills/osprey-build-interview/references/migration-legacy.md
@@ -1,0 +1,111 @@
+# Migration reference — legacy OSPREY / LangGraph-era projects
+
+Loaded when the interview is migrating an existing project. The OLD
+architecture described here is frozen, so this file's facts are safe to
+hardcode. Everything about the NEW side comes from the live deployment repo:
+its profile.yml comments, its convention directories, and `osprey validate`.
+
+## Classification
+
+Every file in the old project gets one of four categories:
+
+| Category  | Meaning                                   | Action                                    |
+|-----------|-------------------------------------------|-------------------------------------------|
+| SALVAGE   | Directly reusable                         | Confirm with user, place in the new repo  |
+| OBSOLETE  | LangGraph-era machinery — discard         | Mention briefly, explain why unneeded     |
+| TRANSFORM | Reusable content, wrong shape             | Extract values, re-express in the profile |
+| EVALUATE  | Custom Python — may work, needs review    | Walk through with the user, one by one    |
+
+When in doubt, EVALUATE — surface it rather than silently discard.
+
+## Architecture mapping (old → classification)
+
+| Old (LangGraph-era)                        | Why                                        | Category  |
+|--------------------------------------------|--------------------------------------------|-----------|
+| LangGraph graph definitions                | Claude Code is the orchestrator now        | OBSOLETE  |
+| `osprey.context.CapabilityContext`         | Removed                                    | OBSOLETE  |
+| `osprey.approval` module                   | Replaced by the approval hook              | OBSOLETE  |
+| `osprey.gateway` / pipeline server         | Replaced by direct agent sessions          | OBSOLETE  |
+| OpenWebUI pipeline server                  | Was the LangGraph gateway                  | OBSOLETE  |
+| `registry.py` (component registry)         | Pattern still exists — check APIs          | EVALUATE  |
+| Custom connectors (`connectors/*.py`)      | Connector layer still exists               | EVALUATE  |
+| Custom providers (`models/providers/*.py`) | Provider registry still exists             | EVALUATE  |
+| Custom prompt builders (`*prompts*/*.py`)  | Customization layer likely still needed    | EVALUATE  |
+| `services/channel_finder/` full copies     | Framework-native now — likely redundant    | EVALUATE  |
+| `data/channel_databases/*.json`            | Same format                                | SALVAGE   |
+| `data/channel_limits.json`                 | Same format                                | SALVAGE   |
+| `data/benchmarks/**`, `data/raw/*.csv`     | Same format                                | SALVAGE   |
+| `data/tools/*.py`, machine-state JSON      | Utility data                               | SALVAGE   |
+| Custom `.claude/rules/`, `.claude/skills/` | Content still valid                        | SALVAGE   |
+| Custom `.claude/hooks/`                    | Hook API may differ — review               | TRANSFORM |
+| `config.yml` (and variants)                | Values survive, shape changed              | TRANSFORM |
+| Multi-role `models:` config                | Single provider+model now (see below)      | TRANSFORM |
+| `requirements.txt` / `pyproject.toml`      | Facility deps → profile                    | TRANSFORM |
+| `.env` / `.env.example`                    | Variable NAMES → profile `env:`            | TRANSFORM |
+| `services/` (Docker, compose)              | Per-service review (see reading rules)     | TRANSFORM |
+
+## Where things land in the NEW repo
+
+Do not memorize target paths — open the live repo and read its profile.yml
+comments — but the general destinations are:
+
+- Data files → the repo's `data/` tree (same formats).
+- Config values (gateways, archiver URLs, timezone, provider/model) →
+  `osprey set key=value` into the live profile.
+- Custom code and assets (rules, skills, agents, MCP servers, services,
+  arbitrary project files) → the matching convention directory
+  (`rules/`, `skills/`, `agents/`, `mcp_servers/`, `services/`,
+  `project/`, …) — the directory name is the declaration.
+- Environment variable NAMES → the profile's `env:` block (`required`
+  vs `defaults`). NEVER copy values — even from a committed file; the
+  user may not realize a token is in there. Flag `*_TOKEN`, `*_KEY`,
+  `*_PASSWORD`, `*_SECRET` names explicitly in INTERVIEW.md.
+
+## Scan patterns
+
+```
+config.yml, config.yaml, config.yml-*, config.yaml-*
+data/**/*.json, data/**/*.csv, data/tools/*.py
+.claude/rules/**, .claude/hooks/**, .claude/skills/**
+registry.py, **/registry.py
+connectors/*.py, **/connectors/*.py
+models/providers/*.py, **/providers/*.py
+*prompts*/*.py, **/prompt_builders/**, **/framework_prompts/**/*.py
+services/, docker-compose*.yml, **/Dockerfile*
+requirements.txt, pyproject.toml, .env, .env.example
+src/**/*.py        # check for langgraph / StateGraph imports
+```
+
+Reading rules: a file importing `langgraph` or `StateGraph` is OBSOLETE; a
+file subclassing a connector/provider base class or defining prompt builders
+is EVALUATE. For `.env`, read variable names only. For channel databases,
+count entries and note the format; show the user a short preview. For
+`services/`, split each service: infrastructure (compose fragments,
+Dockerfiles) is TRANSFORM, custom assets (startup scripts, CSS, seed data)
+are SALVAGE, and anything referencing LangGraph or `CapabilityContext` is
+OBSOLETE.
+
+## Multi-role model config → single provider/model
+
+Old projects assigned models to ~10 roles (orchestrator, response,
+classifier, approval, task_extraction, memory, python_code_generator,
+time_parsing, channel_write, channel_finder). The new architecture takes one
+`provider` + `model`. Pick the dominant pair, record role-level exceptions in
+INTERVIEW.md's migration notes, and check whether the old provider name is a
+current built-in (the live profile's own comment names the selectable set).
+A facility-custom provider module is EVALUATE.
+
+## Config variants
+
+Old projects often carry `config.yml-prod` / `config.yml-mock` variants.
+Find all of them, ask which represents the target deployment, extract from
+that one, and note the differences in INTERVIEW.md — the user may want a
+second deployment repo for the other mode later.
+
+## EVALUATE walkthrough
+
+For each item: say what it does (base class, added functionality, rough
+size); check obvious API compatibility (does the base class still exist?
+`osprey.context` imports always fail); then ask — port now (place in the
+convention directory), port flagged (place it, note needed changes in
+INTERVIEW.md), skip, or defer. Record every verdict in INTERVIEW.md.

--- a/src/osprey/templates/skills/osprey-build-interview/references/osprey-map.md
+++ b/src/osprey/templates/skills/osprey-build-interview/references/osprey-map.md
@@ -10,6 +10,7 @@ providers), run the command and read the live output instead of recalling one.
 | --- | --- |
 | Which presets ship with this version? | `osprey profile presets` |
 | Which build artifacts does the framework manage? | `osprey scaffold list` |
+| Which artifacts can the six profile lists name? | `osprey profile artifacts` — the emitted profile also offers unselected ones as commented entries in each list |
 | What is the whole config surface, with defaults? | `osprey config --defaults` |
 | What does a command accept? | `osprey <command> --help` |
 | Is this profile or project safe? | `osprey audit <profile.yml\|project-dir>` |

--- a/tests/cli/test_emit_artifact_menu.py
+++ b/tests/cli/test_emit_artifact_menu.py
@@ -1,0 +1,53 @@
+"""An emitted profile is menu-complete: every selectable artifact is either
+active in one of the six lists or offered as a commented entry."""
+
+from osprey.cli.build_profile_emit import (
+    _MENU_HEADER,
+    artifact_menu_catalog,
+    emit_standalone_profile_yaml,
+)
+
+
+def _emit(preset: str) -> str:
+    return emit_standalone_profile_yaml(preset, (), (), "Emitted")
+
+
+def test_catalog_covers_the_six_profile_list_keys() -> None:
+    menu = artifact_menu_catalog()
+    assert set(menu) == {"hooks", "rules", "skills", "agents", "output_styles", "web_panels"}
+    # Panels that are universal (always served) are not offered as opt-ins.
+    panel_names = [name for name, _ in menu["web_panels"]]
+    assert "artifacts" not in panel_names
+    assert "lattice" in panel_names
+
+
+def test_menu_offers_unselected_panels_in_control_assistant() -> None:
+    # control-assistant selects ariel/channel-finder/okf/system-health; lattice is the gap.
+    text = _emit("control-assistant")
+    assert "# - lattice" in text
+
+
+def test_menu_dedupes_against_preset_comment_mentions() -> None:
+    # The preset's skills list already discusses setup-mode in a hand-written
+    # comment; the generated menu must not offer it a second time.
+    text = _emit("control-assistant")
+    assert text.count("setup-mode") == 1
+
+
+def test_every_selectable_artifact_is_active_or_offered() -> None:
+    text = _emit("control-assistant")
+    for entries in artifact_menu_catalog().values():
+        for name, _description in entries:
+            assert name in text, f"{name} is neither active nor offered"
+
+
+def test_empty_lists_still_offer_the_menu() -> None:
+    # hello-world's skills list is inline-empty (`skills: []`); the menu still
+    # lands beneath it.
+    text = _emit("hello-world")
+    assert _MENU_HEADER in text
+    assert "# - diagnose" in text
+
+
+def test_menu_insertion_is_deterministic() -> None:
+    assert _emit("control-assistant") == _emit("control-assistant")

--- a/tests/cli/test_profile_cmd.py
+++ b/tests/cli/test_profile_cmd.py
@@ -48,16 +48,27 @@ def test_profile_group_is_registered_on_the_cli() -> None:
     assert group.get_command(None, "profile") is profile
 
 
-def test_profile_help_lists_the_two_subcommands(runner: CliRunner) -> None:
+def test_profile_help_lists_the_three_subcommands(runner: CliRunner) -> None:
     result = runner.invoke(profile, ["--help"])
     assert result.exit_code == 0, result.output
-    for name in ("presets", "validate"):
+    for name in ("presets", "validate", "artifacts"):
         assert name in result.output
 
 
 # --------------------------------------------------------------------------
 # presets
 # --------------------------------------------------------------------------
+
+
+def test_artifacts_lists_every_kind_with_known_members(runner: CliRunner) -> None:
+    """One section per profile list key, populated from the live catalog."""
+    result = runner.invoke(profile, ["artifacts"])
+    assert result.exit_code == 0, result.output
+    for kind in ("hooks", "rules", "skills", "agents", "output_styles", "web_panels"):
+        assert kind in result.output
+    assert "approval" in result.output  # a hook
+    assert "lattice" in result.output  # a web panel
+    assert "control-operator" in result.output  # the output style
 
 
 def test_presets_prints_every_bundled_preset(runner: CliRunner) -> None:

--- a/tests/cli/test_skills_cmd.py
+++ b/tests/cli/test_skills_cmd.py
@@ -44,6 +44,7 @@ def test_install_fresh_succeeds(fake_home: Path) -> None:
     target = fake_home / ".claude" / "skills" / "osprey-build-interview"
     assert (target / "SKILL.md").is_file()
     assert (target / "references" / "osprey-map.md").is_file()
+    assert (target / "references" / "migration-legacy.md").is_file()
 
 
 def test_install_backs_up_existing(fake_home: Path) -> None:

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -189,6 +189,9 @@ skills:
   - writing-bluesky-plans  # Write, check and queue a plan (needs the Bluesky server)
   - operating-bluesky-plans  # Stage, queue and watch a plan (needs the Bluesky server)
   - bluesky-plans  # Browse which plans this deployment can run
+  # Available — uncomment to enable:
+  # - logbook-deep-research  # Multi-phase logbook investigation skill
+  # - sim-scenarios  # List and switch simulated machine scenarios
 
 agents:
   - channel-finder          # Semantic search over channel databases (hierarchical)
@@ -208,6 +211,8 @@ web_panels:
   - system-health   # SYSTEM tab, a framework health dashboard
   # The events and bluesky panels are declared in personas/readwrite.yml
   # instead, so the read-only login is built without them.
+  # Available — uncomment to enable:
+  # - lattice  # Lattice dashboard
 
 # ── Scanning and simulated hardware ──────────────────────────────────────────
 # These three blocks give you a working plan setup with no real hardware: a


### PR DESCRIPTION
Setting up an OSPREY deployment meant knowing, in advance, what there was to
ask for. An emitted `profile.yml` listed only what its preset had already
selected, so the other forty-odd hooks, rules, skills, agents, output styles
and web panels existed only in the source tree — you had to already know a
thing was available in order to discover it. The build interview papered over
that by carrying its own copy of the catalog in prose, which went stale every
time the framework shipped something new.

This turns the profile itself into the menu. At emit time every unselected
artifact is appended to the list it belongs to as a commented entry with a
one-line description, read live from the artifact library, the build-artifacts
catalog and the web-panel registry — the same sources the profile validator
trusts, so the menu cannot offer something a profile is not allowed to name.
Dedupe is per-block and matches hand-written commentary as well as active
entries, so a preset that already explains why it leaves something out keeps
its own wording instead of gaining a generated duplicate.

`osprey profile artifacts` prints the same catalog grouped by kind, for the
question asked before a profile exists to emit.

With the menu living in the artifact sources, the build interview no longer
needs to restate it. The skill now creates the deployment repo first and
refines it in place, reading available artifacts, presets and defaults from
the repo itself; decisions accumulate in an `INTERVIEW.md` a later session can
resume from, and a devil's-advocate pass challenges the result before handover.
LangGraph-era migration knowledge moves to its own reference, with its targets
rewritten to the current convention directories.

The getting-started page still documented the retired nested `profile/`
layout, so it has been rewritten to the flow the tooling actually produces.

## How it hangs together

```text
  artifact library      build-artifacts       web-panel registry
  (hooks, rules,          catalog             (BUILTIN - UNIVERSAL)
   skills, agents,      (descriptions)
   output styles)
        |                     |                        |
        +----------+----------+------------------------+
                   |
                   v
          artifact_menu_catalog()          <-- one source of truth
                   |
        +----------+-----------+
        |                      |
        v                      v
 _insert_artifact_menus   osprey profile
   (emit time)               artifacts
        |                      |
        v                      v
   profile.yml            grouped listing
   hooks:                 on stdout
     - approval
     # Available - uncomment to enable:
     # - diagnose  # ...
        |
        v
  osprey-build-interview  --> INTERVIEW.md
  (reads the repo, not          (resumable
   a copy of the catalog)        decisions)
```
