### PR TITLE
Enforce readonly python execution at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ Compatibility is documented in release notes, not encoded in the version string.
   Readonly runs also can no longer import control-system client libraries
   (`epics`, `p4p`, `caproto`, `pvaccess`, `tango`) — reads go through
   `read_channel()`.
+- The runtime refusal now covers the routes that reach a control system
+  without importing a client: caproto, pvaPy and Tango entry points resolved
+  dynamically, starting a process (a shelled-out `caput`), and loading a
+  shared library through `ctypes`. A readonly script therefore cannot shell
+  out or open a shared library at all; resubmit such work as readwrite.
+- A refused write is now visible, not silent. The operator is alerted that a
+  write was attempted and blocked, and the attempt is recorded — with the
+  offending source — in `var/audit/readonly-refusals.jsonl`, which survives
+  builds and `osprey reset`.
 - Readwrite Python executions now always require human approval under the
   `selective` policy, independent of whether the write-pattern scanner
   recognises the code's spelling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Security
 
+- Readonly Python executions are now enforced at runtime, not just by
+  pattern scanning: the sandbox refuses every direct control-system write
+  entry point (however the call is spelled), the connectors refuse
+  `write_channel`, and the EPICS connector stays on the read-only gateway.
 - Readwrite Python executions now always require human approval under the
   `selective` policy, independent of whether the write-pattern scanner
   recognises the code's spelling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Security
+
+- Readwrite Python executions now always require human approval under the
+  `selective` policy, independent of whether the write-pattern scanner
+  recognises the code's spelling.
+
 ### Added
 
 - A fresh `profile.yml` now shows its whole menu: every hook, rule, skill,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   pattern scanning: the sandbox refuses every direct control-system write
   entry point (however the call is spelled), the connectors refuse
   `write_channel`, and the EPICS connector stays on the read-only gateway.
+  Readonly runs also can no longer import control-system client libraries
+  (`epics`, `p4p`, `caproto`, `pvaccess`, `tango`) — reads go through
+  `read_channel()`.
 - Readwrite Python executions now always require human approval under the
   `selective` policy, independent of whether the write-pattern scanner
   recognises the code's spelling.

--- a/docs/source/how-to/use-python-executor.rst
+++ b/docs/source/how-to/use-python-executor.rst
@@ -155,11 +155,11 @@ Seven safety layers are applied in sequence:
 
 4. **Readonly runtime guard**---the declared mode is exported into the
    subprocess as ``OSPREY_EXECUTION_MODE``. In a ``readonly`` run every
-   direct-library write entry point (``epics.caput``, ``PV.put``, p4p
-   ``Context.put``/``rpc``) is replaced with a refusing function, the
-   connectors refuse ``write_channel``, and the EPICS connector stays on
-   the ``read_only`` gateway --- so a write is refused at runtime and at
-   the network layer however it is spelled.
+   entry point listed under :ref:`python-executor-write-surface` is
+   replaced with a refusing function, the connectors refuse
+   ``write_channel``, and the EPICS connector stays on the ``read_only``
+   gateway --- so a write is refused at runtime and at the network layer
+   however it is spelled.
 
 5. **Limits monkeypatch** (``ExecutionWrapper`` /
    ``LimitsValidator``)---at runtime, ``epics.caput()`` calls are
@@ -177,6 +177,68 @@ Seven safety layers are applied in sequence:
 
    python_executor:
      execution_timeout_seconds: 300
+
+.. _python-executor-write-surface:
+
+What counts as a control-system write
+-------------------------------------
+
+A ``readonly`` run refuses all of the following. The list is generated from
+one table in the code (``_READONLY_WRITE_TARGETS`` in
+``services/python_executor/execution/wrapper.py``), so adding a library there
+is all it takes to enforce it.
+
+**Approved API** --- the path everything should use:
+
+- ``write_channel()`` / ``write_channels()`` from ``osprey.runtime``, and
+  ``connector.write_channel()`` beneath them.
+
+**Control-system clients**, refused whether they are imported, aliased, or
+resolved dynamically:
+
+- **pyepics** --- ``caput``, ``caput_many``, ``PV.put``, ``ca.put``
+- **p4p** --- ``Context.put``/``rpc`` for the thread, asyncio and cothread
+  clients; ``SharedPV.post``/``open`` on the server side
+- **caproto** --- ``sync.client.write``, ``threading.client.PV.write``,
+  ``Batch.write``, ``asyncio.client.PV.write``
+- **pvaPy** --- every ``Channel.put*`` method, including the typed setters
+  such as ``putDouble`` and ``putScalarArray``
+- **Tango** --- ``DeviceProxy.write_attribute`` and its variants,
+  ``AttributeProxy.write``, and ``command_inout`` (a Tango command acts on
+  the device rather than reading it)
+
+**Routes out of Python.** These reach a control system without importing a
+client at all, so they are refused in ``readonly`` runs too:
+
+- Starting a process --- ``subprocess.run``/``Popen``/``call``/
+  ``check_output``, ``os.system``, ``os.popen``, and the ``os.exec*``,
+  ``os.spawn*`` and ``posix_spawn`` families. This is what stops a
+  shelled-out ``caput``.
+- Loading a shared library --- ``ctypes.CDLL`` and friends, which could
+  otherwise open ``libca`` directly.
+
+``os.fork`` is deliberately left working: forking alone cannot start a new
+program, and the ``exec`` half of every fork-and-exec is already refused.
+
+.. note::
+
+   The consequence of the second group is that a ``readonly`` script cannot
+   shell out or load a shared library *at all*, even for something unrelated
+   to the control system. Resubmit such work with
+   ``execution_mode="readwrite"``, which requires human approval.
+
+When a write is refused
+-----------------------
+
+Three things happen, at whichever layer catches it:
+
+1. The agent gets an error naming the mode and what to do instead.
+2. The operator is alerted --- the Web Terminal reports that a write was
+   attempted and blocked, not merely that a script failed.
+3. The attempt is recorded in ``var/audit/readonly-refusals.jsonl`` with a
+   timestamp, the layer that refused, and the offending source. That
+   directory is durable: builds never touch it, and ``osprey reset`` keeps
+   it unless you pass ``--purge-audit``.
 
 .. admonition:: Control system operations in user code
 

--- a/docs/source/how-to/use-python-executor.rst
+++ b/docs/source/how-to/use-python-executor.rst
@@ -137,26 +137,39 @@ project's own environment, so executed code sees the same imports either way.
 Security Model
 ==============
 
-Five safety layers are applied in sequence:
+Seven safety layers are applied in sequence:
 
 1. **Static safety check** (``quick_safety_check``)---blocks dangerous
    patterns such as dynamic code evaluation, dynamic imports, and
    ``subprocess`` calls before execution begins.
 
-2. **Control-system pattern detection**
+2. **Readonly import denylist** (``check_readonly_imports``)---a
+   ``readonly`` run may not import control-system client libraries
+   (``epics``, ``p4p``, ``caproto``, ``pvaccess``, ``tango``) at all.
+   Reads go through ``read_channel()``.
+
+3. **Control-system pattern detection**
    (``detect_control_system_operations``)---identifies read and write
    patterns. In ``readonly`` mode, detected writes cause immediate
    rejection.
 
-3. **Limits monkeypatch** (``ExecutionWrapper`` /
+4. **Readonly runtime guard**---the declared mode is exported into the
+   subprocess as ``OSPREY_EXECUTION_MODE``. In a ``readonly`` run every
+   direct-library write entry point (``epics.caput``, ``PV.put``, p4p
+   ``Context.put``/``rpc``) is replaced with a refusing function, the
+   connectors refuse ``write_channel``, and the EPICS connector stays on
+   the ``read_only`` gateway --- so a write is refused at runtime and at
+   the network layer however it is spelled.
+
+5. **Limits monkeypatch** (``ExecutionWrapper`` /
    ``LimitsValidator``)---at runtime, ``epics.caput()`` calls are
    intercepted and validated against the channel limits database.
    Out-of-range values are blocked.
 
-4. **Process isolation**---code always runs in a separate subprocess, never
+6. **Process isolation**---code always runs in a separate subprocess, never
    inside the MCP server process.
 
-5. **Execution timeout**---configurable via
+7. **Execution timeout**---configurable via
    ``python_executor.execution_timeout_seconds`` (default 600 s). The
    process is killed if it exceeds the limit.
 

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
@@ -8,6 +8,7 @@ subscribing to changes, and retrieving metadata from various control systems.
 
 import functools
 import logging
+import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -102,17 +103,42 @@ class ChannelWriteResult:
     refusal_reason: str | None = None
 
 
+def is_readonly_run() -> bool:
+    """True inside a python-executor sandbox launched with ``execution_mode="readonly"``.
+
+    The executor exports ``OSPREY_EXECUTION_MODE`` into its subprocess so the
+    per-run claim is enforceable at runtime, independent of the pre-execution
+    pattern scan. Outside the sandbox the variable is unset and only the
+    deployment posture (``control_system.writes_enabled``) applies.
+    """
+    return os.environ.get("OSPREY_EXECUTION_MODE") == "readonly"
+
+
 def _writes_disabled_result(channel_address: str, value: Any) -> ChannelWriteResult:
-    """Build the refusal result returned when writes are disabled at launch time."""
+    """Build the refusal result for a write the monitor never attempted.
+
+    Two reasons share this shape: the deployment has writes off, or this
+    particular script was submitted readonly. The message names the right one
+    so the operator is not sent to flip ``writes_enabled`` when the deployment
+    already allows writes and the run simply was not declared readwrite.
+    """
+    if is_readonly_run():
+        message = (
+            f"Write to '{channel_address}' blocked: this script is running in "
+            "readonly execution mode. Resubmit it with execution_mode='readwrite' "
+            "(human approval required) if the write is intended."
+        )
+    else:
+        message = (
+            f"Write to '{channel_address}' blocked: writes are disabled. "
+            "Set control_system.writes_enabled: true in the build profile "
+            "(profile.yml on the host), then rebuild and redeploy."
+        )
     return ChannelWriteResult(
         channel_address=channel_address,
         value_written=value,
         success=False,
-        error_message=(
-            f"Write to '{channel_address}' blocked: writes are disabled. "
-            "Set control_system.writes_enabled: true in the build profile "
-            "(profile.yml on the host), then rebuild and redeploy."
-        ),
+        error_message=message,
         blocked=True,
         refusal_reason="WRITES_DISABLED",
     )
@@ -231,7 +257,12 @@ class ControlSystemConnector(ABC):
         ``permissions.deny`` on the write tool, followed by regenerating and
         relaunching the agent. In-flight control of an active scan is the
         RunEngine's own ``abort`` / ``pause`` — never a config flag.
+
+        A readonly sandbox run (see :func:`is_readonly_run`) is refused
+        regardless of the deployment posture.
         """
+        if is_readonly_run():
+            return False
         try:
             from osprey_connectors.config import get_config_value
 

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -257,9 +257,19 @@ class EPICSConnector(ControlSystemConnector):
             writes_enabled = False  # Can't tell -> assume the safe (read-only) path
 
         write_gateway = gateways.get("write_access") or {}
-        if writes_enabled and write_gateway:
+        # A readonly sandbox run stays on the read_only gateway even on a
+        # write-enabled deployment: the per-run claim is enforced at the
+        # network layer, so a raw caput issued after read_channel() in the
+        # same process is rejected by the gateway rather than trusted.
+        from osprey_connectors.control_system.base import is_readonly_run
+
+        readonly_run = is_readonly_run()
+        if writes_enabled and write_gateway and not readonly_run:
             gateway_config = write_gateway
             logger.debug("EPICS connector: routing through write_access gateway (writes enabled)")
+        elif readonly_run and write_gateway:
+            gateway_config = gateways.get("read_only", {})
+            logger.debug("EPICS connector: readonly run, staying on read_only gateway")
         else:
             gateway_config = gateways.get("read_only", {})
             if writes_enabled and not write_gateway:

--- a/packages/osprey-connectors/src/osprey_connectors/workspace.py
+++ b/packages/osprey-connectors/src/osprey_connectors/workspace.py
@@ -42,13 +42,20 @@ RENDERED_CONFIG_RELPATH = f"{BUILD_DIR_NAME}/config.yml"
 #: does not offer.
 DEFAULT_AGENT_DATA_BASE_DIR = f"{STATE_DIR_NAME}/agent_data"
 
+#: The safety audit log, relative to the repo root: what the agent was asked to
+#: do and what it did. Durable like the agent-data root beside it, and kept by
+#: ``osprey reset`` unless ``--purge-audit`` is passed. Named here rather than
+#: spelled at each end because the directory the reset command promises to keep
+#: has to be the directory the refusal recorder writes into.
+AUDIT_DIR_RELPATH = f"{STATE_DIR_NAME}/audit"
+
 #: The two directories that make up the state zone, created empty and otherwise
 #: the agent's to write. Both ``osprey init`` and ``osprey build`` guarantee they
 #: exist — a fresh clone carries no git-ignored directory, so whichever command
 #: runs first has to make them, and a repo that was reset must end up looking
 #: like one that was freshly cloned. Spelled once for exactly that reason: two
 #: commands agreeing by coincidence is how a reset and a clone start to differ.
-STATE_ZONE_DIRS: tuple[str, ...] = (DEFAULT_AGENT_DATA_BASE_DIR, f"{STATE_DIR_NAME}/audit")
+STATE_ZONE_DIRS: tuple[str, ...] = (DEFAULT_AGENT_DATA_BASE_DIR, AUDIT_DIR_RELPATH)
 
 #: Subdirectory of the agent-data root holding the simulation's mutable
 #: ``active_scenarios`` state file.

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -151,7 +151,7 @@ async def _execute_via_local(
     """Execute code in a host subprocess with the ExecutionWrapper."""
     from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
 
-    wrapper = ExecutionWrapper(limits_validator=limits_validator)
+    wrapper = ExecutionWrapper(limits_validator=limits_validator, execution_mode=execution_mode)
     wrapped_code = wrapper.create_wrapper(code, execution_folder)
 
     # Write wrapped script to execution folder
@@ -167,6 +167,12 @@ async def _execute_via_local(
     python_bin = str(resolve_agent_interpreter(project_root))
 
     sandbox_env = scrub_sensitive_env(os.environ.copy())
+    # The declared mode becomes a runtime property of the subprocess: the
+    # connector base class refuses writes and the EPICS connector stays on
+    # the read_only gateway when this says readonly, so a readonly run cannot
+    # write however the call is spelled — the pre-execution regex only ever
+    # saw the standard spellings.
+    sandbox_env["OSPREY_EXECUTION_MODE"] = execution_mode
 
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/src/osprey/mcp_server/python_executor/tools/_execution_gates.py
+++ b/src/osprey/mcp_server/python_executor/tools/_execution_gates.py
@@ -8,13 +8,23 @@ string falls through both — not "readonly", so write patterns are not blocked;
 not "readwrite", so the kill switch never fires. Rejecting unknown modes here
 closes that hole for every caller at once, and gives the kill switch a single
 implementation instead of one copy per tool.
+
+This module also owns what happens *around* a refusal, which is three things
+the tools must not each spell for themselves: the durable audit record, the
+operator alert, and the error handed back to the agent. Keeping them together
+is what makes "blocked" mean the same thing at every layer — a write stopped by
+the import denylist before launch and one stopped by the runtime guard mid-run
+produce the same audit record and the same alert, differing only in the
+``layer`` field.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any, NoReturn
 
 from osprey.mcp_server.errors import make_error
+from osprey.mcp_server.http import notify_agent_activity_async
 
 logger = logging.getLogger("osprey.mcp_server.tools.execution_gates")
 
@@ -73,3 +83,126 @@ def enforce_deployment_writes_gate(execution_mode: str) -> None:
                 "Set control_system.writes_enabled=true in the project config to enable writes.",
             ],
         )
+
+
+async def record_and_alert_refusal(
+    *,
+    tool: str,
+    layer: str,
+    trigger: Any,
+    code: str,
+    description: str | None = None,
+    execution_mode: str = "readonly",
+) -> None:
+    """Write the audit record and alert the operator for one refused write.
+
+    Both halves of the issue's "the operator should see it, and it should be
+    auditable" requirement, in the order that matters: the durable record is
+    written first, so a Web Terminal that is not running (CLI-only mode, where
+    the alert is a no-op) still leaves the refusal on disk.
+
+    Never raises. The recorder swallows its own errors and
+    ``notify_agent_activity_async`` is fire-and-forget by contract, so a
+    refusal is never turned into a traceback by the act of reporting it.
+    """
+    try:
+        from osprey.services.python_executor.refusal_audit import record_refusal
+
+        record_refusal(
+            layer=layer,
+            trigger=trigger,
+            source=code,
+            description=description,
+            tool=tool,
+            execution_mode=execution_mode,
+        )
+    except Exception:
+        # An import failure here must not mask the refusal itself.
+        logger.warning("Could not record the refusal for audit", exc_info=True)
+
+    await notify_agent_activity_async(
+        tool,
+        "channel",
+        detail=f"BLOCKED a control-system write in {execution_mode} mode ({layer})",
+    )
+
+
+async def refuse_readonly_write(
+    *,
+    tool: str,
+    layer: str,
+    trigger: Any,
+    code: str,
+    description: str | None,
+    message: str,
+    suggestions: list[str],
+) -> NoReturn:
+    """Record, alert, then raise the ``safety_error`` the agent sees.
+
+    The raise is last on purpose: :func:`make_error` raises rather than
+    returning (it is the only path fastmcp turns into a clean error on the
+    wire), so anything that has to happen for a refused write has to happen
+    before it.
+    """
+    await record_and_alert_refusal(
+        tool=tool,
+        layer=layer,
+        trigger=trigger,
+        code=code,
+        description=description,
+    )
+    make_error("safety_error", message, suggestions)
+
+
+async def report_runtime_refusal(
+    *,
+    tool: str,
+    stderr: str,
+    code: str,
+    description: str | None,
+) -> bool:
+    """Report a write the *runtime* guard refused, mid-run. Returns whether it did.
+
+    The static layers refuse by raising, so they control their own reporting.
+    The runtime ones cannot: they run inside the subprocess, and all that
+    reaches here is a traceback on stderr. Without this, the layers that catch
+    the evasive spellings — aliased imports, ``getattr``, ``importlib``, a
+    shelled-out ``caput`` — would be the only ones that never alerted the
+    operator or left an audit record.
+
+    Matching is on
+    :data:`~osprey.services.python_executor.execution.wrapper.READONLY_REFUSAL_MARKER`
+    rather than on the guard's full message, so the connector reference
+    monitor's own refusal — a write that took the *approved* ``write_channel``
+    path in a readonly run — is reported too.
+
+    The script's own result is left alone: its stderr already names the mode
+    and the way forward, and converting it into a tool error here would
+    discard whatever the run legitimately produced before the refusal.
+    """
+    from osprey.services.python_executor.execution.wrapper import READONLY_REFUSAL_MARKER
+    from osprey.services.python_executor.refusal_audit import LAYER_RUNTIME_GUARD
+
+    if READONLY_REFUSAL_MARKER not in (stderr or ""):
+        return False
+
+    await record_and_alert_refusal(
+        tool=tool,
+        layer=LAYER_RUNTIME_GUARD,
+        trigger=_refusal_lines(stderr),
+        code=code,
+        description=description,
+    )
+    return True
+
+
+def _refusal_lines(stderr: str) -> list[str]:
+    """The stderr lines naming the refusal, for the audit record's ``trigger``.
+
+    The whole traceback would bury the fact in noise and the bare marker would
+    drop the channel name the connector's message carries; the matching lines
+    keep what an auditor actually reads.
+    """
+    from osprey.services.python_executor.execution.wrapper import READONLY_REFUSAL_MARKER
+
+    return [line.strip() for line in stderr.splitlines() if READONLY_REFUSAL_MARKER in line]

--- a/src/osprey/mcp_server/python_executor/tools/python_execute.py
+++ b/src/osprey/mcp_server/python_executor/tools/python_execute.py
@@ -30,11 +30,17 @@ async def execute(
 
     Safety layers applied before execution:
       1. ``quick_safety_check()`` — blocks exec/eval/__import__/subprocess
-      2. ``detect_control_system_operations()`` — blocks writes in readonly mode
+      2. ``check_readonly_imports()`` — readonly runs may not import
+         control-system client libraries (epics, p4p, ...) at all
+      3. ``detect_control_system_operations()`` — blocks detected write
+         spellings in readonly mode
     Safety layers applied during execution:
-      3. ``ExecutionWrapper`` monkeypatch — validates epics.caput() against limits DB
-      4. Process isolation — code runs outside the MCP server process
-      5. Execution timeout — kills execution after configured timeout
+      4. Readonly guard — in readonly runs every direct-library write entry
+         point refuses, the connectors refuse ``write_channel``, and the EPICS
+         connector stays on the read_only gateway (``OSPREY_EXECUTION_MODE``)
+      5. ``ExecutionWrapper`` monkeypatch — validates epics.caput() against limits DB
+      6. Process isolation — code runs outside the MCP server process
+      7. Execution timeout — kills execution after configured timeout
 
     A ``save_artifact(obj, title, description)`` helper is available in the
     subprocess for saving objects to the artifact gallery.
@@ -73,6 +79,30 @@ async def execute(
             )
     except ImportError:
         logger.warning("Safety check module unavailable — executing without pre-checks")
+
+    # Readonly runs may not import control-system clients at all. This is the
+    # pre-execution half of the readonly contract; the runtime half (the
+    # wrapper's readonly guard and the connector refusal) catches what no
+    # static check can.
+    if execution_mode == "readonly":
+        try:
+            from osprey.services.python_executor.analysis.safety_checks import (
+                check_readonly_imports,
+            )
+
+            import_issues = check_readonly_imports(code)
+        except ImportError:
+            import_issues = []
+        if import_issues:
+            return make_error(
+                "safety_error",
+                "Control-system client libraries cannot be imported in readonly mode.",
+                [
+                    *import_issues,
+                    "Use read_channel() from osprey.runtime for reads.",
+                    "Set execution_mode to 'readwrite' if writes are intentional.",
+                ],
+            )
 
     # Pattern detection (block writes in readonly mode)
     try:

--- a/src/osprey/mcp_server/python_executor/tools/python_execute.py
+++ b/src/osprey/mcp_server/python_executor/tools/python_execute.py
@@ -8,9 +8,15 @@ from osprey.mcp_server.http import notify_agent_activity_async
 from osprey.mcp_server.python_executor.server import mcp
 from osprey.mcp_server.python_executor.tools._execution_gates import (
     enforce_deployment_writes_gate,
+    refuse_readonly_write,
+    report_runtime_refusal,
     require_known_execution_mode,
 )
 from osprey.mcp_server.python_executor.tools._package_inventory import with_live_packages
+from osprey.services.python_executor.refusal_audit import (
+    LAYER_IMPORT_DENYLIST,
+    LAYER_PATTERN_DETECTION,
+)
 
 logger = logging.getLogger("osprey.mcp_server.tools.execute")
 
@@ -35,12 +41,19 @@ async def execute(
       3. ``detect_control_system_operations()`` — blocks detected write
          spellings in readonly mode
     Safety layers applied during execution:
-      4. Readonly guard — in readonly runs every direct-library write entry
-         point refuses, the connectors refuse ``write_channel``, and the EPICS
-         connector stays on the read_only gateway (``OSPREY_EXECUTION_MODE``)
+      4. Readonly guard — in readonly runs every control-system write entry
+         point refuses, as do the routes that reach one without a client
+         import (starting a process, ``ctypes``); the connectors refuse
+         ``write_channel``, and the EPICS connector stays on the read_only
+         gateway (``OSPREY_EXECUTION_MODE``)
       5. ``ExecutionWrapper`` monkeypatch — validates epics.caput() against limits DB
       6. Process isolation — code runs outside the MCP server process
       7. Execution timeout — kills execution after configured timeout
+
+    A refused write is reported to the operator and recorded in the
+    deployment's audit log, at whichever layer catches it. A readonly script
+    therefore cannot shell out or load a shared library at all, even for
+    unrelated work — resubmit as readwrite, which requires human approval.
 
     A ``save_artifact(obj, title, description)`` helper is available in the
     subprocess for saving objects to the artifact gallery.
@@ -94,10 +107,14 @@ async def execute(
         except ImportError:
             import_issues = []
         if import_issues:
-            return make_error(
-                "safety_error",
-                "Control-system client libraries cannot be imported in readonly mode.",
-                [
+            await refuse_readonly_write(
+                tool="execute",
+                layer=LAYER_IMPORT_DENYLIST,
+                trigger=import_issues,
+                code=code,
+                description=description,
+                message="Control-system client libraries cannot be imported in readonly mode.",
+                suggestions=[
                     *import_issues,
                     "Use read_channel() from osprey.runtime for reads.",
                     "Set execution_mode to 'readwrite' if writes are intentional.",
@@ -120,10 +137,14 @@ async def execute(
 
     # Per-call execution-mode gate (uses pattern detection — readonly-mode safety).
     if patterns.get("has_writes") and execution_mode == "readonly":
-        return make_error(
-            "safety_error",
-            "Control-system write patterns detected in readonly mode.",
-            [
+        await refuse_readonly_write(
+            tool="execute",
+            layer=LAYER_PATTERN_DETECTION,
+            trigger=patterns.get("detected_patterns", {}),
+            code=code,
+            description=description,
+            message="Control-system write patterns detected in readonly mode.",
+            suggestions=[
                 "Set execution_mode to 'readwrite' if writes are intentional.",
                 "Detected patterns: " + json.dumps(patterns.get("detected_patterns", {})),
             ],
@@ -160,6 +181,16 @@ async def execute(
         await notify_agent_activity_async(
             "execute", "channel", detail="ran a script with control-system writes"
         )
+
+    # A write the runtime guard refused mid-run reaches here only as a
+    # traceback on stderr. Report it so the layer that catches the evasive
+    # spellings alerts and audits like the pre-execution ones do.
+    await report_runtime_refusal(
+        tool="execute",
+        stderr=exec_result.stderr,
+        code=code,
+        description=description,
+    )
 
     from osprey.mcp_server.python_executor.tools._response_builder import build_execution_response
 

--- a/src/osprey/mcp_server/python_executor/tools/python_execute_file.py
+++ b/src/osprey/mcp_server/python_executor/tools/python_execute_file.py
@@ -124,6 +124,30 @@ async def execute_file(
     except ImportError:
         logger.warning("Safety check module unavailable — executing without pre-checks")
 
+    # Readonly runs may not import control-system clients at all. This is the
+    # pre-execution half of the readonly contract; the runtime half (the
+    # wrapper's readonly guard and the connector refusal) catches what no
+    # static check can.
+    if execution_mode == "readonly":
+        try:
+            from osprey.services.python_executor.analysis.safety_checks import (
+                check_readonly_imports,
+            )
+
+            import_issues = check_readonly_imports(code)
+        except ImportError:
+            import_issues = []
+        if import_issues:
+            return make_error(
+                "safety_error",
+                "Control-system client libraries cannot be imported in readonly mode.",
+                [
+                    *import_issues,
+                    "Use read_channel() from osprey.runtime for reads.",
+                    "Set execution_mode to 'readwrite' if writes are intentional.",
+                ],
+            )
+
     # Pattern detection (block writes in readonly mode)
     try:
         from osprey.services.python_executor.analysis.pattern_detection import (

--- a/src/osprey/mcp_server/python_executor/tools/python_execute_file.py
+++ b/src/osprey/mcp_server/python_executor/tools/python_execute_file.py
@@ -9,7 +9,13 @@ from osprey.mcp_server.http import notify_agent_activity_async
 from osprey.mcp_server.python_executor.server import mcp
 from osprey.mcp_server.python_executor.tools._execution_gates import (
     enforce_deployment_writes_gate,
+    refuse_readonly_write,
+    report_runtime_refusal,
     require_known_execution_mode,
+)
+from osprey.services.python_executor.refusal_audit import (
+    LAYER_IMPORT_DENYLIST,
+    LAYER_PATTERN_DETECTION,
 )
 
 logger = logging.getLogger("osprey.mcp_server.tools.execute_file")
@@ -138,10 +144,14 @@ async def execute_file(
         except ImportError:
             import_issues = []
         if import_issues:
-            return make_error(
-                "safety_error",
-                "Control-system client libraries cannot be imported in readonly mode.",
-                [
+            await refuse_readonly_write(
+                tool="execute_file",
+                layer=LAYER_IMPORT_DENYLIST,
+                trigger=import_issues,
+                code=code,
+                description=description,
+                message="Control-system client libraries cannot be imported in readonly mode.",
+                suggestions=[
                     *import_issues,
                     "Use read_channel() from osprey.runtime for reads.",
                     "Set execution_mode to 'readwrite' if writes are intentional.",
@@ -163,10 +173,14 @@ async def execute_file(
     enforce_deployment_writes_gate(execution_mode)
 
     if patterns.get("has_writes") and execution_mode == "readonly":
-        return make_error(
-            "safety_error",
-            "Control-system write patterns detected in readonly mode.",
-            [
+        await refuse_readonly_write(
+            tool="execute_file",
+            layer=LAYER_PATTERN_DETECTION,
+            trigger=patterns.get("detected_patterns", {}),
+            code=code,
+            description=description,
+            message="Control-system write patterns detected in readonly mode.",
+            suggestions=[
                 "Set execution_mode to 'readwrite' if writes are intentional.",
                 "Detected patterns: " + json.dumps(patterns.get("detected_patterns", {})),
             ],
@@ -199,6 +213,16 @@ async def execute_file(
         await notify_agent_activity_async(
             "execute_file", "channel", detail="ran a script with control-system writes"
         )
+
+    # Same runtime-refusal reporting as the ``execute`` tool — see the comment
+    # there. The original file contents are recorded, not the argv preamble the
+    # executor prepends, so the audit trail shows what the operator would read.
+    await report_runtime_refusal(
+        tool="execute_file",
+        stderr=exec_result.stderr,
+        code=code,
+        description=description,
+    )
 
     # Build response using original code (not augmented) for metadata/notebook
     from osprey.mcp_server.python_executor.tools._response_builder import build_execution_response

--- a/src/osprey/services/python_executor/analysis/pattern_detection.py
+++ b/src/osprey/services/python_executor/analysis/pattern_detection.py
@@ -27,9 +27,15 @@ def get_framework_standard_patterns() -> dict[str, list[str]]:
     """
     Get framework-standard patterns for detecting control system operations.
 
-    SECURITY PURPOSE: These patterns detect ALL attempts to interact with control systems,
-    whether through the proper unified API or through direct library calls that would
-    bypass the connector's safety features (limits checking, verification, approval).
+    PURPOSE: These patterns detect the *standard spellings* of control system
+    interaction — the unified API and direct library calls that would bypass the
+    connector's safety features (limits checking, verification, approval). They
+    are an intent classifier feeding the approval flow and the audit trail, not
+    an enforcement boundary: a trivially aliased call (``from epics import caput
+    as _w``) evades any call-site regex. Readonly runs are *enforced* at runtime
+    instead — by the wrapper's readonly guard, the connector base class's
+    ``OSPREY_EXECUTION_MODE`` refusal, and the EPICS connector's read_only
+    gateway selection — and readwrite runs always require human approval.
 
     Pattern Categories:
     1. **Approved API**: osprey.runtime unified API with full safety features
@@ -43,12 +49,14 @@ def get_framework_standard_patterns() -> dict[str, list[str]]:
         Dictionary with 'write' and 'read' pattern lists
 
     Security Note:
-        An LLM could try to circumvent the connector by directly importing a
-        control system library. These patterns cover the libraries OSPREY
-        supports: pyepics (Channel Access), p4p (PVAccess), PyTango, and
-        LabVIEW bindings, plus the osprey.runtime API itself. A library outside
-        that list is not detected - add facility-specific spellings under
-        control_system.patterns in config.yml.
+        These patterns cover the libraries OSPREY supports: pyepics (Channel
+        Access), p4p (PVAccess), PyTango, and LabVIEW bindings, plus the
+        osprey.runtime API itself. A library outside that list is not detected
+        - add facility-specific spellings under control_system.patterns in
+        config.yml. Detection here is best-effort text matching; the layers
+        that do not depend on spelling are the readonly runtime guard, the
+        readonly import denylist (``check_readonly_imports``), and the
+        always-ask approval policy for readwrite runs.
     """
     return {
         "write": [
@@ -194,7 +202,7 @@ def detect_control_system_operations(
         >>> result['has_writes']
         True
 
-        EPICS circumvention detected (security layer catches direct library calls):
+        EPICS circumvention detected (standard spelling of a direct library call):
         >>> code = "epics.caput('BEAM:CURRENT', 500.0)"
         >>> result = detect_control_system_operations(code)
         >>> result['has_writes']

--- a/src/osprey/services/python_executor/analysis/safety_checks.py
+++ b/src/osprey/services/python_executor/analysis/safety_checks.py
@@ -61,6 +61,40 @@ def check_imports(code: str) -> list[str]:
     return issues
 
 
+# Control-system client libraries a readonly run may not import. Reads go
+# through ``osprey.runtime.read_channel``; importing a client directly in a
+# readonly script is only ever a route around the write gates. Checking at the
+# import statement is immune to the aliasing that defeats call-site regexes
+# (``from epics import caput as _w``), and an import never appears inside a
+# comment or string, so it has none of the regex false positives either.
+_READONLY_DENIED_IMPORTS = frozenset({"epics", "p4p", "caproto", "pvaccess", "tango", "PyTango"})
+
+
+def check_readonly_imports(code: str) -> list[str]:
+    """Return an issue per control-system client import. Empty = none found.
+
+    Matches on the top-level package, so ``p4p.client.thread`` and
+    ``from epics.ca import put`` are both caught. Syntax errors are the
+    business of :func:`check_syntax`; this walker stays quiet on them.
+    """
+    issues: list[str] = []
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return issues
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names = [node.module]
+        else:
+            continue
+        for name in names:
+            if name.split(".")[0] in _READONLY_DENIED_IMPORTS:
+                issues.append(f"Import of '{name}' is not allowed in readonly mode")
+    return issues
+
+
 def quick_safety_check(code: str) -> tuple[bool, list[str]]:
     """Run all safety checks. Returns (passed, issues).
 

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -13,11 +13,164 @@ logger = get_logger("execution_wrapper")
 
 
 #: Message raised by every refused write in a readonly run. Tests match on
-#: it, so keep it stable.
+#: it, so keep it stable. The MCP tool layer also matches on it to recognise a
+#: runtime refusal in the subprocess's stderr, so that a write blocked *during*
+#: execution reaches the operator alert and the audit log the same way one
+#: blocked before execution does.
 READONLY_REFUSAL = (
     "readonly execution mode: control-system writes are refused — "
     "resubmit with execution_mode='readwrite' (human approval required) "
     "if the write is intended"
+)
+
+#: The substring every readonly refusal message carries, whichever layer
+#: raised it. The wrapper guard raises :data:`READONLY_REFUSAL`; the connector
+#: reference monitor raises its own, channel-named message
+#: (``osprey_connectors.control_system.base._writes_disabled_result``). Both
+#: reach the tool layer only as a traceback on the subprocess's stderr, so the
+#: tool matches on what they share rather than on either full message — which
+#: is what lets a write refused through the *approved* ``write_channel`` path
+#: be alerted and audited exactly like one refused by the guard.
+#:
+#: A test pins the connector's message against this constant, so rewording
+#: either side without the other fails rather than silently stopping the alert.
+READONLY_REFUSAL_MARKER = "readonly execution mode"
+
+
+#: Every entry point a readonly run refuses, as ``(dotted target, attributes)``.
+#: This table is the canonical machine-readable answer to "what counts as a
+#: control-system write from Python" — the docs list is written from it, and a
+#: library added here needs no other change to be enforced.
+#:
+#: The dotted target is resolved by importing its longest importable prefix and
+#: then walking attributes, so a module (``epics``), a module attribute
+#: (``epics.ca``) and a class (``p4p.client.thread.Context``) are all spelled
+#: the same way. Attributes that do not exist on the resolved object are
+#: skipped, which is what makes listing several client flavours free: an
+#: uninstalled or older library simply contributes nothing.
+#:
+#: Patching the object in ``sys.modules`` — rather than inspecting the source —
+#: is what makes this immune to spelling. ``importlib.import_module("epics")``,
+#: ``from epics import caput as _w`` and ``getattr(epics, "ca" + "put")`` all
+#: end up holding the refusing function, because they all resolve through the
+#: one module object this mutates.
+_READONLY_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    # --- EPICS Channel Access (pyepics) ---
+    ("epics", ("caput", "caput_many")),
+    ("epics.PV", ("put",)),
+    ("epics.ca", ("put", "put_complete")),
+    # --- PVAccess (p4p): one client Context per concurrency flavour, plus the
+    # server-side SharedPV, which puts values on the wire when it is opened or
+    # posted to.
+    ("p4p.client.thread.Context", ("put", "rpc")),
+    ("p4p.client.asyncio.Context", ("put", "rpc")),
+    ("p4p.client.cothread.Context", ("put", "rpc")),
+    ("p4p.server.raw.SharedPV", ("post", "open")),
+    ("p4p.server.thread.SharedPV", ("post", "open")),
+    ("p4p.server.asyncio.SharedPV", ("post", "open")),
+    # --- Channel Access (caproto) ---
+    ("caproto.sync.client", ("write", "write_read")),
+    ("caproto.threading.client.PV", ("write", "write_all")),
+    ("caproto.threading.client.Batch", ("write",)),
+    ("caproto.asyncio.client.PV", ("write",)),
+    # --- PVAccess (pvaPy). Its ``Channel`` carries one typed setter per scalar
+    # and array type, so the ``put`` prefix is swept dynamically below rather
+    # than enumerated here; ``put`` itself is listed so the table still names
+    # the library.
+    ("pvaccess.Channel", ("put", "putGet")),
+    # --- Tango. ``command_inout`` is included because a Tango command is an
+    # action on the device, not a read — refusing it is the readonly reading.
+    # ``PyTango`` is the legacy alias for the same package; when both import,
+    # they resolve to the same class object and the second patch is a no-op.
+    (
+        "tango.DeviceProxy",
+        (
+            "write_attribute",
+            "write_attributes",
+            "write_attribute_asynch",
+            "write_attributes_asynch",
+            "write_read_attribute",
+            "write_read_attributes",
+            "write_pipe",
+            "put_property",
+            "command_inout",
+            "command_inout_asynch",
+        ),
+    ),
+    ("tango.AttributeProxy", ("write", "write_asynch", "write_read")),
+    (
+        "PyTango.DeviceProxy",
+        (
+            "write_attribute",
+            "write_attributes",
+            "write_read_attribute",
+            "command_inout",
+        ),
+    ),
+    # --- Routes out of Python. A readonly run has no legitimate use for these:
+    # ``import subprocess`` is already refused in every mode by the static
+    # import check, so anything reaching the process-spawning surface at
+    # runtime got there by an evasion. ``os.fork`` is deliberately absent —
+    # forking alone cannot run a new program, and refusing it would break
+    # ordinary multiprocessing for no security gain, since the exec half of
+    # every fork+exec is refused here.
+    (
+        "subprocess",
+        (
+            "run",
+            "Popen",
+            "call",
+            "check_call",
+            "check_output",
+            "getoutput",
+            "getstatusoutput",
+        ),
+    ),
+    ("_posixsubprocess", ("fork_exec",)),
+    # ``os`` re-exports these from ``posix``; patching only ``os`` would leave
+    # ``import posix; posix.system(...)`` open, so both modules are swept.
+    (
+        "os",
+        (
+            "system",
+            "popen",
+            "execl",
+            "execle",
+            "execlp",
+            "execlpe",
+            "execv",
+            "execve",
+            "execvp",
+            "execvpe",
+            "spawnl",
+            "spawnle",
+            "spawnlp",
+            "spawnlpe",
+            "spawnv",
+            "spawnve",
+            "spawnvp",
+            "spawnvpe",
+            "posix_spawn",
+            "posix_spawnp",
+        ),
+    ),
+    (
+        "posix",
+        (
+            "system",
+            "popen",
+            "execv",
+            "execve",
+            "posix_spawn",
+            "posix_spawnp",
+        ),
+    ),
+    # --- Loading a shared library sidesteps every Python-level guard above:
+    # ``ctypes.CDLL("libca")`` reaches Channel Access without importing a
+    # single client package. ``LibraryLoader.__getattr__`` is patched too,
+    # because ``ctypes.cdll.libca`` never goes through ``CDLL`` by that name.
+    ("ctypes", ("CDLL", "PyDLL", "WinDLL", "OleDLL")),
+    ("ctypes.LibraryLoader", ("LoadLibrary", "__getattr__")),
 )
 
 
@@ -401,13 +554,21 @@ if not _execution_dir.exists():
 
         The pre-execution regex sees only the standard spellings of a write.
         ``from epics import caput as _w`` evades it, so a readonly run is
-        enforced here, at runtime: every direct-library write entry point is
-        replaced with a function that refuses. The guard is emitted *before*
-        user code and *after* the limits monkeypatch, so an alias bound in the
-        user code late-binds to the refusing function, and the refusal — not a
-        limits check — is the first thing a write hits. It is deliberately
-        independent of the limits validator: a deployment with limits checking
-        off is exactly the one with nothing else standing behind the regex.
+        enforced here, at runtime: every entry point in
+        :data:`_READONLY_WRITE_TARGETS` is replaced with a function that
+        refuses. The guard is emitted *before* user code and *after* the limits
+        monkeypatch, so an alias bound in the user code late-binds to the
+        refusing function, and the refusal — not a limits check — is the first
+        thing a write hits. It is deliberately independent of the limits
+        validator: a deployment with limits checking off is exactly the one
+        with nothing else standing behind the regex.
+
+        The table covers three kinds of route: the control-system client
+        libraries themselves, the process-spawning surface that could shell out
+        to ``caput``, and ``ctypes``, which reaches Channel Access without
+        importing any client package at all. It is emitted into the script
+        rather than applied here because the objects to patch only exist in the
+        subprocess.
 
         The connector side of the same contract lives in
         ``osprey_connectors.control_system.base`` (refuses ``write_channel``
@@ -417,41 +578,69 @@ if not _execution_dir.exists():
         if self.execution_mode != "readonly":
             return ""
 
-        guard = """
-            # Readonly run: refuse every direct control-system write entry point.
-            # Installed before user code, so an alias bound later resolves here.
+        guard = f"""
+            # Readonly run: refuse every control-system write entry point, and
+            # every route out of Python that could reach one. Installed before
+            # user code, so an alias bound later resolves here.
+            import importlib as _osprey_importlib
+
+            _osprey_targets = {_READONLY_WRITE_TARGETS!r}
+
+
             def _osprey_readonly_refuse(*_args, **_kwargs):
                 raise RuntimeError("@@REFUSAL@@")
 
-            try:
-                import epics as _osprey_epics
 
-                _osprey_epics.caput = _osprey_readonly_refuse
-                if hasattr(_osprey_epics, "PV"):
-                    _osprey_epics.PV.put = _osprey_readonly_refuse
-                if hasattr(getattr(_osprey_epics, "ca", None), "put"):
-                    _osprey_epics.ca.put = _osprey_readonly_refuse
-            except ImportError:
-                pass
-            except Exception as _osprey_guard_error:
-                print(f"⚠️  readonly guard (epics) failed: {_osprey_guard_error}")
+            def _osprey_resolve(dotted):
+                \"\"\"Import the longest importable prefix of *dotted*, then walk attributes.
 
-            # p4p ships one Context class per concurrency flavor; each is
-            # patched in its own try so an unavailable flavor costs nothing.
-            import importlib as _osprey_importlib
+                One spelling for modules, module attributes and classes alike.
+                Returns None when the target is not present, which is the
+                ordinary case for most of the table — an uninstalled library,
+                or an optional flavour of an installed one. That case has to
+                stay SILENT: it is true on every ordinary deployment, and a
+                warning per absent target would print on every readonly run.
+                \"\"\"
+                parts = dotted.split(".")
+                for _cut in range(len(parts), 0, -1):
+                    try:
+                        obj = _osprey_importlib.import_module(".".join(parts[:_cut]))
+                    except ImportError:
+                        continue
+                    for _attr in parts[_cut:]:
+                        try:
+                            obj = getattr(obj, _attr)
+                        except AttributeError:
+                            # An importable parent without the child: the
+                            # target does not exist here either.
+                            return None
+                    return obj
+                return None
 
-            for _osprey_flavor in ("thread", "asyncio", "cothread"):
+
+            for _osprey_dotted, _osprey_attrs in _osprey_targets:
                 try:
-                    _osprey_ctx = _osprey_importlib.import_module(
-                        f"p4p.client.{_osprey_flavor}"
-                    ).Context
-                    _osprey_ctx.put = _osprey_readonly_refuse
-                    _osprey_ctx.rpc = _osprey_readonly_refuse
-                except ImportError:
-                    pass
+                    _osprey_obj = _osprey_resolve(_osprey_dotted)
+                    if _osprey_obj is None:
+                        continue
+                    for _osprey_attr in _osprey_attrs:
+                        if hasattr(_osprey_obj, _osprey_attr):
+                            setattr(_osprey_obj, _osprey_attr, _osprey_readonly_refuse)
+                    # pvaPy spells one typed setter per scalar and array type
+                    # (putDouble, putScalarArray, ...). Enumerating them would
+                    # go stale against the binding; the prefix will not.
+                    if _osprey_dotted == "pvaccess.Channel":
+                        for _osprey_attr in dir(_osprey_obj):
+                            if _osprey_attr.startswith("put"):
+                                setattr(_osprey_obj, _osprey_attr, _osprey_readonly_refuse)
                 except Exception as _osprey_guard_error:
-                    print(f"⚠️  readonly guard (p4p {_osprey_flavor}) failed: {_osprey_guard_error}")
-            del _osprey_importlib, _osprey_flavor
+                    # A target that cannot be patched must not stop the ones
+                    # after it, and the operator needs to know which one.
+                    print(
+                        f"⚠️  readonly guard ({{_osprey_dotted}}) failed: {{_osprey_guard_error}}"
+                    )
+
+            del _osprey_importlib, _osprey_targets, _osprey_resolve
         """
         return textwrap.dedent(guard).strip().replace("@@REFUSAL@@", READONLY_REFUSAL)
 

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -12,6 +12,15 @@ from osprey.utils.logger import get_logger
 logger = get_logger("execution_wrapper")
 
 
+#: Message raised by every refused write in a readonly run. Tests match on
+#: it, so keep it stable.
+READONLY_REFUSAL = (
+    "readonly execution mode: control-system writes are refused — "
+    "resubmit with execution_mode='readwrite' (human approval required) "
+    "if the write is intended"
+)
+
+
 class ExecutionWrapper:
     """
     Wrapper system for subprocess Python execution.
@@ -24,14 +33,20 @@ class ExecutionWrapper:
     - Error handling
     """
 
-    def __init__(self, limits_validator=None):
+    def __init__(self, limits_validator=None, execution_mode: str = "readonly"):
         """
         Initialize the wrapper.
 
         Args:
             limits_validator: Optional LimitsValidator instance for channel checking
+            execution_mode: The mode the script was submitted under. A
+                ``"readonly"`` run gets the readonly guard (every direct
+                control-system write entry point refuses at runtime); the
+                default is readonly so a wrapper built without a mode fails
+                closed.
         """
         self.limits_validator = limits_validator
+        self.execution_mode = execution_mode
 
     def create_wrapper(self, user_code: str, execution_folder: Path | None = None) -> str:
         """
@@ -49,6 +64,7 @@ class ExecutionWrapper:
         imports = self._get_imports()
         environment_setup = self._get_environment_setup(execution_folder)
         limits_checking = self._get_limits_checking_monkeypatch()
+        readonly_guard = self._get_readonly_guard()
         metadata_init = self._get_metadata_init()
         save_artifact_injection = self._get_save_artifact_injection()
         output_capture_start = self._get_output_capture_start()
@@ -61,6 +77,7 @@ class ExecutionWrapper:
                 imports,
                 environment_setup,
                 limits_checking,
+                readonly_guard,
                 metadata_init,
                 save_artifact_injection,
                 output_capture_start,
@@ -378,6 +395,65 @@ if not _execution_dir.exists():
                 traceback.print_exc()
         """
         ).strip()
+
+    def _get_readonly_guard(self) -> str:
+        """Generate the readonly-run guard; empty for a readwrite run.
+
+        The pre-execution regex sees only the standard spellings of a write.
+        ``from epics import caput as _w`` evades it, so a readonly run is
+        enforced here, at runtime: every direct-library write entry point is
+        replaced with a function that refuses. The guard is emitted *before*
+        user code and *after* the limits monkeypatch, so an alias bound in the
+        user code late-binds to the refusing function, and the refusal — not a
+        limits check — is the first thing a write hits. It is deliberately
+        independent of the limits validator: a deployment with limits checking
+        off is exactly the one with nothing else standing behind the regex.
+
+        The connector side of the same contract lives in
+        ``osprey_connectors.control_system.base`` (refuses ``write_channel``
+        when ``OSPREY_EXECUTION_MODE`` says readonly) and in the EPICS
+        connector's gateway selection (stays on the read_only gateway).
+        """
+        if self.execution_mode != "readonly":
+            return ""
+
+        guard = """
+            # Readonly run: refuse every direct control-system write entry point.
+            # Installed before user code, so an alias bound later resolves here.
+            def _osprey_readonly_refuse(*_args, **_kwargs):
+                raise RuntimeError("@@REFUSAL@@")
+
+            try:
+                import epics as _osprey_epics
+
+                _osprey_epics.caput = _osprey_readonly_refuse
+                if hasattr(_osprey_epics, "PV"):
+                    _osprey_epics.PV.put = _osprey_readonly_refuse
+                if hasattr(getattr(_osprey_epics, "ca", None), "put"):
+                    _osprey_epics.ca.put = _osprey_readonly_refuse
+            except ImportError:
+                pass
+            except Exception as _osprey_guard_error:
+                print(f"⚠️  readonly guard (epics) failed: {_osprey_guard_error}")
+
+            # p4p ships one Context class per concurrency flavor; each is
+            # patched in its own try so an unavailable flavor costs nothing.
+            import importlib as _osprey_importlib
+
+            for _osprey_flavor in ("thread", "asyncio", "cothread"):
+                try:
+                    _osprey_ctx = _osprey_importlib.import_module(
+                        f"p4p.client.{_osprey_flavor}"
+                    ).Context
+                    _osprey_ctx.put = _osprey_readonly_refuse
+                    _osprey_ctx.rpc = _osprey_readonly_refuse
+                except ImportError:
+                    pass
+                except Exception as _osprey_guard_error:
+                    print(f"⚠️  readonly guard (p4p {_osprey_flavor}) failed: {_osprey_guard_error}")
+            del _osprey_importlib, _osprey_flavor
+        """
+        return textwrap.dedent(guard).strip().replace("@@REFUSAL@@", READONLY_REFUSAL)
 
     def _get_metadata_init(self) -> str:
         """Initialize execution metadata tracking."""

--- a/src/osprey/services/python_executor/refusal_audit.py
+++ b/src/osprey/services/python_executor/refusal_audit.py
@@ -1,0 +1,168 @@
+"""Durable audit record for control-system writes refused in a readonly run.
+
+Every readonly refusal — whichever layer catches it — appends one JSON object
+to ``var/audit/readonly-refusals.jsonl`` in the deployment repo. That file is
+the answer to "did an agent ever try to write while the session was readonly,
+and what exactly did it run": the offending source is recorded verbatim
+(bounded), because a refusal whose source is not kept is an alert, not an audit
+trail.
+
+Why ``var/audit`` and not the server log: the audit zone is durable by
+construction. ``osprey build`` re-renders ``build/`` wholesale and never touches
+``var/``, and ``osprey reset`` keeps ``var/audit`` unless the operator passes
+``--purge-audit``. A refusal recorded there outlives the render that produced
+it; one recorded only in a process log does not.
+
+**Recording never fails a refusal.** Every function here swallows its own
+errors: the refusal itself is enforced by the caller, and an unwritable audit
+directory must not turn a blocked write into a traceback that reads like the
+gate malfunctioned.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from osprey.utils.logger import get_logger
+
+logger = get_logger("readonly_refusal_audit")
+
+#: Basename of the append-only refusal log inside the audit zone.
+REFUSAL_LOG_FILENAME = "readonly-refusals.jsonl"
+
+#: Characters of offending source kept per record. Generous enough to hold a
+#: whole ordinary script, bounded so a pathological submission cannot inflate
+#: the log without limit. A truncated record says so via ``source_truncated``
+#: rather than silently looking like the whole script.
+MAX_SOURCE_CHARS = 8000
+
+#: The layer that refused, recorded verbatim in the ``layer`` field. Static
+#: layers refuse before the script is launched; ``runtime_guard`` is the one
+#: that fires inside the subprocess, so it is the layer that catches the
+#: spellings the static ones cannot see.
+LAYER_IMPORT_DENYLIST = "import_denylist"
+LAYER_PATTERN_DETECTION = "pattern_detection"
+LAYER_RUNTIME_GUARD = "runtime_guard"
+
+
+def audit_dir() -> Path:
+    """The deployment's audit zone (``<repo>/var/audit``).
+
+    Anchored with the same resolver the executor uses to pick the subprocess
+    ``cwd`` (:func:`osprey.utils.workspace.resolve_project_root`), so the
+    refusal record lands in the repo whose script was refused rather than in
+    whatever directory the MCP server process happens to run from.
+
+    Imported lazily and kept as its own function so tests have one seam to
+    redirect, rather than having to stand up a project root.
+    """
+    from osprey.utils.workspace import (
+        AUDIT_DIR_RELPATH,
+        load_osprey_config,
+        resolve_project_root,
+    )
+
+    return resolve_project_root(load_osprey_config()) / AUDIT_DIR_RELPATH
+
+
+def refusal_log_path() -> Path:
+    """Full path of the append-only refusal log."""
+    return audit_dir() / REFUSAL_LOG_FILENAME
+
+
+def _truncate(source: str) -> tuple[str, bool]:
+    """Return *source* bounded to :data:`MAX_SOURCE_CHARS`, and whether it was cut."""
+    if len(source) <= MAX_SOURCE_CHARS:
+        return source, False
+    return source[:MAX_SOURCE_CHARS], True
+
+
+def build_record(
+    *,
+    layer: str,
+    trigger: Any,
+    source: str,
+    description: str | None = None,
+    tool: str | None = None,
+    execution_mode: str = "readonly",
+) -> dict[str, Any]:
+    """Assemble one refusal record without writing it.
+
+    Split from :func:`record_refusal` so the record's shape can be asserted on
+    directly, and so a caller that wants to log the same facts somewhere else
+    does not have to re-derive them.
+
+    Args:
+        layer: Which layer refused — one of the ``LAYER_*`` constants.
+        trigger: What matched. A list of import issues, the detected-pattern
+            mapping, or the runtime refusal message; stored as given.
+        source: The offending code, truncated to :data:`MAX_SOURCE_CHARS`.
+        description: The description the agent supplied for the script.
+        tool: MCP tool that was called (``execute`` / ``execute_file``).
+        execution_mode: Mode the run was submitted under.
+    """
+    body, truncated = _truncate(source)
+    record: dict[str, Any] = {
+        "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "layer": layer,
+        "mode": execution_mode,
+        "trigger": trigger,
+        "source": body,
+    }
+    if truncated:
+        record["source_truncated"] = True
+    if tool:
+        record["tool"] = tool
+    if description:
+        record["description"] = description
+    return record
+
+
+def record_refusal(
+    *,
+    layer: str,
+    trigger: Any,
+    source: str,
+    description: str | None = None,
+    tool: str | None = None,
+    execution_mode: str = "readonly",
+) -> Path | None:
+    """Append one refusal record to the audit log and warn on the server log.
+
+    Returns the path written, or ``None`` when the record could not be stored —
+    the caller does not branch on it, but a test can tell "wrote" from "gave up
+    quietly" without reading the directory.
+
+    Never raises: see the module docstring.
+    """
+    record = build_record(
+        layer=layer,
+        trigger=trigger,
+        source=source,
+        description=description,
+        tool=tool,
+        execution_mode=execution_mode,
+    )
+
+    # The server log carries the event even when the durable write fails, so a
+    # read-only filesystem downgrades the audit trail instead of erasing it.
+    logger.warning(
+        "Refused a control-system write in %s mode (layer=%s, tool=%s): %s",
+        record["mode"],
+        record["layer"],
+        record.get("tool", "-"),
+        json.dumps(record["trigger"]),
+    )
+
+    try:
+        path = refusal_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record) + "\n")
+        return path
+    except Exception:
+        logger.warning("Could not append to the refusal audit log", exc_info=True)
+        return None

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -987,7 +987,9 @@ def main():
             code = tool_input.get("code", "")
 
             writes_detected = has_write_patterns(code, config)
-            needs_approval = exec_mode == "write" or writes_detected
+            # The agent asking for write mode is itself the signal: approval must not
+            # rest on the regex recognising the spelling of the write.
+            needs_approval = exec_mode == "readwrite" or writes_detected
             if needs_approval:
                 reason_parts = [f"Python execution (mode: {exec_mode or 'unspecified'})"]
                 if writes_detected:

--- a/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
+++ b/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
@@ -108,8 +108,17 @@ Direct {{ protocol_name }} calls skip all of these protections.
 ## Write Operations
 
 For scripts that write to the control system, use the `execute` MCP tool directly
-with `execution_mode: "write"` —
-the `execute` tool defaults to readonly mode, which blocks write operations.
+with `execution_mode: "readwrite"` — the `execute` tool defaults to readonly
+mode, which blocks write operations. Those are the only two accepted values;
+any other spelling is rejected before the script runs.
+
+A readonly run also refuses the indirect routes to the control system: starting
+a process (so a shelled-out `caput` fails) and loading a shared library through
+`ctypes`. This applies even when the intent is unrelated to hardware, so a
+readonly script cannot shell out at all. Every refusal is reported to the
+operator and recorded in the deployment's audit log, so working around one is
+never the right move — resubmit with `execution_mode: "readwrite"` and let the
+operator approve it.
 {% if "bluesky" in enabled_servers | default([]) %}
 
 ## Measurements Go Through the Queue, Not Through Repeated Writes

--- a/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
+++ b/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
@@ -55,10 +55,11 @@ ctxt.put("SR:MAG:QF:01:CURRENT:SP", 150)    # Bypasses limits + approval
 ctxt.rpc("SR:SVC:ORBIT", request)           # Not approvable — refused at runtime
 ```
 
-`ctxt.rpc(...)` is the one to remember: it is refused at runtime and no
-approval can let it through. An rpc call carries an arbitrary payload, so
-limits checking cannot apply to it — there is nothing for the approval
-workflow to check. Use `write_channel` for the write you actually need.
+`ctxt.rpc(...)` is the one to remember: an rpc call carries an arbitrary
+payload, so limits checking cannot apply to it — there is nothing for the
+approval workflow to check. It is refused at runtime in every readonly run
+and wherever limits checking is enabled. Use `write_channel` for the write
+you actually need.
 {% elif cs_type == 'tango' %}
 ```python
 # DO NOT use these — they bypass safety controls

--- a/tests/connectors/test_epics_gateway_selection.py
+++ b/tests/connectors/test_epics_gateway_selection.py
@@ -90,3 +90,32 @@ async def test_warns_when_writes_enabled_but_no_write_gateway(monkeypatch, clean
 
     assert os.environ["EPICS_CA_ADDR_LIST"] == "ro.example.com"
     assert any("write" in w.lower() for w in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_readonly_run_stays_on_read_only_gateway(monkeypatch, clean_epics_env):
+    """A readonly sandbox run never routes through the write gateway.
+
+    ``writes_enabled`` is the deployment posture; ``OSPREY_EXECUTION_MODE`` is
+    the per-run claim the executor exports into the sandbox. A readonly run on a
+    write-enabled deployment must still land on the read_only gateway so a raw
+    ``caput`` issued after ``read_channel()`` is rejected at the network layer."""
+    _patch_writes_enabled(monkeypatch, True)
+    monkeypatch.setenv("OSPREY_EXECUTION_MODE", "readonly")
+
+    connector = EPICSConnector()
+    await connector.connect({"gateways": _both_gateways()})
+
+    assert os.environ["EPICS_CA_ADDR_LIST"] == "ro.example.com"
+    assert os.environ["EPICS_CA_SERVER_PORT"] == "5064"
+
+
+@pytest.mark.asyncio
+async def test_readwrite_run_uses_write_gateway(monkeypatch, clean_epics_env):
+    _patch_writes_enabled(monkeypatch, True)
+    monkeypatch.setenv("OSPREY_EXECUTION_MODE", "readwrite")
+
+    connector = EPICSConnector()
+    await connector.connect({"gateways": _both_gateways()})
+
+    assert os.environ["EPICS_CA_ADDR_LIST"] == "wr.example.com"

--- a/tests/connectors/test_readonly_run_refusal.py
+++ b/tests/connectors/test_readonly_run_refusal.py
@@ -1,0 +1,138 @@
+"""A readonly sandbox run is refused at the connector, whatever the deployment posture.
+
+``control_system.writes_enabled`` is the launch-time deployment posture. The
+python executor additionally exports ``OSPREY_EXECUTION_MODE`` into its
+sandbox subprocess; when that says ``readonly`` the connector base class
+refuses every write before any connector-specific code runs — so
+``osprey.runtime.write_channel`` and direct ``connector.write_channel`` calls
+alike are blocked in a readonly run even on a write-enabled deployment.
+"""
+
+from typing import Any
+
+import pytest
+
+from osprey.connectors.control_system.base import (
+    ChannelWriteResult,
+    ControlSystemConnector,
+)
+
+
+class _WriteEnabledConnector(ControlSystemConnector):
+    """Concrete connector whose deployment posture says writes are on."""
+
+    def __init__(self):
+        self.writes: list[tuple[str, Any]] = []
+
+    async def connect(self, config: dict[str, Any]) -> None: ...
+    async def disconnect(self) -> None: ...
+
+    async def read_channel(self, channel_address: str, timeout: float | None = None):
+        raise NotImplementedError
+
+    async def read_multiple_channels(self, channel_addresses, timeout=None):
+        raise NotImplementedError
+
+    async def write_channel(
+        self,
+        channel_address: str,
+        value: Any,
+        timeout: float | None = None,
+        verification_level: str = "callback",
+        tolerance: float | None = None,
+    ) -> ChannelWriteResult:
+        self.writes.append((channel_address, value))
+        return ChannelWriteResult(
+            channel_address=channel_address, value_written=value, success=True
+        )
+
+    async def write_multiple_channels(self, operations, timeout=None):
+        return [await self.write_channel(addr, val) for addr, val in operations]
+
+    async def subscribe(self, channel_address, callback):
+        raise NotImplementedError
+
+    async def unsubscribe(self, channel_address):
+        raise NotImplementedError
+
+    async def get_metadata(self, channel_address):
+        raise NotImplementedError
+
+    async def validate_channel(self, channel_address) -> bool:
+        return True
+
+
+@pytest.fixture
+def writes_enabled_deployment(monkeypatch):
+    monkeypatch.setattr(
+        "osprey_connectors.config.get_config_value",
+        lambda key, default=None: True if key == "control_system.writes_enabled" else default,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_readonly_run_refuses_write(monkeypatch, writes_enabled_deployment):
+    monkeypatch.setenv("OSPREY_EXECUTION_MODE", "readonly")
+    connector = _WriteEnabledConnector()
+
+    result = await connector.write_channel("SR:MAG:QF:01:CURRENT:SP", 150.0)
+
+    assert result.blocked is True
+    assert result.success is False
+    assert result.refusal_reason == "WRITES_DISABLED"
+    assert "readonly" in result.error_message
+    assert connector.writes == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_readonly_run_refuses_multi_write(monkeypatch, writes_enabled_deployment):
+    monkeypatch.setenv("OSPREY_EXECUTION_MODE", "readonly")
+    connector = _WriteEnabledConnector()
+
+    results = await connector.write_multiple_channels([("A:SP", 1.0), ("B:SP", 2.0)])
+
+    assert all(r.blocked for r in results)
+    assert connector.writes == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_readonly_refusal_message_does_not_blame_deployment(
+    monkeypatch, writes_enabled_deployment
+):
+    """The operator-facing text must not send anyone to flip writes_enabled —
+    the deployment allows writes; this *run* was declared readonly."""
+    monkeypatch.setenv("OSPREY_EXECUTION_MODE", "readonly")
+    connector = _WriteEnabledConnector()
+
+    result = await connector.write_channel("A:SP", 1.0)
+
+    assert "writes_enabled" not in result.error_message
+    assert "readwrite" in result.error_message
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_readwrite_run_passes_through(monkeypatch, writes_enabled_deployment):
+    monkeypatch.setenv("OSPREY_EXECUTION_MODE", "readwrite")
+    connector = _WriteEnabledConnector()
+
+    result = await connector.write_channel("A:SP", 1.0)
+
+    assert result.success is True
+    assert connector.writes == [("A:SP", 1.0)]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_mode_var_means_not_a_sandbox_run(monkeypatch, writes_enabled_deployment):
+    """Outside the sandbox (e.g. the controls MCP server) the variable is unset
+    and the deployment posture alone decides."""
+    monkeypatch.delenv("OSPREY_EXECUTION_MODE", raising=False)
+    connector = _WriteEnabledConnector()
+
+    result = await connector.write_channel("A:SP", 1.0)
+
+    assert result.success is True

--- a/tests/connectors/test_readonly_run_refusal.py
+++ b/tests/connectors/test_readonly_run_refusal.py
@@ -136,3 +136,26 @@ async def test_no_mode_var_means_not_a_sandbox_run(monkeypatch, writes_enabled_d
     result = await connector.write_channel("A:SP", 1.0)
 
     assert result.success is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_readonly_refusal_message_carries_the_shared_marker(
+    monkeypatch, writes_enabled_deployment
+):
+    """The connector's refusal must stay recognisable to the tool layer.
+
+    A write refused here reaches the executor tools only as a traceback on the
+    subprocess's stderr, where it is matched by substring so that the operator
+    alert and the audit record fire for this layer too. Rewording either
+    message without the other would silently stop that, so the two are pinned
+    to one constant.
+    """
+    from osprey.services.python_executor.execution.wrapper import READONLY_REFUSAL_MARKER
+
+    monkeypatch.setenv("OSPREY_EXECUTION_MODE", "readonly")
+    connector = _WriteEnabledConnector()
+
+    result = await connector.write_channel("A:SP", 1.0)
+
+    assert READONLY_REFUSAL_MARKER in result.error_message

--- a/tests/hooks/test_approval_hook.py
+++ b/tests/hooks/test_approval_hook.py
@@ -118,7 +118,7 @@ def test_selective_mode_blocks_python_write(tmp_path, hook_runner, make_config):
     result = hook_runner(
         "osprey_approval.py",
         "mcp__python__execute",
-        {"code": "caput('PV', 1.0)", "execution_mode": "write"},
+        {"code": "caput('PV', 1.0)", "execution_mode": "readwrite"},
         config_path=config,
         cwd=tmp_path,
         hook_config=DEFAULT_APPROVAL_CONFIG,
@@ -340,7 +340,7 @@ def test_approval_python_write_creates_notebook(tmp_path, hook_runner, make_conf
     result = hook_runner(
         "osprey_approval.py",
         "mcp__python__execute",
-        {"code": "caput('PV', 1.0)", "execution_mode": "write"},
+        {"code": "caput('PV', 1.0)", "execution_mode": "readwrite"},
         config_path=config,
         cwd=tmp_path,
         hook_config=DEFAULT_APPROVAL_CONFIG,
@@ -369,7 +369,7 @@ def test_approval_notebook_failure_nonfatal(tmp_path, hook_runner, make_config):
     result = hook_runner(
         "osprey_approval.py",
         "mcp__python__execute",
-        {"code": "epics.caput('PV', 5.0)", "execution_mode": "write"},
+        {"code": "epics.caput('PV', 5.0)", "execution_mode": "readwrite"},
         config_path=config,
         cwd=tmp_path,
         hook_config=DEFAULT_APPROVAL_CONFIG,
@@ -836,7 +836,7 @@ def test_tool_policy_selective_execute_write_mode_asks(tmp_path, hook_runner, ma
     result = hook_runner(
         "osprey_approval.py",
         "mcp__python__execute",
-        {"code": "print(42)", "execution_mode": "write"},
+        {"code": "print(42)", "execution_mode": "readwrite"},
         config_path=config,
         cwd=tmp_path,
         hook_config=DEFAULT_APPROVAL_CONFIG,
@@ -1050,3 +1050,60 @@ def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     assert returncode == 0
     assert stdout.strip() == ""
     assert "Traceback" not in stderr
+
+
+# ============================================================================
+# readwrite mode always asks — approval does not rest on pattern detection
+# ============================================================================
+
+
+@pytest.mark.unit
+def test_selective_readwrite_asks_without_write_patterns(tmp_path, hook_runner, make_config):
+    """A readwrite run prompts even when the detector sees no write pattern.
+
+    The agent asking for write mode is itself the signal: approval for
+    readwrite must not depend on the regex recognising the spelling."""
+    config = make_config(
+        {
+            "approval": {"enabled": True, "default_policy": "selective"},
+            "control_system": {"writes_enabled": True},
+        }
+    )
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__python__execute",
+        {"code": "print('nothing to see')", "execution_mode": "readwrite"},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=DEFAULT_APPROVAL_CONFIG,
+    )
+
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
+@pytest.mark.unit
+def test_selective_readwrite_asks_for_aliased_caput(tmp_path, hook_runner, make_config):
+    """``from epics import caput as _w`` evades every write regex; readwrite still asks."""
+    config = make_config(
+        {
+            "approval": {"enabled": True, "default_policy": "selective"},
+            "control_system": {"writes_enabled": True},
+        }
+    )
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__python__execute",
+        {
+            "code": "from epics import caput as _w\n_w('SR:MAG:QF:01:CURRENT:SP', 150)",
+            "execution_mode": "readwrite",
+        },
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=DEFAULT_APPROVAL_CONFIG,
+    )
+
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask"

--- a/tests/mcp_server/python_executor/test_executor_adapter.py
+++ b/tests/mcp_server/python_executor/test_executor_adapter.py
@@ -557,3 +557,63 @@ async def test_invalid_execution_method_returns_failure_result(tmp_path, monkeyp
     assert result.success is False
     assert result.execution_method_used == "subprocess"
     assert "unknown_method" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# Execution mode reaches the sandbox
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("mode", ["readonly", "readwrite"])
+async def test_execution_mode_exported_to_sandbox_env(tmp_path, monkeypatch, mode):
+    """The declared mode is a runtime property of the subprocess, not just a
+    pre-execution gate: the wrapper, osprey.runtime and the connectors all read
+    ``OSPREY_EXECUTION_MODE`` to refuse writes in a readonly run."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path)
+    monkeypatch.delenv("OSPREY_EXECUTION_MODE", raising=False)
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+
+    with patch(
+        "osprey.mcp_server.python_executor.executor.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        return_value=mock_proc,
+    ) as mock_spawn:
+        await execute_code("print(42)", mode, "test")
+
+    assert mock_spawn.call_args.kwargs["env"]["OSPREY_EXECUTION_MODE"] == mode
+
+
+@pytest.mark.unit
+async def test_wrapper_built_with_execution_mode(tmp_path, monkeypatch):
+    """The wrapper is told the mode so it can emit the readonly guard."""
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path)
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+
+    seen = {}
+    from osprey.services.python_executor.execution import wrapper as wrapper_module
+
+    real_init = wrapper_module.ExecutionWrapper.__init__
+
+    def spy_init(self, *args, **kwargs):
+        seen.update(kwargs)
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(wrapper_module.ExecutionWrapper, "__init__", spy_init)
+
+    with patch(
+        "osprey.mcp_server.python_executor.executor.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        return_value=mock_proc,
+    ):
+        await execute_code("print(42)", "readonly", "test")
+
+    assert seen.get("execution_mode") == "readonly"

--- a/tests/mcp_server/test_backend_emit_sites.py
+++ b/tests/mcp_server/test_backend_emit_sites.py
@@ -1,8 +1,15 @@
 """Agent-activity emit sites for backend-direct tools.
 
 Verifies that the mutating backend tools report agent activity via
-``notify_agent_activity_async`` — and, just as important, that refusal paths
-emit NOTHING and that tool results are unchanged when the web terminal is down.
+``notify_agent_activity_async`` — and, just as important, that a path which did
+not act emits NOTHING and that tool results are unchanged when the web terminal
+is down.
+
+"Did not act" is the test, not "was refused": a control-system write refused in
+a readonly run *is* reported, because the operator needs to see that one was
+attempted. That emit comes from the shared gate module rather than from either
+executor tool, so it has its own patch seam (``_GATES_MOD``) and the two are
+asserted separately.
 
 Layout: one ``# ── <tool family> ──`` section per tool family, each owning its
 own helpers and fixtures, followed by a trailing cross-cutting "terminal down"
@@ -771,6 +778,33 @@ _EXECUTE_WRITE_CODE = "epics.caput('SR:CORR:SP', 1.0)\n"
 _EXECUTE_DETAIL = "ran a script with control-system writes"
 _EXECUTE_TOOLS = ["execute", "execute_file"]
 
+#: Second patch seam for this family. A refused write is reported by the shared
+#: gate module rather than by either tool, so ``{tool_mod}.notify_agent_activity_async``
+#: does not see it — which is what lets a test assert "the run emitted nothing"
+#: and "the refusal was reported" independently of each other.
+_GATES_MOD = "osprey.mcp_server.python_executor.tools._execution_gates"
+
+
+@contextlib.contextmanager
+def _audit_to(root):
+    """Point the refusal audit log at *root* instead of the real state zone."""
+    from osprey.services.python_executor import refusal_audit
+
+    with patch.object(refusal_audit, "audit_dir", lambda: root / "var" / "audit"):
+        yield
+
+
+def _audit_records(root):
+    """Every refusal recorded under *root*, or ``[]`` when none were."""
+    import json
+
+    from osprey.services.python_executor.refusal_audit import REFUSAL_LOG_FILENAME
+
+    path = root / "var" / "audit" / REFUSAL_LOG_FILENAME
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
 
 def _execute_patterns(has_writes: bool) -> dict:
     """Canned ``detect_control_system_operations()`` return value."""
@@ -914,17 +948,134 @@ async def test_execute_launch_failure_no_emit(tool_name, tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize("tool_name", _EXECUTE_TOOLS)
-async def test_execute_readonly_gate_refusal_no_emit(tool_name, tmp_path, monkeypatch):
-    """Write patterns in readonly mode are refused before launch — emit nothing."""
+async def test_execute_readonly_gate_refusal_alerts_the_operator(tool_name, tmp_path, monkeypatch):
+    """A refused write is an operator-visible event, not just an error to the agent.
+
+    The refusal emit comes from the shared gate module, not the tool module, so
+    the two seams are asserted separately: the tool's own "ran a script with
+    control-system writes" emit must stay silent (nothing ran), while the gate
+    reports that a write was attempted and blocked.
+    """
     monkeypatch.chdir(tmp_path)
     mod, call = _execute_tool_call(tool_name, tmp_path)
 
     with _execute_env(mod, tmp_path) as (notify, exec_code):
-        with assert_raises_error(error_type="safety_error"):
-            await call(execution_mode="readonly")
+        with patch(f"{_GATES_MOD}.notify_agent_activity_async") as blocked, _audit_to(tmp_path):
+            with assert_raises_error(error_type="safety_error"):
+                await call(execution_mode="readonly")
 
     exec_code.assert_not_called()
     notify.assert_not_called()
+    blocked.assert_called_once()
+    emitted_tool, kind = blocked.call_args.args
+    assert (emitted_tool, kind) == (tool_name, "channel")
+    assert "BLOCKED" in blocked.call_args.kwargs["detail"]
+
+
+@pytest.mark.parametrize("tool_name", _EXECUTE_TOOLS)
+async def test_execute_readonly_gate_refusal_is_audited(tool_name, tmp_path, monkeypatch):
+    """...and leaves a durable record naming the source that was refused."""
+    monkeypatch.chdir(tmp_path)
+    mod, call = _execute_tool_call(tool_name, tmp_path)
+
+    with _execute_env(mod, tmp_path) as (_, exec_code):
+        with patch(f"{_GATES_MOD}.notify_agent_activity_async"), _audit_to(tmp_path):
+            with assert_raises_error(error_type="safety_error"):
+                await call(execution_mode="readonly")
+
+    (record,) = _audit_records(tmp_path)
+    assert record["layer"] == "pattern_detection"
+    assert record["mode"] == "readonly"
+    assert record["tool"] == tool_name
+    assert _EXECUTE_WRITE_CODE.strip() in record["source"]
+
+
+@pytest.mark.parametrize("tool_name", _EXECUTE_TOOLS)
+async def test_execute_runtime_refusal_alerts_and_audits(tool_name, tmp_path, monkeypatch):
+    """The guard refused mid-run: the tool recognises it in stderr and reports.
+
+    This is the layer that catches the spellings no static check sees, so it is
+    the one that most needs to reach the operator. Nothing but the subprocess's
+    stderr carries the news back.
+    """
+    from osprey.services.python_executor.execution.wrapper import READONLY_REFUSAL
+
+    monkeypatch.chdir(tmp_path)
+    mod, call = _execute_tool_call(tool_name, tmp_path)
+    refused = _execute_result(
+        success=False,
+        launched=True,
+        stderr=f"Traceback...\nRuntimeError: {READONLY_REFUSAL}",
+        error_message=f"RuntimeError: {READONLY_REFUSAL}",
+    )
+
+    with _execute_env(mod, tmp_path, exec_result=refused, has_writes=False) as (notify, _):
+        with patch(f"{_GATES_MOD}.notify_agent_activity_async") as blocked, _audit_to(tmp_path):
+            with assert_raises_error(error_type="execution_error"):
+                await call(execution_mode="readonly")
+
+    notify.assert_not_called()
+    blocked.assert_called_once()
+    (record,) = _audit_records(tmp_path)
+    assert record["layer"] == "runtime_guard"
+    assert record["tool"] == tool_name
+
+
+@pytest.mark.parametrize("tool_name", _EXECUTE_TOOLS)
+async def test_execute_connector_refusal_is_reported_too(tool_name, tmp_path, monkeypatch):
+    """A write refused by the connector — the *approved* path in the wrong mode.
+
+    Its message is not the guard's, so this pins that the tool matches on what
+    the two share, and that the audit record keeps the channel name the
+    connector's message carries rather than a generic marker.
+    """
+    monkeypatch.chdir(tmp_path)
+    mod, call = _execute_tool_call(tool_name, tmp_path)
+    connector_message = (
+        "Write to 'SR:CORR:SP' blocked: this script is running in readonly "
+        "execution mode. Resubmit it with execution_mode='readwrite' "
+        "(human approval required) if the write is intended."
+    )
+    refused = _execute_result(
+        success=False,
+        launched=True,
+        stderr=f"Traceback...\nChannelWriteBlockedError: {connector_message}",
+        error_message=f"ChannelWriteBlockedError: {connector_message}",
+    )
+
+    with _execute_env(mod, tmp_path, exec_result=refused, has_writes=False) as (_, _exec):
+        with patch(f"{_GATES_MOD}.notify_agent_activity_async") as blocked, _audit_to(tmp_path):
+            with assert_raises_error(error_type="execution_error"):
+                await call(execution_mode="readonly")
+
+    blocked.assert_called_once()
+    (record,) = _audit_records(tmp_path)
+    assert record["layer"] == "runtime_guard"
+    assert any("SR:CORR:SP" in line for line in record["trigger"])
+
+
+@pytest.mark.parametrize("tool_name", _EXECUTE_TOOLS)
+async def test_execute_ordinary_failure_is_not_reported_as_a_refusal(
+    tool_name, tmp_path, monkeypatch
+):
+    """A script that merely crashed must not land in the refusal audit log."""
+    monkeypatch.chdir(tmp_path)
+    mod, call = _execute_tool_call(tool_name, tmp_path)
+    crashed = _execute_result(
+        success=False,
+        launched=True,
+        stderr="Traceback...\nZeroDivisionError: division by zero",
+        error_message="ZeroDivisionError: division by zero",
+    )
+
+    with _execute_env(mod, tmp_path, exec_result=crashed, has_writes=False) as (notify, _):
+        with patch(f"{_GATES_MOD}.notify_agent_activity_async") as blocked, _audit_to(tmp_path):
+            with assert_raises_error(error_type="execution_error"):
+                await call(execution_mode="readonly")
+
+    notify.assert_not_called()
+    blocked.assert_not_called()
+    assert _audit_records(tmp_path) == []
 
 
 @pytest.mark.parametrize("tool_name", _EXECUTE_TOOLS)

--- a/tests/mcp_server/test_python_execute_file_tool.py
+++ b/tests/mcp_server/test_python_execute_file_tool.py
@@ -510,3 +510,26 @@ async def test_execute_file_empty_path():
 
     data = _exc_ctx["envelope"]
     assert "no file path" in data["error_message"].lower()
+
+
+@pytest.mark.unit
+async def test_execute_file_readonly_refuses_epics_import(tmp_path, monkeypatch):
+    """Same readonly import gate as ``execute``: the file's imports are walked."""
+    monkeypatch.chdir(tmp_path)
+    script = tmp_path / "alias.py"
+    script.write_text("from epics import caput as _w\n_w('SR:MAG:QF:01:CURRENT:SP', 150)\n")
+    mock_exec = _mock_execute_code(success=True, stdout="")
+
+    with (
+        patch(
+            "osprey.mcp_server.python_executor.executor._resolve_project_root",
+            return_value=tmp_path,
+        ),
+        patch("osprey.mcp_server.python_executor.executor.execute_code", mock_exec),
+    ):
+        fn = _get_python_execute_file()
+        with assert_raises_error(error_type="safety_error") as _exc_ctx:
+            await fn(file_path=str(script), description="alias", execution_mode="readonly")
+
+    assert any("epics" in s for s in _exc_ctx["envelope"]["suggestions"])
+    mock_exec.assert_not_called()

--- a/tests/mcp_server/test_python_execute_safety.py
+++ b/tests/mcp_server/test_python_execute_safety.py
@@ -215,3 +215,74 @@ def test_readonly_imports_allowed(code):
 def test_readonly_imports_syntax_error_is_not_an_issue_here():
     """Syntax errors belong to check_syntax; this walker stays quiet."""
     assert _readonly_import_issues("def (:") == []
+
+
+# ---------------------------------------------------------------------------
+# Refused writes are audited
+#
+# "Log the attempt with the offending source for audit" is a requirement in its
+# own right: an agent that tries to write while the session is readonly is a
+# fact the operator needs after the fact, not only in the moment.
+# ---------------------------------------------------------------------------
+
+
+def _audit_records(root):
+    import json
+
+    from osprey.services.python_executor.refusal_audit import REFUSAL_LOG_FILENAME
+
+    path = root / "var" / "audit" / REFUSAL_LOG_FILENAME
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+@pytest.mark.unit
+async def test_denied_import_is_recorded_with_its_source(tmp_path, monkeypatch):
+    """The import denylist refusal names the layer and keeps the offending code."""
+    from osprey.services.python_executor import refusal_audit
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(refusal_audit, "audit_dir", lambda: tmp_path / "var" / "audit")
+
+    code = "import epics\nepics.caput('SR:CORR:SP', 1.0)\n"
+    fn = _get_python_execute()
+    gates = "osprey.mcp_server.python_executor.tools._execution_gates"
+    with patch(f"{gates}.notify_agent_activity_async", new=AsyncMock()):
+        with assert_raises_error(error_type="safety_error"):
+            await fn(code=code, description="import a client", execution_mode="readonly")
+
+    (record,) = _audit_records(tmp_path)
+    assert record["layer"] == "import_denylist"
+    assert record["source"] == code
+    assert record["description"] == "import a client"
+    assert any("epics" in issue for issue in record["trigger"])
+
+
+@pytest.mark.unit
+async def test_a_clean_readonly_run_writes_no_audit_record(tmp_path, monkeypatch):
+    """The log must stay a record of refusals, not of executions."""
+    from osprey.services.python_executor import refusal_audit
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(refusal_audit, "audit_dir", lambda: tmp_path / "var" / "audit")
+
+    fn = _get_python_execute()
+    with patch(
+        "osprey.mcp_server.python_executor.executor.execute_code", new=AsyncMock()
+    ) as exec_code:
+        exec_code.return_value = _clean_result()
+        await fn(
+            code="x = 1 + 1\nprint(x)",
+            description="arithmetic",
+            execution_mode="readonly",
+            save_output=False,
+        )
+
+    assert _audit_records(tmp_path) == []
+
+
+def _clean_result():
+    from osprey.mcp_server.python_executor.executor import ExecutionResult
+
+    return ExecutionResult(success=True, stdout="2\n", stderr="", execution_time_seconds=0.1)

--- a/tests/mcp_server/test_python_execute_safety.py
+++ b/tests/mcp_server/test_python_execute_safety.py
@@ -159,3 +159,59 @@ def test_quick_safety_check_standalone():
     # open() — warning level, should NOT block
     passed, issues = quick_safety_check("f = open('file.txt')")
     assert passed is True
+
+
+# ============================================================================
+# readonly import denylist — control-system client libraries
+# ============================================================================
+
+
+def _readonly_import_issues(code):
+    from osprey.services.python_executor.analysis.safety_checks import check_readonly_imports
+
+    return check_readonly_imports(code)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param("import epics", id="import"),
+        pytest.param("import epics as e", id="import-as"),
+        pytest.param("from epics import caput as _w", id="from-import-alias"),
+        pytest.param("from epics.ca import put", id="from-submodule"),
+        pytest.param("import p4p.client.thread", id="dotted-import"),
+        pytest.param("from p4p.client.asyncio import Context", id="from-dotted"),
+        pytest.param("import caproto", id="caproto"),
+        pytest.param("import pvaccess", id="pvaccess"),
+        pytest.param("import tango", id="tango"),
+        pytest.param("from PyTango import DeviceProxy", id="pytango"),
+        pytest.param("def f():\n    import epics\n    return epics", id="nested-in-function"),
+    ],
+)
+def test_readonly_imports_denied(code):
+    issues = _readonly_import_issues(code)
+    assert issues, code
+    assert all("readonly" in i for i in issues), issues
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param("import numpy as np", id="numpy"),
+        pytest.param("from osprey.runtime import read_channel", id="osprey-runtime"),
+        pytest.param("import epicsarchiver_client", id="prefix-is-not-package"),
+        pytest.param("# import epics\nprint('commented out')", id="comment-only"),
+        pytest.param("s = 'import epics'", id="string-only"),
+        pytest.param("x = epics.caput", id="no-import-statement"),
+    ],
+)
+def test_readonly_imports_allowed(code):
+    assert _readonly_import_issues(code) == []
+
+
+@pytest.mark.unit
+def test_readonly_imports_syntax_error_is_not_an_issue_here():
+    """Syntax errors belong to check_syntax; this walker stays quiet."""
+    assert _readonly_import_issues("def (:") == []

--- a/tests/mcp_server/test_python_execute_tool.py
+++ b/tests/mcp_server/test_python_execute_tool.py
@@ -1328,3 +1328,48 @@ def test_enumeration_probe_works_against_a_real_interpreter():
 
     assert names, "live interpreter reported no importable top-level packages"
     assert all(name.isidentifier() and not name.startswith("_") for name in names)
+
+
+# ============================================================================
+# readonly mode refuses control-system client imports before execution
+# ============================================================================
+
+
+ALIASED_CAPUT = "from epics import caput as _w\n_w('SR:MAG:QF:01:CURRENT:SP', 150)\n"
+
+
+@pytest.mark.unit
+async def test_python_execute_readonly_refuses_epics_import(tmp_path, monkeypatch):
+    """An aliased caput evades every write regex; the import itself is refused."""
+    monkeypatch.chdir(tmp_path)
+    mock_exec = _mock_execute_code(success=True, stdout="")
+
+    with patch("osprey.mcp_server.python_executor.executor.execute_code", mock_exec):
+        fn = _get_python_execute()
+        with assert_raises_error(error_type="safety_error") as _exc_ctx:
+            await fn(code=ALIASED_CAPUT, description="alias", execution_mode="readonly")
+
+    data = _exc_ctx["envelope"]
+    assert any("epics" in s for s in data["suggestions"]), data
+    mock_exec.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_python_execute_readwrite_allows_epics_import(tmp_path, monkeypatch):
+    """The denylist is a readonly gate only; readwrite runs are approved by a human."""
+    monkeypatch.chdir(tmp_path)
+    mock_exec = _mock_execute_code(success=True, stdout="")
+    from osprey.services.python_executor.execution.control import ExecutionControlConfig
+
+    with (
+        patch("osprey.mcp_server.python_executor.executor.execute_code", mock_exec),
+        patch(
+            "osprey.services.python_executor.execution.control.get_execution_control_config",
+            return_value=ExecutionControlConfig(control_system_writes_enabled=True),
+        ),
+    ):
+        fn = _get_python_execute()
+        result = await fn(code=ALIASED_CAPUT, description="alias", execution_mode="readwrite")
+
+    assert extract_response_dict(result)["status"] == "success"
+    mock_exec.assert_called_once()

--- a/tests/services/python_executor/execution/test_readonly_guard.py
+++ b/tests/services/python_executor/execution/test_readonly_guard.py
@@ -1,0 +1,234 @@
+"""Tests for the readonly-run guard in the generated execution wrapper.
+
+A script submitted with ``execution_mode="readonly"`` must be unable to write
+to the control system *at runtime*, however the write is spelled. The
+pre-execution regex only sees the standard spellings, so the wrapper installs
+refusing replacements for every direct-library write entry point before the
+user code runs. Late binding makes this spelling-independent: an alias such as
+``from epics import caput as _w`` resolves to the refusing function because the
+patch is already in place when the alias is bound.
+
+Like the limits monkeypatch tests, these execute the generated *source text*
+against fake ``epics``/``p4p`` modules injected into ``sys.modules``.
+"""
+
+import asyncio
+import re
+import sys
+from types import ModuleType
+
+import pytest
+
+from osprey.services.python_executor.execution.wrapper import (
+    READONLY_REFUSAL,
+    ExecutionWrapper,
+)
+
+pytestmark = pytest.mark.unit
+
+# The refusal text contains literal parentheses; escape it for pytest.raises.
+_REFUSAL = re.escape(READONLY_REFUSAL)
+
+
+class _RecordingContext:
+    def __init__(self, *args, **kwargs):
+        self.puts = []
+        self.rpcs = []
+
+    def put(self, name, values, request=None, timeout=5.0, **kwargs):
+        self.puts.append((name, values))
+        return "put-done"
+
+    def rpc(self, name, value=None, request=None, timeout=5.0):
+        self.rpcs.append((name, value))
+        return "rpc-done"
+
+
+class _AsyncRecordingContext(_RecordingContext):
+    async def put(self, name, values, request=None, timeout=5.0, **kwargs):
+        self.puts.append((name, values))
+        return "put-done"
+
+
+def _install_fake_epics(monkeypatch):
+    mod = ModuleType("epics")
+    ca = ModuleType("epics.ca")
+    writes: list = []
+
+    def ca_put(chid, value, **kwargs):
+        writes.append(("ca.put", chid, value))
+        return 1
+
+    def caput(pvname, value, wait=False, timeout=60, **kwargs):
+        writes.append(("caput", pvname, value))
+        return 1
+
+    class PV:
+        def __init__(self, pvname):
+            self.pvname = pvname
+
+        def put(self, value, wait=False, timeout=60, **kwargs):
+            writes.append(("PV.put", self.pvname, value))
+            return 1
+
+    ca.put = ca_put
+    mod.ca = ca
+    mod.caput = caput
+    mod.PV = PV
+    mod._writes = writes
+    monkeypatch.setitem(sys.modules, "epics", mod)
+    monkeypatch.setitem(sys.modules, "epics.ca", ca)
+    return mod
+
+
+def _install_fake_p4p(monkeypatch):
+    p4p_mod = ModuleType("p4p")
+    client_mod = ModuleType("p4p.client")
+    p4p_mod.client = client_mod
+    monkeypatch.setitem(sys.modules, "p4p", p4p_mod)
+    monkeypatch.setitem(sys.modules, "p4p.client", client_mod)
+    classes = {}
+    for flavor, base in (("thread", _RecordingContext), ("asyncio", _AsyncRecordingContext)):
+        flavor_mod = ModuleType(f"p4p.client.{flavor}")
+        ctx_cls = type(f"{flavor.capitalize()}Context", (base,), {})
+        flavor_mod.Context = ctx_cls
+        classes[flavor] = ctx_cls
+        setattr(client_mod, flavor, flavor_mod)
+        monkeypatch.setitem(sys.modules, f"p4p.client.{flavor}", flavor_mod)
+    monkeypatch.setitem(sys.modules, "p4p.client.cothread", None)
+    return classes
+
+
+def _run_guard(execution_mode):
+    source = ExecutionWrapper(execution_mode=execution_mode)._get_readonly_guard()
+    namespace: dict = {}
+    exec(source, namespace)
+    return source
+
+
+# ---------------------------------------------------------------------------
+# Emission
+# ---------------------------------------------------------------------------
+
+
+def test_readwrite_emits_no_guard():
+    assert ExecutionWrapper(execution_mode="readwrite")._get_readonly_guard() == ""
+
+
+def test_default_mode_is_readonly():
+    """Fail closed: a wrapper built without a mode guards like a readonly run."""
+    assert ExecutionWrapper()._get_readonly_guard() != ""
+
+
+def test_guard_precedes_user_code_in_full_wrapper():
+    wrapped = ExecutionWrapper(execution_mode="readonly").create_wrapper("print('hi')")
+    assert wrapped.index(READONLY_REFUSAL) < wrapped.index("print('hi')")
+
+
+def test_guard_is_independent_of_limits_validator():
+    """The guard must exist with limits checking off — that is the case it protects."""
+    wrapper = ExecutionWrapper(limits_validator=None, execution_mode="readonly")
+    assert wrapper._get_limits_checking_monkeypatch() == ""
+    assert READONLY_REFUSAL in wrapper._get_readonly_guard()
+
+
+# ---------------------------------------------------------------------------
+# pyepics
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_refuses_epics_caput(monkeypatch):
+    epics = _install_fake_epics(monkeypatch)
+    _run_guard("readonly")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        epics.caput("SR:MAG:QF:01:CURRENT:SP", 150)
+    assert epics._writes == []
+
+
+def test_readonly_refuses_aliased_caput(monkeypatch):
+    """The regex-evading spelling lands on the same refusing function."""
+    _install_fake_epics(monkeypatch)
+    _run_guard("readonly")
+    from epics import caput as _w  # bound AFTER the guard, as in a real run
+
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        _w("SR:MAG:QF:01:CURRENT:SP", 150)
+
+
+def test_readonly_refuses_getattr_caput(monkeypatch):
+    epics = _install_fake_epics(monkeypatch)
+    _run_guard("readonly")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        getattr(epics, "ca" + "put")("SR:MAG:QF:01:CURRENT:SP", 150)
+
+
+def test_readonly_refuses_pv_put(monkeypatch):
+    epics = _install_fake_epics(monkeypatch)
+    _run_guard("readonly")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        epics.PV("SR:MAG:QF:01:CURRENT:SP").put(150)
+    assert epics._writes == []
+
+
+def test_readonly_refuses_low_level_ca_put(monkeypatch):
+    """``epics.ca.put`` is what caput/PV.put bottom out in; it is refused too."""
+    epics = _install_fake_epics(monkeypatch)
+    _run_guard("readonly")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        epics.ca.put(12345, 150)
+
+
+def test_readwrite_leaves_epics_untouched(monkeypatch):
+    epics = _install_fake_epics(monkeypatch)
+    _run_guard("readwrite")
+    assert epics.caput("SR:MAG:QF:01:CURRENT:SP", 150) == 1
+    assert epics._writes == [("caput", "SR:MAG:QF:01:CURRENT:SP", 150)]
+
+
+def test_readonly_without_epics_installed_is_quiet(monkeypatch):
+    monkeypatch.setitem(sys.modules, "epics", None)
+    monkeypatch.setitem(sys.modules, "epics.ca", None)
+    _install_fake_p4p(monkeypatch)
+    _run_guard("readonly")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# p4p
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_refuses_p4p_thread_put_and_rpc(monkeypatch):
+    _install_fake_epics(monkeypatch)
+    classes = _install_fake_p4p(monkeypatch)
+    _run_guard("readonly")
+    ctxt = classes["thread"]("pva")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        ctxt.put("SR:MAG:QF:01:CURRENT:SP", 150)
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        ctxt.rpc("SR:SVC:ORBIT", {})
+    assert ctxt.puts == [] and ctxt.rpcs == []
+
+
+def test_readonly_refuses_p4p_asyncio_put(monkeypatch):
+    _install_fake_epics(monkeypatch)
+    classes = _install_fake_p4p(monkeypatch)
+    _run_guard("readonly")
+    ctxt = classes["asyncio"]("pva")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        result = ctxt.put("SR:MAG:QF:01:CURRENT:SP", 150)
+        if asyncio.iscoroutine(result):
+            asyncio.run(result)
+    assert ctxt.puts == []
+
+
+def test_readonly_without_p4p_installed_is_quiet(monkeypatch):
+    _install_fake_epics(monkeypatch)
+    for name in (
+        "p4p",
+        "p4p.client",
+        "p4p.client.thread",
+        "p4p.client.asyncio",
+        "p4p.client.cothread",
+    ):
+        monkeypatch.setitem(sys.modules, name, None)
+    _run_guard("readonly")  # must not raise

--- a/tests/services/python_executor/execution/test_readonly_guard.py
+++ b/tests/services/python_executor/execution/test_readonly_guard.py
@@ -13,6 +13,7 @@ against fake ``epics``/``p4p`` modules injected into ``sys.modules``.
 """
 
 import asyncio
+import importlib
 import re
 import sys
 from types import ModuleType
@@ -20,6 +21,7 @@ from types import ModuleType
 import pytest
 
 from osprey.services.python_executor.execution.wrapper import (
+    _READONLY_WRITE_TARGETS,
     READONLY_REFUSAL,
     ExecutionWrapper,
 )
@@ -28,6 +30,56 @@ pytestmark = pytest.mark.unit
 
 # The refusal text contains literal parentheses; escape it for pytest.raises.
 _REFUSAL = re.escape(READONLY_REFUSAL)
+
+
+def _resolve_target(dotted):
+    """Mirror of the resolver the guard emits, for the restore fixture below.
+
+    Deliberately a copy rather than a shared import: the emitted guard has to
+    be self-contained — it runs before the user code in a subprocess that may
+    not be able to import OSPREY at all — so there is no function to share.
+    """
+    parts = dotted.split(".")
+    for cut in range(len(parts), 0, -1):
+        try:
+            obj = importlib.import_module(".".join(parts[:cut]))
+        except ImportError:
+            continue
+        for attr in parts[cut:]:
+            try:
+                obj = getattr(obj, attr)
+            except AttributeError:
+                return None
+        return obj
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _restore_patched_targets():
+    """Undo the guard's patches after every test in this module.
+
+    These tests exec the guard's source *in the test process*, which is the
+    only practical way to assert on its behaviour. The guard patches objects in
+    ``sys.modules``, and some of those — ``os``, ``subprocess``, ``ctypes`` —
+    are the same objects pytest and the rest of the suite use. Without this,
+    the first test to run leaves ``subprocess.run`` refusing for the remainder
+    of the session, and unrelated tests fail with a readonly refusal.
+
+    Snapshotting happens before the fake ``epics``/``p4p`` modules are injected,
+    so it captures the real objects; restoring writes back to those same objects
+    and is therefore unaffected by whatever ``sys.modules`` held in between.
+    """
+    saved = []
+    for dotted, attrs in _READONLY_WRITE_TARGETS:
+        target = _resolve_target(dotted)
+        if target is None:
+            continue
+        for attr in attrs:
+            if hasattr(target, attr):
+                saved.append((target, attr, getattr(target, attr)))
+    yield
+    for target, attr, value in saved:
+        setattr(target, attr, value)
 
 
 class _RecordingContext:
@@ -232,3 +284,215 @@ def test_readonly_without_p4p_installed_is_quiet(monkeypatch):
     ):
         monkeypatch.setitem(sys.modules, name, None)
     _run_guard("readonly")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# caproto, pvaPy, Tango
+#
+# These three had a static import denial and nothing behind it, which
+# ``importlib.import_module("caproto.sync.client")`` walked straight past —
+# the AST check sees no ``ast.Import`` node to match. Patching the resolved
+# object closes that, exactly as it already did for pyepics.
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_caproto(monkeypatch):
+    caproto_mod = ModuleType("caproto")
+    sync_mod = ModuleType("caproto.sync")
+    sync_client = ModuleType("caproto.sync.client")
+    threading_mod = ModuleType("caproto.threading")
+    threading_client = ModuleType("caproto.threading.client")
+    writes: list = []
+
+    def write(pv_name, data, **kwargs):
+        writes.append((pv_name, data))
+        return 1
+
+    class PV:
+        def __init__(self, name):
+            self.name = name
+
+        def write(self, data, **kwargs):
+            writes.append((self.name, data))
+            return 1
+
+    sync_client.write = write
+    threading_client.PV = PV
+    caproto_mod.sync = sync_mod
+    caproto_mod.threading = threading_mod
+    sync_mod.client = sync_client
+    threading_mod.client = threading_client
+    caproto_mod._writes = writes
+    for name, mod in (
+        ("caproto", caproto_mod),
+        ("caproto.sync", sync_mod),
+        ("caproto.sync.client", sync_client),
+        ("caproto.threading", threading_mod),
+        ("caproto.threading.client", threading_client),
+    ):
+        monkeypatch.setitem(sys.modules, name, mod)
+    return caproto_mod
+
+
+def test_readonly_refuses_caproto_sync_write(monkeypatch):
+    caproto = _install_fake_caproto(monkeypatch)
+    _run_guard("readonly")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        caproto.sync.client.write("SR:MAG:QF:01:CURRENT:SP", 150)
+    assert caproto._writes == []
+
+
+def test_readonly_refuses_caproto_via_importlib(monkeypatch):
+    """The spelling the AST import denylist cannot see."""
+    caproto = _install_fake_caproto(monkeypatch)
+    _run_guard("readonly")
+    client = importlib.import_module("caproto.sync.client")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        client.write("SR:MAG:QF:01:CURRENT:SP", 150)
+    assert caproto._writes == []
+
+
+def test_readonly_refuses_caproto_threading_pv_write(monkeypatch):
+    caproto = _install_fake_caproto(monkeypatch)
+    _run_guard("readonly")
+    pv = caproto.threading.client.PV("SR:MAG:QF:01:CURRENT:SP")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        pv.write(150)
+    assert caproto._writes == []
+
+
+def test_readonly_refuses_pvaccess_typed_setters(monkeypatch):
+    """pvaPy spells one setter per type; the ``put`` prefix is swept wholesale."""
+    mod = ModuleType("pvaccess")
+    writes: list = []
+
+    class Channel:
+        def __init__(self, name):
+            self.name = name
+
+        def put(self, value):
+            writes.append(("put", value))
+
+        def putDouble(self, value):  # noqa: N802 — pvaPy's own spelling
+            writes.append(("putDouble", value))
+
+        def get(self):
+            return 1.0
+
+    mod.Channel = Channel
+    monkeypatch.setitem(sys.modules, "pvaccess", mod)
+    _run_guard("readonly")
+
+    channel = mod.Channel("SR:MAG:QF:01:CURRENT:SP")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        channel.put(150)
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        channel.putDouble(150.0)
+    assert writes == []
+    assert channel.get() == 1.0, "reads must survive the guard untouched"
+
+
+def test_readonly_refuses_tango_write_attribute(monkeypatch):
+    mod = ModuleType("tango")
+    writes: list = []
+
+    class DeviceProxy:
+        def __init__(self, name):
+            self.name = name
+
+        def write_attribute(self, attr, value):
+            writes.append((attr, value))
+
+        def command_inout(self, command, arg=None):
+            writes.append((command, arg))
+
+        def read_attribute(self, attr):
+            return 1.0
+
+    mod.DeviceProxy = DeviceProxy
+    monkeypatch.setitem(sys.modules, "tango", mod)
+    _run_guard("readonly")
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        proxy.write_attribute("current", 150)
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        proxy.command_inout("TurnOn")
+    assert writes == []
+    assert proxy.read_attribute("current") == 1.0, "reads must survive the guard untouched"
+
+
+# ---------------------------------------------------------------------------
+# Routes out of Python
+#
+# The issue names two explicitly: a shelled-out ``caput`` and ``ctypes``.
+# Neither touches a control-system client package, so no import-time or
+# call-site check can see them; both are refused at the point of use.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(
+            lambda: __import__("subprocess").run(["caput", "PV", "1"]), id="subprocess-run"
+        ),
+        pytest.param(
+            lambda: __import__("subprocess").Popen(["caput", "PV", "1"]), id="subprocess-Popen"
+        ),
+        pytest.param(
+            lambda: __import__("subprocess").check_output(["caput", "PV", "1"]),
+            id="subprocess-check_output",
+        ),
+        pytest.param(lambda: __import__("os").system("caput PV 1"), id="os-system"),
+        pytest.param(lambda: __import__("os").popen("caput PV 1"), id="os-popen"),
+        pytest.param(
+            lambda: __import__("os").execvp("caput", ["caput", "PV", "1"]), id="os-execvp"
+        ),
+        pytest.param(
+            lambda: __import__("os").posix_spawn("/usr/bin/caput", ["caput", "PV", "1"], {}),
+            id="os-posix_spawn",
+        ),
+        pytest.param(lambda: __import__("posix").system("caput PV 1"), id="posix-system"),
+        pytest.param(lambda: __import__("ctypes").CDLL("libca.so"), id="ctypes-CDLL"),
+        pytest.param(
+            lambda: __import__("ctypes").cdll.LoadLibrary("libca.so"), id="ctypes-LoadLibrary"
+        ),
+        pytest.param(lambda: __import__("ctypes").cdll.libca, id="ctypes-cdll-attribute"),
+    ],
+)
+def test_readonly_refuses_routes_out_of_python(call):
+    _run_guard("readonly")
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        call()
+
+
+def test_readonly_leaves_fork_alone():
+    """Forking cannot run a new program; the exec half of fork+exec is refused."""
+    import os
+
+    _run_guard("readonly")
+    assert os.fork.__name__ != "_osprey_readonly_refuse"
+
+
+def test_readwrite_leaves_the_escape_hatches_alone():
+    import ctypes
+    import os
+    import subprocess
+
+    _run_guard("readwrite")
+    assert subprocess.run.__name__ != "_osprey_readonly_refuse"
+    assert os.system.__name__ != "_osprey_readonly_refuse"
+    assert ctypes.CDLL.__name__ != "_osprey_readonly_refuse"
+
+
+def test_guard_is_silent_when_optional_libraries_are_absent(capsys, monkeypatch):
+    """Most of the table is absent on any given deployment — that must not print.
+
+    A warning per missing target would land on the stdout of every readonly
+    run, which is the agent's own output channel.
+    """
+    for name in ("epics", "p4p", "caproto", "pvaccess", "tango", "PyTango"):
+        monkeypatch.setitem(sys.modules, name, None)
+    _run_guard("readonly")
+    assert capsys.readouterr().out == ""

--- a/tests/services/python_executor/test_refusal_audit.py
+++ b/tests/services/python_executor/test_refusal_audit.py
@@ -1,0 +1,151 @@
+"""Tests for the durable audit record written when a readonly write is refused.
+
+The issue's requirement is "log the attempt with the offending source for
+audit", so these assert on two things the server log alone cannot give: the
+record lands in the durable ``var/audit`` zone, and it carries the source that
+was refused.
+"""
+
+import json
+
+import pytest
+
+from osprey.services.python_executor import refusal_audit
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def audit_root(tmp_path, monkeypatch):
+    """Redirect the audit zone at its single seam."""
+    target = tmp_path / "var" / "audit"
+    monkeypatch.setattr(refusal_audit, "audit_dir", lambda: target)
+    return target
+
+
+def _records(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_record_lands_in_the_audit_zone(audit_root):
+    written = refusal_audit.record_refusal(
+        layer=refusal_audit.LAYER_IMPORT_DENYLIST,
+        trigger=["Import of 'epics' is not allowed in readonly mode"],
+        source="import epics\nepics.caput('SR:MAG:QF:01:CURRENT:SP', 150)",
+        description="nudge the corrector",
+        tool="execute",
+    )
+
+    assert written == audit_root / refusal_audit.REFUSAL_LOG_FILENAME
+    assert written.is_file()
+
+
+def test_record_carries_the_offending_source(audit_root):
+    code = "w = getattr(epics, 'ca' + 'put')\nw('SR:MAG:QF:01:CURRENT:SP', 150)"
+    refusal_audit.record_refusal(
+        layer=refusal_audit.LAYER_RUNTIME_GUARD,
+        trigger="readonly execution mode: control-system writes are refused",
+        source=code,
+        description="nudge the corrector",
+        tool="execute",
+    )
+
+    (record,) = _records(audit_root / refusal_audit.REFUSAL_LOG_FILENAME)
+    assert record["source"] == code
+    assert record["layer"] == refusal_audit.LAYER_RUNTIME_GUARD
+    assert record["mode"] == "readonly"
+    assert record["tool"] == "execute"
+    assert record["description"] == "nudge the corrector"
+    assert record["ts"].endswith("Z")
+
+
+def test_log_is_append_only(audit_root):
+    for index in range(3):
+        refusal_audit.record_refusal(
+            layer=refusal_audit.LAYER_PATTERN_DETECTION,
+            trigger={"writes": [r"\bcaput\s*\("]},
+            source=f"caput('PV{index}', 1)",
+            tool="execute",
+        )
+
+    records = _records(audit_root / refusal_audit.REFUSAL_LOG_FILENAME)
+    assert [r["source"] for r in records] == [
+        "caput('PV0', 1)",
+        "caput('PV1', 1)",
+        "caput('PV2', 1)",
+    ]
+
+
+def test_oversized_source_is_truncated_and_says_so(audit_root):
+    refusal_audit.record_refusal(
+        layer=refusal_audit.LAYER_PATTERN_DETECTION,
+        trigger={"writes": [r"\bcaput\s*\("]},
+        source="x" * (refusal_audit.MAX_SOURCE_CHARS + 500),
+        tool="execute",
+    )
+
+    (record,) = _records(audit_root / refusal_audit.REFUSAL_LOG_FILENAME)
+    assert len(record["source"]) == refusal_audit.MAX_SOURCE_CHARS
+    assert record["source_truncated"] is True
+
+
+def test_source_at_the_bound_is_not_marked_truncated(audit_root):
+    refusal_audit.record_refusal(
+        layer=refusal_audit.LAYER_PATTERN_DETECTION,
+        trigger=[],
+        source="x" * refusal_audit.MAX_SOURCE_CHARS,
+        tool="execute",
+    )
+
+    (record,) = _records(audit_root / refusal_audit.REFUSAL_LOG_FILENAME)
+    assert "source_truncated" not in record
+
+
+def test_unwritable_audit_zone_does_not_raise(monkeypatch, caplog):
+    """A refusal must never become a traceback because the log could not be written."""
+
+    def _explode():
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(refusal_audit, "audit_dir", _explode)
+
+    assert (
+        refusal_audit.record_refusal(
+            layer=refusal_audit.LAYER_RUNTIME_GUARD,
+            trigger="refused",
+            source="epics.caput('PV', 1)",
+        )
+        is None
+    )
+
+
+def test_the_event_reaches_the_server_log_even_without_a_file(monkeypatch, caplog):
+    """The durable record is the goal; the log line is the floor under it."""
+
+    def _explode():
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(refusal_audit, "audit_dir", _explode)
+
+    with caplog.at_level("WARNING"):
+        refusal_audit.record_refusal(
+            layer=refusal_audit.LAYER_IMPORT_DENYLIST,
+            trigger=["Import of 'epics' is not allowed in readonly mode"],
+            source="import epics",
+        )
+
+    assert "Refused a control-system write in readonly mode" in caplog.text
+    assert refusal_audit.LAYER_IMPORT_DENYLIST in caplog.text
+
+
+def test_audit_dir_sits_under_the_state_zone(monkeypatch, tmp_path):
+    """The path is derived, not spelled — it must track the repo the executor uses."""
+    from osprey.utils.workspace import AUDIT_DIR_RELPATH
+
+    monkeypatch.setattr(
+        "osprey.utils.workspace.resolve_project_root", lambda *_args, **_kwargs: tmp_path
+    )
+    monkeypatch.setattr("osprey.utils.workspace.load_osprey_config", lambda *_a, **_k: {})
+
+    assert refusal_audit.audit_dir() == tmp_path / AUDIT_DIR_RELPATH
+    assert refusal_audit.refusal_log_path().name == refusal_audit.REFUSAL_LOG_FILENAME

--- a/tests/templates/test_control_system_safety_rule.py
+++ b/tests/templates/test_control_system_safety_rule.py
@@ -100,13 +100,17 @@ def test_both_client_flavors_and_rpc_carry_bypass_annotations(tmp_path):
         assert "refused at runtime" in annotation
 
 
-def test_rpc_refusal_is_explained_as_unconditional(tmp_path):
-    """The prose behind the rpc line says approval cannot rescue the call."""
+def test_rpc_refusal_is_explained_honestly(tmp_path):
+    """The prose behind the rpc line says approval cannot rescue the call, and
+    names when the runtime refusal actually applies (readonly runs; limits
+    checking) rather than overclaiming an unconditional block."""
     content = _render_safety_rule(tmp_path, "p4p-rpc-prose", "epics")
 
     prose = " ".join(content.split())
     assert "`ctxt.rpc(...)` is the one to remember" in prose
-    assert "refused at runtime and no approval can let it through" in prose
+    assert "there is nothing for the approval workflow to check" in prose
+    assert "refused at runtime in every readonly run" in prose
+    assert "wherever limits checking is enabled" in prose
     assert "Use `write_channel` for the write you actually need." in prose
 
 


### PR DESCRIPTION
## Summary

Closes #661.

Closes the gap where `execution_mode="readonly"` in the python executor was enforced only by pre-execution regex scanning. An aliased spelling (`from epics import caput as _w`) evaded every write pattern and executed without approval — and because gateway selection followed the deployment posture, a readonly script that first called `read_channel()` did so over the **write** gateway on a `writes_enabled: true` deployment.

Six changes, one per commit:

1. **Readwrite always asks** — the approval hook's `selective` policy compared `execution_mode` against `"write"`, which is not a valid mode, so the branch was dead and approval rested entirely on pattern detection. A readwrite run now prompts regardless of how the write is spelled.

2. **Readonly is enforced at runtime** — the executor exports `OSPREY_EXECUTION_MODE` into the sandbox, and the mode is enforced where the write happens:
   - the execution wrapper replaces every direct-library write entry point (`epics.caput`, `PV.put`, `epics.ca.put`, p4p `Context.put`/`rpc` in all three client flavors) with a refusing function — independent of the limits validator, defaulting to readonly (fail closed);
   - the connector base class refuses `write_channel` in readonly runs, with a message that points to `execution_mode='readwrite'` rather than `writes_enabled`;
   - the EPICS connector stays on the `read_only` gateway in readonly runs, so a raw write is also rejected at the network layer.

3. **Readonly runs cannot import control-system clients** — `epics`, `p4p`, `caproto`, `pvaccess`, `tango` are refused at the import statement (AST walk, immune to aliasing, no regex false positives). Reads go through `read_channel()`.

4. **The indirect routes are refused too** — caproto, pvaPy and Tango had a static import denial and nothing behind it, which `importlib.import_module` walks straight past; they now get the same runtime treatment as pyepics and p4p. Added with them are the two routes that reach a control system without importing a client at all: starting a process (a shelled-out `caput` — `subprocess.*`, `os.system`/`popen`/`exec*`/`spawn*`/`posix_spawn`) and loading a shared library (`ctypes.CDLL`, `ctypes.cdll.<name>`). A readonly script therefore cannot shell out or open a shared library even for unrelated work; such work is resubmitted as readwrite, which requires approval. `os.fork` is deliberately left working — forking alone cannot start a new program, and the exec half of every fork-and-exec is refused. The entry points now live in one table, so adding a facility's library enforces it with no other change.

5. **Refused writes are alerted and audited** — a blocked write was previously visible only to the agent, as an error. The Web Terminal is now told that a write was attempted and blocked, and the attempt is appended, with the offending source, to `var/audit/readonly-refusals.jsonl` — a zone builds never touch and `osprey reset` keeps unless `--purge-audit` is passed. This covers the runtime layers too: they refuse inside the subprocess, so the news reaches the tool only as a traceback on stderr, and matching on the substring the guard and the connector refusal share picks up both. Recording never fails a refusal — an unwritable audit directory downgrades the trail to a server-log warning rather than turning a blocked write into a traceback that reads like the gate malfunctioned.

6. **The write surface is documented** — the how-to described it across three docstrings and named no canonical list. It now carries one, written from the same table the guard reads, plus what an operator sees when a write is refused and where the record lands. This commit also corrects the control-system safety rule, which told the agent to pass `execution_mode: "write"` — not an accepted value, so an agent following its own safety rule was rejected before its script ran.

The pattern-detection docstrings and the shipped safety rule now describe the regex scan as what it is — an intent classifier feeding the approval flow and audit trail — instead of a security layer, and the rpc paragraph states when the runtime refusal actually applies.

## Known limits

`ctypes` and process spawning are refused at runtime rather than before execution. No static check can see `importlib.import_module("subpro" + "cess")`, so runtime is the real boundary; the operator alert and the audit record fire either way.

Enforcement now lives in code rather than in a config-held pattern list, so editing `control_system.patterns` degrades the audit trail rather than the enforcement. The code is still agent-writable, which leaves #660 a genuine problem — a differently shaped one.

## Testing

- New: `tests/services/python_executor/execution/test_readonly_guard.py` (guard source executed against fake `epics`/`p4p`/`caproto`/`pvaccess`/`tango`, including the aliased, `getattr` and `importlib` spellings, the process-spawning and `ctypes` routes, and that reads and `os.fork` survive untouched), `tests/connectors/test_readonly_run_refusal.py` (base-class refusal semantics, and a pin keeping the connector's refusal message matchable by the tool layer), `tests/services/python_executor/test_refusal_audit.py` (record shape, truncation, append-only, never raises).
- Extended: approval-hook tests (readwrite-always-asks incl. aliased caput), executor-adapter env plumbing, EPICS gateway selection under readonly runs, readonly import denylist at both tool entry points, and the agent-activity emit sites — where the readonly refusal case is inverted, since a refused write is now reported rather than silent.
- Full unit suite green; the assembled readonly wrapper was also verified end-to-end in a real subprocess, refusing the aliased, `importlib`, shelled-`caput`, `os.popen` and `ctypes` spellings while ordinary numpy work ran normally.
