### PR TITLE
fix(ariel): index semantic search enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Compatibility is documented in release notes, not encoded in the version string.
   `selective` policy, independent of whether the write-pattern scanner
   recognises the code's spelling.
 
+### Fixed
+
+- ARIEL keyword search now keeps raw and semantic full-text indexes in sync so
+  semantic summaries and keywords participate in keyword and hybrid retrieval.
+
 ### Added
 
 - A fresh `profile.yml` now shows its whole menu: every hook, rule, skill,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,9 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
-- ARIEL keyword search now keeps raw and semantic full-text indexes in sync so
-  semantic summaries and keywords participate in keyword and hybrid retrieval.
+- ARIEL keyword search now keeps raw and semantic full-text indexes in sync;
+  semantic summaries and keywords reach keyword and hybrid retrieval immediately,
+  and existing QMD mirrors backfill automatically after the renderer changes.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Compatibility is documented in release notes, not encoded in the version string.
 - ARIEL keyword search now keeps raw and semantic full-text indexes in sync;
   semantic summaries and keywords reach keyword and hybrid retrieval immediately,
   and existing QMD mirrors backfill automatically after the renderer changes.
+- The pyAT specialist now saves and confirms a structured lattice-analysis
+  JSON artifact before returning computed optics results.
 
 ### Added
 

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -509,9 +509,17 @@ async def run_watch(
 # qmd markdown-mirror resync
 # ---------------------------------------------------------------------------
 
-#: File at the mirror root holding the last resync watermark, as an ISO-8601
-#: UTC timestamp. Dot-prefixed so the sidecar skips it as a corpus document.
+#: File at the mirror root holding the last resync watermark. Dot-prefixed so
+#: the sidecar skips it as a corpus document.
 QMD_WATERMARK_NAME = ".qmd-resync-watermark"
+
+#: Serialization schema for the watermark marker itself.
+QMD_WATERMARK_FORMAT_VERSION = 1
+
+#: Markdown renderer format represented by a current watermark. Bump this when
+#: existing rows must be re-rendered even though their database values did not
+#: change; old markers will then force one full backfill scan.
+QMD_RENDERER_VERSION = 1
 
 #: Rows fetched per page while scanning for changed entries. Bounds the memory
 #: a rebuild of a large logbook needs without making the scan chatty.
@@ -585,19 +593,41 @@ def _read_qmd_watermark(mirror_root: Path) -> datetime | None:
 
     Returns:
         The stored timestamp as an aware UTC ``datetime``, or ``None`` when no
-        watermark exists or the stored value cannot be parsed. Both cases fall
-        back to a full scan, which is correct but slower -- never wrong.
+        current, valid watermark exists. Missing, legacy, corrupt, and
+        version-mismatched markers all fall back to a full scan, which is
+        correct but slower -- never wrong.
     """
+    import json
     from datetime import UTC, datetime
 
     marker = mirror_root / QMD_WATERMARK_NAME
     try:
-        raw = marker.read_text(encoding="utf-8").strip()
-    except OSError:
+        raw = marker.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
         return None
 
     try:
-        moment = datetime.fromisoformat(raw)
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    format_version = payload.get("format_version")
+    renderer_version = payload.get("renderer_version")
+    if (
+        type(format_version) is not int
+        or format_version != QMD_WATERMARK_FORMAT_VERSION
+        or type(renderer_version) is not int
+        or renderer_version != QMD_RENDERER_VERSION
+    ):
+        return None
+
+    raw_moment = payload.get("updated_at")
+    if not isinstance(raw_moment, str):
+        return None
+    try:
+        moment = datetime.fromisoformat(raw_moment)
     except ValueError:
         return None
     return moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment.astimezone(UTC)
@@ -615,8 +645,18 @@ def _write_qmd_watermark(mirror_root: Path, moment: datetime) -> None:
             but could not record where it stopped must fail loudly, because the
             silent alternative is re-exporting from the old watermark forever.
     """
+    import json
+    from datetime import UTC
+
+    normalized = moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment.astimezone(UTC)
+    payload = {
+        "format_version": QMD_WATERMARK_FORMAT_VERSION,
+        "renderer_version": QMD_RENDERER_VERSION,
+        "updated_at": normalized.isoformat(),
+    }
+    serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
     mirror_root.mkdir(parents=True, exist_ok=True)
-    _atomic_write_text(mirror_root / QMD_WATERMARK_NAME, f"{moment.isoformat()}\n")
+    _atomic_write_text(mirror_root / QMD_WATERMARK_NAME, f"{serialized}\n")
 
 
 def _touch_qmd_marker(mirror_root: Path) -> bool:

--- a/src/osprey/services/ariel_search/database/core_migration.py
+++ b/src/osprey/services/ariel_search/database/core_migration.py
@@ -7,6 +7,7 @@ regardless of which modules are enabled.
 from typing import TYPE_CHECKING
 
 from osprey.services.ariel_search.database.migrations import BaseMigration
+from osprey.services.ariel_search.database.search_fts import RAW_TEXT_FTS_EXPRESSION
 
 if TYPE_CHECKING:
     from psycopg import AsyncConnection
@@ -86,6 +87,14 @@ class CoreMigration(BaseMigration):
             """
             CREATE INDEX IF NOT EXISTS idx_entries_raw_text_trgm
             ON enhanced_entries USING GIN(raw_text gin_trgm_ops)
+            """
+        )
+
+        # Raw-text full-text index for keyword search when semantic processing is disabled
+        await conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_entries_raw_text_fts
+            ON enhanced_entries USING GIN({RAW_TEXT_FTS_EXPRESSION})
             """
         )
 

--- a/src/osprey/services/ariel_search/database/keyword_search_migration.py
+++ b/src/osprey/services/ariel_search/database/keyword_search_migration.py
@@ -1,0 +1,41 @@
+"""Reconcile the core keyword-search full-text index.
+
+Existing deployments may already have ``core_schema`` marked as applied from
+before keyword search had a raw-text FTS index. This additive migration makes
+that index appear without mutating the historical migration record.
+"""
+
+from typing import TYPE_CHECKING
+
+from osprey.services.ariel_search.database.migrations import BaseMigration
+from osprey.services.ariel_search.database.search_fts import RAW_TEXT_FTS_EXPRESSION
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+
+class KeywordSearchFtsMigration(BaseMigration):
+    """Adds the always-available raw-text FTS index for keyword search."""
+
+    @property
+    def name(self) -> str:
+        """Return migration identifier."""
+        return "keyword_search_fts_index"
+
+    @property
+    def depends_on(self) -> list[str]:
+        """Depends on the core enhanced_entries table."""
+        return ["core_schema"]
+
+    async def up(self, conn: "AsyncConnection") -> None:
+        """Apply the raw-text FTS index migration."""
+        await conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_entries_raw_text_fts
+            ON enhanced_entries USING GIN({RAW_TEXT_FTS_EXPRESSION})
+            """
+        )
+
+    async def down(self, conn: "AsyncConnection") -> None:
+        """Rollback the raw-text FTS index migration."""
+        await conn.execute("DROP INDEX IF EXISTS idx_entries_raw_text_fts")

--- a/src/osprey/services/ariel_search/database/migrations.py
+++ b/src/osprey/services/ariel_search/database/migrations.py
@@ -175,9 +175,21 @@ KNOWN_MIGRATIONS: list[tuple[str, str, str, str | None]] = [
         None,
     ),
     (
+        "keyword_search_fts_index",
+        "osprey.services.ariel_search.database.keyword_search_migration",
+        "KeywordSearchFtsMigration",
+        None,
+    ),
+    (
         "semantic_processor",
         "osprey.services.ariel_search.enhancement.semantic_processor.migration",
         "SemanticProcessorMigration",
+        "semantic_processor",
+    ),
+    (
+        "semantic_processor_search_index",
+        "osprey.services.ariel_search.enhancement.semantic_processor.search_migration",
+        "SemanticProcessorSearchMigration",
         "semantic_processor",
     ),
     (

--- a/src/osprey/services/ariel_search/database/repository.py
+++ b/src/osprey/services/ariel_search/database/repository.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from osprey.services.ariel_search.database.search_fts import keyword_search_expressions
 from osprey.services.ariel_search.exceptions import (
     DatabaseQueryError,
     ModuleNotEnabledError,
@@ -806,15 +807,15 @@ class ARIELRepository:
                 async with conn.cursor(row_factory=dict_row) as cur:
                     where_sql = " AND ".join(where_clauses) if where_clauses else "TRUE"
 
-                    # raw_text contains subject + details merged by adapter
+                    fts_expression, headline_document = keyword_search_expressions(self.config)
                     if include_highlights:
                         query = f"""
                             SELECT e.*,
                                    ts_rank(
-                                       to_tsvector('english', raw_text),
+                                       {fts_expression},
                                        plainto_tsquery('english', %s)
                                    ) AS rank,
-                                   ts_headline('english', raw_text, plainto_tsquery('english', %s),
+                                   ts_headline('english', {headline_document}, plainto_tsquery('english', %s),
                                        'StartSel=<b>, StopSel=</b>, MaxFragments=3'
                                    ) AS headline
                             FROM enhanced_entries e
@@ -827,7 +828,7 @@ class ARIELRepository:
                         query = f"""
                             SELECT e.*,
                                    ts_rank(
-                                       to_tsvector('english', raw_text),
+                                       {fts_expression},
                                        plainto_tsquery('english', %s)
                                    ) AS rank,
                                    NULL AS headline

--- a/src/osprey/services/ariel_search/database/search_fts.py
+++ b/src/osprey/services/ariel_search/database/search_fts.py
@@ -1,0 +1,34 @@
+"""Shared ARIEL keyword-search full-text expressions.
+
+The query predicates and expression indexes must parse to the same PostgreSQL
+expression, or the planner cannot use the index. Keep those strings here rather
+than letting migrations and search code drift independently.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from osprey.services.ariel_search.config import ARIELConfig
+
+RAW_TEXT_SEARCH_DOCUMENT = "raw_text"
+RAW_TEXT_FTS_EXPRESSION = f"to_tsvector('english', {RAW_TEXT_SEARCH_DOCUMENT})"
+SEMANTIC_KEYWORDS_DOCUMENT = "osprey_text_array_to_string(keywords)"
+SEMANTIC_TEXT_SEARCH_DOCUMENT = (
+    f"raw_text || ' ' || COALESCE(summary, '') || ' ' || COALESCE({SEMANTIC_KEYWORDS_DOCUMENT}, '')"
+)
+SEMANTIC_FTS_EXPRESSION = f"to_tsvector('english', {SEMANTIC_TEXT_SEARCH_DOCUMENT})"
+
+
+def keyword_search_expressions(config: ARIELConfig) -> tuple[str, str]:
+    """Return the ranking FTS expression and headline document for keyword search."""
+    if config.is_enhancement_module_enabled("semantic_processor"):
+        return SEMANTIC_FTS_EXPRESSION, SEMANTIC_TEXT_SEARCH_DOCUMENT
+    return RAW_TEXT_FTS_EXPRESSION, RAW_TEXT_SEARCH_DOCUMENT
+
+
+def keyword_fts_expression(config: ARIELConfig) -> str:
+    """Return the FTS predicate expression available for the configured schema."""
+    expression, _document = keyword_search_expressions(config)
+    return expression

--- a/src/osprey/services/ariel_search/enhancement/qmd_export/writer.py
+++ b/src/osprey/services/ariel_search/enhancement/qmd_export/writer.py
@@ -192,6 +192,8 @@ def render_entry(entry: Mapping[str, Any]) -> str:
     author = sanitize_text(entry.get("author")).strip()
     source = sanitize_text(entry.get("source_system")).strip()
     raw_text = sanitize_text(entry.get("raw_text")).strip()
+    summary = sanitize_text(entry.get("summary")).strip()
+    keywords = _render_keywords(entry.get("keywords"))
     stamp = _format_timestamp(entry.get("timestamp"))
 
     lines = [
@@ -203,6 +205,10 @@ def render_entry(entry: Mapping[str, Any]) -> str:
     metadata_line = _render_metadata(entry.get("metadata"))
     if metadata_line:
         lines.append(metadata_line)
+    if summary:
+        lines.append(f"Summary: {_sentence(summary)}")
+    if keywords:
+        lines.append(f"Keywords: {_sentence(keywords)}")
     lines.extend(["", raw_text])
 
     document = "\n".join(lines).rstrip("\n") + "\n"
@@ -382,6 +388,26 @@ def _render_metadata(metadata: Any) -> str:
             continue
         fragments.append(f"{sanitize_text(key).strip()}: {text}.")
     return " ".join(fragments)
+
+
+def _render_keywords(keywords: Any) -> str:
+    """Render semantic keywords as deterministic searchable prose."""
+    if not isinstance(keywords, list | tuple):
+        return ""
+
+    rendered = []
+    for keyword in keywords:
+        text = sanitize_text(keyword).strip()
+        if text:
+            rendered.append(text)
+    if not rendered:
+        return ""
+    return f"{', '.join(rendered)}"
+
+
+def _sentence(text: str) -> str:
+    """End rendered enrichment prose with exactly one sentence terminator."""
+    return text if text.endswith((".", "!", "?")) else f"{text}."
 
 
 def _apply_cap(document: str) -> str:

--- a/src/osprey/services/ariel_search/enhancement/semantic_processor/migration.py
+++ b/src/osprey/services/ariel_search/enhancement/semantic_processor/migration.py
@@ -7,7 +7,6 @@ enhancement module.
 from typing import TYPE_CHECKING
 
 from osprey.services.ariel_search.database.migrations import BaseMigration
-from osprey.services.ariel_search.database.search_fts import SEMANTIC_FTS_EXPRESSION
 
 if TYPE_CHECKING:
     from psycopg import AsyncConnection
@@ -19,7 +18,6 @@ class SemanticProcessorMigration(BaseMigration):
     Creates:
     - summary column on enhanced_entries
     - keywords column on enhanced_entries
-    - Full-text search indexes
     """
 
     @property
@@ -44,28 +42,6 @@ class SemanticProcessorMigration(BaseMigration):
             """
             ALTER TABLE enhanced_entries
             ADD COLUMN IF NOT EXISTS keywords TEXT[] DEFAULT '{}'
-            """
-        )
-
-        await conn.execute(
-            """
-            CREATE OR REPLACE FUNCTION osprey_text_array_to_string(TEXT[])
-            RETURNS TEXT
-            LANGUAGE sql
-            IMMUTABLE
-            PARALLEL SAFE
-            RETURNS NULL ON NULL INPUT
-            AS $$ SELECT array_to_string($1, ' ') $$
-            """
-        )
-        await conn.execute("DROP INDEX IF EXISTS idx_entries_keywords")
-        await conn.execute("DROP INDEX IF EXISTS idx_entries_text_search")
-
-        await conn.execute(
-            f"""
-            CREATE INDEX IF NOT EXISTS idx_entries_text_search
-            ON enhanced_entries
-            USING GIN({SEMANTIC_FTS_EXPRESSION})
             """
         )
 

--- a/src/osprey/services/ariel_search/enhancement/semantic_processor/processor.py
+++ b/src/osprey/services/ariel_search/enhancement/semantic_processor/processor.py
@@ -137,6 +137,12 @@ class SemanticProcessorModule(BaseEnhancementModule):
                     summary=result.summary,
                     conn=conn,
                 )
+                entry.update(
+                    {
+                        "keywords": result.keywords,
+                        "summary": result.summary,
+                    }
+                )
 
         except Exception as e:
             logger.warning(f"Failed to process entry {entry.get('entry_id')}: {e}")

--- a/src/osprey/services/ariel_search/enhancement/semantic_processor/search_migration.py
+++ b/src/osprey/services/ariel_search/enhancement/semantic_processor/search_migration.py
@@ -1,7 +1,8 @@
-"""ARIEL semantic processor migration.
+"""Reconcile semantic processor keyword-search indexes.
 
-This module provides the database migration for the semantic processor
-enhancement module.
+Deployments that applied the original semantic processor migration already have
+its migration record, so they need a separate additive migration to rebuild the
+keyword FTS expression and remove the unqueried keyword-array index.
 """
 
 from typing import TYPE_CHECKING
@@ -13,40 +14,21 @@ if TYPE_CHECKING:
     from psycopg import AsyncConnection
 
 
-class SemanticProcessorMigration(BaseMigration):
-    """Semantic processor enhancement migration.
-
-    Creates:
-    - summary column on enhanced_entries
-    - keywords column on enhanced_entries
-    - Full-text search indexes
-    """
+class SemanticProcessorSearchMigration(BaseMigration):
+    """Rebuilds semantic keyword-search indexes for summary and keywords."""
 
     @property
     def name(self) -> str:
         """Return migration identifier."""
-        return "semantic_processor"
+        return "semantic_processor_search_index"
 
     @property
     def depends_on(self) -> list[str]:
-        """Depends on core schema."""
-        return ["core_schema"]
+        """Depends on semantic processor columns being present."""
+        return ["semantic_processor"]
 
     async def up(self, conn: "AsyncConnection") -> None:
-        """Apply the semantic processor migration."""
-        await conn.execute(
-            """
-            ALTER TABLE enhanced_entries
-            ADD COLUMN IF NOT EXISTS summary TEXT
-            """
-        )
-        await conn.execute(
-            """
-            ALTER TABLE enhanced_entries
-            ADD COLUMN IF NOT EXISTS keywords TEXT[] DEFAULT '{}'
-            """
-        )
-
+        """Apply the enriched semantic FTS index migration."""
         await conn.execute(
             """
             CREATE OR REPLACE FUNCTION osprey_text_array_to_string(TEXT[])
@@ -60,7 +42,6 @@ class SemanticProcessorMigration(BaseMigration):
         )
         await conn.execute("DROP INDEX IF EXISTS idx_entries_keywords")
         await conn.execute("DROP INDEX IF EXISTS idx_entries_text_search")
-
         await conn.execute(
             f"""
             CREATE INDEX IF NOT EXISTS idx_entries_text_search
@@ -70,9 +51,5 @@ class SemanticProcessorMigration(BaseMigration):
         )
 
     async def down(self, conn: "AsyncConnection") -> None:
-        """Rollback the semantic processor migration."""
+        """Rollback the enriched semantic FTS index migration."""
         await conn.execute("DROP INDEX IF EXISTS idx_entries_text_search")
-        await conn.execute("DROP INDEX IF EXISTS idx_entries_keywords")
-
-        await conn.execute("ALTER TABLE enhanced_entries DROP COLUMN IF EXISTS keywords")
-        await conn.execute("ALTER TABLE enhanced_entries DROP COLUMN IF EXISTS summary")

--- a/src/osprey/services/ariel_search/search/keyword.py
+++ b/src/osprey/services/ariel_search/search/keyword.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
+from osprey.services.ariel_search.database.search_fts import keyword_fts_expression
 from osprey.services.ariel_search.search.base import ParameterDescriptor, SearchToolDescriptor
 from osprey.utils.logger import get_logger
 
@@ -198,10 +199,8 @@ async def keyword_search(
         for phrase in phrases:
             params.append(phrase)
 
-        # Search is performed on raw_text which contains subject + details
-        where_clauses.append(
-            f"to_tsvector('english', raw_text) @@ ({build_tsquery(search_text, phrases)})"
-        )
+        fts_expression = keyword_fts_expression(config)
+        where_clauses.append(f"{fts_expression} @@ ({build_tsquery(search_text, phrases)})")
 
     if "author" in field_filters:
         where_clauses.append("author ILIKE %s")

--- a/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
@@ -148,12 +148,15 @@ For chromaticity, call `at.get_optics(ring4d, get_chrom=True, dp=1e-6)` and read
 
 ## Returning Results
 
-Follow this sequence so both a machine-readable channel and a human summary exist:
+Follow this sequence so both a machine-readable channel and a human summary exist.
+**A successful computation is not complete until this artifact exists.**
 
-1. **Inside the executed code, convert every computed quantity to a NATIVE Python
-   type BEFORE saving.** The artifact serializer uses `json.dumps(..., default=str)`,
-   which **lossily stringifies** numpy ndarrays and non-`float64` numpy scalars. Coerce
-   explicitly:
+1. **In the same `mcp__python__execute` call that computes the answer, save the
+   computed quantities as a structured results artifact.** Build a `dict`, convert
+   every computed quantity to a NATIVE Python type, and make the artifact type and
+   category explicit. The serializer uses `json.dumps(..., default=str)`, which
+   **lossily stringifies** numpy ndarrays and non-`float64` numpy scalars, so coerce
+   them before saving:
 
    ```python
    result = {
@@ -165,19 +168,39 @@ Follow this sequence so both a machine-readable channel and a human summary exis
        "lattice": "ALS-U AR design lattice (simulated)",
        "computed_4d": True,
    }
-   save_artifact(result, "AR Optics Result", "Computed from the simulated ALS-U AR design lattice.")
+   save_artifact(
+       result,
+       title="AR Optics Result",
+       description="Computed from the simulated ALS-U AR design lattice.",
+       artifact_type="json",
+       category="lattice_analysis",
+   )
    print(result)   # so the value is also visible in stdout
    ```
 
-   `save_artifact(obj, title, description)` is injected into the execution environment
-   (a dict serializes to full-precision JSON). This is the authoritative results
-   channel — the parent and downstream tools read it.
+   `save_artifact(obj, title, description, artifact_type, category)` is injected
+   into the execution environment by the workspace API. Passing a native `dict`
+   with `artifact_type="json"` and `category="lattice_analysis"` produces the
+   authoritative, full-precision, non-`code_output` results JSON that the parent and
+   downstream tools read.
 
-2. **Summarize in prose** for the parent: the key numbers, the recipe used (4D vs 6D),
-   and the explicit statement that everything was computed from the simulated ALS-U AR
-   design lattice.
+   The automatic notebook, the automatic `code_output` JSON, and the Markdown
+   from `submit_response` do **not** satisfy this requirement. They are
+   supplementary records, not the structured results artifact.
 
-3. **Call `submit_response`** as your last action, tagging provenance:
+2. **Confirm the results artifact before handing off.** Call
+   `artifact_list(category="lattice_analysis", last_n=1)` and verify that the saved
+   entry has `artifact_type="json"`. If it does not, do not submit a successful
+   response; run a self-contained compute-and-save call that creates it.
+
+3. **Summarize in prose** for the parent: the key numbers, the recipe used (4D vs
+   6D), and the explicit statement that everything was computed from the simulated
+   ALS-U AR design lattice.
+
+4. **Call `submit_response`** only after artifact confirmation. Do **not** call
+   `submit_response` until the structured `artifact_type="json"`,
+   `category="lattice_analysis"` results artifact has been saved and confirmed.
+   Then call `submit_response` as your last action, tagging provenance:
 
    ```
    submit_response(
@@ -188,8 +211,8 @@ Follow this sequence so both a machine-readable channel and a human summary exis
    )
    ```
 
-4. **Echo the saved artifact id(s)** in your reply so the parent can reference or
-   re-delegate them.
+5. **Echo the confirmed results artifact id(s)** in your reply so the parent can
+   reference or re-delegate them.
 
 ## Handoff to Visualization
 
@@ -201,6 +224,8 @@ parent can re-delegate them to `data-visualizer`. Do not attempt to visualize yo
 
 - **Never fabricate numbers.** Report only values your executed code actually produced;
   on instability/non-convergence, report the instability.
+- **For every successful computation, save and confirm a non-`code_output` JSON
+  results artifact before calling `submit_response`.**
 - **Always `execution_mode="readonly"`.**
 - **Always label answers as computed from the simulated ALS-U AR design lattice**, in
   both prose and provenance metadata.

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -54,14 +54,11 @@ def _guard_os_exit(monkeypatch: pytest.MonkeyPatch) -> None:
 def _neutral_color_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Strip color-forcing variables from the environment CLI tests run under.
 
-    Leak guarded: Rich and Click honor ``FORCE_COLOR``/``CLICOLOR_FORCE`` as a
-    documented opt-in, so a developer whose terminal exports either gets ANSI
-    escapes inside ``CliRunner``'s captured output — and a false-red lane on
-    pristine main (seven tests: exact-output asserts, plus two whose captured
-    YAML stops parsing on ``\\x1b``). CI is green only because its runners
-    never export them; this makes the suite hermetic instead of lucky.
-    ``NO_COLOR`` is left alone: unset it is the same default CI runs under,
-    and pinning it would hide a command that fails to honor the opt-out.
+    Rich and Click honor ``FORCE_COLOR``/``CLICOLOR_FORCE`` as documented
+    opt-ins, so a developer exporting either gets ANSI escapes inside
+    ``CliRunner`` captures. ``NO_COLOR`` is left alone so command-level tests
+    still catch code that fails to honor the opt-out; test consoles that
+    specifically assert terminal styling override it locally.
     """
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.delenv("CLICOLOR_FORCE", raising=False)
@@ -299,6 +296,7 @@ def terminal_probe(
         width=100,
         force_terminal=True,
         color_system="truecolor",
+        no_color=False,
         legacy_windows=False,
         theme=osprey_theme,
     )

--- a/tests/cli/test_config_view_render.py
+++ b/tests/cli/test_config_view_render.py
@@ -48,6 +48,8 @@ def terminal(monkeypatch: pytest.MonkeyPatch) -> StringIO:
     console = Console(
         file=buffer,
         force_terminal=True,
+        color_system="standard",
+        no_color=False,
         width=100,
         theme=styles.osprey_theme,
         legacy_windows=False,

--- a/tests/cli/test_live_render.py
+++ b/tests/cli/test_live_render.py
@@ -45,7 +45,14 @@ def make_row(
 
 def render(rows, *, phase_open=False, elapsed=0.0, now=0.0, width=100, styles=False) -> str:
     """Render the region at ``width`` and return what a terminal would show."""
-    console = Console(theme=osprey_theme, width=width, record=True, force_terminal=True)
+    console = Console(
+        theme=osprey_theme,
+        width=width,
+        record=True,
+        force_terminal=True,
+        color_system="standard",
+        no_color=False,
+    )
     console.print(
         render_live_region(rows, phase_open=phase_open, elapsed=elapsed, now=now, width=width)
     )
@@ -279,7 +286,12 @@ def test_region_follows_the_active_theme() -> None:
 
     def styled(theme: ColorTheme) -> str:
         console = Console(
-            theme=_build_rich_theme(theme), width=100, record=True, force_terminal=True
+            theme=_build_rich_theme(theme),
+            width=100,
+            record=True,
+            force_terminal=True,
+            color_system="standard",
+            no_color=False,
         )
         console.print(render_live_region(rows, phase_open=True, elapsed=1.0, now=1.0, width=100))
         return console.export_text(styles=True)

--- a/tests/cli/test_output_primitives.py
+++ b/tests/cli/test_output_primitives.py
@@ -94,9 +94,10 @@ def recording_console(*, width: int = 100, terminal: bool = True) -> tuple[Conso
     """A themed terminal console that records everything written to it.
 
     ``force_terminal`` is what makes a ``Live`` real: off a terminal Rich skips
-    the repaint entirely. The theme is not optional either -- the primitives'
-    styles are semantic tokens, and a bare ``Console()`` raises ``MissingStyle``
-    on the first one.
+    the repaint entirely. Explicit color settings keep ANSI output independent
+    of ``NO_COLOR`` and ``TERM``. The theme is not optional either -- the
+    primitives' styles are semantic tokens, and a bare ``Console()`` raises
+    ``MissingStyle`` on the first one.
 
     ``width`` is for the tests that are about layout rather than about words:
     the ledger folds its values at the console's width, so pinning that fold
@@ -104,7 +105,14 @@ def recording_console(*, width: int = 100, terminal: bool = True) -> tuple[Conso
     """
     buffer = io.StringIO()
     return (
-        Console(file=buffer, theme=osprey_theme, force_terminal=terminal, width=width),
+        Console(
+            file=buffer,
+            theme=osprey_theme,
+            force_terminal=terminal,
+            color_system="standard",
+            no_color=False,
+            width=width,
+        ),
         buffer,
     )
 

--- a/tests/cli/test_phase_reporter.py
+++ b/tests/cli/test_phase_reporter.py
@@ -29,7 +29,14 @@ def sink(monkeypatch):
     monkeypatch.setattr(
         phase_reporter,
         "console",
-        Console(file=buffer, theme=osprey_theme, force_terminal=True, width=200),
+        Console(
+            file=buffer,
+            theme=osprey_theme,
+            force_terminal=True,
+            color_system="standard",
+            no_color=False,
+            width=200,
+        ),
     )
     return buffer
 

--- a/tests/cli/test_phase_reporter_live.py
+++ b/tests/cli/test_phase_reporter_live.py
@@ -101,6 +101,8 @@ def recording_console() -> tuple[Console, io.StringIO]:
             file=buffer,
             theme=osprey_theme,
             force_terminal=True,
+            color_system="standard",
+            no_color=False,
             width=100,
             get_time=lambda: 1000.0,
         ),
@@ -939,7 +941,9 @@ def log_handler():
     outlive the buffer it points at.
     """
     stream = io.StringIO()
-    own_console = Console(file=stream, force_terminal=True, width=100)
+    own_console = Console(
+        file=stream, force_terminal=True, color_system="standard", no_color=False, width=100
+    )
     handler = RichHandler(
         console=own_console,
         show_time=False,

--- a/tests/cli/test_phase_reporter_watchers.py
+++ b/tests/cli/test_phase_reporter_watchers.py
@@ -92,7 +92,14 @@ def sink(monkeypatch):
     monkeypatch.setattr(
         phase_reporter,
         "console",
-        Console(file=buffer, theme=osprey_theme, force_terminal=True, width=200),
+        Console(
+            file=buffer,
+            theme=osprey_theme,
+            force_terminal=True,
+            color_system="standard",
+            no_color=False,
+            width=200,
+        ),
     )
     return buffer
 

--- a/tests/cli/test_reset_verb.py
+++ b/tests/cli/test_reset_verb.py
@@ -94,6 +94,8 @@ def live_reporter(monkeypatch: pytest.MonkeyPatch):
     console = Console(
         file=buffer,
         force_terminal=True,
+        color_system="standard",
+        no_color=False,
         width=_WIDTH,
         theme=osprey_theme,
         legacy_windows=False,

--- a/tests/cli/test_summary_card.py
+++ b/tests/cli/test_summary_card.py
@@ -44,11 +44,22 @@ def recording_console(*, terminal: bool = False) -> tuple[Console, io.StringIO]:
 
     The theme is not optional: the card's heading and labels are semantic
     tokens, and a bare ``Console()`` raises ``MissingStyle`` on the first one.
-    ``terminal`` asks for the styled rendering; the default plain one is what
-    every line assertion here reads.
+    Explicit color settings keep the terminal rendering independent of
+    ``NO_COLOR`` and ``TERM``; the default non-terminal rendering stays plain
+    for every line assertion here.
     """
     buffer = io.StringIO()
-    return Console(file=buffer, theme=osprey_theme, force_terminal=terminal, width=200), buffer
+    return (
+        Console(
+            file=buffer,
+            theme=osprey_theme,
+            force_terminal=terminal,
+            color_system="standard" if terminal else None,
+            no_color=not terminal,
+            width=200,
+        ),
+        buffer,
+    )
 
 
 class RecordingReporter(PhaseReporter):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,13 @@ _PRISTINE_LOGGING = {
 os.environ.pop("FORCE_COLOR", None)
 os.environ.pop("CLICOLOR_FORCE", None)
 
+# Rich deliberately clamps ``TERM=dumb`` consoles to 80 columns and suppresses
+# cursor control even when a test explicitly requests ``force_terminal=True``.
+# CI presents a capable TERM, so normalize only the dumb/unknown host values;
+# tests for a restricted terminal can still set one explicitly after collection.
+if os.environ.get("TERM", "").lower() in {"dumb", "unknown"}:
+    os.environ["TERM"] = "xterm-256color"
+
 _PRE_COLLECTION_ENV = dict(os.environ)
 
 

--- a/tests/e2e/claude_code/test_safety_kill_switch.py
+++ b/tests/e2e/claude_code/test_safety_kill_switch.py
@@ -2,15 +2,16 @@
 
 Scenarios 9-10: Master kill switch (writes_enabled: false) blocks all writes.
 
-Uses run_sdk_query_with_hooks to exercise the full hook chain. Kill switch
-returns "deny" (not "ask"), so hook_events should be EMPTY.
+Uses run_sdk_query_with_hooks to exercise the full hook chain. The kill switch
+must deny write paths before they reach approval; unrelated tool hooks may fire.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from tests.e2e.sdk_helpers import run_sdk_query_with_hooks
+from osprey.agent_runner.write_tools import load_write_tools
+from tests.e2e.sdk_helpers import render_dir, run_sdk_query_with_hooks
 
 pytestmark = pytest.mark.harness_benchmark
 
@@ -88,10 +89,25 @@ async def test_channel_write_denied_when_writes_disabled(safety_project_writes_o
         f"  Successful results: {[(t.result or '')[:100] for t in successful_writes]}"
     )
 
-    # Kill switch returns "deny" (not "ask"), so no approval callback fires
-    assert len(result.hook_events) == 0, (
-        f"Expected no hook_events (kill switch denies before ask) "
-        f"but got {len(result.hook_events)}: "
+    # ``hook_events`` records every can_use_tool callback, not only hardware
+    # write approvals. Read-only preparation (for example, channel_limits) may
+    # legitimately produce an allow event. The kill-switch invariant is that no
+    # write-gated invocation reaches approval. ``execute`` is a mixed read/write
+    # tool, so its default readonly mode is not a write attempt.
+    write_tool_names = set(load_write_tools(render_dir(safety_project_writes_off)))
+    write_approval_events = [
+        event
+        for event in result.hook_events
+        if event.tool_name in write_tool_names
+        and (
+            event.tool_name != "mcp__python__execute"
+            or event.tool_input.get("execution_mode", "readonly") != "readonly"
+        )
+    ]
+    assert not write_approval_events, (
+        "Kill switch breached: write path reached the approval callback: "
+        f"{[(e.tool_name, e.tool_input, e.decision) for e in write_approval_events]}. "
+        f"All hook events: "
         f"{[(e.tool_name, e.decision) for e in result.hook_events]}"
     )
 

--- a/tests/e2e/claude_code/test_safety_kill_switch.py
+++ b/tests/e2e/claude_code/test_safety_kill_switch.py
@@ -2,16 +2,15 @@
 
 Scenarios 9-10: Master kill switch (writes_enabled: false) blocks all writes.
 
-Uses run_sdk_query_with_hooks to exercise the full hook chain. The kill switch
-must deny write paths before they reach approval; unrelated tool hooks may fire.
+Uses run_sdk_query_with_hooks to exercise the full hook chain. Kill switch
+returns "deny" (not "ask"), so hook_events should be EMPTY.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from osprey.agent_runner.write_tools import load_write_tools
-from tests.e2e.sdk_helpers import render_dir, run_sdk_query_with_hooks
+from tests.e2e.sdk_helpers import run_sdk_query_with_hooks
 
 pytestmark = pytest.mark.harness_benchmark
 
@@ -89,25 +88,10 @@ async def test_channel_write_denied_when_writes_disabled(safety_project_writes_o
         f"  Successful results: {[(t.result or '')[:100] for t in successful_writes]}"
     )
 
-    # ``hook_events`` records every can_use_tool callback, not only hardware
-    # write approvals. Read-only preparation (for example, channel_limits) may
-    # legitimately produce an allow event. The kill-switch invariant is that no
-    # write-gated invocation reaches approval. ``execute`` is a mixed read/write
-    # tool, so its default readonly mode is not a write attempt.
-    write_tool_names = set(load_write_tools(render_dir(safety_project_writes_off)))
-    write_approval_events = [
-        event
-        for event in result.hook_events
-        if event.tool_name in write_tool_names
-        and (
-            event.tool_name != "mcp__python__execute"
-            or event.tool_input.get("execution_mode", "readonly") != "readonly"
-        )
-    ]
-    assert not write_approval_events, (
-        "Kill switch breached: write path reached the approval callback: "
-        f"{[(e.tool_name, e.tool_input, e.decision) for e in write_approval_events]}. "
-        f"All hook events: "
+    # Kill switch returns "deny" (not "ask"), so no approval callback fires
+    assert len(result.hook_events) == 0, (
+        f"Expected no hook_events (kill switch denies before ask) "
+        f"but got {len(result.hook_events)}: "
         f"{[(e.tool_name, e.decision) for e in result.hook_events]}"
     )
 

--- a/tests/registry/test_pyat_specialist_agent.py
+++ b/tests/registry/test_pyat_specialist_agent.py
@@ -272,6 +272,26 @@ class TestPyatSpecialistAgentTemplate:
         assert "convert every computed quantity to a NATIVE Python type" in normalized
         assert "lossily stringifies" in rendered
 
+    def test_body_requires_results_json_before_submit_response(self, template_manager):
+        """Successful compute must save a distinct lattice-analysis JSON before handoff."""
+        ctx = self._full_ctx(enabled=True)
+        rendered = self._render(template_manager, ctx)
+        normalized = " ".join(rendered.split())
+
+        assert (
+            'save_artifact( result, title="AR Optics Result", description='
+            '"Computed from the simulated ALS-U AR design lattice.", '
+            'artifact_type="json", category="lattice_analysis", )'
+        ) in normalized
+        assert "A successful computation is not complete until this artifact exists" in normalized
+        assert (
+            "The automatic notebook, the automatic `code_output` JSON, and the Markdown "
+            "from `submit_response` do **not** satisfy this requirement"
+        ) in normalized
+        assert '`artifact_list(category="lattice_analysis", last_n=1)`' in rendered
+        assert "Do **not** call `submit_response` until" in normalized
+        assert rendered.index('artifact_type="json"') < rendered.index("**Call `submit_response`**")
+
 
 # ---------------------------------------------------------------------------
 # Control-assistant CLAUDE.md rendering

--- a/tests/services/ariel_search/integration/test_migrations.py
+++ b/tests/services/ariel_search/integration/test_migrations.py
@@ -278,8 +278,8 @@ class TestMigrationSQLExecution:
             # Clean up
             await conn.execute("DELETE FROM enhanced_entries WHERE entry_id = 'test-fts-func-001'")
 
-        # The query plan should reference the index
-        assert "idx_entries_text_search" in plan or "Seq Scan" in plan
+        # The query plan should reference the core raw-text FTS index
+        assert "idx_entries_raw_text_fts" in plan or "Seq Scan" in plan
 
     async def test_primary_key_constraint_exists(self, migrated_pool):
         """Verify primary key constraint exists on enhanced_entries.

--- a/tests/services/ariel_search/integration/test_migrations.py
+++ b/tests/services/ariel_search/integration/test_migrations.py
@@ -102,6 +102,45 @@ class TestSemanticProcessorMigration:
 
         assert len(rows) == 1
 
+    async def test_keyword_search_matches_summary_and_keywords(
+        self, migrated_pool, repository, integration_ariel_config
+    ):
+        """The real PostgreSQL path retrieves terms absent from raw_text."""
+        from osprey.services.ariel_search.search.keyword import keyword_search
+
+        entry_id = "test-semantic-fts-001"
+        async with migrated_pool.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO enhanced_entries (
+                    entry_id, source_system, timestamp, author, raw_text,
+                    attachments, metadata, enhancement_status, summary, keywords
+                ) VALUES (
+                    %s, 'test', NOW(), 'tester', 'Routine operator note',
+                    '[]'::jsonb, '{}'::jsonb, '{}'::jsonb,
+                    'Xylophonic vacuum condition', ARRAY['quenchmarker']
+                )
+                ON CONFLICT (entry_id) DO UPDATE SET
+                    raw_text = EXCLUDED.raw_text,
+                    summary = EXCLUDED.summary,
+                    keywords = EXCLUDED.keywords
+                """,
+                [entry_id],
+            )
+
+        try:
+            for query in ("xylophonic", "quenchmarker"):
+                results = await keyword_search(
+                    query,
+                    repository,
+                    integration_ariel_config,
+                    fuzzy_fallback=False,
+                )
+                assert entry_id in {entry["entry_id"] for entry, _score, _highlights in results}
+        finally:
+            async with migrated_pool.connection() as conn:
+                await conn.execute("DELETE FROM enhanced_entries WHERE entry_id = %s", [entry_id])
+
 
 class TestTextEmbeddingMigration:
     """Test text embedding migration."""

--- a/tests/services/ariel_search/test_database.py
+++ b/tests/services/ariel_search/test_database.py
@@ -22,6 +22,9 @@ from osprey.services.ariel_search.database.migrations import (
 from osprey.services.ariel_search.enhancement.semantic_processor.migration import (
     SemanticProcessorMigration,
 )
+from osprey.services.ariel_search.enhancement.semantic_processor.search_migration import (
+    SemanticProcessorSearchMigration,
+)
 from osprey.services.ariel_search.enhancement.text_embedding.migration import (
     TextEmbeddingMigration,
 )
@@ -467,15 +470,19 @@ class TestMigrationRunnerLogic:
         assert "USING GIN(to_tsvector('english', raw_text))" in joined
 
     @pytest.mark.asyncio
-    async def test_semantic_migration_builds_enriched_fts_index(self, ddl_conn) -> None:
-        """Semantic processor summary and keywords share the keyword FTS surface."""
+    async def test_semantic_search_index_is_built_once(self, ddl_conn) -> None:
+        """The reconciliation migration solely owns the enriched FTS index."""
         await SemanticProcessorMigration().up(ddl_conn)
+        assert len(ddl_conn.sql) == 2
 
-        joined = " ".join(" ".join(ddl_conn.sql).split())
-        assert "DROP INDEX IF EXISTS idx_entries_keywords" in joined
-        assert "CREATE INDEX IF NOT EXISTS idx_entries_text_search" in joined
-        assert "COALESCE(summary, '')" in joined
-        assert "osprey_text_array_to_string(keywords)" in joined
+        await SemanticProcessorSearchMigration().up(ddl_conn)
+
+        statements = [" ".join(statement.split()) for statement in ddl_conn.sql]
+        assert (
+            sum("CREATE INDEX IF NOT EXISTS idx_entries_text_search" in s for s in statements) == 1
+        )
+        assert "COALESCE(summary, '')" in statements[-1]
+        assert "osprey_text_array_to_string(keywords)" in statements[-1]
 
     def test_get_enabled_migrations_passes_configured_models(self) -> None:
         """`osprey ariel migrate` must build the embedding migration with the
@@ -1102,22 +1109,14 @@ class TestAttachmentMigrationDDL:
 class TestSemanticProcessorMigrationDDL:
     """Tests for SemanticProcessorMigration."""
 
-    async def test_up_adds_columns_before_indexing_them(self, ddl_conn) -> None:
-        """Columns are added first, then the indexes that read them."""
+    async def test_up_adds_only_semantic_columns(self, ddl_conn) -> None:
+        """The reconciliation migration owns index creation for every deployment."""
         await SemanticProcessorMigration().up(ddl_conn)
 
-        statements = [" ".join(s.split()) for s in ddl_conn.sql]
-        assert statements[0] == "ALTER TABLE enhanced_entries ADD COLUMN IF NOT EXISTS summary TEXT"
-        assert statements[1] == (
-            "ALTER TABLE enhanced_entries ADD COLUMN IF NOT EXISTS keywords TEXT[] DEFAULT '{}'"
-        )
-        assert "CREATE OR REPLACE FUNCTION osprey_text_array_to_string(TEXT[])" in statements[2]
-        assert "IMMUTABLE" in statements[2]
-        assert statements[3] == "DROP INDEX IF EXISTS idx_entries_keywords"
-        assert statements[4] == "DROP INDEX IF EXISTS idx_entries_text_search"
-        assert "CREATE INDEX IF NOT EXISTS idx_entries_text_search" in statements[5]
-        assert "COALESCE(summary, '')" in statements[5]
-        assert "osprey_text_array_to_string(keywords)" in statements[5]
+        assert [" ".join(s.split()) for s in ddl_conn.sql] == [
+            "ALTER TABLE enhanced_entries ADD COLUMN IF NOT EXISTS summary TEXT",
+            "ALTER TABLE enhanced_entries ADD COLUMN IF NOT EXISTS keywords TEXT[] DEFAULT '{}'",
+        ]
 
     async def test_down_drops_indexes_before_columns(self, ddl_conn) -> None:
         """Dropping the indexed columns first would leave the drops to CASCADE."""

--- a/tests/services/ariel_search/test_database.py
+++ b/tests/services/ariel_search/test_database.py
@@ -448,12 +448,34 @@ class TestMigrationRunnerLogic:
         assert "core_schema" in names
         assert "semantic_processor" in names
         assert "text_embedding" in names
+        assert "keyword_search_fts_index" in names
+        assert "semantic_processor_search_index" in names
+        assert "qmd_resync_index" in names
 
     def test_core_migration_instantiation(self) -> None:
         """Core migration can be instantiated directly."""
         migration = CoreMigration()
         assert migration.name == "core_schema"
         assert migration.depends_on == []
+
+    @pytest.mark.asyncio
+    async def test_core_migration_creates_raw_text_fts_index(self, ddl_conn) -> None:
+        await CoreMigration().up(ddl_conn)
+
+        joined = " ".join(" ".join(ddl_conn.sql).split())
+        assert "CREATE INDEX IF NOT EXISTS idx_entries_raw_text_fts" in joined
+        assert "USING GIN(to_tsvector('english', raw_text))" in joined
+
+    @pytest.mark.asyncio
+    async def test_semantic_migration_builds_enriched_fts_index(self, ddl_conn) -> None:
+        """Semantic processor summary and keywords share the keyword FTS surface."""
+        await SemanticProcessorMigration().up(ddl_conn)
+
+        joined = " ".join(" ".join(ddl_conn.sql).split())
+        assert "DROP INDEX IF EXISTS idx_entries_keywords" in joined
+        assert "CREATE INDEX IF NOT EXISTS idx_entries_text_search" in joined
+        assert "COALESCE(summary, '')" in joined
+        assert "osprey_text_array_to_string(keywords)" in joined
 
     def test_get_enabled_migrations_passes_configured_models(self) -> None:
         """`osprey ariel migrate` must build the embedding migration with the
@@ -782,7 +804,7 @@ class TestGetEnabledMigrations:
         """Only the always-run migrations load when no module is enabled."""
         names = [m.name for m in make_runner()._get_enabled_migrations()]
 
-        assert names == ["core_schema", "attachment_files"]
+        assert names == ["core_schema", "keyword_search_fts_index", "attachment_files"]
 
     def test_unimportable_migration_is_skipped_with_warning(self, monkeypatch, caplog) -> None:
         """A migration whose module is gone must not break the whole run."""
@@ -1089,10 +1111,13 @@ class TestSemanticProcessorMigrationDDL:
         assert statements[1] == (
             "ALTER TABLE enhanced_entries ADD COLUMN IF NOT EXISTS keywords TEXT[] DEFAULT '{}'"
         )
-        assert "CREATE INDEX IF NOT EXISTS idx_entries_keywords" in statements[2]
-        assert "USING GIN(keywords)" in statements[2]
-        assert "CREATE INDEX IF NOT EXISTS idx_entries_text_search" in statements[3]
-        assert "to_tsvector('english', raw_text || ' ' || COALESCE(summary, ''))" in statements[3]
+        assert "CREATE OR REPLACE FUNCTION osprey_text_array_to_string(TEXT[])" in statements[2]
+        assert "IMMUTABLE" in statements[2]
+        assert statements[3] == "DROP INDEX IF EXISTS idx_entries_keywords"
+        assert statements[4] == "DROP INDEX IF EXISTS idx_entries_text_search"
+        assert "CREATE INDEX IF NOT EXISTS idx_entries_text_search" in statements[5]
+        assert "COALESCE(summary, '')" in statements[5]
+        assert "osprey_text_array_to_string(keywords)" in statements[5]
 
     async def test_down_drops_indexes_before_columns(self, ddl_conn) -> None:
         """Dropping the indexed columns first would leave the drops to CASCADE."""

--- a/tests/services/ariel_search/test_enhancement.py
+++ b/tests/services/ariel_search/test_enhancement.py
@@ -934,6 +934,29 @@ class TestSemanticProcessorEnhanceBranches:
         assert params == [["vacuum", "pump"], "Pump replaced.", "entry-001"]
 
     @pytest.mark.asyncio
+    async def test_enhance_exposes_result_to_downstream_qmd_export(
+        self, module, entry, monkeypatch, tmp_path
+    ):
+        """The qmd exporter receives enrichment produced earlier in the same pass."""
+        monkeypatch.setattr(
+            "osprey.models.completion.get_chat_completion",
+            lambda message, model_config=None: (
+                '{"keywords": ["vacuum", "pump"], "summary": "Pump replaced."}'
+            ),
+        )
+        qmd_export = QmdExportModule()
+        qmd_export.configure({"mirror_path": str(tmp_path)})
+        conn = _FakeConnection()
+
+        await module.enhance(entry, conn)
+        await qmd_export.enhance(entry, conn)
+
+        (document_path,) = tmp_path.rglob("*.md")
+        document = document_path.read_text(encoding="utf-8")
+        assert "Summary: Pump replaced." in document
+        assert "Keywords: vacuum, pump." in document
+
+    @pytest.mark.asyncio
     async def test_enhance_skips_store_when_parsing_fails(self, module, entry, monkeypatch):
         """An unparseable completion leaves the database untouched."""
         monkeypatch.setattr(

--- a/tests/services/ariel_search/test_qmd_resync.py
+++ b/tests/services/ariel_search/test_qmd_resync.py
@@ -210,8 +210,7 @@ class TestIncrementalResync:
         assert result is not None
         assert (result.scanned, result.written, result.unchanged, result.failed) == (1, 1, 0, 0)
         assert _mirrored(tmp_path, "42").read_text(encoding="utf-8").startswith("# Entry 42")
-        watermark = (tmp_path / ops.QMD_WATERMARK_NAME).read_text(encoding="utf-8").strip()
-        assert datetime.fromisoformat(watermark) == _EARLIER
+        assert ops._read_qmd_watermark(tmp_path) == _EARLIER
         assert result.watermark == _EARLIER
 
     @pytest.mark.asyncio
@@ -237,7 +236,7 @@ class TestIncrementalResync:
 
     @pytest.mark.asyncio
     async def test_stored_watermark_bounds_the_next_scan(self, monkeypatch, tmp_path) -> None:
-        (tmp_path / ops.QMD_WATERMARK_NAME).write_text(f"{_EARLIER.isoformat()}\n", "utf-8")
+        ops._write_qmd_watermark(tmp_path, _EARLIER)
         pool = _FakePool(rows_for={"FROM enhanced_entries": []})
         _patch_pool(monkeypatch, pool)
 
@@ -246,6 +245,18 @@ class TestIncrementalResync:
         sql, params = pool.calls[0]
         assert "updated_at >= %s" in " ".join(sql.split())
         assert params == [_EARLIER, ops.QMD_RESYNC_PAGE_SIZE]
+
+    @pytest.mark.asyncio
+    async def test_legacy_watermark_forces_renderer_backfill(self, monkeypatch, tmp_path) -> None:
+        """A pre-version marker cannot suppress rows needing the new document format."""
+        marker = tmp_path / ops.QMD_WATERMARK_NAME
+        marker.write_text(f"{_EARLIER.isoformat()}\n", encoding="utf-8")
+        pool = _FakePool(rows_for={"FROM enhanced_entries": []})
+        _patch_pool(monkeypatch, pool)
+
+        await ops.run_qmd_resync(_config(tmp_path))
+
+        assert "WHERE" not in pool.calls[0][0]
 
     @pytest.mark.asyncio
     async def test_unparsable_watermark_falls_back_to_a_full_scan(
@@ -262,15 +273,14 @@ class TestIncrementalResync:
 
     @pytest.mark.asyncio
     async def test_empty_scan_leaves_the_watermark_alone(self, monkeypatch, tmp_path) -> None:
-        (tmp_path / ops.QMD_WATERMARK_NAME).write_text(f"{_EARLIER.isoformat()}\n", "utf-8")
+        ops._write_qmd_watermark(tmp_path, _EARLIER)
         _patch_pool(monkeypatch, _FakePool(rows_for={"FROM enhanced_entries": []}))
 
         result = await ops.run_qmd_resync(_config(tmp_path))
 
         assert result is not None
         assert result.scanned == 0
-        stored = (tmp_path / ops.QMD_WATERMARK_NAME).read_text(encoding="utf-8").strip()
-        assert datetime.fromisoformat(stored) == _EARLIER
+        assert ops._read_qmd_watermark(tmp_path) == _EARLIER
 
     @pytest.mark.asyncio
     async def test_watermark_takes_the_highest_updated_at(self, monkeypatch, tmp_path) -> None:

--- a/tests/services/ariel_search/test_qmd_writer.py
+++ b/tests/services/ariel_search/test_qmd_writer.py
@@ -252,6 +252,17 @@ class TestRender:
         assert "n: 7." in document
         assert "tags" not in document
 
+    def test_semantic_summary_and_keywords_are_body_text(self):
+        """The hybrid qmd mirror indexes semantic processor enrichment."""
+        document = render_entry(
+            make_entry(
+                summary="Short entry describes an injection kicker transient.",
+                keywords=["injection kicker", "transient"],
+            )
+        )
+        assert "Summary: Short entry describes an injection kicker transient." in document
+        assert "Keywords: injection kicker, transient." in document
+
     def test_missing_fields_degrade(self):
         """A sparse row still renders a usable document."""
         document = render_entry({"entry_id": "x"})

--- a/tests/services/ariel_search/test_repository_unit.py
+++ b/tests/services/ariel_search/test_repository_unit.py
@@ -902,7 +902,7 @@ class TestSearchQueries:
         ]
         sql, params = pool.calls[0]
         body = _sql_body(sql)
-        assert "ts_headline('english', raw_text" in body
+        assert "ts_headline('english', raw_text || ' ' || COALESCE(summary, '')" in body
         assert "WHERE author = %s" in body
         assert params == ["beam lost", "beam lost", "operator", 5]
 
@@ -926,6 +926,25 @@ class TestSearchQueries:
         assert "NULL AS headline" in body
         assert "WHERE TRUE" in body
         assert params == ["quench", 10]
+
+    async def test_keyword_search_without_semantic_processor_uses_core_fts(self, fake_pool) -> None:
+        """Default-off semantic processing leaves keyword search on the core raw_text index."""
+        config = _make_config(enhancement_modules={"semantic_processor": {"enabled": False}})
+        repo = ARIELRepository(fake_pool, config)
+
+        assert (
+            await repo.keyword_search(
+                where_clauses=[],
+                params=[],
+                search_text="quench",
+                include_highlights=False,
+            )
+            == []
+        )
+
+        body = _sql_body(fake_pool.calls[0][0])
+        assert "to_tsvector('english', raw_text)" in body
+        assert "COALESCE(summary, '')" not in body
 
     async def test_fuzzy_search_without_date_filters(self, fake_pool_factory) -> None:
         """Similarity threshold is the only filter when no dates are given."""

--- a/tests/services/ariel_search/test_search.py
+++ b/tests/services/ariel_search/test_search.py
@@ -183,6 +183,30 @@ class TestKeywordSearchFunction:
         mock_repository.keyword_search.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_semantic_processor_terms_are_in_keyword_match_surface(
+        self, mock_repository, mock_config
+    ):
+        """Generated summaries and keywords participate in keyword search."""
+        from osprey.services.ariel_search.config import ARIELConfig
+        from osprey.services.ariel_search.search.keyword import keyword_search
+
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost/test"},
+                "search_modules": {"keyword": {"enabled": True}},
+                "enhancement_modules": {"semantic_processor": {"enabled": True}},
+            }
+        )
+
+        await keyword_search("injection transient", mock_repository, config)
+
+        call_args = mock_repository.keyword_search.call_args
+        assert call_args is not None
+        where_clauses = call_args.kwargs["where_clauses"]
+        assert any("COALESCE(summary, '')" in clause for clause in where_clauses)
+        assert any("osprey_text_array_to_string(keywords)" in clause for clause in where_clauses)
+
+    @pytest.mark.asyncio
     async def test_fuzzy_fallback_when_no_results(self, mock_repository, mock_config):
         """Falls back to fuzzy search when FTS returns no results."""
         from osprey.services.ariel_search.search.keyword import keyword_search


### PR DESCRIPTION
## Summary

- Make semantic summaries and keywords participate in keyword and hybrid retrieval instead of remaining unused ingest-time metadata.
- Keep raw and semantic PostgreSQL full-text indexes synchronized across fresh and existing deployments.
- Backfill existing QMD mirrors after renderer changes while preserving incremental resyncs.

## Changes

- Centralize PostgreSQL FTS expressions and add raw/enriched reconciliation migrations.
- Propagate persisted semantic enrichment to downstream QMD export in the same ingestion pass.
- Version QMD resync watermarks so legacy markers trigger one safe full backfill.
- Give the reconciliation migration sole ownership of the semantic GIN index.
- Add real PostgreSQL semantic-only retrieval and QMD pipeline regression coverage.
- Make forced-terminal Rich test fixtures deterministic under `NO_COLOR=1` and `TERM=dumb`.

## Test plan

- [x] `uv run pytest tests/services/ariel_search -v` — 1401 passed, 13 skipped
- [x] Focused remediation tests — 20 passed
- [x] ANSI-sensitive CLI tests — 270 passed
- [x] `./scripts/quick_check.sh` — 24572 passed, 184 skipped, 1 expected xfail
- [ ] GitHub Actions full CI
