### PR TITLE
fix: web terminal copy/state, archiver grant and default bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Compatibility is documented in release notes, not encoded in the version string.
   look one `.claude` too deep).
 - `osprey up`: a persona whose config reads an authenticated archiver now
   receives the store's password variable in its terminal container.
+- `archiver_read` no longer defaults to 1-second bins regardless of span
+  (#117): without an explicit `bin_size` the bin is derived from the time
+  range to target `archiver.auto_bin_points` (default 10 000) per channel, and
+  the summary reports the bin used. Reads under ~2.8 hours are unchanged.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Web terminal: session history, memory and transcripts are found inside the
   per-user container again (`CLAUDE_CONFIG_DIR` is honoured; readers no longer
   look one `.claude` too deep).
+- `osprey up`: a persona whose config reads an authenticated archiver now
+  receives the store's password variable in its terminal container.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   and existing QMD mirrors backfill automatically after the renderer changes.
 - The pyAT specialist now saves and confirms a structured lattice-analysis
   JSON artifact before returning computed optics results.
+- Web terminal: selecting text now copies it, as in a desktop terminal. The
+  agent's copy requests were being dropped by the browser terminal; Option/
+  Shift-drag plus Cmd+C or Ctrl+Shift+C grabs raw screen text.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Web terminal: selecting text now copies it, as in a desktop terminal. The
   agent's copy requests were being dropped by the browser terminal; Option/
   Shift-drag plus Cmd+C or Ctrl+Shift+C grabs raw screen text.
+- Web terminal: session history, memory and transcripts are found inside the
+  per-user container again (`CLAUDE_CONFIG_DIR` is honoured; readers no longer
+  look one `.claude` too deep).
 
 ### Added
 

--- a/docs/source/architecture/mcp-servers.rst
+++ b/docs/source/architecture/mcp-servers.rst
@@ -28,6 +28,10 @@ safety-limits enforcement on all write operations.
   time range. ``processing`` selects the per-bin aggregation (``raw``, ``mean``, ``min``,
   ``max``, ``median``, ``std``, ``count``) and ``bin_size`` sets the bin width in seconds;
   ``bin_size=0`` returns full resolution and is valid only with ``processing="raw"``.
+  When ``bin_size`` is omitted the bin is derived from the time span so a continuously
+  archived channel returns about ``archiver.auto_bin_points`` (default 10 000) points —
+  1 s for anything under ~2.8 hours, ~53 minutes for a year — and the summary reports the
+  bin that was used and whether it was requested or chosen automatically.
 - ``channel_limits`` -- Query the channel safety limits database (lookup, pattern match, summary).
 
 

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -47,6 +47,14 @@ the agent's own setup and memory files — from the browser, so you rarely need
 to drop back to an editor. Changes prompt you to restart the terminal so the
 agent picks them up.
 
+Copying text works the way it does in a desktop terminal: drag over the
+agent's output and the selection is already on your clipboard — no key to
+press. To grab raw screen text instead (say, while the agent is busy), hold
+Option (macOS) or Shift while dragging, then copy with Cmd+C or Ctrl+Shift+C;
+plain Ctrl+C always interrupts the agent. Serve the terminal over HTTPS for
+this to work in every browser — on a plain ``http://`` page copying falls
+back to an older browser mechanism that Safari may refuse.
+
 Documentation and feedback settings
 -----------------------------------
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default [
         Terminal: 'readonly',
         FitAddon: 'readonly',
         WebLinksAddon: 'readonly',
+        ClipboardAddon: 'readonly',
       },
     },
     rules: {

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -268,6 +268,8 @@ keys:
   # control-assistant default became mongodb_archiver — a matcher that tracks a
   # default is a matcher that goes quiet on the change it should have caught.
   archiver.type: {evidence: 'archiver\.type is not set'}
+  # Point budget behind archiver_read's span-derived default bin (issue #117).
+  archiver.auto_bin_points: {evidence: 'archiver\.auto_bin_points'}
   archiver.epics_archiver: {evidence: 'epics_archiver'}
   archiver.epics_archiver.url: {covered-by: archiver.epics_archiver}
   archiver.epics_archiver.timeout: {covered-by: archiver.epics_archiver}

--- a/src/osprey/agent_runner/project_paths.py
+++ b/src/osprey/agent_runner/project_paths.py
@@ -1,14 +1,21 @@
-"""Claude Code project-path encoding.
+"""Claude Code project-path encoding and state-directory resolution.
 
-Derives the ``~/.claude/projects/<encoded>/`` directory name Claude Code uses
-for a project's transcripts, memory, and session state. Consumed by both the
-Web Terminal (``interfaces.web_terminal``) and the workspace MCP server
+Derives the ``<config-dir>/projects/<encoded>/`` directory Claude Code uses for
+a project's transcripts, memory, and session state. Consumed by both the Web
+Terminal (``interfaces.web_terminal``) and the workspace MCP server
 (``mcp_server.workspace``), so it lives in ``agent_runner`` — below both — to
 avoid an interface/CLI import from the low layers.
+
+``<config-dir>`` is ``$CLAUDE_CONFIG_DIR`` when set and ``~/.claude`` otherwise,
+exactly as the CLI resolves it. The distinction matters in the per-user
+web-terminal container, which sets ``CLAUDE_CONFIG_DIR`` *and* ``HOME`` to the
+same mounted volume: a reader that spells ``~/.claude/projects`` there looks one
+``.claude`` too deep, finds nothing, and reports every session as missing.
 """
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -19,15 +26,41 @@ from pathlib import Path
 # producing silent false-negative reads of transcripts, memory, and sessions.
 _CLAUDE_PROJECT_DIR_NORMALIZE = re.compile(r"[^A-Za-z0-9-]")
 
+#: The variable Claude Code reads for its state root (settings, projects,
+#: skills). The web-terminal compose service sets it to the per-user volume.
+CLAUDE_CONFIG_DIR_ENV = "CLAUDE_CONFIG_DIR"
+
 
 def encode_claude_project_path(project_dir: Path | str) -> str:
     """Return the Claude Code project-directory name for *project_dir*.
 
     Claude Code stores per-project state in
-    ``~/.claude/projects/<encoded>/`` where ``<encoded>`` is the absolute
+    ``<config-dir>/projects/<encoded>/`` where ``<encoded>`` is the absolute
     cwd with every non-alphanumeric character normalized to ``-``. This
     helper exists so every callsite computes the same name — keep this in
     sync with the bundled CLI if its encoding ever changes.
     """
     abs_path = str(Path(project_dir).resolve())
     return _CLAUDE_PROJECT_DIR_NORMALIZE.sub("-", abs_path)
+
+
+def claude_config_dir() -> Path:
+    """Return Claude Code's state root: ``$CLAUDE_CONFIG_DIR`` or ``~/.claude``.
+
+    The variable is taken verbatim (after ``~`` expansion) — Claude Code does
+    not append ``.claude`` to it — and a blank value counts as unset.
+    """
+    configured = os.environ.get(CLAUDE_CONFIG_DIR_ENV, "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".claude"
+
+
+def claude_project_dir(project_dir: Path | str) -> Path:
+    """Return the directory Claude Code keeps *project_dir*'s state in.
+
+    This is ``<config-dir>/projects/<encoded>/``: the session transcripts
+    (``<uuid>.jsonl``), the ``memory/`` directory and per-session subagent
+    files all live here.
+    """
+    return claude_config_dir() / "projects" / encode_claude_project_path(project_dir)

--- a/src/osprey/cli/project_utils.py
+++ b/src/osprey/cli/project_utils.py
@@ -28,7 +28,10 @@ belong to a dead-code sweep, not to this module.
 
 from pathlib import Path
 
-from osprey.agent_runner.project_paths import encode_claude_project_path
+from osprey.agent_runner.project_paths import (
+    claude_project_dir,
+    encode_claude_project_path,  # noqa: F401 — re-export
+)
 
 from .output import report
 from .styles import Styles
@@ -39,7 +42,7 @@ def _clear_claude_code_project_state(project_path: Path) -> None:
 
     Claude Code stores trust decisions and session data in two places:
     - ~/.claude.json  →  projects.<absolute-path>.hasTrustDialogAccepted
-    - ~/.claude/projects/<encoded-path>/  →  session transcripts & memory
+    - <config-dir>/projects/<encoded-path>/  →  session transcripts & memory
 
     Removing both ensures the trust prompt appears on next launch.
     """
@@ -61,11 +64,10 @@ def _clear_claude_code_project_state(project_path: Path) -> None:
         except (json.JSONDecodeError, OSError):
             pass  # Don't fail init over this
 
-    # 2. Remove session/memory directory from ~/.claude/projects/
-    encoded_key = encode_claude_project_path(project_path)
-    claude_project_dir = Path.home() / ".claude" / "projects" / encoded_key
-    if claude_project_dir.exists():
-        shutil.rmtree(claude_project_dir)
+    # 2. Remove session/memory directory from <config-dir>/projects/
+    project_state_dir = claude_project_dir(project_path)
+    if project_state_dir.exists():
+        shutil.rmtree(project_state_dir)
         cleared = True
 
     if cleared:

--- a/src/osprey/deployment/web_terminals/artifacts.py
+++ b/src/osprey/deployment/web_terminals/artifacts.py
@@ -27,6 +27,7 @@ from typing import Any
 from osprey.deployment.errors import DeploymentError
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
 from osprey.deployment.web_terminals.personas import (
+    personas_needing_archiver_password,
     personas_needing_ariel_password,
     personas_needing_dispatcher_token,
     personas_needing_facility_bundle,
@@ -329,6 +330,7 @@ def write_web_terminal_artifacts(config: Any, repo_root: Path | str | None = Non
         dispatcher_personas=personas_needing_dispatcher_token(config, root),
         ariel_personas=personas_needing_ariel_password(config, root),
         launch_token_personas=launch_token_personas,
+        archiver_password_personas=personas_needing_archiver_password(config, root),
         facility_bundle_personas=personas_needing_facility_bundle(config, root),
         # A pure read, like every other disk-derived input here: the deploy path
         # provisions the bundle directory before this render (see

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -689,12 +689,14 @@ def _build_env_production_subset(
     that can distinguish users, and that is the per-user ``environment:`` block
     in ``docker-compose.web.yml``. See
     :func:`osprey.deployment.web_terminals.render.render_web_terminals`, whose
-    ``dispatcher_personas``, ``ariel_personas`` and ``launch_token_personas``
-    arguments each carry the subset of the roster entitled to one credential —
-    ``EVENT_DISPATCHER_TOKEN``, ``ARIEL_DB_PASSWORD`` and
-    ``BLUESKY_LAUNCH_TOKEN`` respectively — emitted into that user's own
-    ``environment:`` block and interpolated by compose from the deploy ``.env``,
-    so the secret never lands in a rendered artifact either.
+    ``dispatcher_personas``, ``ariel_personas``, ``launch_token_personas`` and
+    ``archiver_password_personas`` arguments each carry the subset of the
+    roster entitled to one credential — ``EVENT_DISPATCHER_TOKEN``,
+    ``ARIEL_DB_PASSWORD``, ``BLUESKY_LAUNCH_TOKEN`` and the archiver store's
+    ``password_env`` (``MONGO_ROOT_PASSWORD`` on the shipped preset)
+    respectively — emitted into that user's own ``environment:`` block and
+    interpolated by compose from the deploy ``.env``, so the secret never lands
+    in a rendered artifact either.
 
     So this is NOT the claim that no web terminal ever presents a service token —
     the EVENTS panel's proxy presents the dispatcher token server-side, so the

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -161,6 +161,53 @@ def config_needs_launch_token(config: Any) -> bool:
     return as_dict(servers.get("bluesky")).get("enabled", True) is not False
 
 
+#: What a ``password_env`` name must look like to be emitted into a compose
+#: ``environment:`` line verbatim. Anything else is refused rather than rendered.
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def config_archiver_password_env(config: Any) -> str | None:
+    """The variable ``config``'s archiver connector authenticates with, or ``None``.
+
+    The archiver connector reads its password from the environment variable its
+    own block names — ``archiver.<type>.password_env`` — and raises on every
+    read when that variable is unset. For a store the project deploys itself,
+    ``osprey up`` mints the value into the deploy ``.env`` under that name; for
+    a facility-run store the operator puts it there. Either way the web
+    terminal's agent can only authenticate if its container is handed *that*
+    variable, which is why this returns the configured NAME rather than a
+    boolean: the grant carries it, so a project reading a store under any
+    spelling is served.
+
+    Only the SELECTED connector's block counts. The shipped ``config.yml``
+    carries a filled-in ``mongodb_archiver:`` block under ``type:
+    mock_archiver``; a block the selected type never reads entitles nothing,
+    for the reason :func:`config_needs_ariel_password` gives — a credential is
+    gated on what its consumer actually reads.
+
+    Raises:
+        ValueError: when the configured name is not a plain identifier. The
+            name is emitted into a compose ``environment:`` line verbatim, so
+            a value compose would mangle (a space, an ``=``, a ``${``) is
+            refused at the deploy gate rather than rendered broken.
+    """
+    archiver = as_dict(as_dict(config).get("archiver"))
+    connector = archiver.get("type")
+    if not isinstance(connector, str) or not connector:
+        return None
+    password_env = as_dict(archiver.get(connector)).get("password_env")
+    if not isinstance(password_env, str) or not password_env.strip():
+        return None
+    password_env = password_env.strip()
+    if not _ENV_VAR_NAME_RE.match(password_env):
+        raise ValueError(
+            f"archiver.{connector}.password_env must name an environment variable "
+            f"(letters, digits and underscores, not starting with a digit), got "
+            f"{password_env!r}"
+        )
+    return password_env
+
+
 def _referenced_personas(config: Any) -> tuple[dict[str, Any], set[str]]:
     """The persona catalog and the names some roster entry actually resolves to.
 
@@ -195,11 +242,24 @@ def _personas_whose_config(config: Any, project_root: Any, predicate) -> set[str
     a persona whose ``project_path`` is unset, unrendered, or unreadable
     contributes nothing, because a credential is never granted on a guess.
     """
+    return {
+        persona_name
+        for persona_name, persona_config in _persona_configs(config, project_root)
+        if predicate(persona_config)
+    }
+
+
+def _persona_configs(config: Any, project_root: Any) -> Iterable[tuple[str, Any]]:
+    """Yield ``(persona_name, parsed config.yml)`` for every readable referenced persona.
+
+    The one disk walk behind :func:`_personas_whose_config` and
+    :func:`personas_needing_archiver_password`; see the former for why a
+    persona that cannot be read is skipped rather than guessed at.
+    """
     import yaml
 
     catalog, referenced = _referenced_personas(config)
 
-    matching: set[str] = set()
     for persona_name in sorted(referenced):
         entry = as_dict(catalog.get(persona_name))
         project_path = entry.get("project_path")
@@ -213,9 +273,7 @@ def _personas_whose_config(config: Any, project_root: Any, predicate) -> set[str
                 persona_config = yaml.safe_load(fh)
         except (OSError, yaml.YAMLError):
             continue
-        if predicate(persona_config):
-            matching.add(persona_name)
-    return matching
+        yield persona_name, persona_config
 
 
 def personas_needing_dispatcher_token(config: Any, project_root: Any) -> set[str]:
@@ -278,6 +336,32 @@ def personas_needing_launch_token(config: Any, project_root: Any) -> set[str]:
         ``BLUESKY_LAUNCH_TOKEN`` (see :func:`config_needs_launch_token`).
     """
     return _personas_whose_config(config, project_root, config_needs_launch_token)
+
+
+def personas_needing_archiver_password(config: Any, project_root: Any) -> dict[str, str]:
+    """Map each catalog persona whose archiver reads a password to the variable it reads.
+
+    A map rather than a set because the grant carries the variable NAME (see
+    :func:`config_archiver_password_env`): two personas reading two stores each
+    get their own line, and the render emits exactly the name the connector
+    will look up. Walks the same per-persona ``config.yml`` files the other
+    grants walk, so this cannot disagree with them about which personas a
+    roster deploys.
+
+    :param config: The parsed deploy config.
+    :param project_root: Deploy project root; relative ``project_path`` values
+        resolve against it.
+    :return: ``{persona_name: env_var_name}`` for the referenced personas whose
+        selected archiver connector names a ``password_env``.
+    :raises ValueError: when a persona names a variable compose cannot carry
+        (see :func:`config_archiver_password_env`).
+    """
+    grants: dict[str, str] = {}
+    for persona_name, persona_config in _persona_configs(config, project_root):
+        password_env = config_archiver_password_env(persona_config)
+        if password_env is not None:
+            grants[persona_name] = password_env
+    return grants
 
 
 def normalize_users(users_raw: Any) -> list[dict[str, Any]]:

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -26,6 +26,7 @@ from osprey.deployment.web_terminals.personas import (
     SUPPORTED_MCP_TOPOLOGY,
     USERNAME_CHARSET_RE,
     as_dict,
+    config_archiver_password_env,
     config_needs_ariel_password,
     config_needs_dispatcher_token,
     config_needs_facility_bundle,
@@ -197,6 +198,7 @@ def render_web_terminals(
     launch_token_personas: set[str] | None = None,
     facility_bundle_personas: set[str] | None = None,
     facility_bundle_gid: int | None = None,
+    archiver_password_personas: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Render the compose overlay, nginx fragment, and landing page for one facility config.
 
@@ -278,6 +280,19 @@ def render_web_terminals(
             directory does not exist yet, or a platform with no gids) emits no
             ``group_add``, which is the honest render rather than a guessed
             group.
+        archiver_password_personas: ``{persona_name: env_var_name}`` for the
+            personas whose archiver connector authenticates with a password,
+            resolved from disk by
+            :func:`osprey.deployment.web_terminals.personas.personas_needing_archiver_password`.
+            Same placement and same reason as ``dispatcher_personas``; a map
+            rather than a set because the connector reads the variable its own
+            ``archiver.<type>.password_env`` names, and the line emitted into
+            the user's ``environment:`` block carries exactly that name (the
+            control-assistant preset spells it ``MONGO_ROOT_PASSWORD``, which
+            ``osprey up`` mints). Without it the agent's every archiver read
+            fails with "Environment variable '…' is not set" while the same
+            project works on the single-user host path, which reads the whole
+            deploy ``.env``. ``None`` emits no line.
 
     Returns:
         Mapping of output-relative-path to rendered content, for exactly three
@@ -413,6 +428,16 @@ def render_web_terminals(
                     entry["persona"] in (launch_token_personas or set())
                     if entry.get("persona")
                     else config_needs_launch_token(root)
+                ),
+                # The NAME of the variable this user's archiver connector
+                # authenticates with (see the `archiver_password_personas`
+                # arg), or None for no grant. Persona-less entries are
+                # answered from this same config, with no disk read, exactly
+                # as above.
+                "archiver_password_env": (
+                    (archiver_password_personas or {}).get(entry["persona"])
+                    if entry.get("persona")
+                    else config_archiver_password_env(root)
                 ),
                 # Where the deployment's knowledge bundle mounts inside THIS
                 # user's container, or None when the user is not entitled or the

--- a/src/osprey/interfaces/vendor-globals.d.ts
+++ b/src/osprey/interfaces/vendor-globals.d.ts
@@ -11,6 +11,7 @@ declare const katex: any;
 declare const Terminal: any;
 declare const FitAddon: any;
 declare const WebLinksAddon: any;
+declare const ClipboardAddon: any;
 
 // The per-user URL prefix injected into every served HTML document by the
 // web-terminal app (`window.__OSPREY_PREFIX__ = "/u/<user>"` or "" for the

--- a/src/osprey/interfaces/vendor_manifest.json
+++ b/src/osprey/interfaces/vendor_manifest.json
@@ -138,6 +138,16 @@
       ]
     },
     {
+      "name": "xterm addon-clipboard",
+      "filename": "addon-clipboard.min.js",
+      "version": "0.1.0",
+      "url": "https://cdn.jsdelivr.net/npm/@xterm/addon-clipboard@0.1.0/lib/addon-clipboard.min.js",
+      "sha256": "2a4fbd8c4dd8466b31dbc509d7d5db01dc8a0163725add6d6b885d6657e8b14f",
+      "targets": [
+        "web_terminal/static/vendor/"
+      ]
+    },
+    {
       "name": "Plotly.js",
       "filename": "plotly-3.3.1.min.js",
       "version": "3.3.1",

--- a/src/osprey/interfaces/web_terminal/claude_memory_service.py
+++ b/src/osprey/interfaces/web_terminal/claude_memory_service.py
@@ -1,6 +1,6 @@
 """Claude Memory Service — reads/writes Claude Code native memory files.
 
-Provides CRUD operations on ``~/.claude/projects/<encoded>/memory/*.md``
+Provides CRUD operations on ``<config-dir>/projects/<encoded>/memory/*.md``
 files. Stateless service class instantiated per-request with a project
 directory, following the same pattern as :class:`ScaffoldGalleryService`.
 """
@@ -11,7 +11,7 @@ import logging
 import re
 from pathlib import Path
 
-from osprey.agent_runner.project_paths import encode_claude_project_path
+from osprey.agent_runner.project_paths import claude_project_dir
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +49,11 @@ class ClaudeMemoryService:
         """Return the Claude Code memory directory for this project.
 
         Claude Code stores memory files in
-        ``~/.claude/projects/<encoded>/memory/``;
-        see :func:`osprey.cli.project_utils.encode_claude_project_path`
-        for the encoding rule.
+        ``<config-dir>/projects/<encoded>/memory/``;
+        see :func:`osprey.agent_runner.project_paths.claude_project_dir` for
+        how the root and the encoded name are resolved.
         """
-        encoded = encode_claude_project_path(self._project_dir)
-        return Path.home() / ".claude" / "projects" / encoded / "memory"
+        return claude_project_dir(self._project_dir) / "memory"
 
     # ── List ──────────────────────────────────────────────────────────
 

--- a/src/osprey/interfaces/web_terminal/session_discovery.py
+++ b/src/osprey/interfaces/web_terminal/session_discovery.py
@@ -1,6 +1,6 @@
 """Session discovery for Claude Code JSONL conversation files.
 
-Scans ``~/.claude/projects/<encoded-path>/`` for JSONL session files,
+Scans ``<config-dir>/projects/<encoded-path>/`` for JSONL session files,
 extracting metadata (first message, modification time, message count)
 for the session picker UI.
 """
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from osprey.agent_runner.project_paths import encode_claude_project_path
+from osprey.agent_runner.project_paths import claude_project_dir
 
 logger = logging.getLogger(__name__)
 
@@ -38,12 +38,11 @@ class SessionDiscovery:
     def _resolve_sessions_dir(self) -> Path:
         """Return the Claude projects directory for this project.
 
-        Claude Code stores sessions in ``~/.claude/projects/<encoded>/``;
-        see :func:`osprey.cli.project_utils.encode_claude_project_path`
-        for the encoding rule.
+        Claude Code stores sessions in ``<config-dir>/projects/<encoded>/``;
+        see :func:`osprey.agent_runner.project_paths.claude_project_dir` for
+        how the root and the encoded name are resolved.
         """
-        encoded = encode_claude_project_path(self._project_dir)
-        return Path.home() / ".claude" / "projects" / encoded
+        return claude_project_dir(self._project_dir)
 
     def list_sessions(self, allowed_ids: set[str] | None = None) -> list[SessionInfo]:
         """Return sessions sorted newest-first.

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -46,6 +46,7 @@
   <script src="{{ prefixed(vendor_url('xterm.js', '/static/vendor/xterm.min.js')) }}"></script>
   <script src="{{ prefixed(vendor_url('xterm addon-fit', '/static/vendor/addon-fit.min.js')) }}"></script>
   <script src="{{ prefixed(vendor_url('xterm addon-web-links', '/static/vendor/addon-web-links.min.js')) }}"></script>
+  <script src="{{ prefixed(vendor_url('xterm addon-clipboard', '/static/vendor/addon-clipboard.min.js')) }}"></script>
 
   <!-- highlight.js: data-href-dark/light let theme-manager.js swap the stylesheet at runtime -->
   <link id="hljs-theme" rel="stylesheet"

--- a/src/osprey/interfaces/web_terminal/static/js/terminal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal.js
@@ -86,6 +86,98 @@ export function clearStoredSessionId() {
 }
 
 /**
+ * Put `text` on the system clipboard on behalf of the agent.
+ *
+ * The agent's full-screen renderer owns the mouse: a plain click-drag is its
+ * own text selection, which it finishes by asking the terminal to copy the
+ * text (OSC 52) — the same thing it does in a desktop terminal, where the
+ * copy happens through `pbcopy`/`xclip` and the user never notices that
+ * "select" already meant "copy". The clipboard addon routes that request
+ * here.
+ *
+ * Browsers only expose the async clipboard API on secure pages (https or
+ * localhost). Elsewhere the legacy `execCommand('copy')` path still works in
+ * Chromium and Firefox while the drag's user activation is fresh, which it
+ * is: the request is one PTY round-trip behind the mouse-up.
+ *
+ * @param {string} text
+ * @returns {Promise<void>}
+ */
+export async function writeClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const scratch = document.createElement('textarea');
+  scratch.value = text;
+  scratch.setAttribute('readonly', '');
+  scratch.style.position = 'fixed';
+  scratch.style.opacity = '0';
+  document.body.appendChild(scratch);
+  scratch.select();
+  let copied = false;
+  try {
+    copied = document.execCommand('copy');
+  } finally {
+    scratch.remove();
+  }
+  if (!copied) {
+    throw new Error('clipboard write refused: the page is not a secure context and the legacy copy command was rejected');
+  }
+}
+
+/**
+ * The clipboard the agent is allowed to see: write-only.
+ *
+ * OSC 52 can also *query* the clipboard. Nothing the agent does needs that,
+ * and granting it would let any program in the terminal pull whatever the
+ * user last copied — so reads always answer empty, without touching the
+ * browser API (which would prompt for permission).
+ *
+ * @returns {{ readText: () => string, writeText: (selection: string, text: string) => Promise<void> }}
+ */
+export function agentClipboardProvider() {
+  return {
+    readText: () => '',
+    writeText: (_selection, text) =>
+      writeClipboard(text).catch((err) => {
+        console.warn('The agent asked to copy text but the browser refused:', err);
+      }),
+  };
+}
+
+/**
+ * Claim Ctrl+Shift+C as "copy the selection" before xterm sees it.
+ *
+ * This is for the terminal's OWN selection — the one a modifier-drag makes
+ * (see `macOptionClickForcesSelection` below). Plain Ctrl+C must keep
+ * interrupting the agent, and on macOS Cmd+C is the browser's own copy
+ * (xterm leaves Meta chords to it), so the only chord that needs claiming is
+ * Ctrl+Shift+C — the convention every desktop terminal uses. It is swallowed
+ * whether or not anything is selected: xterm would otherwise encode it as ^C
+ * and interrupt the agent.
+ *
+ * Returning `false` tells xterm the event is handled; anything else returns
+ * `true` and is processed as usual.
+ *
+ * @param {KeyboardEvent} event
+ * @returns {boolean}
+ */
+function copyKeyHandler(event) {
+  if (event.type !== 'keydown') return true;
+  if (!(event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey)) return true;
+  if (event.key !== 'c' && event.key !== 'C') return true;
+
+  if (term && term.hasSelection()) {
+    // A refusal surfaces in the console rather than as a pasted ^C.
+    writeClipboard(term.getSelection()).catch((err) => {
+      console.error('Could not copy the terminal selection:', err);
+    });
+  }
+  return false;
+}
+
+/**
  * Initialize xterm.js terminal in the given container.
  * @param {string} containerId
  */
@@ -100,6 +192,12 @@ export function initTerminal(containerId) {
     fontSize: 14,
     lineHeight: 1.2,
     theme: xtermPalette(),
+    // The agent switches mouse tracking on (DECSET 1000/1002/1003/1006): a
+    // plain click-drag is ITS selection, copied through the clipboard addon
+    // below. For the rare raw-screen grab (agent hung, text it won't select)
+    // xterm lets a modifier force its own selection — Shift on Linux/Windows
+    // unconditionally, Option on macOS only with this flag.
+    macOptionClickForcesSelection: true,
   });
 
   // Live theme switching: re-read the palette from computed style on every
@@ -111,9 +209,20 @@ export function initTerminal(containerId) {
 
   fitAddon = new FitAddon.FitAddon();
   const webLinksAddon = new WebLinksAddon.WebLinksAddon();
+  // Honour the agent's "copy this" requests (OSC 52) — without this addon
+  // xterm drops them and "select" silently stops meaning "copy". The shipped
+  // 0.1.0 constructor is (base64Codec, provider) — its typings claim
+  // (provider) alone, and passing the provider first makes every request
+  // hang in the codec slot.
+  const clipboardAddon = new ClipboardAddon.ClipboardAddon(
+    new ClipboardAddon.Base64(),
+    agentClipboardProvider(),
+  );
 
   term.loadAddon(fitAddon);
   term.loadAddon(webLinksAddon);
+  term.loadAddon(clipboardAddon);
+  term.attachCustomKeyEventHandler(copyKeyHandler);
   term.open(container);
 
   // Initial fit — run once now and again after fonts finish loading, since

--- a/src/osprey/mcp_server/control_system/tools/archiver_read.py
+++ b/src/osprey/mcp_server/control_system/tools/archiver_read.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 from collections import Counter
 from datetime import UTC, datetime, timedelta
 from typing import Any, NamedTuple
@@ -15,6 +16,32 @@ from osprey.mcp_server.errors import make_error
 from osprey.utils.config import get_facility_timezone
 
 logger = logging.getLogger("osprey.mcp_server.tools.archiver_read")
+
+#: Points per channel the default bin aims for when the caller names no
+#: ``bin_size``; ``archiver.auto_bin_points`` in config.yml overrides it.
+DEFAULT_AUTO_BIN_POINTS = 10_000
+
+
+def auto_bin_seconds(span: timedelta, target_points: int) -> int:
+    """The whole-second bin that keeps a continuously archived channel near *target_points*.
+
+    ``ceil(span / target_points)``, never below one second: 1 s for anything
+    up to the budget (2.8 h at 10 000), 9 s for a day, ~53 min for a year. A
+    degenerate or inverted window gets the smallest legal bin rather than an
+    exception — the read itself reports the empty window honestly.
+
+    Whole seconds because the EPICS Archiver Appliance only bins in whole
+    seconds (``lastSample_N``); a sub-second width would be refused there.
+    Rounding up, never down, keeps the result under budget.
+
+    Widening the bin loses nothing on a slowly or intermittently archived
+    channel: ``raw`` keeps one real sample per bin and an empty bin yields no
+    row, so the channels issue #117 was filed about come back exactly as before.
+    """
+    seconds = span.total_seconds()
+    if seconds <= 0:
+        return 1
+    return max(1, math.ceil(seconds / target_points))
 
 
 def _parse_time(time_str: str) -> datetime:
@@ -200,19 +227,24 @@ async def archiver_read(
         end_time: End of the time range (default "now").
         processing: Aggregation within each bin — one of "raw", "mean", "min",
             "max", "median", "std", "count".
-        bin_size: Bin size in seconds when using a processing mode other than
-            "raw". ``0`` requests full resolution — every real archived sample
-            in range, with no per-bin decimation — and is only valid with
-            processing="raw" (an aggregate has no bin to aggregate over).
-            ``None`` (the default) uses a 1-second bin. Negative values are
-            rejected.
+        bin_size: Bin size in seconds. ``None`` (the default) picks a
+            whole-second bin from the span so a continuously archived channel
+            returns at most about 10 000 points (``archiver.auto_bin_points``
+            in config.yml): 1 s for anything under ~2.8 hours, 9 s for a day,
+            ~53 minutes for a year. The bin actually used is reported as
+            ``summary.bin_size`` with ``summary.bin_size_source`` ``"auto"``;
+            pass ``bin_size`` explicitly to override it. ``0`` requests full
+            resolution — every real archived sample in range, with no per-bin
+            decimation — and is only valid with processing="raw" (an aggregate
+            has no bin to aggregate over). Negative values are rejected.
 
     Returns:
-        JSON summary with per-channel point counts and stats, and the data
-        file path. When a requested channel has zero points in the window,
-        ``summary.coverage`` explains why — the window precedes/follows the
-        archive's real bounds, the channel was never recorded, or the window
-        holds an honest gap — so an empty answer is never a silent one.
+        JSON summary with per-channel point counts and stats, the bin that was
+        used and whether it was requested or chosen automatically, and the
+        data file path. When a requested channel has zero points in the
+        window, ``summary.coverage`` explains why — the window precedes/follows
+        the archive's real bounds, the channel was never recorded, or the
+        window holds an honest gap — so an empty answer is never a silent one.
     """
     if not channels:
         return make_error(
@@ -268,17 +300,43 @@ async def archiver_read(
         from osprey.mcp_server.control_system.server_context import get_server_context
 
         registry = get_server_context()
+
+        # The connector contract forbids a backend from serving a width other
+        # than the one asked for, so the tool — the only layer that knows the
+        # span — is where a default bin gets chosen. Having chosen it, it says
+        # so in the summary: an auto-picked parameter the agent cannot see
+        # would be the dishonest version of this feature.
+        if bin_size is None:
+            target_points = registry.get("archiver.auto_bin_points", DEFAULT_AUTO_BIN_POINTS)
+            if (
+                isinstance(target_points, bool)
+                or not isinstance(target_points, int)
+                or target_points < 1
+            ):
+                return make_error(
+                    "configuration_error",
+                    f"archiver.auto_bin_points must be a positive integer (got {target_points!r}).",
+                    [
+                        "Fix archiver.auto_bin_points in config.yml, or remove it to use "
+                        f"the default of {DEFAULT_AUTO_BIN_POINTS}.",
+                    ],
+                )
+            resolved_bin = auto_bin_seconds(end_dt - start_dt, target_points)
+            bin_source = "auto"
+        else:
+            resolved_bin = bin_size
+            bin_source = "requested"
+
         connector = await registry.archiver()
 
         # Deduplicate: all counts below must describe what was actually queried.
         unique_channels = list(dict.fromkeys(channels))
 
-        precision_ms = 1000 if bin_size is None else bin_size * 1000
         df = await connector.get_data(
             unique_channels,
             start_dt,
             end_dt,
-            precision_ms=precision_ms,
+            precision_ms=resolved_bin * 1000,
             processing=processing,
         )
 
@@ -325,7 +383,8 @@ async def archiver_read(
                 "start_time": str(start_dt),
                 "end_time": str(end_dt),
                 "processing": processing,
-                "bin_size": bin_size,
+                "bin_size": resolved_bin,
+                "bin_size_source": bin_source,
             },
             "series": series,
         }
@@ -334,6 +393,8 @@ async def archiver_read(
             "channels_queried": len(unique_channels),
             "total_points": total_points,
             "time_range": {"start": str(start_dt), "end": str(end_dt)},
+            "bin_size": resolved_bin,
+            "bin_size_source": bin_source,
             "per_channel": per_channel,
         }
         if coverage is not None:

--- a/src/osprey/mcp_server/workspace/transcript_reader.py
+++ b/src/osprey/mcp_server/workspace/transcript_reader.py
@@ -1,7 +1,7 @@
 """Read Claude Code native transcripts to extract OSPREY tool-call and agent events.
 
 No audit hook is needed for this: Claude Code already logs every tool call to
-``~/.claude/projects/<encoded>/`` as JSONL, and this module reads those
+``<config-dir>/projects/<encoded>/`` as JSONL, and this module reads those
 transcripts on demand.
 """
 
@@ -9,7 +9,7 @@ import json
 import logging
 from pathlib import Path
 
-from osprey.agent_runner.project_paths import encode_claude_project_path
+from osprey.agent_runner.project_paths import claude_project_dir
 
 logger = logging.getLogger("osprey.mcp_server.workspace.transcript_reader")
 
@@ -78,12 +78,11 @@ class TranscriptReader:
     def find_transcript_dir(self) -> Path | None:
         """Locate the Claude Code transcript directory for this project.
 
-        Claude Code stores transcripts in ``~/.claude/projects/<encoded>/``;
-        see :func:`osprey.cli.project_utils.encode_claude_project_path` for
-        the encoding rule.
+        Claude Code stores transcripts in ``<config-dir>/projects/<encoded>/``;
+        see :func:`osprey.agent_runner.project_paths.claude_project_dir` for
+        how the root and the encoded name are resolved.
         """
-        encoded = encode_claude_project_path(self.project_dir)
-        transcript_dir = Path.home() / ".claude" / "projects" / encoded
+        transcript_dir = claude_project_dir(self.project_dir)
         if transcript_dir.is_dir():
             return transcript_dir
         return None

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -524,6 +524,11 @@ archiver:
   # arrives as an `archiver.type` override at build time.
   type: mock_archiver  # <-- 'epics_archiver' for production
 
+  # When a read names no bin size, the bin is chosen from the time span so a
+  # continuously archived channel returns about this many points (1 s bins up
+  # to ~2.8 h, ~53 min bins for a year). The agent is told which bin was used.
+  auto_bin_points: 10000
+
   # Mock archiver (development mode) — synthesizes history from the same
   # simulation machine model as the control-system connector above, so live
   # reads and archiver data stay consistent. The machine file is derived from

--- a/src/osprey/templates/apps/hello_world/config.yml.j2
+++ b/src/osprey/templates/apps/hello_world/config.yml.j2
@@ -185,6 +185,10 @@ control_system:
 # plus an `epics_archiver.url` — the control-assistant preset shows it).
 archiver:
   type: mock_archiver
+  # When a read names no bin size, the bin is chosen from the time span so a
+  # continuously archived channel returns about this many points (1 s bins up
+  # to ~2.8 h, ~53 min bins for a year). The agent is told which bin was used.
+  auto_bin_points: 10000
 
 # ============================================================
 # HUMAN-IN-THE-LOOP APPROVAL

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_memory_guard.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_memory_guard.py
@@ -38,7 +38,8 @@ stdin ──► Parse JSON
 ## Details
 
 Gate for the Write tool. Computes the Claude Code memory directory for the
-current project (``~/.claude/projects/<encoded>/memory/``) and only allows
+current project (``$CLAUDE_CONFIG_DIR/projects/<encoded>/memory/``, with
+``~/.claude`` as the root when the variable is unset) and only allows
 writes targeting ``.md`` files inside it. All other Write operations are
 denied silently — the agent never sees a user prompt for non-memory writes.
 
@@ -67,13 +68,20 @@ def resolve_memory_dir(project_dir: str) -> Path:
     """Compute the Claude Code memory directory for a project.
 
     Claude Code stores memory files in
-    ``~/.claude/projects/<encoded>/memory/`` where ``<encoded>`` is the
+    ``<config-dir>/projects/<encoded>/memory/`` where ``<encoded>`` is the
     absolute project path with every non-alphanumeric character normalized
-    to ``-``.
+    to ``-``, and ``<config-dir>`` is ``$CLAUDE_CONFIG_DIR`` when set and
+    ``~/.claude`` otherwise. The web-terminal container sets the variable
+    (and ``HOME``) to one mounted volume, so the ``~/.claude`` spelling there
+    would name a directory nothing writes to — and deny every memory write.
+    Mirrors ``osprey.agent_runner.project_paths.claude_config_dir``, inlined
+    for the same reason as the regex above.
     """
     abs_project = str(Path(project_dir).resolve())
     encoded = _CLAUDE_PROJECT_DIR_NORMALIZE.sub("-", abs_project)
-    return Path.home() / ".claude" / "projects" / encoded / "memory"
+    configured = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    config_dir = Path(configured).expanduser() if configured else Path.home() / ".claude"
+    return config_dir / "projects" / encoded / "memory"
 
 
 def is_allowed_memory_write(file_path: str, memory_dir: Path) -> bool:

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -528,6 +528,28 @@ services:
          same fail-closed outcome as never emitting this line at all. #}
       - BLUESKY_LAUNCH_TOKEN=${BLUESKY_LAUNCH_TOKEN:-}
 {%- endif %}
+{%- if svc.archiver_password_env %}
+      {#- The archiver store's password, for a persona whose archiver connector
+         authenticates with one. The consumer is the connector inside this
+         container — the `control_system` MCP server's archiver tools and the
+         Python executor's `read_archiver` both open it — and it reads the
+         variable its own `archiver.<type>.password_env` names, which is why
+         this line carries a per-persona NAME rather than a fixed one: the
+         control-assistant preset spells it MONGO_ROOT_PASSWORD (minted by
+         `osprey up`), a facility-run store may spell it anything.
+
+         Per-user for the same reason as the three credentials above: a
+         shared `.env.users` cannot say "the personas whose archiver reads
+         this", and it excludes service tokens by design.
+
+         `${VAR:-}` is resolved by compose from the deploy `.env`, so the
+         secret is never written into this rendered file. The `:-` default
+         keeps compose from warning, and an empty value is refused by the
+         connector exactly as an unset one is — "Environment variable '…' is
+         not set" — so a deploy that never minted it fails where it is visible
+         rather than half-authenticating. #}
+      - {{ svc.archiver_password_env }}={{ "${" ~ svc.archiver_password_env ~ ":-}" }}
+{%- endif %}
     volumes:
       - {{ svc.user }}-claude-config:/data/claude-config
       {#- Mount target comes from render.py's _container_agent_data_dir, which

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -304,6 +304,10 @@ archiver:
   #   - mock_archiver: Development mode (generates synthetic data)
   #   - epics_archiver: EPICS Archiver Appliance (add an `epics_archiver.url`)
   type: mock_archiver  # Change to 'epics_archiver' for production
+  # When a read names no bin size, the bin is chosen from the time span so a
+  # continuously archived channel returns about this many points (1 s bins up
+  # to ~2.8 h, ~53 min bins for a year). The agent is told which bin was used.
+  auto_bin_points: 10000
   # epics_archiver:
   #   url: https://archiver.example.com  # Replace with your archiver address
   #   timeout: 60

--- a/tests/agent_runner/test_project_paths.py
+++ b/tests/agent_runner/test_project_paths.py
@@ -1,0 +1,64 @@
+"""Tests for the Claude Code config-dir / project-dir resolution helpers.
+
+Claude Code keeps per-project state under ``$CLAUDE_CONFIG_DIR/projects/
+<encoded>/`` and falls back to ``~/.claude`` only when the variable is unset.
+The per-user web-terminal container sets ``CLAUDE_CONFIG_DIR`` (and ``HOME``)
+to the same mounted volume, so a reader that spells ``~/.claude`` looks one
+``.claude`` too deep and finds nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from osprey.agent_runner.project_paths import (
+    CLAUDE_CONFIG_DIR_ENV,
+    claude_config_dir,
+    claude_project_dir,
+    encode_claude_project_path,
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+    monkeypatch.delenv(CLAUDE_CONFIG_DIR_ENV, raising=False)
+    return tmp_path / "home"
+
+
+def test_config_dir_defaults_to_dot_claude_under_home(fake_home):
+    assert claude_config_dir() == fake_home / ".claude"
+
+
+def test_config_dir_honours_the_environment(fake_home, tmp_path, monkeypatch):
+    """``CLAUDE_CONFIG_DIR`` is used verbatim — no ``.claude`` appended."""
+    configured = tmp_path / "data" / "claude-config"
+    monkeypatch.setenv(CLAUDE_CONFIG_DIR_ENV, str(configured))
+
+    assert claude_config_dir() == configured
+
+
+def test_blank_environment_value_falls_back_to_home(fake_home, monkeypatch):
+    monkeypatch.setenv(CLAUDE_CONFIG_DIR_ENV, "   ")
+
+    assert claude_config_dir() == fake_home / ".claude"
+
+
+def test_config_dir_expands_a_tilde(fake_home, monkeypatch):
+    # ``expanduser`` reads $HOME, not the patched ``Path.home``.
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv(CLAUDE_CONFIG_DIR_ENV, "~/elsewhere")
+
+    assert claude_config_dir() == fake_home / "elsewhere"
+
+
+def test_project_dir_sits_under_projects_with_the_encoded_name(fake_home, tmp_path, monkeypatch):
+    configured = tmp_path / "data" / "claude-config"
+    monkeypatch.setenv(CLAUDE_CONFIG_DIR_ENV, str(configured))
+    project = tmp_path / "app" / "my_project" / "build"
+
+    assert claude_project_dir(project) == (
+        configured / "projects" / encode_claude_project_path(project)
+    )

--- a/tests/deployment/web_terminals/test_personas.py
+++ b/tests/deployment/web_terminals/test_personas.py
@@ -9,6 +9,7 @@ import pytest
 
 from osprey.deployment.web_terminals.personas import (
     EVENTS_PANEL_ID,
+    config_archiver_password_env,
     config_declares_panel,
     config_needs_ariel_password,
     config_needs_dispatcher_token,
@@ -18,6 +19,7 @@ from osprey.deployment.web_terminals.personas import (
     env_var_suffix_collisions,
     freeze_user_indices,
     normalize_users,
+    personas_needing_archiver_password,
     personas_needing_ariel_password,
     personas_needing_dispatcher_token,
     personas_needing_launch_token,
@@ -1869,3 +1871,118 @@ def test_settings_json_denies_bash_reads_an_artifact_written_with_a_bom(tmp_path
 
     # Act / Assert
     assert settings_json_denies_bash(tmp_path / "bommed") is True
+
+
+# ---------------------------------------------------------------------------
+# Archiver connector -> per-user store password
+#
+# The archiver connector authenticates with the variable its own config block
+# names (`archiver.<type>.password_env`); `osprey up` mints it into the deploy
+# `.env` for a store the project deploys. `.env.users` excludes service tokens
+# by design and cannot say "the personas whose archiver reads this", so the
+# grant is per-user, and it carries the configured NAME because the block may
+# point at a facility-run store under any variable.
+# ---------------------------------------------------------------------------
+
+_MONGO_ARCHIVER = {
+    "type": "mongodb_archiver",
+    "mongodb_archiver": {"host": "localhost", "password_env": "MONGO_ROOT_PASSWORD"},
+}
+
+
+def test_config_archiver_password_env_reads_the_selected_connector_block() -> None:
+    """The variable named by the SELECTED connector's block is the entitlement."""
+    assert config_archiver_password_env({"archiver": _MONGO_ARCHIVER}) == "MONGO_ROOT_PASSWORD"
+
+
+def test_config_archiver_password_env_ignores_an_unselected_connector_block() -> None:
+    """The shipped config carries a `mongodb_archiver:` block under `type: mock_archiver`;
+    a block the selected type never reads entitles nothing."""
+    archiver = {**_MONGO_ARCHIVER, "type": "mock_archiver"}
+
+    assert config_archiver_password_env({"archiver": archiver}) is None
+
+
+def test_config_archiver_password_env_follows_any_connector_that_names_one() -> None:
+    """The key, not the connector name, is what is read: a future connector with a
+    `password_env` is granted exactly like MongoDB's."""
+    archiver = {"type": "facility_db", "facility_db": {"password_env": "FACILITY_DB_PW"}}
+
+    assert config_archiver_password_env({"archiver": archiver}) == "FACILITY_DB_PW"
+
+
+@pytest.mark.parametrize(
+    "missing", [{}, {"archiver": None}, {"archiver": {"type": "mock_archiver"}}]
+)
+def test_config_archiver_password_env_is_none_without_a_named_variable(missing: dict) -> None:
+    assert config_archiver_password_env(missing) is None
+
+
+@pytest.mark.parametrize("blank", ["", "   ", None, 7])
+def test_config_archiver_password_env_treats_a_blank_name_as_unset(blank: Any) -> None:
+    archiver = {"type": "mongodb_archiver", "mongodb_archiver": {"password_env": blank}}
+
+    assert config_archiver_password_env({"archiver": archiver}) is None
+
+
+@pytest.mark.parametrize("bad", ["MONGO PASSWORD", "1PASS", "PW=x", "${PW}", "pw-name"])
+def test_config_archiver_password_env_refuses_a_name_compose_cannot_carry(bad: str) -> None:
+    """The name is emitted into a compose `environment:` line verbatim, so anything
+    that is not a plain identifier is refused here rather than rendered broken."""
+    archiver = {"type": "mongodb_archiver", "mongodb_archiver": {"password_env": bad}}
+
+    with pytest.raises(ValueError, match="password_env"):
+        config_archiver_password_env({"archiver": archiver})
+
+
+def test_personas_needing_archiver_password_maps_each_persona_to_its_variable(tmp_path) -> None:
+    """The grant is a persona -> variable-name map, so two personas reading two
+    different stores each get their own line and a persona with no archiver gets none."""
+    # Arrange
+    catalog = {
+        "readwrite": {
+            "project": "rw",
+            "project_path": _write_persona_project_config(
+                tmp_path, "rw", {"archiver": _MONGO_ARCHIVER}
+            ),
+        },
+        "facility": {
+            "project": "fac",
+            "project_path": _write_persona_project_config(
+                tmp_path,
+                "fac",
+                {"archiver": {"type": "other_db", "other_db": {"password_env": "OTHER_DB_PW"}}},
+            ),
+        },
+        "readonly": {
+            "project": "ro",
+            "project_path": _write_persona_project_config(
+                tmp_path, "ro", {"archiver": {"type": "mock_archiver"}}
+            ),
+        },
+    }
+    config = _catalog_config(
+        catalog,
+        [
+            {"name": "alice", "index": 0, "persona": "readwrite"},
+            {"name": "bob", "index": 1, "persona": "readonly"},
+            {"name": "carol", "index": 2, "persona": "facility"},
+        ],
+    )
+
+    # Act
+    result = personas_needing_archiver_password(config, tmp_path)
+
+    # Assert
+    assert result == {"readwrite": "MONGO_ROOT_PASSWORD", "facility": "OTHER_DB_PW"}
+
+
+def test_personas_needing_archiver_password_skips_unrendered_persona_projects(tmp_path) -> None:
+    """A persona whose project isn't on disk contributes nothing: a credential is
+    never granted on a guess."""
+    config = _catalog_config(
+        {"ghost": {"project": "ghost", "project_path": "../never-rendered"}},
+        [{"name": "alice", "index": 0, "persona": "ghost"}],
+    )
+
+    assert personas_needing_archiver_password(config, tmp_path) == {}

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -3458,6 +3458,100 @@ def test_render_without_ariel_personas_emits_no_password_line() -> None:
 _LAUNCH_TOKEN_LINE = "BLUESKY_LAUNCH_TOKEN=${BLUESKY_LAUNCH_TOKEN:-}"
 
 
+# ---------------------------------------------------------------------------
+# Archiver connector -> per-user store password
+#
+# `osprey up` mints the archiver store's password into the deploy `.env` under
+# the name the connector block reads (`archiver.<type>.password_env`, which the
+# control-assistant preset spells MONGO_ROOT_PASSWORD). The agent inside a web
+# terminal authenticates with exactly that variable, and `.env.users` excludes
+# service tokens by design -- so a container that is not handed it per-user
+# reports "Environment variable 'MONGO_ROOT_PASSWORD' is not set" on every
+# archiver read, while the single-user host path (which reads the whole `.env`)
+# works. The grant carries the configured NAME, so a facility-run store under
+# another variable is granted the same way.
+# ---------------------------------------------------------------------------
+
+_ARCHIVER_PASSWORD_LINE = "MONGO_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD:-}"
+
+
+def test_archiver_persona_gets_the_store_password() -> None:
+    """A user whose persona reads a store password gets it in its own `environment:`
+    block, interpolated from the deploy `.env` at compose time so the secret is
+    never written into a rendered artifact."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(
+            _events_persona_config(),
+            archiver_password_personas={"readwrite": "MONGO_ROOT_PASSWORD"},
+        )["docker-compose.web.yml"]
+    )
+
+    # Assert
+    assert _ARCHIVER_PASSWORD_LINE in compose["services"]["web-alice"]["environment"]
+
+
+def test_archiver_grant_carries_the_configured_variable_name() -> None:
+    """A persona whose connector names another variable is handed THAT one."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(
+            _events_persona_config(), archiver_password_personas={"readwrite": "FACILITY_DB_PW"}
+        )["docker-compose.web.yml"]
+    )
+
+    # Assert
+    alice_env = compose["services"]["web-alice"]["environment"]
+    assert "FACILITY_DB_PW=${FACILITY_DB_PW:-}" in alice_env
+    assert not any("MONGO_ROOT_PASSWORD" in line for line in alice_env)
+
+
+def test_persona_without_an_archiver_password_gets_none() -> None:
+    """A persona whose archiver reads no password needs no store credential."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(
+            _events_persona_config(),
+            archiver_password_personas={"readwrite": "MONGO_ROOT_PASSWORD"},
+        )["docker-compose.web.yml"]
+    )
+
+    # Assert
+    bob_env = compose["services"]["web-bob"]["environment"]
+    assert not any("MONGO_ROOT_PASSWORD" in line for line in bob_env)
+
+
+def test_render_without_archiver_personas_emits_no_password_line() -> None:
+    """The no-project-root render path passes no persona map and so emits no
+    credential, exactly as it does for the other three."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config())["docker-compose.web.yml"]
+    )
+
+    # Assert
+    for service in ("web-alice", "web-bob"):
+        env = compose["services"][service]["environment"]
+        assert not any("MONGO_ROOT_PASSWORD" in line for line in env)
+
+
+def test_persona_less_roster_entry_is_answered_from_the_deploy_config() -> None:
+    """The zero-migration path (no personas; the web image IS the deploy project)
+    reads the grant straight from the deploy config, as the other grants do."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["archiver"] = {
+        "type": "mongodb_archiver",
+        "mongodb_archiver": {"host": "localhost", "password_env": "MONGO_ROOT_PASSWORD"},
+    }
+
+    # Act
+    compose = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+
+    # Assert
+    assert _ARCHIVER_PASSWORD_LINE in compose["services"]["web-alice"]["environment"]
+
+
 def test_entitled_persona_gets_the_launch_token() -> None:
     """A user whose persona is entitled to arm a queue start gets the launch token
     in its own `environment:` block, interpolated from the deploy `.env` at compose

--- a/tests/hooks/conftest.py
+++ b/tests/hooks/conftest.py
@@ -64,6 +64,7 @@ _SYSTEM_VARS = (
 # ``config_path`` argument, never inherited.
 _HOOK_VARS = (
     "CLAUDE_PROJECT_DIR",
+    "CLAUDE_CONFIG_DIR",
     "OSPREY_HOOK_CONFIG",
     "OSPREY_HOOK_DEBUG",
     "OSPREY_DISPATCH_RUN",
@@ -223,6 +224,10 @@ def _isolated_home(hook_home, monkeypatch):
     """
     monkeypatch.setenv("HOME", str(hook_home))
     monkeypatch.setenv("USERPROFILE", str(hook_home))
+    # The state root Claude Code actually honours. Unset here so the default
+    # ``$HOME/.claude`` path is what the tests exercise; a test that wants the
+    # container layout sets it explicitly.
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     yield
 
 

--- a/tests/hooks/test_memory_guard_hook.py
+++ b/tests/hooks/test_memory_guard_hook.py
@@ -49,6 +49,46 @@ def test_memory_dir_is_home_relative(tmp_path, memory_guard, hook_home):
 
 
 @pytest.mark.unit
+def test_memory_dir_honours_claude_config_dir(tmp_path, memory_guard, monkeypatch):
+    """``CLAUDE_CONFIG_DIR`` is the state root; ``$HOME/.claude`` is only the fallback.
+
+    The per-user web-terminal container sets ``CLAUDE_CONFIG_DIR`` and ``HOME``
+    to one mounted volume. Claude Code then keeps memory under
+    ``$CLAUDE_CONFIG_DIR/projects/<encoded>/memory`` — a hook that still spells
+    ``$HOME/.claude`` names a directory nothing writes to, and denies every
+    memory write in the container.
+    """
+    config_dir = tmp_path / "data" / "claude-config"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    encoded = encode_claude_project_path(tmp_path)
+
+    assert memory_guard.resolve_memory_dir(str(tmp_path)) == (
+        config_dir / "projects" / encoded / "memory"
+    )
+
+
+@pytest.mark.unit
+def test_allows_memory_write_under_claude_config_dir(tmp_path, hook_runner, monkeypatch):
+    """End to end: a write into the ``$CLAUDE_CONFIG_DIR`` memory dir is allowed."""
+    config_dir = tmp_path / "data" / "claude-config"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    project_dir = tmp_path / "build"
+    project_dir.mkdir()
+    memory_dir = config_dir / "projects" / encode_claude_project_path(project_dir) / "memory"
+    memory_dir.mkdir(parents=True)
+
+    result = hook_runner(
+        "osprey_memory_guard.py",
+        "Write",
+        {"file_path": str(memory_dir / "notes.md"), "content": "# Notes"},
+        cwd=project_dir,
+    )
+
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "project_name",
     ["plain", "with spaces", "dotted.name.v2", "under_score+plus@sign"],

--- a/tests/interfaces/web_terminal/app-logout.test.mjs
+++ b/tests/interfaces/web_terminal/app-logout.test.mjs
@@ -394,6 +394,7 @@ describe('post-logout: a fresh load does not auto-resume', () => {
     write() {}
     reset() {}
     focus() {}
+    attachCustomKeyEventHandler() {}
   }
 
   class FakeAddon {
@@ -427,6 +428,7 @@ describe('post-logout: a fresh load does not auto-resume', () => {
     vi.stubGlobal('Terminal', FakeTerminal);
     vi.stubGlobal('FitAddon', { FitAddon: FakeAddon });
     vi.stubGlobal('WebLinksAddon', { WebLinksAddon: class {} });
+    vi.stubGlobal('ClipboardAddon', { ClipboardAddon: class {}, Base64: class {} });
     vi.stubGlobal('WebSocket', FakeWebSocket);
     // xtermPalette() logs a console.error when the CSS custom properties it
     // reads are absent, which they are in this bare happy-dom document.

--- a/tests/interfaces/web_terminal/terminal-copy.test.mjs
+++ b/tests/interfaces/web_terminal/terminal-copy.test.mjs
@@ -1,0 +1,281 @@
+// @ts-check
+/**
+ * Unit tests for selecting and copying text out of the Web Terminal
+ * (terminal.js's xterm options and custom key handler):
+ *   npx vitest run tests/interfaces/web_terminal/terminal-copy.test.mjs
+ *
+ * The agent running in the terminal switches xterm's mouse tracking on
+ * (DECSET 1000/1002/1003/1006): a plain click-drag is the agent's OWN text
+ * selection, which it completes by asking the terminal to copy the text
+ * (OSC 52) — exactly what it does in a desktop terminal, where "select"
+ * already means "copy". xterm.js only honours OSC 52 through the clipboard
+ * addon, so the first group of tests pins that the addon is loaded with a
+ * write-only provider (the agent may fill the clipboard, never read it) and
+ * that the write degrades to the legacy copy command on plain-http pages.
+ *
+ * The terminal's own selection stays reachable through a modifier-drag:
+ * Shift on Linux/Windows unconditionally, Option on macOS ONLY when
+ * `macOptionClickForcesSelection` is set. Copying THAT needs a key that never
+ * reaches the agent: Cmd+C is the browser's own copy on macOS, and
+ * Ctrl+Shift+C is claimed for everything else, because plain Ctrl+C must
+ * keep interrupting the agent.
+ *
+ * Same isolation scheme as terminal-resume.test.mjs: fresh module per test,
+ * xterm and WebSocket stubbed.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+/** @type {typeof import('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js')} */
+let terminal;
+
+/** Fake xterm.js Terminal that records its options and the custom key handler. */
+class FakeTerminal {
+  /** @param {any} options */
+  constructor(options) {
+    this.cols = 80;
+    this.rows = 24;
+    this.options = options ?? {};
+    /** @type {((ev: KeyboardEvent) => boolean)|null} */
+    this.keyHandler = null;
+    this.selection = '';
+    /** @type {any[]} */
+    this.addons = [];
+    FakeTerminal.last = this;
+  }
+  /** @param {any} addon */
+  loadAddon(addon) {
+    this.addons.push(addon);
+  }
+  open() {}
+  onData() {}
+  onResize() {}
+  write() {}
+  reset() {}
+  focus() {}
+  /** @param {(ev: KeyboardEvent) => boolean} handler */
+  attachCustomKeyEventHandler(handler) {
+    this.keyHandler = handler;
+  }
+  hasSelection() {
+    return this.selection !== '';
+  }
+  getSelection() {
+    return this.selection;
+  }
+}
+/** @type {FakeTerminal|null} */
+FakeTerminal.last = null;
+
+class FakeAddon {
+  fit() {}
+}
+
+/** Fake `@xterm/addon-clipboard` Base64 codec, standing in for the real one. */
+class FakeBase64 {}
+
+/**
+ * Fake `@xterm/addon-clipboard` that records what it was built with. The
+ * shipped constructor is (base64Codec, provider) — NOT the (provider) its
+ * typings advertise — and `initTerminal()` must honour the real order.
+ */
+class FakeClipboardAddon {
+  /**
+   * @param {any} base64
+   * @param {any} provider
+   */
+  constructor(base64, provider) {
+    this.base64 = base64;
+    this.provider = provider;
+  }
+}
+
+/** @returns {{ readText: (selection: string) => string, writeText: (selection: string, text: string) => Promise<void> }} */
+function clipboardProvider() {
+  const addon = term().addons.find((a) => a instanceof FakeClipboardAddon);
+  if (!addon) throw new Error('initTerminal() loaded no clipboard addon');
+  return addon.provider;
+}
+
+class FakeWebSocket {
+  /** @param {string} url */
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    /** @type {any[]} */
+    this.sent = [];
+    this.onopen = null;
+    this.onmessage = null;
+    this.onclose = null;
+  }
+  /** @param {any} data */
+  send(data) {
+    this.sent.push(data);
+  }
+  close() {}
+}
+
+/**
+ * @param {Partial<KeyboardEvent> & {key: string}} init
+ * @returns {KeyboardEvent}
+ */
+function keyEvent(init) {
+  const { type = 'keydown', ...rest } = init;
+  return new KeyboardEvent(type, { bubbles: true, cancelable: true, ...rest });
+}
+
+/** @returns {FakeTerminal} */
+function term() {
+  return /** @type {FakeTerminal} */ (FakeTerminal.last);
+}
+
+/** @returns {(ev: KeyboardEvent) => boolean} */
+function handler() {
+  const fn = term().keyHandler;
+  if (!fn) throw new Error('initTerminal() attached no custom key handler');
+  return fn;
+}
+
+/** The stubbed `navigator.clipboard.writeText` / `readText`, fresh per test. */
+let writeText = vi.fn(() => Promise.resolve());
+let readText = vi.fn(() => Promise.resolve('secret from another app'));
+
+beforeEach(async () => {
+  vi.resetModules();
+  localStorage.clear();
+
+  document.body.innerHTML = '<div><div id="terminal-container"></div></div>';
+  // @ts-expect-error -- test stub, not a full FontFaceSet
+  document.fonts = { ready: Promise.resolve() };
+
+  vi.stubGlobal('Terminal', FakeTerminal);
+  vi.stubGlobal('FitAddon', { FitAddon: FakeAddon });
+  vi.stubGlobal('WebLinksAddon', { WebLinksAddon: class {} });
+  vi.stubGlobal('ClipboardAddon', { ClipboardAddon: FakeClipboardAddon, Base64: FakeBase64 });
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  writeText = vi.fn(() => Promise.resolve());
+  readText = vi.fn(() => Promise.resolve('secret from another app'));
+  vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText, readText }, userAgent: navigator.userAgent });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  FakeTerminal.last = null;
+  terminal = await import('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js');
+  terminal.initTerminal('terminal-container');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("the agent's own selection (OSC 52 through the clipboard addon)", () => {
+  test('the clipboard addon is loaded with the codec first and the provider second', () => {
+    const addon = term().addons.find((a) => a instanceof FakeClipboardAddon);
+    if (!addon) throw new Error('initTerminal() loaded no clipboard addon');
+    expect(addon.base64).toBeInstanceOf(FakeBase64);
+    expect(typeof addon.provider.writeText).toBe('function');
+    expect(typeof addon.provider.readText).toBe('function');
+  });
+
+  test('a copy request from the agent lands on the system clipboard', async () => {
+    await clipboardProvider().writeText('c', 'SR:BPM:01:X  1.234 mm');
+
+    expect(writeText).toHaveBeenCalledWith('SR:BPM:01:X  1.234 mm');
+  });
+
+  test('the agent can never read the clipboard — queries answer empty without touching the browser API', () => {
+    expect(clipboardProvider().readText('c')).toBe('');
+    expect(readText).not.toHaveBeenCalled();
+  });
+
+  test('on a page without the async clipboard API (plain http) the legacy copy command is used', async () => {
+    vi.stubGlobal('navigator', { ...navigator, clipboard: undefined, userAgent: navigator.userAgent });
+    const execCommand = vi.fn(() => true);
+    document.execCommand = execCommand;
+
+    await clipboardProvider().writeText('c', 'legacy text');
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(writeText).not.toHaveBeenCalled();
+    // The scratch element used to stage the text does not linger in the page.
+    expect(document.querySelector('textarea')).toBeNull();
+  });
+
+  test('a refused copy is reported in the console, never thrown at the addon', async () => {
+    vi.stubGlobal('navigator', { ...navigator, clipboard: undefined, userAgent: navigator.userAgent });
+    document.execCommand = vi.fn(() => false);
+
+    await expect(clipboardProvider().writeText('c', 'text')).resolves.toBeUndefined();
+
+    expect(console.warn).toHaveBeenCalled();
+    expect(document.querySelector('textarea')).toBeNull();
+  });
+});
+
+describe("the terminal's own selection (modifier-drag)", () => {
+  test('Option-drag forces a selection on macOS (macOptionClickForcesSelection)', () => {
+    expect(term().options.macOptionClickForcesSelection).toBe(true);
+  });
+});
+
+describe('copying a selection', () => {
+  test('Ctrl+Shift+C copies the selection and is swallowed, never reaching the agent', () => {
+    term().selection = 'SR:BPM:01:X  1.234 mm';
+
+    const outcome = handler()(keyEvent({ key: 'C', ctrlKey: true, shiftKey: true }));
+
+    expect(writeText).toHaveBeenCalledWith('SR:BPM:01:X  1.234 mm');
+    expect(outcome).toBe(false);
+  });
+
+  test('Ctrl+Shift+C with a lowercase key reading is the same chord', () => {
+    term().selection = 'text';
+
+    const outcome = handler()(keyEvent({ key: 'c', ctrlKey: true, shiftKey: true }));
+
+    expect(writeText).toHaveBeenCalledWith('text');
+    expect(outcome).toBe(false);
+  });
+
+  test('Ctrl+Shift+C with nothing selected is still swallowed (it is never an interrupt)', () => {
+    const outcome = handler()(keyEvent({ key: 'C', ctrlKey: true, shiftKey: true }));
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(outcome).toBe(false);
+  });
+
+  test('plain Ctrl+C keeps interrupting the agent even with a selection', () => {
+    term().selection = 'text';
+
+    const outcome = handler()(keyEvent({ key: 'c', ctrlKey: true }));
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(outcome).toBe(true);
+  });
+
+  test('Cmd+C is left to the browser, which copies the selection natively', () => {
+    term().selection = 'text';
+
+    const outcome = handler()(keyEvent({ key: 'c', metaKey: true }));
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(outcome).toBe(true);
+  });
+
+  test('only keydown is acted on — the keyup of the same chord passes through', () => {
+    term().selection = 'text';
+
+    const outcome = handler()(keyEvent({ type: 'keyup', key: 'C', ctrlKey: true, shiftKey: true }));
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(outcome).toBe(true);
+  });
+
+  test('every other key passes through untouched', () => {
+    for (const init of [{ key: 'a' }, { key: 'Enter' }, { key: 'c', shiftKey: true }, { key: 'v', ctrlKey: true, shiftKey: true }]) {
+      expect(handler()(keyEvent(init))).toBe(true);
+    }
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/tests/interfaces/web_terminal/terminal-resume.test.mjs
+++ b/tests/interfaces/web_terminal/terminal-resume.test.mjs
@@ -44,6 +44,7 @@ class FakeTerminal {
   write() {}
   reset() {}
   focus() {}
+  attachCustomKeyEventHandler() {}
 }
 
 class FakeAddon {
@@ -117,6 +118,7 @@ beforeEach(async () => {
   vi.stubGlobal('Terminal', FakeTerminal);
   vi.stubGlobal('FitAddon', { FitAddon: FakeAddon });
   vi.stubGlobal('WebLinksAddon', { WebLinksAddon: class {} });
+  vi.stubGlobal('ClipboardAddon', { ClipboardAddon: class {}, Base64: class {} });
   vi.stubGlobal('WebSocket', FakeWebSocket);
   // xtermPalette() logs a console.error when the CSS custom properties it
   // reads are absent, which they are in this bare happy-dom document — this

--- a/tests/interfaces/web_terminal/test_claude_memory_service.py
+++ b/tests/interfaces/web_terminal/test_claude_memory_service.py
@@ -20,8 +20,9 @@ from osprey.interfaces.web_terminal.claude_memory_service import (
 
 @pytest.fixture()
 def fake_home(tmp_path, monkeypatch):
-    """Redirect Path.home() to a temp directory."""
+    """Redirect Path.home() to a temp directory (and unset CLAUDE_CONFIG_DIR)."""
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     return tmp_path
 
 
@@ -67,6 +68,22 @@ class TestResolveMemoryDir:
         d = s._resolve_memory_dir()
         # The .. should be resolved away
         assert ".." not in str(d)
+
+    def test_honours_claude_config_dir(self, tmp_path, project_dir, monkeypatch):
+        """Memory lives under ``$CLAUDE_CONFIG_DIR/projects``, not ``~/.claude``.
+
+        The per-user web-terminal container sets ``CLAUDE_CONFIG_DIR`` and
+        ``HOME`` to one mounted volume; the ``~/.claude`` spelling then names a
+        directory Claude Code never writes, and the memory gallery reads empty.
+        """
+        config_dir = tmp_path / "data" / "claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: config_dir))
+
+        d = ClaudeMemoryService(project_dir)._resolve_memory_dir()
+
+        assert d.parent.parent == config_dir / "projects"
+        assert d.name == "memory"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/interfaces/web_terminal/test_session_discovery.py
+++ b/tests/interfaces/web_terminal/test_session_discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+from pathlib import Path
 
 from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
 
@@ -35,6 +36,30 @@ class TestResolveSessionsDir:
         sessions_dir = discovery._resolve_sessions_dir()
         assert "_" not in sessions_dir.name, sessions_dir.name
         assert sessions_dir.name.endswith("-my-proj")
+
+    def test_honours_claude_config_dir(self, tmp_path, monkeypatch):
+        """``CLAUDE_CONFIG_DIR`` names the state root; ``~/.claude`` is only the fallback.
+
+        The per-user web-terminal container sets both ``CLAUDE_CONFIG_DIR``
+        and ``HOME`` to the mounted volume, so a ``~/.claude/projects`` spelling
+        looks one ``.claude`` too deep, never sees the session Claude Code
+        writes, and the terminal never learns its own session id.
+        """
+        config_dir = tmp_path / "data" / "claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: config_dir))
+
+        sessions_dir = SessionDiscovery("/app/project/build")._resolve_sessions_dir()
+
+        assert sessions_dir == config_dir / "projects" / "-app-project-build"
+
+    def test_falls_back_to_home_without_claude_config_dir(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        sessions_dir = SessionDiscovery("/app/project/build")._resolve_sessions_dir()
+
+        assert sessions_dir == tmp_path / ".claude" / "projects" / "-app-project-build"
 
 
 class TestListSessions:

--- a/tests/mcp_server/test_archiver_read_tool.py
+++ b/tests/mcp_server/test_archiver_read_tool.py
@@ -592,6 +592,156 @@ async def test_archiver_read_passes_processing_to_connector(archiver_read_tool):
     assert kwargs["precision_ms"] == 60_000
 
 
+# ---------------------------------------------------------------------------
+# Default bin: chosen from the span, never a fixed second (issue #117)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("span", "expected_seconds"),
+    [
+        (timedelta(hours=1), 1),  # anything up to the budget stays at 1 s
+        (timedelta(seconds=10_000), 1),  # exactly the budget: still 1 s
+        (timedelta(seconds=10_001), 2),  # one over: rounds UP, never under
+        (timedelta(days=1), 9),
+        (timedelta(days=7), 61),
+        (timedelta(days=365), 3154),  # ~53 min
+        (timedelta(0), 1),  # degenerate window: the smallest legal bin
+        (timedelta(hours=-1), 1),  # end before start: same, not an exception
+    ],
+)
+def test_auto_bin_seconds_scales_with_span(span, expected_seconds):
+    from osprey.mcp_server.control_system.tools.archiver_read import auto_bin_seconds
+
+    assert auto_bin_seconds(span, 10_000) == expected_seconds
+
+
+@pytest.mark.unit
+async def test_default_bin_widens_for_a_long_span(archiver_read_tool):
+    """A one-year read with no bin_size asks for ~53-minute bins, and says so."""
+    fn, connector = archiver_read_tool
+    connector.get_data.return_value = _make_archiver_df({"SR:CURRENT:RB": [500.1]})
+
+    # 2023 is not a leap year: 365 days -> ceil(31_536_000 / 10_000) = 3154 s.
+    result = await fn(
+        channels=["SR:CURRENT:RB"],
+        start_time="2023-01-01T00:00:00",
+        end_time="2024-01-01T00:00:00",
+    )
+
+    assert connector.get_data.call_args.kwargs["precision_ms"] == 3154 * 1000
+    summary = extract_response_dict(result)["summary"]
+    assert summary["bin_size"] == 3154
+    assert summary["bin_size_source"] == "auto"
+
+
+@pytest.mark.unit
+async def test_default_bin_stays_one_second_for_a_short_span(archiver_read_tool):
+    """Short reads keep the 1-second default they always had."""
+    fn, connector = archiver_read_tool
+    connector.get_data.return_value = _make_archiver_df({"SR:CURRENT:RB": [500.1]})
+
+    result = await fn(
+        channels=["SR:CURRENT:RB"],
+        start_time="2024-01-15T10:00:00",
+        end_time="2024-01-15T11:00:00",
+    )
+
+    assert connector.get_data.call_args.kwargs["precision_ms"] == 1000
+    summary = extract_response_dict(result)["summary"]
+    assert summary["bin_size"] == 1
+    assert summary["bin_size_source"] == "auto"
+
+
+@pytest.mark.unit
+async def test_explicit_bin_size_is_reported_as_requested(tmp_path, archiver_read_tool):
+    """An explicit bin_size is used verbatim, and the echo says it was the caller's."""
+    fn, connector = archiver_read_tool
+    connector.get_data.return_value = _make_archiver_df({"SR:CURRENT:RB": [500.1]})
+
+    result = await fn(
+        channels=["SR:CURRENT:RB"],
+        start_time="2024-01-01T00:00:00",
+        end_time="2025-01-01T00:00:00",
+        bin_size=60,
+    )
+
+    data = extract_response_dict(result)
+    assert connector.get_data.call_args.kwargs["precision_ms"] == 60_000
+    assert data["summary"]["bin_size"] == 60
+    assert data["summary"]["bin_size_source"] == "requested"
+    # The artifact's query block records the bin that was USED, not the
+    # ``None`` the agent may have passed.
+    query = json.loads((tmp_path / data["data_file"]).read_text())["query"]
+    assert query["bin_size"] == 60
+    assert query["bin_size_source"] == "requested"
+
+
+@pytest.mark.unit
+async def test_full_resolution_is_reported_as_requested_zero(archiver_read_tool):
+    fn, connector = archiver_read_tool
+    connector.get_data.return_value = _make_archiver_df({"SR:CURRENT:RB": [500.1]})
+
+    result = await fn(
+        channels=["SR:CURRENT:RB"],
+        start_time="2024-01-15T10:00:00",
+        end_time="2024-01-15T11:00:00",
+        bin_size=0,
+    )
+
+    summary = extract_response_dict(result)["summary"]
+    assert summary["bin_size"] == 0
+    assert summary["bin_size_source"] == "requested"
+
+
+@pytest.mark.unit
+async def test_auto_bin_budget_comes_from_config(tmp_path, monkeypatch):
+    """``archiver.auto_bin_points`` sets how many points the default bin aims for."""
+    from osprey.connectors.archiver.base import ArchiverMetadata
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text(
+        "archiver:\n  type: mock_archiver\n  auto_bin_points: 100\n"
+    )
+    initialize_server_context()
+
+    connector = AsyncMock()
+    connector.check_availability.side_effect = lambda chans: dict.fromkeys(chans, True)
+    connector.get_metadata.side_effect = lambda ch: ArchiverMetadata(channel=ch, is_archived=True)
+    connector.get_data.return_value = _make_archiver_df({"SR:CURRENT:RB": [500.1]})
+    with patch(
+        "osprey.connectors.factory.ConnectorFactory.create_archiver_connector",
+        new_callable=AsyncMock,
+        return_value=connector,
+    ):
+        result = await _get_archiver_read()(
+            channels=["SR:CURRENT:RB"],
+            start_time="2024-01-15T10:00:00",
+            end_time="2024-01-15T11:00:00",
+        )
+
+    # 3600 s / 100 points -> 36 s bins
+    assert connector.get_data.call_args.kwargs["precision_ms"] == 36_000
+    assert extract_response_dict(result)["summary"]["bin_size"] == 36
+
+
+@pytest.mark.unit
+async def test_invalid_auto_bin_budget_is_refused_not_guessed(tmp_path, monkeypatch):
+    """A budget that is not a positive integer is a config error, not a silent default."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text("archiver:\n  type: mock_archiver\n  auto_bin_points: 0\n")
+    initialize_server_context()
+
+    with assert_raises_error(error_type="configuration_error") as ctx:
+        await _get_archiver_read()(
+            channels=["SR:CURRENT:RB"],
+            start_time="2024-01-15T10:00:00",
+            end_time="2024-01-15T11:00:00",
+        )
+    assert "auto_bin_points" in ctx["envelope"]["error_message"]
+
+
 @pytest.mark.unit
 async def test_archiver_read_rejects_unknown_processing(archiver_project):
     """An unsupported mode errors with the valid set, rather than silently downgrading."""

--- a/tests/mcp_server/workspace/test_transcript_reader.py
+++ b/tests/mcp_server/workspace/test_transcript_reader.py
@@ -126,6 +126,23 @@ class TestFindTranscriptDir:
             result = reader.find_transcript_dir()
         assert result is None
 
+    def test_honours_claude_config_dir(self, tmp_path, monkeypatch):
+        """Transcripts live under ``$CLAUDE_CONFIG_DIR/projects``, not ``~/.claude``.
+
+        Inside a per-user web-terminal container both variables point at the
+        same mounted volume, so the ``~/.claude`` spelling names a directory
+        that does not exist and every session reads as "no transcript".
+        """
+        project_dir = tmp_path / "app" / "build"
+        project_dir.mkdir(parents=True)
+        config_dir = tmp_path / "data" / "claude-config"
+        claude_dir = config_dir / "projects" / encode_claude_project_path(project_dir)
+        claude_dir.mkdir(parents=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: config_dir))
+
+        assert TranscriptReader(project_dir).find_transcript_dir() == claude_dir
+
     def test_preserves_leading_dash_for_absolute_paths(self, tmp_path):
         """Encoding of absolute paths must keep the leading dash.
 


### PR DESCRIPTION
Four independent fixes found while operating a multi-user deployment. They
are separate commits and can be reviewed one at a time.

**Selecting text in the web terminal did not copy it.** xterm.js drops OSC 52
unless the clipboard addon is loaded, so the agent's copy request after a
click-drag went nowhere. The addon is now loaded behind a write-only provider —
clipboard *reads* answer empty, so a program running in the terminal cannot pull
whatever the user last copied. Ctrl+Shift+C copies xterm's own selection, and a
modifier-drag grabs raw screen text while the agent holds the mouse.

**Claude state was read from the wrong directory inside the container.** Session
discovery, the memory service, the transcript reader and the memory-guard hook
each hardcoded `~/.claude`. The per-user container sets `CLAUDE_CONFIG_DIR` and
`HOME` to the same mounted volume, so those readers looked one `.claude` too
deep: no session history, no memory, and a guard protecting a path nothing
writes to. The root is now resolved once, in `agent_runner.project_paths`.

**A persona reading an authenticated archiver got no password.** Its container
was never handed the store's password variable, so every archiver read failed
with "Environment variable '...' is not set" — while the same project worked on
the single-user host path, which reads the whole deploy `.env`. The grant now
follows the same per-persona path as the dispatcher, ARIEL and launch
credentials, and carries the variable *name* rather than a boolean, because the
connector reads whatever `archiver.<type>.password_env` spells.

**`archiver_read` binned at 1 second regardless of span.** A one-year read asked
the store for 31 million bins per channel, and nothing in the result told the
agent that had happened. Without an explicit `bin_size` the bin is now derived
from the span to target `archiver.auto_bin_points` (default 10 000) per channel:
unchanged at 1 s up to ~2.8 hours, 9 s for a day, 61 s for a week. The summary
reports the bin and whether it was requested or derived. An explicit `bin_size`
passes through untouched and `0` still means every raw sample.

The bin choice sits in the tool rather than the connector deliberately: the
connector contract forbids serving a width other than the one asked for, so a
backend must raise rather than silently substitute. Only the tool knows the
span, which makes it the one layer entitled to pick a default — and obliged to
disclose it.

Closes #117