### PR TITLE
feat(control-system): report the outcome of every channel write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,54 @@ Compatibility is documented in release notes, not encoded in the version string.
   relates to the others. Existing files are left alone — the header is
   written only when OSPREY creates the file.
 
+- The generated safety rules now name the tool for each kind of request:
+  reading a channel goes to `channel_read`, writing to `channel_write`,
+  analysis to `execute`, Python that itself touches the control system to
+  `osprey.runtime`, and — where the queue is enabled — a scan to Bluesky. A deployment with no queue is told to
+  say so rather than imitate a scan with a loop of writes. The rules describe
+  how a write's verification level is resolved instead of prescribing one.
+
+- The executor tool descriptions now match what the executor does: it runs
+  Python in a subprocess. They no longer claim a container backend.
+
+- Every `channel_write` result now carries one `write_state` word per channel
+  in `summary.results[]` — `blocked`, `write_failed`,
+  `verification_not_reported`, `verification_not_requested`,
+  `verified_with_alarm`, `verified`, `readback_failed`, `unverified_alarm` or
+  `verification_failed` — so a caller can tell a refused write from one that
+  went out unverified. `summary.verification_failed` counts the executed
+  writes that asked for callback or readback verification and did not get it;
+  refused and failed writes are not counted.
+
+- `channel_write.verification_level` is now optional. Omit it and the
+  deployment resolves the level, and any readback tolerance, per write;
+  `access_details.verification_level` is then null. A level you do pass is
+  honored as written — the validator no longer overrides it, and it no longer
+  costs you the tolerance held in the limits database.
+
+- Batch writes and `osprey.runtime.write_channels` now resolve verification
+  per channel the same way single writes do, instead of being pinned to
+  callback. A project whose defaults ask for readback verification will see
+  batch writes verified by readback, and the Python path raise when a readback
+  does not match.
+
+- A readback-verified write now reports the readback's alarm state by name:
+  `readback_alarm_status` and `readback_alarm_severity`. Channel Access reads
+  and subscriptions report alarm names too; the raw numeric code stays in
+  `raw_metadata["status"]`.
+
+- A write whose readback read itself fails is now reported as such —
+  `failure_kind="readback_failed"` on EPICS, DOOCS and Mock — and DOOCS no
+  longer labels a failed `set()` as verification level `none`.
+
+- `WriteVerification` gained three optional fields for connector authors.
+  Connectors that do not set them keep working; see the connector how-to.
+
+- This partially addresses #465. Still open: carrying the post-write readback
+  value at every verification level, flipping `success` when the readback read
+  fails, and labeling an infrastructure failure differently from a
+  control-system failure.
+
 ### Fixed
 
 - The contribute and release skills' CI watch loops no longer treat an empty

--- a/docs/source/how-to/add-connector.rst
+++ b/docs/source/how-to/add-connector.rst
@@ -386,9 +386,28 @@ All ``write_channel()`` calls return :class:`~osprey.connectors.control_system.b
 ``tolerance_absolute`` takes priority over ``tolerance_percent`` (percentage of value).
 Each channel inherits any field it does not set from the ``defaults`` block, and a
 channel's own value always overrides it. ``writable`` defaults to ``true``; a channel's
-verification falls back to the ``defaults`` block's verification and then to the global
-``control_system.write_verification.default_level``. Set ``"writable": false`` -- on a
-channel, or in ``defaults`` to lock everything down by default -- to block writes.
+verification falls back to the ``defaults`` block's verification. Set ``"writable": false``
+-- on a channel, or in ``defaults`` to lock everything down by default -- to block writes.
+
+**Where the level comes from.** Passing no ``verification_level`` means "no opinion",
+not "no verification". The connector then resolves the level for that channel through
+four layers, using the first one that supplies a value:
+
+1. the channel's own ``verification`` entry in the limits database,
+2. the limits database ``defaults.verification`` block,
+3. ``control_system.write_verification`` in ``config.yml``,
+4. the built-in fallback: ``callback``, with no tolerance.
+
+The tolerance resolves through the same four layers, and it keeps doing so when the
+level was passed explicitly, but a layer only supplies a tolerance when the level it
+resolves to is ``readback``. Asking for ``readback`` on a channel whose limits entry
+declares ``level: readback`` with ``tolerance_percent: 1.0`` verifies at 1%, not at
+the built-in default -- pass ``tolerance`` as well to override that too.
+
+Batch writes resolve the same way. ``write_multiple_channels()`` carries one level for
+the whole batch, so when the caller omits it the keyword is left off each per-channel
+write and every channel resolves its own. This is why ``osprey.runtime.write_channels``
+verifies exactly like ``osprey.runtime.write_channel``.
 
 .. _write-safety-config:
 
@@ -456,6 +475,44 @@ Implementing Custom Connectors
 Subclass :class:`~osprey.connectors.control_system.base.ControlSystemConnector` and implement the abstract methods: ``connect``, ``disconnect``, ``read_channel``, ``write_channel``, ``read_multiple_channels``, ``subscribe``, ``unsubscribe``, ``get_metadata``, ``validate_channel``.
 
 You may also override the non-abstract ``write_multiple_channels()`` method if your backend benefits from atomic batch writes (e.g., disabling lattice recalculation between writes in a simulator). The default implementation writes sequentially via ``write_channel()``.
+
+**The verification arguments are optional.** Declare them as::
+
+   async def write_channel(
+       self,
+       channel_address: str,
+       value: Any,
+       timeout: float | None = None,
+       verification_level: str | None = None,
+       tolerance: float | None = None,
+   ) -> ChannelWriteResult:
+
+``None`` is a sentinel meaning "the caller did not specify a level" -- deliberately
+different from the ``"none"`` level, which means "write, and do not verify". When
+``verification_level`` arrives as ``None``, hand the channel and the value to the
+inherited ``_get_verification_config()`` helper, which walks the four layers described
+under `Write Verification`_ and returns the level and tolerance to use.
+
+A connector written before the sentinel existed -- one declaring a concrete default such
+as ``verification_level: str = "callback"`` -- keeps working unchanged. The batch path
+omits the keyword rather than forwarding ``None``, so that connector's own default still
+applies.
+
+**Three verification fields are optional too.**
+:class:`~osprey.connectors.control_system.base.WriteVerification` accepts, beyond the
+level and the readback value:
+
+- ``readback_alarm_status`` -- the alarm name the readback carried, as the control
+  system spells it (for EPICS, ``"NO_ALARM"``, ``"HIHI"``, and so on).
+- ``readback_alarm_severity`` -- the numeric severity: ``0`` healthy, ``1`` MINOR,
+  ``2`` MAJOR, ``3`` INVALID.
+- ``failure_kind`` -- a short tag for *why* verification failed, when the reason is
+  more specific than "the value did not match". A readback that raised is reported as
+  ``"readback_failed"``; a plain value mismatch leaves the field unset.
+
+Leaving a field at ``None`` means "not reported", which is deliberately different from a
+severity of ``0`` ("reported, and healthy"). A connector whose backend has no alarm
+concept leaves all three unset and remains fully supported.
 
 Your connector must return the standard data models from ``osprey.connectors.control_system.base``: :class:`~osprey.connectors.control_system.base.ChannelValue`, :class:`~osprey.connectors.control_system.base.ChannelMetadata`, :class:`~osprey.connectors.control_system.base.ChannelWriteResult`, and :class:`~osprey.connectors.control_system.base.WriteVerification`.
 

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
@@ -69,6 +69,18 @@ class WriteVerification:
     - "none": No verification performed (fast write)
     - "callback": Control system confirmed request processing (e.g., EPICS IOC callback)
     - "readback": Full verification with readback comparison
+
+    The alarm and ``failure_kind`` fields are the *machine-readable* half of the
+    result: consumers classify a write from them, never by parsing ``notes``,
+    which stays display-only. All three are optional and default to ``None``,
+    so a connector that cannot report them — and every existing construction —
+    stays valid. ``None`` means "not reported", which is deliberately distinct
+    from a reported healthy value (``readback_alarm_severity=0``).
+
+    Alarm state is carried protocol-agnostically: the *name* as a string and the
+    severity as an int. Mapping a protocol's raw codes to those names is the
+    connector's job (EPICS does it in ``epics_connector.py``), so this shared
+    module imports no control-system constants.
     """
 
     level: str  # "none", "callback", "readback"
@@ -76,6 +88,13 @@ class WriteVerification:
     readback_value: float | None = None  # Actual value read back (for "readback" level)
     tolerance_used: float | None = None  # Tolerance used for comparison (for "readback" level)
     notes: str | None = None  # Additional verification details
+    # Alarm name reported for the readback, e.g. "NO_ALARM"/"HIHI"; None if not reported
+    readback_alarm_status: str | None = None
+    # Alarm severity for the readback: 0 healthy, higher is worse; None if not reported
+    readback_alarm_severity: int | None = None
+    # Structured failure classification, e.g. "readback_failed" when the readback
+    # read itself raised. A plain value mismatch leaves this None.
+    failure_kind: str | None = None
 
 
 @dataclass
@@ -311,10 +330,11 @@ class ControlSystemConnector(ABC):
     ) -> tuple[str, float | None]:
         """Get verification level and tolerance for a channel write.
 
-        Priority:
-        1. Per-channel config from limits database
-        2. Global config from config.yml
-        3. Fallback: callback with no tolerance
+        Priority (the four layers documented on :meth:`write_channel`):
+        1. The channel's own ``verification`` entry in the limits database
+        2. The limits database ``defaults.verification`` block
+        3. Global config from config.yml (``control_system.write_verification``)
+        4. Fallback: callback with no tolerance
 
         Args:
             channel_address: Channel being written
@@ -405,7 +425,7 @@ class ControlSystemConnector(ABC):
         channel_address: str,
         value: Any,
         timeout: float | None = None,
-        verification_level: str = "callback",
+        verification_level: str | None = None,
         tolerance: float | None = None,
     ) -> ChannelWriteResult:
         """
@@ -415,8 +435,11 @@ class ControlSystemConnector(ABC):
             channel_address: Address/name of the channel
             value: Value to write
             timeout: Optional timeout in seconds
-            verification_level: Verification strategy ("none", "callback", "readback")
-            tolerance: Absolute tolerance for readback verification (only used if verification_level="readback")
+            verification_level: Verification strategy ("none", "callback", "readback"),
+                or ``None`` to let the connector resolve the level for this channel
+            tolerance: Absolute tolerance for readback verification (only used if
+                verification_level resolves to "readback"); ``None`` lets the
+                connector resolve the tolerance for this channel
 
         Returns:
             ChannelWriteResult with write status and verification details
@@ -435,6 +458,32 @@ class ControlSystemConnector(ABC):
 
             Different control systems may interpret these levels differently based on
             their native capabilities.
+
+        Omission sentinel:
+            ``verification_level=None`` means "not specified" — it is NOT a fourth
+            level, and it is not the same as ``"none"``. Callers that have no opinion
+            leave the keyword off entirely; the connector then resolves the level for
+            this specific channel. ``tolerance=None`` works the same way.
+
+        Resolution order (four layers, level and tolerance alike):
+            1. The channel's own ``verification`` entry in the limits database.
+            2. The limits database ``defaults.verification`` block.
+            3. Global connector config: ``control_system.write_verification``
+               (``default_level``, ``default_tolerance_percent``).
+            4. Hard-coded fallback: ``"callback"``, no tolerance.
+
+            The first layer that supplies a value wins, so a facility can set a
+            house default in the limits database and override it per channel.
+            :meth:`_get_verification_config` implements layers 1-4 for the built-in
+            connectors.
+
+            An explicit ``verification_level`` overrides all four layers for the
+            level only. Tolerance still resolves through them, so asking for
+            ``"readback"`` on a channel whose limits entry declares
+            ``level: readback`` with ``tolerance_percent: 1.0`` verifies at 1%,
+            not at some hard-coded default -- the layers supply a tolerance only
+            when the level they resolve to is ``"readback"``. Pass ``tolerance``
+            explicitly to override that too.
 
         Two-layer safety model:
             **Per-write mechanical safety** lives INSIDE the connector and is applied
@@ -506,7 +555,7 @@ class ControlSystemConnector(ABC):
         self,
         operations: list[tuple[str, Any]],
         timeout: float | None = None,
-        verification_level: str = "callback",
+        verification_level: str | None = None,
         tolerance: float | None = None,
     ) -> list[ChannelWriteResult]:
         """
@@ -519,21 +568,36 @@ class ControlSystemConnector(ABC):
         Args:
             operations: List of (channel_address, value) tuples
             timeout: Optional timeout in seconds
-            verification_level: Verification strategy ("none", "callback", "readback")
-            tolerance: Absolute tolerance for readback verification
+            verification_level: Verification strategy ("none", "callback", "readback"),
+                or ``None`` to let each channel resolve its own level
+            tolerance: Absolute tolerance for readback verification, or ``None`` to
+                let each channel resolve its own tolerance
 
         Returns:
             List of ChannelWriteResult in the same order as operations
+
+        Note:
+            A batch carries one scalar level for every channel in it, so an
+            omitted ``verification_level`` is *not* resolved here — the keyword is
+            simply left off each per-channel ``write_channel()`` call. Each channel
+            then resolves its own level and tolerance through the four layers
+            documented on :meth:`write_channel`, which is what makes batch writes
+            behave like single writes. A connector that declares a concrete default
+            of its own (``verification_level: str = "callback"``) keeps that default,
+            because the keyword never reaches it.
+
+            An explicit level, by contrast, is forwarded unchanged to every channel.
         """
         results = []
         for address, value in operations:
-            result = await self.write_channel(
-                address,
-                value,
-                timeout=timeout,
-                verification_level=verification_level,
-                tolerance=tolerance,
-            )
+            kwargs: dict[str, Any] = {"timeout": timeout, "tolerance": tolerance}
+            # Omission is a sentinel, not a value: forwarding None would override a
+            # legacy connector's own default. Leave the keyword off instead. Only
+            # verification_level has a non-None legacy default in practice --
+            # tolerance and timeout are always forwarded above.
+            if verification_level is not None:
+                kwargs["verification_level"] = verification_level
+            result = await self.write_channel(address, value, **kwargs)
             results.append(result)
         return results
 

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/doocs_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/doocs_connector.py
@@ -182,13 +182,27 @@ class DOOCSConnector(ControlSystemConnector):
                 # Log unexpected errors but don't block (fail-open for non-limit errors)
                 logger.warning(f"Limits validation error (non-blocking): {e}")
 
-        # Step 2: Auto-determine verification config if not provided
-        if verification_level is None:
-            verification_level, auto_tolerance = self._get_verification_config(
-                channel_address, float(value)
+        # Step 2: Resolve verification config.
+        #
+        # The level is auto-determined only when the caller omitted it, but the
+        # tolerance is resolved from the limits DB either way: passing an explicit
+        # level must not silently drop the tolerance configured for the channel.
+        if verification_level is None or tolerance is None:
+            # The value is only used to scale a percentage tolerance. DOOCS also
+            # writes strings, which have no numeric scale, so fall back to 0.0
+            # instead of raising on float().
+            try:
+                tolerance_scale = float(value)
+            except (TypeError, ValueError):
+                tolerance_scale = 0.0
+
+            resolved_level, resolved_tolerance = self._get_verification_config(
+                channel_address, tolerance_scale
             )
+            if verification_level is None:
+                verification_level = resolved_level
             if tolerance is None:
-                tolerance = auto_tolerance
+                tolerance = resolved_tolerance
 
         if verification_level == "callback":
             logger.debug(
@@ -232,7 +246,11 @@ class DOOCSConnector(ControlSystemConnector):
                     value_written=value,
                     success=False,
                     verification=WriteVerification(
-                        level="none", verified=False, notes="Write command failed"
+                        # Readback is the level this arm performs, so report it
+                        # even when the write itself never got that far.
+                        level="readback",
+                        verified=False,
+                        notes="Write command failed",
                     ),
                     error_message=f"Failed to write to '{channel_address}': {e}",
                 )
@@ -296,6 +314,9 @@ class DOOCSConnector(ControlSystemConnector):
                         level="readback",
                         verified=False,
                         notes=f"Readback failed: {str(e)}",
+                        # Machine-readable: the readback read itself raised. A
+                        # plain value mismatch leaves this None.
+                        failure_kind="readback_failed",
                     ),
                     error_message=f"Readback verification failed: {str(e)}",
                 )

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -52,6 +52,51 @@ def _configure_pyepics_libca() -> None:
         logger.debug("epicscorelibs libca unavailable; using pyepics default libca resolution")
 
 
+def _alarm_name(code: Any) -> str:
+    """Map a Channel Access alarm status code onto its EPICS name.
+
+    Channel Access reports the alarm status as a small integer; the rest of
+    OSPREY (and ``ChannelMetadata.alarm_status``) speaks names, which is what
+    PVAccess already emits. This is the one place codes become names, so the
+    shared connector core stays free of EPICS constants.
+
+    Anything the enum cannot map — an out-of-range code, ``None`` from a PV
+    that has not reported yet — becomes ``"UNKNOWN"``. pyepics' enum already
+    does that itself (verified on 3.5.9), but the guard keeps the read path
+    from failing on a pyepics build that decides otherwise, or one where the
+    import is unavailable.
+    """
+    try:
+        from epics.dbr import AlarmStatus
+
+        return str(AlarmStatus(code).name)
+    except Exception:  # unmappable code, or pyepics unavailable
+        return "UNKNOWN"
+
+
+def _readback_alarm_fields(readback: Any) -> tuple[str | None, int | None]:
+    """Alarm name and severity of a readback, or ``(None, None)`` if unreported.
+
+    ``None`` means "the readback carried no alarm metadata" and is deliberately
+    distinct from a reported healthy readback (severity ``0``), so a consumer
+    can tell "no alarm" from "no information".
+    """
+    metadata = getattr(readback, "metadata", None)
+    if metadata is None:
+        return None, None
+
+    status = getattr(metadata, "alarm_status", None)
+    raw = getattr(metadata, "raw_metadata", None) or {}
+    severity = raw.get("severity") if isinstance(raw, dict) else None
+    if severity is not None:
+        try:
+            severity = int(severity)
+        except (TypeError, ValueError):
+            severity = None
+
+    return (str(status) if status is not None else None, severity)
+
+
 # Normative-type identifiers the PVA read path maps specially. Compared with a
 # prefix match so a minor revision ("epics:nt/NTEnum:1.1") keeps its mapping
 # instead of silently degrading to the generic scalar path.
@@ -500,13 +545,16 @@ class EPICSConnector(ControlSystemConnector):
         else:
             timestamp = datetime.now(get_facility_timezone())
 
-        # Extract metadata
+        # Extract metadata. The alarm status is reported by name; the raw CA
+        # code stays in raw_metadata next to the severity so nothing is lost.
+        alarm_code = getattr(pv, "status", None)
         metadata = ChannelMetadata(
             units=getattr(pv, "units", "") or "",
             precision=getattr(pv, "precision", None),
-            alarm_status=pv.status if hasattr(pv, "status") else None,
+            alarm_status=_alarm_name(alarm_code),
             timestamp=timestamp,
             raw_metadata={
+                "status": alarm_code,
                 "severity": getattr(pv, "severity", None),
                 "type": getattr(pv, "type", None),
                 "count": getattr(pv, "count", None),
@@ -794,6 +842,18 @@ class EPICSConnector(ControlSystemConnector):
             )
             if tolerance is None:
                 tolerance = auto_tolerance
+        elif verification_level == "readback" and tolerance is None:
+            # An explicit level must not silently drop the configured tolerance:
+            # resolve it from the same chain (channel limits entry -> limits
+            # defaults -> global config) and keep the caller's level. Without
+            # this, naming "readback" fell back to 0.001 absolute — far tighter
+            # than the percentage tolerances shipped for setpoint channels.
+            try:
+                _, tolerance = self._get_verification_config(channel_address, float(value))
+            except (TypeError, ValueError):
+                # Non-numeric value: no percentage tolerance is computable. The
+                # readback comparison below reports the failure in context.
+                tolerance = None
 
         # Step 2: Validate the verification level up front — reject invalid levels
         # BEFORE issuing any caput (preserves the no-caput-on-invalid-level behavior).
@@ -905,6 +965,7 @@ class EPICSConnector(ControlSystemConnector):
                 # Check tolerance
                 diff = abs(float(readback.value) - float(value))
                 verified = diff <= (tolerance or 0.001)
+                alarm_status, alarm_severity = _readback_alarm_fields(readback)
 
                 logger.debug(
                     f"EPICS write (readback verified={verified}): {channel_address} = {value}, "
@@ -925,6 +986,10 @@ class EPICSConnector(ControlSystemConnector):
                             if verified
                             else f"Readback mismatch: {readback.value} (expected {value}, diff: {diff:.6f} > tolerance {tolerance})"
                         ),
+                        readback_alarm_status=alarm_status,
+                        readback_alarm_severity=alarm_severity,
+                        # A value mismatch is not a failure *kind*: the readback
+                        # itself worked. Only the except branch below classifies.
                     ),
                 )
 
@@ -935,7 +1000,10 @@ class EPICSConnector(ControlSystemConnector):
                     value_written=value,
                     success=True,  # Write succeeded, but readback failed
                     verification=WriteVerification(
-                        level="readback", verified=False, notes=f"Readback failed: {str(e)}"
+                        level="readback",
+                        verified=False,
+                        notes=f"Readback failed: {str(e)}",
+                        failure_kind="readback_failed",
                     ),
                     error_message=f"Readback verification failed: {str(e)}",
                 )
@@ -978,6 +1046,7 @@ class EPICSConnector(ControlSystemConnector):
 
         def epics_callback(pvname=None, value=None, timestamp=None, **kwargs):
             """Wrapper to convert EPICS callback to our format."""
+            alarm_code = kwargs.get("status")
             pv_value = ChannelValue(
                 value=value,
                 timestamp=(
@@ -986,7 +1055,12 @@ class EPICSConnector(ControlSystemConnector):
                     else datetime.now(get_facility_timezone())
                 ),
                 metadata=ChannelMetadata(
-                    units=kwargs.get("units", ""), alarm_status=kwargs.get("status")
+                    units=kwargs.get("units", ""),
+                    alarm_status=_alarm_name(alarm_code),
+                    raw_metadata={
+                        "status": alarm_code,
+                        "severity": kwargs.get("severity"),
+                    },
                 ),
             )
             # Schedule callback in event loop

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/mock_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/mock_connector.py
@@ -167,12 +167,17 @@ class MockConnector(ControlSystemConnector):
         2. Determines verification level from per-channel or global config
         3. Executes write with appropriate verification
 
+        An explicitly passed ``verification_level`` wins over the configured one,
+        but the tolerance is still resolved from the limits database, so an
+        explicit ``"readback"`` keeps the channel's configured tolerance.
+
         Args:
             channel_address: Any channel name
             value: Value to write
             timeout: Ignored for mock connector
             verification_level: Optional override for verification level (auto-determined if None)
-            tolerance: Optional override for tolerance (auto-calculated if None)
+            tolerance: Optional override for tolerance. Resolved from the limits
+                database when None, including when verification_level was given.
 
         Returns:
             ChannelWriteResult with write status and verification details
@@ -196,11 +201,19 @@ class MockConnector(ControlSystemConnector):
                 # Log unexpected errors but don't block (fail-open for non-limit errors)
                 logger.warning(f"Limits validation error (non-blocking): {e}")
 
-        # Step 2: Auto-determine verification config if not provided
-        if verification_level is None:
-            verification_level, auto_tolerance = self._get_verification_config(
+        # Step 2: Resolve verification config.
+        # An explicit level wins, but the tolerance is still resolved from the
+        # limits database: passing verification_level="readback" must not
+        # silently drop the channel's configured tolerance and fall back to the
+        # hard-coded 0.001. Only look it up when it is actually needed, so an
+        # explicit "none"/"callback" write of a non-numeric value never has to
+        # be coerced with float().
+        if verification_level is None or (tolerance is None and verification_level == "readback"):
+            auto_level, auto_tolerance = self._get_verification_config(
                 channel_address, float(value)
             )
+            if verification_level is None:
+                verification_level = auto_level
             if tolerance is None:
                 tolerance = auto_tolerance
 
@@ -290,6 +303,7 @@ class MockConnector(ControlSystemConnector):
                         level="readback",
                         verified=False,
                         notes=f"Simulated readback failed: {str(e)} (mock)",
+                        failure_kind="readback_failed",
                     ),
                     error_message=f"Mock readback verification failed: {str(e)}",
                 )

--- a/src/osprey/mcp_server/control_system/tools/channel_write.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_write.py
@@ -1,7 +1,7 @@
 """MCP tool: channel_write — write values to control-system channels.
 
 Safety: PreToolUse hooks enforce human approval before this tool runs.
-Tool docstring is the static prompt visible to Claude Code.
+The tool docstring is the static prompt the agent sees.
 """
 
 import json
@@ -15,23 +15,110 @@ from osprey.mcp_server.http import notify_agent_activity_async
 
 logger = logging.getLogger("osprey.mcp_server.tools.channel_write")
 
+#: Severity at or above which a *verified* readback is still reported as an
+#: alarm state. EPICS grades MINOR=1, MAJOR=2, INVALID=3; a MINOR alarm on a
+#: channel that read back the value it was given is routine, MAJOR is not.
+VERIFIED_ALARM_SEVERITY = 2
+
+#: The closed set of ``write_state`` words, in the order the predicates below
+#: test them. The generated safety rules name this key, so the spelling here and
+#: the spelling there have to stay one string.
+WRITE_STATE_KEY = "write_state"
+
+
+def _alarm_severity(verification: object) -> int | None:
+    """Readback alarm severity as an int, or None when it was not reported.
+
+    Read through ``getattr`` and type-checked: a custom connector may return any
+    duck-typed verification object, and a missing or non-numeric severity must
+    degrade to "not reported" rather than raise inside the result projection.
+    """
+    severity = getattr(verification, "readback_alarm_severity", None)
+    if isinstance(severity, bool) or not isinstance(severity, int):
+        return None
+    return severity
+
+
+def _derive_write_state(result: object) -> str:
+    """Classify one write result into a single closed-set word.
+
+    Derived only from structured fields — never from ``notes``, which is
+    display-only text — so the state an agent keys on cannot drift with wording.
+    The predicates are ordered: the first one that matches wins, which is what
+    keeps a refused write from also being reported as unverified.
+    """
+    if getattr(result, "blocked", None):
+        return "blocked"
+    if not getattr(result, "success", False):
+        return "write_failed"
+
+    verification = getattr(result, "verification", None)
+    if verification is None:
+        return "verification_not_reported"
+    if getattr(verification, "level", None) == "none":
+        return "verification_not_requested"
+
+    severity = _alarm_severity(verification)
+    if getattr(verification, "verified", False):
+        if severity is not None and severity >= VERIFIED_ALARM_SEVERITY:
+            return "verified_with_alarm"
+        return "verified"
+
+    if getattr(verification, "failure_kind", None) == "readback_failed":
+        return "readback_failed"
+    if severity is not None and severity > 0:
+        return "unverified_alarm"
+    return "verification_failed"
+
 
 @mcp.tool()
 async def channel_write(
     operations: list[dict],
-    verification_level: str = "callback",
+    verification_level: str | None = None,
 ) -> str:
     """Write values to one or more control-system channels.
 
     Each operation is a dict with keys: channel (str), value (any), notes (str, optional).
     PreToolUse hooks handle human approval BEFORE this code runs.
 
+    Every result carries one `write_state` word. Report the outcome its
+    `write_state` names and nothing stronger — an unverified write is not a
+    successful write, and you must not describe it as one. The states, in the
+    order they are decided:
+
+    - `blocked` — refused on policy or limits grounds; never sent to the machine.
+    - `write_failed` — sent to the machine and failed.
+    - `verification_not_reported` — the connector reported no verification at all.
+    - `verification_not_requested` — level `none`: the write was sent, nothing
+      confirmed it took effect.
+    - `verified_with_alarm` — the readback matched, but the channel is in a MAJOR
+      or worse alarm.
+    - `verified` — the write was confirmed.
+    - `readback_failed` — the readback itself could not be read, so the write is
+      unconfirmed.
+    - `unverified_alarm` — unconfirmed, and the channel reports an alarm.
+    - `verification_failed` — unconfirmed: the readback disagreed with the setpoint.
+
+    `summary.verification_failed` counts executed writes that asked for
+    verification and did not get it — never a refused or unrequested one.
+
+    Leave `verification_level` unset unless the operator names one. It is then
+    resolved by the deployment, per write: the channel's limits entry, then the
+    limits database `defaults.verification`, then the connector config, then
+    `callback`. This tool does not raise on an unverified write — it reports it in
+    `write_state`. (`osprey.runtime.write_channel`, on the Python path, raises.)
+
     Args:
         operations: List of write operations, each with "channel", "value", and optional "notes".
-        verification_level: Verification after write — "none", "callback", or "readback".
+        verification_level: Optional override — "none", "callback", or "readback".
+            Omit it to let the deployment resolve the level per write.
 
     Returns:
-        JSON with per-operation results including verification status.
+        JSON with per-operation results. Each `summary.results[]` entry carries
+        `write_state`; its `verification` carries the readback value, the alarm
+        name and severity, and `failure_kind` when the connector reported them.
+        `summary.verification_failed` counts executed writes that asked for
+        verification and did not get it.
     """
     if not operations:
         return make_error(
@@ -116,24 +203,38 @@ async def channel_write(
         if len(operations) == 1:
             op = operations[0]
             channel, value = op["channel"], op["value"]
+            # An explicit level is the caller's decision and is forwarded
+            # unchanged; the limits database only fills in a level the caller
+            # left out. The tolerance is independent of that: a per-channel
+            # tolerance applies whether or not the level was named, or an
+            # explicit "readback" would silently fall back to the connector's
+            # absolute default.
             level = verification_level
             tolerance = None
             if validator:
                 cfg_level, cfg_tol = validator.get_verification_config(channel, value)
-                if cfg_level:
+                if level is None and cfg_level:
                     level = cfg_level
                 if cfg_tol is not None:
                     tolerance = cfg_tol
-            wr = await connector.write_channel(
-                channel, value, verification_level=level, tolerance=tolerance
-            )
+            # Omission is a sentinel, not a value: forwarding None would override
+            # a legacy custom connector's own declared default.
+            write_kwargs: dict = {}
+            if level is not None:
+                write_kwargs["verification_level"] = level
+            if tolerance is not None:
+                write_kwargs["tolerance"] = tolerance
+            wr = await connector.write_channel(channel, value, **write_kwargs)
             connector_results.append(wr)
         else:
+            # A batch carries one scalar level for every channel in it, so an
+            # omitted level is not resolved here: leaving the keyword off lets
+            # each channel resolve its own entry exactly as a single write does.
             write_ops = [(op["channel"], op["value"]) for op in operations]
-            connector_results = await connector.write_multiple_channels(
-                write_ops,
-                verification_level=verification_level,
-            )
+            batch_kwargs: dict = {}
+            if verification_level is not None:
+                batch_kwargs["verification_level"] = verification_level
+            connector_results = await connector.write_multiple_channels(write_ops, **batch_kwargs)
 
         for op, wr in zip(operations, connector_results, strict=True):
             result_entry = {
@@ -144,13 +245,26 @@ async def channel_write(
                 "blocked": wr.blocked,
                 "refusal_reason": wr.refusal_reason,
             }
-            if wr.verification:
+            result_entry[WRITE_STATE_KEY] = _derive_write_state(wr)
+            # "is not None", matching _derive_write_state: absence of a
+            # verification object is what "verification_not_reported" means, and
+            # the two must not disagree about which results have one.
+            verification = getattr(wr, "verification", None)
+            if verification is not None:
                 result_entry["verification"] = {
-                    "level": wr.verification.level,
-                    "verified": wr.verification.verified,
-                    "readback_value": wr.verification.readback_value,
-                    "tolerance_used": wr.verification.tolerance_used,
-                    "notes": wr.verification.notes,
+                    "level": getattr(verification, "level", None),
+                    "verified": getattr(verification, "verified", None),
+                    "readback_value": getattr(verification, "readback_value", None),
+                    "tolerance_used": getattr(verification, "tolerance_used", None),
+                    # Machine-readable half of the verification. Absent fields
+                    # stay null: "not reported" is deliberately distinct from a
+                    # reported healthy severity of 0.
+                    "readback_alarm_status": getattr(verification, "readback_alarm_status", None),
+                    "readback_alarm_severity": getattr(
+                        verification, "readback_alarm_severity", None
+                    ),
+                    "failure_kind": getattr(verification, "failure_kind", None),
+                    "notes": getattr(verification, "notes", None),
                 }
             if op.get("notes"):
                 result_entry["notes"] = op["notes"]
@@ -159,16 +273,27 @@ async def channel_write(
         # Build compact summary inline
         successful = sum(1 for r in results_serialised if r["success"])
         refused = sum(1 for r in results_serialised if r.get("blocked"))
+        # A write that never executed is not a verification failure: only count
+        # writes that succeeded, asked for verification, and did not get it.
+        verification_failed = sum(
+            1
+            for r in results_serialised
+            if r["success"]
+            and (r.get("verification") or {}).get("level") in ("callback", "readback")
+            and not (r.get("verification") or {}).get("verified")
+        )
         summary = {
             "total_writes": len(results_serialised),
             "successful": successful,
             "failed": len(results_serialised) - successful,
             "refused": refused,
+            "verification_failed": verification_failed,
             "results": [
                 {
                     "channel": r["channel"],
                     "value": r["value_written"],
                     "success": r["success"],
+                    WRITE_STATE_KEY: r[WRITE_STATE_KEY],
                     "error": r.get("error_message"),
                     "blocked": r.get("blocked"),
                     "refusal_reason": r.get("refusal_reason"),
@@ -177,6 +302,7 @@ async def channel_write(
                 for r in results_serialised
             ],
         }
+        # The caller's value, or null when they left the level to the deployment.
         access_details = {"verification_level": verification_level}
 
         if results_serialised and successful == 0:

--- a/src/osprey/mcp_server/python_executor/tools/_package_inventory.py
+++ b/src/osprey/mcp_server/python_executor/tools/_package_inventory.py
@@ -2,9 +2,10 @@
 
 The ``execute`` tool description must never name a fixed set of packages
 (``numpy``, ``pandas``, ``scipy``, ``at``, ``matplotlib``, ``plotly``): a fixed
-list makes the agent reason about an import set that may not exist — a package
-present on the host but missing inside the deployed container would be
-described as available either way.
+list makes the agent reason about an import set that may not exist — the
+environment agent code runs in need not be the environment the OSPREY server
+itself runs in, so what is installed alongside the server does not reliably
+describe what agent code can import.
 
 This module enumerates the environment that
 :func:`~osprey.mcp_server.python_executor.executor.resolve_agent_interpreter`
@@ -32,6 +33,10 @@ logger = logging.getLogger("osprey.mcp_server.python_executor.package_inventory"
 
 #: Token that :func:`with_live_packages` replaces in a tool docstring.
 PACKAGES_PLACEHOLDER = "<<AVAILABLE_PACKAGES>>"
+
+#: Leading text of the rendered package line, shared with tests that need to
+#: filter it out of a tool description without duplicating the literal.
+PACKAGE_LINE_PREFIX = "Packages importable in the execution environment include:"
 
 #: Used whenever the environment cannot be enumerated.  It must never name a
 #: package: a stale list is the exact failure this module removes.
@@ -137,7 +142,7 @@ def render_package_line(names: Sequence[str]) -> str:
     line = ", ".join(listed)
     if hidden > 0:
         line += f", +{hidden} more"
-    return f"Packages importable in the execution environment include: {line}."
+    return f"{PACKAGE_LINE_PREFIX} {line}."
 
 
 @lru_cache(maxsize=1)

--- a/src/osprey/mcp_server/python_executor/tools/python_execute.py
+++ b/src/osprey/mcp_server/python_executor/tools/python_execute.py
@@ -31,7 +31,8 @@ async def execute(
 ) -> str:
     """Execute Python code with process isolation, limits enforcement, and timeout.
 
-    Code runs in a container or local subprocess (configured via config.yml).
+    Code runs in a subprocess, in the project's own Python environment when the
+    project has one (otherwise OSPREY's own interpreter).
     <<AVAILABLE_PACKAGES>>
 
     Safety layers applied before execution:
@@ -150,7 +151,7 @@ async def execute(
             ],
         )
 
-    # Execute code via adapter (container or subprocess)
+    # Execute code in the subprocess backend
     from osprey.mcp_server.python_executor.executor import execute_code
 
     exec_result = await execute_code(

--- a/src/osprey/mcp_server/python_executor/tools/python_execute_file.py
+++ b/src/osprey/mcp_server/python_executor/tools/python_execute_file.py
@@ -32,8 +32,9 @@ async def execute_file(
     """Execute an existing Python file with the same safety pipeline as ``execute``.
 
     The file is read, safety-checked, augmented with a script identity preamble
-    (``sys.argv``, ``__file__``), and executed via the same container/subprocess
-    adapter used by the ``execute`` tool.
+    (``sys.argv``, ``__file__``), and run in a subprocess, in the project's own
+    Python environment when the project has one (otherwise OSPREY's own
+    interpreter) — the same execution path used by the ``execute`` tool.
 
     Args:
         file_path: Path to a ``.py`` file.  Absolute paths are used as-is;
@@ -193,7 +194,7 @@ async def execute_file(
     preamble = f"import sys\nsys.argv = {argv_items!r}\n__file__ = {str(resolved)!r}\n"
     augmented_code = preamble + "\n" + code
 
-    # Execute augmented code via adapter (container or subprocess)
+    # Execute augmented code in a subprocess
     from osprey.mcp_server.python_executor.executor import execute_code
 
     exec_result = await execute_code(

--- a/src/osprey/runtime/__init__.py
+++ b/src/osprey/runtime/__init__.py
@@ -178,7 +178,9 @@ def write_channel(channel_address: str, value: Any, **kwargs) -> None:
         value: Value to write (will be coerced to appropriate type)
         **kwargs: Additional arguments passed to connector
                   - timeout: Operation timeout in seconds
-                  - verification_level: 'none', 'callback', or 'readback'
+                  - verification_level: 'none', 'callback', or 'readback'.
+                    Omit to let each channel resolve its own level (see the
+                    connector's four-layer resolution)
                   - tolerance: Tolerance for readback verification
 
     Raises:
@@ -234,7 +236,10 @@ def write_channels(channel_values: dict[str, Any], **kwargs) -> None:
 
     Args:
         channel_values: Dictionary mapping channel names to values
-        **kwargs: Additional arguments passed to each write
+        **kwargs: Additional arguments passed to each write (timeout,
+                  verification_level, tolerance -- see write_channel).
+                  Omit verification_level to let each channel resolve its
+                  own level (see the connector's four-layer resolution)
 
     Raises:
         ChannelLimitsViolationError: If a value violates channel safety limits

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -332,22 +332,25 @@ control_system:
     allow_unlisted_channels: true  # Permissive mode for tutorial
 
   # Write Verification Configuration
-  # How the connector confirms a write took effect. The level below applies only when
-  # the caller does not name one: osprey.runtime.write_channel scripts and direct
-  # connector calls. The channel_write MCP tool, multi-channel writes, and Bluesky
-  # device writes pass an explicit level ("callback"); for those, only a per-channel
-  # "verification" entry in channel_limits.json changes the level, and only on
-  # single-channel tool writes.
-  # A failed verification is not a hard stop. The channel_write MCP tool reports it in
-  # its result (verification.verified: false); osprey.runtime.write_channel discards it
-  # (a readback mismatch is logged at debug level only); only write_channel_checked
-  # raises (plans, which write through the Bluesky bridge's connector-backed
-  # devices). A write the CA layer could not deliver at all - for example a PV that
-  # never connects - is different: it sets success: false, which does raise from
-  # osprey.runtime.write_channel and shows up as a failed write in the MCP tool.
+  # How the connector confirms a write took effect. Every write - single or batch,
+  # from the channel_write MCP tool or from osprey.runtime - resolves its level and
+  # its tolerance through the same four layers, most specific first: the channel's
+  # "verification" entry in channel_limits.json, then that database's "defaults"
+  # block, then the connector config below, then "callback".
+  # The keys below are that third layer: control_system.write_verification.default_level
+  # and control_system.write_verification.default_tolerance_percent.
+  # A caller that names a level explicitly gets exactly that level, and the
+  # per-channel tolerance still applies to it. The channel_write MCP tool names one
+  # only when asked, and a batch write names one only when asked, so each channel in
+  # a batch resolves its own entry exactly as a single write does.
+  # A failed verification is a hard stop on the Python path: osprey.runtime.write_channel
+  # routes through write_channel_checked and raises ChannelWriteFailedError. The
+  # channel_write MCP tool does not raise; it reports the outcome in write_state and
+  # verification.verified. A write the CA layer could not deliver at all - for example
+  # a PV that never connects - sets success: false on both paths.
   write_verification:
     default_level: callback  # Options: none, callback, readback
-                            # - none: Fast write, no verification (off, on the paths above)
+                            # - none: Fast write, no verification
                             # - callback: Control system confirms processing (e.g., EPICS IOC callback)
                             # - readback: Full verification with readback comparison
     default_tolerance_percent: 0.1  # Default tolerance: 0.1% (one per mil)

--- a/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
+++ b/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
@@ -119,6 +119,32 @@ readonly script cannot shell out at all. Every refusal is reported to the
 operator and recorded in the deployment's audit log, so working around one is
 never the right move — resubmit with `execution_mode: "readwrite"` and let the
 operator approve it.
+
+## Choosing the Right Tool
+
+Match the request to one tool and stop there. Reaching past the tool the request
+calls for is how a single read turns into a script and a single write turns into
+a sequence nobody approved.
+
+- **One live value** — use `channel_read`. No script is needed.
+- **One live write the operator asked for by name** — use `channel_write`.
+- **Python analysis over data you already retrieved** — use `execute`. It needs
+  no control-system access.
+- **Python that must touch the control system** — use `execute` and reach the
+  machine through the `osprey.runtime` API, never a protocol library directly.
+{%- if "bluesky" in enabled_servers | default([]) %}
+- **Multi-setting measurements** — use the Bluesky queue. Anything that sets the
+  machine to more than one value is a plan; see below.
+{%- else %}
+- **Multi-setting measurements** — no queue is configured in this deployment. Do
+  not stand in for one with a loop of `channel_write` calls or an `execute`
+  script that steps the setpoint — tell the operator what the measurement
+  would require.
+{%- endif %}
+
+The two write paths report an unverified write differently:
+`osprey.runtime.write_channel` raises, while `channel_write` reports it in
+`write_state`.
 {% if "bluesky" in enabled_servers | default([]) %}
 
 ## Measurements Go Through the Queue, Not Through Repeated Writes

--- a/src/osprey/templates/claude_code/claude/rules/safety.md
+++ b/src/osprey/templates/claude_code/claude/rules/safety.md
@@ -42,8 +42,13 @@ You interact with the control system EXCLUSIVELY through MCP tools.
    Channel writes are validated against configured limits. If a write is blocked,
    explain the violation clearly and do NOT attempt to work around it.
 
-6. **Use readback verification for critical channels.**
-   Default verification_level is "callback."
+6. **Do not override the verification level.**
+   The deployment resolves it per write: the channel's limits entry, then the limits
+   database `defaults.verification`, then the connector config, then `callback`. For
+   a `channel_write` result, report the outcome its `write_state` names and nothing
+   stronger. At `callback` level that result carries no readback value and no alarm
+   state, so do NOT describe the machine state from it — read the channel back (rule 4)
+   if the operator needs the current value.
 
 ## Data Integrity
 

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -208,17 +208,22 @@ control_system:
     allow_unlisted_channels: true
 
   # Write Verification Configuration
-  # How the connector confirms a write took effect. Applies only when the caller does
-  # not name a level: osprey.runtime.write_channel scripts and direct connector calls.
-  # The channel_write MCP tool, multi-channel writes, and Bluesky device writes pass an
-  # explicit level ("callback"); for those, only a per-channel "verification" entry in
-  # channel_limits.json changes the level, and only on single-channel tool writes.
-  # A failed verification is not a hard stop: the channel_write MCP tool reports it
-  # (verification.verified: false), osprey.runtime.write_channel discards it (a readback
-  # mismatch is logged at debug level only), and only write_channel_checked raises (plans,
-  # which write through the Bluesky bridge's connector-backed devices). A write
-  # the CA layer could not deliver at all - for example a PV that never connects -
-  # sets success: false, which does raise from osprey.runtime.write_channel.
+  # How the connector confirms a write took effect. Every write - single or batch,
+  # from the channel_write MCP tool or from osprey.runtime - resolves its level and
+  # its tolerance through the same four layers, most specific first: the channel's
+  # "verification" entry in channel_limits.json, then that database's "defaults"
+  # block, then the connector config below, then "callback".
+  # The keys below are that third layer: control_system.write_verification.default_level
+  # and control_system.write_verification.default_tolerance_percent.
+  # A caller that names a level explicitly gets exactly that level, and the
+  # per-channel tolerance still applies to it. The channel_write MCP tool names one
+  # only when asked, and a batch write names one only when asked, so each channel in
+  # a batch resolves its own entry exactly as a single write does.
+  # A failed verification is a hard stop on the Python path: osprey.runtime.write_channel
+  # routes through write_channel_checked and raises ChannelWriteFailedError. The
+  # channel_write MCP tool does not raise; it reports the outcome in write_state and
+  # verification.verified. A write the CA layer could not deliver at all - for example
+  # a PV that never connects - sets success: false on both paths.
   write_verification:
     default_level: "callback"  # Options: none | callback | readback ("none" = no verification)
     default_tolerance_percent: 0.1  # "readback" only; per-channel override in channel_limits.json

--- a/tests/connectors/test_auto_verification.py
+++ b/tests/connectors/test_auto_verification.py
@@ -43,40 +43,6 @@ class TestAutomaticVerification:
             await connector.disconnect()
 
     @pytest.mark.asyncio
-    async def test_automatic_verification_with_global_config(self, tmp_path):
-        """Test automatic verification uses global config when available."""
-        # Create a temporary config file
-        config_file = tmp_path / "config.yml"
-        config_file.write_text(
-            """
-control_system:
-  type: mock
-  writes_enabled: true
-  write_verification:
-    default_level: readback
-    default_tolerance_percent: 0.5
-"""
-        )
-
-        # Create connector (will try to load config but gracefully fall back)
-        connector = MockConnector()
-        with patch(
-            "osprey.utils.config.get_config_value",
-            side_effect=_config_with_writes_enabled,
-        ):
-            await connector.connect({"response_delay_ms": 1})
-
-            # Without explicit params, uses automatic config
-            result = await connector.write_channel("TEST:CHANNEL", 100.0)
-
-            assert result.success is True
-            assert result.verification is not None
-            # Will be callback (hardcoded fallback) since we can't inject config in tests
-            # This is expected - tests run without config.yml
-
-            await connector.disconnect()
-
-    @pytest.mark.asyncio
     async def test_automatic_verification_with_per_channel_config(self, tmp_path, monkeypatch):
         """Test automatic verification uses per-channel config from limits database."""
         # Create limits database with per-channel verification
@@ -214,5 +180,215 @@ control_system:
         assert result.verification is not None
         assert result.verification.level == "readback"
         assert result.verification.tolerance_used == pytest.approx(0.25, abs=0.01)
+
+        await connector.disconnect()
+
+
+def _limits_config(limits_file, **extra):
+    """Config map that enables limits checking against ``limits_file``."""
+    config_map = {
+        "control_system.limits_checking.enabled": True,
+        "control_system.limits_checking.database_path": str(limits_file),
+        "control_system.limits_checking.allow_unlisted_channels": False,
+        "control_system.limits_checking.on_violation": "skip",
+        "control_system.writes_enabled": True,
+    }
+    config_map.update(extra)
+
+    def get_config_value(key, default=None):
+        return config_map.get(key, default)
+
+    return get_config_value
+
+
+def _write_limits_db(tmp_path, limits_db):
+    limits_file = tmp_path / "limits.json"
+    limits_file.write_text(json.dumps(limits_db, indent=2))
+    return limits_file
+
+
+class TestVerificationPrecedence:
+    """Pin the four-layer resolution order documented on ``write_channel``.
+
+    1. the channel's own ``verification`` entry, 2. the limits database
+    ``defaults.verification`` block, 3. global ``control_system.write_verification``
+    config, 4. the hard-coded ``("callback", None)`` fallback.
+    """
+
+    @pytest.mark.asyncio
+    async def test_channel_entry_beats_defaults_block(self, tmp_path, monkeypatch):
+        """Layer 1 wins over layer 2: a channel entry overrides the defaults block."""
+        limits_file = _write_limits_db(
+            tmp_path,
+            {
+                "defaults": {"writable": True, "verification": {"level": "none"}},
+                "PICKY:CHANNEL": {
+                    "min_value": 0.0,
+                    "max_value": 100.0,
+                    "verification": {"level": "readback", "tolerance_absolute": 0.5},
+                },
+                "PLAIN:CHANNEL": {"min_value": 0.0, "max_value": 100.0},
+            },
+        )
+        monkeypatch.setattr("osprey.utils.config.get_config_value", _limits_config(limits_file))
+
+        connector = MockConnector()
+        await connector.connect({"response_delay_ms": 1, "noise_level": 0.0})
+
+        assert connector._get_verification_config("PICKY:CHANNEL", 10.0) == ("readback", 0.5)
+        # The channel without its own entry falls through to the defaults block.
+        assert connector._get_verification_config("PLAIN:CHANNEL", 10.0) == ("none", None)
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_defaults_block_beats_global_config(self, tmp_path, monkeypatch):
+        """Layer 2 wins over layer 3: the limits database outranks config.yml."""
+        limits_file = _write_limits_db(
+            tmp_path,
+            {
+                "defaults": {
+                    "writable": True,
+                    "verification": {"level": "readback", "tolerance_percent": 1.0},
+                },
+                "ANY:CHANNEL": {"min_value": 0.0, "max_value": 100.0},
+            },
+        )
+        monkeypatch.setattr(
+            "osprey.utils.config.get_config_value",
+            _limits_config(
+                limits_file,
+                **{
+                    "control_system.write_verification.default_level": "none",
+                    "control_system.write_verification.default_tolerance_percent": 25.0,
+                },
+            ),
+        )
+
+        connector = MockConnector()
+        await connector.connect({"response_delay_ms": 1, "noise_level": 0.0})
+
+        level, tolerance = connector._get_verification_config("ANY:CHANNEL", 40.0)
+        assert level == "readback"
+        assert tolerance == pytest.approx(0.4)  # 1 % of 40.0, not the global 25 %
+
+        await connector.disconnect()
+
+    def test_global_config_used_without_limits_database(self, monkeypatch):
+        """Layer 3: with no limits database, config.yml supplies level and tolerance."""
+        config_map = {
+            "control_system.write_verification.default_level": "readback",
+            "control_system.write_verification.default_tolerance_percent": 0.5,
+        }
+        monkeypatch.setattr(
+            "osprey.utils.config.get_config_value",
+            lambda key, default=None: config_map.get(key, default),
+        )
+
+        connector = MockConnector()
+        assert connector._limits_validator is None
+
+        level, tolerance = connector._get_verification_config("TEST:CHANNEL", 100.0)
+        assert level == "readback"
+        assert tolerance == pytest.approx(0.5)  # 0.5 % of 100.0
+
+    def test_hardcoded_fallback_when_config_unavailable(self, monkeypatch):
+        """Layer 4: no limits database and no config leaves the safe built-in default."""
+
+        def no_config(key, default=None):
+            raise FileNotFoundError("no config.yml in this project")
+
+        monkeypatch.setattr("osprey.utils.config.get_config_value", no_config)
+
+        connector = MockConnector()
+        assert connector._get_verification_config("TEST:CHANNEL", 100.0) == ("callback", None)
+
+    @pytest.mark.asyncio
+    async def test_explicit_level_overrides_every_layer(self, tmp_path, monkeypatch):
+        """An explicit ``verification_level`` outranks all four layers."""
+        limits_file = _write_limits_db(
+            tmp_path,
+            {
+                "defaults": {"writable": True, "verification": {"level": "callback"}},
+                "STRICT:CHANNEL": {
+                    "min_value": 0.0,
+                    "max_value": 100.0,
+                    "verification": {"level": "readback"},
+                },
+            },
+        )
+        monkeypatch.setattr("osprey.utils.config.get_config_value", _limits_config(limits_file))
+
+        connector = MockConnector()
+        await connector.connect({"response_delay_ms": 1, "noise_level": 0.0})
+
+        # Omitted: the channel entry decides.
+        omitted = await connector.write_channel("STRICT:CHANNEL", 50.0)
+        assert omitted.verification.level == "readback"
+
+        # Explicit: the caller decides, database entry notwithstanding.
+        explicit = await connector.write_channel("STRICT:CHANNEL", 50.0, verification_level="none")
+        assert explicit.verification.level == "none"
+
+        await connector.disconnect()
+
+
+class TestBatchVerificationResolution:
+    """``write_multiple_channels`` resolves per channel instead of pinning "callback"."""
+
+    @pytest.mark.asyncio
+    async def test_batch_resolves_defaults_block_per_channel(self, tmp_path, monkeypatch):
+        """An omitted level lets every channel in the batch resolve its own.
+
+        This is the ``osprey.runtime.write_channels`` parity change: batches used to
+        arrive at the connector pinned at "callback".
+        """
+        limits_file = _write_limits_db(
+            tmp_path,
+            {
+                "defaults": {"writable": True, "verification": {"level": "readback"}},
+                "BATCH:CH1": {"min_value": 0.0, "max_value": 100.0},
+                "BATCH:CH2": {"min_value": 0.0, "max_value": 100.0},
+            },
+        )
+        monkeypatch.setattr("osprey.utils.config.get_config_value", _limits_config(limits_file))
+
+        connector = MockConnector()
+        await connector.connect({"response_delay_ms": 1, "noise_level": 0.0})
+
+        results = await connector.write_multiple_channels(
+            [("BATCH:CH1", 10.0), ("BATCH:CH2", 20.0)]
+        )
+
+        assert [r.channel_address for r in results] == ["BATCH:CH1", "BATCH:CH2"]
+        for result in results:
+            assert result.verification is not None
+            assert result.verification.level == "readback"
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_batch_forwards_explicit_level_to_every_channel(self, tmp_path, monkeypatch):
+        """An explicit level is forwarded unchanged, overriding the database."""
+        limits_file = _write_limits_db(
+            tmp_path,
+            {
+                "defaults": {"writable": True, "verification": {"level": "readback"}},
+                "BATCH:CH1": {"min_value": 0.0, "max_value": 100.0},
+                "BATCH:CH2": {"min_value": 0.0, "max_value": 100.0},
+            },
+        )
+        monkeypatch.setattr("osprey.utils.config.get_config_value", _limits_config(limits_file))
+
+        connector = MockConnector()
+        await connector.connect({"response_delay_ms": 1, "noise_level": 0.0})
+
+        results = await connector.write_multiple_channels(
+            [("BATCH:CH1", 10.0), ("BATCH:CH2", 20.0)], verification_level="none"
+        )
+
+        for result in results:
+            assert result.verification is not None
+            assert result.verification.level == "none"
 
         await connector.disconnect()

--- a/tests/connectors/test_doocs_connector.py
+++ b/tests/connectors/test_doocs_connector.py
@@ -51,6 +51,29 @@ def _make_doocs4py(names_result=None, get_data_value=42.0):
 # --------------------------------------------------------------------------------------
 
 
+def _structured_write_facts(result):
+    """The machine-readable half of a write result — everything but ``notes``."""
+    v = result.verification
+    return (
+        result.success,
+        v.level,
+        v.verified,
+        v.failure_kind,
+        v.readback_value,
+        v.tolerance_used,
+        v.readback_alarm_status,
+        v.readback_alarm_severity,
+    )
+
+
+def _make_limits_validator(level="callback", tolerance=0.5):
+    """A limits validator that passes validation and reports a verification config."""
+    validator = MagicMock()
+    validator.validate.return_value = None
+    validator.get_verification_config.return_value = (level, tolerance)
+    return validator
+
+
 def _writes_enabled(key, default=None):
     if key == "control_system.writes_enabled":
         return True
@@ -195,6 +218,8 @@ class TestWriteChannel:
 
         assert result.success is False
         assert "write failed" in result.error_message or "FAC/DEV/LOC/PROP" in result.error_message
+        # The fast path performs no verification, so "none" is the honest level here.
+        assert result.verification.level == "none"
 
     async def test_write_readback_verified(self, connector):
         conn, mock_d4py = connector
@@ -270,6 +295,166 @@ class TestWriteChannel:
         assert result.success is True
         assert result.verification.verified is False
         assert "Readback failed" in result.verification.notes
+
+
+class TestWriteFailureKind:
+    """``failure_kind`` classifies a write without anyone parsing ``notes``."""
+
+    async def test_readback_exception_sets_failure_kind(self, connector):
+        conn, mock_d4py = connector
+        mock_d4py.get.side_effect = RuntimeError("readback error")
+
+        result = await conn.write_channel(
+            "FAC/DEV/LOC/PROP", 10.0, verification_level="readback", tolerance=0.1
+        )
+
+        assert result.verification.failure_kind == "readback_failed"
+        # DOOCS has no alarm metadata to report.
+        assert result.verification.readback_alarm_status is None
+        assert result.verification.readback_alarm_severity is None
+
+    async def test_numeric_mismatch_leaves_failure_kind_null(self, connector):
+        conn, mock_d4py = connector
+        mock_d4py.get.return_value = _make_eq_data(value=99.0)
+
+        result = await conn.write_channel(
+            "FAC/DEV/LOC/PROP", 10.0, verification_level="readback", tolerance=0.1
+        )
+
+        assert result.verification.verified is False
+        assert result.verification.failure_kind is None
+
+    async def test_string_mismatch_leaves_failure_kind_null(self, connector):
+        conn, mock_d4py = connector
+        mock_d4py.get.return_value = _make_eq_data(value="OTHER")
+
+        result = await conn.write_channel(
+            "FAC/DEV/LOC/PROP", "DESIRED", verification_level="readback", tolerance=0.1
+        )
+
+        assert result.verification.verified is False
+        assert result.verification.failure_kind is None
+
+    async def test_successful_readback_leaves_failure_kind_null(self, connector):
+        conn, mock_d4py = connector
+        mock_d4py.get.return_value = _make_eq_data(value=10.0)
+
+        result = await conn.write_channel(
+            "FAC/DEV/LOC/PROP", 10.0, verification_level="readback", tolerance=0.1
+        )
+
+        assert result.verification.verified is True
+        assert result.verification.failure_kind is None
+
+    async def test_notes_text_does_not_change_structured_fields(self, connector):
+        """Two readback failures with different messages classify identically."""
+        conn, mock_d4py = connector
+
+        results = []
+        for message in ("readback error", "an entirely different failure text"):
+            mock_d4py.get.side_effect = RuntimeError(message)
+            results.append(
+                await conn.write_channel(
+                    "FAC/DEV/LOC/PROP", 10.0, verification_level="readback", tolerance=0.1
+                )
+            )
+
+        first, second = results
+        assert first.verification.notes != second.verification.notes
+        assert _structured_write_facts(first) == _structured_write_facts(second)
+
+
+class TestWriteLevelReporting:
+    """DOOCS reports the verification level it actually performs."""
+
+    async def test_failed_set_at_callback_level_reports_readback(self, connector):
+        conn, mock_d4py = connector
+        mock_d4py.set.side_effect = RuntimeError("write failed")
+
+        result = await conn.write_channel(
+            "FAC/DEV/LOC/PROP", 5.0, verification_level="callback", tolerance=0.1
+        )
+
+        assert result.success is False
+        # DOOCS downgrades callback to readback, so the failed set() must not
+        # claim "none" — that would read as "no verification was requested".
+        assert result.verification.level == "readback"
+        assert result.verification.verified is False
+        # The write, not the readback, is what failed.
+        assert result.verification.failure_kind is None
+
+    async def test_failed_set_at_readback_level_reports_readback(self, connector):
+        conn, mock_d4py = connector
+        mock_d4py.set.side_effect = RuntimeError("write failed")
+
+        result = await conn.write_channel(
+            "FAC/DEV/LOC/PROP", 5.0, verification_level="readback", tolerance=0.1
+        )
+
+        assert result.success is False
+        assert result.verification.level == "readback"
+
+
+class TestWriteToleranceResolution:
+    """An explicit level must not silently drop the configured tolerance."""
+
+    async def _write(self, validator, **kwargs):
+        mock_d4py = _make_doocs4py()
+        mock_d4py.get.return_value = _make_eq_data(value=10.2)
+
+        with (
+            patch.dict(sys.modules, {"doocs4py": mock_d4py}),
+            patch(_LIMITS_PATCH, return_value=validator),
+            patch(_TZ_PATCH, return_value=UTC),
+            patch("osprey.utils.config.get_config_value", side_effect=_writes_enabled),
+        ):
+            from osprey.connectors.control_system.doocs_connector import DOOCSConnector
+
+            conn = DOOCSConnector()
+            await conn.connect({})
+            result = await conn.write_channel("FAC/DEV/LOC/PROP", 10.0, **kwargs)
+            await conn.disconnect()
+
+        return result
+
+    async def test_explicit_level_still_resolves_limits_db_tolerance(self):
+        validator = _make_limits_validator(level="callback", tolerance=0.5)
+
+        result = await self._write(validator, verification_level="readback")
+
+        # The caller's explicit level wins over the limits DB entry...
+        assert result.verification.level == "readback"
+        # ...but the channel's configured tolerance is still applied.
+        assert result.verification.tolerance_used == 0.5
+        assert result.verification.verified is True
+        validator.get_verification_config.assert_called_once_with("FAC/DEV/LOC/PROP", 10.0)
+
+    async def test_explicit_tolerance_beats_limits_db(self):
+        validator = _make_limits_validator(level="callback", tolerance=0.5)
+
+        result = await self._write(validator, verification_level="readback", tolerance=0.05)
+
+        assert result.verification.tolerance_used == 0.05
+        # Nothing left to resolve, so the limits DB is never consulted.
+        validator.get_verification_config.assert_not_called()
+
+    async def test_omitted_level_resolves_both_from_limits_db(self):
+        validator = _make_limits_validator(level="readback", tolerance=0.5)
+
+        result = await self._write(validator)
+
+        assert result.verification.level == "readback"
+        assert result.verification.tolerance_used == 0.5
+
+    async def test_string_write_with_explicit_level_resolves_without_raising(self, connector):
+        """A non-numeric value has no percentage scale — resolution must not raise."""
+        conn, mock_d4py = connector
+        mock_d4py.get.return_value = _make_eq_data(value="ON")
+
+        result = await conn.write_channel("FAC/DEV/LOC/PROP", "ON", verification_level="readback")
+
+        assert result.success is True
+        assert result.verification.verified is True
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/connectors/test_dynamic_connector.py
+++ b/tests/connectors/test_dynamic_connector.py
@@ -115,3 +115,70 @@ class TestControlSystemContextValidation:
             registry._validate()
         assert "Unknown control_system.type: tango" in caplog.text
         assert "Unknown archiver.type: custom_archiver" in caplog.text
+
+
+class TestCustomConnectorVerificationDefault:
+    """A custom connector keeps its own ``verification_level`` default.
+
+    ``MockDynamicConnector`` predates the omission sentinel and declares
+    ``verification_level="callback"`` outright. The batch path must leave the
+    keyword off rather than forward ``None``, or that default would be lost.
+    """
+
+    @pytest.fixture
+    def writes_enabled(self, monkeypatch):
+        monkeypatch.setattr(
+            "osprey.utils.config.get_config_value",
+            lambda key, default=None: True if key == "control_system.writes_enabled" else default,
+        )
+
+    async def _connector(self):
+        config = {
+            "type": "tests.connectors._mock_dynamic_connector.MockDynamicConnector",
+            "connector": {},
+        }
+        return await ConnectorFactory.create_control_system_connector(config)
+
+    @pytest.mark.asyncio
+    async def test_omitted_level_leaves_connector_default_in_place(self, writes_enabled):
+        """Single write with the keyword omitted: the connector's default applies."""
+        connector = await self._connector()
+
+        result = await connector.write_channel("TEST:CH", 1.0)
+
+        assert result.success is True
+        assert result.verification.level == "callback"
+
+    @pytest.mark.asyncio
+    async def test_batch_omits_keyword_for_custom_connector(self, writes_enabled):
+        """Batch write with the keyword omitted: no ``None`` reaches write_channel."""
+        connector = await self._connector()
+
+        seen_kwargs = []
+        original = connector.write_channel
+
+        async def spy(channel_address, value, **kwargs):
+            seen_kwargs.append(kwargs)
+            return await original(channel_address, value, **kwargs)
+
+        connector.write_channel = spy
+
+        results = await connector.write_multiple_channels([("TEST:CH1", 1.0), ("TEST:CH2", 2.0)])
+
+        assert [r.channel_address for r in results] == ["TEST:CH1", "TEST:CH2"]
+        for result in results:
+            assert result.verification.level == "callback"
+        # The keyword is absent, not None — forwarding None would override the default.
+        assert seen_kwargs and all("verification_level" not in kw for kw in seen_kwargs)
+
+    @pytest.mark.asyncio
+    async def test_batch_forwards_explicit_level(self, writes_enabled):
+        """An explicit level still reaches a custom connector unchanged."""
+        connector = await self._connector()
+
+        results = await connector.write_multiple_channels(
+            [("TEST:CH1", 1.0), ("TEST:CH2", 2.0)], verification_level="readback"
+        )
+
+        for result in results:
+            assert result.verification.level == "readback"

--- a/tests/connectors/test_epics_connector.py
+++ b/tests/connectors/test_epics_connector.py
@@ -593,3 +593,316 @@ class TestValidateChannelAndMetadata:
         )
 
         assert await connector.validate_channel("SR:CH") is False
+
+
+# ---------------------------------------------------------------------------
+# Channel Access alarm names (read + subscribe)
+# ---------------------------------------------------------------------------
+
+
+def _connected_pv(*, status=0, severity=0, value=1.0):
+    """A fake pyepics PV that reports a value and an alarm state."""
+    pv = MagicMock()
+    pv.wait_for_connection.return_value = True
+    pv.connected = True
+    pv.get.return_value = value
+    pv.timestamp = 1_750_000_000.0
+    pv.units = "mA"
+    pv.precision = 3
+    pv.status = status
+    pv.severity = severity
+    return pv
+
+
+class TestChannelAccessAlarmNames:
+    """CA reports alarm status as an int; the connector emits the EPICS name.
+
+    ``ChannelMetadata.alarm_status`` is declared ``str | None`` and PVAccess
+    already emitted names, so the raw CA code was both the wrong type and
+    unreadable downstream. The code itself is not lost — it stays in
+    ``raw_metadata["status"]`` next to the severity.
+    """
+
+    @pytest.mark.asyncio
+    async def test_read_reports_alarm_name_not_code(self):
+        epics = MagicMock()
+        epics.PV.return_value = _connected_pv(status=3, severity=2)
+        connector = _connector(epics=epics)
+
+        result = await connector.read_channel("SR:CH", timeout=1.0)
+
+        assert result.metadata.alarm_status == "HIHI"  # not the integer 3
+
+    @pytest.mark.asyncio
+    async def test_read_reports_healthy_alarm_by_name(self):
+        epics = MagicMock()
+        epics.PV.return_value = _connected_pv(status=0, severity=0)
+        connector = _connector(epics=epics)
+
+        result = await connector.read_channel("SR:CH", timeout=1.0)
+
+        assert result.metadata.alarm_status == "NO_ALARM"
+
+    @pytest.mark.asyncio
+    async def test_read_keeps_the_raw_code_beside_the_severity(self):
+        epics = MagicMock()
+        epics.PV.return_value = _connected_pv(status=5, severity=1)
+        connector = _connector(epics=epics)
+
+        result = await connector.read_channel("SR:CH", timeout=1.0)
+
+        assert result.metadata.alarm_status == "LOLO"
+        assert result.metadata.raw_metadata["status"] == 5
+        assert result.metadata.raw_metadata["severity"] == 1
+
+    @pytest.mark.asyncio
+    async def test_unmappable_code_reads_as_unknown(self):
+        """An out-of-range code must not raise — it degrades to UNKNOWN."""
+        epics = MagicMock()
+        epics.PV.return_value = _connected_pv(status=99, severity=3)
+        connector = _connector(epics=epics)
+
+        result = await connector.read_channel("SR:CH", timeout=1.0)
+
+        assert result.metadata.alarm_status == "UNKNOWN"
+        assert result.metadata.raw_metadata["status"] == 99  # raw code still recorded
+
+    @pytest.mark.asyncio
+    async def test_subscribe_callback_reports_alarm_name(self, monkeypatch):
+        """The monitor path maps codes exactly like the read path."""
+        monkeypatch.setattr(
+            "osprey.connectors.control_system.epics_connector.get_facility_timezone",
+            lambda: __import__("zoneinfo").ZoneInfo("UTC"),
+        )
+        epics = MagicMock()
+        epics.PV.return_value = MagicMock()
+        connector = _connector(epics=epics)
+        received = []
+
+        await connector.subscribe("SR:CH", received.append)
+        epics_callback = epics.PV.call_args.kwargs["callback"]
+        epics_callback(
+            pvname="SR:CH", value=7.0, timestamp=1_750_000_000.0, units="A", status=4, severity=1
+        )
+        await asyncio.sleep(0.01)  # let call_soon_threadsafe flush
+
+        assert received[0].metadata.alarm_status == "HIGH"
+        assert received[0].metadata.raw_metadata["status"] == 4
+        assert received[0].metadata.raw_metadata["severity"] == 1
+
+
+# ---------------------------------------------------------------------------
+# write_channel — readback alarm reporting and failure classification
+# ---------------------------------------------------------------------------
+
+
+def _readback(value, *, alarm=None, severity=None):
+    """A readback ChannelValue, optionally carrying alarm metadata."""
+    raw = {} if severity is None else {"severity": severity}
+    return ChannelValue(
+        value=value,
+        timestamp=None,
+        metadata=ChannelMetadata(alarm_status=alarm, raw_metadata=raw),
+    )
+
+
+def _write_connector(monkeypatch, *, readback=None, raises=None, limits=None):
+    """A connector whose caput succeeds, with ``read_channel`` stubbed.
+
+    Every write test below needs the same setup and differs only in what the
+    readback does, so that is the only thing left at the call site.
+    """
+    epics = MagicMock()
+    epics.caput.return_value = True
+    connector = _connector(epics=epics, limits_validator=limits)
+    if raises is not None:
+        monkeypatch.setattr(connector, "read_channel", AsyncMock(side_effect=raises))
+    elif readback is not None:
+        monkeypatch.setattr(connector, "read_channel", AsyncMock(return_value=readback))
+    return connector
+
+
+@pytest.mark.usefixtures("writes_enabled")
+class TestReadbackAlarmReporting:
+    """The readback carries the channel's alarm state into the result.
+
+    These are the *structured* fields a consumer classifies a write from;
+    ``notes`` stays display-only and is never parsed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_healthy_readback_reports_severity_zero(self, monkeypatch):
+        """Severity 0 is a reported healthy value — not "unreported" (None)."""
+        connector = _write_connector(
+            monkeypatch, readback=_readback(5.0, alarm="NO_ALARM", severity=0)
+        )
+
+        result = await connector.write_channel(
+            "SR:CH", 5.0, verification_level="readback", tolerance=0.01
+        )
+
+        assert result.verification.verified is True
+        assert result.verification.readback_alarm_status == "NO_ALARM"
+        assert result.verification.readback_alarm_severity == 0
+        assert result.verification.readback_alarm_severity is not None
+        assert result.verification.failure_kind is None
+
+    @pytest.mark.asyncio
+    async def test_matching_readback_with_major_alarm_stays_verified(self, monkeypatch):
+        """The value matched, so the write verified — but the alarm is reported.
+
+        Suppressing the alarm here is exactly the narration hole #465 describes:
+        the caller needs both facts, not one of them.
+        """
+        connector = _write_connector(monkeypatch, readback=_readback(5.0, alarm="HIHI", severity=2))
+
+        result = await connector.write_channel(
+            "SR:CH", 5.0, verification_level="readback", tolerance=0.01
+        )
+
+        assert result.verification.verified is True
+        assert result.verification.readback_alarm_status == "HIHI"
+        assert result.verification.readback_alarm_severity == 2
+        assert result.verification.failure_kind is None
+
+    @pytest.mark.asyncio
+    async def test_absent_alarm_metadata_leaves_both_fields_null(self, monkeypatch):
+        """A connector that reports no alarm state says so with None, not 0."""
+        connector = _write_connector(monkeypatch, readback=_readback(5.0))
+
+        result = await connector.write_channel(
+            "SR:CH", 5.0, verification_level="readback", tolerance=0.01
+        )
+
+        assert result.verification.verified is True
+        assert result.verification.readback_alarm_status is None
+        assert result.verification.readback_alarm_severity is None
+
+    @pytest.mark.asyncio
+    async def test_active_alarm_mismatch_reports_alarm_without_failure_kind(self, monkeypatch):
+        """A value mismatch is not a failure *kind*: the readback itself worked."""
+        connector = _write_connector(monkeypatch, readback=_readback(9.9, alarm="HIHI", severity=2))
+
+        result = await connector.write_channel(
+            "SR:CH", 5.0, verification_level="readback", tolerance=0.01
+        )
+
+        assert result.success is True
+        assert result.verification.verified is False
+        assert result.verification.readback_alarm_status == "HIHI"
+        assert result.verification.readback_alarm_severity == 2
+        assert result.verification.failure_kind is None
+
+    @pytest.mark.asyncio
+    async def test_plain_mismatch_leaves_failure_kind_null(self, monkeypatch):
+        connector = _write_connector(
+            monkeypatch, readback=_readback(9.9, alarm="NO_ALARM", severity=0)
+        )
+
+        result = await connector.write_channel(
+            "SR:CH", 5.0, verification_level="readback", tolerance=0.01
+        )
+
+        assert result.verification.verified is False
+        assert result.verification.failure_kind is None
+
+    @pytest.mark.asyncio
+    async def test_readback_exception_sets_failure_kind(self, monkeypatch):
+        """A readback that raised is classified, not left indistinguishable."""
+        connector = _write_connector(monkeypatch, raises=TimeoutError("ca timeout"))
+
+        result = await connector.write_channel(
+            "SR:CH", 5.0, verification_level="readback", tolerance=0.01
+        )
+
+        assert result.verification.failure_kind == "readback_failed"
+        assert result.verification.verified is False
+        # Nothing was read, so no alarm state can be claimed.
+        assert result.verification.readback_alarm_status is None
+        assert result.verification.readback_alarm_severity is None
+
+    @pytest.mark.asyncio
+    async def test_notes_text_never_feeds_the_structured_fields(self, monkeypatch):
+        """Notes are display-only: their wording changes nothing a consumer reads.
+
+        The exception message is echoed verbatim into ``notes``; wording it to
+        look like a healthy verified readback must not move a single field.
+        """
+        connector = _write_connector(
+            monkeypatch, raises=TimeoutError("verified NO_ALARM severity 0 tolerance ok")
+        )
+
+        result = await connector.write_channel(
+            "SR:CH", 5.0, verification_level="readback", tolerance=0.01
+        )
+
+        assert "verified NO_ALARM" in result.verification.notes  # the wording did land
+        assert result.verification.verified is False
+        assert result.verification.readback_alarm_status is None
+        assert result.verification.readback_alarm_severity is None
+        assert result.verification.failure_kind == "readback_failed"
+
+
+# ---------------------------------------------------------------------------
+# write_channel — tolerance resolution under an explicit level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("writes_enabled")
+class TestExplicitLevelToleranceResolution:
+    """Naming the level must not silently discard the configured tolerance.
+
+    Passing ``verification_level="readback"`` used to skip config resolution
+    entirely, falling back to 0.001 *absolute* — far tighter than the
+    percentage tolerances shipped for setpoint channels, so ordinary writes
+    reported as mismatches.
+    """
+
+    @pytest.mark.asyncio
+    async def test_explicit_level_still_resolves_the_limits_db_tolerance(self, monkeypatch):
+        limits = MagicMock()
+        limits.get_verification_config.return_value = ("readback", 0.05)
+        connector = _write_connector(monkeypatch, readback=_readback(5.04), limits=limits)
+
+        # Explicit level, no tolerance: 0.04 is inside the configured 0.05 but
+        # far outside the 0.001 absolute fallback.
+        result = await connector.write_channel("SR:CH", 5.0, verification_level="readback")
+
+        assert result.verification.tolerance_used == 0.05
+        assert result.verification.verified is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_tolerance_still_wins_over_the_limits_db(self, monkeypatch):
+        limits = MagicMock()
+        limits.get_verification_config.return_value = ("readback", 0.05)
+        connector = _write_connector(monkeypatch, readback=_readback(5.0), limits=limits)
+
+        result = await connector.write_channel(
+            "SR:CH", 5.0, verification_level="readback", tolerance=0.5
+        )
+
+        assert result.verification.tolerance_used == 0.5
+
+    @pytest.mark.asyncio
+    async def test_explicit_level_is_not_overridden_by_the_limits_db_level(self, monkeypatch):
+        """Only the tolerance is resolved — the caller's level is authoritative."""
+        limits = MagicMock()
+        limits.get_verification_config.return_value = ("none", None)
+        connector = _write_connector(monkeypatch, readback=_readback(5.0), limits=limits)
+
+        result = await connector.write_channel("SR:CH", 5.0, verification_level="readback")
+
+        assert result.verification.level == "readback"
+
+    @pytest.mark.asyncio
+    async def test_explicit_none_level_does_not_consult_the_config(self, monkeypatch):
+        """Tolerance is meaningless without a readback: no resolution happens."""
+        limits = MagicMock()
+        limits.get_verification_config.side_effect = AssertionError(
+            "verification config resolved for a level that performs no readback"
+        )
+        connector = _write_connector(monkeypatch, limits=limits)
+
+        result = await connector.write_channel("SR:CH", 1.0, verification_level="none")
+
+        assert result.verification.level == "none"

--- a/tests/connectors/test_mock_connector.py
+++ b/tests/connectors/test_mock_connector.py
@@ -6,13 +6,14 @@ import subprocess
 import sys
 import textwrap
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
 from osprey.connectors.archiver.mock_archiver_connector import MockArchiverConnector
+from osprey.connectors.control_system.base import ChannelMetadata, ChannelValue
 from osprey.connectors.control_system.mock_connector import MockConnector
 
 
@@ -640,3 +641,234 @@ class TestKindAwareNoiseFloor:
             await connector.disconnect()
 
         assert len(values) == 1, "noise_level 0.0 must produce identical reads, not just tight ones"
+
+
+class TestMockWriteVerificationContract:
+    """Mock write results must classify readback outcomes structurally.
+
+    Issue #465: consumers decide what happened from ``failure_kind`` and the
+    other structured fields, never by parsing the display-only ``notes``.
+    ``MockConnector.read_channel`` cannot fail on its own — unknown channels
+    fall back to procedural values — so the readback exception path is reached
+    by monkeypatching ``read_channel``.
+    """
+
+    @staticmethod
+    async def _connected_mock(monkeypatch):
+        """A connected mock with writes enabled for the whole test.
+
+        The writes_enabled gate is re-read on every write, so the config patch
+        has to outlive connect().
+        """
+        monkeypatch.setattr("osprey.utils.config.get_config_value", _config_with_writes_enabled)
+        connector = MockConnector()
+        await connector.connect({"response_delay_ms": 0, "noise_level": 0.0})
+        return connector
+
+    @staticmethod
+    def _raising_read(message):
+        async def _read(channel_address, timeout=None):
+            raise RuntimeError(message)
+
+        return _read
+
+    @staticmethod
+    def _fixed_read(value):
+        async def _read(channel_address, timeout=None):
+            now = datetime.now(UTC)
+            return ChannelValue(
+                value=value,
+                timestamp=now,
+                metadata=ChannelMetadata(units="A", timestamp=now, description="stub"),
+            )
+
+        return _read
+
+    @pytest.mark.asyncio
+    async def test_readback_exception_sets_failure_kind(self, monkeypatch):
+        """A readback that raises is reported as failure_kind='readback_failed'."""
+        connector = await self._connected_mock(monkeypatch)
+        monkeypatch.setattr(connector, "read_channel", self._raising_read("CA disconnected"))
+
+        result = await connector.write_channel(
+            "TEST:CHANNEL:SP", 42.0, verification_level="readback", tolerance=0.5
+        )
+
+        verification = result.verification
+        assert verification is not None
+        assert verification.level == "readback"
+        assert verification.verified is False
+        assert verification.failure_kind == "readback_failed"
+        # Mock has no alarm metadata to report; "not reported" stays None.
+        assert verification.readback_alarm_status is None
+        assert verification.readback_alarm_severity is None
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_readback_mismatch_leaves_failure_kind_null(self, monkeypatch):
+        """An ordinary out-of-tolerance readback is not a readback failure."""
+        connector = await self._connected_mock(monkeypatch)
+        monkeypatch.setattr(connector, "read_channel", self._fixed_read(99.0))
+
+        result = await connector.write_channel(
+            "TEST:CHANNEL:SP", 42.0, verification_level="readback", tolerance=0.5
+        )
+
+        verification = result.verification
+        assert verification is not None
+        assert verification.level == "readback"
+        assert verification.verified is False
+        assert verification.failure_kind is None, "a value mismatch is not a readback failure"
+        assert verification.readback_value == pytest.approx(99.0)
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_verified_readback_leaves_failure_kind_null(self, monkeypatch):
+        """A readback inside tolerance carries no failure classification."""
+        connector = await self._connected_mock(monkeypatch)
+        monkeypatch.setattr(connector, "read_channel", self._fixed_read(42.0))
+
+        result = await connector.write_channel(
+            "TEST:CHANNEL:SP", 42.0, verification_level="readback", tolerance=0.5
+        )
+
+        verification = result.verification
+        assert verification is not None
+        assert verification.verified is True
+        assert verification.failure_kind is None
+        assert verification.readback_alarm_status is None
+        assert verification.readback_alarm_severity is None
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_notes_text_does_not_change_structured_fields(self, monkeypatch):
+        """Two readback failures with different messages classify identically.
+
+        The exception text flows into ``notes`` and nowhere else — the machine-
+        readable fields must be byte-identical across the two runs.
+        """
+        connector = await self._connected_mock(monkeypatch)
+
+        monkeypatch.setattr(connector, "read_channel", self._raising_read("timeout after 3s"))
+        first = await connector.write_channel(
+            "TEST:CHANNEL:SP", 42.0, verification_level="readback", tolerance=0.5
+        )
+
+        monkeypatch.setattr(connector, "read_channel", self._raising_read("channel not found"))
+        second = await connector.write_channel(
+            "TEST:CHANNEL:SP", 42.0, verification_level="readback", tolerance=0.5
+        )
+
+        def structured(result):
+            return (
+                result.verification.level,
+                result.verification.verified,
+                result.verification.failure_kind,
+                result.verification.readback_alarm_status,
+                result.verification.readback_alarm_severity,
+                result.success,
+            )
+
+        assert first.verification.notes != second.verification.notes, "notes should differ"
+        assert structured(first) == structured(second)
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_explicit_level_still_resolves_limits_db_tolerance(self, tmp_path, monkeypatch):
+        """An explicit level must not drop the per-channel tolerance.
+
+        Before this fix an explicit ``verification_level="readback"`` skipped the
+        limits-database lookup entirely and fell back to a hard-coded 0.001
+        absolute, which is far tighter than the 1 % most :SP channels declare.
+        """
+        limits_file = tmp_path / "limits.json"
+        limits_file.write_text(
+            json.dumps(
+                {
+                    "MAGNET:CURRENT:SP": {
+                        "min_value": 0.0,
+                        "max_value": 100.0,
+                        "verification": {"level": "readback", "tolerance_percent": 1.0},
+                    }
+                }
+            )
+        )
+
+        def _config(key, default=None):
+            return {
+                "control_system.limits_checking.enabled": True,
+                "control_system.limits_checking.database_path": str(limits_file),
+                "control_system.limits_checking.allow_unlisted_channels": False,
+                "control_system.limits_checking.on_violation": "skip",
+                "control_system.writes_enabled": True,
+            }.get(key, default)
+
+        monkeypatch.setattr("osprey.utils.config.get_config_value", _config)
+
+        connector = MockConnector()
+        await connector.connect({"response_delay_ms": 0, "noise_level": 0.0})
+
+        result = await connector.write_channel(
+            "MAGNET:CURRENT:SP", 50.0, verification_level="readback"
+        )
+
+        assert result.verification.level == "readback"
+        assert result.verification.tolerance_used == pytest.approx(0.5)
+
+        # An explicitly passed tolerance still wins over the database.
+        override = await connector.write_channel(
+            "MAGNET:CURRENT:SP", 50.0, verification_level="readback", tolerance=2.0
+        )
+        assert override.verification.tolerance_used == pytest.approx(2.0)
+
+        await connector.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_explicit_none_level_resolves_like_an_omitted_one(self, tmp_path, monkeypatch):
+        """Passing verification_level=None is identical to omitting it.
+
+        The batch path forwards ``None`` rather than dropping the keyword, so
+        the connector must resolve it from the limits database's defaults block.
+        """
+        limits_file = tmp_path / "limits.json"
+        limits_file.write_text(
+            json.dumps(
+                {
+                    "defaults": {
+                        "writable": True,
+                        "verification": {"level": "readback", "tolerance_percent": 1.0},
+                    },
+                    "MAGNET:CURRENT:SP": {"min_value": 0.0, "max_value": 100.0},
+                }
+            )
+        )
+
+        def _config(key, default=None):
+            return {
+                "control_system.limits_checking.enabled": True,
+                "control_system.limits_checking.database_path": str(limits_file),
+                "control_system.limits_checking.allow_unlisted_channels": False,
+                "control_system.limits_checking.on_violation": "skip",
+                "control_system.writes_enabled": True,
+            }.get(key, default)
+
+        monkeypatch.setattr("osprey.utils.config.get_config_value", _config)
+
+        connector = MockConnector()
+        await connector.connect({"response_delay_ms": 0, "noise_level": 0.0})
+
+        explicit_none = await connector.write_channel(
+            "MAGNET:CURRENT:SP", 50.0, verification_level=None
+        )
+        omitted = await connector.write_channel("MAGNET:CURRENT:SP", 50.0)
+
+        assert explicit_none.verification.level == "readback"
+        assert omitted.verification.level == "readback"
+        assert explicit_none.verification.tolerance_used == pytest.approx(0.5)
+        assert omitted.verification.tolerance_used == pytest.approx(0.5)
+
+        await connector.disconnect()

--- a/tests/connectors/test_write_verification.py
+++ b/tests/connectors/test_write_verification.py
@@ -7,11 +7,17 @@ Tests the three-tier verification approach:
 - readback: Full verification with readback comparison
 """
 
+import ast
+from dataclasses import asdict, fields
+from pathlib import Path
+from typing import get_type_hints
 from unittest.mock import patch
 
 import pytest
 
+from osprey.connectors.control_system import base as base_module
 from osprey.connectors.control_system.base import (
+    ChannelMetadata,
     ChannelWriteResult,
     WriteVerification,
 )
@@ -227,3 +233,213 @@ class TestVerificationTolerance:
         # Both are 0.1% of their respective values
         assert (large_tolerance / large_value) * 100 == pytest.approx(0.1, rel=1e-6)
         assert (small_tolerance / small_value) * 100 == pytest.approx(0.1, rel=1e-6)
+
+
+class TestWriteVerificationAlarmAndFailureFields:
+    """Round-trip the optional alarm / failure-kind fields on WriteVerification.
+
+    These are the machine-readable half of the write contract (issue #465):
+    consumers classify a write from them instead of parsing ``notes``. They are
+    optional, so every pre-existing construction — Mock, DOOCS, EPICS, virtual
+    accelerator, and out-of-tree custom connectors — must stay valid untouched.
+    """
+
+    def test_new_fields_default_to_none(self):
+        """A construction that predates the new fields still works, all null.
+
+        ``None`` means "not reported" and is deliberately distinct from a
+        reported-healthy severity of 0.
+        """
+        verif = WriteVerification(level="callback", verified=True)
+
+        assert verif.readback_alarm_status is None
+        assert verif.readback_alarm_severity is None
+        assert verif.failure_kind is None
+
+    def test_legacy_positional_construction_still_valid(self):
+        """The new fields are appended, so positional callers are unaffected."""
+        verif = WriteVerification("readback", True, 100.5, 0.1, "Readback confirmed")
+
+        assert verif.level == "readback"
+        assert verif.verified is True
+        assert verif.readback_value == 100.5
+        assert verif.tolerance_used == 0.1
+        assert verif.notes == "Readback confirmed"
+        assert verif.readback_alarm_status is None
+        assert verif.readback_alarm_severity is None
+        assert verif.failure_kind is None
+
+    def test_alarm_status_round_trips_as_a_name_string(self):
+        """Alarm status carries the protocol's alarm *name*, not a raw code."""
+        verif = WriteVerification(
+            level="readback",
+            verified=True,
+            readback_value=100.5,
+            readback_alarm_status="NO_ALARM",
+            readback_alarm_severity=0,
+        )
+
+        assert verif.readback_alarm_status == "NO_ALARM"
+
+    def test_alarm_severity_round_trips_as_an_int(self):
+        """Severity is an integer: 0 healthy, 1 MINOR, 2 MAJOR, 3 INVALID."""
+        verif = WriteVerification(
+            level="readback",
+            verified=True,
+            readback_value=100.5,
+            readback_alarm_status="HIHI",
+            readback_alarm_severity=2,
+        )
+
+        assert verif.readback_alarm_severity == 2
+
+    def test_healthy_severity_zero_is_distinct_from_not_reported(self):
+        """Severity 0 is a reported fact; ``None`` is the absence of one."""
+        reported = WriteVerification(level="readback", verified=True, readback_alarm_severity=0)
+        absent = WriteVerification(level="readback", verified=True)
+
+        assert reported.readback_alarm_severity == 0
+        assert reported.readback_alarm_severity is not None
+        assert absent.readback_alarm_severity is None
+
+    def test_failure_kind_readback_failed(self):
+        """A readback that raised is classified structurally, not via notes."""
+        verif = WriteVerification(
+            level="readback",
+            verified=False,
+            failure_kind="readback_failed",
+            notes="Readback read raised TimeoutError",
+        )
+
+        assert verif.failure_kind == "readback_failed"
+        assert verif.verified is False
+
+    def test_plain_mismatch_leaves_failure_kind_none(self):
+        """An ordinary value mismatch is not a readback failure."""
+        verif = WriteVerification(
+            level="readback",
+            verified=False,
+            readback_value=95.0,
+            tolerance_used=0.1,
+            notes="Readback 95.0 outside tolerance of 100.0",
+        )
+
+        assert verif.failure_kind is None
+
+    def test_full_field_set_round_trips_through_asdict(self):
+        """Every field survives a dataclass -> dict -> dataclass round trip."""
+        original = WriteVerification(
+            level="readback",
+            verified=False,
+            readback_value=95.0,
+            tolerance_used=0.1,
+            notes="mismatch with active alarm",
+            readback_alarm_status="HIHI",
+            readback_alarm_severity=2,
+            failure_kind=None,
+        )
+
+        restored = WriteVerification(**asdict(original))
+
+        assert restored == original
+        assert asdict(restored) == asdict(original)
+
+    def test_new_fields_are_optional_on_the_dataclass(self):
+        """Pin the defaults at the dataclass level, not just via a constructor."""
+        defaults = {f.name: f.default for f in fields(WriteVerification)}
+
+        assert defaults["readback_alarm_status"] is None
+        assert defaults["readback_alarm_severity"] is None
+        assert defaults["failure_kind"] is None
+
+    def test_new_field_annotations_are_pinned(self):
+        """The declared types are the contract.
+
+        Pinned on the dataclass, not with ``isinstance`` on a constructed
+        instance: asserting the type of a literal the test itself passed in only
+        re-checks the literal, and would keep passing if a field were widened.
+        """
+        hints = get_type_hints(WriteVerification)
+
+        assert hints["readback_alarm_status"] == (str | None)
+        assert hints["readback_alarm_severity"] == (int | None)
+        assert hints["failure_kind"] == (str | None)
+
+    def test_write_verification_nests_in_channel_write_result(self):
+        """The new fields reach consumers through the shipped result type."""
+        result = ChannelWriteResult(
+            channel_address="TEST:CHANNEL",
+            value_written=100.0,
+            success=True,
+            verification=WriteVerification(
+                level="readback",
+                verified=True,
+                readback_value=100.0,
+                readback_alarm_status="MINOR",
+                readback_alarm_severity=1,
+            ),
+        )
+
+        assert result.verification.readback_alarm_status == "MINOR"
+        assert result.verification.readback_alarm_severity == 1
+        assert result.verification.failure_kind is None
+
+
+class TestChannelMetadataAlarmStatusNotWidened:
+    """``ChannelMetadata.alarm_status`` stays ``str | None`` — no type widening.
+
+    Alarm *names* are produced at the protocol boundary (the EPICS connector
+    maps raw codes), so the shared metadata type does not need to admit ints.
+    """
+
+    def test_alarm_status_annotation_is_str_or_none(self):
+        # get_type_hints, not ``field.type``: the latter degrades to a raw
+        # string the moment the module adopts postponed annotations, and a
+        # string never equals ``str | None``, so the pin would pass vacuously.
+        assert get_type_hints(ChannelMetadata)["alarm_status"] == (str | None)
+
+    def test_alarm_status_defaults_to_none(self):
+        assert ChannelMetadata().alarm_status is None
+
+    def test_alarm_status_holds_a_name(self):
+        assert ChannelMetadata(alarm_status="NO_ALARM").alarm_status == "NO_ALARM"
+
+
+#: Protocol client libraries the shared core must never reach for.
+_PROTOCOL_PACKAGES = {"epics", "pyepics", "p4p", "aioca", "caproto"}
+
+
+class TestSharedCoreIsProtocolAgnostic:
+    """The shared connector core must not import EPICS constants (FR4)."""
+
+    def test_base_module_imports_no_epics_symbols(self):
+        """Checked on the import statements, so prose may still say "EPICS"."""
+        tree = ast.parse(Path(base_module.__file__).read_text())
+
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    # Relative or absolute; a relative one carries no package
+                    # prefix, which is why segments are matched individually.
+                    imported.add(node.module)
+                else:
+                    # ``from . import epics_connector`` puts the module in names.
+                    imported.update(alias.name for alias in node.names)
+
+        # A sibling connector module is just as much of a protocol leak as the
+        # client library itself, so both shapes are flagged, on any segment.
+        offenders = sorted(
+            name
+            for name in imported
+            if any(
+                part in _PROTOCOL_PACKAGES or part.endswith("_connector")
+                for part in name.split(".")
+            )
+        )
+        assert not offenders, (
+            f"shared control-system base must stay protocol-agnostic, but imports {offenders}; "
+            "alarm-code mapping belongs in epics_connector.py"
+        )

--- a/tests/deployment/test_write_verification_config_comments.py
+++ b/tests/deployment/test_write_verification_config_comments.py
@@ -1,0 +1,158 @@
+"""What the generated ``write_verification`` comments must say — and must not.
+
+Those comments are the only place an operator reads about how a write gets
+confirmed, and they were wrong: they claimed a per-channel verification entry
+applied "only on single-channel tool writes" and that
+``osprey.runtime.write_channel`` "discards" a failed verification. Both are
+false — batch writes resolve per channel like single writes, and the Python path
+raises. A comment that lies about a safety knob is worse than no comment, so the
+corrected sentences are pinned here and the retired ones are pinned as absent.
+
+Both shipped templates carry the block, so both are rendered through the real
+deployment render path (``TemplateManager``), not read as raw text: a sentence
+that only survives in the source but is cut by a Jinja branch would pass a
+plain file grep and still never reach a generated project.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import yaml
+
+from osprey.cli.templates.manager import TemplateManager
+
+# Context sufficient to render every template below; extra keys are harmless and
+# missing keys leave the `{% if enable_* %}` blocks off. Mirrors
+# tests/mcp_server/test_channel_read_config_keys.py.
+_CTX = {
+    "project_name": "demo",
+    "facility_name": "Demo",
+    "default_provider": "anthropic",
+    "default_model": "haiku",
+    "current_python_env": "/usr/bin/python3",
+    "selected_web_panels": [],
+    "builtin_panels": [],
+    "channel_finder_mode": "in_context",
+    "default_pipeline": "in_context",
+    "enable_in_context": False,
+    "enable_hierarchical": False,
+    "enable_middle_layer": False,
+    "system": {"timezone": "UTC"},
+    "osprey_labels": {"project_name": "demo", "project_root": "/tmp/demo"},
+}
+
+_PROJECT = "project/config.yml.j2"
+_CONTROL = "apps/control_assistant/config.yml.j2"
+#: Every shipped template that configures write verification.
+_TEMPLATES = [_PROJECT, _CONTROL]
+
+#: The corrected asymmetry, as one sentence pair. Comments wrap across lines, so
+#: the rendered text is normalised before this is looked for.
+CORRECTED_SENTENCE = (
+    "A failed verification is a hard stop on the Python path: "
+    "osprey.runtime.write_channel routes through write_channel_checked and "
+    "raises ChannelWriteFailedError. The channel_write MCP tool does not raise; "
+    "it reports the outcome in write_state and verification.verified."
+)
+
+#: Claims the code never made. Each described the pre-#465 behaviour wrongly.
+RETIRED_CLAIMS = ["only on single-channel tool writes", "discards it"]
+
+#: The four resolution layers, in order, in the wording the generated agent
+#: rules use — the config comments and the rules describe one mechanism.
+LAYER_PHRASES = [
+    '"verification" entry in channel_limits.json',
+    '"defaults" block',
+    "connector config",
+    '"callback"',
+]
+
+
+def _render(path: str) -> str:
+    return TemplateManager().jinja_env.get_template(path).render(**_CTX)
+
+
+def _comment_text(rendered: str) -> str:
+    """All ``#`` comment text from a rendered config, as one normalised string.
+
+    Comments wrap wherever the line length says, so an assertion on a sentence
+    has to be made against text with the ``#`` markers and line breaks taken
+    out; otherwise every reflow would be a test failure.
+    """
+    parts = []
+    for line in rendered.splitlines():
+        marker = line.find("#")
+        if marker != -1:
+            parts.append(line[marker + 1 :])
+    return re.sub(r"\s+", " ", " ".join(parts)).strip()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_corrected_hard_stop_sentence_is_present(template):
+    """Both templates state that Python raises and the MCP tool reports."""
+    text = _comment_text(_render(template))
+    assert CORRECTED_SENTENCE in text, (
+        f"{template} no longer documents the Python-raises / tool-reports "
+        "asymmetry. An operator reading these comments would expect a failed "
+        "verification to be silently tolerated on both paths."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", _TEMPLATES)
+@pytest.mark.parametrize("claim", RETIRED_CLAIMS)
+def test_retired_claims_are_gone(template, claim):
+    """The two false sentences must not come back."""
+    text = _comment_text(_render(template))
+    assert claim not in text, (
+        f"{template} still claims {claim!r}. Per-channel verification applies to "
+        "batch writes too, and osprey.runtime.write_channel raises rather than "
+        "discarding a failed verification."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_four_layer_precedence_is_documented_in_order(template):
+    """The comments name all four resolution layers, most specific first."""
+    text = _comment_text(_render(template))
+    positions = []
+    for phrase in LAYER_PHRASES:
+        index = text.find(phrase)
+        assert index != -1, f"{template} does not name the layer {phrase!r}"
+        positions.append(index)
+    assert positions == sorted(positions), (
+        f"{template} lists the verification layers out of order; the comment has "
+        "to read most-specific-first or it describes a different precedence."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_config_layer_keys_are_named_on_one_line(template):
+    """Both keys are named, each whole on a single line.
+
+    Config-key evidence is collected with single-line regexes, so a key mention
+    split across two comment lines reads as no mention at all.
+    """
+    rendered = _render(template)
+    for key in (
+        "control_system.write_verification.default_level",
+        "control_system.write_verification.default_tolerance_percent",
+    ):
+        assert any(key in line for line in rendered.splitlines()), (
+            f"{template} does not name {key} on a single line"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_keys_and_defaults_are_unchanged(template):
+    """Comments changed; the configuration did not."""
+    config = yaml.safe_load(_render(template))
+    block = config["control_system"]["write_verification"]
+    assert block["default_level"] == "callback"
+    assert block["default_tolerance_percent"] == 0.1

--- a/tests/mcp_server/test_channel_read_tool.py
+++ b/tests/mcp_server/test_channel_read_tool.py
@@ -270,3 +270,50 @@ async def test_channel_read_empty_list(tmp_path, monkeypatch):
         await fn(channels=[])
 
     _exc_ctx["envelope"]
+
+
+@pytest.mark.unit
+async def test_channel_access_alarm_renders_as_a_name(tmp_path, monkeypatch):
+    """A CA alarm reaches the tool payload as its EPICS name, not a raw code.
+
+    Driven through a real ``EPICSConnector`` with a fake pyepics rather than a
+    mocked ``ChannelValue``, so this asserts on what the connector actually
+    ships to the tool. PVAccess already emitted names; Channel Access sent the
+    integer, which is what an agent then had to guess at.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text("control_system:\n  type: epics\n")
+    initialize_server_context()
+
+    from osprey.connectors.control_system.epics_connector import EPICSConnector
+
+    pv = MagicMock()
+    pv.wait_for_connection.return_value = True
+    pv.connected = True
+    pv.get.return_value = 500.2
+    pv.timestamp = 1_750_000_000.0
+    pv.units = "mA"
+    pv.precision = 3
+    pv.status = 3  # HIHI
+    pv.severity = 2
+    fake_epics = MagicMock()
+    fake_epics.PV.return_value = pv
+
+    connector = EPICSConnector()
+    connector._epics = fake_epics
+    connector._connected = True
+    connector._epics_configured = True
+    connector._timeout = 5.0
+
+    with patch(
+        "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
+        new_callable=AsyncMock,
+        return_value=connector,
+    ):
+        fn = _get_channel_read()
+        result = await fn(channels=["SR:CURRENT:RB"], include_metadata=True)
+
+    data = extract_response_dict(result)
+    channel = data["summary"]["readings"]["SR:CURRENT:RB"]
+    assert channel["alarm_status"] == "HIHI"
+    assert channel["value"] == 500.2

--- a/tests/mcp_server/test_channel_write_tool.py
+++ b/tests/mcp_server/test_channel_write_tool.py
@@ -1,22 +1,54 @@
 """Tests for the channel_write MCP tool.
 
 Covers: successful write with readback, limits violation (inline validator),
-verification levels, connection errors, and error format compliance.
+verification levels, connection errors, error format compliance, and the
+``write_state`` contract the agent keys on.
+
+Every assertion about ``write_state`` is made on the PARSED tool output —
+``summary.results[]`` — never on an internal dict. That projection is the only
+thing an agent ever sees, so a field added to the tool's private bookkeeping and
+not to the summary would be invisible in production while looking correct in a
+test.
+
+The verification object in the fixture below is a real ``WriteVerification``, not
+a ``MagicMock``: a mock answers every attribute truthily, so a state predicate
+reading a field no connector populates would pass here and misclassify in the
+field.
 
 Note: writes_enabled check is handled by the PreToolUse hook, not the tool itself.
 The tool does its own limits validation via LimitsValidator.
 """
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from osprey.connectors.control_system.base import WriteVerification
 from osprey.mcp_server.control_system.server_context import initialize_server_context
 from tests.mcp_server.conftest import (
     assert_raises_error,
     extract_response_dict,
     get_tool_fn,
 )
+
+#: Every state the tool can emit, in the order its predicates decide them. Pinned
+#: as a list so a reordering that changes which predicate wins is visible here.
+EXPECTED_WRITE_STATES = [
+    "blocked",
+    "write_failed",
+    "verification_not_reported",
+    "verification_not_requested",
+    "verified_with_alarm",
+    "verified",
+    "readback_failed",
+    "unverified_alarm",
+    "verification_failed",
+]
+
+#: Distinguishes "argument not given" from an explicit ``None``, which is itself
+#: a meaningful value for ``verification`` and ``readback_value``.
+_UNSET = object()
 
 
 def _make_write_result(
@@ -27,7 +59,21 @@ def _make_write_result(
     verification_level="callback",
     blocked=False,
     refusal_reason=None,
+    verified=True,
+    readback_value=_UNSET,
+    tolerance_used=0.1,
+    notes="",
+    readback_alarm_status=None,
+    readback_alarm_severity=None,
+    failure_kind=None,
+    verification=_UNSET,
 ):
+    """A write result whose verification is a real ``WriteVerification``.
+
+    ``verification`` may be passed explicitly — including ``None`` for a
+    connector that reported none, or a duck-typed stand-in for a custom
+    connector — otherwise one is built from the keyword arguments.
+    """
     result = MagicMock()
     result.channel_address = channel
     result.value_written = value
@@ -35,13 +81,24 @@ def _make_write_result(
     result.error_message = error_message
     result.blocked = blocked
     result.refusal_reason = refusal_reason
-    result.verification = MagicMock()
-    result.verification.level = verification_level
-    result.verification.verified = True
-    result.verification.readback_value = value
-    result.verification.tolerance_used = 0.1
-    result.verification.notes = ""
+    if verification is _UNSET:
+        verification = WriteVerification(
+            level=verification_level,
+            verified=verified,
+            readback_value=value if readback_value is _UNSET else readback_value,
+            tolerance_used=tolerance_used,
+            notes=notes,
+            readback_alarm_status=readback_alarm_status,
+            readback_alarm_severity=readback_alarm_severity,
+            failure_kind=failure_kind,
+        )
+    result.verification = verification
     return result
+
+
+def _write_states(data):
+    """``{channel: write_state}`` from a parsed tool response."""
+    return {r["channel"]: r["write_state"] for r in data["summary"]["results"]}
 
 
 def _get_channel_write():
@@ -50,28 +107,45 @@ def _get_channel_write():
     return get_tool_fn(channel_write)
 
 
-@pytest.mark.unit
-async def test_channel_write_success(tmp_path, monkeypatch):
-    """Successful write returns result with verification in summary."""
+def _prepare(tmp_path, monkeypatch):
+    """Minimal project + server context the tool needs to run."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
     initialize_server_context()
+
+
+@contextmanager
+def _patched(connector, validator=None):
+    """Patch the connector factory and the limits validator together.
+
+    Both have to be patched for every call: the tool builds its own validator
+    from config, and an unpatched one would read whatever limits database the
+    working directory happens to have.
+    """
+    with (
+        patch(
+            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
+            new_callable=AsyncMock,
+            return_value=connector,
+        ),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=validator,
+        ),
+    ):
+        yield
+
+
+@pytest.mark.unit
+async def test_channel_write_success(tmp_path, monkeypatch):
+    """Successful write returns result with verification in summary."""
+    _prepare(tmp_path, monkeypatch)
 
     write_result = _make_write_result(channel="TEST:PV", value=42.0)
     mock_connector = AsyncMock()
     mock_connector.write_channel.return_value = write_result
 
-    with (
-        patch(
-            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
-            new_callable=AsyncMock,
-            return_value=mock_connector,
-        ),
-        patch(
-            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            return_value=None,
-        ),
-    ):
+    with _patched(mock_connector):
         fn = _get_channel_write()
         result = await fn(operations=[{"channel": "TEST:PV", "value": 42.0}])
 
@@ -85,26 +159,14 @@ async def test_channel_write_success(tmp_path, monkeypatch):
 @pytest.mark.unit
 async def test_channel_write_with_readback(tmp_path, monkeypatch):
     """Write with readback verification returns verification details in summary."""
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
-    initialize_server_context()
+    _prepare(tmp_path, monkeypatch)
 
     write_result = _make_write_result(channel="TEST:PV", value=42.0, verification_level="readback")
     write_result.verification.readback_value = 42.01
     mock_connector = AsyncMock()
     mock_connector.write_channel.return_value = write_result
 
-    with (
-        patch(
-            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
-            new_callable=AsyncMock,
-            return_value=mock_connector,
-        ),
-        patch(
-            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            return_value=None,
-        ),
-    ):
+    with _patched(mock_connector):
         fn = _get_channel_write()
         result = await fn(
             operations=[{"channel": "TEST:PV", "value": 42.0}],
@@ -162,24 +224,12 @@ async def test_channel_write_limits_violation(tmp_path, monkeypatch):
 @pytest.mark.unit
 async def test_channel_write_connection_error(tmp_path, monkeypatch):
     """Connection error during write returns standard error format."""
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
-    initialize_server_context()
+    _prepare(tmp_path, monkeypatch)
 
     mock_connector = AsyncMock()
     mock_connector.write_channel.side_effect = ConnectionError("IOC unreachable")
 
-    with (
-        patch(
-            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
-            new_callable=AsyncMock,
-            return_value=mock_connector,
-        ),
-        patch(
-            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            return_value=None,
-        ),
-    ):
+    with _patched(mock_connector):
         fn = _get_channel_write()
         with assert_raises_error(error_type="connection_error") as _exc_ctx:
             await fn(operations=[{"channel": "TEST:PV", "value": 1.0}])
@@ -192,9 +242,7 @@ async def test_channel_write_connection_error(tmp_path, monkeypatch):
 @pytest.mark.unit
 async def test_channel_write_multiple_operations(tmp_path, monkeypatch):
     """Multiple write operations are all processed."""
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
-    initialize_server_context()
+    _prepare(tmp_path, monkeypatch)
 
     results = [
         _make_write_result(channel="PV:A", value=1.0),
@@ -203,17 +251,7 @@ async def test_channel_write_multiple_operations(tmp_path, monkeypatch):
     mock_connector = AsyncMock()
     mock_connector.write_multiple_channels.return_value = results
 
-    with (
-        patch(
-            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
-            new_callable=AsyncMock,
-            return_value=mock_connector,
-        ),
-        patch(
-            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            return_value=None,
-        ),
-    ):
+    with _patched(mock_connector):
         fn = _get_channel_write()
         result = await fn(
             operations=[
@@ -233,9 +271,7 @@ async def test_channel_write_connector_limits_violation(tmp_path, monkeypatch):
     """ChannelLimitsViolationError from connector is classified as limits_violation with structured details."""
     from osprey.errors import ChannelLimitsViolationError
 
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
-    initialize_server_context()
+    _prepare(tmp_path, monkeypatch)
 
     mock_connector = AsyncMock()
     mock_connector.write_channel.side_effect = ChannelLimitsViolationError(
@@ -247,17 +283,7 @@ async def test_channel_write_connector_limits_violation(tmp_path, monkeypatch):
         max_value=100.0,
     )
 
-    with (
-        patch(
-            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
-            new_callable=AsyncMock,
-            return_value=mock_connector,
-        ),
-        patch(
-            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            return_value=None,
-        ),
-    ):
+    with _patched(mock_connector):
         fn = _get_channel_write()
         with assert_raises_error() as _exc_ctx:
             await fn(operations=[{"channel": "TEST:PV", "value": 999.0}])
@@ -312,9 +338,7 @@ async def test_channel_write_all_refused_is_write_refused(tmp_path, monkeypatch)
     classifies it as write_refused — NOT the generic internal_error that a bare
     RuntimeError would produce.
     """
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
-    initialize_server_context()
+    _prepare(tmp_path, monkeypatch)
 
     results = [
         _make_write_result(
@@ -337,17 +361,7 @@ async def test_channel_write_all_refused_is_write_refused(tmp_path, monkeypatch)
     mock_connector = AsyncMock()
     mock_connector.write_multiple_channels.return_value = results
 
-    with (
-        patch(
-            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
-            new_callable=AsyncMock,
-            return_value=mock_connector,
-        ),
-        patch(
-            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            return_value=None,
-        ),
-    ):
+    with _patched(mock_connector):
         fn = _get_channel_write()
         with assert_raises_error() as _exc_ctx:
             await fn(
@@ -378,9 +392,7 @@ async def test_channel_write_partial_refusal_reports_per_op(tmp_path, monkeypatc
     it returns a success-status result whose per-op entries carry blocked /
     refusal_reason and whose summary reports refused == 1, successful == 1.
     """
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
-    initialize_server_context()
+    _prepare(tmp_path, monkeypatch)
 
     results = [
         _make_write_result(channel="PV:A", value=1.0, success=True),
@@ -396,17 +408,7 @@ async def test_channel_write_partial_refusal_reports_per_op(tmp_path, monkeypatc
     mock_connector = AsyncMock()
     mock_connector.write_multiple_channels.return_value = results
 
-    with (
-        patch(
-            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
-            new_callable=AsyncMock,
-            return_value=mock_connector,
-        ),
-        patch(
-            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            return_value=None,
-        ),
-    ):
+    with _patched(mock_connector):
         fn = _get_channel_write()
         result = await fn(
             operations=[
@@ -437,9 +439,7 @@ async def test_channel_write_all_failed_caput_is_internal_error(tmp_path, monkey
     is an I/O failure, not a policy refusal, so it must keep the RuntimeError ->
     internal_error classification rather than becoming write_refused.
     """
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "config.yml").write_text("control_system:\n  type: mock\n")
-    initialize_server_context()
+    _prepare(tmp_path, monkeypatch)
 
     results = [
         _make_write_result(
@@ -460,17 +460,7 @@ async def test_channel_write_all_failed_caput_is_internal_error(tmp_path, monkey
     mock_connector = AsyncMock()
     mock_connector.write_multiple_channels.return_value = results
 
-    with (
-        patch(
-            "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
-            new_callable=AsyncMock,
-            return_value=mock_connector,
-        ),
-        patch(
-            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            return_value=None,
-        ),
-    ):
+    with _patched(mock_connector):
         fn = _get_channel_write()
         with assert_raises_error(error_type="internal_error") as _exc_ctx:
             await fn(
@@ -483,3 +473,508 @@ async def test_channel_write_all_failed_caput_is_internal_error(tmp_path, monkey
     data = _exc_ctx["envelope"]
     assert data["error_type"] == "internal_error"
     assert data["error_type"] != "write_refused"
+
+
+# ---------------------------------------------------------------------------
+# write_state — the closed-set word the agent keys on
+# ---------------------------------------------------------------------------
+
+
+async def _run_batch(results, validator=None, **kwargs):
+    """Run the tool over a batch and return (parsed response, connector)."""
+    connector = AsyncMock()
+    connector.write_multiple_channels.return_value = results
+    with _patched(connector, validator):
+        fn = _get_channel_write()
+        raw = await fn(
+            operations=[{"channel": r.channel_address, "value": r.value_written} for r in results],
+            **kwargs,
+        )
+    return extract_response_dict(raw), connector
+
+
+async def _run_single(result, validator=None, **kwargs):
+    """Run the tool over one operation and return (parsed response, connector)."""
+    connector = AsyncMock()
+    connector.write_channel.return_value = result
+    with _patched(connector, validator):
+        fn = _get_channel_write()
+        raw = await fn(
+            operations=[{"channel": result.channel_address, "value": result.value_written}],
+            **kwargs,
+        )
+    return extract_response_dict(raw), connector
+
+
+#: (state, kwargs for the subject result). Each row is one predicate in the
+#: ordered chain, chosen so the row above it does NOT also match — that is what
+#: makes this a precedence test and not nine independent smoke tests.
+_STATE_CASES = [
+    # Refused: never sent. Also success=False, so this pins that `blocked` wins.
+    ("blocked", {"success": False, "blocked": True, "refusal_reason": "WRITES_DISABLED"}),
+    # Attempted and failed. Verification present and "verified" — a failed write
+    # must not be reported by its verification.
+    ("write_failed", {"success": False, "error_message": "caput failed: timeout"}),
+    ("verification_not_reported", {"verification": None}),
+    # Level "none" with verified False: nothing was asked for, so this is not a
+    # verification failure.
+    ("verification_not_requested", {"verification_level": "none", "verified": False}),
+    # MAJOR alarm on a readback that matched.
+    (
+        "verified_with_alarm",
+        {
+            "verification_level": "readback",
+            "verified": True,
+            "readback_alarm_severity": 2,
+            "readback_alarm_status": "HIHI",
+        },
+    ),
+    # MINOR alarm on a readback that matched stays plain "verified".
+    (
+        "verified",
+        {
+            "verification_level": "readback",
+            "verified": True,
+            "readback_alarm_severity": 1,
+            "readback_alarm_status": "HIGH",
+        },
+    ),
+    # The readback read itself raised. Severity is set too, so this pins that
+    # failure_kind outranks the alarm predicate.
+    (
+        "readback_failed",
+        {
+            "verification_level": "readback",
+            "verified": False,
+            "failure_kind": "readback_failed",
+            "readback_alarm_severity": 3,
+        },
+    ),
+    (
+        "unverified_alarm",
+        {
+            "verification_level": "readback",
+            "verified": False,
+            "readback_alarm_severity": 1,
+            "readback_alarm_status": "HIGH",
+        },
+    ),
+    ("verification_failed", {"verification_level": "readback", "verified": False}),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "expected_state,result_kwargs", _STATE_CASES, ids=[c[0] for c in _STATE_CASES]
+)
+async def test_write_state_precedence(tmp_path, monkeypatch, expected_state, result_kwargs):
+    """Each ordered predicate produces its state in the shipped summary.
+
+    Run as a two-op batch with a healthy first write so the refused and failed
+    subjects do not trip the all-refused / all-failed top-level errors, which
+    are a separate contract.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    results = [
+        _make_write_result(channel="PV:OK", value=1.0),
+        _make_write_result(channel="PV:SUBJECT", value=2.0, **result_kwargs),
+    ]
+    data, _ = await _run_batch(results)
+
+    assert _write_states(data)["PV:SUBJECT"] == expected_state
+
+
+@pytest.mark.unit
+def test_state_cases_cover_every_documented_state():
+    """The parametrisation above exercises the whole closed set, in order."""
+    assert [case[0] for case in _STATE_CASES] == EXPECTED_WRITE_STATES
+
+
+@pytest.mark.unit
+async def test_readback_healthy_severity_zero_is_still_verification_failed(tmp_path, monkeypatch):
+    """A REPORTED healthy severity of 0 does not save an unverified readback.
+
+    Kept out of ``_STATE_CASES`` because that table is one row per documented
+    state, pinned 1:1 against ``EXPECTED_WRITE_STATES`` above; this pins the
+    0-vs-None distinction on the SAME ``verification_failed`` predicate instead
+    of adding a tenth state. 0 is a reported healthy severity, distinct from
+    None ("not reported"); the ``> 0`` check in ``_alarm_severity`` correctly
+    excludes it, so it falls through to ``verification_failed`` rather than
+    being read as an alarm.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    results = [
+        _make_write_result(channel="PV:OK", value=1.0),
+        _make_write_result(
+            channel="PV:SUBJECT",
+            value=2.0,
+            verification_level="readback",
+            verified=False,
+            readback_alarm_severity=0,
+        ),
+    ]
+    data, _ = await _run_batch(results)
+
+    assert _write_states(data)["PV:SUBJECT"] == "verification_failed"
+
+
+@pytest.mark.unit
+async def test_write_state_ignores_notes_text(tmp_path, monkeypatch):
+    """Notes are display-only: rewording them cannot change the state.
+
+    The narration bug this whole contract exists to close came from deriving
+    meaning out of prose, so the state must be a pure function of the
+    structured fields.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    states = []
+    for note in ("", "Readback matched.", "MISMATCH: readback failed, value not applied!"):
+        results = [
+            _make_write_result(
+                channel="PV:A",
+                value=1.0,
+                verification_level="readback",
+                verified=True,
+                notes=note,
+            ),
+            _make_write_result(channel="PV:B", value=2.0),
+        ]
+        data, _ = await _run_batch(results)
+        states.append(_write_states(data)["PV:A"])
+
+    assert states == ["verified", "verified", "verified"]
+
+
+@pytest.mark.unit
+async def test_duck_typed_verification_yields_a_state(tmp_path, monkeypatch):
+    """A custom connector's verification object must classify, not raise.
+
+    Out-of-tree connectors may return anything with ``level`` and ``verified``;
+    the new alarm and failure_kind fields are read with ``getattr`` defaults so
+    an object that predates them still produces a result.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    class _MinimalVerification:
+        level = "callback"
+        verified = True
+
+    class _FloatSeverityVerification:
+        level = "callback"
+        verified = True
+        readback_alarm_severity = 2.0
+
+    class _BoolSeverityVerification:
+        level = "callback"
+        verified = True
+        readback_alarm_severity = True
+
+    results = [
+        _make_write_result(channel="PV:A", value=1.0, verification=_MinimalVerification()),
+        _make_write_result(channel="PV:B", value=2.0),
+        _make_write_result(
+            channel="PV:FLOAT", value=3.0, verification=_FloatSeverityVerification()
+        ),
+        _make_write_result(channel="PV:BOOL", value=4.0, verification=_BoolSeverityVerification()),
+    ]
+    data, _ = await _run_batch(results)
+
+    entries = {r["channel"]: r for r in data["summary"]["results"]}
+    entry = entries["PV:A"]
+    assert entry["write_state"] == "verified"
+    # The absent fields are reported as null rather than omitted, so a consumer
+    # can tell "not reported" from a value.
+    assert entry["verification"]["readback_alarm_status"] is None
+    assert entry["verification"]["readback_alarm_severity"] is None
+    assert entry["verification"]["failure_kind"] is None
+    # A float or bool severity fails `_alarm_severity`'s `isinstance(int)` type
+    # guard and degrades to "not reported" (None), so both fall through to the
+    # plain "verified" state rather than "verified_with_alarm" — degrade, don't
+    # raise.
+    assert entries["PV:FLOAT"]["write_state"] == "verified"
+    assert entries["PV:BOOL"]["write_state"] == "verified"
+
+
+@pytest.mark.unit
+async def test_mixed_batch_reports_one_state_per_channel(tmp_path, monkeypatch):
+    """A batch of unlike outcomes reports each channel's own state."""
+    _prepare(tmp_path, monkeypatch)
+
+    results = [
+        _make_write_result(channel="PV:OK", value=1.0),
+        _make_write_result(
+            channel="PV:MISMATCH", value=2.0, verification_level="readback", verified=False
+        ),
+        _make_write_result(
+            channel="PV:REFUSED",
+            value=3.0,
+            success=False,
+            blocked=True,
+            refusal_reason="WRITES_DISABLED",
+        ),
+        _make_write_result(channel="PV:NOVERIF", value=4.0, verification=None),
+    ]
+    data, _ = await _run_batch(results)
+
+    assert _write_states(data) == {
+        "PV:OK": "verified",
+        "PV:MISMATCH": "verification_failed",
+        "PV:REFUSED": "blocked",
+        "PV:NOVERIF": "verification_not_reported",
+    }
+
+
+@pytest.mark.unit
+async def test_alarm_fields_reach_the_shipped_verification_projection(tmp_path, monkeypatch):
+    """The alarm name, severity and failure_kind are in summary.results[]."""
+    _prepare(tmp_path, monkeypatch)
+
+    result = _make_write_result(
+        channel="TEST:PV",
+        value=42.0,
+        verification_level="readback",
+        verified=True,
+        readback_value=42.0,
+        readback_alarm_status="HIHI",
+        readback_alarm_severity=2,
+    )
+    data, _ = await _run_single(result)
+
+    verification = data["summary"]["results"][0]["verification"]
+    assert verification["readback_alarm_status"] == "HIHI"
+    assert verification["readback_alarm_severity"] == 2
+    assert verification["failure_kind"] is None
+    assert data["summary"]["results"][0]["write_state"] == "verified_with_alarm"
+
+
+# ---------------------------------------------------------------------------
+# summary.verification_failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_verification_failed_counts_only_executed_unverified(tmp_path, monkeypatch):
+    """Only writes that executed, asked for verification, and lacked it count.
+
+    A refused write never reached the machine and a level-"none" write never
+    asked, so counting either would overstate how much of the batch is in doubt.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    results = [
+        # Counts: executed, readback requested, not verified.
+        _make_write_result(
+            channel="PV:MISMATCH", value=1.0, verification_level="readback", verified=False
+        ),
+        # Counts: executed, callback requested, not confirmed.
+        _make_write_result(
+            channel="PV:NOCALLBACK", value=2.0, verification_level="callback", verified=False
+        ),
+        # Does not count: refused, never executed.
+        _make_write_result(
+            channel="PV:REFUSED",
+            value=3.0,
+            success=False,
+            blocked=True,
+            refusal_reason="WRITES_DISABLED",
+            verification_level="readback",
+            verified=False,
+        ),
+        # Does not count: no verification was asked for.
+        _make_write_result(channel="PV:NONE", value=4.0, verification_level="none", verified=False),
+        # Does not count: verified.
+        _make_write_result(channel="PV:OK", value=5.0),
+    ]
+    data, _ = await _run_batch(results)
+
+    assert data["summary"]["verification_failed"] == 2
+
+
+# ---------------------------------------------------------------------------
+# verification_level dispatch — explicit vs omitted, single vs batch
+# ---------------------------------------------------------------------------
+
+
+def _validator_returning(level, tolerance):
+    """A limits validator whose database answers with *level* / *tolerance*."""
+    validator = MagicMock()
+    validator.get_verification_config.return_value = (level, tolerance)
+    return validator
+
+
+@pytest.mark.unit
+async def test_explicit_level_beats_the_limits_database_on_a_single_write(tmp_path, monkeypatch):
+    """An explicitly requested level is forwarded unchanged.
+
+    Regression: the validator used to overwrite the caller's level
+    unconditionally, so naming a level did nothing.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    result = _make_write_result(channel="TEST:PV", value=42.0, verification_level="readback")
+    _, connector = await _run_single(
+        result,
+        validator=_validator_returning("callback", None),
+        verification_level="readback",
+    )
+
+    assert connector.write_channel.call_args.kwargs["verification_level"] == "readback"
+
+
+@pytest.mark.unit
+async def test_limits_database_tolerance_applies_to_an_explicit_level(tmp_path, monkeypatch):
+    """A per-channel tolerance survives an explicit level.
+
+    The tolerance and the level are separate decisions: dropping the per-channel
+    tolerance would compare a setpoint against the connector's absolute default
+    instead of the percentage the limits database configured.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    result = _make_write_result(channel="TEST:PV", value=42.0, verification_level="readback")
+    _, connector = await _run_single(
+        result,
+        validator=_validator_returning("callback", 0.42),
+        verification_level="readback",
+    )
+
+    kwargs = connector.write_channel.call_args.kwargs
+    assert kwargs["verification_level"] == "readback"
+    assert kwargs["tolerance"] == 0.42
+
+
+@pytest.mark.unit
+async def test_omitted_level_forwards_the_limits_database_level_and_tolerance(
+    tmp_path, monkeypatch
+):
+    """With no level named, a single write takes the limits database's."""
+    _prepare(tmp_path, monkeypatch)
+
+    result = _make_write_result(channel="TEST:PV", value=42.0, verification_level="readback")
+    _, connector = await _run_single(result, validator=_validator_returning("readback", 0.05))
+
+    kwargs = connector.write_channel.call_args.kwargs
+    assert kwargs["verification_level"] == "readback"
+    assert kwargs["tolerance"] == 0.05
+
+
+@pytest.mark.unit
+async def test_omitted_level_with_silent_database_leaves_the_keyword_absent(tmp_path, monkeypatch):
+    """Omission is a sentinel: the keyword is left off, not passed as None.
+
+    Passing None would override a legacy custom connector's own declared
+    default instead of letting it apply.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    result = _make_write_result(channel="TEST:PV", value=42.0)
+    _, connector = await _run_single(result, validator=_validator_returning(None, None))
+
+    kwargs = connector.write_channel.call_args.kwargs
+    assert "verification_level" not in kwargs
+    assert "tolerance" not in kwargs
+
+
+@pytest.mark.unit
+async def test_explicit_level_is_forwarded_on_a_batch(tmp_path, monkeypatch):
+    """A named level applies to every channel in the batch."""
+    _prepare(tmp_path, monkeypatch)
+
+    results = [
+        _make_write_result(channel="PV:A", value=1.0),
+        _make_write_result(channel="PV:B", value=2.0),
+    ]
+    _, connector = await _run_batch(
+        results,
+        validator=_validator_returning("none", None),
+        verification_level="readback",
+    )
+
+    assert connector.write_multiple_channels.call_args.kwargs["verification_level"] == "readback"
+
+
+@pytest.mark.unit
+async def test_omitted_level_leaves_the_batch_keyword_absent(tmp_path, monkeypatch):
+    """An omitted level is not resolved for the batch as a whole.
+
+    A batch carries one scalar level for every channel in it, so resolving here
+    would pin one channel's entry onto all of them. Leaving the keyword off lets
+    each channel resolve its own, which is what makes batch writes behave like
+    single writes.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    results = [
+        _make_write_result(channel="PV:A", value=1.0),
+        _make_write_result(channel="PV:B", value=2.0),
+    ]
+    _, connector = await _run_batch(results, validator=_validator_returning("readback", 0.05))
+
+    assert "verification_level" not in connector.write_multiple_channels.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# access_details
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_access_details_level_is_null_when_omitted(tmp_path, monkeypatch):
+    """access_details reports what the caller asked for, not what was resolved.
+
+    Null means "the deployment decided"; the level actually used is reported
+    per result under verification.level.
+    """
+    _prepare(tmp_path, monkeypatch)
+
+    result = _make_write_result(channel="TEST:PV", value=42.0, verification_level="readback")
+    data, _ = await _run_single(result, validator=_validator_returning("readback", None))
+
+    assert data["access_details"]["verification_level"] is None
+    assert data["summary"]["results"][0]["verification"]["level"] == "readback"
+
+
+@pytest.mark.unit
+async def test_access_details_level_echoes_an_explicit_request(tmp_path, monkeypatch):
+    """An explicit level is echoed back verbatim."""
+    _prepare(tmp_path, monkeypatch)
+
+    result = _make_write_result(channel="TEST:PV", value=42.0, verification_level="none")
+    data, _ = await _run_single(result, verification_level="none")
+
+    assert data["access_details"]["verification_level"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# the key the rules name and the key the tool emits are one string
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_emitted_state_key_is_the_key_the_generated_rules_name(tmp_path, monkeypatch):
+    """The rules tell the agent to read `write_state`; the tool must emit it.
+
+    Two files, one word. If either is renamed on its own the agent is told to
+    key on something the payload does not contain, which is silent — the tool
+    still returns a valid result and the agent simply has nothing to go on.
+    """
+    from osprey.cli.templates.manager import TemplateManager
+    from osprey.mcp_server.control_system.tools.channel_write import WRITE_STATE_KEY
+
+    _prepare(tmp_path, monkeypatch)
+
+    result = _make_write_result(channel="TEST:PV", value=42.0)
+    data, _ = await _run_single(result)
+    assert WRITE_STATE_KEY in data["summary"]["results"][0]
+
+    manager = TemplateManager()
+    safety = (manager.template_root / "claude_code/claude/rules/safety.md").read_text()
+    routing = manager.jinja_env.get_template(
+        "claude_code/claude/rules/control-system-safety.md.j2"
+    ).render(enabled_servers=[])
+
+    assert WRITE_STATE_KEY in safety
+    assert WRITE_STATE_KEY in routing

--- a/tests/mcp_server/test_python_execute_file_tool.py
+++ b/tests/mcp_server/test_python_execute_file_tool.py
@@ -533,3 +533,25 @@ async def test_execute_file_readonly_refuses_epics_import(tmp_path, monkeypatch)
 
     assert any("epics" in s for s in _exc_ctx["envelope"]["suggestions"])
     mock_exec.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_execute_file_tool_description_has_no_container_claim():
+    """The registered tool description says subprocess, not the old container claim."""
+    from osprey.mcp_server.python_executor.server import mcp
+    from osprey.mcp_server.python_executor.tools import python_execute_file  # noqa: F401
+    from osprey.mcp_server.python_executor.tools._package_inventory import PACKAGE_LINE_PREFIX
+
+    description = (await mcp.get_tool("execute_file")).description
+
+    # execute_file has no package placeholder today, but filter the same way
+    # execute's test does for symmetry, so this stays safe if one is ever added.
+    prose = "\n".join(
+        line
+        for line in description.splitlines()
+        if not line.strip().startswith(PACKAGE_LINE_PREFIX)
+    )
+    assert "subprocess" in prose.lower(), "description must say code runs in a subprocess"
+    assert "container" not in prose.lower(), (
+        "description must not claim a container backend; execution is subprocess-only"
+    )

--- a/tests/mcp_server/test_python_execute_tool.py
+++ b/tests/mcp_server/test_python_execute_tool.py
@@ -1305,14 +1305,28 @@ async def test_execute_tool_description_has_no_hardcoded_list():
     """The registered tool description is generated, not the old literal list."""
     from osprey.mcp_server.python_executor.server import mcp
     from osprey.mcp_server.python_executor.tools import python_execute  # noqa: F401
+    from osprey.mcp_server.python_executor.tools._package_inventory import PACKAGE_LINE_PREFIX
 
     description = (await mcp.get_tool("execute")).description
 
     assert "(e.g. numpy, pandas, scipy, at, matplotlib, plotly)" not in description
     assert "<<AVAILABLE_PACKAGES>>" not in description
     assert (
-        "Packages importable in the execution environment include:" in description
+        PACKAGE_LINE_PREFIX in description
         or "The set of installed packages could not be determined" in description
+    )
+
+    # The backend is subprocess-only. The rendered package line is excluded from
+    # the container check: it names whatever the environment installed, and a
+    # package name is not a backend claim.
+    prose = "\n".join(
+        line
+        for line in description.splitlines()
+        if not line.strip().startswith(PACKAGE_LINE_PREFIX)
+    )
+    assert "subprocess" in prose.lower(), "description must say code runs in a subprocess"
+    assert "container" not in prose.lower(), (
+        "description must not claim a container backend; execution is subprocess-only"
     )
 
 

--- a/tests/templates/test_control_system_safety_rule.py
+++ b/tests/templates/test_control_system_safety_rule.py
@@ -1,4 +1,7 @@
-"""Render tests for the p4p (pvAccess) block in ``control-system-safety.md.j2``.
+"""Render tests for ``control-system-safety.md.j2``.
+
+Two contracts live here: the p4p (pvAccess) prohibition block, and the routing
+section that tells the agent which tool answers which request shape.
 
 The EPICS connector reads pvAccess channels through ``p4p``, so the shipped
 safety rule has to name that library the same way it names ``pyepics`` --
@@ -34,6 +37,36 @@ P4P_LINES = (
 #: Every p4p marker, including the refusal wording that separates rpc from the
 #: merely-prohibited calls.
 P4P_MARKERS = P4P_LINES + ("Not approvable — refused at runtime",)
+
+#: The routing section's heading and the four protocol-neutral cases. The
+#: multi-setting case is deployment-dependent and pinned separately.
+ROUTING_HEADING = "## Choosing the Right Tool"
+ROUTING_CASES = (
+    "**One live value** — use `channel_read`",
+    "**One live write the operator asked for by name** — use `channel_write`",
+    "**Python analysis over data you already retrieved** — use `execute`",
+    "**Python that must touch the control system** — use `execute`",
+)
+
+#: The one asymmetry the agent has to know: the two write paths report an
+#: unverified write in different shapes.
+WRITE_PATH_SENTENCE = (
+    "`osprey.runtime.write_channel` raises, while `channel_write` reports it in `write_state`."
+)
+
+
+def _render_template_directly(control_system_type: str, enabled_servers: set[str]) -> str:
+    """Render the rule straight from Jinja with an explicit ``enabled_servers``.
+
+    The scaffolded projects the other helper builds never enable ``bluesky``,
+    so the queue branch is unreachable through them. Rendering the template
+    directly is the only way to exercise both sides of that conditional.
+    """
+    manager = TemplateManager()
+    template = manager.jinja_env.get_template(
+        "claude_code/claude/rules/control-system-safety.md.j2"
+    )
+    return template.render(control_system_type=control_system_type, enabled_servers=enabled_servers)
 
 
 def _render_safety_rule(tmp_path, project_name: str, control_system_type: str | None) -> str:
@@ -157,7 +190,13 @@ def test_rule_heading_contract_intact(tmp_path):
     content = _render_safety_rule(tmp_path, "p4p-contract", "epics")
 
     assert content.lstrip().startswith("# Control System Safety — EPICS Channel Access")
-    for heading in ("### Allowed", "### Prohibited", "### Why This Matters", "## Write Operations"):
+    for heading in (
+        "### Allowed",
+        "### Prohibited",
+        "### Why This Matters",
+        "## Write Operations",
+        ROUTING_HEADING,
+    ):
         assert heading in content, f"missing section heading: {heading}"
 
     from osprey.services.build_artifacts.catalog import BuildArtifactCatalog
@@ -167,3 +206,100 @@ def test_rule_heading_contract_intact(tmp_path):
     assert artifact.template_path == "claude/rules/control-system-safety.md.j2"
     assert artifact.output_path == ".claude/rules/control-system-safety.md"
     assert artifact.description
+
+
+def test_routing_section_renders_for_every_control_system_type(tmp_path):
+    """The routing cases are about tools, not protocols, so every render gets
+    them -- a mock deployment routes requests the same way an EPICS one does."""
+    for cs_type in ("epics", "virtual_accelerator", "tango", "opcua", "labview", None):
+        label = cs_type or "mock"
+        content = _render_safety_rule(tmp_path / label, f"route-{label}", cs_type)
+
+        assert ROUTING_HEADING in content, f"{label}: routing section missing"
+        for case in ROUTING_CASES:
+            assert case in content, f"{label}: missing routing case: {case!r}"
+
+
+def test_routing_section_is_protocol_neutral(tmp_path):
+    """The section must carry no protocol-specific text: it renders on every
+    control-system type, and ``epics``/``virtual_accelerator`` are included
+    because those are the only renders where the string ``EPICS`` exists
+    elsewhere in the document -- they are where a leak into the routing
+    section would actually be caught."""
+    for cs_type in ("epics", "virtual_accelerator", "tango", "opcua", "labview", None):
+        label = cs_type or "mock"
+        content = _render_safety_rule(tmp_path / label, f"neutral-{label}", cs_type)
+
+        start = content.index(ROUTING_HEADING)
+        next_heading = content.find("\n## ", start + len(ROUTING_HEADING))
+        end = next_heading if next_heading != -1 else len(content)
+        section = content[start:end]
+        for protocol_marker in ("EPICS", "epics", "Tango", "tango", "OPC-UA", "LabVIEW", "p4p"):
+            assert protocol_marker not in section, (
+                f"{label}: routing section names a protocol: {protocol_marker!r}"
+            )
+
+
+def test_routing_section_states_the_write_path_asymmetry(tmp_path):
+    """The Python path raises; the tool reports. An agent that does not know
+    the difference narrates an unverified write as if it had succeeded."""
+    content = _render_safety_rule(tmp_path, "route-asym", "epics")
+
+    prose = " ".join(content.split())
+    assert WRITE_PATH_SENTENCE in prose
+
+
+def test_routing_section_without_bluesky_refuses_the_write_loop(tmp_path):
+    """The scaffolded control_assistant project runs no ``bluesky`` server, so
+    this is the shape a real queue-less deployment renders: the multi-setting
+    case still appears, and it forbids substituting a loop of writes."""
+    content = _render_safety_rule(tmp_path, "route-no-queue", "epics")
+
+    prose = " ".join(content.split())
+    assert "**Multi-setting measurements** — no queue is configured in this deployment." in prose
+    assert "Do not stand in for one with a loop of `channel_write` calls" in prose
+    assert "an `execute` script that steps the setpoint" in prose
+    assert "tell the operator what the measurement would require" in prose
+
+    # Nothing may point at a queue this deployment does not have.
+    assert "Bluesky" not in content
+    assert "## Measurements Go Through the Queue" not in content
+
+
+def test_routing_section_with_bluesky_points_at_the_queue():
+    """With the server enabled the same bullet routes to the queue instead, and
+    the existing queue sections still render behind it."""
+    content = _render_template_directly("epics", {"controls", "bluesky"})
+
+    prose = " ".join(content.split())
+    assert "**Multi-setting measurements** — use the Bluesky queue." in prose
+    assert "no queue is configured in this deployment" not in prose
+    assert "## Measurements Go Through the Queue, Not Through Repeated Writes" in content
+    assert "## Starting a Bluesky Queue" in content
+
+
+def test_routing_section_renders_exactly_one_multi_setting_case():
+    """Guard against both arms of the conditional escaping at once."""
+    for enabled in ({"controls"}, {"controls", "bluesky"}):
+        content = _render_template_directly("epics", enabled)
+        assert content.count("**Multi-setting measurements**") == 1, enabled
+
+
+def test_execution_mode_write_never_renders(tmp_path):
+    """``write`` is not a recognised execution mode -- ``readonly`` and
+    ``readwrite`` are the only two the executor accepts -- so the rendered rule
+    must never spell it. Regression guard on wording that is already correct."""
+    from osprey.mcp_server.python_executor.tools._execution_gates import VALID_EXECUTION_MODES
+
+    assert "write" not in VALID_EXECUTION_MODES
+
+    for cs_type in ("epics", "tango", None):
+        label = cs_type or "mock"
+        content = _render_safety_rule(tmp_path / label, f"mode-{label}", cs_type)
+
+        assert 'execution_mode: "write"' not in content, f"{label}: rendered an invalid mode"
+        assert 'execution_mode: "readwrite"' in content, f"{label}: lost the readwrite mode"
+
+    for enabled in ({"controls"}, {"controls", "bluesky"}):
+        content = _render_template_directly("epics", enabled)
+        assert 'execution_mode: "write"' not in content, enabled

--- a/tests/templates/test_safety_md_verification_guidance.py
+++ b/tests/templates/test_safety_md_verification_guidance.py
@@ -1,0 +1,82 @@
+"""Pin the verification guidance in ``safety.md`` item 6.
+
+Item 6 used to prescribe a level ("Default verification_level is
+'callback.'"). The level is actually resolved per write by the deployment --
+channel limits entry, then the limits database ``defaults.verification``, then
+the connector config, then ``callback`` -- so a prompt-layer default is wrong
+wherever a project configures readback. The rule now *describes* that
+resolution and states the consequence the agent must respect: a
+``callback``-level result carries no readback value and no alarm state, so the
+agent must report ``write_state`` rather than the resulting machine state.
+
+These tests exercise the real delivery path: ``safety.md`` is a non-Jinja
+template copied into ``.claude/rules/safety.md`` by the Claude Code
+integration (catalog entry ``rules/safety``), so the assertions run against a
+scaffolded project rather than the template file.
+"""
+
+import pytest
+
+from osprey.cli.templates.manager import TemplateManager
+
+
+@pytest.fixture(scope="module")
+def rendered_safety_rule(tmp_path_factory) -> str:
+    """Scaffold a project and return its rendered ``.claude/rules/safety.md``."""
+    manager = TemplateManager()
+    project_dir = manager.create_project(
+        project_name="safety-verification-guidance",
+        output_dir=tmp_path_factory.mktemp("safety-md"),
+        data_bundle="control_assistant",
+        context={"channel_finder_mode": "hierarchical"},
+    )
+    rule = project_dir / ".claude" / "rules" / "safety.md"
+    assert rule.is_file(), "safety.md did not reach the generated project"
+    return rule.read_text(encoding="utf-8")
+
+
+def test_prescribed_default_level_is_gone(rendered_safety_rule: str) -> None:
+    """The prompt layer must not name a default verification level."""
+    assert "Default verification_level is" not in rendered_safety_rule
+
+
+def test_rule_describes_the_resolution_order(rendered_safety_rule: str) -> None:
+    """Item 6 names the four resolution steps, in order."""
+    start = rendered_safety_rule.find("\n6. **")
+    assert start != -1, f"item 6 headline not found in: {rendered_safety_rule}"
+    end = rendered_safety_rule.find("## Data Integrity")
+    assert end != -1, f"'## Data Integrity' section not found in: {rendered_safety_rule}"
+    item6 = rendered_safety_rule[start:end]
+
+    positions = [
+        item6.index("limits entry"),
+        item6.index("`defaults.verification`"),
+        item6.index("connector config"),
+        item6.index("`callback`"),
+    ]
+    assert positions == sorted(positions), f"resolution order out of sequence: {item6}"
+
+
+def test_rule_states_callback_carries_no_readback_or_alarm(rendered_safety_rule: str) -> None:
+    """A callback-level result has readback_value and alarm fields as None."""
+    prose = " ".join(rendered_safety_rule.split())
+    assert "no readback value and no alarm state" in prose
+    assert "do NOT describe the machine state from it" in prose
+
+
+def test_rule_points_the_agent_at_write_state(rendered_safety_rule: str) -> None:
+    """The agent reports what the tool result says, not what it infers."""
+    assert "`write_state`" in rendered_safety_rule
+
+
+def test_rule_routes_legitimate_readback_to_rule_four(rendered_safety_rule: str) -> None:
+    """The prohibition is scoped to the write result -- rule 4 still covers explicit readback."""
+    prose = " ".join(rendered_safety_rule.split())
+    assert "read the channel back (rule 4)" in prose
+
+    start = rendered_safety_rule.find("\n4. **")
+    assert start != -1, f"item 4 headline not found in: {rendered_safety_rule}"
+    end = rendered_safety_rule.find("\n5. **")
+    assert end != -1, f"item 5 headline not found in: {rendered_safety_rule}"
+    item4 = rendered_safety_rule[start:end]
+    assert "Read back channels after writing" in item4


### PR DESCRIPTION
A write that the machine did not take looked, in the tool result, much like
one it did. The agent saw `success: true` and a `verification` block whose
`verified: false` was easy to pass over, so an unverified write could be
reported to an operator as a completed one. That is the failure a field
report from BELLA surfaced.

Three narrower defects sat underneath it. DOOCS labelled a readback read
that itself failed as verification level `none`, which reads as "no
verification was asked for" rather than "verification was attempted and
broke". Naming a verification level explicitly discarded the per-channel
tolerance held in the limits database, so the caller who was most specific
about what they wanted got the least accurate comparison. And batch writes
were pinned to `callback` regardless of the deployment's configuration,
so the same channel verified differently depending on whether it was
written alone or alongside others.

Every `channel_write` result now carries one `write_state` word per
channel, drawn from a closed set of nine and derived only from structured
fields — never from `notes`, which stays display-only, so the word an agent
keys on cannot drift with wording. The predicates are ordered and
first-match-wins, which is what keeps a refused write from also being
counted as an unverified one. `summary.verification_failed` is qualified
the same way: it counts executed writes that asked for verification and did
not get it, so refused and failed writes no longer inflate it.

Verification level and tolerance now resolve through one four-layer chain
for every write path — single or batch, MCP tool or `osprey.runtime` —
most specific first: the channel's entry in `channel_limits.json`, that
database's `defaults` block, the connector config, then `callback`. An
explicit level is honoured as written and still gets the per-channel
tolerance. `verification_level` on the tool is now optional; omitting it
is what selects per-channel resolution.

`WriteVerification` gained three optional fields — `readback_alarm_status`,
`readback_alarm_severity`, `failure_kind` — so alarm state travels by name
rather than as a protocol-specific integer. Mapping raw codes to names is
the connector's job, keeping the shared module free of control-system
imports. Connectors that set none of the three keep working.

The two paths deliberately differ on failure, and that asymmetry is the
main thing to disagree with: `osprey.runtime.write_channel` routes through
`write_channel_checked` and raises, while the MCP tool reports and does not.
The reasoning is that a Python script has a caller who can catch, and the
agent has an operator who needs to be told rather than handed a traceback.

Addresses #465. Three gaps remain open and are named in the changelog:
carrying the post-write readback value at every verification level,
flipping `success` when the readback read fails, and distinguishing an
infrastructure failure from a control-system one.

## How it hangs together

```text
  agent
    │  channel_write(channels, verification_level?)
    ▼
  ┌────────────────────────────────────┐
  │ channel_write  (MCP tool)          │
  │   writes_enabled + limits gate     │
  │   _derive_write_state()            │
  └───────────────┬────────────────────┘
                  │  per channel, most specific first:
                  │    channel_limits.json  "verification"
                  │      └─► that DB's "defaults"
                  │            └─► control_system.write_verification
                  │                  └─► "callback"
                  ▼
  ┌────────────────────────────────────┐
  │ connector.write_channel            │
  │   epics · doocs · mock             │
  └───────────────┬────────────────────┘
                  │  put + callback, or readback + alarm
                  ▼
          ┌───────────────────┐
          │  control system   │
          └─────────┬─────────┘
                    │  WriteVerification(level, verified,
                    │    readback_value, tolerance_used,
                    │    readback_alarm_status,
                    │    readback_alarm_severity, failure_kind)
                    ▼
  ┌────────────────────────────────────────────────┐
  │ write_state — one word per channel             │
  │                                                │
  │   blocked                 write_failed         │
  │   verification_not_reported                    │
  │   verification_not_requested                   │
  │   verified                verified_with_alarm  │
  │   readback_failed         unverified_alarm     │
  │   verification_failed                          │
  └───────────────┬────────────────────────────────┘
                  ▼
    generated safety rules: report the outcome that
    word names, and nothing stronger
```
