### PR TITLE
fix(artifacts): resolve Plotly through vendor_url in CDN-mode deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Timeseries previews in the workspace gallery render again in CDN-mode
+  (non-offline) deployments: the lazy Plotly loader now uses the same
+  CDN-or-vendored URL resolution as the gallery's other vendor assets
+  instead of hardcoding the offline-only path.
 - `save_artifact()` inside `execute` now stores a Bokeh layout as a dashboard
   rather than as its text representation, and a `category` passed from
   visualization code stays on the artifact.

--- a/src/osprey/interfaces/artifacts/static/index.html
+++ b/src/osprey/interfaces/artifacts/static/index.html
@@ -41,6 +41,11 @@
   <link rel="stylesheet" href="{{ vendor_url('KaTeX CSS', '/static/css/vendor/katex.min.css') }}">
   <script defer src="{{ vendor_url('KaTeX JS', '/static/js/vendor/katex.min.js') }}"></script>
 
+  <!-- Plotly (timeseries charts) is lazy-loaded from JS (timeseries.js), which
+       cannot call the vendor_url() template global — the resolved URL rides
+       along here instead. -->
+  <meta name="osprey-vendor-plotly" content="{{ vendor_url('Plotly.js', '/static/js/vendor/plotly-3.3.1.min.js') }}">
+
   <!-- Stylesheet -->
   <link rel="stylesheet" href="/static/css/gallery.css">
 

--- a/src/osprey/interfaces/artifacts/static/js/timeseries.js
+++ b/src/osprey/interfaces/artifacts/static/js/timeseries.js
@@ -14,8 +14,12 @@
  * `renderTimeseriesView` is local to a single render call, not shared state
  * across calls. So this module is plain exports, no `createXRenderer(...)`.
  *
- * The lazy `<script src="/static/js/vendor/plotly-3.3.1.min.js">` injection
- * must keep that exact offline-vendored path — do not change it.
+ * The lazy `<script>` injection takes its src from index.html's
+ * `osprey-vendor-plotly` meta tag, where the server's `vendor_url()` template
+ * global resolves it — the CDN URL by default, the offline-vendored copy
+ * under OSPREY_OFFLINE=1 (the vendored path is never populated in online
+ * images, so hardcoding it here 404s every CDN-mode deployment). The
+ * vendored spelling stays as the no-meta fallback.
  *
  * HTML-escaping uses the design-system's canonical `escapeHtml` (quote-safe,
  * nullish-collapsing) — see dom.js. This module used to carry its own
@@ -50,7 +54,11 @@ function ensurePlotlyLoaded() {
   if (_plotlyLoading) return _plotlyLoading;
   _plotlyLoading = new Promise((resolve, reject) => {
     const script = document.createElement("script");
-    script.src = "/static/js/vendor/plotly-3.3.1.min.js";
+    // Resolved server-side by vendor_url() and handed over via index.html's
+    // meta tag (see the module docstring). The vendored path is the fallback
+    // for any page without the meta, preserving prior offline behavior.
+    const meta = document.querySelector('meta[name="osprey-vendor-plotly"]');
+    script.src = (meta && meta.getAttribute("content")) || "/static/js/vendor/plotly-3.3.1.min.js";
     script.onload = () => { _plotlyLoaded = true; resolve(); };
     script.onerror = () => {
       _plotlyLoading = null;

--- a/tests/interfaces/artifacts/test_app_endpoints.py
+++ b/tests/interfaces/artifacts/test_app_endpoints.py
@@ -320,3 +320,28 @@ class TestAppLifecycle:
         assert calls["host"] == "127.0.0.1"
         assert calls["port"] == 59999
         assert calls["app"].title == "OSPREY Artifact Gallery"
+
+
+class TestIndexPlotlyVendorMeta:
+    """GET / carries the resolved Plotly URL for timeseries.js's lazy loader.
+
+    Plotly is the one vendor asset loaded lazily from JS rather than from a
+    template tag, so it cannot call the ``vendor_url`` Jinja global itself —
+    index.html hands it the resolved URL in a meta tag instead. Without the
+    tag, online (CDN-mode) deployments request the never-vendored local path,
+    404, and every timeseries preview dies with "Failed to load Plotly".
+    """
+
+    def test_online_mode_carries_the_cdn_url(self, app_client, monkeypatch):
+        from osprey.interfaces.vendor import asset_cdn_url
+
+        monkeypatch.setenv("OSPREY_OFFLINE", "0")
+        client, _ = app_client
+        html = client.get("/").text
+        assert f'name="osprey-vendor-plotly" content="{asset_cdn_url("Plotly.js")}"' in html
+
+    def test_offline_mode_carries_the_vendored_path(self, app_client, monkeypatch):
+        monkeypatch.setenv("OSPREY_OFFLINE", "1")
+        client, _ = app_client
+        html = client.get("/").text
+        assert 'name="osprey-vendor-plotly" content="/static/js/vendor/plotly-3.3.1.min.js"' in html

--- a/tests/interfaces/artifacts/timeseries.test.mjs
+++ b/tests/interfaces/artifacts/timeseries.test.mjs
@@ -1331,4 +1331,67 @@ describe('Plotly loader edge cases (isolated: fresh module instance per test)', 
     expect(elA.data).toEqual([]);
     expect(elB.data).toEqual([]);
   });
+
+  // The injected src is resolved server-side by the vendor_url() template
+  // global (CDN by default, the vendored copy offline) and handed to this
+  // classic-script loader via index.html's osprey-vendor-plotly meta tag —
+  // static JS cannot call a Jinja global. Both halves of that contract:
+  // the meta wins when present, the vendored spelling survives without it.
+
+  test('the injected <script> src comes from the osprey-vendor-plotly meta when the page carries one', async () => {
+    vi.stubGlobal('Plotly', { newPlot: vi.fn((el) => { el.data = []; }) });
+    stubFetchRouting();
+
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'osprey-vendor-plotly');
+    meta.setAttribute('content', 'https://cdn.plot.ly/plotly-3.3.1.min.js');
+    document.head.appendChild(meta); // before the spy below hijacks appendChild
+
+    /** @type {InjectedScript[]} */
+    const scriptAppends = [];
+    vi.spyOn(document.head, 'appendChild').mockImplementation((node) => {
+      const script = /** @type {InjectedScript} */ (node);
+      if (node && script.tagName === 'SCRIPT') {
+        scriptAppends.push(script);
+        queueMicrotask(() => script.onload && script.onload());
+        return node;
+      }
+      throw new Error('unexpected non-script appendChild in this isolated test');
+    });
+
+    try {
+      const fresh = await import('../../../src/osprey/interfaces/artifacts/static/js/timeseries.js');
+      const container = document.createElement('div');
+      await fresh.renderTimeseriesView(container, { id: 'ts1' });
+
+      expect(scriptAppends.length).toBe(1);
+      expect(scriptAppends[0].getAttribute('src')).toBe('https://cdn.plot.ly/plotly-3.3.1.min.js');
+    } finally {
+      meta.remove(); // this file's document is shared across tests
+    }
+  });
+
+  test('without the meta the loader falls back to the vendored path', async () => {
+    vi.stubGlobal('Plotly', { newPlot: vi.fn((el) => { el.data = []; }) });
+    stubFetchRouting();
+
+    /** @type {InjectedScript[]} */
+    const scriptAppends = [];
+    vi.spyOn(document.head, 'appendChild').mockImplementation((node) => {
+      const script = /** @type {InjectedScript} */ (node);
+      if (node && script.tagName === 'SCRIPT') {
+        scriptAppends.push(script);
+        queueMicrotask(() => script.onload && script.onload());
+        return node;
+      }
+      throw new Error('unexpected non-script appendChild in this isolated test');
+    });
+
+    const fresh = await import('../../../src/osprey/interfaces/artifacts/static/js/timeseries.js');
+    const container = document.createElement('div');
+    await fresh.renderTimeseriesView(container, { id: 'ts1' });
+
+    expect(scriptAppends.length).toBe(1);
+    expect(scriptAppends[0].getAttribute('src')).toBe('/static/js/vendor/plotly-3.3.1.min.js');
+  });
 });


### PR DESCRIPTION
## Problem

In CDN-mode (non-offline) deployments, every timeseries/archiver-data preview in the workspace gallery fails with **"Failed to load timeseries data"**. The console shows:

```
GET .../static/js/vendor/plotly-3.3.1.min.js → 404
Timeseries render failed: Error: Failed to load Plotly
```

The gallery's lazy Plotly loader (`timeseries.js`) hardcoded the offline-vendored path. That directory is gitignored, excluded from the wheel, and only populated when the image is built with `OSPREY_OFFLINE=1` — so in the default CDN mode the path never exists. Plotly is the gallery's only vendor asset loaded lazily from JS rather than from the Jinja template, which is why it alone missed the `vendor_url()` CDN-or-vendored resolution its four sibling assets (highlight.js, marked, KaTeX CSS/JS) already get.

## Fix

- `index.html` carries the `vendor_url('Plotly.js', …)` result in an `osprey-vendor-plotly` meta tag, next to its vendor siblings.
- `timeseries.js` reads the meta for the injected `<script>` src, keeping the vendored path as the no-meta fallback (prior offline behavior unchanged).

## Tests

- `test_app_endpoints.py::TestIndexPlotlyVendorMeta` — `GET /` carries the CDN URL online and the vendored path under `OSPREY_OFFLINE=1` (failed before the fix).
- `timeseries.test.mjs` — the loader uses the meta when present (failed before the fix) and falls back to the vendored path without it.

Verified on a live multi-user deployment where the archiver artifact previously failed to render: backend chart endpoint was always healthy; the 404 on the never-vendored path was the sole break.