### PR TITLE
fix(web-terminal): confirm a terminal's session id at connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The web terminal now knows its own session id from the moment it opens.
+  It previously waited for the session's transcript file to appear on disk,
+  which only happens once the session has content — so a terminal left idle
+  for a few seconds never picked its id up at all, and never did later. That
+  tab then behaved as if no session existed: feedback could not attach
+  session context ("no session yet"), the session was not stored for resume,
+  and every page reload started another one instead of reconnecting.
+- Closing a web terminal no longer risks killing a session another tab is
+  using. A tab whose agent had exited could, on close, terminate whatever
+  session had since taken its place.
+- A web terminal that cannot resume its stored session now falls back to a
+  fresh one instead of stopping at "[Process exited]".
 - Timeseries previews in the workspace gallery render again in CDN-mode
   (non-offline) deployments: the lazy Plotly loader now uses the same
   CDN-or-vendored URL resolution as the gallery's other vendor assets

--- a/docs/screenshots/contact_sheet.py
+++ b/docs/screenshots/contact_sheet.py
@@ -389,7 +389,7 @@ def hermetic_hub() -> Iterator[HermeticHub]:
        — serving the seeded store, and
     2. the web-terminal hub — ``web_terminal.create_app(...)`` — with a canned
        PTY that replays the transcript, its ``project_dir`` pointed at the seeded
-       directory so session discovery resolves to a controlled location.
+       directory so the session store resolves to a controlled location.
 
     The hub is wired to the pre-launched artifacts backend with the three patches
     the visual-regression harness uses (``_load_web_config`` → the seeded
@@ -570,10 +570,11 @@ def _fake_session_line() -> str:
 def _write_fake_session(session_dir: Path) -> Path:
     """Write ``<session_dir>/<DEMO_SESSION_ID>.jsonl`` and return its path.
 
-    Written *after* the PTY has spawned (so the hub's pre-spawn snapshot does not
-    include it) — the hub then discovers it as a new session and pushes the id to
-    the terminal label. Filename stem equals :data:`DEMO_SESSION_ID` so the active
-    session matches the seeded artifacts' ``session_id``.
+    Written *before* the page loads, so the id the browser resumes is already a
+    session the hub can see on disk: it then confirms that exact id back rather
+    than treating the resume as ambiguous. Filename stem equals
+    :data:`DEMO_SESSION_ID` so the active session matches the seeded artifacts'
+    ``session_id``.
     """
     session_dir.mkdir(parents=True, exist_ok=True)
     path = session_dir / f"{DEMO_SESSION_ID}.jsonl"
@@ -582,11 +583,12 @@ def _write_fake_session(session_dir: Path) -> Path:
 
 
 def _wait_for_session_ready(page, mode: str | None) -> None:
-    """Block until the published fake session has reached the terminal chrome.
+    """Block until the resumed session has reached the terminal chrome.
 
     Expert renders the session hex into ``#terminal-label`` (``Session 3f9a1c72``),
-    so it waits for that exact hex — the strong assertion that session discovery
-    ran and pushed the id, unchanged from the theme-only renderer.
+    so it waits for that exact hex — the strong assertion that the hub confirmed
+    the id this harness asked it to resume, unchanged from the theme-only
+    renderer.
 
     Simple mode's shell density pass (Task 5.4) hides ``#terminal-label`` and
     surfaces a ``Connected`` state in a sibling ``.terminal-label-simple`` span,
@@ -594,8 +596,8 @@ def _wait_for_session_ready(page, mode: str | None) -> None:
     writes ``Session <hex>`` into the (now hidden) ``#terminal-label`` on
     ``session_info`` in both modes, so Simple keys off that same write via
     ``textContent`` — which is populated regardless of CSS visibility — detected
-    as the label moving off its static ``Session`` placeholder. That proves
-    session discovery ran without depending on the Simple ``Connected`` chrome,
+    as the label moving off its static ``Session`` placeholder. That proves the
+    confirmation arrived without depending on the Simple ``Connected`` chrome,
     and never weakens the Expert hex wait.
     """
     if mode == "simple":
@@ -875,18 +877,25 @@ def _capture_variant(
     rail: str | None = None,
 ) -> CapturedVariant:
     """Drive one theme/mode variant to a viewport PNG; return its metadata."""
-    session_file = hub.session_dir / f"{DEMO_SESSION_ID}.jsonl"
-    # Ensure a clean slate so this variant's pre-spawn snapshot never already
-    # contains the fake record (a stale one would never be seen as "new").
-    session_file.unlink(missing_ok=True)
+    # Publish the fake session BEFORE the page loads. The terminal's session id
+    # has to be DEMO_SESSION_ID — the seeded artifacts are tagged with it and
+    # the panels scope themselves to the active session — and the resume path
+    # is what lets this harness choose it. With the record already on disk the
+    # hub takes its trusted branch (the requested id was in the pre-spawn
+    # snapshot) and confirms DEMO_SESSION_ID synchronously.
+    _write_fake_session(hub.session_dir)
 
     page = browser.new_page(viewport=_TERMINAL_VIEWPORT)
     try:
-        # Pre-dismiss the one-time rail hint: it floats over the dock tab strip
-        # on a fresh profile, and every capture here runs on a fresh profile —
-        # the sheet documents the shells, not the onboarding callout.
+        # Two seeded localStorage keys, both about starting from a known state
+        # on the fresh profile every capture runs on:
+        #   * the one-time rail hint, pre-dismissed — it floats over the dock
+        #     tab strip, and the sheet documents the shells, not onboarding;
+        #   * the PTY session id, so initTerminal() connects mode=resume on
+        #     DEMO_SESSION_ID instead of letting the hub mint a random one.
         page.add_init_script(
-            "try { localStorage.setItem('osprey-rail-hint-dismissed-v1', '1') } catch (e) {}"
+            "try { localStorage.setItem('osprey-rail-hint-dismissed-v1', '1');"
+            f" localStorage.setItem('osprey-pty-session', '{DEMO_SESSION_ID}') }} catch (e) {{}}"
         )
         page.goto(
             _variant_url(hub.base_url, theme, mode, rail),
@@ -894,8 +903,8 @@ def _capture_variant(
             timeout=_NAV_TIMEOUT_MS,
         )
         # Wait for the canned transcript's sentinel to land in the terminal
-        # (xterm's DOM renderer keeps the text in .xterm-rows). This also implies
-        # the PTY has spawned and the hub's session snapshot has been taken.
+        # (xterm's DOM renderer keeps the text in .xterm-rows). This also
+        # implies the PTY has spawned.
         page.wait_for_function(
             "(s) => { const r = document.querySelector('.xterm-rows');"
             " return !!r && (r.textContent || '').includes(s); }",
@@ -903,10 +912,8 @@ def _capture_variant(
             timeout=_NAV_TIMEOUT_MS,
         )
 
-        # Now publish the fake session so the hub discovers it and the terminal
-        # header updates; wait for it to reach the label (Expert: the hex;
+        # Wait for the confirmed id to reach the header (Expert: the hex;
         # Simple: the Task 5.4 "Connected" state — see _wait_for_session_ready).
-        _write_fake_session(hub.session_dir)
         _wait_for_session_ready(page, mode)
 
         # Guard against a transcript that wraps at the real fitted width.
@@ -949,6 +956,15 @@ def _capture_variant(
         dest.write_bytes(png)
         return CapturedVariant(theme=theme, mode=mode, accent=accent, filename=dest.name, rail=rail)
     finally:
+        # Every variant now resumes the SAME session id, so they share one pool
+        # entry — and the hub hands a warm PTY straight over without re-running
+        # its command. The next variant would sit forever waiting for a
+        # transcript that already played. Emptying the pool makes each capture
+        # spawn its own replay again.
+        try:
+            page.request.post(f"{hub.base_url}/api/terminal/restart")
+        except Exception:
+            pass
         page.close()
 
 

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -149,10 +149,9 @@ async def terminal_ws(websocket: WebSocket):
         # Force a known session UUID so the workspace provenance_locator tool can
         # hand it back (via OSPREY_TELEMETRY_SESSION_ID, injected below) and it
         # matches the value the OTEL emitter tags records with as session.id — a
-        # filed issue's provenance pointer then resolves. Leave claude_session_id
-        # None so the new-session snapshot/discovery path is unchanged: discovery
-        # simply finds the id we forced. (Not claude_session_id, which would set
-        # OSPREY_SESSION_ID and relocate session-scoped agent data.)
+        # filed issue's provenance pointer then resolves. (Not claude_session_id,
+        # which would set OSPREY_SESSION_ID and relocate session-scoped agent
+        # data — this is the CLI's session id, not an agent-data scope.)
         telemetry_session_id = str(uuid.uuid4())
         command = [*base_shell_command, "--session-id", telemetry_session_id]
         claude_session_id = None
@@ -160,8 +159,11 @@ async def terminal_ws(websocket: WebSocket):
     if effort:
         command.extend(["--effort", effort])
 
-    # Use claude_session_id as pool key for resumes, temp key for new sessions
-    current_key = claude_session_id or f"terminal-{uuid.uuid4().hex[:8]}"
+    # Pool key: the requested id for resumes, the forced id for new sessions.
+    # A new session's id is dictated on the command line above, never guessed,
+    # so the pool is keyed by the real session id from the first moment and
+    # needs no later rekey.
+    current_key = claude_session_id or telemetry_session_id
 
     # Wait for the client's initial resize message before spawning the PTY.
     initial_cols, initial_rows = 80, 24
@@ -178,14 +180,9 @@ async def terminal_ws(websocket: WebSocket):
     except TimeoutError:
         logger.warning("No initial resize from client within 5s, using defaults")
 
-    # For new sessions, snapshot existing session files before spawning
-    snapshot: set[str] | None = None
-    if claude_session_id is None:
-        snapshot = discovery.snapshot_session_ids()
-
-    # For resumes, snapshot too — a stale/absent --resume-id can make the CLI
-    # silently start a fresh session instead of resuming, and this is how we
-    # tell the two apart once the PTY is up.
+    # For resumes, snapshot the session files before spawning — a stale/absent
+    # --resume-id can make the CLI silently start a fresh session instead of
+    # resuming, and this is how we tell the two apart once the PTY is up.
     resume_snapshot: set[str] | None = None
     if mode == "resume" and req_session_id:
         resume_snapshot = discovery.snapshot_session_ids()
@@ -202,18 +199,16 @@ async def terminal_ws(websocket: WebSocket):
     )
     registry.attach_session(current_key)
 
-    # For new sessions, discover the Claude-generated UUID asynchronously
-    if snapshot is not None:
-
-        async def _do_initial_discover():
-            nonlocal current_key
-            found = await _discover_and_notify(
-                snapshot, discovery, registry, current_key, websocket
+    # New sessions: confirm the id immediately. It is the id this handler put
+    # on the CLI's own command line a few lines up, so there is nothing to wait
+    # for and nothing to race.
+    if claude_session_id is None:
+        try:
+            await websocket.send_text(
+                json.dumps({"type": "session_info", "session_id": current_key})
             )
-            if found:
-                current_key = found
-
-        asyncio.create_task(_do_initial_discover())
+        except Exception:
+            pass
 
     # For resumes, confirm the actually-attached session id so the client can
     # tell a live resume from a silently-fresh PTY on a stale --resume-id.
@@ -221,11 +216,13 @@ async def terminal_ws(websocket: WebSocket):
     # warm session (same live PTY) and a cold resume whose session file was
     # already on disk before we spawned (the id was genuinely valid). Only a
     # request for an id with no file on disk — stale/absent — is ambiguous:
-    # the CLI may fall back to creating a fresh session, so that case is
-    # confirmed via the same discovery mechanism (and window) used above —
-    # every entry into this branch is racing the CLI's own startup to write
-    # a new session file, so it needs the same generous timeout as the
-    # new-session path, not a shortened one.
+    # the CLI may fall back to creating a fresh session under an id of its own
+    # choosing, and ``--resume`` gives this handler no way to dictate that id
+    # the way the new-session path dictates one. So this branch alone still
+    # discovers, and it keeps the generous window: it is racing the CLI's own
+    # startup, and a fallback id that arrives late is still worth having. When
+    # the window closes with nothing new, the requested id is confirmed rather
+    # than left unanswered, so the client is never stranded without one.
     if resume_snapshot is not None:
         if was_reused or req_session_id in resume_snapshot:
             try:
@@ -243,7 +240,17 @@ async def terminal_ws(websocket: WebSocket):
                 )
                 if found:
                     current_key = found
-                else:
+                elif session.is_alive:
+                    # Nothing new appeared and the PTY is still up, so the
+                    # requested id resumed after all — confirm it. A PTY that
+                    # has already exited says the opposite: ``--resume`` found
+                    # no such conversation and the CLI quit. Confirming the id
+                    # back in that case would tell the client to keep an id
+                    # that resolves to nothing and re-resume it on the next
+                    # reload, which is how a dead tab becomes a permanent one.
+                    # Staying quiet leaves the client's own failover — driven
+                    # by the ``exit`` frame it has already been sent — to
+                    # discard the id and start clean.
                     try:
                         await websocket.send_text(
                             json.dumps({"type": "session_info", "session_id": current_key})
@@ -385,9 +392,20 @@ async def terminal_ws(websocket: WebSocket):
         output_task.cancel()
         # Detach instead of terminate — keep session alive in the pool.
         # Only terminate if the process has already died.
-        registry.detach_session(current_key)
+        #
+        # Both steps are guarded on this handler still OWNING the pool entry,
+        # because the key alone no longer identifies it. Now that every new
+        # session hands the client an id it stores and resumes, two handlers
+        # meeting on one key is ordinary: a second tab (or a reload whose
+        # disconnect the server sees late) can resume the id, find this PTY
+        # dead, and spawn a replacement under the same key. An unguarded
+        # teardown would then terminate the live replacement and clear the
+        # attachment the newer handler holds, killing a terminal the operator
+        # is looking at.
+        if registry.get_session(current_key) is session:
+            registry.detach_session(current_key)
         if not session.is_alive:
-            registry.terminate_session(current_key)
+            registry.terminate_session_if_owner(current_key, session)
 
 
 @router.post("/api/terminal/logout")

--- a/src/osprey/interfaces/web_terminal/static/js/terminal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal.js
@@ -18,9 +18,10 @@ let currentSessionId = null;
 // return round trip. Scoped to the terminal origin.
 const PTY_SESSION_STORAGE_KEY = 'osprey-pty-session';
 
-// A resume connection now gets a 'session_info' confirmation too —
-// routes/websocket.py runs session discovery on mode=resume as well as
-// mode=new — carrying the id ACTUALLY attached, which may differ from the
+// A resume connection gets a 'session_info' confirmation too —
+// routes/websocket.py discovers the attached id on the stale-resume path (a
+// new session needs no discovery: the server dictates its id and confirms it
+// at once) — carrying the id ACTUALLY attached, which may differ from the
 // requested --resume-id if that id was stale/dead and the server silently
 // started a fresh PTY instead of erroring. The 'session_info' branch in
 // onMessage below treats that confirmation as ground truth: a mismatch
@@ -33,15 +34,25 @@ const PTY_SESSION_STORAGE_KEY = 'osprey-pty-session';
 // place as a faster, independent failure signal.
 const RESUME_LIVENESS_TIMEOUT_MS = 2000;
 
+// How long an 'exit' still counts as "that resume failed". Wider than
+// RESUME_LIVENESS_TIMEOUT_MS on purpose: telling the panels which session
+// they are on can be answered the moment the socket looks alive, but ruling
+// out a failed resume cannot be answered until the CLI has had time to start,
+// fail to find the conversation, and exit — around two seconds unloaded, more
+// in a container. Kept under routes/websocket.py's discovery window so the
+// failover resolves before the server's fallback confirmation arrives. See
+// the two timers in startTerminal().
+const RESUME_FAILOVER_WINDOW_MS = 10000;
+
 // Session ID we auto-resumed on page load, if any. Armed by initTerminal()
 // right before the auto-resume startTerminal() call; disarmed by whichever
-// arrives first: a 'session_info' confirmation (see onMessage below), the
-// liveness timer (RESUME_LIVENESS_TIMEOUT_MS after connecting, if neither a
-// confirmation nor an 'exit' arrived — see startTerminal()), or an 'exit'
-// handled by falling back to a fresh session. One-shot:
-// only ever set for the initial page-load resume, never for other resume
-// call sites (e.g. sessions.js's resumeSession), so explicit user-driven
-// resumes are unaffected by this fallback.
+// arrives first: a 'session_info' confirmation (see onMessage below), an
+// 'exit' handled by falling back to a fresh session, or the failover window
+// closing (RESUME_FAILOVER_WINDOW_MS after connecting, if neither of those
+// happened — see startTerminal()). One-shot: only ever set for the initial
+// page-load resume, never for other resume call sites (e.g. sessions.js's
+// resumeSession), so explicit user-driven resumes are unaffected by this
+// fallback.
 /** @type {string|null} */
 let autoResumeFailoverId = null;
 
@@ -336,12 +347,16 @@ export function startTerminal(sessionId = null, mode = 'new') {
             const led = document.getElementById('session-led');
             if (led) led.classList.remove('active');
 
-            // If this was our page-load auto-resume attempt, the server
-            // has no way to report a resume failure other than letting
-            // the PTY exit (resume connections get no session_info
-            // confirmation). Treat it as a stale/expired session: drop
-            // the dead id and fall back to a fresh one so the user isn't
-            // stuck reconnecting to it forever.
+            // If this was our page-load auto-resume attempt, treat the exit
+            // as the resume having failed: drop the dead id and fall back to
+            // a fresh session so the user isn't stuck reconnecting to it
+            // forever. The server does confirm a resume, but only once it has
+            // finished discovering what the CLI actually attached to, which
+            // can take far longer than the CLI takes to fail — so the PTY
+            // exiting is the timely signal, and this is the ONLY place a dead
+            // id leaves storage. It stops counting as a resume failure after
+            // RESUME_FAILOVER_WINDOW_MS (see startTerminal()), past which an
+            // exit is the operator ending a session that did resume.
             if (autoResumeFailoverId) {
               autoResumeFailoverId = null;
               clearStoredSessionId();
@@ -402,24 +417,41 @@ export function startTerminal(sessionId = null, mode = 'new') {
   });
   wsConnection = socket;
 
-  // Disarm the auto-resume failover if this is that attempt and it
-  // survives briefly without an 'exit'. There is no positive "resume
-  // succeeded" message (see RESUME_LIVENESS_TIMEOUT_MS comment above), so
-  // absence-of-failure-within-a-window is the best available signal: a
-  // genuinely stale/expired --resume id causes claude to exit almost
-  // immediately, while a live resumed shell just keeps running. Guarded by
-  // identity (`wsConnection === socket`) so a connection torn down or
-  // replaced in the meantime can't spuriously disarm/notify.
+  // Two jobs on two clocks, deliberately separated — they answer different
+  // questions and a single timer served the shorter one at the longer one's
+  // expense. Both are guarded by identity (`wsConnection === socket`) so a
+  // connection torn down or replaced in the meantime can't spuriously fire.
   if (isAutoResumeAttempt) {
+    // "Which session are the panels looking at?" — answer as soon as the
+    // connection looks alive. Reached only when no session_info has arrived
+    // yet: for a stale id the server is still off discovering what the CLI
+    // actually started (routes/websocket.py), and that can outlast this
+    // timer, so this is the one place panel iframes learn the resumed id when
+    // the confirmation is slow. A confirmation that does arrive notifies with
+    // the id the server actually attached rather than the one we
+    // optimistically asked for.
     setTimeout(() => {
       if (autoResumeFailoverId === sessionId && wsConnection === socket) {
-        autoResumeFailoverId = null;
-        // The resume never gets a session_info message (server-side —
-        // discovery only runs for new sessions), so this is the only
-        // place panel iframes learn the resumed session id.
         notifySessionChange(/** @type {string} */ (sessionId));
       }
     }, RESUME_LIVENESS_TIMEOUT_MS);
+
+    // "Did the resume fail?" — keep listening for the 'exit' that says so
+    // until a failed resume could no longer plausibly be the cause. There is
+    // no positive "resume succeeded" message, so absence-of-failure-within-a-
+    // window is the best available signal, and the window has to be wider
+    // than the CLI takes to start up, fail to find the conversation, and
+    // exit. Measured at roughly two seconds on an idle laptop and slower in a
+    // container — so the notify timer above is far too tight to double as
+    // this one. Disarming early is not harmless: the 'exit' branch in
+    // onMessage is the only thing that drops a dead id from storage, and a
+    // tab that misses it prints "[Process exited]" and stays there, resuming
+    // the same dead id on every reload.
+    setTimeout(() => {
+      if (autoResumeFailoverId === sessionId && wsConnection === socket) {
+        autoResumeFailoverId = null;
+      }
+    }, RESUME_FAILOVER_WINDOW_MS);
   }
 }
 

--- a/tests/e2e/web_terminals/test_prefix_routing.py
+++ b/tests/e2e/web_terminals/test_prefix_routing.py
@@ -318,14 +318,17 @@ def _recv_json(ws, msg_type: str, max_frames: int = 30) -> dict:
 
 @pytest.fixture
 def ws_app(tmp_path, monkeypatch):
-    """An isolated app for driving a real websocket handshake. Uses the
-    ``mode=resume`` path (not the bare ``mode=new`` default): the ``new``-session
-    path only sends ``session_info`` when discovery finds a NEWLY-created
-    session file, so with ``discover_new_session`` patched to return ``None``
-    (no real filesystem poll) it would never send anything and this test would
-    hang forever waiting on a frame that never arrives. The resume path, by
-    contrast, always confirms synchronously (real or discovered id) -- the
-    exact, proven shape ``test_ws_resume_confirm.py`` already relies on.
+    """An isolated app for driving a real websocket handshake.
+
+    Uses the ``mode=resume`` path, which confirms synchronously with the
+    requested id -- the exact shape ``test_ws_resume_confirm.py`` relies on, so
+    the frame this test waits for is guaranteed to arrive. ``mode=new`` would
+    serve equally well now that it confirms the id it forces on the CLI, but
+    there is no reason to churn a passing handshake test onto it.
+
+    ``discover_new_session`` is patched to ``None`` so nothing polls the real
+    filesystem; on the resume path that simply means the requested id is the
+    one confirmed.
     """
     monkeypatch.setenv("OSPREY_TERMINAL_USER", "alice")
     ws_dir = tmp_path / "var" / "agent_data"

--- a/tests/interfaces/web_terminal/terminal-resume.test.mjs
+++ b/tests/interfaces/web_terminal/terminal-resume.test.mjs
@@ -70,6 +70,7 @@ class FakeWebSocket {
     /** @type {((ev?: any) => void)|null} */
     this.onclose = null;
     FakeWebSocket.last = this;
+    FakeWebSocket.created += 1;
   }
   /** @param {any} data */
   send(data) {
@@ -86,6 +87,8 @@ FakeWebSocket.CLOSING = 2;
 FakeWebSocket.CLOSED = 3;
 /** @type {FakeWebSocket|null} */
 FakeWebSocket.last = null;
+/** How many have been constructed — a reconnect is a new one. */
+FakeWebSocket.created = 0;
 
 /** Flip the most recently created fake socket to OPEN and fire its onopen. */
 function openSocket() {
@@ -126,6 +129,7 @@ beforeEach(async () => {
   vi.spyOn(console, 'error').mockImplementation(() => {});
 
   FakeWebSocket.last = null;
+  FakeWebSocket.created = 0;
   terminal = await import('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js');
 });
 
@@ -182,5 +186,79 @@ describe('resume confirmation: stale id self-correction', () => {
 
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     expect(terminal.getCurrentSessionId()).toBe('fresh-explicit-id');
+  });
+});
+
+describe('auto-resume failover window', () => {
+  // The confirmation above is the tidy signal; these cover the untidy one.
+  // When `claude --resume <dead-id>` cannot find the conversation it just
+  // exits, and the resulting 'exit' frame is the ONLY thing that drops the
+  // dead id from storage. How long that stays true is the window under test:
+  // the CLI takes roughly two seconds to start up and fail, so a window that
+  // closed at two seconds was racing the very event it existed to catch.
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Auto-resume `id` from storage and open the socket.
+   * @param {string} id
+   */
+  function autoResume(id) {
+    localStorage.setItem(STORAGE_KEY, id);
+    terminal.initTerminal('terminal-container');
+    openSocket();
+  }
+
+  test('exit after the notify timer but inside the window still fails over', () => {
+    autoResume('dead-id');
+
+    // Past the 2s panel-notify timer, well inside the 10s failover window —
+    // the interval a failed resume actually lands in.
+    vi.advanceTimersByTime(5000);
+    receive({ type: 'exit', code: 1 });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(terminal.getCurrentSessionId()).toBeNull();
+  });
+
+  test('exit inside the window fails over to a fresh session', () => {
+    autoResume('dead-id');
+
+    vi.advanceTimersByTime(2500);
+    const socketsBefore = FakeWebSocket.created;
+    receive({ type: 'exit', code: 1 });
+
+    // Failover reconnects, and does so without a session_id — a fresh session.
+    expect(FakeWebSocket.created).toBeGreaterThan(socketsBefore);
+    const url = /** @type {FakeWebSocket} */ (FakeWebSocket.last).url;
+    expect(url).not.toContain('session_id=');
+  });
+
+  test('exit after the window closes is left alone', () => {
+    autoResume('live-id');
+
+    // Past RESUME_FAILOVER_WINDOW_MS: a resume this old did work, and the exit
+    // is the operator ending their own session. Dropping the id here would
+    // discard a session they may well want to resume.
+    vi.advanceTimersByTime(11000);
+    receive({ type: 'exit', code: 0 });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('live-id');
+  });
+
+  test('a confirmation disarms the failover, so a later exit is left alone', () => {
+    autoResume('live-id');
+
+    receive({ type: 'session_info', session_id: 'live-id' });
+    vi.advanceTimersByTime(3000);
+    receive({ type: 'exit', code: 0 });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('live-id');
   });
 });

--- a/tests/interfaces/web_terminal/test_feedback_modal_browser.py
+++ b/tests/interfaces/web_terminal/test_feedback_modal_browser.py
@@ -235,14 +235,15 @@ def test_tab_cycles_through_every_control_and_wraps(tmp_path, chromium_browser):
         try:
             _open_modal(page)
 
-            # The form is there in full, including the session-context checkbox
-            # that this fixture correctly greys out (no PTY session to attach).
+            # The form is there in full, including the session-context checkbox:
+            # the server confirms the terminal's session id on connect, so even
+            # this fresh, never-typed-in fixture has a session to attach.
             dialog = page.locator(".feedback-modal-dialog")
             expect(dialog.locator("button.feedback-modal-close")).to_have_count(1)
             expect(dialog.locator("textarea.feedback-text")).to_have_count(1)
             expect(dialog.locator('input[type="radio"][name="feedback-channel"]')).to_have_count(3)
             expect(dialog.locator("input.feedback-metadata-check")).to_be_enabled()
-            expect(dialog.locator("input.feedback-context-check")).to_be_disabled()
+            expect(dialog.locator("input.feedback-context-check")).to_be_enabled()
             expect(dialog.locator("button.feedback-help-toggle")).to_have_count(1)
             expect(dialog.locator("button.feedback-send")).to_have_count(1)
 
@@ -251,12 +252,11 @@ def test_tab_cycles_through_every_control_and_wraps(tmp_path, chromium_browser):
             # sides of the set comparison below are read off the live DOM, so a
             # control that becomes untabbable (``tabindex="-1"``, or newly
             # disabled) would drop out of BOTH and pass unnoticed; the inventory
-            # catches deletion, and this count catches un-tabbing. The six: the
-            # close button, the textarea, the channel radios (one stop — they
-            # share a name), the metadata checkbox, the help toggle, and Send.
-            # The context checkbox is disabled in this fixture and is correctly
-            # not a stop.
-            assert len(expected) == 6, f"tab order changed shape: {expected}"
+            # catches deletion, and this count catches un-tabbing. The seven:
+            # the close button, the textarea, the channel radios (one stop —
+            # they share a name), the metadata checkbox, the context checkbox,
+            # the help toggle, and Send.
+            assert len(expected) == 7, f"tab order changed shape: {expected}"
 
             start = _focus_probe(page)["key"]
             visited = [start]

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -3102,6 +3102,22 @@ def _palette_live_server(workspace):
             yield base_url, app
 
 
+def _wait_for_ariel_ready(page: Page) -> None:
+    """Block until ARIEL's standalone URL has resolved through /api/ariel-server.
+
+    The palette builds its rows once per open (palette.js re-renders per open,
+    not per keystroke), so an open that outruns ARIEL's config fetch is missing
+    the ARIEL rows for as long as it stays open — no amount of typing brings
+    them back. The rail entry sheds ``.disabled`` in the same settle that
+    publishes the URL (initPanel → assumeHealthy), so waiting on the class is
+    waiting on the rows' precondition. Every test that opens the palette and
+    expects an ARIEL row must pass through here first.
+    """
+    expect(
+        page.locator('button.panel-rail-button[data-panel-id="ariel"]:not(.disabled)')
+    ).to_be_attached(timeout=10_000)
+
+
 def _palette_input(page: Page):
     return page.locator(_PALETTE_INPUT)
 
@@ -3225,6 +3241,7 @@ def test_palette_query_ariel_offers_popout_of_the_active_panel(tmp_path, chromiu
 
     with _palette_live_server(workspace) as (base_url, _app):
         page = _open_page(chromium_browser, base_url)
+        _wait_for_ariel_ready(page)
         _focus_service_panel(page, "ariel", "ARIEL")
 
         _open_palette(page)
@@ -3259,6 +3276,7 @@ def test_palette_logbook_synonym_matches_ariel(tmp_path, chromium_browser):
 
     with _palette_live_server(workspace) as (base_url, _app):
         page = _open_page(chromium_browser, base_url)
+        _wait_for_ariel_ready(page)
 
         _open_palette(page)
         _palette_query(page, "logbook")
@@ -3284,6 +3302,7 @@ def test_palette_popout_row_opens_the_proxied_panel_url(tmp_path, chromium_brows
 
     with _palette_live_server(workspace) as (base_url, _app):
         page = _open_page(chromium_browser, base_url)
+        _wait_for_ariel_ready(page)
 
         _open_palette(page)
         _palette_query(page, "ariel window")

--- a/tests/interfaces/web_terminal/test_session_switching.py
+++ b/tests/interfaces/web_terminal/test_session_switching.py
@@ -307,6 +307,11 @@ class TestSessionSwitchingContract:
         mock_reg = MagicMock(spec=PtyRegistry)
         mock_reg.get_or_create_session.return_value = (fake_session, False)
         mock_reg.attach_session.return_value = True
+        # The handler's teardown asks who currently owns the key before
+        # touching it; answer with the session it was handed, i.e. "still the
+        # owner". test_disconnect_leaves_a_replacement_session_alone below
+        # overrides this to model the other case.
+        mock_reg.get_session.return_value = fake_session
         app.state.pty_registry = mock_reg
         return mock_reg, fake_session
 
@@ -407,8 +412,9 @@ class TestSessionSwitchingContract:
 
         # Handler's finally: detach(current_key)
         mock_reg.detach_session.assert_called_with(sid)
-        # Session is alive → terminate_session should NOT be called
+        # Session is alive → nothing is terminated
         mock_reg.terminate_session.assert_not_called()
+        mock_reg.terminate_session_if_owner.assert_not_called()
 
     def test_disconnect_terminates_dead_session(self, app, sessions_dir):
         """On WS close with dead session: detach AND terminate."""
@@ -427,4 +433,40 @@ class TestSessionSwitchingContract:
                 time.sleep(0.2)  # let output loop notice and exit
 
         mock_reg.detach_session.assert_called_with(sid)
-        mock_reg.terminate_session.assert_called_with(sid)
+        # Terminated through the owner-checked entry point, which takes the
+        # session this handler owns as well as the key — see
+        # test_disconnect_leaves_a_replacement_session_alone.
+        mock_reg.terminate_session_if_owner.assert_called_with(sid, dead)
+
+    def test_disconnect_leaves_a_replacement_session_alone(self, app, sessions_dir):
+        """A stale handler's teardown must not touch a newer session.
+
+        Two handlers meeting on one pool key is ordinary: a second tab (or a
+        reload whose disconnect the server sees late) resumes the id, finds
+        this PTY dead, and gets a replacement spawned under the same key.
+        Teardown keyed on the id alone would then terminate the replacement
+        and clear its attachment, killing a terminal someone is looking at.
+        """
+        sid = _uuid()
+        import time
+
+        _seed_session_file(sessions_dir, sid)
+        with TestClient(app) as client:
+            dead = FakePtySession()
+            mock_reg, _ = self._mock_registry(app, fake_session=dead)
+            with client.websocket_connect(_resume_url(sid)) as ws:
+                _send_resize(ws)
+                mock_reg.reset_mock()
+                dead._alive = False
+                time.sleep(0.2)  # let output loop notice and exit
+                # A newer handler has since put its own session under this key.
+                replacement = FakePtySession()
+                mock_reg.get_session.return_value = replacement
+
+        # The newer handler's attachment is left intact...
+        mock_reg.detach_session.assert_not_called()
+        # ...and the registry entry is not terminated by key. The dead PTY is
+        # still handed to the owner-checked call, which terminates the process
+        # this handler owns without disturbing the pool.
+        mock_reg.terminate_session.assert_not_called()
+        mock_reg.terminate_session_if_owner.assert_called_with(sid, dead)

--- a/tests/interfaces/web_terminal/test_ws_new_session_confirm.py
+++ b/tests/interfaces/web_terminal/test_ws_new_session_confirm.py
@@ -1,0 +1,299 @@
+"""WebSocket new-session confirmation tests.
+
+``session_info`` is the client's only source for ``currentSessionId``, and a
+new terminal's id is not something the server has to find out — it is dictated
+on the CLI's own command line (``claude --session-id <uuid>``, built in
+``terminal_ws``). These tests pin that the handler confirms that id straight
+away, on its own, from nothing but what it already knows.
+
+The regression they guard is a race that the old implementation lost as a
+matter of course. It used to poll the transcript directory for a
+newly-appeared ``<uuid>.jsonl`` and confirm whatever turned up. But Claude Code
+writes a session's transcript once that session first has content, not when
+the process starts, so a terminal that sat idle past the poll window never got
+a ``session_info`` at all — and never got one later either, because there is no
+retry. That tab then ran on ``currentSessionId === null`` for as long as it
+lived, however much work the operator went on to do in it: feedback filed with
+no session context, nothing stored to resume from, and a fresh PTY spawned on
+every reload. Hence :func:`test_idle_terminal_is_confirmed_without_a_transcript`,
+which is the same assertion made against an empty transcript directory to say
+so out loud.
+
+Harness mirrors ``test_ws_resume_confirm.py``: a real ``PtyRegistry`` with
+``_spawn_session`` patched to a ``FakePtySession``, so no PTY is ever created.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from osprey.interfaces.web_terminal.app import create_app
+from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="PTY not available on Windows")
+
+
+class FakePtySession:
+    """Minimal PtySession substitute — stays alive, produces no output."""
+
+    def __init__(self):
+        self._alive = True
+
+    @property
+    def is_alive(self):
+        return self._alive
+
+    @property
+    def exit_code(self):
+        return None if self._alive else 0
+
+    def start(self, initial_rows=24, initial_cols=80, extra_env=None, cwd=None):
+        pass
+
+    def resize(self, rows, cols):
+        pass
+
+    def write_input(self, data):
+        pass
+
+    def terminate(self):
+        self._alive = False
+
+    async def read_output(self):
+        """Async generator that blocks quietly until the session dies."""
+        try:
+            while self._alive:
+                await asyncio.sleep(0.05)
+        except (asyncio.CancelledError, GeneratorExit):
+            return
+        # Unreachable yield — makes this function an async generator.
+        if False:
+            yield b""  # pragma: no cover
+
+
+def _recv_json(ws, msg_type: str, max_frames: int = 30):
+    """Receive frames until a JSON message with the given ``type`` arrives."""
+    collected = []
+    for _ in range(max_frames):
+        raw = ws.receive()
+        if "text" in raw:
+            data = json.loads(raw["text"])
+            collected.append(data)
+            if data.get("type") == msg_type:
+                return data
+        # binary frames are silently skipped
+    types = [d.get("type") for d in collected]
+    raise AssertionError(
+        f"Expected JSON type '{msg_type}' not received within {max_frames} frames. "
+        f"Got types: {types}"
+    )
+
+
+def _send_resize(ws, cols: int = 80, rows: int = 24):
+    """Send the initial resize the handler waits for before spawning."""
+    ws.send_json({"type": "resize", "cols": cols, "rows": rows})
+
+
+def _forced_session_id(command: list[str]) -> str:
+    """Return the id the handler put after ``--session-id`` in *command*."""
+    assert "--session-id" in command, f"no --session-id in spawned command: {command}"
+    return command[command.index("--session-id") + 1]
+
+
+@pytest.fixture()
+def app(tmp_path):
+    """Create a web terminal app pointed at a temp project dir."""
+    with patch(
+        "osprey.interfaces.web_terminal.app._load_web_config",
+        return_value={"watch_dir": str(tmp_path / "ws")},
+    ):
+        yield create_app(shell_command="fake-not-used", project_dir=str(tmp_path))
+
+
+def _patch_spawn(app):
+    """Replace ``_spawn_session`` so no real PTY is created.
+
+    Returns the registry and the list of commands it was asked to spawn, which
+    is where the forced ``--session-id`` can be read back from.
+    """
+    reg = app.state.pty_registry
+    commands: list[list[str]] = []
+
+    def tracked_spawn(command, *_args, **_kwargs):
+        commands.append(list(command))
+        return FakePtySession()
+
+    reg._spawn_session = tracked_spawn
+    return reg, commands
+
+
+def _patch_spawn_tracking_sessions(app):
+    """As :func:`_patch_spawn`, but hands back the sessions themselves."""
+    reg = app.state.pty_registry
+    spawned: list[FakePtySession] = []
+
+    def tracked_spawn(*_args, **_kwargs):
+        s = FakePtySession()
+        spawned.append(s)
+        return s
+
+    reg._spawn_session = tracked_spawn
+    return reg, spawned
+
+
+# ---------------------------------------------------------------------------
+# The confirmation itself
+# ---------------------------------------------------------------------------
+
+
+def test_new_session_confirms_the_forced_id(app):
+    """A new terminal is confirmed with the id spawned on its command line."""
+    with TestClient(app) as client:
+        _, commands = _patch_spawn(app)
+        with client.websocket_connect("/ws/terminal") as ws:
+            _send_resize(ws)
+            msg = _recv_json(ws, "session_info")
+
+        assert len(commands) == 1
+        assert msg["session_id"] == _forced_session_id(commands[0])
+
+
+def test_new_session_confirmation_does_not_consult_discovery(app):
+    """The id is known, so nothing polls the transcript directory for it."""
+    with patch(
+        "osprey.interfaces.web_terminal.routes.websocket.SessionDiscovery.discover_new_session"
+    ) as mock_discover:
+        with TestClient(app) as client:
+            _patch_spawn(app)
+            with client.websocket_connect("/ws/terminal") as ws:
+                _send_resize(ws)
+                _recv_json(ws, "session_info")
+
+        mock_discover.assert_not_called()
+
+
+def test_idle_terminal_is_confirmed_without_a_transcript(app, tmp_path):
+    """The regression: a terminal nobody has typed into is still confirmed.
+
+    Claude Code has written no ``<uuid>.jsonl`` at this point and may never
+    write one. Under the old discovery-based implementation that meant no
+    ``session_info`` and a client stuck on a null session id for the life of
+    the tab; the confirmation must not depend on the transcript existing.
+    """
+    sessions_dir = tmp_path / "claude_sessions"
+    sessions_dir.mkdir()
+
+    with patch.object(SessionDiscovery, "_resolve_sessions_dir", lambda self: sessions_dir):
+        with TestClient(app) as client:
+            _, commands = _patch_spawn(app)
+            with client.websocket_connect("/ws/terminal") as ws:
+                _send_resize(ws)
+                msg = _recv_json(ws, "session_info")
+
+            session_id = msg["session_id"]
+            assert session_id == _forced_session_id(commands[0])
+            # Nothing on disk backs that id — the confirmation stands alone.
+            assert list(sessions_dir.glob("*.jsonl")) == []
+
+
+# ---------------------------------------------------------------------------
+# The pool key
+# ---------------------------------------------------------------------------
+
+
+def test_new_session_is_pooled_under_its_real_id(app):
+    """The pool is keyed by the session id, not a placeholder needing a rekey.
+
+    A placeholder key is what let a reconnect miss the warm PTY it should have
+    found and spawn a second one against the same session.
+    """
+    with TestClient(app) as client:
+        reg, commands = _patch_spawn(app)
+        with client.websocket_connect("/ws/terminal") as ws:
+            _send_resize(ws)
+            msg = _recv_json(ws, "session_info")
+
+        session_id = msg["session_id"]
+        assert reg.get_session(session_id) is not None
+        assert list(reg._sessions) == [session_id]
+        assert len(commands) == 1
+
+
+def test_resuming_the_confirmed_id_reuses_the_warm_session(app):
+    """Reconnecting with the confirmed id finds the pooled PTY, not a new one.
+
+    This is the round trip the fix restores end to end: the client stores the
+    id it was given and resumes it on the next page load.
+    """
+    with patch(
+        "osprey.interfaces.web_terminal.routes.websocket.SessionDiscovery.discover_new_session",
+        return_value=None,
+    ):
+        with TestClient(app) as client:
+            reg, commands = _patch_spawn(app)
+
+            with client.websocket_connect("/ws/terminal") as ws:
+                _send_resize(ws)
+                session_id = _recv_json(ws, "session_info")["session_id"]
+
+            with client.websocket_connect(
+                f"/ws/terminal?session_id={session_id}&mode=resume"
+            ) as ws:
+                _send_resize(ws)
+                msg = _recv_json(ws, "session_info")
+                assert msg["session_id"] == session_id
+
+            # Warm reuse: the second connection spawned nothing.
+            assert len(commands) == 1
+            assert list(reg._sessions) == [session_id]
+
+
+def test_stale_handler_teardown_spares_the_replacement_session(app):
+    """A first tab closing must not kill the PTY a second tab is using.
+
+    Handing every new session an id the client stores and resumes makes two
+    handlers on one pool key ordinary rather than accidental, so teardown has
+    to check ownership: this handler's PTY has died and been replaced under
+    the same key, and terminating by key alone would take the live
+    replacement — and the operator's terminal — down with it.
+    """
+    with patch(
+        "osprey.interfaces.web_terminal.routes.websocket.SessionDiscovery.discover_new_session",
+        return_value=None,
+    ):
+        with TestClient(app) as client, ExitStack() as stack:
+            reg, spawned = _patch_spawn_tracking_sessions(app)
+
+            # Tab one: a new session, confirmed with the forced id.
+            first = stack.enter_context(client.websocket_connect("/ws/terminal"))
+            _send_resize(first)
+            session_id = _recv_json(first, "session_info")["session_id"]
+
+            # Its CLI exits. The socket stays open, as it does in the browser
+            # — the tab just shows "[Process exited]".
+            spawned[0].terminate()
+
+            # Tab two resumes the id tab one stored. The dead PTY is dropped
+            # and a replacement spawned under the same key.
+            with client.websocket_connect(
+                f"/ws/terminal?session_id={session_id}&mode=resume"
+            ) as second:
+                _send_resize(second)
+                assert _recv_json(second, "session_info")["session_id"] == session_id
+                assert len(spawned) == 2
+                assert reg.get_session(session_id) is spawned[1]
+
+                # Tab one goes away WHILE tab two is still open, so its
+                # teardown runs against a session that is no longer the one
+                # the pool holds under this key.
+                stack.close()
+
+                assert spawned[1].is_alive, "tab one's teardown killed tab two's PTY"
+                assert reg.get_session(session_id) is spawned[1]

--- a/tests/interfaces/web_terminal/test_ws_resume_confirm.py
+++ b/tests/interfaces/web_terminal/test_ws_resume_confirm.py
@@ -25,6 +25,7 @@ import asyncio
 import json
 import sys
 import threading
+import time
 import uuid as uuid_mod
 from unittest.mock import patch
 
@@ -100,6 +101,24 @@ def _recv_json(ws, msg_type: str, max_frames: int = 30):
         f"Expected JSON type '{msg_type}' not received within {max_frames} frames. "
         f"Got types: {types}"
     )
+
+
+def _collect_until(ws, msg_type: str, max_frames: int = 30) -> list[dict]:
+    """Return every JSON message up to and including the first *msg_type*.
+
+    The twin of :func:`_recv_json` for asserting what did NOT arrive: read to a
+    frame the server is guaranteed to send, then inspect the whole run.
+    """
+    collected = []
+    for _ in range(max_frames):
+        raw = ws.receive()
+        if "text" in raw:
+            data = json.loads(raw["text"])
+            collected.append(data)
+            if data.get("type") == msg_type:
+                return collected
+    types = [d.get("type") for d in collected]
+    raise AssertionError(f"'{msg_type}' not received within {max_frames} frames. Got: {types}")
 
 
 def _uuid() -> str:
@@ -296,3 +315,63 @@ def test_stale_resume_with_delayed_file_confirms_discovered_id(app, tmp_path):
     # The stale branch must use the same (full) window as the new-session
     # discovery path — not a shortened one that races the CLI and loses.
     assert captured_timeouts == [15.0]
+
+
+# ---------------------------------------------------------------------------
+# Stale id whose PTY died — the resume demonstrably failed, so say nothing
+# ---------------------------------------------------------------------------
+
+
+def test_stale_resume_with_dead_pty_is_not_confirmed(app, tmp_path):
+    """A resume whose PTY has already exited must not have its id confirmed.
+
+    The no-discovery fallback reasons "nothing new appeared, so the requested
+    id resumed after all". A PTY that has since exited is evidence against
+    exactly that: ``--resume`` found no such conversation and the CLI quit.
+    Confirming the id back there would tell the client to keep an id that
+    resolves to nothing and re-resume it on the next page load, which is how a
+    dead tab becomes a permanently dead one. Silence hands the verdict to the
+    client's own failover, which the ``exit`` frame has already triggered.
+    """
+    dead_sid = _uuid()
+    sessions_dir = tmp_path / "claude_sessions"
+    sessions_dir.mkdir()
+
+    # Order the two events: discovery does not give up until the client has
+    # seen the PTY exit, so the confirm decision is made against a session
+    # that is unambiguously dead.
+    exit_seen = threading.Event()
+
+    def _discover_after_exit(self, before, timeout=15.0):
+        exit_seen.wait(timeout=5.0)
+        return None
+
+    with patch.object(SessionDiscovery, "_resolve_sessions_dir", lambda self: sessions_dir):
+        with patch.object(SessionDiscovery, "discover_new_session", _discover_after_exit):
+            with TestClient(app) as client:
+                _, spawned = _patch_spawn(app)
+                with client.websocket_connect(_resume_url(dead_sid)) as ws:
+                    _send_resize(ws)
+                    # The handler spawns once it has the resize; wait for it.
+                    deadline = time.monotonic() + 5.0
+                    while not spawned and time.monotonic() < deadline:
+                        time.sleep(0.01)
+                    assert spawned, "handler never spawned a PTY"
+
+                    # The CLI cannot find the conversation and quits.
+                    spawned[0].terminate()
+                    assert _recv_json(ws, "exit")["code"] == 0
+                    exit_seen.set()
+                    # Let the confirm task reach its decision and, if it sends,
+                    # get the frame onto the wire ahead of the fence below.
+                    time.sleep(0.5)
+
+                    # Fence: an invalid switch is answered immediately, so a
+                    # confirmation would already be queued in front of it.
+                    ws.send_json({"type": "switch_session", "session_id": "not-a-uuid"})
+                    seen = _collect_until(ws, "error")
+
+        assert [m["type"] for m in seen] == ["error"], (
+            "a dead PTY's resume was confirmed back to the client: "
+            f"{[m for m in seen if m['type'] == 'session_info']}"
+        )


### PR DESCRIPTION
## Summary

The web terminal learned its own session id by polling the transcript directory for a newly-appeared `<uuid>.jsonl` — but Claude Code only writes that file once the session has content. A terminal left idle past the poll window never received `session_info`, so that tab lived with `currentSessionId = null`: feedback filed without session context, nothing stored to resume from, and a fresh PTY spawned on every reload.

**Core fix:** for new sessions the server dictates the id on the CLI's own command line, so there is nothing to discover — it now confirms that id the moment the socket connects. Discovery survives only on the one genuinely ambiguous path: resuming an id whose session file is not on disk, where the CLI may fall back to a fresh session under an id of its own choosing.

With every tab now storing a resumable id, auto-resume becomes the routine path, and two hazards that used to be rare become routine; both are closed here:

- **Teardown guard:** closing a tab releases its pool key only if the closing handler still owns the session (`terminate_session_if_owner`), so a stale handler can't kill a replacement PTY another tab is using.
- **Failover window:** the client keeps listening for a failed page-load resume for 10s (was 2s — about how long `claude --resume <dead-id>` takes to fail, i.e. a coin flip). A dead stored id now reliably falls back to a fresh session instead of leaving the tab at "[Process exited]" and reopening dead.

The screenshot contact-sheet harness is reworked to match: its choreography depended on the deleted discovery flow and would hang without it.

**Accepted tradeoff:** a genuinely-resumed session whose CLI exits within 10s of page load is treated as a failed resume and the stored id is dropped. This is only reachable when the server cannot see the transcript dir (otherwise the immediate confirmation disarms the failover first), and main had the same heuristic at 2s.

Also includes a test-only deflake commit: the three ARIEL palette tests opened the command palette without waiting for ARIEL's config fetch, and the palette snapshots its rows once per open — a pre-existing race on main measured flaking at 20–60% locally, now guarded by waiting for the rail entry to enable.

## Testing

- `tests/interfaces/web_terminal/`: 1426 passed
- vitest: 2326 passed (104 files)
- ruff / eslint / tsc / mypy clean
- New coverage: `test_ws_new_session_confirm.py` (immediate confirmation incl. idle terminals), resume-confirm and teardown-ownership cases in `test_ws_resume_confirm.py` / `test_session_switching.py`, failover-window timing in `terminal-resume.test.mjs`
- ARIEL palette tests: 20/20 hammer runs green after the deflake (previously up to 60% local failure)