### PR TITLE
fix(web): feedback paste-step UX, stable prefill title, SVG rail icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Feedback sent by GitHub or Email no longer arrives without its session
+  context because nobody knew about the paste step. The context travels by
+  clipboard (it cannot fit a `mailto:` URL), and the dialog now says so:
+  ticking the context box on an outbound channel shows a paste hint, and the
+  post-send confirmation tells the sender the full report is on the clipboard.
+  The session id also rides inline in the prefilled body when context is
+  attached, so a message can be matched to the deployment's own record even
+  when the paste never happened.
+- The prefilled issue title / mail subject is no longer the first line of the
+  report text. It is now a stable "OSPREY feedback" title, suffixed with a
+  short session id when context is attached.
 - The web terminal now knows its own session id from the moment it opens.
   It previously waited for the session's transcript file to appear on disk,
   which only happens once the session has content — so a terminal left idle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ Compatibility is documented in release notes, not encoded in the version string.
 - The prefilled issue title / mail subject is no longer the first line of the
   report text. It is now a stable "OSPREY feedback" title, suffixed with a
   short session id when context is attached.
+- The rail's Documentation and Feedback controls now draw SVG marks (open
+  book, speech bubble) instead of font glyphs. The old `ⓘ` read as "About"
+  and rendered oversized; the old `✉` rendered small, painted full-colour
+  emoji on Windows/Android, and promised email for a dialog that also files
+  locally or to GitHub.
 - The web terminal now knows its own session id from the moment it opens.
   It previously waited for the session's transcript file to appear on disk,
   which only happens once the session has content — so a terminal left idle

--- a/docs/source/how-to/send-feedback.rst
+++ b/docs/source/how-to/send-feedback.rst
@@ -77,6 +77,9 @@ way.
 **Session context** — the checkbox is **off** by default, and is greyed out with
 "no session yet" when there is no live session to attach. It adds:
 
+- the session's id — on the GitHub and Email channels this one also appears
+  inline in the prefilled body, so the message can be matched to the
+  deployment's own record even if the paste step below is missed,
 - the session's tool-call and agent event log,
 - its chat history,
 - the terminal scrollback,
@@ -114,9 +117,14 @@ without writing a record. It is enabled only when the session-context checkbox
 is ticked and a session exists; otherwise it stays visible but greyed, so it
 never looks like a control that disappeared.
 
-Use it when the prefilled issue or draft is too small to carry the context
-inline: the prefilled body already contains a ``paste the copied session context
-here`` placeholder to drop it into.
+The context never travels inside the prefilled issue or draft itself — a
+``mailto:`` URL in particular is far too small to carry it. Sending on an
+outbound channel already copies the whole report to the clipboard, the
+prefilled body contains a ``paste the copied session context here``
+placeholder to drop it into, and the dialog says so twice: beside the ticked
+checkbox before sending, and in the confirmation afterwards. Reach for this
+button when the clipboard has since been overwritten and the paste still has
+to happen.
 
 .. _feedback-retrieval:
 

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -812,12 +812,14 @@ html[data-ui-mode="simple"] .session-selector {
 }
 
 .panel-utility-icon {
-  font-size: var(--text-xl);
-  line-height: var(--leading-none);
+  display: inline-flex;
 }
 
-.panel-utility-icon[data-icon="docs"]::before { content: "\24d8"; }     /* ⓘ documentation */
-.panel-utility-icon[data-icon="feedback"]::before { content: "\2709"; } /* ✉ feedback */
+.panel-utility-icon svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
 
 /* The popover opens to the RIGHT of the rail (the "+" sits in a narrow left
    column), top-aligned to the button. */

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -262,11 +262,21 @@
         <a class="panel-utility-btn" id="panel-docs-link"
            target="_blank" rel="noopener"
            title="Documentation" aria-label="Documentation" hidden>
-          <span class="panel-utility-icon" data-icon="docs" aria-hidden="true"></span>
+          <span class="panel-utility-icon" data-icon="docs" aria-hidden="true">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8 4.7C6.5 3.6 4.6 3.2 2.6 3.4L2.6 11.6C4.6 11.4 6.5 11.8 8 12.9"/>
+              <path d="M8 4.7C9.5 3.6 11.4 3.2 13.4 3.4L13.4 11.6C11.4 11.4 9.5 11.8 8 12.9"/>
+              <path d="M8 4.7L8 12.9"/>
+            </svg>
+          </span>
         </a>
         <button class="panel-utility-btn" id="panel-feedback-btn" type="button"
                 title="Send feedback" aria-label="Send feedback">
-          <span class="panel-utility-icon" data-icon="feedback" aria-hidden="true"></span>
+          <span class="panel-utility-icon" data-icon="feedback" aria-hidden="true">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4.6 2.7H11.4A2.1 2.1 0 0 1 13.5 4.8V9.3A2.1 2.1 0 0 1 11.4 11.4H7.0L3.5 14.1L4.4 11.4A2.1 2.1 0 0 1 2.5 9.3V4.8A2.1 2.1 0 0 1 4.6 2.7Z"/>
+            </svg>
+          </span>
         </button>
       </div>
     </div>

--- a/src/osprey/interfaces/web_terminal/static/js/feedback-client.js
+++ b/src/osprey/interfaces/web_terminal/static/js/feedback-client.js
@@ -82,10 +82,32 @@ export const NOTICE_CONTEXT_COPIED = 'Session context copied to your clipboard.'
 /** Shown when the bundle response carried no context string. */
 export const NOTICE_EMPTY_BUNDLE = 'This deployment returned no session context.';
 
+/**
+ * Appended to the outbound confirmation when the clipboard carries something
+ * the prefilled body could not: the session context (which never fits a
+ * `mailto:` URL), or text the URL cap forced out. Without this line the sender
+ * has no way to know the paste step exists — the draft looks complete and gets
+ * sent with the placeholder still in it.
+ */
+export const NOTICE_PASTE_GITHUB =
+  'the full report is on your clipboard — paste it over the placeholder in the issue';
+
+/** Email variant of {@link NOTICE_PASTE_GITHUB}. */
+export const NOTICE_PASTE_EMAIL =
+  'the full report is on your clipboard — paste it over the placeholder in the draft';
+
+/**
+ * Prefilled issue title / mail subject. Deliberately generic: the report text
+ * is not a title (a short report would duplicate itself, a long one would be
+ * an arbitrary slice), so the sender is given a stable name to overwrite.
+ */
+export const DEFAULT_TITLE = 'OSPREY feedback';
+
 const REQUEST_FAILED = 'Feedback request failed';
 const TEXT_MIME = 'text/plain';
-const DEFAULT_TITLE = 'OSPREY feedback';
-const TITLE_MAX = 80;
+
+/** UTF-16 length of the session-id prefix quoted in a derived title. */
+const SESSION_TITLE_CHARS = 8;
 
 /**
  * @typedef {object} FeedbackForm
@@ -190,6 +212,10 @@ export async function sendFeedback(form, deps) {
   const [copied, outcome] = await Promise.all([copying, settle(request)]);
   const id = readString(outcome.data, 'id');
   const contextStatus = readString(outcome.data, 'context_status');
+  // The paste step exists whenever the clipboard holds more than the prefilled
+  // body does: always with context attached (it travels only by paste), and
+  // whenever the URL cap forced text out of the body.
+  const needsPaste = form.contextOn === true || link.truncated;
   return {
     ok: outcome.ok,
     id,
@@ -198,7 +224,7 @@ export async function sendFeedback(form, deps) {
     truncated: link.truncated,
     contextStatus,
     error: outcome.error,
-    notice: emit(deps, outboundNotice(outcome.ok, id, contextStatus, copied)),
+    notice: emit(deps, outboundNotice(outcome.ok, id, contextStatus, copied, channel, needsPaste)),
   };
 }
 
@@ -426,7 +452,15 @@ function buildSendBody(form, deps) {
  */
 function buildOutboundLink(form, deps) {
   const buildBody = deps.buildPrefillBody ?? defaultPrefillBody;
-  const metadata = form.metadataOn === true ? (deps.metadata ?? {}) : {};
+  const metadata = form.metadataOn === true ? { ...(deps.metadata ?? {}) } : {};
+  // The session id is the one context fact that fits the body inline, and the
+  // one a maintainer needs to correlate the message with the deployment's own
+  // record even when the paste never happens. It travels under the context
+  // checkbox — with the box unticked no session id reaches the record either,
+  // so there would be nothing for it to correlate with.
+  if (form.contextOn === true && form.sessionId) {
+    metadata.Session = String(form.sessionId);
+  }
   const body = buildBody(String(form.text ?? ''), metadata);
   const title = deriveTitle(form);
 
@@ -441,9 +475,12 @@ function buildOutboundLink(form, deps) {
 }
 
 /**
- * Issue title / mail subject: the first non-blank line of the report, since the
- * dialog has no separate title field. Truncated for readability only — the
- * builders never shorten a title, so an unbounded one would eat the URL budget.
+ * Issue title / mail subject: an explicit `form.title` verbatim, otherwise
+ * {@link DEFAULT_TITLE} — suffixed with a session-id prefix when context is
+ * attached, so two reports from one inbox stay tellable apart and the subject
+ * alone finds the deployment's record. Never derived from the report text: a
+ * short report would become its own title and a long one an arbitrary slice,
+ * and the builders never shorten a title, so it must stay bounded here.
  *
  * @param {FeedbackForm} form
  * @returns {string}
@@ -451,12 +488,10 @@ function buildOutboundLink(form, deps) {
 function deriveTitle(form) {
   const explicit = String(form.title ?? '').trim();
   if (explicit) return explicit;
-  const firstLine = String(form.text ?? '')
-    .split('\n')
-    .map((line) => line.trim())
-    .find(Boolean);
-  if (!firstLine) return DEFAULT_TITLE;
-  return firstLine.length <= TITLE_MAX ? firstLine : `${firstLine.slice(0, TITLE_MAX)}…`;
+  if (form.contextOn === true && form.sessionId) {
+    return `${DEFAULT_TITLE} (session ${String(form.sessionId).slice(0, SESSION_TITLE_CHARS)})`;
+  }
+  return DEFAULT_TITLE;
 }
 
 /**
@@ -501,19 +536,27 @@ function localResult(deps, data) {
 /**
  * The one line to show after an outbound (GitHub/Email) submission, in priority
  * order: a clipboard the user has to act on outranks a missing paper trail,
- * which outranks the ordinary confirmation.
+ * which outranks the ordinary confirmation. The confirmation itself names the
+ * paste step whenever the clipboard carries more than the prefilled body did —
+ * a no-transcript warning keeps its own wording, because "paste the full
+ * report" would promise context the server just said it could not find.
  *
  * @param {boolean} ok
  * @param {string|null} id
  * @param {string|null} contextStatus
  * @param {CopyRung} copied
+ * @param {'local'|'github'|'email'} channel
+ * @param {boolean} needsPaste - the clipboard holds more than the body does
  * @returns {FeedbackNotice}
  */
-function outboundNotice(ok, id, contextStatus, copied) {
+function outboundNotice(ok, id, contextStatus, copied, channel, needsPaste) {
   if (copied === 'none') return { kind: 'error', message: NOTICE_COPY_FAILED };
   if (copied === 'manual') return { kind: 'warning', message: NOTICE_MANUAL_COPY };
   if (!ok) return { kind: 'warning', message: NOTICE_NOT_RECORDED };
-  return recordedNotice(id, contextStatus);
+  const base = recordedNotice(id, contextStatus);
+  if (!needsPaste || base.kind !== 'success') return base;
+  const hint = channel === 'email' ? NOTICE_PASTE_EMAIL : NOTICE_PASTE_GITHUB;
+  return { kind: 'success', message: `${base.message} — ${hint}` };
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/feedback-modal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/feedback-modal.js
@@ -45,6 +45,15 @@ const DEFAULT_TITLE = 'Send feedback';
 export const NO_SESSION_HINT = 'no session yet';
 
 /**
+ * Hint shown beside the ticked session-context checkbox on the GitHub and
+ * Email channels, where the context travels by clipboard paste rather than
+ * inside the prefilled body. Shown at the moment of ticking the box — before
+ * the draft opens looking complete — so the paste step is announced twice: here
+ * and in the post-send notice.
+ */
+export const CONTEXT_PASTE_HINT = 'copied to your clipboard on send — paste it over the placeholder';
+
+/**
  * The artifact-inventory time-window sentence, pinned so the dialog and the
  * server-side composer's block header cannot drift apart. Quoted verbatim from
  * the proposal's functional requirement 6.
@@ -75,10 +84,12 @@ export const FEEDBACK_DISCLOSURE_PARAGRAPHS = Object.freeze([
     'when the deployment knows it.',
   'Deployment metadata (on by default): the OSPREY version and the ' +
     'application name.',
-  'Session context (off by default): this session’s tool-call and agent ' +
-    'event log, its chat history, and the terminal scrollback. It is triaged ' +
-    'newest-first and truncated to fit a size budget, so a long session is ' +
-    'attached in part rather than in full.',
+  'Session context (off by default): this session’s id, its tool-call and ' +
+    'agent event log, its chat history, and the terminal scrollback. It is ' +
+    'triaged newest-first and truncated to fit a size budget, so a long ' +
+    'session is attached in part rather than in full. On the GitHub and ' +
+    'Email channels it travels by paste: sending copies it to your ' +
+    'clipboard, and the prefilled body marks where to drop it.',
   'The artifact inventory lists titles and ids only — artifacts tagged to ' +
     `this session, ${ARTIFACT_WINDOW_DISCLOSURE}.`,
   'Nothing leaves this page until you click an action button.',
@@ -540,7 +551,13 @@ export class FeedbackModal {
       this._contextCheckEl.checked = this._contextOn && sessionId !== null;
     }
     if (this._contextHintEl) {
-      this._contextHintEl.textContent = sessionId === null ? NO_SESSION_HINT : '';
+      if (sessionId === null) {
+        this._contextHintEl.textContent = NO_SESSION_HINT;
+      } else if (this._contextOn && this._channel !== 'local') {
+        this._contextHintEl.textContent = CONTEXT_PASTE_HINT;
+      } else {
+        this._contextHintEl.textContent = '';
+      }
     }
 
     this._renderActions(sessionId);

--- a/tests/interfaces/web_terminal/feedback-client.test.mjs
+++ b/tests/interfaces/web_terminal/feedback-client.test.mjs
@@ -22,6 +22,7 @@ import {
   sendFeedback,
   copyContext,
   BUNDLE_PATH,
+  DEFAULT_TITLE,
   FEEDBACK_PATH,
   NOTICE_COPY_FAILED,
   NOTICE_EMPTY_BUNDLE,
@@ -29,8 +30,23 @@ import {
   NOTICE_NOT_RECORDED,
   NOTICE_NO_SESSION,
   NOTICE_NO_TRANSCRIPT,
+  NOTICE_PASTE_EMAIL,
+  NOTICE_PASTE_GITHUB,
   NOTICE_TOO_LARGE,
 } from '../../../src/osprey/interfaces/web_terminal/static/js/feedback-client.js';
+
+/**
+ * Read one query parameter back out of a built URL.
+ *
+ * @param {string} url
+ * @param {string} name
+ * @returns {string} the decoded value
+ */
+function param(url, name) {
+  const match = new RegExp(`[?&]${name}=([^&]*)`).exec(url);
+  if (match === null) throw new Error(`no ?${name}= in ${url.slice(0, 80)}`);
+  return decodeURIComponent(match[1]);
+}
 
 /** A promise whose settlement the test controls. */
 function deferred() {
@@ -425,6 +441,139 @@ describe('sendFeedback — Email channel', () => {
     expect(deps.clipboard.write).toHaveBeenCalledTimes(1);
     expect(await copiedText(written[0])).toBe('SERVER PAYLOAD');
     expect(result.copied).toBe('clipboard');
+  });
+});
+
+describe('outbound prefill — title, subject and session line', () => {
+  test('the issue title is generic, never the first line of the report', async () => {
+    const { deps } = makeDeps();
+
+    await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+
+    expect(param(deps.windowOpen.mock.calls[0][0], 'title')).toBe(DEFAULT_TITLE);
+  });
+
+  test('a thousand-character report never becomes a thousand-character title', async () => {
+    const { deps } = makeDeps();
+    const oneLongLine = 'the beam dropped and the archiver shows nothing '.repeat(25);
+
+    await sendFeedback({ ...BASE_FORM, channel: 'github', text: oneLongLine }, deps);
+
+    expect(param(deps.windowOpen.mock.calls[0][0], 'title')).toBe(DEFAULT_TITLE);
+  });
+
+  test('the title names the session when context is attached', async () => {
+    const { deps } = makeDeps();
+
+    await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+
+    expect(param(deps.windowOpen.mock.calls[0][0], 'title')).toBe(
+      `${DEFAULT_TITLE} (session 11111111)`
+    );
+  });
+
+  test('an explicit title still wins', async () => {
+    const { deps } = makeDeps();
+
+    await sendFeedback(
+      { ...BASE_FORM, channel: 'github', title: 'Rail button dead in top mode' },
+      deps
+    );
+
+    expect(param(deps.windowOpen.mock.calls[0][0], 'title')).toBe('Rail button dead in top mode');
+  });
+
+  test('the mail subject follows the same rule', async () => {
+    const { deps } = makeDeps();
+
+    await sendFeedback({ ...BASE_FORM, channel: 'email', contextOn: true }, deps);
+
+    expect(param(deps.navigate.mock.calls[0][0], 'subject')).toBe(
+      `${DEFAULT_TITLE} (session 11111111)`
+    );
+  });
+
+  test('the session id rides in the body when context is attached', async () => {
+    const { deps } = makeDeps();
+
+    await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+
+    expect(param(deps.windowOpen.mock.calls[0][0], 'body')).toContain(
+      `**Session:** ${BASE_FORM.sessionId}`
+    );
+  });
+
+  test('the session line travels even with metadata unticked', async () => {
+    const { deps } = makeDeps();
+
+    await sendFeedback(
+      { ...BASE_FORM, channel: 'github', contextOn: true, metadataOn: false },
+      deps
+    );
+
+    const body = param(deps.windowOpen.mock.calls[0][0], 'body');
+    expect(body).toContain(`**Session:** ${BASE_FORM.sessionId}`);
+    expect(body).not.toContain('**version:**');
+  });
+
+  test('no session line when context is unticked', async () => {
+    const { deps } = makeDeps();
+
+    await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+
+    expect(param(deps.windowOpen.mock.calls[0][0], 'body')).not.toContain('**Session:**');
+  });
+});
+
+describe('outbound notices — the paste step is announced', () => {
+  test('a successful GitHub send with context points at the clipboard paste', async () => {
+    const { deps } = makeDeps();
+
+    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+
+    expect(result.notice.kind).toBe('success');
+    expect(result.notice.message).toBe(
+      `Recorded on this deployment (fb-1) — ${NOTICE_PASTE_GITHUB}`
+    );
+  });
+
+  test('a successful email send with context points at the clipboard paste', async () => {
+    const { deps } = makeDeps();
+
+    const result = await sendFeedback({ ...BASE_FORM, channel: 'email', contextOn: true }, deps);
+
+    expect(result.notice.message).toBe(
+      `Recorded on this deployment (fb-1) — ${NOTICE_PASTE_EMAIL}`
+    );
+  });
+
+  test('a truncated body earns the paste hint even without context', async () => {
+    const { deps } = makeDeps();
+
+    const result = await sendFeedback(
+      { ...BASE_FORM, channel: 'email', text: 'y'.repeat(5000) },
+      deps
+    );
+
+    expect(result.notice.message).toBe(
+      `Recorded on this deployment (fb-1) — ${NOTICE_PASTE_EMAIL}`
+    );
+  });
+
+  test('an outbound send with nothing to paste keeps the plain confirmation', async () => {
+    const { deps } = makeDeps();
+
+    const result = await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+
+    expect(result.notice.message).toBe('Recorded on this deployment (fb-1)');
+  });
+
+  test('the local channel never carries a paste hint', async () => {
+    const { deps } = makeDeps();
+
+    const result = await sendFeedback({ ...BASE_FORM, contextOn: true }, deps);
+
+    expect(result.notice.message).toBe('Recorded on this deployment (fb-1)');
   });
 });
 

--- a/tests/interfaces/web_terminal/feedback-modal.test.mjs
+++ b/tests/interfaces/web_terminal/feedback-modal.test.mjs
@@ -29,6 +29,7 @@ vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/palette.js', () =
 const {
   ARTIFACT_WINDOW_DISCLOSURE,
   CHANNEL_HINTS,
+  CONTEXT_PASTE_HINT,
   FEEDBACK_DISCLOSURE,
   FEEDBACK_DISCLOSURE_PARAGRAPHS,
   FeedbackModal,
@@ -493,6 +494,24 @@ describe('feedback modal state — context availability', () => {
   test('state: with a session the context box is enabled and unhinted', () => {
     openForm();
     expect(input('.feedback-context-check').disabled).toBe(false);
+    expect(qs(document, '.feedback-context-hint').textContent).toBe('');
+  });
+
+  test('state: ticking context on an outbound channel explains the paste step', () => {
+    openForm();
+    pickChannel('email');
+    setChecked(input('.feedback-context-check'), true);
+    expect(qs(document, '.feedback-context-hint').textContent).toBe(CONTEXT_PASTE_HINT);
+
+    pickChannel('github');
+    expect(qs(document, '.feedback-context-hint').textContent).toBe(CONTEXT_PASTE_HINT);
+
+    // Local sends the context inline with the record — nothing to paste.
+    pickChannel('local');
+    expect(qs(document, '.feedback-context-hint').textContent).toBe('');
+
+    pickChannel('email');
+    setChecked(input('.feedback-context-check'), false);
     expect(qs(document, '.feedback-context-hint').textContent).toBe('');
   });
 

--- a/tests/interfaces/web_terminal/rail-utility.test.mjs
+++ b/tests/interfaces/web_terminal/rail-utility.test.mjs
@@ -196,9 +196,13 @@ describe('utility cluster styling', () => {
     expect(body).toMatch(/border-radius:\s*0;/);
   });
 
-  test('gives both controls a glyph', () => {
-    expect(terminalCss).toMatch(/\.panel-utility-icon\[data-icon="docs"\]::before/);
-    expect(terminalCss).toMatch(/\.panel-utility-icon\[data-icon="feedback"\]::before/);
+  test('gives both controls a drawn SVG mark, not a font glyph', () => {
+    const cluster = qs(parseRailRegion(), '#panel-utility');
+
+    for (const id of ['#panel-docs-link', '#panel-feedback-btn']) {
+      const svg = qs(cluster, `${id} .panel-utility-icon svg[viewBox="0 0 16 16"]`);
+      expect(svg.getAttribute('stroke')).toBe('currentColor');
+    }
   });
 });
 


### PR DESCRIPTION
## What

Two web-terminal fixes on one branch.

### Feedback dialog: the paste step is now announced

Session context cannot ride in a `mailto:` URL (~1800 encoded chars) or reliably in a GitHub new-issue URL, so it travels by clipboard paste — but nothing in the UI said so. A sender ticked *Include session context*, the draft opened looking complete, and the mail went out with the `paste the copied session context here` placeholder still in it. Fixes:

- Ticking the context box on the GitHub/Email channel now shows a hint beside the checkbox: *copied to your clipboard on send — paste it over the placeholder*.
- The post-send confirmation now reads *Recorded on this deployment (fb-…) — the full report is on your clipboard — paste it over the placeholder in the draft/issue*, shown exactly when the clipboard holds more than the prefilled body (context attached, or URL-cap truncation).
- The session id now rides inline in the prefilled body's metadata block when context is attached, so a message can be matched to the deployment's own record (`osprey feedback`) even when the paste never happened.
- The prefilled issue title / mail subject is no longer the first line of the report (a short report duplicated itself; a long one became an arbitrary 80-char slice). It is now a stable **OSPREY feedback**, suffixed with a short session id when context is attached.
- The `(?)` privacy disclosure names the session id and the travel-by-paste mechanics.

### Rail utility icons

The Documentation/Feedback controls drew CSS `content:` codepoints: `ⓘ` is the About mark and renders oversized; `✉` renders small, paints full-colour emoji on Windows/Android, and promises email for a dialog that also files locally or to GitHub. Both are now stroke SVGs on `currentColor` (open book, speech bubble), matching the `js/svg-icons.js` contract, sized 18px in the utility cell.

## Testing

- 13 new vitest cases (written red-first): title rules incl. the long-single-line case, session-line presence/absence, all notice variants, the checkbox hint across channel switches.
- Full JS suite: 2352/2352; eslint and `tsc --noEmit` clean.
- Playwright feedback-modal browser tests: 5/5.
- `quick_check.sh`: 25754 passed.

## Open item

The icon change still wants a human eyeball in a running terminal (light + dark, left + top rail) — happy-dom asserts markup, not rendering.