### PR TITLE
test(interfaces): deflake browser suites under parallel load

### DIFF
--- a/src/osprey/interfaces/_serving.py
+++ b/src/osprey/interfaces/_serving.py
@@ -51,7 +51,7 @@ def _wait_until_serving(
     thread: threading.Thread,
     thread_error: list[BaseException],
     port: int,
-    timeout: float = 10.0,
+    timeout: float = 30.0,
 ) -> None:
     """Block until *server* is serving, or explain why it never will be.
 
@@ -61,6 +61,11 @@ def _wait_until_serving(
     exactly like one that is merely slow, so the caller pays the whole timeout
     and is then told the server "did not become ready", which points at the
     timeout rather than at the error that actually occurred.
+
+    Because a dead server is detected immediately through the thread check,
+    the timeout only ever bounds a *slow but alive* startup — app lifespans do
+    real work (service imports, degraded-mode probes) that stretches under
+    parallel test load, so the bound is generous rather than tight.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/tests/interfaces/test_app_server_helper.py
+++ b/tests/interfaces/test_app_server_helper.py
@@ -17,8 +17,10 @@ from fastapi import FastAPI
 
 from osprey.interfaces._serving import run_app_server
 
-# The helper's own readiness budget. A startup *failure* must be reported well
-# inside it rather than consuming the whole budget first.
+# Bound for reporting a startup *failure*. The helper's readiness budget for a
+# slow-but-alive startup is far larger (30 s), but a server whose thread died
+# must be reported well inside even this small bound, never after burning the
+# budget.
 READINESS_BUDGET = 10.0
 
 

--- a/tests/interfaces/web_terminal/test_scaffold_detail.py
+++ b/tests/interfaces/web_terminal/test_scaffold_detail.py
@@ -153,15 +153,19 @@ def _open_settings_drawer(page: Page) -> None:
     the first-time warning if shown."""
     page.click(DISPLAY_MENU_BTN_SELECTOR)
     page.click(TRIGGER_SELECTOR)
+    # The trigger click yields exactly one of two states: the first-time
+    # warning overlay (fresh server session) or the drawer opening directly
+    # (already acked). Wait for whichever arrives rather than probing the
+    # warning with a short timeout -- deciding the branch by "did it appear
+    # within N seconds" misreads a slow warning as an absent one under
+    # parallel test load.
     proceed = page.locator(WARNING_PROCEED_SELECTOR)
-    try:
-        expect(proceed).to_be_visible(timeout=2_000)
-        proceed.click()
-    except AssertionError:
-        pass  # already acked this server session -- drawer opened directly
     drawer = page.locator(DRAWER_SELECTOR)
-    expect(drawer).to_have_attribute("open", "", timeout=5_000)
-    expect(drawer).to_have_css("transform", "matrix(1, 0, 0, 1, 0, 0)", timeout=2_000)
+    expect(proceed.or_(page.locator(f"{DRAWER_SELECTOR}[open]"))).to_be_visible(timeout=15_000)
+    if proceed.is_visible():
+        proceed.click()
+    expect(drawer).to_have_attribute("open", "", timeout=15_000)
+    expect(drawer).to_have_css("transform", "matrix(1, 0, 0, 1, 0, 0)", timeout=15_000)
 
 
 def _once_dialog(page: Page, *, accept: bool) -> None:
@@ -227,7 +231,7 @@ def test_edit_dirty_guard_blocks_close_and_discard_restores_clean(
 
         _open_settings_drawer(page)
         page.locator(SAFETY_CARD_SELECTOR).click()
-        expect(page.locator(".osprey-md-rendered")).to_be_visible(timeout=5_000)
+        expect(page.locator(".osprey-md-rendered")).to_be_visible(timeout=15_000)
 
         # Preview -> Edit: still framework-owned, so this claims the file
         # first (a real confirm() dialog + POST /claim), then switches mode.
@@ -235,10 +239,10 @@ def test_edit_dirty_guard_blocks_close_and_discard_restores_clean(
         page.locator(".prompts-mode-btn", has_text="Edit").click()
 
         expect(page.locator(".prompts-detail-header .prompts-badge")).to_have_class(
-            "prompts-badge user-owned", timeout=5_000
+            "prompts-badge user-owned", timeout=15_000
         )
         textarea = page.locator(".prompts-edit-textarea")
-        expect(textarea).to_be_visible(timeout=5_000)
+        expect(textarea).to_be_visible(timeout=15_000)
         original_value = textarea.input_value()
         assert "Tool Confinement" in original_value, (
             "expected the claimed file's original content in the edit textarea"
@@ -248,32 +252,32 @@ def test_edit_dirty_guard_blocks_close_and_discard_restores_clean(
         textarea.fill(original_value + "\nEDITED-BY-SCAFFOLD-DETAIL-PIN-TEST\n")
         discard_btn = page.locator(".prompts-discard-btn")
         save_btn = page.locator(".prompts-save-btn")
-        expect(discard_btn).to_be_enabled(timeout=2_000)
-        expect(save_btn).to_be_enabled(timeout=2_000)
+        expect(discard_btn).to_be_enabled(timeout=15_000)
+        expect(save_btn).to_be_enabled(timeout=15_000)
 
         # The dirty guard vetoes a drawer close via the backdrop -- same
         # composite `registerUnsavedGuard` contract test_osprey_drawer.py
         # pins with a synthetic guard, driven here by a real edit.
         _once_dialog(page, accept=False)
         page.locator(BACKDROP_SELECTOR).click(position={"x": 10, "y": 10})
-        expect(page.locator(DRAWER_SELECTOR)).to_have_attribute("open", "", timeout=2_000)
+        expect(page.locator(DRAWER_SELECTOR)).to_have_attribute("open", "", timeout=15_000)
 
         # Discard restores clean state: back to Preview, and (crucially) the
         # content comes from a server refetch of the on-disk file, which was
         # never actually written -- proving the edit was truly discarded,
         # not just hidden client-side.
         discard_btn.click()
-        expect(page.locator(".prompts-mode-btn.active")).to_have_text("Preview", timeout=5_000)
+        expect(page.locator(".prompts-mode-btn.active")).to_have_text("Preview", timeout=15_000)
         expect(page.locator(".prompts-discard-btn")).to_have_count(0)
         preview = page.locator(".osprey-md-rendered")
-        expect(preview).to_be_visible(timeout=5_000)
+        expect(preview).to_be_visible(timeout=15_000)
         expect(preview).to_contain_text("Tool Confinement")
         expect(preview).not_to_contain_text("EDITED-BY-SCAFFOLD-DETAIL-PIN-TEST")
 
         # Clean now -- closing succeeds with no dialog at all (the guard
         # returns true immediately without prompting).
         page.locator(BACKDROP_SELECTOR).click(position={"x": 10, "y": 10})
-        expect(page.locator(DRAWER_SELECTOR)).not_to_have_attribute("open", "", timeout=5_000)
+        expect(page.locator(DRAWER_SELECTOR)).not_to_have_attribute("open", "", timeout=15_000)
         page.close()
 
 


### PR DESCRIPTION
Two waits in the browser suites were tight enough to lose a race under full-suite CPU contention. The failure rate is roughly one run in fifteen thousand tests, which is frequent enough to redden an unrelated PR's unit lane and rare enough that it never reproduces when you go looking for it.

The serving helper allowed a slow-but-alive startup 10 seconds. Real interface apps do work in their lifespan — ARIEL spends about 1.6s on service imports and a degraded-mode probe on an idle machine — and that stretches past the bound under four parallel workers. A server that actually dies is still reported immediately through the thread-liveness check, so this bound only ever covers a live startup; it is now 30 seconds.

The settings-drawer helper decided whether the first-time warning was present by whether it appeared within 2 seconds, which is a timeout used as a branch decision and flaky by construction: a slow warning read as an absent one, so the helper skipped the click that opens the drawer and every later assertion failed on a drawer that was never opened. It now waits for whichever state actually arrives — the warning or the open drawer — and clicks through only the one it got.

Every asserted end-state is unchanged, so a genuinely broken UI still fails exactly as before. This was found and fixed while working an unrelated branch; it is split out here so the fix is not stranded on a long-running epic branch while every other branch keeps hitting the flake.
