### PR TITLE
feat(cli): print a composition card under osprey init's report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- `osprey init` now prints a composition card under its report: who can sign
+  in (each user's persona, rights, login method and port), what the agent runs
+  on (model, MCP servers, bundled toolkit), what machine it talks to
+  (connector, archiver, channel database) and what else runs beside it. The
+  card is derived from the resolved profile, so it shows exactly the
+  deployment about to be built — useful reading while a chained `--up` pulls
+  its images.
 - ARIEL search now speaks your control room's shorthand. Drop a
   `vocabulary.yml` in your project, set `ariel.vocabulary.enabled: true` and
   point `ariel.vocabulary.path` at it, and a search for `t/s bpm` also finds

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -623,16 +623,16 @@ def _merge_subtree(into: dict[str, Any], value: Mapping[str, Any]) -> None:
             into[key] = copy.deepcopy(item)
 
 
-def effective_web_terminals(config: Mapping[str, Any]) -> dict[str, Any]:
-    """The single ``modules.web_terminals`` subtree a ``config:`` block sets.
+def effective_config_subtree(
+    config: Mapping[str, Any], subtree_path: tuple[str, ...]
+) -> dict[str, Any]:
+    """The single subtree a ``config:`` block sets at ``subtree_path``.
 
     ORDER IS THE WHOLE POINT, and it is fixed here so no caller can get it
     wrong. A ``config:`` block is a flat bag of dotted keys applied verbatim in
-    iteration order, and the bundled persona presets inherit their parent's
-    whole ``modules.web_terminals:`` subtree (``enabled: true``, catalog and
-    all) while switching the module off with a separate
-    ``modules.web_terminals.enabled: false``. Reading either key alone answers
-    "enabled". So:
+    iteration order, and two keys may address the same path at different
+    depths — a whole subtree beside a single leaf under it — where reading
+    either key alone answers wrong. So:
 
     1. :func:`_collapse_config_prefixes` runs FIRST, folding every
        prefix-related pair deeper-key-wins;
@@ -645,15 +645,15 @@ def effective_web_terminals(config: Mapping[str, Any]) -> dict[str, Any]:
     """
     collapsed = _collapse_config_prefixes(dict(config))
     segments = _config_segments(collapsed)
-    depth = len(_WEB_TERMINALS_PATH)
+    depth = len(subtree_path)
     subtree: dict[str, Any] = {}
     for key in sorted(segments, key=lambda k: len(segments[k])):
         path = segments[key]
         value = collapsed[key]
-        if path == _WEB_TERMINALS_PATH:
+        if path == subtree_path:
             if isinstance(value, Mapping):
                 _merge_subtree(subtree, value)
-        elif path[:depth] == _WEB_TERMINALS_PATH:
+        elif path[:depth] == subtree_path:
             # A key addressing INSIDE the subtree, e.g.
             # `modules.web_terminals.personas.ops.build_profile`.
             node = subtree
@@ -664,18 +664,30 @@ def effective_web_terminals(config: Mapping[str, Any]) -> dict[str, Any]:
                     node[part] = child
                 node = child
             node[path[-1]] = copy.deepcopy(value)
-        elif _WEB_TERMINALS_PATH[: len(path)] == path:
+        elif subtree_path[: len(path)] == path:
             # An ancestor key (`modules:`) carrying the subtree nested inside
             # its own value. Bundled presets never spell it this way — they
             # warn against it, since a nested `modules:` wholesale-replaces the
             # rendered subtree — but a facility's own profile may, and a
-            # predicate that missed it would silently emit no personas.
+            # predicate that missed it would silently read no subtree.
             probe: Any = value
-            for part in _WEB_TERMINALS_PATH[len(path) :]:
+            for part in subtree_path[len(path) :]:
                 probe = probe.get(part) if isinstance(probe, Mapping) else None
             if isinstance(probe, Mapping):
                 _merge_subtree(subtree, probe)
     return subtree
+
+
+def effective_web_terminals(config: Mapping[str, Any]) -> dict[str, Any]:
+    """The single ``modules.web_terminals`` subtree a ``config:`` block sets.
+
+    The bundled persona presets inherit their parent's whole
+    ``modules.web_terminals:`` subtree (``enabled: true``, catalog and all)
+    while switching the module off with a separate
+    ``modules.web_terminals.enabled: false`` — the pair whose folding order
+    :func:`effective_config_subtree` exists to fix.
+    """
+    return effective_config_subtree(config, _WEB_TERMINALS_PATH)
 
 
 def emits_persona_profiles(config: Mapping[str, Any]) -> bool:

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1491,6 +1491,7 @@ def _report(
     pin.
     """
     from .phase_reporter import current_reporter
+    from .profile_card import print_profile_card
     from .profile_cmd import _skipped_keys_note
 
     echo = current_reporter().echo
@@ -1508,6 +1509,12 @@ def _report(
 
     for line in _ci_report(deploy_files, target):
         echo(line)
+
+    # Last, so the report keeps its shape: files first, then what the profile
+    # those files describe consists of. It stays on screen through everything a
+    # chained `--up` does, which is the point — the composition is what someone
+    # reads while the containers pull.
+    print_profile_card(materialized.resolved, materialized.persona_deltas)
 
 
 def _entry_list(target: Path, materialized: _MaterializedProfile) -> list[str]:

--- a/src/osprey/cli/phase_reporter.py
+++ b/src/osprey/cli/phase_reporter.py
@@ -300,16 +300,12 @@ class PhaseReporter:
         every subclass that intercepts ``emit`` (the ``--verbose`` swallower,
         the tests' recorders) seeing one seam, and keeps the bytes a pipe reads
         exactly what they always were. With color on, the styles ride on the
-        Text's own spans — never on a ``style=`` argument, which Rich would
-        apply to a mounted live region repainted in the same call.
+        Text's own spans — see :meth:`_print_styled`.
         """
         if not self.color:
             self.emit("".join(part for part, _ in segments))
             return
-        text = Text()
-        for part, style in segments:
-            text.append(part, style=style or "")
-        self.out().print(text, soft_wrap=True)
+        self._print_styled(segments)
 
     def echo(self, text: str) -> None:
         """Print one line of a verb's OWN output, rather than of the phase record.
@@ -328,6 +324,34 @@ class PhaseReporter:
         style tags).
         """
         self.out().print(text, markup=False, highlight=False, soft_wrap=True)
+
+    def echo_segments(self, segments: Sequence[tuple[str, str | None]]) -> None:
+        """Print one echo-class line assembled from ``(text, style)`` segments.
+
+        :meth:`emit_segments`'s shape with :meth:`echo`'s altitude: for the
+        lines of a verb's own output that carry more than one style — the
+        profile card's rows, say — and must print under every reporter. With
+        color off the segments ARE their joined text and go through
+        :meth:`echo`, so a pipe reads the same bytes a styled terminal would
+        strip to and every interceptor of ``echo`` sees the line.
+        """
+        if not self.color:
+            self.echo("".join(part for part, _ in segments))
+            return
+        self._print_styled(segments)
+
+    def _print_styled(self, segments: Sequence[tuple[str, str | None]]) -> None:
+        """Print the segments as one line, styles riding on the Text's spans.
+
+        The spans are the point: a ``style=`` argument would be applied by Rich
+        to a mounted live region repainted in the same call. The colored half of
+        both segment printers, which differ only in the plain line they fall
+        back to when color is off.
+        """
+        text = Text()
+        for part, style in segments:
+            text.append(part, style=style or "")
+        self.out().print(text, soft_wrap=True)
 
     def phase(self, title: str) -> Phase:
         """Start a phase, printing a blank line and its opening line.

--- a/src/osprey/cli/profile_card.py
+++ b/src/osprey/cli/profile_card.py
@@ -1,0 +1,430 @@
+"""The composition card ``osprey init`` prints under its report.
+
+One glance at what the deployment that was just materialized consists of,
+before anything is built or started: who can sign in and with what rights,
+what the agent runs on, what machine it talks to, and what else runs beside
+it. Everything on the card is read off the resolved
+:class:`~osprey.cli.build_profile_model.BuildProfile` (plus the emitted
+persona deltas), so the card is a pure function of the profile — a build with
+no web tier simply has no ``web terminal`` group, and a profile that declares
+no extra services has no ``services`` group. Nothing here probes the host or
+the container runtime.
+
+The card is echo-class: it is part of what ``init`` owes its operator, so it
+prints under every reporter, through
+:meth:`~osprey.cli.phase_reporter.PhaseReporter.echo_segments` — styled on a
+terminal, byte-identical to its plain rendering through a pipe. The one
+derivation feeds both the printer and :func:`format_profile_card`, the
+plain-text twin the tests pin, so the card an operator reads cannot differ
+from the card a test reads (:mod:`osprey.cli.summary_card`'s precedent).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from osprey.utils.logger import get_logger
+
+from .styles import Styles
+
+if TYPE_CHECKING:
+    from .build_profile_model import BuildProfile
+
+logger = get_logger("cli.profile_card")
+
+#: One styled run of text: ``(text, style token or None)``.
+Segment = tuple[str, str | None]
+
+#: One cell of a row — a list of segments, so a single cell can carry a plain
+#: value with a dim separator or an accent port inside it.
+Cell = list[Segment]
+
+#: The list separator, always dim: lists should read as items, not dot soup.
+_SEP: Segment = (" · ", Styles.DIM)
+
+_INDENT = "  "
+_GUTTER = "   "
+
+
+@dataclass
+class CardGroup:
+    """One titled block of the card."""
+
+    title: str
+    """The group anchor, rendered in the header token."""
+
+    suffix: str = ""
+    """Text after the title (the web tier's entry port), rendered accent."""
+
+    rows: list[list[Cell]] = field(default_factory=list)
+    """Rows of cells. The first cell is the row's label; within a group every
+    column is padded to a common width, except each row's last non-empty cell,
+    which flows free (so a long panels list never pushes the user columns)."""
+
+
+# ---------------------------------------------------------------------------
+# Derivation — profile in, groups out
+# ---------------------------------------------------------------------------
+
+
+def _dotted_lookup(config: Mapping[str, Any], wanted: tuple[str, ...]) -> Any:
+    """What a flat dotted ``config:`` bag sets at ``wanted``, or ``None``.
+
+    Reads every spelling — the dotted key itself or an ancestor carrying the
+    path nested inside its value — and later keys win, matching the order the
+    build applies them in.
+    """
+    from .profile_cmd import _config_node
+
+    found: Any = None
+    for key, value in config.items():
+        if not isinstance(key, str):
+            continue
+        node = _config_node(tuple(key.split(".")), value, wanted)
+        if node is not None:
+            found = node
+    return found
+
+
+def _persona_writes_enabled(
+    profile: BuildProfile, persona_deltas: Mapping[str, Mapping[str, Any]], persona: str
+) -> bool:
+    """Whether ``persona``'s render arms the control system's write surface.
+
+    The persona delta's own ``config:`` wins over the host profile's — the
+    bundled tiers pin ``control_system.writes_enabled`` on both sides of the
+    boundary, and a facility persona that says nothing inherits the host's
+    posture.
+    """
+    wanted = ("control_system", "writes_enabled")
+    config = persona_deltas.get(persona, {}).get("config")
+    if isinstance(config, Mapping):
+        value = _dotted_lookup(config, wanted)
+        if value is not None:
+            return bool(value)
+    return bool(_dotted_lookup(profile.config, wanted))
+
+
+def _panel_labels(
+    profile: BuildProfile, persona_deltas: Mapping[str, Mapping[str, Any]]
+) -> list[str]:
+    """Display labels for every panel any login of this deployment gets.
+
+    The union across the host profile and the persona deltas, in declaration
+    order — panel sets are per-persona (the write tier adds its own), and the
+    card summarizes the deployment. Labels come from the same sources the web
+    terminal reads: :data:`~osprey.profiles.web_panels.BUILTIN_PANEL_LABELS`
+    for built-ins, ``web.panels.<id>.label`` for URL-backed custom panels, and
+    the id itself, uppercased, when neither says.
+    """
+    from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS
+
+    ids: list[str] = list(dict.fromkeys(profile.web_panels))
+    for delta in persona_deltas.values():
+        extra = delta.get("web_panels")
+        if not isinstance(extra, list):
+            continue
+        for panel_id in extra:
+            if isinstance(panel_id, str) and panel_id not in ids:
+                ids.append(panel_id)
+
+    return [
+        BUILTIN_PANEL_LABELS.get(panel_id)
+        or _custom_panel_label(profile, persona_deltas, panel_id)
+        or panel_id.upper()
+        for panel_id in ids
+    ]
+
+
+def _custom_panel_label(
+    profile: BuildProfile, persona_deltas: Mapping[str, Mapping[str, Any]], panel_id: str
+) -> str | None:
+    """The ``web.panels.<id>.label`` any layer of this deployment declares."""
+    wanted = ("web", "panels", panel_id, "label")
+    value = _dotted_lookup(profile.config, wanted)
+    for delta in persona_deltas.values():
+        config = delta.get("config")
+        if isinstance(config, Mapping):
+            value = _dotted_lookup(config, wanted) or value
+    return str(value) if value else None
+
+
+def _joined(parts: Sequence[Cell]) -> Cell:
+    """One cell from several, separated by the dim list separator."""
+    cell: Cell = []
+    for part in parts:
+        if cell:
+            cell.append(_SEP)
+        cell.extend(part)
+    return cell
+
+
+def _dotted_list(items: Sequence[str]) -> Cell:
+    """Plain items joined by the dim separator."""
+    return _joined([[(item, None)] for item in items])
+
+
+def _web_terminal_group(
+    profile: BuildProfile, persona_deltas: Mapping[str, Mapping[str, Any]]
+) -> CardGroup | None:
+    """Who gets in, with what rights, how, and where — plus what they see."""
+    from .build_profile_emit import effective_web_terminals
+
+    web_tier = effective_web_terminals(profile.config)
+    if not web_tier.get("enabled"):
+        return None
+
+    rows: list[list[Cell]] = []
+    auth = web_tier.get("auth")
+    auth_method = auth.get("method") if isinstance(auth, Mapping) else None
+    base_port = web_tier.get("web_base_port")
+    default_persona = web_tier.get("default_persona")
+    users = web_tier.get("users")
+    for position, user in enumerate(users if isinstance(users, list) else []):
+        if not isinstance(user, Mapping):
+            continue
+        name = str(user.get("name") or "")
+        if not name:
+            continue
+        persona = str(user.get("persona") or default_persona or "")
+        rights: list[str] = []
+        if persona:
+            rights.append(persona)
+            if _persona_writes_enabled(profile, persona_deltas, persona):
+                rights.append("rights approval-gated")
+        if user.get("login") is False:
+            # The one warning tone on the card: an open surface must not be
+            # skimmed past, so `password` stays dim precisely to keep it alone.
+            auth_cell: Cell = [("no login", Styles.WARNING)]
+        elif auth_method:
+            auth_cell = [(str(auth_method), Styles.DIM)]
+        else:
+            auth_cell = []
+        index = user.get("index", position)
+        port_cell: Cell = []
+        if isinstance(base_port, int) and isinstance(index, int):
+            port_cell = [(f":{base_port + index}", Styles.ACCENT)]
+        rows.append([[(name, Styles.BOLD)], _dotted_list(rights), auth_cell, port_cell])
+
+    panels = _panel_labels(profile, persona_deltas)
+    if panels:
+        rows.append([[("panels", Styles.DIM)], _dotted_list(panels)])
+
+    if not rows:
+        return None
+    nginx_port = web_tier.get("nginx_port")
+    suffix = f":{nginx_port}" if isinstance(nginx_port, int) else ""
+    return CardGroup("web terminal", suffix, rows)
+
+
+def _enabled_mcp_servers(profile: BuildProfile) -> list[str]:
+    """The MCP servers the agent gets, resolved as the render resolves them.
+
+    :func:`~osprey.registry.mcp.resolve_servers` over the profile's effective
+    ``claude_code`` subtree — the registry's own defaults plus the profile's
+    ``claude_code.servers.<name>.enabled`` overrides — with the channel-finder
+    condition keyed the way the render keys it, plus the profile's own
+    ``mcp_servers:`` declarations.
+    """
+    from osprey.registry.mcp import resolve_servers
+
+    from .build_profile_emit import effective_config_subtree
+
+    claude_code = effective_config_subtree(profile.config, ("claude_code",))
+    ctx: dict[str, Any] = {}
+    if profile.channel_finder_mode and "channel-finder" in profile.agents:
+        ctx["channel_finder_pipeline"] = profile.channel_finder_mode
+    names = [server["name"] for server in resolve_servers(claude_code, ctx) if server["enabled"]]
+    for name in profile.mcp_servers:
+        if name not in names:
+            names.append(name)
+    return names
+
+
+def _agent_group(profile: BuildProfile) -> CardGroup | None:
+    """What thinks: the model, its tool surface, and its bundled toolkit."""
+    rows: list[list[Cell]] = []
+    model_bits = [bit for bit in (profile.provider, profile.model) if bit]
+    if model_bits:
+        rows.append([[("model", Styles.DIM)], _dotted_list(model_bits)])
+    servers = _enabled_mcp_servers(profile)
+    if servers:
+        rows.append([[("mcp", Styles.DIM)], _dotted_list(servers)])
+    toolkit = [
+        f"{len(entries)} {noun}"
+        for entries, noun in (
+            (profile.hooks, "hooks"),
+            (profile.rules, "rules"),
+            (profile.skills, "skills"),
+            (profile.agents, "agents"),
+        )
+        if entries
+    ]
+    if toolkit:
+        rows.append([[("toolkit", Styles.DIM)], _dotted_list(toolkit)])
+    return CardGroup("agent", rows=rows) if rows else None
+
+
+def _machine_group(profile: BuildProfile) -> CardGroup | None:
+    """What the agent talks to: connector, archive, channel database."""
+    rows: list[list[Cell]] = []
+
+    control: list[Cell] = []
+    connector = _dotted_lookup(profile.config, ("control_system", "type"))
+    if isinstance(connector, str) and connector:
+        control.append([(connector.replace("_", " "), None)])
+    if profile.virtual_accelerator is not None:
+        port = profile.virtual_accelerator.port
+        control.append([("EPICS ", None), (f":{port}", Styles.ACCENT)])
+    if control:
+        rows.append([[("control", Styles.DIM)], _joined(control)])
+
+    archiver: list[str] = []
+    archiver_type = _dotted_lookup(profile.config, ("archiver", "type"))
+    if isinstance(archiver_type, str) and archiver_type:
+        archiver.append(archiver_type.removesuffix("_archiver").replace("_", " "))
+    if profile.va_archiver is not None:
+        archiver.append(f"{profile.va_archiver.retention_days} d retention")
+    if archiver:
+        rows.append([[("archiver", Styles.DIM)], _dotted_list(archiver)])
+
+    if profile.channel_finder_mode:
+        finder = f"{profile.channel_finder_mode.replace('_', ' ')} finder"
+        tier = f"tier {profile.resolved_tier()}"
+        rows.append([[("channels", Styles.DIM)], _dotted_list([finder, tier])])
+
+    return CardGroup("machine", rows=rows) if rows else None
+
+
+def _services_group(profile: BuildProfile) -> CardGroup | None:
+    """What else runs beside the terminals, named as the build names it."""
+    rows: list[list[Cell]] = []
+
+    if profile.bluesky is not None:
+        parts: list[Cell] = [[(f":{profile.bluesky.port}", Styles.ACCENT)]]
+        if profile.bluesky.tiled_enabled:
+            parts.append([("tiled ", None), (f":{profile.bluesky.tiled_port}", Styles.ACCENT)])
+        if profile.bluesky_web is not None:
+            parts.append([("web ", None), (f":{profile.bluesky_web.port}", Styles.ACCENT)])
+        rows.append([[("bluesky", Styles.DIM)], _joined(parts)])
+    elif profile.bluesky_web is not None:
+        rows.append(
+            [[("bluesky web", Styles.DIM)], [(f":{profile.bluesky_web.port}", Styles.ACCENT)]]
+        )
+
+    if profile.dispatch is not None:
+        dispatch = profile.dispatch
+        noun = "worker" if dispatch.worker_count == 1 else "workers"
+        workers: Cell = [(f"{dispatch.worker_count} {noun}", None)]
+        triggers: Cell = [("triggers ", None), (dispatch.triggers, Styles.PATH)]
+        rows.append([[("dispatch", Styles.DIM)], _joined([workers, triggers])])
+
+    if profile.nextcloud_bridge is not None:
+        rows.append([[("bridge", Styles.DIM)], [("Nextcloud Talk", None)]])
+    if profile.gchat_bridge is not None:
+        rows.append([[("bridge", Styles.DIM)], [("Google Chat", None)]])
+    for name in profile.services:
+        rows.append([[(name, Styles.DIM)], [("profile service", None)]])
+
+    return CardGroup("services", rows=rows) if rows else None
+
+
+def _card_groups(
+    profile: BuildProfile, persona_deltas: Mapping[str, Mapping[str, Any]]
+) -> list[CardGroup]:
+    """The card's groups, in the fixed order the reader learns once."""
+    candidates = (
+        _web_terminal_group(profile, persona_deltas),
+        _agent_group(profile),
+        _machine_group(profile),
+        _services_group(profile),
+    )
+    return [group for group in candidates if group is not None]
+
+
+# ---------------------------------------------------------------------------
+# Layout — groups in, lines out
+# ---------------------------------------------------------------------------
+
+
+def _plain_text(segments: Sequence[Segment]) -> str:
+    """The text of a run of segments, with the styles dropped."""
+    return "".join(part for part, _ in segments)
+
+
+def _last_filled(row: list[Cell]) -> int:
+    """The index of ``row``'s last non-empty cell, or 0 for an empty row."""
+    return max((column for column, cell in enumerate(row) if cell), default=0)
+
+
+def _group_lines(group: CardGroup) -> list[list[Segment]]:
+    """Lay one group out as segment lines: title, then padded rows."""
+    title: list[Segment] = [(_INDENT, None), (group.title, Styles.HEADER)]
+    if group.suffix:
+        title += [("  ", None), (group.suffix, Styles.ACCENT)]
+    lines = [title]
+
+    # Each row is cut at its last non-empty cell, so that cell flows free and
+    # only the columns before it are padded to the group's common width.
+    rows = [row[: _last_filled(row) + 1] for row in group.rows]
+    widths: dict[int, int] = {}
+    for row in rows:
+        for column, cell in enumerate(row[:-1]):
+            widths[column] = max(widths.get(column, 0), len(_plain_text(cell)))
+
+    for row in rows:
+        line: list[Segment] = [(_INDENT * 2, None)]
+        for column, cell in enumerate(row):
+            line.extend(cell)
+            if column < len(row) - 1:
+                line.append((" " * (widths[column] - len(_plain_text(cell))) + _GUTTER, None))
+        lines.append(line)
+    return lines
+
+
+def _card_segment_lines(
+    profile: BuildProfile, persona_deltas: Mapping[str, Mapping[str, Any]]
+) -> list[list[Segment]]:
+    """The whole card as segment lines; an empty line separates the groups.
+
+    Starts with its own separator line when there is anything to say, so the
+    card always stands one blank line off whatever printed above it.
+    """
+    lines: list[list[Segment]] = []
+    for group in _card_groups(profile, persona_deltas):
+        lines.append([])
+        lines.extend(_group_lines(group))
+    return lines
+
+
+def format_profile_card(
+    profile: BuildProfile, persona_deltas: Mapping[str, Mapping[str, Any]]
+) -> list[str]:
+    """The card as plain lines — what a pipe reads, and what the tests pin."""
+    return [_plain_text(line) for line in _card_segment_lines(profile, persona_deltas)]
+
+
+def print_profile_card(
+    profile: BuildProfile, persona_deltas: Mapping[str, Mapping[str, Any]]
+) -> None:
+    """Print the card through the reporter; advisory, never raises.
+
+    ``init`` has created the repo by the time this runs, and a card that
+    cannot be derived — a config shape this reader never met — must not turn
+    that into a failure.
+    """
+    from .phase_reporter import current_reporter
+
+    try:
+        lines = _card_segment_lines(profile, persona_deltas)
+    except Exception as exc:  # noqa: BLE001 — see docstring: the card is advisory
+        logger.debug("Profile card skipped: %s", exc)
+        return
+    reporter = current_reporter()
+    for line in lines:
+        if line:
+            reporter.echo_segments(line)
+        else:
+            reporter.echo("")

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -869,6 +869,17 @@ class _MaterializedProfile(NamedTuple):
     commented out, so this is normally false on a fresh materialization; it
     decides whether there is anything to render a CI pipeline from."""
 
+    resolved: BuildProfile
+    """The materialized profile, resolved back from the written ``profile.yml``
+    — the same read-back that validates the round-trip, so what the caller
+    summarizes (the composition card) is a fact about what is on disk rather
+    than about what the inputs asked for."""
+
+    persona_deltas: dict[str, Mapping[str, Any]]
+    """The emitted persona deltas, parsed, keyed by persona name — empty for a
+    profile that emits none. The per-persona facts a summary needs (each tier's
+    panels and its write posture) live in these, not in the host profile."""
+
 
 def _materialize_profile_directory(
     target_dir: Path,
@@ -1120,4 +1131,6 @@ def _materialize_profile_directory(
         shell_keys.skipped,
         profile_name_default,
         written.deploy is not None,
+        written,
+        persona_deltas,
     )

--- a/tests/cli/test_profile_card.py
+++ b/tests/cli/test_profile_card.py
@@ -1,0 +1,254 @@
+"""The composition card ``osprey init`` prints under its report.
+
+What is pinned here, and kept apart on purpose: what the card SAYS for the
+exemplar preset (derived from the resolved profile and its persona deltas,
+through the plain-text renderer), that the printed card and the plain-text
+twin cannot disagree (the parity :mod:`osprey.cli.summary_card`'s tests pin
+for the closing card), that a profile with none of a group's facts prints no
+such group, and that the card is advisory — a derivation failure must never
+fail the ``init`` that has already created the repo.
+
+Content assertions read :func:`~osprey.cli.profile_card.format_profile_card`
+rather than a CliRunner's captured stdout: the card's widest row (the MCP
+server list) is longer than a default console, and an assertion on captured
+output would be an assertion about wrapping. The one end-to-end assertion
+against ``init``'s stdout sticks to lines that fit any width.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+from osprey.cli.build_profile import resolve_build_profile
+from osprey.cli.build_profile_model import BuildProfile
+from osprey.cli.main import cli
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+from osprey.cli.profile_card import format_profile_card, print_profile_card
+from osprey.cli.profile_cmd import _parsed_persona_deltas, _persona_profile_texts
+from osprey.cli.styles import osprey_theme
+
+# ---------------------------------------------------------------------------
+# The exemplar: the control-assistant preset, resolved the way `init` resolves
+# it, with the persona deltas the materializer parses. Session-scoped: the
+# preset is packaged data, identical for every test here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def exemplar() -> tuple[BuildProfile, dict]:
+    resolved, _preset_dir = resolve_build_profile(None, "control-assistant", (), ())
+    texts = _persona_profile_texts(resolved, "Exemplar", "", "control-assistant")
+    return resolved, _parsed_persona_deltas(texts)
+
+
+@pytest.fixture(scope="session")
+def exemplar_lines(exemplar: tuple[BuildProfile, dict]) -> list[str]:
+    profile, deltas = exemplar
+    return format_profile_card(profile, deltas)
+
+
+def line_with(lines: list[str], *needles: str) -> str:
+    """The one line carrying every needle — asserting there is exactly one."""
+    hits = [line for line in lines if all(needle in line for needle in needles)]
+    assert len(hits) == 1, f"expected one line with {needles!r}, got {hits!r}"
+    return hits[0]
+
+
+# ---------------------------------------------------------------------------
+# What the card says for the exemplar
+# ---------------------------------------------------------------------------
+
+
+def test_the_groups_come_in_the_fixed_order(exemplar_lines: list[str]) -> None:
+    titles = [line.strip() for line in exemplar_lines if line and not line.startswith("    ")]
+    assert titles == ["web terminal  :9080", "agent", "machine", "services"]
+
+
+def test_a_blank_line_stands_before_every_group(exemplar_lines: list[str]) -> None:
+    assert exemplar_lines[0] == ""
+    for index, line in enumerate(exemplar_lines):
+        if line and not line.startswith("    "):
+            assert exemplar_lines[index - 1] == ""
+
+
+def test_each_user_row_carries_rights_auth_and_port(exemplar_lines: list[str]) -> None:
+    alice = line_with(exemplar_lines, "alice")
+    assert "readwrite · rights approval-gated" in alice
+    assert "password" in alice
+    assert alice.rstrip().endswith(":9091")
+
+    bob = line_with(exemplar_lines, "bob")
+    assert "readonly" in bob
+    assert "rights approval-gated" not in bob
+    assert bob.rstrip().endswith(":9092")
+
+
+def test_a_login_free_user_says_no_login(exemplar_lines: list[str]) -> None:
+    ariel = line_with(exemplar_lines, "ariel", ":909")
+    assert "no login" in ariel
+    assert "password" not in ariel
+
+
+def test_the_panels_row_is_the_union_across_personas(exemplar_lines: list[str]) -> None:
+    # EVENTS and BLUESKY are declared by the readwrite persona, not the host
+    # profile; a card that read only the host would miss them. Their labels
+    # come from `web.panels.<id>.label` — they are not built-ins.
+    panels = line_with(exemplar_lines, "panels")
+    assert "ARIEL · CHANNELS · KNOWLEDGE · SYSTEM · EVENTS · BLUESKY" in panels
+
+
+def test_the_agent_group_names_servers_and_counts_its_toolkit(
+    exemplar_lines: list[str],
+) -> None:
+    mcp = line_with(exemplar_lines, "mcp ")
+    # The registry defaults, plus the two servers the preset switches on.
+    for server in ("controls", "python", "bluesky", "health", "channel-finder"):
+        assert server in mcp
+    toolkit = line_with(exemplar_lines, "toolkit")
+    assert re.search(r"\d+ hooks", toolkit)
+    assert re.search(r"\d+ agents", toolkit)
+
+
+def test_the_machine_group_reads_connector_archiver_and_channels(
+    exemplar_lines: list[str],
+) -> None:
+    control = line_with(exemplar_lines, "control ")
+    assert "virtual accelerator" in control
+    assert "EPICS :5064" in control
+    archiver = line_with(exemplar_lines, "archiver")
+    assert "mongodb · 30 d retention" in archiver
+    channels = line_with(exemplar_lines, "channels")
+    assert "hierarchical finder · tier 3" in channels
+
+
+def test_the_services_group_names_the_injected_stack(exemplar_lines: list[str]) -> None:
+    bluesky = line_with(exemplar_lines, "bluesky ", ":8090")
+    assert "tiled :8091" in bluesky
+    assert "web :8095" in bluesky
+    dispatch = line_with(exemplar_lines, "dispatch")
+    assert "1 worker · triggers " in dispatch
+
+
+# ---------------------------------------------------------------------------
+# What the card leaves out
+# ---------------------------------------------------------------------------
+
+
+def test_a_bare_profile_gets_no_web_machine_or_services_group() -> None:
+    lines = format_profile_card(BuildProfile(name="bare"), {})
+    text = "\n".join(lines)
+    assert "web terminal" not in text
+    assert "machine" not in text
+    assert "services" not in text
+    # The agent group still stands: the registry's default servers are what a
+    # bare profile's render would get, and saying so is the card's job.
+    assert "  agent" in lines
+    assert any("controls" in line for line in lines)
+
+
+def test_a_profile_with_nothing_to_say_prints_nothing() -> None:
+    # No web tier, no model, no services — and the one row a bare profile
+    # would still get (the registry's default servers) suppressed the same way
+    # a facility profile would do it.
+    profile = BuildProfile(
+        name="silent",
+        config={
+            "claude_code.servers.controls.enabled": False,
+            "claude_code.servers.python.enabled": False,
+            "claude_code.servers.osprey_workspace.enabled": False,
+            "claude_code.servers.ariel.enabled": False,
+            "claude_code.servers.osprey_facility_knowledge.enabled": False,
+        },
+    )
+    assert format_profile_card(profile, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# Parity, and the card's altitude
+# ---------------------------------------------------------------------------
+
+
+class RecordingReporter(PhaseReporter):
+    """A real reporter whose console is a buffer, not the terminal."""
+
+    def __init__(self, console: Console, *, color: bool) -> None:
+        super().__init__(color=color)
+        self._console = console
+
+    def out(self) -> Console:
+        return self._console
+
+
+def recording_console(*, terminal: bool) -> tuple[Console, io.StringIO]:
+    buffer = io.StringIO()
+    return (
+        Console(
+            file=buffer,
+            theme=osprey_theme,
+            force_terminal=terminal,
+            color_system="standard" if terminal else None,
+            no_color=not terminal,
+            width=300,
+        ),
+        buffer,
+    )
+
+
+def test_the_printed_card_is_the_plain_renderer_byte_for_byte(
+    exemplar: tuple[BuildProfile, dict],
+) -> None:
+    profile, deltas = exemplar
+    console, buffer = recording_console(terminal=False)
+    previous = install_reporter(RecordingReporter(console, color=False))
+    try:
+        print_profile_card(profile, deltas)
+    finally:
+        install_reporter(previous)
+    assert buffer.getvalue().splitlines() == format_profile_card(profile, deltas)
+
+
+def test_the_styled_card_strips_to_the_plain_renderer(
+    exemplar: tuple[BuildProfile, dict],
+) -> None:
+    profile, deltas = exemplar
+    console, buffer = recording_console(terminal=True)
+    previous = install_reporter(RecordingReporter(console, color=True))
+    try:
+        print_profile_card(profile, deltas)
+    finally:
+        install_reporter(previous)
+    styled = buffer.getvalue()
+    assert "\x1b[" in styled  # it really was styled
+    stripped = [line.rstrip() for line in re.sub(r"\x1b\[[0-9;]*m", "", styled).splitlines()]
+    assert stripped == [line.rstrip() for line in format_profile_card(profile, deltas)]
+
+
+def test_a_derivation_failure_is_swallowed() -> None:
+    # The card is advisory: whatever it meets, `init` has already succeeded.
+    print_profile_card(None, {})  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# End to end: `osprey init` prints the card under its report
+# ---------------------------------------------------------------------------
+
+
+def test_init_prints_the_card_after_its_report(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["init", str(tmp_path / "exemplar"), "--preset", "control-assistant", "--no-git"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    # Short lines only — the wide rows are the plain renderer's tests' business.
+    assert "  web terminal  :9080" in result.output
+    assert "no login" in result.output
+    report_at = result.output.index("✓ Created")
+    assert result.output.index("  web terminal  :9080") > report_at


### PR DESCRIPTION
## What

\`osprey init\` now prints a composition card under its report — one glance at what the deployment that was just materialized consists of, before anything is built or started. It stays on screen through everything a chained \`--up\` does, which is when someone actually has time to read it.

\`\`\`
✓ Created my-control-assistant

  profile.yml   your assistant's settings; edit this
  ...
  Started a git repo and made the first commit.

  web terminal  :9080
    alice    readwrite · rights approval-gated   password   :9091
    bob      readonly                            password   :9092
    ariel    ariel                               no login   :9093
    panels   ARIEL · CHANNELS · KNOWLEDGE · SYSTEM · EVENTS · BLUESKY

  agent
    model     als-apg · sonnet
    mcp       controls · python · osprey_workspace · ariel · osprey_facility_knowledge · bluesky · health · channel-finder
    toolkit   13 hooks · 10 rules · 7 skills · 6 agents

  machine
    control    virtual accelerator · EPICS :5064
    archiver   mongodb · 30 d retention
    channels   hierarchical finder · tier 3

  services
    bluesky    :8090 · tiled :8091 · web :8095
    dispatch   1 worker · triggers triggers.yml
\`\`\`

On a terminal: group anchors in the header rose, usernames bold, attribute labels and separators dim, ports accent, and exactly one warning tone — \`no login\`.

## How

- The card is a pure function of the resolved \`BuildProfile\` plus the parsed persona deltas (both already computed by the materializer, now returned on \`_MaterializedProfile\`). Groups and rows print only when the profile has the facts for them, so a minimal profile gets a short card and nothing ever reads "none".
- Per-persona facts come from the deltas: \`rights approval-gated\` from each tier's \`control_system.writes_enabled\`, the panels row is the union across personas with labels from \`BUILTIN_PANEL_LABELS\` / \`web.panels.<id>.label\`.
- MCP servers resolve through \`resolve_servers\` over the profile's effective \`claude_code\` subtree, keyed the way the render keys the channel-finder condition.
- Two enablers: \`effective_web_terminals\` generalized into \`effective_config_subtree\`; the reporter gained \`echo_segments\` (a multi-style line at echo altitude — survives \`-v\`, byte-identical through a pipe).
- Advisory by contract: a derivation failure is logged and the card skipped; \`init\` has already succeeded.

## Tests

\`tests/cli/test_profile_card.py\` pins the exemplar card's content (resolved from the real preset + deltas), group order, printed/plain parity (plain and styled), degradation for a bare profile, the advisory contract, and one end-to-end \`init\`. \`quick_check.sh\` green.