### PR TITLE
fix(workspace): hand the pyAT specialist's numbers in with its answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,15 @@ Compatibility is documented in release notes, not encoded in the version string.
   numbers it describes both appeared as "Lattice Analysis", and neither the
   gallery nor the agent could tell them apart. The summary is now an "Agent
   Response", and a `data_type` you pass is no longer overridden.
+- The pyAT specialist no longer sometimes answers without filing its numbers.
+  Its computed quantities used to be saved by a separate step inside the
+  computing code that the agent could skip — and did, intermittently, leaving
+  a prose answer with no "Lattice Analysis" JSON behind it. The numbers now
+  travel with the answer: `submit_response` takes a `data` dict and files it as
+  the JSON results artifact in the category the agent's definition declares
+  (`results_category:` in its frontmatter), and refuses a hand-in that owes
+  data and carries none. Prose and numbers arrive in one call, so there is no
+  step to skip.
 - Timeseries previews in the workspace gallery render again in CDN-mode
   (non-offline) deployments: the lazy Plotly loader now uses the same
   CDN-or-vendored URL resolution as the gallery's other vendor assets

--- a/src/osprey/mcp_server/agent_frontmatter.py
+++ b/src/osprey/mcp_server/agent_frontmatter.py
@@ -1,0 +1,106 @@
+"""What a project's subagents declare about themselves.
+
+The rendered ``<project>/.claude/agents/*.md`` files (from
+``src/osprey/templates/claude_code/claude/agents/*.md.j2``) are the one place
+an agent says what it is: its ``name``, the ``tools`` it may use, and — for an
+agent that computes something — the ``results_category`` it owes a data
+artifact to. Two runtime readers consume that frontmatter: the dispatch worker
+(tool surfaces, :mod:`osprey.mcp_server.dispatch_worker.agent_surfaces`) and
+``submit_response`` (the results contract). They share this parser so they
+cannot disagree about which files are agents or what an agent is called.
+
+Frontmatter contract (matching what the Claude Code CLI loads):
+
+* Only files directly in ``.claude/agents/`` (non-recursive; the templates
+  ship a ``_terminology`` sibling directory that must not be scanned).
+* A file must start with ``---``; the block up to the closing ``---`` is
+  parsed with ``yaml.safe_load``.
+* Agents are keyed by the frontmatter ``name:`` (what the CLI dispatches on),
+  not the filename. Duplicate names: last file in sorted order wins, with a
+  warning.
+
+Parsing is best-effort and never raises: a malformed or unreadable file is
+skipped with a warning so one bad agent file cannot take down a run.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger("osprey.mcp_server.agent_frontmatter")
+
+#: Frontmatter key naming the artifact category an agent owes its computed
+#: results to. ``submit_response`` files the agent's ``data`` there and refuses
+#: a hand-in that carries none.
+RESULTS_CATEGORY_KEY = "results_category"
+
+
+def parse_agent_frontmatter(project_dir: str | Path) -> dict[str, dict[str, Any]]:
+    """Parse every declared subagent's frontmatter from a project.
+
+    Args:
+        project_dir: Project root containing ``.claude/agents/``.
+
+    Returns:
+        Mapping of frontmatter agent name to its frontmatter dict. Missing
+        directory or no parseable files ⇒ empty mapping.
+    """
+    agents_dir = Path(project_dir) / ".claude" / "agents"
+    declared: dict[str, dict[str, Any]] = {}
+    if not agents_dir.is_dir():
+        return declared
+
+    for path in sorted(agents_dir.glob("*.md")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            logger.warning("Skipping unreadable agent file %s", path, exc_info=True)
+            continue
+
+        if not text.startswith("---"):
+            continue
+        parts = text.split("---", 2)
+        if len(parts) < 3:
+            continue
+
+        try:
+            frontmatter = yaml.safe_load(parts[1])
+        except yaml.YAMLError:
+            logger.warning("Skipping agent file with malformed frontmatter: %s", path.name)
+            continue
+        if not isinstance(frontmatter, dict):
+            continue
+
+        name = frontmatter.get("name")
+        if not isinstance(name, str) or not name.strip():
+            logger.warning("Skipping agent file without a name: %s", path.name)
+            continue
+        name = name.strip()
+
+        if name in declared:
+            logger.warning("Duplicate agent name %r — %s overrides earlier file", name, path.name)
+        declared[name] = frontmatter
+
+    return declared
+
+
+def results_category_for(agent_name: str, project_dir: str | Path) -> str | None:
+    """The artifact category *agent_name* declares it owes its results to.
+
+    ``None`` for an agent that declares nothing, for a blank or non-string
+    declaration, and for a name no agent file carries — all of which mean the
+    same thing to the caller: this agent hands in prose only.
+    """
+    frontmatter = parse_agent_frontmatter(project_dir).get(agent_name)
+    if not frontmatter:
+        return None
+    category = frontmatter.get(RESULTS_CATEGORY_KEY)
+    if not isinstance(category, str) or not category.strip():
+        return None
+    return category.strip()

--- a/src/osprey/mcp_server/dispatch_worker/agent_surfaces.py
+++ b/src/osprey/mcp_server/dispatch_worker/agent_surfaces.py
@@ -1,27 +1,18 @@
 """Declared-subagent tool surfaces for dispatch permission policy.
 
-Parses the provisioned ``<project>/.claude/agents/*.md`` files (rendered from
-``src/osprey/templates/claude_code/claude/agents/*.md.j2``) into a mapping of
-agent name to declared tool surface. The dispatch worker uses this to grant
+Reads the provisioned ``<project>/.claude/agents/*.md`` files into a mapping
+of agent name to declared tool surface. The dispatch worker uses this to grant
 each subagent exactly its declared tools — parity with the web terminal —
 without the trigger having to enumerate them.
 
-Frontmatter contract (matching what the Claude Code CLI loads):
+Which files are agents, and what they are called, is decided by
+:mod:`osprey.mcp_server.agent_frontmatter` (shared with ``submit_response``);
+this module only interprets the ``tools:`` key:
 
-* Only files directly in ``.claude/agents/`` (non-recursive; the templates
-  ship a ``_terminology`` sibling directory that must not be scanned).
-* A file must start with ``---``; the block up to the closing ``---`` is
-  parsed with ``yaml.safe_load``.
-* Agents are keyed by the frontmatter ``name:`` (what the CLI dispatches on),
-  not the filename. Duplicate names: last file in sorted order wins, with a
-  warning.
 * ``tools:`` may be a comma-separated scalar (the template form) or a YAML
   list. An absent or malformed ``tools:`` yields ``None`` — the agent exists
   but has inherits-all semantics, which dispatch treats as non-delegable
   rather than granting an unbounded surface.
-
-Parsing is best-effort and never raises: a malformed or unreadable file is
-skipped with a warning so one bad agent file cannot take down dispatch runs.
 """
 
 from __future__ import annotations
@@ -29,7 +20,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import yaml
+from osprey.mcp_server.agent_frontmatter import parse_agent_frontmatter
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker.agent_surfaces")
 
@@ -58,50 +49,14 @@ def parse_project_agents(project_dir: str | Path) -> dict[str, frozenset[str] | 
         ``None`` for agents without an explicit ``tools:`` list. Missing
         directory or no parseable files ⇒ empty mapping.
     """
-    agents_dir = Path(project_dir) / ".claude" / "agents"
     surfaces: dict[str, frozenset[str] | None] = {}
-    if not agents_dir.is_dir():
-        return surfaces
-
-    for path in sorted(agents_dir.glob("*.md")):
-        if not path.is_file():
-            continue
-        try:
-            text = path.read_text(encoding="utf-8")
-        except OSError:
-            logger.warning("Skipping unreadable agent file %s", path, exc_info=True)
-            continue
-
-        if not text.startswith("---"):
-            continue
-        parts = text.split("---", 2)
-        if len(parts) < 3:
-            continue
-
-        try:
-            frontmatter = yaml.safe_load(parts[1])
-        except yaml.YAMLError:
-            logger.warning("Skipping agent file with malformed frontmatter: %s", path.name)
-            continue
-        if not isinstance(frontmatter, dict):
-            continue
-
-        name = frontmatter.get("name")
-        if not isinstance(name, str) or not name.strip():
-            logger.warning("Skipping agent file without a name: %s", path.name)
-            continue
-        name = name.strip()
-
+    for name, frontmatter in parse_agent_frontmatter(project_dir).items():
         tools = _parse_tools(frontmatter.get("tools"))
         if tools is None:
             logger.warning(
-                "Agent %r (%s) declares no explicit tools list — "
+                "Agent %r declares no explicit tools list — "
                 "it will not be delegable in dispatch runs",
                 name,
-                path.name,
             )
-        if name in surfaces:
-            logger.warning("Duplicate agent name %r — %s overrides earlier file", name, path.name)
         surfaces[name] = tools
-
     return surfaces

--- a/src/osprey/mcp_server/workspace/tools/submit_response.py
+++ b/src/osprey/mcp_server/workspace/tools/submit_response.py
@@ -3,6 +3,13 @@
 Sub-agents call this as their last action to save their synthesis to
 the artifact gallery so the parent session, other tools, and the gallery
 UI can all reference it.
+
+An agent that computes something hands its computed quantities in here too,
+as ``data``, and the tool files them as a JSON artifact in the category the
+agent's own definition declares (``results_category:`` in its frontmatter).
+The prose and the numbers arrive in one call, so there is no separate step
+for the agent to skip; an agent that owes data and hands in none is refused,
+with the fix in the error.
 """
 
 import json
@@ -10,11 +17,20 @@ import logging
 
 from fastmcp.exceptions import ToolError
 
+from osprey.mcp_server.agent_frontmatter import RESULTS_CATEGORY_KEY, results_category_for
 from osprey.mcp_server.errors import make_error
 from osprey.mcp_server.http import gallery_url
 from osprey.mcp_server.workspace.server import mcp
+from osprey.utils.workspace import resolve_config_path
 
 logger = logging.getLogger("osprey.mcp_server.tools.submit_response")
+
+
+def _declared_results_category(agent: str) -> str | None:
+    """The category *agent* owes a data artifact to, per its rendered definition."""
+    if not agent:
+        return None
+    return results_category_for(agent, resolve_config_path().parent)
 
 
 @mcp.tool()
@@ -25,6 +41,7 @@ async def submit_response(
     entry_ids: list[str] | None = None,
     source_agent: str | None = None,
     skip_artifact: bool = False,
+    data: dict | None = None,
 ) -> str:
     """Submit your final synthesized response. Call this as your LAST action
     before responding. This persists your findings to the workspace so
@@ -33,24 +50,35 @@ async def submit_response(
     Include all entry IDs, channel addresses, or other identifiers you
     cited in the entry_ids parameter for cross-referencing.
 
+    If your agent definition declares a ``results_category``, you computed
+    something, and the numbers go in ``data``: a dict of native Python values
+    (floats, ints, strings, small lists) holding every quantity your prose
+    reports. It is filed as a JSON artifact in that category so the parent
+    session and other tools read exact values, never prose. A hand-in without
+    it is refused.
+
     Args:
         title: Short title for the response (e.g. "Vacuum Event Analysis").
         content: The full synthesized response text (markdown).
-        data_type: Category tag for filtering.  Must be a registered type:
+        data_type: Category tag for the prose.  Must be a registered type:
             "agent_response" (default), "channel_addresses",
             "logbook_research", "search_results", or any other key from
             the type registry.
         entry_ids: List of ARIEL entry IDs or channel addresses cited,
             stored as structured metadata for cross-referencing.
         source_agent: Name of the agent submitting the response
-            (e.g. "logbook-search", "wiki-search"). Used for filtering
-            and grouping results by agent.
+            (e.g. "logbook-search", "pyat-specialist"). Used for filtering
+            and grouping results by agent, and to look up what the agent
+            declares it owes.
         skip_artifact: If True, skip creating a new artifact (use when
             the agent already created plot/dashboard artifacts and wants
             to avoid double-registration).
+        data: The computed quantities, for an agent whose definition
+            declares a ``results_category``. Filed as a JSON artifact there.
 
     Returns:
-        JSON with artifact_id, gallery_url, and summary.
+        JSON with artifact_id, gallery_url, and summary — plus
+        data_artifact_id when data was filed.
     """
     if not title or not title.strip():
         return make_error(
@@ -76,11 +104,55 @@ async def submit_response(
             ["Use one of the registered data_type or category values."],
         )
 
+    agent = source_agent or ""
+    results_category = _declared_results_category(agent)
+
+    # The contract is checked BEFORE anything is written, so a refused hand-in
+    # leaves no half-filed prose behind for the parent to mistake for a result.
+    if results_category is not None and results_category not in valid:
+        return make_error(
+            "validation_error",
+            f"Agent '{agent}' declares {RESULTS_CATEGORY_KEY}='{results_category}', "
+            f"which is not a registered category. Valid: {sorted(valid)}",
+            [
+                f"Fix {RESULTS_CATEGORY_KEY} in the agent's definition "
+                f"(.claude/agents/{agent}.md) to a registered category."
+            ],
+        )
+    if data is not None and not isinstance(data, dict):
+        return make_error(
+            "validation_error",
+            "data must be a dict of computed quantities.",
+            ["Pass data={...} with native Python values (floats, ints, strings, lists)."],
+        )
+    if results_category is not None and not data:
+        return make_error(
+            "validation_error",
+            f"Agent '{agent}' owes its computed results in the '{results_category}' "
+            "category, and this hand-in carries none. Call submit_response again "
+            "with data={...}: a dict holding every computed quantity your prose "
+            "reports, as native Python values.",
+            [
+                "The prose alone is not the result — the parent session and other "
+                "tools read the exact values from the data artifact, never from prose.",
+            ],
+        )
+    if data and results_category is None:
+        return make_error(
+            "validation_error",
+            f"data was passed, but agent '{agent or '(none)'}' declares no "
+            f"{RESULTS_CATEGORY_KEY}, so there is no category to file it in.",
+            [
+                f"Declare `{RESULTS_CATEGORY_KEY}: <registered category>` in the agent's "
+                "definition frontmatter, or hand in prose only.",
+                "Pass source_agent=<your agent name> so the declaration can be found.",
+            ],
+        )
+
     try:
         from osprey.stores.artifact_store import get_artifact_store
 
         cited = entry_ids or []
-        agent = source_agent or ""
 
         if skip_artifact:
             return json.dumps(
@@ -96,9 +168,9 @@ async def submit_response(
 
         # The category is the declared data_type, never the agent's name. An
         # agent-derived category would put this prose in the same bucket as the
-        # structured results the agent saves through save_artifact(), leaving
-        # that bucket unable to say which of the two it holds. Grouping by agent
-        # is already served by source_agent below.
+        # structured results filed below, leaving that bucket unable to say
+        # which of the two it holds. Grouping by agent is already served by
+        # source_agent.
         category = data_type
 
         store = get_artifact_store()
@@ -131,6 +203,35 @@ async def submit_response(
         )
 
         response = artifact.to_tool_response()
+
+        if data:
+            # The data sheet: the agent's computed quantities as JSON, in the
+            # category it declared. Saved second so its metadata can name the
+            # prose it belongs to; the prose is then pointed back at it.
+            results = store.save_data(
+                tool=tool_name,
+                data=data,
+                title=title,
+                description=f"{results_category} from {agent}",
+                category=results_category,
+                source_agent=agent,
+                summary={
+                    "title": title,
+                    "keys": sorted(str(k) for k in data)[:50],
+                    "source_agent": agent,
+                },
+                metadata={
+                    "source_agent": agent,
+                    "response_artifact_id": artifact.id,
+                },
+            )
+            store.update_entry_metadata(
+                artifact.id,
+                metadata={**artifact.metadata, "data_artifact_id": results.id},
+            )
+            response["data_artifact_id"] = results.id
+            response["data_category"] = results_category
+
         response["gallery_url"] = gallery_url()
         return json.dumps(response, default=str)
 

--- a/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
@@ -4,8 +4,11 @@ description: "Delegate to this agent when the user needs lattice/optics quantiti
 summary: Computes lattice/optics quantities by writing and executing pyAT code on the simulated ring
 model: {{ claude_code_model_spec.agent_tier("pyat-specialist") if claude_code_model_spec is defined and claude_code_model_spec else "sonnet" }}
 maxTurns: 30
-tools: mcp__python__execute, mcp__osprey_workspace__submit_response, mcp__osprey_workspace__artifact_list, mcp__osprey_workspace__artifact_read, Read
+tools: mcp__python__execute, mcp__osprey_workspace__submit_response, mcp__osprey_workspace__artifact_read, Read
 disallowedTools: Bash, Write, Edit, Glob, Grep, WebFetch, WebSearch, NotebookEdit, Task, Skill, Agent
+# The computed quantities this agent hands in as submit_response(data=...) are
+# filed as a JSON artifact in this category; a hand-in without them is refused.
+results_category: lattice_analysis
 ---
 
 # pyAT Specialist Agent
@@ -148,76 +151,36 @@ For chromaticity, call `at.get_optics(ring4d, get_chrom=True, dp=1e-6)` and read
 
 ## Returning Results
 
-Follow this sequence so both a machine-readable channel and a human summary exist.
-**A successful computation is not complete until this artifact exists.**
+Your last action is one `submit_response` call that carries both the prose and the
+numbers. The prose is for the parent to read; `data` is the machine-readable result
+the parent and other tools take the exact values from, so it must hold **every
+quantity your prose reports**, as native Python values:
 
-1. **In the same `mcp__python__execute` call that computes the answer, save the
-   computed quantities as a structured results artifact.** Build a `dict`, convert
-   every computed quantity to a NATIVE Python type, and make the artifact type and
-   category explicit. The serializer uses `json.dumps(..., default=str)`, which
-   **lossily stringifies** numpy ndarrays and non-`float64` numpy scalars, so coerce
-   them before saving:
+```
+submit_response(
+    title="AR optics at BPM01 and BPM03",
+    content="<prose: the key numbers, the recipe used (4D vs 6D), and that everything "
+            "was computed from the simulated ALS-U AR design lattice>",
+    source_agent="pyat-specialist",
+    data={
+        "tune_x": 0.2345, "tune_y": 0.1876,
+        "circumference_m": 182.0,
+        "beta_x_BPM01_m": 3.21, "beta_y_BPM01_m": 5.67,
+        "lattice": "ALS-U AR design lattice (simulated)",
+        "computed_4d": True,
+    },
+)
+```
 
-   ```python
-   result = {
-       "tune_x": float(tunes[0]),
-       "tune_y": float(tunes[1]),
-       "n_monitors": int(len(monitors)),
-       "stable": bool(abs(tr_x) < 2 and abs(tr_y) < 2),
-       "beta_x": np.asarray(beta[:, 0]).tolist(),
-       "lattice": "ALS-U AR design lattice (simulated)",
-       "computed_4d": True,
-   }
-   save_artifact(
-       result,
-       title="AR Optics Result",
-       description="Computed from the simulated ALS-U AR design lattice.",
-       artifact_type="json",
-       category="lattice_analysis",
-   )
-   print(result)   # so the value is also visible in stdout
-   ```
+The tool files `data` as a JSON artifact in `lattice_analysis` and returns its id;
+echo that id in your reply so the parent can reference or re-delegate it. A
+`submit_response` without `data` is refused — the prose alone is not the result.
 
-   `save_artifact(obj, title, description, artifact_type, category)` is injected
-   into the execution environment by the workspace API. Passing a native `dict`
-   with `artifact_type="json"` and `category="lattice_analysis"` produces the
-   authoritative, full-precision, non-`code_output` results JSON that the parent and
-   downstream tools read.
-
-   The automatic notebook, the automatic `code_output` JSON, and the Markdown
-   from `submit_response` do **not** satisfy this requirement. They are
-   supplementary records, not the structured results artifact.
-
-2. **Confirm the results artifact before handing off.** Call
-   `artifact_list(category="lattice_analysis", last_n=1)` and verify that the saved
-   entry has `artifact_type="json"`. If it does not, do not submit a successful
-   response; run a self-contained compute-and-save call that creates it.
-
-3. **Summarize in prose** for the parent: the key numbers, the recipe used (4D vs
-   6D), and the explicit statement that everything was computed from the simulated
-   ALS-U AR design lattice.
-
-4. **Call `submit_response`** only after artifact confirmation. Do **not** call
-   `submit_response` until the structured `artifact_type="json"`,
-   `category="lattice_analysis"` results artifact has been saved and confirmed.
-   Then call `submit_response` as your last action, tagging provenance:
-
-   ```
-   submit_response(
-       title="...",
-       content="<your prose summary>",
-       data_type="agent_response",
-       source_agent="pyat-specialist",
-   )
-   ```
-
-   The prose is an `agent_response`, not a `lattice_analysis`. That category
-   holds the JSON results artifact from step 1 and nothing else, which is what
-   makes the check in step 2 mean something: if `artifact_list` returns a
-   Markdown entry there, the results artifact was never saved.
-
-5. **Echo the confirmed results artifact id(s)** in your reply so the parent can
-   reference or re-delegate them.
+For a **large array** the operator wants plotted (beta along the whole ring, a
+response matrix), do not retype it into `data`: save it from inside the computing
+`mcp__python__execute` call with the injected `save_artifact(obj, title, description,
+artifact_type="json", category="lattice_analysis")`, coerced to native types first
+(`np.asarray(x).tolist()`), and put the returned artifact id in `data` instead.
 
 ## Handoff to Visualization
 
@@ -229,8 +192,7 @@ parent can re-delegate them to `data-visualizer`. Do not attempt to visualize yo
 
 - **Never fabricate numbers.** Report only values your executed code actually produced;
   on instability/non-convergence, report the instability.
-- **For every successful computation, save and confirm a non-`code_output` JSON
-  results artifact before calling `submit_response`.**
+- **Hand in every computed quantity in `submit_response(data=...)`.**
 - **Always `execution_mode="readonly"`.**
 - **Always label answers as computed from the simulated ALS-U AR design lattice**, in
   both prose and provenance metadata.

--- a/tests/cli/test_profile_to_claude_contract.py
+++ b/tests/cli/test_profile_to_claude_contract.py
@@ -312,7 +312,6 @@ _FRAMEWORK_AGENT_EXPECTED: dict[str, dict[str, list[str]]] = {
         "tools": [
             "mcp__python__execute",
             "mcp__osprey_workspace__submit_response",
-            "mcp__osprey_workspace__artifact_list",
             "mcp__osprey_workspace__artifact_read",
             "Read",
         ],

--- a/tests/e2e/claude_code/test_pyat_specialist_e2e.py
+++ b/tests/e2e/claude_code/test_pyat_specialist_e2e.py
@@ -10,8 +10,8 @@ Two halves share one deployment-build path:
   ``execution_mode="readonly"`` for the in-memory simulation).
 
 - **Grounding** (:func:`test_pyat_specialist_grounding`): reads the exact
-  floats the subagent saved to its results JSON artifact and checks them
-  against ground truth computed in-test from ``build_ring()`` with the
+  floats the subagent handed in as ``submit_response(data=...)`` — filed by
+  the tool as its results JSON artifact — and checks them against ground truth computed in-test from ``build_ring()`` with the
   *identical* 4D recipe (no pinned numeric literals). An LLM judge confirms
   provenance and simulation-derived labeling in the prose only — numbers are
   never parsed out of prose.
@@ -250,8 +250,8 @@ def _leaves(obj, prefix: str = ""):
 def _coerce_float(value, label: str) -> float:
     """Coerce a saved value to float, failing loudly on a numpy display-repr string.
 
-    The template requires native ``float()`` coercion before ``save_artifact``;
-    a value like ``'np.float64(0.22)'`` means that step was skipped. Surface it
+    The template requires native Python values in ``submit_response(data=...)``;
+    a value like ``'np.float64(0.22)'`` means a numpy repr was handed in instead. Surface it
     as a clear, actionable error rather than an opaque ``ValueError``.
     """
     if isinstance(value, bool):  # bool is an int subclass — never a physics scalar
@@ -261,9 +261,9 @@ def _coerce_float(value, label: str) -> float:
     except (TypeError, ValueError) as exc:
         raise AssertionError(
             f"{label}: expected a numeric value but got {value!r} — likely an "
-            "un-coerced numpy display-repr string. The subagent must convert to "
-            "native float()/int() before save_artifact (per the template's "
-            "'Returning Results' recipe)."
+            "un-coerced numpy display-repr string. The subagent must hand in "
+            "native float()/int() values in submit_response(data=...) (per the "
+            "template's 'Returning Results' recipe)."
         ) from exc
 
 
@@ -302,15 +302,14 @@ def _load_results_artifacts(repo: Path) -> list[tuple[dict, dict]]:
     so the shared root ``<repo>/var/agent_data/artifacts/`` holds every
     artifact this run produced. Filter to ``artifact_type == 'json'`` AND
     ``category != 'code_output'`` — the latter drops the executor's auto-saved
-    code+stdout wrapper (also stored as json), leaving the ``save_artifact``
-    results dicts.
+    code+stdout wrapper (also stored as json), leaving the results dicts filed
+    by ``submit_response(data=...)`` (or by ``save_artifact`` for large arrays).
     """
     index_path = agent_data_dir(repo) / "artifacts" / "artifacts.json"
     assert index_path.exists(), (
         "No artifact index at "
-        f"{index_path} — the pyat-specialist never saved a results artifact. "
-        "save_artifact failures are swallowed upstream (non-fatal), so a missing "
-        "index means the subagent's compute/save pipeline did not complete."
+        f"{index_path} — the pyat-specialist never produced a results artifact: "
+        "its submit_response(data=...) hand-in did not complete."
     )
     index = json.loads(index_path.read_text(encoding="utf-8"))
     artifacts_dir = index_path.parent
@@ -386,13 +385,13 @@ async def test_pyat_specialist_grounding(tmp_path: Path) -> None:
     results = _load_results_artifacts(repo)
     assert results, (
         "No results JSON artifact found (artifact_type=='json' and "
-        "category!='code_output'). The subagent must save its computed "
-        "quantities via save_artifact(dict, ...). Index entries seen: "
+        "category!='code_output'). The subagent must hand its computed "
+        "quantities in as submit_response(data={...}). Index entries seen: "
         f"{[(e.get('artifact_type'), e.get('category')) for e, _ in _all_index_entries(repo)]}"
     )
 
     # Union the leaves across every results artifact so the check is robust to a
-    # subagent that split its output across more than one save_artifact call.
+    # subagent that split its output across more than one results artifact.
     leaves: list[tuple[str, object]] = []
     for _entry, data in results:
         leaves.extend(_leaves(data))

--- a/tests/mcp_server/test_agent_frontmatter.py
+++ b/tests/mcp_server/test_agent_frontmatter.py
@@ -1,0 +1,87 @@
+"""Tests for the shared ``.claude/agents/*.md`` frontmatter reader.
+
+The dispatch worker and ``submit_response`` both read what an agent declares
+about itself from the rendered agent file. One parser, so the two cannot
+disagree about which files are agents or what their names are.
+"""
+
+import logging
+
+from osprey.mcp_server.agent_frontmatter import (
+    parse_agent_frontmatter,
+    results_category_for,
+)
+
+
+def _write_agent(agents_dir, filename, body):
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / filename).write_text(body, encoding="utf-8")
+
+
+class TestParseAgentFrontmatter:
+    def test_keyed_by_frontmatter_name_not_filename(self, tmp_path):
+        agents = tmp_path / ".claude" / "agents"
+        _write_agent(agents, "file.md", "---\nname: declared\ntools: a, b\n---\nbody\n")
+
+        parsed = parse_agent_frontmatter(tmp_path)
+
+        assert set(parsed) == {"declared"}
+        assert parsed["declared"]["tools"] == "a, b"
+
+    def test_missing_dir_and_subdirs(self, tmp_path):
+        assert parse_agent_frontmatter(tmp_path) == {}
+
+        agents = tmp_path / ".claude" / "agents"
+        _write_agent(agents / "_terminology", "x.md", "---\nname: nested\n---\n")
+        assert parse_agent_frontmatter(tmp_path) == {}
+
+    def test_malformed_and_nameless_files_skipped_with_warning(self, tmp_path, caplog):
+        agents = tmp_path / ".claude" / "agents"
+        _write_agent(agents, "broken.md", "---\nname: [unclosed\n---\n")
+        _write_agent(agents, "nameless.md", "---\ntools: a\n---\n")
+        _write_agent(agents, "plain.md", "no frontmatter here\n")
+        _write_agent(agents, "scalar.md", "---\njust a string\n---\n")
+
+        with caplog.at_level(logging.WARNING):
+            parsed = parse_agent_frontmatter(tmp_path)
+
+        assert parsed == {}
+        assert any("broken.md" in r.message for r in caplog.records)
+        assert any("nameless.md" in r.message for r in caplog.records)
+
+    def test_duplicate_name_last_wins(self, tmp_path, caplog):
+        agents = tmp_path / ".claude" / "agents"
+        _write_agent(agents, "a.md", "---\nname: dup\nresults_category: first\n---\n")
+        _write_agent(agents, "b.md", "---\nname: dup\nresults_category: second\n---\n")
+
+        with caplog.at_level(logging.WARNING):
+            parsed = parse_agent_frontmatter(tmp_path)
+
+        assert parsed["dup"]["results_category"] == "second"
+        assert any("dup" in r.message for r in caplog.records)
+
+
+class TestResultsCategoryFor:
+    def test_declared(self, tmp_path):
+        agents = tmp_path / ".claude" / "agents"
+        _write_agent(
+            agents,
+            "pyat-specialist.md",
+            "---\nname: pyat-specialist\nresults_category: lattice_analysis\n---\n",
+        )
+        assert results_category_for("pyat-specialist", tmp_path) == "lattice_analysis"
+
+    def test_undeclared_agent_and_unknown_agent(self, tmp_path):
+        agents = tmp_path / ".claude" / "agents"
+        _write_agent(agents, "logbook-search.md", "---\nname: logbook-search\n---\n")
+
+        assert results_category_for("logbook-search", tmp_path) is None
+        assert results_category_for("nobody", tmp_path) is None
+
+    def test_blank_or_non_string_declaration_is_none(self, tmp_path):
+        agents = tmp_path / ".claude" / "agents"
+        _write_agent(agents, "a.md", "---\nname: a\nresults_category: ''\n---\n")
+        _write_agent(agents, "b.md", "---\nname: b\nresults_category: [x]\n---\n")
+
+        assert results_category_for("a", tmp_path) is None
+        assert results_category_for("b", tmp_path) is None

--- a/tests/mcp_server/test_submit_response.py
+++ b/tests/mcp_server/test_submit_response.py
@@ -8,7 +8,12 @@ Covers:
   - Custom data_type passed through
   - source_agent / category mapping
   - skip_artifact mode
+  - The results-data contract: an agent whose rendered definition declares a
+    ``results_category`` hands in its computed quantities as ``data`` and the
+    tool files them as a JSON artifact there — and refuses a hand-in without them
 """
+
+import json
 
 import pytest
 
@@ -28,11 +33,28 @@ _fn = submit_response.fn if hasattr(submit_response, "fn") else submit_response
 
 
 @pytest.fixture
-def workspace(tmp_path):
-    """Initialize a temporary ArtifactStore workspace."""
+def workspace(tmp_path, monkeypatch):
+    """Initialize a temporary ArtifactStore workspace.
+
+    ``OSPREY_CONFIG`` is pinned into the same temp dir so the tool resolves its
+    project — and therefore its ``.claude/agents/`` declarations — there rather
+    than wherever pytest happens to run.
+    """
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
     initialize_artifact_store(workspace_root=tmp_path)
     yield tmp_path
     reset_artifact_store()
+
+
+def _declare_agent(project_dir, name, results_category=None):
+    """Render a minimal ``.claude/agents/<name>.md`` the way the build would."""
+    agents_dir = project_dir / ".claude" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["---", f"name: {name}"]
+    if results_category is not None:
+        lines.append(f"results_category: {results_category}")
+    lines += ["---", f"# {name}", ""]
+    (agents_dir / f"{name}.md").write_text("\n".join(lines), encoding="utf-8")
 
 
 class TestSubmitResponse:
@@ -241,10 +263,9 @@ class TestSubmitResponse:
     async def test_narrative_does_not_claim_a_domain_category(self, workspace):
         """The prose artifact must not land in a domain results category.
 
-        pyat-specialist saves its computed quantities as JSON under
-        ``category="lattice_analysis"``. If this markdown claimed the same key,
-        that category would stop identifying structured results and the agent's
-        own verification step could not tell the two apart.
+        pyat-specialist's computed quantities are filed as JSON under
+        ``lattice_analysis``. If this markdown claimed the same key, that
+        category would stop identifying structured results.
         """
         raw = await _fn(
             title="AR Optics Summary",
@@ -273,3 +294,123 @@ class TestSubmitResponse:
         entry = get_artifact_store().get_entry(data["artifact_id"])
         assert entry is not None
         assert entry.category == "channel_addresses"
+
+
+class TestResultsDataContract:
+    """An agent that declares ``results_category`` owes ``data`` at hand-in.
+
+    The declaration lives in the agent's own rendered definition — the same
+    frontmatter the dispatch worker reads for tool surfaces — so one file says
+    both what the agent may use and what it must hand back.
+    """
+
+    @pytest.mark.asyncio
+    async def test_data_is_filed_as_json_in_the_declared_category(self, workspace):
+        _declare_agent(workspace, "pyat-specialist", "lattice_analysis")
+        payload = {"tune_x": 0.2345, "tune_y": 0.1876, "circumference_m": 182.0}
+
+        raw = await _fn(
+            title="AR optics",
+            content="Tunes and circumference computed from the design lattice.",
+            source_agent="pyat-specialist",
+            data=payload,
+        )
+        data = extract_response_dict(raw)
+
+        assert data["status"] == "success"
+        store = get_artifact_store()
+
+        # The prose is still the agent_response markdown it always was.
+        prose = store.get_entry(data["artifact_id"])
+        assert prose is not None
+        assert prose.artifact_type == "markdown"
+        assert prose.category == "agent_response"
+
+        # The data sheet is a second artifact, JSON, in the declared category,
+        # attributed to the same agent, and holds exactly what was handed in.
+        results = store.get_entry(data["data_artifact_id"])
+        assert results is not None
+        assert results.artifact_type == "json"
+        assert results.category == "lattice_analysis"
+        assert results.source_agent == "pyat-specialist"
+        assert json.loads(store.get_file_path(results.id).read_text()) == payload
+        # The two know about each other.
+        assert results.metadata["response_artifact_id"] == prose.id
+        assert prose.metadata["data_artifact_id"] == results.id
+
+    @pytest.mark.asyncio
+    async def test_declared_agent_without_data_is_refused(self, workspace):
+        _declare_agent(workspace, "pyat-specialist", "lattice_analysis")
+
+        with assert_raises_error(error_type="validation_error") as ctx:
+            await _fn(
+                title="AR optics",
+                content="Tunes computed from the design lattice.",
+                source_agent="pyat-specialist",
+            )
+
+        msg = ctx["envelope"]["error_message"]
+        assert "pyat-specialist" in msg
+        assert "lattice_analysis" in msg
+        assert "data=" in msg
+        # Nothing half-filed: no prose artifact either.
+        assert get_artifact_store().list_entries() == []
+
+    @pytest.mark.asyncio
+    async def test_empty_data_counts_as_missing(self, workspace):
+        _declare_agent(workspace, "pyat-specialist", "lattice_analysis")
+
+        with assert_raises_error(error_type="validation_error"):
+            await _fn(
+                title="AR optics",
+                content="Tunes computed from the design lattice.",
+                source_agent="pyat-specialist",
+                data={},
+            )
+        assert get_artifact_store().list_entries() == []
+
+    @pytest.mark.asyncio
+    async def test_data_from_an_agent_with_no_declaration_is_refused(self, workspace):
+        _declare_agent(workspace, "logbook-search")
+
+        with assert_raises_error(error_type="validation_error") as ctx:
+            await _fn(
+                title="Vacuum events",
+                content="Three events found.",
+                source_agent="logbook-search",
+                data={"events": 3},
+            )
+
+        assert "results_category" in ctx["envelope"]["error_message"]
+        assert get_artifact_store().list_entries() == []
+
+    @pytest.mark.asyncio
+    async def test_unregistered_declared_category_is_refused(self, workspace):
+        _declare_agent(workspace, "odd-agent", "not_a_real_category")
+
+        with assert_raises_error(error_type="validation_error") as ctx:
+            await _fn(
+                title="Something",
+                content="Some prose.",
+                source_agent="odd-agent",
+                data={"x": 1},
+            )
+
+        assert "not_a_real_category" in ctx["envelope"]["error_message"]
+        assert get_artifact_store().list_entries() == []
+
+    @pytest.mark.asyncio
+    async def test_agents_with_no_declaration_are_untouched(self, workspace):
+        """A searcher hands in prose exactly as before — no data, no refusal."""
+        _declare_agent(workspace, "logbook-search")
+
+        raw = await _fn(
+            title="Vacuum events",
+            content="Three events found.",
+            source_agent="logbook-search",
+        )
+        data = extract_response_dict(raw)
+
+        assert data["status"] == "success"
+        assert "data_artifact_id" not in data
+        assert len(get_artifact_store().list_entries()) == 1

--- a/tests/registry/test_pyat_specialist_agent.py
+++ b/tests/registry/test_pyat_specialist_agent.py
@@ -186,14 +186,33 @@ class TestPyatSpecialistAgentTemplate:
         assert "name: pyat-specialist" in rendered
 
     def test_frontmatter_tools_exact(self, template_manager):
-        """The tools: line pins exactly the five allowed tools, in order."""
+        """The tools: line pins exactly the four allowed tools, in order."""
         ctx = self._full_ctx(enabled=True)
         rendered = self._render(template_manager, ctx)
         expected = (
             "tools: mcp__python__execute, mcp__osprey_workspace__submit_response, "
-            "mcp__osprey_workspace__artifact_list, mcp__osprey_workspace__artifact_read, Read"
+            "mcp__osprey_workspace__artifact_read, Read"
         )
         assert expected in rendered
+
+    def test_frontmatter_declares_results_category(self, template_manager):
+        """The agent owes its computed quantities to lattice_analysis — declared
+        where submit_response reads it (results_category_for)."""
+        from osprey.mcp_server.agent_frontmatter import results_category_for
+
+        ctx = self._full_ctx(enabled=True)
+        rendered = self._render(template_manager, ctx)
+        assert "results_category: lattice_analysis" in rendered
+
+        # And the rendered file is what the runtime reader actually resolves.
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            agents = Path(tmp) / ".claude" / "agents"
+            agents.mkdir(parents=True)
+            (agents / "pyat-specialist.md").write_text(rendered, encoding="utf-8")
+            assert results_category_for("pyat-specialist", tmp) == "lattice_analysis"
 
     def test_frontmatter_disallowed_tools_exact(self, template_manager):
         """The disallowedTools: line pins exactly the eleven blocked tools, in order."""
@@ -263,33 +282,27 @@ class TestPyatSpecialistAgentTemplate:
         rendered = self._render(template_manager, ctx)
         assert "Flag heavy runs before launching them" in rendered
 
-    def test_body_native_type_conversion_instruction(self, template_manager):
-        """Native-type coercion before save (json.dumps default=str lossily stringifies)."""
-        ctx = self._full_ctx(enabled=True)
-        rendered = self._render(template_manager, ctx)
-        normalized = " ".join(rendered.split())
-        assert "convert every computed quantity to a NATIVE Python type" in normalized
-        assert "lossily stringifies" in rendered
+    def test_body_hands_in_data_with_the_response(self, template_manager):
+        """The numbers travel in submit_response(data=...) — one call, prose + data.
 
-    def test_body_requires_results_json_before_submit_response(self, template_manager):
-        """Successful compute must save a distinct lattice-analysis JSON before handoff."""
+        The agent is told the hand-in is refused without data, and that large
+        arrays go through save_artifact in the computing call instead of being
+        retyped — the one case the single-call contract deliberately leaves open.
+        """
         ctx = self._full_ctx(enabled=True)
         rendered = self._render(template_manager, ctx)
         normalized = " ".join(rendered.split())
 
-        assert (
-            'save_artifact( result, title="AR Optics Result", description='
-            '"Computed from the simulated ALS-U AR design lattice.", '
-            'artifact_type="json", category="lattice_analysis", )'
-        ) in normalized
-        assert "A successful computation is not complete until this artifact exists" in normalized
-        assert (
-            "The automatic notebook, the automatic `code_output` JSON, and the Markdown "
-            "from `submit_response` do **not** satisfy this requirement"
-        ) in normalized
-        assert '`artifact_list(category="lattice_analysis", last_n=1)`' in rendered
-        assert "Do **not** call `submit_response` until" in normalized
-        assert rendered.index('artifact_type="json"') < rendered.index("**Call `submit_response`**")
+        assert 'source_agent="pyat-specialist"' in rendered
+        assert "data={" in rendered
+        assert "every quantity your prose reports" in normalized
+        assert "A `submit_response` without `data` is refused" in normalized
+        assert "Hand in every computed quantity in `submit_response(data=...)`" in normalized
+        # The large-array escape hatch names the injected helper and the category.
+        assert 'category="lattice_analysis"' in rendered
+        assert "np.asarray(x).tolist()" in rendered
+        # The old self-verification step is gone — the tool does it now.
+        assert "artifact_list" not in rendered
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The pyat-specialist's computed quantities were saved by a separate step inside the computing code — a `save_artifact` call the agent had to remember after it already had its answer on screen. It skipped that step intermittently: the executor's auto-saved `code_output` JSON looked like a filed result, so the agent's own "check the category" step was satisfied, and the prose went out with no `lattice_analysis` artifact behind it. Nothing in the runtime held the contract; only the prompt did. `test_pyat_specialist_grounding` failed three times running on #682's full suite and passed first try when run alone — on both `main` and that branch.

This makes the hand-in carry the numbers. `submit_response` takes a `data` dict and files it as the JSON results artifact in the category the agent's own definition declares (`results_category:` in its frontmatter); an agent that declares one and hands in none is refused, with the fix in the error. Prose and data arrive in one call — the same shape as every other specialist's output — so there is no second step to skip. The declaration is read from the rendered `.claude/agents/*.md` the way the dispatch worker already reads tool surfaces; the parser is now shared.

Large arrays still go through `save_artifact` from inside the computing call, by reference — retyping a beta function along the ring into a tool argument is waste, not a contract.

The grounding e2e's assertions are unchanged; only its messages name the new mechanism.
