### PR TITLE
fix: log and display every MCP server, not a frozen five-server list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,34 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The session event log — and everything built on it: the agent-activity
+  view, feedback bundles, logbook context, and the agent's own `session_log`
+  tool — now records tool calls from every MCP server in the session instead
+  of a fixed five. Calls from `osprey_facility_knowledge`, `phoebus`,
+  `bluesky`, `health`, and any facility-declared custom server were silently
+  dropped, so a sub-agent's work could vanish from a feedback report while
+  the drill-down timeline still showed it.
+- Tool names from servers with underscores in their name (`osprey_workspace`,
+  `osprey_facility_knowledge`, or a facility's own) now display cleanly in
+  the web terminal. The prefix strip assumed no underscores, so the activity
+  strip showed "Mcp Osprey Workspace Submit Response" instead of
+  "Submit Response", and the facility-knowledge tools never resolved their
+  operator phrases ("browsing facility knowledge").
+- The activity view's server badges are colored again for every framework
+  server. The color map still said `workspace` after the server was renamed
+  `osprey_workspace` (so those badges rendered grey), and the facility
+  knowledge, Phoebus, Bluesky, and health servers never had a color at all.
+  A facility's own server takes the neutral badge.
+- A sub-agent that made no MCP tool calls no longer sorts to the top of the
+  event log with an empty timestamp — its start/stop now carry the dispatch
+  time of the Task that launched it.
+- A custom MCP server whose configured name contains `__` (or ends in `_`)
+  is now rejected at build time with a warning, like an `extends` clone
+  name. Tool names are `mcp__<server>__<tool>`, so such a name would make
+  the event log and the display misattribute every call the server makes.
+- Logbook composition no longer sends tool arguments to the configured LLM
+  provider — the session-activity section now carries tool names and result
+  snippets only, matching the feedback report's privacy policy.
 - Feedback sent by GitHub or Email no longer arrives without its session
   context because nobody knew about the paste step. The context travels by
   clipboard (it cannot fit a `mailto:` URL), and the dialog now says so:

--- a/src/osprey/interfaces/artifacts/logbook.py
+++ b/src/osprey/interfaces/artifacts/logbook.py
@@ -300,11 +300,12 @@ def _build_user_prompt(ctx: ComposedContext) -> str:
         for evt in ctx.audit_trail[-10:]:
             tool = evt.get("tool", evt.get("type", "?"))
             ts = evt.get("timestamp", "")[:19]
-            args = evt.get("arguments", {})
             result = evt.get("result_summary", "")
+            # Tool arguments are deliberately left out: they are the part of
+            # a session most likely to carry values the operator did not mean
+            # to publish, and this prompt leaves the deployment for an
+            # external LLM provider (same policy as the feedback composer).
             line = f"  {ts} {tool}"
-            if args:
-                line += f" args={json.dumps(args, default=str)}"
             if result:
                 line += f" → {result[:200]}"
             trail_lines.append(line)

--- a/src/osprey/interfaces/web_terminal/operator_session.py
+++ b/src/osprey/interfaces/web_terminal/operator_session.py
@@ -95,7 +95,10 @@ def build_operator_child_env(project_cwd: str | None) -> dict[str, str]:
 
 
 # Pattern for MCP tool name prefixes: mcp__<server>__<tool>
-_MCP_PREFIX_RE = re.compile(r"^mcp__[^_]+__")
+# Non-greedy so the FIRST ``__`` after the server name ends the prefix — a
+# server name may itself contain single underscores (osprey_workspace,
+# osprey_facility_knowledge, or any facility-declared server named that way).
+_MCP_PREFIX_RE = re.compile(r"^mcp__.+?__")
 
 # Bound (seconds) for draining an interrupted turn toward its terminal message
 # before the reader is hard-cancelled. Enforced inside OperatorSession.cancel().

--- a/src/osprey/interfaces/web_terminal/static/css/session.css
+++ b/src/osprey/interfaces/web_terminal/static/css/session.css
@@ -18,6 +18,10 @@
     .srv-workspace    { --srv: #60a5fa; }
     .srv-ariel        { --srv: #f472b6; }
     .srv-channel-finder { --srv: #22d3ee; }
+    .srv-facility-knowledge { --srv: #34d399; }
+    .srv-phoebus      { --srv: #fbbf24; }
+    .srv-bluesky      { --srv: #fb923c; }
+    .srv-health       { --srv: #a3e635; }
     .srv-unknown      { --srv: #64748b; }
     /* hygiene-allow-color-end */
 

--- a/src/osprey/interfaces/web_terminal/static/js/chat-render.js
+++ b/src/osprey/interfaces/web_terminal/static/js/chat-render.js
@@ -171,6 +171,11 @@ export function renderMarkdownInto(el, text) {
  * route (`_strip_for_chat`) drops a `tool_use` event's `input` before it leaves
  * the server, so no arguments reach this module.
  *
+ * The keyspace is server-agnostic by design: keys are short tool names with
+ * the `mcp__<server>__` prefix stripped, so a name owned by two servers
+ * (e.g. `capabilities` on both ariel and osprey_facility_knowledge) would
+ * share one phrase. Keep phrases generic enough to be true for every owner.
+ *
  * @type {Readonly<Record<string, string>>}
  */
 export const TOOL_PHRASES = Object.freeze({
@@ -300,13 +305,18 @@ export const TOOL_PHRASES = Object.freeze({
  * (`mcp__osprey__channel_write`) and the server-formatted `tool_name`
  * (`Channel Write`, from operator_session `_format_tool_name`) — and both fold
  * to the same key, so the table works whichever spelling an event carries.
+ * (Caveat: a tool name containing a literal `__` folds differently per
+ * spelling — no framework tool is named that way.)
  *
  * @param {string} name
  * @returns {string}
  */
 export function normaliseToolName(name) {
   return name
-    .replace(/^mcp__[^_]+__/, '')
+    // Non-greedy: the FIRST `__` after the server name ends the prefix — the
+    // server name may itself contain single underscores (osprey_workspace,
+    // osprey_facility_knowledge, or a facility-declared server named that way).
+    .replace(/^mcp__.+?__/, '')
     .trim()
     .replace(/[\s-]+/g, '_')
     .toLowerCase();

--- a/src/osprey/interfaces/web_terminal/static/js/session-helpers.js
+++ b/src/osprey/interfaces/web_terminal/static/js/session-helpers.js
@@ -13,10 +13,16 @@
 
 import { escapeHtml as esc } from '/design-system/js/dom.js';
 
-/** @type {Record<string, string>} */
+/** Keys are the server names the transcript reader emits (the segment
+ * between `mcp__` and the next `__`) — for framework servers, the registry
+ * names in registry/mcp.py. test_server_color_parity.py pins the set against
+ * the registry; a facility-declared custom server takes the neutral badge.
+ * @type {Record<string, string>} */
 const SERVER_COLORS = {
-  controls: 'srv-controls', python: 'srv-python', workspace: 'srv-workspace',
+  controls: 'srv-controls', python: 'srv-python', osprey_workspace: 'srv-workspace',
   ariel: 'srv-ariel', 'channel-finder': 'srv-channel-finder',
+  osprey_facility_knowledge: 'srv-facility-knowledge', phoebus: 'srv-phoebus',
+  bluesky: 'srv-bluesky', health: 'srv-health',
 };
 
 /**

--- a/src/osprey/mcp_server/workspace/transcript_reader.py
+++ b/src/osprey/mcp_server/workspace/transcript_reader.py
@@ -1,4 +1,4 @@
-"""Read Claude Code native transcripts to extract OSPREY tool-call and agent events.
+"""Read Claude Code native transcripts to extract MCP tool-call and agent events.
 
 No audit hook is needed for this: Claude Code already logs every tool call to
 ``<config-dir>/projects/<encoded>/`` as JSONL, and this module reads those
@@ -13,13 +13,7 @@ from osprey.agent_runner.project_paths import claude_project_dir
 
 logger = logging.getLogger("osprey.mcp_server.workspace.transcript_reader")
 
-OSPREY_MCP_PREFIXES = (
-    "mcp__controls__",
-    "mcp__python__",
-    "mcp__osprey_workspace__",
-    "mcp__ariel__",
-    "mcp__channel-finder__",
-)
+_MCP_TOOL_PREFIX = "mcp__"
 
 MAX_RESULT_LENGTH = 500
 MAX_ERROR_RESULT_LENGTH = 2000
@@ -55,22 +49,27 @@ def _extract_text(content_blocks: list) -> str:
     return "\n".join(parts) if parts else ""
 
 
-def _match_osprey_prefix(tool_name: str) -> tuple[str, str, str] | None:
-    """Match a tool name against OSPREY prefixes.
+def _split_mcp_tool_name(tool_name: str) -> tuple[str, str, str] | None:
+    """Split an MCP tool name into (short_name, server, full_name).
 
-    Returns (short_name, server, full_name) or None if no match.
+    Matches structurally on Claude Code's ``mcp__<server>__<tool>`` naming
+    rather than an enumerated server list: every MCP server in a deployed
+    session is deployment-declared (the registry and the profile render the
+    agent's ``.mcp.json``), so the prefix alone is the audit boundary and a
+    facility's custom server is captured without any OSPREY source edit. Only
+    the first ``__`` after the prefix delimits the server — a further ``__``
+    belongs to the tool name. Returns ``None`` for built-in (non-MCP) tools.
     """
-    for prefix in OSPREY_MCP_PREFIXES:
-        if tool_name.startswith(prefix):
-            short_name = tool_name[len(prefix) :]
-            parts = tool_name.split("__")
-            server = parts[1] if len(parts) >= 3 else "unknown"
-            return short_name, server, tool_name
-    return None
+    if not tool_name.startswith(_MCP_TOOL_PREFIX):
+        return None
+    server, sep, short_name = tool_name[len(_MCP_TOOL_PREFIX) :].partition("__")
+    if not sep or not server or not short_name:
+        return None
+    return short_name, server, tool_name
 
 
 class TranscriptReader:
-    """Read Claude Code native JSONL transcripts and extract OSPREY events."""
+    """Read Claude Code native JSONL transcripts and extract MCP events."""
 
     def __init__(self, project_dir: Path | str) -> None:
         self.project_dir = Path(project_dir).resolve()
@@ -104,7 +103,7 @@ class TranscriptReader:
         include_subagents: bool = True,
         agent_id: str | None = None,
     ) -> list[dict]:
-        """Read a single transcript file and extract OSPREY events.
+        """Read a single transcript file and extract MCP events.
 
         Args:
             path: Path to a ``.jsonl`` transcript file.
@@ -159,7 +158,7 @@ class TranscriptReader:
 
                     if tool_name == "Task":
                         task_uses[tool_id] = (block, timestamp)
-                    elif _match_osprey_prefix(tool_name):
+                    elif _split_mcp_tool_name(tool_name):
                         tool_uses[tool_id] = (block, timestamp, session_id)
 
             elif entry_type == "tool_result":
@@ -170,7 +169,9 @@ class TranscriptReader:
 
                 if tool_use_id in tool_uses:
                     block, ts, sid = tool_uses.pop(tool_use_id)
-                    events.append(self._make_tool_event(block, content, is_err, ts, sid, agent_id))
+                    event = self._make_tool_event(block, content, is_err, ts, sid, agent_id)
+                    if event:
+                        events.append(event)
                 elif tool_use_id in task_uses:
                     block, ts = task_uses.pop(tool_use_id)
                     if include_subagents:
@@ -190,9 +191,9 @@ class TranscriptReader:
 
                     if tool_use_id in tool_uses:
                         tu_block, ts, sid = tool_uses.pop(tool_use_id)
-                        events.append(
-                            self._make_tool_event(tu_block, content, is_err, ts, sid, agent_id)
-                        )
+                        event = self._make_tool_event(tu_block, content, is_err, ts, sid, agent_id)
+                        if event:
+                            events.append(event)
                     elif tool_use_id in task_uses:
                         tu_block, ts = task_uses.pop(tool_use_id)
                         if include_subagents:
@@ -231,15 +232,20 @@ class TranscriptReader:
                     )
 
                     sub_prompt = self._read_first_user_text(agent_file)
-                    agent_type = self._match_subagent_to_task(
+                    matched_meta = self._match_subagent_to_task(
                         agent_fname,
                         sub_events,
                         task_meta,
                         matched_task_indices,
                         subagent_prompt=sub_prompt,
                     )
-                    start_ts = sub_events[0].get("timestamp", "") if sub_events else ""
-                    stop_ts = sub_events[-1].get("timestamp", "") if sub_events else ""
+                    agent_type = matched_meta["agent_type"] if matched_meta else ""
+                    # A sub-agent that made no MCP calls has no datable events
+                    # of its own; fall back to the Task's dispatch timestamp so
+                    # its lifecycle doesn't sort (as "") before everything.
+                    fallback_ts = matched_meta["timestamp"] if matched_meta else ""
+                    start_ts = sub_events[0].get("timestamp", "") if sub_events else fallback_ts
+                    stop_ts = sub_events[-1].get("timestamp", "") if sub_events else fallback_ts
 
                     events.append(
                         {
@@ -648,8 +654,12 @@ class TranscriptReader:
         matched: set[int],
         *,
         subagent_prompt: str = "",
-    ) -> str:
+    ) -> dict | None:
         """Match a subagent transcript to a Task metadata entry.
+
+        Returns the matched ``task_meta`` entry (the caller reads its
+        ``agent_type`` and, when the subagent produced no datable events of
+        its own, its ``timestamp``), or ``None`` when nothing matches.
 
         Matching strategies (in priority order):
         1. Prompt comparison — the Task's prompt field should be the subagent's
@@ -664,14 +674,14 @@ class TranscriptReader:
                 task_prompt = meta.get("prompt", "")
                 if task_prompt and task_prompt.strip() == subagent_prompt:
                     matched.add(i)
-                    return meta["agent_type"]
+                    return meta
 
         for i, meta in enumerate(task_meta):
             if i in matched:
                 continue
             if meta.get("result_agent_id") == agent_fname:
                 matched.add(i)
-                return meta["agent_type"]
+                return meta
 
         for i, meta in enumerate(task_meta):
             if i in matched:
@@ -679,14 +689,14 @@ class TranscriptReader:
             tp = meta.get("transcript_path", "")
             if tp and agent_fname in tp:
                 matched.add(i)
-                return meta["agent_type"]
+                return meta
 
         for i, meta in enumerate(task_meta):
             if i not in matched:
                 matched.add(i)
-                return meta["agent_type"]
+                return meta
 
-        return ""
+        return None
 
     def _make_tool_event(
         self,
@@ -699,7 +709,7 @@ class TranscriptReader:
     ) -> dict:
         """Build a tool_call event dict from a tool_use + tool_result pair."""
         tool_name = tool_use_block.get("name", "")
-        match = _match_osprey_prefix(tool_name)
+        match = _split_mcp_tool_name(tool_name)
         if not match:
             return {}
 

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -782,7 +782,21 @@ def _custom_server_from_spec(name: str, spec: dict) -> ServerDefinition | None:
     value — silently defaulting a typo like ``trasnport: ssse`` to HTTP would
     ship a server that can never connect, so the spec is rejected loudly
     instead (matches the missing-command/url handling in resolve_servers).
+
+    The name is validated like an ``extends`` clone name: tool names are
+    ``mcp__<name>__<tool>``, so a ``__`` inside the name (or a trailing
+    ``_``) would make every consumer that splits on the first ``__`` — the
+    transcript reader, the display formatters — silently mis-attribute this
+    server's calls to a differently-named server.
     """
+    if not isinstance(name, str) or not _SERVER_NAME_RE.match(name) or "__" in name:
+        logger.warning(
+            "Invalid custom server name %r — must match [A-Za-z0-9][A-Za-z0-9_-]* "
+            "without '__' and not ending in '_'; skipping",
+            name,
+        )
+        return None
+
     perms = spec.get("permissions", {})
 
     transport = spec.get("transport", "http")

--- a/src/osprey/templates/claude_code/claude/skills/diagnose/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/diagnose/SKILL.md
@@ -53,7 +53,7 @@ Query the session log in this order:
    - If timing matters: `session_log(since="<timestamp>")`
 
 **If session_log returns empty results**, this IS evidence. Record it as a finding and note the possible causes:
-- No OSPREY MCP tool calls were made (only built-in tools like Read/Write/Bash were used)
+- No MCP tool calls were made (only built-in tools like Read/Write/Bash were used)
 - The transcript hasn't been written yet (session still in progress, no flush)
 - The agent used only non-MCP tools that don't appear in the session log
 - The MCP server wasn't connected or wasn't running

--- a/tests/e2e/sdk_helpers.py
+++ b/tests/e2e/sdk_helpers.py
@@ -655,7 +655,7 @@ def find_html_files(root: Path) -> list[Path]:
 
 
 def read_audit_events(repo: Path) -> list[dict]:
-    """Read OSPREY tool-call events from Claude Code native transcripts.
+    """Read MCP tool-call events from Claude Code native transcripts.
 
     Takes the REPO ROOT. Claude Code keys its transcript directory on the
     session's working directory, which is the RENDER, so that is what the reader

--- a/tests/interfaces/artifacts/test_logbook.py
+++ b/tests/interfaces/artifacts/test_logbook.py
@@ -781,8 +781,14 @@ class TestUserPromptContent:
         assert "ASSISTANT: The beam current is 500 mA." in user_msg
 
     @pytest.mark.unit
-    def test_prompt_includes_tool_arguments_and_results(self, app_client):
-        """Audit trail entries include tool arguments and result summaries."""
+    def test_prompt_excludes_tool_arguments(self, app_client):
+        """Audit trail entries carry tool names and results but NOT arguments.
+
+        Arguments are the part of a session most likely to hold values the
+        operator did not mean to publish (the feedback composer states and
+        enforces the same policy), and the composition prompt leaves the
+        deployment for an external LLM provider.
+        """
         store = app_client.app.state.artifact_store
         entry = _make_artifact(store)
 
@@ -817,8 +823,9 @@ class TestUserPromptContent:
         user_msg = self._get_user_prompt(mock_llm)
         assert "## Recent session activity" in user_msg
         assert "channel_read" in user_msg
-        assert "SR:CURRENT" in user_msg
         assert "500.0" in user_msg
+        assert "SR:CURRENT" not in user_msg
+        assert "args=" not in user_msg
 
     @pytest.mark.unit
     def test_prompt_chat_history_excluded_when_session_log_disabled(self, app_client):

--- a/tests/interfaces/web_terminal/chat-render.test.mjs
+++ b/tests/interfaces/web_terminal/chat-render.test.mjs
@@ -266,6 +266,28 @@ describe('tool vocabulary', () => {
     expect(normaliseToolName('mcp__osprey__phoebus_drive')).toBe('phoebus_drive');
   });
 
+  test('normaliseToolName strips underscored server names too', () => {
+    // Framework servers whose names contain underscores, and any
+    // facility-declared server named the same way.
+    expect(normaliseToolName('mcp__osprey_workspace__submit_response')).toBe(
+      'submit_response'
+    );
+    expect(normaliseToolName('mcp__osprey_facility_knowledge__list_concepts')).toBe(
+      'list_concepts'
+    );
+    expect(normaliseToolName('mcp__als_custom_srv__do_thing')).toBe('do_thing');
+  });
+
+  test('facility-knowledge tools resolve their operator phrase', () => {
+    // The TOOL_PHRASES "Facility knowledge" section must be reachable.
+    expect(
+      toolPhrase({
+        type: 'tool_use',
+        tool_name_raw: 'mcp__osprey_facility_knowledge__list_concepts',
+      })
+    ).toBe('browsing facility knowledge');
+  });
+
   test('the raw name maps even when the display name is unhelpful', () => {
     expect(
       activityLabel({

--- a/tests/interfaces/web_terminal/session-helpers.test.mjs
+++ b/tests/interfaces/web_terminal/session-helpers.test.mjs
@@ -1,0 +1,43 @@
+// @ts-check
+/* Session Activity Log render helpers — server badge color mapping.
+ *
+ * serverClass keys must match the server names the transcript reader emits
+ * (the segment between `mcp__` and the next `__`), which for framework
+ * servers are the registry names in src/osprey/registry/mcp.py. A Python
+ * parity test (test_server_color_parity.py) pins that full set against the
+ * registry; this file covers the mapping behavior itself.
+ */
+import { describe, expect, test } from 'vitest';
+
+import { serverClass } from '../../../src/osprey/interfaces/web_terminal/static/js/session-helpers.js';
+
+describe('serverClass', () => {
+  test('maps the underscored framework server names the reader emits', () => {
+    // `osprey_workspace` is the registry name — the pre-rename `workspace`
+    // key colored nothing once the server was renamed.
+    expect(serverClass('osprey_workspace')).toBe('srv-workspace');
+    expect(serverClass('osprey_facility_knowledge')).toBe('srv-facility-knowledge');
+  });
+
+  test('maps every framework server to a color, not the grey fallback', () => {
+    for (const name of [
+      'controls',
+      'python',
+      'osprey_workspace',
+      'ariel',
+      'channel-finder',
+      'osprey_facility_knowledge',
+      'phoebus',
+      'bluesky',
+      'health',
+    ]) {
+      expect(serverClass(name), name).not.toBe('srv-unknown');
+    }
+  });
+
+  test('a facility-declared custom server falls back to the neutral badge', () => {
+    expect(serverClass('als_custom_srv')).toBe('srv-unknown');
+    expect(serverClass(null)).toBe('srv-unknown');
+    expect(serverClass(undefined)).toBe('srv-unknown');
+  });
+});

--- a/tests/interfaces/web_terminal/test_operator_session.py
+++ b/tests/interfaces/web_terminal/test_operator_session.py
@@ -100,6 +100,19 @@ class TestFormatToolName:
     def test_multi_segment_mcp(self):
         assert _format_tool_name("mcp__ariel__entry_create") == "Entry Create"
 
+    def test_underscored_server_name(self):
+        """Framework servers with underscores in the name (osprey_workspace,
+        osprey_facility_knowledge) must strip cleanly too."""
+        assert _format_tool_name("mcp__osprey_workspace__submit_response") == "Submit Response"
+        assert (
+            _format_tool_name("mcp__osprey_facility_knowledge__resolve_channel")
+            == "Resolve Channel"
+        )
+
+    def test_underscored_facility_custom_server(self):
+        """A facility-declared server name OSPREY never saw at authoring time."""
+        assert _format_tool_name("mcp__als_custom_srv__do_thing") == "Do Thing"
+
 
 # ---------------------------------------------------------------------------
 # _message_to_events

--- a/tests/interfaces/web_terminal/test_server_color_parity.py
+++ b/tests/interfaces/web_terminal/test_server_color_parity.py
@@ -1,0 +1,69 @@
+"""Registry ↔ frontend parity: every framework MCP server has a badge color.
+
+``session-helpers.js`` keys its ``SERVER_COLORS`` map on the server names the
+transcript reader emits — for framework servers, the registry names. A server
+registered without a matching key silently renders the grey ``srv-unknown``
+badge, which is how ``osprey_facility_knowledge``, ``phoebus``, ``bluesky``
+and ``health`` were invisible on the activity view's color axis for months
+(and how the ``workspace`` → ``osprey_workspace`` rename orphaned its color).
+
+This test reads the JS source, so it fails the moment a server is added to
+the registry without a color — the same pin pattern as the reader's
+``test_captures_every_framework_server``.
+"""
+
+import re
+from pathlib import Path
+
+from osprey.registry.mcp import FRAMEWORK_SERVERS
+
+_HELPERS_JS = (
+    Path(__file__).parents[3]
+    / "src"
+    / "osprey"
+    / "interfaces"
+    / "web_terminal"
+    / "static"
+    / "js"
+    / "session-helpers.js"
+)
+
+_CSS = (
+    Path(__file__).parents[3]
+    / "src"
+    / "osprey"
+    / "interfaces"
+    / "web_terminal"
+    / "static"
+    / "css"
+    / "session.css"
+)
+
+
+def _server_colors_map() -> dict[str, str]:
+    """Parse the SERVER_COLORS object literal out of session-helpers.js."""
+    source = _HELPERS_JS.read_text()
+    match = re.search(r"const SERVER_COLORS = \{(.*?)\};", source, re.DOTALL)
+    assert match, "SERVER_COLORS map not found in session-helpers.js"
+    return dict(re.findall(r"['\"]?([\w-]+)['\"]?\s*:\s*'([\w-]+)'", match.group(1)))
+
+
+def test_every_framework_server_has_a_badge_color():
+    colors = _server_colors_map()
+    registered = {definition.name for definition in FRAMEWORK_SERVERS.values()}
+    missing = registered - colors.keys()
+    assert not missing, f"framework servers without a SERVER_COLORS entry: {sorted(missing)}"
+
+
+def test_every_badge_class_has_a_css_rule():
+    css = _CSS.read_text()
+    for server, css_class in _server_colors_map().items():
+        assert f".{css_class}" in css, f"{server}: no .{css_class} rule in session.css"
+
+
+def test_no_stale_color_keys():
+    """A key naming no registered server is dead weight — the rename trap."""
+    colors = _server_colors_map()
+    registered = {definition.name for definition in FRAMEWORK_SERVERS.values()}
+    stale = colors.keys() - registered
+    assert not stale, f"SERVER_COLORS keys naming no registered server: {sorted(stale)}"

--- a/tests/mcp_server/workspace/test_transcript_reader.py
+++ b/tests/mcp_server/workspace/test_transcript_reader.py
@@ -18,6 +18,7 @@ from osprey.mcp_server.workspace.transcript_reader import (
     TranscriptReader,
     _is_error_response,
 )
+from osprey.registry.mcp import FRAMEWORK_SERVERS
 
 
 def _ts(minute: int) -> str:
@@ -267,8 +268,8 @@ class TestReadSession:
         assert ev["arguments"] == {"channels": ["SR:CURRENT"]}
         assert "500.0" in ev["result_summary"]
 
-    def test_filters_non_osprey_tools(self, tmp_path):
-        """Non-OSPREY tools (e.g., Read, Bash) are not included."""
+    def test_filters_non_mcp_tools(self, tmp_path):
+        """Built-in (non-MCP) tools (e.g., Read, Bash) are not included."""
         transcript = tmp_path / "session.jsonl"
         entries = [
             _make_assistant_entry(
@@ -309,6 +310,175 @@ class TestReadSession:
 
         assert len(events) == 1
         assert events[0]["tool"] == "session_log"
+
+    @pytest.mark.parametrize("server_name", sorted(s.name for s in FRAMEWORK_SERVERS.values()))
+    def test_captures_every_framework_server(self, tmp_path, server_name):
+        """A tool call from ANY registered framework server appears in the log.
+
+        Pin test against silent observability loss: the reader must never
+        require a source edit to see a server the registry already knows.
+        """
+        transcript = tmp_path / "session.jsonl"
+        tool_name = f"mcp__{server_name}__some_tool"
+        entries = [
+            _make_assistant_entry(_ts(0), [{"id": "tu-1", "name": tool_name, "input": {}}]),
+            _make_user_entry(_ts(1), [{"tool_use_id": "tu-1", "content": "ok", "is_error": False}]),
+        ]
+        _write_transcript(transcript, entries)
+
+        events = TranscriptReader(tmp_path).read_session(transcript)
+
+        assert len(events) == 1, f"tool call from server {server_name!r} was dropped"
+        assert events[0]["tool"] == "some_tool"
+        assert events[0]["server"] == server_name
+
+    def test_captures_facility_custom_server(self, tmp_path):
+        """A facility-declared server with an underscored name OSPREY has never
+        heard of is captured — no source edit may be required."""
+        transcript = tmp_path / "session.jsonl"
+        entries = [
+            _make_assistant_entry(
+                _ts(0),
+                [
+                    {
+                        "id": "tu-1",
+                        "name": "mcp__als_custom_srv__do_thing",
+                        "input": {"x": 1},
+                    }
+                ],
+            ),
+            _make_user_entry(_ts(1), [{"tool_use_id": "tu-1", "content": "ok", "is_error": False}]),
+        ]
+        _write_transcript(transcript, entries)
+
+        events = TranscriptReader(tmp_path).read_session(transcript)
+
+        assert len(events) == 1
+        assert events[0]["tool"] == "do_thing"
+        assert events[0]["server"] == "als_custom_srv"
+        assert events[0]["full_tool_name"] == "mcp__als_custom_srv__do_thing"
+
+    def test_subagent_facility_knowledge_calls_survive(self, tmp_path):
+        """The reported bug: a facility-knowledge sub-agent's tool calls must
+        appear between its agent_start/agent_stop, not vanish."""
+        transcript = tmp_path / "parent.jsonl"
+        entries = [
+            _make_assistant_entry(
+                _ts(0),
+                [
+                    {
+                        "id": "task-1",
+                        "name": "Task",
+                        "input": {
+                            "subagent_type": "facility-knowledge",
+                            "prompt": "Look up DIPOLE01",
+                        },
+                    }
+                ],
+            ),
+            _make_user_entry(
+                _ts(5), [{"tool_use_id": "task-1", "content": "done", "is_error": False}]
+            ),
+        ]
+        _write_transcript(transcript, entries)
+
+        subagent_dir = tmp_path / "parent" / "subagents"
+        subagent_dir.mkdir(parents=True)
+        sub_entries = [
+            {
+                "type": "user",
+                "timestamp": _ts(1),
+                "sessionId": "test-session-123",
+                "message": {"role": "user", "content": "Look up DIPOLE01"},
+            },
+            _make_assistant_entry(
+                _ts(2),
+                [
+                    {
+                        "id": "fk-1",
+                        "name": "mcp__osprey_facility_knowledge__resolve_channel",
+                        "input": {"q": "DIPOLE01"},
+                    }
+                ],
+            ),
+            _make_user_entry(_ts(3), [{"tool_use_id": "fk-1", "content": "{}", "is_error": False}]),
+        ]
+        _write_transcript(subagent_dir / "agent-abc123.jsonl", sub_entries)
+
+        events = TranscriptReader(tmp_path).read_session(transcript)
+
+        tool_events = [e for e in events if e["type"] == "tool_call"]
+        assert len(tool_events) == 1
+        assert tool_events[0]["tool"] == "resolve_channel"
+        assert tool_events[0]["agent_id"] == "agent-abc123"
+        # The sub-agent's own tool events supply the lifecycle timestamps
+        # (a sub-agent with no MCP calls falls back to the Task's timestamp —
+        # see test_subagent_without_mcp_calls_gets_task_timestamp).
+        starts = [e for e in events if e["type"] == "agent_start"]
+        assert starts and starts[0]["timestamp"] == _ts(2)
+
+    def test_subagent_without_mcp_calls_gets_task_timestamp(self, tmp_path):
+        """A sub-agent that used only built-in tools still gets real lifecycle
+        timestamps — the Task dispatch time, not ``""`` (which sorts the
+        agent's lifecycle before the parent's first action)."""
+        transcript = tmp_path / "parent.jsonl"
+        entries = [
+            _make_assistant_entry(
+                _ts(4),
+                [
+                    {
+                        "id": "task-1",
+                        "name": "Task",
+                        "input": {"subagent_type": "grepper", "prompt": "Search the docs"},
+                    }
+                ],
+            ),
+            _make_user_entry(
+                _ts(6), [{"tool_use_id": "task-1", "content": "done", "is_error": False}]
+            ),
+        ]
+        _write_transcript(transcript, entries)
+
+        subagent_dir = tmp_path / "parent" / "subagents"
+        subagent_dir.mkdir(parents=True)
+        sub_entries = [
+            {
+                "type": "user",
+                "timestamp": _ts(5),
+                "sessionId": "test-session-123",
+                "message": {"role": "user", "content": "Search the docs"},
+            },
+            _make_assistant_entry(
+                _ts(5), [{"id": "g-1", "name": "Grep", "input": {"pattern": "x"}}]
+            ),
+        ]
+        _write_transcript(subagent_dir / "agent-grep1.jsonl", sub_entries)
+
+        events = TranscriptReader(tmp_path).read_session(transcript)
+
+        lifecycle = [e for e in events if e["type"] in ("agent_start", "agent_stop")]
+        assert len(lifecycle) == 2
+        assert all(e["timestamp"] == _ts(4) for e in lifecycle)
+        assert all(e["agent_type"] == "grepper" for e in lifecycle)
+
+    def test_tool_name_with_double_underscore_keeps_full_tool(self, tmp_path):
+        """Only the first ``__``-pair after ``mcp__`` delimits the server; a
+        ``__`` inside the tool name belongs to the tool."""
+        transcript = tmp_path / "session.jsonl"
+        entries = [
+            _make_assistant_entry(
+                _ts(0),
+                [{"id": "tu-1", "name": "mcp__srv__group__action", "input": {}}],
+            ),
+            _make_user_entry(_ts(1), [{"tool_use_id": "tu-1", "content": "ok", "is_error": False}]),
+        ]
+        _write_transcript(transcript, entries)
+
+        events = TranscriptReader(tmp_path).read_session(transcript)
+
+        assert len(events) == 1
+        assert events[0]["server"] == "srv"
+        assert events[0]["tool"] == "group__action"
 
     def test_error_detection_native(self, tmp_path):
         """Detects is_error from native tool_result flag."""

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -139,6 +139,30 @@ class TestResolveServers:
         assert not [s for s in servers if s["name"] == "typo-api"]
         assert "invalid transport" in caplog.text
 
+    def test_resolve_custom_server_double_underscore_name_rejected(self, caplog):
+        """A ``__`` in a custom server name is rejected loudly, like extends clones.
+
+        Tool names are ``mcp__<server>__<tool>``, so a server named
+        ``my__server`` would make every consumer that splits on the first
+        ``__`` (transcript reader, display formatting) silently mis-attribute
+        its calls to a server named ``my``.
+        """
+        ctx = _base_ctx()
+        cfg = {"servers": {"my__server": {"command": "node", "args": ["s.js"]}}}
+        with caplog.at_level("WARNING"):
+            servers = resolve_servers(cfg, ctx)
+        assert not [s for s in servers if s["name"] == "my__server"]
+        assert "my__server" in caplog.text
+
+    def test_resolve_custom_server_trailing_underscore_rejected(self, caplog):
+        """A trailing ``_`` makes ``mcp__<server>__`` ambiguous — rejected."""
+        ctx = _base_ctx()
+        cfg = {"servers": {"srv_": {"command": "node", "args": ["s.js"]}}}
+        with caplog.at_level("WARNING"):
+            servers = resolve_servers(cfg, ctx)
+        assert not [s for s in servers if s["name"] == "srv_"]
+        assert "srv_" in caplog.text
+
     def test_resolve_custom_server_transport_on_stdio_ignored(self, caplog):
         """A command server declaring transport keeps working; the key is ignored loudly."""
         ctx = _base_ctx()


### PR DESCRIPTION
The transcript reader matched tool calls against an allowlist of five server
prefixes, frozen when it was written. Calls from `osprey_facility_knowledge`,
`phoebus`, `bluesky`, `health`, and any facility-declared custom server were
dropped, so a sub-agent's work could vanish from a feedback report while the
drill-down timeline still showed it.

The display path had the mirror bug. Both formatters stripped the prefix with
`^mcp__[^_]+__`, which stops at the first underscore inside the server name.
`osprey_workspace` tools rendered as "Mcp Osprey Workspace Submit Response",
facility-knowledge tools never resolved their operator phrases, and the badge
color map still keyed on `workspace` after the server was renamed.

Tool names are `mcp__<server>__<tool>`, so the split is structural: the first
`__` after the prefix ends the server name. The reader and both formatters now
split that way, and a custom server name containing `__` (or ending in `_`) is
rejected at build time, since such a name would make the split misattribute
every call that server makes.

Two adjacent fixes ride along. A sub-agent that made no MCP calls now carries
the dispatch time of the Task that launched it, instead of sorting to the top
of the event log with an empty timestamp. Logbook composition no longer sends
tool arguments to the configured LLM provider, matching the feedback
composer's policy for provider-bound text.

## How it hangs together

```text
  mcp__<server>__<tool>
      └───┬───┘  the FIRST "__" after the prefix ends the server name
          │      (was: [^_]+ — stopped at the first "_" inside the name)
          │
  Claude Code       ┌──────────────────────┐        ┌─ agent-activity view
  transcript ──────►│ transcript_reader.py │──────► │─ feedback bundles
  (JSONL)           │  structural split,   │ event  │─ logbook context
                    │  no server allowlist │  log   └─ session_log tool
                    └──────────────────────┘

  display path — same split, three consumers of the short name
    operator_session.py  ─► tool name in the activity strip
    chat-render.js       ─► operator phrase ("browsing facility knowledge")
    session-helpers.js   ─► server badge color (registry-pinned)

  registry/mcp.py ─► rejects a custom server name carrying "__" at build time,
                     so no facility name can defeat the split
```
