### PR TITLE
fix(artifacts): follow the active theme on served artifact pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,6 +799,8 @@ jobs:
           theming:
             - 'src/osprey/interfaces/**'
             - 'src/osprey/dispatch/**'
+            - 'tests/interfaces/artifacts/test_gallery_interactions.py'
+            - 'tests/interfaces/artifacts/test_plot_theme_browser.py'
             - 'tests/interfaces/design_system/**'
             - 'tests/interfaces/web_terminal/**'
             - 'tests/interfaces/bluesky_web/**'
@@ -840,6 +842,8 @@ jobs:
         uv run pytest tests/interfaces/design_system/test_behavioral.py \
           tests/interfaces/design_system/test_theme_lab.py \
           tests/interfaces/design_system/test_dispatch_dashboard_unauthorized.py \
+          tests/interfaces/artifacts/test_gallery_interactions.py \
+          tests/interfaces/artifacts/test_plot_theme_browser.py \
           tests/interfaces/web_terminal/test_panels_browser.py \
           tests/interfaces/web_terminal/test_panels_collab_browser.py \
           tests/interfaces/web_terminal/test_agent_activity_browser.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- Interactive plot artifacts now follow the active theme everywhere: opened in
+  their own tab ("Open in new tab"), on first visit with a deployment-pinned
+  `web.theme`, and under every theme family — not just light/dark inside the
+  gallery. Previously a standalone plot page always rendered dark, and any
+  theme outside the main family fell back to the dark palette. HTML and table
+  artifacts without styling of their own now take the theme's colors too, and
+  the print view is always light.
+
 - The graph channel finder no longer mistakes its own row limit for the whole
   answer: `read_cypher` now warns when a result exactly fills the query's own
   `LIMIT`, the example catalogue gained a census query (count before listing

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -721,13 +721,15 @@ keys:
   # ── Web UI / CLI ────────────────────────────────────────────────────
   web: {evidence: 'config\.get\("web", \{\}\)'}
   web.theme:
-    evidence: 'get_config_value\("web\.theme", "main"\)'
+    evidence: 'get_config_value\("web\.theme", DEFAULT_WEB_THEME\)'
     note: >-
       Live in project only; commented in control_assistant; absent from the
       three others. The default is "main" whether the key is live or absent,
       so no behaviour depends on the form. Deliberately per-template.
-      The shipped default family was renamed from "osprey" to "main"; the
-      evidence tracks the default in app.py, so it moves with that rename.
+      Read in one place — theme_config.configured_web_theme(), the shared
+      resolver the web terminal and the artifact gallery both call — where
+      the shipped default family lives as the DEFAULT_WEB_THEME constant
+      the evidence cites, so it survives a future rename of the family.
   web.panels: {evidence: 'web\.panels'}
   web.panels.ariel: {covered-by: web.panels}
   web.panels.ariel.enabled: {covered-by: web.panels.ariel}

--- a/src/osprey/interfaces/artifacts/app.py
+++ b/src/osprey/interfaces/artifacts/app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import threading
 from collections.abc import AsyncIterator, Collection
@@ -28,151 +29,118 @@ from osprey.utils.timeseries import (
     extract_channel_series,
 )
 
+logger = logging.getLogger(__name__)
+
 STATIC_DIR = Path(__file__).parent / "static"
 
 templates = Jinja2Templates(directory=str(STATIC_DIR))
 templates.env.globals["vendor_url"] = vendor_url
 
-# Snippet injected into Plotly/table/generic HTML artifacts so they fill the
-# iframe viewport in Focus Mode.  CSS alone is not enough for Plotly because
-# Plotly.newPlot() applies layout.width/height via JS *after* load, overriding
-# CSS.  We therefore inject a script that deletes those fixed dimensions and
-# calls Plotly.Plots.resize() once the library is ready.
-_RESPONSIVE_PLOTLY = r"""<style>
-/* OSPREY: fill iframe viewport */
-html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; }
+# Head of every injected snippet: it makes the served artifact a design-system
+# page like any other.  theme-boot.js resolves `data-theme` pre-paint (?theme=
+# from the gallery, then the operator's stored preference, then the
+# server-rendered `web.theme` pin, then the OS) and tokens.css supplies that
+# theme's colors.  Each snippet's own module script then takes the follower
+# role, so the page also follows what the hub broadcasts while it is embedded
+# as a preview iframe.
+_DESIGN_SYSTEM_HEAD = """<script src="/design-system/js/theme-boot.js"></script>
+<link rel="stylesheet" href="/design-system/css/tokens.css">"""
+
+# Snippet injected into Plotly artifacts so they fill the iframe viewport in
+# Focus Mode and follow the OSPREY theme.  CSS alone is not enough for the
+# sizing: Plotly.newPlot() applies layout.width/height via JS *after* load,
+# overriding CSS, so the script below deletes those fixed dimensions and calls
+# Plotly.Plots.resize() once the library is ready.  Every color comes from the
+# --chart-* tokens via chartRelayout(), so all eight themes work and nothing
+# here needs to know what "light" or "dark" looks like.
+_RESPONSIVE_PLOTLY = (
+    _DESIGN_SYSTEM_HEAD
+    + r"""
+<style>
+/* OSPREY: fill iframe viewport; page background from the theme in force,
+   painted before any chart -- the chart itself stays hidden until it has been
+   re-themed (anti-flash: Plotly first draws the author's baked-in colors). */
+html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden;
+             background: var(--chart-paper-bg) !important; }
 .plotly-graph-div { width: 100% !important; height: 100vh !important; }
 .js-plotly-plot { width: 100% !important; height: 100vh !important; visibility: hidden; }
 table { max-width: 100%; }
 </style>
-<script>
-/* OSPREY: responsive sizing + theme-aware backgrounds
- *
- * Anti-flash strategy: Plotly renders with its original colors before we can
- * re-theme it.  We hide charts via CSS (visibility:hidden) and only reveal
- * them after Plotly.relayout() applies the correct theme.  The page background
- * is set immediately from a <style> injected before any body content paints.
- */
-(function(){
-  var THEMES = {
-    dark: {
-      paper_bgcolor: '#131c2e', plot_bgcolor: '#0b1120',
-      font: { color: '#8b9ab5' },
-      xaxis: { gridcolor: 'rgba(100,116,139,0.1)', linecolor: 'rgba(100,116,139,0.18)' },
-      yaxis: { gridcolor: 'rgba(100,116,139,0.1)', linecolor: 'rgba(100,116,139,0.18)' },
-      legend: { bgcolor: 'rgba(19,28,46,0.85)', bordercolor: 'rgba(100,116,139,0.18)' },
-      scene: { bgcolor: '#0b1120', axis_bg: '#131c2e',
-               gridcolor: 'rgba(100,116,139,0.15)', spikecolor: 'rgba(100,116,139,0.4)' }
-    },
-    light: {
-      paper_bgcolor: '#f7f9fc', plot_bgcolor: '#f7f9fc',
-      font: { color: '#0c1322' },
-      xaxis: { gridcolor: 'rgba(0,0,0,0.08)', linecolor: 'rgba(0,0,0,0.12)' },
-      yaxis: { gridcolor: 'rgba(0,0,0,0.08)', linecolor: 'rgba(0,0,0,0.12)' },
-      legend: { bgcolor: 'rgba(247,249,252,0.9)', bordercolor: 'rgba(0,0,0,0.1)' },
-      scene: { bgcolor: '#f7f9fc', axis_bg: '#eef2f7',
-               gridcolor: 'rgba(0,0,0,0.1)', spikecolor: 'rgba(0,0,0,0.2)' }
-    }
-  };
+<script type="module">
+/* OSPREY: responsive sizing + live re-theming from the design tokens. */
+import { initTheme, subscribe, chartRelayout } from '/design-system/js/theme-manager.js';
 
-  function detectTheme() {
-    try { return window.parent.document.documentElement.getAttribute('data-theme') || 'dark'; }
-    catch(e) { return 'dark'; }
-  }
+function plots() { return Array.from(document.querySelectorAll('.js-plotly-plot')); }
+function reveal(gd) { gd.style.visibility = 'visible'; }
 
-  /* Set page background immediately (runs in <head>, before body paints) */
-  var _bgTheme = THEMES[detectTheme()] || THEMES.dark;
-  var _bgStyle = document.createElement('style');
-  _bgStyle.textContent = 'html, body { background: ' + _bgTheme.paper_bgcolor + ' !important; }';
-  document.head.appendChild(_bgStyle);
-
-  function revealCharts() {
-    document.querySelectorAll('.js-plotly-plot').forEach(function(gd) {
-      gd.style.visibility = 'visible';
-    });
-  }
-
-  function applyTheme(theme) {
-    var t = THEMES[theme] || THEMES.dark;
-    _bgStyle.textContent = 'html, body { background: ' + t.paper_bgcolor + ' !important; }';
-    if (document.body) document.body.style.background = t.paper_bgcolor;
-    if (typeof Plotly === 'undefined') { revealCharts(); return; }
-    var plots = document.querySelectorAll('.js-plotly-plot');
-    if (!plots.length) { return; }
-    var pending = plots.length;
-    plots.forEach(function(gd) {
-      var update = {
-        paper_bgcolor: t.paper_bgcolor, plot_bgcolor: t.plot_bgcolor,
-        'font.color': t.font.color,
-        'xaxis.gridcolor': t.xaxis.gridcolor, 'xaxis.linecolor': t.xaxis.linecolor,
-        'yaxis.gridcolor': t.yaxis.gridcolor, 'yaxis.linecolor': t.yaxis.linecolor,
-        'legend.bgcolor': t.legend.bgcolor, 'legend.bordercolor': t.legend.bordercolor
-      };
-      /* 3D scenes: theme the box, axis planes, grids, and spike lines */
-      if (gd.layout) {
-        Object.keys(gd.layout).forEach(function(key) {
-          if (key === 'scene' || /^scene\d+$/.test(key)) {
-            var s = t.scene, p = key + '.';
-            update[p + 'bgcolor'] = s.bgcolor;
-            ['xaxis','yaxis','zaxis'].forEach(function(ax) {
-              update[p + ax + '.backgroundcolor'] = s.axis_bg;
-              update[p + ax + '.gridcolor'] = s.gridcolor;
-              update[p + ax + '.color'] = t.font.color;
-              update[p + ax + '.spikecolor'] = s.spikecolor;
-            });
-          }
-        });
-      }
-      try {
-        Plotly.relayout(gd, update).then(function() {
-          gd.style.visibility = 'visible';
-        }).catch(function() {
-          gd.style.visibility = 'visible';
-        });
-      } catch(e) {
-        gd.style.visibility = 'visible';
-      }
-    });
-  }
-
-  function resizeAll() {
-    document.querySelectorAll('.js-plotly-plot').forEach(function(gd) {
-      if (gd.layout) { delete gd.layout.width; delete gd.layout.height; }
-      if (typeof Plotly !== 'undefined') { Plotly.Plots.resize(gd); }
-    });
-  }
-
-  function initAll() {
-    resizeAll();
-    applyTheme(detectTheme());
-    /* Safety net: if relayout somehow fails to reveal, force-show after 400ms */
-    setTimeout(revealCharts, 400);
-  }
-
-  if (document.readyState === 'complete') { initAll(); }
-  else { window.addEventListener('load', initAll); }
-  window.addEventListener('resize', resizeAll);
-  window.addEventListener('message', function(e) {
-    if (e.data && e.data.type === 'osprey-theme-change' && e.data.theme) {
-      applyTheme(e.data.theme);
+function applyTheme() {
+  if (typeof Plotly === 'undefined') { plots().forEach(reveal); return; }
+  plots().forEach((gd) => {
+    try {
+      Plotly.relayout(gd, chartRelayout(gd)).then(() => reveal(gd), () => reveal(gd));
+    } catch {
+      reveal(gd);
     }
   });
-  // Also observe parent document's data-theme attribute directly (bypasses
-  // postMessage chain which can be unreliable across nested iframes)
-  try {
-    var parentRoot = window.parent.document.documentElement;
-    new MutationObserver(function() {
-      applyTheme(parentRoot.getAttribute('data-theme') || 'dark');
-    }).observe(parentRoot, { attributes: true, attributeFilter: ['data-theme'] });
-  } catch(e) {}
-})();
-</script>"""
+}
 
-_RESPONSIVE_TABLE_HTML = """<style>
+function resizeAll() {
+  plots().forEach((gd) => {
+    if (gd.layout) { delete gd.layout.width; delete gd.layout.height; }
+    if (typeof Plotly !== 'undefined') { Plotly.Plots.resize(gd); }
+  });
+}
+
+let loaded = false;
+function initAll() {
+  loaded = true;
+  resizeAll();
+  applyTheme();
+  /* Safety net: if relayout somehow fails to reveal, force-show after 400ms */
+  setTimeout(() => plots().forEach(reveal), 400);
+}
+
+initTheme({ role: 'follower' });
+// Re-theme in place on every later apply (a hub broadcast, or the gallery's
+// re-send when a hidden iframe becomes visible). Before `load` there are no
+// charts to theme, and revealing them then would flash the author's own
+// colors -- so initAll() owns the first apply.
+subscribe(() => { if (loaded) applyTheme(); });
+
+if (document.readyState === 'complete') { initAll(); }
+else { window.addEventListener('load', initAll); }
+window.addEventListener('resize', resizeAll);
+</script>"""
+)
+
+# Injected into table_html, agent-authored html, and dashboard_html artifacts.
+# Beyond viewport sizing it paints THEMED DEFAULTS at zero specificity via
+# :where() -- a page that styles itself (an agent-authored report with its own
+# palette) beats every one of these rules regardless of rule order, while an
+# unstyled fragment (a pandas table, a bare snippet) stops rendering as a
+# black-on-white browser-default island inside a themed gallery.
+# ``.artifact-table`` is the class serialize_object() puts on DataFrame tables.
+_RESPONSIVE_TABLE_HTML = (
+    _DESIGN_SYSTEM_HEAD
+    + """
+<style>
 /* OSPREY: fill iframe viewport */
 html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: auto; }
 table { max-width: 100%; }
-</style>"""
+/* OSPREY: themed defaults -- zero specificity, author styles always win */
+:where(html) { background: var(--bg-primary); }
+:where(body) { color: var(--text-primary); }
+:where(table.artifact-table) { border-collapse: collapse; }
+:where(.artifact-table th, .artifact-table td) {
+  border: 1px solid var(--border-default); padding: 4px 8px;
+}
+:where(.artifact-table th) { background: var(--bg-secondary); }
+</style>
+<script type="module">
+import { initTheme } from '/design-system/js/theme-manager.js';
+initTheme({ role: 'follower' });
+</script>"""
+)
 
 # JupyterLab-style nbconvert uses <body class="jp-Notebook"> and .jp-Cell,
 # NOT the classic #notebook-container.
@@ -195,7 +163,9 @@ _RESPONSIVE_SNIPPETS = {
     "plot_html": _RESPONSIVE_PLOTLY,
     "table_html": _RESPONSIVE_TABLE_HTML,
     "html": _RESPONSIVE_TABLE_HTML,
-    "dashboard_html": _RESPONSIVE_TABLE_HTML,  # Bokeh handles its own JS sizing
+    # Bokeh handles its own JS sizing, and bakes its plot colors into its own
+    # model -- the page around it follows the theme, the plot itself does not.
+    "dashboard_html": _RESPONSIVE_TABLE_HTML,
 }
 
 # Standalone HTML page for server-side rendered markdown.
@@ -331,6 +301,61 @@ def _rewrite_plotly_cdn(html_bytes: bytes) -> bytes:
     html = _CDN_PLOTLY_RE.sub(r"\1/static/js/vendor/plotly-3.3.1.min.js\2", html)
     html = _SRI_ATTR_RE.sub("", html)
     return html.encode("utf-8")
+
+
+#: The opening ``<html`` tag, provided it carries no ``data-theme`` of its own.
+_HTML_TAG_WITHOUT_THEME_RE = re.compile(r"<html(?![^>]*\bdata-theme=)", re.IGNORECASE)
+
+
+def _stamp_data_theme(html: str, theme_id: str | None) -> str:
+    """Server-render a pinned theme as ``<html data-theme="...">``.
+
+    The same server rung the web terminal renders for its own page: a page
+    served standalone (an artifact opened in its own tab, a rendered markdown
+    or notebook page) has no hub to follow, and on a first visit -- nothing in
+    ``localStorage``, no ``?theme=`` -- ``theme-boot.js`` would otherwise fall
+    through to the OS preference and ignore a deployment's pin.
+
+    ``theme_id`` is ``None`` when nothing is pinned, and the page is then left
+    untouched. A page that already carries ``data-theme`` keeps it; a fragment
+    with no ``<html`` tag is returned unchanged.
+    """
+    if not theme_id:
+        return html
+    return _HTML_TAG_WITHOUT_THEME_RE.sub(f'<html data-theme="{theme_id}"', html, count=1)
+
+
+def _resolve_pinned_web_theme() -> str | None:
+    """The concrete theme id ``web.theme`` pins, or ``None`` if it names a family.
+
+    Resolved through the design system's shared chain, so the gallery and the
+    web terminal cannot disagree about what a configured value means.
+
+    Only a *pin* is stamped. A served artifact page is a follower: it takes a
+    server-rendered ``data-theme`` verbatim and has no mode of its own to
+    re-resolve, so stamping a family-only value -- which resolves to that
+    family's dark id -- would hand a light-OS viewer a dark page, the opposite
+    of what an unpinned terminal does with the same config.
+
+    Fails open: an unreadable config or registry must never block the gallery
+    from starting, and costs only the pin.
+    """
+    try:
+        from osprey.interfaces.design_system.theme_config import resolve_configured_web_theme
+
+        resolved = resolve_configured_web_theme()
+    except FileNotFoundError:
+        # No config primed (standalone gallery, tests) — not a fault.
+        logger.debug("No config available for web.theme; served pages are unpinned")
+        return None
+    except Exception:  # noqa: BLE001 - config/registry trouble must not block startup
+        logger.warning(
+            "Could not resolve web.theme for served artifact pages; "
+            "they will follow the viewer's own preference",
+            exc_info=True,
+        )
+        return None
+    return resolved.id if resolved.pinned_mode else None
 
 
 def _inject_html_snippet(html_bytes: bytes, snippet: str) -> bytes:
@@ -555,6 +580,11 @@ def create_app(workspace_root: Path | None = None) -> FastAPI:
     except Exception:
         pass  # Config may not be available in all contexts
 
+    # Resolved once, after config priming, and stamped onto every served HTML
+    # page (see _stamp_data_theme) so a pinned ``web.theme`` reaches a page
+    # opened outside the hub.
+    web_theme_pin = _resolve_pinned_web_theme()
+
     broadcaster = _SSEBroadcaster()
 
     index_watcher = StoreIndexWatcher(
@@ -625,7 +655,10 @@ def create_app(workspace_root: Path | None = None) -> FastAPI:
 
     @app.get("/")
     async def root(request: Request):
-        return templates.TemplateResponse(request, "index.html", {})
+        # A pinned web.theme reaches the gallery shell too. Embedded, the hub's
+        # ?theme= outranks it in theme-boot.js's ladder, so this only shows up
+        # on a first standalone visit.
+        return templates.TemplateResponse(request, "index.html", {"web_theme_pin": web_theme_pin})
 
     @app.get("/health")
     async def health():
@@ -869,8 +902,9 @@ def create_app(workspace_root: Path | None = None) -> FastAPI:
                 plotly_src = vendor_url("Plotly.js", "/static/js/vendor/plotly-3.3.1.min.js")
                 snippet = f'<script src="{plotly_src}"></script>\n' + snippet
         content = _inject_html_snippet(content, snippet)
+        page = _stamp_data_theme(content.decode("utf-8", errors="replace"), web_theme_pin)
         return Response(
-            content=content,
+            content=page.encode("utf-8"),
             media_type=entry.mime_type,
             headers={"Content-Disposition": f'inline; filename="{entry.filename}"'},
         )
@@ -904,7 +938,9 @@ def create_app(workspace_root: Path | None = None) -> FastAPI:
             cache_dir = store.artifact_dir / "_notebook_cache"
             html, _ = get_or_render_html(filepath, cache_dir=cache_dir)
             html_bytes = _inject_html_snippet(html.encode("utf-8"), _NOTEBOOK_RESPONSIVE_CSS)
-            return HTMLResponse(content=html_bytes.decode("utf-8"))
+            return HTMLResponse(
+                content=_stamp_data_theme(html_bytes.decode("utf-8"), web_theme_pin)
+            )
         except Exception as exc:
             raise HTTPException(
                 status_code=500, detail=f"Notebook rendering failed: {exc}"
@@ -925,7 +961,7 @@ def create_app(workspace_root: Path | None = None) -> FastAPI:
 
         md_source = filepath.read_text(encoding="utf-8", errors="replace")
         html = _build_markdown_page(md_source, entry.title or entry.filename or "Markdown")
-        return HTMLResponse(content=html)
+        return HTMLResponse(content=_stamp_data_theme(html, web_theme_pin))
 
     # Logbook entry composer
     from osprey.interfaces.artifacts.logbook import logbook_router

--- a/src/osprey/interfaces/artifacts/static/index.html
+++ b/src/osprey/interfaces/artifacts/static/index.html
@@ -2,7 +2,7 @@
 <!-- data-browse-orient: axis of the browse split (row = browser left /
      artifact right, column = stacked band). "row" is the shipped default;
      browse-layout.js re-applies a persisted "column" choice at module load. -->
-<html lang="en" data-browse-orient="row">
+<html lang="en" data-browse-orient="row"{% if web_theme_pin %} data-theme="{{ web_theme_pin }}"{% endif %}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/osprey/interfaces/artifacts/static/js/artifact-viewport.js
+++ b/src/osprey/interfaces/artifacts/static/js/artifact-viewport.js
@@ -44,9 +44,24 @@
  * @module artifact-viewport
  */
 
+import { getTheme } from "/design-system/js/theme-manager.js";
 import { fileUrl } from "./state.js";
-import { escapeHtml, hasTimeseriesData } from "./types.js";
+import { escapeHtml, hasTimeseriesData, withTheme } from "./types.js";
 import { renderMarkdownView, renderJsonView } from "./preview-content.js";
+
+/**
+ * The src for an embedded artifact page: the URL stamped with the theme the
+ * gallery is showing right now, so the page first-paints in it (its own
+ * theme-boot.js honors `?theme=` first). Without this a freshly mounted
+ * preview resolves a theme of its own -- from storage this follower never
+ * writes, or the OS -- and can boot dark inside a light gallery until the
+ * next theme change reaches it.
+ * @param {string} url
+ * @returns {string}
+ */
+function embedSrc(url) {
+  return withTheme(url, getTheme());
+}
 
 /**
  * Build the viewport markup for one artifact.
@@ -74,9 +89,9 @@ export function artifactViewportHtml(a) {
     case "table_html":
     case "dashboard_html":
     case "html":
-      return `<iframe src="${fileUrl(a)}" class="preview-iframe-light" sandbox="allow-scripts allow-same-origin"></iframe>`;
+      return `<iframe src="${embedSrc(fileUrl(a))}" class="preview-iframe-light" sandbox="allow-scripts allow-same-origin"></iframe>`;
     case "notebook":
-      return `<iframe src="/api/notebooks/${encodeURIComponent(a.id)}/rendered" class="preview-iframe-light" sandbox="allow-scripts allow-same-origin"></iframe>`;
+      return `<iframe src="${embedSrc(`/api/notebooks/${encodeURIComponent(a.id)}/rendered`)}" class="preview-iframe-light" sandbox="allow-scripts allow-same-origin"></iframe>`;
     case "plot_png":
     case "image":
       return `<img src="${fileUrl(a)}" alt="${escapeHtml(a.title)}" />`;

--- a/src/osprey/interfaces/artifacts/static/js/gallery.js
+++ b/src/osprey/interfaces/artifacts/static/js/gallery.js
@@ -5,7 +5,7 @@
  * Single gallery for all artifacts with type filtering, pin flag,
  * and inline timeseries rendering.
  */
-import { initTheme, subscribe } from "/design-system/js/theme-manager.js";
+import { getTheme, initTheme, subscribe } from "/design-system/js/theme-manager.js";
 import { onModeChange } from "/design-system/js/frame-params.js";
 import { applyEmbedded } from "/design-system/js/frame-params.js";
 import { contributeHeader, isSimpleMode, onHeaderAction } from "/design-system/js/header-contrib.js";
@@ -254,7 +254,10 @@ function renderSimple() {
     simpleResult?.classList.remove("hidden");
     if (simpleResultTitle) simpleResultTitle.textContent = latest.title;
     if (simpleResultBadge) simpleResultBadge.hidden = !isNewThisSession(latest, _sessionStart);
-    if (simpleOpenFull) simpleOpenFull.href = openUrl(latest);
+    if (simpleOpenFull) {
+      simpleOpenFull.href = openUrl(latest, getTheme());
+      simpleOpenFull.setAttribute("data-theme-link", "");
+    }
     if (simpleSave) { simpleSave.href = fileUrl(latest); simpleSave.setAttribute("download", latest.filename); }
     if (simpleResultPreview) {
       // Same dispatch the Expert preview pane renders through — Simple has no
@@ -538,19 +541,50 @@ initTheme({ role: "follower" });
 // to the hub's chrome when this page is loaded inside a web_terminal panel.
 applyEmbedded();
 
-/** @param {string} theme */
-function _forwardThemeToPreviewFrames(theme) {
-  document.querySelectorAll(".preview-viewport iframe, .browse-preview-pane iframe").forEach((iframe) => {
-    // Intentional '*' (same-origin contract exception): nested preview iframe may be null/cross-origin.
-    // eslint-disable-next-line no-empty -- intentional empty catch: postMessage to a stale/cross-origin frame is best-effort
-    try { /** @type {any} */ (iframe).contentWindow.postMessage({ type: "osprey-theme-change", theme }, "*"); } catch {}
+/**
+ * Send a theme to one embedded artifact page.
+ * @param {Element} iframe
+ * @param {string} theme
+ */
+function _sendThemeToFrame(iframe, theme) {
+  // Intentional '*' (same-origin contract exception): nested preview iframe may be null/cross-origin.
+  // eslint-disable-next-line no-empty -- intentional empty catch: postMessage to a stale/cross-origin frame is best-effort
+  try { /** @type {any} */ (iframe).contentWindow.postMessage({ type: "osprey-theme-change", theme }, "*"); } catch {}
+}
+
+/**
+ * The "Open in new tab" links carry `?theme=` (see types.js `openUrl`),
+ * computed when their pane was rendered; a theme change in between would
+ * otherwise open the new tab in the stale id -- and `?theme=` is the top
+ * rung of theme-boot.js's ladder, so it would win. Re-stamp them in place.
+ * @param {string} theme
+ */
+function _refreshThemeLinks(theme) {
+  document.querySelectorAll("a[data-theme-link]").forEach((a) => {
+    const url = new URL(/** @type {HTMLAnchorElement} */ (a).href, window.location.origin);
+    url.searchParams.set("theme", theme);
+    /** @type {HTMLAnchorElement} */ (a).href = `${url.pathname}${url.search}${url.hash}`;
   });
 }
 
 subscribe((theme) => {
-  _forwardThemeToPreviewFrames(theme);
+  // Every iframe the gallery mounts is a served artifact page (preview pane,
+  // browse pane, Simple's result card, each card thumbnail) running the same
+  // follower bridge, so there is no selector here to keep in step with the markup.
+  document.querySelectorAll("iframe").forEach((iframe) => _sendThemeToFrame(iframe, theme));
+  _refreshThemeLinks(theme);
   restyleMountedCharts();
 });
+
+// The load-time half of the same contract: an artifact page that finishes
+// loading after the last apply (a newly selected preview, a lazily loaded
+// card thumbnail scrolled into view) gets the theme in force right away
+// instead of waiting for the next change. `load` doesn't bubble, so it is
+// caught in the capture phase at the document.
+document.addEventListener("load", (e) => {
+  const theme = getTheme();
+  if (theme && e.target instanceof HTMLIFrameElement) _sendThemeToFrame(e.target, theme);
+}, true);
 
 // Session changes are unrelated to theming and stay a plain message
 // listener (theme-manager owns the 'osprey-theme-change' type now).

--- a/src/osprey/interfaces/artifacts/static/js/preview.js
+++ b/src/osprey/interfaces/artifacts/static/js/preview.js
@@ -52,6 +52,9 @@ import {
 import { artifactViewportHtml, mountArtifactViewport } from "./artifact-viewport.js";
 import { injectLogbookButtons } from "./logbook.js";
 import { injectPrintButton } from "./print.js";
+// Only for the "Open in new tab" link, which carries the theme in force —
+// the standalone page it opens has no hub to follow (see openUrl()).
+import { getTheme } from "/design-system/js/theme-manager.js";
 
 /**
  * Nudge the preview's embedded media to re-measure after a fullscreen
@@ -149,7 +152,7 @@ export function createPreviewRenderer(callbacks) {
           <button class="btn-action-icon fullscreen-enter-btn" id="fullscreen-enter" title="Maximize (F)">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 00-2 2v3M21 8V5a2 2 0 00-2-2h-3M16 21h3a2 2 0 002-2v-3M3 16v3a2 2 0 002 2h3"/></svg>
           </button>
-          <a href="${openUrl(a)}" target="_blank" class="btn-action-icon" title="Open in new tab">
+          <a href="${openUrl(a, getTheme())}" data-theme-link target="_blank" class="btn-action-icon" title="Open in new tab">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3"/></svg>
           </a>
           <button class="btn-action-icon btn-action-danger" id="preview-delete" title="Delete artifact">

--- a/src/osprey/interfaces/artifacts/static/js/print.js
+++ b/src/osprey/interfaces/artifacts/static/js/print.js
@@ -146,8 +146,11 @@ function openBlobAndPrint(html) {
 /** @param {any} a */
 function printIframe(a) {
   // openUrl() owns the type -> URL mapping (rendered endpoints for
-  // markdown/notebook, raw file URL otherwise).
-  const url = openUrl(a);
+  // markdown/notebook, raw file URL otherwise). The theme is pinned to
+  // light, not the gallery's: printed output stays light-on-white (see
+  // PRINT_STYLES), and the `@media print` body repaint below cannot undo
+  // colors a themed Plotly page has already written into its SVG.
+  const url = openUrl(a, "light");
 
   const w = window.open(url, "_blank", "width=900,height=700");
   if (!w) {

--- a/src/osprey/interfaces/artifacts/static/js/timeseries.js
+++ b/src/osprey/interfaces/artifacts/static/js/timeseries.js
@@ -38,7 +38,7 @@
  * @module timeseries
  */
 
-import { chartTheme, chartSeries } from "/design-system/js/theme-manager.js";
+import { chartTheme, chartRelayout, chartSeries } from "/design-system/js/theme-manager.js";
 import { escapeHtml } from "/design-system/js/dom.js";
 import { isoToDate } from "./types.js";
 
@@ -341,15 +341,15 @@ export async function renderTimeseriesView(container, artifact) {
 
 /**
  * A Plotly layout fragment for the timeseries chart, built from
- * chartTheme()'s --chart-* computed-style bridge plus a couple of
- * gallery-specific extras (axis/legend line color, legend background)
- * that bridge doesn't cover -- read directly via getComputedStyle so
- * they still track the design tokens rather than being hardcoded.
+ * chartTheme()'s --chart-* computed-style bridge plus the axis/legend line
+ * color and legend background the initial layout also needs -- the same
+ * --chart-axis-line token chartRelayout() applies on a live re-theme, so
+ * the first render and every later one agree.
  * @returns {any}
  */
 export function _tsChartTheme() {
   const base = chartTheme();
-  const line = getComputedStyle(document.documentElement).getPropertyValue("--border-default").trim();
+  const line = getComputedStyle(document.documentElement).getPropertyValue("--chart-axis-line").trim();
   return { ...base, line: line || base.xaxis.gridcolor, legendBg: base.paper_bgcolor, legendBorder: line };
 }
 
@@ -373,17 +373,12 @@ export function restyleMountedCharts() {
   // Target the actual Plotly graph divs, not the outer viewport wrappers.
   const charts = document.querySelectorAll(".ts-viewport-container [data-ts-chart]");
   if (!charts.length) return;
-  const t = _tsChartTheme();
   const series = chartSeries();
   charts.forEach((tsChart) => {
     try {
-      Plotly.relayout(tsChart, {
-        paper_bgcolor: t.paper_bgcolor, plot_bgcolor: t.plot_bgcolor,
-        "font.color": t.font.color,
-        "xaxis.gridcolor": t.xaxis.gridcolor, "xaxis.linecolor": t.line,
-        "yaxis.gridcolor": t.yaxis.gridcolor, "yaxis.linecolor": t.line,
-        "legend.bgcolor": t.legendBg, "legend.bordercolor": t.legendBorder,
-      });
+      // The shared token -> layout-key mapping (design-system owned); it
+      // covers yaxis2 too when a categorical channel added one.
+      Plotly.relayout(tsChart, chartRelayout(tsChart));
       // relayout doesn't touch trace colors, so the data lines and their legend
       // dots keep the prior theme's palette until reload. Restyle each trace's
       // line+marker to the current series palette so they re-theme live too.
@@ -453,8 +448,11 @@ export async function renderTimeseriesChart(el, chartData) {
     font: { family: "'JetBrains Mono', monospace", size: 11, color: t.font.color },
     margin: { t: 30, r: 20, b: 50, l: 60 },
     hovermode: "x unified",
-    xaxis: { gridcolor: t.xaxis.gridcolor, linecolor: t.line, tickfont: { size: 10 } },
-    yaxis: { gridcolor: t.yaxis.gridcolor, linecolor: t.line, tickfont: { size: 10 } },
+    // zerolinecolor too: chartRelayout() sets it on a live re-theme, so the
+    // first render must as well or the zero line changes color on the
+    // first theme flip.
+    xaxis: { gridcolor: t.xaxis.gridcolor, linecolor: t.line, zerolinecolor: t.line, tickfont: { size: 10 } },
+    yaxis: { gridcolor: t.yaxis.gridcolor, linecolor: t.line, zerolinecolor: t.line, tickfont: { size: 10 } },
     ...(hasNonNumeric
       ? {
           yaxis2: {

--- a/src/osprey/interfaces/artifacts/static/js/types.js
+++ b/src/osprey/interfaces/artifacts/static/js/types.js
@@ -268,15 +268,38 @@ export function hasTimeseriesData(a) {
 /**
  * URL for "Open in new tab" — uses rendered endpoints for types that
  * browsers can't display natively (markdown, notebook).
+ *
+ * A page opened in its own tab has no hub parent to follow, so a theme id
+ * passed here rides along as `?theme=` (see {@link withTheme}) and the new tab
+ * opens in exactly the theme the operator is looking at.
  * @param {any} a
+ * @param {string|null} [theme] - concrete theme id to carry, if any
  * @returns {string}
  */
-export function openUrl(a) {
+export function openUrl(a, theme) {
   switch (a.artifact_type) {
-    case "markdown": return `/api/markdown/${encodeURIComponent(a.id)}/rendered`;
-    case "notebook": return `/api/notebooks/${encodeURIComponent(a.id)}/rendered`;
-    default:         return fileUrl(a);
+    case "markdown": return withTheme(`/api/markdown/${encodeURIComponent(a.id)}/rendered`, theme);
+    case "notebook": return withTheme(`/api/notebooks/${encodeURIComponent(a.id)}/rendered`, theme);
+    default:         return withTheme(fileUrl(a), theme);
   }
+}
+
+/**
+ * Stamp a concrete theme id onto an artifact-page URL as `?theme=` — the
+ * load-time half of the gallery's theme contract with the pages it embeds or
+ * opens (the same shape the web terminal's `buildEmbedSrc()` uses for its
+ * panels): theme-boot.js honors `?theme=` ahead of storage and the OS, so the
+ * page first-paints in the theme the gallery is showing instead of resolving
+ * one of its own. An empty/`null` theme (theme-manager not initialised yet)
+ * leaves the URL bare.
+ * @param {string} url - a root-relative artifact-page URL
+ * @param {string|null} [theme] - concrete theme id to carry, if any
+ * @returns {string}
+ */
+export function withTheme(url, theme) {
+  if (!theme) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}theme=${encodeURIComponent(theme)}`;
 }
 
 /**

--- a/src/osprey/interfaces/design_system/DESIGN.md
+++ b/src/osprey/interfaces/design_system/DESIGN.md
@@ -109,6 +109,16 @@ switcher — it's discovered from the token tree.
 Theme switching is entirely client-side (`theme-manager.js`): no server round
 trip, no page reload.
 
+Chart colors cross into JS only through `theme-manager.js`'s computed-style
+bridges: `chartTheme()`/`chartSeries()` build a Plotly layout fragment and
+categorical palette from the `--chart-*` tokens, and `chartRelayout(gd)`
+builds the flat relayout update that re-themes an already-plotted figure in
+place — including 3D scenes (box, axis panes via `--chart-pane-bg`, grids,
+spikes) and only for the subplots the figure actually has. The artifact
+gallery's served Plotly pages and its timeseries charts both apply exactly
+this, so a plot re-themes identically whether it was just rendered or is
+being flipped live, and no page carries a palette of its own.
+
 ## 5. Hygiene rules
 
 Enforced by `tests/interfaces/design_system/test_hygiene.py`, which scans

--- a/src/osprey/interfaces/design_system/static/css/tokens.css
+++ b/src/osprey/interfaces/design_system/static/css/tokens.css
@@ -152,6 +152,8 @@
   --chart-plot-bg: #111217;
   --chart-grid: rgba(142, 142, 154, 0.1);
   --chart-axis-text: #8e8e9a;
+  --chart-pane-bg: #141619;
+  --chart-axis-line: #2c3235;
   --chart-series-1: #4fd1c5;
   --chart-series-2: #f59e0b;
   --chart-series-3: #22c55e;
@@ -298,6 +300,8 @@
   --chart-plot-bg: #091720;
   --chart-grid: rgba(149, 173, 187, 0.1);
   --chart-axis-text: #95adbb;
+  --chart-pane-bg: #0c1d27;
+  --chart-axis-line: #1e3848;
   --chart-series-1: #009fdf;
   --chart-series-2: #f18f1f;
   --chart-series-3: #00a54b;
@@ -444,6 +448,8 @@
   --chart-plot-bg: #f3f8fc;
   --chart-grid: rgba(73, 103, 121, 0.1);
   --chart-axis-text: #496779;
+  --chart-pane-bg: #deeaf2;
+  --chart-axis-line: #b3c8d6;
   --chart-series-1: #007bc8;
   --chart-series-2: #eb6e0f;
   --chart-series-3: #00a54b;
@@ -590,6 +596,8 @@
   --chart-plot-bg: #000000;
   --chart-grid: rgba(204, 204, 204, 0.1);
   --chart-axis-text: #cccccc;
+  --chart-pane-bg: #1a1a1a;
+  --chart-axis-line: rgba(255, 255, 255, 0.24);
   --chart-series-1: #ffffff;
   --chart-series-2: #e6e6e6;
   --chart-series-3: #cccccc;
@@ -736,6 +744,8 @@
   --chart-plot-bg: #ffffff;
   --chart-grid: rgba(51, 51, 51, 0.1);
   --chart-axis-text: #333333;
+  --chart-pane-bg: #e6e6e6;
+  --chart-axis-line: #b3b3b3;
   --chart-series-1: #000000;
   --chart-series-2: #1a1a1a;
   --chart-series-3: #333333;
@@ -882,6 +892,8 @@
   --chart-plot-bg: #f4f5f5;
   --chart-grid: rgba(110, 110, 119, 0.1);
   --chart-axis-text: #6e6e77;
+  --chart-pane-bg: #ecedef;
+  --chart-axis-line: #d8d9da;
   --chart-series-1: #0a8f8c;
   --chart-series-2: #d97706;
   --chart-series-3: #16a34a;
@@ -1028,6 +1040,8 @@
   --chart-plot-bg: #0a0f1a;
   --chart-grid: rgba(139, 154, 181, 0.1);
   --chart-axis-text: #8b9ab5;
+  --chart-pane-bg: #111a2e;
+  --chart-axis-line: rgba(148, 163, 184, 0.12);
   --chart-series-1: #4fd1c5;
   --chart-series-2: #f59e0b;
   --chart-series-3: #22c55e;
@@ -1174,6 +1188,8 @@
   --chart-plot-bg: #f7f9fc;
   --chart-grid: rgba(55, 65, 85, 0.1);
   --chart-axis-text: #374155;
+  --chart-pane-bg: #eef2f7;
+  --chart-axis-line: #d1d8e3;
   --chart-series-1: #0a8f8c;
   --chart-series-2: #d97706;
   --chart-series-3: #16a34a;

--- a/src/osprey/interfaces/design_system/static/js/theme-manager.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-manager.js
@@ -579,8 +579,8 @@ export function initTheme({ role = 'follower' } = {}) {
     // The mode comes from the server too, when the server stated one.
     // `data-theme-mode` is set only when the deployment configured a concrete
     // theme id (`web.theme: desy-light`) rather than a bare family
-    // (`web.theme: desy`) -- see resolve_web_theme_pinned_mode() in the web
-    // terminal's app.py. Without reading it, a configured light default would
+    // (`web.theme: desy`) -- see resolve_pinned_mode() in the design system's
+    // theme_config.py. Without reading it, a configured light default would
     // paint correctly and then be discarded one frame later by 'auto'
     // re-resolving the mode from the OS. A stored preference still outranks
     // it: config sets the DEFAULT, not a lock.
@@ -775,6 +775,93 @@ export function chartTheme() {
     xaxis: { gridcolor },
     yaxis: { gridcolor },
   };
+}
+
+/**
+ * A flat `Plotly.relayout()` update that re-themes an ALREADY-PLOTTED figure
+ * in place from the --chart-* tokens, whatever palette its author baked into
+ * the layout. The one owner of the token -> Plotly layout-key mapping for
+ * live re-theming: the artifact gallery's served plot pages and its own
+ * timeseries charts both apply exactly this.
+ *
+ * Always: paper/plot backgrounds, font color, legend background/border.
+ * Per subplot actually present on the figure (read from Plotly's own
+ * `_fullLayout._subplots`, falling back to the `layout` keys before the
+ * first plot): cartesian axes get grid/line/zeroline colors; every 3D scene
+ * gets its box, axis panes, grids, tick text and spike lines. Keys are only
+ * emitted for subplots the figure has -- relayouting `xaxis.*` onto a
+ * scene-only figure would make Plotly conjure an empty cartesian axis
+ * underneath it. Trace colors are never touched.
+ *
+ * @param {any} gd - the plotted Plotly graph div
+ * @returns {Record<string, string>}
+ */
+export function chartRelayout(gd) {
+  const styles = _computedStyles();
+  _checkSentinel(styles);
+  const paper = _readVar(styles, '--chart-paper-bg');
+  const plot = _readVar(styles, '--chart-plot-bg');
+  const text = _readVar(styles, '--chart-axis-text');
+  const grid = _readVar(styles, '--chart-grid');
+  const line = _readVar(styles, '--chart-axis-line');
+  const pane = _readVar(styles, '--chart-pane-bg');
+
+  /** @type {Record<string, string>} */
+  const update = {
+    paper_bgcolor: paper,
+    plot_bgcolor: plot,
+    'font.color': text,
+    'legend.bgcolor': paper,
+    'legend.bordercolor': line,
+  };
+  for (const axis of _cartesianAxes(gd)) {
+    update[`${axis}.gridcolor`] = grid;
+    update[`${axis}.linecolor`] = line;
+    update[`${axis}.zerolinecolor`] = line;
+  }
+  for (const scene of _scenes(gd)) {
+    update[`${scene}.bgcolor`] = plot;
+    for (const axis of ['xaxis', 'yaxis', 'zaxis']) {
+      update[`${scene}.${axis}.backgroundcolor`] = pane;
+      update[`${scene}.${axis}.gridcolor`] = grid;
+      // plotly.py's default template bakes an explicit white linecolor
+      // into every scene axis, and an explicit linecolor beats the
+      // `.color` cascade below -- so it has to be set by name.
+      update[`${scene}.${axis}.linecolor`] = line;
+      update[`${scene}.${axis}.zerolinecolor`] = line;
+      update[`${scene}.${axis}.color`] = text;
+      update[`${scene}.${axis}.spikecolor`] = text;
+    }
+  }
+  return update;
+}
+
+/**
+ * Layout keys of the cartesian axes a figure has (`xaxis`, `yaxis2`, ...).
+ * Plotly's `_fullLayout._subplots.xaxis`/`.yaxis` list axis ids (`x`,
+ * `y2`); before the first plot only the author's own `layout` keys exist.
+ * @param {any} gd
+ * @returns {string[]}
+ */
+function _cartesianAxes(gd) {
+  const subplots = gd?._fullLayout?._subplots;
+  if (subplots) {
+    return [...(subplots.xaxis || []), ...(subplots.yaxis || [])].map((id) =>
+      id.replace(/^([xy])(\d*)$/, '$1axis$2')
+    );
+  }
+  return Object.keys(gd?.layout || {}).filter((key) => /^[xy]axis\d*$/.test(key));
+}
+
+/**
+ * Layout keys of the 3D scenes a figure has (`scene`, `scene2`, ...).
+ * @param {any} gd
+ * @returns {string[]}
+ */
+function _scenes(gd) {
+  const subplots = gd?._fullLayout?._subplots;
+  if (subplots) return [...(subplots.gl3d || [])];
+  return Object.keys(gd?.layout || {}).filter((key) => /^scene\d*$/.test(key));
 }
 
 /** The categorical chart color palette, built from --chart-series-N. */

--- a/src/osprey/interfaces/design_system/theme_config.py
+++ b/src/osprey/interfaces/design_system/theme_config.py
@@ -1,17 +1,21 @@
 """Resolving a configured theme name into concrete themes and their CSS values.
 
-Two surfaces need to turn a configured ``web.theme`` value into something
+Three surfaces need to turn a configured ``web.theme`` value into something
 concrete, and they must agree:
 
 - The **web terminal** server-renders a theme id onto ``<html data-theme>`` so
   the generated ``theme-boot.js`` first-paints without a flash.
+- The **artifact gallery** stamps the same attribute onto the artifact pages it
+  serves, so one opened outside the hub honors the deployment's pin too.
 - The **multi-user landing page** is a flat file nginx serves with no app
   behind it, so it cannot link the token stylesheet at all — its renderer bakes
   the resolved theme's values straight into the page's inline ``<style>``.
 
-Both read the same ``tokens/`` source tree the design-system generator builds
-from, rather than parsing a generated artifact, so neither can drift from a
-stale build.
+All three read the same ``tokens/`` source tree the design-system generator
+builds from, rather than parsing a generated artifact, so none can drift from a
+stale build. The first two also read the *deployment's* configured value rather
+than being handed one, so :func:`resolve_configured_web_theme` owns that read
+(environment before config) as well as the resolution.
 
 A configured value may name either a **family** (``"desy"`` — a palette, with
 light/dark left to each viewer's OS) or a concrete **theme id**
@@ -25,13 +29,19 @@ explicitly configured dark id.
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 
 from osprey.interfaces.design_system.generator.emit_js import ThemeManifestEntry
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "DEFAULT_WEB_THEME",
+    "ConfiguredWebTheme",
+    "configured_web_theme",
+    "resolve_configured_web_theme",
     "load_theme_registry",
     "resolve_theme_id",
     "resolve_pinned_mode",
@@ -39,6 +49,10 @@ __all__ = [
     "theme_css_variables",
     "MissingThemeVariableError",
 ]
+
+#: Used when neither ``OSPREY_WEB_THEME`` nor ``web.theme`` names anything: the
+#: built-in family, which pins no mode and so leaves light/dark to each viewer.
+DEFAULT_WEB_THEME = "main"
 
 
 class MissingThemeVariableError(KeyError):
@@ -169,6 +183,77 @@ def family_of(theme_id: str, entries: Sequence[ThemeManifestEntry]) -> str | Non
         if entry.id == theme_id:
             return entry.family
     return None
+
+
+@dataclass(frozen=True)
+class ConfiguredWebTheme:
+    """What a deployment's configured web-theme value resolves to.
+
+    Attributes:
+        id: The concrete baked theme id — always a real id, never a family.
+        pinned_mode: ``"dark"``/``"light"`` if the configured value named a
+            concrete id, ``None`` if it named a family (or was unknown). See
+            :func:`resolve_pinned_mode` for why this cannot be read back off
+            ``id``.
+        family: The family ``id`` belongs to, or ``None`` if unknown.
+    """
+
+    id: str
+    pinned_mode: str | None
+    family: str | None
+
+
+def configured_web_theme() -> str:
+    """The raw web-theme value a deployment configured.
+
+    ``OSPREY_WEB_THEME`` wins over ``web.theme``, so several containers sharing
+    one baked config image can each be themed individually through the
+    environment — the same shape ``OSPREY_WEB_APP_NAME`` uses, and how
+    multi-user deployments theme each user's container from the roster's
+    ``theme:`` key. Falls back to :data:`DEFAULT_WEB_THEME`.
+
+    Raises:
+        Exception: Whatever reading the config raises — ``FileNotFoundError``
+            when none is primed. The servers that call this disagree about what
+            that should mean (the terminal must still render *some* theme, the
+            gallery simply serves unpinned pages), so the fallback is theirs.
+    """
+    from_env = os.environ.get("OSPREY_WEB_THEME", "").strip()
+    if from_env:
+        return from_env
+
+    from osprey.utils.config import get_config_value
+
+    return str(get_config_value("web.theme", DEFAULT_WEB_THEME) or DEFAULT_WEB_THEME)
+
+
+def resolve_configured_web_theme(configured: str | None = None) -> ConfiguredWebTheme:
+    """Resolve the configured web theme into id, pin and family in one read.
+
+    The single interpretation of the environment → config → family/id chain, so
+    the surfaces that server-render a theme cannot disagree about what a
+    configured value means.
+
+    Args:
+        configured: A raw value to resolve instead of reading the deployment's
+            own (mainly for tests).
+
+    Returns:
+        The resolved :class:`ConfiguredWebTheme`.
+
+    Raises:
+        Exception: As :func:`configured_web_theme`, plus anything
+            :func:`load_theme_registry` raises. Callers own the fallback.
+    """
+    if configured is None:
+        configured = configured_web_theme()
+    entries, defaults = load_theme_registry()
+    theme_id = resolve_theme_id(configured, entries, defaults)
+    return ConfiguredWebTheme(
+        id=theme_id,
+        pinned_mode=resolve_pinned_mode(configured, entries),
+        family=family_of(theme_id, entries),
+    )
 
 
 def theme_css_variables(theme_id: str, names: Iterable[str]) -> dict[str, str]:

--- a/src/osprey/interfaces/design_system/tokens/themes/dark.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/dark.json
@@ -138,6 +138,8 @@
     "plot-bg": { "$value": "{color.gray.950}", "$type": "color" },
     "grid": { "$value": "rgba(142, 142, 154, 0.1)", "$type": "color", "$description": "text.secondary base (#8e8e9a) at 10% alpha." },
     "axis-text": { "$value": "{color.gray.400}", "$type": "color" },
+    "pane-bg": { "$value": "{color.gray.900}", "$type": "color", "$description": "3D scene axis panes (Plotly scene.*axis.backgroundcolor): bg.secondary, one step off the plot canvas." },
+    "axis-line": { "$value": "{color.gray.700}", "$type": "color", "$description": "Axis and legend lines (Plotly *.linecolor, legend.bordercolor): border.default." },
     "series": {
       "1": { "$value": "{color.teal.100}", "$type": "color" },
       "2": { "$value": "{color.amber.400}", "$type": "color" },

--- a/src/osprey/interfaces/design_system/tokens/themes/desy-dark.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/desy-dark.json
@@ -142,6 +142,8 @@
     "plot-bg": { "$value": "{color.petrol.950}", "$type": "color" },
     "grid": { "$value": "rgba(149, 173, 187, 0.1)", "$type": "color", "$description": "text.secondary base (#95adbb) at 10% alpha." },
     "axis-text": { "$value": "{color.petrol.400}", "$type": "color" },
+    "pane-bg": { "$value": "{color.petrol.900}", "$type": "color", "$description": "3D scene axis panes (Plotly scene.*axis.backgroundcolor): bg.secondary, one step off the plot canvas." },
+    "axis-line": { "$value": "{color.petrol.750}", "$type": "color", "$description": "Axis and legend lines (Plotly *.linecolor, legend.bordercolor): border.default." },
     "series": {
       "1": { "$value": "{color.cyan.300}", "$type": "color" },
       "2": { "$value": "{color.orange.300}", "$type": "color" },

--- a/src/osprey/interfaces/design_system/tokens/themes/desy-light.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/desy-light.json
@@ -144,6 +144,8 @@
     "plot-bg": { "$value": "{color.petrol.50}", "$type": "color" },
     "grid": { "$value": "rgba(73, 103, 121, 0.1)", "$type": "color", "$description": "text.secondary base (#496779) at 10% alpha." },
     "axis-text": { "$value": "{color.petrol.600}", "$type": "color" },
+    "pane-bg": { "$value": "{color.petrol.150}", "$type": "color", "$description": "3D scene axis panes (Plotly scene.*axis.backgroundcolor): bg.secondary, one step off the plot canvas." },
+    "axis-line": { "$value": "{color.petrol.300}", "$type": "color", "$description": "Axis and legend lines (Plotly *.linecolor, legend.bordercolor): border.default." },
     "series": {
       "1": { "$value": "{color.cyan.400}", "$type": "color" },
       "2": { "$value": "{color.orange.500}", "$type": "color" },

--- a/src/osprey/interfaces/design_system/tokens/themes/high-contrast-dark.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/high-contrast-dark.json
@@ -140,6 +140,8 @@
     "plot-bg": { "$value": "{color.mono.1000}", "$type": "color" },
     "grid": { "$value": "rgba(204, 204, 204, 0.1)", "$type": "color", "$description": "text.secondary base (#cccccc) at 10% alpha." },
     "axis-text": { "$value": "{color.mono.200}", "$type": "color" },
+    "pane-bg": { "$value": "{color.mono.900}", "$type": "color", "$description": "3D scene axis panes (Plotly scene.*axis.backgroundcolor): bg.secondary, one step off the plot canvas." },
+    "axis-line": { "$value": "rgba(255, 255, 255, 0.24)", "$type": "color", "$description": "Axis and legend lines (Plotly *.linecolor, legend.bordercolor): border.default, white at 24% alpha." },
     "series": {
       "1": { "$value": "{color.mono.0}", "$type": "color" },
       "2": { "$value": "{color.mono.100}", "$type": "color" },

--- a/src/osprey/interfaces/design_system/tokens/themes/high-contrast-light.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/high-contrast-light.json
@@ -140,6 +140,8 @@
     "plot-bg": { "$value": "{color.mono.0}", "$type": "color" },
     "grid": { "$value": "rgba(51, 51, 51, 0.1)", "$type": "color", "$description": "text.secondary base (#333333) at 10% alpha." },
     "axis-text": { "$value": "{color.mono.800}", "$type": "color" },
+    "pane-bg": { "$value": "{color.mono.100}", "$type": "color", "$description": "3D scene axis panes (Plotly scene.*axis.backgroundcolor): bg.secondary, one step off the plot canvas." },
+    "axis-line": { "$value": "{color.mono.300}", "$type": "color", "$description": "Axis and legend lines (Plotly *.linecolor, legend.bordercolor): border.default." },
     "series": {
       "1": { "$value": "{color.mono.1000}", "$type": "color" },
       "2": { "$value": "{color.mono.900}", "$type": "color" },

--- a/src/osprey/interfaces/design_system/tokens/themes/light.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/light.json
@@ -139,6 +139,8 @@
     "plot-bg": { "$value": "{color.gray.100}", "$type": "color" },
     "grid": { "$value": "rgba(110, 110, 119, 0.1)", "$type": "color", "$description": "text.secondary base (#6e6e77) at 10% alpha, mirroring dark's grid formula." },
     "axis-text": { "$value": "{color.gray.500}", "$type": "color" },
+    "pane-bg": { "$value": "{color.gray.150}", "$type": "color", "$description": "3D scene axis panes (Plotly scene.*axis.backgroundcolor): bg.secondary, one step off the plot canvas." },
+    "axis-line": { "$value": "{color.gray.200}", "$type": "color", "$description": "Axis and legend lines (Plotly *.linecolor, legend.bordercolor): border.default." },
     "series": {
       "1": { "$value": "{color.teal.400}", "$type": "color" },
       "2": { "$value": "{color.amber.600}", "$type": "color" },

--- a/src/osprey/interfaces/design_system/tokens/themes/retro-dark.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/retro-dark.json
@@ -136,6 +136,8 @@
     "plot-bg": { "$value": "{color.slate.1000}", "$type": "color" },
     "grid": { "$value": "rgba(139, 154, 181, 0.1)", "$type": "color", "$description": "text.secondary base (#8b9ab5) at 10% alpha — tuning's exact dark-mode grid value." },
     "axis-text": { "$value": "{color.slate.600}", "$type": "color" },
+    "pane-bg": { "$value": "{color.slate.850}", "$type": "color", "$description": "3D scene axis panes (Plotly scene.*axis.backgroundcolor): bg.secondary, one step off the plot canvas." },
+    "axis-line": { "$value": "rgba(148, 163, 184, 0.12)", "$type": "color", "$description": "Axis and legend lines (Plotly *.linecolor, legend.bordercolor): border.default, slate at 12% alpha." },
     "series": {
       "$description": "Canonical 6-slot categorical palette = tuning's COLORS.bo_palette verbatim (all 6 steps already existed as ramp aliases). Artifacts' own 8-color array (which adds #d4a574 and an unratified pink #e879f9 not in any of the 7 approved ramp families) is NOT carried forward; artifacts' migration (Task 3.1, out of this task's scope) maps down to these 6 slots.",
       "1": { "$value": "{color.teal.100}", "$type": "color" },

--- a/src/osprey/interfaces/design_system/tokens/themes/retro-light.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/retro-light.json
@@ -137,6 +137,8 @@
     "plot-bg": { "$value": "{color.slate.150}", "$type": "color" },
     "grid": { "$value": "rgba(55, 65, 85, 0.1)", "$type": "color", "$description": "text.secondary (light) base (#374155) at 10% alpha, mirroring dark's grid formula (text.secondary base at 10%). Not present in any current source file — constructed for consistency, disagreement noted in task report." },
     "axis-text": { "$value": "{color.slate.700}", "$type": "color" },
+    "pane-bg": { "$value": "{color.slate.300}", "$type": "color", "$description": "3D scene axis panes (Plotly scene.*axis.backgroundcolor): bg.secondary, one step off the plot canvas." },
+    "axis-line": { "$value": "{color.slate.450}", "$type": "color", "$description": "Axis and legend lines (Plotly *.linecolor, legend.bordercolor): border.default." },
     "series": {
       "1": { "$value": "{color.teal.400}", "$type": "color" },
       "2": { "$value": "{color.amber.600}", "$type": "color" },

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -38,11 +38,9 @@ from osprey.profiles.web_panels import BUILTIN_PANELS, UNIVERSAL_PANELS
 from osprey.registry.web import PANEL_ID_TO_REGISTRY_KEY, panel_url_state_attr
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Sequence
+    from collections.abc import AsyncIterator
 
     from jinja2.runtime import Context
-
-    from osprey.interfaces.design_system.generator.emit_js import ThemeManifestEntry
 
 STATIC_DIR = Path(__file__).parent / "static"
 
@@ -143,87 +141,6 @@ def _launch_panel_server(app: FastAPI, key: str) -> None:
         setattr(app.state, attr, None)
 
 
-def _load_theme_registry() -> tuple[list[ThemeManifestEntry], dict[str, dict[str, str]]]:
-    """Load the baked theme manifest + per-family defaults for SSR resolution.
-
-    Thin alias for
-    :func:`osprey.interfaces.design_system.theme_config.load_theme_registry`,
-    kept because this module's lifespan and its tests both reach for it by this
-    name. The multi-user landing-page renderer resolves the same config value
-    through that same module, so the two surfaces cannot disagree about what
-    ``web.theme`` means.
-
-    Returns:
-        ``(entries, defaults)`` as produced by
-        :func:`~osprey.interfaces.design_system.generator.emit_js.build_theme_manifest`
-        and :func:`~osprey.interfaces.design_system.generator.emit_js.build_theme_defaults`.
-    """
-    from osprey.interfaces.design_system.theme_config import load_theme_registry
-
-    return load_theme_registry()
-
-
-def resolve_web_theme_id(
-    configured: str,
-    entries: Sequence[ThemeManifestEntry],
-    defaults: dict[str, dict[str, str]],
-) -> str:
-    """Resolve the ``web.theme`` config value into a concrete baked theme id.
-
-    ``web.theme``-named alias for
-    :func:`osprey.interfaces.design_system.theme_config.resolve_theme_id`,
-    which documents the full contract (family vs concrete id, the warn +
-    fallback on an unknown value, and the guarantee that the result is always a
-    real baked id — what the pre-paint ``theme-boot.js`` rung requires). The
-    multi-user landing-page renderer calls that same function, so the two
-    surfaces cannot disagree about what ``web.theme`` means.
-
-    The returned id alone does NOT say whether the deployment pinned a mode —
-    see :func:`resolve_web_theme_pinned_mode` for that half.
-
-    Args:
-        configured: The raw ``web.theme`` config value.
-        entries: The theme manifest.
-        defaults: The per-family ``{family: {mode: id}}`` map.
-
-    Returns:
-        A concrete theme id present in ``entries``.
-    """
-    from osprey.interfaces.design_system.theme_config import resolve_theme_id
-
-    return resolve_theme_id(configured, entries, defaults, config_key="web.theme")
-
-
-def resolve_web_theme_pinned_mode(
-    configured: str,
-    entries: Sequence[ThemeManifestEntry],
-) -> str | None:
-    """The light/dark mode a ``web.theme`` value *pins*, if any.
-
-    ``web.theme``-named alias for
-    :func:`osprey.interfaces.design_system.theme_config.resolve_pinned_mode`,
-    which documents why the pin has to be carried separately from the resolved
-    id at all.
-
-    The lifespan server-renders the result as ``<html data-theme-mode>``, and
-    the browser needs it: without that attribute ``theme-manager.js``'s hub
-    assumes ``mode: 'auto'`` on a first visit and immediately re-resolves the
-    mode from the OS, silently discarding a configured pin one frame after
-    paint.
-
-    Args:
-        configured: The raw ``web.theme`` config value.
-        entries: The theme manifest.
-
-    Returns:
-        ``"dark"`` or ``"light"`` when ``configured`` names a concrete theme id;
-        ``None`` when it names a family or is unknown.
-    """
-    from osprey.interfaces.design_system.theme_config import resolve_pinned_mode
-
-    return resolve_pinned_mode(configured, entries)
-
-
 #: The two supported web UI modes. ``expert`` is the full split-pane terminal
 #: workspace; ``simple`` is the pared-down operator layout. ``expert`` is the
 #: default so an absent/misconfigured ``web.ui_mode`` never strands a deployment
@@ -239,7 +156,8 @@ def resolve_ui_mode(configured: str) -> str:
     ``"simple"``). Anything else — a typo, ``None``, an empty string — is
     logged as a warning and resolved to :data:`DEFAULT_UI_MODE`.
 
-    Mirrors the warn+fallback shape of :func:`resolve_web_theme_id`: it never
+    Mirrors the warn+fallback shape of the ``web.theme`` resolver
+    (:func:`~osprey.interfaces.design_system.theme_config.resolve_theme_id`): it never
     raises, so a bad value degrades to the safe default instead of blocking
     server startup.
 
@@ -776,34 +694,24 @@ def _create_lifespan(
         # flash. Fails open on any load error — a missing/broken theme
         # registry must never block server startup.
         try:
-            from osprey.utils.config import get_config_value
+            from osprey.interfaces.design_system.theme_config import (
+                resolve_configured_web_theme,
+            )
 
-            # ``OSPREY_WEB_THEME`` takes precedence over ``web.theme``, so
-            # several containers sharing one baked config image can each be
-            # themed individually via the environment — the same shape
-            # ``OSPREY_WEB_APP_NAME`` uses above. Multi-user deployments set it
-            # per user from the roster's ``theme:`` key.
-            configured_web_theme = os.environ.get(
-                "OSPREY_WEB_THEME", ""
-            ).strip() or get_config_value("web.theme", "main")
-            theme_entries, theme_defaults = _load_theme_registry()
-            app.state.web_theme_id = resolve_web_theme_id(
-                configured_web_theme, theme_entries, theme_defaults
-            )
+            # The shared environment → ``web.theme`` → id/pin/family chain, so
+            # this page and the artifact pages the gallery serves cannot
+            # disagree about what a configured value means.
+            web_theme = resolve_configured_web_theme()
+            app.state.web_theme_id = web_theme.id
             # Whether the configured value pinned a mode (a concrete id) or only
-            # a palette (a family). Server-rendered alongside data-theme so the
-            # browser hub can honor a pin instead of assuming 'auto' — see
-            # resolve_web_theme_pinned_mode().
-            app.state.web_theme_mode = resolve_web_theme_pinned_mode(
-                configured_web_theme, theme_entries
-            )
-            # The resolved theme's family, kept for the rail-position block
-            # below (an unconfigured rail follows the family — see
-            # FAMILY_RAIL_DEFAULTS).
-            app.state.web_theme_family = next(
-                (entry.family for entry in theme_entries if entry.id == app.state.web_theme_id),
-                None,
-            )
+            # a palette (a family). Server-rendered alongside data-theme because
+            # without it theme-manager.js's hub assumes 'auto' on a first visit
+            # and re-resolves the mode from the OS one frame after paint,
+            # silently discarding the pin.
+            app.state.web_theme_mode = web_theme.pinned_mode
+            # Kept for the rail-position block below (an unconfigured rail
+            # follows the family — see FAMILY_RAIL_DEFAULTS).
+            app.state.web_theme_family = web_theme.family
         except Exception:  # noqa: BLE001 — never let config/theme-registry load block startup
             logger.warning(
                 "Could not resolve web.theme (config or theme-registry load failed); "

--- a/src/osprey/mcp_server/workspace/tools/create_interactive_plot.py
+++ b/src/osprey/mcp_server/workspace/tools/create_interactive_plot.py
@@ -47,6 +47,11 @@ async def create_interactive_plot(
     You MUST call ``save_artifact(fig, "title")`` on your Plotly figure to
     produce output — figures are not auto-captured.
 
+    Leave backgrounds, font colors, and grid colors unset (no ``template=``,
+    ``paper_bgcolor``, ``plot_bgcolor`` or ``font.color``): the gallery
+    re-themes every interactive plot to the operator's active theme, and
+    hand-picked page colors fight that. Trace colors are kept as you set them.
+
     Args:
         code: Python code using Plotly to create interactive charts.
         title: Human-readable title for the chart.

--- a/src/osprey/templates/claude_code/claude/agents/data-visualizer.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/data-visualizer.md.j2
@@ -83,7 +83,11 @@ When asked to create an interactive chart (data exploration, hover tooltips, zoo
 - **Always label axes** with units (e.g., "Time [s]", "Current [mA]")
 - **Use descriptive titles** that explain what the plot shows
 - **Include legends** when multiple traces are present
-- **Use colorblind-safe palettes**: tab10, Set2, or Paired from matplotlib
+- **Use colorblind-safe palettes** for trace/marker colors: tab10, Set2, or Paired from matplotlib
+- **Leave Plotly backgrounds, font colors, and grid colors unset** (no `template=`,
+  `paper_bgcolor`, `plot_bgcolor`, or `font.color`): the gallery re-themes every
+  interactive plot to the operator's active theme, and hand-picked page colors
+  fight that. Trace colors are kept as you set them.
 - **Set appropriate figure size**: (10, 6) for standard, (12, 8) for complex plots
 - **Add grid lines** for readability (enabled by default styling in static plots)
 - **Use appropriate plot types**: scatter for correlations, line for time series,

--- a/src/osprey/templates/claude_code/claude/skills/demo-gallery/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/demo-gallery/SKILL.md
@@ -31,7 +31,7 @@ Use the `create_interactive_plot` MCP tool to produce a **multi-panel Plotly fig
 - Particle beam phase space (x-x', y-y') with color-coded amplitude
 - Resonance diagram with tune footprint overlay
 
-Use `plotly.subplots.make_subplots` for multi-panel layout. Apply a clean template (`plotly_white` or `plotly_dark`). Add descriptive axis labels and a figure title. Call `save_artifact(fig, "Title")` at the end.
+Use `plotly.subplots.make_subplots` for multi-panel layout. Leave backgrounds, font colors, and grid colors unset — the gallery re-themes every interactive plot to the operator's active theme, and hand-picked colors fight that. Add descriptive axis labels and a figure title. Call `save_artifact(fig, "Title")` at the end.
 
 ### 1b. Matplotlib Static Plot — `execute`
 
@@ -44,7 +44,7 @@ Use the `execute` MCP tool to create a **publication-quality matplotlib figure**
 - Frequency map analysis colored by diffusion rate
 - Mountain range plot of bunch profiles over multiple turns
 
-Use `plt.subplots()`, apply `plt.style.use("seaborn-v0_8-whitegrid")` or similar, and call `save_artifact(fig, "Title", "description")`.
+Use `plt.subplots()` and call `save_artifact(fig, "Title", "description")`. Static PNGs are not re-themed by the gallery, so keep the default light styling (e.g. `plt.style.use("seaborn-v0_8-whitegrid")`) rather than a dark one.
 
 ### 1c. Markdown Report with LaTeX — `artifact_register`
 

--- a/tests/interfaces/artifacts/artifact-viewport.test.mjs
+++ b/tests/interfaces/artifacts/artifact-viewport.test.mjs
@@ -30,6 +30,15 @@ vi.mock('../../../src/osprey/interfaces/artifacts/static/js/preview-content.js',
   renderJsonView: vi.fn(),
 }));
 
+// theme-manager is mocked so the theme the viewport stamps onto embedded
+// pages is under test control: `null` (not initialised -- the default for
+// every test below) leaves srcs bare, a concrete id must ride along as
+// `?theme=` so the page first-paints in the gallery's theme.
+const themeState = vi.hoisted(() => ({ current: /** @type {string|null} */ (null) }));
+vi.mock('/design-system/js/theme-manager.js', () => ({
+  getTheme: () => themeState.current,
+}));
+
 import {
   artifactViewportHtml,
   mountArtifactViewport,
@@ -70,6 +79,42 @@ function mount(artifact, onTimeseriesNeeded = vi.fn()) {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  themeState.current = null;
+});
+
+describe('artifactViewportHtml: embedded pages carry the gallery theme', () => {
+  // The old in-page bridge read the parent gallery's data-theme at load, so a
+  // freshly mounted preview always matched. The served page now resolves via
+  // theme-boot.js, whose top rung is `?theme=` -- the viewport must supply it,
+  // or a new preview can boot in the OS theme inside a gallery showing another.
+  test.each(['plot_html', 'table_html', 'dashboard_html', 'html'])(
+    'artifact_type "%s" iframe src carries the theme in force as ?theme=',
+    (artifact_type) => {
+      themeState.current = 'retro-light';
+      const container = document.createElement('div');
+      container.innerHTML = artifactViewportHtml(makeArtifact({ id: 'a1', artifact_type }));
+
+      expect(qs(container, 'iframe').getAttribute('src')).toMatch(/\?theme=retro-light$/);
+    }
+  );
+
+  test('the notebook rendered endpoint carries it too', () => {
+    themeState.current = 'high-contrast-dark';
+    const container = document.createElement('div');
+    container.innerHTML = artifactViewportHtml(makeArtifact({ id: 'nb1', artifact_type: 'notebook' }));
+
+    expect(qs(container, 'iframe').getAttribute('src')).toBe(
+      '/api/notebooks/nb1/rendered?theme=high-contrast-dark'
+    );
+  });
+
+  test('images are not iframes and get no theme param', () => {
+    themeState.current = 'retro-light';
+    const container = document.createElement('div');
+    container.innerHTML = artifactViewportHtml(makeArtifact({ artifact_type: 'plot_png' }));
+
+    expect(qs(container, 'img').getAttribute('src')).not.toContain('theme=');
+  });
 });
 
 describe('artifactViewportHtml: per-type dispatch', () => {

--- a/tests/interfaces/artifacts/print.test.mjs
+++ b/tests/interfaces/artifacts/print.test.mjs
@@ -183,14 +183,14 @@ describe('printArtifact: guards and dispatch', () => {
 
   describe('iframe strategy (plot_html, table_html, dashboard_html, html, text, json, unknown)', () => {
     test.each([
-      ['plot_html', '/files/a1/beam_profile.png'],
-      ['table_html', '/files/a1/beam_profile.png'],
-      ['dashboard_html', '/files/a1/beam_profile.png'],
-      ['html', '/files/a1/beam_profile.png'],
-      ['text', '/files/a1/beam_profile.png'],
-      ['json', '/files/a1/beam_profile.png'],
-      ['some_unrecognized_type', '/files/a1/beam_profile.png'],
-    ])('%s opens the raw file URL in a sized popup and injects print-cleanup styles', (artifact_type, expectedUrl) => {
+      ['plot_html', '/files/a1/beam_profile.png?theme=light'],
+      ['table_html', '/files/a1/beam_profile.png?theme=light'],
+      ['dashboard_html', '/files/a1/beam_profile.png?theme=light'],
+      ['html', '/files/a1/beam_profile.png?theme=light'],
+      ['text', '/files/a1/beam_profile.png?theme=light'],
+      ['json', '/files/a1/beam_profile.png?theme=light'],
+      ['some_unrecognized_type', '/files/a1/beam_profile.png?theme=light'],
+    ])('%s opens the raw file URL pinned to the light theme in a sized popup and injects print-cleanup styles', (artifact_type, expectedUrl) => {
       const win = makeFakeWindow();
       const openSpy = vi.fn(() => win);
       vi.stubGlobal('open', openSpy);
@@ -209,9 +209,9 @@ describe('printArtifact: guards and dispatch', () => {
     });
 
     test.each([
-      ['markdown', '/api/markdown/a1/rendered'],
-      ['notebook', '/api/notebooks/a1/rendered'],
-    ])('%s opens its server-rendered endpoint', (artifact_type, expectedUrl) => {
+      ['markdown', '/api/markdown/a1/rendered?theme=light'],
+      ['notebook', '/api/notebooks/a1/rendered?theme=light'],
+    ])('%s opens its server-rendered endpoint pinned to the light theme', (artifact_type, expectedUrl) => {
       const win = makeFakeWindow();
       const openSpy = vi.fn(() => win);
       vi.stubGlobal('open', openSpy);

--- a/tests/interfaces/artifacts/test_app_endpoints.py
+++ b/tests/interfaces/artifacts/test_app_endpoints.py
@@ -257,6 +257,115 @@ class TestServeFileEndpoint:
         assert body.count("plotly-3.3.1.min.js") == 1
 
 
+class TestServedPlotThemeBridge:
+    """The theme bridge injected into served Plotly artifacts.
+
+    Regression pins for the dark-locked-artifact bug: the bridge used to carry
+    its own two-entry ``{dark, light}`` hex palette and resolve the theme by
+    reading ``window.parent``'s ``data-theme`` with a hardcoded ``'dark'``
+    fallback -- so a plot opened in its own tab (no parent) always rendered
+    dark, and any theme outside the ``main`` family (``high-contrast-light``,
+    ``retro-light``, ...) fell to the dark palette even inside the gallery.
+    The served page must instead resolve its theme the way every other
+    design-system page does (theme-boot.js pre-paint, theme-manager.js at
+    runtime) and take every color from the ``--chart-*`` tokens.
+    """
+
+    def test_bridge_loads_design_system_instead_of_reading_parent(self, app_client):
+        client, _ = app_client
+        entry = _save_html_artifact(
+            client.app.state.artifact_store,
+            '<html><head></head><body><div class="plotly-graph-div"></div></body></html>',
+        )
+        body = client.get(f"/files/{entry.id}/{entry.filename}").text
+        assert '/design-system/js/theme-boot.js"' in body
+        assert '/design-system/css/tokens.css"' in body
+        assert "/design-system/js/theme-manager.js" in body
+        assert "window.parent" not in body
+
+    def test_snippets_carry_no_hardcoded_palette(self):
+        """No injected snippet may carry a color literal or a baked theme id --
+        the hygiene scanner cannot see HTML/CSS/JS inside Python strings, so
+        this is the guard that keeps the old two-entry hex map from coming
+        back in any of them."""
+        import re
+
+        from osprey.interfaces.artifacts.app import _RESPONSIVE_SNIPPETS
+
+        for artifact_type, snippet in _RESPONSIVE_SNIPPETS.items():
+            literals = re.findall(r"#[0-9a-fA-F]{3,8}\b|\brgba?\(|\bhsla?\(", snippet)
+            assert literals == [], f"color literals in the {artifact_type} snippet: {literals}"
+            assert "'dark'" not in snippet and '"dark"' not in snippet
+
+    def test_html_and_table_artifacts_get_design_system_wiring(self, app_client):
+        """table_html / html / dashboard_html pages join the design system too:
+        theme-boot pre-paint, tokens.css, follower role -- an unstyled table
+        must not render as a black-on-white browser-default island."""
+        client, _ = app_client
+        store = client.app.state.artifact_store
+        entry = store.save_file(
+            file_content=b'<table class="artifact-table"><tr><td>1</td></tr></table>',
+            filename="table.html",
+            artifact_type="table_html",
+            title="Table",
+            description="",
+            mime_type="text/html",
+            tool_source="test",
+        )
+        body = client.get(f"/files/{entry.id}/{entry.filename}").text
+        assert '/design-system/js/theme-boot.js"' in body
+        assert '/design-system/css/tokens.css"' in body
+        assert "initTheme({ role: 'follower' })" in body
+        assert "artifact-table" in body  # the DataFrame hook finally has CSS behind it
+
+    def test_gallery_shell_stamps_pinned_web_theme(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSPREY_WEB_THEME", "light")
+        client = TestClient(create_app(workspace_root=tmp_path))
+        body = client.get("/").text
+        assert 'data-theme="light"' in body
+
+        monkeypatch.setenv("OSPREY_WEB_THEME", "main")
+        client = TestClient(create_app(workspace_root=tmp_path))
+        body = client.get("/").text
+        assert "data-theme=" not in body.split("<head>")[0]  # the <html> tag carries no pin
+
+    def test_pinned_web_theme_is_server_rendered_on_served_html(self, tmp_path, monkeypatch):
+        """A deployment that pinned ``web.theme`` (a concrete id) gets that id
+        stamped as ``<html data-theme>`` on every served HTML artifact page, so
+        a first visit with nothing in localStorage and no ``?theme=`` paints the
+        configured theme -- the same server rung the web terminal renders."""
+        monkeypatch.setenv("OSPREY_WEB_THEME", "high-contrast-light")
+        client = TestClient(create_app(workspace_root=tmp_path))
+        store = client.app.state.artifact_store
+        plot = _save_html_artifact(store, "<html><head></head><body></body></html>")
+        body = client.get(f"/files/{plot.id}/{plot.filename}").text
+        assert 'data-theme="high-contrast-light"' in body
+
+        md = store.save_file(
+            file_content=b"# hi",
+            filename="hi.md",
+            artifact_type="markdown",
+            title="hi",
+            description="",
+            mime_type="text/markdown",
+            tool_source="test",
+        )
+        body = client.get(f"/api/markdown/{md.id}/rendered").text
+        assert 'data-theme="high-contrast-light"' in body
+
+    def test_family_web_theme_is_not_pinned_on_served_html(self, tmp_path, monkeypatch):
+        """A bare family (``main``) states a palette but not a mode: no
+        ``data-theme`` is stamped, so the page follows the viewer's own
+        preference (localStorage / OS) exactly as an unpinned terminal does."""
+        monkeypatch.setenv("OSPREY_WEB_THEME", "main")
+        client = TestClient(create_app(workspace_root=tmp_path))
+        plot = _save_html_artifact(
+            client.app.state.artifact_store, "<html><head></head><body></body></html>"
+        )
+        body = client.get(f"/files/{plot.id}/{plot.filename}").text
+        assert "data-theme=" not in body
+
+
 def test_inject_snippet_without_head_or_body_prepends():
     result = _inject_html_snippet(b"<div>fragment</div>", "<style>s</style>")
     assert result == b"<style>s</style><div>fragment</div>"

--- a/tests/interfaces/artifacts/test_gallery_interactions.py
+++ b/tests/interfaces/artifacts/test_gallery_interactions.py
@@ -47,6 +47,7 @@ Skips cleanly when the chromium headless binary is not installed.
 
 from __future__ import annotations
 
+import re
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -340,4 +341,57 @@ def test_simple_mode_renders_the_same_viewports_as_expert(tmp_path, monkeypatch,
         # Nothing anywhere in the card fell back to the sidebar-thumbnail
         # placeholder the old builder produced for unrenderable types.
         expect(preview.locator(".thumb-placeholder, .thumb-summary")).to_have_count(0)
+        page.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: an embedded artifact page inherits the gallery's theme
+# ---------------------------------------------------------------------------
+
+
+def test_preview_iframe_inherits_gallery_theme(tmp_path, monkeypatch, chromium_browser):
+    """A freshly mounted preview boots in the gallery's theme, follows a hub
+    theme change, and the "Open in new tab" link is re-stamped with it.
+
+    The served page resolves its own theme through theme-boot.js (whose top
+    rung is ``?theme=``) rather than reading the parent gallery's
+    ``data-theme`` the way the old in-page bridge did -- so the gallery has
+    to carry its theme onto the iframe src and re-send it on load and on
+    every change. Drives the whole chain: a gallery opened in a non-main
+    theme, a preview mounted afterwards, then a hub-style broadcast.
+    """
+    with _launch_artifacts(tmp_path, monkeypatch) as base_url:
+        ctx = chromium_browser.new_context(viewport=VIEWPORT, color_scheme="dark")
+        page = ctx.new_page()
+        page.goto(f"{base_url}/?theme=retro-light", wait_until="domcontentloaded")
+        expect(page.locator("html")).to_have_attribute("data-theme", "retro-light")
+
+        _card_for_title(page, HTML_TITLE).click()
+        iframe = page.locator(".preview-viewport iframe.preview-iframe-light")
+        expect(iframe).to_be_visible(timeout=5_000)
+        # Load-time half: the src carries the theme in force, and the page
+        # inside painted in it (not the OS-dark it would resolve on its own).
+        assert "theme=retro-light" in (iframe.get_attribute("src") or "")
+        page.wait_for_function(
+            "() => document.querySelector('.preview-viewport iframe')"
+            "  ?.contentDocument?.documentElement.getAttribute('data-theme') === 'retro-light'",
+            timeout=10_000,
+        )
+        link = page.locator(".preview-header a[data-theme-link]")
+        assert "theme=retro-light" in (link.get_attribute("href") or "")
+
+        # Live half: a hub broadcast re-themes the gallery, the embedded page,
+        # and the new-tab link -- to an id outside the main family.
+        page.evaluate(
+            "() => window.postMessage({type: 'osprey-theme-change',"
+            " theme: 'high-contrast-light'}, window.location.origin)"
+        )
+        expect(page.locator("html")).to_have_attribute("data-theme", "high-contrast-light")
+        page.wait_for_function(
+            "() => document.querySelector('.preview-viewport iframe')"
+            "  ?.contentDocument?.documentElement.getAttribute('data-theme')"
+            "  === 'high-contrast-light'",
+            timeout=10_000,
+        )
+        expect(link).to_have_attribute("href", re.compile(r"theme=high-contrast-light"))
         page.close()

--- a/tests/interfaces/artifacts/test_plot_theme_browser.py
+++ b/tests/interfaces/artifacts/test_plot_theme_browser.py
@@ -1,0 +1,262 @@
+"""Browser Playwright suite: a served Plotly artifact follows the OSPREY theme.
+
+Regression pins for the dark-locked-artifact bug. The theme bridge the gallery
+injects into ``plot_html`` artifacts used to carry a private ``{dark, light}``
+hex palette and read ``window.parent``'s ``data-theme`` with a hardcoded
+``'dark'`` fallback, so:
+
+  - a plot opened in its own tab ("Open in new tab") had no parent and always
+    rendered dark, whatever the operator's theme or OS preference;
+  - every theme outside the ``main`` family (``high-contrast-light``,
+    ``retro-light``, ``desy-light``, ...) missed the two-entry map and fell
+    to the dark palette even inside the gallery.
+
+These tests drive the real served page in a real browser and check the colors
+Plotly actually applied against the ``--chart-*`` tokens of the theme in
+force, for a figure whose author baked a dark palette into the layout (the
+shape of the reported artifact: a 3D scatter with dark ``paper_bgcolor``,
+``scene.bgcolor`` and white text).
+
+Run:
+    .venv/bin/pytest tests/interfaces/artifacts/test_plot_theme_browser.py -v
+
+Skips cleanly when the chromium headless binary is not installed.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.interfaces.conftest import _run_app_server
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from playwright.sync_api import Page
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+# A Plotly page the way ``go.Figure.to_html(include_plotlyjs=False)`` writes
+# one, with the author's dark palette baked into the layout. A 2D trace plus
+# a 3D scene so both the cartesian and the scene branches of the bridge are
+# exercised; the 3D trace is what the reported artifact used. The scene's
+# axis panes are switched on the way plotly.py's default template does it --
+# Plotly only carries ``backgroundcolor`` into the full layout for an axis
+# whose ``showbackground`` is on, so this is what makes the pane assertion
+# observable.
+_DARK_BAKED_PLOT = """<html>
+<head><meta charset="utf-8" /></head>
+<body>
+<div style="height:600px; width:800px;">
+<div id="plot-a" class="plotly-graph-div" style="height:100%; width:100%;"></div>
+<script>
+Plotly.newPlot("plot-a",
+  [{"type":"scatter","x":[0,1,2],"y":[1,3,2],"mode":"lines"}],
+  {"paper_bgcolor":"rgba(15, 15, 25, 1)","plot_bgcolor":"rgba(15, 15, 25, 1)",
+   "font":{"color":"white"},"width":800,"height":600});
+</script>
+<div id="plot-b" class="plotly-graph-div" style="height:100%; width:100%;"></div>
+<script>
+Plotly.newPlot("plot-b",
+  [{"type":"scatter3d","x":[0,1],"y":[0,1],"z":[0,1],"mode":"markers"}],
+  {"paper_bgcolor":"rgba(15, 15, 25, 1)",
+   "scene":{"bgcolor":"rgba(10, 10, 20, 0.95)",
+            "xaxis":{"showbackground":true},"yaxis":{"showbackground":true},
+            "zaxis":{"showbackground":true}},
+   "font":{"color":"white"},"width":800,"height":600});
+</script>
+</div>
+</body>
+</html>"""
+
+# JS that reports what Plotly actually applied next to the tokens the page's
+# own stylesheet resolves for the theme in force -- one read, one object.
+_PROBE = """() => {
+  const css = getComputedStyle(document.documentElement);
+  const tok = (n) => css.getPropertyValue(n).trim();
+  const a = document.getElementById('plot-a'), b = document.getElementById('plot-b');
+  const fa = a && a._fullLayout, fb = b && b._fullLayout;
+  return {
+    theme: document.documentElement.getAttribute('data-theme'),
+    tokens: { paper: tok('--chart-paper-bg'), plot: tok('--chart-plot-bg'),
+              text: tok('--chart-axis-text'), pane: tok('--chart-pane-bg') },
+    a: fa && { paper: fa.paper_bgcolor, plot: fa.plot_bgcolor, font: fa.font.color,
+               visible: a.style.visibility },
+    b: fb && { paper: fb.paper_bgcolor, font: fb.font.color,
+               scene: fb.scene && fb.scene.bgcolor,
+               pane: fb.scene && fb.scene.xaxis && fb.scene.xaxis.backgroundcolor,
+               hasCartesianAxis: 'xaxis' in b.layout },
+    bodyBg: getComputedStyle(document.body).backgroundColor,
+  };
+}"""
+
+
+@contextmanager
+def _launch(tmp_path, monkeypatch, *, web_theme: str | None = None) -> Iterator[tuple[str, str]]:
+    """Serve the gallery with one dark-baked ``plot_html`` artifact seeded.
+
+    Yields ``(base_url, file_path)`` where ``file_path`` is the artifact's
+    ``/files/...`` route. ``OSPREY_OFFLINE=1`` pins the injected Plotly bundle
+    to the vendored copy so the page is self-contained.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OSPREY_OFFLINE", "1")
+    if web_theme is None:
+        monkeypatch.delenv("OSPREY_WEB_THEME", raising=False)
+    else:
+        monkeypatch.setenv("OSPREY_WEB_THEME", web_theme)
+
+    from osprey.stores.artifact_store import ArtifactStore
+
+    entry = ArtifactStore(workspace_root=tmp_path).save_file(
+        file_content=_DARK_BAKED_PLOT.encode(),
+        filename="dark-baked.html",
+        artifact_type="plot_html",
+        title="Dark-baked 3D correlation",
+        description="fixture",
+        mime_type="text/html",
+        tool_source="test_fixture",
+        category="visualization",
+    )
+
+    from osprey.interfaces.artifacts.app import create_app
+
+    app = create_app(workspace_root=tmp_path)
+    with _run_app_server(app) as base_url:
+        yield base_url, f"/files/{entry.id}/{entry.filename}"
+
+
+def _probe(page: Page) -> dict:
+    # The bridge reveals a chart only after its relayout resolved; wait for
+    # that rather than for a fixed delay.
+    page.wait_for_function(
+        "() => { const a = document.getElementById('plot-a');"
+        " return a && a._fullLayout && a.style.visibility === 'visible'; }",
+        timeout=15_000,
+    )
+    return page.evaluate(_PROBE)
+
+
+def _assert_follows_tokens(probe: dict, expected_theme: str) -> None:
+    assert probe["theme"] == expected_theme
+    tokens = probe["tokens"]
+    assert tokens["paper"], "tokens.css did not resolve on the served page"
+    assert probe["a"]["paper"] == tokens["paper"]
+    assert probe["a"]["plot"] == tokens["plot"]
+    assert probe["a"]["font"] == tokens["text"]
+    assert probe["bodyBg"] != "rgba(0, 0, 0, 0)", "page background must be painted"
+    # The 3D scene: box and axis panes re-themed, and the bridge must not
+    # have conjured a cartesian axis onto a scene-only figure.
+    assert probe["b"]["paper"] == tokens["paper"]
+    assert probe["b"]["scene"] == tokens["plot"]
+    assert probe["b"]["pane"] == tokens["pane"]
+    assert probe["b"]["hasCartesianAxis"] is False
+
+
+def test_standalone_page_follows_query_theme_outside_main_family(
+    tmp_path, monkeypatch, chromium_browser
+):
+    """No parent frame, a non-main light theme requested: the plot must take
+    that theme's tokens, not a dark fallback."""
+    with _launch(tmp_path, monkeypatch) as (base_url, path):
+        page = chromium_browser.new_page()
+        page.goto(f"{base_url}{path}?theme=high-contrast-light")
+        _assert_follows_tokens(_probe(page), "high-contrast-light")
+
+
+def test_standalone_page_follows_os_light_preference(tmp_path, monkeypatch, chromium_browser):
+    """Nothing stored, nothing requested, OS prefers light: the plot is light."""
+    with _launch(tmp_path, monkeypatch) as (base_url, path):
+        ctx = chromium_browser.new_context(color_scheme="light")
+        page = ctx.new_page()
+        page.goto(f"{base_url}{path}")
+        _assert_follows_tokens(_probe(page), "light")
+
+
+def test_standalone_page_honors_pinned_web_theme(tmp_path, monkeypatch, chromium_browser):
+    """A deployment pin (``web.theme: light``) wins over a dark OS preference
+    on a first visit, exactly as it does for the terminal itself."""
+    with _launch(tmp_path, monkeypatch, web_theme="light") as (base_url, path):
+        ctx = chromium_browser.new_context(color_scheme="dark")
+        page = ctx.new_page()
+        page.goto(f"{base_url}{path}")
+        _assert_follows_tokens(_probe(page), "light")
+
+
+def test_unstyled_html_artifact_gets_themed_defaults(tmp_path, monkeypatch, chromium_browser):
+    """A served table/html artifact with no styling of its own paints the
+    theme's background and text color (zero-specificity defaults), instead of
+    browser-default black-on-white."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OSPREY_OFFLINE", "1")
+    monkeypatch.delenv("OSPREY_WEB_THEME", raising=False)
+
+    from osprey.stores.artifact_store import ArtifactStore
+
+    entry = ArtifactStore(workspace_root=tmp_path).save_file(
+        file_content=(
+            b'<html><head></head><body><table class="artifact-table">'
+            b"<tr><th>ch</th></tr><tr><td>SR01C:HCM1</td></tr></table></body></html>"
+        ),
+        filename="readings.html",
+        artifact_type="table_html",
+        title="Readings",
+        description="fixture",
+        mime_type="text/html",
+        tool_source="test_fixture",
+    )
+
+    from osprey.interfaces.artifacts.app import create_app
+
+    app = create_app(workspace_root=tmp_path)
+    with _run_app_server(app) as base_url:
+        page = chromium_browser.new_page()
+        page.goto(f"{base_url}/files/{entry.id}/{entry.filename}?theme=dark")
+        page.wait_for_function(
+            "() => document.documentElement.getAttribute('data-theme') === 'dark'"
+        )
+        probe = page.evaluate(
+            """() => {
+              const css = getComputedStyle(document.documentElement);
+              return {
+                bgToken: css.getPropertyValue('--bg-primary').trim(),
+                htmlBg: getComputedStyle(document.documentElement).backgroundColor,
+                bodyColor: getComputedStyle(document.body).color,
+                textToken: css.getPropertyValue('--text-primary').trim(),
+              };
+            }"""
+        )
+        assert probe["bgToken"], "tokens.css did not resolve"
+
+        def _rgb(hex_color: str) -> str:
+            hex_color = hex_color.lstrip("#")
+            r, g, b = (int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+            return f"rgb({r}, {g}, {b})"
+
+        assert probe["htmlBg"] == _rgb(probe["bgToken"])
+        assert probe["bodyColor"] == _rgb(probe["textToken"])
+
+
+def test_embedded_page_retheme_on_hub_broadcast(tmp_path, monkeypatch, chromium_browser):
+    """Inside the gallery the hub broadcasts ``osprey-theme-change``; the
+    bridge must re-theme live to whatever id arrives -- including one outside
+    the main family -- through the same token path."""
+    with _launch(tmp_path, monkeypatch) as (base_url, path):
+        page = chromium_browser.new_page()
+        page.goto(f"{base_url}{path}?theme=dark")
+        _assert_follows_tokens(_probe(page), "dark")
+        page.evaluate(
+            "() => window.postMessage({type: 'osprey-theme-change', theme: 'retro-light'},"
+            " window.location.origin)"
+        )
+        page.wait_for_function(
+            "() => document.documentElement.getAttribute('data-theme') === 'retro-light'"
+            " && document.getElementById('plot-a')._fullLayout.paper_bgcolor"
+            "    === getComputedStyle(document.documentElement)"
+            "         .getPropertyValue('--chart-paper-bg').trim()",
+            timeout=15_000,
+        )
+        _assert_follows_tokens(page.evaluate(_PROBE), "retro-light")

--- a/tests/interfaces/artifacts/timeseries.test.mjs
+++ b/tests/interfaces/artifacts/timeseries.test.mjs
@@ -170,7 +170,7 @@ function setChartVars({ bgPrimary = '#000', paperBg, plotBg, axisText, grid, bor
   root.setProperty('--chart-plot-bg', plotBg);
   root.setProperty('--chart-axis-text', axisText);
   root.setProperty('--chart-grid', grid);
-  root.setProperty('--border-default', border);
+  root.setProperty('--chart-axis-line', border);
 }
 
 beforeEach(() => {
@@ -186,7 +186,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
-  ['--bg-primary', '--chart-paper-bg', '--chart-plot-bg', '--chart-axis-text', '--chart-grid', '--border-default']
+  ['--bg-primary', '--chart-paper-bg', '--chart-plot-bg', '--chart-axis-text', '--chart-grid', '--chart-axis-line']
     .forEach((v) => document.documentElement.style.removeProperty(v));
 });
 

--- a/tests/interfaces/artifacts/types.test.mjs
+++ b/tests/interfaces/artifacts/types.test.mjs
@@ -26,6 +26,7 @@ import {
   typeColor,
   thumbnailHtml,
   escapeHtml,
+  withTheme,
   formatSize,
   formatTime,
   formatFullTime,
@@ -303,6 +304,41 @@ describe('openUrl', () => {
 
   test('notebook branch is byte-identical for a real 12-hex artifact id', () => {
     expect(openUrl({ id: '0123456789ab', artifact_type: 'notebook', filename: 'x.ipynb' })).toBe('/api/notebooks/0123456789ab/rendered');
+  });
+
+  // A page opened in its own tab has no hub parent to follow: the link
+  // carries the theme the operator is looking at, which theme-boot.js honors
+  // ahead of storage and the OS preference on that page.
+  test('a theme id is carried as ?theme= on every branch', () => {
+    expect(openUrl({ id: 'a3', artifact_type: 'plot_html', filename: 'p.html' }, 'retro-light'))
+      .toBe('/files/a3/p.html?theme=retro-light');
+    expect(openUrl({ id: 'a1', artifact_type: 'markdown', filename: 'x.md' }, 'high-contrast-dark'))
+      .toBe('/api/markdown/a1/rendered?theme=high-contrast-dark');
+    expect(openUrl({ id: 'a2', artifact_type: 'notebook', filename: 'x.ipynb' }, 'light'))
+      .toBe('/api/notebooks/a2/rendered?theme=light');
+  });
+
+  test('a missing theme (theme-manager not initialised) leaves the URL bare', () => {
+    expect(openUrl({ id: 'a3', artifact_type: 'plot_html', filename: 'p.html' }, null)).toBe('/files/a3/p.html');
+    expect(openUrl({ id: 'a3', artifact_type: 'plot_html', filename: 'p.html' }, undefined)).toBe('/files/a3/p.html');
+  });
+
+  test('the theme id is percent-encoded, so a hostile value cannot smuggle extra query parameters', () => {
+    const url = openUrl({ id: 'a3', artifact_type: 'plot_html', filename: 'p.html' }, 'x&y=1');
+    expect(url).toBe('/files/a3/p.html?theme=x%26y%3D1');
+  });
+});
+
+describe('withTheme', () => {
+  test('appends ?theme= to a bare URL and &theme= after an existing query', () => {
+    expect(withTheme('/files/a1/p.html', 'light')).toBe('/files/a1/p.html?theme=light');
+    expect(withTheme('/files/a1/p.html?v=2', 'light')).toBe('/files/a1/p.html?v=2&theme=light');
+  });
+
+  test('a missing theme leaves the URL untouched', () => {
+    expect(withTheme('/files/a1/p.html', null)).toBe('/files/a1/p.html');
+    expect(withTheme('/files/a1/p.html', undefined)).toBe('/files/a1/p.html');
+    expect(withTheme('/files/a1/p.html', '')).toBe('/files/a1/p.html');
   });
 });
 

--- a/tests/interfaces/web_terminal/test_theme_config.py
+++ b/tests/interfaces/web_terminal/test_theme_config.py
@@ -6,7 +6,7 @@ concrete baked theme id and server-rendered onto `<html data-theme>` so the
 generated `theme-boot.js` (Task 1.8) first-paints with no flash.
 
 Covers:
-    - `resolve_web_theme_id` (pure resolver): family -> family's dark id,
+    - `resolve_theme_id` (pure resolver): family -> family's dark id,
       concrete id passthrough, unknown -> warn + fallback to osprey's dark id.
     - The render path: GET "/" contains the expected `data-theme="..."`.
 """
@@ -20,11 +20,14 @@ import pytest
 from fastapi.testclient import TestClient
 
 from osprey.interfaces.design_system.generator.emit_js import ThemeManifestEntry
-from osprey.interfaces.web_terminal.app import (
-    create_app,
-    resolve_web_theme_id,
-    resolve_web_theme_pinned_mode,
+from osprey.interfaces.design_system.theme_config import (
+    DEFAULT_WEB_THEME,
+    configured_web_theme,
+    resolve_configured_web_theme,
+    resolve_pinned_mode,
+    resolve_theme_id,
 )
+from osprey.interfaces.web_terminal.app import create_app
 
 # A synthetic manifest mirroring the real baked tokens.js THEMES: the
 # `main` family (dark/light) plus a `high-contrast` family (dark/light).
@@ -49,22 +52,22 @@ class TestResolveWebThemeId:
 
     def test_family_resolves_to_family_dark_id(self):
         """A family name resolves to that family's dark id (the SSR default)."""
-        assert resolve_web_theme_id("high-contrast", _ENTRIES, _DEFAULTS) == "high-contrast-dark"
+        assert resolve_theme_id("high-contrast", _ENTRIES, _DEFAULTS) == "high-contrast-dark"
 
     def test_main_family_resolves_to_dark(self):
-        assert resolve_web_theme_id("main", _ENTRIES, _DEFAULTS) == "dark"
+        assert resolve_theme_id("main", _ENTRIES, _DEFAULTS) == "dark"
 
     def test_concrete_id_passes_through(self):
         """A concrete id (e.g. pinning a specific mode) is used as-is."""
-        assert resolve_web_theme_id("light", _ENTRIES, _DEFAULTS) == "light"
-        assert resolve_web_theme_id("high-contrast-light", _ENTRIES, _DEFAULTS) == (
+        assert resolve_theme_id("light", _ENTRIES, _DEFAULTS) == "light"
+        assert resolve_theme_id("high-contrast-light", _ENTRIES, _DEFAULTS) == (
             "high-contrast-light"
         )
 
     def test_unknown_value_warns_and_falls_back_to_osprey_dark(self, caplog):
         """An unrecognized value logs a warning and falls back to osprey's dark id."""
         with caplog.at_level(logging.WARNING):
-            result = resolve_web_theme_id("nonsense", _ENTRIES, _DEFAULTS)
+            result = resolve_theme_id("nonsense", _ENTRIES, _DEFAULTS)
 
         assert result == "dark"
         assert any(
@@ -75,10 +78,10 @@ class TestResolveWebThemeId:
     def test_unknown_value_never_raises(self):
         """The resolver never raises on bad input — it only warns and falls back."""
         try:
-            resolve_web_theme_id("", _ENTRIES, _DEFAULTS)
-            resolve_web_theme_id(None, _ENTRIES, _DEFAULTS)  # type: ignore[arg-type]
+            resolve_theme_id("", _ENTRIES, _DEFAULTS)
+            resolve_theme_id(None, _ENTRIES, _DEFAULTS)  # type: ignore[arg-type]
         except Exception as exc:  # pragma: no cover - failure path
-            pytest.fail(f"resolve_web_theme_id raised unexpectedly: {exc}")
+            pytest.fail(f"resolve_theme_id raised unexpectedly: {exc}")
 
     def test_result_is_always_a_valid_baked_id(self):
         """Whatever is returned must be one of the concrete ids in the manifest.
@@ -89,7 +92,7 @@ class TestResolveWebThemeId:
         """
         valid_ids = {entry.id for entry in _ENTRIES}
         for configured in ("main", "high-contrast", "dark", "high-contrast-light", "bogus"):
-            assert resolve_web_theme_id(configured, _ENTRIES, _DEFAULTS) in valid_ids
+            assert resolve_theme_id(configured, _ENTRIES, _DEFAULTS) in valid_ids
 
 
 # ---- Render path: GET "/" server-renders the resolved data-theme ----
@@ -214,18 +217,18 @@ class TestResolveWebThemePinnedMode:
     """A configured value either states a mode or leaves it to the OS."""
 
     def test_concrete_id_pins_its_own_mode(self):
-        assert resolve_web_theme_pinned_mode("high-contrast-light", _ENTRIES) == "light"
-        assert resolve_web_theme_pinned_mode("dark", _ENTRIES) == "dark"
+        assert resolve_pinned_mode("high-contrast-light", _ENTRIES) == "light"
+        assert resolve_pinned_mode("dark", _ENTRIES) == "dark"
 
     def test_family_pins_nothing(self):
         """A family states a palette only — light/dark stays the operator's OS call."""
-        assert resolve_web_theme_pinned_mode("high-contrast", _ENTRIES) is None
-        assert resolve_web_theme_pinned_mode("main", _ENTRIES) is None
+        assert resolve_pinned_mode("high-contrast", _ENTRIES) is None
+        assert resolve_pinned_mode("main", _ENTRIES) is None
 
     def test_unknown_value_pins_nothing(self):
         """An unknown value falls back; a fallback must not pose as stated intent."""
-        assert resolve_web_theme_pinned_mode("nonsense", _ENTRIES) is None
-        assert resolve_web_theme_pinned_mode("", _ENTRIES) is None
+        assert resolve_pinned_mode("nonsense", _ENTRIES) is None
+        assert resolve_pinned_mode("", _ENTRIES) is None
 
 
 class TestRenderedThemeMode:
@@ -329,3 +332,96 @@ class TestThemeEnvOverride:
             assert "data-theme-mode" not in body
         finally:
             next(gen, None)
+
+
+# ---- The shared chain: environment -> web.theme -> id + pin + family ----
+
+
+class TestConfiguredWebTheme:
+    """`configured_web_theme()` — the raw value, read once for every surface.
+
+    The web terminal (above) and the artifact gallery both server-render a
+    theme, and both used to spell this precedence out for themselves; it now
+    lives in the design system so the two cannot drift apart.
+    """
+
+    def test_env_var_outranks_config(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_WEB_THEME", "desy-light")
+        with patch("osprey.utils.config.get_config_value", return_value="main") as get_value:
+            assert configured_web_theme() == "desy-light"
+        get_value.assert_not_called()  # the config is not even read
+
+    def test_blank_env_var_falls_through_to_config(self, monkeypatch):
+        """An empty env var is 'unset', not 'the empty theme'."""
+        monkeypatch.setenv("OSPREY_WEB_THEME", "   ")
+        with patch("osprey.utils.config.get_config_value", return_value="retro") as get_value:
+            assert configured_web_theme() == "retro"
+        get_value.assert_called_once_with("web.theme", "main")
+
+    def test_absent_env_var_reads_web_theme_with_the_main_default(self, monkeypatch):
+        monkeypatch.delenv("OSPREY_WEB_THEME", raising=False)
+        with patch("osprey.utils.config.get_config_value", return_value="main") as get_value:
+            assert configured_web_theme() == DEFAULT_WEB_THEME
+        get_value.assert_called_once_with("web.theme", "main")
+
+    def test_empty_config_value_falls_back_to_the_default(self, monkeypatch):
+        """`web.theme:` with nothing after it reads as None, not as a theme name."""
+        monkeypatch.delenv("OSPREY_WEB_THEME", raising=False)
+        with patch("osprey.utils.config.get_config_value", return_value=None):
+            assert configured_web_theme() == DEFAULT_WEB_THEME
+
+    def test_config_read_error_propagates(self, monkeypatch):
+        """No config primed: the callers disagree about what to do (the terminal
+        renders a fallback theme, the gallery serves unpinned pages), so this
+        must not decide for them."""
+        monkeypatch.delenv("OSPREY_WEB_THEME", raising=False)
+        with (
+            patch(
+                "osprey.utils.config.get_config_value",
+                side_effect=FileNotFoundError("no config.yml found"),
+            ),
+            pytest.raises(FileNotFoundError),
+        ):
+            configured_web_theme()
+
+
+class TestResolveConfiguredWebTheme:
+    """`resolve_configured_web_theme()` — id, pin and family in one read.
+
+    Resolved against the real baked token tree, since the point of the helper
+    is that every surface sees the same registry.
+    """
+
+    def test_concrete_id_resolves_to_itself_and_pins_its_mode(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_WEB_THEME", "high-contrast-light")
+        resolved = resolve_configured_web_theme()
+        assert (resolved.id, resolved.pinned_mode, resolved.family) == (
+            "high-contrast-light",
+            "light",
+            "high-contrast",
+        )
+
+    def test_family_resolves_to_its_dark_id_but_pins_nothing(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_WEB_THEME", "high-contrast")
+        resolved = resolve_configured_web_theme()
+        assert resolved.id == "high-contrast-dark"
+        assert resolved.pinned_mode is None
+        assert resolved.family == "high-contrast"
+
+    def test_unknown_value_falls_back_without_posing_as_a_pin(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_WEB_THEME", "nonsense")
+        resolved = resolve_configured_web_theme()
+        assert resolved.id == "dark"
+        assert resolved.pinned_mode is None
+        assert resolved.family == "main"
+
+    def test_explicit_value_bypasses_the_environment(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_WEB_THEME", "high-contrast-light")
+        assert resolve_configured_web_theme("light").id == "light"
+
+    def test_result_is_immutable(self):
+        """A resolved theme is read once at startup and shared; it must not be
+        editable in place by whatever reads it later."""
+        resolved = resolve_configured_web_theme("light")
+        with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError is a dataclass detail
+            resolved.id = "dark"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- An interactive plot opened in its own tab always rendered dark, and any theme outside the `main` family fell back to the dark palette even inside the gallery — the snippet injected into served pages carried its own two-entry hex palette and resolved the theme by reading `window.parent`, which a standalone tab does not have.
- Served artifact pages are now design-system pages like any other, so all eight themes work and no page carries a palette of its own.
- The token → Plotly mapping and the `web.theme` resolution chain each become one shared implementation instead of being written out per surface.

## Changes

**Design system**
- `chartRelayout(gd)` re-themes an already-plotted figure from the `--chart-*` tokens, covering only the subplots a figure actually has (relayouting `xaxis.*` onto a scene-only figure would conjure a phantom 2D axis). The gallery's served pages and its own timeseries charts both apply it, so a first render and a live flip agree.
- Two tokens it needs — `chart.pane-bg` (3D axis panes) and `chart.axis-line` (axis/legend lines) — added to all eight themes.
- `resolve_configured_web_theme()` makes the environment → `web.theme` → registry chain one function returning id, pin and family together; the web terminal and the gallery both call it, each keeping its own failure posture.

**Artifacts gallery**
- `plot_html` / `table_html` / `html` / `dashboard_html` pages load `theme-boot.js` + `tokens.css` and init as followers. Pages with no styling of their own get themed defaults at zero specificity, so a self-styled report keeps its look while a bare pandas table stops being a white island.
- Because such a page resolves its own theme rather than reading the parent's, the gallery now states it: embedded pages carry it on their `src` and are re-sent it as they load (which also keeps card thumbnails in step), and "open in new tab" links are re-stamped as it changes.
- A pinned `web.theme` is server-rendered onto served pages and the gallery shell. The print window is pinned light, since printed output stays light-on-white and a themed page's colors are already in its SVG by then.

**Guidance and CI**
- The plotting guidance told the agent to apply a Plotly template and pick colors — that is how plots ended up with a palette that then fought the theming. Corrected where the agent actually reads it (the `data-visualizer` subagent and the `create_interactive_plot` tool), and only about page chrome; trace colors remain the agent's.
- Both artifact browser suites are now run by the theming job. They are chromium-gated and no job installed chromium for `tests/interfaces/artifacts`, so they had always skipped — including the regression pins for this bug.

## Test plan

- [x] New browser suite `test_plot_theme_browser.py` (5 tests) drives the real served page in a real browser: a standalone page under a non-main light theme, an OS light preference, a deployment pin beating a dark OS, unstyled table defaults, and a live re-theme to `retro-light` — asserting the colors Plotly actually applied against the theme's own tokens.
- [x] New `test_preview_iframe_inherits_gallery_theme` covers the embed path end to end: the iframe `src` carries the theme, the page inside paints in it, and a broadcast re-themes page and link together.
- [x] Endpoint tests pin the server-stamped theme, the design-system wiring, and that no injected snippet carries a color literal or a baked theme id — the hygiene scanner cannot see HTML inside Python strings, so this is the guard that keeps the old hex map from coming back.
- [x] Unit tests for `withTheme`, the viewport `src` stamping, and the light-pinned print URLs.
- [x] `ruff check` / `ruff format --check`, `npm run typecheck`, `npm run lint`, `npm run test:js`, and the design-system generator's `build --check` (the hand-edited `tokens.css` is byte-identical to a regeneration).
- [x] Full `pytest` suite. Remaining local failures are environmental and unrelated: the `test_graph_mcp.py` `@docker` tests need a Neo4j container that was not running (`ServiceUnavailable`), and two timing-sensitive tests (`test_file_watcher`, `test_panels_browser`) fail only under `-n 4` and pass in isolation. This branch touches no graph, watcher or panel code.