### PR TITLE
fix: subagents hand back a pointer; bake the graph snapshot into every container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,11 @@ Compatibility is documented in release notes, not encoded in the version string.
   pointer — the artifact id, a short headline and the identifiers asked for —
   instead of repeating the artifact, and the orchestrator focuses that artifact
   in the gallery rather than re-typing its tables into the chat.
+- Container deployments now get the graph schema snapshot baked into the agent
+  prompts. `osprey up` patched only the host renders, so every container shipped
+  the "no snapshot yet" placeholder and each delegation paid a schema prelude.
+  The channel finder's graph paradigm carries the same snapshot now, with its
+  own example catalogue.
 - Interactive plot artifacts now follow the active theme everywhere: opened in
   their own tab ("Open in new tab"), on first visit with a deployment-pinned
   `web.theme`, and under every theme family — not just light/dark inside the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,12 @@ Compatibility is documented in release notes, not encoded in the version string.
   pointer — the artifact id, a short headline and the identifiers asked for —
   instead of repeating the artifact, and the orchestrator focuses that artifact
   in the gallery rather than re-typing its tables into the chat.
+- Readonly Python runs can import `at` (accelerator-toolbox) again: h5py's
+  import reads the processor name, which CPython resolves by running `uname -p`,
+  and the readonly guard refused that as a subprocess call — so the pyAT
+  specialist could not load its own simulation library. The guard now resolves
+  the value before it locks subprocess down; nothing user code can call was
+  loosened.
 - Container deployments now get the graph schema snapshot baked into the agent
   prompts. `osprey up` patched only the host renders, so every container shipped
   the "no snapshot yet" placeholder and each delegation paid a schema prelude.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,11 @@ Compatibility is documented in release notes, not encoded in the version string.
   control system turned it down, and that no value was written, so the
   operator is not sent to check OSPREY's own write settings for access the
   control system grants.
+- Sub-agents that file their answer as an artifact (channel finder, knowledge
+  graph, logbook search, facility knowledge, pyAT) now hand the orchestrator a
+  pointer — the artifact id, a short headline and the identifiers asked for —
+  instead of repeating the artifact, and the orchestrator focuses that artifact
+  in the gallery rather than re-typing its tables into the chat.
 - Interactive plot artifacts now follow the active theme everywhere: opened in
   their own tab ("Open in new tab"), on first visit with a deployment-pinned
   `web.theme`, and under every theme family — not just light/dark inside the

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -5559,13 +5559,6 @@ def _start_stack(
     if web_terminals_enabled:
         preflight_web_terminals(config, repo_root=Path(repo_root))
 
-    # Build the <project>:local image the dispatch worker references. The worker
-    # has no compose build block (that would race the event-dispatcher on the
-    # shared tag), so this is the only thing that produces its image. No-op
-    # unless the worker is deployed on the local project image. Run before
-    # `compose up` (which, non-detached, os.execvpe-replaces this process).
-    _build_project_image(config, dev_mode, env, build_context)
-
     # Stage the archiver store and seed its history BEFORE the branch split, so
     # both deploy paths inherit it and the recorder — started by whichever `up`
     # follows — finds a collection that already exists with the right indexes.
@@ -5594,6 +5587,16 @@ def _start_stack(
     # both deploy paths need it. No-op unless this project deploys the store
     # itself; never aborts (see _stage_graphdb_store).
     _stage_graphdb_store(config, compose_files, env, Path(repo_root), provider=provider)
+
+    # Build the <project>:local image the dispatch worker references. The worker
+    # has no compose build block (that would race the event-dispatcher on the
+    # shared tag), so this is the only thing that produces its image. No-op
+    # unless the worker is deployed on the local project image. Run before
+    # `compose up` (which, non-detached, os.execvpe-replaces this process) and
+    # AFTER the graph staging above: that step bakes the live store's schema
+    # into the agent prompts inside this image's build context, and an image
+    # built before the bake ships the placeholder prompt.
+    _build_project_image(config, dev_mode, env, build_context)
 
     # And the telemetry store, for a third reason: its ingest credential is one
     # the STORE issues, so the only moment it can be harvested is with the store

--- a/src/osprey/mcp_server/agent_frontmatter.py
+++ b/src/osprey/mcp_server/agent_frontmatter.py
@@ -12,7 +12,8 @@ cannot disagree about which files are agents or what an agent is called.
 Frontmatter contract (matching what the Claude Code CLI loads):
 
 * Only files directly in ``.claude/agents/`` (non-recursive; the templates
-  ship a ``_terminology`` sibling directory that must not be scanned).
+  ship ``_terminology`` and ``_shared`` partial directories alongside the
+  agents that must not be scanned).
 * A file must start with ``---``; the block up to the closing ``---`` is
   parsed with ``yaml.safe_load``.
 * Agents are keyed by the frontmatter ``name:`` (what the CLI dispatches on),

--- a/src/osprey/services/facility_knowledge/seeder/prompt_snapshot.py
+++ b/src/osprey/services/facility_knowledge/seeder/prompt_snapshot.py
@@ -1,10 +1,12 @@
 """Seed-time schema snapshot, baked into the graph agent's rendered prompt.
 
-The facility-knowledge-graph agent needs the store's vocabulary — labels,
+The facility-knowledge-graph agent — and the channel finder in its graph
+paradigm, which reads the same store — needs the store's vocabulary: labels,
 relationship types, property spellings — before it can write a Cypher query
 that returns rows instead of a confident zero. At run time that vocabulary
 comes from the ``get_schema`` and ``example_queries`` tools; this module moves
-the common case earlier, so a fresh subagent starts already knowing it.
+the common case earlier, so a fresh subagent starts already knowing it. Each
+agent file is baked with the example catalogue its own server serves.
 
 **The seeder owns the baked block, not the build.** ``osprey build`` renders
 the agent prompt before any store exists, so it ships a placeholder that tells
@@ -30,11 +32,13 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
 from osprey.services.facility_knowledge.seeder.graph_seeder import NARAD_PREFIXES
+from osprey.utils.workspace import BUILD_DIR_NAME, IMAGE_DIR_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -193,13 +197,36 @@ def detect_corpus(run: RunCypher, known: frozenset[str] | set[str]) -> str | Non
 SNAPSHOT_BEGIN = "<!-- osprey:graph-snapshot begin -->"
 SNAPSHOT_END = "<!-- osprey:graph-snapshot end -->"
 
-#: The rendered agent file this module patches, wherever a render holds one.
+#: The heading the shared template partial puts above the markers. A file that
+#: carries it without the marker pair has been hand-edited.
+SNAPSHOT_HEADING = "## The Graph at Hand"
+
+#: The rendered agent files this module patches, each paired with the module
+#: holding the curated example catalogue its own MCP server serves. One
+#: registry, so a file cannot be found without a catalogue or rendered without
+#: being found. The catalogues are named rather than imported: both are pure
+#: stdlib data, but reaching them through the tools packages must not become
+#: an import-time dependency of the seeder.
 AGENT_FILENAME = "facility-knowledge-graph.md"
+CHANNEL_FINDER_FILENAME = "channel-finder.md"
+_CATALOGUE_MODULES: dict[str, str] = {
+    AGENT_FILENAME: "osprey.mcp_server.graph.tools.examples_data",
+    CHANNEL_FINDER_FILENAME: "osprey.mcp_server.channel_finder_graph.tools.examples_data",
+}
+TARGET_FILENAMES = tuple(_CATALOGUE_MODULES)
+
+
+def _example_catalogues() -> dict[str, Sequence[Any]]:
+    """The curated catalogue each target file is baked with, keyed by filename."""
+    return {
+        filename: import_module(module).EXAMPLE_QUERIES
+        for filename, module in _CATALOGUE_MODULES.items()
+    }
 
 
 def render_block(
     schema: dict[str, Any],
-    examples: list[Any],
+    examples: Sequence[Any],
     *,
     corpus: str | None,
     digest: str | None,
@@ -278,29 +305,44 @@ def render_block(
 
 
 def snapshot_targets(render_dir: Path) -> list[Path]:
-    """Every rendered graph-agent file under *render_dir*.
+    """Every rendered graph-querying agent file under *render_dir*.
 
-    The render's own ``.claude/agents/`` plus one directory level down, which
-    is where attached persona renders (the operator terminals sharing this
-    deployment's store) keep theirs. Deliberately not a recursive walk: a
-    render carries a ``.venv`` that makes ``rglob`` pay for tens of thousands
-    of directories to find at most a handful of files.
+    Three places, all of them renders of this one deployment: the render's own
+    ``.claude/agents/``; one directory level down, where attached persona
+    renders (the operator terminals sharing this deployment's store) keep
+    theirs; and the container-path copies ``osprey build`` stages as each
+    image's build context (:func:`osprey.utils.workspace.container_image_context`),
+    which the images are built from.
+
+    Deliberately not a recursive walk: a render carries a ``.venv`` that makes
+    ``rglob`` pay for tens of thousands of directories to find a handful of
+    files.
     """
-    candidates = [render_dir / ".claude" / "agents" / AGENT_FILENAME]
-    candidates += sorted(render_dir.glob(f"*/.claude/agents/{AGENT_FILENAME}"))
+    agent_dirs = [
+        render_dir / ".claude" / "agents",
+        *sorted(render_dir.glob("*/.claude/agents")),
+        *sorted(render_dir.glob(f"{IMAGE_DIR_NAME}/*/{BUILD_DIR_NAME}/.claude/agents")),
+    ]
+    candidates = [agents / filename for agents in agent_dirs for filename in TARGET_FILENAMES]
     return [path for path in candidates if path.is_file()]
 
 
-def apply_snapshot(render_dir: Path, block: str) -> list[Path]:
-    """Replace the managed region of every target file with *block*.
+def apply_snapshot(render_dir: Path, blocks: Mapping[str, str]) -> list[Path]:
+    """Replace the managed region of every target file with its block.
 
-    A file without both markers is skipped rather than appended to: the marker
-    pair ships with the agent template, so its absence means a hand-edited or
-    pre-snapshot render, and growing an unmarked section in someone's edited
-    prompt is worse than leaving the tools to answer at run time.
+    Args:
+        render_dir: The directory holding the rendered ``config.yml``.
+        blocks: The rendered block per target filename (:data:`TARGET_FILENAMES`).
+
+    A file without the marker pair is never appended to. One that still shows
+    a trace of the section — the heading, or a lone marker — has been
+    hand-edited, and growing an unmarked section in someone's edited prompt is
+    worse than leaving the tools to answer at run time, so it is reported and
+    left alone. One with no trace at all never shipped the section (the
+    channel finder outside its graph paradigm) and is skipped quietly.
 
     Returns:
-        The files now carrying *block* (rewritten or already current).
+        The files now carrying their block (rewritten or already current).
     """
     patched: list[Path] = []
     for path in snapshot_targets(render_dir):
@@ -308,10 +350,11 @@ def apply_snapshot(render_dir: Path, block: str) -> list[Path]:
         begin = text.find(SNAPSHOT_BEGIN)
         end = text.find(SNAPSHOT_END)
         if begin == -1 or end < begin:
-            logger.warning("No snapshot markers in %s; leaving it alone", path)
+            if begin != -1 or end != -1 or SNAPSHOT_HEADING in text:
+                logger.warning("No snapshot marker pair in %s; leaving it alone", path)
             continue
         end += len(SNAPSHOT_END)
-        updated = text[:begin] + block + text[end:]
+        updated = text[:begin] + blocks[path.name] + text[end:]
         if updated != text:
             path.write_text(updated, encoding="utf-8")
         patched.append(path)
@@ -331,24 +374,31 @@ def bake_snapshot(session: Any, render_dir: Path) -> list[Path]:
 
     Returns:
         The rendered agent files now carrying the snapshot; empty when the
-        render has none (the agent is disabled, or this is a store-only
-        project).
+        render has none (the agents are disabled, the channel finder runs
+        another paradigm, or this is a store-only project).
     """
-    # Function-local: examples_data is pure stdlib data, but importing it
-    # through the tools package must not become an import-time dependency of
-    # the seeder.
-    from osprey.mcp_server.graph.tools.examples_data import EXAMPLE_QUERIES
     from osprey.services.facility_knowledge.seeder import graph_seeder
 
     def run(cypher: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         return [record.data() for record in session.run(cypher, params or {})]
 
-    known = frozenset(corpus for example in EXAMPLE_QUERIES for corpus in example.parameters)
-    block = render_block(
-        collect_schema(run),
-        list(EXAMPLE_QUERIES),
-        corpus=detect_corpus(run, known),
-        digest=graph_seeder.read_marker(session),
-        resource_count=graph_seeder.resource_count(session),
+    catalogues = _example_catalogues()
+    known = frozenset(
+        corpus
+        for examples in catalogues.values()
+        for example in examples
+        for corpus in example.parameters
     )
-    return apply_snapshot(render_dir, block)
+    # One capture, rendered once per catalogue: the schema is the store's and
+    # the same for both agents; only the curated examples differ.
+    schema = collect_schema(run)
+    corpus = detect_corpus(run, known)
+    digest = graph_seeder.read_marker(session)
+    resource_count = graph_seeder.resource_count(session)
+    blocks = {
+        filename: render_block(
+            schema, examples, corpus=corpus, digest=digest, resource_count=resource_count
+        )
+        for filename, examples in catalogues.items()
+    }
+    return apply_snapshot(render_dir, blocks)

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -584,6 +584,17 @@ if not _execution_dir.exists():
             # user code, so an alias bound later resolves here.
             import importlib as _osprey_importlib
 
+            # CPython resolves ``platform.uname().processor`` lazily, by
+            # shelling out to ``uname -p`` on first read — and h5py reads it
+            # while ``import at`` initialises its type layer, so the subprocess
+            # refusal below would kill the import of a pure-simulation library.
+            # Resolve it once now, while spawning is still allowed; the cached
+            # value answers every later lookup without touching subprocess.
+            import platform as _osprey_platform
+
+            _osprey_platform.processor()
+            del _osprey_platform
+
             _osprey_targets = {_READONLY_WRITE_TARGETS!r}
 
 

--- a/src/osprey/templates/claude_code/claude/agents/_shared/graph_snapshot.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/_shared/graph_snapshot.md.j2
@@ -1,0 +1,20 @@
+{#- The seed-time schema snapshot, shared by every agent that queries the
+    knowledge graph (facility-knowledge-graph, and the channel finder in its
+    graph paradigm). The managed region between the markers is REWRITTEN IN
+    THE RENDER by whichever verb seeds or re-verifies the store (`osprey up`'s
+    staging step, or `osprey knowledge seed-graph`): prompt_snapshot
+    .bake_snapshot() replaces marker-to-marker with the schema and the
+    including agent's own curated examples, captured from the live store and
+    stamped with the seed marker's checksum. The placeholder is what an
+    unseeded render ships. Keep the marker comments byte-identical to
+    prompt_snapshot.SNAPSHOT_BEGIN/END — a consistency test pins them. -#}
+## The Graph at Hand
+
+<!-- osprey:graph-snapshot begin -->
+
+No snapshot has been captured yet. The store is seeded at deploy time, and
+whichever verb touches it (`osprey up`, `osprey knowledge seed-graph`) fills
+this section in from the live store. Until then, start with
+`example_queries()` and `get_schema()` before writing any Cypher.
+
+<!-- osprey:graph-snapshot end -->

--- a/src/osprey/templates/claude_code/claude/agents/_shared/handback.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/_shared/handback.md.j2
@@ -1,0 +1,22 @@
+{#- The hand-back contract every subagent that files its answer with
+    submit_response shares. The artifact is the deliverable; the text the
+    subagent returns to the parent is a pointer to it. Set `handback_label`
+    before including to relabel the id line (the channel finder keeps its
+    tested "Channels found"); the default is "Results". -#}
+## Handing Back
+
+`submit_response` files your answer as an artifact and returns its `artifact_id`.
+The artifact is the deliverable. Your reply to the parent is a pointer to it, not
+a copy of it: the parent shows it to the user by focusing it in the gallery, and
+reads it with `artifact_read` only when the next step needs the detail. Your
+reply to the parent is exactly this:
+
+**{{ handback_label | default("Results") }}** (artifact_id: <id>)
+<the headline, a few sentences at most: the answer itself, and anything the
+parent must know before acting on it — a list that came back truncated, an
+ambiguity you resolved, a scope you narrowed>
+<the definitive identifiers, one per line, when the question asked for them —
+the same identifiers you filed with the artifact>
+
+Never paste the artifact body — tables, per-device listings, full entry text —
+into the reply.

--- a/src/osprey/templates/claude_code/claude/agents/channel-finder.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/channel-finder.md.j2
@@ -316,10 +316,6 @@ As your FINAL action, call `submit_response` to persist your findings:
 - `data_type`: "channel_addresses"
 - `source_agent`: "channel-finder"
 
-Include the returned `artifact_id` in your final answer:
-**Channels found** (artifact_id: 2):
-- CHANNEL:ADDRESS:ONE
-- CHANNEL:ADDRESS:TWO
-
-This allows the orchestrator to reference the artifact entry for downstream tools.
+{% set handback_label = "Channels found" -%}
+{% include "claude_code/claude/agents/_shared/handback.md.j2" %}
 {%- endif %}

--- a/src/osprey/templates/claude_code/claude/agents/channel-finder.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/channel-finder.md.j2
@@ -168,6 +168,11 @@ verbatim or summarize.
 The channel database is a knowledge graph and you query it by writing read-only
 Cypher. Work in this order — do not open by composing a query from scratch.
 
+The **Graph at Hand** section below may already carry the store's schema and
+the curated examples, captured from the live store when its corpus was seeded.
+When it does, go straight to Step 3; Steps 1 and 2 are for what that snapshot
+does not answer.
+
 ### Step 1: Read the curated examples
 
 Call `example_queries()`. It returns runnable Cypher for the shapes that answer
@@ -281,6 +286,8 @@ Every address you report must have come back from a query as a `fullPv` value.
 A query naming a label or property that does not exist returns zero rows rather
 than an error, so an empty result means "check the spelling with `get_schema()`"
 at least as often as it means "the facility has no such device".
+
+{% include "claude_code/claude/agents/_shared/graph_snapshot.md.j2" %}
 
 {% include "claude_code/claude/agents/_terminology/graph.md.j2" %}
 {% else %}

--- a/src/osprey/templates/claude_code/claude/agents/facility-knowledge-graph.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/facility-knowledge-graph.md.j2
@@ -124,6 +124,5 @@ As your FINAL action, call `submit_response` to persist your findings:
 - `data_type`: "agent_response"
 - `source_agent`: "facility-knowledge-graph"
 
-Include the returned `artifact_id` in your final answer:
-**Results** (artifact_id: 3): ...
-{% endif %}
+{% include "claude_code/claude/agents/_shared/handback.md.j2" %}
+{%- endif %}

--- a/src/osprey/templates/claude_code/claude/agents/facility-knowledge-graph.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/facility-knowledge-graph.md.j2
@@ -95,23 +95,7 @@ remedy — and never retry an unreachable store.
   rows, never kinds. When unsure, prefer the narrower set and say what you
   excluded.
 
-## The Graph at Hand
-
-{#- The managed region below is REWRITTEN IN THE RENDER by whichever verb
-    seeds or re-verifies the store (`osprey up`'s staging step, or `osprey
-    knowledge seed-graph`): prompt_snapshot.bake_snapshot() replaces
-    marker-to-marker with the schema and curated examples captured from the
-    live store, stamped with the seed marker's checksum. The placeholder is
-    what an unseeded render ships. Keep the marker comments byte-identical to
-    prompt_snapshot.SNAPSHOT_BEGIN/END — a consistency test pins them. -#}
-<!-- osprey:graph-snapshot begin -->
-
-No snapshot has been captured yet. The store is seeded at deploy time, and
-whichever verb touches it (`osprey up`, `osprey knowledge seed-graph`) fills
-this section in from the live store. Until then, start with
-`example_queries()` and `get_schema()` before writing any Cypher.
-
-<!-- osprey:graph-snapshot end -->
+{% include "claude_code/claude/agents/_shared/graph_snapshot.md.j2" %}
 
 ## Submitting Results
 

--- a/src/osprey/templates/claude_code/claude/agents/facility-knowledge.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/facility-knowledge.md.j2
@@ -60,6 +60,5 @@ As your FINAL action, call `submit_response` to persist your findings:
 - `data_type`: "facility_knowledge"
 - `source_agent`: "facility-knowledge"
 
-Include the returned `artifact_id` in your final answer:
-**Results** (artifact_id: 3): ...
-{% endif %}
+{% include "claude_code/claude/agents/_shared/handback.md.j2" %}
+{%- endif %}

--- a/src/osprey/templates/claude_code/claude/agents/logbook-deep-research.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/logbook-deep-research.md.j2
@@ -102,6 +102,5 @@ As your FINAL action, call `submit_response` to persist your findings:
 - `data_type`: "logbook_research"
 - `source_agent`: "logbook-deep-research"
 
-Include the returned `artifact_id` in your final answer:
-**Results** (artifact_id: 5): ...
-{% endif %}
+{% include "claude_code/claude/agents/_shared/handback.md.j2" %}
+{%- endif %}

--- a/src/osprey/templates/claude_code/claude/agents/logbook-search.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/logbook-search.md.j2
@@ -91,6 +91,5 @@ As your FINAL action, call `submit_response` to persist your findings:
 - `data_type`: "logbook_research"
 - `source_agent`: "logbook-search"
 
-Include the returned `artifact_id` in your final answer:
-**Results** (artifact_id: 5): ...
-{% endif %}
+{% include "claude_code/claude/agents/_shared/handback.md.j2" %}
+{%- endif %}

--- a/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
@@ -172,9 +172,9 @@ submit_response(
 )
 ```
 
-The tool files `data` as a JSON artifact in `lattice_analysis` and returns its id;
-echo that id in your reply so the parent can reference or re-delegate it. A
-`submit_response` without `data` is refused — the prose alone is not the result.
+The tool files `data` as a JSON artifact in `lattice_analysis` and returns its id
+(see **Handing Back** below). A `submit_response` without `data` is refused — the
+prose alone is not the result.
 
 For a **large array** the operator wants plotted (beta along the whole ring, a
 response matrix), do not retype it into `data`: save it from inside the computing
@@ -182,11 +182,13 @@ response matrix), do not retype it into `data`: save it from inside the computin
 artifact_type="json", category="lattice_analysis")`, coerced to native types first
 (`np.asarray(x).tolist()`), and put the returned artifact id in `data` instead.
 
+{% include "claude_code/claude/agents/_shared/handback.md.j2" %}
+
 ## Handoff to Visualization
 
 You cannot spawn other agents. If the operator wants plots or dashboards of what you
-computed, **return the results artifact id(s) to the parent** and note that the
-parent can re-delegate them to `data-visualizer`. Do not attempt to visualize yourself.
+computed, note in your hand-back that the parent can re-delegate the results
+artifact to `data-visualizer`. Do not attempt to visualize yourself.
 
 ## Rules
 

--- a/src/osprey/templates/claude_code/claude/rules/artifacts.md
+++ b/src/osprey/templates/claude_code/claude/rules/artifacts.md
@@ -81,6 +81,16 @@ The user's current gallery selection is automatically included in your context
 via the `UserPromptSubmit` hook (reads `focus_state.txt`). Use this to
 understand what the user is looking at.
 
+## Subagent Hand-Backs
+
+A subagent that files its answer returns a pointer, not the answer:
+`**Results** (artifact_id: …)` (or `**Channels found**`), a headline of a few
+sentences, and the identifiers the question asked for. The artifact holds the
+full answer. Call `artifact_focus(artifact_id)` on it so the user sees the
+whole thing in the gallery, and relay the headline — do not re-type the
+artifact's tables or listings into your reply. Read it with
+`artifact_read(artifact_id)` only when the next step needs its detail.
+
 ## Math in Markdown Artifacts
 
 The gallery renders LaTeX math via KaTeX. Use `$...$` for inline math and

--- a/src/osprey/templates/claude_code/claude/rules/workflows.md
+++ b/src/osprey/templates/claude_code/claude/rules/workflows.md
@@ -46,3 +46,5 @@ For complex requests, follow this pattern:
 3. **Delegate** — Launch agent calls (parallel where possible).
 4. **Synthesize** — Combine results into a coherent answer.
 5. **Present** — Show findings with artifact references and clear structure.
+   Focus the artifact a subagent handed back rather than re-typing it (see the
+   artifacts rule).

--- a/tests/cli/test_build_artifact_catalog.py
+++ b/tests/cli/test_build_artifact_catalog.py
@@ -132,8 +132,10 @@ class TestRegistryMatchesTemplateDirectory:
     def test_no_unregistered_templates(self):
         """All files in the template directory should be registered.
 
-        Exemptions: __pycache__, .pyc, directories-only, __init__.py,
-        ``_terminology`` partials, and ``web-terminal-context/`` — the
+        Exemptions: __pycache__, .pyc, directories-only, __init__.py, partials
+        under an underscore-prefixed directory (``_terminology``, ``_shared`` —
+        included by the agent templates, never rendered on their own; the same
+        rule the renderer applies), and ``web-terminal-context/`` — the
         web-terminal persona baseline. The catalog governs artifacts rendered
         into ``.claude/`` and claimable via ``osprey scaffold claim``; base.md
         is copied verbatim to ``docker/web-terminal-context/`` for deploy-time
@@ -154,12 +156,13 @@ class TestRegistryMatchesTemplateDirectory:
                 continue
             if template_file.name == "__init__.py":
                 continue
-            if "_terminology" in template_file.parts:
+            rel_path = template_file.relative_to(template_root)
+            if any(part.startswith("_") for part in rel_path.parts[:-1]):
                 continue
-            if "web-terminal-context" in template_file.parts:
+            if "web-terminal-context" in rel_path.parts:
                 continue
 
-            rel = str(template_file.relative_to(template_root))
+            rel = str(rel_path)
             assert rel in registered_templates, (
                 f"Template file {rel} is not registered in the BuildArtifactCatalog"
             )

--- a/tests/cli/test_channel_finder_graph_tools.py
+++ b/tests/cli/test_channel_finder_graph_tools.py
@@ -310,3 +310,39 @@ def test_graph_paradigm_prompt_requires_a_definitive_channel_list(tmp_path):
     assert "## Report Format" in body, "the graph arm must carry the report-format section"
     assert "**Channels found**" in body, "the contract must reuse the existing list label"
     assert "**Channels found**: none" in body, "the empty answer must have a spelled-out form"
+
+
+# ---------------------------------------------------------------------------
+# The graph arm carries the seed-time snapshot region; the others carry none
+# ---------------------------------------------------------------------------
+
+
+def test_graph_paradigm_prompt_carries_the_snapshot_placeholder(tmp_path):
+    """The graph arm ships the marker pair the seed-time bake rewrites.
+
+    The channel finder's graph paradigm reads the same store the
+    facility-knowledge-graph subagent does, and until it carried the region it
+    paid a three-call schema prelude on every delegation that the other agent
+    was designed to skip.
+    """
+    from osprey.services.facility_knowledge.seeder import prompt_snapshot
+
+    _manager, project_dir = _control_assistant(tmp_path, "cf-graph-snapshot", "graph")
+    body = _agent_path(project_dir).read_text(encoding="utf-8")
+
+    assert body.count(prompt_snapshot.SNAPSHOT_BEGIN) == 1
+    assert body.count(prompt_snapshot.SNAPSHOT_END) == 1
+    assert body.find(prompt_snapshot.SNAPSHOT_BEGIN) < body.find(prompt_snapshot.SNAPSHOT_END)
+    assert "No snapshot has been captured yet" in body
+
+
+@pytest.mark.parametrize("mode", [m for m in VALID_CHANNEL_FINDER_MODES if m != "graph"])
+def test_other_paradigms_carry_no_snapshot_region(tmp_path, mode):
+    """A file-backed paradigm has no store to snapshot, so it ships no markers."""
+    from osprey.services.facility_knowledge.seeder import prompt_snapshot
+
+    _manager, project_dir = _control_assistant(tmp_path, f"cf-nosnap-{mode}", mode)
+    body = _agent_path(project_dir).read_text(encoding="utf-8")
+
+    assert prompt_snapshot.SNAPSHOT_BEGIN not in body
+    assert "Graph at Hand" not in body

--- a/tests/cli/test_subagent_handback_contract.py
+++ b/tests/cli/test_subagent_handback_contract.py
@@ -1,0 +1,95 @@
+"""Every artifact-filing subagent hands back a pointer, not a copy.
+
+A subagent that calls ``submit_response`` has two outputs: the artifact, which
+is durable and is what the gallery and downstream tools read, and the text it
+returns to the parent session, which is transient context. When the return
+text repeats the artifact body, the parent sees no reason to focus the
+artifact and re-narrates the tables into chat instead — the user gets the
+answer twice in the transcript and never in the gallery. The channel finder
+always carried an explicit closing contract; the other agents ended on
+``**Results** (artifact_id: 5): ...``, and a small model fills that ellipsis
+with the whole artifact.
+
+Two claims, rendered on ``control_assistant`` in the graph paradigm so every
+agent template is exercised:
+
+1. **Every agent whose frontmatter carries ``submit_response`` ships the shared
+   hand-back section**, and none ships the open-ended ellipsis.
+2. **The orchestrator's artifact rule tells it what to do with a hand-back**:
+   focus the artifact and relay the headline, read it only when the next step
+   needs the detail.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from osprey.cli.templates.manager import TemplateManager
+from osprey.mcp_server.dispatch_worker.agent_surfaces import parse_project_agents
+
+pytestmark = pytest.mark.unit
+
+_SUBMIT_RESPONSE = "mcp__osprey_workspace__submit_response"
+_OPEN_ENDED_ELLIPSIS = re.compile(r"\(artifact_id: \d+\): \.\.\.")
+#: The id-line label each agent hands back; the channel finder keeps the
+#: ``**Channels found**`` list its report-format tests already pin.
+_LABELS = {"channel-finder": "Channels found"}
+
+
+@pytest.fixture(scope="module")
+def rendered_project(tmp_path_factory) -> Path:
+    return TemplateManager().create_project(
+        project_name="handback-contract",
+        output_dir=tmp_path_factory.mktemp("render"),
+        data_bundle="control_assistant",
+        context={"channel_finder_mode": "graph"},
+    )
+
+
+def _submitting_agents(project_dir: Path) -> dict[str, str]:
+    """Rendered prompt text of every agent whose tool surface carries ``submit_response``.
+
+    Agent names come from the frontmatter the dispatch worker parses — the same
+    rule that decides what is delegable — and equal the file stems on this render.
+    """
+    return {
+        name: (project_dir / ".claude" / "agents" / f"{name}.md").read_text(encoding="utf-8")
+        for name, tools in parse_project_agents(project_dir).items()
+        if tools and _SUBMIT_RESPONSE in tools
+    }
+
+
+def test_fixture_renders_the_whole_roster(rendered_project):
+    """Precondition: the agents under test are actually on this render."""
+    names = set(_submitting_agents(rendered_project))
+    assert {
+        "channel-finder",
+        "facility-knowledge-graph",
+        "facility-knowledge",
+        "logbook-search",
+        "logbook-deep-research",
+        "pyat-specialist",
+    } <= names, names
+
+
+def test_every_submitting_agent_ships_the_handback_section(rendered_project):
+    for name, text in _submitting_agents(rendered_project).items():
+        assert "## Handing Back" in text, f"{name}: no hand-back section"
+        assert f"**{_LABELS.get(name, 'Results')}** (artifact_id: <id>)" in text, (
+            f"{name}: the id line is not spelled out with its label"
+        )
+        assert "artifact_read" in text, f"{name}: must say the parent reads the artifact itself"
+        assert not _OPEN_ENDED_ELLIPSIS.search(text), (
+            f"{name}: the open-ended '(artifact_id: N): ...' invites echoing the artifact body"
+        )
+
+
+def test_orchestrator_focuses_a_handed_back_artifact(rendered_project):
+    rule = (rendered_project / ".claude" / "rules" / "artifacts.md").read_text(encoding="utf-8")
+    assert "## Subagent Hand-Backs" in rule
+    tail = rule.split("## Subagent Hand-Backs", 1)[1]
+    assert "artifact_focus" in tail
+    assert "artifact_read" in tail

--- a/tests/services/facility_knowledge/test_prompt_snapshot.py
+++ b/tests/services/facility_knowledge/test_prompt_snapshot.py
@@ -25,11 +25,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from osprey.services.facility_knowledge.seeder import prompt_snapshot as mod
+from osprey.utils.workspace import BUILD_DIR_NAME, IMAGE_DIR_NAME
 
 pytestmark = pytest.mark.unit
 
@@ -220,25 +222,49 @@ class TestRenderBlock:
         assert "MATCH (d:Resource) RETURN count(d) LIMIT 100" in block
 
 
-class TestApplySnapshot:
-    PLACEHOLDER = (
-        "---\nname: facility-knowledge-graph\n---\n\n# Agent\n\n## The Graph at Hand\n\n"
-        f"{mod.SNAPSHOT_BEGIN}\n\nNo snapshot yet.\n\n{mod.SNAPSHOT_END}\n\n## Submitting\n"
+PLACEHOLDER = (
+    f"---\nname: facility-knowledge-graph\n---\n\n# Agent\n\n{mod.SNAPSHOT_HEADING}\n\n"
+    f"{mod.SNAPSHOT_BEGIN}\n\nNo snapshot yet.\n\n{mod.SNAPSHOT_END}\n\n## Submitting\n"
+)
+
+
+def _render(tmp_path: Path, *personas: str, images: tuple[str, ...] = ()) -> Path:
+    """A render with the placeholder agent file at every place the bake looks.
+
+    The render's own agents, one attached persona render per *personas*, and
+    one staged image build context per *images*.
+    """
+    agent_dirs = [tmp_path / ".claude" / "agents"]
+    agent_dirs += [tmp_path / persona / ".claude" / "agents" for persona in personas]
+    agent_dirs += [
+        tmp_path / IMAGE_DIR_NAME / image / BUILD_DIR_NAME / ".claude" / "agents"
+        for image in images
+    ]
+    for agents in agent_dirs:
+        agents.mkdir(parents=True)
+        (agents / mod.AGENT_FILENAME).write_text(PLACEHOLDER, encoding="utf-8")
+    return tmp_path
+
+
+class _Record:
+    def __init__(self, row: dict[str, Any]) -> None:
+        self._row = row
+
+    def data(self) -> dict[str, Any]:
+        return self._row
+
+
+def _session(store: _FakeStore) -> Any:
+    """The fake store behind the driver-session seam ``bake_snapshot`` reads."""
+    return SimpleNamespace(
+        run=lambda cypher, params=None: [_Record(row) for row in store.run(cypher, params)]
     )
 
-    def _render(self, tmp_path: Path, *personas: str) -> Path:
-        agents = tmp_path / ".claude" / "agents"
-        agents.mkdir(parents=True)
-        (agents / mod.AGENT_FILENAME).write_text(self.PLACEHOLDER, encoding="utf-8")
-        for persona in personas:
-            sub = tmp_path / persona / ".claude" / "agents"
-            sub.mkdir(parents=True)
-            (sub / mod.AGENT_FILENAME).write_text(self.PLACEHOLDER, encoding="utf-8")
-        return tmp_path
 
+class TestApplySnapshot:
     def test_replaces_the_managed_region_only(self, tmp_path: Path):
-        render = self._render(tmp_path)
-        patched = mod.apply_snapshot(render, _block())
+        render = _render(tmp_path)
+        patched = mod.apply_snapshot(render, {mod.AGENT_FILENAME: _block()})
 
         text = (render / ".claude" / "agents" / mod.AGENT_FILENAME).read_text(encoding="utf-8")
         assert patched == [render / ".claude" / "agents" / mod.AGENT_FILENAME]
@@ -248,40 +274,128 @@ class TestApplySnapshot:
         assert text.endswith("## Submitting\n"), "text after the region was touched"
 
     def test_applying_twice_is_applying_once(self, tmp_path: Path):
-        render = self._render(tmp_path)
-        mod.apply_snapshot(render, _block())
+        render = _render(tmp_path)
+        mod.apply_snapshot(render, {mod.AGENT_FILENAME: _block()})
         once = (render / ".claude" / "agents" / mod.AGENT_FILENAME).read_text(encoding="utf-8")
-        mod.apply_snapshot(render, _block())
+        mod.apply_snapshot(render, {mod.AGENT_FILENAME: _block()})
         twice = (render / ".claude" / "agents" / mod.AGENT_FILENAME).read_text(encoding="utf-8")
         assert once == twice
 
     def test_a_new_capture_replaces_the_old_one(self, tmp_path: Path):
-        render = self._render(tmp_path)
-        mod.apply_snapshot(render, _block(resource_count=512))
-        mod.apply_snapshot(render, _block(resource_count=513))
+        render = _render(tmp_path)
+        mod.apply_snapshot(render, {mod.AGENT_FILENAME: _block(resource_count=512)})
+        mod.apply_snapshot(render, {mod.AGENT_FILENAME: _block(resource_count=513)})
         text = (render / ".claude" / "agents" / mod.AGENT_FILENAME).read_text(encoding="utf-8")
         assert "513 Resource" in text
         assert "512 Resource" not in text
 
     def test_attached_persona_renders_are_patched_too(self, tmp_path: Path):
-        render = self._render(tmp_path, "demo-readonly", "demo-readwrite")
-        patched = mod.apply_snapshot(render, _block())
+        render = _render(tmp_path, "demo-readonly", "demo-readwrite")
+        patched = mod.apply_snapshot(render, {mod.AGENT_FILENAME: _block()})
         assert len(patched) == 3
         for path in patched:
             assert "512 Resource" in path.read_text(encoding="utf-8")
 
-    def test_a_file_without_markers_is_left_alone(self, tmp_path: Path):
+    def test_a_hand_edited_file_is_reported_and_left_alone(self, tmp_path: Path, caplog):
+        """The section survived but its markers did not: say so, never append."""
         agents = tmp_path / ".claude" / "agents"
         agents.mkdir(parents=True)
         target = agents / mod.AGENT_FILENAME
-        target.write_text("# Hand-edited prompt, markers removed\n", encoding="utf-8")
+        edited = f"# Hand-edited prompt\n\n{mod.SNAPSHOT_HEADING}\n\nMarkers removed.\n"
+        target.write_text(edited, encoding="utf-8")
 
-        patched = mod.apply_snapshot(tmp_path, _block())
+        with caplog.at_level("WARNING"):
+            patched = mod.apply_snapshot(tmp_path, {mod.AGENT_FILENAME: _block()})
+
         assert patched == []
-        assert target.read_text(encoding="utf-8") == "# Hand-edited prompt, markers removed\n"
+        assert target.read_text(encoding="utf-8") == edited
+        assert [r for r in caplog.records if r.levelname == "WARNING"], "no warning was logged"
 
     def test_a_render_without_the_agent_is_a_quiet_no_op(self, tmp_path: Path):
-        assert mod.apply_snapshot(tmp_path, _block()) == []
+        assert mod.apply_snapshot(tmp_path, {mod.AGENT_FILENAME: _block()}) == []
+
+    def test_image_contexts_are_patched_too(self, tmp_path: Path):
+        """The bake must reach the renders the container images are built from.
+
+        ``osprey build`` stages ``build/.image/<name>/build/`` as each image's
+        build context; the seed-time bake ran after that staging and patched
+        only the host renders, so every container shipped the placeholder —
+        the failure the deployed prompt in this bug showed.
+        """
+        images = ("demo", "demo-readwrite")
+        render = _render(tmp_path, "demo-readwrite", images=images)
+
+        patched = mod.apply_snapshot(render, {mod.AGENT_FILENAME: _block()})
+
+        assert len(patched) == 4
+        for name in images:
+            context = tmp_path / IMAGE_DIR_NAME / name / BUILD_DIR_NAME / ".claude" / "agents"
+            assert "512 Resource" in (context / mod.AGENT_FILENAME).read_text(encoding="utf-8")
+
+    def test_each_agent_file_gets_its_own_block(self, tmp_path: Path):
+        """The channel finder's graph arm carries the same region with its own catalogue."""
+        render = _render(tmp_path)
+        cf = tmp_path / ".claude" / "agents" / mod.CHANNEL_FINDER_FILENAME
+        cf.write_text(PLACEHOLDER.replace("facility-knowledge-graph", "channel-finder"))
+
+        patched = mod.apply_snapshot(
+            render,
+            {
+                mod.AGENT_FILENAME: _block(resource_count=512),
+                mod.CHANNEL_FINDER_FILENAME: _block(resource_count=777),
+            },
+        )
+
+        assert sorted(patched) == sorted([render / ".claude" / "agents" / mod.AGENT_FILENAME, cf])
+        kg = (render / ".claude" / "agents" / mod.AGENT_FILENAME).read_text(encoding="utf-8")
+        assert "512 Resource" in kg and "777 Resource" not in kg
+        assert "777 Resource" in cf.read_text(encoding="utf-8")
+
+    def test_a_channel_finder_without_markers_is_quietly_skipped(self, tmp_path: Path, caplog):
+        """A non-graph channel finder has no region; that is expected, not a warning."""
+        render = _render(tmp_path)
+        cf = tmp_path / ".claude" / "agents" / mod.CHANNEL_FINDER_FILENAME
+        cf.write_text("---\nname: channel-finder\n---\n\n# Hierarchical arm\n", encoding="utf-8")
+
+        with caplog.at_level("WARNING"):
+            patched = mod.apply_snapshot(
+                render, {mod.AGENT_FILENAME: _block(), mod.CHANNEL_FINDER_FILENAME: _block()}
+            )
+
+        assert patched == [render / ".claude" / "agents" / mod.AGENT_FILENAME]
+        assert cf.read_text(encoding="utf-8").endswith("# Hierarchical arm\n")
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+
+class TestBakeSnapshot:
+    """The bake hands each agent file the catalogue its server actually serves."""
+
+    def test_each_file_carries_its_servers_catalogue(self, tmp_path: Path, monkeypatch):
+        from osprey.mcp_server.channel_finder_graph.tools.examples_data import (
+            EXAMPLE_QUERIES as cf_examples,
+        )
+        from osprey.mcp_server.graph.tools.examples_data import EXAMPLE_QUERIES as graph_examples
+        from osprey.services.facility_knowledge.seeder import graph_seeder
+
+        monkeypatch.setattr(graph_seeder, "read_marker", lambda session: "0123456789abcdef")
+        monkeypatch.setattr(graph_seeder, "resource_count", lambda session: 42)
+
+        agents = _render(tmp_path) / ".claude" / "agents"
+        (agents / mod.CHANNEL_FINDER_FILENAME).write_text(PLACEHOLDER, encoding="utf-8")
+
+        patched = mod.bake_snapshot(_session(_FakeStore()), tmp_path)
+
+        assert len(patched) == 2
+        kg = (agents / mod.AGENT_FILENAME).read_text(encoding="utf-8")
+        cf = (agents / mod.CHANNEL_FINDER_FILENAME).read_text(encoding="utf-8")
+        graph_only = {e.key for e in graph_examples} - {e.key for e in cf_examples}
+        cf_only = {e.key for e in cf_examples} - {e.key for e in graph_examples}
+        assert graph_only and cf_only, "fixture precondition: the catalogues differ"
+        for key in graph_only:
+            assert f"#### {key} " in kg and f"#### {key} " not in cf
+        for key in cf_only:
+            assert f"#### {key} " in cf and f"#### {key} " not in kg
+        assert "42 Resource" in kg and "42 Resource" in cf
 
 
 # ---------------------------------------------------------------------------
@@ -289,8 +403,12 @@ class TestApplySnapshot:
 # ---------------------------------------------------------------------------
 
 
-def test_agent_template_carries_exactly_these_markers():
-    """A marker respelled on either side turns every bake into a silent no-op."""
+def test_shared_partial_carries_exactly_these_markers():
+    """A marker respelled on either side turns every bake into a silent no-op.
+
+    Every graph-querying agent includes this one partial, so pinning it pins
+    them all; the channel finder's render test checks its graph arm includes it.
+    """
     from osprey.cli.templates.manager import TemplateManager
 
     template = (
@@ -298,11 +416,13 @@ def test_agent_template_carries_exactly_these_markers():
         / "claude_code"
         / "claude"
         / "agents"
-        / "facility-knowledge-graph.md.j2"
+        / "_shared"
+        / "graph_snapshot.md.j2"
     ).read_text(encoding="utf-8")
 
+    assert mod.SNAPSHOT_HEADING in template
     assert mod.SNAPSHOT_BEGIN in template
     assert mod.SNAPSHOT_END in template
     assert template.count("osprey:graph-snapshot") == 2, (
-        "the template must carry exactly one begin and one end marker"
+        "the partial must carry exactly one begin and one end marker"
     )

--- a/tests/services/python_executor/execution/test_readonly_guard.py
+++ b/tests/services/python_executor/execution/test_readonly_guard.py
@@ -14,6 +14,7 @@ against fake ``epics``/``p4p`` modules injected into ``sys.modules``.
 
 import asyncio
 import importlib
+import platform
 import re
 import sys
 from types import ModuleType
@@ -465,6 +466,21 @@ def test_readonly_refuses_routes_out_of_python(call):
     _run_guard("readonly")
     with pytest.raises(RuntimeError, match=_REFUSAL):
         call()
+
+
+def test_readonly_prewarms_platform_processor(monkeypatch):
+    """An innocent stdlib metadata lookup must survive the subprocess refusal.
+
+    CPython resolves ``platform.uname().processor`` lazily by shelling out to
+    ``uname -p`` on first read, and h5py reads it while ``import at``
+    initialises its type layer — so a cold cache under the guard killed the
+    import of a pure-simulation library. The guard resolves it before patching
+    subprocess; with the cache forced cold here, a guard without the pre-warm
+    raises the refusal out of this lookup.
+    """
+    monkeypatch.setattr(platform, "_uname_cache", None)
+    _run_guard("readonly")
+    assert isinstance(platform.processor(), str)
 
 
 def test_readonly_leaves_fork_alone():


### PR DESCRIPTION
## Summary

Two related fixes to how the knowledge-graph subagents show up in a session.

**Hand-backs.** A subagent that files its answer with `submit_response` used to close on `**Results** (artifact_id: N): ...`, and a small model fills that ellipsis with the whole artifact — so the orchestrator saw no reason to focus the artifact and re-typed its tables into chat. All six artifact-filing agents now share one closing contract (`_shared/handback.md.j2`): the artifact id, a short headline, and the identifiers asked for — never the body. The orchestrator's artifacts rule gains a matching section: `artifact_focus` it, relay the headline, `artifact_read` only when the next step needs the detail.

**Snapshot bake.** The seed-time schema snapshot ("The Graph at Hand") was patched into the host renders only; containers are built from `build/.image/<name>/build/`, so every container shipped the placeholder and each delegation paid a `get_schema`/`example_queries` prelude. The bake now reaches those contexts, and `deploy_up` builds the project image *after* the graph store is staged so the dispatch worker consumes a baked context too. The channel finder's graph paradigm carries the same region via a shared partial, baked with its own example catalogue. `prompt_snapshot` keeps one registry (filename → catalogue module), spells the image path with the workspace constants, and reports a hand-edited file by content (heading or lone marker) instead of a filename allowlist.

## Test plan

- [x] New pins: every `submit_response` agent ships the hand-back section with its label; the orchestrator rule names `artifact_focus`/`artifact_read`; the graph-mode channel finder renders the marker pair and the other paradigms don't; image contexts and the channel finder are patched; each file gets its own server's catalogue; a hand-edited file warns and is left alone; the shared partial carries exactly the module's markers.
- [x] `tests/deployment tests/cli tests/services/facility_knowledge`: 9245 passed, 4 skipped.
- [x] Rendered `control_assistant` in graph mode and read the resulting `channel-finder.md` / `pyat-specialist.md` sections.
