### PR TITLE
fix(ci): tabulate the unit lane's slowest tests in the step summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,22 +230,36 @@ jobs:
         # it into a silent wedge rather than a death. A live CA client/server
         # pair is only safe in a process of its own.
         #
-        # --durations=50: the ubuntu cells run ~2x the macOS wall clock and the
-        # gap is undiagnosed. A per-cell slow-test ranking in every run is what
+        # --durations=50: a per-cell slow-test ranking in every run is what
         # tells "one group of tests got expensive" apart from "the whole suite
-        # is uniformly slower on this runner" — remove once the unit lane's
-        # runtime question is settled.
-        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -m "not pty" -v --tb=short --durations=50 -n 4 --dist loadgroup $COV_ARGS
+        # is uniformly slower on this runner". It settled the ubuntu-vs-macOS
+        # question once (#582: no runner gap, the profile is the same on both)
+        # and stays on so the next drift is diagnosable from the summary
+        # instead of by re-instrumenting the lane.
+        #
+        # Teed into ci-diag/ rather than read from the job log: `gh run view
+        # --log` returns a fraction of a 60k-line log, and the durations
+        # report is at the end of it. scripts/ci/diag_summary.py renders the
+        # top of the report into the step summary, and the upload below keeps
+        # the whole log. `pipefail` is set explicitly because an unspecified
+        # `shell:` runs `bash -e` WITHOUT it — the pipe would otherwise turn
+        # every red suite into tee's green exit. The directory is created here
+        # because tests/ci_diagnostics.py creates it at pytest configure time,
+        # which is after tee has to open its file.
+        mkdir -p ci-diag
+        set -o pipefail
+        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -m "not pty" -v --tb=short --durations=50 -n 4 --dist loadgroup $COV_ARGS 2>&1 | tee ci-diag/pytest.log
 
     # The two steps below are the reason the step above has its own timeout.
-    # They run on success too: on a green lane the summary is one line, and on
-    # a killed lane it is the only place the answer exists.
+    # They run on success too: on a green lane the summary is the slow-test
+    # ranking, and on a killed lane it is the only place the answer exists.
     - name: Summarise lane diagnostics
       if: always()
       # Names the test each worker was inside when the lane stopped. All four
       # workers stalling at once means the runner went away; one worker stalling
       # means the test it names deadlocked. That distinction decides whether a
-      # rerun is legitimate, and it is not recoverable from the job log.
+      # rerun is legitimate, and it is not recoverable from the job log. On a
+      # lane that finished, tabulates the top of the durations report instead.
       #
       # `python3`, not `uv run`: the script is stdlib-only and standalone by
       # design, so it still reports when the failure being diagnosed is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,6 +438,8 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- CI: the unit lane's step summary now tabulates the slowest tests of the run
+  and the uploaded diagnostics artifact carries the full pytest log.
 - `osprey-connectors` now versions with the framework's calendar stream —
   both wheels are built from one checkout and carry one number, so the
   independent `0.x` line (and the question of what counts as a minor) is

--- a/scripts/ci/diag_summary.py
+++ b/scripts/ci/diag_summary.py
@@ -10,6 +10,13 @@ This reads them and says so, in the run's step summary, so nobody has to
 download the artifact to learn whether a freeze was one stuck test or the whole
 runner going away.
 
+The lane also tees pytest's own output into the same directory as
+``pytest.log``. When that file holds a ``--durations`` report, its top entries
+are rendered here too: the ranking is the one fact that tells "one group of
+tests got expensive" apart from "the whole suite is uniformly slower", and the
+job log it would otherwise live in is truncated by ``gh run view --log`` to a
+fraction of its length, so the table was unreachable from the CLI.
+
 Deliberately standalone — no imports from ``tests/`` — so the reader cannot be
 broken by the writer, and so it still runs in a job that never installed the
 project. Usage::
@@ -20,6 +27,7 @@ project. Usage::
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -73,6 +81,44 @@ def stalled_tests(directory: Path | str) -> dict[str, str]:
     return stalled
 
 
+PYTEST_LOG = "pytest.log"
+"""File name the lane tees pytest's output into, inside the diagnostics dir."""
+
+SLOWEST_ROWS = 15
+"""Rows of the durations report shown in the summary. The full report stays in
+``pytest.log`` in the uploaded artifact; the summary is a screen, not a log."""
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_DURATIONS_HEADER = re.compile(r"slowest \d+ durations")
+_DURATION_ROW = re.compile(r"^\s*(\d+(?:\.\d+)?)s\s+(call|setup|teardown)\s+(\S.*?)\s*$")
+
+
+def slowest_tests(directory: Path | str) -> list[tuple[float, str, str]] | None:
+    """The ``--durations`` report from ``pytest.log`` as (seconds, phase, nodeid).
+
+    ``None`` when there is no log to read; an empty list when the log exists
+    but never reached the report (the lane was killed first). pytest writes
+    the report with ``--color=yes`` escapes on its rule lines, so the text is
+    stripped of ANSI sequences before matching.
+    """
+    path = Path(directory) / PYTEST_LOG
+    try:
+        text = _ANSI.sub("", path.read_text(encoding="utf-8", errors="replace"))
+    except OSError:
+        return None
+    rows: list[tuple[float, str, str]] = []
+    in_report = False
+    for line in text.splitlines():
+        if not in_report:
+            in_report = bool(_DURATIONS_HEADER.search(line))
+            continue
+        match = _DURATION_ROW.match(line)
+        if match is None:
+            break
+        rows.append((float(match.group(1)), match.group(2), match.group(3)))
+    return rows
+
+
 def _counts(directory: Path) -> dict[str, int]:
     return {
         path.stem.removeprefix("events-"): sum(
@@ -121,6 +167,26 @@ def render_report(directory: Path | str) -> str:
     stacks = sorted(directory.glob("stacks-*.txt"))
     if stacks:
         lines += ["", f"**Stack dumps captured:** {', '.join(p.name for p in stacks)}"]
+
+    slowest = slowest_tests(directory)
+    if slowest:
+        lines += [
+            "",
+            f"**Slowest tests (top {min(SLOWEST_ROWS, len(slowest))} of {len(slowest)} "
+            f"reported; the full report is `{PYTEST_LOG}` in the artifact):**",
+            "",
+            "| Seconds | Phase | Test |",
+            "| ---: | --- | --- |",
+        ]
+        lines += [
+            f"| {seconds:.1f} | {phase} | `{nodeid}` |"
+            for seconds, phase, nodeid in slowest[:SLOWEST_ROWS]
+        ]
+    elif slowest is not None:
+        lines += [
+            "",
+            f"No durations report in `{PYTEST_LOG}`: the suite never reached its final summary.",
+        ]
 
     return "\n".join(lines) + "\n"
 

--- a/tests/infrastructure/test_ci_diagnostics.py
+++ b/tests/infrastructure/test_ci_diagnostics.py
@@ -348,3 +348,80 @@ def _isolate_env(monkeypatch):
     """Keep the ambient CI diag settings out of these tests."""
     monkeypatch.delenv(ENV_DIR, raising=False)
     monkeypatch.delenv(ENV_STACK_TIMEOUT, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# The durations report the lane tees into pytest.log reaches the summary
+# ---------------------------------------------------------------------------
+
+_DURATIONS_LOG = (
+    "tests/test_a.py::test_fast PASSED\n"
+    "\x1b[33m============================= slowest 50 durations =============================\x1b[0m\n"
+    "140.79s call     tests/templates/test_limits.py::TestStable::test_every_edge\n"
+    "53.67s setup    tests/integration/test_export.py::test_formats[text/csv]@docker\n"
+    "0.51s teardown tests/test_a.py::test_fast\n"
+    "\x1b[33m=========================== short test summary info ============================\x1b[0m\n"
+    "1 passed in 195.0s\n"
+)
+
+_FINISHED_RUN = [
+    {"event": "start", "nodeid": "tests/test_a.py::test_fast", "worker": "gw0"},
+    {"event": "finish", "nodeid": "tests/test_a.py::test_fast", "worker": "gw0"},
+]
+
+
+def test_summary_reads_the_durations_report_from_the_teed_log(tmp_path):
+    (tmp_path / "pytest.log").write_text(_DURATIONS_LOG)
+    assert _load_summary().slowest_tests(tmp_path) == [
+        (140.79, "call", "tests/templates/test_limits.py::TestStable::test_every_edge"),
+        (53.67, "setup", "tests/integration/test_export.py::test_formats[text/csv]@docker"),
+        (0.51, "teardown", "tests/test_a.py::test_fast"),
+    ]
+
+
+def test_summary_distinguishes_no_log_from_a_log_without_a_report(tmp_path):
+    assert _load_summary().slowest_tests(tmp_path) is None
+    # A lane killed mid-suite has a log that stops before the final report.
+    (tmp_path / "pytest.log").write_text("tests/test_a.py::test_fast PASSED\n")
+    assert _load_summary().slowest_tests(tmp_path) == []
+
+
+def test_summary_report_tabulates_the_slowest_tests(tmp_path):
+    _write_jsonl(tmp_path / "events-gw0.jsonl", _FINISHED_RUN)
+    (tmp_path / "pytest.log").write_text(_DURATIONS_LOG)
+    report = _load_summary().render_report(tmp_path)
+    assert "**Slowest tests (top 3 of 3 reported" in report
+    assert (
+        "| 140.8 | call | `tests/templates/test_limits.py::TestStable::test_every_edge` |" in report
+    )
+
+
+def test_summary_report_caps_the_table_and_says_so(tmp_path):
+    summary = _load_summary()
+    rows = "".join(
+        f"{100 - i}.00s call tests/test_a.py::t{i}\n" for i in range(summary.SLOWEST_ROWS + 5)
+    )
+    (tmp_path / "pytest.log").write_text(
+        f"=== slowest 50 durations ===\n{rows}=== short test summary info ===\n"
+    )
+    _write_jsonl(tmp_path / "events-gw0.jsonl", _FINISHED_RUN)
+    report = summary.render_report(tmp_path)
+    assert f"top {summary.SLOWEST_ROWS} of {summary.SLOWEST_ROWS + 5} reported" in report
+    assert report.count("| call |") == summary.SLOWEST_ROWS
+
+
+def test_summary_report_names_a_killed_lanes_missing_report(tmp_path):
+    _write_jsonl(
+        tmp_path / "events-gw0.jsonl",
+        [{"event": "start", "nodeid": "tests/test_a.py::wedged", "worker": "gw0"}],
+    )
+    (tmp_path / "pytest.log").write_text("tests/test_a.py::wedged\n")
+    report = _load_summary().render_report(tmp_path)
+    assert "No durations report in `pytest.log`" in report
+
+
+def test_summary_report_omits_the_section_without_a_log(tmp_path):
+    _write_jsonl(tmp_path / "events-gw0.jsonl", _FINISHED_RUN)
+    report = _load_summary().render_report(tmp_path)
+    assert "Slowest tests" not in report
+    assert "durations report" not in report


### PR DESCRIPTION
Closes #582.

## What changed

- The unit lane tees pytest's output into `ci-diag/pytest.log`. `scripts/ci/diag_summary.py` renders the top 15 rows of the `--durations=50` report into the step summary; the diagnostics artifact carries the full log.
- `set -o pipefail` explicitly — an unspecified `shell:` runs `bash -e` *without* it, so the pipe would otherwise report tee's exit for the suite's.
- `mkdir -p ci-diag` before pytest starts: the diagnostics plugin creates the directory at configure time, after tee has opened its file.
- The `--durations=50` comment no longer says "remove once settled" — the ranking stays on so the next drift is diagnosable from the summary.

## What the ranking settled (the diagnosis #582 asked for)

Read from today's main run via the raw jobs API:

- **The ubuntu/macOS gap is gone.** Both cells run 17–23 min; top-50 totals 1,136 s (ubuntu) vs 1,192 s (macOS). The four xdist workers are balanced to within a minute, install is cached, collection is ~1.4 min. The suite is ~78 CPU-min everywhere — uniformly large, not runner-specific.
- **One test dominates on both platforms:** `tests/templates/test_channel_limits_va.py::TestQuadLimitsArePhysicallyStable::test_every_band_edge_survives_a_fresh_bridge_write` at 140.8 s (ubuntu) / 133.9 s (macOS). Its docstring measured ~21 s locally (reproduced: 24 s) and set ~2–3 min as the line for sampling instead of covering all 216 edges; CI sits at 2.3 min. BLAS thread pinning has no effect; `PhysicsBridge()` construction is ~100 ms, so the cost is honest. Left as is — the one known lever if the lane ever needs two minutes back.
- **The tail** is the build/render integration tests (`tests/cli` alone is 27 CPU-min: `test_build_zero_arg.py` 5.9, `test_build_cmd.py` 3.3, `test_persona_render_e2e.py` 3.2). Many run a full `osprey build` per test; a per-worker session-scoped built-project fixture is the refactor that would halve the lane.
- **The zmq.auth lead is closed:** the `plane` fixture in `test_document_plane.py` stops its authenticator in a `finally`.
- **The 45/40 caps stay.** Runtime hasn't come down (macOS came up to meet ubuntu), and the diagnostic steps already turn a timeout into a readable failure.

## Verification

- `tests/infrastructure/test_ci_diagnostics.py` (+6 tests) and `tests/deployment/test_ci_workflow_wiring.py`: 342 passed.
- `diag_summary.py` run against the real ubuntu log renders the expected table.
- This PR's own unit-lane summaries show the table live.
