### PR TITLE
feat(deployment): declare each service's reach once and tell every persona where it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,63 @@ Compatibility is documented in release notes, not encoded in the version string.
   theme outside the main family fell back to the dark palette. HTML and table
   artifacts without styling of their own now take the theme's colors too, and
   the print view is always light.
+- Web-terminal personas now reach every service the hosting deployment runs.
+  `osprey build` copies each client-facing fact — the qmd sidecar's port, the
+  graph store's bolt port, the Postgres the logbook lives in, the telemetry
+  store's port, the Bluesky bridge, the EVENTS and BLUESKY tab URLs — from the
+  deployment's own render into every persona built beside it, so a service
+  moved on the hosting profile moves every persona with it and the persona
+  presets pin nothing. A persona whose `config:` contradicts one of these
+  facts is refused, naming both values; one built alone is told what its app
+  template deploys. Fixes hybrid logbook search failing in every persona with "no qmd
+  sidecar is configured", and `osprey build` now refuses any consumer switched
+  on with nothing to dial instead of rendering it. **Upgrading:** persona files
+  written by an earlier `osprey init` (`personas/*.yml`) pin these facts
+  themselves (`services.graphdb.port_host`, `web.panels.events.*`,
+  `web.panels.bluesky.*`); `osprey build` refuses each such line by name —
+  delete them, the build supplies the values.
+- The qmd sidecar indexes the logbook mirror again: `qmd_export` wrote the
+  mirror under `build/var/ariel_mirror` while the sidecar mounted
+  `var/ariel_mirror`, so a live deployment searched an empty corpus.
+  Config-relative paths (`mirror_path`, `facility_knowledge.bundle_path`,
+  `ariel.vocabulary.path`) now resolve against the project root, the one
+  anchor the compose mounts already use; `services.graphdb.ttl_path` alone
+  stays relative to the render, because the corpus it names is read from the
+  `data/` tree the build assembles for the project. A deployment
+  with files under the legacy `build/var/ariel_mirror` regenerates the mirror
+  with `osprey ariel qmd-resync`.
+- Agent telemetry from per-user web-terminal containers is delivered again:
+  the exporter posted to `http://openobserve:5080`, a name a host-networked
+  container cannot resolve, and to the store's listen port rather than the
+  port the deployment publishes. Per-user containers now post to the loopback
+  address on `services.openobserve.port`.
+- `osprey health`'s ARIEL rows probe the port the interface actually listens
+  on (`OSPREY_ARIEL_PORT` in multi-user deployments), as the panel rows already
+  did.
+- Persona containers mount the hosting deployment's logbook mirror, so an
+  entry created from a persona is indexed by the sidecar rather than written
+  into the container's writable layer; each user's Python-executor refusal
+  audit is kept on the host under `var/audit/<user>/` instead of being lost on
+  recreate.
+- The Bluesky MCP server and the virtual-accelerator connector follow a
+  bridge or CA port moved on the hosting profile (`services.bluesky.port`,
+  `services.virtual_accelerator.port`) instead of dialing compiled-in defaults.
+- The BLUESKY tab works in web-terminal personas: the bluesky-web sidecar now
+  accepts each user's own operator secret (the one their terminal proxies
+  with) beside the deployment-wide one, for every user whose persona shows the
+  tab — no user's container is handed the deployment secret, and no other
+  process (the host's own `osprey web` included) accepts roster secrets.
+- The EVENTS tab's label and health endpoint are written by the build where
+  its URL is derived, so the tab health-gates itself on the host and in every
+  persona; a web-terminal persona is told exactly the tabs it selects, and is
+  refused rather than rendered tabless when the deployment it was told about
+  runs no such sidecar.
+- The graph channel finder follows the graph store like the graph MCP server
+  does: a persona that switches that server off but keeps the channel finder
+  is still told the store's address.
+- `osprey up` refuses a persona that runs a logbook mirror export the
+  deployment does not write (or writes elsewhere), instead of letting that
+  persona's mirror land in its container's writable layer.
 - The graph channel finder no longer mistakes its own row limit for the whole
   answer: `read_cypher` now warns when a result exactly fills the query's own
   `LIMIT`, the example catalogue gained a census query (count before listing
@@ -313,6 +370,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- `osprey health` gained a `reach` category, also shown in the system-health
+  tab inside each user's container: one row per shared service a client is
+  switched on for, knocked on at the address the client itself resolves. A
+  closed port or a client with nothing to dial warns and names the config key.
 - `osprey init` now prints a composition card under its report: who can sign
   in (each user's persona, rights, login method and port), what the agent runs
   on (model, MCP servers, bundled toolkit), what machine it talks to

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -162,7 +162,7 @@ The built-in enhancement modules:
                settings:
                  mirror_path: var/ariel_mirror
 
-      ``mirror_path`` is resolved against the directory holding ``config.yml``. Keep it under ``var/``: the mirror is machine-written from PostgreSQL, it is as large as the logbook, and ``var/`` is the directory git ignores --- a path under ``data/`` would commit a generated corpus. An enabled export with no ``mirror_path`` is refused at startup rather than skipped, because a mirror nobody writes looks exactly like "search returns nothing".
+      ``mirror_path`` is resolved against the project root --- the deployment repo, not the ``build/`` render inside it, which is exactly where the qmd sidecar bind-mounts the same path from. Keep it under ``var/``: the mirror is machine-written from PostgreSQL, it is as large as the logbook, and ``var/`` is the directory git ignores --- a path under ``data/`` would commit a generated corpus. An enabled export with no ``mirror_path`` is refused at startup rather than skipped, because a mirror nobody writes looks exactly like "search returns nothing".
 
       **Requirements:** the ``services.qmd`` sidecar, which bind-mounts this same directory read-only. See :ref:`qmd-search-sidecar`.
 

--- a/docs/source/how-to/ariel/search-modes.rst
+++ b/docs/source/how-to/ariel/search-modes.rst
@@ -146,7 +146,7 @@ Search modules are leaf-level functions that execute a single search strategy ag
       1. the ``services.qmd`` sidecar (see :ref:`qmd-search-sidecar`), and
       2. the ``qmd_export`` :ref:`enhancement module <Enhancement Pipeline>`, which writes the markdown mirror the sidecar indexes.
 
-      Either one alone is useless: an export with no sidecar indexes nothing, and a sidecar with no export searches an empty corpus. The shipped ``control-assistant`` and ``ariel-standalone`` templates enable both, together with the sidecar itself.
+      Either one alone is useless: an export with no sidecar indexes nothing, and a sidecar with no export searches an empty corpus. The shipped ``control-assistant`` and ``ariel-standalone`` templates enable both, together with the sidecar itself. A web-terminal persona deploys no sidecar of its own and reaches the hosting deployment's through ``services.qmd.port`` instead — a key the build copies from the hosting deployment's render into every persona, so nothing pins it by hand — and ``osprey build`` refuses a persona that keeps ``hybrid`` on with no sidecar to dial (:doc:`../build-profiles`).
 
       ``hybrid`` also does not degrade the way semantic search does. A query against a sidecar that is not there is reported as *search is down*, deliberately, so that the agent cannot read an outage as "nothing matched".
 
@@ -482,10 +482,11 @@ Configuration
            patterns_enabled: true          # default: true
            pattern_timeout_seconds: 10.0   # default: 10.0
 
-A relative ``path`` resolves against the directory holding the ``config.yml``
-that was loaded --- the same rule as ``qmd_export.mirror_path`` and
-``facility_knowledge.bundle_path`` --- so the panel, the CLI and the MCP server
-all read the same file no matter where the process was started.
+A relative ``path`` resolves against the project root of the ``config.yml``
+that was loaded (the deployment repo, not its ``build/`` render) --- the same
+rule as ``qmd_export.mirror_path`` and ``facility_knowledge.bundle_path`` ---
+so the panel, the CLI and the MCP server all read the same file no matter
+where the process was started.
 
 ``enabled: true`` with no ``path``, an ``expand_modes`` entry naming a module
 that is unknown or not enabled, and a malformed pattern knob are all

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -1185,6 +1185,41 @@ template says. For what the mode changes about the agent's answers, see
 :doc:`use-channel-finder`; for the corpus behind them,
 :doc:`use-facility-graph`.
 
+The qmd sidecar behind hybrid logbook search is guarded the same way. The
+``control-assistant`` and ``ariel-standalone`` templates switch
+``ariel.search_modules.hybrid`` on and deploy the ``services.qmd`` sidecar that
+answers it, but an attached project renders ``services: {}`` — so on its own it
+would keep the mode with nothing behind it, and every logbook query would fail
+with *no qmd sidecar is configured*. ``osprey build`` refuses that instead of
+rendering it.
+
+An attached project rarely has to say anything, because **the build tells it
+where the host's services are**. Every client-facing fact — the sidecar's port,
+the graph store's bolt port, the Postgres the logbook lives in, the telemetry
+store's port, the Bluesky bridge, the EVENTS and BLUESKY tab URLs — is copied
+from the hosting deployment's own render into each persona built beside it, so
+a service moved on the hosting profile moves every persona with it, and the
+shipped ``control-assistant-*`` presets pin none of them. A persona profile
+that spells one of these keys with a *different* value is refused — the two
+copies would dial different places, and the build names both. (A persona
+inherits the hosting profile's ``config:`` keys, so a port moved there is
+spelled in every persona as the host's own value, and agrees.) A persona
+built *alone* (``osprey init --preset control-assistant-ariel`` in a
+repo with no hosting deployment) is told what its app template deploys at the
+shipped defaults instead, and there its ``config:`` is where a host that
+differs is named:
+
+.. code-block:: yaml
+
+   config:
+     services.qmd.port: 9180        # the sidecar of the deployment this build shares a host with
+     # or: ariel.search_modules.hybrid.enabled: false
+
+The same facts are checked again at run time: the ``reach`` category of
+``osprey health`` (and of the system-health tab, inside each user's container)
+resolves every live client's endpoint the way the client does and knocks on it
+(:doc:`configure-health-checks`).
+
 .. _profile-va-archiver:
 
 The ``va_archiver`` block

--- a/docs/source/how-to/configure-health-checks.rst
+++ b/docs/source/how-to/configure-health-checks.rst
@@ -223,7 +223,7 @@ keys happened to be read.
 Built-in service categories
 ---------------------------
 
-Beyond the always-on framework checks, three built-in categories are
+Beyond the always-on framework checks, four built-in categories are
 **presence-gated on their config blocks**: they contribute rows only when the
 corresponding service is configured, so a minimal build shows no empty tiles.
 
@@ -259,6 +259,20 @@ corresponding service is configured, so a minimal build shows no empty tiles.
   names ``osprey knowledge seed-graph`` as the remedy. The agent's own graph
   tools report the same degraded states from the inside — see
   :doc:`use-facility-graph`.
+- ``reach`` — appears when this render has a client switched on for a shared
+  service: hybrid logbook search and the OKF panel (the qmd sidecar), the
+  graph MCP server (the graph store), the ARIEL panel and MCP server
+  (Postgres), agent telemetry (the OpenObserve store), the Bluesky MCP server
+  (the bridge), the EVENTS and BLUESKY tabs (their sidecars), and the
+  virtual-accelerator connector. One row per service, and the address it
+  knocks on is the one **the client itself resolves** from this config, in the
+  process running the check — so the same category answers a different
+  question on the host (what ``osprey`` commands reach) and inside a per-user
+  web-terminal container, where the health MCP server runs it (what that
+  user's agent reaches). A knock is a TCP connect; a closed port warns and
+  names the config key the client resolved it from, and a client switched on
+  with nothing to resolve warns with the key that would give it one — the
+  same condition ``osprey build`` refuses (:doc:`build-profiles`).
 
 .. note::
 

--- a/docs/source/how-to/event-dispatch.rst
+++ b/docs/source/how-to/event-dispatch.rst
@@ -179,32 +179,33 @@ separate browser window. The tab health-gates itself: while the dispatcher is
 down the tab is disabled with an offline indicator rather than showing a broken
 frame, and it turns live once the dispatcher answers ``/health``.
 
-The panel points at ``${EVENT_DISPATCHER_URL:-http://localhost:8020}``, which
-works out of the box for the host-run flow above. When the web terminal runs in
-a container, repoint it at the dispatcher service:
-
-.. code-block:: bash
-
-   EVENT_DISPATCHER_URL=http://event-dispatcher:8020
+The panel points at ``http://localhost:<dispatcher_port>``, which works out of
+the box for the host-run flow above and for every web-terminal persona built
+beside the deployment: per-user containers share the host's network, so the
+dispatcher answers on their loopback too, and the build copies this entry from
+the deployment's render into each persona (:doc:`build-profiles`).
 
 Auto-derived URL
 ----------------
 
 You do not have to set ``web.panels.events.url`` by hand. Whenever a profile
 lists the ``events`` panel **and** declares a ``dispatch:`` block, the build
-derives the panel's route from ``dispatch.dispatcher_port``:
+derives the whole panel entry from ``dispatch.dispatcher_port``:
 
 .. code-block:: yaml
 
    web.panels.events.url: http://localhost:<dispatcher_port>   # bare host
    web.panels.events.path: /dashboard                          # route
+   web.panels.events.label: EVENTS                             # tab title
+   web.panels.events.health_endpoint: /health                  # what the tab health-gates on
 
 The ``url`` is the bare dispatcher host and ``path`` carries the ``/dashboard``
 route — the web terminal composes the backend target as ``url`` + ``path``, so
 baking ``/dashboard`` into ``url`` would double-prefix sub-routes. Keep them
-split. If a profile already pins ``web.panels.events.path`` the build leaves it
-untouched, and an explicit ``web.panels.events.url`` override always wins (use it
-for remote/containerized terminals that cannot reach ``localhost``).
+split. Any of these keys a profile already pins the build leaves untouched, and
+an explicit ``web.panels.events.url`` always wins — pin it on the **hosting**
+profile when the web terminals cannot reach the dispatcher on ``localhost``;
+every persona follows it, and a persona that pins a different one is refused.
 
 Authoring Triggers
 ==================

--- a/docs/source/how-to/monitor-agent.rst
+++ b/docs/source/how-to/monitor-agent.rst
@@ -282,28 +282,38 @@ name rather than a secret.
 .. important::
 
    For ``backend: openobserve`` the OTLP endpoint is **auto-derived** and you
-   should not hardcode it. The derived form is ``http://<host>:5080/api/<org>``
-   — note the ``5080`` is fixed: the derivation does *not* follow a changed
-   ``services.openobserve.port``, so if you publish the store on a different
-   host port, set ``endpoint:`` explicitly instead. The ``<host>`` part is
-   chosen for the running context:
+   should not hardcode it. The derived form is ``http://<host>:<port>/api/<org>``,
+   with both halves chosen for the running context:
 
    - **On the host** (``osprey web`` / ``osprey query`` on your machine) the host
-     is ``localhost`` — the store's published port.
-   - **Inside a bridge-networked container** (for example the containerized
+     is ``localhost`` and the port is the one the store **publishes** —
+     ``services.openobserve.port``, so moving the store moves the exporter
+     with it.
+   - **Inside a host-networked container** (every web-terminal persona
+     container, a dispatch worker on the host network) the container's
+     loopback is the host's, so the address is the same published one. The
+     framework's compose files declare the host explicitly
+     (``OSPREY_OTEL_OPENOBSERVE_HOST=127.0.0.1`` or ``localhost``), because
+     the emitter's own container detection would otherwise pick the compose
+     DNS name, which resolves to nothing there.
+   - **Inside a bridge-networked container** (the default containerized
      dispatch worker) the store is reachable only by its compose service DNS
-     name, ``openobserve``. The framework's dispatch-worker service declares this
-     by setting ``OSPREY_OTEL_OPENOBSERVE_HOST=openobserve`` in its compose
-     environment. That explicit declaration — rather than sniffing the container
-     runtime — is what makes emit work identically under Docker and Podman.
+     name, ``openobserve``, and on the port it **listens** on inside its own
+     container (5080) rather than the published one. The dispatch-worker
+     service declares both, ``OSPREY_OTEL_OPENOBSERVE_HOST=openobserve`` and
+     ``OSPREY_OTEL_OPENOBSERVE_PORT=5080``. That explicit declaration — rather
+     than sniffing the container runtime — is what makes emit work identically
+     under Docker and Podman.
 
    If you run your own containerized emitter, set
    ``OSPREY_OTEL_OPENOBSERVE_HOST`` to whatever host reaches OpenObserve from
-   inside that container: the compose service name on a bridge network, or
+   inside that container — the compose service name on a bridge network
+   (with ``OSPREY_OTEL_OPENOBSERVE_PORT`` naming the listen port), or
    ``localhost`` when the container uses host networking (``network_mode: host``),
-   where the compose DNS name would not resolve. Leave it unset on a plain host
-   run. Hardcoding ``endpoint:`` instead would point every context at the same
-   host and silently drop records from the ones it doesn't fit.
+   where the compose DNS name would not resolve and the published port
+   applies. Leave both unset on a plain host run. Hardcoding ``endpoint:``
+   instead would point every context at the same address and silently drop
+   records from the ones it doesn't fit.
 
 On its next run the agent emits to OpenObserve, and its logs and metrics appear
 in the UI.

--- a/docs/source/how-to/okf-bundle.rst
+++ b/docs/source/how-to/okf-bundle.rst
@@ -141,9 +141,10 @@ Working with a Bundle
          facility_knowledge:
            bundle_path: data/facility_knowledge
 
-      Relative paths are resolved against the directory containing ``config.yml``
-      (the project root).  For the ``control-assistant`` preset the example
-      bundle is scaffolded into ``data/facility_knowledge/`` automatically.
+      Relative paths are resolved against the project root — the deployment
+      repo, not the ``build/`` render inside it, which every ``osprey build``
+      re-creates. For the ``control-assistant`` preset the example bundle is
+      scaffolded into ``data/facility_knowledge/`` automatically.
 
       .. _shared-bundle-multi-user:
 

--- a/docs/source/how-to/use-facility-graph.rst
+++ b/docs/source/how-to/use-facility-graph.rst
@@ -440,9 +440,12 @@ directly:
 
 Two consequences worth knowing before you move anything:
 
-* **Move the port on the hosting deployment and you must move the same number
-  in both persona presets.** They carry their own copy; nothing derives it for
-  them.
+* **Move the port on the hosting deployment and every persona follows.** A
+  persona built beside its deployment is told the store's bolt port from the
+  deployment's own render — the same way it is told the qmd sidecar's port,
+  the Postgres the logbook lives in and the rest (:doc:`build-profiles`) — so
+  nothing in a persona preset restates it, and a persona that restates it
+  with a different number is refused at build time.
 * A ``deployment.bind_address`` pinned to a specific non-loopback interface
   publishes the store there and not on ``localhost``, so the personas would no
   longer reach it. URL-backed panels have the same shape — they name

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -130,7 +130,14 @@ keys:
   # matches exactly one file, so deleting the resolver fails the guard rather
   # than rotting quietly.
   services.qmd:
-    evidence: 'services\.get\("qmd"\)'
+    evidence: 'QMD_SERVICE_NAME = "qmd"'
+    note: >-
+      The block's name is spelled once, as `qmd_service.QMD_SERVICE_NAME`, and
+      every reader goes through that constant — the resolver, the two dotted
+      keys below that build their own paths from it, and the reach contract
+      asking whether there is a block to dial. Pinning the constant rather
+      than one reader's `services.get(...)` keeps the guard on the spelling
+      itself, which is the thing a config file has to match.
   services.qmd.path:
     evidence: 'service_config\["path"\]'
     note: >-

--- a/src/osprey/bluesky_bridge_connection.py
+++ b/src/osprey/bluesky_bridge_connection.py
@@ -36,8 +36,56 @@ functions, only when a config fallback is actually needed.
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
+from typing import Any
 
-DEFAULT_BRIDGE_URL = "http://127.0.0.1:8090"
+#: The port the bridge publishes when nothing configures one — the schema
+#: default of the build profile's ``bluesky.port``.
+DEFAULT_BRIDGE_PORT = 8090
+
+DEFAULT_BRIDGE_URL = f"http://127.0.0.1:{DEFAULT_BRIDGE_PORT}"
+
+#: The variable that names lane 1's bridge outright — set per bridge instance
+#: by a compose service that reaches it by its in-network name, or by an
+#: operator. Every lane has one, spelled ``<PREFIX>_BRIDGE_URL`` for
+#: :func:`lane_env_prefix` of that lane; this is that spelling for
+#: :data:`LANE_ONE`, whose prefix is the pre-lane name unchanged.
+BRIDGE_URL_ENV_VAR = "BLUESKY_BRIDGE_URL"
+
+
+def bridge_url_from_config(config: Mapping[str, Any] | None) -> str:
+    """The bridge base URL a loaded ``config.yml`` implies, trailing slash stripped.
+
+    Resolution order, the config half of :func:`resolve_bridge_url` for
+    :data:`LANE_ONE`. A second lane has no ``bluesky.bridge_url`` of its own
+    and no default to fall back to, so it resolves its port directly there.
+
+    1. ``bluesky.bridge_url`` — a full URL, for a bridge that is not the one
+       this deployment publishes on loopback (a dev convenience).
+    2. ``services.bluesky.port`` — the port the deployment publishes its own
+       bridge on. Written by the build for a deploying project and projected
+       into every attached render (a web-terminal persona), so a bridge moved
+       on the hosting profile moves every client with it. Dialed on loopback:
+       a persona container shares the host network namespace, and the host's
+       own processes reach the published port there too.
+    3. :data:`DEFAULT_BRIDGE_URL`.
+
+    Duplicated, deliberately and knowingly, by the approval hook's
+    ``_resolve_bridge_url`` (``templates/claude_code/claude/hooks/osprey_approval.py``),
+    which runs standalone in a different venv and cannot import this module;
+    a change here is a change there.
+    """
+    bluesky = (config or {}).get("bluesky")
+    url = bluesky.get("bridge_url") if isinstance(bluesky, Mapping) else None
+    if url:
+        return str(url).rstrip("/")
+    services = (config or {}).get("services")
+    block = services.get("bluesky") if isinstance(services, Mapping) else None
+    port = block.get("port") if isinstance(block, Mapping) else None
+    if port:
+        return f"http://127.0.0.1:{port}"
+    return DEFAULT_BRIDGE_URL
+
 
 #: Service key of the plan lane every deployment has had since the bridge
 #: shipped. It stays the default everywhere here, so a caller that knows
@@ -96,12 +144,16 @@ def resolve_bridge_url(lane: str | None = None) -> str:
 
     1. ``<PREFIX>_BRIDGE_URL`` env var (full URL) -- set by the framework server
        definition per bridge instance; wins outright.
-    2. For lane 1, ``bluesky.bridge_url`` in config.yml. For a second lane, the
-       loopback URL of its own published port (``services.<lane>.port``), which
-       is where ``_inject_bluesky`` put it -- there is no second
-       ``bluesky.bridge_url`` to read, and inventing one would be a key an
-       operator has to keep in step with a port the build derives.
-    3. ``http://127.0.0.1:8090`` default (lane 1 only).
+    2. For lane 1, the loaded ``config.yml`` through
+       :func:`bridge_url_from_config` -- ``bluesky.bridge_url``, then the
+       loopback URL of the port the deployment publishes its own bridge on
+       (``services.bluesky.port``). For a second lane, the loopback URL of its
+       own published port (``services.<lane>.port``), which is where
+       ``_inject_bluesky`` put it -- there is no second ``bluesky.bridge_url``
+       to read, and inventing one would be a key an operator has to keep in
+       step with a port the build derives.
+    3. :data:`DEFAULT_BRIDGE_URL` (lane 1 only, and only when its config names
+       no port either).
 
     The returned URL has any trailing slash stripped so callers can append a
     path verbatim.
@@ -120,8 +172,7 @@ def resolve_bridge_url(lane: str | None = None) -> str:
 
     config = load_osprey_config()
     if lane_key == LANE_ONE:
-        url = config.get("bluesky", {}).get("bridge_url", DEFAULT_BRIDGE_URL)
-        return str(url).rstrip("/")
+        return bridge_url_from_config(config)
 
     port = (config.get("services", {}).get(lane_key) or {}).get("port")
     if not port:

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -28,6 +28,7 @@ from osprey.build.claude_code_telemetry import (
     _build_telemetry_env,
     _openobserve_host_override,
     _running_in_container,
+    resolve_openobserve_port,
 )
 from osprey.models.tiers import VALID_TIERS
 from osprey.utils.dotenv import chain_files
@@ -503,6 +504,13 @@ def load_provider_spec(
         include_telemetry=include_telemetry,
         defer_unresolved_telemetry_creds=defer_unresolved_telemetry_creds,
         environ=lookup,
+        # A runtime launch: the deploy environment's port declaration wins,
+        # else the port this deployment publishes the store on. Resolved only
+        # when telemetry is being built: it is a telemetry input, and a
+        # malformed port must not poison provider resolution for a caller
+        # that asked for none (the dispatch worker's degrade-and-retry relies
+        # on include_telemetry=False never raising a telemetry fault).
+        openobserve_port=resolve_openobserve_port(cfg) if include_telemetry else None,
     )
 
 
@@ -654,6 +662,7 @@ class ClaudeCodeModelResolver:
         include_telemetry: bool = True,
         defer_unresolved_telemetry_creds: bool = False,
         environ: Mapping[str, str] | None = None,
+        openobserve_port: int | None = None,
     ) -> ClaudeCodeModelSpec | None:
         """Build a ``ClaudeCodeModelSpec`` from config.
 
@@ -698,6 +707,15 @@ class ClaudeCodeModelResolver:
                 :func:`load_provider_spec` passes its ``os.environ`` +
                 project-``.env`` overlay, which is what enables the override on
                 every runtime path.
+            openobserve_port: The port the telemetry store is reached on from
+                where this spec will run — ``services.openobserve.port`` for a
+                build-time render, the deploy environment's declaration or
+                that same key for a runtime launch
+                (:func:`~osprey.build.claude_code_telemetry.resolve_openobserve_port`).
+                Threaded in rather than read here, for the same reason as
+                ``environ``: this method also renders ``settings.json`` at
+                build time. Omitted, the derived endpoint falls back to the
+                store's listen port.
 
         Returns:
             Resolved spec, or ``None`` when no provider is configured.
@@ -914,6 +932,7 @@ class ClaudeCodeModelResolver:
                     telemetry_cfg,
                     in_container=_running_in_container(),
                     openobserve_host=_openobserve_host_override(),
+                    openobserve_port=openobserve_port,
                     defer_unresolved_creds=defer_unresolved_telemetry_creds,
                 )
             )

--- a/src/osprey/build/claude_code_telemetry.py
+++ b/src/osprey/build/claude_code_telemetry.py
@@ -15,6 +15,8 @@ import base64
 import os
 import re
 import warnings
+from collections.abc import Mapping
+from typing import Any
 
 # OTEL / Claude Code telemetry vars the resolver may inject into the env block.
 #
@@ -209,6 +211,117 @@ def _openobserve_host_override() -> str | None:
     return os.environ.get("OSPREY_OTEL_OPENOBSERVE_HOST") or None
 
 
+#: The port the OpenObserve container LISTENS on. Fixed by the image, and what
+#: the service template publishes ``services.openobserve.port`` onto
+#: (``<bind>:<port>:5080/tcp``). It is the right port only from inside the
+#: store's own compose network, where the store is reached by DNS name; from
+#: anywhere else — the host, a host-networked container — the store is reached
+#: at the port it PUBLISHES, which a project moves freely.
+OPENOBSERVE_LISTEN_PORT = 5080
+
+#: The variable a compose author sets beside ``OSPREY_OTEL_OPENOBSERVE_HOST``
+#: when the host it names is reached on a port the config cannot know — the
+#: bridge case, where the compose DNS name answers on the listen port. Same
+#: convention as the host variable: topology is declared, never sniffed.
+OPENOBSERVE_PORT_ENV_VAR = "OSPREY_OTEL_OPENOBSERVE_PORT"
+
+
+def openobserve_published_port(config: Mapping[str, Any] | None) -> int:
+    """The port this deployment publishes the telemetry store on.
+
+    Read from ``services.openobserve.port`` — the one key that moves it, and the
+    same key the service template, the deploy preflight and ``osprey health``
+    read — falling back to :data:`OPENOBSERVE_LISTEN_PORT`, which is what the
+    template publishes when the key is absent. A persona render carries the
+    key too: profile inheritance copies the hosting profile's ``config:``
+    overlay into every attached render, so a moved store moves every client.
+
+    Args:
+        config: Loaded ``config.yml`` mapping, or ``None``.
+
+    Returns:
+        The published port, as an ``int``.
+
+    Raises:
+        TelemetryConfigError: The key is present but not an integer port.
+    """
+    services = (config or {}).get("services") or {}
+    block = services.get("openobserve") if isinstance(services, Mapping) else None
+    raw = block.get("port") if isinstance(block, Mapping) else None
+    if raw is None:
+        return OPENOBSERVE_LISTEN_PORT
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        raise TelemetryConfigError(
+            f"services.openobserve.port must be an integer port, got {raw!r}"
+        ) from None
+
+
+def _openobserve_port_override() -> int | None:
+    """Explicit OpenObserve port from the deploy environment, or ``None``.
+
+    The port half of :func:`_openobserve_host_override`, read the same way and
+    for the same reason. An unset or empty variable is no override; a set one
+    that is not an integer is a compose-authoring error and is refused rather
+    than silently ignored, because the value was written deliberately.
+
+    Raises:
+        TelemetryConfigError: The variable is set but not an integer port.
+    """
+    raw = os.environ.get(OPENOBSERVE_PORT_ENV_VAR)
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        raise TelemetryConfigError(
+            f"{OPENOBSERVE_PORT_ENV_VAR} must be an integer port, got {raw!r}"
+        ) from None
+
+
+def resolve_openobserve_port(config: Mapping[str, Any] | None) -> int:
+    """The port a runtime launch reaches the telemetry store on.
+
+    The deploy environment's declaration wins (:func:`_openobserve_port_override`);
+    otherwise the port this deployment publishes
+    (:func:`openobserve_published_port`). Runtime launch paths call this;
+    build-time renders, which must not read the builder's environment, call
+    :func:`openobserve_published_port` directly.
+    """
+    return _openobserve_port_override() or openobserve_published_port(config)
+
+
+def resolve_runtime_telemetry_endpoint(config: Mapping[str, Any] | None) -> str | None:
+    """The OTLP endpoint an agent launched from this process would post to.
+
+    The same inputs the launch path hands :func:`_build_telemetry_env` —
+    container context, the deploy environment's host and port overrides, the
+    port the deployment publishes — so what the ``reach`` health category
+    knocks on is what the exporter dials from here, not a re-derivation.
+
+    Args:
+        config: Loaded ``config.yml`` mapping, or ``None``.
+
+    Returns:
+        The endpoint URL, or ``None`` when telemetry is off, not the
+        OpenObserve backend, or misconfigured (the launch path refuses that
+        loudly; the probe has nothing to knock on).
+    """
+    telemetry_cfg = ((config or {}).get("claude_code") or {}).get("telemetry")
+    if not isinstance(telemetry_cfg, dict) or not telemetry_cfg.get("enabled"):
+        return None
+    try:
+        return _resolve_telemetry_endpoint(
+            telemetry_cfg,
+            in_container=_running_in_container(),
+            openobserve_host=_openobserve_host_override(),
+            openobserve_port=resolve_openobserve_port(config),
+        )
+    except (TelemetryConfigError, ValueError):
+        return None
+
+
 def _parse_header_map(value: dict | str) -> dict[str, str]:
     """Parse OTLP headers config into a ``{key: value}`` dict.
 
@@ -241,13 +354,30 @@ def _render_kv_map(value: dict | str) -> str:
 
 
 def _resolve_telemetry_endpoint(
-    telemetry_cfg: dict, *, in_container: bool, openobserve_host: str | None = None
+    telemetry_cfg: dict,
+    *,
+    in_container: bool,
+    openobserve_host: str | None = None,
+    openobserve_port: int | None = None,
 ) -> str:
     """Resolve the OTLP exporter endpoint, failing loud on misconfiguration.
 
     Priority: an explicit ``endpoint`` wins verbatim; otherwise an
     ``openobserve`` backend derives the org endpoint from the container context.
     Any other enabled-but-unaddressed config is a misconfiguration and raises.
+
+    Args:
+        telemetry_cfg: The ``claude_code.telemetry`` section.
+        in_container: Whether the agent runs in a container — selects the
+            OpenObserve default host (``openobserve`` vs ``localhost``).
+        openobserve_host: Explicit store host from the deploy env; wins over
+            the ``in_container`` derivation.
+        openobserve_port: The port the store is reached on from where this
+            launch runs — the deploy env's declaration or the port the
+            deployment publishes (:func:`resolve_openobserve_port`). ``None``
+            falls back to :data:`OPENOBSERVE_LISTEN_PORT`, which is right only
+            for a caller inside the store's own compose network; every launch
+            path passes the resolved port.
 
     Raises:
         ValueError: If no endpoint can be resolved; if ``protocol`` is ``grpc``
@@ -269,7 +399,7 @@ def _resolve_telemetry_endpoint(
                 raise TelemetryConfigError(
                     "claude_code.telemetry.protocol is 'grpc' but the OTLP endpoint "
                     "is auto-derived from backend: openobserve, which serves HTTP "
-                    "only (port 5080) — a gRPC exporter aimed there would drop every "
+                    "only — a gRPC exporter aimed there would drop every "
                     "metric and log silently. Use protocol: http/protobuf, or set an "
                     "explicit claude_code.telemetry.endpoint pointing at a collector "
                     "that speaks gRPC."
@@ -277,8 +407,9 @@ def _resolve_telemetry_endpoint(
             # An explicit host from the deploy env wins (the compose author knows
             # the network topology); otherwise derive from container context.
             host = openobserve_host or ("openobserve" if in_container else "localhost")
+            port = openobserve_port or OPENOBSERVE_LISTEN_PORT
             org = telemetry_cfg.get("openobserve", {}).get("org", "default")
-            endpoint = f"http://{host}:5080/api/{org}"
+            endpoint = f"http://{host}:{port}/api/{org}"
         else:
             raise TelemetryConfigError(
                 "claude_code.telemetry is enabled but no 'endpoint' is set and "
@@ -369,12 +500,13 @@ def _build_telemetry_env(
     *,
     in_container: bool = False,
     openobserve_host: str | None = None,
+    openobserve_port: int | None = None,
     defer_unresolved_creds: bool = False,
 ) -> dict[str, str]:
     """Build the OTEL/telemetry env block from the ``claude_code.telemetry`` config.
 
     Reads no environment and does no filesystem/network I/O — the
-    ``${VAR}``-expansion, container detection, and host override happen
+    ``${VAR}``-expansion, container detection, and host/port resolution happen
     upstream. Its only side effect is a single advisory ``warnings.warn`` when
     full content capture is active on a non-openobserve backend. Returns an
     empty dict when telemetry is absent or disabled.
@@ -387,6 +519,8 @@ def _build_telemetry_env(
         openobserve_host: Explicit OpenObserve host from the deploy env; when
             set it wins over the ``in_container`` derivation (the compose author
             knows the network topology).
+        openobserve_port: The port the store is reached on from where this
+            launch runs (see :func:`_resolve_telemetry_endpoint`).
 
     Returns:
         A ``{VAR: "value"}`` dict; every value is a string (never bool). Keys
@@ -408,7 +542,10 @@ def _build_telemetry_env(
         "OTEL_LOGS_EXPORTER": "otlp",
         "OTEL_EXPORTER_OTLP_PROTOCOL": str(telemetry_cfg.get("protocol", "http/protobuf")),
         "OTEL_EXPORTER_OTLP_ENDPOINT": _resolve_telemetry_endpoint(
-            telemetry_cfg, in_container=in_container, openobserve_host=openobserve_host
+            telemetry_cfg,
+            in_container=in_container,
+            openobserve_host=openobserve_host,
+            openobserve_port=openobserve_port,
         ),
     }
 

--- a/src/osprey/cli/ariel.py
+++ b/src/osprey/cli/ariel.py
@@ -67,10 +67,11 @@ def _load_ariel_config() -> dict:
 def _config_dir() -> Path | None:
     """Return the directory of the config.yml this CLI run is reading.
 
-    A relative ``ariel.vocabulary.path`` names a file next to that config, not
-    next to whatever directory the operator happened to run from — so every
-    process reading the same config finds the same vocabulary file. Delegates
-    to the framework rule rather than restating it.
+    A relative ``ariel.vocabulary.path`` names a file in that config's project
+    (the shared resolver anchors it on the project root), not in whatever
+    directory the operator happened to run from — so every process reading the
+    same config finds the same vocabulary file. Delegates to the framework rule
+    rather than restating it.
 
     Returns:
         The config's parent directory, or None when it cannot be determined, in

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -41,7 +41,7 @@ import shlex
 import shutil
 import sys
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, NamedTuple
 from uuid import uuid4
@@ -628,20 +628,6 @@ _HOST_NETWORK = "host"
 #: recognize it by.
 _DISPATCH_PAIR_ADDRESS_VARS = ("DISPATCHER_URL", "WORKER_URL")
 
-#: The variable a host-mode service is rendered with to name the telemetry
-#: store, read by :mod:`osprey.build.claude_code_telemetry`. It carries a HOST
-#: and nothing else — see :data:`_OPENOBSERVE_ENDPOINT_PORT`.
-_OTEL_OPENOBSERVE_HOST_VAR = "OSPREY_OTEL_OPENOBSERVE_HOST"
-
-#: The port the OTLP endpoint derived from ``backend: openobserve`` is pinned
-#: at (``osprey/build/claude_code_telemetry.py``'s
-#: ``http://{host}:5080/api/{org}``). The pin is invisible under bridge
-#: networking, where the store is reached by its compose DNS name on the port it
-#: LISTENS on; under host networking the address is the port it PUBLISHES, which
-#: a project is free to move. The test suite binds this constant to the endpoint
-#: the resolver actually derives, so the two cannot drift apart.
-_OPENOBSERVE_ENDPOINT_PORT = 5080
-
 
 class _RenderedService(NamedTuple):
     """One container stanza as this build rendered it.
@@ -996,68 +982,6 @@ def _cross_network_errors(
     return errors
 
 
-def _openobserve_endpoint_errors(
-    config: dict[str, Any], indexed: Sequence[_RenderedService]
-) -> list[str]:
-    """A host-mode telemetry exporter aimed at a port the store does not publish.
-
-    ``OSPREY_OTEL_OPENOBSERVE_HOST`` carries a host and no port, and the
-    endpoint derived from it pins :data:`_OPENOBSERVE_ENDPOINT_PORT`. On the
-    bridge that is the port the store LISTENS on, which no project changes;
-    on the host namespace it is the port the store PUBLISHES, which
-    ``services.openobserve.port`` moves freely. The two disagreeing costs
-    nothing at boot and drops every metric and log afterwards.
-
-    Fails the build only when the derivation is live — telemetry enabled, the
-    openobserve backend, no explicit endpoint. Otherwise the variable is inert
-    and refusing to build would be an error about nothing; that case gets a
-    warning, because enabling telemetry later would break it silently.
-    """
-    published = _mapping(_mapping(config.get("services")).get("openobserve")).get("port")
-    if published is None or str(published) == str(_OPENOBSERVE_ENDPOINT_PORT):
-        return []
-
-    exporters = [
-        service
-        for service in indexed
-        if service.on_host and _OTEL_OPENOBSERVE_HOST_VAR in service.environment
-    ]
-    if not exporters:
-        return []
-
-    named = ", ".join(sorted({_service_label(service) for service in exporters}))
-    telemetry = _mapping(_mapping(config.get("claude_code")).get("telemetry"))
-    derived = (
-        bool(telemetry.get("enabled"))
-        and telemetry.get("backend") == "openobserve"
-        and not telemetry.get("endpoint")
-    )
-    org = _mapping(telemetry.get("openobserve")).get("org", "default")
-    if not derived:
-        logger.warning(
-            "  services.openobserve.port publishes the store on %s, while %s runs on the "
-            "host network and derives the telemetry endpoint's port from a pinned %s. "
-            "Nothing is broken today, since claude_code.telemetry is not deriving an "
-            "endpoint. Enabling it with backend: openobserve will need "
-            "claude_code.telemetry.endpoint set explicitly.",
-            published,
-            named,
-            _OPENOBSERVE_ENDPOINT_PORT,
-        )
-        return []
-
-    return [
-        f"{named} runs on the host network and reaches the telemetry store over the host's "
-        f"own loopback ({_OTEL_OPENOBSERVE_HOST_VAR}), but claude_code.telemetry derives its "
-        f"OTLP endpoint from backend: openobserve with the store's port pinned at "
-        f"{_OPENOBSERVE_ENDPOINT_PORT}, while services.openobserve.port publishes it on "
-        f"{published}. The exporter would post to "
-        f"http://localhost:{_OPENOBSERVE_ENDPOINT_PORT}/api/{org}, where nothing is "
-        f"listening. Set `claude_code.telemetry.endpoint: http://localhost:{published}"
-        f"/api/{org}` — the variable carries a host only, so it has no port half to correct."
-    ]
-
-
 def _network_check_errors(config: dict[str, Any], compose_files: Sequence[str]) -> list[str]:
     """Everything wrong with the network axis of the render that just happened.
 
@@ -1071,7 +995,6 @@ def _network_check_errors(config: dict[str, Any], compose_files: Sequence[str]) 
         *_inert_axis_errors(config, indexed),
         *parity_errors,
         *_cross_network_errors(indexed, dispatch_consumers),
-        *_openobserve_endpoint_errors(config, indexed),
     ]
 
 
@@ -1259,6 +1182,71 @@ class _SharedRenderInputs(NamedTuple):
     See :data:`_CONTAINER_INTERPRETER`.
     """
 
+    host_config: Mapping[str, Any] | None = None
+    """The deployment's own rendered ``config.yml``, once it has been rendered.
+
+    What every attached render in this repo is told about the services the
+    deployment runs (:func:`osprey.deployment.reach.project_attached_overrides`):
+    the ports it publishes, the panel URLs its injectors derived. ``None``
+    until the deployment's render is done — it is the first render of every
+    build — and ``None`` throughout a build whose profile is itself attached,
+    which has no host in this repo and is told the app template's defaults
+    instead (:func:`_template_host_config`).
+    """
+
+
+def _rendered_config(render_dir: Path) -> dict[str, Any]:
+    """The ``config.yml`` a render wrote, as a plain mapping."""
+    import yaml
+
+    with (render_dir / "config.yml").open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _template_host_config(
+    shared: _SharedRenderInputs,
+    build_profile: Any,
+    *,
+    project_name: str,
+    render_dir: Path,
+    profile_dir: Path,
+    context: Mapping[str, Any],
+    artifacts: dict[str, list[str]] | None,
+) -> dict[str, Any]:
+    """What the app template deploys at its defaults — the host an attached
+    profile built with no deployment in its repo is told about.
+
+    The template rendered AS a deployment (``deploy_services: true``) with
+    this render's own context, the profile's ``config:`` laid over it (the
+    same overlay the render itself gets, because a host that differs from
+    the template's defaults is named there), and then the service injectors
+    run over it exactly as for a deploying profile: an attached profile
+    inherits the blocks they read (``dispatch:``, ``bluesky_web:``, …) from
+    the deployment profile it extends, and what they derive — the EVENTS and
+    BLUESKY tab entries above all — is what a persona beside a real host is
+    told from that host's render. Rendered into a scratch directory the build
+    zone never sees — it is a reading, not a render.
+    """
+    import tempfile
+    from dataclasses import replace
+
+    with tempfile.TemporaryDirectory() as scratch:
+        scratch_dir = Path(scratch)
+        shared.manager.render_config(
+            project_name,
+            render_dir,
+            scratch_dir / "config.yml",
+            data_bundle=build_profile.data_bundle,
+            context={**context, "deploy_services": True},
+            artifacts=artifacts,
+        )
+        if build_profile.config:
+            _apply_config_overrides(scratch_dir, build_profile.config)
+        # A view of the profile as the deployment it extends: the injectors
+        # skip an attached profile wholesale, and this reading is of the host.
+        _inject_services(replace(build_profile, deploy_services=True), profile_dir, scratch_dir)
+        return _rendered_config(scratch_dir)
+
 
 def _render_project(
     shared: _SharedRenderInputs,
@@ -1327,6 +1315,7 @@ def _render_project(
     """
     from osprey.build.build_tiers import tier_mode_conflict
     from osprey.build.claude_code_resolver import load_provider_spec
+    from osprey.deployment.reach import reach_errors
     from osprey.services.virtual_accelerator.manifest.build import (
         prepare_project_manifest,
         write_project_manifest,
@@ -1334,6 +1323,12 @@ def _render_project(
 
     from .build_profile_archiver import va_archiver_config_overrides
     from .build_profile_deploy import deploy_config_overrides
+    from .build_profile_reach import (
+        attached_render_overrides,
+        orphan_panel_fragments,
+        reach_override_errors,
+        selected_panel_errors,
+    )
     from .validate_claude_artifacts import validate_agent_tools_against_permissions
 
     build_profile = resolved.profile
@@ -1417,9 +1412,90 @@ def _render_project(
             for key, value in entries.items():
                 progress("      %s: %s (from the profile's %s block)", key, value, block)
 
+    # What an attached render is told about the services its host deploys —
+    # the ports it publishes, the panel URLs its injectors derived — copied
+    # from the deployment's own render (the Reach Contract,
+    # osprey.deployment.reach). After the profile's overlay, because the
+    # projection is gated on what THIS render switches on; before the
+    # service injection and the Claude Code re-render, because a projected
+    # block is what makes a server render at all (`graphdb_configured`).
+    # A deploying project projects nothing: its injectors write the blocks.
+    if not build_profile.deploy_services:
+        if shared.host_config is not None:
+            host_config, told_by = shared.host_config, "the hosting deployment's render"
+        else:
+            # Built alone, with no deployment in this repo: the profile extends
+            # a deployment of the same app template, so that template rendered
+            # AS a deployment is what the host says at the shipped defaults —
+            # and the profile's own `config:` is where a host that differs is
+            # named, so it is laid over those defaults first.
+            host_config = _template_host_config(
+                shared,
+                build_profile,
+                project_name=project_name,
+                render_dir=render_dir,
+                profile_dir=repo_root,
+                context=context,
+                artifacts=artifacts or None,
+            )
+            told_by = "the app template's defaults"
+        projected = attached_render_overrides(
+            host_config,
+            _rendered_config(render_dir),
+            selected_panels=build_profile.web_panels or (),
+        )
+        # A `config:` spelling that contradicts the projection is refused;
+        # one that agrees (inherited from the hosting profile, or laid over
+        # the template's defaults when built alone) is the same fact.
+        duplicate_errors = reach_override_errors(build_profile.config, projected)
+        if duplicate_errors:
+            raise BuildProfileError(
+                "Profile validation failed:\n  " + "\n  ".join(duplicate_errors)
+            )
+        if projected:
+            _apply_config_overrides(render_dir, projected)
+            progress(
+                "  ✓ Told this attached render %d fact(s) about the host's services", len(projected)
+            )
+            for key, value in projected.items():
+                progress("      %s: %s (from %s)", key, value, told_by)
+        # The reverse: a tab this profile does NOT select, inherited from the
+        # hosting profile's `config:` as a url-less fragment (a pinned route),
+        # would render as an empty-url panel. Dropped — the selection is what
+        # puts a projected tab in an attached render.
+        from osprey.utils.config_writer import config_delete_field
+
+        for key in orphan_panel_fragments(
+            build_profile.web_panels or (), _rendered_config(render_dir)
+        ):
+            config_delete_field(render_dir / "config.yml", key)
+            progress(
+                "  ✓ Dropped %s: a tab this profile does not select, inherited with no url", key
+            )
+        # A tab this profile selects (`web_panels:`) that the projection gave
+        # no address — the host it was told about runs no such sidecar — would
+        # otherwise vanish from the render without a word.
+        tabless = selected_panel_errors(
+            build_profile.web_panels or (), _rendered_config(render_dir), told_by=told_by
+        )
+        if tabless:
+            raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(tabless))
+
     injected = _inject_services(build_profile, repo_root, render_dir)
     if injected_out is not None:
         injected_out.extend(injected)
+
+    # The ground truth every client loads is the rendered config, so this is
+    # where a consumer switched on with nothing to dial is refused — for a
+    # deployment that dropped a block its modules still use, and for an
+    # attached render that was told nothing (a host, or an app template, that
+    # deploys no such service) alike. AFTER the injectors: a deploying profile
+    # that pins only `web.panels.events.path` has its `url` written by the
+    # dispatch injector, and refusing before that would name a key the build
+    # was about to write.
+    unreachable = reach_errors(_rendered_config(render_dir))
+    if unreachable:
+        raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(unreachable))
 
     applied = _apply_conventions(
         repo_root,
@@ -2386,7 +2462,7 @@ def _build_repo(
             # Only this pass records what it injected: all six inject the same
             # set, and the operator wants the components named once.
             injected: list[str] = []
-            _render_project(
+            host_render = _render_project(
                 shared,
                 resolved,
                 profile_path=profile_path,
@@ -2399,6 +2475,12 @@ def _build_repo(
                 progress=logger.debug,
                 injected_out=injected,
             )
+            # Every render after this one — each persona's, and each image
+            # copy's — is told about the deployment's services from the render
+            # just written (see _SharedRenderInputs.host_config). A profile
+            # that is itself attached hosts nothing and projects nothing.
+            if build_profile.deploy_services:
+                shared = shared._replace(host_config=_rendered_config(host_render))
             phase.step("project files, agent artifacts and services")
             if injected:
                 phase.step(f"services injected: {', '.join(injected)}")

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -552,20 +552,25 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
             anchored_append(deployed, name)
     config["deployed_services"] = deployed
 
-    # Derive web.panels.events.url from dispatcher_port so the port is a single
-    # source of truth.  Write only if the profile has not already set an explicit
-    # ``web.panels.events.url`` via a config override (merged earlier in the
-    # build); explicit overrides take precedence.
+    # Derive the whole web.panels.events entry from dispatcher_port so the port
+    # is a single source of truth — url, the `/dashboard` path, the tab's label
+    # and the `/health` endpoint the tab health-gates on. Written here, in the
+    # deployment's own render, because every web-terminal persona built beside
+    # it is TOLD this entry from this render (osprey.deployment.reach): a key
+    # left out here is a key no persona ever sees. Filled only where the
+    # profile has not already set an explicit value via a config override
+    # (merged earlier in the build); explicit overrides take precedence, and
+    # an explicit ``url`` leaves the whole entry alone.
     #
     # Emit a bare-host ``url`` plus a ``/dashboard`` ``path`` (rather than baking
     # ``/dashboard`` into ``url``) to match the custom-panel proxy convention:
     # the web terminal composes ``url.rstrip('/') + '/' + path``, so a path baked
-    # into ``url`` double-prefixes sub-routes. ``setdefault`` on ``path`` honors a
-    # facility that pinned its own ``web.panels.events.path``.
+    # into ``url`` double-prefixes sub-routes.
     existing_events_url = config.get("web", {}).get("panels", {}).get("events", {}).get("url", "")
     if not existing_events_url:
         panels = config.setdefault("web", {}).setdefault("panels", {})
         events_panel = panels.get("events")
+        events_url = f"http://localhost:{dispatch.dispatcher_port}"
         if events_panel is None:
             # Put the complete panel in one shot: anchored_put re-anchors a
             # section comment beneath the new entry, which needs the entry's
@@ -573,12 +578,17 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
             anchored_put(
                 panels,
                 "events",
-                {"url": f"http://localhost:{dispatch.dispatcher_port}", "path": "/dashboard"},
+                {
+                    "url": events_url,
+                    "path": "/dashboard",
+                    "label": "EVENTS",
+                    "health_endpoint": "/health",
+                },
             )
         else:
-            anchored_put(events_panel, "url", f"http://localhost:{dispatch.dispatcher_port}")
-            if "path" not in events_panel:
-                anchored_put(events_panel, "path", "/dashboard")
+            _fill_panel_defaults(
+                events_panel, events_url, "/dashboard", "EVENTS", health_endpoint="/health"
+            )
 
     with open(config_path, "w") as fh:
         yaml.dump(config, fh)
@@ -1073,13 +1083,17 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
     )
 
 
-def _fill_panel_defaults(panel_cfg: Any, url: str, path: str, label: str) -> None:
+def _fill_panel_defaults(
+    panel_cfg: Any, url: str, path: str, label: str, health_endpoint: str | None = None
+) -> None:
     """Fill a partially-specified ``web.panels.<id>`` entry in place.
 
     Explicit values win: a facility override merged earlier in the build keeps
     whatever it set, and only the keys it left out are derived. ``url`` is
     additionally treated as unset when empty, so a blank override cannot leave
-    the panel pointing nowhere.
+    the panel pointing nowhere. ``health_endpoint`` is filled only for a
+    service that serves one (the dispatcher's ``/health``): it is what lets
+    the tab health-gate itself instead of treating any answer as healthy.
     """
     if not panel_cfg.get("url"):
         anchored_put(panel_cfg, "url", url)
@@ -1087,6 +1101,8 @@ def _fill_panel_defaults(panel_cfg: Any, url: str, path: str, label: str) -> Non
         anchored_put(panel_cfg, "path", path)
     if "label" not in panel_cfg:
         anchored_put(panel_cfg, "label", label)
+    if health_endpoint is not None and "health_endpoint" not in panel_cfg:
+        anchored_put(panel_cfg, "health_endpoint", health_endpoint)
 
 
 def _inject_bluesky_web(bluesky_web: BlueskyWebConfig, project_path: Path) -> None:

--- a/src/osprey/cli/build_profile_model.py
+++ b/src/osprey/cli/build_profile_model.py
@@ -27,6 +27,11 @@ from osprey.deployment.graphdb_service import (
     GRAPHDB_SERVICE_NAME,
     resolve_graphdb_service_config,
 )
+from osprey.deployment.qmd_service import DEFAULT_PORT as QMD_DEFAULT_PORT
+from osprey.deployment.qmd_service import (
+    QMD_SERVICE_NAME,
+    resolve_qmd_service_config,
+)
 from osprey.errors import BuildProfileError
 from osprey.profiles.web_panels import BUILTIN_PANELS
 
@@ -73,8 +78,17 @@ _APP_TEMPLATE_ROOT = Path(__file__).resolve().parent.parent / "templates" / "app
 _GRAPHDB_CONFIG_PREFIX = f"services.{GRAPHDB_SERVICE_NAME}"
 """Dotted-key spelling of the graph-store block on a profile's ``config:`` surface."""
 
+_QMD_CONFIG_PREFIX = f"services.{QMD_SERVICE_NAME}"
+"""Dotted-key spelling of the qmd sidecar's block on a profile's ``config:`` surface."""
+
 _CHANNEL_FINDER_SERVER_ENABLED_KEY = "claude_code.servers.channel-finder.enabled"
 """The switch a persona flips to take the channel finder out of its render."""
+
+_HYBRID_SEARCH_BLOCK_KEY = "ariel.search_modules.hybrid"
+"""The ARIEL search module the qmd sidecar answers; ``None`` here removes it."""
+
+_HYBRID_SEARCH_ENABLED_KEY = f"{_HYBRID_SEARCH_BLOCK_KEY}.enabled"
+"""The switch that takes hybrid logbook search out of a render."""
 
 _MISSING = object()
 """Sentinel for "this profile says nothing about that key"."""
@@ -113,42 +127,111 @@ def _config_lookup(config: Any, dotted_key: str) -> Any:
     return node
 
 
-def _app_template_declares_graphdb(data_bundle: str) -> bool:
-    """Whether app template *data_bundle* renders a ``services.graphdb`` block.
+def _app_template_lookup(data_bundle: str, dotted_path: str) -> Any:
+    """Read what app template *data_bundle* declares at *dotted_path*.
 
     Read off the template source rather than off a render: this validator runs
-    before anything reaches disk, and the block is a fixed part of the app
-    template — what varies per profile is the ``config:`` overlay applied after
-    the render, which :meth:`BuildProfile._renders_graphdb_block` reads itself.
+    before anything reaches disk, and what a template declares is a fixed part
+    of it — what varies per profile is the ``config:`` overlay applied after
+    the render, which the ``BuildProfile`` readers below consult themselves.
+
+    The file is walked by indentation rather than parsed: it is a Jinja
+    template, not YAML, until it is rendered. Each mapping key is pushed onto a
+    stack as its line is met and popped when a shallower line arrives, so the
+    stack at any line spells the dotted path that line sits under. Comments,
+    blank lines, Jinja statements and list items are stepped over, and the
+    body of a block scalar (``key: |``) is skipped wholesale so its prose
+    cannot pose as keys. A template that spells a section twice under
+    different Jinja branches — ``services:`` with a block, ``services: {}``
+    without — answers with the first spelling, which is the declaring one.
+
+    Args:
+        data_bundle: App template directory name (the ``app_template:`` key).
+        dotted_path: The path to read, in the dotted spelling.
+
+    Returns:
+        :data:`_MISSING` when no line of the template sits at that path — also
+        how a bundle that ships no ``config.yml.j2`` reads, and so how an
+        unknown bundle name reads: the build names that fault itself, and
+        reporting it twice would not help. ``None`` when the path heads a
+        nested mapping and so carries no scalar of its own. Otherwise the
+        scalar's source text, inline comment removed, exactly as the template
+        spells it — ``true``, ``8180``, ``{{ default_model }}``.
+    """
+    template = _APP_TEMPLATE_ROOT / data_bundle / "config.yml.j2"
+    try:
+        text = template.read_text(encoding="utf-8")
+    except OSError:
+        return _MISSING
+    target = dotted_path.split(".")
+    stack: list[tuple[int, str]] = []  # (indent, key) per enclosing mapping
+    block_scalar_indent: int | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        indent = len(line) - len(line.lstrip())
+        if block_scalar_indent is not None:
+            if indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
+        if stripped.startswith(("#", "{%", "{{", "-")):
+            continue
+        key, separator, rest = stripped.partition(":")
+        if not separator or (rest and not rest[0].isspace()):
+            # `http://host` is a scalar with a colon in it, not a key.
+            continue
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        stack.append((indent, key.strip()))
+        value = rest.split(" #", 1)[0].strip()
+        if value[:1] in ("|", ">") and value[1:2] in ("", "-", "+"):
+            block_scalar_indent = indent
+        if [name for _, name in stack] == target:
+            return value or None
+    return _MISSING
+
+
+def _app_template_declares_graphdb(data_bundle: str) -> bool:
+    """Whether app template *data_bundle* renders a ``services.graphdb`` block.
 
     Args:
         data_bundle: App template directory name (the ``app_template:`` key).
 
     Returns:
         Whether that template's ``services:`` section carries a ``graphdb``
-        key. False for a bundle that ships no ``config.yml.j2``, which is also
-        how an unknown bundle name reads here — the build names that fault
-        itself, and reporting it twice would not help.
+        key; see :func:`_app_template_lookup` for how that is read.
     """
-    template = _APP_TEMPLATE_ROOT / data_bundle / "config.yml.j2"
-    try:
-        text = template.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    # Which top-level section each indented key belongs to is all this needs,
-    # so the file is walked by indentation rather than parsed: it is a Jinja
-    # template, not YAML, until it is rendered.
-    section: str | None = None
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith(("#", "{%", "{{")):
-            continue
-        if not line[0].isspace():
-            section = stripped.split(":", 1)[0]
-            continue
-        if section == "services" and stripped.split(":", 1)[0] == GRAPHDB_SERVICE_NAME:
-            return True
-    return False
+    return _app_template_lookup(data_bundle, _GRAPHDB_CONFIG_PREFIX) is not _MISSING
+
+
+def _app_template_declares_qmd(data_bundle: str) -> bool:
+    """Whether app template *data_bundle* renders a ``services.qmd`` block.
+
+    Args:
+        data_bundle: App template directory name (the ``app_template:`` key).
+
+    Returns:
+        Whether that template's ``services:`` section carries a ``qmd`` key;
+        see :func:`_app_template_lookup` for how that is read.
+    """
+    return _app_template_lookup(data_bundle, _QMD_CONFIG_PREFIX) is not _MISSING
+
+
+def _app_template_enables_hybrid_search(data_bundle: str) -> bool:
+    """Whether app template *data_bundle* switches hybrid logbook search on.
+
+    Args:
+        data_bundle: App template directory name (the ``app_template:`` key).
+
+    Returns:
+        Whether the template spells ``enabled: true`` under
+        ``ariel.search_modules.hybrid``. A template with no ``ariel:`` section
+        at all — the channel-finder one — reads as off, which is what it
+        renders.
+    """
+    value = _app_template_lookup(data_bundle, _HYBRID_SEARCH_ENABLED_KEY)
+    return isinstance(value, str) and value.lower() == "true"
 
 
 # VALID_CHANNEL_FINDER_MODES / default_tier_for_mode / tier_mode_conflict are
@@ -653,12 +736,15 @@ class BuildProfile:
             # A whole-block override replaces what the template rendered —
             # including the bare `services.graphdb:` that removes it.
             block = overrides[_GRAPHDB_CONFIG_PREFIX]
-        elif not self.deploy_services:
-            # An attached project renders `services: {}` whatever its app
-            # template says: it scaffolds nothing and reaches a shared stack
-            # through client config, so its store has to be named above.
-            return False
         else:
+            # An attached project renders `services: {}` whatever its app
+            # template says — but it is built beside the deployment it
+            # narrows, whose render carries the block, and the build projects
+            # the store's address into it (osprey.deployment.reach). Its
+            # profile IS that deployment's profile plus a delta, so the same
+            # question answers for both. An attached profile built with no
+            # host in its repo is caught by the build's post-render refusal,
+            # which reads the rendered config and finds nothing projected.
             return GRAPHDB_SERVICE_NAME in self.services or _app_template_declares_graphdb(
                 self.data_bundle
             )
@@ -673,6 +759,77 @@ class BuildProfile:
             # fault.
             return True
         return resolved is not None
+
+    def _renders_qmd_block(self) -> bool:
+        """Whether this profile's build renders a ``services.qmd`` block.
+
+        The same two surfaces as :meth:`_renders_graphdb_block`, read the same
+        way. The app template carries the block for a deployment that runs its
+        own sidecar; the profile's ``config:`` overlay is how an attached
+        render names the sidecar of the deployment it shares a host with
+        (``services.qmd.port``) and how a template's block is dropped. Whether
+        what those produce counts as a sidecar is
+        :func:`~osprey.deployment.qmd_service.resolve_qmd_service_config`'s
+        own decision, borrowed rather than re-implemented so this validator and
+        the hybrid search module that resolves its endpoint through the same
+        function cannot disagree about whether one exists.
+
+        Returns:
+            Whether the rendered ``config.yml`` will carry a sidecar to dial.
+        """
+        overrides = self.config if isinstance(self.config, dict) else {}
+        sub_keys = [
+            key
+            for key in overrides
+            if isinstance(key, str) and key.startswith(f"{_QMD_CONFIG_PREFIX}.")
+        ]
+        if sub_keys:
+            # `services.qmd.port:` and its siblings write into the block,
+            # creating it when the app template carries none.
+            block: Any = {key.split(".", 2)[2]: overrides[key] for key in sub_keys}
+        elif _QMD_CONFIG_PREFIX in overrides:
+            # A whole-block override replaces what the template rendered —
+            # including the bare `services.qmd:` that removes it.
+            block = overrides[_QMD_CONFIG_PREFIX]
+        else:
+            # Same reasoning as the graph store above: an attached project is
+            # told the sidecar's port by the build, from the hosting
+            # deployment's render, and the profile that decides whether that
+            # render carries a sidecar is the one this profile extends.
+            return QMD_SERVICE_NAME in self.services or _app_template_declares_qmd(self.data_bundle)
+
+        try:
+            resolved = resolve_qmd_service_config({"services": {QMD_SERVICE_NAME: block}})
+        except ValueError:
+            # A malformed key (a port that is not a positive integer, a relative
+            # models_dir) still names a sidecar this profile means to dial. The
+            # resolver raises about it where it can be acted on — the deploy
+            # preflight — and answering "no block" here would report the wrong
+            # fault.
+            return True
+        return resolved is not None
+
+    def _enables_hybrid_search(self) -> bool:
+        """Whether this profile's build switches hybrid logbook search on.
+
+        The switch lives in the rendered ``config.yml``, so it is read from the
+        two places that write it: the ``config:`` overlay first, because it is
+        applied last, and the app template for a profile whose overlay says
+        nothing — the common case, since the key is absent from every profile
+        that keeps the template's default. On the overlay only an explicit
+        ``false`` counts, the same way the channel-finder switch reads for the
+        graph rule; a bare ``ariel.search_modules.hybrid:`` that removes the
+        whole module counts as off too, since there is then no module to answer.
+
+        Returns:
+            Whether the rendered project offers the ``hybrid`` search mode.
+        """
+        if _config_lookup(self.config, _HYBRID_SEARCH_BLOCK_KEY) is None:
+            return False
+        switch = _config_lookup(self.config, _HYBRID_SEARCH_ENABLED_KEY)
+        if switch is _MISSING:
+            return _app_template_enables_hybrid_search(self.data_bundle)
+        return switch is not False
 
     def validate(self, profile_dir: Path) -> None:
         """Validate profile consistency. Raises BuildProfileError with all issues."""
@@ -745,6 +902,33 @@ class BuildProfile:
                 f"template that deploys a graph store, or name one the facility "
                 f"already runs with `config: services.{GRAPHDB_SERVICE_NAME}.uri: "
                 f"bolt://host:7687` plus GRAPHDB_PASSWORD in the project .env."
+            )
+
+        # Hybrid logbook search is the one ARIEL search mode answered by a
+        # service rather than by Postgres, so it is the one with a prerequisite
+        # outside the ARIEL database: the `services.qmd` sidecar, which the
+        # module locates through that block and nothing else. Without the block
+        # the build would render the mode switched on with nothing behind it,
+        # and unlike semantic search it does not degrade — every query then
+        # fails, by design, with "no qmd sidecar is configured". Named here
+        # instead, on every configuration path, because where it would surface
+        # otherwise is the worst place for it: inside a per-user web-terminal
+        # container, on the first logbook question, for a persona whose render
+        # emptied `services:` on purpose.
+        #
+        # Skipped for a profile that switches the module off, whichever way it
+        # spells that. A deployment that drops the sidecar is expected to drop
+        # the module with it (the template's own comment says so); this is the
+        # rule that catches a deployment that dropped one and not the other.
+        if self._enables_hybrid_search() and not self._renders_qmd_block():
+            attached = "" if self.deploy_services else ", deploy_services: false"
+            errors.append(
+                f"{_HYBRID_SEARCH_BLOCK_KEY} is enabled and needs a "
+                f"{_QMD_CONFIG_PREFIX} block, and this build renders none "
+                f"(app_template: {self.data_bundle}{attached}). Name the sidecar of "
+                f"the deployment this profile shares a host with using `config: "
+                f"{_QMD_CONFIG_PREFIX}.port: {QMD_DEFAULT_PORT}`, or switch the "
+                f"module off with `config: {_HYBRID_SEARCH_ENABLED_KEY}: false`."
             )
 
         # The data tree may legitimately sit above the profile dir (persona

--- a/src/osprey/cli/build_profile_reach.py
+++ b/src/osprey/cli/build_profile_reach.py
@@ -1,0 +1,208 @@
+"""What an attached render is told about the services its host deploys.
+
+An *attached* project (``deploy_services: false`` — every web-terminal persona)
+scaffolds no services and so never reaches the build-step injectors that write
+``services.<name>`` blocks into a deploying project's config. Its in-container
+clients still resolve their endpoints from those blocks — the bluesky MCP
+server through :func:`osprey.bluesky_bridge_connection.resolve_bridge_url`, the
+VA connector through
+:func:`osprey_connectors.control_system.va_connector.fill_gateway_ports`, hybrid
+logbook search through :func:`osprey.deployment.qmd_service.resolve_qmd_service_config`
+— and each either bottoms out in a compiled-in default when the block is
+absent, or refuses at first use inside a per-user container. At the shipped
+defaults a default equals the port the host publishes, so the drift is
+invisible until an operator moves a port on the hosting profile and every
+persona keeps dialing the old one.
+
+The build therefore PROJECTS: for an attached render built beside its hosting
+deployment, the client-facing facts the Reach Contract registry
+(:mod:`osprey.deployment.reach`) declares are copied from the host's rendered
+config into the attached render on the ordinary config-override path, exactly
+as :func:`osprey.cli.build_profile_archiver.va_archiver_config_overrides` does
+for the archive: the build already knows where every service is, and no
+persona restates it. Built with no host in its repo, an attached profile is
+projected from what its app template deploys at the shipped defaults (it
+extends a deployment of that template), with its own ``config:`` laid over
+them. A deploying project gets nothing from here; its injectors write the
+full blocks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from osprey.deployment.reach import REACH_CONTRACTS, dotted_get, project_attached_overrides
+
+
+def attached_render_overrides(
+    host_config: Mapping[str, Any] | None,
+    rendered_config: Mapping[str, Any],
+    *,
+    selected_panels: Iterable[str] = (),
+) -> dict[str, Any]:
+    """The dotted keys projected into an attached render from its host's render.
+
+    Thin, named entry point over
+    :func:`osprey.deployment.reach.project_attached_overrides` — the build's
+    side of the contract — so the build reads one function and the registry
+    stays the one place the keys are declared.
+
+    Args:
+        host_config: The hosting deployment's rendered config — or, for an
+            attached profile built with no host in its repo, the app
+            template rendered as a deployment with the profile's ``config:``
+            over it. ``None`` projects nothing.
+        rendered_config: The attached render's config after its own
+            ``config:`` overlay — what the projection's gates read.
+        selected_panels: The attached profile's ``web_panels`` selection.
+
+    Returns:
+        Dotted config keys to apply after the profile's own; empty without a
+        host.
+    """
+    return project_attached_overrides(host_config, rendered_config, selected_panels=selected_panels)
+
+
+def _spelled_values(config: Any, dotted_key: str) -> list[tuple[str, Any]]:
+    """Every way *config* writes *dotted_key*, with the value each gives.
+
+    A ``config:`` block may spell one leaf as the whole dotted key
+    (``services.bluesky.port``), as a dotted prefix over a mapping
+    (``services.bluesky: {port: …}``), fully nested
+    (``services: {bluesky: {port: …}}``), or any mix of the two — every
+    split of the segments is legal YAML that
+    :func:`osprey.cli.build_profile_model._config_lookup` reads, and all of
+    them reach the same rendered leaf. Each spelling found is reported the way
+    it was written, so a refusal can name the line to remove.
+    """
+    return _spellings(config, dotted_key.split("."), [])
+
+
+def _spellings(node: Any, segments: list[str], written: list[str]) -> list[tuple[str, Any]]:
+    """Walk every split of *segments* through the mapping *node*."""
+    if not isinstance(node, dict):
+        return []
+    found: list[tuple[str, Any]] = []
+    for cut in range(1, len(segments) + 1):
+        head = ".".join(segments[:cut])
+        if head not in node:
+            continue
+        rest = segments[cut:]
+        if not rest:
+            found.append((": ".join([*written, head]), node[head]))
+        else:
+            found.extend(_spellings(node[head], rest, [*written, head]))
+    return found
+
+
+def reach_override_errors(config: Any, projected: Mapping[str, Any]) -> list[str]:
+    """Refuse an attached profile whose ``config:`` contradicts a projected key.
+
+    The build derives *projected* from the hosting deployment's render, so a
+    ``config:`` entry for the same key is a second home for one fact. The
+    two are allowed to agree — a persona profile INHERITS the hosting
+    profile's ``config:`` dotted keys, so a host that moved a port there
+    spells it in every persona's merged config too, and those spellings ARE
+    the host's value — and refused when they disagree, because that case is
+    the silent one: a persona dialing a port the host stopped publishing gets
+    connection refused with nothing to say which of the two spellings was
+    stale. A hand-copied value that agrees today is refused the day the host
+    moves and it does not. Built alone, the profile's ``config:`` is laid
+    over the app template's defaults before projection, so it can only agree.
+
+    Args:
+        config: The attached profile's ``config:`` block, as merged.
+        projected: What :func:`attached_render_overrides` will apply.
+
+    Returns:
+        One error per contradicting spelling; empty when there is none.
+    """
+    errors: list[str] = []
+    for dotted_key, value in projected.items():
+        for spelling, spelled in _spelled_values(config, dotted_key):
+            if spelled == value:
+                continue
+            errors.append(
+                f"config spells {spelling!r} as {spelled!r}, but the hosting deployment's "
+                f"render says {dotted_key} is {value!r}, and the build copies that into "
+                f"every attached render — a second copy that disagrees would dial the "
+                f"wrong place. Remove it from config: (the host's value is what this "
+                f"render is told), or move the service on the hosting deployment. A "
+                f"persona file materialized by an earlier release pinned this key "
+                f"itself; delete that line — the build now supplies it."
+            )
+    return errors
+
+
+def selected_panel_errors(
+    selected_panels: Iterable[str], rendered_config: Mapping[str, Any], *, told_by: str
+) -> list[str]:
+    """Refuse an attached profile whose selected tab was told no address.
+
+    A ``web_panels:`` entry for a panel the Reach Contract projects (the
+    EVENTS and BLUESKY tabs) is a consumer switched on by the PROFILE, which
+    the rendered config alone cannot tell: the render carries a
+    ``web.panels.<id>`` block only once something wrote one. After projection
+    the block is there whenever the host ran the sidecar; when it is not, the
+    tab would silently be missing from the render — the operator selected it
+    and nothing said it was dropped.
+
+    Args:
+        selected_panels: The attached profile's ``web_panels`` selection.
+        rendered_config: The attached render's config after projection.
+        told_by: What the render was told from, for the message.
+
+    Returns:
+        One error per selected contract panel with no ``url``.
+    """
+    selected = set(selected_panels)
+    errors: list[str] = []
+    for contract in REACH_CONTRACTS.values():
+        for panel in sorted({key.panel for key in contract.projected if key.panel}):
+            if panel not in selected or dotted_get(rendered_config, f"web.panels.{panel}.url"):
+                continue
+            errors.append(
+                f"web_panels selects {panel!r} but this render carries no "
+                f"web.panels.{panel}.url — {told_by} runs no {contract.service}, so nothing "
+                f"told this attached render where the tab's sidecar is. Deploy the "
+                f"{contract.service} service on the hosting deployment, name the tab's target "
+                f"under `config:` (web.panels.{panel}.url), or drop the panel."
+            )
+    return errors
+
+
+def orphan_panel_fragments(
+    selected_panels: Iterable[str], rendered_config: Mapping[str, Any]
+) -> list[str]:
+    """The ``web.panels.<id>`` blocks an attached render must drop.
+
+    A persona profile inherits the hosting profile's ``config:`` keys, so a
+    host that pins ``web.panels.events.path`` — the documented way to move
+    the dashboard's route — hands every persona a ``web.panels.events``
+    fragment. For a persona that selects the tab the projection completes it
+    with the host's ``url``; for one that does not, the fragment is a tab this
+    persona never asked for, with an EMPTY url — the web terminal makes a
+    custom panel of any such block — that would either fail at first click or
+    be refused by :func:`osprey.deployment.reach.reach_errors` as a consumer
+    with nothing to dial. Neither is what the operator meant, so the fragment
+    goes: a tab the Reach Contract projects exists in an attached render on
+    the strength of the profile's selection alone.
+
+    Args:
+        selected_panels: The attached profile's ``web_panels`` selection.
+        rendered_config: The attached render's config after projection.
+
+    Returns:
+        Dotted ``web.panels.<id>`` keys to delete, registry order.
+    """
+    selected = set(selected_panels)
+    keys: list[str] = []
+    for contract in REACH_CONTRACTS.values():
+        for panel in sorted({key.panel for key in contract.projected if key.panel}):
+            if panel in selected:
+                continue
+            block = dotted_get(rendered_config, f"web.panels.{panel}")
+            if isinstance(block, Mapping) and not block.get("url"):
+                keys.append(f"web.panels.{panel}")
+    return keys

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -280,8 +280,8 @@ def _resolve_ttl(ttl: Path | None) -> Path:
     if ttl is not None:
         return ttl
 
-    from osprey.services.facility_knowledge.bundle_path import resolve_bundle_path
     from osprey.utils.config import get_config_value
+    from osprey.utils.config_paths import resolve_render_relative_path
 
     raw = get_config_value("services.graphdb.ttl_path", None)
     if raw is None:
@@ -289,7 +289,9 @@ def _resolve_ttl(ttl: Path | None) -> Path:
             "No TTL path given and services.graphdb.ttl_path is not set in config."
         )
 
-    path = resolve_bundle_path(raw)
+    # Render-relative, like the deploy's own seeding (container_lifecycle
+    # `_graphdb_ttl_text`): the corpus is an artifact of the render.
+    path = resolve_render_relative_path(raw)
     if not path.is_file():
         raise click.ClickException(
             f"services.graphdb.ttl_path names a file that is not there: {path}\n"

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -576,14 +576,20 @@ def build_claude_code_context(
 
     # Model provider resolution for Claude Code
     from osprey.build.claude_code_resolver import ClaudeCodeModelResolver
+    from osprey.build.claude_code_telemetry import openobserve_published_port
 
     api_providers = config.get("api", {}).get("providers", {})
     try:
         # Build time: telemetry credentials may legitimately be the
         # deployment's to supply (the runtime re-resolves them at agent-spawn),
         # so an unresolved ${VAR} omits the auth header instead of aborting.
+        # The store's port is the one this config publishes — never the
+        # builder's environment, which a rendered artifact must not bake in.
         model_spec = ClaudeCodeModelResolver.resolve(
-            claude_code_config, api_providers, defer_unresolved_telemetry_creds=True
+            claude_code_config,
+            api_providers,
+            defer_unresolved_telemetry_creds=True,
+            openobserve_port=openobserve_published_port(config),
         )
     except ValueError as exc:
         warnings.warn(str(exc), stacklevel=2)

--- a/src/osprey/cli/templates/manager.py
+++ b/src/osprey/cli/templates/manager.py
@@ -226,103 +226,11 @@ class TemplateManager:
         if not project_dir.exists():
             project_dir.mkdir(parents=True)
 
-        # 3. Prepare template context
-        package_name = project_name.replace("-", "_").lower()
-        class_name = self._generate_class_name(package_name)
-
-        # Detect current Python environment
-        import sys
-
-        current_python = sys.executable
-
-        # Fall back to preset profile artifacts when the caller didn't pass any.
-        # An explicit empty dict from `osprey build` means the
-        # profile deliberately selects nothing, and must not be overridden.
-        if artifacts is None:
-            tmpl_manifest = manifest.load_template_manifest(self.template_root, data_bundle)
-            if tmpl_manifest:
-                artifacts = tmpl_manifest.get("artifacts", {})
-
-        # Derive feature flags from artifact selections.
-        selected_hooks = (artifacts or {}).get("hooks", [])
-        selected_web_panels = (artifacts or {}).get("web_panels", [])
-
-        ctx = {
-            "project_name": project_name,
-            "package_name": package_name,
-            "app_display_name": project_name,  # Used in templates for display/documentation
-            "app_class_name": class_name,  # Used in templates for class names
-            "registry_class_name": class_name,  # Backward compatibility
-            "project_description": f"{project_name} - Osprey Agent Application",
-            "framework_version": manifest.get_framework_version(),
-            "project_root": str(project_dir.absolute()),
-            "venv_path": "${LOCAL_PYTHON_VENV}",
-            "current_python_env": current_python,  # Default; overridden by caller context
-            "template_name": data_bundle,  # Make bundle name available in config.yml
-            "data_bundle": data_bundle,
-            "selected_hooks": selected_hooks,
-            "selected_web_panels": selected_web_panels,
-            # Enable-able builtin panel registry (single source of truth in
-            # osprey.profiles.web_panels). Templates derive their enable list
-            # from this so it can't drift from the real registry. sorted() for
-            # deterministic rendered output.
-            "builtin_panels": sorted(BUILTIN_PANELS),
-            # No `env` key: the render reads nothing from `os.environ`, and
-            # writes no `.env` at all — the deployment's one secret store is the
-            # repo-root `.env`, outside this tree.
-            # Provider API-key env vars, derived from the provider registry
-            # (single source of truth in osprey.models.provider_registry) so
-            # env.example.j2 can't drift from the real provider list.
-            # Ordered list of {"provider", "var"} dicts; key-less providers
-            # (ollama, vllm, …) are excluded.
-            "provider_api_keys": scaffolding.provider_api_key_entries(),
-            # The subset of the above this profile actually uses. Empty here so
-            # a caller with no profile still renders the whole list uncommented;
-            # `osprey init` fills it in and the rest drop below a divider.
-            "active_provider_vars": [],
-            # Deploy-minted service credentials, derived from the map the
-            # deploy path mints from, so .env.example documents every one of
-            # them. Ordered list of {"var", "services", "note"} dicts.
-            "service_token_vars": scaffolding.service_token_var_entries(),
-            # The build profile's `env:` block, documented in .env.example.
-            # Defaulted here so a caller that has no profile (programmatic
-            # create_project) still renders the file.
-            "env_required": [],
-            "env_defaults": {},
-            **(context or {}),
-        }
-
-        # Derive channel finder configuration when the channel-finder agent
-        # is selected (either explicitly via build profile artifacts, or via
-        # the preset-profile fallback above for programmatic callers).
-        _profile_agents = (artifacts or {}).get("agents", [])
-        if "channel-finder" in _profile_agents:
-            channel_finder_mode = ctx.get("channel_finder_mode")
-            if channel_finder_mode is None:
-                raise BuildProfileError(
-                    "channel_finder_mode is required when the channel-finder agent "
-                    "is selected. Pin it in your profile "
-                    "(e.g. `channel_finder_mode: hierarchical`) or pass "
-                    "`--set channel_finder_mode=<paradigm>` to `osprey build`."
-                )
-            if channel_finder_mode not in VALID_CHANNEL_FINDER_MODES:
-                raise BuildProfileError(
-                    f"channel_finder_mode must be one of {VALID_CHANNEL_FINDER_MODES} "
-                    f"(got {channel_finder_mode!r})"
-                )
-            from osprey.registry.mcp import CHANNEL_FINDER_TOOLS_BY_PIPELINE
-
-            ctx.update(
-                {
-                    "channel_finder_mode": channel_finder_mode,
-                    **_enable_flags(channel_finder_mode),
-                    "default_pipeline": channel_finder_mode,
-                    "channel_finder_pipeline": channel_finder_mode,
-                    "channel_finder_tools": list(
-                        CHANNEL_FINDER_TOOLS_BY_PIPELINE.get(channel_finder_mode, [])
-                    ),
-                }
-            )
+        # 3. Prepare template context. The artifact fallback is resolved into
+        # the local so the manifest-output filtering below reads the same
+        # effective selection the context was built from.
+        artifacts = self._effective_artifacts(data_bundle, artifacts)
+        ctx = self._project_context(project_name, project_dir, data_bundle, context, artifacts)
 
         # 4. Create project structure
         scaffolding.create_project_structure(
@@ -367,7 +275,7 @@ class TemplateManager:
         scaffolding.copy_template_data(
             self.template_root,
             project_dir,
-            package_name,
+            ctx["package_name"],
             data_bundle,
             ctx,
             jinja_env=self.jinja_env,
@@ -437,10 +345,15 @@ class TemplateManager:
             ctx["facility_permissions"] = cc_config.get("permissions", {})
             # Model provider resolution for init-time rendering
             from osprey.build.claude_code_resolver import ClaudeCodeModelResolver
+            from osprey.build.claude_code_telemetry import openobserve_published_port
 
             api_providers = rendered_config.get("api", {}).get("providers", {})
             try:
-                model_spec = ClaudeCodeModelResolver.resolve(cc_config, api_providers)
+                model_spec = ClaudeCodeModelResolver.resolve(
+                    cc_config,
+                    api_providers,
+                    openobserve_port=openobserve_published_port(rendered_config),
+                )
             except ValueError:
                 model_spec = None
             ctx["claude_code_model_spec"] = model_spec
@@ -533,6 +446,179 @@ class TemplateManager:
         )
 
         return project_dir
+
+    def render_config(
+        self,
+        project_name: str,
+        project_dir: Path,
+        output_path: Path,
+        data_bundle: str = "control_assistant",
+        context: dict[str, Any] | None = None,
+        artifacts: dict[str, list[str]] | None = None,
+    ) -> None:
+        """Render only the ``config.yml`` that :meth:`create_project` would.
+
+        Same template, same context — what the project says it deploys and
+        where, without the rest of the render. ``osprey build`` uses it to
+        read what an app template deploys at its defaults: the hosting
+        deployment an attached profile built alone is told about.
+
+        Args:
+            project_name: Name of the project the context is built for.
+            project_dir: Where the project would render (``project_root``
+                in the context).
+            output_path: Where the rendered ``config.yml`` is written.
+            data_bundle: Data bundle (app template) to render.
+            context: Additional template context variables.
+            artifacts: Profile-driven artifact selection, as for
+                :meth:`create_project`.
+
+        Raises:
+            ValueError: If the data bundle does not exist or renders no
+                ``config.yml``.
+        """
+        bundle_dir = self.template_root / "apps" / data_bundle
+        if not bundle_dir.is_dir():
+            raise ValueError(
+                f"Template '{data_bundle}' not found. "
+                f"Available templates: {', '.join(self.list_app_templates())}"
+            )
+        artifacts = self._effective_artifacts(data_bundle, artifacts)
+        ctx = self._project_context(project_name, project_dir, data_bundle, context, artifacts)
+        scaffolding.render_project_config(
+            self.template_root, self.jinja_env, output_path, data_bundle, ctx
+        )
+
+    def _effective_artifacts(
+        self, data_bundle: str, artifacts: dict[str, list[str]] | None
+    ) -> dict[str, list[str]] | None:
+        """The artifact selection a render of *data_bundle* is made with.
+
+        The caller's own selection where it supplied one — an explicit empty
+        dict from ``osprey build`` means the profile deliberately selects
+        nothing, and must not be overridden — and the data bundle's manifest
+        otherwise. Every public entry point resolves this into its local
+        before building the context, because the same value gates the
+        manifest-output filtering after the render.
+        """
+        if artifacts is not None:
+            return artifacts
+        tmpl_manifest = manifest.load_template_manifest(self.template_root, data_bundle)
+        if tmpl_manifest:
+            return tmpl_manifest.get("artifacts", {})
+        return None
+
+    def _project_context(
+        self,
+        project_name: str,
+        project_dir: Path,
+        data_bundle: str,
+        context: dict[str, Any] | None,
+        artifacts: dict[str, list[str]] | None,
+    ) -> dict[str, Any]:
+        """The template context a project render of *data_bundle* is made with.
+
+        The defaults every template may read, the caller's *context* over
+        them, and the channel-finder flags derived from the artifact
+        selection.
+
+        Raises:
+            BuildProfileError: If the channel-finder agent is selected with no
+                valid ``channel_finder_mode``.
+        """
+        package_name = project_name.replace("-", "_").lower()
+        class_name = self._generate_class_name(package_name)
+
+        # Detect current Python environment
+        import sys
+
+        current_python = sys.executable
+
+        # Callers resolve the manifest fallback (_effective_artifacts) before
+        # calling; *artifacts* here is already the effective selection.
+
+        # Derive feature flags from artifact selections.
+        selected_hooks = (artifacts or {}).get("hooks", [])
+        selected_web_panels = (artifacts or {}).get("web_panels", [])
+
+        ctx = {
+            "project_name": project_name,
+            "package_name": package_name,
+            "app_display_name": project_name,  # Used in templates for display/documentation
+            "app_class_name": class_name,  # Used in templates for class names
+            "registry_class_name": class_name,  # Backward compatibility
+            "project_description": f"{project_name} - Osprey Agent Application",
+            "framework_version": manifest.get_framework_version(),
+            "project_root": str(project_dir.absolute()),
+            "venv_path": "${LOCAL_PYTHON_VENV}",
+            "current_python_env": current_python,  # Default; overridden by caller context
+            "template_name": data_bundle,  # Make bundle name available in config.yml
+            "data_bundle": data_bundle,
+            "selected_hooks": selected_hooks,
+            "selected_web_panels": selected_web_panels,
+            # Enable-able builtin panel registry (single source of truth in
+            # osprey.profiles.web_panels). Templates derive their enable list
+            # from this so it can't drift from the real registry. sorted() for
+            # deterministic rendered output.
+            "builtin_panels": sorted(BUILTIN_PANELS),
+            # No `env` key: the render reads nothing from `os.environ`, and
+            # writes no `.env` at all — the deployment's one secret store is the
+            # repo-root `.env`, outside this tree.
+            # Provider API-key env vars, derived from the provider registry
+            # (single source of truth in osprey.models.provider_registry) so
+            # env.example.j2 can't drift from the real provider list.
+            # Ordered list of {"provider", "var"} dicts; key-less providers
+            # (ollama, vllm, …) are excluded.
+            "provider_api_keys": scaffolding.provider_api_key_entries(),
+            # The subset of the above this profile actually uses. Empty here so
+            # a caller with no profile still renders the whole list uncommented;
+            # `osprey init` fills it in and the rest drop below a divider.
+            "active_provider_vars": [],
+            # Deploy-minted service credentials, derived from the map the
+            # deploy path mints from, so .env.example documents every one of
+            # them. Ordered list of {"var", "services", "note"} dicts.
+            "service_token_vars": scaffolding.service_token_var_entries(),
+            # The build profile's `env:` block, documented in .env.example.
+            # Defaulted here so a caller that has no profile (programmatic
+            # create_project) still renders the file.
+            "env_required": [],
+            "env_defaults": {},
+            **(context or {}),
+        }
+
+        # Derive channel finder configuration when the channel-finder agent
+        # is selected (either explicitly via build profile artifacts, or via
+        # the preset-profile fallback above for programmatic callers).
+        _profile_agents = (artifacts or {}).get("agents", [])
+        if "channel-finder" in _profile_agents:
+            channel_finder_mode = ctx.get("channel_finder_mode")
+            if channel_finder_mode is None:
+                raise BuildProfileError(
+                    "channel_finder_mode is required when the channel-finder agent "
+                    "is selected. Pin it in your profile "
+                    "(e.g. `channel_finder_mode: hierarchical`) or pass "
+                    "`--set channel_finder_mode=<paradigm>` to `osprey build`."
+                )
+            if channel_finder_mode not in VALID_CHANNEL_FINDER_MODES:
+                raise BuildProfileError(
+                    f"channel_finder_mode must be one of {VALID_CHANNEL_FINDER_MODES} "
+                    f"(got {channel_finder_mode!r})"
+                )
+            from osprey.registry.mcp import CHANNEL_FINDER_TOOLS_BY_PIPELINE
+
+            ctx.update(
+                {
+                    "channel_finder_mode": channel_finder_mode,
+                    **_enable_flags(channel_finder_mode),
+                    "default_pipeline": channel_finder_mode,
+                    "channel_finder_pipeline": channel_finder_mode,
+                    "channel_finder_tools": list(
+                        CHANNEL_FINDER_TOOLS_BY_PIPELINE.get(channel_finder_mode, [])
+                    ),
+                }
+            )
+
+        return ctx
 
     def regenerate_claude_code(
         self,

--- a/src/osprey/cli/templates/scaffolding.py
+++ b/src/osprey/cli/templates/scaffolding.py
@@ -27,6 +27,70 @@ logger = logging.getLogger("osprey.cli.templates")
 # pin.
 _DEFAULT_CLAUDE_CLI_VERSION = "2.1.146"
 
+CONFIG_TEMPLATE = "config.yml.j2"
+"""The project-file template that renders ``config.yml``."""
+
+
+def _default_cli_version(ctx: dict) -> None:
+    """Expose ``claude_code.cli_version`` to Dockerfile.j2's CLAUDE_CLI_VERSION
+    ARG default, so the same version pin that ``osprey chat``/``osprey web``
+    honor at runtime (osprey.utils.claude_launcher) also pins the image's
+    build-time CLI install. Callers may pre-populate
+    ``ctx["claude_code_cli_version"]`` (flat) or ``ctx["claude_code"]["cli_version"]``
+    (nested, mirroring config.yml's shape); absent either, fall back to the
+    framework's last verified pin."""
+    if "claude_code_cli_version" not in ctx:
+        ctx["claude_code_cli_version"] = (
+            ctx.get("claude_code", {}).get("cli_version") or _DEFAULT_CLAUDE_CLI_VERSION
+        )
+
+
+def project_template_for(template_root: Path, data_bundle: str, template_file: str) -> str | None:
+    """The template that renders project file *template_file* for *data_bundle*.
+
+    An app template's own copy wins over the shared ``project/`` default
+    (``apps/control_assistant/config.yml.j2`` over ``project/config.yml.j2``).
+
+    Returns:
+        The template's path relative to the templates root, in the spelling the
+        Jinja environment loads by, or ``None`` when neither ships the file.
+    """
+    name = template_file if template_file.endswith(".j2") else template_file + ".j2"
+    if (template_root / "apps" / data_bundle / name).exists():
+        return f"apps/{data_bundle}/{name}"
+    if (template_root / "project" / template_file).exists():
+        return f"project/{template_file}"
+    return None
+
+
+def render_project_config(
+    template_root: Path,
+    jinja_env,
+    output_path: Path,
+    data_bundle: str,
+    ctx: dict,
+) -> None:
+    """Render ``config.yml`` alone — the one file of a project render that
+    says what the project deploys and where — with the template
+    :func:`create_project_structure` would pick for *data_bundle* and the
+    same context.
+
+    Args:
+        template_root: Path to osprey's bundled templates directory
+        jinja_env: Jinja2 environment for template rendering
+        output_path: Where the rendered ``config.yml`` is written
+        data_bundle: Name of the data bundle (apps/ subdirectory) to use
+        ctx: Template context variables
+
+    Raises:
+        ValueError: If neither the bundle nor ``project/`` ships the template.
+    """
+    _default_cli_version(ctx)
+    template_path = project_template_for(template_root, data_bundle, CONFIG_TEMPLATE)
+    if template_path is None:
+        raise ValueError(f"App template {data_bundle!r} renders no config.yml")
+    render_template(jinja_env, template_path, ctx, output_path)
+
 
 def provider_api_key_entries() -> list[dict[str, str]]:
     """Provider API-key env vars for env-file templates, in registry order.
@@ -142,22 +206,12 @@ def create_project_structure(
         ctx: Template context variables
     """
     project_template_dir = template_root / "project"
-    app_template_dir = template_root / "apps" / data_bundle
 
-    # Expose claude_code.cli_version to Dockerfile.j2's CLAUDE_CLI_VERSION ARG
-    # default, so the same version pin that `osprey chat`/`osprey web`
-    # honor at runtime (osprey.utils.claude_launcher) also pins the image's
-    # build-time CLI install. Callers may pre-populate ctx["claude_code_cli_version"]
-    # (flat) or ctx["claude_code"]["cli_version"] (nested, mirroring config.yml's
-    # shape); absent either, fall back to the framework's last verified pin.
-    if "claude_code_cli_version" not in ctx:
-        ctx["claude_code_cli_version"] = (
-            ctx.get("claude_code", {}).get("cli_version") or _DEFAULT_CLAUDE_CLI_VERSION
-        )
+    _default_cli_version(ctx)
 
     # Render template files (no pyproject.toml or requirements.txt -- no src/ package)
     files_to_render = [
-        ("config.yml.j2", "config.yml"),
+        (CONFIG_TEMPLATE, "config.yml"),
         ("env.example.j2", ".env.example"),
         ("README.md.j2", "README.md"),
         # Reference container image — rendered once at build; regen never touches it
@@ -179,23 +233,9 @@ def create_project_structure(
     ]
 
     for template_file, output_file in files_to_render:
-        # Check if app template has its own version first (e.g., requirements.txt.j2)
-        app_specific_template = app_template_dir / (
-            template_file + ".j2" if not template_file.endswith(".j2") else template_file
-        )
-        default_template = project_template_dir / template_file
-
-        if app_specific_template.exists():
-            # Use app-specific template
-            render_template(
-                jinja_env,
-                f"apps/{data_bundle}/{app_specific_template.name}",
-                ctx,
-                project_dir / output_file,
-            )
-        elif default_template.exists():
-            # Use default project template
-            render_template(jinja_env, f"project/{template_file}", ctx, project_dir / output_file)
+        template_path = project_template_for(template_root, data_bundle, template_file)
+        if template_path is not None:
+            render_template(jinja_env, template_path, ctx, project_dir / output_file)
 
     # Copy static files
     for src_name, dst_name in static_files:

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -1705,6 +1705,37 @@ def _stage_channel_snapshot(config, source_dir, out_dir):
     return True
 
 
+#: The one service whose compose environment lists the roster's per-user
+#: operator secrets: the bluesky_web sidecar, which each per-user web terminal
+#: proxies its BLUESKY tab into with the secret ITS container holds.
+_ROSTER_SECRET_SERVICE = "bluesky_web"
+
+
+def _bluesky_panel_secret_env_vars(config, source_dir):
+    """The per-user secret variables the bluesky_web sidecar's compose lists.
+
+    Empty for every other service render, and for a deployment with no
+    web-terminal roster. Resolved here, in the services render, because the
+    sidecar is part of the SERVICES compose project — the web-terminal overlay
+    is brought up by its own single-file invocation
+    (:func:`osprey.deployment.web_terminals.provision.web_stack_compose_cmd`),
+    so a ``bluesky-web:`` fragment there would never merge into this service
+    and would instead fail that stack as an image-less service.
+
+    :param config: Full project configuration dictionary
+    :type config: dict
+    :param source_dir: Service source directory being rendered
+    :type source_dir: str
+    :return: ``OSPREY_TERMINAL_SECRET_<SUFFIX>`` names, roster order
+    :rtype: list[str]
+    """
+    if os.path.basename(os.path.normpath(source_dir)) != _ROSTER_SECRET_SERVICE:
+        return []
+    from osprey.deployment.web_terminals.personas import bluesky_panel_secret_env_vars
+
+    return bluesky_panel_secret_env_vars(config, resolve_repo_root(config))
+
+
 def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
     """Create complete build environment for service deployment.
 
@@ -1858,6 +1889,8 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
         **config,
         "dev_mode": dev_mode and wheel_staged,
         "channel_snapshot": _stage_channel_snapshot(config, source_dir, out_dir),
+        # The bluesky_web sidecar's roster grant (see the helper); [] elsewhere.
+        "bluesky_panel_secret_env_vars": _bluesky_panel_secret_env_vars(config, source_dir),
     }
     compose_filepath = render_template(template_path, render_config, out_dir)
 
@@ -2043,6 +2076,8 @@ def _incremental_setup_build_dir(template_path, config, service_config, out_dir,
         **config,
         "dev_mode": dev_mode and wheel_staged,
         "channel_snapshot": _stage_channel_snapshot(config, source_dir, out_dir),
+        # The bluesky_web sidecar's roster grant (see the helper); [] elsewhere.
+        "bluesky_panel_secret_env_vars": _bluesky_panel_secret_env_vars(config, source_dir),
     }
     compose_filepath = render_template(template_path, render_config, out_dir)
 

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -662,22 +662,105 @@ def _resolve_qmd_corpora(config, repo_root):
     if isinstance(bundle_path, str) and bundle_path.strip():
         corpora.append(corpus(QMD_OKF_COLLECTION, bundle_path.strip()))
 
-    ariel = config.get("ariel")
-    modules = ariel.get("enhancement_modules") if isinstance(ariel, dict) else None
-    export = modules.get("qmd_export") if isinstance(modules, dict) else None
-    if isinstance(export, dict) and export.get("enabled"):
-        # `mirror_path` may be written directly on the module block or inside
-        # its `settings:` mapping — ARIEL's own loader merges the two with
-        # `settings` winning, and the mount must follow whichever the exporter
-        # will actually write to.
-        settings = export.get("settings")
-        mirror_path = export.get("mirror_path")
-        if isinstance(settings, dict) and settings.get("mirror_path"):
-            mirror_path = settings["mirror_path"]
-        if isinstance(mirror_path, str) and mirror_path.strip():
-            corpora.append(corpus(QMD_ARIEL_COLLECTION, mirror_path.strip()))
+    mirror_path = configured_ariel_mirror_path(config)
+    if mirror_path is not None:
+        corpora.append(corpus(QMD_ARIEL_COLLECTION, mirror_path))
 
     return corpora
+
+
+def configured_ariel_mirror_path(config):
+    """The ``mirror_path`` an enabled ARIEL qmd export writes to, or ``None``.
+
+    One reader for the key, shared by the sidecar's corpus list, the host
+    directory the deploy provisions and the per-user mount the web-terminal
+    overlay emits — so the directory the exporter fills, the one the sidecar
+    indexes and the one a persona container writes into are provably the same
+    configured string.
+
+    ``mirror_path`` may be written directly on the module block or inside its
+    ``settings:`` mapping — ARIEL's own loader merges the two with ``settings``
+    winning, and every consumer must follow whichever the exporter will
+    actually write to. A disabled export names nothing: there is then no
+    writer, so nothing to mount or index. An enabled export with no path is a
+    config error the exporter itself refuses at runtime; ``None`` here too.
+
+    :param config: Configuration dictionary
+    :type config: dict
+    :return: The configured path as written (relative or absolute), stripped,
+        or ``None``
+    :rtype: str | None
+    """
+    ariel = (config or {}).get("ariel")
+    modules = ariel.get("enhancement_modules") if isinstance(ariel, dict) else None
+    export = modules.get("qmd_export") if isinstance(modules, dict) else None
+    if not isinstance(export, dict) or not export.get("enabled"):
+        return None
+    settings = export.get("settings")
+    mirror_path = export.get("mirror_path")
+    if isinstance(settings, dict) and settings.get("mirror_path"):
+        mirror_path = settings["mirror_path"]
+    if isinstance(mirror_path, str) and mirror_path.strip():
+        return mirror_path.strip()
+    return None
+
+
+def resolve_ariel_mirror_dir(config, repo_root=None):
+    """The ARIEL qmd mirror on the host, or ``None`` when no export writes one.
+
+    The mirror counterpart of :func:`resolve_facility_bundle_dir`, anchored the
+    same way and for the same reason: a relative value resolves against the
+    deployment repo root, which is what every bind source in a rendered
+    compose file resolves against — and, since the exporter's own resolver
+    anchors on the project root too
+    (:func:`osprey.services.ariel_search.enhancement.qmd_export.exporter.resolve_mirror_path`),
+    the directory provisioned here is the directory the exporter fills.
+
+    :param config: Configuration dictionary
+    :type config: dict
+    :param repo_root: Deployment repo root; ``None`` resolves it from *config*
+    :type repo_root: str | pathlib.Path | None
+    :return: Absolute path to the mirror root, or ``None``
+    :rtype: pathlib.Path | None
+    """
+    raw = configured_ariel_mirror_path(config)
+    if raw is None:
+        return None
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        return path
+    root = Path(repo_root) if repo_root is not None else Path(resolve_repo_root(config))
+    return root / path
+
+
+def user_audit_relpath(user):
+    """Repo-relative host directory backing one web-terminal user's audit zone.
+
+    ``<var/audit>/<user>``: the deployment's own audit zone
+    (:data:`osprey.utils.workspace.AUDIT_DIR_RELPATH`, where the host's python
+    executor appends its refusal log) with one subdirectory per roster user, so
+    the per-user containers — each of which writes the same fixed filename
+    into what it sees as ``<project>/var/audit`` — cannot overwrite one
+    another's log, and an operator reading the host finds every user's records
+    under the one zone the audit already lives in.
+
+    Spelled here, and read from here by both the web-terminal render (the bind
+    source) and the deploy provisioning (the directory it pre-creates), so the
+    two cannot name different places.
+
+    :param user: Roster user name
+    :type user: str
+    :return: The repo-relative path, POSIX-spelled
+    :rtype: str
+    """
+    from osprey.utils.workspace import AUDIT_DIR_RELPATH
+
+    return f"{AUDIT_DIR_RELPATH}/{user}"
+
+
+def resolve_user_audit_dir(repo_root, user):
+    """Absolute host path of :func:`user_audit_relpath` under *repo_root*."""
+    return Path(repo_root) / user_audit_relpath(user)
 
 
 def _resolve_qmd_render_context(config, repo_root):
@@ -1557,6 +1640,15 @@ def _ensure_agent_data_structure(config):
     bundle_dir = resolve_facility_bundle_dir(config, project_root)
     if bundle_dir is not None:
         ensure_shared_corpus_dir(bundle_dir, relative_to=project_root)
+
+    # The ARIEL qmd mirror, for the same reasons: the sidecar binds it
+    # read-only, so a missing directory would be created root-owned by the
+    # runtime and the host exporter could never write it; and in a multi-user
+    # deployment every entitled web terminal's exporter writes into it too, so
+    # it needs the shared-group mode the bundle has.
+    mirror_dir = resolve_ariel_mirror_dir(config, project_root)
+    if mirror_dir is not None:
+        ensure_shared_corpus_dir(mirror_dir, relative_to=project_root)
 
     logger.debug(f"Ensured agent data structure exists at: {agent_data_path}")
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -34,6 +34,7 @@ from osprey.deployment.compose_generator import (
     clean_deployment,
     compose_base_cmd,
     compose_provider_env,
+    configured_ariel_mirror_path,
     prepare_compose_files,
     repo_identity,
     resolve_image_defaults,
@@ -4752,10 +4753,11 @@ def _graphdb_config_dir(project_dir: Path) -> Path:
 
     What a relative ``services.graphdb.ttl_path`` resolves against — see
     :func:`_graphdb_ttl_text`. Derived from the project root the deploy was
-    handed rather than from :func:`osprey_connectors.workspace.resolve_config_path`,
-    which falls back to the process working directory: a deploy driven with
-    ``--repo`` from somewhere else would otherwise resolve the corpus against
-    whatever directory the operator happened to be standing in.
+    handed rather than from
+    :func:`osprey_connectors.workspace.resolve_config_path`, which falls back
+    to the process working directory: a deploy driven with ``--repo`` from
+    somewhere else would otherwise resolve the corpus against whatever
+    directory the operator happened to be standing in.
 
     Both project shapes are covered by one rule, the same one
     ``resolve_config_path`` applies to a working directory: the render one zone
@@ -4771,12 +4773,17 @@ def _graphdb_config_dir(project_dir: Path) -> Path:
 def _graphdb_ttl_text(ttl_path: str, project_dir: Path) -> tuple[Path, str]:
     """Read the configured TTL corpus, resolving its path the documented way.
 
-    ``ttl_path`` follows the ``facility_knowledge.bundle_path`` rule — ``~``
-    expanded, an absolute value used as written, a relative one resolved against
-    the ``config.yml`` directory — because ``osprey knowledge seed-graph`` reads
-    the same key by the same rule. Two resolutions of one key would mean the
-    deploy and the verb could seed a store from different files while both
-    reporting success.
+    ``ttl_path`` is render-relative: ``~`` expanded, an absolute value used as
+    written, a relative one resolved against the ``config.yml`` directory
+    (:func:`osprey.utils.config_paths.resolve_render_relative_path`) — the
+    one config-relative key that is, because the corpus it names is an
+    artifact of the render: the documented default,
+    ``./data/demo_machine.ttl``, is read from the ``data/`` tree the build
+    assembled for this project, so a corpus regenerated into the profile's
+    data tree reaches the store on the next build like every other rendered
+    artifact. ``osprey knowledge seed-graph`` reads the same key by the same
+    rule; two resolutions of one key would mean the deploy and the verb could
+    seed a store from different files while both reporting success.
 
     :param ttl_path: The configured ``services.graphdb.ttl_path`` value.
     :param project_dir: Root of the built project.
@@ -4784,9 +4791,9 @@ def _graphdb_ttl_text(ttl_path: str, project_dir: Path) -> tuple[Path, str]:
     :raises OSError: If the corpus is not on disk or cannot be read — reported
         by the caller's envelope, never fatal.
     """
-    from osprey.services.facility_knowledge.bundle_path import resolve_bundle_path
+    from osprey.utils.config_paths import resolve_render_relative_path
 
-    resolved = resolve_bundle_path(ttl_path, _graphdb_config_dir(project_dir))
+    resolved = resolve_render_relative_path(ttl_path, _graphdb_config_dir(project_dir))
     return resolved, resolved.read_text(encoding="utf-8")
 
 
@@ -5290,6 +5297,42 @@ def _collect_unmet_preconditions(
         raise UnmetPreconditionsError(findings)
 
 
+def _preflight_legacy_ariel_mirror(config: dict, repo_root: Path) -> None:
+    """Warn when the logbook mirror still sits where an earlier release wrote it.
+
+    ``ariel.enhancement_modules.qmd_export.mirror_path`` used to resolve
+    against the directory holding ``config.yml`` — ``build/`` — while the qmd
+    sidecar bind-mounted the same relative path from the repo root, so the
+    exporter filled ``build/var/ariel_mirror`` and the sidecar indexed an
+    empty ``var/ariel_mirror``. Config-relative paths now anchor on the
+    project root (:func:`osprey.utils.config_paths.resolve_config_relative_path`),
+    which puts writer and reader in one place — and leaves a deployment
+    upgraded in place with its corpus in the old one. Files there are not
+    moved: the mirror is a derived artifact and ``osprey ariel qmd-resync``
+    regenerates it in seconds, which is what this names.
+    """
+    relpath = configured_ariel_mirror_path(config)
+    if not relpath or Path(relpath).is_absolute():
+        return
+    legacy = repo_root / "build" / relpath
+    current = repo_root / relpath
+    if not legacy.is_dir() or legacy.resolve() == current.resolve():
+        return
+    count = sum(1 for entry in legacy.rglob("*") if entry.is_file())
+    if not count:
+        return
+    logger.warning(
+        "%d file(s) under %s were written by an earlier release, which resolved "
+        "ariel.enhancement_modules.qmd_export.mirror_path against build/; the qmd "
+        "sidecar indexes %s. Run `osprey ariel qmd-resync` to regenerate the mirror "
+        "there, then remove %s.",
+        count,
+        legacy,
+        current,
+        legacy,
+    )
+
+
 def _start_stack(
     config: dict,
     compose_files: list[str],
@@ -5373,6 +5416,7 @@ def _start_stack(
     # on a host that was configured this way because it has no route out. Checked
     # here, before the build the setting is meant to shorten.
     preflight_qmd_models_dir(config)
+    _preflight_legacy_ariel_mirror(config, Path(repo_root))
 
     # And the same shape once more for the graph store: a `graphdb` in
     # deployed_services with no `services.graphdb` block describes no store at

--- a/src/osprey/deployment/qmd_service.py
+++ b/src/osprey/deployment/qmd_service.py
@@ -49,6 +49,12 @@ from typing import Any
 
 from osprey.deployment.errors import DeploymentPreconditionError
 
+#: Key of the sidecar's block under ``services:`` — also its compose service
+#: name and its ``deployed_services`` entry. Spelled once so the build-time
+#: validator that asks "is there a block to dial" reads the same key the
+#: resolver below does.
+QMD_SERVICE_NAME = "qmd"
+
 #: Host port the sidecar publishes. Deliberately NOT qmd's own default of
 #: 8181: the daemon binds loopback only (``listen(port, "localhost")``,
 #: hardcoded, no ``--host`` flag), so the container's entrypoint runs qmd on the
@@ -76,11 +82,11 @@ DEFAULT_INTERVAL_SECONDS = 30
 
 #: Config key an operator edits to move the published host port. Spelled once
 #: so the deploy-time port-conflict remedy and the schema cannot drift apart.
-PORT_CONFIG_KEY = "services.qmd.port"
+PORT_CONFIG_KEY = f"services.{QMD_SERVICE_NAME}.port"
 
 #: Config key naming a host directory of pre-staged GGUF model files. Spelled
 #: once so the schema, the deploy-time preflight and its refusal text agree.
-MODELS_DIR_CONFIG_KEY = "services.qmd.models_dir"
+MODELS_DIR_CONFIG_KEY = f"services.{QMD_SERVICE_NAME}.models_dir"
 
 #: The exact filenames the three models must carry, in the order the sidecar
 #: loads them: embedding, reranker, query expansion.
@@ -162,7 +168,7 @@ def resolve_qmd_service_config(config: Mapping[str, Any] | None) -> QMDServiceCo
     services = config.get("services")
     if not isinstance(services, Mapping):
         return None
-    block = services.get("qmd")
+    block = services.get(QMD_SERVICE_NAME)
     if not isinstance(block, Mapping):
         return None
     return QMDServiceConfig(

--- a/src/osprey/deployment/reach.py
+++ b/src/osprey/deployment/reach.py
@@ -1,0 +1,889 @@
+"""The Reach Contract: how a container reaches the services its deployment runs.
+
+A deployment's services are reached by clients that do not deploy them — every
+web-terminal persona is an *attached* render (``deploy_services: false``) whose
+container shares the host's network namespace and dials the hosting
+deployment's Postgres, its qmd sidecar, its graph store, its bluesky bridge,
+its telemetry store — and each of those clients resolves its endpoint through
+a different mechanism: a ``services.<name>`` block the build writes for a
+deploying project, a compiled-in default, an env var a compose author sets.
+Nothing tied the three together, so a client could be switched ON in a render
+that carried nothing for it to resolve, and the failure surfaced at first use,
+inside a per-user container: "no qmd sidecar is configured", telemetry posting
+to a DNS name that resolves to nothing, a bridge dialed on a port the host
+stopped publishing.
+
+This module is the one place those facts are declared, so that every
+enforcement reads the same declaration:
+
+* **The build projects.** For an attached render in the same repo as its host,
+  :func:`project_attached_overrides` copies each contract's client-facing
+  keys from the HOST's rendered config into the attached render, gated on the
+  consumer being switched on there. The build already knows every
+  client-facing fact about its services; no persona restates one, and a
+  service moved on the hosting profile moves every client with it.
+  An attached profile built with no deployment in its repo is projected from
+  what its app template deploys at the shipped defaults instead — the
+  deployment it extends is one of that template — with its own ``config:``
+  laid over them, which is where a host that differs is named.
+* **The build refuses.** :func:`reach_errors` reads a rendered config and
+  refuses a consumer that is on with nothing to resolve — the generic backstop
+  for a render whose host, or whose app template, deploys no such service.
+* **Tests check the seams.** The credential grants and shared paths declared
+  here are what ``tests/deployment/test_reach_contract.py`` walks over a real
+  built stack: switch on ⇒ endpoint resolves ∧ credential in the container's
+  compose block ∧ shared directory mounted. And every ``services.<name>`` a
+  shipped template can deploy must have a contract or say why it needs none.
+* **``osprey health`` probes.** The ``reach`` category resolves each live
+  consumer's endpoint from inside any container and knocks on it.
+
+The registry is a mapping keyed by the ``services.<name>`` key, collected
+here like :data:`osprey.registry.mcp.FRAMEWORK_SERVERS`. Predicates are the
+ones the web-terminal render already grants credentials by
+(:mod:`osprey.deployment.web_terminals.personas`), imported rather than
+restated, so the registry and the render cannot disagree about who is
+entitled to what.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+from osprey.bluesky_bridge_connection import (
+    BRIDGE_URL_ENV_VAR,
+    DEFAULT_BRIDGE_PORT,
+    SECOND_LANE_KEYS,
+    bridge_url_from_config,
+    lane_env_prefix,
+)
+from osprey.deployment.graphdb_service import DEFAULT_PORT as GRAPHDB_DEFAULT_PORT
+from osprey.deployment.graphdb_service import (
+    GRAPHDB_PASSWORD_ENV,
+    GRAPHDB_PORT_CONFIG_KEY,
+    GRAPHDB_SERVICE_NAME,
+    resolve_graphdb_connection,
+    resolve_graphdb_service_config,
+)
+from osprey.deployment.qmd_service import DEFAULT_PORT as QMD_DEFAULT_PORT
+from osprey.deployment.qmd_service import PORT_CONFIG_KEY as QMD_PORT_CONFIG_KEY
+from osprey.deployment.qmd_service import QMD_SERVICE_NAME, resolve_qmd_service_config
+from osprey.deployment.web_terminals.personas import (
+    BLUESKY_PANEL_ID,
+    EVENTS_PANEL_ID,
+    as_dict,
+    config_declares_panel,
+    config_needs_ariel_mirror,
+    config_needs_ariel_password,
+    config_needs_dispatcher_token,
+    config_needs_facility_bundle,
+    config_needs_graphdb_password,
+    config_needs_launch_token,
+)
+
+__all__ = [
+    "Consumer",
+    "CredentialGrant",
+    "ProjectedKey",
+    "ReachContract",
+    "SharedPath",
+    "REACH_CONTRACTS",
+    "SHARED_PATHS",
+    "BLUESKY_PANEL_ID",
+    "Dial",
+    "dotted_get",
+    "project_attached_overrides",
+    "reach_errors",
+    "live_consumers",
+    "reach_dials",
+]
+
+Predicate = Callable[[Mapping[str, Any]], bool]
+
+#: ``(host, port)`` — what a consumer's client actually connects to.
+Dial = tuple[str, int]
+Dialer = Callable[[Mapping[str, Any]], "Dial | None"]
+
+
+def dotted_get(config: Mapping[str, Any] | None, dotted_key: str) -> Any:
+    """The value at *dotted_key* in a nested config, or ``None`` when any
+    segment is missing or not a mapping."""
+    node: Any = config
+    for part in dotted_key.split("."):
+        if not isinstance(node, Mapping):
+            return None
+        node = node.get(part)
+    return node
+
+
+def _servers_enabled(config: Mapping[str, Any], server: str, *, default: bool) -> bool:
+    """Whether ``claude_code.servers.<server>.enabled`` leaves the server on.
+
+    Read the way :func:`osprey.registry.mcp.resolve_servers` reads it: an
+    explicit ``false`` switches a server off, an explicit ``true`` switches one
+    on, and absence leaves the server's own default.
+    """
+    value = as_dict(
+        as_dict(as_dict(as_dict(config).get("claude_code")).get("servers")).get(server)
+    ).get("enabled")
+    if value is False:
+        return False
+    if value is True:
+        return True
+    return default
+
+
+@dataclass(frozen=True)
+class Consumer:
+    """One in-container client of a shared service.
+
+    Attributes:
+        name: What it is, for messages (``"ARIEL hybrid search"``).
+        switch_key: The dotted config key that switches it on, for messages.
+        is_on: Whether this rendered config switches the consumer on.
+        resolves: Whether this rendered config gives the consumer an endpoint.
+            A resolver that always answers (a compiled-in default it would
+            dial) reports ``True`` unconditionally; such a consumer is served
+            by projection, never by refusal.
+        refuse: Whether ``on ∧ not resolves`` refuses the build. ``False`` for
+            a consumer that degrades on purpose (the OKF panel's ranked
+            search falls back to substring matching); the health probe still
+            reports it.
+        dial: The ``(host, port)`` this consumer's client connects to, resolved
+            THROUGH the client's own resolver (the bridge URL the MCP server
+            builds, the DSN the panel server derives, the OTLP endpoint the
+            exporter posts to) — so the ``reach`` health category knocks on
+            what the client dials, not on what the service block says.
+            ``None`` from the dialer means the client has nothing to dial.
+    """
+
+    name: str
+    switch_key: str
+    is_on: Predicate
+    resolves: Predicate
+    refuse: bool = True
+    dial: Dialer | None = None
+
+
+@dataclass(frozen=True)
+class ProjectedKey:
+    """A client-facing fact the build copies from the host render into an
+    attached render.
+
+    Attributes:
+        key: Dotted config key, in both renders.
+        gate: Whether the attached render has a consumer for it. ``None``
+            projects whenever the host render carries the key. A gate keeps a
+            fact out of a render that would grow a surface from it — a
+            ``services.graphdb`` block makes the graph MCP server render, so
+            it is projected only where that server is not switched off.
+        panel: When set, the key belongs to this panel's ``web.panels`` entry
+            and is projected only for a render whose profile selects the
+            panel (``web_panels:``), which the rendered config alone cannot
+            tell: custom panels reach it through ``config:`` only.
+    """
+
+    key: str
+    gate: Predicate | None = None
+    panel: str | None = None
+
+
+@dataclass(frozen=True)
+class CredentialGrant:
+    """An env var a container needs to authenticate to the service.
+
+    Attributes:
+        env: The variable's name in the container.
+        gate: Which renders get it — the same predicate the web-terminal
+            render grants by. ``None`` is ungated: every container gets it.
+    """
+
+    env: str
+    gate: Predicate | None
+
+
+@dataclass(frozen=True)
+class ReachContract:
+    """Everything a client needs to reach one shared service.
+
+    Attributes:
+        service: The ``services.<name>`` key.
+        consumers: The in-container clients, each with its switch and resolver.
+        projected: The keys copied into an attached render from its host.
+        credentials: The env vars entitled containers receive.
+        no_client_reach: The service is dialed by nothing inside a persona
+            container (a host-side writer, a worker the host dials); the
+            contract exists to say so, and ``note`` says why.
+        derived_by: Name of the build block that already derives this
+            service's client facts for attached renders on its own path
+            (the archive: :func:`osprey.cli.build_profile_archiver.va_archiver_config_overrides`).
+        note: One line for the completeness report.
+    """
+
+    service: str
+    consumers: tuple[Consumer, ...] = ()
+    projected: tuple[ProjectedKey, ...] = ()
+    credentials: tuple[CredentialGrant, ...] = ()
+    no_client_reach: bool = False
+    derived_by: str | None = None
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class SharedPath:
+    """A host directory bound into every entitled persona container.
+
+    Attributes:
+        config_key: The dotted key naming the directory.
+        gate: Which renders are entitled — the predicate the render mounts by.
+        describe: What lives there, for messages.
+    """
+
+    config_key: str
+    gate: Predicate
+    describe: str
+
+
+# ---------------------------------------------------------------------------
+# Switches and resolvers, one per consumer
+# ---------------------------------------------------------------------------
+
+
+def _hybrid_search_on(config: Mapping[str, Any]) -> bool:
+    hybrid = dotted_get(config, "ariel.search_modules.hybrid")
+    return isinstance(hybrid, Mapping) and hybrid.get("enabled") is not False
+
+
+def _okf_ranked_search_on(config: Mapping[str, Any]) -> bool:
+    return config_declares_panel(config, "okf") and config_needs_facility_bundle(config)
+
+
+def _qmd_resolves(config: Mapping[str, Any]) -> bool:
+    try:
+        return resolve_qmd_service_config(config) is not None
+    except ValueError:
+        # A malformed block still names a sidecar this render means to dial;
+        # the resolver reports the fault where it can be acted on.
+        return True
+
+
+def _graph_server_on(config: Mapping[str, Any]) -> bool:
+    # The graph server's own default is "on when a store is configured"
+    # (``condition="graphdb_configured"``), so absence reads as on here: the
+    # question this switch answers is whether the render WANTS the server —
+    # the projection's gate, asked of an attached render that has no store
+    # yet — and the resolver below answers whether it has one.
+    return _servers_enabled(config, "graph", default=True)
+
+
+def _graphdb_resolves(config: Mapping[str, Any]) -> bool:
+    try:
+        return resolve_graphdb_service_config(config) is not None
+    except ValueError:
+        return True
+
+
+def _graph_server_renders(config: Mapping[str, Any]) -> bool:
+    # The consumer's switch: whether the server is IN this render — read the
+    # way resolve_servers reads it, with its own default. Explicitly on with
+    # no store is the one misconfiguration left to report; a render that
+    # never asked for the server and has no store has no consumer.
+    return _servers_enabled(config, "graph", default=_graphdb_resolves(config))
+
+
+def _channel_finder_graph_on(config: Mapping[str, Any]) -> bool:
+    # The graph paradigm's channel finder is its own MCP server, shipped on
+    # the rendered pipeline (registry: condition="channel_finder_pipeline")
+    # and dialing the store through its own server context — independent of
+    # the `graph` server's switch. A persona that switches the graph server
+    # off but keeps the channel finder still needs the store.
+    return dotted_get(config, "channel_finder.pipeline_mode") == "graph" and _servers_enabled(
+        config, "channel-finder", default=True
+    )
+
+
+def _graph_store_wanted(config: Mapping[str, Any]) -> bool:
+    # The projection's gate: either client of the store makes the render
+    # want its address.
+    return _graph_server_on(config) or _channel_finder_graph_on(config)
+
+
+def _ariel_on(config: Mapping[str, Any]) -> bool:
+    return config_needs_ariel_password(config)
+
+
+def _telemetry_on(config: Mapping[str, Any]) -> bool:
+    telemetry = as_dict(as_dict(as_dict(config).get("claude_code")).get("telemetry"))
+    return (
+        bool(telemetry.get("enabled"))
+        and telemetry.get("backend") == "openobserve"
+        and not telemetry.get("endpoint")
+    )
+
+
+def _bluesky_server_on(config: Mapping[str, Any]) -> bool:
+    return _servers_enabled(config, "bluesky", default=False)
+
+
+def _second_lane_on(lane: str) -> Predicate:
+    """The bluesky MCP server's consumer of a SECOND plan lane.
+
+    A second lane exists only where the build rendered its block
+    (``bluesky.second_lane`` on the deploying profile writes
+    ``services.<lane>``), so its consumer is on where the bluesky server is
+    on AND this render carries the block — a single-lane render has no such
+    consumer at all, and a render told the lane by projection has one from
+    that moment on. That is what lets one registry entry serve both shapes:
+    absent on the host means absent from the persona means nothing to refuse.
+    """
+
+    def _on(config: Mapping[str, Any]) -> bool:
+        return _bluesky_server_on(config) and isinstance(
+            as_dict(config.get("services")).get(lane), Mapping
+        )
+
+    return _on
+
+
+def _second_lane_launch_token_needed(lane: str) -> Predicate:
+    # Lane 1's tier boundary (config_needs_launch_token), applied to a lane
+    # this render carries: a persona entitled to arm lane 1 is entitled to arm
+    # every lane it is told, since its session may be switched to either
+    # target — and a render that carries no such lane has nothing to arm.
+    def _needed(config: Mapping[str, Any]) -> bool:
+        return config_needs_launch_token(config) and isinstance(
+            as_dict(config.get("services")).get(lane), Mapping
+        )
+
+    return _needed
+
+
+def _second_lane_resolves(lane: str) -> Predicate:
+    # resolve_bridge_url(lane) has no default to fall back to for a second
+    # lane: no port is a refusal there, so it is a refusal here.
+    def _resolves(config: Mapping[str, Any]) -> bool:
+        return bool(dotted_get(config, f"services.{lane}.port"))
+
+    return _resolves
+
+
+def _va_connector_on(config: Mapping[str, Any]) -> bool:
+    from osprey_connectors.types import VIRTUAL_ACCELERATOR
+
+    return bool(dotted_get(config, "control_system.type") == VIRTUAL_ACCELERATOR)
+
+
+def _events_panel_on(config: Mapping[str, Any]) -> bool:
+    return config_declares_panel(config, EVENTS_PANEL_ID)
+
+
+def _bluesky_panel_on(config: Mapping[str, Any]) -> bool:
+    return config_declares_panel(config, BLUESKY_PANEL_ID)
+
+
+def _panel_url_resolves(panel_id: str) -> Predicate:
+    def _resolves(config: Mapping[str, Any]) -> bool:
+        return bool(dotted_get(config, f"web.panels.{panel_id}.url"))
+
+    return _resolves
+
+
+def _always(_config: Mapping[str, Any]) -> bool:
+    return True
+
+
+# ---------------------------------------------------------------------------
+# What each consumer's client dials — through the client's own resolver
+# ---------------------------------------------------------------------------
+
+
+def _host_port(url: str, default_port: int) -> Dial | None:
+    """``(host, port)`` of *url*, or ``None`` when it names no host."""
+    try:
+        parts = urlsplit(url if "//" in url else f"//{url}")
+        host, port = parts.hostname, parts.port
+    except ValueError:
+        return None
+    if not host:
+        return None
+    return host, port or default_port
+
+
+def _qmd_dial(config: Mapping[str, Any]) -> Dial | None:
+    try:
+        resolved = resolve_qmd_service_config(config)
+    except ValueError:
+        return None
+    return None if resolved is None else _host_port(resolved.base_url, QMD_DEFAULT_PORT)
+
+
+def _graphdb_dial(config: Mapping[str, Any]) -> Dial | None:
+    try:
+        if resolve_graphdb_service_config(config) is None:
+            return None
+        connection = resolve_graphdb_connection(
+            dotted_get(config, f"services.{GRAPHDB_SERVICE_NAME}")
+        )
+    except ValueError:
+        return None
+    return _host_port(connection.uri, GRAPHDB_DEFAULT_PORT)
+
+
+def _postgres_dial(config: Mapping[str, Any]) -> Dial | None:
+    from osprey.services.ariel_search.config import resolve_ariel_dsn
+
+    try:
+        dsn = resolve_ariel_dsn(
+            as_dict(as_dict(config).get("ariel")),
+            as_dict(dotted_get(config, "services.postgresql")) or None,
+        )
+    except (TypeError, ValueError):
+        return None
+    return _host_port(dsn, 5432)
+
+
+def _telemetry_dial(config: Mapping[str, Any]) -> Dial | None:
+    from osprey.build.claude_code_telemetry import resolve_runtime_telemetry_endpoint
+
+    endpoint = resolve_runtime_telemetry_endpoint(config)
+    return None if endpoint is None else _host_port(endpoint, 80)
+
+
+def _bridge_dial(config: Mapping[str, Any]) -> Dial | None:
+    # The env half of resolve_bridge_url, then the config half — the same
+    # order, on the config the caller holds rather than the loaded one.
+    url = os.environ.get(BRIDGE_URL_ENV_VAR) or bridge_url_from_config(config)
+    return _host_port(url, DEFAULT_BRIDGE_PORT)
+
+
+def _second_lane_dial(lane: str) -> Dialer:
+    # resolve_bridge_url(lane) for a second lane: its own `<PREFIX>_BRIDGE_URL`
+    # wins outright, else the loopback URL of its published port — there is
+    # no `bluesky.bridge_url` for a second lane and no default, so no port is
+    # nothing to dial.
+    def _dial(config: Mapping[str, Any]) -> Dial | None:
+        url = os.environ.get(f"{lane_env_prefix(lane)}_BRIDGE_URL")
+        if url:
+            return _host_port(url, DEFAULT_BRIDGE_PORT)
+        port = dotted_get(config, f"services.{lane}.port")
+        return ("127.0.0.1", int(port)) if port else None
+
+    return _dial
+
+
+def _panel_dial(panel_id: str) -> Dialer:
+    def _dial(config: Mapping[str, Any]) -> Dial | None:
+        url = dotted_get(config, f"web.panels.{panel_id}.url")
+        return _host_port(str(url), 80) if url else None
+
+    return _dial
+
+
+def _va_dial(config: Mapping[str, Any]) -> Dial | None:
+    # fill_gateway_ports' rule: an explicit gateway port wins, else the port
+    # the deployment publishes, else the connector's default — on the
+    # gateway's own address.
+    from osprey_connectors.control_system.va_connector import DEFAULT_VA_PORT
+
+    published = dotted_get(config, "services.virtual_accelerator.port") or DEFAULT_VA_PORT
+    gateways = as_dict(dotted_get(config, "control_system.connector.virtual_accelerator.gateways"))
+    for gateway in gateways.values():
+        if isinstance(gateway, Mapping):
+            address = str(gateway.get("address") or "localhost")
+            port = gateway.get("port") or published
+            break
+    else:
+        address, port = "localhost", published
+    try:
+        return address, int(port)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+
+def _second_lane_contract(lane: str) -> ReachContract:
+    """The contract of one second plan lane (``bluesky_va`` or ``bluesky_live``)."""
+    prefix = lane_env_prefix(lane)
+    return ReachContract(
+        service=lane,
+        consumers=(
+            Consumer(
+                name=f"bluesky MCP server, {lane} lane (and the approval hook's lane lookup)",
+                switch_key="claude_code.servers.bluesky.enabled",
+                is_on=_second_lane_on(lane),
+                resolves=_second_lane_resolves(lane),
+                dial=_second_lane_dial(lane),
+            ),
+        ),
+        projected=(
+            ProjectedKey(f"services.{lane}.port", gate=_bluesky_server_on),
+            ProjectedKey(f"services.{lane}.target", gate=_bluesky_server_on),
+        ),
+        credentials=(
+            CredentialGrant(f"{prefix}_LAUNCH_TOKEN", _second_lane_launch_token_needed(lane)),
+        ),
+        note=f"resolve_bridge_url({lane!r}) dials the lane's published port on loopback",
+    )
+
+
+REACH_CONTRACTS: dict[str, ReachContract] = {
+    QMD_SERVICE_NAME: ReachContract(
+        service=QMD_SERVICE_NAME,
+        consumers=(
+            Consumer(
+                name="ARIEL hybrid search",
+                switch_key="ariel.search_modules.hybrid.enabled",
+                is_on=_hybrid_search_on,
+                resolves=_qmd_resolves,
+                dial=_qmd_dial,
+            ),
+            Consumer(
+                name="OKF panel ranked search",
+                switch_key="web.panels.okf",
+                is_on=_okf_ranked_search_on,
+                resolves=_qmd_resolves,
+                # Falls back to substring matching without a sidecar, by
+                # design (interfaces/okf_panel/app.py); reported, not refused.
+                refuse=False,
+                dial=_qmd_dial,
+            ),
+        ),
+        projected=(
+            ProjectedKey(
+                QMD_PORT_CONFIG_KEY,
+                gate=lambda config: _hybrid_search_on(config) or _okf_ranked_search_on(config),
+            ),
+        ),
+        note="hybrid logbook search and the OKF panel dial the sidecar on loopback",
+    ),
+    GRAPHDB_SERVICE_NAME: ReachContract(
+        service=GRAPHDB_SERVICE_NAME,
+        consumers=(
+            Consumer(
+                name="graph MCP server",
+                switch_key="claude_code.servers.graph.enabled",
+                is_on=_graph_server_renders,
+                resolves=_graphdb_resolves,
+                # The server is gated on ``graphdb_configured`` and left out of
+                # a render with no store — a coherent surface, never a
+                # half-configured one. Refusing here would make every attached
+                # render without a store fail; the profile rule refuses the
+                # case that matters (channel_finder_mode: graph).
+                refuse=False,
+                dial=_graphdb_dial,
+            ),
+            Consumer(
+                name="graph channel finder",
+                switch_key="channel_finder.pipeline_mode",
+                is_on=_channel_finder_graph_on,
+                resolves=_graphdb_resolves,
+                # Its own server, its own dial: a graph-paradigm channel finder
+                # with no store fails every query at first use, so a render
+                # that keeps it on with nothing to dial is refused — the
+                # profile rule refuses the same shape before the render, and
+                # this catches an attached render that was told nothing.
+                dial=_graphdb_dial,
+            ),
+        ),
+        projected=(
+            # Both spellings of "where is the store": the published bolt port
+            # for a store this deployment runs, the uri (and account) for one
+            # it merely names. Gated on either client wanting it — the graph
+            # server not switched off, or the channel finder on its graph
+            # paradigm — since the block's presence is what makes the graph
+            # server render, and a store the channel finder dials must be there
+            # whether or not that server is.
+            ProjectedKey(GRAPHDB_PORT_CONFIG_KEY, gate=_graph_store_wanted),
+            ProjectedKey(f"services.{GRAPHDB_SERVICE_NAME}.uri", gate=_graph_store_wanted),
+            ProjectedKey(f"services.{GRAPHDB_SERVICE_NAME}.username", gate=_graph_store_wanted),
+        ),
+        credentials=(CredentialGrant(GRAPHDB_PASSWORD_ENV, config_needs_graphdb_password),),
+        note="the graph MCP server and the graph channel finder dial bolt on loopback",
+    ),
+    "postgresql": ReachContract(
+        service="postgresql",
+        consumers=(
+            Consumer(
+                name="ARIEL database (panel server and ariel MCP server)",
+                switch_key="ariel",
+                is_on=_ariel_on,
+                # resolve_ariel_dsn always derives a DSN (shipped defaults);
+                # the projection is what keeps it the host's.
+                resolves=_always,
+                dial=_postgres_dial,
+            ),
+        ),
+        projected=(
+            ProjectedKey("services.postgresql.port_host", gate=_ariel_on),
+            ProjectedKey("services.postgresql.username", gate=_ariel_on),
+            ProjectedKey("services.postgresql.database_name", gate=_ariel_on),
+        ),
+        credentials=(CredentialGrant("ARIEL_DB_PASSWORD", config_needs_ariel_password),),
+        note="resolve_ariel_dsn derives the DSN from the block on loopback",
+    ),
+    "openobserve": ReachContract(
+        service="openobserve",
+        consumers=(
+            Consumer(
+                name="agent telemetry (OTLP exporter)",
+                switch_key="claude_code.telemetry.enabled",
+                is_on=_telemetry_on,
+                # The endpoint always derives (host from context, port from the
+                # block or the listen port); the projection keeps the port the
+                # host's.
+                resolves=_always,
+                dial=_telemetry_dial,
+            ),
+        ),
+        projected=(ProjectedKey("services.openobserve.port", gate=_telemetry_on),),
+        # Every container emits as the one ingest account, by design (the
+        # compose template's ZO_INGEST_SA_TOKEN note): ungated.
+        credentials=(CredentialGrant("ZO_INGEST_SA_TOKEN", None),),
+        note="the exporter posts to the published port on loopback",
+    ),
+    "bluesky": ReachContract(
+        service="bluesky",
+        consumers=(
+            Consumer(
+                name="bluesky MCP server (and the approval hook's bridge lookup)",
+                switch_key="claude_code.servers.bluesky.enabled",
+                is_on=_bluesky_server_on,
+                # bridge_url_from_config always answers (the shipped default);
+                # the projection keeps it the host's port.
+                resolves=_always,
+                dial=_bridge_dial,
+            ),
+        ),
+        projected=(
+            ProjectedKey("services.bluesky.port", gate=_bluesky_server_on),
+            # Written by the build only on a two-lane deployment, where it says
+            # which control target lane 1 serves; the lane resolver reads it
+            # to pick the lane the session is on. Absent on a single-lane host
+            # means absent here, which is that resolver's single-lane answer.
+            ProjectedKey("services.bluesky.target", gate=_bluesky_server_on),
+        ),
+        credentials=(CredentialGrant("BLUESKY_LAUNCH_TOKEN", config_needs_launch_token),),
+        note="resolve_bridge_url dials the published port on loopback",
+    ),
+    # The SECOND plan lane a deploying profile opts into (`bluesky.second_lane`),
+    # one entry per name it can have — a lane is named for the target it
+    # serves, and which one is rendered depends on the deployment baseline.
+    # Not an app-template service: the injector writes the block beside lane
+    # 1's, reusing the bluesky service template. Projected exactly like lane
+    # 1, port and target, so a persona's session switched to the other
+    # machine is routed to that machine's lane rather than refused as a
+    # single-lane render — and armed by that lane's own token, granted on the
+    # same tier boundary as lane 1's.
+    **{lane: _second_lane_contract(lane) for lane in SECOND_LANE_KEYS.values()},
+    "bluesky_web": ReachContract(
+        service="bluesky_web",
+        consumers=(
+            Consumer(
+                name="BLUESKY panel",
+                switch_key=f"web.panels.{BLUESKY_PANEL_ID}",
+                is_on=_bluesky_panel_on,
+                resolves=_panel_url_resolves(BLUESKY_PANEL_ID),
+                dial=_panel_dial(BLUESKY_PANEL_ID),
+            ),
+        ),
+        projected=tuple(
+            ProjectedKey(f"web.panels.{BLUESKY_PANEL_ID}.{leaf}", panel=BLUESKY_PANEL_ID)
+            for leaf in ("url", "path", "label", "health_endpoint")
+        ),
+        # The reverse grant — the sidecar is handed each entitled user's own
+        # secret — is in the sidecar's OWN compose file (services/bluesky_web,
+        # rendered in the services stack), keyed on the same panel declaration
+        # (personas.bluesky_panel_secret_env_vars).
+        note="the panel proxy dials the sidecar at web.panels.bluesky.url with the user's own secret",
+    ),
+    "event_dispatcher": ReachContract(
+        service="event_dispatcher",
+        consumers=(
+            Consumer(
+                name="EVENTS panel",
+                switch_key=f"web.panels.{EVENTS_PANEL_ID}",
+                is_on=_events_panel_on,
+                resolves=_panel_url_resolves(EVENTS_PANEL_ID),
+                dial=_panel_dial(EVENTS_PANEL_ID),
+            ),
+        ),
+        projected=tuple(
+            ProjectedKey(f"web.panels.{EVENTS_PANEL_ID}.{leaf}", panel=EVENTS_PANEL_ID)
+            for leaf in ("url", "path", "label", "health_endpoint")
+        ),
+        credentials=(CredentialGrant("EVENT_DISPATCHER_TOKEN", config_needs_dispatcher_token),),
+        note="the panel proxy dials the dispatcher at web.panels.events.url",
+    ),
+    "virtual_accelerator": ReachContract(
+        service="virtual_accelerator",
+        consumers=(
+            Consumer(
+                name="virtual-accelerator connector (controls MCP server, osprey.runtime)",
+                switch_key="control_system.type",
+                is_on=_va_connector_on,
+                # fill_gateway_ports always answers (DEFAULT_VA_PORT); the
+                # projection keeps it the host's port.
+                resolves=_always,
+                dial=_va_dial,
+            ),
+        ),
+        projected=(ProjectedKey("services.virtual_accelerator.port", gate=_va_connector_on),),
+        note="the connector fills every gateway port from the block",
+    ),
+    "mongodb": ReachContract(
+        service="mongodb",
+        derived_by="va_archiver",
+        # The connector's connection keys and MONGO_ROOT_PASSWORD's name come
+        # from the ``va_archiver:`` block on their own path
+        # (``archiver.mongodb_archiver.*``, ``config_archiver_password_env``),
+        # which an attached project also gets and which refuses an attached
+        # profile that names no host.
+        note="derived from the va_archiver block; the archiver connector dials it on loopback",
+    ),
+    "archiver_recorder": ReachContract(
+        service="archiver_recorder",
+        no_client_reach=True,
+        note="a host-side writer; a persona reads the store, not the recorder",
+    ),
+    "dispatch_worker": ReachContract(
+        service="dispatch_worker",
+        no_client_reach=True,
+        note="the worker dials the persona's project, never the reverse",
+    ),
+    "nextcloud_bridge": ReachContract(
+        service="nextcloud_bridge",
+        no_client_reach=True,
+        note="a chat poller that dials the dispatcher; nothing in a container dials it",
+    ),
+    "gchat_bridge": ReachContract(
+        service="gchat_bridge",
+        no_client_reach=True,
+        note="a chat bridge that dials the dispatcher; nothing in a container dials it",
+    ),
+}
+
+#: Host directories bound into entitled persona containers, each at the path
+#: the container's own resolver derives for the key (see
+#: :mod:`osprey.deployment.web_terminals.render`).
+SHARED_PATHS: tuple[SharedPath, ...] = (
+    SharedPath(
+        "facility_knowledge.bundle_path",
+        config_needs_facility_bundle,
+        "the facility-knowledge bundle (OKF panel, facility_knowledge MCP server)",
+    ),
+    SharedPath(
+        "ariel.enhancement_modules.qmd_export.mirror_path",
+        config_needs_ariel_mirror,
+        "the ARIEL qmd mirror (qmd_export writes it; the sidecar indexes it)",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# What the build does with the registry
+# ---------------------------------------------------------------------------
+
+
+def project_attached_overrides(
+    host_config: Mapping[str, Any] | None,
+    attached_config: Mapping[str, Any],
+    *,
+    selected_panels: Iterable[str] = (),
+) -> dict[str, Any]:
+    """The dotted keys an attached render is told from its host's render.
+
+    For every contract's projected key: the host render carries a value AND
+    the attached render has a consumer for it (the key's gate, or — for a
+    panel key — the panel among *selected_panels*). Absent from the host
+    render means absent here: a host that dropped its qmd block projects no
+    ``services.qmd.port``, and the attached render's own refusal
+    (:func:`reach_errors`) then names the consumer left without it.
+
+    Args:
+        host_config: The hosting deployment's rendered ``config.yml``, or
+            ``None`` for an attached profile built with no host in its repo.
+        attached_config: The attached render's config after its profile's own
+            ``config:`` overlay — what the gates read.
+        selected_panels: The attached profile's ``web_panels`` selection.
+
+    Returns:
+        ``{dotted_key: value}``, in registry order; empty without a host.
+    """
+    if not host_config:
+        return {}
+    panels = set(selected_panels)
+    overrides: dict[str, Any] = {}
+    for contract in REACH_CONTRACTS.values():
+        for projected in contract.projected:
+            value = dotted_get(host_config, projected.key)
+            if value is None:
+                continue
+            if projected.panel is not None:
+                if projected.panel not in panels:
+                    continue
+            elif projected.gate is not None and not projected.gate(attached_config):
+                continue
+            overrides[projected.key] = value
+    return overrides
+
+
+def live_consumers(config: Mapping[str, Any]) -> list[tuple[ReachContract, Consumer]]:
+    """Every consumer *config* switches on, with its contract."""
+    return [
+        (contract, consumer)
+        for contract in REACH_CONTRACTS.values()
+        for consumer in contract.consumers
+        if consumer.is_on(config)
+    ]
+
+
+def reach_dials(config: Mapping[str, Any]) -> list[tuple[ReachContract, Consumer, Dial | None]]:
+    """Every live consumer with what its client dials from *config*.
+
+    Resolved through each client's own resolver, in the process that asks —
+    so from inside a per-user container this is the endpoint the agent's own
+    tools connect to, env overrides included. ``None`` for a consumer whose
+    client has nothing to dial (the same state :func:`reach_errors` refuses
+    at build time, seen at run time).
+    """
+    return [
+        (contract, consumer, consumer.dial(config) if consumer.dial else None)
+        for contract, consumer in live_consumers(config)
+    ]
+
+
+def reach_errors(config: Mapping[str, Any]) -> list[str]:
+    """Refuse a rendered config whose consumer is on with nothing to resolve.
+
+    Read on the RENDERED config — the ground truth every client loads — so it
+    holds for a deploying project that dropped a block its modules still use,
+    for an attached render whose host projected nothing, and for a standalone
+    attached profile that pinned nothing, alike.
+
+    Returns:
+        One error per unresolvable consumer whose contract refuses, naming
+        the switch and the key that fixes it.
+    """
+    errors: list[str] = []
+    for contract, consumer in live_consumers(config):
+        if not consumer.refuse or consumer.resolves(config):
+            continue
+        keys = ", ".join(projected.key for projected in contract.projected) or (
+            f"services.{contract.service}"
+        )
+        errors.append(
+            f"{consumer.name} is switched on ({consumer.switch_key}) but this render carries "
+            f"nothing for it to dial: no {keys}. An attached render (deploy_services: false) "
+            f"is told these by the build — from its hosting deployment's render, or, built "
+            f"on its own, from what its app template deploys — so the deployment it shares "
+            f"a host with runs no such service. Name one under `config:` ({keys}), or "
+            f"switch the consumer off."
+        )
+    return errors

--- a/src/osprey/deployment/web_terminals/artifacts.py
+++ b/src/osprey/deployment/web_terminals/artifacts.py
@@ -33,6 +33,7 @@ from osprey.deployment.web_terminals.auth_credentials import (
 from osprey.deployment.web_terminals.personas import (
     normalize_users,
     personas_needing_archiver_password,
+    personas_needing_ariel_mirror,
     personas_needing_ariel_password,
     personas_needing_dispatcher_token,
     personas_needing_facility_bundle,
@@ -45,7 +46,7 @@ from osprey.deployment.web_terminals.render import (
     render_web_terminals,
 )
 from osprey.utils.dotenv import ENV_LOCAL_FILENAME, parse_dotenv_file
-from osprey.utils.workspace import BUILD_DIR_NAME
+from osprey.utils.workspace import AUDIT_DIR_RELPATH, BUILD_DIR_NAME
 
 #: Filename of the rendered web-stack compose file, as
 #: :func:`~osprey.deployment.web_terminals.render.render_web_terminals` keys it.
@@ -315,6 +316,84 @@ def _terminal_secrets(config: Any, root: Path) -> dict[str, str] | None:
     return secrets or None
 
 
+def resolve_render_inputs(config: Any, repo_root: Path | str) -> dict[str, Any]:
+    """Every disk-derived input the deploy hands :func:`render_web_terminals`.
+
+    Resolved HERE and passed down, because ``render_web_terminals()`` reads no
+    filesystem of its own (see its docstring): the ``.env.auth`` digest; which
+    personas declare the EVENTS panel and so need the dispatcher's bearer,
+    which configure ARIEL and so need its Postgres password, which both allow
+    writes and run the bluesky server and so may arm a queue start, which
+    configure a graph store and so need its Neo4j password — each in their own
+    per-user environment block; which name a facility-knowledge bundle or run
+    a qmd export and so get the deployment's bundle or mirror bind-mounted,
+    and the groups those shared directories (and every user's audit zone)
+    were provisioned with; and the roster's operator secrets.
+
+    The one seam between "what is on disk" and "what the render is told", so a
+    test that wants the render the deploy actually produces asks this rather
+    than restating a subset of the inputs — a subset is exactly how a mount the
+    deploy emits can be invisible to a test that never passed its entitlement.
+
+    Fails closed BEFORE any render, so a refused deploy leaves no half-written
+    artifacts behind: a persona holding ``BLUESKY_LAUNCH_TOKEN`` whose shipped
+    settings still permit ``Bash`` can arm a queue start from a shell, with none
+    of the chat approval the token exists to make sufficient. ``osprey up`` and
+    ``decommission_user`` each already refused this earlier, where refusing is
+    cheaper and cannot half-apply; ``force_recreate_auth_sidecar``'s
+    pre-recreate re-render reaches here having passed neither, which is why the
+    seam checks for itself. The entitled set comes back from the guard so the
+    render is handed exactly the set that was cleared.
+
+    Args:
+        config: The parsed facility config.
+        repo_root: The deployment repo root.
+
+    Returns:
+        Keyword arguments for :func:`render_web_terminals`.
+
+    Raises:
+        BashLaunchTokenConflictError: See :func:`check_bash_launch_token_conflict`.
+    """
+    from osprey.deployment.compose_generator import (
+        resolve_ariel_mirror_dir,
+        resolve_facility_bundle_dir,
+        shared_corpus_gid,
+    )
+
+    root = Path(repo_root)
+    launch_token_personas = check_bash_launch_token_conflict(config, root)
+    return {
+        "auth_env_digest": auth_env_digest(root),
+        "dispatcher_personas": personas_needing_dispatcher_token(config, root),
+        "ariel_personas": personas_needing_ariel_password(config, root),
+        "launch_token_personas": launch_token_personas,
+        "graphdb_personas": personas_needing_graphdb_password(config, root),
+        "archiver_password_personas": personas_needing_archiver_password(config, root),
+        "facility_bundle_personas": personas_needing_facility_bundle(config, root),
+        # A pure read, like every other disk-derived input here: the deploy path
+        # provisions the bundle directory before this render (see
+        # deploy_up_web_terminals), and this asks what group it ended up with so
+        # each entitled service can join it. An unprovisioned directory answers
+        # None and emits no `group_add` — the honest render, since joining a
+        # group that was never established would be a guess.
+        "facility_bundle_gid": shared_corpus_gid(resolve_facility_bundle_dir(config, root)),
+        # The ARIEL mirror and each user's audit zone: the same pure reads, for
+        # the same reason, of directories the deploy provisioned before this
+        # render. The audit zone's group is read off its root, which the
+        # per-user subdirectories inherit.
+        "ariel_mirror_personas": personas_needing_ariel_mirror(config, root),
+        "ariel_mirror_gid": shared_corpus_gid(resolve_ariel_mirror_dir(config, root)),
+        "audit_gid": shared_corpus_gid(root / AUDIT_DIR_RELPATH),
+        # The roster's operator secrets, read back off the deploy .env (see
+        # _terminal_secrets for the None case and why it is not an open door).
+        # Without this the render emits no per-user snippet at all, while
+        # nginx.conf.j2 still emits the `include` that reads one — an nginx that
+        # refuses to start, pointing at a path nothing ever wrote.
+        "terminal_secrets": _terminal_secrets(config, root),
+    }
+
+
 def write_web_terminal_artifacts(config: Any, repo_root: Path | str | None = None) -> list[Path]:
     """Render the web-terminal artifacts into the repo's ``build/`` zone.
 
@@ -382,55 +461,10 @@ def write_web_terminal_artifacts(config: Any, repo_root: Path | str | None = Non
             its own (see :func:`_terminal_secrets`). Raised before any file is
             written or cleared.
     """
-    from osprey.deployment.compose_generator import (
-        resolve_facility_bundle_dir,
-        resolve_repo_root,
-        shared_corpus_gid,
-    )
+    from osprey.deployment.compose_generator import resolve_repo_root
 
     root = Path(repo_root) if repo_root is not None else resolve_repo_root(config)
-    # Every disk-derived input is resolved HERE and passed down, because
-    # render_web_terminals() reads no filesystem of its own (see its docstring):
-    # the .env.auth digest, which personas declare the EVENTS panel and so need
-    # the dispatcher's bearer, which configure ARIEL and so need its Postgres
-    # password, which both allow writes and run the bluesky server and so may
-    # arm a queue start, which configure a graph store and so need its Neo4j
-    # password — each in their own per-user environment block — and which name a
-    # facility-knowledge bundle and so get it bind-mounted.
-    # Fail closed BEFORE the render, so a refused deploy leaves no half-written
-    # artifacts behind: a persona holding BLUESKY_LAUNCH_TOKEN whose shipped
-    # settings still permit `Bash` can arm a queue start from a shell, with none
-    # of the chat approval the token exists to make sufficient. `osprey up` and
-    # `decommission_user` each already refused this earlier, where refusing is
-    # cheaper and cannot half-apply; force_recreate_auth_sidecar's pre-recreate
-    # re-render reaches here having passed neither, which is why the seam checks
-    # for itself. The entitled set comes back from the guard so the render is
-    # handed exactly the set that was cleared.
-    launch_token_personas = check_bash_launch_token_conflict(config, root)
-
-    artifacts = render_web_terminals(
-        config,
-        auth_env_digest=auth_env_digest(root),
-        dispatcher_personas=personas_needing_dispatcher_token(config, root),
-        ariel_personas=personas_needing_ariel_password(config, root),
-        launch_token_personas=launch_token_personas,
-        graphdb_personas=personas_needing_graphdb_password(config, root),
-        archiver_password_personas=personas_needing_archiver_password(config, root),
-        facility_bundle_personas=personas_needing_facility_bundle(config, root),
-        # A pure read, like every other disk-derived input here: the deploy path
-        # provisions the bundle directory before this render (see
-        # deploy_up_web_terminals), and this asks what group it ended up with so
-        # each entitled service can join it. An unprovisioned directory answers
-        # None and emits no `group_add` — the honest render, since joining a
-        # group that was never established would be a guess.
-        facility_bundle_gid=shared_corpus_gid(resolve_facility_bundle_dir(config, root)),
-        # The roster's operator secrets, read back off the deploy .env (see
-        # _terminal_secrets for the None case and why it is not an open door).
-        # Without this the render emits no per-user snippet at all, while
-        # nginx.conf.j2 still emits the `include` that reads one — an nginx that
-        # refuses to start, pointing at a path nothing ever wrote.
-        terminal_secrets=_terminal_secrets(config, root),
-    )
+    artifacts = render_web_terminals(config, **resolve_render_inputs(config, root))
     dest = web_artifacts_dir(root)
     # Before the first write, never after: a render that raised above must not
     # have removed the snippets the currently-deployed stack is still reading,

--- a/src/osprey/deployment/web_terminals/auth_credentials.py
+++ b/src/osprey/deployment/web_terminals/auth_credentials.py
@@ -68,6 +68,7 @@ from osprey.deployment.web_terminals.personas import (
     env_var_suffix,
     env_var_suffix_collisions,
 )
+from osprey.interfaces.web_auth import ROSTER_SECRET_ENV_PREFIX
 from osprey.services.auth_sidecar.passwords import hash_password
 from osprey.utils.dotenv import (
     DEPLOY_MINTED_BANNER,
@@ -111,8 +112,10 @@ SESSION_SECRET_VARS = (SESSION_SECRET_VAR, STATE_SECRET_VAR)
 #: reads it (to stamp the header on every proxied request) and so does that
 #: user's own terminal container (to verify it), and ``.env.auth`` is the file
 #: only the auth sidecar ever mounts. The deploy ``.env`` is the one store both
-#: of those services already interpolate from.
-TERMINAL_SECRET_VAR_PREFIX = "OSPREY_TERMINAL_SECRET_"
+#: of those services already interpolate from. Spelled by the web gate that
+#: verifies these secrets (:data:`osprey.interfaces.web_auth.ROSTER_SECRET_ENV_PREFIX`),
+#: so the mint and the gate cannot disagree about the prefix.
+TERMINAL_SECRET_VAR_PREFIX = ROSTER_SECRET_ENV_PREFIX
 
 #: What a terminal-secret refusal calls the thing it could not provision. The
 #: mint runs in EVERY auth method, so this message reaches operators who

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -191,6 +191,11 @@ def lint_web_terminals(
                 root, web_terminals, users, project_root=project_root
             )
         )
+        # Same split, for the ARIEL mirror: entitlement from the persona's
+        # config, the bind's source and target from the deploy's.
+        findings.extend(
+            _check_persona_mirror_agreement(root, web_terminals, users, project_root=project_root)
+        )
         # Resolves notice paths against the project directory, so it rides the
         # same gate: a profile has no rendered project to look in yet.
         findings.extend(_check_notice_docs(root, web_terminals))
@@ -1764,6 +1769,91 @@ def _check_persona_bundle_path_agreement(
                     "persona's knowledge tools read its own, so that container would "
                     "see an empty bundle and report no error. Make the two agree"
                 ),
+            )
+        )
+    return findings
+
+
+def _read_config(config_yml_path: Path) -> dict[str, Any]:
+    """Best-effort parse of a rendered ``config.yml``; ``{}`` on any failure,
+    like :func:`_read_bundle_path` (an unreadable project is already its own
+    finding)."""
+    try:
+        with config_yml_path.open("r", encoding="utf-8") as fh:
+            return as_dict(yaml.safe_load(fh))
+    except (OSError, yaml.YAMLError):
+        return {}
+
+
+def _check_persona_mirror_agreement(
+    root: dict[str, Any],
+    web_terminals: dict[str, Any],
+    users: list[Any],
+    *,
+    project_root: Path | None = None,
+) -> list[Finding]:
+    """Every persona that writes the ARIEL mirror must write the deployment's.
+
+    The mirror counterpart of :func:`_check_persona_bundle_path_agreement`.
+    **Entitlement** to the mirror bind is decided by each persona's own
+    rendered ``config.yml`` (does it run a qmd export with a ``mirror_path``?),
+    while the bind's SOURCE and its in-container TARGET both come from the
+    deploy config's ``ariel.enhancement_modules.qmd_export.mirror_path``. Two
+    ways for those to disagree, both silent:
+
+    * The deployment writes no mirror at all. The persona is entitled but the
+      overlay emits no bind (there is no source), so its exporter writes the
+      mirror into the container's writable layer — indexed by nothing,
+      discarded at the next recreate — while every layer reports success.
+    * The deployment writes one somewhere else. The deployment's directory is
+      bound at the deployment's path; the persona's exporter writes its own
+      path, which nothing mounted.
+
+    An ERROR: nothing at run time resolves either, and a search that returns
+    nothing looks exactly like a logbook with nothing in it.
+    """
+    from osprey.deployment.compose_generator import configured_ariel_mirror_path
+
+    deploy_mirror = configured_ariel_mirror_path(root)
+
+    catalog = _persona_catalog(web_terminals)
+    findings: list[Finding] = []
+    for persona_name in sorted(_referenced_persona_names(web_terminals, users)):
+        entry = catalog.get(persona_name)
+        if not isinstance(entry, dict):
+            continue
+        project_path_raw = entry.get("project_path")
+        if not isinstance(project_path_raw, str) or not project_path_raw:
+            continue
+        config_yml = (project_root or Path(".")) / project_path_raw / "config.yml"
+        if not config_yml.is_file():
+            continue
+        persona_mirror = configured_ariel_mirror_path(_read_config(config_yml))
+        if persona_mirror is None or persona_mirror == deploy_mirror:
+            continue
+        if deploy_mirror is None:
+            message = (
+                f"persona {persona_name!r} runs an ARIEL qmd export writing "
+                f"{persona_mirror!r}, but this deployment runs none, so no mirror "
+                "directory is bound into that container: its exporter would write into "
+                "the container's writable layer, which the qmd sidecar never indexes and "
+                "the next recreate discards. Enable the export on the hosting profile "
+                "(one shared mirror, indexed by the sidecar) or switch it off in the "
+                "persona"
+            )
+        else:
+            message = (
+                f"persona {persona_name!r} sets ariel.enhancement_modules.qmd_export."
+                f"mirror_path to {persona_mirror!r}, but this deployment sets "
+                f"{deploy_mirror!r}. The mirror is bind-mounted at the DEPLOYMENT's path "
+                "while the persona's exporter writes its own, so its entries would land "
+                "in the writable layer and never reach the sidecar. Make the two agree"
+            )
+        findings.append(
+            Finding(
+                severity="error",
+                code="web_terminals.persona_mirror_path_divergence",
+                message=message,
             )
         )
     return findings

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -70,6 +70,12 @@ def as_dict(value: Any) -> dict[str, Any]:
 #: no separate config key to set (and to forget to set) alongside it.
 EVENTS_PANEL_ID = "events"
 
+#: The bluesky-web sidecar's tab. A persona that declares it proxies into the
+#: sidecar with its own operator secret, so the sidecar is handed that user's
+#: secret variable (the web overlay's ``bluesky-web`` fragment) — the panel
+#: declaration IS the entitlement, exactly as for :data:`EVENTS_PANEL_ID`.
+BLUESKY_PANEL_ID = "bluesky"
+
 
 def config_declares_panel(config: Any, panel_id: str) -> bool:
     """True if ``config`` declares ``web.panels.<panel_id>`` and hasn't disabled it.
@@ -136,6 +142,25 @@ def config_needs_facility_bundle(config: Any) -> bool:
     """
     bundle_path = as_dict(as_dict(config).get("facility_knowledge")).get("bundle_path")
     return isinstance(bundle_path, str) and bool(bundle_path.strip())
+
+
+def config_needs_ariel_mirror(config: Any) -> bool:
+    """True if ``config`` runs an ARIEL qmd export that writes a mirror.
+
+    The entitlement to have the deployment's ARIEL markdown mirror bound into
+    this project's container, and the mirror counterpart of
+    :func:`config_needs_facility_bundle`. Read through the same reader the
+    sidecar's corpus list and the deploy's provisioning use
+    (:func:`osprey.deployment.compose_generator.configured_ariel_mirror_path`),
+    because the key IS the entitlement: an enabled export with a path is a
+    writer, and a writer inside a container that mounts nothing fills the
+    container's writable layer — a tree the sidecar never indexes and the next
+    recreate discards. A disabled export, or one naming no path, writes
+    nothing and so entitles nothing.
+    """
+    from osprey.deployment.compose_generator import configured_ariel_mirror_path
+
+    return configured_ariel_mirror_path(as_dict(config)) is not None
 
 
 def config_needs_launch_token(config: Any) -> bool:
@@ -387,6 +412,75 @@ def personas_needing_dispatcher_token(config: Any, project_root: Any) -> set[str
     return _personas_whose_config(config, project_root, config_needs_dispatcher_token)
 
 
+def config_declares_bluesky_panel(config: Any) -> bool:
+    """Whether this project shows the BLUESKY tab, and so proxies into the
+    bluesky-web sidecar with its own operator secret."""
+    return config_declares_panel(config, BLUESKY_PANEL_ID)
+
+
+def personas_declaring_bluesky_panel(config: Any, project_root: Any) -> set[str]:
+    """Names of catalog personas whose rendered project declares the BLUESKY tab.
+
+    :param config: The parsed deploy config.
+    :param project_root: Deploy project root; relative ``project_path`` values
+        resolve against it.
+    :return: The subset of referenced persona names whose users' operator
+        secrets the bluesky-web sidecar is handed (see
+        :func:`config_declares_bluesky_panel`).
+    """
+    return _personas_whose_config(config, project_root, config_declares_bluesky_panel)
+
+
+def bluesky_panel_secret_env_vars(config: Any, project_root: Any) -> list[str]:
+    """The per-user secret variables the bluesky-web sidecar is handed.
+
+    One name per roster user whose terminal shows the BLUESKY tab — and so
+    proxies into the sidecar with the operator secret ITS container holds,
+    under the fixed ``OSPREY_TERMINAL_SECRET`` name. The sidecar's own compose
+    file (``services/bluesky_web``) lists each of these variables so its web
+    gate accepts every entitled user's secret beside the deployment-wide one,
+    and no user's container is ever handed the deployment secret.
+
+    Entitlement is decided the way the web-terminal render decides every
+    per-user grant: a user with a persona (their own, else
+    ``default_persona``) by that persona's rendered ``config.yml``
+    (:func:`personas_declaring_bluesky_panel`); a persona-less user runs the
+    deployment's own project, so the deploy config answers for them. Roster
+    order, so the rendered compose is stable across runs.
+
+    Read off the personas' rendered ``config.yml`` files, like every other
+    per-persona grant — so the render that carries it is the deploy's:
+    ``osprey up`` re-renders every services compose file from the repo root
+    with the persona projects in place, while ``osprey build`` renders the
+    services compose before its persona renders and so lists nothing (or what
+    the previous build's personas declared).
+
+    :param config: The parsed deploy config.
+    :param project_root: Deploy project root; relative ``project_path`` values
+        resolve against it.
+    :return: Variable names (``OSPREY_TERMINAL_SECRET_<SUFFIX>``), one per
+        entitled user; empty when no user shows the tab.
+    """
+    from osprey.deployment.web_terminals.auth_credentials import terminal_secret_var
+
+    web_terminals = as_dict(as_dict(as_dict(config).get("modules")).get("web_terminals"))
+    raw_users = web_terminals.get("users")
+    refs = _persona_ref_by_name(raw_users)
+    default_persona = web_terminals.get("default_persona")
+    if not isinstance(default_persona, str) or not default_persona:
+        default_persona = None
+    entitled_personas = personas_declaring_bluesky_panel(config, project_root)
+    deploy_declares = config_declares_bluesky_panel(config)
+
+    names: list[str] = []
+    for entry in normalize_users(raw_users):
+        persona = refs.get(entry["name"]) or default_persona
+        entitled = persona in entitled_personas if persona else deploy_declares
+        if entitled:
+            names.append(terminal_secret_var(entry["name"]))
+    return names
+
+
 def personas_needing_ariel_password(config: Any, project_root: Any) -> set[str]:
     """Names of catalog personas whose rendered project configures ARIEL.
 
@@ -409,6 +503,18 @@ def personas_needing_facility_bundle(config: Any, project_root: Any) -> set[str]
         deployment bundle bind-mounted (see :func:`config_needs_facility_bundle`).
     """
     return _personas_whose_config(config, project_root, config_needs_facility_bundle)
+
+
+def personas_needing_ariel_mirror(config: Any, project_root: Any) -> set[str]:
+    """Names of catalog personas whose rendered project writes the ARIEL mirror.
+
+    :param config: The parsed deploy config.
+    :param project_root: Deploy project root; relative ``project_path`` values
+        resolve against it.
+    :return: The subset of referenced persona names whose container gets the
+        deployment's mirror bind-mounted (see :func:`config_needs_ariel_mirror`).
+    """
+    return _personas_whose_config(config, project_root, config_needs_ariel_mirror)
 
 
 def personas_needing_launch_token(config: Any, project_root: Any) -> set[str]:

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -31,9 +31,11 @@ from osprey.deployment.compose_generator import (
     compose_base_cmd,
     compose_provider_env,
     ensure_shared_corpus_dir,
+    resolve_ariel_mirror_dir,
     resolve_facility_bundle_dir,
     resolve_project_name,
     resolve_repo_root,
+    resolve_user_audit_dir,
 )
 from osprey.deployment.runtime_helper import (
     ComposeProvider,
@@ -74,6 +76,7 @@ from osprey.deployment.web_terminals.personas import (
     entry_requires_login,
     normalize_users,
     resolve_personas,
+    roster_user_names,
 )
 from osprey.deployment.web_terminals.postup_hooks import (
     enable_linger,
@@ -84,6 +87,7 @@ from osprey.deployment.web_terminals.postup_hooks import (
 from osprey.deployment.web_terminals.render import _auth_tls_context
 from osprey.deployment.web_terminals.seeding import seed_user_containers
 from osprey.utils.logger import get_logger
+from osprey.utils.workspace import AUDIT_DIR_RELPATH
 
 logger = get_logger("deployment.lifecycle")
 
@@ -1337,6 +1341,28 @@ def deploy_up_web_terminals(
                 f"Facility-knowledge bundle shared via group {bundle_gid} "
                 "(every web terminal joins it; the sidecar indexes it read-only)."
             )
+
+    # The ARIEL qmd mirror, for exactly the reasons above: every entitled
+    # terminal's own qmd_export module writes into it, the sidecar indexes it
+    # read-only, and the render can only emit the group it can read off disk.
+    mirror_dir = resolve_ariel_mirror_dir(config, repo_root)
+    if mirror_dir is not None:
+        mirror_gid = ensure_shared_corpus_dir(mirror_dir, relative_to=repo_root)
+        if mirror_gid is not None:
+            logger.info(
+                f"ARIEL qmd mirror shared via group {mirror_gid} "
+                "(every entitled web terminal writes it; the sidecar indexes it read-only)."
+            )
+
+    # Each roster user's audit zone (`var/audit/<user>/`), bound into that
+    # user's container where its python executor appends the refusal log. The
+    # zone's root is provisioned first so the per-user directories inherit
+    # its group — the one the render emits for every service — and each
+    # subdirectory is created here rather than by the runtime, which would
+    # create a missing bind source owned by root.
+    ensure_shared_corpus_dir(Path(repo_root) / AUDIT_DIR_RELPATH, relative_to=repo_root)
+    for user in roster_user_names((config.get("modules") or {}).get("web_terminals") or {}):
+        ensure_shared_corpus_dir(resolve_user_audit_dir(repo_root, user), relative_to=repo_root)
 
     write_web_terminal_artifacts(config, repo_root)
 

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -20,9 +20,11 @@ from urllib.parse import quote
 from jinja2 import Environment, FileSystemLoader
 
 from osprey.deployment.compose_generator import (
+    configured_ariel_mirror_path,
     repo_identity,
     repo_relative_mount_source,
     resolve_repo_root,
+    user_audit_relpath,
 )
 from osprey.deployment.web_terminals.auth_credentials import (
     TERMINAL_SECRET_VAR_PREFIX,
@@ -33,6 +35,7 @@ from osprey.deployment.web_terminals.personas import (
     USERNAME_CHARSET_RE,
     as_dict,
     config_archiver_password_env,
+    config_needs_ariel_mirror,
     config_needs_ariel_password,
     config_needs_dispatcher_token,
     config_needs_facility_bundle,
@@ -50,7 +53,7 @@ from osprey.deployment.web_terminals.ports import (
     base_ports_from_config,
 )
 from osprey.utils.facility import resolve_facility_name
-from osprey.utils.workspace import agent_data_base_dir
+from osprey.utils.workspace import AUDIT_DIR_RELPATH, agent_data_base_dir
 
 # Package-relative location of the .j2 sources (Tasks 1.3/1.6). Resolved via
 # importlib.resources, NOT Path(__file__).parent, so this works from an installed
@@ -510,6 +513,53 @@ def _container_bundle_dir(config: Any, container_project_dir: str) -> str | None
     return (PurePosixPath(container_project_dir) / base).as_posix()
 
 
+def _container_mirror_dir(config: Any, container_project_dir: str) -> str | None:
+    """Where the deployment's ARIEL qmd mirror mounts, as this container sees it.
+
+    The mirror counterpart of :func:`_container_bundle_dir`, derived the same
+    way and for the same reason: the target has to be the directory the
+    exporter inside the container actually WRITES — it resolves
+    ``ariel.enhancement_modules.qmd_export.mirror_path`` against the project
+    root, which in-container is *container_project_dir* — or the bind covers
+    nothing and the container's own logbook enhancements land in its writable
+    layer, unindexed by the sidecar and gone at the next recreate. Read through
+    the one reader every other consumer of the key uses
+    (:func:`~osprey.deployment.compose_generator.configured_ariel_mirror_path`),
+    ``settings`` winning over the module block exactly as the exporter merges
+    them. Absolute values are not re-anchored, as for the bundle. Same known
+    limit as its sibling: the path is read from the DEPLOY config, not each
+    persona's own, and the lint reports a persona that relocated it.
+
+    :return: The in-container mount target, or ``None`` when the deployment
+        writes no mirror at all.
+    """
+    from osprey.deployment.compose_generator import configured_ariel_mirror_path
+
+    raw = configured_ariel_mirror_path(as_dict(config))
+    if raw is None:
+        return None
+    base = PurePosixPath(raw)
+    if base.is_absolute():
+        return base.as_posix()
+    return (PurePosixPath(container_project_dir) / base).as_posix()
+
+
+def _container_audit_dir(container_project_dir: str) -> str:
+    """Where a per-user container's audit zone mounts, as that container sees it.
+
+    The python executor appends its refusal log under
+    ``<project root>/<AUDIT_DIR_RELPATH>``
+    (:func:`osprey.services.python_executor.refusal_audit.audit_dir`), and the
+    project root in-container is *container_project_dir*. Derived from the
+    same constant the writer uses rather than spelled here, for the reason
+    :func:`_container_agent_data_dir` gives: a path the container does not
+    write to is a mount over an empty directory, while the log — the one
+    record of what the agent tried and was refused — accumulates in the
+    writable layer and vanishes at the next recreate.
+    """
+    return (PurePosixPath(container_project_dir) / AUDIT_DIR_RELPATH).as_posix()
+
+
 def render_web_terminals(
     config: Any,
     auth_env_digest: str | None = None,
@@ -519,6 +569,9 @@ def render_web_terminals(
     graphdb_personas: set[str] | None = None,
     facility_bundle_personas: set[str] | None = None,
     facility_bundle_gid: int | None = None,
+    ariel_mirror_personas: set[str] | None = None,
+    ariel_mirror_gid: int | None = None,
+    audit_gid: int | None = None,
     archiver_password_personas: dict[str, str] | None = None,
     terminal_secrets: dict[str, str] | None = None,
 ) -> dict[str, str]:
@@ -618,6 +671,25 @@ def render_web_terminals(
             directory does not exist yet, or a platform with no gids) emits no
             ``group_add``, which is the honest render rather than a guessed
             group.
+        ariel_mirror_personas: Persona names whose project runs an ARIEL qmd
+            export that writes a mirror, and whose container therefore gets the
+            deployment's mirror directory bind-mounted at the path its own
+            exporter writes (see
+            :func:`osprey.deployment.web_terminals.personas.personas_needing_ariel_mirror`).
+            Same placement and same reason as ``facility_bundle_personas``:
+            a mount, not a secret, resolved from disk and passed in. Without it
+            an entry enhanced inside that container is written into the
+            container's writable layer — never indexed by the sidecar, gone at
+            the next recreate. ``None`` emits no mount for any user.
+        ariel_mirror_gid: Group id of the mirror directory on the host, for
+            the same ``group_add:`` reason as ``facility_bundle_gid``. ``None``
+            emits no group for it.
+        audit_gid: Group id of the deployment's audit zone on the host
+            (``var/audit``), under which the deploy provisions one directory
+            per roster user and this render binds it at the user's container
+            audit path. Every per-user service joins it, because every
+            container writes its refusal log there. ``None`` emits no group
+            for it.
         archiver_password_personas: ``{persona_name: env_var_name}`` for the
             personas whose archiver connector authenticates with a password,
             resolved from disk by
@@ -853,6 +925,28 @@ def render_web_terminals(
                     )
                     else None
                 ),
+                # Where the deployment's ARIEL qmd mirror mounts inside THIS
+                # user's container, or None when the user is not entitled or
+                # the deployment writes no mirror. Same shape and same reason
+                # as container_bundle_dir: per service, and the template
+                # cannot emit the mount without a target.
+                "container_mirror_dir": (
+                    _container_mirror_dir(root, entry["container_project_dir"])
+                    if (
+                        entry["persona"] in (ariel_mirror_personas or set())
+                        if entry.get("persona")
+                        else config_needs_ariel_mirror(root)
+                    )
+                    else None
+                ),
+                # Where this user's refusal audit log is written inside the
+                # container, and the host directory that backs it. Every user,
+                # unconditionally: the python executor runs in every persona
+                # and its audit zone is the one path here that the roster's
+                # tier does not gate. The source is per user so two containers
+                # writing the same fixed filename cannot clobber each other.
+                "container_audit_dir": _container_audit_dir(entry["container_project_dir"]),
+                "audit_source": repo_relative_mount_source(user_audit_relpath(entry["name"])),
             }
         )
 
@@ -925,6 +1019,7 @@ def render_web_terminals(
     # only the target differs per persona.
     raw_bundle_path = as_dict(root.get("facility_knowledge")).get("bundle_path")
     bundle_path = raw_bundle_path.strip() if isinstance(raw_bundle_path, str) else ""
+    mirror_path = configured_ariel_mirror_path(root)
 
     compose_ctx = {
         "facility_prefix": facility_prefix,
@@ -971,6 +1066,19 @@ def render_web_terminals(
         # `group_add` accepts group names as well as numeric ids, and quoting
         # keeps a numeric one from being read as anything else.
         "facility_bundle_gid": str(facility_bundle_gid) if facility_bundle_gid is not None else "",
+        # The ONE host directory every entitled user's mirror mount writes into
+        # — the deployment's mirror, the same one the qmd sidecar indexes and
+        # the host exporter fills — spelled through the same bind-source rule
+        # as the bundle above and for the same reasons. Empty string when the
+        # deployment writes no mirror.
+        "ariel_mirror_source": (
+            repo_relative_mount_source(mirror_path) if mirror_path is not None else ""
+        ),
+        "ariel_mirror_gid": str(ariel_mirror_gid) if ariel_mirror_gid is not None else "",
+        # The group of the deployment's audit zone, joined by every per-user
+        # service; its per-user subdirectories are provisioned by the deploy
+        # with the same inherited group.
+        "audit_gid": str(audit_gid) if audit_gid is not None else "",
         **auth_tls_ctx,
     }
 

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -19,6 +19,7 @@ from urllib.parse import quote
 
 from jinja2 import Environment, FileSystemLoader
 
+from osprey.bluesky_bridge_connection import discover_lane_keys, lane_env_prefix
 from osprey.deployment.compose_generator import (
     configured_ariel_mirror_path,
     repo_identity,
@@ -1026,6 +1027,15 @@ def render_web_terminals(
         "registry_url": registry.get("url") or "",
         "image_source": image_source,
         "services": services,
+        # The launch token of every plan lane this deployment renders, granted
+        # together to each entitled persona (`svc.wants_launch_token`): lane
+        # 1's `BLUESKY_LAUNCH_TOKEN` alone on the single-lane deployment every
+        # project is by default, plus the second lane's own on a deployment
+        # that opted into one. Read off the deploy config's `services.<lane>`
+        # blocks, which is how every other lane consumer counts lanes.
+        "launch_token_env_vars": [
+            f"{lane_env_prefix(lane)}_LAUNCH_TOKEN" for lane in discover_lane_keys(root)
+        ],
         "nginx_port": nginx_port,
         "landing_url": landing_url,
         "facility_timezone": facility.get("timezone") or "UTC",

--- a/src/osprey/health/core/__init__.py
+++ b/src/osprey/health/core/__init__.py
@@ -32,7 +32,7 @@ core, YAML and plugin categories.
 
 Lazy resolution
 ----------------
-``CORE_CATEGORIES`` is a lazy mapping: iterating it yields the thirteen canonical
+``CORE_CATEGORIES`` is a lazy mapping: iterating it yields the fourteen canonical
 names without importing anything, and indexing a name imports only that one
 sibling module on demand. Sibling category modules are authored independently
 and must never edit this file; a not-yet-written or import-failing module
@@ -55,7 +55,7 @@ CategoryCallable = Callable[[], "list[CheckResult] | Awaitable[list[CheckResult]
 CategoryFactory = Callable[..., CategoryCallable]
 
 # Canonical category name -> (sibling module name, factory attribute) within
-# this package. Static so the thirteen valid names are known without importing any
+# this package. Static so the fourteen valid names are known without importing any
 # sibling module; resolution imports the module lazily on first access.
 _CORE_CATEGORY_SPECS: dict[str, tuple[str, str]] = {
     "configuration": ("configuration", "configuration"),
@@ -71,6 +71,7 @@ _CORE_CATEGORY_SPECS: dict[str, tuple[str, str]] = {
     "channel_finder": ("channel_finder", "channel_finder"),
     "graphdb": ("graphdb", "graphdb"),
     "web_panels": ("web_panels", "web_panels"),
+    "reach": ("reach", "reach"),
 }
 
 
@@ -102,7 +103,7 @@ class _LazyCoreCategoryRegistry(Mapping[str, CategoryFactory]):
 
 CORE_CATEGORIES: Mapping[str, CategoryFactory] = _LazyCoreCategoryRegistry()
 
-# The thirteen canonical core category names, without importing any sibling module.
+# The fourteen canonical core category names, without importing any sibling module.
 CORE_CATEGORY_NAMES: tuple[str, ...] = tuple(_CORE_CATEGORY_SPECS)
 
 

--- a/src/osprey/health/core/ariel.py
+++ b/src/osprey/health/core/ariel.py
@@ -9,8 +9,10 @@ contributes no rows (a silent skip), so a minimal build shows no ARIEL tile at
 all.
 
 When configured the category issues a single ``GET /api/status`` request against
-``deployment.bind_address`` + ``ariel.web.port`` and derives every row from that
-one response:
+the address the panel actually binds —
+:func:`osprey.registry.web.resolve_web_server_address` for ``"ariel"``, the one
+derivation the panel launcher itself is bound to — and derives every row from
+that one response:
 
 * ``ariel_status`` — the interface is reachable (``ok`` with ``latency_ms``);
   ``warning`` when the store reports itself unhealthy, and — as the sole row —
@@ -29,6 +31,13 @@ one response:
 
 Every row is advisory (``ok``/``warning``); the interface's absence is never an
 error, and a single unreachable probe never crashes the suite.
+
+The address is never re-derived here from ``ariel.web.port`` alone. Multi-user
+compose renders export ``OSPREY_ARIEL_PORT`` per user because the per-user
+containers share the host network namespace, and the registry resolver is
+what honours that override; a config-only reading probed the default port
+inside every multi-user terminal while the panel listened elsewhere, and
+reported ARIEL unreachable in exactly the deployments that run it.
 """
 
 from __future__ import annotations
@@ -40,6 +49,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from osprey.health.models import CheckResult, Status
+from osprey.registry.web import WebServerConfigDepthError, resolve_web_server_address
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -49,9 +59,11 @@ if TYPE_CHECKING:
 
 CATEGORY = "ariel"
 
+#: Registry key of the ARIEL panel — the address this category probes is the
+#: one the launcher binds for it.
+_REGISTRY_KEY = "ariel"
+
 _STATUS_TIMEOUT_S = 5.0
-_DEFAULT_PORT = 8085  # mirrors registry.web ariel port_default
-_DEFAULT_BIND = "127.0.0.1"
 
 
 def ariel(
@@ -64,8 +76,8 @@ def ariel(
 
     Args:
         config: Parsed config mapping (``None`` when config is unavailable). Read
-            for the top-level ``ariel`` block (presence gate + ``ariel.web.port``)
-            and ``deployment.bind_address``.
+            for the top-level ``ariel`` block (the presence gate) and, through
+            the registry resolver, the panel's ``ariel.web`` address.
         context: Health runtime. Unused — ARIEL is probed over HTTP, no
             control-system connector is needed.
         transport: Optional httpx transport for dependency injection in tests
@@ -81,10 +93,22 @@ def ariel(
         if not isinstance(ariel_block, dict) or not ariel_block:
             return []
 
-        ariel_cfg = ariel_block.get("web") or {}
-        port = ariel_cfg.get("port", _DEFAULT_PORT)
-        bind = (cfg.get("deployment", {}) or {}).get("bind_address", _DEFAULT_BIND)
-        url = f"http://{bind}:{port}/api/status"
+        try:
+            host, port = resolve_web_server_address(_REGISTRY_KEY, cfg)
+        except WebServerConfigDepthError as exc:
+            # The panel's own launch pre-flight refuses this config; what the
+            # advisory row owes the operator is the key to fix, not a probe of
+            # an address nothing can derive.
+            return [
+                CheckResult(
+                    "ariel_status",
+                    CATEGORY,
+                    Status.WARNING,
+                    "ARIEL panel address is misconfigured",
+                    details=str(exc),
+                )
+            ]
+        url = f"http://{host}:{port}/api/status"
 
         status_row, payload = await _fetch_status(url, transport)
         if payload is None:

--- a/src/osprey/health/core/reach.py
+++ b/src/osprey/health/core/reach.py
@@ -1,0 +1,188 @@
+"""Core ``reach`` health category.
+
+Reports whether each shared service this render's clients are switched on for
+answers at the address **the client itself dials** — one row per service,
+all knocked on concurrently.
+
+This is the run-time half of the Reach Contract
+(:mod:`osprey.deployment.reach`). The build refuses a consumer switched on
+with nothing to resolve; this category takes the consumers that passed and
+asks the only question left: from *here*, does anything answer? "Here" is
+what makes the row worth having. The ``ariel``, ``graphdb`` and
+``openobserve`` categories probe a service where its config block says it is;
+this one resolves the endpoint through the consumer's own resolver — the
+bridge URL the bluesky MCP server builds, the DSN the panel server derives,
+the OTLP endpoint the exporter posts to, env overrides included — in the
+process that runs the check. Run inside a per-user container by the health
+MCP server, the rows say what that container's agent will reach; run by
+``osprey health`` on the host, what the host's own processes will.
+
+A knock is a TCP connect and nothing more: every shared service is a TCP
+listener, and what this category owes the operator is "the port the client
+dials is open", not a second implementation of each service's health
+contract. Rows are advisory (``ok``/``warning``), matching ``web_panels``: a
+service that is down is a warning, never a suite error, and a consumer whose
+client has nothing to dial — the state the build refuses, met at run time —
+is a warning naming the switch and the key. With no live consumer the
+category contributes no rows at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+from osprey.deployment.reach import Consumer, Dial, ReachContract, reach_dials
+from osprey.health.models import CheckResult, Status
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from osprey.health.core import CategoryCallable
+    from osprey.health.runtime import HealthRuntime
+
+CATEGORY = "reach"
+
+_KNOCK_TIMEOUT_S = 3.0
+
+#: Opens a TCP connection to ``(host, port)`` and closes it, raising
+#: :class:`OSError` (or :class:`TimeoutError`) when nothing answers.
+Knock = Callable[[str, int], Awaitable[None]]
+
+
+class _Target(NamedTuple):
+    """One shared service to knock on, for every live consumer that dials it.
+
+    Attributes:
+        contract: The service's contract, for the row name and the remedy.
+        consumers: The live consumers, in registry order; all share one dial.
+        dial: What they connect to, or ``None`` when the client resolves
+            nothing.
+    """
+
+    contract: ReachContract
+    consumers: tuple[Consumer, ...]
+    dial: Dial | None
+
+
+def reach(
+    config: Mapping[str, Any] | None = None,
+    context: HealthRuntime | None = None,
+    *,
+    knock: Knock | None = None,
+) -> CategoryCallable:
+    """Build the ``reach`` category callable.
+
+    Args:
+        config: Parsed config mapping (``None`` when config is unavailable).
+            Every consumer switch and resolver in the registry reads it.
+        context: Health runtime. Unused — the knock is a plain TCP connect.
+        knock: Optional connect function for dependency injection in tests;
+            ``None`` opens a real connection.
+
+    Returns:
+        A no-argument async callable returning the category's check results.
+    """
+    cfg: Mapping[str, Any] = config or {}
+
+    async def _run() -> list[CheckResult]:
+        targets = _targets(cfg)
+        if not targets:
+            return []
+        rows = await asyncio.gather(*(_probe(t, knock or _tcp_knock) for t in targets))
+        return sorted(rows, key=lambda row: row.name)
+
+    return _run
+
+
+def _targets(cfg: Mapping[str, Any]) -> list[_Target]:
+    """One target per service with a live consumer.
+
+    Consumers of one service dial through one resolver (hybrid search and the
+    OKF panel both ask :func:`osprey.deployment.qmd_service.resolve_qmd_service_config`),
+    so a service is knocked on once and its row names every consumer that
+    depends on the answer.
+    """
+    by_service: dict[str, _Target] = {}
+    for contract, consumer, dial in reach_dials(cfg):
+        target = by_service.get(contract.service)
+        if target is None:
+            by_service[contract.service] = _Target(contract, (consumer,), dial)
+        else:
+            by_service[contract.service] = target._replace(
+                consumers=(*target.consumers, consumer), dial=target.dial or dial
+            )
+    return list(by_service.values())
+
+
+async def _tcp_knock(host: str, port: int) -> None:
+    """Open and close one TCP connection, within the knock timeout."""
+    _reader, writer = await asyncio.wait_for(
+        asyncio.open_connection(host, port), timeout=_KNOCK_TIMEOUT_S
+    )
+    writer.close()
+    await writer.wait_closed()
+
+
+async def _probe(target: _Target, knock: Knock) -> CheckResult:
+    """Knock on one target and turn the outcome into a row."""
+    # `<category>.<service>`: the dashboard's fmtName() strips the leading
+    # category segment, so the row reads "Qmd" / "Postgresql" / "Bluesky".
+    name = f"{CATEGORY}.{target.contract.service}"
+    who = " / ".join(consumer.name for consumer in target.consumers)
+    switches = ", ".join(consumer.switch_key for consumer in target.consumers)
+    keys = ", ".join(projected.key for projected in target.contract.projected) or (
+        f"services.{target.contract.service}"
+    )
+
+    if target.dial is None:
+        degrades = all(not consumer.refuse for consumer in target.consumers)
+        return CheckResult(
+            name,
+            CATEGORY,
+            Status.WARNING,
+            f"{who}: nothing to dial",
+            value="unresolved",
+            details=(
+                f"Switched on ({switches}) but this config resolves no endpoint for it: "
+                f"no {keys}. "
+                + (
+                    "The consumer degrades without one, by design. "
+                    if degrades
+                    else "Every use will fail. "
+                )
+                + "An attached render is told the key by the build from its hosting "
+                "deployment; name it under `config:` or switch the consumer off."
+            ),
+        )
+
+    host, port = target.dial
+    address = f"{host}:{port}"
+    start = time.perf_counter()
+    try:
+        await knock(host, port)
+    except (OSError, TimeoutError) as exc:
+        return CheckResult(
+            name,
+            CATEGORY,
+            Status.WARNING,
+            f"{who}: unreachable at {address}",
+            value="offline",
+            details=(
+                f"{address} — {exc or 'no answer'}. This is the address the client "
+                f"itself resolves from this config ({keys}) and would connect to from "
+                f"here; check that the service is up and published on that port on "
+                f"the host it shares with this render."
+            ),
+        )
+
+    return CheckResult(
+        name,
+        CATEGORY,
+        Status.OK,
+        f"{who}: reachable at {address}",
+        value="up",
+        latency_ms=(time.perf_counter() - start) * 1000.0,
+    )

--- a/src/osprey/health/records.py
+++ b/src/osprey/health/records.py
@@ -59,6 +59,7 @@ CONFIG_DEPENDENT = frozenset(
         "channel_finder",
         "graphdb",
         "web_panels",
+        "reach",
     }
 )
 

--- a/src/osprey/interfaces/web_auth.py
+++ b/src/osprey/interfaces/web_auth.py
@@ -74,6 +74,8 @@ __all__ = [
     "BIND_HOST_ENV",
     "DEFAULT_SESSION_TTL_SECONDS",
     "OPERATOR_SECRET_ENV",
+    "ROSTER_ACCEPT_ENV",
+    "ROSTER_SECRET_ENV_PREFIX",
     "PANEL_REGISTER_ROUTE",
     "PANEL_TIER_ROUTES",
     "PANEL_TOKEN_ENV",
@@ -91,6 +93,28 @@ __all__ = [
 #: ``.env`` supplies it per user and nginx forwards the same value as a header;
 #: in the single-user shape nothing sets it and this module mints one.
 OPERATOR_SECRET_ENV = "OSPREY_TERMINAL_SECRET"
+
+#: Prefix of the per-user operator secrets a multi-user deployment mints
+#: (``OSPREY_TERMINAL_SECRET_<USER>``). Each per-user container receives its
+#: own under the fixed name above; a shared sidecar that per-user terminals
+#: proxy into — the bluesky-web panel — is handed every entitled user's
+#: variable under its own name — with :data:`ROSTER_ACCEPT_ENV` beside them —
+#: and accepts any of them, so a persona presenting its own secret is let in
+#: without the deployment-wide one ever leaving the deploy ``.env``. The one
+#: definition of the prefix: the mint
+#: (:data:`osprey.deployment.web_terminals.auth_credentials.TERMINAL_SECRET_VAR_PREFIX`)
+#: and nginx's ``NGINX_ENVSUBST_FILTER`` spell it from here.
+ROSTER_SECRET_ENV_PREFIX = f"{OPERATOR_SECRET_ENV}_"
+
+#: The switch that lets a process ACCEPT the roster secrets it finds. Set to
+#: ``"1"`` in exactly one place: the bluesky-web sidecar's compose environment
+#: (``services/bluesky_web/docker-compose.yml``), beside the roster variables
+#: it lists. Every roster variable is popped from the environment wherever it
+#: is found — the deploy ``.env`` carries them all, and ``osprey web`` on the
+#: host loads that file — but only a process whose compose declared this flag
+#: treats them as operators. Without it the host's own terminal, loading the
+#: same ``.env``, would let any roster user in as its operator.
+ROSTER_ACCEPT_ENV = "OSPREY_TERMINAL_ACCEPT_ROSTER_SECRETS"
 
 #: The panel token's environment carrier.
 PANEL_TOKEN_ENV = "OSPREY_PANEL_TOKEN"
@@ -144,6 +168,13 @@ class WebCredentials:
     operator_secret: str
     panel_token: str
 
+    #: Other secrets that authorise as the operator: the per-user secrets of a
+    #: multi-user roster, handed to a shared sidecar whose environment also
+    #: sets :data:`ROSTER_ACCEPT_ENV` (see :data:`ROSTER_SECRET_ENV_PREFIX`).
+    #: Empty everywhere else — including a process that merely SEES roster
+    #: variables (the host's ``osprey web`` loading the deploy ``.env``).
+    roster_secrets: tuple[str, ...] = ()
+
     #: Live browser sessions, ``{session_id: monotonic deadline}``. Monotonic
     #: rather than wall-clock so a machine that adjusts its clock — an NTP step,
     #: a laptop resuming — cannot retroactively extend or void a session.
@@ -162,8 +193,16 @@ class WebCredentials:
         return f"WebCredentials(sessions={len(self.sessions)})"
 
     def verify_operator(self, candidate: str | None) -> bool:
-        """Whether ``candidate`` is the operator secret, compared in constant time."""
-        return _same_secret(candidate, self.operator_secret)
+        """Whether ``candidate`` is the operator secret — or one of the roster's
+        — each compared in constant time.
+
+        Every accepted secret is compared, never just until the first match,
+        so the answer's timing does not say which one matched.
+        """
+        matched = _same_secret(candidate, self.operator_secret)
+        for secret in self.roster_secrets:
+            matched = _same_secret(candidate, secret) or matched
+        return matched
 
     def verify_panel(self, candidate: str | None) -> bool:
         """Whether ``candidate`` is the panel token, compared in constant time.
@@ -287,6 +326,10 @@ def _populate() -> WebCredentials:
     # be the one path that leaks it.
     operator_secret = os.environ.pop(OPERATOR_SECRET_ENV, "").strip()
     supplied_panel_token = os.environ.pop(PANEL_TOKEN_ENV, "").strip()
+    # Popped unconditionally (they must not reach any child process); kept
+    # only where the compose environment said so — see ROSTER_ACCEPT_ENV.
+    harvested = _pop_roster_secrets()
+    roster_secrets = harvested if _roster_accepted() else ()
 
     if not operator_secret:
         if os.environ.get(BIND_HOST_ENV):
@@ -303,7 +346,30 @@ def _populate() -> WebCredentials:
     return WebCredentials(
         operator_secret=operator_secret,
         panel_token=supplied_panel_token or mint_secret(),
+        roster_secrets=roster_secrets,
     )
+
+
+def _roster_accepted() -> bool:
+    """Whether this process's environment opted in to the roster secrets.
+
+    Popped like the secrets themselves, so the flag is read once at
+    construction and inherited by nothing.
+    """
+    return os.environ.pop(ROSTER_ACCEPT_ENV, "").strip() == "1"
+
+
+def _pop_roster_secrets() -> tuple[str, ...]:
+    """Take every ``OSPREY_TERMINAL_SECRET_<USER>`` out of the environment.
+
+    Popped for the reason the operator secret is: a value left in
+    ``os.environ`` is inherited by every child this process spawns. Blank
+    values (an unset variable compose interpolated as ``${VAR:-}``) count as
+    absent. Sorted by name so the tuple is deterministic.
+    """
+    names = sorted(name for name in os.environ if name.startswith(ROSTER_SECRET_ENV_PREFIX))
+    values = (os.environ.pop(name, "").strip() for name in names)
+    return tuple(value for value in values if value)
 
 
 def get_web_credentials(app: Any = None) -> WebCredentials:
@@ -371,6 +437,8 @@ def close_env_carriers() -> None:
     """
     os.environ.pop(OPERATOR_SECRET_ENV, None)
     os.environ.pop(PANEL_TOKEN_ENV, None)
+    os.environ.pop(ROSTER_ACCEPT_ENV, None)
+    _pop_roster_secrets()
 
 
 def reset_web_credentials() -> None:

--- a/src/osprey/mcp_server/facility_knowledge/server.py
+++ b/src/osprey/mcp_server/facility_knowledge/server.py
@@ -163,7 +163,8 @@ def _resolve_bundle_path(config: dict, config_dir: Path) -> Path:
 
     Args:
         config: Parsed OSPREY config dict.
-        config_dir: Directory of the config file, used to resolve relative paths.
+        config_dir: Directory of the config file; relative paths resolve
+            against the project root derived from it.
 
     Returns:
         Absolute :class:`~pathlib.Path` to the bundle root.

--- a/src/osprey/profiles/presets/control-assistant-admin.yml
+++ b/src/osprey/profiles/presets/control-assistant-admin.yml
@@ -70,12 +70,15 @@ config:
   # containers). Without this override the inherited roster would make this
   # render try to host a second web tier on the same host ports.
   modules.web_terminals.enabled: false
-  # This persona is an attached render (`services: {}` — no graphdb block of
-  # its own), so the agent's graph tools need to be told which host-published
-  # bolt port the hosting deployment's `graphdb` store listens on. Per-user
-  # web-terminal containers run `network_mode: host`, so container
-  # `localhost` IS the deployment host. If an operator moves
-  # `services.graphdb.port_host` on the hosting deployment, this number must
-  # move with it here AND in control-assistant-readonly and
-  # control-assistant-readwrite.
-  services.graphdb.port_host: 7687
+  # Nothing here says where the hosting deployment's services are — the graph
+  # store's bolt port, the qmd sidecar's port, the Postgres the logbook lives
+  # in, the telemetry store, the bluesky bridge. This persona is an attached
+  # render (`services: {}` of its own) built beside that deployment, and the
+  # build copies every such fact from the deployment's own render into it
+  # (the Reach Contract, `osprey.deployment.reach`). Per-user web-terminal
+  # containers run `network_mode: host`, so container `localhost` IS the
+  # deployment host and the copied ports are dialed there. Move a port on the
+  # hosting profile and every persona follows; spell a different one here and
+  # the build refuses the contradiction. Built alone, with no hosting
+  # deployment in the repo, the build copies what the app template deploys
+  # at its defaults instead — and a host that differs IS named here.

--- a/src/osprey/profiles/presets/control-assistant-ariel.yml
+++ b/src/osprey/profiles/presets/control-assistant-ariel.yml
@@ -96,6 +96,12 @@ config:
   claude_code.servers.bluesky.enabled: false
   claude_code.servers.health.enabled: false
   claude_code.servers.osprey_facility_knowledge.enabled: false
+  # The graph store is a control-room surface too, and this tier's exclusion
+  # of it has to be said: the build tells every attached render where the
+  # hosting deployment's services are (the Reach Contract), and a
+  # `services.graphdb` block is what makes the graph server render. Only a
+  # server switched off is told nothing about the store.
+  claude_code.servers.graph.enabled: false
   # Pinned even though the server that would honour it is gone, for the same
   # reason the other two tiers pin it: this key is the write boundary, and it
   # must not drift if the base's default ever changes.
@@ -111,3 +117,13 @@ config:
   # containers). Without this override the inherited roster would make this
   # render try to host a second web tier on the same host ports.
   modules.web_terminals.enabled: false
+  # Nothing here says where the hosting deployment's services are — the qmd
+  # sidecar hybrid logbook search dials (the point of this tier), the Postgres
+  # the logbook lives in, the telemetry store. This persona is an attached
+  # render (`services: {}` of its own) built beside that deployment, and the
+  # build copies every such fact from the deployment's own render into it
+  # (the Reach Contract, `osprey.deployment.reach`). Per-user web-terminal
+  # containers run `network_mode: host`, so container `localhost` IS the
+  # deployment host and the copied ports are dialed there. Built alone, with
+  # no hosting deployment in the repo, the build copies what the app template
+  # deploys at its defaults instead — and a host that differs is named here.

--- a/src/osprey/profiles/presets/control-assistant-readonly.yml
+++ b/src/osprey/profiles/presets/control-assistant-readonly.yml
@@ -40,12 +40,15 @@ config:
   # per-user containers). Without this override the inherited roster would
   # make this render try to host a second web tier on the same host ports.
   modules.web_terminals.enabled: false
-  # This persona is an attached render (`services: {}` — no graphdb block of
-  # its own), so the agent's graph tools need to be told which host-published
-  # bolt port the hosting deployment's `graphdb` store listens on. Per-user
-  # web-terminal containers run `network_mode: host`, so container
-  # `localhost` IS the deployment host. If an operator moves
-  # `services.graphdb.port_host` on the hosting deployment, this number must
-  # move with it here AND in control-assistant-readwrite and
-  # control-assistant-admin.
-  services.graphdb.port_host: 7687
+  # Nothing here says where the hosting deployment's services are — the graph
+  # store's bolt port, the qmd sidecar's port, the Postgres the logbook lives
+  # in, the telemetry store, the bluesky bridge. This persona is an attached
+  # render (`services: {}` of its own) built beside that deployment, and the
+  # build copies every such fact from the deployment's own render into it
+  # (the Reach Contract, `osprey.deployment.reach`). Per-user web-terminal
+  # containers run `network_mode: host`, so container `localhost` IS the
+  # deployment host and the copied ports are dialed there. Move a port on the
+  # hosting profile and every persona follows; spell a different one here and
+  # the build refuses the contradiction. Built alone, with no hosting
+  # deployment in the repo, the build copies what the app template deploys
+  # at its defaults instead — and a host that differs IS named here.

--- a/src/osprey/profiles/presets/control-assistant-readwrite.yml
+++ b/src/osprey/profiles/presets/control-assistant-readwrite.yml
@@ -19,9 +19,12 @@ extends: control-assistant
 # connects to the shared web tier the hosting deployment runs on the same host.
 deploy_services: false
 
-# The write-oriented panels, listed beside their web.panels.<id>.url overrides
-# below (a panel id and its URL declaration travel together). Persona lists
-# UNION over the base, so these are added to the inherited builtin set.
+# The write-oriented panels. Persona lists UNION over the base, so these are
+# added to the inherited builtin set. Each tab's URL, path and label are not
+# spelled here: the hosting deployment's build derives them when it injects
+# the event dispatcher and the bluesky-web sidecar, and this attached render
+# is told them from that render (the Reach Contract, `osprey.deployment.reach`)
+# — so a sidecar moved on the hosting profile moves the tab with it.
 web_panels:
   - events          # EVENTS dashboard tab (event dispatcher)
   - bluesky         # Plan authoring, the plan queue, and the run's live results
@@ -40,29 +43,16 @@ config:
   # per-user containers). Without this override the inherited roster would
   # make this render try to host a second web tier on the same host ports.
   modules.web_terminals.enabled: false
-  # This persona is an attached render (`services: {}` — no graphdb block of
-  # its own), so the agent's graph tools need to be told which host-published
-  # bolt port the hosting deployment's `graphdb` store listens on. Per-user
-  # web-terminal containers run `network_mode: host`, so container
-  # `localhost` IS the deployment host. If an operator moves
-  # `services.graphdb.port_host` on the hosting deployment, this number must
-  # move with it here AND in control-assistant-readonly and
-  # control-assistant-admin.
-  services.graphdb.port_host: 7687
-  # EVENTS + BLUESKY: the write-oriented panels, declared HERE and not in the
-  # base so the readonly persona is built without them (a persona can only add
-  # config keys, never subtract inherited ones — see the note in the base's
-  # config: block).
-  # EVENTS — the event-dispatcher dashboard as an in-terminal tab. URL defaults
-  # to the host-run dispatcher; override EVENT_DISPATCHER_URL for
-  # containerized/remote web terminals.
-  web.panels.events.label: EVENTS
-  web.panels.events.url: "${EVENT_DISPATCHER_URL:-http://localhost:8020}"
-  web.panels.events.path: /dashboard
-  web.panels.events.health_endpoint: /health
-  # BLUESKY — operator UI for the mediated Bluesky stack, served by the
-  # bluesky-web sidecar. Override BLUESKY_WEB_URL for containerized/
-  # remote web terminals (same pattern as EVENTS above).
-  web.panels.bluesky.label: BLUESKY
-  web.panels.bluesky.url: "${BLUESKY_WEB_URL:-http://localhost:8095}"
-  web.panels.bluesky.path: /bluesky/
+  # Nothing here says where the hosting deployment's services are — the graph
+  # store's bolt port, the qmd sidecar's port, the Postgres the logbook lives
+  # in, the telemetry store, the bluesky bridge, the EVENTS and BLUESKY tabs'
+  # URLs. This persona is an attached render (`services: {}` of its own) built
+  # beside that deployment, and the build copies every such fact from the
+  # deployment's own render into it (the Reach Contract,
+  # `osprey.deployment.reach`). Per-user web-terminal containers run
+  # `network_mode: host`, so container `localhost` IS the deployment host and
+  # the copied ports are dialed there. Move a port on the hosting profile and
+  # every persona follows; spell a different one here and the build refuses
+  # the contradiction. Built alone, with no hosting deployment in the repo,
+  # the build copies what the app template deploys at its defaults instead
+  # — and a host that differs IS named here.

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -332,7 +332,14 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
         env={
             "OSPREY_CONFIG": RENDERED_CONFIG_ENV_VALUE,
             "CONFIG_FILE": RENDERED_CONFIG_ENV_VALUE,
-            "BLUESKY_BRIDGE_URL": "${BLUESKY_BRIDGE_URL:-http://127.0.0.1:8090}",
+            # No literal default: an unset variable reaches the server EMPTY,
+            # which resolve_bridge_url reads as "no override" and falls back
+            # to the rendered config — `services.bluesky.port`, the port this
+            # deployment actually publishes. A `:-http://127.0.0.1:8090`
+            # default here was a second copy of the bridge's port that the
+            # config could never correct, so a bridge moved on the profile
+            # left every agent dialing the old port.
+            "BLUESKY_BRIDGE_URL": "${BLUESKY_BRIDGE_URL:-}",
             "BLUESKY_LAUNCH_TOKEN": "${BLUESKY_LAUNCH_TOKEN:-}",
         },
         # Tool names resolve from osprey.bluesky_tool_names (the single source of

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -546,8 +546,9 @@ class ARIELConfig:
                 ``ariel.database.uri`` unset, the DSN is derived from it — see
                 :func:`resolve_ariel_dsn`.
             config_dir: Directory holding the config.yml this dictionary came
-                from. A relative ``ariel.vocabulary.path`` resolves against it,
-                so every process reading the same config finds the same file.
+                from. A relative ``ariel.vocabulary.path`` resolves against the
+                project root derived from it, so every process reading the
+                same config finds the same file.
                 Keyword-only with a None default: callers that never name a
                 config-relative path are unaffected, and None falls back to the
                 shared helper's own rule.

--- a/src/osprey/services/ariel_search/enhancement/qmd_export/exporter.py
+++ b/src/osprey/services/ariel_search/enhancement/qmd_export/exporter.py
@@ -51,15 +51,16 @@ def resolve_mirror_path(raw: str | Path, config_dir: Path | None = None) -> Path
     :func:`osprey.utils.config_paths.resolve_config_relative_path`, which is
     what every config-relative path in a rendered project promises: expand
     ``~``, return an absolute value unchanged, and resolve a relative one
-    against the directory holding ``config.yml``. The exporter, the resync CLI
-    and the compose mount must all land on the same directory, or the sidecar
-    indexes a tree nobody writes to.
+    against the project root — the repo, not the ``build/`` render inside it.
+    The exporter, the resync CLI and the compose mount must all land on the
+    same directory, or the sidecar indexes a tree nobody writes to; the compose
+    mount is anchored on the repo root, which is why the resolver is.
 
     Args:
         raw: The configured value, as read from
             ``enhancement_modules.qmd_export.mirror_path``.
-        config_dir: Directory containing ``config.yml``. When omitted it is
-            derived from
+        config_dir: Directory containing ``config.yml``; the project root is
+            derived from it. When omitted it is derived from
             :func:`osprey.utils.workspace.resolve_config_path`, which falls
             back to the process CWD when ``OSPREY_CONFIG`` is unset.
 

--- a/src/osprey/services/facility_knowledge/bundle_path.py
+++ b/src/osprey/services/facility_knowledge/bundle_path.py
@@ -7,8 +7,9 @@ different bundles in different places. :func:`resolve_bundle_path` is that one
 rule for this key: it delegates to
 :func:`osprey.utils.config_paths.resolve_config_relative_path`, the framework's
 rule for every config-relative path — expand ``~``, then resolve a
-still-relative value against the directory containing ``config.yml``, which is
-what the config template and ``how-to/okf-bundle.rst`` promise.
+still-relative value against the project root (the repo, not its ``build/``
+render), which is what the config template and ``how-to/okf-bundle.rst``
+promise and what the compose layer binds into every container.
 """
 
 from __future__ import annotations
@@ -24,13 +25,14 @@ def resolve_bundle_path(raw: str | Path, config_dir: Path | None = None) -> Path
     """Resolve a configured ``facility_knowledge.bundle_path`` to an absolute path.
 
     ``~`` is expanded first. An absolute value is then returned unchanged; a
-    relative one is resolved against *config_dir*.
+    relative one is resolved against the project root of *config_dir*.
 
     Args:
         raw: The configured value, as read from ``facility_knowledge.bundle_path``.
-        config_dir: Directory containing ``config.yml``. When omitted it is
-            derived from :func:`osprey.utils.workspace.resolve_config_path`,
-            which falls back to the process CWD when ``OSPREY_CONFIG`` is unset.
+        config_dir: Directory containing ``config.yml``; the project root is
+            derived from it. When omitted it is derived from
+            :func:`osprey.utils.workspace.resolve_config_path`, which falls
+            back to the process CWD when ``OSPREY_CONFIG`` is unset.
 
     Returns:
         Absolute :class:`~pathlib.Path` to the bundle root.

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -223,8 +223,11 @@ services:
                           # (default 127.0.0.1); no per-service bind_address.
     ttl_path: ./data/demo_machine.ttl
                           # Corpus to seed the store from, resolved against this
-                          # file's directory (the same rule as
-                          # `facility_knowledge.bundle_path`). This is the demo
+                          # file's directory — the render — unlike
+                          # `facility_knowledge.bundle_path` and every other
+                          # config-relative path, which resolve against the
+                          # project root: the store is seeded from the `data/`
+                          # the build assembled here. This is the demo
                           # machine — the same corpus the control-assistant
                           # preset seeds, so every OSPREY demo describes one
                           # facility. Point it at your own TTL to seed that

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -372,9 +372,9 @@ ariel:
   vocabulary:
     enabled: false
 
-    # Resolved against the directory holding this file, like every other
-    # config-relative path here (`qmd_export.mirror_path` below follows the
-    # same rule).
+    # Resolved against the project root (the deployment repo, not this
+    # rendered file's build/ directory), like every other config-relative
+    # path here (`qmd_export.mirror_path` below follows the same rule).
     # path: data/ariel/vocabulary.yml
 
     # Whether a search that expresses no preference gets expansion. The
@@ -478,12 +478,13 @@ ariel:
     qmd_export:
       enabled: true
       settings:
-        # Resolved against the directory holding this file, like every other
-        # config-relative path here. It belongs under var/, the durable STATE
-        # zone: the mirror is machine-written from Postgres, is as large as the
-        # logbook, and the repo's .gitignore keeps var/ out of git. The compose
-        # generator binds this same path into the sidecar read-only, so moving
-        # it stays a one-place edit.
+        # Resolved against the project root (the deployment repo, not this
+        # rendered file's build/ directory), like every other config-relative
+        # path here. It belongs under var/, the durable STATE zone: the mirror
+        # is machine-written from Postgres, is as large as the logbook, and the
+        # repo's .gitignore keeps var/ out of git. The compose generator binds
+        # this same path into the sidecar read-only from that same root, so
+        # moving it stays a one-place edit.
         mirror_path: var/ariel_mirror
 
   # Default provider for EMBEDDING modules that name none of their own. It is

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -274,8 +274,11 @@ services:
                           # (default 127.0.0.1); no per-service bind_address.
     ttl_path: ./data/demo_machine.ttl
                           # Corpus to seed the store from, resolved against this
-                          # file's directory (the same rule as
-                          # `facility_knowledge.bundle_path`). This one is the
+                          # file's directory — the render — unlike
+                          # `facility_knowledge.bundle_path` and every other
+                          # config-relative path, which resolve against the
+                          # project root: the store is seeded from the `data/`
+                          # the build assembled here. This one is the
                           # demo machine — the same devices and channels the
                           # channel database in `data/` describes, rebuilt as a
                           # graph, so the agent's graph answers and its channel

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -990,9 +990,10 @@ ariel:
   vocabulary:
     enabled: true
 
-    # Resolved against the directory holding this file, like every other
-    # config-relative path here (`qmd_export.mirror_path` and
-    # `facility_knowledge.bundle_path` follow the same rule).
+    # Resolved against the project root (the deployment repo, not this
+    # rendered file's build/ directory), like every other config-relative
+    # path here (`qmd_export.mirror_path` and `facility_knowledge.bundle_path`
+    # follow the same rule).
     path: data/ariel/vocabulary.yml
 
     # Whether a search that expresses no preference gets expansion. Shipped
@@ -1120,14 +1121,15 @@ ariel:
     qmd_export:
       enabled: true
       settings:
-        # Resolved against the directory holding this file, like every other
-        # config-relative path here (`facility_knowledge.bundle_path` follows
-        # the same rule). It belongs under var/, the durable STATE zone: the
-        # mirror is machine-written from Postgres, is as large as the logbook,
-        # and the repo's .gitignore keeps var/ out of git — a path under data/
-        # would commit a generated corpus. The compose generator binds this
-        # same value into the sidecar read-only, so moving the mirror stays a
-        # one-place edit.
+        # Resolved against the project root (the deployment repo, not this
+        # rendered file's build/ directory), like every other config-relative
+        # path here (`facility_knowledge.bundle_path` follows the same rule).
+        # It belongs under var/, the durable STATE zone: the mirror is
+        # machine-written from Postgres, is as large as the logbook, and the
+        # repo's .gitignore keeps var/ out of git — a path under data/ would
+        # commit a generated corpus. The compose generator binds this same
+        # value into the sidecar read-only from that same root, so moving the
+        # mirror stays a one-place edit.
         mirror_path: var/ariel_mirror
 
   # Default provider for EMBEDDING modules that name none of their own. It is
@@ -1159,9 +1161,10 @@ logbook:
 # ============================================================
 # OKF bundle providing deep facility knowledge (subsystems, devices,
 # procedures, physics notes, references) to the facility_knowledge
-# MCP server.  Resolved relative to this config file's directory
-# (project root).  Replace with the absolute path to your own bundle
-# once you have customised the example content.
+# MCP server.  Resolved relative to the project root (the deployment
+# repo, not this rendered file's build/ directory).  Replace with the
+# absolute path to your own bundle once you have customised the example
+# content.
 
 facility_knowledge:
   bundle_path: data/facility_knowledge

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -311,13 +311,22 @@ def _resolve_bridge_url(config: dict) -> str:
 
     Resolution order mirrors `osprey.bluesky_bridge_connection.resolve_bridge_url`
     exactly: ``BLUESKY_BRIDGE_URL`` env var, then ``bluesky.bridge_url`` in
-    config.yml, then the loopback default above.
+    config.yml, then the port the deployment publishes its bridge on
+    (``services.bluesky.port``, dialed on loopback), then the default above.
     """
     full = os.environ.get("BLUESKY_BRIDGE_URL")
     if full:
         return full.rstrip("/")
-    url = config.get("bluesky", {}).get("bridge_url", _DEFAULT_BRIDGE_URL)
-    return str(url).rstrip("/")
+    bluesky = config.get("bluesky") or {}
+    url = bluesky.get("bridge_url") if isinstance(bluesky, dict) else None
+    if url:
+        return str(url).rstrip("/")
+    services = config.get("services") or {}
+    block = services.get("bluesky") if isinstance(services, dict) else None
+    port = block.get("port") if isinstance(block, dict) else None
+    if port:
+        return f"http://127.0.0.1:{port}"
+    return _DEFAULT_BRIDGE_URL
 
 
 def _bridge_get_json(base_url: str, path: str, timeout: float = 3.0):

--- a/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
+++ b/src/osprey/templates/claude_code/claude/rules/control-system-safety.md.j2
@@ -197,10 +197,10 @@ for a plan that is not.
 
 ## Starting a Bluesky Queue
 
-Starting a queue moves accelerator hardware. Arming a start needs
-`BLUESKY_LAUNCH_TOKEN`, which a persona is granted only when its config sets
+Starting a queue moves accelerator hardware. Arming a start needs the lane's
+launch token, which a persona is granted only when its config sets
 `control_system.writes_enabled: true` **and** runs the `bluesky` MCP server.
-A read-only persona never holds it.
+A read-only persona never holds one.
 
 Where it is granted, one approval is the whole gate: approving `queue_start` in
 chat starts the queue. There is no second confirmation step anywhere else.

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -774,7 +774,16 @@ services:
          from warning, and an empty value is falsy to `resolve_launch_token`,
          which then resolves no token and refuses the launch client-side — the
          same fail-closed outcome as never emitting this line at all. #}
-      - BLUESKY_LAUNCH_TOKEN=${BLUESKY_LAUNCH_TOKEN:-}
+{%- for var in launch_token_env_vars %}
+      {#- One token PER PLAN LANE the deployment renders (`BLUESKY_LAUNCH_TOKEN`
+         for lane 1; `BLUESKY_VA_LAUNCH_TOKEN` / `BLUESKY_LIVE_LAUNCH_TOKEN`
+         for a second lane), because each lane is a whole bridge stack armed by
+         its own token — one shared token would let a launch approved against
+         one machine be replayed against the other. The persona is told both
+         lanes' addresses by the build for the same reason it is handed both
+         tokens here: its session may be switched to either target. #}
+      - {{ var }}={{ '${' ~ var ~ ':-}' }}
+{%- endfor %}
 {%- endif %}
 {%- if svc.wants_graphdb %}
       {#- The graph store's Neo4j password, for a persona that configures one.

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -61,6 +61,22 @@
                                         #   Joined in Python for the same reason as
                                         #   container_agent_data_dir above.
                                         #   Pairs with the file-level `facility_bundle_source`.
+          "container_mirror_dir": str | None,
+                                        # where the DEPLOYMENT's ARIEL qmd mirror mounts for
+                                        #   this user, or None when the user is not entitled
+                                        #   (its persona's project runs no qmd export) or the
+                                        #   deployment writes no mirror. Built by
+                                        #   render._container_mirror_dir() from
+                                        #   `qmd_export.mirror_path` anchored on
+                                        #   container_project_dir — the path this persona's own
+                                        #   exporter writes. Pairs with the file-level
+                                        #   `ariel_mirror_source`.
+          "container_audit_dir": str,   # where this user's refusal audit log is written inside
+                                        #   the container (`<container_project_dir>/var/audit`,
+                                        #   render._container_audit_dir()).
+          "audit_source": str,          # the host directory backing it, spelled as a compose
+                                        #   bind source (`./var/audit/<user>`, from
+                                        #   compose_generator.user_audit_relpath()).
           "extra_mounts": [str, ...],   # resolved by resolve_personas() from the persona's
                                         #   `extra_mounts` -> extra per-user `volumes:` lines
                                         #   (compose volume strings, e.g. "/opt/data:/app/data:ro").
@@ -97,6 +113,22 @@
       deployment configures no `facility_knowledge.bundle_path`, which emits no
       mount for anyone. Note this mount SHADOWS whatever the persona image baked
       at that path; the reasoning is at the mount line itself.
+
+    ariel_mirror_source: str, required (may be "")
+      The deployment's ARIEL qmd mirror on the HOST, spelled as a compose bind
+      source the same way as `facility_bundle_source`, and paired with each
+      service's own `container_mirror_dir` target. ONE directory for every user
+      and for the host's own exporter — the sidecar indexes the union. `""` when
+      the deployment runs no qmd export, which emits no mount for anyone.
+
+    ariel_mirror_gid: str, required (may be "")
+      Group id of that host directory, for the same `group_add:` reason as
+      `facility_bundle_gid` below.
+
+    audit_gid: str, required (may be "")
+      Group id of the deployment's audit zone (`var/audit`), whose per-user
+      subdirectories every service binds. Emitted in `group_add:` on every
+      service, since every container writes its refusal log there.
 
     facility_bundle_gid: str, required (may be "")
       Group id of that host directory, read off disk by the deploy and emitted as
@@ -583,6 +615,20 @@ services:
       - OSPREY_TERMINAL_BIND_HOST={{ bind_host }}
       - OSPREY_TERMINAL_WEB_PORT={{ svc.web }}
       - OSPREY_WEB_PORT={{ svc.web }}
+      {#- Where the telemetry store is from inside this container. The agent's
+         launch derives its OTLP endpoint from `claude_code.telemetry` with the
+         host chosen for the running context, and the context it would sniff
+         here is wrong: `/.dockerenv` says "container", which selects the
+         compose DNS name `openobserve` — a name that resolves to nothing under
+         `network_mode: host`, so every metric and log would be dropped with no
+         error anywhere. Under host networking this container's loopback IS
+         the deployment host's, and the store answers there on the port it
+         PUBLISHES — which the emitter reads from `services.openobserve.port`
+         in this persona's own config (inherited from the hosting profile), so
+         no port is declared here. Same convention, same reason, as the
+         dispatch worker's compose. Inert unless telemetry is enabled with
+         backend: openobserve. #}
+      - OSPREY_OTEL_OPENOBSERVE_HOST={{ bind_host }}
       {#- This user's operator secret, in the container-shape variable the app
          pops at construction (web_auth.OPERATOR_SECRET_ENV). The per-user
          variable it is interpolated FROM is the same one nginx exports and this
@@ -839,23 +885,83 @@ services:
       # it, but not for one container to overwrite another's file in place.
       - {{ facility_bundle_source }}:{{ svc.container_bundle_dir }}
 {%- endif %}
+{%- if ariel_mirror_source and svc.container_mirror_dir %}
+      {#- THE DEPLOYMENT'S ARIEL MIRROR, at the path THIS persona's exporter
+         writes. The `qmd_export` enhancement module runs inside every persona
+         container that enables it — an entry enhanced from a terminal is
+         mirrored by that terminal's own process — and it resolves `mirror_path`
+         against the project root, which in here is this persona's
+         container_project_dir (render._container_mirror_dir, the same
+         derivation as the bundle target above). Without this bind the mirror
+         it writes is a directory in the container's writable layer: the qmd
+         sidecar, which indexes the HOST's mirror, never sees those entries, and
+         the next recreate discards them.
+
+         Source is the ONE deployment mirror for every user and for the host's
+         own exporter, so the sidecar's corpus is the union of everything any
+         process enhanced. Read-write, like the bundle and unlike the sidecar's
+         `:ro` mount of the same directory; shared through the same setgid group
+         (see `group_add` below). #}
+      # The DEPLOYMENT's ARIEL qmd mirror, written by this container's own
+      # qmd_export module and indexed by the qmd sidecar. Bound here so an entry
+      # enhanced from this terminal reaches the sidecar's corpus instead of a
+      # directory in the container's writable layer that nothing indexes and
+      # the next recreate discards.
+      - {{ ariel_mirror_source }}:{{ svc.container_mirror_dir }}
+{%- endif %}
+      {#- THIS USER'S AUDIT ZONE. The python executor appends its refusal log
+         under `<project>/var/audit` (services/python_executor/refusal_audit.py,
+         anchored on the project root exactly as the agent-data root is), and
+         nothing else in this service backs that path: the agent-data volume
+         beside it is a sibling, not an ancestor. Unbacked, the one record of
+         what the agent tried and was refused lands in the writable layer and
+         is gone at the next recreate — the opposite of what an audit log is
+         for. A host bind rather than a named volume, because the log has to be
+         readable from the host without entering a container. Per user
+         (`var/audit/<user>/`, see compose_generator.user_audit_relpath): every
+         container writes the same fixed filename, so one shared directory
+         would have them overwrite each other. The deploy provisions the
+         directory before this render, in the shared group joined below. #}
+      # This user's refusal audit log (`var/audit/<user>/` on the host), bound
+      # so the record survives a recreate and is readable from the host.
+      - {{ svc.audit_source }}:{{ svc.container_audit_dir }}
 {%- for mount in svc.extra_mounts %}
       - {{ mount }}
 {%- endfor %}
-{%- if facility_bundle_gid and svc.container_bundle_dir %}
-    # Supplementary group for the shared bundle mounted above. This is the half
-    # of the sharing story setgid cannot supply: setgid decides which group OWNS
-    # a newly written file, but a process is a MEMBER of only the groups its
-    # image gives it, so without this line the directory's group bits would
-    # grant this container nothing and access would hold only where the
-    # deploying user's uid happened to equal the image's.
+{#- Every shared host directory bound above, and the group each was provisioned
+    with: the bundle and the mirror where this service is entitled to them, the
+    audit zone always. Collected into one list so one `group_add:` is emitted
+    per service, with each gid once — the deploy creates all of them as the same
+    user, so they usually share a group, and compose rejects nothing for a
+    repeat, but a list that says the same thing twice reads like two groups. #}
+{%- set shared_gids = [] %}
+{%- if facility_bundle_gid and svc.container_bundle_dir and facility_bundle_gid not in shared_gids %}
+{%- set _ = shared_gids.append(facility_bundle_gid) %}
+{%- endif %}
+{%- if ariel_mirror_gid and svc.container_mirror_dir and ariel_mirror_gid not in shared_gids %}
+{%- set _ = shared_gids.append(ariel_mirror_gid) %}
+{%- endif %}
+{%- if audit_gid and audit_gid not in shared_gids %}
+{%- set _ = shared_gids.append(audit_gid) %}
+{%- endif %}
+{%- if shared_gids %}
+    # Supplementary group(s) for the shared host directories mounted above (the
+    # knowledge bundle, the ARIEL mirror, this user's audit zone — whichever
+    # this service binds). This is the half of the sharing story setgid cannot
+    # supply: setgid decides which group OWNS a newly written file, but a
+    # process is a MEMBER of only the groups its image gives it, so without
+    # this line the directory's group bits would grant this container nothing
+    # and access would hold only where the deploying user's uid happened to
+    # equal the image's.
     #
-    # The value is the bundle directory's OWN group id, read off the host at
-    # render time -- never a hardcoded id, which would be wrong on every host
-    # but the one it was chosen on. Retarget it by chgrp'ing the bundle and
+    # Each value is the directory's OWN group id, read off the host at render
+    # time -- never a hardcoded id, which would be wrong on every host but the
+    # one it was chosen on. Retarget it by chgrp'ing the directory and
     # re-running `osprey up`.
     group_add:
-      - "{{ facility_bundle_gid }}"
+{%- for gid in shared_gids %}
+      - "{{ gid }}"
+{%- endfor %}
 {%- endif %}
     healthcheck:
       # osprey web's own default listen port is the fixed constant 8087

--- a/src/osprey/templates/services/bluesky_web/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky_web/docker-compose.yml.j2
@@ -96,8 +96,29 @@ services:
       # a non-browser client sends it as `X-Osprey-Terminal-Secret`. No
       # :-default for the same reason as the launch token above; `osprey up`
       # mints it into the project .env (container_lifecycle's per-service
-      # token-mint map).
+      # token-mint map). In a multi-user deployment each per-user terminal
+      # proxies its BLUESKY tab here with ITS OWN secret, never this one —
+      # see the roster grant just below.
       OSPREY_TERMINAL_SECRET: ${OSPREY_TERMINAL_SECRET}
+{%- if bluesky_panel_secret_env_vars | default([]) %}
+      # THE ROSTER GRANT. Every web-terminal user whose persona shows the
+      # BLUESKY tab proxies it here with the operator secret THEIR container
+      # holds (under the fixed OSPREY_TERMINAL_SECRET name, interpolated from
+      # their own OSPREY_TERMINAL_SECRET_<SUFFIX> in the deploy .env). Listing
+      # each of those variables here lets this sidecar's web gate accept any
+      # of them beside the deployment-wide secret above, so no user's
+      # container is ever handed that secret, and a user purged from the
+      # roster is refused here the moment `osprey up` re-renders. Only the
+      # entitled users are listed (compose_generator resolves them from the
+      # personas' rendered configs); the others cannot reach this sidecar and
+      # get no key to it. The flag is what makes web_auth ACCEPT the roster
+      # variables it finds: every process that loads the deploy .env sees
+      # them all, and only this sidecar may treat them as its operators.
+      OSPREY_TERMINAL_ACCEPT_ROSTER_SECRETS: "1"
+{%- for var in bluesky_panel_secret_env_vars %}
+      {{ var }}: ${{ "{" }}{{ var }}:-}
+{%- endfor %}
+{%- endif %}
       # Marks the container shape for web_auth: an empty secret then refuses
       # startup naming the variable, instead of minting a value that is
       # announced only to the container log and reachable by nobody.

--- a/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
+++ b/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
@@ -146,12 +146,11 @@ services:
       # own fallback sees a container and would reach for the service name.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
       #
-      # The variable carries a HOST, and the endpoint the emitter derives from
-      # it pins the store's port at 5080 (build/claude_code_telemetry.py) —
-      # which is what `services.openobserve.port` publishes by default. A
-      # deployment that republishes the store on some other host port must set
-      # `claude_code.telemetry.endpoint` outright; there is no port half of this
-      # variable to carry it.
+      # The variable carries a HOST only. The port half needs no declaration
+      # here: from the host's loopback the store answers on the port it
+      # PUBLISHES, and the emitter reads that from `services.openobserve.port`
+      # in the config this worker already mounts — so moving the store moves
+      # the exporter with it.
       OSPREY_OTEL_OPENOBSERVE_HOST: localhost
 {%- else %}
       # OpenObserve telemetry (opt-in): the worker and its CLI subprocess run on
@@ -159,7 +158,14 @@ services:
       # DNS name, not localhost. Declaring the host here — rather than sniffing
       # the container runtime — is what makes emit work under docker AND podman.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
+      #
+      # The port is declared beside it because on this network it is NOT the
+      # published one: the DNS name answers on the port the store LISTENS on
+      # inside its container, which `services.openobserve.port` says nothing
+      # about. Without this line the emitter would derive the published port,
+      # which is right from the host and wrong from here.
       OSPREY_OTEL_OPENOBSERVE_HOST: openobserve
+      OSPREY_OTEL_OPENOBSERVE_PORT: "5080"
 {%- endif %}
 {#- Address of the archiver store, for the same reason and by the same
     convention as OSPREY_OTEL_OPENOBSERVE_HOST above: whichever address is the

--- a/src/osprey/utils/config_paths.py
+++ b/src/osprey/utils/config_paths.py
@@ -1,13 +1,41 @@
 """One rule for resolving a path that a config file names relatively.
 
-Several config keys point at a directory or file next to ``config.yml`` —
+Several config keys point at a directory or file inside the project —
 ``facility_knowledge.bundle_path``, the qmd export mirror, the ARIEL vocabulary
 file. Each is read by more than one process (an MCP server, a CLI command, a
 web app, a container), and if any of them resolves the value against its own
-working directory instead of the config's directory, the same configured string
+working directory instead of the project's, the same configured string
 silently means a different place in each process. That divergence is exactly
 what this module exists to prevent: :func:`resolve_config_relative_path` is the
 single rule, and every reader of such a key delegates to it.
+
+The anchor is the **project root** — the deployment repo, the directory holding
+``profile.yml`` — and not the directory holding ``config.yml``. The two differ
+on a host, where the render lives one zone down in ``build/`` and is re-created
+from scratch by every ``osprey build``; they coincide in a container, whose
+project directory *is* its own render, and in a flat legacy project. The repo
+root is the anchor for one reason beyond durability: it is what every compose
+bind source resolves against (every invocation is pinned with
+``--project-directory <repo>``, see
+:func:`osprey.deployment.compose_generator.compose_base_cmd`), so it is the
+only anchor under which the directory a process WRITES is the directory a
+container is handed to read. Anchored on the render, the qmd exporter wrote
+``build/var/ariel_mirror`` while the sidecar indexed ``var/ariel_mirror`` — an
+empty tree — and a persona's readers opened the image's baked bundle at
+``build/data/...`` while the deployment's live bundle was mounted at
+``data/...`` one directory over. Same rule as
+:func:`osprey_connectors.workspace.resolve_project_root` and every other
+relative path the runtime resolves.
+
+One key is the deliberate exception, through :func:`resolve_render_relative_path`:
+``services.graphdb.ttl_path``. The corpus it names is an artifact OF the
+render: its documented default, ``./data/demo_machine.ttl``, is read from the
+``data/`` tree the build assembled for exactly this project — the app
+template's data, or the profile's own ``data:`` tree in its place — so a corpus regenerated
+into the profile's data tree reaches the store on the next build, like every
+other rendered artifact. It therefore resolves against the ``config.yml``
+directory. The store is seeded from it once, by the deploy; nothing writes it
+back and nothing mounts it, which is why the argument above does not apply.
 
 Note that :func:`osprey.cli.project_utils.resolve_config_path` is a *different*
 function that happens to share a name with the workspace helper used below; the
@@ -19,7 +47,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__all__ = ["resolve_config_dir", "resolve_config_relative_path"]
+__all__ = [
+    "resolve_config_dir",
+    "resolve_config_relative_path",
+    "resolve_render_relative_path",
+    "project_root_for_config_dir",
+]
 
 
 def resolve_config_dir() -> Path | None:
@@ -45,19 +78,43 @@ def resolve_config_dir() -> Path | None:
         return None
 
 
+def project_root_for_config_dir(config_dir: Path) -> Path:
+    """The project root that a ``config.yml`` in *config_dir* belongs to.
+
+    The one place the "is this the build zone?" question is asked for
+    config-relative paths, delegating to the workspace helper that answers it
+    for every other runtime path (:func:`osprey.utils.workspace.repo_root_for_config`)
+    so the two cannot disagree: the parent when *config_dir* is the render
+    zone, *config_dir* itself otherwise.
+
+    Args:
+        config_dir: Directory containing ``config.yml``.
+
+    Returns:
+        The project root — ``<repo>`` for a host render at ``<repo>/build``, the
+        directory itself for a container project or a flat legacy one.
+    """
+    from osprey.utils.workspace import repo_root_for_config
+
+    return repo_root_for_config(Path(config_dir) / "config.yml")
+
+
 def resolve_config_relative_path(value: str | Path, config_dir: Path | None = None) -> Path:
     """Resolve a configured path value to an absolute path.
 
     ``~`` is expanded first. An absolute value is then returned unchanged — it
     already names one place, and re-resolving it would silently follow symlinks
-    the operator wrote deliberately. A relative value is resolved against
-    *config_dir*.
+    the operator wrote deliberately. A relative value is resolved against the
+    project root of the config in *config_dir* (see the module docstring for
+    why the root, not the config's own directory).
 
     Args:
         value: The configured value, as read from the config file.
         config_dir: Directory containing ``config.yml``. Callers that loaded a
-            config themselves should pass its parent. When omitted it is derived
-            from :func:`osprey.utils.workspace.resolve_config_path`, which falls
+            config themselves should pass its parent; the project root is
+            derived from it here (:func:`project_root_for_config_dir`). When
+            omitted it is derived from
+            :func:`osprey.utils.workspace.resolve_config_path`, which falls
             back to the process CWD when ``OSPREY_CONFIG`` is unset.
 
     Returns:
@@ -71,4 +128,32 @@ def resolve_config_relative_path(value: str | Path, config_dir: Path | None = No
         config_dir = resolve_config_dir()
     if config_dir is None:
         return path.resolve()
-    return (config_dir / path).resolve()
+    return (project_root_for_config_dir(config_dir) / path).resolve()
+
+
+def resolve_render_relative_path(value: str | Path, config_dir: Path | None = None) -> Path:
+    """Resolve a configured path that names an artifact of the render.
+
+    The exception the module docstring describes, for ``services.graphdb.ttl_path``:
+    ``~`` expanded, an absolute value returned unchanged, a relative value
+    resolved against the directory holding ``config.yml`` itself — the render
+    — rather than against the project root.
+
+    Args:
+        value: The configured value, as read from the config file.
+        config_dir: Directory containing ``config.yml``. When omitted it is
+            derived from :func:`osprey.utils.workspace.resolve_config_path`,
+            which falls back to the process CWD when ``OSPREY_CONFIG`` is unset.
+
+    Returns:
+        Absolute :class:`~pathlib.Path`.
+    """
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path
+
+    if config_dir is None:
+        config_dir = resolve_config_dir()
+    if config_dir is None:
+        return path.resolve()
+    return (Path(config_dir) / path).resolve()

--- a/src/osprey/utils/config_writer.py
+++ b/src/osprey/utils/config_writer.py
@@ -499,6 +499,34 @@ def config_update_fields(
     logger.debug("config_update_fields: updated %d field(s) in %s", len(updates), config_path)
 
 
+def config_delete_field(config_path: Path, dotted_key: str) -> bool:
+    """Remove one dotted key from a YAML config, preserving comments.
+
+    The inverse of one :func:`config_update_fields` entry. Never creates
+    anything: a missing parent or leaf is a no-op.
+
+    Args:
+        config_path: Path to the YAML file.
+        dotted_key: ``"dot.separated.key"`` of the entry to remove.
+
+    Returns:
+        Whether the key was present and removed.
+    """
+    data = _load(config_path)
+    parts = dotted_key.split(".")
+    node = data
+    for part in parts[:-1]:
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    if not isinstance(node, dict) or parts[-1] not in node:
+        return False
+    del node[parts[-1]]
+    _save(config_path, data)
+    logger.debug("config_delete_field: removed %s from %s", dotted_key, config_path)
+    return True
+
+
 def _set_dotted_anchored(
     root: Any, data: Any, dotted_key: str, value: Any, *, create_only: bool
 ) -> None:

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -182,7 +182,7 @@ class TestProfileLoading:
     def test_deploy_services_explicit_false_parses(self, tmp_path: Path):
         """An explicit false marks the project as attached."""
         p = tmp_path / "a.yml"
-        p.write_text("name: Attached\ndeploy_services: false\n")
+        p.write_text("name: Attached\ndeploy_services: false\nconfig:\n  services.qmd.port: 8180\n")
         assert load_profile(p).deploy_services is False
 
     def test_deploy_services_inherited_child_wins(self, tmp_path: Path):
@@ -195,7 +195,10 @@ class TestProfileLoading:
         base = tmp_path / "base.yml"
         base.write_text("name: Base\ndeploy_services: true\n")
         child = tmp_path / "child.yml"
-        child.write_text("name: Child\nextends: base.yml\ndeploy_services: false\n")
+        child.write_text(
+            "name: Child\nextends: base.yml\ndeploy_services: false\n"
+            "config:\n  services.qmd.port: 8180\n"
+        )
         assert load_profile(child).deploy_services is False
 
     def test_load_profile_lifecycle_parsed(self, tmp_path: Path):

--- a/tests/cli/test_build_network_checks.py
+++ b/tests/cli/test_build_network_checks.py
@@ -19,9 +19,7 @@ build:
   it is rendered with are written for one side of the boundary or the other;
 * an address that crosses the boundary — a hand-authored one on a host-mode
   service still naming a bridge-resident service, which osprey deliberately does
-  not rewrite;
-* a host-mode telemetry exporter aimed at the pinned OpenObserve port while the
-  project publishes the store somewhere else.
+  not rewrite.
 
 The bridge default is covered too, and is the load-bearing case: today's
 deployments must render through all of this without a word.
@@ -40,7 +38,6 @@ from ruamel.yaml import YAML
 
 from osprey.cli.build_cmd import (
     _HOST_NETWORK,
-    _OPENOBSERVE_ENDPOINT_PORT,
     _index_rendered_services,
     _names_service,
     _network_check_errors,
@@ -203,21 +200,6 @@ def test_host_network_constant_names_a_real_mode() -> None:
     """
     assert _HOST_NETWORK in VALID_NETWORK_MODES
     assert _HOST_NETWORK != DEFAULT_NETWORK_MODE
-
-
-def test_openobserve_endpoint_port_matches_the_resolver_pin() -> None:
-    """The port the telemetry check reasons about is the one the emitter derives.
-
-    Bound to the resolver rather than restated: if the derived endpoint ever
-    stops pinning a port, the check that exists BECAUSE it pins one has to be
-    revisited rather than quietly keep asserting the old number.
-    """
-    from osprey.build.claude_code_telemetry import _resolve_telemetry_endpoint
-
-    endpoint = _resolve_telemetry_endpoint(
-        {"backend": "openobserve"}, in_container=True, openobserve_host="localhost"
-    )
-    assert endpoint == f"http://localhost:{_OPENOBSERVE_ENDPOINT_PORT}/api/default"
 
 
 # ---------------------------------------------------------------------------
@@ -624,141 +606,6 @@ def test_environment_declared_as_a_list_is_read(
 
     assert len(errors) == 1
     assert "STORE_URL -> http://store:5080" in errors[0]
-
-
-# ---------------------------------------------------------------------------
-# (d) The pinned OpenObserve endpoint port
-# ---------------------------------------------------------------------------
-
-
-def _telemetry(**overrides: Any) -> dict[str, Any]:
-    """A live ``claude_code.telemetry`` block — enabled, openobserve, derived."""
-    return {"telemetry": {"enabled": True, "backend": "openobserve", **overrides}}
-
-
-def _otel_worker_render(project: Path, *, on_host: bool = True) -> str:
-    """A rendered worker naming the telemetry store the way its mode does."""
-    stanza = (
-        _host_stanza(environment={"OSPREY_OTEL_OPENOBSERVE_HOST": "localhost"})
-        if on_host
-        else _bridge_stanza(environment={"OSPREY_OTEL_OPENOBSERVE_HOST": "openobserve"})
-    )
-    return _write_render(project, "dispatch_worker", {"dispatch-worker-1": stanza})
-
-
-def test_host_mode_with_a_republished_store_and_live_telemetry_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A derived endpoint aimed at 5080 while the store publishes elsewhere fails.
-
-    The failure it prevents is silent: the exporter posts into a closed port
-    and every metric and log is dropped without an error anywhere.
-    """
-    monkeypatch.chdir(tmp_path)
-    config = _config(
-        tmp_path,
-        {"dispatch_worker": {"network": _HOST_NETWORK}, "openobserve": {"port": 5081}},
-        claude_code=_telemetry(),
-    )
-    worker = _otel_worker_render(tmp_path)
-    store = _write_render(tmp_path, "openobserve", {"openobserve": _bridge_stanza()})
-
-    errors = _network_check_errors(config, [worker, store])
-
-    assert len(errors) == 1
-    message = errors[0]
-    assert "services.dispatch_worker" in message
-    assert "5080" in message and "5081" in message
-    assert "`claude_code.telemetry.endpoint: http://localhost:5081/api/default`" in message
-
-
-def test_the_endpoint_remedy_carries_the_configured_org(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The remedy is copy-pasteable, so it names the org this deployment uses."""
-    monkeypatch.chdir(tmp_path)
-    config = _config(
-        tmp_path,
-        {"dispatch_worker": {"network": _HOST_NETWORK}, "openobserve": {"port": 5081}},
-        claude_code=_telemetry(openobserve={"org": "facility"}),
-    )
-    worker = _otel_worker_render(tmp_path)
-
-    errors = _network_check_errors(config, [worker])
-
-    assert "http://localhost:5081/api/facility" in errors[0]
-
-
-def test_a_republished_store_with_inert_telemetry_warns_instead_of_failing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """With telemetry off the variable is inert, so the build proceeds — loudly.
-
-    Refusing here would be an error about nothing; saying nothing would leave
-    the trap armed for whoever enables telemetry later.
-    """
-    monkeypatch.chdir(tmp_path)
-    config = _config(
-        tmp_path,
-        {"dispatch_worker": {"network": _HOST_NETWORK}, "openobserve": {"port": 5081}},
-    )
-    worker = _otel_worker_render(tmp_path)
-
-    with caplog.at_level("WARNING"):
-        errors = _network_check_errors(config, [worker])
-
-    assert errors == []
-    assert "claude_code.telemetry.endpoint" in caplog.text
-    assert "5081" in caplog.text
-
-
-def test_an_explicit_endpoint_settles_the_question(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Nothing is derived when the endpoint is written out, so nothing can be wrong."""
-    monkeypatch.chdir(tmp_path)
-    config = _config(
-        tmp_path,
-        {"dispatch_worker": {"network": _HOST_NETWORK}, "openobserve": {"port": 5081}},
-        claude_code=_telemetry(endpoint="http://localhost:5081/api/default"),
-    )
-    worker = _otel_worker_render(tmp_path)
-
-    assert _network_check_errors(config, [worker]) == []
-
-
-def test_the_default_store_port_is_never_flagged(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Publishing the store where the endpoint is pinned is the case that works."""
-    monkeypatch.chdir(tmp_path)
-    config = _config(
-        tmp_path,
-        {
-            "dispatch_worker": {"network": _HOST_NETWORK},
-            "openobserve": {"port": _OPENOBSERVE_ENDPOINT_PORT},
-        },
-        claude_code=_telemetry(),
-    )
-    worker = _otel_worker_render(tmp_path)
-
-    assert _network_check_errors(config, [worker]) == []
-
-
-def test_a_bridge_mode_worker_is_never_flagged(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """On the bridge the pin is the port the store LISTENS on, which never moves."""
-    monkeypatch.chdir(tmp_path)
-    config = _config(
-        tmp_path,
-        {"dispatch_worker": {}, "openobserve": {"port": 5081}},
-        claude_code=_telemetry(),
-    )
-    worker = _otel_worker_render(tmp_path, on_host=False)
-    store = _write_render(tmp_path, "openobserve", {"openobserve": _bridge_stanza()})
-
-    assert _network_check_errors(config, [worker, store]) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_build_preset.py
+++ b/tests/cli/test_build_preset.py
@@ -613,6 +613,113 @@ def test_each_bundled_preset_builds_clean(preset: str, runner: CliRunner, tmp_pa
     )
 
 
+def _attached_presets() -> list[str]:
+    """Every bundled preset that builds attached (``deploy_services: false``)."""
+    return [
+        name
+        for name in list_presets()
+        if not resolve_build_profile(None, preset=name)[0].deploy_services
+    ]
+
+
+@pytest.mark.parametrize("preset", _attached_presets())
+def test_attached_preset_built_alone_is_told_its_templates_defaults(
+    preset: str, runner: CliRunner, tmp_path: Path
+) -> None:
+    """A persona preset materialized on its own — no hosting deployment in the
+    repo — still builds, and is told what its app template deploys.
+
+    Built beside its host, an attached render is told the host's client-facing
+    facts from the host's render (``osprey.deployment.reach``). Built alone
+    there is no such render, but the persona extends a deployment of the SAME
+    app template, so the template rendered as a deployment is what the host
+    would say at the shipped defaults. Every consumer the preset switches on
+    must then resolve, and the sidecar port must be the one the template
+    deploys — read from a real render of the parent preset rather than spelled
+    here, so a moved default moves both.
+    """
+    from osprey.cli.build_profile_presets import _load_preset_raw
+    from osprey.deployment.reach import reach_errors
+
+    result = _materialize(runner, str(tmp_path), "alone", preset)
+    assert result.exit_code == 0, result.output
+    config = _config_yaml(_project(tmp_path, "alone"))
+    assert reach_errors(config) == []
+
+    parent = _load_preset_raw(preset)[0].get("extends")
+    assert parent, f"{preset} extends nothing — which deployment is its host?"
+    assert _materialize(runner, str(tmp_path), "host", Path(parent).stem).exit_code == 0
+    host = _config_yaml(_project(tmp_path, "host"))
+    assert config["services"]["qmd"]["port"] == host["services"]["qmd"]["port"]
+    # The tabs the preset selects are told their address too — what a
+    # deployment of the template derives when it injects the sidecars, read
+    # by running the same injectors over the template-as-deployment.
+    from osprey.cli.build_profile import resolve_build_profile
+
+    selected = resolve_build_profile(None, preset=preset)[0].web_panels
+    for panel in ("events", "bluesky"):
+        if panel in selected:
+            assert config["web"]["panels"][panel] == host["web"]["panels"][panel], panel
+
+
+def test_deploying_profile_may_pin_only_the_events_path(runner: CliRunner, tmp_path: Path) -> None:
+    """The reach refusal reads the config the injectors have FINISHED writing.
+
+    A deploying profile that pins ``web.panels.events.path`` and nothing else
+    — the documented way to move the dashboard's route — has its ``url``
+    written by the dispatch injector moments later; refusing before that
+    would name the very key the build was about to supply. The injector also
+    fills the label and the health endpoint, so the tab health-gates itself
+    and every persona told this entry gets the whole of it.
+    """
+    repo = tmp_path / "pathpin"
+    created = runner.invoke(init, [str(repo), "--preset", "control-assistant", "--no-git"])
+    assert created.exit_code == 0, created.output
+    profile = _profile_yaml(repo)
+    profile.setdefault("config", {})["web.panels.events.path"] = "/custom-route"
+    (repo / "profile.yml").write_text(yaml.safe_dump(profile, sort_keys=False), encoding="utf-8")
+
+    result = _render_from(runner, repo / "profile.yml")
+    assert result.exit_code == 0, result.output
+    events = _config_yaml(_project(tmp_path, "pathpin"))["web"]["panels"]["events"]
+    assert events["path"] == "/custom-route"
+    assert events["url"].startswith("http://localhost:")
+    assert events["label"] == "EVENTS"
+    assert events["health_endpoint"] == "/health"
+    # Every persona inherited the pin. The one that selects the tab is told
+    # the whole entry from this render; the ones that do not drop the
+    # url-less fragment instead of rendering an empty-url tab.
+    personas = {
+        path.name.rsplit("-", 1)[1]: yaml.safe_load((path / "config.yml").read_text())
+        for path in _project(tmp_path, "pathpin").glob("pathpin-*")
+    }
+    assert set(personas) >= {"readonly", "readwrite"}
+    assert personas["readwrite"]["web"]["panels"]["events"] == events
+    assert "events" not in personas["readonly"]["web"]["panels"]
+
+
+def test_attached_profile_built_alone_may_name_its_host_by_hand(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Built alone, the profile's ``config:`` is where a host that differs from
+    the template's defaults is named, and it wins over those defaults.
+
+    Beside a host the same spelling is refused as a second home for one fact;
+    alone there is no first home, so the hand-spelled value IS the projection.
+    """
+    preset = "control-assistant-ariel"
+    repo = tmp_path / "alone"
+    created = runner.invoke(init, [str(repo), "--preset", preset, "--no-git"])
+    assert created.exit_code == 0, created.output
+    profile = _profile_yaml(repo)
+    profile["config"]["services.qmd.port"] = 9180
+    (repo / "profile.yml").write_text(yaml.safe_dump(profile, sort_keys=False), encoding="utf-8")
+
+    result = _render_from(runner, repo / "profile.yml")
+    assert result.exit_code == 0, result.output
+    assert _config_yaml(_project(tmp_path, "alone"))["services"]["qmd"]["port"] == 9180
+
+
 def test_control_assistant_preset_ships_simulation_model(runner: CliRunner, tmp_path: Path) -> None:
     """The control-assistant preset bundles the simulation machine model.
 
@@ -814,16 +921,23 @@ class TestDeployServicesKnob:
         assert "postgresql" in cfg["services"]
 
     def test_false_scaffolds_nothing(self, runner: CliRunner, tmp_path: Path) -> None:
-        """An attached project writes no services/ tree, no services.* blocks,
-        and an explicit empty deployed_services list."""
+        """An attached project writes no services/ tree, scaffolds no service,
+        and lists an explicit empty deployed_services.
+
+        Its ``services:`` map is not empty: the build tells an attached render
+        the client-facing facts of the services it reaches (``osprey.deployment.reach``
+        — here, built alone, what the app template deploys). Those are ports
+        and names to dial, never a service to run: no block carries the
+        ``path`` a scaffolded service is declared by.
+        """
         project = self._build(runner, tmp_path, extra="deploy_services: false\n")
         cfg = _config_yaml(project)
         # Explicit empty list — present so `osprey up` reads [] not None.
         assert cfg["deployed_services"] == []
-        # None of the would-be-scaffolded services leak into services.*.
-        assert cfg.get("services") in ({}, None)
-        for name in ("postgresql", "openobserve", "bluesky"):
-            assert name not in (cfg.get("services") or {})
+        # Client facts only: nothing here is a service this render would run.
+        services = cfg.get("services") or {}
+        assert services, "an attached render is told where its host's services are"
+        assert all("path" not in block for block in services.values()), services
         # No services/ directory at all.
         assert not (project / "services").exists()
 
@@ -1066,3 +1180,52 @@ class TestGraphModeRequiresAGraphStore:
         )
         assert result.exit_code == 0, result.output
         assert _profile_yaml(repo)["channel_finder_mode"] == "graph"
+
+
+class TestRenderConfigReading:
+    """`TemplateManager.render_config` — the config-only reading `osprey build`
+    takes of an app template when a standalone attached profile has no hosting
+    deployment to be told by."""
+
+    def test_unknown_bundle_is_refused_by_name(self, tmp_path: Path) -> None:
+        from osprey.cli.templates.manager import TemplateManager
+
+        with pytest.raises(ValueError, match="no-such-bundle"):
+            TemplateManager().render_config(
+                "probe", tmp_path, tmp_path / "config.yml", data_bundle="no-such-bundle"
+            )
+
+    def test_a_bundle_without_a_config_template_is_refused(self, tmp_path: Path) -> None:
+        """`project_template_for` finds neither an app copy nor the shared
+        `project/` default, and the reading names the bundle instead of
+        rendering nothing."""
+        from osprey.cli.templates import scaffolding
+        from osprey.cli.templates.manager import TemplateManager
+
+        manager = TemplateManager()
+        assert (
+            scaffolding.project_template_for(
+                manager.template_root, "control_assistant", "no-such-file.txt"
+            )
+            is None
+        )
+        # An empty template root ships the file for no bundle at all.
+        with pytest.raises(ValueError, match="renders no config.yml"):
+            scaffolding.render_project_config(
+                tmp_path,
+                manager.jinja_env,
+                tmp_path / "config.yml",
+                "bare-bundle",
+                {},
+            )
+
+    def test_effective_artifacts_without_a_manifest_stays_none(self, tmp_path: Path) -> None:
+        """A bundle that ships no manifest widens nothing: the caller's `None`
+        stays `None`, so downstream output filtering stays off exactly as for
+        a programmatic render before the fallback existed."""
+        from osprey.cli.templates.manager import TemplateManager
+
+        manager = TemplateManager()
+        manager.template_root = tmp_path  # no apps/, no manifests
+        assert manager._effective_artifacts("anything", None) is None
+        assert manager._effective_artifacts("anything", {"agents": []}) == {"agents": []}

--- a/tests/cli/test_build_profile_validate.py
+++ b/tests/cli/test_build_profile_validate.py
@@ -47,6 +47,21 @@ def _errors(profile: BuildProfile, profile_dir: Path) -> list[str]:
     return body.split("\n  - ")
 
 
+def _graph_errors(profile: BuildProfile, profile_dir: Path) -> list[str]:
+    """The validation errors about the graph store alone, or ``[]`` if it validates.
+
+    An attached profile fails the qmd-sidecar rule on the same run — its render
+    keeps hybrid search on over ``services: {}`` — and these tests are about
+    the store rule, not the count of rules.
+    """
+    try:
+        profile.validate(profile_dir)
+    except BuildProfileError as exc:
+        _, _, body = str(exc).partition(":\n  - ")
+        return [error for error in body.split("\n  - ") if "services.graphdb" in error]
+    return []
+
+
 def _write_triggers(tmp_path: Path, name: str = "trig.yml") -> str:
     """Write a minimal triggers file into ``tmp_path`` and return its name."""
     (tmp_path / name).write_text("triggers: []", encoding="utf-8")
@@ -590,14 +605,27 @@ def test_graph_mode_with_an_external_store_uri_validates(tmp_path: Path) -> None
     profile.validate(tmp_path)
 
 
-def test_graph_mode_on_an_attached_project_is_rejected(tmp_path: Path) -> None:
-    """``deploy_services: false`` renders ``services: {}`` whatever the template says.
+def test_graph_mode_on_an_attached_project_follows_its_hosts_template(tmp_path: Path) -> None:
+    """``deploy_services: false`` renders ``services: {}`` — and is then told the
+    store's address by the build, from the hosting deployment's render.
 
-    So an attached project inherits no store from ``control_assistant``, and the
-    refusal says which knob emptied the block.
+    The attached profile IS the hosting profile plus a delta, so whether a
+    store will be there to project is the hosting template's question, answered
+    the same way: ``control_assistant`` deploys one, so no refusal; a storeless
+    template refuses exactly as it does for a deploying profile. An attached
+    profile built with no host in its repo is caught after the render instead
+    (``osprey.deployment.reach.reach_errors``), on the config it actually wrote.
     """
-    profile = BuildProfile(name="x", channel_finder_mode="graph", deploy_services=False)
-    (error,) = _errors(profile, tmp_path)
+    assert (
+        _graph_errors(
+            BuildProfile(name="x", channel_finder_mode="graph", deploy_services=False), tmp_path
+        )
+        == []
+    )
+    profile = BuildProfile(
+        name="x", data_bundle="hello_world", channel_finder_mode="graph", deploy_services=False
+    )
+    (error,) = _graph_errors(profile, tmp_path)
     assert "services.graphdb" in error
     assert "deploy_services: false" in error
 
@@ -612,7 +640,7 @@ def test_graph_mode_on_an_attached_project_with_an_external_store_validates(
         deploy_services=False,
         config={"services.graphdb.uri": "bolt://127.0.0.1:7687"},
     )
-    profile.validate(tmp_path)
+    assert _graph_errors(profile, tmp_path) == []
 
 
 def test_graph_mode_with_the_template_block_overridden_away_is_rejected(tmp_path: Path) -> None:
@@ -674,12 +702,13 @@ def test_graph_mode_skips_the_store_rule_when_the_channel_finder_is_off(
     nested = {"claude_code": {"servers": {"channel-finder": {"enabled": False}}}}
     mixed = {"claude_code.servers": {"channel-finder": {"enabled": False}}}
     for overlay in (dotted, nested, mixed):
-        BuildProfile(
+        profile = BuildProfile(
             name="x",
             channel_finder_mode="graph",
             deploy_services=False,
             config=overlay,
-        ).validate(tmp_path)
+        )
+        assert _graph_errors(profile, tmp_path) == []
 
 
 def test_graph_mode_still_needs_a_store_when_the_channel_finder_is_on(
@@ -688,8 +717,9 @@ def test_graph_mode_still_needs_a_store_when_the_channel_finder_is_on(
     """The carve-out is an explicit ``false``, not any mention of the key.
 
     A persona that leaves the channel finder on — or spells the switch ``true``
-    — is exactly the render the rule protects, so it is still refused without a
-    store.
+    — is exactly the render the rule protects, so on a template that deploys
+    no store (``hello_world``; ``control_assistant`` would answer the store
+    question itself) it is still refused.
     """
     for overlay in (
         {},
@@ -698,7 +728,118 @@ def test_graph_mode_still_needs_a_store_when_the_channel_finder_is_on(
         {"claude_code.servers.controls.enabled": False},
     ):
         profile = BuildProfile(
-            name="x", channel_finder_mode="graph", deploy_services=False, config=overlay
+            name="x",
+            data_bundle="hello_world",
+            channel_finder_mode="graph",
+            deploy_services=False,
+            config=overlay,
         )
-        (error,) = _errors(profile, tmp_path)
+        (error,) = _graph_errors(profile, tmp_path)
         assert "services.graphdb" in error
+
+
+# ---------------------------------------------------------------------------
+# Hybrid logbook search needs the qmd sidecar it dials
+# ---------------------------------------------------------------------------
+
+
+def _qmd_errors(profile: BuildProfile, profile_dir: Path) -> list[str]:
+    """The validation errors about the qmd sidecar alone.
+
+    An attached profile can fail the graph-store rule at the same time, and
+    these tests are about the sidecar rule, not the count of rules.
+    """
+    return [e for e in _errors(profile, profile_dir) if "services.qmd" in e]
+
+
+def test_hybrid_search_on_a_sidecar_deploying_app_template_validates(tmp_path: Path) -> None:
+    """The app templates that render a ``services.qmd`` block need nothing else."""
+    for bundle in ("control_assistant", "ariel_standalone"):
+        BuildProfile(name="x", data_bundle=bundle).validate(tmp_path)
+
+
+def test_hybrid_search_on_an_attached_project_follows_its_hosts_template(tmp_path: Path) -> None:
+    """``deploy_services: false`` renders ``services: {}`` — and is then told the
+    sidecar's port by the build, from the hosting deployment's render.
+
+    The template still switches ``ariel.search_modules.hybrid`` on, and the
+    hosting template deploys the sidecar the module dials, so nothing is
+    refused here; the build copies ``services.qmd.port`` into the attached
+    render (``osprey.deployment.reach``). What IS refused is the same shape a
+    deploying profile is refused for — a template that deploys no sidecar while
+    the module stays on — and, after the render, an attached profile built with
+    no host to be told by (``reach_errors``, on the config it actually wrote).
+    """
+    BuildProfile(name="x", deploy_services=False).validate(tmp_path)
+    profile = BuildProfile(name="x", deploy_services=False, config={"services.qmd": None})
+    (error,) = _qmd_errors(profile, tmp_path)
+    assert "ariel.search_modules.hybrid" in error
+    assert "services.qmd.port" in error
+    assert "deploy_services: false" in error
+
+
+def test_hybrid_search_on_an_attached_project_with_the_sidecar_port_validates(
+    tmp_path: Path,
+) -> None:
+    """An attached project with no host names a shared stack's sidecar itself."""
+    profile = BuildProfile(name="x", deploy_services=False, config={"services.qmd.port": 8180})
+    profile.validate(tmp_path)
+
+
+def test_hybrid_search_switched_off_needs_no_sidecar(tmp_path: Path) -> None:
+    """A profile that turns the module off has nothing to dial.
+
+    Only an explicit ``false`` counts, the same way the channel-finder switch
+    reads for the graph rule: the key is absent from every profile that keeps
+    the template's default, so absence reads as on. Both spellings of the
+    switch are honoured.
+    """
+    dotted = {"ariel.search_modules.hybrid.enabled": False}
+    nested = {"ariel": {"search_modules": {"hybrid": {"enabled": False}}}}
+    for overlay in (dotted, nested):
+        BuildProfile(name="x", deploy_services=False, config=overlay).validate(tmp_path)
+
+
+def test_hybrid_search_with_the_sidecar_block_overridden_away_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """A bare ``services.qmd:`` override deletes the block the template rendered.
+
+    The template's own comment tells an operator to drop the block, the
+    ``deployed_services`` entry AND the two ariel modules together; dropping
+    the block alone leaves hybrid search enabled with nothing behind it.
+    """
+    profile = BuildProfile(name="x", config={"services.qmd": None})
+    (error,) = _qmd_errors(profile, tmp_path)
+    assert "ariel.search_modules.hybrid" in error
+
+
+def test_hybrid_search_with_the_sidecar_block_and_the_module_dropped_together_validates(
+    tmp_path: Path,
+) -> None:
+    """Dropping the block together with the module is the supported no-sidecar path."""
+    BuildProfile(
+        name="x",
+        config={"services.qmd": None, "ariel.search_modules.hybrid.enabled": False},
+    ).validate(tmp_path)
+
+
+def test_a_malformed_sidecar_port_override_is_not_reported_as_a_missing_block(
+    tmp_path: Path,
+) -> None:
+    """A sidecar named with a bad port is still one this profile means to dial.
+
+    The resolver raises about the port where it can be acted on — the deploy
+    preflight — so this validator must not turn that into "no block at all".
+    """
+    BuildProfile(
+        name="x", deploy_services=False, config={"services.qmd.port": "not-a-port"}
+    ).validate(tmp_path)
+
+
+def test_an_app_template_without_ariel_needs_no_sidecar(tmp_path: Path) -> None:
+    """The prerequisite belongs to the hybrid module; a template with no ARIEL passes."""
+    BuildProfile(name="x", data_bundle="channel_finder_standalone").validate(tmp_path)
+    BuildProfile(name="x", data_bundle="channel_finder_standalone", deploy_services=False).validate(
+        tmp_path
+    )

--- a/tests/cli/test_dispatch_network_injection.py
+++ b/tests/cli/test_dispatch_network_injection.py
@@ -57,6 +57,8 @@ web:
     events:
       url: http://localhost:8020
       path: /dashboard
+      label: EVENTS
+      health_endpoint: /health
 """
 
 # The dispatcher block of the copied triggers file, likewise captured from the

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -315,6 +315,10 @@ class TestBuildPhases:
             lifecycle = _Lifecycle()
             config: dict = {}
             deploy = None
+            # A deploying profile: _build_repo reads the flag to decide whether
+            # the render just written becomes the host config every attached
+            # render after it is projected from.
+            deploy_services = True
 
             def resolved_tier(self) -> int:
                 return 1
@@ -334,9 +338,18 @@ class TestBuildPhases:
         monkeypatch.setattr(build_cmd, "_create_project_venv", lambda *a, **k: [])
 
         def _render(*a, injected_out=None, **k):
-            """Stand in for a render, recording one injected service."""
+            """Stand in for a render, recording one injected service.
+
+            Returns a directory with a ``config.yml`` because the real render
+            does: `_build_repo` reads the deployment's rendered config back as
+            the host every later attached render is projected from.
+            """
             if injected_out is not None:
                 injected_out.append("event dispatch")
+            render_dir = tmp_path / "build-stage"
+            render_dir.mkdir(exist_ok=True)
+            (render_dir / "config.yml").write_text("{}\n", encoding="utf-8")
+            return render_dir
 
         monkeypatch.setattr(build_cmd, "_render_project", _render)
         monkeypatch.setattr(build_cmd, "_render_compose_files", lambda *a, **k: {})

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -45,6 +45,8 @@ import pytest
 import yaml
 
 from osprey.cli.build_profile import BuildProfile, resolve_build_profile
+from osprey.deployment.qmd_service import DEFAULT_PORT as QMD_DEFAULT_PORT
+from osprey.deployment.qmd_service import resolve_qmd_service_config
 from osprey.deployment.web_terminals.lint import Finding, lint_web_terminals
 from osprey.registry.mcp import FRAMEWORK_SERVERS
 from osprey.utils.config_writer import config_update_fields
@@ -76,18 +78,13 @@ GALLERY_WRITE_KEY = "web.scaffold_gallery.write_enabled"
 ADMIN_LIFTED_FLOOR_KEYS = (CONFIG_PANEL_KEY, GALLERY_WRITE_KEY)
 # The skill that drives those surfaces from the agent side.
 ADMIN_ONLY_SKILL = "setup-mode"
-# The write-oriented panels: declared only in the readwrite persona, so the
-# readonly build genuinely lacks them (a persona delta can only add config
-# keys; `enabled: false` is inert for URL panels).
-READWRITE_PANEL_KEYS = (
-    "web.panels.events.label",
-    "web.panels.events.url",
-    "web.panels.events.path",
-    "web.panels.events.health_endpoint",
-    "web.panels.bluesky.label",
-    "web.panels.bluesky.url",
-    "web.panels.bluesky.path",
-)
+# The write-oriented panels: declared only in the readwrite persona's
+# `web_panels` list, so the readonly build genuinely lacks them (a persona
+# delta can only add; `enabled: false` is inert for URL panels). Their URL,
+# path and label are NOT preset config — the build projects them from the
+# hosting deployment's render (osprey.deployment.reach), which is asserted on
+# a real build in test_readwrite_is_told_its_panel_urls.
+READWRITE_PANELS = ("events", "bluesky")
 
 # The literal dotted key the hosting preset must carry: the whole web-terminals
 # module subtree addressed as one leaf so config_writer sets only this leaf and
@@ -589,10 +586,14 @@ class TestControlAssistantPersonas:
         for key in ADMIN_LIFTED_FLOOR_KEYS:
             assert rw_cfg.pop(key) is False, f"readwrite persona must not enable {key}"
             assert ad_cfg.pop(key) is True
-        # Operator-only panel declarations.
-        for key in READWRITE_PANEL_KEYS:
-            assert key not in ad_cfg, f"admin persona must not declare {key}"
-            rw_cfg.pop(key)
+        # The operator-only panels ride the readwrite persona's `web_panels`
+        # list, not its config: their URLs are projected by the build, so
+        # neither tier may spell one.
+        for panel in READWRITE_PANELS:
+            for cfg in (rw_cfg, ad_cfg):
+                assert not any(key.startswith(f"web.panels.{panel}.") for key in cfg), (
+                    f"no persona preset may pin web.panels.{panel}.* — the build projects it"
+                )
         assert ad_cfg == rw_cfg
 
     def test_personas_retain_base_config_overrides(self) -> None:
@@ -618,11 +619,16 @@ class TestControlAssistantPersonas:
         # Axis 2 — surface: chat-first for the viewer, full dock for the operator.
         assert ro_cfg.pop(UI_MODE_KEY) == "simple"
         assert rw_cfg.pop(UI_MODE_KEY) == "expert"
-        # Axis 3 — write-oriented panels: declared for the write tier only.
-        # pop() without default doubles as the presence assertion on rw_cfg.
-        for key in READWRITE_PANEL_KEYS:
-            assert key not in ro_cfg, f"readonly persona must not declare {key}"
-            rw_cfg.pop(key)
+        # Axis 3 — write-oriented panels — is not a config axis at all: the
+        # tabs ride the readwrite persona's `web_panels` list (asserted in
+        # test_personas_share_every_artifact_list_except_panels_and_the_admin_skill), and their
+        # URLs are projected from the hosting deployment's render rather than
+        # spelled in any preset.
+        for panel in READWRITE_PANELS:
+            for cfg in (ro_cfg, rw_cfg):
+                assert not any(key.startswith(f"web.panels.{panel}.") for key in cfg), (
+                    f"no persona preset may pin web.panels.{panel}.* — the build projects it"
+                )
         # With the tier-contract keys removed, the personas are identical.
         assert ro_cfg == rw_cfg
 
@@ -635,8 +641,8 @@ class TestControlAssistantPersonas:
         are allowed to differ, and both differ by ADDITION:
 
         * panels — the readwrite persona adds the write-oriented EVENTS/BLUESKY
-          tabs beside their URL declarations, and the readonly persona is built
-          without them;
+          tabs (their URLs are projected by the build, not declared), and the
+          readonly persona is built without them;
         * skills — the admin persona adds ``setup-mode``, the guided workflow
           that edits config.yml and .mcp.json, which is the agent-side half of
           the privilege its config keys turn on.
@@ -691,29 +697,31 @@ class TestControlAssistantPersonas:
             profile = resolve_preset(name)
             assert profile.config.get("modules.web_terminals.enabled") is False
 
-    def test_personas_pin_the_graph_store_port(self) -> None:
-        """All three tiers carry ``services.graphdb.port_host``, identically.
+    def test_personas_pin_no_service_address(self) -> None:
+        """No tier spells where the hosting deployment's services are.
 
         The personas render attached (``deploy_services: false``), so the app
-        template gives them ``services: {}`` and nothing says where the graph
-        store listens. This one dotted key is what puts a ``services.graphdb``
-        block into a persona's config at all — which is what makes the graph MCP
-        server render for them (see the build test below).
-
-        Spelled identically on both sides on purpose: the key cancels in
-        ``test_personas_differ_only_on_the_tier_contract``'s wholesale
-        comparison, so the tier contract stays three axes wide. It is NOT a
-        write boundary — reading the graph is a read on either tier.
+        template gives them ``services: {}`` — and the build then tells each
+        render every client-facing fact from the hosting deployment's own
+        render (``osprey.deployment.reach``): the graph store's bolt port, the
+        qmd sidecar's port, the Postgres, the telemetry store, the bridge, the
+        EVENTS and BLUESKY tab URLs. A preset that pinned one would be a second
+        copy of a number the host already states, free to drift when an
+        operator moves the service — and the build refuses such a pin.
         """
         for name in (
             "control-assistant-readonly",
             "control-assistant-readwrite",
             "control-assistant-admin",
+            "control-assistant-ariel",
         ):
             profile = resolve_preset(name)
-            assert profile.config.get("services.graphdb.port_host") == 7687
-            # Flat dotted key: a nested ``services:`` mapping here is silently
-            # dropped by the deep merge, so the block would never arrive.
+            pinned = sorted(
+                key
+                for key in profile.config
+                if str(key).startswith(("services.", "web.panels.events.", "web.panels.bluesky."))
+            )
+            assert pinned == [], f"{name} pins {pinned}"
             assert "services" not in profile.config
 
     @pytest.mark.parametrize("persona", ("readonly", "readwrite", "admin"))
@@ -723,13 +731,13 @@ class TestControlAssistantPersonas:
         """Every tier's terminal can query the hosting deployment's graph.
 
         Asserted on a real build rather than on the resolved profile, because the
-        claim spans the whole pipeline: the preset's dotted key has to survive
-        ``_apply_config_overrides``, land as a ``services.graphdb`` block in the
-        rendered config, be seen by ``config_derived_context`` as
+        claim spans the whole pipeline: the store's port has to be projected
+        from the hosting deployment's render (``osprey.deployment.reach``),
+        land as a ``services.graphdb`` block in the rendered config through
+        ``_apply_config_overrides``, be seen by ``config_derived_context`` as
         ``graphdb_configured``, and only then reach ``resolve_servers`` before
-        the Claude Code artifacts are written. An overlay applied after server
-        resolution would leave every assertion below false while the profile
-        still carried the key.
+        the Claude Code artifacts are written. A projection applied after
+        server resolution would leave every assertion below false.
 
         The whole main-agent surface is checked — permissions, a launchable
         ``.mcp.json`` entry and the PostToolUse prefix, with nothing behind
@@ -763,45 +771,114 @@ class TestControlAssistantPersonas:
         assert _graph_entries(tools) == []
 
     @pytest.mark.parametrize("persona", ("readonly", "readwrite"))
-    def test_graph_port_lands_inside_the_attached_renders_services_map(
+    def test_projected_facts_land_inside_the_attached_renders_services_map(
         self, built_persona_stack: Path, persona: str
     ) -> None:
-        """The dotted key is written *into* the attached render's empty
-        ``services`` map, and leaves nothing else behind.
+        """The projected keys are written *into* the attached render's empty
+        ``services`` map, carry the host's values, and leave nothing else behind.
 
         An attached persona scaffolds no services of its own — the app template
-        gives it ``services: {}`` — so after the overlay that map must hold the
-        graph store and nothing more. The test above asks what
-        ``services.graphdb`` is; this one asks what the whole map is, which is
-        the half that catches a dotted overlay landing beside the map instead of
-        inside it: a literal top-level ``"services.graphdb.port_host"`` string
-        key would satisfy ``config.yml`` as YAML, be ignored in silence by every
-        reader of ``services.graphdb``, and leave the assertion above free to
-        pass on a second, correct copy.
+        gives it ``services: {}`` — so after the projection that map must hold
+        exactly the client-facing facts of the services this tier's consumers
+        dial, each equal to the hosting render's, and nothing more: not the
+        host's own service knobs (image, heap, retention), and no literal
+        top-level ``"services.graphdb.port_host"`` string key beside the map,
+        which would satisfy ``config.yml`` as YAML and be read by nobody.
         """
         project = built_persona_stack / "build" / f"{built_persona_stack.name}-{persona}"
         config = yaml.safe_load((project / "config.yml").read_text(encoding="utf-8"))
+        host = yaml.safe_load(
+            (built_persona_stack / "build" / "config.yml").read_text(encoding="utf-8")
+        )
 
-        assert config["services"] == {"graphdb": {"port_host": 7687}}
+        assert config["services"] == {
+            "qmd": {"port": host["services"]["qmd"]["port"]},
+            "graphdb": {"port_host": host["services"]["graphdb"]["port_host"]},
+            "postgresql": {
+                "port_host": host["services"]["postgresql"]["port_host"],
+                "username": host["services"]["postgresql"]["username"],
+                "database_name": host["services"]["postgresql"]["database_name"],
+            },
+            "openobserve": {"port": host["services"]["openobserve"]["port"]},
+            "bluesky": {"port": host["services"]["bluesky"]["port"]},
+            "virtual_accelerator": {"port": host["services"]["virtual_accelerator"]["port"]},
+        }
+        assert config["services"]["qmd"]["port"] == QMD_DEFAULT_PORT
         assert [key for key in config if "." in str(key)] == []
 
+    def test_readwrite_is_told_its_panel_urls(self, built_persona_stack: Path) -> None:
+        """The EVENTS and BLUESKY tabs the readwrite tier declares are told
+        exactly what the hosting render carries for them — where the dispatch
+        and bluesky-web injectors derived them — not what any preset spells.
+        Every projected leaf matches, absent ones included — the whole entry
+        the dispatch and bluesky-web injectors derive (url, path, label, and
+        the health endpoint where the service serves one) and nothing more."""
+        project = built_persona_stack / "build" / f"{built_persona_stack.name}-readwrite"
+        config = yaml.safe_load((project / "config.yml").read_text(encoding="utf-8"))
+        host = yaml.safe_load(
+            (built_persona_stack / "build" / "config.yml").read_text(encoding="utf-8")
+        )
+        for panel in ("events", "bluesky"):
+            told = config["web"]["panels"][panel]
+            hosts = host["web"]["panels"][panel]
+            assert told["url"] == hosts["url"], panel
+            for leaf in ("path", "label", "health_endpoint"):
+                assert told.get(leaf) == hosts.get(leaf), (panel, leaf)
+        readonly = yaml.safe_load(
+            (
+                built_persona_stack
+                / "build"
+                / f"{built_persona_stack.name}-readonly"
+                / "config.yml"
+            ).read_text(encoding="utf-8")
+        )
+        assert "events" not in readonly["web"]["panels"]
+        assert "bluesky" not in readonly["web"]["panels"]
+
+    @pytest.mark.parametrize("persona", ("readonly", "readwrite", "ariel"))
+    def test_attached_personas_resolve_the_qmd_sidecar(
+        self, built_persona_stack: Path, persona: str
+    ) -> None:
+        """Every persona's rendered config names the sidecar its hybrid search dials.
+
+        Asserted on a real build and through the client's own resolver, because
+        this is the seam the query-time failure lives on: the app template
+        enables ``ariel.search_modules.hybrid`` for the persona, and the module
+        resolves its endpoint from ``services.qmd`` of the *same* config. A
+        persona that renders one without the other is a terminal whose logbook
+        search fails on every query, and nothing before this test looked at
+        both halves together.
+        """
+        project = built_persona_stack / "build" / f"{built_persona_stack.name}-{persona}"
+        assert project.is_dir(), f"{persona} was never rendered"
+        config = yaml.safe_load((project / "config.yml").read_text(encoding="utf-8"))
+
+        hybrid = config["ariel"]["search_modules"]["hybrid"]
+        assert hybrid["enabled"] is True, "the template no longer enables hybrid search"
+
+        resolved = resolve_qmd_service_config(config)
+        assert resolved is not None, f"{persona}: hybrid search is on but no services.qmd"
+        assert resolved.port == QMD_DEFAULT_PORT
+        assert resolved.base_url == f"http://127.0.0.1:{QMD_DEFAULT_PORT}"
+
     def test_ariel_persona_renders_no_graph_surface(self, built_persona_stack: Path) -> None:
-        """The logbook tier is graph-less, and by omission rather than by veto.
+        """The logbook tier is graph-less, and by veto rather than by omission.
 
         ``control-assistant-ariel`` switches off every control-surface tool
-        server explicitly (``claude_code.servers.<name>.enabled: false``), but
-        carries no ``services.graphdb`` key at all — so the graph server never
-        becomes eligible in the first place and needs no such line. That
-        distinction matters for whoever edits these presets next: adding the port
-        key to this tier would hand it the graph tools, and no ``enabled: false``
-        elsewhere would take them away again.
+        server explicitly (``claude_code.servers.<name>.enabled: false``), the
+        graph server among them. The line is load-bearing now: the build tells
+        every attached render where the hosting deployment's services are, and
+        a ``services.graphdb`` block is what makes the graph server render —
+        so only a server switched off is told nothing about the store
+        (``osprey.deployment.reach``, the graphdb contract's gate).
         """
         project = built_persona_stack / "build" / f"{built_persona_stack.name}-ariel"
         assert project.is_dir(), "the ariel persona was never rendered"
 
         config = yaml.safe_load((project / "config.yml").read_text(encoding="utf-8"))
         assert (config.get("services") or {}).get("graphdb") is None
-        assert "services.graphdb.port_host" not in resolve_preset("control-assistant-ariel").config
+        preset = resolve_preset("control-assistant-ariel").config
+        assert preset.get("claude_code.servers.graph.enabled") is False
 
         hits = sorted(
             str(path.relative_to(project))

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -104,16 +104,20 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Re-recorded again where the render-zone/posture branch met main: the
     # tier floor, the admin tier, the `target-state` hook and the
     # facility-knowledge-graph agent all sit in the resolved content now, so
-    # the five control-assistant digests below are the merged value. The admin
-    # digest moved once more when the persona gained the `services.graphdb.port_host`
-    # pin its two siblings already carried — the graph paradigm's build rule
-    # requires it on every attached render.
+    # the five control-assistant digests below are the merged value.
+    # Re-recorded once more where the Reach Contract met the tiers: the admin
+    # persona's `services.graphdb.port_host` pin left with its two siblings'
+    # (the build projects every service address into an attached render), so
+    # the four attached digests are what the merged presets hash to. The base
+    # is NOT among them — it pinned no address to lose — and its digest below
+    # is main's, unmoved, which is the check that the contract touched only
+    # the attached tiers.
     "control-assistant": "sha256:cb3ea6aecf66e90326c0be0dcead918c98a30fb3fe606ada26e07187ac2f2f64",
     "control-assistant-admin": (
-        "sha256:ec9c084fec32f0eb749b167d070a847c7510956a421b0b3ea28d3fabd49b3bac"
+        "sha256:ff2492ee9f5001ed3b385f987b6cff882834dd8fcd4d53130c8cdc7e6186c24b"
     ),
     "control-assistant-ariel": (
-        "sha256:1543570519193a43675a6caf97fcae47dd02d8db51d2c1b08db7f58e13332479"
+        "sha256:646df29c8945900f8535191a3a496df86b83d09ff23ad7f4e87746fe8ce4e16f"
     ),
     # The two operator tiers below moved together, and alone, when each gained
     # the single dotted key `services.graphdb.port_host: 7687` in its `config:`
@@ -132,11 +136,30 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # content, so the digest here is neither branch's recorded value but the one
     # the merged preset actually hashes to. Deploy-visible for both reasons at
     # once, which is what the advisory should say.
+    # Moved again — with `control-assistant-ariel` this time, all three leaves
+    # and not the base — when each gained the single dotted key
+    # `services.qmd.port: 8180`: the same attached-render reasoning as the graph
+    # port above, for the qmd sidecar that hybrid logbook search dials. NOT
+    # behavior-neutral: a rebuilt persona terminal's logbook search stops
+    # failing with "no qmd sidecar is configured", so the deploy-side staleness
+    # advisory firing on already-deployed persona projects is the correct
+    # signal.
+    # Moved again — all three leaves, not the base — when the Reach Contract
+    # landed and every service-address pin left these presets: the
+    # `services.graphdb.port_host` and `services.qmd.port` keys recorded
+    # above, and (readwrite) the `web.panels.events.*`/`web.panels.bluesky.*`
+    # URL pins. The build now copies each of those facts — and more: the
+    # Postgres, the telemetry store, the bridge, the VA port — from the
+    # hosting deployment's render into every attached persona, so the presets
+    # state nothing an operator's port move could strand. Deploy-visible: a
+    # rebuilt persona's rendered config gains the projected blocks, so the
+    # staleness advisory firing on already-deployed persona projects is the
+    # correct signal.
     "control-assistant-readonly": (
-        "sha256:510040faaf8f74b06fdec79fd074802f267d72778149415c028faaa94fc9aff2"
+        "sha256:d06220d4429a3f627efb71205c9f53a1b179c194f964a662a2947bcabfbb4dc5"
     ),
     "control-assistant-readwrite": (
-        "sha256:d89ba4a562bb0281afd6215f8ce8b8031c24f0f3567730883ea8aba4e251a6e3"
+        "sha256:b5c68c2b9f64bf83eec5902ffb3cdf3697f9ae4b9d88d39a2afc400d4f6073b7"
     ),
     # Moved when the onboarding rewrite dropped the `facility` rule. The
     # wholesale comment rewrite that shipped alongside it contributed nothing:

--- a/tests/cli/test_profile_reach_overrides.py
+++ b/tests/cli/test_profile_reach_overrides.py
@@ -1,0 +1,375 @@
+"""What an attached render is told about the services its host deploys.
+
+A web-terminal persona is an attached project: it scaffolds no services, so
+the injectors that write ``services.<name>`` blocks never run for it — yet its
+in-container clients resolve their endpoints from exactly those blocks, and
+bottom out in a compiled-in default (or refuse at first use) when a block is
+absent. The build therefore PROJECTS the client-facing facts the Reach
+Contract registry declares from the hosting deployment's render into the
+attached render. These tests pin the projection's rules — gated on the
+attached render's own switches, panel keys on the profile's selection, nothing
+without a host — the refusal of a profile that spells a projected key by hand,
+and the client resolvers' half of the contract.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from osprey.bluesky_bridge_connection import (
+    DEFAULT_BRIDGE_PORT,
+    DEFAULT_BRIDGE_URL,
+    bridge_url_from_config,
+    resolve_bridge_url,
+)
+from osprey.cli.build_profile_reach import (
+    attached_render_overrides,
+    orphan_panel_fragments,
+    reach_override_errors,
+    selected_panel_errors,
+)
+from osprey.cli.build_profile_schema import BlueskyConfig
+from osprey.deployment.reach import REACH_CONTRACTS, project_attached_overrides
+
+HOST = {
+    "services": {
+        "qmd": {"port": 18180, "interval": 30},
+        "graphdb": {"port_host": 17687, "heap_max_size": "1G"},
+        "postgresql": {"port_host": 15432, "username": "ariel", "database_name": "ariel"},
+        "openobserve": {"port": 15080, "retention_days": 14},
+        "bluesky": {"port": 18090, "tiled_port": 8091},
+        "virtual_accelerator": {"port": 15064},
+    },
+    "web": {
+        "panels": {
+            "events": {
+                "url": "${EVENT_DISPATCHER_URL:-http://localhost:18020}",
+                "path": "/dashboard",
+                "label": "EVENTS",
+                "health_endpoint": "/health",
+            },
+            "bluesky": {
+                "url": "${BLUESKY_WEB_URL:-http://localhost:18095}",
+                "path": "/bluesky/",
+                "label": "BLUESKY",
+            },
+        }
+    },
+}
+
+#: An attached render that switches every consumer on.
+ALL_ON = {
+    "ariel": {"database": {}, "search_modules": {"hybrid": {"enabled": True}}},
+    "claude_code": {
+        "servers": {"bluesky": {"enabled": True}},
+        "telemetry": {"enabled": True, "backend": "openobserve"},
+    },
+    "control_system": {"type": "virtual_accelerator"},
+}
+
+
+# ---------------------------------------------------------------------------
+# The projection
+# ---------------------------------------------------------------------------
+
+
+def test_every_live_consumer_is_told_its_hosts_fact():
+    projected = project_attached_overrides(HOST, ALL_ON, selected_panels=("events", "bluesky"))
+    assert projected == {
+        "services.qmd.port": 18180,
+        "services.graphdb.port_host": 17687,
+        "services.postgresql.port_host": 15432,
+        "services.postgresql.username": "ariel",
+        "services.postgresql.database_name": "ariel",
+        "services.openobserve.port": 15080,
+        "services.bluesky.port": 18090,
+        "web.panels.bluesky.url": "${BLUESKY_WEB_URL:-http://localhost:18095}",
+        "web.panels.bluesky.path": "/bluesky/",
+        "web.panels.bluesky.label": "BLUESKY",
+        "web.panels.events.url": "${EVENT_DISPATCHER_URL:-http://localhost:18020}",
+        "web.panels.events.path": "/dashboard",
+        "web.panels.events.label": "EVENTS",
+        "web.panels.events.health_endpoint": "/health",
+        "services.virtual_accelerator.port": 15064,
+    }
+
+
+def test_a_two_lane_host_projects_both_lanes_port_and_target():
+    """``bluesky.second_lane`` renders a second bridge and stamps ``target`` on
+    both lane blocks; a persona told only lane 1's port would be a single-lane
+    render whose session, switched to the other machine, is refused rather
+    than routed. Port AND target: the lane resolver picks the active lane by
+    matching each lane's declared target against the session's."""
+    host = copy.deepcopy(HOST)
+    host["services"]["bluesky"]["target"] = "va"
+    host["services"]["bluesky_live"] = {
+        "path": "./services/bluesky",
+        "port": 18190,
+        "target": "live",
+        "ca_name_servers": "${EPICS_CA_NAME_SERVERS:?set it}",
+    }
+    projected = project_attached_overrides(host, ALL_ON)
+    lane_keys = {k: v for k, v in projected.items() if ".bluesky" in k}
+    assert lane_keys == {
+        "services.bluesky.port": 18090,
+        "services.bluesky.target": "va",
+        "services.bluesky_live.port": 18190,
+        "services.bluesky_live.target": "live",
+    }
+
+
+def test_a_single_lane_host_projects_no_lane_target():
+    """``target`` is written only on a two-lane deploy; a single-lane persona
+    stays byte-for-byte the pre-lane render, which is that resolver's
+    single-lane answer."""
+    projected = project_attached_overrides(HOST, ALL_ON)
+    assert not any(key.endswith(".target") for key in projected)
+    assert not any("bluesky_va" in key or "bluesky_live" in key for key in projected)
+
+
+def test_a_persona_with_the_bluesky_server_off_is_told_no_lane():
+    host = copy.deepcopy(HOST)
+    host["services"]["bluesky_va"] = {"port": 18190, "target": "va"}
+    off = copy.deepcopy(ALL_ON)
+    off["claude_code"]["servers"]["bluesky"] = {"enabled": False}
+    projected = project_attached_overrides(host, off)
+    assert not any("bluesky" in key for key in projected)
+
+
+def test_only_the_client_facing_keys_are_projected():
+    """The host's ``interval``, ``heap_max_size``, ``retention_days``,
+    ``tiled_port`` describe the service it RUNS; a client needs none of them."""
+    projected = project_attached_overrides(HOST, ALL_ON, selected_panels=("events", "bluesky"))
+    assert not any(
+        key.endswith((".interval", ".heap_max_size", ".retention_days", ".tiled_port"))
+        for key in projected
+    )
+
+
+def test_a_consumer_switched_off_is_told_nothing():
+    """A fact projected into a render with no consumer for it would grow a
+    surface — a ``services.graphdb`` block makes the graph server render."""
+    off = {
+        "ariel": {"database": {}, "search_modules": {"hybrid": {"enabled": False}}},
+        "claude_code": {
+            "servers": {"graph": {"enabled": False}, "bluesky": {"enabled": False}},
+            "telemetry": {"enabled": False},
+        },
+        "control_system": {"type": "mock"},
+    }
+    projected = project_attached_overrides(HOST, off)
+    assert set(projected) == {
+        # The ARIEL database: the ``ariel:`` block is present, so its DSN is
+        # still derived — and must be derived from the host's Postgres.
+        "services.postgresql.port_host",
+        "services.postgresql.username",
+        "services.postgresql.database_name",
+    }
+
+
+def test_panel_keys_follow_the_profiles_panel_selection():
+    """A custom panel exists in a render only through its ``web.panels`` keys, so
+    the rendered config cannot say whether the profile selected it — the
+    ``web_panels`` list can, and does."""
+    assert not any(
+        key.startswith("web.panels.") for key in project_attached_overrides(HOST, ALL_ON)
+    )
+    events_only = project_attached_overrides(HOST, ALL_ON, selected_panels=("events",))
+    assert {k for k in events_only if k.startswith("web.panels.")} == {
+        "web.panels.events.url",
+        "web.panels.events.path",
+        "web.panels.events.label",
+        "web.panels.events.health_endpoint",
+    }
+
+
+def test_a_host_that_dropped_a_service_projects_nothing_for_it():
+    host = {"services": {"postgresql": {"port_host": 5432}}}
+    projected = project_attached_overrides(host, ALL_ON, selected_panels=("events",))
+    assert projected == {"services.postgresql.port_host": 5432}
+
+
+def test_no_host_projects_nothing():
+    assert project_attached_overrides(None, ALL_ON, selected_panels=("events",)) == {}
+    assert project_attached_overrides({}, ALL_ON) == {}
+
+
+def test_the_build_entry_point_is_the_registrys_projection():
+    assert attached_render_overrides(HOST, ALL_ON, selected_panels=("events",)) == (
+        project_attached_overrides(HOST, ALL_ON, selected_panels=("events",))
+    )
+
+
+def test_the_projected_keys_are_the_ones_the_injectors_and_remedies_name():
+    """The attached render and the deploying render must name each fact under
+    one spelling, or a client following the deploying spelling reads nothing
+    in a persona. Pinned against the deploy preflight's own remedy table."""
+    from osprey.deployment.host_ports import _SERVICE_REMEDY_KEYS
+
+    projected = {p.key for c in REACH_CONTRACTS.values() for p in c.projected}
+    for compose_name, key in _SERVICE_REMEDY_KEYS.items():
+        if compose_name in (
+            "dispatch-worker",
+            "tiled",
+            "bluesky-web",
+            "event-dispatcher",
+            "mongodb",
+        ):
+            continue  # not a client-facing key: the worker base, a port only the bridge dials, panel URLs, the archive's own path
+        assert key in projected, (
+            f"{compose_name}: {key} is a published port no attached render is told"
+        )
+
+
+# ---------------------------------------------------------------------------
+# A hand-spelled duplicate is refused
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"services.bluesky.port": 1},
+        {"services.bluesky": {"port": 1}},
+    ],
+    ids=["dotted", "nested-under-prefix"],
+)
+def test_a_spelling_that_contradicts_the_projection_is_refused(config):
+    """One fact with two homes is free to disagree, and the disagreeing case
+    is the silent one — so it is the one refused, naming both values."""
+    errors = reach_override_errors(config, {"services.bluesky.port": 18090})
+    assert len(errors) == 1
+    assert "services.bluesky.port" in errors[0]
+    assert "18090" in errors[0] and "1" in errors[0]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"services.bluesky.port": 18090},
+        {"services.bluesky": {"port": 18090}},
+    ],
+    ids=["dotted", "nested-under-prefix"],
+)
+def test_a_spelling_that_agrees_is_the_same_fact(config):
+    """A persona profile inherits the hosting profile's ``config:`` dotted
+    keys, so a host that moved its bridge port there spells it in every
+    persona's merged config — as the host's own value. Refusing that would
+    refuse every moved port; the spelling and the projection agree."""
+    assert reach_override_errors(config, {"services.bluesky.port": 18090}) == []
+
+
+def test_nothing_projected_refuses_nothing():
+    assert reach_override_errors({"services.bluesky.port": 1}, {}) == []
+    assert reach_override_errors({}, {"services.bluesky.port": 18090}) == []
+
+
+# ---------------------------------------------------------------------------
+# The client's half: the bridge URL follows the published port
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_url_follows_the_published_port():
+    assert bridge_url_from_config({"services": {"bluesky": {"port": 18090}}}) == (
+        "http://127.0.0.1:18090"
+    )
+
+
+def test_bridge_url_config_url_beats_the_published_port():
+    config = {"bluesky": {"bridge_url": "http://bridge:9/"}, "services": {"bluesky": {"port": 1}}}
+    assert bridge_url_from_config(config) == "http://bridge:9"
+
+
+@pytest.mark.parametrize("config", [None, {}, {"bluesky": {}}, {"services": {"bluesky": {}}}])
+def test_bridge_url_falls_back_to_the_default(config):
+    assert bridge_url_from_config(config) == DEFAULT_BRIDGE_URL
+    assert DEFAULT_BRIDGE_URL.endswith(f":{DEFAULT_BRIDGE_PORT}")
+
+
+def test_default_port_is_the_profiles_default():
+    """The compiled-in fallback and the schema default are one number, so a
+    profile that declares nothing and a client that reads nothing agree."""
+    assert DEFAULT_BRIDGE_PORT == BlueskyConfig().port
+
+
+def test_resolve_bridge_url_reads_the_config_when_the_env_is_empty(monkeypatch, tmp_path):
+    """The MCP server definition exports ``${BLUESKY_BRIDGE_URL:-}`` — an unset
+    variable reaches the server EMPTY and must count as no override."""
+    import yaml
+
+    from osprey.utils.workspace import reset_config_cache
+
+    (tmp_path / "config.yml").write_text(
+        yaml.safe_dump({"services": {"bluesky": {"port": 18090}}}), encoding="utf-8"
+    )
+    monkeypatch.setenv("BLUESKY_BRIDGE_URL", "")
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
+    reset_config_cache()
+    try:
+        assert resolve_bridge_url() == "http://127.0.0.1:18090"
+    finally:
+        reset_config_cache()
+
+
+def test_a_non_mapping_config_block_spells_nothing():
+    """A profile with no ``config:`` at all (None) contradicts no projection."""
+    assert reach_override_errors(None, {"services.qmd.port": 8180}) == []
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        {"services.bluesky.port": 9999},
+        {"services.bluesky": {"port": 9999}},
+        {"services": {"bluesky.port": 9999}},
+        {"services": {"bluesky": {"port": 9999}}},
+    ],
+)
+def test_every_spelling_of_a_contradicting_pin_is_refused(spelling):
+    """Dotted, prefix-over-mapping, fully nested and mixed: each is legal YAML
+    for the same rendered leaf, so each is found — a spelling missed here is
+    a pin the projection would silently overwrite."""
+    (error,) = reach_override_errors(spelling, {"services.bluesky.port": 18090})
+    assert "9999" in error and "18090" in error
+
+
+def test_every_spelling_of_an_agreeing_pin_is_allowed():
+    for spelling in (
+        {"services.bluesky.port": 18090},
+        {"services": {"bluesky": {"port": 18090}}},
+    ):
+        assert reach_override_errors(spelling, {"services.bluesky.port": 18090}) == []
+
+
+def test_a_selected_tab_told_no_address_is_refused():
+    """``web_panels: [events]`` is a consumer the profile switches on; when
+    the host it was told about runs no dispatcher, the render would simply
+    lack the tab. Named instead, with the service and the key."""
+    rendered = {"web": {"panels": {"bluesky": {"url": "http://localhost:8095"}}}}
+    (error,) = selected_panel_errors(["events", "bluesky", "okf"], rendered, told_by="the host")
+    assert "web.panels.events.url" in error
+    assert "event_dispatcher" in error
+    assert "the host" in error
+    assert selected_panel_errors(["bluesky"], rendered, told_by="the host") == []
+    assert selected_panel_errors(["okf"], {}, told_by="the host") == []
+
+
+def test_an_inherited_fragment_of_an_unselected_tab_is_dropped():
+    """A host that pins ``web.panels.events.path`` hands every persona the
+    fragment; a persona that never selected the tab drops it, one that did
+    keeps it (the projection supplies the url), and a fragment that names a
+    url is a tab in its own right and stays."""
+    rendered = {
+        "web": {
+            "panels": {
+                "events": {"path": "/custom-route"},
+                "bluesky": {"url": "http://localhost:8095", "path": "/bluesky/"},
+                "okf": {"enabled": True},
+            }
+        }
+    }
+    assert orphan_panel_fragments([], rendered) == ["web.panels.events"]
+    assert orphan_panel_fragments(["events"], rendered) == []
+    assert orphan_panel_fragments(["okf"], {"web": {"panels": {"okf": {"enabled": True}}}}) == []

--- a/tests/cli/test_profile_schema.py
+++ b/tests/cli/test_profile_schema.py
@@ -192,19 +192,19 @@ def test_servicedef_osprey_prefix_skips_filesystem_check(tmp_path: Path) -> None
 
 def test_control_assistant_readwrite_persona_ships_events_panel() -> None:
     """The control-assistant family exposes the event-dispatcher dashboard as
-    a custom ``events`` web panel on its write-capable tier: the readwrite
-    persona declares the panel id beside the URL override that makes
-    ``BuildProfile.validate`` accept it (custom panels require
-    ``web.panels.<id>.url``), while the base and readonly presets carry
-    neither. Guards the wiring — id and URL travel together — against
-    regressions."""
+    an ``events`` web panel on its write-capable tier: the readwrite persona
+    declares the panel id and nothing else — its URL is projected into the
+    persona's render from the hosting deployment's own, where the dispatch
+    injector derived it (``osprey.deployment.reach``), so no preset carries a
+    second copy the injector could drift from. The base preset carries
+    neither the id nor a URL."""
     presets_dir = bp._presets_dir()
     profile, _dir = bp.resolve_build_profile(None, preset="control-assistant-readwrite")
 
     profile.validate(presets_dir)  # raises BuildProfileError on any issue
 
     assert "events" in profile.web_panels
-    assert profile.config["web.panels.events.url"]
+    assert "web.panels.events.url" not in profile.config
 
     base, _dir = bp.resolve_build_profile(None, preset="control-assistant")
     assert "events" not in base.web_panels

--- a/tests/cli/test_telemetry_env.py
+++ b/tests/cli/test_telemetry_env.py
@@ -558,6 +558,95 @@ def test_host_override_none_falls_through_to_derivation():
     assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:5080/api/default"
 
 
+def test_resolved_port_is_the_endpoints_port():
+    """The endpoint dials the port handed in — never a literal.
+
+    The store is reached on the port it PUBLISHES from the host and from a
+    host-networked container, and a project moves that port freely; the 5080
+    the image listens on is right only inside the store's own compose network.
+    """
+    env = _build_telemetry_env(_OO_CFG, in_container=False, openobserve_port=15080)
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:15080/api/default"
+    env2 = _build_telemetry_env(
+        _OO_CFG, in_container=True, openobserve_host="127.0.0.1", openobserve_port=15080
+    )
+    assert env2["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://127.0.0.1:15080/api/default"
+
+
+def test_no_port_falls_back_to_the_listen_port():
+    """Omitted, the port is the one the image listens on (5080)."""
+    from osprey.build.claude_code_telemetry import OPENOBSERVE_LISTEN_PORT
+
+    env = _build_telemetry_env(_OO_CFG, in_container=True, openobserve_port=None)
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == (
+        f"http://openobserve:{OPENOBSERVE_LISTEN_PORT}/api/default"
+    )
+
+
+def test_published_port_reads_the_services_block():
+    """``openobserve_published_port`` follows ``services.openobserve.port``."""
+    from osprey.build.claude_code_telemetry import (
+        OPENOBSERVE_LISTEN_PORT,
+        openobserve_published_port,
+    )
+
+    assert openobserve_published_port({"services": {"openobserve": {"port": 15080}}}) == 15080
+    assert openobserve_published_port({"services": {"openobserve": {"port": "15080"}}}) == 15080
+    assert openobserve_published_port({"services": {}}) == OPENOBSERVE_LISTEN_PORT
+    assert openobserve_published_port({}) == OPENOBSERVE_LISTEN_PORT
+    assert openobserve_published_port(None) == OPENOBSERVE_LISTEN_PORT
+    with pytest.raises(TelemetryConfigError, match="services.openobserve.port"):
+        openobserve_published_port({"services": {"openobserve": {"port": "five"}}})
+
+
+def test_port_override_helper(monkeypatch):
+    """``OSPREY_OTEL_OPENOBSERVE_PORT`` is the port half of the host override."""
+    from osprey.build.claude_code_telemetry import (
+        OPENOBSERVE_PORT_ENV_VAR,
+        _openobserve_port_override,
+        resolve_openobserve_port,
+    )
+
+    published = {"services": {"openobserve": {"port": 15080}}}
+    monkeypatch.delenv(OPENOBSERVE_PORT_ENV_VAR, raising=False)
+    assert _openobserve_port_override() is None
+    assert resolve_openobserve_port(published) == 15080
+    monkeypatch.setenv(OPENOBSERVE_PORT_ENV_VAR, "")
+    assert _openobserve_port_override() is None
+    monkeypatch.setenv(OPENOBSERVE_PORT_ENV_VAR, "5080")
+    assert _openobserve_port_override() == 5080
+    # The bridge case: the compose author declared the listen port, and it
+    # wins over the published port the config names.
+    assert resolve_openobserve_port(published) == 5080
+    monkeypatch.setenv(OPENOBSERVE_PORT_ENV_VAR, "x")
+    with pytest.raises(TelemetryConfigError, match=OPENOBSERVE_PORT_ENV_VAR):
+        _openobserve_port_override()
+
+
+def test_load_provider_spec_dials_the_published_port(tmp_path, monkeypatch):
+    """The runtime launch path threads ``services.openobserve.port`` through."""
+    import yaml
+
+    from osprey.build.claude_code_resolver import load_provider_spec
+    from osprey.build.claude_code_telemetry import OPENOBSERVE_PORT_ENV_VAR
+
+    monkeypatch.delenv(OPENOBSERVE_PORT_ENV_VAR, raising=False)
+    monkeypatch.delenv("OSPREY_OTEL_OPENOBSERVE_HOST", raising=False)
+    monkeypatch.setattr(resolver, "_running_in_container", lambda: False)
+    (tmp_path / "config.yml").write_text(
+        yaml.safe_dump(
+            {
+                "claude_code": {"provider": "anthropic", "telemetry": _OO_CFG},
+                "services": {"openobserve": {"port": 15080}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    spec = load_provider_spec(tmp_path)
+    assert spec is not None
+    assert spec.env_block["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:15080/api/default"
+
+
 def test_host_override_helper_empty_string_is_none(monkeypatch):
     monkeypatch.delenv("OSPREY_OTEL_OPENOBSERVE_HOST", raising=False)
     assert _openobserve_host_override() is None
@@ -829,3 +918,48 @@ def test_deferred_var_credential_warns_not_raises_through_resolve(monkeypatch, r
     assert "OTEL_EXPORTER_OTLP_HEADERS" not in spec.env_block
     assert spec.env_block["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
     assert any("unresolved" in str(w.message) for w in recwarn)
+
+
+class TestTelemetryPortIsATelemetryInput:
+    """A malformed ``services.openobserve.port`` is a telemetry fault, and a
+    caller that asked for no telemetry must not see it: the dispatch worker's
+    degrade-and-retry re-resolves with ``include_telemetry=False`` precisely
+    to keep the provider's auth when telemetry is misconfigured."""
+
+    _CONFIG = (
+        "api:\n"
+        "  providers:\n"
+        "    anthropic:\n"
+        "      api_key: ${ANTHROPIC_API_KEY}\n"
+        "claude_code:\n"
+        "  provider: anthropic\n"
+        "  telemetry:\n"
+        "    enabled: true\n"
+        "    backend: openobserve\n"
+        "services:\n"
+        "  openobserve:\n"
+        "    port: not-a-port\n"
+    )
+
+    def test_without_telemetry_the_port_is_never_resolved(self, tmp_path, monkeypatch):
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        (tmp_path / "config.yml").write_text(self._CONFIG)
+
+        spec = load_provider_spec(tmp_path, include_telemetry=False)
+
+        assert spec.provider == "anthropic"
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in spec.env_block
+
+    def test_with_telemetry_the_port_fault_is_loud(self, tmp_path, monkeypatch):
+        import pytest
+
+        from osprey.build.claude_code_resolver import load_provider_spec
+        from osprey.build.claude_code_telemetry import TelemetryConfigError
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        (tmp_path / "config.yml").write_text(self._CONFIG)
+
+        with pytest.raises(TelemetryConfigError, match="services.openobserve.port"):
+            load_provider_spec(tmp_path, include_telemetry=True)

--- a/tests/deployment/test_legacy_mirror_preflight.py
+++ b/tests/deployment/test_legacy_mirror_preflight.py
@@ -1,0 +1,71 @@
+"""``osprey up`` names a logbook mirror left under the retired ``build/`` anchor.
+
+The mirror is derived, so nothing is moved: the preflight warns, counts the
+files, and names ``osprey ariel qmd-resync`` — and stays silent when there is
+nothing under the old path, when the export is off, or when the path is
+absolute (no anchor to have moved).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from osprey.deployment.container_lifecycle import _preflight_legacy_ariel_mirror
+
+
+def _config(mirror_path: str = "var/ariel_mirror", *, enabled: bool = True) -> dict:
+    return {
+        "ariel": {
+            "enhancement_modules": {
+                "qmd_export": {"enabled": enabled, "mirror_path": mirror_path},
+            }
+        }
+    }
+
+
+def test_files_under_the_legacy_anchor_are_named(tmp_path, caplog):
+    legacy = tmp_path / "build" / "var" / "ariel_mirror"
+    legacy.mkdir(parents=True)
+    (legacy / "2026-01-01_entry.md").write_text("# entry\n")
+    (legacy / "2026-01-02_entry.md").write_text("# entry\n")
+
+    with caplog.at_level(logging.WARNING):
+        _preflight_legacy_ariel_mirror(_config(), tmp_path)
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "2 file(s)" in message
+    assert str(legacy) in message
+    assert str(tmp_path / "var" / "ariel_mirror") in message
+    assert "osprey ariel qmd-resync" in message
+
+
+def test_an_empty_legacy_directory_is_silent(tmp_path, caplog):
+    (tmp_path / "build" / "var" / "ariel_mirror").mkdir(parents=True)
+    with caplog.at_level(logging.WARNING):
+        _preflight_legacy_ariel_mirror(_config(), tmp_path)
+    assert caplog.records == []
+
+
+def test_no_legacy_directory_is_silent(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING):
+        _preflight_legacy_ariel_mirror(_config(), tmp_path)
+    assert caplog.records == []
+
+
+def test_a_disabled_export_is_silent(tmp_path, caplog):
+    legacy = tmp_path / "build" / "var" / "ariel_mirror"
+    legacy.mkdir(parents=True)
+    (legacy / "entry.md").write_text("# entry\n")
+    with caplog.at_level(logging.WARNING):
+        _preflight_legacy_ariel_mirror(_config(enabled=False), tmp_path)
+    assert caplog.records == []
+
+
+def test_an_absolute_mirror_path_is_silent(tmp_path, caplog):
+    """An absolute path never had an anchor to move."""
+    mirror = tmp_path / "elsewhere"
+    mirror.mkdir()
+    with caplog.at_level(logging.WARNING):
+        _preflight_legacy_ariel_mirror(_config(str(mirror)), tmp_path)
+    assert caplog.records == []

--- a/tests/deployment/test_persona_reach_drift.py
+++ b/tests/deployment/test_persona_reach_drift.py
@@ -1,0 +1,243 @@
+"""Persona clients must follow the ports their hosting deployment actually publishes.
+
+The invariant under test: **an attached render dials the ports its hosting
+deployment actually publishes.** Web-terminal persona projects (the
+``control-assistant-{readonly,readwrite,ariel}`` presets) render as *attached*
+projects whose ``services:`` carries no ``bluesky`` or ``virtual_accelerator``
+block, so several in-container clients resolve their endpoint through a
+fallback chain that bottoms out in a compiled-in default. At the shipped
+defaults that default happens to equal the port the host publishes — so every
+existing test passes while proving nothing about *following*. This module
+breaks the coincidence: it builds one control-assistant stack whose hosting
+profile MOVES the ports, confirms the host render moved (the premise), then
+resolves each endpoint exactly the way the in-container client does and
+asserts the persona followed.
+
+Closest existing tests, and why they were blind:
+
+* ``tests/cli/test_profile_va_archiver_block.py`` proves the invariant for the
+  one client that does it right — ``va_archiver_config_overrides`` derives
+  ``archiver.mongodb_archiver.*`` for attached renders from the hosting
+  profile, and refuses an attached profile without ``va_archiver.host``. It
+  never looks at the bluesky, VA-gateway, or telemetry clients.
+* ``tests/services/ariel_search/test_dsn_derivation.py`` proves
+  ``resolve_ariel_dsn`` follows ``services.postgresql`` when the block is
+  present — but it hands the resolver hand-built dicts and never renders an
+  attached persona, so it cannot say what block a persona actually has.
+* ``tests/deployment/test_persona_reach_endpoints.py`` catches the telemetry
+  endpoint deriving a wrong HOST under ``network_mode: host`` — at the shipped
+  default ports. It never moves a port, so port drift stays invisible there
+  for every client.
+* ``tests/cli/test_persona_presets.py`` builds this same stack — at default
+  ports, where "follows the config" and "hardcodes the default" produce
+  identical renders.
+
+One candidate client is deliberately NOT parametrized here: the ARIEL
+Postgres DSN. Its only operator-facing port lever is the profile's
+``config: services.postgresql.port_host`` dotted key, and a persona profile is
+the persona delta merged over the hosting ``profile.yml`` — ``config:``
+overlay included — so the moved key lands in every persona render's own
+``services.postgresql`` block and ``resolve_ariel_dsn`` follows it (verified:
+with ``services.postgresql.port_host: 15432`` on the hosting profile, every
+persona render carries the same block and the derived DSN dials 15432). That
+client already satisfies the invariant; asserting drift for it would fail to
+fail.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import NamedTuple
+from urllib.parse import urlsplit
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+#: The fixture drives a real ``osprey init`` + ``osprey build`` — seconds, not
+#: milliseconds, exactly like tests/deployment/test_persona_reach_endpoints.py.
+pytestmark = pytest.mark.slow
+
+# Moved host ports — each distinct from the shipped default it replaces
+# (bluesky 8090, virtual_accelerator 5064, openobserve 5080), so a client that
+# keeps its compiled-in default is distinguishable from one that follows.
+MOVED_BLUESKY_PORT = 18090
+MOVED_VA_PORT = 15064
+MOVED_OPENOBSERVE_PORT = 15080
+
+
+@pytest.fixture(scope="module")
+def moved_port_stack(tmp_path_factory) -> Path:
+    """A control-assistant stack whose hosting profile moved its service ports.
+
+    Same build pattern as ``tests/cli/test_persona_presets.py::
+    _build_persona_stack``, with one twist: between ``init`` and ``build`` the
+    hosting ``profile.yml`` is edited to move every port under test — the
+    top-level ``bluesky.port`` and ``virtual_accelerator.port`` blocks, and the
+    ``config:`` dotted key ``services.openobserve.port``. The build renders the
+    host project at ``build/`` and one attached project per catalog persona
+    beside it at ``build/<repo>-<persona>``.
+    """
+    from osprey.cli.build_cmd import build
+    from osprey.cli.init_cmd import init
+
+    repo = tmp_path_factory.mktemp("persona-drift") / "my-facility"
+    runner = CliRunner()
+    created = runner.invoke(init, [str(repo), "--preset", "control-assistant", "--no-git"])
+    assert created.exit_code == 0, created.output
+
+    profile_path = repo / "profile.yml"
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    profile.setdefault("bluesky", {})["port"] = MOVED_BLUESKY_PORT
+    profile.setdefault("virtual_accelerator", {})["port"] = MOVED_VA_PORT
+    profile.setdefault("config", {})["services.openobserve.port"] = MOVED_OPENOBSERVE_PORT
+    profile_path.write_text(yaml.safe_dump(profile, sort_keys=False), encoding="utf-8")
+
+    built = runner.invoke(build, ["--repo", str(repo), "--skip-deps", "--skip-lifecycle"])
+    assert built.exit_code == 0, built.output
+    return repo
+
+
+def _load_config(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _dial_port_bluesky(persona_dir: Path, persona_cfg: dict, monkeypatch) -> int:
+    """The port the persona's Bluesky clients dial — via the real resolver.
+
+    ``resolve_bridge_url`` is the single source of truth both the bluesky MCP
+    server and the bluesky-web sidecar import; its config fallback reads the
+    ``OSPREY_CONFIG`` file, which here is the persona's own rendered
+    ``config.yml`` — exactly the file the in-container process sees. The
+    env-var override is cleared: it is minted per bridge instance at runtime
+    and an attached persona render carries none.
+    """
+    from osprey.bluesky_bridge_connection import resolve_bridge_url
+    from osprey.utils.workspace import reset_config_cache
+
+    monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
+    monkeypatch.setenv("OSPREY_CONFIG", str(persona_dir / "config.yml"))
+    reset_config_cache()
+    try:
+        url = resolve_bridge_url()
+        return urlsplit(url).port or 80
+    finally:
+        reset_config_cache()
+
+
+def _dial_port_va(persona_dir: Path, persona_cfg: dict, monkeypatch) -> int:
+    """The CA port the persona's VA connector dials — via the real fill.
+
+    ``VirtualAcceleratorConnector`` default-fills every gateway ``port`` from
+    ``services.virtual_accelerator.port`` through ``fill_gateway_ports`` before
+    any socket is opened; that pure resolution path is called here with the
+    persona's own rendered connector block and the persona's own rendered
+    ``config.yml`` as the ambient config (``CONFIG_FILE``).
+    """
+    from osprey_connectors.control_system.va_connector import fill_gateway_ports
+    from osprey_connectors.workspace import reset_config_cache
+
+    monkeypatch.setenv("CONFIG_FILE", str(persona_dir / "config.yml"))
+    monkeypatch.delenv("OSPREY_CONFIG", raising=False)
+    reset_config_cache()
+    try:
+        va_block = persona_cfg["control_system"]["connector"]["virtual_accelerator"]
+        filled = fill_gateway_ports(va_block)
+        ports = {gateway["port"] for gateway in filled["gateways"].values()}
+        assert len(ports) == 1, f"gateways disagree on the VA port: {sorted(ports)}"
+        return int(ports.pop())
+    finally:
+        reset_config_cache()
+
+
+def _dial_port_telemetry(persona_dir: Path, persona_cfg: dict, monkeypatch) -> int:
+    """The OTLP port the persona's agent launch exports to — via the real resolver.
+
+    The port is resolved the way the launch path resolves it
+    (``resolve_openobserve_port``): the deploy environment's declaration, else
+    the port the persona's own config publishes the store on. The environment
+    is cleared because the per-user compose declares a host and no port.
+    """
+    from osprey.build.claude_code_telemetry import (
+        OPENOBSERVE_PORT_ENV_VAR,
+        _resolve_telemetry_endpoint,
+        resolve_openobserve_port,
+    )
+
+    monkeypatch.delenv(OPENOBSERVE_PORT_ENV_VAR, raising=False)
+    endpoint = _resolve_telemetry_endpoint(
+        persona_cfg["claude_code"]["telemetry"],
+        in_container=True,
+        openobserve_host=None,
+        openobserve_port=resolve_openobserve_port(persona_cfg),
+    )
+    return urlsplit(endpoint).port or 80
+
+
+class _Client(NamedTuple):
+    """One in-container persona client and the host port it must follow."""
+
+    client: str
+    persona: str
+    host_key: str  # dotted key under `services` in the HOST build/config.yml
+    moved_port: int
+    dial_port: Callable[[Path, dict, pytest.MonkeyPatch], int]
+
+
+CLIENTS = [
+    _Client(
+        client="bluesky bridge URL",
+        persona="readwrite",  # the only persona that runs the bluesky MCP server
+        host_key="bluesky.port",
+        moved_port=MOVED_BLUESKY_PORT,
+        dial_port=_dial_port_bluesky,
+    ),
+    _Client(
+        client="virtual-accelerator CA gateway port",
+        persona="readonly",
+        host_key="virtual_accelerator.port",
+        moved_port=MOVED_VA_PORT,
+        dial_port=_dial_port_va,
+    ),
+    _Client(
+        client="telemetry OTLP endpoint",
+        persona="readonly",
+        host_key="openobserve.port",
+        moved_port=MOVED_OPENOBSERVE_PORT,
+        dial_port=_dial_port_telemetry,
+    ),
+]
+
+
+@pytest.mark.parametrize("spec", CLIENTS, ids=[c.client.replace(" ", "-") for c in CLIENTS])
+def test_persona_clients_follow_the_hosts_moved_ports(
+    moved_port_stack: Path, spec: _Client, monkeypatch
+) -> None:
+    """An attached render dials the ports its hosting deployment actually
+    publishes — even after the operator moves them on the hosting profile.
+
+    Premise first: the HOST render must reflect the moved port (it does — the
+    host stack genuinely moves). Then the persona's endpoint is resolved
+    exactly the way the in-container client resolves it, and the port it would
+    dial must equal the port the host publishes.
+    """
+    host_cfg = _load_config(moved_port_stack / "build" / "config.yml")
+    service, key = spec.host_key.split(".")
+    host_port = ((host_cfg.get("services") or {}).get(service) or {}).get(key)
+    assert host_port == spec.moved_port, (
+        f"premise broken: host render services.{spec.host_key} is {host_port}, "
+        f"expected the moved port {spec.moved_port}"
+    )
+
+    persona_dir = moved_port_stack / "build" / f"{moved_port_stack.name}-{spec.persona}"
+    persona_cfg = _load_config(persona_dir / "config.yml")
+
+    dialed = spec.dial_port(persona_dir, persona_cfg, monkeypatch)
+    assert dialed == host_port, (
+        f"{spec.client}: the '{spec.persona}' persona would dial port {dialed}, but the "
+        f"hosting deployment publishes this service on port {host_port} (host "
+        f"build/config.yml services.{spec.host_key}) — the attached render silently kept "
+        f"its compiled-in default after the operator moved the port on the hosting profile."
+    )

--- a/tests/deployment/test_persona_reach_endpoints.py
+++ b/tests/deployment/test_persona_reach_endpoints.py
@@ -1,0 +1,227 @@
+"""Persona containers must reach host-network endpoints where they actually live.
+
+Web-terminal persona projects (the ``control-assistant-{readonly,readwrite,
+ariel}`` presets) render as *attached* projects and run as per-user containers
+with ``network_mode: host``. Inside such a container ``localhost`` IS the
+deployment host, and compose service DNS names (``openobserve``) resolve to
+nothing. Every URL a persona container derives therefore has to target the
+loopback address and the HOST deployment's ports — and every host-side probe of
+a persona sidecar has to knock on the port the sidecar actually binds.
+
+Both tests here join two subsystems that each have thorough unit coverage in
+isolation — the telemetry endpoint resolver and the compose render; the ariel
+health category and the web-server address registry — because the defects live
+exactly in the seam neither suite crosses.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import httpx
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from osprey.build.claude_code_telemetry import (
+    OPENOBSERVE_PORT_ENV_VAR,
+    _resolve_telemetry_endpoint,
+    openobserve_published_port,
+)
+from osprey.deployment.web_terminals.personas import resolve_personas
+from osprey.deployment.web_terminals.render import render_web_terminals
+from osprey.health.core.ariel import ariel
+from osprey.registry.web import resolve_web_server_address
+
+#: The T4 fixture drives a real ``osprey init`` + ``osprey build`` — seconds,
+#: not milliseconds, exactly like tests/deployment/test_persona_render_e2e.py.
+pytestmark = pytest.mark.slow
+
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1"}
+
+#: Minimal compose ``${VAR}`` / ``${VAR:-default}`` interpolation against an
+#: empty deploy env — what compose does for a variable unset at create time.
+_COMPOSE_INTERP = re.compile(r"^\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}$")
+
+
+def _interpolate(value: str) -> str:
+    match = _COMPOSE_INTERP.match(value)
+    if match is None:
+        return value
+    return match.group("default") or ""
+
+
+def _service_env(service: dict) -> dict[str, str | None]:
+    """The env mapping a compose service hands its container, both YAML forms.
+
+    The list form (``- KEY=value``) is what the web overlay template emits; the
+    mapping form is accepted too so the test keeps working if the template ever
+    switches. A ``- KEY`` entry with no ``=`` maps to ``None`` (pass-through).
+    """
+    raw = service.get("environment") or []
+    env: dict[str, str | None] = {}
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            env[str(key)] = None if value is None else _interpolate(str(value))
+    else:
+        for line in raw:
+            key, sep, value = str(line).partition("=")
+            env[key.strip()] = _interpolate(value) if sep else None
+    return env
+
+
+@pytest.fixture(scope="module")
+def built_persona_stack(tmp_path_factory) -> Path:
+    """The control-assistant hosting preset built once, personas included.
+
+    Same pattern as ``tests/cli/test_persona_presets.py::_build_persona_stack``:
+    one real ``osprey init --preset control-assistant`` + ``osprey build``
+    renders the host project at ``build/`` and one attached project per catalog
+    persona beside it at ``build/<repo>-<persona>``.
+    """
+    from osprey.cli.build_cmd import build
+    from osprey.cli.init_cmd import init
+
+    repo = tmp_path_factory.mktemp("persona-reach") / "my-facility"
+    runner = CliRunner()
+    created = runner.invoke(init, [str(repo), "--preset", "control-assistant", "--no-git"])
+    assert created.exit_code == 0, created.output
+    built = runner.invoke(build, ["--repo", str(repo), "--skip-deps", "--skip-lifecycle"])
+    assert built.exit_code == 0, built.output
+    return repo
+
+
+def test_host_networked_persona_telemetry_targets_loopback(built_persona_stack: Path) -> None:
+    """A host-networked persona container's derived OTLP endpoint must target
+    loopback at the HOST deployment's ``services.openobserve.port`` — inside
+    ``network_mode: host`` the compose DNS name ``openobserve`` resolves to
+    nothing, so an endpoint carrying it drops every metric and log silently.
+
+    Closest existing tests, and why they could not see this:
+
+    * ``tests/cli/test_telemetry_env.py::test_openobserve_default_endpoint_container_host``
+      pins ``in_container=True`` → ``http://openobserve:5080/...`` as the
+      CORRECT behaviour — true for a bridge-networked service, but the test
+      never joins the resolver to a compose service that declares
+      ``network_mode: host`` and exports no ``OSPREY_OTEL_OPENOBSERVE_HOST``.
+    * ``tests/deployment/web_terminals/test_render.py`` /
+      ``test_golden_render.py`` parse the rendered compose (and see
+      ``network_mode: host``) but never feed a per-user service's environment
+      into the telemetry resolver, so the endpoint the agent would actually
+      derive inside that container is asserted nowhere.
+    """
+    repo = built_persona_stack
+    host_config = yaml.safe_load((repo / "build" / "config.yml").read_text(encoding="utf-8"))
+    host_openobserve_port = int(host_config["services"]["openobserve"]["port"])
+
+    compose = yaml.safe_load(render_web_terminals(host_config)["docker-compose.web.yml"])
+    web_terminals = host_config["modules"]["web_terminals"]
+    catalog = web_terminals["personas"]
+    roster = resolve_personas(
+        web_terminals,
+        host_config.get("registry") or {},
+        (host_config.get("facility") or {}).get("prefix") or "",
+        strict=True,
+    )
+
+    checked = 0
+    wrong: list[str] = []
+    for entry in roster:
+        persona = entry.get("persona")
+        if not persona or persona not in catalog:
+            continue
+        persona_config = yaml.safe_load(
+            (repo / catalog[persona]["project_path"] / "config.yml").read_text(encoding="utf-8")
+        )
+        telemetry = (persona_config.get("claude_code") or {}).get("telemetry") or {}
+        if not telemetry.get("enabled") or telemetry.get("backend") != "openobserve":
+            continue
+
+        service = compose["services"][f"web-{entry['name']}"]
+        if service.get("network_mode") != "host":
+            continue
+        env = _service_env(service)
+
+        # Exactly what the agent launcher resolves inside this container:
+        # /.dockerenv exists in every persona container (in_container=True), the
+        # only host override is whatever this compose service exports, and the
+        # port is the service's declaration or else the port this persona's own
+        # config says the store publishes (resolve_openobserve_port's rule).
+        declared_port = env.get(OPENOBSERVE_PORT_ENV_VAR)
+        endpoint = _resolve_telemetry_endpoint(
+            telemetry,
+            in_container=True,
+            openobserve_host=env.get("OSPREY_OTEL_OPENOBSERVE_HOST"),
+            openobserve_port=(
+                int(declared_port) if declared_port else openobserve_published_port(persona_config)
+            ),
+        )
+        parsed = urlsplit(endpoint)
+        checked += 1
+        if parsed.hostname not in _LOOPBACK_HOSTS or parsed.port != host_openobserve_port:
+            wrong.append(f"web-{entry['name']} (persona {persona}): {endpoint}")
+
+    assert checked, (
+        "Precondition failed: the built control-assistant stack exposed no "
+        "host-networked persona with an enabled openobserve telemetry backend — "
+        "the defect surface this test exists for was never reached."
+    )
+    assert not wrong, (
+        "Host-networked persona containers derive an OTLP endpoint that is not "
+        f"loopback:{host_openobserve_port} (the host deployment's "
+        "services.openobserve.port): "
+        + "; ".join(wrong)
+        + ". The web-terminal compose overlay sets no OSPREY_OTEL_OPENOBSERVE_HOST "
+        "for per-user services (only the dispatch-worker compose does), so "
+        "in_container=True derives the compose DNS name 'openobserve' — which "
+        "resolves to nothing under network_mode: host, and every web-terminal "
+        "agent's telemetry is dropped silently."
+    )
+
+
+async def test_ariel_health_probes_the_port_the_panel_listens_on(monkeypatch) -> None:
+    """The ``ariel`` health category must probe the address the ARIEL panel
+    actually binds — ``resolve_web_server_address("ariel", cfg)``, which honours
+    the ``OSPREY_ARIEL_PORT`` env override multi-user compose renders export —
+    not the ``ariel.web.port``/default-8085 config value alone.
+
+    Closest existing tests, and why they could not see this:
+
+    * ``tests/health/core/test_ariel.py::test_status_url_defaults`` pins the
+      probe URL to ``http://127.0.0.1:8085/api/status`` with the env var unset —
+      it asserts the config-only derivation as CORRECT and never sets
+      ``OSPREY_ARIEL_PORT``.
+    * ``tests/health/core/test_web_panels.py::TestBuiltinAddressResolution::
+      test_port_env_override_is_honoured`` proves exactly this env override —
+      with OSPREY_ARIEL_PORT=9391, even — but for the ``web_panels`` category,
+      which was converted to the canonical resolver; the ``ariel`` category
+      never was, and no test joins the two.
+    """
+    monkeypatch.setenv("OSPREY_ARIEL_PORT", "9391")
+
+    config = {"ariel": {"database": {"uri": "postgresql://ariel@localhost/ariel"}}}
+    # The expectation is the resolver's answer, not a literal: this is the same
+    # derivation the panel launcher is partial-bound to, so the test encodes
+    # "the address the panel binds" rather than restating 9391.
+    expected_host, expected_port = resolve_web_server_address("ariel", config)
+    assert expected_port == 9391  # sanity: the override reached the resolver
+
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, json={"healthy": True})
+
+    await ariel(config, transport=httpx.MockTransport(handler))()
+
+    assert len(seen) == 1
+    probed = urlsplit(seen[0])
+    assert probed.port == expected_port, (
+        f"osprey health probed ARIEL at port {probed.port}, but the panel in this "
+        f"environment binds {expected_host}:{expected_port} (OSPREY_ARIEL_PORT, "
+        "per registry.web.resolve_web_server_address). The ariel category reads "
+        "ariel.web.port / the 8085 default only and ignores the multi-user env "
+        "override — so every multi-user terminal reports ARIEL unreachable."
+    )

--- a/tests/deployment/test_persona_reach_lanes.py
+++ b/tests/deployment/test_persona_reach_lanes.py
@@ -1,0 +1,96 @@
+"""A persona of a two-lane deployment is told both plan lanes.
+
+``bluesky.second_lane`` renders a second bridge, and the lane resolver picks
+the lane a session is on by matching each lane's declared ``target`` against
+the session target. These tests drive the REAL injector's output through the
+Reach Contract's projection and then ask the REAL lane resolver what it makes
+of the persona's config — so a projection that copied the port but not the
+target, or lane 1 but not lane 2, fails here rather than in a container.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osprey.bluesky_bridge_connection import discover_lane_keys, lane_declared_target
+from osprey.cli.build_injectors import _inject_bluesky
+from osprey.cli.build_profile_schema import BlueskyConfig
+from osprey.deployment.reach import project_attached_overrides, reach_dials, reach_errors
+from tests.cli.test_bluesky_lane_config import _read_config, _write_config
+
+
+def _host_render(tmp_path: Path, *, second_lane: bool) -> dict[str, Any]:
+    """The deploying project's config after the bluesky injector ran on it."""
+    project = tmp_path / "host"
+    _write_config(project, cs_type="virtual_accelerator")
+    _inject_bluesky(BlueskyConfig(second_lane=second_lane), project)
+    return _read_config(project)
+
+
+def _persona(host: dict[str, Any]) -> dict[str, Any]:
+    """An attached render that runs the bluesky server, told the host's facts."""
+    config: dict[str, Any] = {
+        "claude_code": {"servers": {"bluesky": {"enabled": True}}},
+        "control_system": {"type": "virtual_accelerator", "writes_enabled": True},
+    }
+    for dotted, value in project_attached_overrides(host, config).items():
+        node = config
+        *parents, leaf = dotted.split(".")
+        for part in parents:
+            node = node.setdefault(part, {})
+        node[leaf] = value
+    return config
+
+
+@pytest.fixture(autouse=True)
+def _no_bridge_overrides(monkeypatch):
+    for var in ("BLUESKY_BRIDGE_URL", "BLUESKY_VA_BRIDGE_URL", "BLUESKY_LIVE_BRIDGE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_the_persona_renders_both_lanes_with_their_targets(tmp_path):
+    host = _host_render(tmp_path, second_lane=True)
+    persona = _persona(host)
+
+    assert discover_lane_keys(persona) == ("bluesky", "bluesky_live")
+    assert lane_declared_target("bluesky", persona) == "va"
+    assert lane_declared_target("bluesky_live", persona) == "live"
+    assert persona["services"]["bluesky_live"]["port"] == host["services"]["bluesky_live"]["port"]
+
+
+def test_the_persona_carries_nothing_of_the_lane_but_its_reach(tmp_path):
+    """The bridge's own settings — its plan directory, its CA name servers —
+    describe the service the HOST runs; a client needs none of them."""
+    persona = _persona(_host_render(tmp_path, second_lane=True))
+    assert set(persona["services"]["bluesky_live"]) == {"port", "target"}
+    assert set(persona["services"]["bluesky"]) == {"port", "target"}
+
+
+def test_both_lanes_are_live_consumers_the_persona_can_dial(tmp_path):
+    host = _host_render(tmp_path, second_lane=True)
+    dials = {contract.service: dial for contract, _, dial in reach_dials(_persona(host))}
+    assert dials["bluesky"] == ("127.0.0.1", host["services"]["bluesky"]["port"])
+    assert dials["bluesky_live"] == ("127.0.0.1", host["services"]["bluesky_live"]["port"])
+    assert reach_errors(_persona(host)) == []
+
+
+def test_a_lane_told_without_its_port_is_refused_by_name(tmp_path):
+    persona = _persona(_host_render(tmp_path, second_lane=True))
+    del persona["services"]["bluesky_live"]["port"]
+    (error,) = reach_errors(persona)
+    assert "bluesky_live lane" in error
+    assert "services.bluesky_live.port" in error
+
+
+def test_a_single_lane_host_leaves_the_persona_single_lane(tmp_path):
+    """No second lane on the host means no second lane here — and no
+    ``target`` on lane 1 either, which is the pre-lane render exactly."""
+    persona = _persona(_host_render(tmp_path, second_lane=False))
+    assert discover_lane_keys(persona) == ("bluesky",)
+    assert set(persona["services"]) == {"bluesky"}
+    assert "target" not in persona["services"]["bluesky"]
+    lanes = [c.service for c, _, _ in reach_dials(persona) if c.service.startswith("bluesky")]
+    assert lanes == ["bluesky"]

--- a/tests/deployment/test_persona_reach_paths.py
+++ b/tests/deployment/test_persona_reach_paths.py
@@ -1,0 +1,305 @@
+"""Reachability of the paths one deployment's writers and readers must share.
+
+A deployment repo has two path anchors, and they disagree. The compose layer
+anchors every relative bind source on the repo root — every invocation is
+pinned with ``--project-directory <repo>`` — while the runtime resolvers
+(:func:`osprey.utils.config_paths.resolve_config_relative_path` and everything
+delegating to it) anchor the same configured strings on the directory holding
+``config.yml``, which after a build is ``<repo>/build``. Nothing fails loudly
+when the two disagree: the exporter writes a mirror the sidecar never mounts,
+a persona's readers open a baked copy while the host bundle is mounted one
+directory over, and an audit log lands in a container's writable layer.
+
+So every test here asserts a REACH property on one real built stack: the path
+one component writes is the path the other component reads, with both sides
+derived through the production functions rather than restated. Each test
+fails today, each for a real defect, and each docstring names the existing
+test that came closest and why it could not see the gap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+import pytest
+import yaml
+
+from osprey.deployment.compose_generator import _resolve_qmd_corpora
+from osprey.deployment.web_terminals.artifacts import resolve_render_inputs
+from osprey.deployment.web_terminals.personas import resolve_personas
+from osprey.deployment.web_terminals.render import render_web_terminals
+from osprey.services.ariel_search.enhancement.qmd_export.exporter import resolve_mirror_path
+from osprey.services.facility_knowledge.bundle_path import resolve_bundle_path
+from osprey.utils.workspace import AUDIT_DIR_RELPATH
+from tests.cli.test_persona_presets import _build_persona_stack
+
+#: Every test here builds the hosting preset for real — seconds, not
+#: milliseconds — because reach is a property of what a build actually writes.
+pytestmark = pytest.mark.slow
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _mounts(service: dict) -> list[tuple[str, str]]:
+    """``(source, target)`` pairs from a compose service's volume entries.
+
+    Normalizes both spellings compose accepts: ``"src:dst[:mode]"`` strings and
+    long-form mappings. A long-form entry with no source (a tmpfs) contributes
+    an empty source, which matches nothing a test here looks for.
+    """
+    pairs: list[tuple[str, str]] = []
+    for entry in service.get("volumes", []):
+        if isinstance(entry, str):
+            parts = entry.split(":")
+            if len(parts) >= 2:
+                pairs.append((parts[0], parts[1]))
+        elif isinstance(entry, dict):
+            pairs.append((str(entry.get("source", "")), str(entry.get("target", ""))))
+    return pairs
+
+
+def _mount_targets(service: dict) -> list[str]:
+    """The in-container target of every volume entry on *service*."""
+    return [target for _source, target in _mounts(service)]
+
+
+def _host_path(repo: Path, source: str) -> Path:
+    """A compose bind source as the pinned project directory resolves it.
+
+    Every compose invocation is pinned with ``--project-directory <repo>``
+    (see :func:`osprey.deployment.compose_generator.compose_base_cmd`), so a
+    relative source means ``<repo>/<source>`` and an absolute one means itself.
+    """
+    path = Path(source)
+    if path.is_absolute():
+        return path
+    return (repo / path).resolve()
+
+
+def _qmd_export_mirror(config: dict) -> str | None:
+    """The mirror path an enabled qmd export writes to, ``settings`` winning.
+
+    The same merge rule ARIEL's loader and ``_resolve_qmd_corpora`` apply: a
+    ``settings.mirror_path`` overrides one written directly on the module
+    block. ``None`` when the export is absent or disabled.
+    """
+    ariel = config.get("ariel") or {}
+    export = (ariel.get("enhancement_modules") or {}).get("qmd_export") or {}
+    if not export.get("enabled"):
+        return None
+    settings = export.get("settings") or {}
+    return settings.get("mirror_path") or export.get("mirror_path")
+
+
+@pytest.fixture(scope="module")
+def built_stack(tmp_path_factory) -> Path:
+    """The hosting preset built once, personas included."""
+    return _build_persona_stack(tmp_path_factory.mktemp("reach-paths") / "my-facility")
+
+
+@pytest.fixture(scope="module")
+def host_config(built_stack: Path) -> dict:
+    """The deployment's own render — what every host-side process runs against."""
+    return _load(built_stack / "build" / "config.yml")
+
+
+@pytest.fixture(scope="module")
+def resolved_entries(host_config: dict) -> list[dict]:
+    """The roster as render/build resolve it, one entry per per-user service."""
+    return resolve_personas(
+        host_config["modules"]["web_terminals"],
+        host_config.get("registry") or {},
+        (host_config.get("facility") or {}).get("prefix") or "",
+        strict=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def web_compose(built_stack: Path, host_config: dict) -> dict:
+    """The multi-user overlay, rendered with exactly the disk-derived inputs the
+    deploy path resolves (``artifacts.resolve_render_inputs`` — the one seam
+    ``write_web_terminal_artifacts`` hands the render)."""
+    artifacts = render_web_terminals(host_config, **resolve_render_inputs(host_config, built_stack))
+    return yaml.safe_load(artifacts["docker-compose.web.yml"])
+
+
+def _persona_config(repo: Path, entry: dict) -> dict:
+    """A persona's own rendered ``config.yml`` — what its container's readers load."""
+    return _load(repo / "build" / entry["project"] / "config.yml")
+
+
+# ---------------------------------------------------------------------------
+# T1: the host exporter and the qmd sidecar
+# ---------------------------------------------------------------------------
+
+
+def test_host_exporter_writes_where_the_sidecar_reads(built_stack, host_config):
+    """The directory the qmd exporter writes must be the directory the sidecar
+    bind-mounts, or the sidecar indexes a tree nobody writes to.
+
+    ``tests/deployment/test_qmd_compose_fragment.py::
+    test_one_read_only_mount_per_configured_corpus`` came closest: it pins the
+    bind SOURCE string the fragment renders, but nothing compares that string
+    with where the exporter's own resolver (:func:`resolve_mirror_path`,
+    anchored on the config's directory) actually WRITES — so the two anchors
+    can disagree while both sides' tests stay green.
+    """
+    repo = built_stack
+    corpora = {c["collection"]: c for c in _resolve_qmd_corpora(host_config, str(repo))}
+
+    raw_mirror = _qmd_export_mirror(host_config)
+    assert raw_mirror, "fixture lost its enabled qmd_export — nothing to compare"
+    assert "ariel" in corpora, "fixture lost the sidecar's ARIEL corpus — nothing to compare"
+    exporter_writes = resolve_mirror_path(raw_mirror, config_dir=repo / "build")
+    sidecar_reads = _host_path(repo, corpora["ariel"]["source"])
+
+    assert exporter_writes == sidecar_reads, (
+        f"the exporter resolves mirror_path {raw_mirror!r} against the config dir and writes "
+        f"{exporter_writes}, but the sidecar bind-mounts {sidecar_reads} (the same string "
+        f"anchored on the compose project directory, the repo root) — the sidecar indexes an "
+        f"empty directory while the mirror grows inside build/"
+    )
+
+    raw_bundle = host_config["facility_knowledge"]["bundle_path"]
+    reader_opens = resolve_bundle_path(raw_bundle, config_dir=repo / "build")
+    assert "okf" in corpora, "fixture lost the sidecar's OKF corpus — nothing to compare"
+    sidecar_bundle = _host_path(repo, corpora["okf"]["source"])
+
+    assert reader_opens == sidecar_bundle, (
+        f"the OKF readers resolve bundle_path {raw_bundle!r} against the config dir and open "
+        f"{reader_opens}, but the sidecar bind-mounts {sidecar_bundle} — the corpus the "
+        f"readers serve is not the corpus the sidecar indexes"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T2: a persona's bundle mount and its readers
+# ---------------------------------------------------------------------------
+
+
+def test_persona_bundle_mount_lands_where_its_readers_look(
+    built_stack, web_compose, resolved_entries
+):
+    """A persona service's bundle mount target must be the path that persona's
+    own readers resolve from its rendered config, or the mount shadows nothing
+    and the readers open the image's stale baked copy.
+
+    ``tests/deployment/web_terminals/test_bundle_mount.py::
+    test_target_is_computed_per_persona_from_its_own_project_dir`` came
+    closest: it asserts the target equals the render's OWN derivation
+    (``/app/<project>/<bundle_path>``), never comparing it with where the
+    in-container readers — anchored on the config's directory,
+    ``/app/<project>/build`` — resolve the same key.
+    """
+    checked = 0
+    for entry in resolved_entries:
+        service = web_compose["services"][f"web-{entry['name']}"]
+        persona_config = _persona_config(built_stack, entry)
+        raw = (persona_config.get("facility_knowledge") or {}).get("bundle_path")
+        bundle_mounts = [
+            (source, target)
+            for source, target in _mounts(service)
+            if raw and target.endswith(f"/{PurePosixPath(str(raw).strip())}")
+        ]
+        if not bundle_mounts:
+            continue
+        checked += 1
+        reader_opens = resolve_bundle_path(
+            str(raw).strip(), config_dir=Path(entry["container_project_dir"]) / "build"
+        ).as_posix()
+        for _source, target in bundle_mounts:
+            assert target == reader_opens, (
+                f"persona {entry['persona']!r} mounts the host bundle at {target}, but its "
+                f"OKF panel and facility_knowledge MCP server resolve bundle_path {raw!r} "
+                f"against the config dir and read {reader_opens} — the baked copy, not the "
+                f"live mount"
+            )
+    assert checked, "no per-user service carried a bundle mount — fixture lost the precondition"
+
+
+# ---------------------------------------------------------------------------
+# T3: a persona's exporter and the host mirror
+# ---------------------------------------------------------------------------
+
+
+def test_persona_mirror_is_the_hosts_mirror(
+    built_stack, host_config, web_compose, resolved_entries
+):
+    """A persona whose render enables ``qmd_export`` must bind-mount the HOST
+    mirror directory at the path its in-container exporter writes, or entries
+    enhanced inside that container land in its writable layer — unindexed by
+    the sidecar and discarded on the next recreate.
+
+    ``tests/deployment/test_qmd_compose_fragment.py::
+    test_one_read_only_mount_per_configured_corpus`` covers the sidecar's own
+    mount, and ``tests/deployment/web_terminals/test_bundle_mount.py`` covers
+    the bundle grant per persona — but no test asks whether the per-user
+    services mount the MIRROR at all, so the compose template's silence about
+    it (claude-config volume, agent-data volume, optional bundle mount,
+    ``extra_mounts`` — no mirror) was never visible.
+    """
+    repo = built_stack
+    corpora = {c["collection"]: c for c in _resolve_qmd_corpora(host_config, str(repo))}
+    assert "ariel" in corpora, "fixture lost the sidecar's ARIEL corpus — nothing to compare"
+    host_mirror = _host_path(repo, corpora["ariel"]["source"])
+
+    checked = 0
+    for entry in resolved_entries:
+        persona_config = _persona_config(repo, entry)
+        raw = _qmd_export_mirror(persona_config)
+        if raw is None:
+            continue
+        checked += 1
+        exporter_writes = resolve_mirror_path(
+            raw, config_dir=Path(entry["container_project_dir"]) / "build"
+        ).as_posix()
+        service = web_compose["services"][f"web-{entry['name']}"]
+        matching = [
+            (source, target)
+            for source, target in _mounts(service)
+            if _host_path(repo, source) == host_mirror and target == exporter_writes
+        ]
+        assert matching, (
+            f"persona {entry['persona']!r} enables qmd_export, but its service mounts the "
+            f"host mirror {host_mirror} nowhere — its exporter writes {exporter_writes} in "
+            f"the container's writable layer, a tree the sidecar never indexes and the next "
+            f"recreate discards (volumes: {_mount_targets(service)})"
+        )
+    assert checked, "no persona render enables qmd_export — fixture lost the precondition"
+
+
+# ---------------------------------------------------------------------------
+# T4: the refusal audit log
+# ---------------------------------------------------------------------------
+
+
+def test_persona_refusal_audit_log_is_backed_by_a_volume(web_compose, resolved_entries):
+    """Every per-user container's audit zone (``<project>/var/audit``) must be
+    covered by a volume or bind mount, or the append-only refusal log the
+    python executor writes there is silently discarded on the next recreate.
+
+    ``tests/services/python_executor/test_refusal_audit.py::
+    test_audit_dir_sits_under_the_state_zone`` came closest: it pins the
+    host-side derivation of the path, but nothing asks whether the compose
+    service a persona actually runs in backs that path with any mount — the
+    agent-data volume beside it (``var/agent_data``) is a sibling, not an
+    ancestor.
+    """
+    for entry in resolved_entries:
+        service = web_compose["services"][f"web-{entry['name']}"]
+        audit_dir = PurePosixPath(entry["container_project_dir"]) / AUDIT_DIR_RELPATH
+        targets = [PurePosixPath(target) for target in _mount_targets(service)]
+        covered = any(target == audit_dir or target in audit_dir.parents for target in targets)
+        assert covered, (
+            f"web-{entry['name']} writes its refusal audit log under {audit_dir}, but no "
+            f"volume or bind mount covers that path or an ancestor of it (mount targets: "
+            f"{[str(t) for t in targets]}) — the log lands in the container's writable "
+            f"layer and is discarded on the next recreate"
+        )

--- a/tests/deployment/test_reach_contract.py
+++ b/tests/deployment/test_reach_contract.py
@@ -1,0 +1,423 @@
+"""The Reach Contract, enforced from its one registry.
+
+:mod:`osprey.deployment.reach` declares, per shared service, which in-container
+consumers dial it, what the build projects into an attached render, which
+credential each entitled container receives and which host directories it is
+handed. Two kinds of test here read that declaration and nothing else:
+
+* **Completeness.** Every service a shipped template can deploy — the app
+  templates' ``services:`` blocks and every ``templates/services/<name>``
+  directory the injectors copy — has a contract, or a contract that says why
+  nothing in a container dials it. A service added without one fails here,
+  which is the point: the registry is only a single source of truth while it
+  is complete.
+* **The seams, on a real built stack.** For every persona render the
+  control-assistant preset builds: each consumer the render switches on
+  resolves an endpoint; each credential its gate grants is a line in that
+  persona's compose ``environment:``; each shared path its gate entitles is a
+  mount in that persona's compose ``volumes:``. One walk over the registry,
+  so a grant added to the registry without a compose line — or the reverse —
+  is visible here rather than inside a container at first use.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from osprey.bluesky_bridge_connection import SECOND_LANE_KEYS
+from osprey.deployment.reach import (
+    REACH_CONTRACTS,
+    SHARED_PATHS,
+    dotted_get,
+    live_consumers,
+    reach_errors,
+)
+from osprey.deployment.web_terminals.artifacts import resolve_render_inputs
+from osprey.deployment.web_terminals.personas import resolve_personas
+from osprey.deployment.web_terminals.render import render_web_terminals
+from tests.cli.test_persona_presets import _build_persona_stack
+
+pytestmark = pytest.mark.slow
+
+_SRC = Path(__file__).resolve().parents[2] / "src" / "osprey"
+_TEMPLATES = _SRC / "templates"
+
+
+# ---------------------------------------------------------------------------
+# Completeness
+# ---------------------------------------------------------------------------
+
+
+def _app_template_services() -> set[str]:
+    """Every ``services.<name>`` a shipped app template renders."""
+    names: set[str] = set()
+    for template in (_TEMPLATES / "apps").glob("*/config.yml.j2"):
+        text = template.read_text(encoding="utf-8")
+        match = re.search(r"^services:\n((?:  .*\n|\n)*)", text, re.MULTILINE)
+        if match is None:
+            continue
+        names.update(re.findall(r"^  ([a-z_]+):", match.group(1), re.MULTILINE))
+    return names
+
+
+def _service_template_dirs() -> set[str]:
+    """Every service the injectors can copy into a project."""
+    return {
+        path.name
+        for path in (_TEMPLATES / "services").iterdir()
+        if path.is_dir() and not path.name.startswith("_")
+    }
+
+
+def _injected_services() -> set[str]:
+    """Services the build injects that have no template of their own.
+
+    A second plan lane (``bluesky.second_lane``) is written by the bluesky
+    injector beside lane 1's block, reusing lane 1's service template — so
+    neither scan above sees it, and without this it could never be missing.
+    """
+    return set(SECOND_LANE_KEYS.values())
+
+
+def _deployable_services() -> set[str]:
+    return _app_template_services() | _service_template_dirs() | _injected_services()
+
+
+def test_every_deployable_service_has_a_contract():
+    deployable = _deployable_services()
+    assert deployable, "found no deployable services — the template scan is broken"
+    missing = sorted(deployable - set(REACH_CONTRACTS))
+    assert missing == [], (
+        f"services with no Reach Contract: {missing}. Add a ReachContract to "
+        f"osprey.deployment.reach — with its consumers and projected keys, or with "
+        f"no_client_reach=True and a note saying why nothing in a container dials it."
+    )
+
+
+def test_every_contract_names_a_deployable_service():
+    deployable = _deployable_services()
+    stale = sorted(set(REACH_CONTRACTS) - deployable)
+    assert stale == [], f"contracts for services no template deploys: {stale}"
+
+
+def test_every_contract_says_how_it_is_reached():
+    """A contract either has consumers and projected keys, is derived on another
+    build path, or says nothing dials it — never silent on all three."""
+    for name, contract in REACH_CONTRACTS.items():
+        assert contract.service == name
+        assert contract.note, f"{name}: a contract needs a one-line note"
+        if contract.no_client_reach:
+            assert not contract.consumers and not contract.projected, name
+        elif contract.derived_by:
+            assert not contract.projected, f"{name}: derived elsewhere, projects nothing here"
+        else:
+            assert contract.consumers, f"{name}: no consumer and no no_client_reach marker"
+            assert contract.projected, f"{name}: consumers but nothing projected for them"
+
+
+def test_every_projected_key_lives_under_a_known_prefix():
+    for contract in REACH_CONTRACTS.values():
+        for projected in contract.projected:
+            if projected.panel is not None:
+                assert projected.key.startswith(f"web.panels.{projected.panel}."), projected
+            else:
+                assert projected.key.startswith(f"services.{contract.service}."), projected
+
+
+# ---------------------------------------------------------------------------
+# The seams, on a real built stack
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def built_stack(tmp_path_factory) -> Path:
+    return _build_persona_stack(tmp_path_factory.mktemp("reach-contract") / "my-facility")
+
+
+@pytest.fixture(scope="module")
+def host_config(built_stack: Path) -> dict:
+    return yaml.safe_load((built_stack / "build" / "config.yml").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def entries(host_config: dict) -> list[dict]:
+    return resolve_personas(
+        host_config["modules"]["web_terminals"],
+        host_config.get("registry") or {},
+        (host_config.get("facility") or {}).get("prefix") or "",
+        strict=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def web_compose(built_stack: Path, host_config: dict) -> dict:
+    artifacts = render_web_terminals(host_config, **resolve_render_inputs(host_config, built_stack))
+    return yaml.safe_load(artifacts["docker-compose.web.yml"])
+
+
+def _persona_config(repo: Path, entry: dict) -> dict:
+    return yaml.safe_load(
+        (repo / "build" / entry["project"] / "config.yml").read_text(encoding="utf-8")
+    )
+
+
+def _env_names(service: dict) -> set[str]:
+    names: set[str] = set()
+    for line in service.get("environment") or []:
+        names.add(str(line).partition("=")[0].strip())
+    return names
+
+
+def _mount_targets(service: dict) -> list[str]:
+    targets = []
+    for entry in service.get("volumes") or []:
+        parts = str(entry).split(":")
+        if len(parts) >= 2:
+            targets.append(parts[1])
+    return targets
+
+
+def test_the_built_stack_refuses_nothing(built_stack, host_config, entries):
+    """Every render the preset builds — the host's and each persona's — has an
+    endpoint for every consumer it switches on."""
+    assert reach_errors(host_config) == []
+    for entry in entries:
+        assert reach_errors(_persona_config(built_stack, entry)) == [], entry["persona"]
+
+
+def test_every_live_consumer_in_every_persona_resolves(built_stack, entries):
+    checked = 0
+    for entry in entries:
+        config = _persona_config(built_stack, entry)
+        for contract, consumer in live_consumers(config):
+            checked += 1
+            assert consumer.resolves(config), (
+                f"persona {entry['persona']!r}: {consumer.name} is on "
+                f"({consumer.switch_key}) but resolves nothing for services.{contract.service}"
+            )
+    assert checked, "no persona switched any consumer on — the fixture lost its preconditions"
+
+
+def test_every_projected_fact_matches_the_hosts(built_stack, host_config, entries):
+    """What a persona was told is what the host render says — value for value."""
+    checked = 0
+    for entry in entries:
+        config = _persona_config(built_stack, entry)
+        for contract in REACH_CONTRACTS.values():
+            for projected in contract.projected:
+                told = dotted_get(config, projected.key)
+                if told is None:
+                    continue
+                checked += 1
+                assert told == dotted_get(host_config, projected.key), (
+                    f"persona {entry['persona']!r}: {projected.key} is {told!r}, "
+                    f"host says {dotted_get(host_config, projected.key)!r}"
+                )
+    assert checked
+
+
+def test_every_granted_credential_is_in_the_personas_compose_block(
+    built_stack, web_compose, entries
+):
+    """switch on ⇒ the credential's env line is on that persona's service, and
+    a credential the gate withholds is NOT — the tier boundary, registry-side."""
+    checked = 0
+    for entry in entries:
+        config = _persona_config(built_stack, entry)
+        env = _env_names(web_compose["services"][f"web-{entry['name']}"])
+        for contract in REACH_CONTRACTS.values():
+            for grant in contract.credentials:
+                entitled = grant.gate is None or grant.gate(config)
+                checked += 1
+                assert (grant.env in env) == entitled, (
+                    f"persona {entry['persona']!r}: {grant.env} "
+                    f"{'missing from' if entitled else 'leaked into'} web-{entry['name']} "
+                    f"(services.{contract.service})"
+                )
+    assert checked
+
+
+def test_every_entitled_shared_path_is_mounted(built_stack, web_compose, entries):
+    """gate ⇒ a mount whose target ends with the configured relative path."""
+    checked = 0
+    for entry in entries:
+        config = _persona_config(built_stack, entry)
+        targets = _mount_targets(web_compose["services"][f"web-{entry['name']}"])
+        for shared in SHARED_PATHS:
+            raw = dotted_get(config, shared.config_key) or dotted_get(
+                config, shared.config_key.replace(".mirror_path", ".settings.mirror_path")
+            )
+            if not shared.gate(config):
+                continue
+            checked += 1
+            assert raw, f"{shared.config_key} entitles but names nothing"
+            assert any(t.endswith(f"/{str(raw).strip()}") for t in targets), (
+                f"persona {entry['persona']!r} is entitled to {shared.describe} "
+                f"({shared.config_key}={raw!r}) but web-{entry['name']} mounts it nowhere: {targets}"
+            )
+    assert checked
+
+
+def test_the_bluesky_web_sidecar_accepts_every_entitled_users_secret(
+    built_stack, host_config, web_compose, entries, monkeypatch
+):
+    """A persona proxies its BLUESKY tab into the sidecar with the secret ITS
+    container holds — its own, under the fixed ``OSPREY_TERMINAL_SECRET``.
+    The sidecar's OWN compose file (the services stack — the web overlay is a
+    separate single-file compose project that could never merge into it)
+    lists every entitled user's variable beside the accept flag the web gate
+    requires; a user whose persona shows no BLUESKY tab gets no key to it.
+    """
+    from osprey.deployment.compose_generator import prepare_compose_files
+    from osprey.deployment.web_terminals.personas import config_declares_bluesky_panel
+    from osprey.deployment.web_terminals.render import terminal_secret_env_var
+    from osprey.interfaces.web_auth import ROSTER_ACCEPT_ENV
+
+    assert "bluesky_web" in host_config["deployed_services"]
+    # The deploy-faithful render: `osprey up` re-renders every services compose
+    # file from the repo root with the persona projects in place. The build's
+    # own render precedes the persona renders, so it is the deploy's that
+    # carries the roster grant (see compose_generator._bluesky_panel_secret_env_vars).
+    monkeypatch.chdir(built_stack / "build")
+    _, compose_files = prepare_compose_files(str(built_stack / "build" / "config.yml"))
+    (sidecar_path,) = [f for f in compose_files if f.endswith("/bluesky_web/docker-compose.yml")]
+    sidecar_compose = yaml.safe_load(Path(sidecar_path).read_text(encoding="utf-8"))
+    environment = sidecar_compose["services"]["bluesky-web"]["environment"]
+    assert isinstance(environment, dict)
+    assert environment.get(ROSTER_ACCEPT_ENV) == "1"
+    handed = set(environment)
+    # The overlay carries no such fragment any more: as a separate compose
+    # project it would fail `osprey up` with an image-less service.
+    assert "bluesky-web" not in web_compose["services"]
+
+    checked = 0
+    for entry in entries:
+        var = terminal_secret_env_var(entry["name"])
+        presented = f"OSPREY_TERMINAL_SECRET=${{{var}:-}}"
+        assert presented in (web_compose["services"][f"web-{entry['name']}"]["environment"]), (
+            f"web-{entry['name']} presents {var}"
+        )
+        entitled = config_declares_bluesky_panel(_persona_config(built_stack, entry))
+        checked += entitled
+        assert (var in handed) == entitled, (
+            f"{var} {'missing from' if entitled else 'leaked into'} the bluesky-web sidecar"
+        )
+        if entitled:
+            assert environment[var] == f"${{{var}:-}}"
+    assert checked
+
+
+# ---------------------------------------------------------------------------
+# The refusal, on a synthetic render
+# ---------------------------------------------------------------------------
+
+
+def test_a_consumer_switched_on_with_nothing_to_dial_is_refused():
+    """The state the whole contract exists to catch: hybrid logbook search
+    switched on over ``services: {}``. The error names the switch that turned
+    the consumer on and the projected key that would give it an endpoint, so
+    the operator can act on either end."""
+    config = {"ariel": {"search_modules": {"hybrid": {"enabled": True}}}}
+
+    (error,) = reach_errors(config)
+
+    assert "ARIEL hybrid search" in error
+    assert "ariel.search_modules.hybrid.enabled" in error
+    assert "services.qmd.port" in error
+
+
+def test_a_degrading_consumer_is_not_refused():
+    """The OKF panel's ranked search falls back to substring matching without
+    a sidecar, by design — its contract says ``refuse=False``, so the same
+    unresolved state that refuses hybrid search builds cleanly here (the
+    ``reach`` health category still reports it)."""
+    config = {
+        "web": {"panels": {"okf": {"enabled": True}}},
+        "facility_knowledge": {"bundle_path": "data/facility_knowledge"},
+    }
+
+    live = [consumer.name for _, consumer in live_consumers(config)]
+    assert "OKF panel ranked search" in live
+    assert reach_errors(config) == []
+
+
+def test_a_render_with_no_live_consumer_is_refused_nothing():
+    assert reach_errors({}) == []
+
+
+def test_bluesky_panel_secret_vars_follow_each_users_own_project(tmp_path):
+    """The roster grant is per USER: a persona user by their persona's rendered
+    config, a persona-less user by the deploy config they run (the same rule
+    the web-terminal render grants every other credential by), in roster
+    order."""
+    from osprey.deployment.web_terminals.personas import bluesky_panel_secret_env_vars
+    from osprey.deployment.web_terminals.render import terminal_secret_env_var
+
+    for persona, declares in (("viewer", False), ("operator", True)):
+        project = tmp_path / "build" / f"demo-{persona}"
+        project.mkdir(parents=True)
+        panels = {"bluesky": {"url": "http://localhost:8095"}} if declares else {}
+        (project / "config.yml").write_text(
+            yaml.safe_dump({"web": {"panels": panels}}), encoding="utf-8"
+        )
+    config = {
+        "web": {"panels": {"bluesky": {"url": "http://localhost:8095"}}},
+        "modules": {
+            "web_terminals": {
+                "personas": {
+                    "viewer": {"project_path": "build/demo-viewer"},
+                    "operator": {"project_path": "build/demo-operator"},
+                },
+                # Object entries carry the frozen `index` every materialized
+                # roster has; a bare string is the legacy spelling.
+                "users": [
+                    {"name": "alice", "index": 0, "persona": "operator"},
+                    {"name": "bob", "index": 1, "persona": "viewer"},
+                    "carol",  # no persona: runs the deploy config, which shows the tab
+                ],
+            }
+        },
+    }
+
+    assert bluesky_panel_secret_env_vars(config, tmp_path) == [
+        terminal_secret_env_var("alice"),
+        terminal_secret_env_var("carol"),
+    ]
+
+    config["web"]["panels"] = {}
+    assert bluesky_panel_secret_env_vars(config, tmp_path) == [terminal_secret_env_var("alice")]
+
+
+def test_the_graph_channel_finder_is_a_store_consumer_of_its_own():
+    """The graph paradigm's channel finder dials the store through its own
+    server, whether or not the `graph` MCP server is switched on — so a
+    persona that switches that server off but keeps the channel finder is
+    still projected the store's address, and refused without one."""
+    from osprey.deployment.reach import project_attached_overrides
+
+    attached = {
+        "channel_finder": {"pipeline_mode": "graph"},
+        "claude_code": {"servers": {"graph": {"enabled": False}}},
+    }
+    host = {"services": {"graphdb": {"port_host": 17687, "uri": "bolt://localhost:17687"}}}
+
+    projected = project_attached_overrides(host, attached)
+    assert projected["services.graphdb.port_host"] == 17687
+
+    (error,) = reach_errors(attached)
+    assert "graph channel finder" in error
+    assert "channel_finder.pipeline_mode" in error
+
+    # Channel finder switched off too: no consumer, nothing projected.
+    off = {
+        **attached,
+        "claude_code": {
+            "servers": {"graph": {"enabled": False}, "channel-finder": {"enabled": False}}
+        },
+    }
+    assert project_attached_overrides(host, off) == {}
+    assert reach_errors(off) == []

--- a/tests/deployment/test_reach_dials.py
+++ b/tests/deployment/test_reach_dials.py
@@ -1,0 +1,205 @@
+"""Each Reach Contract consumer dials what its own client would.
+
+The ``dial`` of every consumer in :data:`osprey.deployment.reach.REACH_CONTRACTS`
+goes through the client's real resolver — the qmd base URL, the graph
+connection, the ARIEL DSN, the OTLP endpoint, the bridge URL, the panel URL,
+the VA gateway fill — so these tests pin the resolver-against-config seam:
+a moved key moves the dial, an env override wins where the client honours
+one, and a client with nothing to dial says ``None``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.deployment.reach import REACH_CONTRACTS, reach_dials
+
+
+def _dial(service: str, config: dict, index: int = 0):
+    consumer = REACH_CONTRACTS[service].consumers[index]
+    assert consumer.dial is not None, f"{service} consumer {consumer.name} declares no dial"
+    return consumer.dial(config)
+
+
+class TestQmd:
+    def test_follows_the_published_port_on_loopback(self):
+        assert _dial("qmd", {"services": {"qmd": {"port": 9180}}}) == ("127.0.0.1", 9180)
+
+    def test_both_consumers_share_the_resolver(self):
+        config = {"services": {"qmd": {"port": 9180}}}
+        assert _dial("qmd", config, 0) == _dial("qmd", config, 1)
+
+    def test_no_block_is_nothing_to_dial(self):
+        assert _dial("qmd", {}) is None
+
+    def test_a_malformed_block_is_nothing_to_dial(self):
+        """The resolver refuses the block; the client would too."""
+        assert _dial("qmd", {"services": {"qmd": {"port": "eighty"}}}) is None
+
+
+class TestGraphdb:
+    def test_derives_bolt_from_the_published_port(self):
+        assert _dial("graphdb", {"services": {"graphdb": {"port_host": 7688}}}) == (
+            "localhost",
+            7688,
+        )
+
+    def test_an_explicit_uri_is_dialed_as_written(self):
+        config = {"services": {"graphdb": {"uri": "bolt://graph.example:7000"}}}
+        assert _dial("graphdb", config) == ("graph.example", 7000)
+
+    def test_no_store_is_nothing_to_dial(self):
+        assert _dial("graphdb", {}) is None
+
+
+class TestPostgresql:
+    def test_follows_the_published_port(self):
+        config = {"ariel": {}, "services": {"postgresql": {"port_host": 15432}}}
+        assert _dial("postgresql", config) == ("localhost", 15432)
+
+    def test_an_explicit_uri_wins(self):
+        config = {"ariel": {"database": {"uri": "postgresql://u:p@db.example:6543/ariel"}}}
+        assert _dial("postgresql", config) == ("db.example", 6543)
+
+
+class TestOpenobserve:
+    CONFIG = {
+        "claude_code": {"telemetry": {"enabled": True, "backend": "openobserve"}},
+        "services": {"openobserve": {"port": 15080}},
+    }
+
+    def test_follows_the_published_port(self, monkeypatch):
+        monkeypatch.delenv("OSPREY_OTEL_OPENOBSERVE_HOST", raising=False)
+        monkeypatch.delenv("OSPREY_OTEL_OPENOBSERVE_PORT", raising=False)
+        monkeypatch.delenv("OSPREY_IN_CONTAINER", raising=False)
+        host, port = _dial("openobserve", self.CONFIG)
+        assert port == 15080
+
+    def test_the_compose_authors_host_wins(self, monkeypatch):
+        """A host-networked persona container is told 127.0.0.1 by its compose
+        block; the exporter, and so the knock, go there."""
+        monkeypatch.setenv("OSPREY_OTEL_OPENOBSERVE_HOST", "127.0.0.1")
+        monkeypatch.delenv("OSPREY_OTEL_OPENOBSERVE_PORT", raising=False)
+        assert _dial("openobserve", self.CONFIG) == ("127.0.0.1", 15080)
+
+    def test_an_explicit_endpoint_is_dialed_as_written(self):
+        config = {
+            "claude_code": {
+                "telemetry": {"enabled": True, "endpoint": "http://collector.example:4318"}
+            }
+        }
+        assert _dial("openobserve", config) == ("collector.example", 4318)
+
+    def test_telemetry_off_is_nothing_to_dial(self):
+        assert _dial("openobserve", {"claude_code": {"telemetry": {"enabled": False}}}) is None
+
+
+class TestBluesky:
+    def test_follows_the_published_port(self, monkeypatch):
+        monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
+        assert _dial("bluesky", {"services": {"bluesky": {"port": 18090}}}) == (
+            "127.0.0.1",
+            18090,
+        )
+
+    def test_the_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("BLUESKY_BRIDGE_URL", "http://bridge:9/")
+        assert _dial("bluesky", {"services": {"bluesky": {"port": 18090}}}) == ("bridge", 9)
+
+
+@pytest.mark.parametrize(
+    ("lane", "prefix"), [("bluesky_va", "BLUESKY_VA"), ("bluesky_live", "BLUESKY_LIVE")]
+)
+class TestSecondLane:
+    """A second plan lane resolves like ``resolve_bridge_url(lane)``: its own
+    ``<PREFIX>_BRIDGE_URL`` outright, else its published port on loopback —
+    and, having no ``bluesky.bridge_url`` and no default of its own, nothing
+    at all without a port."""
+
+    def test_follows_the_lanes_published_port(self, lane, prefix, monkeypatch):
+        monkeypatch.delenv(f"{prefix}_BRIDGE_URL", raising=False)
+        assert _dial(lane, {"services": {lane: {"port": 18190, "target": "live"}}}) == (
+            "127.0.0.1",
+            18190,
+        )
+
+    def test_the_lanes_own_env_override_wins(self, lane, prefix, monkeypatch):
+        monkeypatch.setenv(f"{prefix}_BRIDGE_URL", "http://lane-bridge:9/")
+        assert _dial(lane, {"services": {lane: {"port": 18190}}}) == ("lane-bridge", 9)
+
+    def test_lane_ones_override_is_not_this_lanes(self, lane, prefix, monkeypatch):
+        """``BLUESKY_BRIDGE_URL`` names lane 1's bridge; a second lane dialing it
+        would send the other machine's plans to the baseline's bridge."""
+        monkeypatch.delenv(f"{prefix}_BRIDGE_URL", raising=False)
+        monkeypatch.setenv("BLUESKY_BRIDGE_URL", "http://lane-one:8090")
+        assert _dial(lane, {"services": {lane: {"port": 18190}}}) == ("127.0.0.1", 18190)
+
+    def test_no_port_is_nothing_to_dial(self, lane, prefix, monkeypatch):
+        monkeypatch.delenv(f"{prefix}_BRIDGE_URL", raising=False)
+        assert _dial(lane, {"services": {lane: {"target": "live"}}}) is None
+        assert _dial(lane, {}) is None
+
+
+@pytest.mark.parametrize(
+    ("service", "panel"), [("bluesky_web", "bluesky"), ("event_dispatcher", "events")]
+)
+class TestPanels:
+    def test_dials_the_panel_url(self, service, panel):
+        config = {"web": {"panels": {panel: {"url": "http://127.0.0.1:8097"}}}}
+        assert _dial(service, config) == ("127.0.0.1", 8097)
+
+    def test_no_url_is_nothing_to_dial(self, service, panel):
+        assert _dial(service, {"web": {"panels": {panel: {"enabled": True}}}}) is None
+
+
+class TestVirtualAccelerator:
+    def test_follows_the_published_port_on_the_gateway_address(self):
+        config = {
+            "services": {"virtual_accelerator": {"port": 15064}},
+            "control_system": {
+                "connector": {
+                    "virtual_accelerator": {"gateways": {"read_only": {"address": "localhost"}}}
+                }
+            },
+        }
+        assert _dial("virtual_accelerator", config) == ("localhost", 15064)
+
+    def test_an_explicit_gateway_port_wins(self):
+        """fill_gateway_ports' own precedence: a gateway that names its port
+        is pointed at a VA this project does not deploy."""
+        config = {
+            "services": {"virtual_accelerator": {"port": 15064}},
+            "control_system": {
+                "connector": {
+                    "virtual_accelerator": {
+                        "gateways": {"read_only": {"address": "va.example", "port": 5074}}
+                    }
+                }
+            },
+        }
+        assert _dial("virtual_accelerator", config) == ("va.example", 5074)
+
+    def test_the_connector_default_when_nothing_is_configured(self):
+        from osprey_connectors.control_system.va_connector import DEFAULT_VA_PORT
+
+        assert _dial("virtual_accelerator", {}) == ("localhost", DEFAULT_VA_PORT)
+
+
+def test_every_consumer_declares_a_dial():
+    """The health category can only knock on what the registry can dial;
+    a consumer without one would be silently absent from the readout."""
+    missing = [
+        (contract.service, consumer.name)
+        for contract in REACH_CONTRACTS.values()
+        for consumer in contract.consumers
+        if consumer.dial is None
+    ]
+    assert missing == []
+
+
+def test_reach_dials_lists_only_live_consumers():
+    config = {"ariel": {"search_modules": {"hybrid": {"enabled": True}}}}
+    assert [(c.service, d) for c, _k, d in reach_dials(config) if c.service == "qmd"] == [
+        ("qmd", None)
+    ]
+    assert all(c.service != "bluesky" for c, _k, _d in reach_dials(config))

--- a/tests/deployment/web_terminals/golden/docker-compose.web.yml
+++ b/tests/deployment/web_terminals/golden/docker-compose.web.yml
@@ -46,6 +46,7 @@ services:
       - OSPREY_TERMINAL_BIND_HOST=127.0.0.1
       - OSPREY_TERMINAL_WEB_PORT=9091
       - OSPREY_WEB_PORT=9091
+      - OSPREY_OTEL_OPENOBSERVE_HOST=127.0.0.1
       - OSPREY_TERMINAL_SECRET=${OSPREY_TERMINAL_SECRET_ALICE:-}
       - OSPREY_TERMINAL_EXTERNAL_ORIGIN=http://dls-deploy.dls.example.org:9080
       - ZO_INGEST_SA_TOKEN=${ZO_INGEST_SA_TOKEN:-}
@@ -58,6 +59,9 @@ services:
     volumes:
       - alice-claude-config:/data/claude-config
       - alice-agent-data:/app/dls-assistant/var/agent_data
+      # This user's refusal audit log (`var/audit/<user>/` on the host), bound
+      # so the record survives a recreate and is readable from the host.
+      - ./var/audit/alice:/app/dls-assistant/var/audit
     healthcheck:
       # osprey web's own default listen port is the fixed constant 8087
       # (cli/web_cmd.py) — only relevant to a bare `osprey web` with no
@@ -91,6 +95,7 @@ services:
       - OSPREY_TERMINAL_BIND_HOST=127.0.0.1
       - OSPREY_TERMINAL_WEB_PORT=9092
       - OSPREY_WEB_PORT=9092
+      - OSPREY_OTEL_OPENOBSERVE_HOST=127.0.0.1
       - OSPREY_TERMINAL_SECRET=${OSPREY_TERMINAL_SECRET_BOB:-}
       - OSPREY_TERMINAL_EXTERNAL_ORIGIN=http://dls-deploy.dls.example.org:9080
       - ZO_INGEST_SA_TOKEN=${ZO_INGEST_SA_TOKEN:-}
@@ -103,6 +108,9 @@ services:
     volumes:
       - bob-claude-config:/data/claude-config
       - bob-agent-data:/app/dls-assistant/var/agent_data
+      # This user's refusal audit log (`var/audit/<user>/` on the host), bound
+      # so the record survives a recreate and is readable from the host.
+      - ./var/audit/bob:/app/dls-assistant/var/audit
     healthcheck:
       # osprey web's own default listen port is the fixed constant 8087
       # (cli/web_cmd.py) — only relevant to a bare `osprey web` with no

--- a/tests/deployment/web_terminals/test_mirror_and_audit_mounts.py
+++ b/tests/deployment/web_terminals/test_mirror_and_audit_mounts.py
@@ -1,0 +1,410 @@
+"""The ARIEL mirror and the per-user audit zone, bound into web terminals.
+
+Two more host directories the per-user containers WRITE, each with the same
+shape as the knowledge bundle (``test_bundle_mount.py``) and asserted the same
+way:
+
+* **The ARIEL qmd mirror.** A persona whose render enables ``qmd_export``
+  runs that module inside its own container, and the module writes wherever
+  ``mirror_path`` resolves — the persona's project root, in-container. Bound
+  to the deployment's one mirror (the directory the host exporter fills and
+  the sidecar indexes), the entry reaches the search corpus; unbound, it lands
+  in the container's writable layer where nothing indexes it and the next
+  recreate discards it. Entitlement is per persona, the source is shared, the
+  target is per service.
+* **The refusal audit zone.** The python executor in every container appends
+  its refusal log under ``<project>/var/audit``. Nothing else backs that path
+  — the agent-data volume is a sibling — so it is bound to a per-user host
+  directory (``var/audit/<user>``): per user because every container writes
+  the same fixed filename, a host bind because an audit log has to be readable
+  without entering a container. Every user, no entitlement.
+
+Both join the same ``group_add`` story as the bundle, and the three are
+emitted as one list per service.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import yaml
+
+from osprey.deployment.web_terminals.render import render_web_terminals
+from osprey.utils.workspace import AUDIT_DIR_RELPATH
+
+from .test_golden_render import EXAMPLE_CONFIG
+
+MIRROR_PATH = "var/ariel_mirror"
+MIRROR_SOURCE = f"./{MIRROR_PATH}"
+
+
+def _config(*, mirror: bool = True, personas: bool = False, via_settings: bool = True) -> dict:
+    """The reference roster, optionally persona-backed and running a qmd export."""
+    config = copy.deepcopy(EXAMPLE_CONFIG)
+    if mirror:
+        export: dict = {"enabled": True}
+        if via_settings:
+            export["settings"] = {"mirror_path": MIRROR_PATH}
+        else:
+            export["mirror_path"] = MIRROR_PATH
+        config["ariel"] = {"enhancement_modules": {"qmd_export": export}}
+    if personas:
+        web_terminals = config["modules"]["web_terminals"]
+        web_terminals["personas"] = {
+            "operator": {"project": "dls-operator", "project_path": "../dls-operator"},
+            "physicist": {"project": "dls-physicist", "project_path": "../dls-physicist"},
+        }
+        web_terminals["users"] = [
+            {"name": "alice", "index": 0, "persona": "operator"},
+            {"name": "bob", "index": 1, "persona": "physicist"},
+        ]
+    return config
+
+
+def _services(config: dict, **kwargs) -> dict[str, dict]:
+    compose = yaml.safe_load(render_web_terminals(config, **kwargs)["docker-compose.web.yml"])
+    return {name: service for name, service in compose["services"].items() if name != "nginx"}
+
+
+def _volumes(config: dict, **kwargs) -> dict[str, list[str]]:
+    return {name: svc.get("volumes", []) for name, svc in _services(config, **kwargs).items()}
+
+
+def _mirror_mounts(config: dict, **kwargs) -> dict[str, list[str]]:
+    return {
+        name: [v for v in volumes if v.startswith(f"{MIRROR_SOURCE}:")]
+        for name, volumes in _volumes(config, **kwargs).items()
+    }
+
+
+def _audit_mounts(config: dict, **kwargs) -> dict[str, list[str]]:
+    return {
+        name: [v for v in volumes if v.startswith(f"./{AUDIT_DIR_RELPATH}/")]
+        for name, volumes in _volumes(config, **kwargs).items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# The mirror mount
+# ---------------------------------------------------------------------------
+
+
+def test_no_qmd_export_mounts_no_mirror():
+    assert _mirror_mounts(_config(mirror=False)) == {"web-alice": [], "web-bob": []}
+
+
+def test_every_persona_less_user_gets_the_mirror():
+    """With no catalog the deploy config is every user's config, so its own
+    export entitles everyone — answered with no disk read."""
+    assert _mirror_mounts(_config()) == {
+        "web-alice": [f"{MIRROR_SOURCE}:/app/dls-assistant/{MIRROR_PATH}"],
+        "web-bob": [f"{MIRROR_SOURCE}:/app/dls-assistant/{MIRROR_PATH}"],
+    }
+
+
+def test_mirror_path_on_the_module_block_is_honoured_too():
+    """``settings.mirror_path`` wins when present; the bare key is read otherwise —
+    the exporter's own merge rule, followed here so the mount lands where it writes."""
+    assert _mirror_mounts(_config(via_settings=False)) == {
+        "web-alice": [f"{MIRROR_SOURCE}:/app/dls-assistant/{MIRROR_PATH}"],
+        "web-bob": [f"{MIRROR_SOURCE}:/app/dls-assistant/{MIRROR_PATH}"],
+    }
+
+
+def test_target_is_computed_per_persona_from_its_own_project_dir():
+    mounts = _mirror_mounts(_config(personas=True), ariel_mirror_personas={"operator", "physicist"})
+    assert mounts == {
+        "web-alice": [f"{MIRROR_SOURCE}:/app/dls-operator/{MIRROR_PATH}"],
+        "web-bob": [f"{MIRROR_SOURCE}:/app/dls-physicist/{MIRROR_PATH}"],
+    }
+
+
+def test_only_entitled_personas_get_the_mirror():
+    mounts = _mirror_mounts(_config(personas=True), ariel_mirror_personas={"operator"})
+    assert mounts == {
+        "web-alice": [f"{MIRROR_SOURCE}:/app/dls-operator/{MIRROR_PATH}"],
+        "web-bob": [],
+    }
+
+
+def test_no_entitled_personas_mounts_no_mirror():
+    assert _mirror_mounts(_config(personas=True)) == {"web-alice": [], "web-bob": []}
+
+
+def test_disabled_export_mounts_nothing():
+    config = _config()
+    config["ariel"]["enhancement_modules"]["qmd_export"]["enabled"] = False
+    assert _mirror_mounts(config) == {"web-alice": [], "web-bob": []}
+
+
+def test_absolute_mirror_path_is_not_re_anchored():
+    config = _config()
+    config["ariel"]["enhancement_modules"]["qmd_export"]["settings"]["mirror_path"] = "/srv/mirror"
+    volumes = _volumes(config)["web-alice"]
+    assert "/srv/mirror:/srv/mirror" in volumes
+
+
+def test_mirror_mount_is_read_write():
+    """The container's exporter writes here; only the sidecar mounts it ``:ro``."""
+    (mount,) = _mirror_mounts(_config())["web-alice"]
+    assert not mount.endswith(":ro")
+
+
+# ---------------------------------------------------------------------------
+# The audit mount
+# ---------------------------------------------------------------------------
+
+
+def test_every_user_gets_a_per_user_audit_bind():
+    assert _audit_mounts(_config(mirror=False)) == {
+        "web-alice": [f"./{AUDIT_DIR_RELPATH}/alice:/app/dls-assistant/{AUDIT_DIR_RELPATH}"],
+        "web-bob": [f"./{AUDIT_DIR_RELPATH}/bob:/app/dls-assistant/{AUDIT_DIR_RELPATH}"],
+    }
+
+
+def test_audit_target_follows_each_personas_project_dir():
+    assert _audit_mounts(_config(mirror=False, personas=True)) == {
+        "web-alice": [f"./{AUDIT_DIR_RELPATH}/alice:/app/dls-operator/{AUDIT_DIR_RELPATH}"],
+        "web-bob": [f"./{AUDIT_DIR_RELPATH}/bob:/app/dls-physicist/{AUDIT_DIR_RELPATH}"],
+    }
+
+
+def test_audit_sources_are_distinct_per_user():
+    """Two containers write the same filename; one shared directory would
+    have them clobber each other."""
+    sources = {
+        name: mount.split(":")[0] for name, (mount,) in _audit_mounts(_config(mirror=False)).items()
+    }
+    assert len(set(sources.values())) == len(sources)
+
+
+def test_audit_target_is_where_the_executor_writes():
+    """The target is the writer's own derivation — the project root plus
+    :data:`AUDIT_DIR_RELPATH` — never a literal that could drift from it."""
+    from osprey.deployment.web_terminals.render import _container_audit_dir
+
+    assert _container_audit_dir("/app/x") == f"/app/x/{AUDIT_DIR_RELPATH}"
+    (mount,) = _audit_mounts(_config(mirror=False))["web-alice"]
+    assert mount.endswith(f":{_container_audit_dir('/app/dls-assistant')}")
+
+
+# ---------------------------------------------------------------------------
+# group_add: one list per service, every shared directory's group once
+# ---------------------------------------------------------------------------
+
+
+def _group_add(config: dict, **kwargs) -> dict[str, list[str]]:
+    return {name: svc.get("group_add", []) for name, svc in _services(config, **kwargs).items()}
+
+
+def test_no_gids_emits_no_group_add():
+    assert _group_add(_config()) == {"web-alice": [], "web-bob": []}
+
+
+def test_audit_gid_is_joined_by_every_service():
+    assert _group_add(_config(mirror=False), audit_gid=1234) == {
+        "web-alice": ["1234"],
+        "web-bob": ["1234"],
+    }
+
+
+def test_each_distinct_gid_is_listed_once():
+    """The deploy creates every shared directory as one user, so they usually
+    share a group; a list that repeats it would read like two groups."""
+    config = _config()
+    config["facility_knowledge"] = {"bundle_path": "data/facility_knowledge"}
+    groups = _group_add(config, facility_bundle_gid=20, ariel_mirror_gid=20, audit_gid=20)
+    assert groups == {"web-alice": ["20"], "web-bob": ["20"]}
+    groups = _group_add(config, facility_bundle_gid=20, ariel_mirror_gid=21, audit_gid=22)
+    assert groups == {"web-alice": ["20", "21", "22"], "web-bob": ["20", "21", "22"]}
+
+
+def test_mirror_gid_reaches_only_entitled_services():
+    groups = _group_add(
+        _config(personas=True), ariel_mirror_personas={"operator"}, ariel_mirror_gid=21
+    )
+    assert groups == {"web-alice": ["21"], "web-bob": []}
+
+
+# ---------------------------------------------------------------------------
+# Entitlement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        pytest.param(
+            {
+                "ariel": {
+                    "enhancement_modules": {"qmd_export": {"enabled": True, "mirror_path": "m"}}
+                }
+            },
+            True,
+            id="enabled-with-path",
+        ),
+        pytest.param(
+            {
+                "ariel": {
+                    "enhancement_modules": {
+                        "qmd_export": {"enabled": True, "settings": {"mirror_path": "m"}}
+                    }
+                }
+            },
+            True,
+            id="enabled-with-settings-path",
+        ),
+        pytest.param(
+            {
+                "ariel": {
+                    "enhancement_modules": {"qmd_export": {"enabled": False, "mirror_path": "m"}}
+                }
+            },
+            False,
+            id="disabled",
+        ),
+        pytest.param(
+            {"ariel": {"enhancement_modules": {"qmd_export": {"enabled": True}}}},
+            False,
+            id="enabled-without-path",
+        ),
+        pytest.param({"ariel": {}}, False, id="no-modules"),
+        pytest.param({}, False, id="absent"),
+    ],
+)
+def test_config_needs_ariel_mirror(config, expected):
+    from osprey.deployment.web_terminals.personas import config_needs_ariel_mirror
+
+    assert config_needs_ariel_mirror(config) is expected
+
+
+def test_personas_needing_ariel_mirror_reads_each_personas_config(tmp_path):
+    from osprey.deployment.web_terminals.personas import personas_needing_ariel_mirror
+
+    (tmp_path / "dls-operator").mkdir()
+    (tmp_path / "dls-operator" / "config.yml").write_text(
+        yaml.safe_dump(
+            {
+                "ariel": {
+                    "enhancement_modules": {"qmd_export": {"enabled": True, "mirror_path": "m"}}
+                }
+            }
+        )
+    )
+    (tmp_path / "dls-physicist").mkdir()
+    (tmp_path / "dls-physicist" / "config.yml").write_text(yaml.safe_dump({"facility": {}}))
+    config = _config(personas=True)
+    catalog = config["modules"]["web_terminals"]["personas"]
+    catalog["operator"]["project_path"] = "dls-operator"
+    catalog["physicist"]["project_path"] = "dls-physicist"
+
+    assert personas_needing_ariel_mirror(config, tmp_path) == {"operator"}
+
+
+# ---------------------------------------------------------------------------
+# The host side: one reader, one directory, provisioned before the render
+# ---------------------------------------------------------------------------
+
+
+def test_mirror_reader_is_shared_with_the_sidecar_corpus_list(tmp_path):
+    """The mount source, the sidecar's corpus and the provisioned directory all
+    come from ``configured_ariel_mirror_path`` — one string, three consumers."""
+    from osprey.deployment.compose_generator import (
+        _resolve_qmd_corpora,
+        configured_ariel_mirror_path,
+        resolve_ariel_mirror_dir,
+    )
+
+    config = _config()
+    assert configured_ariel_mirror_path(config) == MIRROR_PATH
+    corpora = {c["collection"]: c for c in _resolve_qmd_corpora(config, str(tmp_path))}
+    assert corpora["ariel"]["source"] == MIRROR_SOURCE
+    assert resolve_ariel_mirror_dir(config, tmp_path) == tmp_path / MIRROR_PATH
+    (mount,) = _mirror_mounts(config)["web-alice"]
+    assert mount.split(":")[0] == corpora["ariel"]["source"]
+
+
+def test_user_audit_dir_is_the_bind_source(tmp_path):
+    from osprey.deployment.compose_generator import resolve_user_audit_dir, user_audit_relpath
+
+    assert user_audit_relpath("alice") == f"{AUDIT_DIR_RELPATH}/alice"
+    assert resolve_user_audit_dir(tmp_path, "alice") == tmp_path / AUDIT_DIR_RELPATH / "alice"
+    (mount,) = _audit_mounts(_config(mirror=False))["web-alice"]
+    assert mount.split(":")[0] == f"./{user_audit_relpath('alice')}"
+
+
+# ---------------------------------------------------------------------------
+# The entitlement/source split, caught by lint
+# ---------------------------------------------------------------------------
+
+
+def _mirror_lintable(tmp_path, persona_mirror: str | None, deploy_mirror: str | None) -> dict:
+    """A local-mode roster with one rendered persona, linted from *tmp_path*."""
+    project = tmp_path / "dls-operator"
+    project.mkdir(exist_ok=True)
+    (project / "Dockerfile").write_text("FROM scratch")
+    persona_config: dict = {"project_name": "dls-operator"}
+    if persona_mirror is not None:
+        persona_config["ariel"] = {
+            "enhancement_modules": {"qmd_export": {"enabled": True, "mirror_path": persona_mirror}}
+        }
+    (project / "config.yml").write_text(yaml.safe_dump(persona_config))
+
+    config = _config(mirror=deploy_mirror is not None, personas=True, via_settings=False)
+    if deploy_mirror is not None:
+        config["ariel"]["enhancement_modules"]["qmd_export"]["mirror_path"] = deploy_mirror
+    web_terminals = config["modules"]["web_terminals"]
+    web_terminals["image_source"] = "local"
+    web_terminals["personas"] = {
+        "operator": {
+            "project": "dls-operator",
+            "project_path": "dls-operator",
+            "build_profile": "personas/operator.yml",
+        }
+    }
+    web_terminals["users"] = [{"name": "alice", "index": 0, "persona": "operator"}]
+    return config
+
+
+def _mirror_findings(config: dict) -> list:
+    from osprey.deployment.web_terminals.lint import lint_web_terminals
+
+    return [
+        f
+        for f in lint_web_terminals(config)
+        if f.code == "web_terminals.persona_mirror_path_divergence"
+    ]
+
+
+def test_lint_flags_a_persona_exporting_where_the_deployment_writes_no_mirror(
+    tmp_path, monkeypatch
+):
+    """The persona is entitled (its config runs a qmd export) but the
+    deployment writes no mirror, so the overlay has no source to bind: the
+    persona's exporter would write into its writable layer, unindexed and
+    lost at the next recreate, with every layer reporting success."""
+    monkeypatch.chdir(tmp_path)
+    config = _mirror_lintable(tmp_path, persona_mirror=MIRROR_PATH, deploy_mirror=None)
+
+    (finding,) = _mirror_findings(config)
+
+    assert finding.severity == "error"
+    assert "runs none" in finding.message
+
+
+def test_lint_flags_a_persona_that_relocated_its_mirror(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = _mirror_lintable(tmp_path, persona_mirror="var/elsewhere", deploy_mirror=MIRROR_PATH)
+
+    (finding,) = _mirror_findings(config)
+
+    assert finding.severity == "error"
+    assert "var/elsewhere" in finding.message and MIRROR_PATH in finding.message
+
+
+def test_lint_is_quiet_when_persona_and_deployment_agree_on_the_mirror(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert _mirror_findings(_mirror_lintable(tmp_path, MIRROR_PATH, MIRROR_PATH)) == []
+    assert _mirror_findings(_mirror_lintable(tmp_path, None, MIRROR_PATH)) == []
+    assert _mirror_findings(_mirror_lintable(tmp_path, None, None)) == []

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -3610,6 +3610,65 @@ def test_unentitled_persona_gets_no_launch_token() -> None:
     assert not any("BLUESKY_LAUNCH_TOKEN" in line for line in bob_env)
 
 
+# A deployment that opted into a second plan lane (`bluesky.second_lane`) renders
+# a second bridge with its own launch token, because each lane is a whole stack
+# armed separately -- one shared token would let a launch approved against one
+# machine be replayed against the other. An entitled persona is told both lanes
+# and so is handed both tokens; the tier boundary is the same one.
+
+_SECOND_LANE_TOKEN_LINE = "BLUESKY_LIVE_LAUNCH_TOKEN=${BLUESKY_LIVE_LAUNCH_TOKEN:-}"
+
+
+def _two_lane_persona_config() -> dict:
+    config = _events_persona_config()
+    config["services"] = {
+        "bluesky": {"port": 8090, "target": "va"},
+        "bluesky_live": {"port": 8190, "target": "live"},
+    }
+    return config
+
+
+def test_entitled_persona_on_a_two_lane_deployment_gets_both_launch_tokens() -> None:
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_two_lane_persona_config(), launch_token_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    alice_env = compose["services"]["web-alice"]["environment"]
+    assert _LAUNCH_TOKEN_LINE in alice_env
+    assert _SECOND_LANE_TOKEN_LINE in alice_env
+
+
+def test_unentitled_persona_on_a_two_lane_deployment_gets_neither_token() -> None:
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_two_lane_persona_config(), launch_token_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    bob_env = compose["services"]["web-bob"]["environment"]
+    assert not any("LAUNCH_TOKEN" in line for line in bob_env)
+
+
+def test_single_lane_deployment_grants_lane_ones_token_alone() -> None:
+    """The pre-lane render exactly: one token line, the historical name."""
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config(), launch_token_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    alice_env = compose["services"]["web-alice"]["environment"]
+    assert [line for line in alice_env if "LAUNCH_TOKEN" in line] == [_LAUNCH_TOKEN_LINE]
+
+
 def test_render_without_launch_token_personas_emits_no_token_line() -> None:
     """The no-project-root render path (`osprey scaffold web-terminals render`)
     passes no persona set, so no user is armed. Harmless: every `osprey up`

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -1417,24 +1417,27 @@ def test_persona_extra_mounts_render_as_extra_per_user_volume_lines() -> None:
     artifacts = render_web_terminals(config)
     compose = yaml.safe_load(artifacts["docker-compose.web.yml"])
 
-    # Assert — bob (gui) carries the two default mounts plus the persona's two
+    # Assert — bob (gui) carries the three default mounts plus the persona's two
     bob_volumes = compose["services"]["web-bob"]["volumes"]
     assert bob_volumes == [
         "bob-claude-config:/data/claude-config",
         "bob-agent-data:/app/dls-gui/var/agent_data",
+        "./var/audit/bob:/app/dls-gui/var/audit",
         "/opt/site-data:/app/site-data:ro",
         "shared-cache:/app/cache",
     ]
-    # alice (default persona, no extra_mounts) keeps exactly the two default mounts
+    # alice (default persona, no extra_mounts) keeps exactly the three default mounts
     assert compose["services"]["web-alice"]["volumes"] == [
         "alice-claude-config:/data/claude-config",
         "alice-agent-data:/app/dls-assistant/var/agent_data",
+        "./var/audit/alice:/app/dls-assistant/var/audit",
     ]
 
 
-def test_no_extra_mounts_leaves_only_the_two_default_volume_lines() -> None:
-    """A no-personas config (the zero-migration default) emits exactly the two
-    default per-user volume lines — the extra_mounts loop adds nothing."""
+def test_no_extra_mounts_leaves_only_the_default_volume_lines() -> None:
+    """A no-personas config (the zero-migration default) emits exactly the three
+    default per-user volume lines (claude-config, agent-data, the per-user audit
+    zone) — the extra_mounts loop adds nothing."""
     # Arrange
     config = copy.deepcopy(_MULTI_USER_CONFIG)
 
@@ -1447,6 +1450,7 @@ def test_no_extra_mounts_leaves_only_the_two_default_volume_lines() -> None:
         assert compose["services"][f"web-{user}"]["volumes"] == [
             f"{user}-claude-config:/data/claude-config",
             f"{user}-agent-data:/app/dls-assistant/var/agent_data",
+            f"./var/audit/{user}:/app/dls-assistant/var/audit",
         ]
 
 

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -707,6 +707,12 @@ config:
   claude_code.servers.bluesky.enabled: false
   claude_code.servers.health.enabled: false
   claude_code.servers.osprey_facility_knowledge.enabled: false
+  # The graph store is a control-room surface too, and this tier's exclusion
+  # of it has to be said: the build tells every attached render where the
+  # hosting deployment's services are (the Reach Contract), and a
+  # `services.graphdb` block is what makes the graph server render. Only a
+  # server switched off is told nothing about the store.
+  claude_code.servers.graph.enabled: false
   # Pinned even though the server that would honour it is gone, for the same
   # reason the other two tiers pin it: this key is the write boundary, and it
   # must not drift if the base's default ever changes.
@@ -722,6 +728,16 @@ config:
   # containers). Without this override the inherited roster would make this
   # render try to host a second web tier on the same host ports.
   modules.web_terminals.enabled: false
+  # Nothing here says where the hosting deployment's services are — the qmd
+  # sidecar hybrid logbook search dials (the point of this tier), the Postgres
+  # the logbook lives in, the telemetry store. This persona is an attached
+  # render (`services: {}` of its own) built beside that deployment, and the
+  # build copies every such fact from the deployment's own render into it
+  # (the Reach Contract, `osprey.deployment.reach`). Per-user web-terminal
+  # containers run `network_mode: host`, so container `localhost` IS the
+  # deployment host and the copied ports are dialed there. Built alone, with
+  # no hosting deployment in the repo, the build copies what the app template
+  # deploys at its defaults instead — and a host that differs is named here.
 """
 
 PERSONA_READONLY_YML = """\
@@ -764,15 +780,18 @@ config:
   # per-user containers). Without this override the inherited roster would
   # make this render try to host a second web tier on the same host ports.
   modules.web_terminals.enabled: false
-  # This persona is an attached render (`services: {}` — no graphdb block of
-  # its own), so the agent's graph tools need to be told which host-published
-  # bolt port the hosting deployment's `graphdb` store listens on. Per-user
-  # web-terminal containers run `network_mode: host`, so container
-  # `localhost` IS the deployment host. If an operator moves
-  # `services.graphdb.port_host` on the hosting deployment, this number must
-  # move with it here AND in control-assistant-readwrite and
-  # control-assistant-admin.
-  services.graphdb.port_host: 7687
+  # Nothing here says where the hosting deployment's services are — the graph
+  # store's bolt port, the qmd sidecar's port, the Postgres the logbook lives
+  # in, the telemetry store, the bluesky bridge. This persona is an attached
+  # render (`services: {}` of its own) built beside that deployment, and the
+  # build copies every such fact from the deployment's own render into it
+  # (the Reach Contract, `osprey.deployment.reach`). Per-user web-terminal
+  # containers run `network_mode: host`, so container `localhost` IS the
+  # deployment host and the copied ports are dialed there. Move a port on the
+  # hosting profile and every persona follows; spell a different one here and
+  # the build refuses the contradiction. Built alone, with no hosting
+  # deployment in the repo, the build copies what the app template deploys
+  # at its defaults instead — and a host that differs IS named here.
 """
 
 PERSONA_READWRITE_YML = """\
@@ -794,9 +813,12 @@ name: Als Exemplar (readwrite)
 # connects to the shared web tier the hosting deployment runs on the same host.
 deploy_services: false
 
-# The write-oriented panels, listed beside their web.panels.<id>.url overrides
-# below (a panel id and its URL declaration travel together). Persona lists
-# UNION over the base, so these are added to the inherited builtin set.
+# The write-oriented panels. Persona lists UNION over the base, so these are
+# added to the inherited builtin set. Each tab's URL, path and label are not
+# spelled here: the hosting deployment's build derives them when it injects
+# the event dispatcher and the bluesky-web sidecar, and this attached render
+# is told them from that render (the Reach Contract, `osprey.deployment.reach`)
+# — so a sidecar moved on the hosting profile moves the tab with it.
 web_panels:
   - events          # EVENTS dashboard tab (event dispatcher)
   - bluesky         # Plan authoring, the plan queue, and the run's live results
@@ -815,32 +837,19 @@ config:
   # per-user containers). Without this override the inherited roster would
   # make this render try to host a second web tier on the same host ports.
   modules.web_terminals.enabled: false
-  # This persona is an attached render (`services: {}` — no graphdb block of
-  # its own), so the agent's graph tools need to be told which host-published
-  # bolt port the hosting deployment's `graphdb` store listens on. Per-user
-  # web-terminal containers run `network_mode: host`, so container
-  # `localhost` IS the deployment host. If an operator moves
-  # `services.graphdb.port_host` on the hosting deployment, this number must
-  # move with it here AND in control-assistant-readonly and
-  # control-assistant-admin.
-  services.graphdb.port_host: 7687
-  # EVENTS + BLUESKY: the write-oriented panels, declared HERE and not in the
-  # base so the readonly persona is built without them (a persona can only add
-  # config keys, never subtract inherited ones — see the note in the base's
-  # config: block).
-  # EVENTS — the event-dispatcher dashboard as an in-terminal tab. URL defaults
-  # to the host-run dispatcher; override EVENT_DISPATCHER_URL for
-  # containerized/remote web terminals.
-  web.panels.events.label: EVENTS
-  web.panels.events.url: "${EVENT_DISPATCHER_URL:-http://localhost:8020}"
-  web.panels.events.path: /dashboard
-  web.panels.events.health_endpoint: /health
-  # BLUESKY — operator UI for the mediated Bluesky stack, served by the
-  # bluesky-web sidecar. Override BLUESKY_WEB_URL for containerized/
-  # remote web terminals (same pattern as EVENTS above).
-  web.panels.bluesky.label: BLUESKY
-  web.panels.bluesky.url: "${BLUESKY_WEB_URL:-http://localhost:8095}"
-  web.panels.bluesky.path: /bluesky/
+  # Nothing here says where the hosting deployment's services are — the graph
+  # store's bolt port, the qmd sidecar's port, the Postgres the logbook lives
+  # in, the telemetry store, the bluesky bridge, the EVENTS and BLUESKY tabs'
+  # URLs. This persona is an attached render (`services: {}` of its own) built
+  # beside that deployment, and the build copies every such fact from the
+  # deployment's own render into it (the Reach Contract,
+  # `osprey.deployment.reach`). Per-user web-terminal containers run
+  # `network_mode: host`, so container `localhost` IS the deployment host and
+  # the copied ports are dialed there. Move a port on the hosting profile and
+  # every persona follows; spell a different one here and the build refuses
+  # the contradiction. Built alone, with no hosting deployment in the repo,
+  # the build copies what the app template deploys at its defaults instead
+  # — and a host that differs IS named here.
 """
 
 PERSONA_ADMIN_YML = """\
@@ -902,15 +911,18 @@ config:
   # containers). Without this override the inherited roster would make this
   # render try to host a second web tier on the same host ports.
   modules.web_terminals.enabled: false
-  # This persona is an attached render (`services: {}` — no graphdb block of
-  # its own), so the agent's graph tools need to be told which host-published
-  # bolt port the hosting deployment's `graphdb` store listens on. Per-user
-  # web-terminal containers run `network_mode: host`, so container
-  # `localhost` IS the deployment host. If an operator moves
-  # `services.graphdb.port_host` on the hosting deployment, this number must
-  # move with it here AND in control-assistant-readonly and
-  # control-assistant-readwrite.
-  services.graphdb.port_host: 7687
+  # Nothing here says where the hosting deployment's services are — the graph
+  # store's bolt port, the qmd sidecar's port, the Postgres the logbook lives
+  # in, the telemetry store, the bluesky bridge. This persona is an attached
+  # render (`services: {}` of its own) built beside that deployment, and the
+  # build copies every such fact from the deployment's own render into it
+  # (the Reach Contract, `osprey.deployment.reach`). Per-user web-terminal
+  # containers run `network_mode: host`, so container `localhost` IS the
+  # deployment host and the copied ports are dialed there. Move a port on the
+  # hosting profile and every persona follows; spell a different one here and
+  # the build refuses the contradiction. Built alone, with no hosting
+  # deployment in the repo, the build copies what the app template deploys
+  # at its defaults instead — and a host that differs IS named here.
 """
 
 

--- a/tests/health/core/test_ariel.py
+++ b/tests/health/core/test_ariel.py
@@ -2,7 +2,8 @@
 
 Drives the category's async ``/api/status`` probe through an injected
 :class:`httpx.MockTransport`, exercising the presence gate (a top-level ``ariel``
-config block), endpoint construction from ``bind_address`` + ``ariel.web.port``,
+config block), endpoint construction through the web-server registry resolver
+(``ariel.web.host``/``port``, with the multi-user ``OSPREY_ARIEL_PORT`` override),
 and every derived row (reachability, entry count, last-ingestion age, and the
 search/enhancement module rows).
 """
@@ -203,14 +204,40 @@ async def test_empty_enhancement_modules_is_ok() -> None:
 # --------------------------------------------------------------------------- #
 
 
-async def test_status_url_uses_bind_and_port() -> None:
-    config = _cfg(web={"port": 9999}, deployment={"bind_address": "10.0.0.5"})
+async def test_status_url_uses_the_panels_host_and_port(monkeypatch) -> None:
+    """The probe targets ``ariel.web.host``/``port`` — what the panel binds."""
+    monkeypatch.delenv("OSPREY_ARIEL_PORT", raising=False)
+    config = _cfg(web={"host": "10.0.0.5", "port": 9999})
     captured: list[str] = []
     await _run(config, transport=_ok_transport(captured=captured))
     assert captured == ["http://10.0.0.5:9999/api/status"]
 
 
-async def test_status_url_defaults() -> None:
+async def test_status_url_defaults(monkeypatch) -> None:
+    monkeypatch.delenv("OSPREY_ARIEL_PORT", raising=False)
     captured: list[str] = []
     await _run(_cfg(), transport=_ok_transport(captured=captured))
     assert captured == ["http://127.0.0.1:8085/api/status"]
+
+
+async def test_status_url_honours_the_multi_user_port_override(monkeypatch) -> None:
+    """``OSPREY_ARIEL_PORT`` — exported per user by the multi-user compose
+    render because the per-user containers share the host network namespace —
+    is the port the panel binds, so it is the port the probe knocks on."""
+    monkeypatch.setenv("OSPREY_ARIEL_PORT", "9391")
+    captured: list[str] = []
+    await _run(_cfg(web={"port": 9999}), transport=_ok_transport(captured=captured))
+    assert captured == ["http://127.0.0.1:9391/api/status"]
+
+
+async def test_misplaced_address_key_is_reported_not_probed() -> None:
+    """``ariel.port`` (correct: ``ariel.web.port``) is a warning naming the key,
+    with no probe issued — the same verdict the ``web_panels`` category gives."""
+    config = _cfg()
+    config["ariel"]["port"] = 9999
+    captured: list[str] = []
+    by_name = await _run(config, transport=_ok_transport(captured=captured))
+    assert captured == []
+    assert set(by_name) == {"ariel_status"}
+    assert by_name["ariel_status"].status is Status.WARNING
+    assert "ariel.web.port" in by_name["ariel_status"].details

--- a/tests/health/core/test_configuration.py
+++ b/tests/health/core/test_configuration.py
@@ -32,6 +32,7 @@ _CANONICAL_NAMES = (
     "channel_finder",
     "graphdb",
     "web_panels",
+    "reach",
 )
 
 
@@ -65,7 +66,7 @@ class TestCoreRegistry:
     def test_canonical_names_present_without_import(self):
         assert set(CORE_CATEGORY_NAMES) == set(_CANONICAL_NAMES)
         assert set(CORE_CATEGORIES) == set(_CANONICAL_NAMES)
-        assert len(CORE_CATEGORIES) == 13
+        assert len(CORE_CATEGORIES) == 14
 
     def test_contains(self):
         assert "configuration" in CORE_CATEGORIES

--- a/tests/health/core/test_reach.py
+++ b/tests/health/core/test_reach.py
@@ -1,0 +1,125 @@
+"""Tests for the core ``reach`` health category.
+
+Drives the category through an injected ``knock`` so no socket is opened,
+exercising: no live consumer ⇒ no rows; one row per service naming every
+consumer that dials it; the address in the row is the one the client's own
+resolver produces; and the three outcomes — reachable, unreachable, nothing
+to dial.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.health.core.reach import CATEGORY, reach
+from osprey.health.models import CheckResult, Status
+
+HYBRID_ON = {"ariel": {"search_modules": {"hybrid": {"enabled": True}}}}
+
+
+async def _run(config, *, knock=None) -> dict[str, CheckResult]:
+    """Run the category with a knock that answers, keyed by row name."""
+
+    async def _answers(host: str, port: int) -> None:
+        return None
+
+    results = await reach(config, knock=knock or _answers)()
+    assert isinstance(results, list)
+    assert all(r.category == CATEGORY for r in results)
+    return {r.name: r for r in results}
+
+
+class TestRows:
+    async def test_no_live_consumer_contributes_no_rows(self):
+        """A render that switches nothing on has nothing to reach."""
+        assert await _run({}) == {}
+
+    async def test_one_row_per_service_naming_every_consumer(self):
+        """Hybrid search and the OKF panel both dial the qmd sidecar: one knock,
+        one row, both names — a service is not reported twice because two
+        clients depend on it."""
+        config = {
+            **HYBRID_ON,
+            "services": {"qmd": {"port": 8180}},
+            "web": {"panels": {"okf": {"enabled": True}}},
+            "facility_knowledge": {"bundle_path": "data/facility_knowledge"},
+        }
+        rows = await _run(config)
+        assert "reach.qmd" in rows
+        assert "ARIEL hybrid search" in rows["reach.qmd"].message
+        assert "OKF panel ranked search" in rows["reach.qmd"].message
+
+    async def test_knocks_on_what_the_client_dials(self):
+        """The address comes from the client's resolver, not from a literal:
+        a moved sidecar port is the port knocked on."""
+        seen: list[tuple[str, int]] = []
+
+        async def knock(host: str, port: int) -> None:
+            seen.append((host, port))
+
+        rows = await _run({**HYBRID_ON, "services": {"qmd": {"port": 9180}}}, knock=knock)
+        # The `ariel:` section also makes the ARIEL database a live consumer;
+        # the sidecar's knock is the one this test is about.
+        assert ("127.0.0.1", 9180) in seen
+        row = rows["reach.qmd"]
+        assert row.status is Status.OK
+        assert row.value == "up"
+        assert "127.0.0.1:9180" in row.message
+
+
+class TestOutcomes:
+    async def test_unreachable_is_a_warning_naming_the_address(self):
+        async def refused(host: str, port: int) -> None:
+            raise ConnectionRefusedError(111, "Connection refused")
+
+        rows = await _run({**HYBRID_ON, "services": {"qmd": {"port": 8180}}}, knock=refused)
+        row = rows["reach.qmd"]
+        assert row.status is Status.WARNING
+        assert row.value == "offline"
+        assert "127.0.0.1:8180" in row.message
+        assert "services.qmd.port" in row.details
+
+    async def test_timeout_is_unreachable_too(self):
+        async def hangs(host: str, port: int) -> None:
+            raise TimeoutError()
+
+        rows = await _run({**HYBRID_ON, "services": {"qmd": {"port": 8180}}}, knock=hangs)
+        assert rows["reach.qmd"].value == "offline"
+
+    async def test_nothing_to_dial_is_a_warning_naming_the_key(self):
+        """The state the build refuses, met at run time (a hand-edited render,
+        an older build): switched on, no endpoint. Never a knock."""
+        from osprey.deployment.qmd_service import DEFAULT_PORT
+
+        seen: list[tuple[str, int]] = []
+
+        async def knock(host: str, port: int) -> None:
+            seen.append((host, port))
+
+        rows = await _run(HYBRID_ON, knock=knock)
+        row = rows["reach.qmd"]
+        # No knock at the sidecar's default: nothing was resolved, nothing is
+        # guessed. (The ARIEL database, live from the same `ariel:` section,
+        # is knocked on as usual.)
+        assert all(port != DEFAULT_PORT for _host, port in seen)
+        assert row.status is Status.WARNING
+        assert row.value == "unresolved"
+        assert "ariel.search_modules.hybrid.enabled" in row.details
+        assert "services.qmd.port" in row.details
+        assert "Every use will fail" in row.details
+
+    async def test_a_degrading_consumer_says_so(self):
+        """The OKF panel alone falls back to substring search without a
+        sidecar; the row reports the missing endpoint without crying wolf."""
+        config = {
+            "web": {"panels": {"okf": {"enabled": True}}},
+            "facility_knowledge": {"bundle_path": "data/facility_knowledge"},
+        }
+        rows = await _run(config)
+        assert rows["reach.qmd"].value == "unresolved"
+        assert "degrades" in rows["reach.qmd"].details
+
+
+@pytest.mark.parametrize("config", [None, {}])
+async def test_missing_config_is_no_rows(config):
+    assert await reach(config)() == []

--- a/tests/health/test_config.py
+++ b/tests/health/test_config.py
@@ -357,7 +357,7 @@ def test_empty_metadata_override_block() -> None:
 def test_core_category_names_content() -> None:
     assert "providers" in CORE_CATEGORY_NAMES
     assert "claude_cli_pinned" in CORE_CATEGORY_NAMES
-    assert len(CORE_CATEGORY_NAMES) == 13
+    assert len(CORE_CATEGORY_NAMES) == 14
 
 
 # --- timeout resolution helpers ---------------------------------------------

--- a/tests/health/test_records.py
+++ b/tests/health/test_records.py
@@ -62,6 +62,7 @@ class TestPolicySets:
                 "channel_finder",
                 "graphdb",
                 "web_panels",
+                "reach",
             }
         )
 

--- a/tests/hooks/test_approval_helpers.py
+++ b/tests/hooks/test_approval_helpers.py
@@ -236,14 +236,41 @@ def test_resolve_bridge_url_falls_back_to_config(approval, monkeypatch):
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "config",
-    [{}, {"bluesky": {}}],
-    ids=["no-bluesky-section", "no-bridge-url-key"],
+    [{}, {"bluesky": {}}, {"services": {}}, {"services": {"bluesky": {}}}],
+    ids=["no-bluesky-section", "no-bridge-url-key", "no-services", "no-published-port"],
 )
 def test_resolve_bridge_url_falls_back_to_the_loopback_default(approval, monkeypatch, config):
     """Neither env nor config leaves the loopback default."""
     monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
 
     assert approval._resolve_bridge_url(config) == "http://127.0.0.1:8090"
+
+
+@pytest.mark.unit
+def test_resolve_bridge_url_dials_the_port_the_deployment_publishes(approval, monkeypatch):
+    """With no env and no `bluesky.bridge_url`, `services.bluesky.port` — the port
+    the build wrote for the bridge it deploys, or projected into an attached
+    render — is dialed on loopback. The same rule as
+    `osprey.bluesky_bridge_connection.bridge_url_from_config`."""
+    monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
+
+    url = approval._resolve_bridge_url({"services": {"bluesky": {"port": 18090}}})
+
+    assert url == "http://127.0.0.1:18090"
+
+
+@pytest.mark.unit
+def test_resolve_bridge_url_config_url_beats_the_published_port(approval, monkeypatch):
+    monkeypatch.delenv("BLUESKY_BRIDGE_URL", raising=False)
+
+    url = approval._resolve_bridge_url(
+        {
+            "bluesky": {"bridge_url": "http://bridge.config:8000"},
+            "services": {"bluesky": {"port": 1}},
+        }
+    )
+
+    assert url == "http://bridge.config:8000"
 
 
 @pytest.mark.unit

--- a/tests/integration/test_preset_static.py
+++ b/tests/integration/test_preset_static.py
@@ -150,19 +150,33 @@ def test_preset_web_panels_against_registry(preset_path: Path) -> None:
     if it is in the shared ``osprey.profiles.web_panels`` registry *or* it is
     backed by a ``web.panels.<id>.url`` config override (rendered as an iframe
     tab). A drifted entry that is neither would render a broken UI tab at runtime.
+
+    Plus the third case the Reach Contract introduced, which is why this check
+    reads the registry rather than a hardcoded pair: a panel whose URL the
+    build DERIVES is legitimately url-less in the preset. The deploying profile
+    derives it from its own sidecar block, and an attached persona is told it
+    by projection from the hosting render — so a persona preset that spelled
+    the URL would be stating a fact it cannot keep true. Each preset is loaded
+    unresolved here, without its ``extends:`` chain, so the sidecar block that
+    satisfies the real validator is not visible at this level either way; the
+    build-time refusal for a selected panel the deployment cannot back is
+    ``reach.selected_panel_errors``, not this static scan.
     """
+    from osprey.deployment.reach import REACH_CONTRACTS
     from osprey.profiles.web_panels import BUILTIN_PANELS
 
+    derived = {p.panel for c in REACH_CONTRACTS.values() for p in c.projected if p.panel}
     profile = load_profile(preset_path)
     config = getattr(profile, "config", {}) or {}
     unknown = [
         p
         for p in profile.web_panels
-        if p not in BUILTIN_PANELS and f"web.panels.{p}.url" not in config
+        if p not in BUILTIN_PANELS and p not in derived and f"web.panels.{p}.url" not in config
     ]
     assert not unknown, (
         f"{preset_path.name} declares unknown web_panels: {unknown} "
-        f"(valid: built-in {sorted(BUILTIN_PANELS)} or a web.panels.<id>.url override)"
+        f"(valid: built-in {sorted(BUILTIN_PANELS)}, a panel the Reach Contract "
+        f"projects a URL for {sorted(derived)}, or a web.panels.<id>.url override)"
     )
 
 

--- a/tests/interfaces/test_web_auth.py
+++ b/tests/interfaces/test_web_auth.py
@@ -22,6 +22,8 @@ from osprey.interfaces.web_auth import (
     BIND_HOST_ENV,
     OPERATOR_SECRET_ENV,
     PANEL_TOKEN_ENV,
+    ROSTER_ACCEPT_ENV,
+    ROSTER_SECRET_ENV_PREFIX,
     WebCredentials,
     get_web_credentials,
     mint_secret,
@@ -364,6 +366,70 @@ def test_absent_candidates_are_refused(credentials: WebCredentials, missing: str
     assert credentials.verify_operator(missing) is False
     assert credentials.verify_panel(missing) is False
     assert credentials.verify_session(missing) is False
+
+
+def test_roster_secrets_authorise_as_the_operator() -> None:
+    """A shared sidecar handed the roster's per-user secrets lets each of them
+    in as the operator — and still nothing else."""
+    credentials = WebCredentials(
+        operator_secret="operator-value",
+        panel_token="panel-value",
+        roster_secrets=("alice-value", "bob-value"),
+    )
+    assert credentials.verify_operator("operator-value") is True
+    assert credentials.verify_operator("alice-value") is True
+    assert credentials.verify_operator("bob-value") is True
+    assert credentials.verify_operator("panel-value") is False
+    assert credentials.verify_operator("alice-valu") is False
+    assert credentials.verify_panel("alice-value") is False
+
+
+def test_roster_secrets_are_popped_not_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the sidecar's accept flag set, every ``OSPREY_TERMINAL_SECRET_<USER>``
+    leaves ``os.environ`` for the reason the operator secret does (the flag
+    with them), blank ones (``${VAR:-}`` of an unset variable) count as
+    absent, and the rest are accepted."""
+    import os
+
+    monkeypatch.setenv(OPERATOR_SECRET_ENV, "supplied-operator-secret")
+    monkeypatch.setenv(ROSTER_ACCEPT_ENV, "1")
+    monkeypatch.setenv(f"{ROSTER_SECRET_ENV_PREFIX}ALICE", "alice-value")
+    monkeypatch.setenv(f"{ROSTER_SECRET_ENV_PREFIX}BOB", " bob-value ")
+    monkeypatch.setenv(f"{ROSTER_SECRET_ENV_PREFIX}CAROL", "")
+
+    credentials = get_web_credentials()
+
+    assert credentials.roster_secrets == ("alice-value", "bob-value")
+    assert credentials.verify_operator("alice-value") is True
+    assert credentials.verify_operator("bob-value") is True
+    assert credentials.verify_operator("") is False
+    assert not [name for name in os.environ if name.startswith(ROSTER_SECRET_ENV_PREFIX)]
+    assert ROSTER_ACCEPT_ENV not in os.environ
+
+
+def test_roster_secrets_without_the_accept_flag_are_popped_and_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The host's own ``osprey web`` loads the deploy ``.env``, which carries
+    EVERY roster user's secret. Seeing them is not being told to accept them:
+    without the flag only the bluesky-web sidecar's compose sets, they are
+    popped (never inherited by a child) and no roster user is the operator."""
+    import os
+
+    monkeypatch.setenv(OPERATOR_SECRET_ENV, "supplied-operator-secret")
+    monkeypatch.delenv(ROSTER_ACCEPT_ENV, raising=False)
+    monkeypatch.setenv(f"{ROSTER_SECRET_ENV_PREFIX}ALICE", "alice-value")
+
+    credentials = get_web_credentials()
+
+    assert credentials.roster_secrets == ()
+    assert credentials.verify_operator("alice-value") is False
+    assert credentials.verify_operator("supplied-operator-secret") is True
+    assert not [name for name in os.environ if name.startswith(ROSTER_SECRET_ENV_PREFIX)]
+
+
+def test_single_user_shape_has_no_roster() -> None:
+    assert get_web_credentials().roster_secrets == ()
 
 
 def test_non_ascii_candidate_is_refused_not_raised(credentials: WebCredentials) -> None:

--- a/tests/registry/test_bluesky_server_definition.py
+++ b/tests/registry/test_bluesky_server_definition.py
@@ -49,7 +49,11 @@ def test_bluesky_server_env():
     assert bluesky["env"]["OSPREY_CONFIG"] == "/tmp/test-project/build/config.yml"
     assert bluesky["env"]["CONFIG_FILE"] == "/tmp/test-project/build/config.yml"
     # Shell variable references pass through untouched for runtime expansion.
-    assert bluesky["env"]["BLUESKY_BRIDGE_URL"] == "${BLUESKY_BRIDGE_URL:-http://127.0.0.1:8090}"
+    # No literal default on the URL: unset must reach the server EMPTY so the
+    # resolver falls back to the rendered config's `services.bluesky.port` —
+    # a baked `http://127.0.0.1:8090` was a second copy of the port that a
+    # moved bridge could never correct.
+    assert bluesky["env"]["BLUESKY_BRIDGE_URL"] == "${BLUESKY_BRIDGE_URL:-}"
     assert bluesky["env"]["BLUESKY_LAUNCH_TOKEN"] == "${BLUESKY_LAUNCH_TOKEN:-}"
 
 

--- a/tests/services/ariel_search/test_enhancement.py
+++ b/tests/services/ariel_search/test_enhancement.py
@@ -1354,14 +1354,20 @@ class TestQmdExportModule:
         module = self._module(tmp_path / "mirror")
         assert module._mirror_root == tmp_path / "mirror"
 
-    def test_configure_resolves_relative_path_against_config_dir(self, tmp_path, monkeypatch):
-        """A relative mirror_path resolves against the directory holding config.yml."""
+    def test_configure_resolves_relative_path_against_the_project_root(self, tmp_path, monkeypatch):
+        """A relative mirror_path resolves against the project root, not ``build/``.
+
+        The config lives in the render zone; the mirror must not, because the
+        sidecar bind-mounts the same configured path from the repo root (the
+        pinned compose project directory) and would otherwise index an empty
+        tree while the exporter fills one inside ``build/``.
+        """
         monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "build" / "config.yml"))
         module = QmdExportModule()
 
         module.configure({"mirror_path": "qmd-mirror"})
 
-        assert module._mirror_root == (tmp_path / "build" / "qmd-mirror").resolve()
+        assert module._mirror_root == (tmp_path / "qmd-mirror").resolve()
 
     def test_configure_expands_user_home(self, tmp_path, monkeypatch):
         """A tilde-prefixed mirror_path expands before the absolute check."""

--- a/tests/templates/render_axis_shapes/env-shared-chain/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/env-shared-chain/dispatch_worker.yml
@@ -105,7 +105,14 @@ services:
       # DNS name, not localhost. Declaring the host here — rather than sniffing
       # the container runtime — is what makes emit work under docker AND podman.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
+      #
+      # The port is declared beside it because on this network it is NOT the
+      # published one: the DNS name answers on the port the store LISTENS on
+      # inside its container, which `services.openobserve.port` says nothing
+      # about. Without this line the emitter would derive the published port,
+      # which is right from the host and wrong from here.
       OSPREY_OTEL_OPENOBSERVE_HOST: openobserve
+      OSPREY_OTEL_OPENOBSERVE_PORT: "5080"
 
     # Bind-mount sources are relative to the pinned compose project directory,
     # which is the deployment REPO ROOT — hence the build/services/ prefix on

--- a/tests/templates/render_axis_shapes/images-on-a-registry/bluesky_web.yml
+++ b/tests/templates/render_axis_shapes/images-on-a-registry/bluesky_web.yml
@@ -88,7 +88,9 @@ services:
       # a non-browser client sends it as `X-Osprey-Terminal-Secret`. No
       # :-default for the same reason as the launch token above; `osprey up`
       # mints it into the project .env (container_lifecycle's per-service
-      # token-mint map).
+      # token-mint map). In a multi-user deployment each per-user terminal
+      # proxies its BLUESKY tab here with ITS OWN secret, never this one —
+      # see the roster grant just below.
       OSPREY_TERMINAL_SECRET: ${OSPREY_TERMINAL_SECRET}
       # Marks the container shape for web_auth: an empty secret then refuses
       # startup naming the variable, instead of minting a value that is

--- a/tests/templates/render_axis_shapes/images-on-a-registry/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/images-on-a-registry/dispatch_worker.yml
@@ -104,7 +104,14 @@ services:
       # DNS name, not localhost. Declaring the host here — rather than sniffing
       # the container runtime — is what makes emit work under docker AND podman.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
+      #
+      # The port is declared beside it because on this network it is NOT the
+      # published one: the DNS name answers on the port the store LISTENS on
+      # inside its container, which `services.openobserve.port` says nothing
+      # about. Without this line the emitter would derive the published port,
+      # which is right from the host and wrong from here.
       OSPREY_OTEL_OPENOBSERVE_HOST: openobserve
+      OSPREY_OTEL_OPENOBSERVE_PORT: "5080"
 
       # `archiver-mongodb` is the store's network alias, pinned in the mongodb
       # template precisely so this name survives the per-project container_name;

--- a/tests/templates/render_axis_shapes/pair-on-host/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/pair-on-host/dispatch_worker.yml
@@ -113,12 +113,11 @@ services:
       # own fallback sees a container and would reach for the service name.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
       #
-      # The variable carries a HOST, and the endpoint the emitter derives from
-      # it pins the store's port at 5080 (build/claude_code_telemetry.py) —
-      # which is what `services.openobserve.port` publishes by default. A
-      # deployment that republishes the store on some other host port must set
-      # `claude_code.telemetry.endpoint` outright; there is no port half of this
-      # variable to carry it.
+      # The variable carries a HOST only. The port half needs no declaration
+      # here: from the host's loopback the store answers on the port it
+      # PUBLISHES, and the emitter reads that from `services.openobserve.port`
+      # in the config this worker already mounts — so moving the store moves
+      # the exporter with it.
       OSPREY_OTEL_OPENOBSERVE_HOST: localhost
 
       # On the host namespace the store is reached where it PUBLISHES, so this

--- a/tests/templates/render_axis_shapes/service-env-passthrough/bluesky_web.yml
+++ b/tests/templates/render_axis_shapes/service-env-passthrough/bluesky_web.yml
@@ -79,7 +79,9 @@ services:
       # a non-browser client sends it as `X-Osprey-Terminal-Secret`. No
       # :-default for the same reason as the launch token above; `osprey up`
       # mints it into the project .env (container_lifecycle's per-service
-      # token-mint map).
+      # token-mint map). In a multi-user deployment each per-user terminal
+      # proxies its BLUESKY tab here with ITS OWN secret, never this one —
+      # see the roster grant just below.
       OSPREY_TERMINAL_SECRET: ${OSPREY_TERMINAL_SECRET}
       # Marks the container shape for web_auth: an empty secret then refuses
       # startup naming the variable, instead of minting a value that is

--- a/tests/templates/render_axis_shapes/two-workers-on-host/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/two-workers-on-host/dispatch_worker.yml
@@ -113,12 +113,11 @@ services:
       # own fallback sees a container and would reach for the service name.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
       #
-      # The variable carries a HOST, and the endpoint the emitter derives from
-      # it pins the store's port at 5080 (build/claude_code_telemetry.py) —
-      # which is what `services.openobserve.port` publishes by default. A
-      # deployment that republishes the store on some other host port must set
-      # `claude_code.telemetry.endpoint` outright; there is no port half of this
-      # variable to carry it.
+      # The variable carries a HOST only. The port half needs no declaration
+      # here: from the host's loopback the store answers on the port it
+      # PUBLISHES, and the emitter reads that from `services.openobserve.port`
+      # in the config this worker already mounts — so moving the store moves
+      # the exporter with it.
       OSPREY_OTEL_OPENOBSERVE_HOST: localhost
 
     # Bind-mount sources are relative to the pinned compose project directory,
@@ -256,12 +255,11 @@ services:
       # own fallback sees a container and would reach for the service name.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
       #
-      # The variable carries a HOST, and the endpoint the emitter derives from
-      # it pins the store's port at 5080 (build/claude_code_telemetry.py) —
-      # which is what `services.openobserve.port` publishes by default. A
-      # deployment that republishes the store on some other host port must set
-      # `claude_code.telemetry.endpoint` outright; there is no port half of this
-      # variable to carry it.
+      # The variable carries a HOST only. The port half needs no declaration
+      # here: from the host's loopback the store answers on the port it
+      # PUBLISHES, and the emitter reads that from `services.openobserve.port`
+      # in the config this worker already mounts — so moving the store moves
+      # the exporter with it.
       OSPREY_OTEL_OPENOBSERVE_HOST: localhost
 
     # Bind-mount sources are relative to the pinned compose project directory,

--- a/tests/templates/render_defaults/bluesky_web.yml
+++ b/tests/templates/render_defaults/bluesky_web.yml
@@ -79,7 +79,9 @@ services:
       # a non-browser client sends it as `X-Osprey-Terminal-Secret`. No
       # :-default for the same reason as the launch token above; `osprey up`
       # mints it into the project .env (container_lifecycle's per-service
-      # token-mint map).
+      # token-mint map). In a multi-user deployment each per-user terminal
+      # proxies its BLUESKY tab here with ITS OWN secret, never this one —
+      # see the roster grant just below.
       OSPREY_TERMINAL_SECRET: ${OSPREY_TERMINAL_SECRET}
       # Marks the container shape for web_auth: an empty secret then refuses
       # startup naming the variable, instead of minting a value that is

--- a/tests/templates/render_defaults/dispatch_worker.yml
+++ b/tests/templates/render_defaults/dispatch_worker.yml
@@ -104,7 +104,14 @@ services:
       # DNS name, not localhost. Declaring the host here — rather than sniffing
       # the container runtime — is what makes emit work under docker AND podman.
       # Inert unless claude_code.telemetry is enabled with backend: openobserve.
+      #
+      # The port is declared beside it because on this network it is NOT the
+      # published one: the DNS name answers on the port the store LISTENS on
+      # inside its container, which `services.openobserve.port` says nothing
+      # about. Without this line the emitter would derive the published port,
+      # which is right from the host and wrong from here.
       OSPREY_OTEL_OPENOBSERVE_HOST: openobserve
+      OSPREY_OTEL_OPENOBSERVE_PORT: "5080"
 
     # Bind-mount sources are relative to the pinned compose project directory,
     # which is the deployment REPO ROOT — hence the build/services/ prefix on

--- a/tests/utils/test_config_paths.py
+++ b/tests/utils/test_config_paths.py
@@ -1,11 +1,13 @@
 """The one rule for resolving a config-relative path.
 
-Every config key that names a directory or file relative to ``config.yml`` —
+Every config key that names a directory or file relative to the project —
 ``facility_knowledge.bundle_path``, the qmd mirror, the ARIEL vocabulary file —
 must land on the same directory no matter which process reads it. These tests
-pin all five branches of :func:`osprey.utils.config_paths.resolve_config_relative_path`
-and assert that the two pre-existing resolvers really delegate to it rather than
-keeping private copies of the rule that can drift.
+pin every branch of :func:`osprey.utils.config_paths.resolve_config_relative_path`
+— including the one that matters on a host, where the config sits in the
+``build/`` render zone and the anchor is the repo above it — and assert that the
+two pre-existing resolvers really delegate to it rather than keeping private
+copies of the rule that can drift.
 """
 
 from __future__ import annotations
@@ -14,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from osprey.utils.config_paths import resolve_config_relative_path
+from osprey.utils.config_paths import project_root_for_config_dir, resolve_config_relative_path
 
 
 @pytest.fixture
@@ -58,10 +60,46 @@ def test_relative_value_resolves_against_config_dir(foreign_cwd, tmp_path):
     assert resolved != (foreign_cwd / "data/facility_knowledge").resolve()
 
 
+def test_relative_value_in_the_build_zone_resolves_against_the_repo(foreign_cwd, tmp_path):
+    """A config at ``<repo>/build/config.yml`` anchors on ``<repo>``, not ``build/``.
+
+    The render zone is disposable — every ``osprey build`` re-creates it — and
+    it is not what the compose layer binds into containers: every bind source is
+    resolved against the repo root (the pinned ``--project-directory``). A
+    resolver anchored on ``build/`` had the qmd exporter writing a mirror the
+    sidecar never mounted, and persona readers opening a baked bundle while the
+    live one was bound one directory over.
+    """
+    repo = tmp_path / "repo"
+    build = repo / "build"
+    build.mkdir(parents=True)
+
+    resolved = resolve_config_relative_path("var/ariel_mirror", build)
+
+    assert resolved == (repo / "var/ariel_mirror").resolve()
+    assert project_root_for_config_dir(build) == repo
+
+
+def test_a_container_project_dir_is_its_own_root(foreign_cwd, tmp_path):
+    """A config not in a ``build/`` zone anchors on its own directory.
+
+    A container's project directory IS its render (``/app/<project>`` holds the
+    config at ``build/config.yml`` only when the image carries the repo layout;
+    a flat legacy project holds it at the root), so a directory not named
+    ``build`` is the root — the same rule ``repo_root_for_config`` applies to
+    every other runtime path.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+
+    assert project_root_for_config_dir(project) == project
+    assert resolve_config_relative_path("data/kb", project) == (project / "data/kb").resolve()
+
+
 def test_relative_value_without_config_dir_uses_the_resolved_config_file(
     foreign_cwd, tmp_path, monkeypatch
 ):
-    """Without *config_dir*, the directory of ``OSPREY_CONFIG``'s file wins."""
+    """Without *config_dir*, the project of ``OSPREY_CONFIG``'s file wins."""
     config_dir = tmp_path / "project"
     config_dir.mkdir()
     (config_dir / "config.yml").write_text("", encoding="utf-8")
@@ -70,6 +108,21 @@ def test_relative_value_without_config_dir_uses_the_resolved_config_file(
     resolved = resolve_config_relative_path("data/vocab.yml", None)
 
     assert resolved == (config_dir / "data/vocab.yml").resolve()
+
+
+def test_without_config_dir_a_build_zone_config_still_anchors_on_the_repo(
+    foreign_cwd, tmp_path, monkeypatch
+):
+    """The ``OSPREY_CONFIG`` fallback applies the same build-zone rule."""
+    repo = tmp_path / "repo"
+    build = repo / "build"
+    build.mkdir(parents=True)
+    (build / "config.yml").write_text("", encoding="utf-8")
+    monkeypatch.setenv("OSPREY_CONFIG", str(build / "config.yml"))
+
+    resolved = resolve_config_relative_path("data/vocab.yml", None)
+
+    assert resolved == (repo / "data/vocab.yml").resolve()
 
 
 def test_relative_value_falls_back_to_the_cwd_when_config_lookup_raises(foreign_cwd, monkeypatch):

--- a/tests/utils/test_config_writer_comment_anchoring.py
+++ b/tests/utils/test_config_writer_comment_anchoring.py
@@ -245,3 +245,41 @@ class TestConfigAddToList:
 
         text = path.read_text(encoding="utf-8")
         assert _line_no(text, "- virtual_accelerator") < _line_no(text, "# SAFETY CONTROLS")
+
+
+class TestConfigDeleteField:
+    """``config_delete_field`` — the inverse of one update, comments kept."""
+
+    _DOC = (
+        "# Header comment\n"
+        "web:\n"
+        "  panels:\n"
+        "    events:  # inherited fragment\n"
+        "      path: /custom-route\n"
+        "    okf:\n"
+        "      enabled: true  # keep me\n"
+        "# Footer comment\n"
+    )
+
+    def test_removes_the_leaf_and_keeps_every_other_line(self, tmp_path):
+        from osprey.utils.config_writer import config_delete_field, config_read
+
+        path = tmp_path / "config.yml"
+        path.write_text(self._DOC, encoding="utf-8")
+
+        assert config_delete_field(path, "web.panels.events") is True
+
+        text = path.read_text(encoding="utf-8")
+        assert config_read(path) == {"web": {"panels": {"okf": {"enabled": True}}}}
+        assert "# Header comment" in text and "# Footer comment" in text
+        assert "# keep me" in text
+
+    def test_missing_key_is_a_no_op(self, tmp_path):
+        from osprey.utils.config_writer import config_delete_field
+
+        path = tmp_path / "config.yml"
+        path.write_text(self._DOC, encoding="utf-8")
+
+        assert config_delete_field(path, "web.panels.bluesky") is False
+        assert config_delete_field(path, "nothing.here") is False
+        assert path.read_text(encoding="utf-8") == self._DOC

--- a/tests/utils/test_render_relative_path.py
+++ b/tests/utils/test_render_relative_path.py
@@ -1,0 +1,62 @@
+"""``resolve_render_relative_path`` — the one render-anchored config path.
+
+``services.graphdb.ttl_path`` names an artifact of the render (the
+``data/demo_machine.ttl`` the build assembled), so unlike every other config-relative key it
+resolves against the ``config.yml`` directory itself, never the project root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from osprey.utils.config_paths import resolve_config_relative_path, resolve_render_relative_path
+
+
+def test_relative_value_resolves_against_the_render_not_the_repo(tmp_path):
+    render = tmp_path / "build"
+    render.mkdir()
+    (render / "config.yml").write_text("project_name: demo\n", encoding="utf-8")
+
+    resolved = resolve_render_relative_path("./data/demo_machine.ttl", render)
+
+    assert resolved == (render / "data" / "demo_machine.ttl").resolve()
+    # The project-root rule, for the same inputs, would leave the render zone.
+    assert (
+        resolve_config_relative_path("./data/demo_machine.ttl", render)
+        == (tmp_path / "data" / "demo_machine.ttl").resolve()
+    )
+
+
+def test_absolute_value_passes_through_unchanged(tmp_path):
+    elsewhere = tmp_path / "corpus.ttl"
+    assert resolve_render_relative_path(str(elsewhere), tmp_path / "build") == elsewhere
+
+
+def test_tilde_value_is_expanded(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert resolve_render_relative_path("~/corpus.ttl", tmp_path) == Path(tmp_path, "corpus.ttl")
+
+
+def test_without_config_dir_uses_the_resolved_config_file(tmp_path, monkeypatch):
+    render = tmp_path / "build"
+    render.mkdir()
+    (render / "config.yml").write_text("project_name: demo\n", encoding="utf-8")
+    monkeypatch.setenv("OSPREY_CONFIG", str(render / "config.yml"))
+
+    assert (
+        resolve_render_relative_path("data/demo_machine.ttl")
+        == (render / "data" / "demo_machine.ttl").resolve()
+    )
+
+
+def test_without_any_config_at_all_resolves_against_the_cwd(tmp_path, monkeypatch):
+    """No *config_dir* and no resolvable config file: the CWD fallback, the
+    same last resort ``resolve_config_relative_path`` documents."""
+    import osprey.utils.config_paths as config_paths
+
+    monkeypatch.setattr(config_paths, "resolve_config_dir", lambda: None)
+    monkeypatch.chdir(tmp_path)
+
+    resolved = config_paths.resolve_render_relative_path("data/demo_machine.ttl")
+
+    assert resolved == (tmp_path / "data" / "demo_machine.ttl").resolve()


### PR DESCRIPTION
A web-terminal persona is a project built beside the deployment it belongs to,
and it was told nothing about where that deployment's services actually listen.
Its hybrid logbook search dialed the qmd sidecar's default port while the
deployment published another, so search failed in every persona with "no qmd
sidecar is configured". The presets papered over the same gap by pinning ports
and panel URLs by hand — facts an operator's port move silently invalidated,
in a file the operator does not think of as a copy of the deployment's.

Underneath it were two more copies of the same mistake. Config-relative paths
resolved against the directory holding `config.yml`, which on a host is the
`build/` render — so the ARIEL exporter filled `build/var/ariel_mirror` while
the sidecar indexed an empty `var/ariel_mirror`, and a persona read the image's
baked bundle while the live one was mounted a directory over. And several
clients carried compiled-in addresses no config could correct: the telemetry
endpoint's port, the Bluesky bridge's URL default.

The fix is one declaration per service instead of a copy per client.
`deployment/reach.py` states, for every service, who dials it, by which config
key, and through which client resolver. The build projects those facts into
each attached render rather than the profile pinning them; a `config:` key that
contradicts the projection is refused, naming both values; a persona built with
no host beside it is projected from its own app template rendered as a
deployment. `osprey health reach` then knocks at the address each client's own
resolver produces, which is the only check that what a client dials is what the
deployment published — and the ARIEL probe turned out to have that very bug.

Paths anchor on the project root, the same anchor every compose bind source
already resolves against, so the directory a process writes is the directory a
container is handed to read. `services.graphdb.ttl_path` is the one deliberate
exception: the corpus it names is an artifact of the render itself.

Two findings worth a reviewer's attention, both fixed here with tests:

- The `bluesky-web:` roster-secret fragment initially lived in the web overlay,
  which is brought up as its own single-file compose project — so it would
  never have merged into the sidecar and would have failed `osprey up` as an
  image-less service. It belongs in the sidecar's own compose template.
- `verify_operator` accepted any `OSPREY_TERMINAL_SECRET_*` present in the
  environment. On the host, `osprey web` loads the deploy `.env` holding every
  roster user's secret, so any roster user authenticated as the operator.
  Roster secrets are now accepted only behind
  `OSPREY_TERMINAL_ACCEPT_ROSTER_SECRETS`, which only the sidecar's compose
  sets.

One interaction with what landed on `main` meanwhile, caught by the registry's
own coverage guard: `bluesky.second_lane` renders a second bridge
(`services.bluesky_va` / `services.bluesky_live`) with its own launch token.
Without a contract for it, a persona on a two-lane deployment would have been a
single-lane render whose session, switched to the other machine, is refused
rather than routed — the second-lane feature silently dead for every
multi-user deployment. The contract now declares both lanes: port and declared
target are projected (the lane resolver picks the active lane by target), and a
persona entitled to arm lane 1 is handed every lane's token on the same tier
boundary, so a read-only persona still holds none. The projection is driven
through the real injector and checked with the real lane resolver in
`tests/deployment/test_persona_reach_lanes.py`.

A second one with #702 (safety-hardening P2): its new `control-assistant-admin`
persona pinned `services.graphdb.port_host: 7687` — the same hand-copied
address this branch removes from the readonly and readwrite tiers, with a
comment asking operators to keep three copies in sync. The admin tier is an
attached render like its siblings, so the projection covers it and the pin is
gone; `test_personas_pin_no_service_address` now walks all three tiers plus
the ariel persona, and the admin persona is built and told its port in
`test_operator_personas_render_the_graph_server[admin]`.

## How it hangs together

```text
                        ┌────────────────────────────────────┐
                        │      deployment/reach.py           │
                        │      REACH_CONTRACTS               │
                        │  one entry per service, declaring  │
                        │   · who dials it      (Consumer)   │
                        │   · by which key    (ProjectedKey) │
                        │   · what it needs (CredentialGrant)│
                        │   · which paths it shares          │
                        └───────────────┬────────────────────┘
                                        │  read by all four
          ┌───────────────────┬─────────┴────────┬────────────────────┐
          ▼                   ▼                  ▼                    ▼
    osprey build         osprey build        osprey up          osprey health
   (host render)      (attached render)      (compose)             reach
          │                   │                  │                    │
   injectors write     project each fact    bind SHARED_PATHS    knock at what
   services.* and      into the persona     per entitled user    the client's
   web.panels.*        ─────────────────    (mirror, audit)      own resolver
   blocks              refuse a config:     grant credentials    produces
          │            key that contradicts        │                    │
          │            drop an unselected          │                    │
          │            panel fragment              │                    │
          ▼                   ▼                    ▼                    ▼
    config.yml          <persona>/config.yml   docker-compose      reachable
   (deployment)         pins nothing           .web.yml            unreachable
                                               sidecar compose     nothing-to-dial
```

The path anchor sits under all four: `config_paths.resolve_config_relative_path`
resolves against the project root, so the mirror the exporter writes, the one
the sidecar indexes and the one a persona container binds are provably the same
directory.
