### PR TITLE
ci(frontend): install from the lockfile with npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -928,18 +928,19 @@ jobs:
       uses: actions/setup-node@v7
       with:
         node-version: '22'
+        cache: 'npm'
 
     - name: Install JS dependencies
-      # `npm install --no-package-lock`, not `npm ci`: the committed
-      # package-lock.json records a resolved entry only for the host platform's
-      # rollup binary (the lock is authored on macOS), and both `npm ci` AND a
-      # plain `npm install` honor that incomplete tree, so the Linux runner
-      # never installs @rollup/rollup-linux-x64-gnu that vitest needs (npm
-      # optional-deps bug, npm/cli#4828 — its own error message says to ignore
-      # the lockfile). `--no-package-lock` resolves fresh from package.json and
-      # installs the correct platform binary. This is a dev/CI-only
-      # typecheck+test job, so strict lock reproduction is not required here.
-      run: npm install --no-package-lock
+      # `npm ci`, so this lane tests exactly the lockfile-pinned versions that
+      # Dependabot's cooldown vetted — a fresh resolve would silently pull
+      # newer releases. The lockfile is complete for every platform (all
+      # optional native bindings carry os/cpu fields); the old macOS-authored
+      # lock that omitted the Linux binding (npm/cli#4828) no longer
+      # reproduces on current npm. If an incomplete lock ever lands again,
+      # `npm ci` fails loudly here rather than drifting. Regenerate the lock
+      # by hand with `npm install --package-lock-only`, which resolves from
+      # registry metadata and is platform-neutral by construction.
+      run: npm ci
 
     - name: Typecheck (tsc --noEmit)
       run: npm run typecheck

--- a/tools/eslint/no-ts-nocheck.js
+++ b/tools/eslint/no-ts-nocheck.js
@@ -7,7 +7,7 @@
  * else caps that list. This rule closes that hole by reporting the directive
  * wherever `tsc` actually honors it.
  *
- * Matches `tsc` 5.9's real acceptance grammar (verified): it honors a
+ * Matches `tsc` 7.0's real acceptance grammar (verified): it honors a
  * `// @ts-nocheck` LINE comment anywhere in the leading comment block — not
  * just line 1, and with or without a space after `//`. It does NOT honor the
  * block form `/* @ts-nocheck *\/` or a mid-line prose mention. So this rule


### PR DESCRIPTION
The JS lane installed with `npm install --no-package-lock`: the original lockfile was authored on macOS and omitted the Linux rollup binary (npm/cli#4828), so honoring it broke vitest on the runner. The workaround's cost surfaced with the js-toolchain Dependabot group — the lane resolved fresh from the caret ranges at run time, so CI executed versions the 7-day cooldown never vetted (eslint@10.9.1 at seven hours old, while the lock pinned 10.8.1).

Both grounds for the workaround are gone. Dependabot's lockfile regeneration wrote the complete platform matrix (all optional native bindings with `os`/`cpu` fields — now rolldown bindings, since vitest 4's Vite 8 dropped rollup), and the macOS-authored-lock omission no longer reproduces on current npm: a plain install, and even a delete-and-regenerate with a darwin-only `node_modules` present, both preserve all 20 Linux entries. `npm ci` from this lockfile was verified in a linux/amd64 node:22 container (same npm 10.9.8 as the runner): it installs `@rolldown/binding-linux-x64-gnu` and tsc/vitest run.

With the lockfile honored, the lane becomes deterministic, tests exactly the Dependabot-pinned versions, gains `setup-node` npm caching, and fails loudly pre-merge if an incomplete lock ever lands again. If a lock must be regenerated by hand, `npm install --package-lock-only` resolves from registry metadata and is platform-neutral by construction.

Also refreshes `tools/eslint/no-ts-nocheck.js`'s header, which claimed its match was verified against tsc 5.9: re-probed against tsc 7.0.2 — the acceptance grammar is unchanged.