### PR TITLE
feat(deploy): tag persona images by their render alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- Local-mode persona images are now tagged by their rendered project alone
+  (`my-assistant-readwrite:local` instead of
+  `my-assistant-readwrite-readwrite:local`). Lint newly rejects two personas
+  sharing a `project` across different renders, and a persona `project` equal
+  to the deployment's own name. Images under the old doubled tags are not
+  removed automatically — prune them by hand after the next `osprey up`.
 - CI: the unit lane's step summary now tabulates the slowest tests of the run
   and the uploaded diagnostics artifact carries the full pytest log.
 - `osprey-connectors` now versions with the framework's calendar stream —

--- a/docs/source/how-to/multi-user/index.rst
+++ b/docs/source/how-to/multi-user/index.rst
@@ -321,7 +321,8 @@ What ``osprey build`` and ``osprey up`` do for the web tier
 
 #. **The start builds each persona's image.** In the preset's local mode
    (``image_source: local``), ``osprey up`` builds each persona's image
-   (tagged ``<project>-<persona>:local``) from that rendered project —
+   (tagged ``<project>:local`` after the persona's rendered project, e.g.
+   ``my-control-assistant-readwrite:local``) from that rendered project —
    no registry, no CI.
 
 #. **Brings up the web tier.** An nginx reverse proxy (container ``ca-nginx``)

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -60,8 +60,8 @@ from any directory.
 
 Image-scoping boundary (applies only to :func:`nuke_stack`'s persona-image
 teardown): unlike containers and volumes, image tags are host-global — two
-OSPREY deployments that happen to use identically-named personas would build
-identically-named ``<persona.project>-<persona>:local`` tags. There is no
+OSPREY deployments that happen to use identically-named persona renders would
+build identically-named ``<persona.project>:local`` tags. There is no
 label-filtered *listing* equivalent to ``ps -a``/``volume ls`` for this (image
 tags aren't compose-project-scoped), so each candidate tag is instead
 individually verified with ``image inspect`` against its own
@@ -440,7 +440,7 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
     scoping boundary this relies on).
 
     Image removal is deliberately the least trusting step: image tags
-    (``<persona.project>-<persona>:local``) are host-global, not scoped to this
+    (``<persona.project>:local``) are host-global, not scoped to this
     project the way ``com.docker.compose.project``-labeled containers/volumes
     are, so a same-named tag could belong to an entirely different deployment.
     Every candidate tag is therefore ``image inspect``-verified against its own
@@ -1287,7 +1287,7 @@ def remove_image(
 
     Args:
         runtime: Runtime binary, e.g. ``"docker"`` or ``"podman"``.
-        tag: Exact image tag, e.g. ``"<persona.project>-<persona>:local"``.
+        tag: Exact image tag, e.g. ``"<persona.project>:local"``.
             Never a glob or label selector.
         env: Environment for the subprocess call. Defaults to inheriting the
             parent process environment.

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -180,6 +180,7 @@ def lint_web_terminals(
     findings.extend(_check_image_tag_empty(web_terminals))
     findings.extend(_check_registry_url_coherence(root, web_terminals))
     findings.extend(_check_local_mode_requires_catalog(web_terminals))
+    findings.extend(_check_persona_project_collisions(root, web_terminals, users))
     if rendered_project:
         findings.extend(
             _check_persona_project_paths(web_terminals, users, project_root=project_root)
@@ -1856,6 +1857,94 @@ def _check_persona_mirror_agreement(
                 message=message,
             )
         )
+    return findings
+
+
+def _check_persona_project_collisions(
+    root: dict[str, Any], web_terminals: dict[str, Any], users: list[Any]
+) -> list[Finding]:
+    """Local mode: every persona image tag must name exactly one image.
+
+    A persona image is tagged by its render alone
+    (``<project>:local`` — see
+    :func:`osprey.deployment.web_terminals.personas.resolve_personas`), so tag
+    uniqueness is exactly ``project`` uniqueness, and that is enforced here
+    rather than by a tag suffix. Config-only, so it runs at both altitudes —
+    no filesystem is consulted. Two invariants:
+
+    * **Persona vs persona.** Two referenced personas may share a ``project``
+      only when they also share the same ``project_path`` — one render, one
+      image, deliberately serving both. The same ``project`` over DIFFERENT
+      renders would race both builds onto one tag: the last build wins, and
+      every user of the losing persona silently runs the winning persona's
+      image — an entitlement bleed, not just a naming wart.
+    * **Persona vs worker.** No persona ``project`` may equal the deployment's
+      own project name: the dispatch worker's image already owns that
+      ``<project>:local`` tag, and a persona build would overwrite it (or be
+      overwritten) with entirely different content. Checked only when the
+      config declares an explicit ``project_name`` — the resolver's
+      path-derived fallbacks are unknowable at profile altitude, and every
+      rendered project carries the key.
+
+    A catalog entry with no ``project`` of its own resolves to the legacy
+    suffixed tag (``<default>-<persona>:local``) and cannot collide with
+    either, so it is skipped.
+    """
+    if effective_image_source(web_terminals) != "local":
+        return []
+    catalog = _persona_catalog(web_terminals)
+    by_project: dict[str, list[tuple[str, str]]] = {}
+    for persona_name in sorted(_referenced_persona_names(web_terminals, users)):
+        entry = catalog.get(persona_name)
+        if not isinstance(entry, dict):
+            continue  # unresolvable reference — reported elsewhere
+        project = entry.get("project")
+        if not isinstance(project, str) or not project:
+            continue  # legacy suffixed fallback; no collision possible
+        project_path = entry.get("project_path")
+        by_project.setdefault(project, []).append(
+            (persona_name, project_path if isinstance(project_path, str) else "")
+        )
+
+    deployment_project = root.get("project_name")
+    if isinstance(deployment_project, str) and deployment_project:
+        from osprey.deployment.compose_generator import resolve_project_name
+
+        deployment_project = resolve_project_name(root)
+
+    findings: list[Finding] = []
+    for project, members in sorted(by_project.items()):
+        if len(members) > 1 and len({path for _, path in members}) > 1:
+            names = ", ".join(repr(name) for name, _ in members)
+            findings.append(
+                Finding(
+                    severity="error",
+                    code="web_terminals.persona_project_collision",
+                    message=(
+                        f"personas {names} share project {project!r} but point at "
+                        "different project_paths; their builds would race onto the "
+                        f"one image tag '{project}:local', and users of the losing "
+                        "persona would silently run the winning persona's image. "
+                        "Give each persona its own project (matching its render), "
+                        "or point them at the same project_path to share one image "
+                        "deliberately"
+                    ),
+                )
+            )
+        if project == deployment_project:
+            findings.append(
+                Finding(
+                    severity="error",
+                    code="web_terminals.persona_project_shadows_worker_image",
+                    message=(
+                        f"personas {', '.join(repr(name) for name, _ in members)} use "
+                        f"project {project!r}, which is this deployment's own project "
+                        f"name; the persona image tag '{project}:local' would collide "
+                        "with the dispatch worker's image. Rename the persona's render "
+                        "(osprey build names each one <repo>-<persona>)"
+                    ),
+                )
+            )
     return findings
 
 

--- a/src/osprey/deployment/web_terminals/persona_images.py
+++ b/src/osprey/deployment/web_terminals/persona_images.py
@@ -1,7 +1,10 @@
 """Per-persona local image builds for multi-user web-terminal deployments.
 
-``image_source: local`` deploys build one ``<project>-<persona>:local`` image
-per referenced persona before any compose invocation. Each of those builds needs
+``image_source: local`` deploys build one ``<project>:local`` image per
+referenced persona render before any compose invocation (the tag names the
+persona's rendered project — see
+:func:`osprey.deployment.web_terminals.personas.resolve_personas` for the
+naming rules, including the legacy suffixed fallback). Each of those builds needs
 a rendered persona project as its context, and ``osprey build`` is what writes
 one: :func:`verify_persona_renders` checks that every referenced persona has
 one and refuses the start when it does not. Nothing here renders — a start runs
@@ -148,12 +151,11 @@ def _resolve_persona_claude_cli_version(project_path: str) -> str | None:
 def _persona_image_build_cmd(
     runtime: str,
     context: str,
-    project: str,
-    persona: str,
+    image_tag: str,
     project_label: str,
     dev_mode: bool = False,
 ) -> list[str]:
-    """Construct the ``<runtime> build`` argv that produces ``<project>-<persona>:local``.
+    """Construct the ``<runtime> build`` argv that produces *image_tag*.
 
     Mirrors :func:`_project_image_build_cmd`'s argv shape (same
     ``OSPREY_PIP_SPEC`` build-arg, same runtime/tag/``-f``/context layout)
@@ -166,10 +168,10 @@ def _persona_image_build_cmd(
     :param runtime: Base container command (``docker`` or ``podman``).
     :param context: The persona's image build context — its container repo,
         :func:`_persona_image_context` of the rendered project.
-    :param project: The persona catalog entry's resolved ``project`` name
-        (tag prefix, matching :func:`osprey.deployment.web_terminals.personas.resolve_personas`'s
-        ``<project>-<persona>:local`` naming).
-    :param persona: The persona catalog key (tag suffix).
+    :param image_tag: The tag to build, exactly as
+        :func:`osprey.deployment.web_terminals.personas.resolve_personas`
+        resolved it into the entry's ``image`` — the single derivation site
+        for persona tag naming, never recomputed here.
     :param dev_mode: Whether ``--dev`` was passed (adds an ``OSPREY_DEV=1``
         build-arg, mirroring :func:`_project_image_build_cmd`'s dev path).
     :param project_label: THIS DEPLOYMENT's project name
@@ -192,7 +194,7 @@ def _persona_image_build_cmd(
         runtime,
         "build",
         "-t",
-        f"{project}-{persona}:local",
+        image_tag,
         "-f",
         os.path.join(render, "Dockerfile"),
         "--label",
@@ -236,10 +238,12 @@ def _referenced_personas(config: dict, resolved_users: list[dict]) -> list[dict[
     :param config: Raw deploy config (read for ``modules.web_terminals.personas``).
     :param resolved_users: :func:`osprey.deployment.web_terminals.personas.resolve_personas`'s
         output.
-    :return: One ``{"persona", "project", "project_path", "build_profile"}``
-        dict per distinct referenced persona, in first-seen order
+    :return: One ``{"persona", "project", "project_path", "build_profile",
+        "image"}`` dict per distinct referenced persona, in first-seen order
         (``build_profile`` is the catalog entry's value, or ``""`` when it has
-        none or a non-string one).
+        none or a non-string one; ``image`` is the tag ``resolve_personas``
+        resolved for the entry — the single derivation site, carried through
+        rather than recomputed).
     """
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
     personas_raw = web_terminals.get("personas")
@@ -267,10 +271,11 @@ def _referenced_personas(config: dict, resolved_users: list[dict]) -> list[dict[
             continue
         seen.add(persona_name)
         # Trust resolve_personas' contract that every resolved entry carries a
-        # non-empty "project" — no persona_name fallback here, which would
-        # silently diverge from the tag resolve_personas itself resolved
-        # (<project>-<persona>:local) if that contract were ever violated.
+        # non-empty "project" and "image" — no fallback derivation here, which
+        # would silently diverge from the tag resolve_personas itself resolved
+        # if that contract were ever violated.
         project = cast(str, entry.get("project"))
+        image = cast(str, entry.get("image"))
         # The delta this entry says its project was rendered from; carried here
         # so verify_persona_renders need not re-walk the catalog to explain an
         # absent one. Normalized to "" when absent or non-str, which that caller
@@ -282,6 +287,7 @@ def _referenced_personas(config: dict, resolved_users: list[dict]) -> list[dict[
                 "project": project,
                 "project_path": project_path,
                 "build_profile": build_profile if isinstance(build_profile, str) else "",
+                "image": image,
             }
         )
     return referenced
@@ -759,7 +765,7 @@ def verify_persona_renders(
 def build_persona_images(
     config: dict, resolved_users: list[dict], dev_mode: bool, env: dict
 ) -> None:
-    """Build every REFERENCED persona's ``<project>-<persona>:local`` image (local mode only).
+    """Build every REFERENCED persona's ``<project>:local`` image (local mode only).
 
     Generalizes :func:`_build_project_image`'s local-build pattern (build
     context + ``-f`` Dockerfile + ``OSPREY_PIP_SPEC`` build-arg + dev-wheel
@@ -768,8 +774,11 @@ def build_persona_images(
     :func:`_referenced_personas` finds in ``resolved_users``, even when
     several users share it. :func:`_build_project_image` itself is untouched:
     the dispatch worker's ``<project>:local`` image is a different tag,
-    disjoint from every ``<persona.project>-<persona>:local`` tag this
-    function produces, and is built independently.
+    disjoint from every persona tag this function produces — a disjointness
+    the ``persona_project_shadows_worker_image`` lint rule enforces now that
+    persona tags carry no ``-<persona>`` suffix of their own (the legacy
+    no-``project`` fallback keeps its suffix and stays disjoint by
+    construction) — and is built independently.
 
     No-op when ``modules.web_terminals.image_source`` is not ``"local"``
     (the default, ``"registry"``): a registry-mode deploy pulls every
@@ -828,9 +837,19 @@ def build_persona_images(
     # The deployment repo whose var/logs/ takes each build's spooled output.
     repo_root = resolve_repo_root(config)
 
+    # Personas sharing one render (same catalog `project` AND `project_path`)
+    # resolve to the same tag and the same content — one build serves them all.
+    built_tags: set[str] = set()
+
     for unit in referenced:
         persona_name = unit["persona"]
-        project = unit["project"]
+        if unit["image"] in built_tags:
+            logger.debug(
+                "Persona %r shares the already-built image %r; skipping its build.",
+                persona_name,
+                unit["image"],
+            )
+            continue
         # The container repo the build renders for this persona — NOT the flat
         # host render the catalog names. See _persona_image_context.
         context = str(_persona_image_context(unit["project_path"]))
@@ -855,15 +874,14 @@ def build_persona_images(
                 )
 
         try:
+            image_tag = unit["image"]
             cmd = _persona_image_build_cmd(
                 runtime,
                 context,
-                project,
-                persona_name,
+                image_tag,
                 project_label,
                 dev_mode and wheel_staged,
             )
-            image_tag = f"{project}-{persona_name}:local"
             # No "building X:" announcement: the live build region carries the
             # progress while it runs, and the step line below reports the
             # finished image.
@@ -881,7 +899,7 @@ def build_persona_images(
                 run_captured(
                     cmd,
                     env=env,
-                    spool_name=f"build-persona-{project}-{persona_name}",
+                    spool_name=f"build-persona-{image_tag.split(':', 1)[0]}",
                     repo_root=repo_root,
                     on_line=report,
                 )
@@ -889,6 +907,7 @@ def build_persona_images(
             # local-mode deploy, and the only progress an operator gets while
             # a handful of multi-minute builds run one after another.
             _report_step(f"persona image {image_tag}")
+            built_tags.add(image_tag)
         finally:
             # Remove BOTH staged artifacts (wheel + requirements manifest) so
             # neither can poison a later non-dev build in this context.

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -1517,7 +1517,7 @@ def resolve_personas(
       a catalog entry exists for it): registry mode keeps the same un-suffixed
       ``<registry_url>/web-terminal:<tag>`` image (so the default persona's
       *image* never changes when a catalog is introduced); local mode still
-      builds ``<persona.project>-<persona>:local`` like every other persona.
+      builds ``<persona.project>:local`` like every other persona.
       ``container_project_dir`` is ``/app/<project>`` from the catalog entry,
       exactly as for any other persona: the image is built FROM that project, so
       pinning the directory to the facility default would name a path that
@@ -1528,7 +1528,12 @@ def resolve_personas(
       reads.
     * **Non-default persona**: registry mode uses
       ``<registry_url>/web-terminal-<persona>:<tag>``; local mode uses
-      ``<persona.project>-<persona>:local`` (same rule as the default persona);
+      ``<persona.project>:local`` (same rule as the default persona) — the
+      persona image is tagged by its render alone, since the persona name
+      contributes nothing to the image beyond the tag; a catalog entry with
+      no ``project`` of its own falls back to the legacy
+      ``<facility_prefix>-assistant-<persona>:local``, whose suffix keeps it
+      clear of the dispatch worker's ``<project>:local`` tag;
       ``container_project_dir`` is derived from the persona's own
       ``/app/<project>``.
 
@@ -1680,7 +1685,8 @@ def resolve_personas(
             continue
 
         project = catalog_entry.get("project")
-        if not isinstance(project, str) or not project:
+        has_own_project = isinstance(project, str) and bool(project)
+        if not has_own_project:
             project = default_project
 
         # Persona-level host mounts, applied to every user of this persona. A
@@ -1716,7 +1722,22 @@ def resolve_personas(
         is_default = persona_ref == default_persona_name
 
         if image_source == "local":
-            image = f"{project}-{persona_ref}:local"
+            # A persona image IS its render — the persona name never reaches
+            # the build beyond the tag — so a catalog entry with its own
+            # `project` tags the image by that render alone. Lint enforces the
+            # distinctness this relies on (`persona_project_collision` /
+            # `persona_project_shadows_worker_image`): no two personas may
+            # share a `project` across different renders, and none may take
+            # the deployment's own name, which the dispatch worker's
+            # `<project>:local` tag occupies. Only the legacy entry WITHOUT
+            # its own `project` (resolved to the facility default above)
+            # keeps the `-<persona>` suffix: it has no render name of its own
+            # to be distinct by, so the suffix is what keeps it clear of the
+            # worker tag.
+            if has_own_project:
+                image = f"{project}:local"
+            else:
+                image = f"{project}-{persona_ref}:local"
         elif is_default:
             image = default_image
         else:

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -1201,7 +1201,7 @@ def deploy_up_web_terminals(
       then the web stack runs ``pull`` before ``up -d``.
     - **local**: :func:`ensure_env_production` generates ``.env.users``
       from ``.env`` when absent. Then :func:`build_persona_images` builds
-      every referenced persona's ``<project>-<persona>:local`` image —
+      every referenced persona's ``<project>:local`` image —
       called with :func:`osprey.deployment.web_terminals.personas.resolve_personas`'s
       ``strict=True`` output, so an unresolvable persona reference (unknown
       catalog entry, or ``local`` mode with no catalog/``default_persona``

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -180,10 +180,11 @@
     auth_image: str | None
       Registry-mode image for the sidecar. When unset, the local-build tag
       `<facility_prefix>-assistant-auth:local` is referenced instead — the
-      persona-image pattern (`<project>-<persona>:local`, personas.py) applied
-      to the sidecar, whose `<project>` is resolve_personas()'s default
-      `<facility_prefix>-assistant`. Producing that image is the runtime build's
-      job; this template only names the tag.
+      suffixed local-tag pattern personas.py keeps for entries without their
+      own render (`<project>-<suffix>:local`) applied to the sidecar, whose
+      `<project>` is resolve_personas()'s default `<facility_prefix>-assistant`.
+      Producing that image is the runtime build's job; this template only
+      names the tag.
     auth_oidc_issuer: str | None, auth_oidc_client_id_env / auth_oidc_client_secret_env: str
       Emitted only in `oidc` mode. The two `*_env` values are env-var NAMES, not
       credentials: the sidecar reads the named variable out of its `.env.auth`

--- a/tests/deployment/test_reset_scoping.py
+++ b/tests/deployment/test_reset_scoping.py
@@ -1334,7 +1334,7 @@ def _with_web_terminals(repo: Path) -> None:
 def test_a_web_terminal_personas_local_image_is_a_candidate(repo, no_down):
     """Reset absorbs ``deploy nuke``, whose image half is the persona tags."""
     _with_web_terminals(repo)
-    persona_tag = "acc-control-control-room:local"
+    persona_tag = "acc-control:local"
     fake = FakeRuntime(
         images={
             f"{PROJECT}:local": {reset_mod.OSPREY_PROJECT_LABEL: PROJECT},
@@ -1349,7 +1349,7 @@ def test_a_web_terminal_personas_local_image_is_a_candidate(repo, no_down):
 def test_a_persona_image_belonging_to_another_deployment_survives(repo, no_down):
     """Image tags are host-global, so the project label is checked tag by tag."""
     _with_web_terminals(repo)
-    persona_tag = "acc-control-control-room:local"
+    persona_tag = "acc-control:local"
     fake = FakeRuntime(images={persona_tag: {reset_mod.OSPREY_PROJECT_LABEL: "someone-else"}})
     run_reset(repo, fake)
 
@@ -1544,7 +1544,7 @@ def test_a_local_roster_image_stays_a_candidate_under_a_set_axis(repo, monkeypat
     """``:local`` is the persona convention and the axes do not move it."""
     _with_web_terminals(repo)
     _with_image_axes(repo, _AXIS_REGISTRY, _AXIS_TAG)
-    persona_tag = "acc-control-control-room:local"
+    persona_tag = "acc-control:local"
     _roster_of(monkeypatch, persona_tag)
 
     assert reset_mod._candidate_image_tags(repo, PROJECT) == [_AXIS_IMAGE, persona_tag]

--- a/tests/deployment/test_web_terminals_capture.py
+++ b/tests/deployment/test_web_terminals_capture.py
@@ -165,13 +165,18 @@ def _stub_persona_builds(monkeypatch, tmp_path, units, build_cmd=None):
 
 
 def _unit(project: str, persona: str, tmp_path) -> dict:
-    return {"project": project, "persona": persona, "project_path": str(tmp_path / persona)}
+    return {
+        "project": project,
+        "persona": persona,
+        "project_path": str(tmp_path / persona),
+        "image": f"{project}:local",
+    }
 
 
 def test_persona_build_captures_per_image_with_its_own_spool(monkeypatch, tmp_path, reporter):
     """Each persona image is its own captured run, named for the image it
     builds, so a failed build names a spool holding only that build's output."""
-    units = [_unit("demo", "ops", tmp_path), _unit("demo", "physics", tmp_path)]
+    units = [_unit("demo-ops", "ops", tmp_path), _unit("demo-physics", "physics", tmp_path)]
     _stub_persona_builds(monkeypatch, tmp_path, units)
     recorder = RunRecorder()
     monkeypatch.setattr(persona_images, "run_captured", recorder)
@@ -189,7 +194,7 @@ def test_persona_build_captures_per_image_with_its_own_spool(monkeypatch, tmp_pa
 def test_persona_build_reports_one_step_per_image(monkeypatch, tmp_path, reporter):
     """One sub-step per persona image, naming that image: the only progress an
     operator sees while a run of multi-minute builds goes by."""
-    units = [_unit("demo", "ops", tmp_path), _unit("demo", "physics", tmp_path)]
+    units = [_unit("demo-ops", "ops", tmp_path), _unit("demo-physics", "physics", tmp_path)]
     _stub_persona_builds(monkeypatch, tmp_path, units)
     monkeypatch.setattr(persona_images, "run_captured", RunRecorder())
 
@@ -205,7 +210,7 @@ def test_default_view_hides_buildkit_lines_but_the_spool_keeps_them(
     progress, the real reporter, the real capture helper. The operator's
     terminal shows the step line and nothing of the build; the spool file
     exists and holds every line."""
-    units = [_unit("demo", "ops", tmp_path)]
+    units = [_unit("demo-ops", "ops", tmp_path)]
     _stub_persona_builds(monkeypatch, tmp_path, units, build_cmd=_echo_cmd(BUILDKIT_OUTPUT))
 
     persona_images.build_persona_images(_persona_config(), [], False, None)
@@ -229,7 +234,7 @@ def test_persona_build_is_watched_under_its_own_image_tag(monkeypatch, tmp_path,
     so the watcher carries the image tag as its label. Without it the whole
     build parses into nothing — silently, with no error — so the assertion is
     behavioural: a nameless header must come back attributed to the tag."""
-    _stub_persona_builds(monkeypatch, tmp_path, [_unit("demo", "ops", tmp_path)])
+    _stub_persona_builds(monkeypatch, tmp_path, [_unit("demo-ops", "ops", tmp_path)])
     recorder = RunRecorder()
     monkeypatch.setattr(persona_images, "run_captured", recorder)
 

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -999,13 +999,13 @@ def test_nuke_removes_label_verified_persona_local_image(tmp_path, monkeypatch, 
     monkeypatch.chdir(tmp_path)
     config = _persona_config(["alice"], project_name="demo-project")
     config_path = _write_config(tmp_path, config)
-    image_labels["acc-control-control-room:local"] = "demo-project"  # matches THIS deployment
+    image_labels["acc-control:local"] = "demo-project"  # matches THIS deployment
     _assert_no_input_prompt(monkeypatch)
 
     lifecycle.nuke_stack(str(config_path), assume_yes=True)
 
     image_rm_calls = [c for c in calls if c[1:3] == ["image", "rm"]]
-    assert image_rm_calls == [["docker", "image", "rm", "acc-control-control-room:local"]]
+    assert image_rm_calls == [["docker", "image", "rm", "acc-control:local"]]
 
 
 def test_nuke_skips_image_with_mismatched_project_label_and_warns(
@@ -1019,7 +1019,7 @@ def test_nuke_skips_image_with_mismatched_project_label_and_warns(
     monkeypatch.chdir(tmp_path)
     config = _persona_config(["alice"], project_name="demo-project")
     config_path = _write_config(tmp_path, config)
-    image_labels["acc-control-control-room:local"] = "some-other-project"
+    image_labels["acc-control:local"] = "some-other-project"
     _assert_no_input_prompt(monkeypatch)
 
     lifecycle.nuke_stack(str(config_path), assume_yes=True)
@@ -1028,7 +1028,7 @@ def test_nuke_skips_image_with_mismatched_project_label_and_warns(
     assert image_rm_calls == []
 
     out = capsys.readouterr().out
-    assert "acc-control-control-room:local" in out
+    assert "acc-control:local" in out
     assert "SKIPPED" in out
     assert "some-other-project" in out
 
@@ -1042,7 +1042,7 @@ def test_nuke_skips_image_with_missing_label_and_warns(
     monkeypatch.chdir(tmp_path)
     config = _persona_config(["alice"], project_name="demo-project")
     config_path = _write_config(tmp_path, config)
-    image_labels["acc-control-control-room:local"] = None  # exists, but unlabeled
+    image_labels["acc-control:local"] = None  # exists, but unlabeled
     _assert_no_input_prompt(monkeypatch)
 
     lifecycle.nuke_stack(str(config_path), assume_yes=True)
@@ -1095,7 +1095,7 @@ def test_nuke_dedupes_one_image_removal_per_shared_persona(
     monkeypatch.chdir(tmp_path)
     config = _persona_config(["alice", "bob"], project_name="demo-project")
     config_path = _write_config(tmp_path, config)
-    image_labels["acc-control-control-room:local"] = "demo-project"
+    image_labels["acc-control:local"] = "demo-project"
     _assert_no_input_prompt(monkeypatch)
 
     lifecycle.nuke_stack(str(config_path), assume_yes=True)
@@ -1106,13 +1106,13 @@ def test_nuke_dedupes_one_image_removal_per_shared_persona(
             "docker",
             "image",
             "inspect",
-            "acc-control-control-room:local",
+            "acc-control:local",
             "--format",
             "{{json .Config.Labels}}",
         ]
     ]
     image_rm_calls = [c for c in calls if c[1:3] == ["image", "rm"]]
-    assert image_rm_calls == [["docker", "image", "rm", "acc-control-control-room:local"]]
+    assert image_rm_calls == [["docker", "image", "rm", "acc-control:local"]]
 
 
 def test_nuke_image_removal_happens_after_compose_down_and_volume_removal(
@@ -1122,7 +1122,7 @@ def test_nuke_image_removal_happens_after_compose_down_and_volume_removal(
     monkeypatch.chdir(tmp_path)
     config = _persona_config(["alice"], project_name="demo-project")
     config_path = _write_config(tmp_path, config)
-    image_labels["acc-control-control-room:local"] = "demo-project"
+    image_labels["acc-control:local"] = "demo-project"
     _assert_no_input_prompt(monkeypatch)
 
     lifecycle.nuke_stack(str(config_path), assume_yes=True)
@@ -1143,7 +1143,7 @@ def test_nuke_prints_image_plan_before_confirmation(
     monkeypatch.chdir(tmp_path)
     config = _persona_config(["alice"], project_name="demo-project")
     config_path = _write_config(tmp_path, config)
-    image_labels["acc-control-control-room:local"] = "demo-project"
+    image_labels["acc-control:local"] = "demo-project"
 
     prompts: list[str] = []
 
@@ -1156,7 +1156,7 @@ def test_nuke_prints_image_plan_before_confirmation(
     lifecycle.nuke_stack(str(config_path), assume_yes=False)
 
     out = capsys.readouterr().out
-    assert "acc-control-control-room:local" in out
+    assert "acc-control:local" in out
     # "image(s)", not "persona image(s)": the set now also carries the auth
     # sidecar's own local tag when authentication is on in local mode.
     assert "image(s)" in out
@@ -1174,7 +1174,7 @@ def test_nuke_without_confirmation_never_removes_or_inspects_images_when_decline
     monkeypatch.chdir(tmp_path)
     config = _persona_config(["alice"], project_name="demo-project")
     config_path = _write_config(tmp_path, config)
-    image_labels["acc-control-control-room:local"] = "demo-project"
+    image_labels["acc-control:local"] = "demo-project"
     monkeypatch.setattr("builtins.input", lambda prompt="": "")
 
     with pytest.raises(RuntimeError):
@@ -1192,7 +1192,7 @@ def test_nuke_argv_safety_image_rm_is_single_exact_named_tag(
     monkeypatch.chdir(tmp_path)
     config = _persona_config(["alice", "bob"], project_name="demo-project")
     config_path = _write_config(tmp_path, config)
-    image_labels["acc-control-control-room:local"] = "demo-project"
+    image_labels["acc-control:local"] = "demo-project"
 
     lifecycle.nuke_stack(str(config_path), assume_yes=True)
 
@@ -2002,7 +2002,7 @@ def test_nuke_auth_sidecar_image_is_removed_when_label_verified(
     monkeypatch.chdir(tmp_path)
     config_path = _write_config(tmp_path, _auth_persona_config(["alice"]))
     image_labels["dls-assistant-auth:local"] = "demo-project"
-    image_labels["acc-control-control-room:local"] = "demo-project"
+    image_labels["acc-control:local"] = "demo-project"
     _assert_no_input_prompt(monkeypatch)
 
     lifecycle.nuke_stack(str(config_path), assume_yes=True)
@@ -2028,7 +2028,7 @@ def test_nuke_auth_sidecar_image_is_not_a_candidate(
     monkeypatch.chdir(tmp_path)
     config_path = _write_config(tmp_path, _auth_persona_config(["alice"], **kwargs))
     image_labels["dls-assistant-auth:local"] = "demo-project"  # exists and is ours
-    image_labels["acc-control-control-room:local"] = "demo-project"
+    image_labels["acc-control:local"] = "demo-project"
     _assert_no_input_prompt(monkeypatch)
 
     lifecycle.nuke_stack(str(config_path), assume_yes=True)

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -1522,6 +1522,127 @@ def test_lint_registry_mode_does_not_run_project_path_name_invariant(tmp_path) -
     assert not any(f.code == "web_terminals.persona_project_path_name_mismatch" for f in findings)
 
 
+def test_lint_two_personas_sharing_a_project_across_renders_is_an_error() -> None:
+    """Two referenced personas with one `project` over DIFFERENT renders would
+    race both builds onto the single `<project>:local` tag — the losing
+    persona's users silently run the winning persona's image."""
+    # Arrange
+    config = _persona_config(
+        web_terminals={
+            "image_source": "local",
+            "users": [
+                {"name": "alice", "index": 0, "persona": "assistant"},
+                {"name": "bob", "index": 1, "persona": "analysis"},
+            ],
+            "personas": {
+                "assistant": {"project": "shared", "project_path": "build/shared"},
+                "analysis": {"project": "shared", "project_path": "elsewhere/shared"},
+            },
+        }
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    collisions = [f for f in errors if f.code == "web_terminals.persona_project_collision"]
+    assert collisions
+    assert any(
+        "'assistant'" in f.message and "'analysis'" in f.message and "shared:local" in f.message
+        for f in collisions
+    )
+
+
+def test_lint_two_personas_sharing_one_render_is_not_a_collision() -> None:
+    """The same `project` AND the same `project_path` is one render deliberately
+    serving both personas — one image, no race, no finding."""
+    # Arrange
+    config = _persona_config(
+        web_terminals={
+            "image_source": "local",
+            "users": [
+                {"name": "alice", "index": 0, "persona": "assistant"},
+                {"name": "bob", "index": 1, "persona": "analysis"},
+            ],
+            "personas": {
+                "assistant": {"project": "shared", "project_path": "build/shared"},
+                "analysis": {"project": "shared", "project_path": "build/shared"},
+            },
+        }
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.persona_project_collision" for f in findings)
+
+
+def test_lint_persona_project_equal_to_deployment_project_name_is_an_error() -> None:
+    """The dispatch worker already owns `<deployment project>:local`; a persona
+    render with the same name would overwrite it (or be overwritten) with
+    entirely different content."""
+    # Arrange
+    config = _persona_config(
+        web_terminals={
+            "image_source": "local",
+            "personas": {
+                "assistant": {"project": "my-deploy", "project_path": "build/my-deploy"},
+            },
+        }
+    )
+    config["project_name"] = "my-deploy"
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    shadows = [f for f in errors if f.code == "web_terminals.persona_project_shadows_worker_image"]
+    assert shadows
+    assert any("my-deploy:local" in f.message for f in shadows)
+
+
+def test_lint_registry_mode_skips_persona_project_collision_checks() -> None:
+    """Registry mode pulls per-persona images; no local tags exist to collide."""
+    # Arrange (both collisions present, but image_source is registry)
+    config = _persona_config(
+        web_terminals={
+            "users": [
+                {"name": "alice", "index": 0, "persona": "assistant"},
+                {"name": "bob", "index": 1, "persona": "analysis"},
+            ],
+            "personas": {
+                "assistant": {
+                    "project": "shared",
+                    "build_profile": "profiles/assistant.yml",
+                },
+                "analysis": {
+                    "project": "shared",
+                    "project_path": "elsewhere/shared",
+                    "build_profile": "profiles/analysis.yml",
+                },
+            },
+        },
+        registry={"url": "registry.example.org:5050"},
+    )
+    config["project_name"] = "shared"
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(
+        f.code
+        in (
+            "web_terminals.persona_project_collision",
+            "web_terminals.persona_project_shadows_worker_image",
+        )
+        for f in findings
+    )
+
+
 def test_lint_registry_mode_non_default_persona_without_build_profile_is_an_error() -> None:
     """In registry mode, a non-default persona has no local project_path to
     build from — `build_profile` is its only route to a CI build job."""

--- a/tests/deployment/web_terminals/test_persona_images.py
+++ b/tests/deployment/web_terminals/test_persona_images.py
@@ -109,9 +109,14 @@ def test_build_persona_images_builds_each_referenced_persona_once(
         },
     }
     resolved_users = [
-        {"name": "alice", "persona": "ops", "project": "ops-app"},
-        {"name": "bob", "persona": "ops", "project": "ops-app"},  # shares ops -- must not rebuild
-        {"name": "carol", "persona": "sci", "project": "sci-app"},
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"},
+        {
+            "name": "bob",
+            "persona": "ops",
+            "project": "ops-app",
+            "image": "ops-app:local",
+        },  # shares ops -- must not rebuild
+        {"name": "carol", "persona": "sci", "project": "sci-app", "image": "sci-app:local"},
     ]
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
@@ -122,8 +127,8 @@ def test_build_persona_images_builds_each_referenced_persona_once(
 
     assert len(calls) == 2  # one build per DISTINCT persona, not per user
 
-    ops_cmd = next(c for c in calls if "ops-app-ops:local" in c)
-    sci_cmd = next(c for c in calls if "sci-app-sci:local" in c)
+    ops_cmd = next(c for c in calls if "ops-app:local" in c)
+    sci_cmd = next(c for c in calls if "sci-app:local" in c)
 
     # The context is the persona's CONTAINER repo, not its flat host render:
     # the render records this machine's project_root, so an image built from it
@@ -140,6 +145,42 @@ def test_build_persona_images_builds_each_referenced_persona_once(
 
     assert "com.osprey.project=myfacility" in sci_cmd
     assert str(persona_images._persona_image_context(sci_path)) == sci_cmd[-1]
+
+
+def test_build_persona_images_builds_a_shared_render_once(
+    monkeypatch, tmp_path, _no_dev_wheel_staging
+):
+    """Two personas resolving to one image (same catalog `project` and
+    `project_path` — one render deliberately serving both) build that image
+    once, not once per persona: same tag, same content, second build wasted."""
+    shared_path = _make_persona_project(tmp_path, "shared-app")
+
+    config = {
+        "project_name": "myfacility",
+        "modules": {
+            "web_terminals": {
+                "image_source": "local",
+                "default_persona": "ops",
+                "personas": {
+                    "ops": {"project": "shared-app", "project_path": shared_path},
+                    "sci": {"project": "shared-app", "project_path": shared_path},
+                },
+            }
+        },
+    }
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "shared-app", "image": "shared-app:local"},
+        {"name": "bob", "persona": "sci", "project": "shared-app", "image": "shared-app:local"},
+    ]
+
+    monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker"])
+    calls = []
+    monkeypatch.setattr(persona_images, "run_captured", lambda cmd, **k: calls.append(cmd))
+
+    persona_images.build_persona_images(config, resolved_users, False, {})
+
+    assert len(calls) == 1
+    assert "shared-app:local" in calls[0]
 
 
 def test_build_persona_images_never_builds_zero_migration_entries(
@@ -183,7 +224,9 @@ def test_build_persona_images_includes_cli_version_from_persona_config(
             }
         },
     }
-    resolved_users = [{"name": "alice", "persona": "ops", "project": "ops-app"}]
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+    ]
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
@@ -212,7 +255,9 @@ def test_build_persona_images_omits_cli_version_when_unset_in_persona_config(
             }
         },
     }
-    resolved_users = [{"name": "alice", "persona": "ops", "project": "ops-app"}]
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+    ]
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
@@ -246,7 +291,9 @@ def test_build_persona_images_never_reads_facility_cli_version(
             }
         },
     }
-    resolved_users = [{"name": "alice", "persona": "ops", "project": "ops-app"}]
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+    ]
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
@@ -274,7 +321,9 @@ def test_build_persona_images_dev_mode_adds_osprey_dev_build_arg(
             }
         },
     }
-    resolved_users = [{"name": "alice", "persona": "ops", "project": "ops-app"}]
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+    ]
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
@@ -302,7 +351,9 @@ def test_build_persona_images_dev_mode_omits_osprey_dev_when_staging_fails(monke
             }
         },
     }
-    resolved_users = [{"name": "alice", "persona": "ops", "project": "ops-app"}]
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+    ]
 
     monkeypatch.setattr(
         persona_images, "_copy_local_framework_for_override", lambda project_root: False
@@ -331,7 +382,9 @@ def test_build_persona_images_non_dev_omits_osprey_dev_build_arg(
             }
         },
     }
-    resolved_users = [{"name": "alice", "persona": "ops", "project": "ops-app"}]
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+    ]
 
     monkeypatch.setattr(persona_images, "get_runtime_command", lambda config: ["docker", "compose"])
     calls = []
@@ -355,7 +408,9 @@ def test_build_persona_images_dev_mode_stages_and_cleans_wheel(monkeypatch, tmp_
             }
         },
     }
-    resolved_users = [{"name": "alice", "persona": "ops", "project": "ops-app"}]
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+    ]
 
     def _fake_stage(project_root):
         (Path(project_root) / "osprey_framework-0.0.0-py3-none-any.whl").write_text("wheel")
@@ -393,7 +448,9 @@ def test_build_persona_images_dev_mode_cleans_staged_artifacts_on_build_failure(
             }
         },
     }
-    resolved_users = [{"name": "alice", "persona": "ops", "project": "ops-app"}]
+    resolved_users = [
+        {"name": "alice", "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+    ]
 
     def _fake_stage(project_root):
         (Path(project_root) / "osprey_framework-0.0.0-py3-none-any.whl").write_text("wheel")
@@ -523,7 +580,9 @@ def _persona_config(repo: Path, deployed_services=("openobserve",), **persona_ov
     }
 
 
-_PERSONA_USERS = [{"name": "alice", "index": 0, "persona": "ops", "project": "ops-app"}]
+_PERSONA_USERS = [
+    {"name": "alice", "index": 0, "persona": "ops", "project": "ops-app", "image": "ops-app:local"}
+]
 
 
 @pytest.fixture

--- a/tests/deployment/web_terminals/test_personas.py
+++ b/tests/deployment/web_terminals/test_personas.py
@@ -503,9 +503,10 @@ def test_resolve_personas_non_default_persona_registry_mode_suffixes_image() -> 
     ]
 
 
-def test_resolve_personas_local_mode_suffixes_every_persona_including_default() -> None:
-    """Local mode builds `<persona.project>-<persona>:local` for every persona —
-    unlike registry mode, the default persona is not special-cased on the image."""
+def test_resolve_personas_local_mode_tags_every_persona_by_render_including_default() -> None:
+    """Local mode builds `<persona.project>:local` for every persona — the tag
+    names the render alone, and unlike registry mode, the default persona is
+    not special-cased on the image."""
     # Arrange
     web_terminals = {
         "users": ["alice", {"name": "gmartino", "index": 1, "persona": "gui"}],
@@ -523,13 +524,34 @@ def test_resolve_personas_local_mode_suffixes_every_persona_including_default() 
     # Assert
     images = {entry["name"]: entry["image"] for entry in result}
     assert images == {
-        "alice": "als-assistant-cli:local",
-        "gmartino": "als-gui-assistant-gui:local",
+        "alice": "als-assistant:local",
+        "gmartino": "als-gui-assistant:local",
     }
     # Default persona's container dir follows its own catalog project, like every
     # other persona — no facility-prefix special case (here `als-assistant`).
     default_entry = next(entry for entry in result if entry["name"] == "alice")
     assert default_entry["container_project_dir"] == "/app/als-assistant"
+
+
+def test_resolve_personas_local_mode_entry_without_project_keeps_suffixed_tag() -> None:
+    """A catalog entry with no `project` of its own resolves onto the facility
+    default project, whose `<default>-<persona>:local` suffix is what keeps the
+    tag disjoint from the dispatch worker's `<project>:local` image — a render
+    of its own is what earns a persona the unsuffixed tag."""
+    # Arrange
+    web_terminals = {
+        "users": [{"name": "alice", "index": 0, "persona": "bare"}],
+        "default_persona": "bare",
+        "image_source": "local",
+        "personas": {"bare": {"project_path": "profiles/bare"}},
+    }
+
+    # Act
+    result = resolve_personas(web_terminals, _REGISTRY, "als")
+
+    # Assert
+    assert result[0]["image"] == "als-assistant-bare:local"
+    assert result[0]["project"] == "als-assistant"
 
 
 def test_resolve_personas_entry_without_persona_key_inherits_default_persona() -> None:

--- a/tests/e2e/test_deploy_lifecycle.py
+++ b/tests/e2e/test_deploy_lifecycle.py
@@ -713,8 +713,8 @@ PORTS_B = {"nginx": 19181, "web": 19900, "artifact": 20000, "ariel": 20100, "lat
 # sibling deployment already built and labeled as its own.
 A_PERSONA_PROJECT = "e2e-two-proj-a-persona"
 COLLISION_PERSONA_PROJECT = "e2e-two-proj-collision"
-TAG_A_OWN = f"{A_PERSONA_PROJECT}-mainp:local"
-TAG_COLLISION = f"{COLLISION_PERSONA_PROJECT}-borrowed:local"
+TAG_A_OWN = f"{A_PERSONA_PROJECT}:local"
+TAG_COLLISION = f"{COLLISION_PERSONA_PROJECT}:local"
 
 
 def _make_isolation_repo(
@@ -1011,8 +1011,8 @@ HETERO_ALT_PERSONA = "alt"
 # and resolve_personas()'s resolved mount path agree by construction.
 HETERO_DEFAULT_PROJECT = f"{HETERO_PREFIX}-assistant"
 HETERO_ALT_PROJECT = f"{HETERO_PREFIX}-alt"
-HETERO_DEFAULT_TAG = f"{HETERO_DEFAULT_PROJECT}-{HETERO_DEFAULT_PERSONA}:local"
-HETERO_ALT_TAG = f"{HETERO_ALT_PROJECT}-{HETERO_ALT_PERSONA}:local"
+HETERO_DEFAULT_TAG = f"{HETERO_DEFAULT_PROJECT}:local"
+HETERO_ALT_TAG = f"{HETERO_ALT_PROJECT}:local"
 
 # The .env fixture content: one var the generated .env.users MUST carry
 # (the LLM key, copied unconditionally), and three it must NEVER carry

--- a/tests/e2e/test_deploy_lifecycle.py
+++ b/tests/e2e/test_deploy_lifecycle.py
@@ -1380,9 +1380,10 @@ def test_deploy_lifecycle_heterogeneous_registry_mode_up(repo: Path, stub_image:
         },
     )
 
-    # The tag a LOCAL build would have produced for this persona -- must
+    # The tag a LOCAL build would have produced for this persona (it has its
+    # own catalog `project`, so the tag names the render alone) -- must
     # never exist, since registry mode builds nothing.
-    never_built_tag = f"{FACILITY_PREFIX}-assistant-assistant:local"
+    never_built_tag = f"{FACILITY_PREFIX}-assistant:local"
 
     try:
         up = _run_osprey(osprey_bin, ["up"], repo, timeout=DEPLOY_UP_TIMEOUT_SEC)

--- a/tests/e2e/test_dispatch_deploy.py
+++ b/tests/e2e/test_dispatch_deploy.py
@@ -107,8 +107,8 @@ READONLY_USER = "alice"
 READWRITE_USER = "bob"
 READONLY_PROJECT = f"{PROJECT_NAME}-readonly"
 READWRITE_PROJECT = f"{PROJECT_NAME}-readwrite"
-READONLY_IMAGE = f"{READONLY_PROJECT}-readonly:local"
-READWRITE_IMAGE = f"{READWRITE_PROJECT}-readwrite:local"
+READONLY_IMAGE = f"{READONLY_PROJECT}:local"
+READWRITE_IMAGE = f"{READWRITE_PROJECT}:local"
 
 # The write tool the readonly tier's rendered settings.json must deny and the
 # readwrite tier's must not (write tools land in permissions.deny when

--- a/tests/e2e/web_terminals/test_auth_perimeter.py
+++ b/tests/e2e/web_terminals/test_auth_perimeter.py
@@ -145,10 +145,10 @@ BASE_PORTS = {
 UPSTREAM_MARKER = "osprey-e2e-auth-perimeter upstream"
 
 AUTH_IMAGE_TAG = f"{PREFIX}-assistant-auth:local"
-# `<catalog project>-<persona>:local`, exactly as resolve_personas derives a
+# `<catalog project>:local`, exactly as resolve_personas derives a
 # local-mode persona tag. Teardown-only, but spelled the way the render spells
 # it so an `rmi` here removes the tag this deploy actually built.
-PERSONA_IMAGE_TAG = f"{PERSONA_PROJECT}-{PERSONA}:local"
+PERSONA_IMAGE_TAG = f"{PERSONA_PROJECT}:local"
 
 NGINX_C = f"{PREFIX}-nginx"
 AUTH_C = f"{PREFIX}-auth"

--- a/tests/e2e/web_terminals/test_terminal_auth_multiuser_e2e.py
+++ b/tests/e2e/web_terminals/test_terminal_auth_multiuser_e2e.py
@@ -140,7 +140,7 @@ BASE_PORTS = {
     "channel_finder": 19981,
 }
 
-PERSONA_IMAGE_TAG = f"{PERSONA_PROJECT}-{PERSONA}:local"
+PERSONA_IMAGE_TAG = f"{PERSONA_PROJECT}:local"
 NGINX_C = f"{PREFIX}-nginx"
 
 # The persona build is a real framework install; give it room.


### PR DESCRIPTION
Local-mode persona images were tagged `<project>-<persona>:local`, while the scaffold already names each persona's render `<repo>-<persona>` — so every generated deployment built doubled tags like `my-control-assistant-readwrite-readwrite:local`. The suffix carried no content (the persona name never reaches the build beyond the tag); it only disambiguated tags, and most of that job was already done elsewhere: lint's name invariant pins each catalog `project` to its render's basename.

Persona images are now tagged `<project>:local` — the name of the render they are built from. The two collisions the suffix was accidentally preventing become explicit lint errors:

- `persona_project_collision`: two referenced personas sharing a `project` across **different** renders. Their builds would race onto one tag, and users of the losing persona would silently run the winning persona's image — an entitlement bleed, not just a naming wart. Sharing a project **and** its render stays legal and now builds the image once instead of once per persona.
- `persona_project_shadows_worker_image`: a persona `project` equal to the deployment's own project name, whose `<project>:local` tag the dispatch worker image already occupies.

A catalog entry with no `project` of its own keeps the legacy suffixed fallback tag, which is what keeps it clear of the worker image. Registry-mode naming (`web-terminal-<persona>:<tag>`) is untouched. The tag is now derived in exactly one place — `resolve_personas` — and carried into the build loop instead of being recomputed there.

Migration: images under the old doubled tags are left on operators' disks (reset resolves tags from the current formula); the CHANGELOG notes the one-time manual prune.