### PR TITLE
feat(skills): watch for upstream fit gaps in the build interview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ## [Unreleased]
 
+### Added
+
+- Build interview: an upstream fit watch — places where OSPREY cannot express what a
+  facility needs are recorded as candidates in `INTERVIEW.md`, verified against the
+  installed framework by a scout, and offered to the user as a GitHub issue or email
+  to the maintainers. Nothing is sent without the user approving the full text.
+
 ### Security
 
 - Every OSPREY interface — the Web Terminal, ARIEL, Channel Finder, the artifact

--- a/src/osprey/templates/skills/osprey-build-interview/SKILL.md
+++ b/src/osprey/templates/skills/osprey-build-interview/SKILL.md
@@ -8,6 +8,9 @@ description: >
   Also handles migration from existing OSPREY projects (including
   LangGraph-era projects) — trigger on "migrate my project", "I have an
   existing project", "upgrade from old OSPREY", "bring my project forward".
+  Also use when OSPREY cannot cleanly express something a facility needs
+  and the gap should become an upstream change request — "OSPREY can't do
+  X here", "file this with the OSPREY team", "is this an OSPREY gap".
   Resume a previous interview by invoking this skill inside a deployment
   repo that contains an INTERVIEW.md.
 ---
@@ -61,6 +64,65 @@ Practical consequences:
 - **Use AskUserQuestion for forks**, with short ASCII previews when a
   choice is easier shown than described.
 
+## Upstream fit watch
+
+OSPREY is facility-agnostic by intent but grew up with one reference
+facility. A new facility is the first real test of an abstraction
+somewhere, and this interview is where a misfit surfaces first — as a
+workaround, an "Other", or a sentence like "OSPREY can't do that yet, so
+for now we'll…". Those workarounds are signal the OSPREY team wants;
+capture them instead of letting them dissolve into the repo. Watch for
+them through the whole interview.
+
+**A candidate** is any point where the facility's reality cannot be
+expressed by the live repo: a control system or archiver the connector
+set doesn't cover, or two protocols at once (one deployment, one
+connector); a safety model beyond per-channel limits plus single-human
+approval (relational limits, two-person sign-off, per-user or per-shift
+write scopes, readback on a different channel); a provider or auth scheme
+the provider list can't name; a logbook or metadata source with no config
+surface; a migration EVALUATE module that exists because "OSPREY had no
+X" (ask why it was written). **Not a candidate:** facility data the
+deployment owns (channel names, limits, URLs, timezone), or a placeholder
+for information the user simply doesn't have yet. Before logging, ground
+the gap in the live repo — `profile.yml`'s comments,
+`osprey config --defaults`, `osprey profile artifacts` — because the most
+common "gap" is an option you hadn't read yet.
+
+Record candidates in `INTERVIEW.md` under `## Upstream candidates`, one
+entry each:
+
+```
+- <short-id>: <what the facility needs> [blocking|worked-around]
+  offered: <what OSPREY offers instead>
+  workaround: <what this deployment does about it>
+  status: open
+```
+
+`status` may only be `open`, `filed <url>`, `emailed <date>`, `dropped`,
+`profile-local`, or `already-supported (<key>)` — and only the scout
+(below) moves an entry beyond `open`/`dropped`.
+
+**Severity is one question: with the workaround in place, does the
+deployment still serve the purpose the user stated?** No → `blocking`:
+offer an investigation on the spot — "I think this is better solved by a
+change in OSPREY than by a workaround here. Want me to investigate? You
+decide afterwards whether anything gets sent." Yes, degraded but working →
+`worked-around`: acknowledge in one line and let the devil's advocate
+round review the list; don't interrupt per item. A facility safety rule
+OSPREY cannot enforce is always `blocking`, and writes stay off while it
+is open — never let "the operators will follow the rule themselves" stand
+in for enforcement. If the user declines an investigation, set
+`status: dropped` and never raise that candidate again.
+
+When the user says yes — on the spot, at the devil's advocate round, or
+on a later resume — read `references/upstream-scout.md` and follow it: it
+verifies the gap against the installed framework (a verdict of "already
+supported" fixes the deployment instead of filing anything), drafts an
+issue-quality write-up into `upstream/<short-id>.md`, and asks whether to
+file it on GitHub, email the maintainers, keep it local, or drop it.
+Nothing is ever sent without the user seeing the full text first.
+
 ## Flow
 
 ### 0. Resume check
@@ -68,7 +130,8 @@ Practical consequences:
 If the current directory (or a path the user gives) contains an
 `INTERVIEW.md`, this is a resume: read it, summarize the state in two or
 three sentences ("Decided: …; still open: …"), and continue from the Open
-section. Do not re-ask decided questions.
+section. Mention any upstream candidates still at `status: open` and
+offer to investigate them. Do not re-ask decided questions.
 
 ### 1. Pre-init round
 
@@ -158,22 +221,35 @@ Spawn one subagent with: the full `INTERVIEW.md`, the current
 
 > Find gaps and inconsistencies in this OSPREY deployment setup. Check at
 > least: write access enabled without limits or with safety hooks/rules
-> removed; provider configured but no key in `.env`; a real control system
-> selected without the connection details its comments require; declared
-> feature blocks nothing reads (comments state the pairings); decisions in
-> INTERVIEW.md not reflected in profile.yml and vice versa; use cases the
-> user described that the current selection cannot serve. Classify each
+> removed; write access enabled while an Upstream candidate records a
+> facility approval rule OSPREY cannot enforce (CRITICAL); provider
+> configured but no key in `.env`; a real control system selected without
+> the connection details its comments require; declared feature blocks
+> nothing reads (comments state the pairings); decisions in INTERVIEW.md
+> not reflected in profile.yml and vice versa; use cases the user
+> described that the current selection cannot serve; a workaround, "for
+> now", or deferred stub in INTERVIEW.md that is not in its Upstream
+> candidates section (facility data and missing-data placeholders are not
+> gaps); a logged candidate an existing profile option plausibly covers —
+> name the option, as a lead to verify, not a verdict. Classify each
 > finding CRITICAL (unsafe or broken) / RECOMMENDED / OPTIONAL. Judge only
 > against the provided artifacts, not against assumptions about OSPREY.
 
 Resolve every CRITICAL finding with the user; offer RECOMMENDED ones;
-mention OPTIONAL ones in passing.
+mention OPTIONAL ones in passing. Then, if any upstream candidates are
+still `open`, show them as one-liners and ask once whether to investigate
+now (all or some — `references/upstream-scout.md` per candidate) or leave
+them recorded for a later resume. A candidate the reviewer thinks is
+already covered gets verified against the live repo before anything
+changes — its status moves only on evidence.
 
 ### 7. Wrap-up
 
 - Final `osprey validate` and `osprey build`; fix anything they raise.
 - Set `INTERVIEW.md` status to `complete`; move anything unresolved to
-  Open/Deferred so it is not lost.
+  Open/Deferred so it is not lost. Upstream candidates keep their own
+  section and statuses — resuming the interview later offers the `open`
+  ones again.
 - Close with next steps read from the repo itself (its README and CLI
   help): typically `osprey up -d`, `osprey chat`, the web terminal, and
   where to edit `profile.yml` later.
@@ -203,6 +279,12 @@ touched: <optional topics discussed>
 ## Deferred / follow-up work
 - <custom work or later phase, with pointers>
 
+## Upstream candidates        # only when OSPREY didn't fit — see Upstream fit watch
+- <short-id>: <what the facility needs> [blocking|worked-around]
+  offered: <what OSPREY offers instead>
+  workaround: <what this deployment does about it>
+  status: open
+
 ## Migration notes            # only when migrating
 - <source path, classification decisions, ported/skipped items>
 ```
@@ -217,6 +299,9 @@ SALVAGE / OBSOLETE / TRANSFORM / EVALUATE classification rules (that file
 describes the frozen legacy architecture, so its hardcoded knowledge is
 safe). Then:
 
+- For each EVALUATE item, ask why it was written before deciding its
+  fate — "because OSPREY had no X" makes it an upstream candidate (see
+  Upstream fit watch) as well as a port decision.
 - Channel databases and data files → the new repo's `data/` tree.
 - Config values (gateways, archiver URLs, provider) → `osprey set` into the
   live profile, guided by the new profile's own comments.

--- a/src/osprey/templates/skills/osprey-build-interview/references/upstream-scout.md
+++ b/src/osprey/templates/skills/osprey-build-interview/references/upstream-scout.md
@@ -1,0 +1,190 @@
+# Upstream scout — investigating a framework-fit gap
+
+Read this when the user says **yes** to "should I investigate whether this is better
+solved by a change in OSPREY?" — during the interview, at the devil's advocate round,
+or on a resume that found open candidates.
+
+The scout answers one question per candidate: **is this a gap in OSPREY, a gap in this
+deployment, or not a gap at all?** — and, when it is an OSPREY gap, produces a write-up
+good enough to file as-is. It does **not** write code or draft a patch; turning an
+accepted issue into a change is the maintainers' side of the conversation.
+
+Input: one entry from `INTERVIEW.md`'s `## Upstream candidates` section, plus the
+interview context (facility, control system, stated purpose).
+
+## Step 1: Locate the framework
+
+The fit check reads OSPREY, not recollections of it. Everything ships in the wheel
+(see `references/osprey-map.md`, "Without a source checkout"):
+
+```bash
+python3 -c "import osprey, pathlib; print(pathlib.Path(osprey.__file__).parent)"
+```
+
+Record that as `OSPREY_ROOT`. Paths below are wheel-relative (`connectors/`,
+`profiles/presets/`, ...). Also check whether the forge is reachable — it decides
+whether the prior-art search (2b) runs and whether the GitHub option is offered later:
+
+```bash
+gh auth status >/dev/null 2>&1 && echo GH_OK || echo GH_UNAVAILABLE
+```
+
+## Step 2: Investigations in parallel
+
+Spawn 2a and 2c always, and 2b only on `GH_OK` — all in a single message (two or three
+Agent tool calls). Each is independent. Give each the candidate entry verbatim,
+`OSPREY_ROOT`, and the facility context.
+
+### 2a — Fit check: is it already supported?
+
+```
+You are checking whether OSPREY already supports a capability that a build interview
+flagged as missing. Read, do not guess.
+
+Candidate: <entry>
+Facility context: <facility, control system, purpose>
+Installed OSPREY package: <OSPREY_ROOT>
+Deployment repo: <path> (its profile.yml comments document every configured option)
+
+Search for an existing config key, preset, connector, artifact, or extension point
+that covers this. Use, at minimum:
+- `osprey config --defaults` (the whole config surface) and `osprey profile artifacts`
+- the deployment's profile.yml comments around the relevant section
+- <OSPREY_ROOT>/profiles/presets/*.yml
+- <OSPREY_ROOT>/connectors/ (base classes and the factory) when the gap is a
+  control-system or archiver protocol
+
+Return exactly one verdict with evidence (config keys, file paths, class names):
+- SUPPORTED: <how — the exact key / class / preset>
+- PARTIAL: <what exists, what is missing>
+- NOT_SUPPORTED: <what you searched and did not find>
+Under 200 words. Do not propose a fix — that is another agent's job.
+```
+
+### 2b — Prior art (only on `GH_OK`)
+
+```
+Search the public OSPREY repository for existing issues and PRs covering this need,
+using only:
+  gh issue list -R als-apg/osprey --state all --limit 30 --search "<2-4 keywords>"
+  gh pr list    -R als-apg/osprey --state all --limit 30 --search "<2-4 keywords>"
+Try 2-3 keyword variants (protocol name, abstraction name, synonyms).
+
+Candidate: <entry>
+
+Return matches as `#<number> <title> (<state>) — <one line on the relation>`, or
+`NO_PRIOR_ART` with the queries tried. Under 150 words.
+```
+
+### 2c — Shape of the fix: where would it live, and does it belong upstream?
+
+```
+You are assessing where a capability gap in OSPREY should be closed. OSPREY is a
+facility-agnostic agent harness for control systems with one reference deployment;
+gaps are expected as new facilities arrive. Say whether this gap is OSPREY's to close
+or the facility's.
+
+Candidate: <entry>
+Facility context: <facility, control system, purpose>
+Installed OSPREY package: <OSPREY_ROOT> — read the owning subpackage (connectors/,
+mcp_server/, services/, templates/, ...) before answering.
+
+Judge against OSPREY's design rules:
+- Convention over configuration; components are discovered, not hand-registered.
+- One deployment, one connector: mixed protocols are an abstraction gap, not a
+  config problem.
+- Every hardware write passes human approval; a new safety model adds a layer,
+  never replaces the gate.
+- Config keys are cheap; a real, documented option beats a hardcoded constant.
+- Facility data (channel names, limits, URLs) lives in the deployment, never in
+  the framework.
+
+Answer tersely:
+1. OWNING SUBSYSTEM: the package/module that would change (path).
+2. ABSTRACTION LEVEL: (a) new value for an existing option, (b) new option on an
+   existing abstraction, or (c) new abstraction/extension point. Name it.
+3. BLAST RADIUS: files that would change; is there a base class/protocol to extend?
+4. VERDICT: UPSTREAM (a second facility would hit this too) | DEPLOYMENT_LOCAL
+   (specific to this facility) | UNCLEAR (say what would decide it).
+5. One sentence: the smallest change that closes the gap.
+Under 250 words. Evidence = paths and names, not adjectives.
+```
+
+## Step 3: Synthesize
+
+The **fit check overrides everything**: `SUPPORTED` means the gap was an unread
+option — apply it to the deployment (`osprey set` / Edit, then `osprey validate`),
+set the entry to `status: already-supported (<key>)`, tell the user what changed,
+and stop. No issue.
+
+Otherwise write the report to `upstream/<short-id>.md` in the deployment repo
+(`mkdir -p upstream`), and add `scouted: <YYYY-MM-DD>` under the entry's `status:`
+line. The entry itself stays four short lines; the write-up never goes inline.
+
+```markdown
+## <Short imperative title, e.g. "Support Tango as a control-system connector">
+
+**Facility:** <name> · **Control system:** <type> · **Found during:** OSPREY build interview
+
+### What the facility needs
+<2-4 concrete sentences; name the protocol / policy / data shape>
+
+### What OSPREY offers today
+<fit-check verdict with its evidence — keys, classes, paths>
+
+### Workaround in use
+<what the deployment does instead, and what it costs the user>
+
+### Proposed change
+<from 2c: owning subsystem, abstraction level, smallest change — one paragraph>
+
+### Prior art
+<from 2b: matches; "none found (searched: …)"; or, when 2b did not run,
+"not searched — no GitHub access from this machine">
+
+### Scout verdict
+<UPSTREAM | DEPLOYMENT_LOCAL | UNCLEAR — one sentence why>
+```
+
+`DEPLOYMENT_LOCAL` → set `status: profile-local`, tell the user why in one sentence,
+and skip the disposition below — there is nothing to send. `UNCLEAR` → present the
+write-up and let the user decide anyway; "we're not sure this is general" is still
+useful signal to the maintainers.
+
+## Step 4: Disposition — draft first, then ask
+
+Show the complete write-up, then one AskUserQuestion. Omit the GitHub option when
+Step 1 said `GH_UNAVAILABLE` — don't offer a path you know fails, and don't walk the
+user through `gh auth login` mid-interview.
+
+- **File a GitHub issue** — an `enhancement` issue on `als-apg/osprey` from the
+  user's account
+- **Email the OSPREY maintainers** — a pre-filled mail to thellert@lbl.gov
+- **Keep it local** — the write-up stays in `upstream/`; a later resume of this
+  interview offers it again
+- **Drop it** — set `status: dropped`; never raise it again (the entry stays so the
+  same gap isn't re-logged)
+
+Nothing is filed without the user seeing the draft, and a previous candidate's
+disposition never carries over — each is its own decision.
+
+**GitHub:** append a final line `_Filed from an OSPREY build interview._` to the
+write-up file, then:
+
+```bash
+gh issue create -R als-apg/osprey --title "<title>" --label enhancement \
+  --body-file upstream/<short-id>.md
+```
+
+On success set `status: filed <returned url>`; on failure show stderr and offer the
+email option.
+
+**Email:** build a `mailto:` URL — recipient `thellert@lbl.gov`, subject
+`OSPREY upstream request — <title> (<facility>)`, body = the write-up as plain text,
+URL-encoded (space `%20`, newline `%0A`, `&` `%26`, `=` `%3D`, `#` `%23`). Open it
+with `open` (macOS) / `xdg-open` (Linux). If the URL exceeds ~2000 characters or no
+opener works (headless host), tell the user to send `upstream/<short-id>.md` to that
+address themselves. Then set `status: emailed <YYYY-MM-DD>`.
+
+**Keep it local:** leave `status: open`. The `scouted:` line means a later run skips
+Steps 1-3 and goes straight to this disposition step with the saved write-up.

--- a/tests/cli/test_skills_cmd.py
+++ b/tests/cli/test_skills_cmd.py
@@ -45,6 +45,7 @@ def test_install_fresh_succeeds(fake_home: Path) -> None:
     assert (target / "SKILL.md").is_file()
     assert (target / "references" / "osprey-map.md").is_file()
     assert (target / "references" / "migration-legacy.md").is_file()
+    assert (target / "references" / "upstream-scout.md").is_file()
 
 
 def test_install_backs_up_existing(fake_home: Path) -> None:


### PR DESCRIPTION
OSPREY is facility-agnostic by intent but has exactly one reference deployment, so a new facility's build interview is the first real test of many abstractions — and until now, every misfit it uncovered (an unsupported protocol, a safety model the config can't express, a provider outside the list) dissolved into a silent workaround inside the deployment repo. The maintainers, whose job is to close those gaps quickly, never heard about them.

The bundled `osprey-build-interview` skill now runs an **upstream fit watch** throughout the interview:

- Misfits between the facility's reality and what the live repo can express are recorded as candidates in `INTERVIEW.md` (`## Upstream candidates`), with a fixed status vocabulary. Facility data and missing-information placeholders are explicitly not candidates.
- Severity is a single test — does the deployment still serve the user's stated purpose after the workaround? Blocking gaps get an immediate offer to investigate; worked-around ones batch into the existing devil's advocate round, whose brief now also catches unlogged workarounds and flags writes enabled against an unenforceable facility safety rule as CRITICAL.
- On a "yes", `references/upstream-scout.md` runs parallel subagents: a fit check against the installed wheel and `osprey config --defaults` (a verdict of "already supported" fixes the deployment instead of filing anything), a prior-art search of this repo's issues/PRs when `gh` is available, and a shape-of-the-fix assessment that ends in UPSTREAM / DEPLOYMENT_LOCAL / UNCLEAR.
- Disposition is always draft-first: the user sees the full write-up, then chooses GitHub issue (`enhancement` on this repo), email to the maintainers, keep local, or drop. Nothing is ever sent unseen.

A facility safety rule OSPREY cannot enforce (two-person sign-off, shift-scoped writes) keeps the deployment read-only while the candidate is open, rather than letting procedure stand in for enforcement.

## How it hangs together

```text
interview ──► fit-watch detectors ──► INTERVIEW.md ## Upstream candidates
   │            (blocking → offer now;      status: open|filed|emailed|
   │             worked-around → batch)     dropped|profile-local|
   ▼                                        already-supported
devil's advocate ── unlogged workarounds; "plausibly covered" = lead, not verdict
   │  "investigate?"
   ▼
upstream-scout ── fit check (veto: already supported ⇒ fix deployment)
   │              prior art (gh, optional) · shape of fix ⇒ verdict
   ▼
write-up upstream/<id>.md ──► user chooses: gh issue │ email │ keep │ drop
```