### PR TITLE
feat(ariel): search panel follows deployment config, reranks in two phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -582,6 +582,19 @@ Compatibility is documented in release notes, not encoded in the version string.
   sharing a `project` across different renders, and a persona `project` equal
   to the deployment's own name. Images under the old doubled tags are not
   removed automatically — prune them by hand after the next `osprey up`.
+- The ARIEL search panel now follows the deployment's configuration for every
+  knob you have not touched — Reset returns it to that state — and shows the
+  fast results of a reranked search before the reranking finishes, replacing
+  them when it does. When the reranker is unavailable the fast ranking stays on
+  screen with a note instead of the search failing. The `hybrid_search` tool
+  takes a per-query `rerank` argument; panel and tool share the one
+  `ariel.search_modules.hybrid.settings.rerank` key.
+
+- A malformed ARIEL `hybrid` or `semantic` search setting is now named at
+  startup validation instead of passing silently, and a malformed per-query
+  `rerank` or `candidate_limit` sent over HTTP is refused with a 400 rather
+  than coerced.
+
 - CI: the unit lane's step summary now tabulates the slowest tests of the run
   and the uploaded diagnostics artifact carries the full pytest log.
 - `osprey-connectors` now versions with the framework's calendar stream —

--- a/docs/source/how-to/ariel/search-modes.rst
+++ b/docs/source/how-to/ariel/search-modes.rst
@@ -182,16 +182,22 @@ Search modules are leaf-level functions that execute a single search strategy ag
            - --
            - 1587 ms
 
-      Reranking costs roughly **4x** the query budget, and its cost barely grows with corpus size --- so no logbook is small enough to outrun it. ``hybrid_search`` is an agent tool with no interactive budget to protect, so it ships with the quality path on. Set ``rerank: false`` for the fast path. (The OKF bundle, which backs an interactive panel, defaults the other way; see :doc:`../okf-bundle`.)
+      An LLM reviews every candidate before the results come back, which is what makes reranking the dominant term: its cost is dominated by the candidate pool and grows far more slowly than the corpus does, so no logbook is small enough to outrun it. Both surfaces ship with the quality path on.
+
+      **One key, both surfaces.** ``search_modules.hybrid.settings.rerank`` governs the agent-facing ``hybrid_search`` tool *and* the web interface's search panel --- and ``candidate_limit`` likewise. There is no separate panel key. The two surfaces override it differently. The panel's **Rerank Results** toggle opens showing whatever the deployment configured, and clicking it overrides that value for every search you run from then on, until **Reset** returns the panel to the deployment's value. On the agent side, ``hybrid_search`` takes a ``rerank`` argument that applies to the one call: leave it unset and the tool follows the configured key, pass ``false`` and that one search takes the fast path and nothing else changes. Set the key itself to ``false`` only when you want the fast path for every search, on both surfaces. (The OKF bundle is a different key over a different corpus and defaults the other way; see :doc:`../okf-bundle`.)
+
+      **What the panel does with a reranked search.** Rather than hold an empty screen for the length of a reranked query, the panel runs it in two phases: it fetches and paints the fast ranking first, under a status line saying the results are being reranked, then replaces them with the reranked ranking under a line saying they were updated. The second response is drawn from a larger candidate pool, so *which* entries come back can change, not only the order they come back in.
+
+      **Reranking is never load-bearing.** A reranked query that fails, for any reason, is retried once without the reranker; the results come back normally, carrying a WARNING diagnostic that says the ranking was not improved. The panel keeps the fast results on screen and says so in its status line. Only a failure of that retry is a failed search.
 
       ``candidate_limit`` is how many candidates the reranker considers. Lowering it trades recall for latency.
 
       **Filtering is best-effort.** ``hybrid_search`` ranks the corpus first and applies the date, author and source filters *afterwards*, to the top of that ranking --- not inside the database. A selective filter can therefore return fewer entries than you asked for even when more matching entries exist. Read a short result set as "the ranked window ran out", not as "there is nothing else". When a filter has to be exhaustive, use ``keyword_search`` or ``sql_query``, which filter in the database.
 
-      .. admonition:: Known limitation --- the first reranked query times out
-         :class: warning
+      .. admonition:: The first reranked query after a sidecar start is slow
+         :class: note
 
-         The first query with ``rerank: true`` loads a 610 MB model on CPU, and that load exceeds the client's default timeout. A deployment that enables reranking gets a hard failure on its **first** query; subsequent queries are fine. Run one throwaway query after starting the sidecar, or start with ``rerank: false``.
+         The first query with ``rerank: true`` loads a 610 MB model on CPU, and that load commonly runs past the client's 30-second request timeout. That first query is not lost: it falls back to the non-reranked ordering with a warning, and every query after the model is resident is reranked normally. This is the ordinary first-run experience after starting or restarting the sidecar, not a fault to chase. Run one throwaway query when the sidecar comes up if you want the first real one to be fast.
 
       .. admonition:: Known limitation --- entry IDs that are not numeric
          :class: note

--- a/docs/source/how-to/ariel/web-interface.rst
+++ b/docs/source/how-to/ariel/web-interface.rst
@@ -62,6 +62,55 @@ The interface has four views, accessible via the navigation bar. All views are r
 The four ARIEL views above were captured with OSPREY |captured_ariel| from the
 ``control-assistant`` tutorial's seeded logbook.
 
+Advanced Options
+================
+
+The **Filters & Options** panel is built from whatever the enabled search
+modules declare, so the controls in it depend on the deployment. Two things
+about how it behaves are worth knowing before you tune anything.
+
+**Every knob shows its own explanation.** The description a module writes for a
+parameter is rendered as a line of hint text under the control, rather than
+hidden behind a hover tooltip --- readable on a touch screen, and readable
+without having to discover that there was something to hover over.
+
+**Knobs you have not touched follow the deployment's configuration.** The panel
+opens on the deployment's configured value for every control that has one, and
+on the shipped default for the rest; a search sends only the controls you
+actually changed. Anything you left alone is not sent at all, so it resolves on
+the server to whatever the configuration says --- which means a change to the
+deployment's config reaches the panel without anyone re-picking anything, after
+the service restarts and the page is reloaded. **Reset** clears the whole set:
+values return to the configured defaults, and every knob counts as untouched
+again.
+
+That is also why the reranking control behaves the way it does. **Rerank
+Results** opens showing ``search_modules.hybrid.settings.rerank`` exactly as the
+deployment set it, and clicking it overrides the configured value for your
+searches from then on, without changing the deployment. **Reset** returns it to
+the deployment's value. The key itself is described in :doc:`search-modes`.
+
+Watching a reranked search run
+------------------------------
+
+Reranking costs seconds, and the interface does not ask you to spend them
+looking at a spinner. A search that will be reranked runs in two phases: the
+fast ranking is fetched and drawn first, then the reranked ranking replaces it
+when it arrives. A status line above the results says which of the two you are
+looking at. Expert view names the mechanism --- *Search complete --- reranking
+with LLM…*, then *Results updated after reranking*. Simple view says the same
+thing in one plain line --- *Showing quick results --- improving the order
+now…*, then *Order improved --- best matches first*.
+
+The second response is drawn from a larger candidate pool, so entries can appear
+or drop out between the phases: the list is redrawn, not merely reordered.
+
+If the reranker cannot answer --- most often on the first query after the search
+sidecar starts, while its model is still loading --- the fast results stay on
+screen under *Could not improve the ranking --- showing fast results*. Nothing
+is lost, and there is nothing to do about it; the next query is normally
+reranked.
+
 Display Preferences
 ===================
 

--- a/docs/source/how-to/okf-bundle.rst
+++ b/docs/source/how-to/okf-bundle.rst
@@ -397,14 +397,16 @@ quietly defaulted — silently ignoring ``rerank: "false"`` would leave the
 deployment on the path it explicitly asked to leave.
 
 **``rerank`` defaults to ``false`` here, and to ``true`` on the ARIEL side.**
-That split is deliberate. qmd's reranker improves ranking quality but costs
-roughly **4x** the query budget — measured p95 3927 ms with it against 811 ms
-without, on a 135,000-document corpus — and its cost barely changes with corpus
-size, so no bundle is small enough to outrun it. The OKF surfaces are
-interactive and hold a sub-second budget that reranking does not fit in. The
-ARIEL ``hybrid_search`` tool is an agent tool with no such budget, so it keeps the
-quality path. Set ``rerank: true`` if you would rather have the ranking than
-the latency.
+That split is deliberate. qmd's reranker improves ranking quality at a real
+latency cost — an LLM reviews each candidate before the results come back,
+measured p95 3927 ms with it against 811 ms without, on a 135,000-document
+corpus — and that cost barely changes with corpus size, so no bundle is small
+enough to outrun it. The OKF surfaces are interactive and hold a sub-second
+budget that reranking does not fit in. ARIEL's ``hybrid`` module keeps the
+quality path instead: one key there serves both the agent tool and the search
+panel, and the panel absorbs the wait by showing the fast ranking first and
+replacing it when the reranked one arrives.
+Set ``rerank: true`` if you would rather have the ranking than the latency.
 
 ``candidate_limit`` is how many candidates the reranker considers. Lowering it
 trades recall for latency.

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -701,19 +701,22 @@ keys:
   ariel.search_modules.hybrid.settings.rerank:
     evidence: '_SETTINGS_PREFIX\}\.rerank must be a boolean'
     note: >-
-      Shipped as `true`, matching DEFAULT_RERANK and qmd's own default. The
-      reranker costs ~4x the query latency at near-constant cost in corpus
-      size; this is the agent-facing tool, which has no interactive budget to
-      protect, so it keeps the quality path. The OKF side defaults the other
-      way. The evidence anchors on the type refusal rather than the read: a
-      present-but-malformed knob is rejected, never defaulted, because
+      Shipped as `true`, matching DEFAULT_RERANK and qmd's own default. One
+      key, both surfaces: the agent-facing hybrid_search tool and the ARIEL
+      search panel read it, and each can override it without changing the
+      deployment — the tool per call, the panel per session until Reset. The
+      reranker dominates query latency — an LLM reviews each candidate — but
+      it is not load-bearing: a reranked query that fails is
+      retried once without it. The OKF side is a separate key and defaults the
+      other way. The evidence anchors on the type refusal rather than the read:
+      a present-but-malformed knob is rejected, never defaulted, because
       defaulting it would strand a deployment on the path it asked to leave.
   ariel.search_modules.hybrid.settings.candidate_limit:
     evidence: '_SETTINGS_PREFIX\}\.candidate_limit must be a positive integer'
     note: >-
       Shipped as `40`, matching DEFAULT_CANDIDATE_LIMIT and qmd's own
-      `candidateLimit`. The other documented latency lever: lowering it trades
-      recall for speed.
+      `candidateLimit`. One key for both surfaces, like `rerank` above. The
+      other documented latency lever: lowering it trades recall for speed.
   ariel.enhancement_modules:
     evidence: 'get\("enhancement_modules", \{\}\)'
     note: >-

--- a/src/osprey/interfaces/ariel/api/routes.py
+++ b/src/osprey/interfaces/ariel/api/routes.py
@@ -175,6 +175,45 @@ def _resolve_search_mode(service: ARIELSearchService, requested: str | None) -> 
     return mode
 
 
+def _validate_hybrid_overrides(advanced_params: dict[str, Any]) -> None:
+    """Reject malformed hybrid per-query overrides before the search runs.
+
+    The search panel sends ``rerank`` from a toggle and ``candidate_limit`` from
+    a number field, so real traffic is already well-formed; a hand-written HTTP
+    caller is not. Both keys are forwarded to the hybrid module verbatim, where
+    ``"false"`` is truthy and would silently run the slow reranked path the
+    caller asked to skip, and a zero or negative width is a nonsense retrieval
+    size. The wording matches the config-side parser, so an operator who sets
+    the same value badly in ``config.yml`` reads the same sentence either way.
+
+    A missing key -- and an explicit ``null``, which is how JSON spells the same
+    thing -- means "use the configured default" and is left alone.
+
+    Args:
+        advanced_params: The request's mode-specific parameters.
+
+    Raises:
+        HTTPException: 400 naming the offending key and the value it got.
+    """
+    rerank = advanced_params.get("rerank")
+    if rerank is not None and not isinstance(rerank, bool):
+        raise HTTPException(
+            status_code=400,
+            detail=f"rerank must be a boolean, got {rerank!r}",
+        )
+
+    candidate_limit = advanced_params.get("candidate_limit")
+    if candidate_limit is not None and (
+        not isinstance(candidate_limit, int)
+        or isinstance(candidate_limit, bool)
+        or candidate_limit < 1
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"candidate_limit must be a positive integer, got {candidate_limit!r}",
+        )
+
+
 def _invalid_capabilities(config_errors: list[str], remedy: str | None) -> dict:
     """Build the capabilities payload for a configuration that did not parse.
 
@@ -346,6 +385,8 @@ async def search(request: Request, search_req: SearchRequest) -> SearchResponse:
 
     # Validated before the try block so the 400 is not swallowed into a 500.
     service_mode = _resolve_search_mode(service, search_req.mode)
+    if service_mode == "hybrid":
+        _validate_hybrid_overrides(search_req.advanced_params)
 
     try:
         # advanced_params takes precedence over top-level filter fields

--- a/src/osprey/interfaces/ariel/static/css/components.css
+++ b/src/osprey/interfaces/ariel/static/css/components.css
@@ -1172,6 +1172,17 @@ textarea.input {
 }
 
 /* === Slider Control === */
+/* Each control's descriptor documentation, rendered under the control by
+   renderParameter(). The section body is a flex column at --space-3, which
+   would leave the hint floating equidistant between its own control and the
+   next one; the negative margin pulls it back to --space-2 so it reads as
+   belonging to the control above it. */
+.param-hint {
+  margin-top: calc(var(--space-2) - var(--space-3));
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
 .slider-control {
   display: flex;
   flex-direction: column;

--- a/src/osprey/interfaces/ariel/static/js/advanced-options.js
+++ b/src/osprey/interfaces/ariel/static/js/advanced-options.js
@@ -73,6 +73,11 @@ let currentMode = 'keyword';
 let isPanelOpen = false;
 /** @type {Object<string, *>} */
 let paramValues = {};
+// Names the operator actually moved this session. Key-presence in `paramValues`
+// cannot answer this: resetToDefaults() pre-seeds every non-null descriptor
+// default, so every knob looks "set" before the panel is ever opened.
+/** @type {Set<string>} */
+const touched = new Set();
 /** @type {Object<string, AdvancedParamOption[]>} */
 const dynamicOptionsCache = {};
 
@@ -179,7 +184,8 @@ export function getAdvancedParams() {
   /** @type {Object<string, *>} */
   const result = {};
   for (const name of allParamNames) {
-    if (name in paramValues && paramValues[name] !== undefined && paramValues[name] !== null) {
+    if (!touched.has(name)) continue;
+    if (paramValues[name] !== undefined && paramValues[name] !== null) {
       result[name] = paramValues[name];
     }
   }
@@ -192,6 +198,20 @@ export function getAdvancedParams() {
  */
 export function getAdvancedOptions() {
   return getAdvancedParams();
+}
+
+/**
+ * The value a search would actually run with for one parameter of the current
+ * mode: the operator's value when they touched it, otherwise the deployment's
+ * configured default from the mode descriptor. Callers use this to read a knob
+ * that getAdvancedParams() deliberately omits because it was never touched.
+ * @param {string} name - Parameter name
+ * @returns {*} Effective value, or undefined if the current mode has no such parameter
+ */
+export function getEffectiveParam(name) {
+  const descriptor = getModeParameters(currentMode).find(p => p.name === name);
+  if (!descriptor) return undefined;
+  return paramValues[name] ?? descriptor.default;
 }
 
 /**
@@ -393,21 +413,27 @@ function renderAdvancedPanel() {
  */
 function renderParameter(param) {
   const value = paramValues[param.name] ?? param.default;
+  // The description is the knob's documentation, so it is shown rather than
+  // hidden behind a hover. escapeHtml() stringifies undefined, so a descriptor
+  // without a description is skipped here instead of rendering an empty hint.
+  const hint = param.description
+    ? `<p class="param-hint">${escapeHtml(param.description)}</p>`
+    : '';
 
   switch (param.type) {
     case 'float':
     case 'int':
-      return renderSlider(param, value);
+      return renderSlider(param, value) + hint;
     case 'bool':
-      return renderToggle(param, value);
+      return renderToggle(param, value) + hint;
     case 'select':
-      return renderSelect(param, value);
+      return renderSelect(param, value) + hint;
     case 'date':
-      return renderDateInput(param, value);
+      return renderDateInput(param, value) + hint;
     case 'text':
-      return renderTextInput(param, value);
+      return renderTextInput(param, value) + hint;
     case 'dynamic_select':
-      return renderDynamicSelect(param);
+      return renderDynamicSelect(param) + hint;
     default:
       return '';
   }
@@ -424,7 +450,7 @@ function renderSlider(param, value) {
   return `
     <div class="slider-control">
       <div class="slider-header">
-        <label class="slider-label" for="param-${param.name}" title="${escapeHtml(param.description)}">${escapeHtml(param.label)}</label>
+        <label class="slider-label" for="param-${param.name}">${escapeHtml(param.label)}</label>
         <span class="slider-value" id="param-${param.name}-value">${displayValue}</span>
       </div>
       <input type="range" id="param-${param.name}" class="slider"
@@ -445,7 +471,7 @@ function renderToggle(param, value) {
   const checked = value ? 'checked' : '';
   return `
     <div class="toggle-control">
-      <label class="toggle-label" for="param-${param.name}" title="${escapeHtml(param.description)}">${escapeHtml(param.label)}</label>
+      <label class="toggle-label" for="param-${param.name}">${escapeHtml(param.label)}</label>
       <label class="toggle-switch">
         <input type="checkbox" id="param-${param.name}"
           data-param="${param.name}" data-type="bool" ${checked}>
@@ -470,7 +496,7 @@ function renderSelect(param, value) {
 
   return `
     <div class="input-group">
-      <label class="input-label" for="param-${param.name}" title="${escapeHtml(param.description)}">${escapeHtml(param.label)}</label>
+      <label class="input-label" for="param-${param.name}">${escapeHtml(param.label)}</label>
       <select id="param-${param.name}" class="select"
         data-param="${param.name}" data-type="select">
         ${optionsHtml}
@@ -489,7 +515,7 @@ function renderDateInput(param, value) {
   const val = value || '';
   return `
     <div class="input-group">
-      <label class="input-label" for="param-${param.name}" title="${escapeHtml(param.description)}">${escapeHtml(param.label)}</label>
+      <label class="input-label" for="param-${param.name}">${escapeHtml(param.label)}</label>
       <input type="date" id="param-${param.name}" class="input"
         data-param="${param.name}" data-type="date" value="${escapeHtml(val)}">
     </div>
@@ -507,7 +533,7 @@ function renderTextInput(param, value) {
   const placeholder = param.placeholder || '';
   return `
     <div class="input-group">
-      <label class="input-label" for="param-${param.name}" title="${escapeHtml(param.description)}">${escapeHtml(param.label)}</label>
+      <label class="input-label" for="param-${param.name}">${escapeHtml(param.label)}</label>
       <input type="text" id="param-${param.name}" class="input"
         data-param="${param.name}" data-type="text"
         value="${escapeHtml(val)}" placeholder="${escapeHtml(placeholder)}">
@@ -523,7 +549,7 @@ function renderTextInput(param, value) {
 function renderDynamicSelect(param) {
   return `
     <div class="input-group">
-      <label class="input-label" for="param-${param.name}" title="${escapeHtml(param.description)}">${escapeHtml(param.label)}</label>
+      <label class="input-label" for="param-${param.name}">${escapeHtml(param.label)}</label>
       <select id="param-${param.name}" class="select"
         data-param="${param.name}" data-type="dynamic_select"
         data-endpoint="${escapeHtml(param.options_endpoint || '')}">
@@ -586,6 +612,7 @@ function attachParamListeners(container) {
     slider.addEventListener('input', () => {
       const name = slider.dataset.param;
       if (!name) return;
+      touched.add(name);
       const type = slider.dataset.type;
       const val = type === 'float' ? parseFloat(slider.value) : parseInt(slider.value, 10);
       paramValues[name] = val;
@@ -606,6 +633,7 @@ function attachParamListeners(container) {
     toggle.addEventListener('change', () => {
       const name = toggle.dataset.param;
       if (!name) return;
+      touched.add(name);
       paramValues[name] = toggle.checked;
     });
   });
@@ -618,6 +646,7 @@ function attachParamListeners(container) {
     select.addEventListener('change', () => {
       const name = select.dataset.param;
       if (!name) return;
+      touched.add(name);
       paramValues[name] = select.value || null;
     });
   });
@@ -630,6 +659,7 @@ function attachParamListeners(container) {
     input.addEventListener('change', () => {
       const name = input.dataset.param;
       if (!name) return;
+      touched.add(name);
       paramValues[name] = input.value || null;
     });
   });
@@ -642,6 +672,7 @@ function attachParamListeners(container) {
     input.addEventListener('input', () => {
       const name = input.dataset.param;
       if (!name) return;
+      touched.add(name);
       paramValues[name] = input.value.trim() || null;
     });
   });
@@ -652,6 +683,7 @@ function attachParamListeners(container) {
  */
 function resetToDefaults() {
   paramValues = {};
+  touched.clear();
   const categories = capabilities?.categories || {};
 
   // Collect defaults from all modes
@@ -678,6 +710,7 @@ export default {
   getCurrentMode,
   getAdvancedParams,
   getAdvancedOptions,
+  getEffectiveParam,
   isAdvancedPanelOpen,
   closeAdvancedPanel,
 };

--- a/src/osprey/interfaces/ariel/static/js/search.js
+++ b/src/osprey/interfaces/ariel/static/js/search.js
@@ -18,7 +18,12 @@ import {
   renderErrorState,
   escapeHtml,
 } from './components.js';
-import { getCurrentMode, getAdvancedParams, closeAdvancedPanel } from './advanced-options.js';
+import {
+  getCurrentMode,
+  getAdvancedParams,
+  getEffectiveParam,
+  closeAdvancedPanel,
+} from './advanced-options.js';
 import { showEntry } from './entries-detail.js';
 
 /**
@@ -53,6 +58,68 @@ let lastResults = null;
 // The search mode of the last render, kept so a live Expert<->Simple UI-mode
 // flip can re-render the same results without re-running the query.
 let lastSearchMode = 'keyword';
+// Monotonic id of the newest search the module has started. A reranked search
+// paints twice, and the second paint arrives long after the first; every render
+// a search performs is guarded on still owning this id, so a late phase-2
+// response from a superseded (or cleared) search can never repaint the view.
+let searchSeq = 0;
+/**
+ * Where the current search sits on the two-phase rerank path, or null when the
+ * search never had a second phase. Read by both renderers so any repaint — a
+ * phase completing, or a live Expert<->Simple flip — shows the same line.
+ * @type {'reranking'|'updated'|'fallback'|null}
+ */
+let rerankStatus = null;
+
+/**
+ * The one-line status each phase shows, per UI mode. Expert names the mechanism
+ * because Expert users tune it; Simple says what changed in plain words. The
+ * fallback wording is deliberately gentle and shared: a reranker that could not
+ * load in time is the normal first-query experience after a sidecar restart,
+ * not an error the operator has to act on.
+ * @type {Record<'expert'|'simple', Record<'reranking'|'updated'|'fallback', string>>}
+ */
+const RERANK_STATUS_TEXT = {
+  expert: {
+    reranking: 'Search complete — reranking with LLM…',
+    updated: 'Results updated after reranking',
+    fallback: 'Could not improve the ranking — showing fast results',
+  },
+  simple: {
+    reranking: 'Showing quick results — improving the order now…',
+    updated: 'Order improved — best matches first',
+    fallback: 'Could not improve the ranking — showing fast results',
+  },
+};
+
+/**
+ * The rerank status line, or '' when the search has no second phase.
+ * @param {'expert'|'simple'} uiMode - Which wording to use
+ * @returns {string} HTML string
+ */
+function renderRerankStatus(uiMode) {
+  if (!rerankStatus) return '';
+  const message = RERANK_STATUS_TEXT[uiMode][rerankStatus];
+  return `
+    <div class="results-modes" data-testid="rerank-status" role="status" aria-live="polite">
+      ${escapeHtml(message)}
+    </div>
+  `;
+}
+
+/**
+ * Whether a successful response is really the backend's rerank fallback: the
+ * hybrid search answered 200 with the fast ranking and a warning diagnostic
+ * because the reranker was unavailable. The status line has to say so — from
+ * the outside this is indistinguishable from a real rerank.
+ * @param {SearchResults} results - A phase-2 response
+ * @returns {boolean}
+ */
+function hasRerankFallbackWarning(results) {
+  return (results.diagnostics ?? []).some(
+    d => d.level === 'warning' && d.category === 'rerank'
+  );
+}
 
 /**
  * Wire up delegated click handling for entry cards and cited-source links.
@@ -160,6 +227,16 @@ export function initSearch(capabilities = null) {
 
 /**
  * Perform a search.
+ *
+ * A reranked search runs in two phases rather than one: reranking costs seconds
+ * the operator would otherwise spend looking at a spinner, so the fast ranking
+ * is fetched and painted first, then the reranked one replaces it. The second
+ * response is a full result set drawn from a larger candidate pool, so the view
+ * is re-rendered wholesale — membership, not just order, may differ.
+ *
+ * Everything else — any mode that does not declare `rerank`, or declares it and
+ * has it off — takes the single-request path unchanged, with no `rerank` key
+ * added to the wire params.
  * @param {string|null} [query] - Optional query override
  */
 export async function performSearch(query = null) {
@@ -171,6 +248,13 @@ export async function performSearch(query = null) {
 
   currentQuery = query;
   isSearching = true;
+  const seq = ++searchSeq;
+  rerankStatus = null;
+
+  // The button stays disabled across BOTH phases: the search is still running
+  // while phase-1 results are on screen, and a second search cannot start.
+  const searchBtn = /** @type {HTMLButtonElement|null} */ (document.getElementById('search-btn'));
+  if (searchBtn) searchBtn.disabled = true;
 
   // Collapse the filters & options panel
   closeAdvancedPanel();
@@ -184,24 +268,66 @@ export async function performSearch(query = null) {
   const mode = getCurrentMode();
   /** @type {Object<string, *>} */
   const advancedParams = getAdvancedParams();
+  const maxResults = advancedParams.max_results || 10;
+  // getEffectiveParam answers for the knob even when the operator never touched
+  // it (getAdvancedParams deliberately omits untouched knobs), and returns
+  // undefined for a mode that has no reranker at all.
+  const twoPhase = getEffectiveParam('rerank') === true;
 
   try {
-    const results = await searchApi.search({
+    if (!twoPhase) {
+      const results = await searchApi.search({ query, mode, maxResults, advancedParams });
+      if (seq !== searchSeq) return;
+      lastResults = results;
+      renderSearchResults(results, mode);
+      return;
+    }
+
+    // Phase 1 — the fast ranking. Only the per-phase `rerank` key is layered on
+    // top of the touched params, on a copy: the operator's panel is untouched.
+    const fastResults = await searchApi.search({
       query,
       mode,
-      maxResults: advancedParams.max_results || 10,
-      advancedParams,
+      maxResults,
+      advancedParams: { ...advancedParams, rerank: false },
     });
+    if (seq !== searchSeq) return;
+    lastResults = fastResults;
+    rerankStatus = 'reranking';
+    renderSearchResults(fastResults, mode);
 
-    lastResults = results;
-    renderSearchResults(results, mode);
+    // Phase 2 — the reranked ranking. Its own catch, because a failure here is
+    // not a failed search: phase 1's results stay on screen behind a warning.
+    try {
+      const rerankedResults = await searchApi.search({
+        query,
+        mode,
+        maxResults,
+        advancedParams: { ...advancedParams, rerank: true },
+      });
+      if (seq !== searchSeq) return;
+      lastResults = rerankedResults;
+      rerankStatus = hasRerankFallbackWarning(rerankedResults) ? 'fallback' : 'updated';
+      renderSearchResults(rerankedResults, mode);
+    } catch (error) {
+      console.error('Rerank phase failed:', error);
+      if (seq !== searchSeq) return;
+      rerankStatus = 'fallback';
+      renderSearchResults(fastResults, mode);
+    }
   } catch (error) {
     console.error('Search failed:', error);
+    if (seq !== searchSeq) return;
     if (resultsContainer) {
       resultsContainer.innerHTML = renderErrorState('Search Failed', error);
     }
   } finally {
-    isSearching = false;
+    // A superseded search must not hand the controls back: the search that took
+    // its place still owns them.
+    if (seq === searchSeq) {
+      isSearching = false;
+      if (searchBtn) searchBtn.disabled = false;
+    }
   }
 }
 
@@ -237,6 +363,9 @@ function renderSearchResults(results, mode = 'keyword') {
   if ((results.diagnostics?.length ?? 0) > 0) {
     html += renderDiagnosticsBar(results.diagnostics ?? []);
   }
+
+  // Two-phase rerank status, immediately above the results header it describes
+  html += renderRerankStatus('expert');
 
   // Results header
   html += `
@@ -289,6 +418,11 @@ function renderSearchResultsSimple(container, results) {
     html += renderAnswerBox(results.answer, results.sources);
   }
 
+  // The one plain-language status line Simple mode gets. It is emitted before
+  // the empty-results branch too: "still improving the order" is exactly as
+  // true of an empty fast ranking as of a full one.
+  html += renderRerankStatus('simple');
+
   const entries = results.entries ?? [];
   if (entries.length === 0) {
     html += renderEmptyState(
@@ -330,6 +464,10 @@ export function onUiModeChange() {
 
 /**
  * Clear search results.
+ *
+ * Clearing also abandons any search still in flight — bumping the sequence makes
+ * every render it has left stale, so a reranked search whose second phase lands
+ * after the operator emptied the box cannot repaint the cleared view.
  */
 export function clearSearch() {
   const searchInput = /** @type {HTMLInputElement|null} */ (document.getElementById('search-input'));
@@ -338,8 +476,18 @@ export function clearSearch() {
   if (searchInput) searchInput.value = '';
   if (resultsContainer) resultsContainer.innerHTML = '';
 
+  searchSeq++;
+  isSearching = false;
+  rerankStatus = null;
   currentQuery = '';
   lastResults = null;
+
+  // Hand back the button the cancelled search was holding — but never the one
+  // the configuration_invalid banner disabled, which owns it permanently.
+  const searchBtn = /** @type {HTMLButtonElement|null} */ (document.getElementById('search-btn'));
+  if (searchBtn?.disabled && !document.getElementById('config-invalid-banner')) {
+    searchBtn.disabled = false;
+  }
 }
 
 /**

--- a/src/osprey/mcp_server/ariel/tools/hybrid_search.py
+++ b/src/osprey/mcp_server/ariel/tools/hybrid_search.py
@@ -18,6 +18,7 @@ from osprey.mcp_server.ariel.server_context import get_ariel_context
 from osprey.mcp_server.ariel.tools.search_envelope import (
     ResultWindow,
     advanced_params,
+    diagnostics,
     raise_for_fault_exception,
     raise_for_vocabulary_error,
     raise_on_statement_fault,
@@ -35,6 +36,13 @@ logger = logging.getLogger("osprey.mcp_server.ariel.tools.hybrid_search")
 # Diagnostic source the search service stamps on a failure of this mode.
 _QMD_DIAGNOSTIC_SOURCE = "service.hybrid"
 
+# Diagnostic category the service stamps when the module refused its own
+# settings block. The sidecar is healthy in that case, so the advice differs.
+_CONFIGURATION_CATEGORY = "configuration"
+
+# Prefix of the config keys the hybrid module resolves and can refuse.
+_SETTINGS_PREFIX = "search_modules.hybrid.settings"
+
 
 @mcp.tool()
 async def hybrid_search(
@@ -46,6 +54,7 @@ async def hybrid_search(
     source_system: str | None = None,
     exclude_entry_ids: list[str] | None = None,
     expand_query: bool | None = None,
+    rerank: bool | None = None,
 ) -> str:
     """Search the ARIEL logbook using hybrid keyword + semantic ranking.
 
@@ -73,11 +82,16 @@ async def hybrid_search(
         exclude_entry_ids: Entry IDs to exclude from results (for iterative search).
         expand_query: Apply the facility vocabulary (shorthand/acronym expansion).
             None = the configured default; see capabilities().vocabulary.expand_by_default.
+        rerank: Reorder the merged ranking with the qmd sidecar's LLM reranker.
+            None = the configured default. Reranking significantly improves
+            which entries come back and how they are ordered but is much
+            slower, so pass rerank=false and judge relevance yourself when
+            speed matters.
 
     Returns:
-        JSON with matching entries and relevance scores, plus the vocabulary
-        expansion applied. Scores order the results and are not comparable
-        across queries.
+        JSON with matching entries and relevance scores, the vocabulary
+        expansion applied, and any diagnostics the search reported. Scores
+        order the results and are not comparable across queries.
     """
     if not query or not query.strip():
         return make_error(
@@ -101,14 +115,25 @@ async def hybrid_search(
             time_range=time_range,
             mode="hybrid",
             advanced_params=advanced_params(
-                author=author, source_system=source_system, expand_query=expand_query
+                author=author,
+                source_system=source_system,
+                expand_query=expand_query,
+                rerank=rerank,
             ),
         )
 
         # Category-specific faults first: a rejected pattern or a cancelled
-        # statement is not a sidecar outage, and _sidecar_fault matches on the
-        # source alone.
+        # statement is not a sidecar outage, and _sidecar_fault matches on this
+        # mode's source with only the configuration category carved out.
         raise_on_statement_fault(result, "hybrid")
+
+        settings_fault = _settings_fault(result)
+        if settings_fault is not None:
+            return make_error(
+                "service_unavailable",
+                f"ARIEL hybrid search is misconfigured: {settings_fault}",
+                _settings_hints(settings_fault),
+            )
 
         fault = _sidecar_fault(result)
         if fault is not None:
@@ -117,6 +142,7 @@ async def hybrid_search(
             )
 
         response = success_envelope(query, "hybrid", result, window.select(result.entries))
+        response["diagnostics"] = diagnostics(result)
 
         return json.dumps(response, default=str)
 
@@ -177,20 +203,21 @@ def _configuration_hints(config_key: str) -> list[str]:
     return ["Check the ARIEL search module configuration in config.yml."]
 
 
-def _sidecar_fault(result: object) -> str | None:
-    """Return the message of a qmd-mode error diagnostic, or ``None``.
+def _mode_error(result: object) -> object | None:
+    """Return this mode's own ERROR diagnostic, or ``None``.
 
     The search service catches a module's exception and returns an empty result
-    carrying one ERROR diagnostic instead of propagating it, so an unreachable
-    sidecar reaches this tool looking exactly like a query that matched nothing.
-    Surfacing it as an error envelope is what keeps the agent from concluding
-    the corpus holds no answer when in fact nothing was searched.
+    carrying one ERROR diagnostic instead of propagating it, so a failed hybrid
+    query reaches this tool looking exactly like a query that matched nothing.
+    Finding that diagnostic is what keeps the agent from concluding the corpus
+    holds no answer when in fact nothing was searched.
 
     Args:
         result: The service's search result.
 
     Returns:
-        The diagnostic message, or ``None`` when the mode answered normally.
+        The diagnostic, or ``None`` when the mode answered normally. Another
+        mode's ERROR is not this mode's failure, so the source has to match.
     """
     from osprey.services.ariel_search.models import DiagnosticLevel
 
@@ -199,7 +226,86 @@ def _sidecar_fault(result: object) -> str | None:
             getattr(diagnostic, "level", None) is DiagnosticLevel.ERROR
             and getattr(diagnostic, "source", "") == _QMD_DIAGNOSTIC_SOURCE
         ):
-            return str(getattr(diagnostic, "message", "") or "no detail reported")
+            return diagnostic
+    return None
+
+
+def _settings_fault(result: object) -> str | None:
+    """Return the message of a refused-settings diagnostic, or ``None``.
+
+    Args:
+        result: The service's search result.
+
+    Returns:
+        The diagnostic message when the module refused its own configuration,
+        else ``None``. The service stamps the ``configuration`` category for
+        exactly this reason: the sidecar is answering fine and the operator
+        needs to be sent to a config key rather than to a health endpoint.
+    """
+    diagnostic = _mode_error(result)
+    if diagnostic is None or getattr(diagnostic, "category", None) != _CONFIGURATION_CATEGORY:
+        return None
+    return str(getattr(diagnostic, "message", "") or "no detail reported")
+
+
+def _sidecar_fault(result: object) -> str | None:
+    """Return the message of a qmd-mode outage diagnostic, or ``None``.
+
+    Args:
+        result: The service's search result.
+
+    Returns:
+        The diagnostic message, or ``None`` when the mode answered normally.
+        A ``configuration``-category error is deliberately not one of these --
+        ``_settings_fault`` claims that one first, because sidecar advice about
+        a healthy sidecar is worse than no advice at all.
+    """
+    diagnostic = _mode_error(result)
+    if diagnostic is None or getattr(diagnostic, "category", None) == _CONFIGURATION_CATEGORY:
+        return None
+    return str(getattr(diagnostic, "message", "") or "no detail reported")
+
+
+def _settings_hints(message: str) -> list[str]:
+    """Advise on a settings value the hybrid module refused.
+
+    Args:
+        message: The module's own error text, which normally names the key.
+
+    Returns:
+        Suggestions for the error envelope. The module raises with the full
+        dotted key in its message, so the first suggestion names it when it is
+        there and falls back to the settings block when it is not -- a module
+        message is the module's to write and is not guaranteed to carry one.
+    """
+    key = _offending_key(message)
+    return [
+        f"Fix ariel.{key} in config.yml and restart the ARIEL service."
+        if key
+        else (
+            f"Fix the hybrid search module's settings in config.yml "
+            f"(ariel.{_SETTINGS_PREFIX}) and restart the ARIEL service."
+        ),
+        "The qmd sidecar is not the problem here — the module rejected its own "
+        "configuration before querying it.",
+        "Use keyword_search or semantic_search meanwhile.",
+    ]
+
+
+def _offending_key(message: str) -> str | None:
+    """Pull the settings key out of the module's own error text.
+
+    Args:
+        message: The module's error text.
+
+    Returns:
+        The dotted key it names, or ``None``. Matching on the settings prefix
+        keeps this from quoting an arbitrary word back at the operator when the
+        message happens not to name a key.
+    """
+    for token in message.replace(",", " ").split():
+        if token.startswith(_SETTINGS_PREFIX):
+            return token.rstrip(".:")
     return None
 
 

--- a/src/osprey/mcp_server/ariel/tools/search_envelope.py
+++ b/src/osprey/mcp_server/ariel/tools/search_envelope.py
@@ -62,6 +62,7 @@ def advanced_params(
     source_system: str | None = None,
     similarity_threshold: float | None = None,
     expand_query: bool | None = None,
+    rerank: bool | None = None,
 ) -> dict[str, Any]:
     """Build the ``advanced_params`` mapping a search request carries.
 
@@ -75,6 +76,8 @@ def advanced_params(
         similarity_threshold: Semantic threshold, omitted when not given.
         expand_query: Vocabulary-expansion preference, omitted when not given
             so the deployment's ``expand_by_default`` decides.
+        rerank: Reranking preference, omitted when not given so the
+            deployment's ``search_modules.hybrid.settings.rerank`` decides.
 
     Returns:
         The mapping to hand to :meth:`ARIELSearchService.search`.
@@ -88,6 +91,8 @@ def advanced_params(
         params["similarity_threshold"] = similarity_threshold
     if expand_query is not None:
         params["expand_query"] = expand_query
+    if rerank is not None:
+        params["rerank"] = rerank
     return params
 
 
@@ -145,9 +150,10 @@ def success_envelope(
 ) -> dict[str, Any]:
     """Build the flat success envelope every search tool returns.
 
-    ``diagnostics`` is deliberately not here: ``keyword_search`` and
-    ``semantic_search`` add it, while ``hybrid_search`` reads its own
-    diagnostics as sidecar faults and reports them as an error envelope instead.
+    ``diagnostics`` is not here because each tool attaches it after the fact:
+    all three do so with ``diagnostics(result)``, but ``hybrid_search`` first
+    promotes its own sidecar and configuration faults to an error envelope, so
+    the diagnostics it attaches are always ones a successful search reported.
 
     Args:
         query: The query text as the caller typed it.

--- a/src/osprey/services/ariel_search/capabilities.py
+++ b/src/osprey/services/ariel_search/capabilities.py
@@ -6,6 +6,7 @@ available search modes and their tunable parameters.
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any
 
 from osprey.services.ariel_search.search.base import ParameterDescriptor
@@ -150,7 +151,21 @@ def _add_search_modules(
         parameters: list[dict[str, Any]] = []
         get_params = getattr(module, "get_parameter_descriptors", None)
         if get_params:
-            parameters = [p.to_dict() for p in get_params()]
+            # Some modules derive their defaults from the deployment's config
+            # (the built-ins report the operator's own ``rerank`` and
+            # ``similarity_threshold``, not the shipped ones); others are fixed.
+            # Passing ``config`` only when the signature names it keeps the "add
+            # a module, get a UI knob for free" contract intact -- a facility's
+            # third-party module stays a zero-argument function and is never
+            # forced to grow a parameter it has no use for. A callable whose
+            # signature cannot be read at all is treated as zero-argument, the
+            # older and safer of the two shapes.
+            try:
+                accepts_config = "config" in inspect.signature(get_params).parameters
+            except (TypeError, ValueError):
+                accepts_config = False
+            descriptors = get_params(config) if accepts_config else get_params()
+            parameters = [p.to_dict() for p in descriptors]
         categories["direct"]["modes"].append(
             {
                 "name": name,

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -774,10 +774,10 @@ class ARIELConfig:
                         f"module: {mode}. Enabled modules: {enabled_text}"
                     )
 
-        # The keyword module's own knobs. The resolver that the search path uses
+        # Each search module's own knobs. The resolver that the search path uses
         # is the one consulted here, so a malformed knob surfaces at startup and
         # in `ariel vocab-check` / `ariel status` rather than on the first search
-        # that happens to carry a pattern. Imported lazily: the search package
+        # that happens to read it. Imported lazily: the search package
         # reaches back into this module, and a module-level import would close
         # that loop. A disabled module is not consulted at all — its settings
         # block reaches no reader, so refusing it would be refusing dead config.
@@ -786,6 +786,22 @@ class ARIELConfig:
 
             try:
                 KeywordSearchSettings.from_ariel_config(self)
+            except ValueError as exc:
+                errors.append(str(exc))
+
+        if self.is_search_module_enabled("hybrid"):
+            from osprey.services.ariel_search.search.qmd import HybridSearchSettings
+
+            try:
+                HybridSearchSettings.from_ariel_config(self)
+            except ValueError as exc:
+                errors.append(str(exc))
+
+        if self.is_search_module_enabled("semantic"):
+            from osprey.services.ariel_search.search.semantic import SemanticSearchSettings
+
+            try:
+                SemanticSearchSettings.from_ariel_config(self)
             except ValueError as exc:
                 errors.append(str(exc))
 

--- a/src/osprey/services/ariel_search/exceptions.py
+++ b/src/osprey/services/ariel_search/exceptions.py
@@ -289,6 +289,36 @@ class ConfigurationError(ARIELException, _FrameworkConfigurationError):
         self.config_key = config_key
 
 
+class SearchConfigurationError(ARIELException):
+    """A search module's own ``settings`` block holds a knob it must refuse.
+
+    Raised on the query path, while the module is executing, when it resolves
+    ``search_modules.<mode>.settings`` and finds a malformed value. The message
+    is the module's own, verbatim, so it still names the offending config key.
+
+    Deliberately *not* a subclass of :class:`ConfigurationError`. That one is
+    raised by the service *before* a module runs -- an unknown or disabled mode
+    -- and propagates out to become an HTTP 400 or a hard tool error. This one
+    is caught by the service and turned into an ERROR diagnostic carrying
+    category ``configuration``, which is the only machine-readable signal an
+    agent-side caller has to offer configuration help rather than advice about
+    a sidecar that is in fact perfectly healthy.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        technical_details: dict | None = None,
+    ) -> None:
+        """Initialize SearchConfigurationError.
+
+        Args:
+            message: The module's own error text, naming the offending key.
+            technical_details: Additional debugging information
+        """
+        super().__init__(message, ErrorCategory.CONFIGURATION, technical_details)
+
+
 class ModuleNotEnabledError(ARIELException):
     """Module not enabled in configuration.
 

--- a/src/osprey/services/ariel_search/search/qmd.py
+++ b/src/osprey/services/ariel_search/search/qmd.py
@@ -36,10 +36,16 @@ would starve the result set, so a filtered query asks the sidecar for
 :data:`MAX_FETCH_LIMIT`.
 
 **Reranking is the deployment's choice, not this module's.** qmd's LLM reranker
-dominates query latency — roughly 4x — and its cost is near-constant in corpus
-size. This is an agent-facing tool with no interactive budget to blow, so the
-default is qmd's own (``True``), and a deployment that wants the fast path sets
-``search_modules.hybrid.settings.rerank: false``.
+reads every candidate, so a reranked query is markedly slower than a plain one,
+at a cost driven by the candidate pool that grows far more slowly than the
+corpus does. One key — ``search_modules.hybrid.settings.rerank`` — governs both
+surfaces this module serves: the agent-facing tool, whose ``rerank`` argument
+overrides the key for the one call, and the search panel, whose toggle opens
+showing the configured value and whose click overrides it for that session's
+later searches, until Reset, rather than changing the config. The default is
+qmd's own (``True``), because an agent has no interactive budget to blow; a
+deployment that wants the fast path sets the key to ``false``. Reranking is also not load-bearing for correctness: a query whose
+rerank fails degrades to the non-reranked ordering rather than failing.
 """
 
 from __future__ import annotations
@@ -53,6 +59,8 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel, Field
 
 from osprey.services.ariel_search.enhancement.qmd_export.writer import entry_id_from_path
+from osprey.services.ariel_search.exceptions import SearchConfigurationError
+from osprey.services.ariel_search.models import DiagnosticLevel, SearchDiagnostic
 from osprey.services.ariel_search.search.base import (
     ModuleOutput,
     ParameterDescriptor,
@@ -285,17 +293,32 @@ async def hybrid_search(
         conditional so that direct callers keep the return value they have
         always received; the service unwraps either form.
 
+        A `ModuleOutput` is also returned — with or without an expansion —
+        when the query produced a diagnostic, which today means the reranked
+        query failed and the results come from the unreranked retry.
+
     Raises:
         QMDUnavailableError: If no sidecar is configured, or the configured one
             is not answering. This is deliberately not an empty result: "search
             is down" and "nothing matched" must not look alike to the agent.
-        QMDClientError: If the sidecar was reached but could not answer.
-        ValueError: If the module's config block holds a malformed knob.
+        QMDClientError: If the sidecar was reached but could not answer. A
+            reranked query that fails is retried once without the reranker, so
+            what surfaces here is the retry's failure, not the first attempt's.
+        SearchConfigurationError: If the module's config block holds a
+            malformed knob. Typed so the service can report it as a
+            configuration problem rather than a generic module failure.
     """
     if not query.strip():
         return module_result([], query_expansion)
 
-    settings = HybridSearchSettings.from_ariel_config(config)
+    try:
+        settings = HybridSearchSettings.from_ariel_config(config)
+    except ValueError as exc:
+        # The parse refuses a bad knob with a ValueError naming the key. On the
+        # query path that has to reach the service as a *configuration* failure:
+        # an untyped crash is reported to the agent as a broken sidecar, and it
+        # goes looking at a service that is perfectly healthy. Message verbatim.
+        raise SearchConfigurationError(str(exc)) from exc
     effective_rerank = settings.rerank if rerank is None else bool(rerank)
     effective_candidates = settings.candidate_limit if candidate_limit is None else candidate_limit
 
@@ -315,11 +338,8 @@ async def hybrid_search(
         f"rerank={effective_rerank}, candidate_limit={effective_candidates}"
     )
 
-    # The client is synchronous by design (stdlib urllib, no new dependency), and
-    # a reranked query is measured in seconds — running it inline would stall the
-    # event loop for every other request in the process.
-    hits = await asyncio.to_thread(
-        qmd.query,
+    hits, diagnostics = await _fetch_hits(
+        qmd,
         settings.collection,
         query_expansion.flattened_text if query_expansion else query,
         limit=fetch_limit,
@@ -327,10 +347,27 @@ async def hybrid_search(
         candidate_limit=effective_candidates,
     )
 
+    def shaped(
+        entries: list[tuple[EnhancedLogbookEntry, float, list[str]]],
+    ) -> list[tuple[EnhancedLogbookEntry, float, list[str]]] | ModuleOutput:
+        """Return `entries` in the shape this call's contract asks for.
+
+        Same rule as `module_result`, with diagnostics folded in: a caller that
+        gets neither an expansion nor a diagnostic keeps the bare list it has
+        always received, and anything richer travels as one `ModuleOutput`.
+        """
+        if not diagnostics:
+            return module_result(entries, query_expansion)
+        return ModuleOutput(
+            entries=entries,
+            diagnostics=diagnostics,
+            expansion=query_expansion.groups if query_expansion else (),
+        )
+
     ranked = _decode_hits(hits)
     if not ranked:
         logger.info("hybrid_search: returning 0 results")
-        return module_result([], query_expansion)
+        return shaped([])
 
     entries = await repository.get_entries_by_ids([entry_id for entry_id, _ in ranked])
     by_id = {entry["entry_id"]: entry for entry in entries}
@@ -349,7 +386,81 @@ async def hybrid_search(
             break
 
     logger.info(f"hybrid_search: returning {len(results)} results")
-    return module_result(results, query_expansion)
+    return shaped(results)
+
+
+async def _fetch_hits(
+    qmd: QMDClient,
+    collection: str,
+    text: str,
+    *,
+    limit: int,
+    rerank: bool,
+    candidate_limit: int | None,
+) -> tuple[list[QMDSearchResult], tuple[SearchDiagnostic, ...]]:
+    """Ask the sidecar to rank, degrading to the unreranked ordering if it must.
+
+    Reranking is not load-bearing for correctness — it improves an ordering that
+    is already usable — so a reranker fault costs the query its ranking quality
+    rather than its results.
+
+    Args:
+        qmd: The resolved sidecar client, already known to be answering.
+        collection: qmd collection to search.
+        text: The query text as the sidecar should see it.
+        limit: How many hits to ask for.
+        rerank: Whether to run the reranker at all.
+        candidate_limit: qmd's ``candidateLimit``; ``None`` leaves qmd's own.
+
+    Returns:
+        The hits, and the diagnostics to carry back with them — one WARNING
+        when the hits came from the unreranked retry, otherwise empty.
+
+    Raises:
+        Exception: Whatever the client raised, when the unreranked query fails
+            too. One retry, not a loop: if the fast path is down, search is down.
+    """
+
+    async def run(*, rerank: bool) -> list[QMDSearchResult]:
+        # The client is synchronous by design (stdlib urllib, no new dependency),
+        # and a reranked query is measured in seconds — running it inline would
+        # stall the event loop for every other request in the process.
+        return await asyncio.to_thread(
+            qmd.query,
+            collection,
+            text,
+            limit=limit,
+            rerank=rerank,
+            candidate_limit=candidate_limit,
+        )
+
+    if not rerank:
+        return await run(rerank=False), ()
+
+    try:
+        return await run(rerank=True), ()
+    except Exception as exc:  # noqa: BLE001 - any reranker fault falls back
+        # The client already proved /health answers at resolve time, so a
+        # failure here is the reranker itself: the model is still loading
+        # after a sidecar restart and the query outran the timeout, or the
+        # reranked query took the daemon down with it. Either way the
+        # unreranked path is a different code path in the daemon and is
+        # worth one try — a dead daemon refuses it fast.
+        logger.warning(
+            f"hybrid_search: reranked query failed ({type(exc).__name__}: {exc}); "
+            "retrying without the reranker"
+        )
+        return await run(rerank=False), (
+            SearchDiagnostic(
+                level=DiagnosticLevel.WARNING,
+                source="hybrid",
+                message=(
+                    "Reranker unavailable — results are not reranked, so the "
+                    "ordering may be less relevant than usual."
+                ),
+                category="rerank",
+            ),
+        )
 
 
 def _fetch_limit(max_results: int, has_filters: bool) -> int:
@@ -594,18 +705,46 @@ def format_qmd_result(
     return {**_format_entry_base(entry), "score": score, "highlights": highlights}
 
 
-def get_parameter_descriptors() -> list[ParameterDescriptor]:
-    """Return tunable parameter descriptors for the capabilities API."""
+def get_parameter_descriptors(config: ARIELConfig | None = None) -> list[ParameterDescriptor]:
+    """Return tunable parameter descriptors for the capabilities API.
+
+    The defaults reported here are the deployment's, not the shipped ones: a
+    panel that opened on ``rerank: true`` while the deployment had turned
+    reranking off would invite an operator to "leave the default alone" and get
+    the opposite of it. Reading them from the same
+    ``search_modules.hybrid.settings`` block the query path reads keeps the two
+    in step.
+
+    Describing the module never fails on bad config. ``/api/capabilities``, the
+    search page and the MCP capabilities tool all walk this function, and a
+    deployment with one malformed key should still see a described, usable
+    module; the key itself is reported by startup validation, which is the
+    surface that can explain it. So a refusal from the settings parser falls
+    back to the shipped defaults here rather than propagating.
+
+    Args:
+        config: The loaded ARIEL configuration. ``None`` — the case for a
+            caller that has no config in hand — yields the shipped defaults.
+
+    Returns:
+        One descriptor per tunable knob, in panel order.
+    """
+    try:
+        settings = HybridSearchSettings.from_ariel_config(config)
+    except ValueError:
+        settings = HybridSearchSettings()
+
     return [
         ParameterDescriptor(
             name="rerank",
             label="Rerank Results",
             description=(
-                "Re-order candidates with the sidecar's reranker model. "
-                "Improves ranking quality at roughly 4x the query latency."
+                "Re-order candidates with the sidecar's reranker model for better "
+                "ordering. Significantly slower — an LLM reviews each result. If "
+                "reranking fails, the results are shown without it."
             ),
             param_type="bool",
-            default=DEFAULT_RERANK,
+            default=settings.rerank,
             section="Retrieval",
         ),
         ParameterDescriptor(
@@ -615,7 +754,7 @@ def get_parameter_descriptors() -> list[ParameterDescriptor]:
                 "How many candidates the reranker considers. Lowering it trades recall for latency."
             ),
             param_type="int",
-            default=DEFAULT_CANDIDATE_LIMIT,
+            default=settings.candidate_limit,
             min_value=1,
             max_value=MAX_FETCH_LIMIT,
             step=1,

--- a/src/osprey/services/ariel_search/search/semantic.py
+++ b/src/osprey/services/ariel_search/search/semantic.py
@@ -5,6 +5,7 @@ This module provides embedding-based similarity search using pgvector.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -28,6 +29,62 @@ if TYPE_CHECKING:
 logger = get_logger("ariel")
 
 DEFAULT_SIMILARITY_THRESHOLD = 0.5
+
+#: Config block the semantic knobs are read from.
+_SETTINGS_PREFIX = "search_modules.semantic.settings"
+
+
+@dataclass(frozen=True)
+class SemanticSearchSettings:
+    """Query knobs read from ``search_modules.semantic.settings``.
+
+    Attributes:
+        similarity_threshold: Minimum cosine similarity a row must reach to be
+            returned. Defaults to :data:`DEFAULT_SIMILARITY_THRESHOLD`.
+    """
+
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD
+
+    @classmethod
+    def from_ariel_config(cls, config: ARIELConfig | None) -> SemanticSearchSettings:
+        """Read the module's ``settings`` block, defaults filled in.
+
+        An absent block is the normal case and yields the defaults. A *present*
+        key of the wrong type is refused rather than defaulted, for the same
+        reason the keyword and hybrid modules refuse one: a threshold written
+        as ``"0.8"`` used to travel unexamined into the query and into the
+        capabilities slider, where it reads as an empty box rather than as the
+        configuration error it is. Naming the key is the cheaper diagnosis.
+
+        Args:
+            config: The loaded ARIEL configuration, or ``None``.
+
+        Returns:
+            The resolved settings.
+
+        Raises:
+            ValueError: If ``similarity_threshold`` is present but not a number
+                within ``[0, 1]``.
+        """
+        module = config.search_modules.get("semantic") if config is not None else None
+        settings = module.settings if module is not None else None
+        if not isinstance(settings, dict):
+            return cls()
+
+        threshold = settings.get("similarity_threshold", cls.similarity_threshold)
+        # ``bool`` is a subclass of ``int``, so ``True`` would otherwise pass as
+        # the number 1 — a spelling that means nothing here and is refused.
+        if (
+            not isinstance(threshold, (int, float))
+            or isinstance(threshold, bool)
+            or not 0 <= threshold <= 1
+        ):
+            raise ValueError(
+                f"{_SETTINGS_PREFIX}.similarity_threshold must be a float in [0, 1], "
+                f"got {threshold!r}"
+            )
+
+        return cls(similarity_threshold=float(threshold))
 
 
 async def semantic_search(
@@ -90,13 +147,7 @@ async def semantic_search(
 
     threshold = similarity_threshold
     if threshold is None:
-        if semantic_config and semantic_config.settings:
-            threshold = semantic_config.settings.get(
-                "similarity_threshold",
-                DEFAULT_SIMILARITY_THRESHOLD,
-            )
-        else:
-            threshold = DEFAULT_SIMILARITY_THRESHOLD
+        threshold = SemanticSearchSettings.from_ariel_config(config).similarity_threshold
 
     model_name = config.get_search_model()
     if not model_name:
@@ -228,15 +279,43 @@ def format_semantic_result(
     return {**_format_entry_base(entry), "similarity": similarity}
 
 
-def get_parameter_descriptors() -> list[ParameterDescriptor]:
-    """Return tunable parameter descriptors for the capabilities API."""
+def get_parameter_descriptors(config: ARIELConfig | None = None) -> list[ParameterDescriptor]:
+    """Return tunable parameter descriptors for the capabilities API.
+
+    The default reported here is the deployment's, not the shipped one: a panel
+    that opened its slider on ``0.5`` while the deployment searched at ``0.8``
+    would invite an operator to "leave the default alone" and get a looser
+    search than the deployment's own. Reading it from the same
+    ``search_modules.semantic.settings`` block the query path reads keeps the
+    two in step.
+
+    Describing the module never fails on bad config. ``/api/capabilities``, the
+    search page and the MCP capabilities tool all walk this function, and a
+    deployment with one malformed key should still see a described, usable
+    module — a refusal propagating from here would leave the panel with a
+    slider that has no default at all. The key itself is reported by startup
+    validation, which is the surface that can explain it. So a refusal from the
+    settings parser falls back to the shipped defaults here.
+
+    Args:
+        config: The loaded ARIEL configuration. ``None`` — the case for a
+            caller that has no config in hand — yields the shipped defaults.
+
+    Returns:
+        One descriptor per tunable knob, in panel order.
+    """
+    try:
+        settings = SemanticSearchSettings.from_ariel_config(config)
+    except ValueError:
+        settings = SemanticSearchSettings()
+
     return [
         ParameterDescriptor(
             name="similarity_threshold",
             label="Similarity Threshold",
             description="Minimum cosine similarity score for results (0-1)",
             param_type="float",
-            default=0.5,
+            default=settings.similarity_threshold,
             min_value=0.0,
             max_value=1.0,
             step=0.01,

--- a/src/osprey/services/ariel_search/service.py
+++ b/src/osprey/services/ariel_search/service.py
@@ -19,6 +19,7 @@ from osprey.services.ariel_search.exceptions import (
     ARIELException,
     ConfigurationError,
     PatternError,
+    SearchConfigurationError,
     SearchExecutionError,
     SearchTimeoutError,
     VocabularyError,
@@ -189,13 +190,22 @@ class ARIELSearchService:
         source: str,
         error: Exception,
         *,
+        category: str = "search",
         expanded_terms: tuple[dict[str, Any], ...] = (),
     ) -> ARIELSearchResult:
+        """Build the ERROR diagnostic for a module that failed.
+
+        ``category`` defaults to the ordinary case -- the search itself broke.
+        A caller that knows better says so: a module refusing its own malformed
+        ``settings`` block passes ``"configuration"``, which is what lets an
+        agent-side surface answer with the offending config key instead of
+        advice about a sidecar that is not the problem.
+        """
         return ARIELSearchService._diagnostic_result(
             reasoning=f"{mode.capitalize()} search failed: {error}",
             level=DiagnosticLevel.ERROR,
             source=source,
-            category="search",
+            category=category,
             modes=(mode,),
             expanded_terms=expanded_terms,
         )
@@ -579,6 +589,18 @@ class ARIELSearchService:
             # named. Swallowing them into a generic error result would show the
             # agent an empty search instead.
             raise
+        except SearchConfigurationError as e:
+            # The module refused its own settings block. Same empty-result
+            # shape as any other module failure, but categorised so the caller
+            # can tell "this deployment is misconfigured" from "search broke".
+            logger.warning(f"{mode.capitalize()} search is misconfigured: {e}")
+            return self._error_result(
+                mode,
+                f"service.{mode}",
+                e,
+                category="configuration",
+                expanded_terms=_expansion_dicts(expansion.groups) if expansion else (),
+            )
         except Exception as e:
             logger.warning(f"{mode.capitalize()} search failed: {e}")
             return self._error_result(

--- a/src/osprey/services/facility_knowledge/okf/bundle.py
+++ b/src/osprey/services/facility_knowledge/okf/bundle.py
@@ -110,11 +110,12 @@ class OKFSearchSettings:
     Args:
         rerank: Whether qmd reranks candidates with its LLM reranker. qmd's own
             default is ``True``; OKF's is ``False``, because reranking is the
-            dominant latency term — roughly 4x — and its cost is near-constant
-            in corpus size, so no bundle is small enough to outrun it. The OKF
-            surfaces are interactive and hold a sub-second budget that
-            reranking does not fit in. A deployment that values ranking quality
-            over latency sets ``facility_knowledge.search.rerank: true``.
+            dominant latency term — an LLM reviews each candidate — at a cost
+            that is near-constant in corpus size, so no bundle is small enough
+            to outrun it. The OKF surfaces are interactive and hold a sub-second
+            budget that reranking does not fit in. A deployment that values
+            ranking quality over latency sets
+            ``facility_knowledge.search.rerank: true``.
         candidate_limit: qmd's ``candidateLimit`` — how many candidates the
             reranker considers (qmd's default is 40). Lowering it trades recall
             for latency. ``None`` leaves qmd's default in place.

--- a/src/osprey/services/qmd/client.py
+++ b/src/osprey/services/qmd/client.py
@@ -376,10 +376,12 @@ class QMDClient:
                 ``candidateLimit``, default 40). Lowering it trades recall for
                 latency. ``None`` leaves qmd's default in place.
             rerank: Whether to rerank with the LLM reranker. qmd defaults this
-                to ``True``, and reranking dominates query latency — roughly 4x
-                — so an interactive caller will usually pass ``False`` and an
-                agent-facing caller ``True``. ``None`` leaves qmd's default in
-                place; the choice belongs to the caller's config, not here.
+                to ``True``. An LLM reviews each candidate, so reranking
+                dominates query latency, at a cost driven by the candidate pool
+                that grows far more slowly than the corpus does — which is why
+                a caller holding an interactive budget usually passes
+                ``False``. ``None`` leaves qmd's default in place; the choice
+                belongs to the caller's config, not here.
             intent: Background context disambiguating the query. It does not
                 search on its own.
 

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -446,13 +446,19 @@ ariel:
       # other key without a word, so a knob written as a sibling of `enabled`
       # is silently inert — no error, just the defaults forever.
       settings:
-        rerank: true          # qmd's LLM reranker. Costs roughly 4x the query
-                              # latency and its cost barely grows with corpus
-                              # size. This is an agent tool with no interactive
-                              # budget to blow, so it keeps the quality path;
-                              # set false for the fast one.
-        candidate_limit: 40   # Candidates the reranker considers. Lowering it
-                              # trades recall for latency.
+        rerank: true          # qmd's LLM reranker. An LLM reviews every
+                              # candidate, so it dominates query latency, at a
+                              # cost driven by the candidate pool that grows
+                              # far more slowly than the corpus does. This ONE
+                              # key governs both surfaces: the agent's
+                              # hybrid_search tool and the ARIEL search panel.
+                              # Both can override it — the tool's `rerank`
+                              # argument per call, the panel's toggle per
+                              # session until Reset — so set it false only when
+                              # you want the fast path everywhere.
+        candidate_limit: 40   # Candidates the reranker considers, for both
+                              # surfaces. Lowering it trades recall for
+                              # latency.
 
   # Enhancement modules — run during ingestion
   enhancement_modules:

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -1082,14 +1082,20 @@ ariel:
       # other key without a word, so a knob written as a sibling of `enabled`
       # is silently inert — no error, no warning, just the defaults forever.
       settings:
-        rerank: true          # qmd's LLM reranker. Costs roughly 4x the query
-                              # latency and its cost barely grows with corpus
-                              # size, so no logbook is small enough to outrun
-                              # it. This is an agent tool with no interactive
-                              # budget to blow, so it keeps the quality path;
-                              # set false for the fast one.
-        candidate_limit: 40   # Candidates the reranker considers. Lowering it
-                              # trades recall for latency.
+        rerank: true          # qmd's LLM reranker. An LLM reviews every
+                              # candidate, so it dominates query latency, at a
+                              # cost driven by the candidate pool that grows
+                              # far more slowly than the corpus does — no
+                              # logbook is small enough to outrun it. This ONE
+                              # key governs both surfaces: the agent's
+                              # hybrid_search tool and the ARIEL search panel.
+                              # Both can override it — the tool's `rerank`
+                              # argument per call, the panel's toggle per
+                              # session until Reset — so set it false only when
+                              # you want the fast path everywhere.
+        candidate_limit: 40   # Candidates the reranker considers, for both
+                              # surfaces. Lowering it trades recall for
+                              # latency.
 
   # Enhancement modules
   # provider: references api.providers for credentials

--- a/tests/interfaces/ariel/advanced-options.test.mjs
+++ b/tests/interfaces/ariel/advanced-options.test.mjs
@@ -1,0 +1,311 @@
+// @ts-check
+/**
+ * Front-end proofs for the ARIEL advanced-options panel's touched-parameter
+ * contract (Task 4.1):
+ *
+ *   - `getAdvancedParams()` emits ONLY knobs the operator actually moved, so a
+ *     search never overrides the deployment's own configuration for a knob
+ *     nobody touched — the panel pre-seeds every non-null descriptor default
+ *     into its value map, and those seeds must stay invisible on the wire;
+ *   - clearing a text/select/date control writes a literal null, which stays
+ *     filtered out even though the name is now touched;
+ *   - Reset returns the panel to the untouched state;
+ *   - `getEffectiveParam(name)` reports what a search would really run with —
+ *     the operator's value if touched, else the mode descriptor's default —
+ *     and `undefined` for a name the current mode does not declare.
+ *
+ *   npx vitest run tests/interfaces/ariel/advanced-options.test.mjs
+ *
+ * Runs under happy-dom (vitest.config.js). The module keeps its state at module
+ * scope, so each test re-imports it fresh via vi.resetModules(). Nothing is
+ * mocked: the fixture declares no dynamic_select, so no fetch fires.
+ */
+
+import { test, expect, describe, beforeEach, vi } from 'vitest';
+
+const MODULE_PATH = '../../../src/osprey/interfaces/ariel/static/js/advanced-options.js';
+
+/** Capabilities payload shaped like the backend's /api/capabilities response. */
+const CAPABILITIES = /** @type {any} */ ({
+  categories: {
+    direct: {
+      label: 'Direct',
+      modes: [
+        {
+          name: 'hybrid',
+          label: 'Hybrid',
+          description: 'Keyword and semantic combined',
+          parameters: [
+            {
+              name: 'rerank',
+              label: 'Rerank Results',
+              description: 'Re-score candidates with the cross-encoder',
+              type: 'bool',
+              default: true,
+              section: 'Retrieval',
+            },
+            {
+              name: 'candidate_limit',
+              label: 'Candidate Limit',
+              description: 'How many candidates to retrieve before reranking',
+              type: 'int',
+              default: 40,
+              min: 1,
+              max: 200,
+              step: 1,
+              section: 'Retrieval',
+            },
+            {
+              name: 'sort',
+              label: 'Sort Order',
+              description: 'Result ordering',
+              type: 'select',
+              default: null,
+              options: [
+                { value: '', label: 'Relevance' },
+                { value: 'newest', label: 'Newest first' },
+              ],
+              section: 'Retrieval',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  default_mode: 'hybrid',
+  shared_parameters: [
+    {
+      name: 'author',
+      label: 'Author',
+      description: 'Restrict to entries by this author',
+      type: 'text',
+      default: null,
+      placeholder: 'e.g. thellert',
+      section: 'Filters',
+    },
+  ],
+  vocabulary: { enabled: false, concepts: 0, expand_by_default: false },
+});
+
+/** The advanced-options surface as static/index.html lays it out. */
+function mountFixture() {
+  document.body.innerHTML = `
+    <div id="search-mode-tabs" class="search-mode-tabs"></div>
+    <div class="search-options-bar">
+      <button type="button" id="advanced-toggle-btn">Filters &amp; Options</button>
+    </div>
+    <div id="advanced-panel" class="advanced-panel hidden">
+      <div class="advanced-header">
+        <button type="button" id="advanced-reset-btn">Reset</button>
+        <button type="button" id="advanced-close-btn">Close</button>
+      </div>
+      <div class="advanced-sections" id="advanced-sections"></div>
+    </div>
+  `;
+}
+
+/**
+ * @param {string} id - Element id
+ * @returns {HTMLElement} The element (the fixture guarantees it exists)
+ */
+function el(id) {
+  return /** @type {HTMLElement} */ (document.getElementById(id));
+}
+
+/**
+ * @param {string} name - Parameter name
+ * @returns {HTMLInputElement} The rendered control for that parameter
+ */
+function control(name) {
+  return /** @type {HTMLInputElement} */ (el(`param-${name}`));
+}
+
+describe('advanced options: touched parameters and effective values', () => {
+  /** @type {typeof import('../../../src/osprey/interfaces/ariel/static/js/advanced-options.js')} */
+  let mod;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mountFixture();
+    mod = await import(MODULE_PATH);
+    mod.initAdvancedOptions(CAPABILITIES);
+    // attachParamListeners only runs from renderAdvancedPanel, which only runs
+    // when the panel is opened.
+    el('advanced-toggle-btn').click();
+  });
+
+  test('the panel starts on the deployment mode with its controls rendered', () => {
+    expect(mod.getCurrentMode()).toBe('hybrid');
+    expect(control('rerank').checked).toBe(true);
+    expect(control('candidate_limit').value).toBe('40');
+  });
+
+  test('an untouched panel sends nothing, despite pre-seeded defaults', () => {
+    expect(mod.getAdvancedParams()).toEqual({});
+  });
+
+  test('flipping one toggle sends that knob and only that knob', () => {
+    const toggle = control('rerank');
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change'));
+
+    expect(mod.getAdvancedParams()).toEqual({ rerank: false });
+  });
+
+  test('moving a slider sends only the slider, not its untouched neighbours', () => {
+    const slider = control('candidate_limit');
+    slider.value = '80';
+    slider.dispatchEvent(new Event('input'));
+
+    expect(mod.getAdvancedParams()).toEqual({ candidate_limit: 80 });
+  });
+
+  test('Reset returns the panel to the untouched state', () => {
+    const toggle = control('rerank');
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change'));
+    expect(mod.getAdvancedParams()).toEqual({ rerank: false });
+
+    el('advanced-reset-btn').click();
+
+    expect(mod.getAdvancedParams()).toEqual({});
+    expect(mod.getEffectiveParam('rerank')).toBe(true);
+  });
+
+  test('a text filter typed and then cleared sends nothing', () => {
+    const input = control('author');
+    input.value = 'thellert';
+    input.dispatchEvent(new Event('input'));
+    expect(mod.getAdvancedParams()).toEqual({ author: 'thellert' });
+
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+
+    expect(mod.getAdvancedParams()).toEqual({});
+  });
+
+  test('a select set and then cleared sends nothing', () => {
+    const select = /** @type {HTMLSelectElement} */ (
+      /** @type {unknown} */ (control('sort'))
+    );
+    select.value = 'newest';
+    select.dispatchEvent(new Event('change'));
+    expect(mod.getAdvancedParams()).toEqual({ sort: 'newest' });
+
+    select.value = '';
+    select.dispatchEvent(new Event('change'));
+
+    expect(mod.getAdvancedParams()).toEqual({});
+  });
+
+  test('getEffectiveParam reports the configured default until the knob moves', () => {
+    expect(mod.getEffectiveParam('rerank')).toBe(true);
+    expect(mod.getEffectiveParam('candidate_limit')).toBe(40);
+
+    const toggle = control('rerank');
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change'));
+
+    expect(mod.getEffectiveParam('rerank')).toBe(false);
+    // ...without leaking into the wire payload of its neighbours.
+    expect(mod.getEffectiveParam('candidate_limit')).toBe(40);
+  });
+
+  test('getEffectiveParam is undefined for names the current mode does not declare', () => {
+    expect(mod.getEffectiveParam('not_a_parameter')).toBeUndefined();
+    // `author` is a shared filter, not a mode descriptor: it has no mode-level
+    // default to report.
+    expect(mod.getEffectiveParam('author')).toBeUndefined();
+  });
+});
+
+/**
+ * Task 4.2: the descriptor's description is documentation, and documentation
+ * that only appears on hover is documentation nobody reads. Every control
+ * renders its description inline, and no renderer keeps the old `title=`.
+ */
+const HINT_CAPABILITIES = /** @type {any} */ ({
+  categories: {
+    direct: {
+      label: 'Direct',
+      modes: [
+        {
+          name: 'hybrid',
+          label: 'Hybrid',
+          parameters: [
+            {
+              name: 'rerank',
+              label: 'Rerank Results',
+              description: 'Re-score candidates with the cross-encoder',
+              type: 'bool',
+              default: true,
+              section: 'Retrieval',
+            },
+            {
+              name: 'min_score',
+              label: 'Minimum Score',
+              description: 'Drop results scoring below this threshold',
+              type: 'float',
+              default: 0.25,
+              min: 0,
+              max: 1,
+              step: 0.05,
+              section: 'Retrieval',
+            },
+            {
+              name: 'undocumented',
+              label: 'Undocumented Knob',
+              type: 'int',
+              default: 3,
+              min: 1,
+              max: 9,
+              section: 'Retrieval',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  default_mode: 'hybrid',
+  shared_parameters: [],
+  vocabulary: { enabled: false, concepts: 0, expand_by_default: false },
+});
+
+describe('advanced options: visible parameter hints', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    mountFixture();
+    const mod = await import(MODULE_PATH);
+    mod.initAdvancedOptions(HINT_CAPABILITIES);
+    el('advanced-toggle-btn').click();
+  });
+
+  /** @returns {string[]} Text of every rendered hint, in document order. */
+  function hintTexts() {
+    return Array.from(
+      el('advanced-sections').querySelectorAll('.param-hint'),
+      (node) => (node.textContent || '').trim()
+    );
+  }
+
+  test('a bool descriptor renders its description under the toggle', () => {
+    expect(hintTexts()).toContain('Re-score candidates with the cross-encoder');
+  });
+
+  test('a float descriptor renders its description under the slider', () => {
+    expect(hintTexts()).toContain('Drop results scoring below this threshold');
+  });
+
+  test('a descriptor without a description renders no empty hint', () => {
+    // escapeHtml() stringifies undefined, so the absent description would
+    // otherwise render as a blank <p> taking up a row.
+    expect(hintTexts()).toEqual([
+      'Re-score candidates with the cross-encoder',
+      'Drop results scoring below this threshold',
+    ]);
+  });
+
+  test('no rendered control keeps the old hover-only title attribute', () => {
+    expect(el('advanced-sections').querySelectorAll('[title]')).toHaveLength(0);
+  });
+});

--- a/tests/interfaces/ariel/search-two-phase.test.mjs
+++ b/tests/interfaces/ariel/search-two-phase.test.mjs
@@ -1,0 +1,581 @@
+// @ts-check
+/**
+ * Front-end proofs for the two-phase reranked search (Task 4.3).
+ *
+ * Reranking costs seconds. Rather than hold a spinner for the whole of it, a
+ * reranked search issues TWO queries: the fast ranking is fetched and painted
+ * first with a "reranking…" status, then the reranked ranking replaces it
+ * wholesale (the reranker draws from a larger candidate pool, so membership and
+ * not just order may change). What these tests pin down:
+ *
+ *   - the exact wire bodies of both phases — the driver layers ONLY the
+ *     per-phase `rerank` key on top of the operator's touched params, on a copy,
+ *     and adds nothing else;
+ *   - both paints happen, each carrying its own status line;
+ *   - a superseded search's phase-2 response cannot repaint the view — the
+ *     second query outlives the state that asked for it, so every render is
+ *     guarded on still owning the newest search sequence;
+ *   - a phase-2 failure keeps phase-1's results on screen behind a warning,
+ *     covering BOTH shapes it arrives in: an HTTP rejection, and the backend's
+ *     own 200-with-WARNING rerank fallback (indistinguishable from success
+ *     except for the diagnostic);
+ *   - Simple mode gets one plain-language line, and a UI-mode flip repaints the
+ *     status the search actually finished on rather than resurrecting a stale
+ *     "still reranking";
+ *   - a mode with reranking off (or no reranker at all) still issues exactly
+ *     ONE query, with no `rerank` key injected.
+ *
+ *   npx vitest run tests/interfaces/ariel/search-two-phase.test.mjs
+ *
+ * Runs under happy-dom (vitest.config.js). Only api.js is mocked (the network
+ * boundary); advanced-options.js, components.js and search.js all run for real,
+ * so the effective-parameter read and the render sinks are exercised
+ * end-to-end. search.js keeps its sequence/status at module scope, so every
+ * test re-imports the graph fresh via vi.resetModules().
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../../src/osprey/interfaces/ariel/static/js/api.js', async (importOriginal) => {
+  const actual = /** @type {any} */ (await importOriginal());
+  return {
+    ...actual,
+    searchApi: { ...actual.searchApi, search: vi.fn() },
+  };
+});
+
+const API_PATH = '../../../src/osprey/interfaces/ariel/static/js/api.js';
+const SEARCH_PATH = '../../../src/osprey/interfaces/ariel/static/js/search.js';
+const OPTIONS_PATH = '../../../src/osprey/interfaces/ariel/static/js/advanced-options.js';
+
+/**
+ * A capabilities payload whose single mode declares `rerank`.
+ * @param {boolean} rerankDefault - The deployment's configured default
+ * @returns {any}
+ */
+function hybridCapabilities(rerankDefault) {
+  return {
+    categories: {
+      direct: {
+        label: 'Direct',
+        modes: [
+          {
+            name: 'hybrid',
+            label: 'Hybrid',
+            description: 'Keyword and semantic combined',
+            parameters: [
+              {
+                name: 'rerank',
+                label: 'Rerank Results',
+                description: 'Re-score candidates with the cross-encoder',
+                type: 'bool',
+                default: rerankDefault,
+                section: 'Retrieval',
+              },
+              {
+                name: 'candidate_limit',
+                label: 'Candidate Limit',
+                description: 'How many candidates to retrieve before reranking',
+                type: 'int',
+                default: 40,
+                min: 1,
+                max: 200,
+                step: 1,
+                section: 'Retrieval',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    default_mode: 'hybrid',
+    shared_parameters: [],
+    vocabulary: { enabled: false, concepts: 0, expand_by_default: false },
+  };
+}
+
+/** A mode with no reranker at all: `rerank` is not in its descriptor list. */
+const KEYWORD_CAPABILITIES = /** @type {any} */ ({
+  categories: {
+    direct: {
+      label: 'Direct',
+      modes: [
+        { name: 'keyword', label: 'Keyword', description: 'Text search', parameters: [] },
+      ],
+    },
+  },
+  default_mode: 'keyword',
+  shared_parameters: [],
+  vocabulary: { enabled: false, concepts: 0, expand_by_default: false },
+});
+
+/** The search view plus the advanced-options surface, as index.html lays them out. */
+function mountFixture() {
+  document.body.innerHTML = `
+    <div id="search-mode-tabs" class="search-mode-tabs"></div>
+    <div class="search-form" id="search-form">
+      <div class="search-input-wrapper">
+        <input type="text" id="search-input" class="input">
+        <div class="search-input-actions">
+          <button id="search-btn" class="btn btn-primary">Search</button>
+        </div>
+      </div>
+    </div>
+    <div class="search-options-bar">
+      <button type="button" id="advanced-toggle-btn">Filters &amp; Options</button>
+    </div>
+    <div id="advanced-panel" class="advanced-panel hidden">
+      <div class="advanced-header">
+        <button type="button" id="advanced-reset-btn">Reset</button>
+        <button type="button" id="advanced-close-btn">Close</button>
+      </div>
+      <div class="advanced-sections" id="advanced-sections"></div>
+    </div>
+    <div id="search-results"></div>
+  `;
+}
+
+/**
+ * Import the module graph fresh and initialise the panel from `capabilities`,
+ * so `getEffectiveParam('rerank')` answers the way that deployment would.
+ * @param {any} capabilities - /api/capabilities payload
+ * @returns {Promise<{search: any, options: any, searchMock: any}>}
+ */
+async function loadModules(capabilities) {
+  const api = await import(API_PATH);
+  const options = await import(OPTIONS_PATH);
+  const search = await import(SEARCH_PATH);
+  options.initAdvancedOptions(capabilities);
+  return { search, options, searchMock: vi.mocked(api.searchApi.search) };
+}
+
+/**
+ * A promise whose settlement this test controls, so the DOM can be inspected
+ * between phase 1 and phase 2.
+ * @returns {{promise: Promise<any>, resolve: (value: any) => void, reject: (reason: any) => void}}
+ */
+function deferred() {
+  /** @type {(value: any) => void} */
+  let resolve = () => {};
+  /** @type {(reason: any) => void} */
+  let reject = () => {};
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let every pending microtask (and the awaits chained behind it) run. */
+function flush() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+/**
+ * A search response carrying the given entries and diagnostics.
+ * @param {{entries?: any[], diagnostics?: any[]}} [overrides]
+ * @returns {any}
+ */
+function searchResponse({ entries = [], diagnostics = [] } = {}) {
+  return {
+    answer: '',
+    sources: [],
+    search_modes_used: ['hybrid'],
+    execution_time_ms: 5,
+    total_results: entries.length,
+    entries,
+    diagnostics,
+    expanded_terms: [],
+  };
+}
+
+/**
+ * @param {string} id - The entry id, used as the marker these tests look for
+ * @returns {any} An entry shaped like the backend's
+ */
+function entry(id) {
+  return {
+    entry_id: id,
+    timestamp: '2026-08-25T12:00:00Z',
+    author: 'thellert',
+    source_system: 'demo',
+    raw_text: `body of ${id}`,
+    score: null,
+    attachments: [],
+    keywords: [],
+    highlights: [],
+  };
+}
+
+/** The backend's own rerank fallback: 200, fast ranking, warning diagnostic. */
+const RERANK_FALLBACK_DIAGNOSTIC = {
+  level: 'warning',
+  source: 'hybrid',
+  category: 'rerank',
+  message: 'Reranker unavailable — returning the unreranked ranking',
+};
+
+/** @returns {HTMLElement} */
+function results() {
+  return /** @type {HTMLElement} */ (document.getElementById('search-results'));
+}
+
+/** @returns {HTMLButtonElement} */
+function searchBtn() {
+  return /** @type {HTMLButtonElement} */ (document.getElementById('search-btn'));
+}
+
+/**
+ * The rerank status line's collapsed text, or null when no line is rendered.
+ * @returns {string|null}
+ */
+function statusText() {
+  const el = results().querySelector('[data-testid="rerank-status"]');
+  return el ? (el.textContent ?? '').replace(/\s+/g, ' ').trim() : null;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mountFixture();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-ui-mode');
+  vi.restoreAllMocks();
+});
+
+describe('two-phase search: the wire bodies', () => {
+  test('a reranked search issues exactly two queries, rerank false then true', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    searchMock.mockResolvedValue(searchResponse({ entries: [entry('E1')] }));
+
+    await search.performSearch('quench');
+
+    expect(searchMock.mock.calls.length, 'one query per phase').toBe(2);
+    expect(searchMock.mock.calls[0][0]).toEqual({
+      query: 'quench',
+      mode: 'hybrid',
+      maxResults: 10,
+      advancedParams: { rerank: false },
+    });
+    expect(searchMock.mock.calls[1][0]).toEqual({
+      query: 'quench',
+      mode: 'hybrid',
+      maxResults: 10,
+      advancedParams: { rerank: true },
+    });
+  });
+
+  test('the touched params ride along untouched, with only rerank layered on', async () => {
+    const { search, options, searchMock } = await loadModules(hybridCapabilities(true));
+    // attachParamListeners only runs from renderAdvancedPanel, i.e. on open.
+    /** @type {HTMLElement} */ (document.getElementById('advanced-toggle-btn')).click();
+    const slider = /** @type {HTMLInputElement} */ (document.getElementById('param-candidate_limit'));
+    slider.value = '80';
+    slider.dispatchEvent(new Event('input'));
+    expect(options.getAdvancedParams()).toEqual({ candidate_limit: 80 });
+
+    searchMock.mockResolvedValue(searchResponse({ entries: [entry('E1')] }));
+    await search.performSearch('quench');
+
+    expect(searchMock.mock.calls[0][0].advancedParams)
+      .toEqual({ candidate_limit: 80, rerank: false });
+    expect(searchMock.mock.calls[1][0].advancedParams)
+      .toEqual({ candidate_limit: 80, rerank: true });
+    // The driver copied; it did not mutate the panel's own view of the world.
+    expect(options.getAdvancedParams()).toEqual({ candidate_limit: 80 });
+  });
+
+  test('rerank off sends ONE query with no rerank key injected', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(false));
+    searchMock.mockResolvedValue(searchResponse({ entries: [entry('E1')] }));
+
+    await search.performSearch('quench');
+
+    expect(searchMock.mock.calls.length, 'single-phase path').toBe(1);
+    expect(searchMock.mock.calls[0][0]).toEqual({
+      query: 'quench',
+      mode: 'hybrid',
+      maxResults: 10,
+      advancedParams: {},
+    });
+    expect(statusText(), 'no phase status on a single-phase search').toBeNull();
+  });
+
+  test('a mode with no reranker at all sends ONE query with no rerank key', async () => {
+    const { search, searchMock } = await loadModules(KEYWORD_CAPABILITIES);
+    searchMock.mockResolvedValue(searchResponse({ entries: [entry('E1')] }));
+
+    await search.performSearch('quench');
+
+    expect(searchMock.mock.calls.length).toBe(1);
+    expect(searchMock.mock.calls[0][0].mode).toBe('keyword');
+    expect(searchMock.mock.calls[0][0].advancedParams).toEqual({});
+    expect(statusText()).toBeNull();
+  });
+});
+
+describe('two-phase search: both paints', () => {
+  test('phase 1 paints the fast ranking, phase 2 replaces it', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fast = deferred();
+    const reranked = deferred();
+    searchMock.mockImplementationOnce(() => fast.promise).mockImplementationOnce(() => reranked.promise);
+
+    const pending = search.performSearch('quench');
+
+    fast.resolve(searchResponse({ entries: [entry('FAST-1'), entry('FAST-2')] }));
+    await flush();
+
+    expect(results().textContent).toContain('FAST-1');
+    expect(statusText()).toBe('Search complete — reranking with LLM…');
+    expect(searchBtn().disabled, 'still searching between the phases').toBe(true);
+
+    // The reranked pool is not a re-ordering of the same set: membership moves.
+    reranked.resolve(searchResponse({ entries: [entry('RERANKED-1'), entry('FAST-2')] }));
+    await pending;
+
+    expect(results().textContent).toContain('RERANKED-1');
+    expect(results().textContent, 'phase 1 was replaced wholesale').not.toContain('FAST-1');
+    expect(statusText()).toBe('Results updated after reranking');
+    expect(searchBtn().disabled, 'controls handed back once both phases are done').toBe(false);
+  });
+
+  test('a search cannot start while the first one is still on its second phase', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fast = deferred();
+    const reranked = deferred();
+    searchMock.mockImplementationOnce(() => fast.promise).mockImplementationOnce(() => reranked.promise);
+
+    const pending = search.performSearch('quench');
+    fast.resolve(searchResponse({ entries: [entry('FAST-1')] }));
+    await flush();
+
+    await search.performSearch('second query');
+    expect(searchMock.mock.calls.length, 'no third query was issued').toBe(2);
+
+    reranked.resolve(searchResponse({ entries: [entry('RERANKED-1')] }));
+    await pending;
+  });
+});
+
+describe('two-phase search: a superseded phase 2 must not repaint', () => {
+  test('clearing and re-searching strands the first search\'s phase 2', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fastA = deferred();
+    const rerankedA = deferred();
+    const fastB = deferred();
+    searchMock
+      .mockImplementationOnce(() => fastA.promise)
+      .mockImplementationOnce(() => rerankedA.promise)
+      .mockImplementationOnce(() => fastB.promise);
+
+    const pendingA = search.performSearch('alpha');
+    fastA.resolve(searchResponse({ entries: [entry('ALPHA-FAST')] }));
+    await flush();
+    expect(results().textContent).toContain('ALPHA-FAST');
+
+    // The operator clears the box and searches again while alpha's reranked
+    // query is still in flight.
+    search.clearSearch();
+    search.performSearch('beta');
+    await flush();
+    expect(searchMock.mock.calls.length, 'beta started its own phase 1').toBe(3);
+    expect(searchMock.mock.calls[2][0].query).toBe('beta');
+
+    rerankedA.resolve(searchResponse({ entries: [entry('ALPHA-RERANKED')] }));
+    await pendingA;
+
+    expect(results().textContent, 'the stranded response did not repaint')
+      .not.toContain('ALPHA-RERANKED');
+    expect(statusText(), 'nor did it plant a status line').toBeNull();
+    expect(search.getSearchState().results, 'nor did it become the current results')
+      .toBeNull();
+    expect(search.getSearchState().isSearching, 'beta still owns the in-flight flag').toBe(true);
+  });
+});
+
+describe('two-phase search: a phase-2 failure keeps the fast results', () => {
+  test('an HTTP rejection leaves phase 1 on screen behind a warning', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fast = deferred();
+    const reranked = deferred();
+    searchMock.mockImplementationOnce(() => fast.promise).mockImplementationOnce(() => reranked.promise);
+
+    const pending = search.performSearch('quench');
+    fast.resolve(searchResponse({ entries: [entry('FAST-1'), entry('FAST-2')] }));
+    await flush();
+
+    reranked.reject(new Error('HTTP 504: reranker timed out loading the model'));
+    await pending;
+
+    expect(results().textContent, 'the fast ranking survived').toContain('FAST-1');
+    expect(results().textContent).toContain('FAST-2');
+    expect(statusText()).toBe('Could not improve the ranking — showing fast results');
+    expect(results().querySelector('.text-error'), 'not an error state').toBeNull();
+    expect(searchBtn().disabled, 'controls handed back').toBe(false);
+    expect(search.getSearchState().results.entries[0].entry_id, 'phase 1 is still current')
+      .toBe('FAST-1');
+  });
+
+  test('a 200 carrying the backend rerank warning reads as the fallback, not success', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    searchMock
+      .mockResolvedValueOnce(searchResponse({ entries: [entry('FAST-1')] }))
+      .mockResolvedValueOnce(searchResponse({
+        entries: [entry('FAST-1')],
+        diagnostics: [RERANK_FALLBACK_DIAGNOSTIC],
+      }));
+
+    await search.performSearch('quench');
+
+    expect(statusText()).toBe('Could not improve the ranking — showing fast results');
+  });
+
+  test('an unrelated warning does not masquerade as the rerank fallback', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    searchMock
+      .mockResolvedValueOnce(searchResponse({ entries: [entry('FAST-1')] }))
+      .mockResolvedValueOnce(searchResponse({
+        entries: [entry('RERANKED-1')],
+        diagnostics: [{
+          level: 'warning',
+          source: 'vocabulary',
+          category: 'expansion',
+          message: 'One term could not be expanded',
+        }],
+      }));
+
+    await search.performSearch('quench');
+
+    expect(statusText()).toBe('Results updated after reranking');
+  });
+
+  test('a phase-1 failure is a failed search: no phase 2, error state', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    searchMock.mockRejectedValueOnce(new Error('HTTP 500: search backend down'));
+
+    await search.performSearch('quench');
+
+    expect(searchMock.mock.calls.length, 'no reranked query on a dead search').toBe(1);
+    expect(results().querySelector('.text-error')).not.toBeNull();
+    expect(statusText()).toBeNull();
+    expect(searchBtn().disabled).toBe(false);
+  });
+});
+
+describe('two-phase search: Simple mode', () => {
+  test('Simple gets one plain-language line per phase', async () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fast = deferred();
+    const reranked = deferred();
+    searchMock.mockImplementationOnce(() => fast.promise).mockImplementationOnce(() => reranked.promise);
+
+    const pending = search.performSearch('quench');
+    fast.resolve(searchResponse({ entries: [entry('FAST-1')] }));
+    await flush();
+
+    expect(results().querySelectorAll('[data-testid="rerank-status"]').length, 'exactly one line')
+      .toBe(1);
+    expect(statusText()).toBe('Showing quick results — improving the order now…');
+    // Simple deliberately omits the search-mechanics chrome, status line aside.
+    expect(results().querySelector('.diagnostics-bar')).toBeNull();
+
+    reranked.resolve(searchResponse({ entries: [entry('RERANKED-1')] }));
+    await pending;
+
+    expect(statusText()).toBe('Order improved — best matches first');
+  });
+
+  test('an empty fast ranking still gets its Simple status line', async () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fast = deferred();
+    const reranked = deferred();
+    searchMock.mockImplementationOnce(() => fast.promise).mockImplementationOnce(() => reranked.promise);
+
+    const pending = search.performSearch('nothing matches this');
+    fast.resolve(searchResponse({ entries: [] }));
+    await flush();
+
+    expect(results().textContent).toContain('No entries found');
+    expect(statusText()).toBe('Showing quick results — improving the order now…');
+
+    reranked.resolve(searchResponse({ entries: [entry('RERANKED-1')] }));
+    await pending;
+  });
+
+  test('a UI-mode flip repaints the phase the search finished on, not a stale one', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    searchMock.mockResolvedValue(searchResponse({ entries: [entry('E1')] }));
+
+    await search.performSearch('quench');
+    expect(statusText()).toBe('Results updated after reranking');
+
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    search.onUiModeChange();
+
+    expect(statusText(), 'the finished phase, in Simple words')
+      .toBe('Order improved — best matches first');
+    expect(results().textContent, 'no resurrected "still reranking"')
+      .not.toContain('improving the order now');
+  });
+
+  test('a flip mid-flight keeps saying reranking, because it still is', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fast = deferred();
+    const reranked = deferred();
+    searchMock.mockImplementationOnce(() => fast.promise).mockImplementationOnce(() => reranked.promise);
+
+    const pending = search.performSearch('quench');
+    fast.resolve(searchResponse({ entries: [entry('FAST-1')] }));
+    await flush();
+    expect(statusText()).toBe('Search complete — reranking with LLM…');
+
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    search.onUiModeChange();
+    expect(statusText()).toBe('Showing quick results — improving the order now…');
+
+    reranked.resolve(searchResponse({ entries: [entry('RERANKED-1')] }));
+    await pending;
+    expect(statusText()).toBe('Order improved — best matches first');
+  });
+});
+
+describe('two-phase search: the search button', () => {
+  test('the button is disabled for the whole of a two-phase search', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fast = deferred();
+    const reranked = deferred();
+    searchMock.mockImplementationOnce(() => fast.promise).mockImplementationOnce(() => reranked.promise);
+
+    expect(searchBtn().disabled).toBe(false);
+    const pending = search.performSearch('quench');
+    expect(searchBtn().disabled, 'disabled from the first request').toBe(true);
+
+    fast.resolve(searchResponse({ entries: [entry('FAST-1')] }));
+    await flush();
+    expect(searchBtn().disabled, 'still disabled with phase-1 results on screen').toBe(true);
+
+    reranked.resolve(searchResponse({ entries: [entry('RERANKED-1')] }));
+    await pending;
+    expect(searchBtn().disabled).toBe(false);
+  });
+
+  test('clearing an in-flight search hands the button back', async () => {
+    const { search, searchMock } = await loadModules(hybridCapabilities(true));
+    const fast = deferred();
+    searchMock.mockImplementationOnce(() => fast.promise);
+
+    search.performSearch('quench');
+    expect(searchBtn().disabled).toBe(true);
+
+    search.clearSearch();
+
+    expect(searchBtn().disabled).toBe(false);
+    expect(search.getSearchState().isSearching).toBe(false);
+  });
+});

--- a/tests/interfaces/ariel/test_routes.py
+++ b/tests/interfaces/ariel/test_routes.py
@@ -43,13 +43,46 @@ def _build_mock_registry():
     )
     semantic_mod.get_parameter_descriptors = None  # type: ignore[attr-defined]
 
-    registry.list_ariel_search_modules.return_value = ["keyword", "semantic"]
+    # Registered but left disabled by the shared fixture config, so it stays out
+    # of every existing test's capabilities; the hybrid tests enable it locally.
+    hybrid_mod = types.ModuleType("hybrid")
+    hybrid_mod.get_tool_descriptor = lambda: SearchToolDescriptor(  # type: ignore[attr-defined]
+        name="hybrid_search",
+        description="Hybrid retrieval with optional reranking",
+        search_mode="hybrid",
+        args_schema=MagicMock(),
+        execute=AsyncMock(),
+        format_result=MagicMock(),
+    )
+    hybrid_mod.get_parameter_descriptors = None  # type: ignore[attr-defined]
+
+    registry.list_ariel_search_modules.return_value = ["keyword", "semantic", "hybrid"]
     registry.get_ariel_search_module.side_effect = lambda n: {
         "keyword": keyword_mod,
         "semantic": semantic_mod,
+        "hybrid": hybrid_mod,
     }.get(n)
 
     return registry
+
+
+def _enable_hybrid(service) -> None:
+    """Give the mock service a config in which the hybrid module is enabled.
+
+    Applied per test rather than in the shared ``mock_ariel_service`` fixture,
+    whose config several other tests assert against verbatim.
+    """
+    service.config = ARIELConfig.from_dict(
+        {
+            "database": {"uri": "postgresql://localhost:5432/test"},
+            "search_modules": {
+                "keyword": {"enabled": True},
+                "semantic": {"enabled": True, "model": "test-model"},
+                "hybrid": {"enabled": True},
+            },
+            "default_search_mode": "keyword",
+        }
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -698,6 +731,157 @@ def test_search_honors_configured_default_mode(client, mock_ariel_service):
 
     assert response.status_code == 200
     assert mock_ariel_service.search.call_args.kwargs["mode"] == "semantic"
+
+
+@pytest.mark.parametrize("value", ["yes", "false", 1, 0, 1.0, []])
+def test_search_hybrid_rejects_non_boolean_rerank(client, mock_ariel_service, value):
+    """A non-boolean ``rerank`` override is a 400, not a truthiness accident.
+
+    The panel sends the toggle's boolean, but a hand-written caller can send
+    ``"false"`` -- which is truthy everywhere downstream and would silently run
+    the slow reranked path the caller asked to skip.
+    """
+    _enable_hybrid(mock_ariel_service)
+
+    response = client.post(
+        "/api/search",
+        json={
+            "query": "test",
+            "mode": "hybrid",
+            "max_results": 10,
+            "advanced_params": {"rerank": value},
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "rerank must be a boolean" in detail
+    assert repr(value) in detail
+    mock_ariel_service.search.assert_not_called()
+
+
+@pytest.mark.parametrize("value", [0, -1, "40", 12.5, True])
+def test_search_hybrid_rejects_bad_candidate_limit(client, mock_ariel_service, value):
+    """``candidate_limit`` must be a positive int -- booleans and zero included."""
+    _enable_hybrid(mock_ariel_service)
+
+    response = client.post(
+        "/api/search",
+        json={
+            "query": "test",
+            "mode": "hybrid",
+            "max_results": 10,
+            "advanced_params": {"candidate_limit": value},
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "candidate_limit must be a positive integer" in detail
+    assert repr(value) in detail
+    mock_ariel_service.search.assert_not_called()
+
+
+def test_search_hybrid_forwards_valid_overrides_verbatim(client, mock_ariel_service):
+    """Well-formed overrides reach the service untouched -- ``False`` included.
+
+    ``rerank: false`` is the whole point of the override, so it must survive as
+    the boolean ``False`` rather than being dropped as falsy.
+    """
+    _enable_hybrid(mock_ariel_service)
+
+    response = client.post(
+        "/api/search",
+        json={
+            "query": "test",
+            "mode": "hybrid",
+            "max_results": 10,
+            "advanced_params": {"rerank": False, "candidate_limit": 12},
+        },
+    )
+
+    assert response.status_code == 200
+    call_kwargs = mock_ariel_service.search.call_args.kwargs
+    assert call_kwargs["mode"] == "hybrid"
+    assert call_kwargs["advanced_params"]["rerank"] is False
+    assert call_kwargs["advanced_params"]["candidate_limit"] == 12
+
+
+def test_search_hybrid_without_overrides_is_accepted(client, mock_ariel_service):
+    """Absent keys mean "use the configured default" and are not rejected."""
+    _enable_hybrid(mock_ariel_service)
+
+    response = client.post(
+        "/api/search",
+        json={"query": "test", "mode": "hybrid", "max_results": 10},
+    )
+
+    assert response.status_code == 200
+    assert mock_ariel_service.search.call_args.kwargs["mode"] == "hybrid"
+
+
+def test_search_hybrid_accepts_explicit_null_overrides(client, mock_ariel_service):
+    """An explicit ``null`` says "no override" just as an absent key does."""
+    _enable_hybrid(mock_ariel_service)
+
+    response = client.post(
+        "/api/search",
+        json={
+            "query": "test",
+            "mode": "hybrid",
+            "max_results": 10,
+            "advanced_params": {"rerank": None, "candidate_limit": None},
+        },
+    )
+
+    assert response.status_code == 200
+    call_kwargs = mock_ariel_service.search.call_args.kwargs
+    assert call_kwargs["advanced_params"]["rerank"] is None
+    assert call_kwargs["advanced_params"]["candidate_limit"] is None
+
+
+@pytest.mark.parametrize("mode", ["keyword", "semantic"])
+def test_search_non_hybrid_modes_ignore_hybrid_overrides(client, mock_ariel_service, mode):
+    """The check is hybrid-only: other modes never see these keys as theirs.
+
+    ``rerank`` and ``candidate_limit`` are hybrid's parameter names. Another
+    module is free to give them any meaning, so validating them everywhere
+    would reject requests this route has no business judging.
+    """
+    _enable_hybrid(mock_ariel_service)
+
+    response = client.post(
+        "/api/search",
+        json={
+            "query": "test",
+            "mode": mode,
+            "max_results": 10,
+            "advanced_params": {"rerank": "yes", "candidate_limit": 0},
+        },
+    )
+
+    assert response.status_code == 200
+    call_kwargs = mock_ariel_service.search.call_args.kwargs
+    assert call_kwargs["advanced_params"]["rerank"] == "yes"
+    assert call_kwargs["advanced_params"]["candidate_limit"] == 0
+
+
+def test_search_hybrid_leaves_expand_query_alone(client, mock_ariel_service):
+    """Only the two hybrid keys are judged; ``expand_query`` passes through."""
+    _enable_hybrid(mock_ariel_service)
+
+    response = client.post(
+        "/api/search",
+        json={
+            "query": "test",
+            "mode": "hybrid",
+            "max_results": 10,
+            "advanced_params": {"expand_query": "yes", "rerank": True},
+        },
+    )
+
+    assert response.status_code == 200
+    assert mock_ariel_service.search.call_args.kwargs["advanced_params"]["expand_query"] == "yes"
 
 
 def test_capabilities_advertises_default_mode(client, mock_ariel_service):

--- a/tests/mcp_server/ariel/test_hybrid_search.py
+++ b/tests/mcp_server/ariel/test_hybrid_search.py
@@ -338,6 +338,122 @@ async def test_non_qmd_diagnostics_do_not_trip_the_fault_path(tmp_path, monkeypa
 
 
 @pytest.mark.unit
+async def test_envelope_carries_the_rerank_fallback_warning(tmp_path, monkeypatch):
+    """The degraded ordering has to reach the agent, not just the server log.
+
+    When the reranker is unavailable the module retries unreranked and reports
+    a WARNING. Those results are real, so the tool must succeed — but an agent
+    reading the ranking deserves to know it is the weaker one.
+    """
+    _setup_registry(tmp_path, monkeypatch)
+
+    fallback = SearchDiagnostic(
+        level=DiagnosticLevel.WARNING,
+        source="hybrid",
+        message=(
+            "Reranker unavailable — results are not reranked, so the "
+            "ordering may be less relevant than usual."
+        ),
+        category="rerank",
+    )
+    entries = [make_mock_entry(entry_id="e1")]
+
+    mock_service = AsyncMock()
+    mock_service.search.return_value = _make_search_result(entries, diagnostics=[fallback])
+
+    with patch(
+        "osprey.mcp_server.ariel.server_context.ARIELContext.service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        fn = _get_hybrid_search()
+        result = await fn(query="beam loss")
+
+    data = extract_response_dict(result)
+    assert not data.get("error", False)
+    assert data["results_found"] == 1
+    assert data["diagnostics"] == [
+        {
+            "level": "warning",
+            "source": "hybrid",
+            "message": fallback.message,
+            "category": "rerank",
+        }
+    ]
+
+
+@pytest.mark.unit
+async def test_config_typo_advises_the_config_key_not_the_health_endpoint(tmp_path, monkeypatch):
+    """A refused settings value is an operator typo, not a dead sidecar.
+
+    The service categorises it as "configuration" precisely so this tool can
+    tell the two apart. Sending the reader to curl a health endpoint that
+    answers perfectly well wastes the one hint they get.
+    """
+    _setup_registry(
+        tmp_path,
+        monkeypatch,
+        config='{"ariel": {"database": {"uri": "postgresql://localhost/test"}},'
+        ' "services": {"qmd": {"port": 8199}}}',
+    )
+
+    misconfigured = SearchDiagnostic(
+        level=DiagnosticLevel.ERROR,
+        source="service.hybrid",
+        message="search_modules.hybrid.settings.rerank must be a boolean, got 'junk'",
+        category="configuration",
+    )
+
+    mock_service = AsyncMock()
+    mock_service.search.return_value = _make_search_result([], diagnostics=[misconfigured])
+
+    with patch(
+        "osprey.mcp_server.ariel.server_context.ARIELContext.service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        fn = _get_hybrid_search()
+        with assert_raises_error(error_type="service_unavailable") as _exc_ctx:
+            await fn(query="beam loss")
+
+    envelope = _exc_ctx["envelope"]
+    assert "search_modules.hybrid.settings.rerank" in envelope["error_message"]
+
+    suggestions = envelope["suggestions"]
+    assert any("search_modules.hybrid.settings.rerank" in s for s in suggestions)
+    assert any("config.yml" in s for s in suggestions)
+    assert not any("curl" in s for s in suggestions)
+    assert not any("/health" in s for s in suggestions)
+
+
+@pytest.mark.unit
+async def test_config_fault_without_a_key_still_points_at_the_settings_block(tmp_path, monkeypatch):
+    """The module's message is its own, so the key is not guaranteed to be in it."""
+    _setup_registry(tmp_path, monkeypatch)
+
+    misconfigured = SearchDiagnostic(
+        level=DiagnosticLevel.ERROR,
+        source="service.hybrid",
+        message="the settings block is malformed",
+        category="configuration",
+    )
+
+    mock_service = AsyncMock()
+    mock_service.search.return_value = _make_search_result([], diagnostics=[misconfigured])
+
+    with patch(
+        "osprey.mcp_server.ariel.server_context.ARIELContext.service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        fn = _get_hybrid_search()
+        with assert_raises_error(error_type="service_unavailable") as _exc_ctx:
+            await fn(query="beam loss")
+
+    suggestions = _exc_ctx["envelope"]["suggestions"]
+    assert any("search_modules.hybrid.settings" in s for s in suggestions)
+    assert any("config.yml" in s for s in suggestions)
+    assert not any("curl" in s for s in suggestions)
+
+
+@pytest.mark.unit
 async def test_disabled_mode_names_the_enable_key(tmp_path, monkeypatch):
     """A registered-but-disabled mode is an operator state, not an internal error."""
     from osprey.services.ariel_search.exceptions import ConfigurationError
@@ -447,6 +563,8 @@ def test_docstring_promises_no_field_the_response_omits():
 
     assert "workspace file path" not in doc
     assert "matching entries and relevance scores" in doc
+    # The envelope carries diagnostics now, so the Returns line must say so.
+    assert "diagnostics" in doc
 
 
 @pytest.mark.unit
@@ -539,9 +657,9 @@ async def test_envelope_reports_the_applied_expansion(tmp_path, monkeypatch):
 async def test_pattern_fault_is_not_reported_as_a_sidecar_outage(tmp_path, monkeypatch):
     """A rejected pattern carries the mode's own source, but is not an outage.
 
-    ``_sidecar_fault`` matches on the source alone, so the category-specific
-    fault has to be checked first or a caller typo would send an operator to
-    look at a healthy sidecar.
+    ``_sidecar_fault`` carves out only the ``configuration`` category, so the
+    category-specific fault has to be checked first or a caller typo would send
+    an operator to look at a healthy sidecar.
     """
     _setup_registry(tmp_path, monkeypatch)
 
@@ -570,3 +688,57 @@ async def test_pattern_fault_is_not_reported_as_a_sidecar_outage(tmp_path, monke
     data = _exc_ctx["envelope"]
     assert "SR0[1-4" in data["error_message"]
     assert data["details"]["expanded_terms"] == [TS_GROUP]
+
+
+# --- rerank override --------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [True, False])
+async def test_rerank_is_forwarded_in_advanced_params(tmp_path, monkeypatch, value):
+    """An explicit rerank reaches the service as an advanced parameter."""
+    _setup_registry(tmp_path, monkeypatch)
+
+    mock_service = AsyncMock()
+    mock_service.search.return_value = _make_search_result([])
+
+    with patch(
+        "osprey.mcp_server.ariel.server_context.ARIELContext.service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        fn = _get_hybrid_search()
+        await fn(query="beam loss", rerank=value)
+
+    assert mock_service.search.call_args.kwargs["advanced_params"]["rerank"] is value
+
+
+@pytest.mark.unit
+async def test_rerank_omitted_when_unset(tmp_path, monkeypatch):
+    """Silence leaves the deployment's ``settings.rerank`` in charge."""
+    _setup_registry(tmp_path, monkeypatch)
+
+    mock_service = AsyncMock()
+    mock_service.search.return_value = _make_search_result([])
+
+    with patch(
+        "osprey.mcp_server.ariel.server_context.ARIELContext.service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        fn = _get_hybrid_search()
+        await fn(query="beam loss")
+
+    assert "rerank" not in mock_service.search.call_args.kwargs["advanced_params"]
+
+
+@pytest.mark.unit
+def test_docstring_gives_the_rerank_speed_tradeoff():
+    """The agent can only choose rerank if the prompt tells it what it costs."""
+    from osprey.mcp_server.ariel.tools.hybrid_search import hybrid_search
+
+    doc = get_tool_fn(hybrid_search).__doc__ or ""
+    # The guidance is one wrapped sentence, so the pin must not depend on where
+    # the line breaks fall.
+    flat = " ".join(doc.split())
+
+    assert "rerank" in flat
+    assert "judge relevance yourself when speed matters" in flat

--- a/tests/mcp_server/ariel/test_search_envelope.py
+++ b/tests/mcp_server/ariel/test_search_envelope.py
@@ -1,0 +1,26 @@
+"""Unit tests for the shared ARIEL search-tool envelope helpers."""
+
+import pytest
+
+from osprey.mcp_server.ariel.tools.search_envelope import advanced_params
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [True, False])
+def test_advanced_params_carries_an_explicit_rerank(value):
+    """An explicit choice is an override and has to reach the service."""
+    assert advanced_params(rerank=value)["rerank"] is value
+
+
+@pytest.mark.unit
+def test_advanced_params_omits_an_unset_rerank():
+    """An absent key is how the service hears "no preference"."""
+    assert "rerank" not in advanced_params()
+
+
+@pytest.mark.unit
+def test_advanced_params_keeps_the_other_filters_independent():
+    """Adding rerank must not disturb what the other arguments emit."""
+    params = advanced_params(author="chen", expand_query=False, rerank=True)
+
+    assert params == {"author": "chen", "expand_query": False, "rerank": True}

--- a/tests/services/ariel_search/test_capabilities.py
+++ b/tests/services/ariel_search/test_capabilities.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import types
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from osprey.services.ariel_search.capabilities import (
@@ -10,6 +13,7 @@ from osprey.services.ariel_search.capabilities import (
     shared_parameters,
 )
 from osprey.services.ariel_search.config import ARIELConfig
+from osprey.services.ariel_search.search import keyword as keyword_module
 from osprey.services.ariel_search.search.base import ParameterDescriptor
 from osprey.services.ariel_search.search.keyword import (
     get_parameter_descriptors as keyword_params,
@@ -360,6 +364,165 @@ class TestGetCapabilities:
         result = get_capabilities(config)
         direct_modes = result["categories"]["direct"]["modes"]
         assert direct_modes == []
+
+
+class TestModeParametersFollowTheConfig:
+    """``_add_search_modules`` hands the config to modules that ask for it."""
+
+    def _make_config(self, search_modules: dict) -> ARIELConfig:
+        """Create an ARIELConfig with the given ``search_modules`` block."""
+        return ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost:5432/test"},
+                "search_modules": search_modules,
+            }
+        )
+
+    def _mode_defaults(self, config: ARIELConfig, mode: str) -> dict:
+        """Return ``{parameter name: advertised default}`` for one direct mode."""
+        modes = get_capabilities(config)["categories"]["direct"]["modes"]
+        entry = next(m for m in modes if m["name"] == mode)
+        return {p["name"]: p["default"] for p in entry["parameters"]}
+
+    def _modes_from_stub(self, name: str, module: types.ModuleType) -> list[dict]:
+        """Describe a registry holding one stub search module, enabled.
+
+        Args:
+            name: The module's registry name, also its mode name.
+            module: The stub, carrying ``get_tool_descriptor`` and
+                ``get_parameter_descriptors``.
+
+        Returns:
+            The ``direct`` modes the capabilities payload describes.
+        """
+        registry = MagicMock()
+        registry.list_ariel_search_modules.return_value = [name]
+        registry.get_ariel_search_module.side_effect = {name: module}.get
+
+        config = self._make_config({name: {"enabled": True}})
+        with patch("osprey.registry.get_registry", return_value=registry):
+            return get_capabilities(config)["categories"]["direct"]["modes"]
+
+    def test_hybrid_defaults_mirror_the_deployment(self):
+        """The panel opens hybrid's knobs on the deployment's settings block."""
+        config = self._make_config(
+            {"hybrid": {"enabled": True, "settings": {"rerank": False, "candidate_limit": 12}}}
+        )
+
+        defaults = self._mode_defaults(config, "hybrid")
+
+        assert defaults["rerank"] is False
+        assert defaults["candidate_limit"] == 12
+
+    def test_semantic_default_mirrors_the_deployment(self):
+        """The similarity slider opens on the deployment's own threshold."""
+        config = self._make_config(
+            {
+                "semantic": {
+                    "enabled": True,
+                    "model": "test",
+                    "settings": {"similarity_threshold": 0.8},
+                }
+            }
+        )
+
+        assert self._mode_defaults(config, "semantic")["similarity_threshold"] == 0.8
+
+    def test_shipped_defaults_survive_an_absent_settings_block(self):
+        """A deployment that tunes nothing still sees the shipped defaults."""
+        config = self._make_config(
+            {"hybrid": {"enabled": True}, "semantic": {"enabled": True, "model": "test"}}
+        )
+
+        hybrid = self._mode_defaults(config, "hybrid")
+        assert hybrid["rerank"] is True
+        assert hybrid["candidate_limit"] == 40
+        assert self._mode_defaults(config, "semantic")["similarity_threshold"] == 0.5
+
+    def test_malformed_settings_still_yield_a_payload(self):
+        """One bad key must not cost the panel its modes.
+
+        Startup validation is the surface that names a malformed key. Describing
+        the modules falls back to the shipped defaults instead of raising, so an
+        operator with a typo still gets a usable page to fix it from.
+        """
+        config = self._make_config(
+            {
+                "hybrid": {"enabled": True, "settings": {"rerank": "junk"}},
+                "semantic": {
+                    "enabled": True,
+                    "model": "test",
+                    "settings": {"similarity_threshold": "0.8"},
+                },
+            }
+        )
+
+        result = get_capabilities(config)
+        mode_names = [m["name"] for m in result["categories"]["direct"]["modes"]]
+
+        assert mode_names == ["semantic", "hybrid"]
+        assert self._mode_defaults(config, "hybrid")["rerank"] is True
+        assert self._mode_defaults(config, "semantic")["similarity_threshold"] == 0.5
+
+    def test_zero_arg_module_still_contributes_parameters(self):
+        """A third-party module that takes no config keeps its UI knobs.
+
+        The "add a module, get a UI knob for free" contract: a module whose
+        descriptors do not depend on the deployment stays a zero-argument
+        function, and calling it with a config would raise ``TypeError``.
+        """
+        third_party = types.ModuleType("legacy_third_party")
+        third_party.get_tool_descriptor = keyword_module.get_tool_descriptor
+        third_party.get_parameter_descriptors = lambda: [
+            ParameterDescriptor(
+                name="pin_depth",
+                label="Pin Depth",
+                description="A knob that owes nothing to the deployment config",
+                param_type="int",
+                default=7,
+                section="Options",
+            )
+        ]
+
+        modes = self._modes_from_stub("legacy_third_party", third_party)
+
+        assert [m["name"] for m in modes] == ["legacy_third_party"]
+        assert modes[0]["parameters"][0]["name"] == "pin_depth"
+        assert modes[0]["parameters"][0]["default"] == 7
+
+    def test_uninspectable_callable_is_treated_as_zero_arg(self):
+        """A callable whose signature cannot be read falls back to no arguments.
+
+        Some builtins and C-implemented callables refuse ``inspect.signature``.
+        Guessing "config-aware" there would break a working module; guessing
+        "zero-arg" only reproduces the older shape.
+        """
+
+        class _Opaque:
+            """A callable that refuses signature inspection."""
+
+            def __call__(self):
+                return [
+                    ParameterDescriptor(
+                        name="opaque",
+                        label="Opaque",
+                        description="From a callable with no readable signature",
+                        param_type="bool",
+                        default=True,
+                    )
+                ]
+
+            @property
+            def __signature__(self):
+                raise ValueError("no signature available")
+
+        module = types.ModuleType("opaque_module")
+        module.get_tool_descriptor = keyword_module.get_tool_descriptor
+        module.get_parameter_descriptors = _Opaque()
+
+        modes = self._modes_from_stub("opaque_module", module)
+
+        assert [p["name"] for p in modes[0]["parameters"]] == ["opaque"]
 
 
 VOCABULARY_YML = """

--- a/tests/services/ariel_search/test_config.py
+++ b/tests/services/ariel_search/test_config.py
@@ -913,3 +913,111 @@ class TestKeywordPatternSettings:
         """Same for the boolean knob: dead config is not refused."""
         errors = _keyword_config({"patterns_enabled": "yes"}, enabled=False).validate()
         assert not [error for error in errors if "patterns_enabled" in error]
+
+
+def _hybrid_config(
+    settings: dict[str, object] | None = None, *, enabled: bool = True
+) -> ARIELConfig:
+    """Build a config whose hybrid module carries the given settings block.
+
+    Args:
+        settings: The ``search_modules.hybrid.settings`` mapping, or None to
+            omit the block entirely.
+        enabled: Whether the hybrid module is enabled.
+
+    Returns:
+        The parsed configuration.
+    """
+    hybrid: dict[str, object] = {"enabled": enabled}
+    if settings is not None:
+        hybrid["settings"] = settings
+    return ARIELConfig.from_dict(
+        {
+            "database": {"uri": "postgresql://localhost:5432/ariel"},
+            "search_modules": {"hybrid": hybrid},
+        }
+    )
+
+
+def _semantic_config(
+    settings: dict[str, object] | None = None, *, enabled: bool = True
+) -> ARIELConfig:
+    """Build a config whose semantic module carries the given settings block.
+
+    A ``model`` is always named: semantic search without one is a separate,
+    unrelated validate() error, and these tests are about the settings block.
+
+    Args:
+        settings: The ``search_modules.semantic.settings`` mapping, or None to
+            omit the block entirely.
+        enabled: Whether the semantic module is enabled.
+
+    Returns:
+        The parsed configuration.
+    """
+    semantic: dict[str, object] = {"enabled": enabled, "model": "nomic-embed-text"}
+    if settings is not None:
+        semantic["settings"] = settings
+    return ARIELConfig.from_dict(
+        {
+            "database": {"uri": "postgresql://localhost:5432/ariel"},
+            "search_modules": {"semantic": semantic},
+        }
+    )
+
+
+class TestHybridSettingsValidation:
+    """Tests for ``search_modules.hybrid.settings`` reaching validate()."""
+
+    def test_rerank_error_surfaces_from_validate(self) -> None:
+        """``vocab-check``, ``status`` and startup all report it, naming the key."""
+        errors = _hybrid_config({"rerank": "junk"}).validate()
+        assert "search_modules.hybrid.settings.rerank must be a boolean, got 'junk'" in errors
+
+    def test_candidate_limit_error_surfaces_from_validate(self) -> None:
+        """The other knob in the block is validated by the same resolver call."""
+        errors = _hybrid_config({"candidate_limit": 0}).validate()
+        assert (
+            "search_modules.hybrid.settings.candidate_limit must be a positive integer, got 0"
+            in errors
+        )
+
+    def test_settings_are_not_validated_when_hybrid_is_disabled(self) -> None:
+        """A disabled module's settings reach no reader, so validate() stays quiet."""
+        errors = _hybrid_config({"rerank": "junk"}, enabled=False).validate()
+        assert not [error for error in errors if "search_modules.hybrid.settings" in error]
+
+    def test_absent_settings_block_is_quiet_when_hybrid_is_enabled(self) -> None:
+        """No block is the normal case: the defaults resolve and nothing is reported."""
+        errors = _hybrid_config().validate()
+        assert not [error for error in errors if "search_modules.hybrid.settings" in error]
+
+
+class TestSemanticSettingsValidation:
+    """Tests for ``search_modules.semantic.settings`` reaching validate()."""
+
+    def test_similarity_threshold_error_surfaces_from_validate(self) -> None:
+        """``vocab-check``, ``status`` and startup all report it, naming the key."""
+        errors = _semantic_config({"similarity_threshold": "high"}).validate()
+        assert (
+            "search_modules.semantic.settings.similarity_threshold must be a float in [0, 1], "
+            "got 'high'" in errors
+        )
+
+    def test_out_of_range_threshold_surfaces_from_validate(self) -> None:
+        """A number outside ``[0, 1]`` is named rather than clamped into range."""
+        errors = _semantic_config({"similarity_threshold": 1.5}).validate()
+        assert (
+            "search_modules.semantic.settings.similarity_threshold must be a float in [0, 1], "
+            "got 1.5" in errors
+        )
+
+    def test_settings_are_not_validated_when_semantic_is_disabled(self) -> None:
+        """A disabled module's settings reach no reader, so validate() stays quiet."""
+        errors = _semantic_config({"similarity_threshold": "high"}, enabled=False).validate()
+        assert not [error for error in errors if "search_modules.semantic.settings" in error]
+
+    def test_absent_settings_block_is_quiet_when_semantic_is_enabled(self) -> None:
+        """No block is the normal case: the defaults resolve and nothing is reported."""
+        errors = _semantic_config().validate()
+        assert not [error for error in errors if "search_modules.semantic.settings" in error]

--- a/tests/services/ariel_search/test_hybrid_search.py
+++ b/tests/services/ariel_search/test_hybrid_search.py
@@ -19,6 +19,7 @@ import pytest
 
 from osprey.services.ariel_search.config import ARIELConfig, DatabaseConfig, SearchModuleConfig
 from osprey.services.ariel_search.enhancement.qmd_export.writer import encode_entry_id
+from osprey.services.ariel_search.models import DiagnosticLevel
 from osprey.services.ariel_search.search.base import (
     ExpansionGroup,
     ModuleOutput,
@@ -170,6 +171,29 @@ class TestDescriptor:
         assert by_name["rerank"].default is DEFAULT_RERANK
         assert by_name["candidate_limit"].default == DEFAULT_CANDIDATE_LIMIT
 
+    def test_parameter_descriptors_report_the_configured_values(self):
+        """The panel opens on what a query would do, not on what ships."""
+        by_name = {
+            p.name: p
+            for p in get_parameter_descriptors(
+                make_config({"rerank": False, "candidate_limit": 12})
+            )
+        }
+        assert by_name["rerank"].default is False
+        assert by_name["candidate_limit"].default == 12
+
+    def test_malformed_config_falls_back_instead_of_raising(self):
+        """Describing the module survives a key the query path would refuse."""
+        by_name = {p.name: p for p in get_parameter_descriptors(make_config({"rerank": "junk"}))}
+        assert by_name["rerank"].default is DEFAULT_RERANK
+        assert by_name["candidate_limit"].default == DEFAULT_CANDIDATE_LIMIT
+
+    def test_rerank_description_describes_the_cost_without_a_multiplier(self):
+        """The panel hint explains the mechanism; perf ratios are not ours to promise."""
+        rerank = {p.name: p for p in get_parameter_descriptors()}["rerank"]
+        assert "4x" not in rerank.description
+        assert "slower" in rerank.description.casefold()
+
     def test_registered_in_builtins(self):
         from osprey.registry.builtins import FrameworkRegistryProvider
 
@@ -191,6 +215,13 @@ class TestDescriptor:
 
 class TestSettings:
     """``search_modules.hybrid.settings`` resolution."""
+
+    def test_shipped_defaults_are_rerank_on_and_forty_candidates(self):
+        """Pinned here because the descriptors no longer pin them by construction."""
+        assert DEFAULT_RERANK is True
+        assert DEFAULT_CANDIDATE_LIMIT == 40
+        assert HybridSearchSettings().rerank is True
+        assert HybridSearchSettings().candidate_limit == 40
 
     def test_defaults_when_unconfigured(self):
         settings = HybridSearchSettings.from_ariel_config(make_config())
@@ -790,6 +821,164 @@ class TestSidecarFaults:
         assert results == []
         # Nothing to hydrate, so Postgres is not touched at all.
         assert repo.requested == []
+
+
+# --------------------------------------------------------------------------
+# Reranker fallback
+# --------------------------------------------------------------------------
+
+
+class RerankFaultClient(StubClient):
+    """A client whose reranked queries fail and whose fast queries answer.
+
+    Models the fault this fallback exists for: the sidecar is up — ``/health``
+    answered at resolve time — but the reranker itself cannot serve the query,
+    because its model is still loading after a restart or because the reranked
+    query took the daemon down. The unreranked path still answers.
+    """
+
+    def __init__(
+        self,
+        hits: list[QMDSearchResult] | None = None,
+        *,
+        error: Exception | None = None,
+        retry_error: Exception | None = None,
+    ) -> None:
+        super().__init__(hits)
+        self._rerank_error = error or RuntimeError("reranker model is still loading")
+        self._retry_error = retry_error
+
+    def query(self, collection: str | None, text: str, **kwargs: Any) -> list[QMDSearchResult]:
+        if kwargs.get("rerank"):
+            self.calls.append({"collection": collection, "text": text, **kwargs})
+            raise self._rerank_error
+        if self._retry_error is not None:
+            self.calls.append({"collection": collection, "text": text, **kwargs})
+            raise self._retry_error
+        return super().query(collection, text, **kwargs)
+
+
+class TestRerankFallback:
+    """A reranked-query failure degrades the ranking; it never breaks search."""
+
+    @pytest.mark.asyncio
+    async def test_failed_rerank_retries_without_the_reranker(self):
+        client = RerankFaultClient([make_hit("1")])
+        repo = StubRepository([make_entry("1")])
+
+        result = await hybrid_search("beam", repo, make_config({"rerank": True}), client=client)
+
+        assert isinstance(result, ModuleOutput)
+        assert [call["rerank"] for call in client.calls] == [True, False]
+        ((entry, _, _),) = result.entries
+        assert entry["entry_id"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_the_retry_is_otherwise_the_same_query(self):
+        """Only ``rerank`` changes — a narrower retry would answer differently."""
+        client = RerankFaultClient([])
+
+        await hybrid_search(
+            "beam",
+            StubRepository([]),
+            make_config({"rerank": True}),
+            client=client,
+            max_results=7,
+            candidate_limit=11,
+        )
+
+        first, retry = client.calls
+        assert {key: value for key, value in first.items() if key != "rerank"} == {
+            key: value for key, value in retry.items() if key != "rerank"
+        }
+
+    @pytest.mark.asyncio
+    async def test_the_degraded_ranking_is_reported_as_a_warning(self):
+        client = RerankFaultClient([make_hit("1")])
+        repo = StubRepository([make_entry("1")])
+
+        result = await hybrid_search("beam", repo, make_config({"rerank": True}), client=client)
+
+        (diagnostic,) = result.diagnostics
+        assert diagnostic.level is DiagnosticLevel.WARNING
+        assert diagnostic.source == "hybrid"
+        assert "rerank" in diagnostic.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_any_exception_triggers_the_retry(self):
+        """The client raises whatever its transport raised; all of it falls back."""
+        client = RerankFaultClient([make_hit("1")], error=TimeoutError("read timed out"))
+        repo = StubRepository([make_entry("1")])
+
+        result = await hybrid_search("beam", repo, make_config({"rerank": True}), client=client)
+
+        assert isinstance(result, ModuleOutput)
+        assert [call["rerank"] for call in client.calls] == [True, False]
+
+    @pytest.mark.asyncio
+    async def test_a_failed_retry_raises_the_retrys_error(self):
+        """One retry, not a loop: if the fast path is down too, search is down."""
+        client = RerankFaultClient(
+            error=TimeoutError("read timed out"),
+            retry_error=RuntimeError("qmd daemon is gone"),
+        )
+
+        with pytest.raises(RuntimeError, match="qmd daemon is gone"):
+            await hybrid_search(
+                "beam", StubRepository([]), make_config({"rerank": True}), client=client
+            )
+        assert [call["rerank"] for call in client.calls] == [True, False]
+
+    @pytest.mark.asyncio
+    async def test_a_working_reranker_queries_once_and_returns_a_bare_list(self):
+        client = StubClient([make_hit("1")])
+        repo = StubRepository([make_entry("1")])
+
+        results = await hybrid_search("beam", repo, make_config({"rerank": True}), client=client)
+
+        assert isinstance(results, list)
+        assert len(client.calls) == 1
+        assert client.calls[0]["rerank"] is True
+
+    @pytest.mark.asyncio
+    async def test_an_unreranked_query_is_never_retried(self):
+        """With the reranker off there is nothing to fall back to."""
+        client = StubClient([make_hit("1")], error=RuntimeError("index missing"))
+
+        with pytest.raises(RuntimeError, match="index missing"):
+            await hybrid_search(
+                "beam", StubRepository([]), make_config({"rerank": False}), client=client
+            )
+        assert len(client.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_zero_hit_fallback_still_reports_the_warning(self):
+        """The degraded ranking is news even when it ranked nothing."""
+        client = RerankFaultClient([])
+
+        result = await hybrid_search(
+            "beam", StubRepository([]), make_config({"rerank": True}), client=client
+        )
+
+        assert isinstance(result, ModuleOutput)
+        assert result.entries == []
+        assert len(result.diagnostics) == 1
+
+    @pytest.mark.asyncio
+    async def test_one_output_carries_both_the_warning_and_the_expansion(self):
+        client = RerankFaultClient([make_hit("1")])
+        repo = StubRepository([make_entry("1")])
+
+        result = await hybrid_search(
+            "ts fault",
+            repo,
+            make_config({"rerank": True}),
+            client=client,
+            query_expansion=AMBIGUOUS_EXPANSION,
+        )
+
+        assert result.expansion == AMBIGUOUS_GROUPS
+        assert len(result.diagnostics) == 1
 
 
 # --------------------------------------------------------------------------

--- a/tests/services/ariel_search/test_semantic_search.py
+++ b/tests/services/ariel_search/test_semantic_search.py
@@ -1,0 +1,262 @@
+"""Tests for the ARIEL semantic search module's settings parser.
+
+The parser is what turns ``search_modules.semantic.settings`` from a bag of
+whatever YAML happened to hold into a typed value the query path can trust. A
+present-but-malformed threshold used to travel all the way to the repository
+(and to the capabilities slider) as-is; these tests pin the refusal instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from osprey.services.ariel_search.config import (
+    ARIELConfig,
+    DatabaseConfig,
+    SearchModuleConfig,
+)
+from osprey.services.ariel_search.search.semantic import (
+    DEFAULT_SIMILARITY_THRESHOLD,
+    SemanticSearchSettings,
+    get_parameter_descriptors,
+    semantic_search,
+)
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def make_config(settings: dict[str, Any] | None = None) -> ARIELConfig:
+    """Build an ARIELConfig whose ``semantic`` module carries *settings*."""
+    config = ARIELConfig(database=DatabaseConfig(uri="postgresql://localhost/ariel"))
+    config.search_modules["semantic"] = SearchModuleConfig(enabled=True, settings=settings or {})
+    return config
+
+
+def make_wired_config(settings: dict[str, Any] | None = None) -> ARIELConfig:
+    """Build a config complete enough for :func:`semantic_search` to run."""
+    module: dict[str, Any] = {"enabled": True, "model": "test-model"}
+    if settings is not None:
+        module["settings"] = settings
+    return ARIELConfig.from_dict(
+        {
+            "database": {"uri": "postgresql://localhost/test"},
+            "search_modules": {"semantic": module},
+        }
+    )
+
+
+@pytest.fixture
+def mock_repository():
+    """A repository that records the arguments the query path hands it."""
+    repo = MagicMock()
+    repo.semantic_search = AsyncMock(return_value=[])
+    return repo
+
+
+@pytest.fixture
+def mock_embedder():
+    """An embedding provider that answers with a fixed vector."""
+    embedder = MagicMock()
+    embedder.default_base_url = "http://localhost:11434"
+    embedder.execute_embedding = MagicMock(return_value=[[0.1, 0.2, 0.3]])
+    return embedder
+
+
+# --------------------------------------------------------------------------
+# Settings
+# --------------------------------------------------------------------------
+
+
+class TestSettings:
+    """``search_modules.semantic.settings`` resolution."""
+
+    def test_defaults_when_unconfigured(self):
+        settings = SemanticSearchSettings.from_ariel_config(make_config())
+        assert settings.similarity_threshold == DEFAULT_SIMILARITY_THRESHOLD
+
+    def test_defaults_when_module_absent_entirely(self):
+        bare = ARIELConfig(database=DatabaseConfig(uri="postgresql://localhost/ariel"))
+        parsed = SemanticSearchSettings.from_ariel_config(bare)
+        assert parsed.similarity_threshold == DEFAULT_SIMILARITY_THRESHOLD
+
+    def test_defaults_when_config_is_none(self):
+        parsed = SemanticSearchSettings.from_ariel_config(None)
+        assert parsed.similarity_threshold == DEFAULT_SIMILARITY_THRESHOLD
+
+    def test_config_sets_threshold(self):
+        settings = SemanticSearchSettings.from_ariel_config(
+            make_config({"similarity_threshold": 0.85})
+        )
+        assert settings.similarity_threshold == 0.85
+
+    @pytest.mark.parametrize("value", [0, 1])
+    def test_integer_bounds_are_accepted_as_floats(self, value):
+        settings = SemanticSearchSettings.from_ariel_config(
+            make_config({"similarity_threshold": value})
+        )
+        assert settings.similarity_threshold == float(value)
+        assert isinstance(settings.similarity_threshold, float)
+
+    @pytest.mark.parametrize("bad", ["0.8", None, [], {}])
+    def test_malformed_threshold_is_refused(self, bad):
+        with pytest.raises(
+            ValueError, match="search_modules.semantic.settings.similarity_threshold"
+        ):
+            SemanticSearchSettings.from_ariel_config(make_config({"similarity_threshold": bad}))
+
+    @pytest.mark.parametrize("bad", [True, False])
+    def test_boolean_threshold_is_refused(self, bad):
+        with pytest.raises(
+            ValueError, match="search_modules.semantic.settings.similarity_threshold"
+        ):
+            SemanticSearchSettings.from_ariel_config(make_config({"similarity_threshold": bad}))
+
+    @pytest.mark.parametrize("bad", [-0.1, 1.5, -1, 2])
+    def test_out_of_range_threshold_is_refused(self, bad):
+        with pytest.raises(ValueError, match=r"must be a float in \[0, 1\]"):
+            SemanticSearchSettings.from_ariel_config(make_config({"similarity_threshold": bad}))
+
+    def test_settings_are_frozen(self):
+        settings = SemanticSearchSettings.from_ariel_config(make_config())
+        with pytest.raises(Exception):
+            settings.similarity_threshold = 0.1  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------
+# Wiring into the query path
+# --------------------------------------------------------------------------
+
+
+class TestThresholdResolution:
+    """What :func:`semantic_search` hands the repository."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_argument_wins_over_config(self, mock_repository, mock_embedder):
+        await semantic_search(
+            "test",
+            mock_repository,
+            make_wired_config({"similarity_threshold": 0.8}),
+            mock_embedder,
+            similarity_threshold=0.3,
+        )
+        assert mock_repository.semantic_search.call_args.kwargs["similarity_threshold"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_config_value_is_used_without_an_argument(self, mock_repository, mock_embedder):
+        await semantic_search(
+            "test",
+            mock_repository,
+            make_wired_config({"similarity_threshold": 0.9}),
+            mock_embedder,
+        )
+        assert mock_repository.semantic_search.call_args.kwargs["similarity_threshold"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_default_applies_when_settings_are_absent(self, mock_repository, mock_embedder):
+        await semantic_search("test", mock_repository, make_wired_config(), mock_embedder)
+        assert (
+            mock_repository.semantic_search.call_args.kwargs["similarity_threshold"]
+            == DEFAULT_SIMILARITY_THRESHOLD
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_settings_raise_instead_of_reaching_the_repository(
+        self, mock_repository, mock_embedder
+    ):
+        with pytest.raises(
+            ValueError, match="search_modules.semantic.settings.similarity_threshold"
+        ):
+            await semantic_search(
+                "test",
+                mock_repository,
+                make_wired_config({"similarity_threshold": "high"}),
+                mock_embedder,
+            )
+        mock_repository.semantic_search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_explicit_argument_short_circuits_the_config_block(
+        self, mock_repository, mock_embedder
+    ):
+        # A caller that named the threshold never reaches the config block, so
+        # a malformed one does not fail a query that had no use for it. The
+        # deployment-wide answer to a malformed block is startup validation,
+        # not a per-query surprise on the one path that already has a value.
+        await semantic_search(
+            "test",
+            mock_repository,
+            make_wired_config({"similarity_threshold": "high"}),
+            mock_embedder,
+            similarity_threshold=0.4,
+        )
+        assert mock_repository.semantic_search.call_args.kwargs["similarity_threshold"] == 0.4
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_before_parsing(self, mock_repository, mock_embedder):
+        # The empty-query short circuit stays ahead of the parser, so a blank
+        # box in the panel is not the thing that surfaces a config error.
+        result = await semantic_search(
+            "   ",
+            mock_repository,
+            make_wired_config({"similarity_threshold": "high"}),
+            mock_embedder,
+        )
+        assert result == []
+
+
+# --------------------------------------------------------------------------
+# Parameter descriptors
+# --------------------------------------------------------------------------
+
+
+class TestParameterDescriptors:
+    """What the capabilities API reports as the panel's starting point.
+
+    Only the semantic module grew a ``config`` parameter alongside hybrid's.
+    The keyword module's two descriptors (``include_highlights``,
+    ``fuzzy_fallback``) have no counterpart in ``KeywordSearchSettings``, which
+    covers ``patterns_enabled`` and ``pattern_timeout_seconds`` instead — there
+    is no configured value for them to report, so ``keyword`` stays zero-arg
+    deliberately rather than by oversight.
+    """
+
+    def test_defaults_to_the_shipped_threshold_with_no_config(self):
+        descriptor = get_parameter_descriptors()[0]
+        assert descriptor.name == "similarity_threshold"
+        assert descriptor.default == DEFAULT_SIMILARITY_THRESHOLD
+
+    def test_bounds_are_the_slider_the_panel_draws(self):
+        descriptor = get_parameter_descriptors()[0]
+        assert descriptor.param_type == "float"
+        assert descriptor.min_value == 0.0
+        assert descriptor.max_value == 1.0
+        assert descriptor.step == 0.01
+        assert descriptor.section == "Retrieval"
+
+    def test_reports_the_configured_threshold(self):
+        """The panel opens on what a query would do, not on what ships."""
+        descriptor = get_parameter_descriptors(make_config({"similarity_threshold": 0.8}))[0]
+        assert descriptor.default == 0.8
+
+    def test_malformed_config_falls_back_instead_of_raising(self):
+        """Describing the module survives a key the query path would refuse.
+
+        Without the fallback the capabilities endpoint raises and the slider
+        renders with no default at all; startup validation is what names the
+        offending key.
+        """
+        descriptor = get_parameter_descriptors(make_config({"similarity_threshold": "high"}))[0]
+        assert descriptor.default == DEFAULT_SIMILARITY_THRESHOLD
+
+    @pytest.mark.parametrize("bad", [True, -0.1, 1.5, None])
+    def test_every_refused_spelling_falls_back(self, bad):
+        descriptor = get_parameter_descriptors(make_config({"similarity_threshold": bad}))[0]
+        assert descriptor.default == DEFAULT_SIMILARITY_THRESHOLD
+
+    def test_config_of_none_matches_the_zero_argument_call(self):
+        assert get_parameter_descriptors(None) == get_parameter_descriptors()

--- a/tests/services/ariel_search/test_service.py
+++ b/tests/services/ariel_search/test_service.py
@@ -462,6 +462,56 @@ class TestServiceRouting:
         assert isinstance(error.__cause__, RuntimeError)
 
     @pytest.mark.asyncio
+    async def test_malformed_module_settings_reported_as_configuration(self):
+        """A module refusing its own settings block yields a *configuration* error.
+
+        The service answers module failures with an empty result plus one ERROR
+        diagnostic, so the diagnostic's category is the only machine-readable
+        signal an agent-side caller has. A malformed knob must not look like a
+        broken search -- otherwise the caller sends the operator to check a
+        sidecar that is healthy instead of the config key that is not.
+        """
+        from osprey.services.ariel_search.models import DiagnosticLevel
+
+        service = self._create_mock_service(
+            search_modules={"hybrid": {"enabled": True, "settings": {"rerank": "junk"}}}
+        )
+
+        result = await service.search("beam current", mode="hybrid")
+
+        assert result.entries == ()
+        errors = [d for d in result.diagnostics if d.level is DiagnosticLevel.ERROR]
+        assert len(errors) == 1
+        assert errors[0].category == "configuration"
+        assert errors[0].source == "service.hybrid"
+        # The module's own message survives verbatim, so it still names the key.
+        assert "search_modules.hybrid.settings.rerank" in errors[0].message
+
+    @pytest.mark.asyncio
+    async def test_generic_module_failure_keeps_search_category(self):
+        """An ordinary module crash stays category "search"."""
+        from osprey.services.ariel_search.models import DiagnosticLevel
+
+        service = self._create_mock_service(search_modules={"keyword": {"enabled": True}})
+
+        with patch(
+            "osprey.services.ariel_search.search.keyword.keyword_search",
+            new=AsyncMock(side_effect=RuntimeError("index is on fire")),
+        ):
+            result = await service.search("beam current", mode="keyword")
+
+        errors = [d for d in result.diagnostics if d.level is DiagnosticLevel.ERROR]
+        assert len(errors) == 1
+        assert errors[0].category == "search"
+        assert "index is on fire" in errors[0].message
+
+    def test_error_result_defaults_to_search_category(self):
+        """The new category parameter does not move the default out from under callers."""
+        result = ARIELSearchService._error_result("keyword", "service.keyword", RuntimeError("x"))
+
+        assert result.diagnostics[0].category == "search"
+
+    @pytest.mark.asyncio
     async def test_semantic_results_projected_to_entries_and_sources(self, fake_embedding_provider):
         """Semantic hits become entries carrying _score, plus an entry_id source tuple."""
         service = self._create_mock_service(
@@ -851,6 +901,24 @@ class TestAdvancedParamsWiring:
         kwargs = keyword_search.call_args.kwargs
         assert kwargs["include_highlights"] is False
         assert kwargs["fuzzy_fallback"] is False
+
+    @pytest.mark.asyncio
+    async def test_advanced_params_rerank_reaches_hybrid(self):
+        """A per-query rerank override survives the trip into the hybrid module.
+
+        The spread at ``_run_module`` strips ``expand_query`` before dispatch;
+        this pins that ``rerank`` is not swallowed the same way, since the
+        module's ``**kwargs`` would hide the loss without a TypeError.
+        """
+        service = self._create_mock_service(search_modules={"hybrid": {"enabled": True}})
+
+        with patch(
+            "osprey.services.ariel_search.search.qmd.hybrid_search",
+            new=AsyncMock(return_value=[]),
+        ) as hybrid_search:
+            await service.search("test", mode="hybrid", advanced_params={"rerank": False})
+
+        assert hybrid_search.call_args.kwargs["rerank"] is False
 
     @pytest.mark.asyncio
     async def test_advanced_params_default_empty(self):


### PR DESCRIPTION
The ARIEL search panel seeded every knob from hardcoded descriptor defaults and
sent all of them on every request, so it silently overrode deployment config in
both directions — a deployment that had turned reranking off got it back the
moment someone opened the panel, and one that had tuned `candidate_limit` had
that tuning discarded. A reranked hybrid query then gave no feedback at all for
roughly twenty seconds, any reranker fault failed the whole search, and a typo
in a search setting surfaced as advice to go check the sidecar rather than as
the name of the key that was wrong.

Descriptor defaults now derive from the deployment config, the panel sends only
the knobs the operator actually touched, and Reset clears that set. One key,
`ariel.search_modules.hybrid.settings.rerank`, governs both surfaces rather
than each growing its own: the `hybrid_search` tool takes a per-call `rerank`
argument, and the panel toggle overrides for the session until Reset.

The wait becomes legible instead of shorter. With rerank active the panel
issues two requests — the fast ranking renders immediately behind a status
line, then the reranked ranking replaces it, guarded so a late response from a
superseded search cannot repaint. A reranked query that fails is retried once
without the reranker and carries a WARNING diagnostic, so a reranker fault
costs the query its ranking quality rather than its results; only the retry's
failure is a real error. Malformed settings are named at startup validation,
malformed per-query overrides are refused with a 400, and module config errors
reach the agent as configuration hints.

## How it hangs together

```text
                       deployment config
          ariel.search_modules.hybrid.settings.rerank
          (+ candidate_limit, semantic similarity_threshold)
                              │
                              │  one key, two surfaces
               ┌──────────────┴───────────────┐
               ▼                              ▼
    ── search panel ──────────      ── agent tool ─────────────
    capabilities.py                  mcp/hybrid_search.py
      descriptor defaults              rerank: bool | None
      derived from config              (absent = config default)
               │                              │
    advanced-options.js                       │
      touched:Set → send only touched         │
      Reset → clear                           │
               │                              │
    search.js — two requests                  │
      1. rerank:false → fast hits             │
         + renderRerankStatus()               │
      2. rerank:true  → re-render             │
         guarded by search id                 │
               │                              │
               ▼                              │
    routes.py  malformed override → 400       │
               └───────────────┬──────────────┘
                               ▼
                   ariel_search/service.py ──► config.py validate()
                     module error → config       names a malformed
                     diagnostic                  setting at startup
                               │
                               ▼
                   search/qmd.py  _fetch_hits(rerank)
                     ├─ reranked ok ──────────► hits
                     └─ reranked fails ─► one retry, no reranker
                                           └──► hits + WARNING diagnostic
                               │
                               ▼
                   search_envelope.py — diagnostics reach both surfaces
```
