### PR TITLE
fix(deploy): make the injected graphdb service healthy, droppable, and seedable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,9 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- The graphdb container's healthcheck now probes with `wget`, which the Neo4j
+  community image ships, instead of `curl`, which it does not — the container
+  no longer sits at `unhealthy` forever while the store is serving.
 - Dependabot pull requests no longer fail CI: the Deploy E2E lane now skips on
   Dependabot runs (which get no Actions secrets) like every other secret-gated
   lane, and the run summary names it among the lanes to revalidate. Dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,11 @@ Compatibility is documented in release notes, not encoded in the version string.
 - The graphdb container's healthcheck now probes with `wget`, which the Neo4j
   community image ships, instead of `curl`, which it does not — the container
   no longer sits at `unhealthy` forever while the store is serving.
+- The documented removal spelling for the graph store works: a bare
+  `services.graphdb:` in a profile's `config:` block now renders a project with
+  no graphdb container, no `graphdb` in `deployed_services`, and no `graph` MCP
+  server, instead of crashing the build. The ambiguous `services.graphdb: {}`
+  is refused at validation with a message naming both working spellings.
 - Dependabot pull requests no longer fail CI: the Deploy E2E lane now skips on
   Dependabot runs (which get no Actions secrets) like every other secret-gated
   lane, and the run summary names it among the lanes to revalidate. Dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,11 @@ Compatibility is documented in release notes, not encoded in the version string.
   no graphdb container, no `graphdb` in `deployed_services`, and no `graph` MCP
   server, instead of crashing the build. The ambiguous `services.graphdb: {}`
   is refused at validation with a message naming both working spellings.
+- `osprey knowledge seed-graph` can succeed out of the box again: the graphdb
+  service's default image moved to `neo4j:5.26-community`, the newest server
+  line the neosemantics (n10s) plugin manifest covers. A store whose plugin
+  never installed is now reported as "no compatible n10s plugin installed for
+  Neo4j <version>" with the remedy, instead of a missing stored procedure.
 - Dependabot pull requests no longer fail CI: the Deploy E2E lane now skips on
   Dependabot runs (which get no Actions secrets) like every other secret-gated
   lane, and the run summary names it among the lanes to revalidate. Dependency

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -196,11 +196,12 @@ keys:
   services.graphdb.image:
     evidence: '_text\(block\.get\("image"\)'
     note: >-
-      Pinned to neo4j:5.20-community by DEFAULT_IMAGE, and the pin is about the
+      Pinned to neo4j:5.26-community by DEFAULT_IMAGE, and the pin is about the
       neosemantics (n10s) plugin's release cadence rather than Neo4j's: without
-      n10s the store cannot import the RDF corpus at all, and it publishes no
-      build for 5.23+. Overridable per project for a mirror or a pre-baked
-      image; the compose fragment layers ${OSPREY_GRAPHDB_IMAGE} over it.
+      n10s the store cannot import the RDF corpus at all, and 5.26 is the
+      newest server line its plugin manifest covers. Overridable per project
+      for a mirror or a pre-baked image; the compose fragment layers
+      ${OSPREY_GRAPHDB_IMAGE} over it.
   services.graphdb.port_host:
     evidence: '_port\(block\.get\("port_host"\)'
     note: >-

--- a/src/osprey/cli/build_persistence.py
+++ b/src/osprey/cli/build_persistence.py
@@ -43,6 +43,37 @@ def _apply_config_overrides(project_path: Path, config_dict: dict[str, Any]) -> 
         logger.warning("config.yml not found at %s. Skipping the config overrides.", config_path)
         return
     config_update_fields(config_path, config_dict)
+    _finish_graphdb_removal(project_path, config_dict)
+
+
+def _finish_graphdb_removal(project_path: Path, config_dict: dict[str, Any]) -> None:
+    """Honor the bare ``services.graphdb:`` override as removal of the store.
+
+    A whole-block override replaces what the app template rendered, and the
+    bare key-with-no-value (YAML ``None``) replaces it with nothing — the
+    documented spelling for a deployment that wants no graph store. The write
+    above leaves a literal ``graphdb:`` null under ``services:``, which every
+    resolver already reads as "no store"; but the template also put
+    ``graphdb`` in ``deployed_services``, and that entry is what the
+    service-template copy and the compose render key off — the first crashed
+    on the null block, the second aborted on a service with no block. Removal
+    therefore has to be finished here: delete the null key, withdraw the
+    ``deployed_services`` entry, and drop the service-template directory the
+    base render copied in by name, so the render carries no trace of a store —
+    no compose fragment, and (through the ``graphdb_configured`` gate at the
+    Claude Code render) no ``graph`` MCP server.
+    """
+    from osprey.deployment.graphdb_service import GRAPHDB_SERVICE_NAME
+    from osprey.utils.config_writer import config_delete_field, config_remove_from_list
+
+    key = f"services.{GRAPHDB_SERVICE_NAME}"
+    if key not in config_dict or config_dict[key] is not None:
+        return
+    config_delete_field(project_path / "config.yml", key)
+    config_remove_from_list(
+        project_path / "config.yml", ["deployed_services"], GRAPHDB_SERVICE_NAME, prune_empty=False
+    )
+    shutil.rmtree(project_path / "services" / GRAPHDB_SERVICE_NAME, ignore_errors=True)
 
 
 @dataclass

--- a/src/osprey/cli/build_profile_model.py
+++ b/src/osprey/cli/build_profile_model.py
@@ -855,6 +855,22 @@ class BuildProfile:
                 f"(got {type(self.config).__name__})"
             )
 
+        # The empty whole-block override is refused by name. `{}` is not the
+        # removal spelling — an empty mapping reads as "a store at the
+        # defaults" everywhere the block is resolved — but as a replacement it
+        # drops the `path` the compose render locates the service's fragment
+        # by, so the deploy it describes can only fail. Both working spellings
+        # are handed back instead of letting that failure surface as a missing
+        # compose file three phases later.
+        if isinstance(self.config, dict) and self.config.get(_GRAPHDB_CONFIG_PREFIX) == {}:
+            errors.append(
+                f"config: `{_GRAPHDB_CONFIG_PREFIX}: {{}}` replaces the rendered block "
+                f"with an empty mapping, which keeps the store but drops the `path` its "
+                f"compose fragment is rendered from. Write the bare "
+                f"`{_GRAPHDB_CONFIG_PREFIX}:` (no value) to remove the graph store, or "
+                f"set `{_GRAPHDB_CONFIG_PREFIX}.<key>:` entries to re-point it."
+            )
+
         if self.tier is not None and self.tier not in (1, 3):
             errors.append(f"tier must be 1 or 3 (got {self.tier!r})")
 

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -559,6 +559,16 @@ def seed_graph(ttl: Path | None, force: bool) -> None:
             _bake_prompt_snapshot(session)
     except click.ClickException:
         raise
+    except graph_seeder.MissingN10sPluginError as exc:
+        # The store answered — this is not a connection failure, and folding it
+        # into one would send the operator to check an address that works. The
+        # seeder's message names the plugin gap and the server version.
+        fail(
+            "The graph store cannot import RDF.",
+            str(exc),
+            "Nothing was seeded; the store's data was not touched.",
+        )
+        raise SystemExit(1) from exc
     except ImportError as exc:
         # The driver is a core dependency, so this means a broken install; the
         # seeder's own message says how to repair it.

--- a/src/osprey/deployment/graphdb_service.py
+++ b/src/osprey/deployment/graphdb_service.py
@@ -17,7 +17,7 @@ Config shape, as it appears in a project's ``config.yml``::
     services:
       graphdb:
         path: ./services/graphdb
-        image: neo4j:5.20-community
+        image: neo4j:5.26-community
         port_host: 7687                            # bolt, the driver protocol
         http_port_host: 7474                       # Neo4j Browser / HTTP API
         ttl_path: ./data/demo_machine.ttl          # optional; corpus to seed
@@ -103,12 +103,16 @@ GRAPHDB_SERVICE_NAME = "graphdb"
 
 #: Image the store runs by default, overridable per project.
 #:
-#: Pinned to 5.20 rather than tracking a newer Neo4j: neosemantics (n10s) — the
-#: plugin that imports RDF, without which the store has no way to load the
-#: corpus at all — publishes no build for 5.23 or later. The pin is therefore a
+#: Pinned to the 5.26 LTS line rather than tracking a newer Neo4j: neosemantics
+#: (n10s) — the plugin that imports RDF, without which the store has no way to
+#: load the corpus at all — is installed at container start from its plugin
+#: manifest (https://neo4j-labs.github.io/neosemantics/versions.json), and 5.26
+#: is the newest server line that manifest covers; it does so patch-by-patch,
+#: where older lines get at most a single frozen entry. The pin is therefore a
 #: statement about the plugin's release cadence, not about Neo4j's, and it can
-#: move as soon as n10s ships for a newer server.
-DEFAULT_IMAGE = "neo4j:5.20-community"
+#: move as soon as n10s ships for a newer server. Check the manifest — and the
+#: supported-set pin test beside this module's config tests — before bumping.
+DEFAULT_IMAGE = "neo4j:5.26-community"
 
 #: Published host port for the bolt protocol, which is the only thing the neo4j
 #: driver speaks. Matches the container-internal port, so the derived
@@ -224,7 +228,7 @@ class GraphdbConnection:
 
     Consumers should keep to driver APIs common to the 5.x and 6.x lines
     (``execute_query``, ``execute_read``): the repo's ``neo4j>=5.20`` floor
-    resolves to the 6.x driver, while the server it dials is pinned to 5.20.
+    resolves to the 6.x driver, while the server it dials is pinned to 5.26.
 
     Attributes:
         uri: Address to dial — an explicit external one, or the derived

--- a/src/osprey/services/facility_knowledge/seeder/graph_seeder.py
+++ b/src/osprey/services/facility_knowledge/seeder/graph_seeder.py
@@ -14,7 +14,7 @@ must not pull the driver into the runtime read path's ``sys.modules``, which is
 guarded by ``tests/services/facility_knowledge/test_import_isolation.py``.
 
 Driver-API constraint: the repo's ``neo4j>=5.20`` floor resolves to the 6.x
-driver line while the server it dials is pinned to ``neo4j:5.20-community``.
+driver line while the server it dials is pinned to ``neo4j:5.26-community``.
 Only APIs present in *both* lines are used — ``session.run()`` and
 ``result.consume()``/``result.single()``, never ``Session.read_transaction`` /
 ``Session.write_transaction`` (removed in 6.0).
@@ -143,6 +143,43 @@ _IMPORT_CYPHER = (
 )
 
 _WIPE_CYPHER = "MATCH (n) DETACH DELETE n"
+
+#: Server identity, read only to name the version in the missing-plugin error.
+_COMPONENTS_CYPHER = "CALL dbms.components() YIELD name, versions, edition"
+
+#: Driver error code for a Cypher ``CALL`` naming a procedure the server does
+#: not have. Matched by attribute rather than by exception type so this module
+#: keeps its no-driver-import property (see :func:`open_session`).
+_PROCEDURE_NOT_FOUND_CODE = "Neo.ClientError.Procedure.ProcedureNotFound"
+
+
+class MissingN10sPluginError(RuntimeError):
+    """The store answered, but the neosemantics (n10s) plugin is not loaded.
+
+    The default image installs n10s at container start from the plugin
+    manifest; on a Neo4j version the manifest has no entry for — or on a host
+    whose egress mangles the manifest fetch — the jar is silently absent, the
+    server comes up healthy, and the first ``n10s.*`` call dies with
+    ``ProcedureNotFound``. Surfaced raw, that reads like a corrupt database;
+    this error says what actually happened and which server version has no
+    plugin, so the remedy (a Neo4j version n10s publishes for, or a pre-baked
+    jar) is findable.
+    """
+
+
+def _server_identity(session: Session) -> str:
+    """Best-effort ``<version> <edition>`` of the server, for error text only.
+
+    Never raises: an error message that dies producing itself reports the
+    wrong fault, so any failure here degrades to a placeholder.
+    """
+    try:
+        for record in session.run(_COMPONENTS_CYPHER):
+            if record["name"] == "Neo4j Kernel":
+                return f"{record['versions'][0]} {record['edition']}"
+    except Exception:  # noqa: BLE001 — see docstring
+        pass
+    return "<unknown version>"
 
 
 # ---------------------------------------------------------------------------
@@ -351,10 +388,28 @@ def bootstrap(session: Session) -> BootstrapResult:
         Callers should treat :attr:`BootstrapStatus.DIFFERS` as "do not import;
         tell the operator to re-seed with ``--force``" — see
         :attr:`BootstrapResult.message`.
+
+    Raises:
+        MissingN10sPluginError: If the store has no ``n10s.*`` procedures —
+            the plugin never installed. Detected on the first n10s call, which
+            is what any later one would die on too, and named as the plugin
+            gap it is rather than surfacing as a missing stored procedure.
     """
     session.run(_CONSTRAINT_CYPHER).consume()
 
-    live = _live_graph_config(session)
+    try:
+        live = _live_graph_config(session)
+    except Exception as exc:
+        if getattr(exc, "code", None) != _PROCEDURE_NOT_FOUND_CODE:
+            raise
+        raise MissingN10sPluginError(
+            f"no compatible n10s plugin installed for Neo4j {_server_identity(session)} — "
+            f"the server is up and answering, but the neosemantics plugin that imports "
+            f"RDF never loaded (the container log carries the matching 'No compatible "
+            f"n10s plugin found' line from startup). Point services.graphdb.image at a "
+            f"Neo4j version neosemantics publishes a build for, or bake the n10s jar "
+            f"into the image, then recreate the store."
+        ) from exc
     if not live:
         session.run(_GRAPHCONFIG_INIT_CYPHER, params=dict(N10S_GRAPH_CONFIG)).consume()
         result = BootstrapResult(status=BootstrapStatus.INITIALIZED)

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -208,10 +208,11 @@ services:
   # in the project .env yourself, or the store refuses the connection.
   graphdb:
     path: ./services/graphdb
-    image: neo4j:5.20-community  # Pinned to 5.20: neosemantics (n10s), the
-                                 # plugin that imports the RDF, publishes no
-                                 # build for 5.23+. Repoint it at a mirror or a
-                                 # pre-baked image on an air-gapped host.
+    image: neo4j:5.26-community  # Pinned to the 5.26 LTS line: neosemantics
+                                 # (n10s), the plugin that imports the RDF, has
+                                 # no manifest entry for anything newer. Repoint
+                                 # it at a mirror or a pre-baked image on an
+                                 # air-gapped host.
     port_host: 7687       # Bolt — the only protocol the neo4j driver speaks,
                           # so this is what the seeder and the agent dial.
     http_port_host: 7474  # HTTP — the Neo4j Browser an operator opens, and the

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -259,10 +259,11 @@ services:
   # in the project .env yourself, or the store refuses the connection.
   graphdb:
     path: ./services/graphdb
-    image: neo4j:5.20-community  # Pinned to 5.20: neosemantics (n10s), the
-                                 # plugin that imports the RDF, publishes no
-                                 # build for 5.23+. Repoint it at a mirror or a
-                                 # pre-baked image on an air-gapped host.
+    image: neo4j:5.26-community  # Pinned to the 5.26 LTS line: neosemantics
+                                 # (n10s), the plugin that imports the RDF, has
+                                 # no manifest entry for anything newer. Repoint
+                                 # it at a mirror or a pre-baked image on an
+                                 # air-gapped host.
     port_host: 7687       # Bolt — the only protocol the neo4j driver speaks,
                           # so this is what the seeder and the agent dial.
     http_port_host: 7474  # HTTP — the Neo4j Browser an operator opens, and the

--- a/src/osprey/templates/services/graphdb/docker-compose.yml.j2
+++ b/src/osprey/templates/services/graphdb/docker-compose.yml.j2
@@ -43,14 +43,16 @@ services:
     # services.graphdb.image in config.yml, to point at a mirror or a pinned
     # digest (e.g. for air-gapped registries).
     #
-    # The 5.20 default is a pin, not a snapshot of "current". neosemantics —
+    # The 5.26 default is a pin, not a snapshot of "current". neosemantics —
     # the plugin that imports RDF, without which this store has no way to load
-    # the corpus at all — publishes no build for Neo4j 5.23 or later as of May
-    # 2026. So the pin tracks the PLUGIN's release cadence, not the server's:
-    # check https://github.com/neo4j-labs/neosemantics/releases for a build
+    # the corpus at all — is installed at container start from its plugin
+    # manifest, and the 5.26 LTS line is the newest server line that manifest
+    # covers as of August 2026. So the pin tracks the PLUGIN's release
+    # cadence, not the server's: check
+    # https://neo4j-labs.github.io/neosemantics/versions.json for an entry
     # matching the newer server before bumping this, because a server the
     # plugin has no jar for comes up healthy and then fails every import.
-    image: ${OSPREY_GRAPHDB_IMAGE:-{{ graphdb.image | default('neo4j:5.20-community', true) }}}
+    image: ${OSPREY_GRAPHDB_IMAGE:-{{ graphdb.image | default('neo4j:5.26-community', true) }}}
     # container_name is a HOST-GLOBAL docker identifier: a bare `graphdb`
     # collides when two OSPREY projects deploy a graph store on one host,
     # forcing them to serialize. Namespace it per-project so concurrent deploys

--- a/src/osprey/templates/services/graphdb/docker-compose.yml.j2
+++ b/src/osprey/templates/services/graphdb/docker-compose.yml.j2
@@ -178,7 +178,12 @@ services:
       # becoming a second place the minted password has to be spelled. A pass
       # means the server is up and serving, which is the condition the seeder
       # waits on before it bootstraps the graph config and imports the corpus.
-      test: ["CMD-SHELL", "curl -fsS -o /dev/null --max-time 5 http://127.0.0.1:{{ probe_port }}/"]
+      #
+      # wget, not curl: the neo4j community image ships wget (its own
+      # entrypoint fetches the n10s jar with it) and no curl at all — a curl
+      # probe fails on every attempt and parks the container at `unhealthy`
+      # while the store serves normally.
+      test: ["CMD-SHELL", "wget -q -O /dev/null -T 5 http://127.0.0.1:{{ probe_port }}/"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/tests/_graphdb_container.py
+++ b/tests/_graphdb_container.py
@@ -58,14 +58,15 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 #: Same server pin as the shipped compose template.  Load-bearing twice over:
-#: neosemantics publishes no build for 5.23+, and the n10s release below is the
-#: build made for exactly this server line.
-NEO4J_IMAGE = "neo4j:5.20-community"
+#: the 5.26 LTS line is the newest one the neosemantics plugin manifest
+#: covers, and the n10s release below is the build made for exactly this
+#: server line.
+NEO4J_IMAGE = "neo4j:5.26-community"
 
 #: neosemantics release matching :data:`NEO4J_IMAGE`.  n10s versions track the
 #: server they are built against, so this moves with the image pin or not at
 #: all — a mismatched jar loads and then fails every procedure call.
-N10S_VERSION = "5.20.0"
+N10S_VERSION = "5.26.0"
 
 N10S_JAR_URL = (
     f"https://github.com/neo4j-labs/neosemantics/releases/download/"

--- a/tests/cli/test_build_graphdb_removal.py
+++ b/tests/cli/test_build_graphdb_removal.py
@@ -1,0 +1,139 @@
+"""Dropping the app template's graphdb block from a profile (issue #714).
+
+The control-assistant app template injects a graph store into every render: a
+Neo4j container, two published host ports, and the ``graph`` MCP server in the
+rendered ``.mcp.json``. The documented way out is the profile's ``config:``
+overlay — ``_renders_graphdb_block``'s own comment says the bare
+``services.graphdb:`` (YAML ``null``) whole-block override removes the block.
+
+These tests build a real minimal profile through ``osprey build`` and pin the
+two spellings an operator will try:
+
+* ``services.graphdb:`` (bare null) — the documented removal spelling. It must
+  render a project with NO graph store anywhere it would otherwise appear:
+  no ``services.graphdb`` block, no ``graphdb`` in ``deployed_services``, no
+  compose fragment, no ``graph`` MCP server. It used to crash the build with
+  ``'NoneType' object has no attribute 'get'`` in the service-template copy.
+* ``services.graphdb: {}`` — an empty whole-block override. It is NOT removal
+  (an empty mapping reads as "a store at the defaults" everywhere else) but it
+  also cannot deploy, because replacing the block drops the ``path`` the
+  compose render needs. It used to die late with "Service 'graphdb' not found
+  in configuration"; it must instead be refused at validation with a message
+  that points at the working spellings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from osprey.cli.build_cmd import build
+from osprey.cli.build_profile import load_profile
+from osprey.errors import BuildProfileError
+
+CI_FLAGS = ["--skip-deps", "--skip-lifecycle"]
+
+#: A minimal deploying profile on the app template that injects the store.
+PROFILE = """\
+name: Graphdb Drop
+app_template: control_assistant
+provider: anthropic
+channel_finder_mode: hierarchical
+config:
+  control_system.type: mock
+{override}"""
+
+
+def _build_repo(tmp_path: Path, monkeypatch, override: str):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "profile.yml").write_text(PROFILE.format(override=override))
+    monkeypatch.chdir(repo)
+    result = CliRunner().invoke(build, CI_FLAGS)
+    return repo, result
+
+
+def _rendered_config(repo: Path) -> dict:
+    return yaml.safe_load((repo / "build" / "config.yml").read_text())
+
+
+class TestBareNullRemovesTheStore:
+    """``services.graphdb:`` renders a project with no graph store at all."""
+
+    def test_build_succeeds(self, tmp_path: Path, monkeypatch):
+        _, result = _build_repo(tmp_path, monkeypatch, "  services.graphdb:\n")
+        assert result.exit_code == 0, result.output
+
+    def test_rendered_config_has_no_graphdb_block(self, tmp_path: Path, monkeypatch):
+        repo, result = _build_repo(tmp_path, monkeypatch, "  services.graphdb:\n")
+        assert result.exit_code == 0, result.output
+        config = _rendered_config(repo)
+        assert "graphdb" not in (config.get("services") or {})
+
+    def test_graphdb_leaves_deployed_services(self, tmp_path: Path, monkeypatch):
+        repo, result = _build_repo(tmp_path, monkeypatch, "  services.graphdb:\n")
+        assert result.exit_code == 0, result.output
+        config = _rendered_config(repo)
+        assert "graphdb" not in [str(s) for s in config.get("deployed_services") or []]
+
+    def test_no_compose_fragment_is_bundled(self, tmp_path: Path, monkeypatch):
+        repo, result = _build_repo(tmp_path, monkeypatch, "  services.graphdb:\n")
+        assert result.exit_code == 0, result.output
+        assert not (repo / "build" / "services" / "graphdb").exists()
+
+    def test_no_graph_mcp_server_is_rendered(self, tmp_path: Path, monkeypatch):
+        repo, result = _build_repo(tmp_path, monkeypatch, "  services.graphdb:\n")
+        assert result.exit_code == 0, result.output
+        mcp = json.loads((repo / "build" / ".mcp.json").read_text())
+        assert "graph" not in mcp.get("mcpServers", {})
+
+
+class TestEmptyMappingIsRefusedByName:
+    """``services.graphdb: {}`` is a named refusal, not a late crash."""
+
+    def test_profile_validation_names_the_working_spellings(self, tmp_path: Path):
+        (tmp_path / "profile.yml").write_text(PROFILE.format(override="  services.graphdb: {}\n"))
+        with pytest.raises(BuildProfileError) as excinfo:
+            load_profile(tmp_path / "profile.yml")
+        message = str(excinfo.value)
+        assert "services.graphdb: {}" in message
+        # The refusal hands the operator both working spellings.
+        assert "services.graphdb:" in message
+        assert "services.graphdb.<key>:" in message
+
+    def test_build_refuses_before_rendering(self, tmp_path: Path, monkeypatch, caplog):
+        with caplog.at_level(logging.ERROR):
+            repo, result = _build_repo(tmp_path, monkeypatch, "  services.graphdb: {}\n")
+        assert result.exit_code != 0
+        reported = result.output + caplog.text + str(result.exception or "")
+        assert "services.graphdb" in reported
+        # A refusal, not the crashes this spelling used to die with.
+        assert "Unexpected error" not in reported
+        assert "not found in configuration" not in reported
+        assert not (repo / "build").exists()
+
+
+@pytest.fixture()
+def baseline(tmp_path: Path, monkeypatch):
+    """A build with no override at all — what the removal is removing."""
+    return _build_repo(tmp_path, monkeypatch, "")
+
+
+class TestBaselineKeepsTheStore:
+    """Guard against the removal tests passing vacuously: with no override the
+    template's store must actually be there to remove."""
+
+    def test_template_renders_the_store(self, baseline):
+        repo, result = baseline
+        assert result.exit_code == 0, result.output
+        config = _rendered_config(repo)
+        assert "graphdb" in config["services"]
+        assert "graphdb" in [str(s) for s in config["deployed_services"]]
+        mcp = json.loads((repo / "build" / ".mcp.json").read_text())
+        assert "graph" in mcp["mcpServers"]
+        assert (repo / "build" / "services" / "graphdb").is_dir()

--- a/tests/cli/test_knowledge_cmd.py
+++ b/tests/cli/test_knowledge_cmd.py
@@ -960,6 +960,31 @@ def test_seed_graph_unreachable_store_is_a_clean_error(
     assert "Traceback" not in result.output
 
 
+def test_seed_graph_names_a_missing_n10s_plugin(
+    graph: _GraphStub, graph_ttl: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A store without the plugin is reported in those words — not as a
+    missing stored procedure, and not as a connection failure."""
+    from osprey.services.facility_knowledge.seeder import graph_seeder
+
+    _patch_config(monkeypatch, {})
+
+    def _bootstrap(_session: object) -> BootstrapResult:
+        raise graph_seeder.MissingN10sPluginError(
+            "no compatible n10s plugin installed for Neo4j 5.20.0 community"
+        )
+
+    monkeypatch.setattr(graph_seeder, "bootstrap", _bootstrap)
+
+    result = CliRunner().invoke(knowledge, ["seed-graph", str(graph_ttl)])
+
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "no compatible n10s plugin installed for Neo4j 5.20.0" in flat
+    assert "no procedure with the name" not in flat
+    assert "Traceback" not in result.output
+
+
 # ---------------------------------------------------------------------------
 # Import isolation
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_graphdb_compose_render.py
+++ b/tests/deployment/test_graphdb_compose_render.py
@@ -1,0 +1,73 @@
+"""Render tests for the graphdb service's container healthcheck.
+
+The healthcheck runs INSIDE the ``neo4j:<ver>-community`` container, so the
+probe binary has to be one that image actually carries. It ships ``wget`` (the
+entrypoint itself fetches the n10s jar with it) and no ``curl`` — a probe that
+shells curl fails on every attempt with "command not found", and the container
+settles into ``unhealthy`` permanently while the store serves normally. That
+false negative poisons everything that treats container health as ground
+truth: ``podman ps``, smoke rosters, and any ``depends_on: service_healthy``
+gate (issue #717).
+
+These tests render the packaged compose template exactly as ``osprey up``
+does and pin the probe to the binary the default image has, on both network
+modes — the bridge default (container-internal 7474) and ``host`` (the
+published port, since there is no port map left to translate).
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+
+import pytest
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+GRAPHDB_TEMPLATE = "services/graphdb/docker-compose.yml.j2"
+
+
+def _render(**graphdb_block: object) -> dict:
+    """Render the packaged graphdb compose template at its defaults.
+
+    An Environment rooted at the packaged ``templates/`` directory, not a bare
+    ``jinja2.Template``: the template imports the shared network-axis macros by
+    a project-root-relative path, which only a loader can resolve.
+    """
+    templates_root = resources.files("osprey").joinpath("templates")
+    env = Environment(loader=FileSystemLoader(str(templates_root)), autoescape=False)
+    rendered = env.get_template(GRAPHDB_TEMPLATE).render(
+        services={"graphdb": graphdb_block},
+        deployment={},
+        system={"timezone": "UTC"},
+        osprey_labels={"project_name": "probe-test", "project_root": "/r/probe-test"},
+    )
+    return yaml.safe_load(rendered)
+
+
+def _probe_command(doc: dict) -> str:
+    test = doc["services"]["graphdb"]["healthcheck"]["test"]
+    assert test[0] == "CMD-SHELL"
+    return test[1]
+
+
+def test_healthcheck_probes_with_wget():
+    """The default render's probe shells a binary the default image carries."""
+    command = _probe_command(_render())
+    assert command.startswith("wget ")
+    assert "http://127.0.0.1:7474/" in command
+
+
+def test_healthcheck_never_shells_curl():
+    """No curl anywhere: the neo4j community image does not ship it."""
+    command = _probe_command(_render())
+    assert "curl" not in command
+
+
+@pytest.mark.parametrize("http_port_host", [7474, 17474])
+def test_host_mode_probe_uses_wget_on_the_published_port(http_port_host: int):
+    """Under ``network: host`` the probe dials the published HTTP port, still
+    with the binary the image has."""
+    command = _probe_command(_render(network="host", http_port_host=http_port_host))
+    assert command.startswith("wget ")
+    assert f"http://127.0.0.1:{http_port_host}/" in command
+    assert "curl" not in command

--- a/tests/deployment/test_graphdb_service_config.py
+++ b/tests/deployment/test_graphdb_service_config.py
@@ -156,9 +156,29 @@ class TestConstants:
     def test_default_ports_match_neo4j_container_ports(self) -> None:
         assert (DEFAULT_PORT, DEFAULT_HTTP_PORT) == (7687, 7474)
 
-    def test_image_is_pinned_to_the_last_release_neosemantics_builds_for(self) -> None:
-        """n10s publishes no build for 5.23+, and without n10s nothing seeds."""
-        assert DEFAULT_IMAGE == "neo4j:5.20-community"
+    #: Neo4j community lines the neosemantics plugin manifest actually covers —
+    #: the entries in https://neo4j-labs.github.io/neosemantics/versions.json,
+    #: which is what the image's plugin loader consults at container start
+    #: (verified 2026-08-25). 5.20 is covered by a single frozen exact-match
+    #: entry; the 5.26 LTS line is covered patch-by-patch (5.26.0–5.26.30 at
+    #: the time of checking); nothing newer has any entry at all. Re-verify the
+    #: manifest and extend this set BEFORE bumping :data:`DEFAULT_IMAGE` — a
+    #: server the plugin loader has no entry for comes up healthy and then
+    #: fails every import.
+    N10S_SUPPORTED_LINES = frozenset({"5.20", "5.26"})
+
+    def test_image_is_pinned_to_a_release_neosemantics_publishes_for(self) -> None:
+        """A default image outside the n10s manifest cannot seed; see the set above."""
+        line = DEFAULT_IMAGE.removeprefix("neo4j:").removesuffix("-community")
+        assert line in self.N10S_SUPPORTED_LINES, (
+            f"DEFAULT_IMAGE pins Neo4j {line}, which the neosemantics plugin "
+            f"manifest has no entry for. Check the versions.json above, extend "
+            f"N10S_SUPPORTED_LINES with evidence, then move the pin."
+        )
+
+    def test_image_is_pinned_to_the_supported_lts_line(self) -> None:
+        """5.26 is the last line with an actively regenerated manifest entry."""
+        assert DEFAULT_IMAGE == "neo4j:5.26-community"
 
     def test_service_name_matches_the_dotted_keys(self) -> None:
         assert GRAPHDB_SERVICE_NAME == "graphdb"

--- a/tests/e2e/test_graph_mcp_smoke.py
+++ b/tests/e2e/test_graph_mcp_smoke.py
@@ -1,7 +1,7 @@
 """Agentic e2e acceptance gate for the graph MCP server.
 
 This is the feature's acceptance test: a deployment built from the
-``control_assistant`` preset, pointed at a *real* Neo4j 5.20 + neosemantics
+``control_assistant`` preset, pointed at a *real* Neo4j 5.26 + neosemantics
 store seeded with the shipped demo-machine corpus, driven by a real agent
 session with an operator-style question about the machine's structure. The
 claim under test is the whole chain at once — the preset renders ``graph`` into
@@ -11,8 +11,8 @@ read-only Cypher path answers, and the answer is right about the corpus.
 
 What the fixture stands up, and why each piece is shaped the way it is:
 
-* **A store of its own.** ``neo4j:5.20-community`` with the pinned neosemantics
-  5.20.0 jar bind-mounted at ``/plugins`` and APOC copied out of the image —
+* **A store of its own.** ``neo4j:5.26-community`` with the pinned neosemantics
+  5.26.0 jar bind-mounted at ``/plugins`` and APOC copied out of the image —
   the recipe ``tests/integration/test_graphdb_store.py`` established; see that
   module's docstring for why ``NEO4J_PLUGINS`` is deliberately unset. The
   container takes a **random published port and testcontainers' own generated

--- a/tests/e2e/test_graph_paradigm_smoke.py
+++ b/tests/e2e/test_graph_paradigm_smoke.py
@@ -21,7 +21,7 @@ Three claims, in the order the chain makes them:
    ``tests/cli/test_channel_finder_graph_tools.py`` pins the same shape off
    ``create_project``; this module pins it off the render ``osprey build``
    actually produces, which is a second code path (``regenerate_claude_code``).
-2. **That server talks to a real store.** A throwaway Neo4j 5.20 +
+2. **That server talks to a real store.** A throwaway Neo4j 5.26 +
    neosemantics container, seeded with the shipped demo-machine corpus through
    ``osprey knowledge seed-graph`` — the container, plugin and seeding recipe
    are imported wholesale from the sibling module rather than restated, so the

--- a/tests/integration/test_graph_mcp.py
+++ b/tests/integration/test_graph_mcp.py
@@ -1,4 +1,4 @@
-"""The graph MCP tools against a real Neo4j 5.20 + neosemantics store.
+"""The graph MCP tools against a real Neo4j 5.26 + neosemantics store.
 
 Every other graph test mocks the driver.  That proves the call shapes and the
 envelope wiring, but it cannot prove the four things this feature actually

--- a/tests/services/facility_knowledge/test_graph_seeder.py
+++ b/tests/services/facility_knowledge/test_graph_seeder.py
@@ -541,6 +541,82 @@ class TestWipe:
 
 
 # ---------------------------------------------------------------------------
+# missing n10s plugin
+# ---------------------------------------------------------------------------
+
+
+class _FakeClientError(Exception):
+    """The shape of a driver ``Neo4jError``: a message plus a ``code``."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _procedure_not_found() -> _FakeClientError:
+    return _FakeClientError(
+        "Neo.ClientError.Procedure.ProcedureNotFound",
+        "There is no procedure with the name `n10s.graphconfig.show` "
+        "registered for this database instance.",
+    )
+
+
+class _NoPluginSession(FakeSession):
+    """A store that answers Cypher but has no n10s procedures registered."""
+
+    def __init__(self, raising: Exception, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._raising = raising
+
+    def run(self, query: str, **params: Any) -> FakeResult:
+        if "n10s." in query:
+            self.calls.append((query, params))
+            raise self._raising
+        return super().run(query, **params)
+
+
+class TestMissingPlugin:
+    """A store with no n10s plugin is named as such, not as a bad procedure.
+
+    The default image installs n10s at container start from the plugin
+    manifest; on a Neo4j version the manifest has no entry for, the jar is
+    silently absent and the first ``n10s.*`` call dies with
+    ``ProcedureNotFound`` — which reads like a corrupt database rather than an
+    unbuilt plugin (issue #715). ``bootstrap`` converts exactly that failure
+    into a :class:`MissingN10sPluginError` naming the server version.
+    """
+
+    _COMPONENTS = {
+        "dbms.components": [
+            {"name": "Neo4j Kernel", "versions": ["5.20.0"], "edition": "community"}
+        ]
+    }
+
+    def test_bootstrap_names_the_missing_plugin_and_the_server(self):
+        cause = _procedure_not_found()
+        session = _NoPluginSession(cause, responses=self._COMPONENTS)
+        with pytest.raises(graph_seeder.MissingN10sPluginError) as excinfo:
+            bootstrap(session)
+        message = str(excinfo.value)
+        assert "no compatible n10s plugin installed for Neo4j 5.20.0 community" in message
+        assert excinfo.value.__cause__ is cause
+
+    def test_message_survives_a_failed_version_lookup(self):
+        session = _NoPluginSession(_procedure_not_found())  # no components rows
+        with pytest.raises(graph_seeder.MissingN10sPluginError) as excinfo:
+            bootstrap(session)
+        assert "no compatible n10s plugin installed" in str(excinfo.value)
+
+    def test_other_client_errors_propagate_unchanged(self):
+        """Only the missing-procedure code is converted; a real fault keeps
+        its own type and message."""
+        cause = _FakeClientError("Neo.ClientError.Security.Unauthorized", "bad credentials")
+        session = _NoPluginSession(cause)
+        with pytest.raises(_FakeClientError, match="bad credentials"):
+            bootstrap(session)
+
+
+# ---------------------------------------------------------------------------
 # lazy import
 # ---------------------------------------------------------------------------
 

--- a/tests/templates/render_defaults/graphdb.yml
+++ b/tests/templates/render_defaults/graphdb.yml
@@ -17,14 +17,16 @@ services:
     # services.graphdb.image in config.yml, to point at a mirror or a pinned
     # digest (e.g. for air-gapped registries).
     #
-    # The 5.20 default is a pin, not a snapshot of "current". neosemantics —
+    # The 5.26 default is a pin, not a snapshot of "current". neosemantics —
     # the plugin that imports RDF, without which this store has no way to load
-    # the corpus at all — publishes no build for Neo4j 5.23 or later as of May
-    # 2026. So the pin tracks the PLUGIN's release cadence, not the server's:
-    # check https://github.com/neo4j-labs/neosemantics/releases for a build
+    # the corpus at all — is installed at container start from its plugin
+    # manifest, and the 5.26 LTS line is the newest server line that manifest
+    # covers as of August 2026. So the pin tracks the PLUGIN's release
+    # cadence, not the server's: check
+    # https://neo4j-labs.github.io/neosemantics/versions.json for an entry
     # matching the newer server before bumping this, because a server the
     # plugin has no jar for comes up healthy and then fails every import.
-    image: ${OSPREY_GRAPHDB_IMAGE:-neo4j:5.20-community}
+    image: ${OSPREY_GRAPHDB_IMAGE:-neo4j:5.26-community}
     # container_name is a HOST-GLOBAL docker identifier: a bare `graphdb`
     # collides when two OSPREY projects deploy a graph store on one host,
     # forcing them to serialize. Namespace it per-project so concurrent deploys

--- a/tests/templates/render_defaults/graphdb.yml
+++ b/tests/templates/render_defaults/graphdb.yml
@@ -125,7 +125,12 @@ services:
       # becoming a second place the minted password has to be spelled. A pass
       # means the server is up and serving, which is the condition the seeder
       # waits on before it bootstraps the graph config and imports the corpus.
-      test: ["CMD-SHELL", "curl -fsS -o /dev/null --max-time 5 http://127.0.0.1:7474/"]
+      #
+      # wget, not curl: the neo4j community image ships wget (its own
+      # entrypoint fetches the n10s jar with it) and no curl at all — a curl
+      # probe fails on every attempt and parks the container at `unhealthy`
+      # while the store serves normally.
+      test: ["CMD-SHELL", "wget -q -O /dev/null -T 5 http://127.0.0.1:7474/"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Three fixes to the injected `graphdb` service, one per commit, each filed from a live facility deployment bring-up.

**Healthy (#717).** The container healthcheck shelled `curl`, which the `neo4j:<ver>-community` image does not carry — the store reported `unhealthy` permanently while serving. The probe now uses `wget`, which the image ships (its own entrypoint fetches the n10s jar with it), on both network modes. A render test pins the probe to a binary the default image has.

**Droppable (#714).** The documented removal spelling — a bare `services.graphdb:` in a profile's `config:` block — crashed the build with an `AttributeError` in the service-template copy, and `services.graphdb: {}` died later with "Service 'graphdb' not found in configuration". The bare-null override now finishes the removal it documents: the rendered project carries no `services.graphdb` block, no `graphdb` in `deployed_services`, no compose fragment, and no `graph` MCP server in `.mcp.json`. The empty-mapping spelling is not removal (an empty block resolves to "a store at the defaults" everywhere else) and is refused at profile validation with a message naming both working spellings. Regression tests build a real minimal profile through `osprey build` and pin the full removal plus the baseline that keeps the store.

**Seedable (#715).** The default image moves from `neo4j:5.20-community` to `neo4j:5.26-community`, the newest server line the neosemantics plugin manifest (`https://neo4j-labs.github.io/neosemantics/versions.json`) covers — per-patch entries for 5.26.0–5.26.30, all resolving to the n10s 5.26.0 jar, verified with the image entrypoint's own semver match; nothing newer has any entry, and the old 5.20 pin is a single frozen entry the live deployment's plugin install failed on regardless. The seeder now detects the missing-plugin state on the first n10s call and reports "no compatible n10s plugin installed for Neo4j \<version\>" with the remedy — through `osprey knowledge seed-graph` and the deploy-time staging warning alike — instead of surfacing a missing stored procedure. A unit test pins the default image's minor line to the manifest-covered set so a future bump fails loudly until the manifest is re-checked.

With these landed, the downstream carve-outs they forced become deletable: the smoke-test WARN carve-out that downgraded this container's `unhealthy` after a host-side liveness re-probe, and the empty-ontology tolerance around seeding.

Closes #717
Closes #714
Closes #715
