### PR TITLE
fix(deploy): diagnose the empty registry credential podman's compose provider sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- A deploy on podman served by Docker Compose v2 now says so. On that provider
+  pairing, image builds that must fetch a base image reach the registry with an
+  empty credential and are refused with a 401 naming a password that was never
+  sent — after the build has already run for minutes. `osprey up` now warns
+  which provider is in use before building, and both `osprey up` and
+  `osprey build` translate the registry refusal into the two things that
+  resolve it: pin podman-compose in `containers.conf`, or deploy on docker.
+  `podman login` does not help, because the credential does not come from
+  podman's auth file.
+
 - The build-drift gate no longer counts material `osprey up` mints itself: the
   per-lane Bluesky CURVE certificates now live under `data/.runtime/`, a
   reserved runtime-output subpath the fingerprint never hashes and the build

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2316,6 +2316,7 @@ def _build_repo(
         click.UsageError: When no deployment repo encloses the search path.
     """
     from osprey.deployment.errors import CapturedProcessError
+    from osprey.deployment.subprocess_capture import diagnose_captured_failure
 
     from .build_profile import resolve_build_document
     from .build_profile_deploy import deploy_aware_config_errors, deploy_aware_config_warnings
@@ -2575,6 +2576,13 @@ def _build_repo(
         # under, so the message names the spool rather than repeating it — and
         # carries no ✗ of its own, because that phase's failure line has one.
         logger.error("Build failed: %s", e)
+        # Some of those failures say nothing an operator can act on — a registry
+        # 401 naming a password that was never sent is the standing example. The
+        # same seam `osprey up` uses answers them here, and stays silent on
+        # every failure it cannot name.
+        remedy = diagnose_captured_failure(e)
+        if remedy is not None:
+            logger.error("→ %s", remedy)
         raise click.Abort() from e
     except Exception as e:
         logger.error("✗ Unexpected error: %s", e)

--- a/src/osprey/cli/deploy_cmd.py
+++ b/src/osprey/cli/deploy_cmd.py
@@ -607,7 +607,12 @@ def up_verb(
         except (click.Abort, click.ClickException):
             raise
         except Exception as e:
-            _abort("Deployment failed", str(e))
+            # Some deploy failures carry a cause OSPREY can name and the raw
+            # text cannot -- a registry 401 for a password never sent. Local
+            # import to keep this module's import cost off every CLI start.
+            from osprey.deployment.subprocess_capture import diagnose_captured_failure
+
+            _abort("Deployment failed", str(e), diagnose_captured_failure(e))
         finally:
             os.chdir(previous)
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -3854,7 +3854,7 @@ def _preflight_bluesky_network_backend(config: dict) -> None:
     )
 
 
-def _preflight_podman_compose_provider(config: dict) -> None:
+def _preflight_podman_compose_provider(config: dict, provider: ComposeProvider) -> None:
     """Name the podman + Docker-Compose-v2 registry break before anything is built.
 
     Purely advisory, and silent on every host but that one pairing. See
@@ -3867,9 +3867,28 @@ def _preflight_podman_compose_provider(config: dict) -> None:
     failure it describes is also translated in place, if it happens, by
     :func:`~osprey.deployment.runtime_helper.diagnose_build_failure`.
 
+    Takes the provider the caller already resolved rather than probing for it.
+    That is not just thrift: this note asks the HOST a question, so it must sit
+    below every refusal that reads only this deployment's own files -- a deploy
+    about to abort on a drifted env chain or a machine-minted pin should not
+    first start a provider process to be told something it will never use. Both
+    names it does read are the ones bound in THIS module, the seam the lifecycle
+    tests patch, so it adds no bare subprocess to a site that forbids them.
+
+    Total, like :func:`_podman_network_backend`: a host with no usable runtime
+    gets no advisory. That failure is not this note's to report --
+    ``verify_runtime_is_running`` says it far better, and pre-empting it with a
+    provider aside would bury the refusal that actually stops the deploy.
+
     :param config: Raw deploy config, for the runtime it may pin.
+    :param provider: The compose provider the start sequence already detected.
     """
-    advisory = podman_compose_provider_advisory(config)
+    try:
+        runtime = get_runtime_command(config)[0]
+    except RuntimeError:
+        return
+
+    advisory = podman_compose_provider_advisory(runtime, provider)
     if advisory is None:
         return
 
@@ -5409,13 +5428,6 @@ def _start_stack(
     # leaves the host untouched.
     _preflight_bluesky_network_backend(config)
 
-    # And one question about the compose provider behind it: podman served by
-    # Docker Compose v2 cannot fetch a base image during a build, and the 401
-    # that produces names a password nobody typed. Advisory only -- a host with
-    # its images already local builds fine on that pairing -- so it warns here
-    # and, if the build does fail, says it again in place.
-    _preflight_podman_compose_provider(config)
-
     # Fail fast on a host-port collision (a foreign stack, or a second project
     # on the same host) with an actionable diagnosis, rather than letting
     # `compose up` collapse mid-start on a bare "address already in use". Runs
@@ -5502,6 +5514,14 @@ def _start_stack(
     # be told something it will never use. Above the advisory below, which is
     # the first thing whose wording depends on the answer.
     provider = _compose_provider(config)
+
+    # First use of that answer: podman served by Docker Compose v2 cannot fetch a
+    # base image during a build, and the 401 it gets names a password nobody
+    # typed. Here rather than up with the other preflights for the reason the
+    # comment above gives -- it needs the host's answer, so it must not run ahead
+    # of the refusals that read only this deployment's own files. Still well above
+    # the image build, which is the only thing it is trying to get ahead of.
+    _preflight_podman_compose_provider(config, provider)
 
     # Advisory, and last of the .env preflights so it reads the files every
     # provisioner above has finished writing: the shell and the env chain can

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -60,10 +60,12 @@ from osprey.deployment.host_ports import (
 )
 from osprey.deployment.qmd_service import preflight_qmd_models_dir
 from osprey.deployment.runtime_helper import (
+    PODMAN_COMPOSE_PROVIDER_REMEDY,
     ComposeProvider,
     UnsupportedComposeProviderError,
     detect_compose_provider,
     get_runtime_command,
+    podman_compose_provider_advisory,
     runtime_env,
     verify_runtime_is_running,
     with_plain_progress,
@@ -3852,6 +3854,32 @@ def _preflight_bluesky_network_backend(config: dict) -> None:
     )
 
 
+def _preflight_podman_compose_provider(config: dict) -> None:
+    """Name the podman + Docker-Compose-v2 registry break before anything is built.
+
+    Purely advisory, and silent on every host but that one pairing. See
+    :func:`~osprey.deployment.runtime_helper.podman_compose_provider_advisory`
+    for why this warns rather than refuses, and why a probe would have to build
+    an image to be sure.
+
+    Placed with the other preflights so the operator reads it in the second
+    before a build starts rather than in the minutes after one fails. The
+    failure it describes is also translated in place, if it happens, by
+    :func:`~osprey.deployment.runtime_helper.diagnose_build_failure`.
+
+    :param config: Raw deploy config, for the runtime it may pin.
+    """
+    advisory = podman_compose_provider_advisory(config)
+    if advisory is None:
+        return
+
+    _warn_fact(
+        "podman's compose provider is Docker Compose v2, not podman-compose",
+        advisory,
+        PODMAN_COMPOSE_PROVIDER_REMEDY,
+    )
+
+
 def _web_terminals_enabled(config: dict) -> bool:
     """True if ``modules.web_terminals.enabled`` is set on ``config``.
 
@@ -5380,6 +5408,13 @@ def _start_stack(
     # on. Ahead of every container-touching command below, so the refusal
     # leaves the host untouched.
     _preflight_bluesky_network_backend(config)
+
+    # And one question about the compose provider behind it: podman served by
+    # Docker Compose v2 cannot fetch a base image during a build, and the 401
+    # that produces names a password nobody typed. Advisory only -- a host with
+    # its images already local builds fine on that pairing -- so it warns here
+    # and, if the build does fail, says it again in place.
+    _preflight_podman_compose_provider(config)
 
     # Fail fast on a host-port collision (a foreign stack, or a second project
     # on the same host) with an actionable diagnosis, rather than letting

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -836,7 +836,7 @@ PODMAN_COMPOSE_PROVIDER_REMEDY = (
 )
 
 
-def podman_compose_provider_advisory(config: Mapping[str, Any] | None = None) -> str | None:
+def podman_compose_provider_advisory(runtime: str, provider: ComposeProvider) -> str | None:
     """Warn ahead of a build that this host's compose provider breaks base-image pulls.
 
     Fires only for podman served by Docker Compose v2 -- the pairing
@@ -853,30 +853,21 @@ def podman_compose_provider_advisory(config: Mapping[str, Any] | None = None) ->
     needs before a long build is the name of the thing that is about to go
     wrong; :func:`diagnose_build_failure` says it again, in place, if it does.
 
-    Total in the same sense as
-    :func:`~osprey.deployment.container_lifecycle._podman_network_backend`:
-    a host that cannot answer gets no opinion. Both failures it might raise on
-    -- no usable runtime, an unsupported provider -- are already reported by the
-    callers that own them, far better than a provider note could.
+    Takes the resolved runtime and provider rather than probing for them. The
+    deploy has already paid for both by the time a preflight runs, and probing
+    again from here would reach past the module-bound ``get_runtime_command``
+    that the lifecycle tests patch -- shelling out for an answer the caller is
+    holding. Being a pure function of the pairing also means it cannot fail, so
+    unlike its sibling preflights it needs no totality contract of its own: the
+    caller owns "the host could not be interrogated", which is where the two
+    exceptions involved were already being reported.
 
-    :param config: Optional deploy config, for the runtime it may pin.
+    :param runtime: The resolved container runtime (``docker`` or ``podman``).
+    :param provider: The compose provider detected behind it.
     :returns: Operator-facing advisory text, or ``None`` when the pairing is
-        absent or the host cannot be interrogated.
+        anything else.
     """
-    try:
-        base = get_runtime_command(config)
-    except RuntimeError:
-        return None
-
-    if not base or base[0] != "podman":
-        return None
-
-    try:
-        info = detect_compose_provider(base, config)
-    except (RuntimeError, UnsupportedComposeProviderError):
-        return None
-
-    if info.provider is not ComposeProvider.DOCKER_V2:
+    if runtime != "podman" or provider is not ComposeProvider.DOCKER_V2:
         return None
 
     return (

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -747,3 +747,142 @@ def get_container_image_id(
     return _inspect_image_id(
         [runtime, "container", "inspect", "--format", "{{.Image}}", container], env
     )
+
+
+# ---------------------------------------------------------------------------
+# podman + Docker Compose v2: the empty-credential registry refusal
+#
+# `podman compose` is a dispatcher, and one of the providers it will dispatch
+# to is the Docker Compose v2 CLI plugin. detect_compose_provider reports that
+# host as DOCKER_V2 and OSPREY invokes it correctly -- the argv shape is not the
+# problem. Image BUILDS are: a `FROM` that has to fetch its base image reaches
+# the registry with an empty credential instead of with none at all, and the
+# registry answers 401. The same host pulls the same image fine through `podman
+# pull` and through `podman compose pull`; only the build path carries the
+# empty credential, which is why this cannot be fixed with `podman login`.
+#
+# An anonymous pull would have worked. Supplying ""/"" is strictly worse than
+# supplying nothing, and it is what converts a working public pull into a
+# refusal whose wording ("incorrect username or password") points at a password
+# nobody typed.
+
+
+#: Substrings that together identify the empty-credential refusal. All must be
+#: present: the 401 wording alone is also what a genuinely wrong `podman login`
+#: produces, and mistaking that for this bug would send an operator to change a
+#: provider when they should fix their password. Requiring the pull-time frame
+#: ("fetching manifest") pins it to the build path this actually affects.
+_REGISTRY_AUTH_DENIED_MARKERS: tuple[str, ...] = (
+    "fetching manifest",
+    "unable to retrieve auth token",
+    "incorrect username or password",
+)
+
+
+#: What to do about it. Both entries are real escapes, in the order a facility
+#: would prefer them: podman-compose is the provider OSPREY's own CI pins for
+#: the podman lane, and docker is the other supported runtime outright.
+_REGISTRY_AUTH_REMEDY = (
+    "podman handed the registry an EMPTY credential for this pull, and the registry "
+    "rejected it -- the wording names a password, but none was ever sent. This is the "
+    "podman-with-Docker-Compose-v2 provider pairing, not a wrong login: `podman login` "
+    "does not fix it, because the credential does not come from podman's auth file.\n"
+    "Either:\n"
+    "  - install podman-compose and pin it as podman's provider, in containers.conf:\n"
+    "\n"
+    "        [engine]\n"
+    '        compose_providers = ["/absolute/path/to/podman-compose"]\n'
+    "\n"
+    "  - or run this deployment on docker (start the Docker daemon, or set\n"
+    "    container_runtime: docker), which uses its own compose provider.\n"
+    "\n"
+    "Pre-pulling the base images (`podman pull <image>`) also unblocks a single run: "
+    "a build that needs no fetch never presents the credential."
+)
+
+
+def diagnose_build_failure(output: str) -> str | None:
+    """Explain a failed build's output, or ``None`` when there is nothing to add.
+
+    Reads a captured build log (or any fragment of one) and recognizes the
+    empty-credential registry refusal described above, which otherwise reaches
+    the operator as a 401 about a password they never entered.
+
+    Substring matching rather than a parse: the text arrives wrapped in the
+    dispatcher's own chatter, in whichever line-ending and ANSI decoration the
+    provider emitted, and every one of those variants is the same failure.
+
+    Deliberately conservative. It answers only the signature it can name, so a
+    build that failed for any other reason -- a missing wheel, a compile error,
+    an unreachable private registry -- passes through untouched rather than
+    collecting a confident and wrong remedy.
+
+    :param output: Captured build output, whole or partial.
+    :returns: Operator-facing remedy text, or ``None`` for no opinion.
+    """
+    if not output:
+        return None
+    if all(marker in output for marker in _REGISTRY_AUTH_DENIED_MARKERS):
+        return _REGISTRY_AUTH_REMEDY
+    return None
+
+
+#: The one action that resolves the pairing, rendered in the CLI's remedy slot
+#: rather than inside the advisory so it is not said twice.
+PODMAN_COMPOSE_PROVIDER_REMEDY = (
+    "install podman-compose and pin it in containers.conf "
+    '([engine] compose_providers = ["/absolute/path/to/podman-compose"]), '
+    "or deploy on docker"
+)
+
+
+def podman_compose_provider_advisory(config: Mapping[str, Any] | None = None) -> str | None:
+    """Warn ahead of a build that this host's compose provider breaks base-image pulls.
+
+    Fires only for podman served by Docker Compose v2 -- the pairing
+    :func:`detect_compose_provider` reports as
+    :attr:`ComposeProvider.DOCKER_V2` behind a ``podman`` argv. podman served by
+    podman-compose is the configuration OSPREY's CI podman lane pins, and docker
+    served by Docker Compose v2 is the ordinary docker case; both stay silent.
+
+    A warning and not a refusal, on purpose. The pairing is one OSPREY declares
+    supported and invokes correctly, and the break lands only on builds that
+    must FETCH a base image -- a host whose images are already local, or which
+    pulls from a registry that accepts the empty credential, completes normally.
+    Refusing those would be causing an outage to describe one. What the operator
+    needs before a long build is the name of the thing that is about to go
+    wrong; :func:`diagnose_build_failure` says it again, in place, if it does.
+
+    Total in the same sense as
+    :func:`~osprey.deployment.container_lifecycle._podman_network_backend`:
+    a host that cannot answer gets no opinion. Both failures it might raise on
+    -- no usable runtime, an unsupported provider -- are already reported by the
+    callers that own them, far better than a provider note could.
+
+    :param config: Optional deploy config, for the runtime it may pin.
+    :returns: Operator-facing advisory text, or ``None`` when the pairing is
+        absent or the host cannot be interrogated.
+    """
+    try:
+        base = get_runtime_command(config)
+    except RuntimeError:
+        return None
+
+    if not base or base[0] != "podman":
+        return None
+
+    try:
+        info = detect_compose_provider(base, config)
+    except (RuntimeError, UnsupportedComposeProviderError):
+        return None
+
+    if info.provider is not ComposeProvider.DOCKER_V2:
+        return None
+
+    return (
+        "`podman compose` on this host is served by Docker Compose v2, not by "
+        "podman-compose. Image builds that must fetch a base image reach the registry "
+        "with an empty credential on that pairing and are refused with a 401 naming a "
+        "password that was never sent. Images already present locally are unaffected, "
+        "so a build with nothing to fetch still succeeds."
+    )

--- a/src/osprey/deployment/subprocess_capture.py
+++ b/src/osprey/deployment/subprocess_capture.py
@@ -216,4 +216,40 @@ def _run_teeing(
     return subprocess.CompletedProcess(list(cmd), returncode)
 
 
-__all__ = ["SPOOL_DIR", "SPOOL_RETENTION", "CapturedProcess", "run_captured"]
+def diagnose_captured_failure(exc: BaseException) -> str | None:
+    """Translate a captured child's failure into a remedy, or ``None``.
+
+    A :class:`~osprey.deployment.errors.CapturedProcessError` names the file its
+    child's output went to, and some of those failures have a cause OSPREY can
+    recognize and answer in words the raw text never uses. This is the one seam
+    that reads that spool and asks the diagnosers, so every verb that runs a
+    build gets the same translation rather than each growing its own.
+
+    Total by construction. No spool (a ``--verbose`` run, where the output went
+    to the terminal instead, or an exception of some other type), a spool that
+    cannot be read, or output that nothing recognizes all yield ``None`` — and
+    the caller then renders the failure exactly as it did before.
+
+    :param exc: The exception a verb is about to fail on.
+    :returns: Operator-facing remedy text, or ``None`` when there is nothing
+        honest to add.
+    """
+    from osprey.deployment.runtime_helper import diagnose_build_failure
+
+    spool_path = getattr(exc, "spool_path", None)
+    if spool_path is None:
+        return None
+    try:
+        output = Path(spool_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    return diagnose_build_failure(output)
+
+
+__all__ = [
+    "SPOOL_DIR",
+    "SPOOL_RETENTION",
+    "CapturedProcess",
+    "diagnose_captured_failure",
+    "run_captured",
+]

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -280,6 +280,9 @@ def captured_web_runs(monkeypatch, tmp_path):
     monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
     monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["docker", "compose"])
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
 
     def _fake_write_artifacts(config, dest_dir="."):
         written.append(config)
@@ -480,6 +483,9 @@ def captured_combined_runs(monkeypatch, tmp_path):
     monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
     monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["docker", "compose"])
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
     monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest_dir=".": [])
 
     def _fake_build(config, dev_mode, env, build_context=None):
@@ -629,6 +635,9 @@ def test_web_deploy_callsenable_linger_in_post_up_hook(monkeypatch, tmp_path):
     monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
     monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["podman", "compose"])
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["podman", "compose"])
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["podman", "compose"]
+    )
     monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest_dir=".": [])
     monkeypatch.setattr(
         container_lifecycle.subprocess,
@@ -702,6 +711,9 @@ def _mode_wiring_collab(monkeypatch, tmp_path):
     monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
     monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["docker", "compose"])
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
     monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest_dir=".": [])
     # The persona-render check is a separate concern with its own dedicated
     # tests below; keep it inert here so the mode-wiring tests exercise only the
@@ -1456,6 +1468,9 @@ def test_rebuild_deployment_reconciles_web_terminals_stack(monkeypatch, tmp_path
     monkeypatch.setattr(container_lifecycle, "clean_deployment", lambda *a, **k: None)
     monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["docker", "compose"])
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
     monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest_dir=".": [])
     calls: list = []
 
@@ -1590,6 +1605,9 @@ def test_web_services_dev_mode_splits_build_from_up(monkeypatch, tmp_path):
     monkeypatch.setattr(provision, "run_verify_script", lambda *a, **k: None)
     monkeypatch.setattr(provision, "get_runtime_command", lambda config: ["docker", "compose"])
     monkeypatch.setattr(postup_hooks, "get_runtime_command", lambda config: ["docker", "compose"])
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
     runs: list = []
 
     def _fake_run(cmd, env=None, **k):

--- a/tests/deployment/test_registry_auth_diagnostics.py
+++ b/tests/deployment/test_registry_auth_diagnostics.py
@@ -16,13 +16,8 @@ the two things that actually resolve it.
 
 from __future__ import annotations
 
-import pytest
-
-from osprey.deployment import runtime_helper
 from osprey.deployment.runtime_helper import (
     ComposeProvider,
-    ComposeProviderInfo,
-    UnsupportedComposeProviderError,
     diagnose_build_failure,
     podman_compose_provider_advisory,
 )
@@ -38,29 +33,6 @@ REAL_FAILURE = (
     "retrieve auth token: invalid username/password: unauthorized: incorrect "
     "username or password\n"
 )
-
-
-def _provider(provider: ComposeProvider) -> ComposeProviderInfo:
-    """A minimal ComposeProviderInfo carrying just the provider identity."""
-    return ComposeProviderInfo(
-        provider=provider,
-        version=(2, 24, 5),
-        version_text="2.24.5",
-        banner="probe banner",
-    )
-
-
-def _pin(monkeypatch, runtime: str, provider: ComposeProvider | None) -> None:
-    """Pin the resolved runtime and, unless None, the detected provider."""
-    monkeypatch.setattr(
-        runtime_helper, "get_runtime_command", lambda config=None: [runtime, "compose"]
-    )
-    if provider is not None:
-        monkeypatch.setattr(
-            runtime_helper,
-            "detect_compose_provider",
-            lambda cmd=None, config=None: _provider(provider),
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -104,52 +76,48 @@ def test_diagnosis_survives_a_partial_or_wrapped_log() -> None:
 
 
 # ---------------------------------------------------------------------------
-# podman_compose_provider_advisory -- the up-front warning
+# podman_compose_provider_advisory -- a pure function of the resolved pairing
 
 
-def test_advises_on_podman_with_the_docker_compose_provider(monkeypatch) -> None:
+def test_advises_on_podman_with_the_docker_compose_provider() -> None:
     """The broken pairing is named before any image is built."""
-    _pin(monkeypatch, "podman", ComposeProvider.DOCKER_V2)
-
-    advisory = podman_compose_provider_advisory({})
+    advisory = podman_compose_provider_advisory("podman", ComposeProvider.DOCKER_V2)
 
     assert advisory is not None
     assert "podman-compose" in advisory
 
 
-def test_no_advisory_for_podman_with_podman_compose(monkeypatch) -> None:
+def test_no_advisory_for_podman_with_podman_compose() -> None:
     """The supported podman pairing is silent -- this is the CI configuration."""
-    _pin(monkeypatch, "podman", ComposeProvider.PODMAN_COMPOSE)
-    assert podman_compose_provider_advisory({}) is None
+    assert podman_compose_provider_advisory("podman", ComposeProvider.PODMAN_COMPOSE) is None
 
 
-def test_no_advisory_for_docker(monkeypatch) -> None:
+def test_no_advisory_for_docker() -> None:
     """Docker Compose v2 behind the docker runtime is the ordinary case."""
-    _pin(monkeypatch, "docker", ComposeProvider.DOCKER_V2)
-    assert podman_compose_provider_advisory({}) is None
+    assert podman_compose_provider_advisory("docker", ComposeProvider.DOCKER_V2) is None
+    assert podman_compose_provider_advisory("docker", ComposeProvider.PODMAN_COMPOSE) is None
 
 
-@pytest.mark.parametrize(
-    "boom",
-    [RuntimeError("no runtime"), UnsupportedComposeProviderError("unsupported")],
-)
-def test_advisory_stays_silent_when_the_host_cannot_be_interrogated(monkeypatch, boom) -> None:
-    """Total, like _podman_network_backend: no answer means no opinion.
+def test_the_advisory_never_probes() -> None:
+    """It must not shell out: the lifecycle site that calls it forbids that.
 
-    An advisory that raised would become the outage it exists to describe, and
-    the callers that own these two failures say them far better than a
-    provider note can.
+    The deploy has already resolved both values by the time the preflight runs,
+    and a probe from here would reach past the module-bound `get_runtime_command`
+    the lifecycle tests patch -- which is exactly how this function's first
+    version broke twenty-three of them.
     """
+    import subprocess
 
-    def _raise(*_args, **_kwargs):
-        raise boom
+    def _forbidden(*args, **kwargs):
+        raise AssertionError(f"the advisory ran a subprocess: {args!r}")
 
-    monkeypatch.setattr(runtime_helper, "get_runtime_command", _raise)
-    assert podman_compose_provider_advisory({}) is None
-
-    _pin(monkeypatch, "podman", None)
-    monkeypatch.setattr(runtime_helper, "detect_compose_provider", _raise)
-    assert podman_compose_provider_advisory({}) is None
+    original = subprocess.run
+    subprocess.run = _forbidden
+    try:
+        assert podman_compose_provider_advisory("podman", ComposeProvider.DOCKER_V2) is not None
+        assert podman_compose_provider_advisory("docker", ComposeProvider.DOCKER_V2) is None
+    finally:
+        subprocess.run = original
 
 
 # ---------------------------------------------------------------------------
@@ -187,7 +155,7 @@ def test_captured_failure_is_silent_on_an_unreadable_spool(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# the preflight itself
+# the preflight itself -- resolution through the seam the lifecycle tests patch
 
 
 def test_preflight_warns_once_on_the_broken_pairing(monkeypatch) -> None:
@@ -201,31 +169,47 @@ def test_preflight_warns_once_on_the_broken_pairing(monkeypatch) -> None:
         lambda summary, detail=None, remedy=None: warned.append((summary, detail, remedy)),
     )
     monkeypatch.setattr(
-        container_lifecycle, "podman_compose_provider_advisory", lambda config: "the advisory"
+        container_lifecycle, "get_runtime_command", lambda config=None: ["podman", "compose"]
     )
 
-    container_lifecycle._preflight_podman_compose_provider({})
+    container_lifecycle._preflight_podman_compose_provider({}, ComposeProvider.DOCKER_V2)
 
     assert len(warned) == 1
     summary, detail, remedy = warned[0]
     assert "podman-compose" in summary
-    assert detail == "the advisory"
+    assert "empty credential" in detail
     assert "containers.conf" in remedy
 
 
-def test_preflight_is_silent_when_there_is_no_advisory(monkeypatch) -> None:
-    """Every host but the broken pairing sees nothing at all."""
+def test_preflight_is_silent_on_the_supported_pairing(monkeypatch) -> None:
+    """podman served by podman-compose -- the CI configuration -- says nothing."""
     from osprey.deployment import container_lifecycle
 
     warned: list[tuple] = []
+    monkeypatch.setattr(container_lifecycle, "_warn_fact", lambda *a, **k: warned.append(a))
     monkeypatch.setattr(
-        container_lifecycle,
-        "_warn_fact",
-        lambda *a, **k: warned.append(a),
-    )
-    monkeypatch.setattr(
-        container_lifecycle, "podman_compose_provider_advisory", lambda config: None
+        container_lifecycle, "get_runtime_command", lambda config=None: ["podman", "compose"]
     )
 
-    container_lifecycle._preflight_podman_compose_provider({})
+    container_lifecycle._preflight_podman_compose_provider({}, ComposeProvider.PODMAN_COMPOSE)
+    assert warned == []
+
+
+def test_preflight_defers_to_the_refusal_that_owns_a_dead_runtime(monkeypatch) -> None:
+    """A host with no usable runtime gets no advisory, and no exception.
+
+    verify_runtime_is_running reports that far better than a provider aside
+    could, and raising from here would bury the refusal that stops the deploy.
+    """
+    from osprey.deployment import container_lifecycle
+
+    warned: list[tuple] = []
+    monkeypatch.setattr(container_lifecycle, "_warn_fact", lambda *a, **k: warned.append(a))
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("no usable runtime")
+
+    monkeypatch.setattr(container_lifecycle, "get_runtime_command", _raise)
+
+    container_lifecycle._preflight_podman_compose_provider({}, ComposeProvider.DOCKER_V2)
     assert warned == []

--- a/tests/deployment/test_registry_auth_diagnostics.py
+++ b/tests/deployment/test_registry_auth_diagnostics.py
@@ -1,0 +1,231 @@
+"""Tests for the podman + Docker-Compose-v2 registry-auth diagnosis.
+
+``podman compose`` is a dispatcher: it hands the work to whichever external
+provider the host has configured. When that provider is the Docker Compose v2
+CLI plugin, a ``build`` that has to fetch a base image reaches the registry with
+an EMPTY credential rather than with no credential at all, and Docker Hub
+answers ``401 incorrect username or password``. An anonymous pull would have
+succeeded; supplying ``""``/``""`` is what turns it into a refusal.
+
+Nothing in the resulting message names podman, the provider, or the fact that a
+credential was involved, so the failure reads as a wrong password nobody typed.
+These tests cover the two surfaces that make it legible: an up-front advisory
+naming the provider pairing, and a translation of the raw registry error into
+the two things that actually resolve it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.deployment import runtime_helper
+from osprey.deployment.runtime_helper import (
+    ComposeProvider,
+    ComposeProviderInfo,
+    UnsupportedComposeProviderError,
+    diagnose_build_failure,
+    podman_compose_provider_advisory,
+)
+
+# The failure exactly as podman renders it, from a real `osprey up` on a macOS
+# host whose `podman compose` resolved to Docker Desktop's compose plugin.
+REAL_FAILURE = (
+    "STEP 1/14: FROM --platform=linux/amd64 python:3.11-slim\n"
+    "Trying to pull docker.io/library/python:3.11-slim...\n"
+    "creating build container: unable to copy from source "
+    "docker://python:3.11-slim: initializing source docker://python:3.11-slim: "
+    "fetching manifest 3.11-slim in docker.io/library/python: unable to "
+    "retrieve auth token: invalid username/password: unauthorized: incorrect "
+    "username or password\n"
+)
+
+
+def _provider(provider: ComposeProvider) -> ComposeProviderInfo:
+    """A minimal ComposeProviderInfo carrying just the provider identity."""
+    return ComposeProviderInfo(
+        provider=provider,
+        version=(2, 24, 5),
+        version_text="2.24.5",
+        banner="probe banner",
+    )
+
+
+def _pin(monkeypatch, runtime: str, provider: ComposeProvider | None) -> None:
+    """Pin the resolved runtime and, unless None, the detected provider."""
+    monkeypatch.setattr(
+        runtime_helper, "get_runtime_command", lambda config=None: [runtime, "compose"]
+    )
+    if provider is not None:
+        monkeypatch.setattr(
+            runtime_helper,
+            "detect_compose_provider",
+            lambda cmd=None, config=None: _provider(provider),
+        )
+
+
+# ---------------------------------------------------------------------------
+# diagnose_build_failure -- translating the raw registry refusal
+
+
+def test_diagnoses_the_real_registry_auth_refusal() -> None:
+    """The captured 401 is recognised and answered with both real remedies."""
+    remedy = diagnose_build_failure(REAL_FAILURE)
+
+    assert remedy is not None
+    # Names the mechanism rather than restating the registry's wording.
+    assert "empty" in remedy.lower()
+    # Both escapes an operator actually has.
+    assert "podman-compose" in remedy
+    assert "docker" in remedy.lower()
+
+
+def test_diagnosis_ignores_unrelated_build_failures() -> None:
+    """A build that failed for any other reason gets no opinion."""
+    assert diagnose_build_failure("STEP 4/13: RUN pip install\nERROR: no matching dist") is None
+    assert diagnose_build_failure("") is None
+
+
+def test_diagnosis_ignores_a_genuine_bad_credential() -> None:
+    """A real `podman login` rejection is not this bug and must not claim to be.
+
+    The registry says the same words when a human typed the wrong password. The
+    signature therefore requires the build-time shape -- a manifest fetch during
+    an image pull -- not merely the 401 text.
+    """
+    assert (
+        diagnose_build_failure('Error: logging into "docker.io": invalid username/password') is None
+    )
+
+
+def test_diagnosis_survives_a_partial_or_wrapped_log() -> None:
+    """Matching is substring-based, so log decoration does not defeat it."""
+    noisy = "\x1b[0m " + REAL_FAILURE.replace("\n", "\r\n") + "\nError: exit status 1\n"
+    assert diagnose_build_failure(noisy) is not None
+
+
+# ---------------------------------------------------------------------------
+# podman_compose_provider_advisory -- the up-front warning
+
+
+def test_advises_on_podman_with_the_docker_compose_provider(monkeypatch) -> None:
+    """The broken pairing is named before any image is built."""
+    _pin(monkeypatch, "podman", ComposeProvider.DOCKER_V2)
+
+    advisory = podman_compose_provider_advisory({})
+
+    assert advisory is not None
+    assert "podman-compose" in advisory
+
+
+def test_no_advisory_for_podman_with_podman_compose(monkeypatch) -> None:
+    """The supported podman pairing is silent -- this is the CI configuration."""
+    _pin(monkeypatch, "podman", ComposeProvider.PODMAN_COMPOSE)
+    assert podman_compose_provider_advisory({}) is None
+
+
+def test_no_advisory_for_docker(monkeypatch) -> None:
+    """Docker Compose v2 behind the docker runtime is the ordinary case."""
+    _pin(monkeypatch, "docker", ComposeProvider.DOCKER_V2)
+    assert podman_compose_provider_advisory({}) is None
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [RuntimeError("no runtime"), UnsupportedComposeProviderError("unsupported")],
+)
+def test_advisory_stays_silent_when_the_host_cannot_be_interrogated(monkeypatch, boom) -> None:
+    """Total, like _podman_network_backend: no answer means no opinion.
+
+    An advisory that raised would become the outage it exists to describe, and
+    the callers that own these two failures say them far better than a
+    provider note can.
+    """
+
+    def _raise(*_args, **_kwargs):
+        raise boom
+
+    monkeypatch.setattr(runtime_helper, "get_runtime_command", _raise)
+    assert podman_compose_provider_advisory({}) is None
+
+    _pin(monkeypatch, "podman", None)
+    monkeypatch.setattr(runtime_helper, "detect_compose_provider", _raise)
+    assert podman_compose_provider_advisory({}) is None
+
+
+# ---------------------------------------------------------------------------
+# diagnose_captured_failure -- the one seam both building verbs share
+
+
+def test_captured_failure_translates_a_spooled_registry_refusal(tmp_path) -> None:
+    """A CapturedProcessError's spool is read and answered."""
+    from osprey.deployment.errors import CapturedProcessError
+    from osprey.deployment.subprocess_capture import diagnose_captured_failure
+
+    spool = tmp_path / "build-services.log"
+    spool.write_text(REAL_FAILURE, encoding="utf-8")
+
+    exc = CapturedProcessError(["podman", "compose", "build"], 1, spool)
+    assert diagnose_captured_failure(exc) == diagnose_build_failure(REAL_FAILURE)
+
+
+def test_captured_failure_is_silent_without_a_spool() -> None:
+    """A --verbose run has no spool, and any other exception has no attribute."""
+    from osprey.deployment.errors import CapturedProcessError
+    from osprey.deployment.subprocess_capture import diagnose_captured_failure
+
+    assert diagnose_captured_failure(CapturedProcessError(["x"], 1)) is None
+    assert diagnose_captured_failure(RuntimeError("unrelated")) is None
+
+
+def test_captured_failure_is_silent_on_an_unreadable_spool(tmp_path) -> None:
+    """A spool that has since been pruned must not take down the error path."""
+    from osprey.deployment.errors import CapturedProcessError
+    from osprey.deployment.subprocess_capture import diagnose_captured_failure
+
+    exc = CapturedProcessError(["x"], 1, tmp_path / "vanished.log")
+    assert diagnose_captured_failure(exc) is None
+
+
+# ---------------------------------------------------------------------------
+# the preflight itself
+
+
+def test_preflight_warns_once_on_the_broken_pairing(monkeypatch) -> None:
+    """The advisory reaches the operator through the lifecycle's warn seam."""
+    from osprey.deployment import container_lifecycle
+
+    warned: list[tuple] = []
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_warn_fact",
+        lambda summary, detail=None, remedy=None: warned.append((summary, detail, remedy)),
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "podman_compose_provider_advisory", lambda config: "the advisory"
+    )
+
+    container_lifecycle._preflight_podman_compose_provider({})
+
+    assert len(warned) == 1
+    summary, detail, remedy = warned[0]
+    assert "podman-compose" in summary
+    assert detail == "the advisory"
+    assert "containers.conf" in remedy
+
+
+def test_preflight_is_silent_when_there_is_no_advisory(monkeypatch) -> None:
+    """Every host but the broken pairing sees nothing at all."""
+    from osprey.deployment import container_lifecycle
+
+    warned: list[tuple] = []
+    monkeypatch.setattr(
+        container_lifecycle,
+        "_warn_fact",
+        lambda *a, **k: warned.append(a),
+    )
+    monkeypatch.setattr(
+        container_lifecycle, "podman_compose_provider_advisory", lambda config: None
+    )
+
+    container_lifecycle._preflight_podman_compose_provider({})
+    assert warned == []


### PR DESCRIPTION
`podman compose` dispatches to whichever external compose provider the host has
configured. When that provider is the Docker Compose v2 CLI plugin, an image build
that must **fetch** its base image reaches the registry with an *empty* credential
rather than with none at all, and the registry refuses it:

```
unable to retrieve auth token: invalid username/password:
unauthorized: incorrect username or password
```

An anonymous pull would have succeeded. Supplying `""`/`""` is what converts a
working public pull into a refusal — and the refusal names a password that was
never sent, minutes into a build, with nothing in the text naming podman, the
provider, or the fact that a credential was involved.

`podman login` does not fix it: the credential never comes from podman's auth
file. The same host pulls the same image fine through `podman pull` and through
`podman compose pull` — only the build path carries the empty credential.

This is a pairing OSPREY already declares supported: `detect_compose_provider`
reports podman-behind-Docker-Compose-v2 as `DOCKER_V2` and invokes it correctly.
The CI podman lane pins podman-compose by absolute path, so the combination is
never exercised there.

**Approach.** Warn which provider is in use before anything is built, and
translate the refusal in place for both verbs that build. The advisory is a
warning and not a refusal on purpose: a host whose base images are already local
builds fine on that pairing, so refusing would cause the outage it describes. The
translation requires the pull-time frame (`fetching manifest`), not merely the 401
wording, so a genuinely wrong `podman login` is not misdiagnosed as this bug.

## How it hangs together

```text
  BEFORE BUILDING                        ON A FAILED BUILD

  osprey up                              osprey up ──┐
     │ preflight                                     ├── osprey build
     ▼                                               ▼
  _preflight_podman_compose_provider     diagnose_captured_failure
     │  (container_lifecycle)               │  (subprocess_capture)
     ▼                                      │  reads that run's spool
  podman_compose_provider_advisory          ▼
     │  runtime   == podman              diagnose_build_failure
     │  provider  == DOCKER_V2              │  "fetching manifest"
     ▼                                      │  + "auth token" + 401
  ⚠  warn, never refuse                     ▼
     local images still build            →  pin podman-compose in
     no opinion if unreadable               containers.conf, or
                                            deploy on docker
```

Both diagnosers are total: a host that cannot be interrogated, a spool that
cannot be read, and any failure the signature does not match all yield no
opinion, and the failure renders exactly as it did before.
