### PR TITLE
fix(deployment): derive the channel snapshot from the graph corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   resolve it: pin podman-compose in `containers.conf`, or deploy on docker.
   `podman login` does not help, because the credential does not come from
   podman's auth file.
-
+- Graph-mode builds now write the channel-suggestions snapshot from the corpus
+  named by `services.graphdb.ttl_path`, so the web-panel typeahead keeps
+  working after a project moves to the graph pipeline instead of going quiet.
 - The build-drift gate no longer counts material `osprey up` mints itself: the
   per-lane Bluesky CURVE certificates now live under `data/.runtime/`, a
   reserved runtime-output subpath the fingerprint never hashes and the build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Changed
 
+- `rdflib` is now a core dependency instead of a member of the `knowledge`
+  extra, which keeps `linkml-runtime`. Every build can parse a Turtle corpus
+  whichever extras are installed; the extra itself stays, so existing install
+  commands keep working.
 - Web Terminal and every standalone panel (workspace, Channel Finder, lattice
   dashboard, knowledge panel) now use the same display menu as ARIEL: the sliders
   button opens one popover with the light/dark switch, the Expert/Simple view and

--- a/docs/source/how-to/facility-knowledge/okf-bundle.rst
+++ b/docs/source/how-to/facility-knowledge/okf-bundle.rst
@@ -284,11 +284,10 @@ Working with a Bundle
       on a clean bundle, 1 if any file fails.
 
       **seed-from-ttl** — seeds one OKF stub document per device node in a
-      NARAD/als-ontology Turtle file.  Requires the ``knowledge`` extra:
+      NARAD/als-ontology Turtle file:
 
       .. code-block:: console
 
-         $ pip install "osprey-framework[knowledge]"
          $ osprey knowledge seed-from-ttl devices.ttl data/facility_knowledge
 
       Idempotency rules applied per stub:
@@ -351,6 +350,7 @@ Working with a Bundle
 
       .. code-block:: console
 
+         $ pip install "osprey-framework[knowledge]"
          $ osprey knowledge compile-ontology demo_ontology.yaml demo_ontology.json
 
       The output is deterministic, so a committed table can be reviewed like any

--- a/docs/source/how-to/use-channel-finder.rst
+++ b/docs/source/how-to/use-channel-finder.rst
@@ -215,9 +215,10 @@ Launch the browser-based channel explorer:
 The explorer browses a channel database, so on the graph pipeline it shows a
 short pane saying so instead of a tree; database statistics and validation are
 not offered there. Ask the OSPREY agent for the channels you need — it answers
-from the graph. The channel-suggestion typeahead in the web panels is off in
-graph mode for the same reason: it is built from a database file on the build
-host, and there is none.
+from the graph. The channel-suggestion typeahead in the web panels still
+works in graph mode: ``osprey build`` reads the channel names out of the
+Turtle corpus named by ``services.graphdb.ttl_path`` and writes them into the
+snapshot the panels use.
 
 
 The ``config.yml`` keys for every pipeline, and how the active one is served to

--- a/docs/source/how-to/web-terminal/panels.rst
+++ b/docs/source/how-to/web-terminal/panels.rst
@@ -79,11 +79,12 @@ when those run dry. Arrow keys move through the list, **Enter** takes the
 highlighted name, **Escape** dismisses it. The suggestions only suggest — a
 name typed in full is accepted whether or not it appears in the list.
 
-The names come from the project's Channel Finder catalog: ``osprey build``
-writes a snapshot of it next to the generated config, and the panel reads
-that snapshot — no control-system traffic, and nothing to keep in sync at run
-time. A project with no channel database configured shows no suggestions and
-is otherwise unchanged.
+The names come from the project's Channel Finder catalog — the channel
+database, or in graph mode the Turtle corpus named by
+``services.graphdb.ttl_path``: ``osprey build`` writes a snapshot of it next
+to the generated config, and the panel reads that snapshot — no
+control-system traffic, and nothing to keep in sync at run time. A project
+that configures neither shows no suggestions and is otherwise unchanged.
 
 The feature is on by default, tuned under ``web.channel_suggestions`` in
 ``config.yml``:
@@ -96,18 +97,19 @@ The feature is on by default, tuned under ``web.channel_suggestions`` in
        max_channels: 50000   # the default
 
 ``max_channels`` guards the browser, not the build: every panel load fetches
-the whole snapshot, so a database holding more channels than the limit is
+the whole snapshot, so a catalog holding more channels than the limit is
 skipped instead of shipped — the build log names the limit it hit, and the
 form falls back to plain fields. Raise the limit to cover a larger facility,
 or set ``enabled: false`` to turn the feature off and write no snapshot at
 all. A build profile overrides these keys from its ``config:`` block in the
 dotted form, e.g. ``web.channel_suggestions.max_channels: 200000``.
 
-One staleness rule to know: editing a channel database inside the profile's
-``data/`` tree changes the build fingerprint, so ``osprey up`` refuses until
-you rebuild — the snapshot cannot silently go stale on that path. A database
-referenced from *outside* the profile tree is not fingerprinted; its snapshot
-refreshes only on the next explicit ``osprey build``.
+One staleness rule to know: editing a channel database or Turtle corpus
+inside the profile's ``data/`` tree changes the build fingerprint, so
+``osprey up`` refuses until you rebuild — the snapshot cannot silently go
+stale on that path. A database or corpus referenced from *outside* the
+profile tree is not fingerprinted; its snapshot refreshes only on the next
+explicit ``osprey build``.
 
 Adding your own panel
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,12 @@ dependencies = [
     # no build step, so it carries none of the platform-wheel concerns that
     # justify keeping other clients optional. Core rather than an extra.
     "neo4j>=5.20",
+    # RDF/Turtle parser for the graph-mode channel snapshot: `osprey build` reads
+    # the corpus at services.graphdb.ttl_path in the CLI's own process
+    # (deployment.channel_snapshot). Pure Python, no build step, so it carries
+    # none of the platform-wheel concerns that justify keeping other clients
+    # optional. Core rather than an extra.
+    "rdflib>=7.0",
     # ARIEL proxy support for HTTP ingestion through SOCKS tunnels
     "aiohttp-socks>=0.8.0",
     # File system monitoring for web terminal
@@ -241,7 +247,6 @@ dev = [
     "psycopg[binary,pool]>=3.3.4,<4.0.0",  # ARIEL search integration tests
     "psycopg-pool>=3.3.1,<4.0.0",  # ARIEL search integration tests
     "pillow>=12.3.0",  # Perceptual diffing for the design-system visual regression suite
-    "rdflib>=7.0",  # TTL generator tests (semantic round-trip); runtime use stays in the knowledge extra
     "linkml-runtime>=1.11.1,<2",  # Ontology compiler + its tests; runtime use stays in the knowledge extra
 ]
 
@@ -279,9 +284,8 @@ gchat = [
     "pysocks>=1.7",
 ]
 
-# Facility knowledge / ontology support (OKF markdown bundles, RDF reasoning)
+# Facility knowledge / ontology support (LinkML schema loading for the ontology compiler)
 knowledge = [
-    "rdflib>=7.0",
     # LinkML schema loading for the ontology compiler. Known transitive baggage:
     # prefixcommons -> pytest-logging (2015) -> pytest lands in this extra; inert, accepted.
     "linkml-runtime>=1.11.1,<2",

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -12,9 +12,10 @@ seed.  ``compile-ontology`` stands upstream of ``build-ttl`` in turn: it is the
 authoring verb, turning a LinkML schema into the compiled FAMILY-to-class table
 that ``build-ttl`` emits the corpus against.
 
-Note: this module is intentionally importable WITHOUT the ``knowledge``
-extra (rdflib) installed, and without the ``neo4j`` driver.  Any rdflib or
-neo4j usage must be guarded by a lazy import inside the command body.
+Note: this module is intentionally importable without ``rdflib`` or the
+``neo4j`` driver in the import graph.  Both are core dependencies, so this is
+about keeping the CLI's import graph small, not about optional installs: any
+rdflib or neo4j usage must be guarded by a lazy import inside the command body.
 """
 
 from __future__ import annotations
@@ -179,23 +180,21 @@ def seed_from_ttl(ttl: Path, bundle: Path, force: bool) -> None:
     - File present, diff body, no --force → skip and report "differs, use --force".
     - File present, diff body, --force   → overwrite and report "overwritten".
 
-    The 'knowledge' extra (rdflib) is required.  A clean error is printed
-    when it is absent — no traceback.
+    The TTL is read with rdflib, a core dependency.  If rdflib is missing the
+    installation is incomplete, and a clean error is printed — no traceback.
     """
+    # rdflib is imported lazily inside the seeder, so an absent one surfaces
+    # either here at import time or inside seed_from_ttl itself.  Both mean the
+    # same broken environment, so both get the same repair hint.
     try:
         from osprey.services.facility_knowledge.seeder.ttl_seeder import seed_from_ttl as _seed
-    except ImportError as exc:  # rdflib absent
-        raise click.ClickException(
-            f"The 'knowledge' extra is required for seed-from-ttl: {exc}\n"
-            "Install it with: pip install 'osprey-framework[knowledge]'"
-        ) from exc
 
-    try:
         stubs = _seed(ttl)
-    except ImportError as exc:  # rdflib absent (raised inside seed_from_ttl)
+    except ImportError as exc:
         raise click.ClickException(
-            f"The 'knowledge' extra is required for seed-from-ttl: {exc}\n"
-            "Install it with: pip install 'osprey-framework[knowledge]'"
+            f"rdflib is not importable: {exc}\n"
+            "It is a core dependency, so this environment is incomplete. "
+            "Reinstall it with: pip install --upgrade osprey-framework"
         ) from exc
 
     from osprey.services.facility_knowledge.okf.bundle import OKFBundle

--- a/src/osprey/deployment/channel_snapshot.py
+++ b/src/osprey/deployment/channel_snapshot.py
@@ -1,9 +1,10 @@
 """Build-time channel snapshot decision for web channel suggestions.
 
 Web panels offer a typeahead over the control-system addresses a project knows
-about. The addresses come from the project's Channel Finder database, which
-lives on the build host and is not reachable from a browser, so the build emits
-a static snapshot of them next to the rendered service files instead.
+about. The addresses come from the project's Channel Finder database — or, on
+the graph paradigm, from the Turtle corpus the build stages for the graph
+store — and a browser can reach neither, so the build emits a static snapshot
+of them next to the rendered service files instead.
 
 This module answers the single question the build needs: *should a snapshot be
 written, and what goes in it?* :func:`compute_channel_snapshot` returns one
@@ -11,18 +12,24 @@ written, and what goes in it?* :func:`compute_channel_snapshot` returns one
 re-deriving the predicate, so the compose fragment, the mount, and the file on
 disk can never disagree about whether a snapshot exists.
 
-The decision fails soft in almost every direction. A project with no Channel
-Finder database, an empty one, one too large to be useful as a typeahead, one
-that cannot be read at all, or one on the graph paradigm — whose channels live
-in a graph database rather than in a file on the build host — simply gets no
-snapshot. The build itself is never blocked, because a missing autocomplete list
-is a degraded panel, not a broken deployment. The one exception is a
-``pipeline_mode`` naming a paradigm that does not exist: that is a configuration
-mistake rather than a degraded panel, so it stops the build.
+The decision fails soft in almost every direction. A project that configures no
+channel source at all, one whose source is empty, too large to be useful as a
+typeahead, or unreadable — a database file that cannot be opened, a graph
+corpus that is missing, unreadable or empty, or an rdflib that will not import
+and so cannot parse one — gets no snapshot at all. The build itself is never
+blocked, because a missing autocomplete list is a degraded panel, not a broken
+deployment. The one exception is a ``pipeline_mode`` naming a paradigm that
+does not exist: that is a configuration mistake rather than a degraded panel,
+so it stops the build.
 
-Working-directory precondition: a relative ``database.path`` is resolved against
-the process working directory, which the build sets to the project root before
-generating compose files.
+Path preconditions: a relative ``database.path`` is resolved against the process
+working directory, which the build sets to the project root before generating
+compose files. A relative ``services.graphdb.ttl_path`` is render-relative
+instead, and resolves against the ``config_dir`` recorded by
+:func:`~osprey.deployment.compose_generator.prepare_compose_files` — falling
+back to the directory of the ``config.yml`` this process runs against, which is
+``OSPREY_CONFIG`` when that is set, else ``build/config.yml`` under the working
+directory when that file exists, else the working directory itself.
 """
 
 from __future__ import annotations
@@ -46,6 +53,19 @@ MAX_CHANNELS_CONFIG_KEY = "web.channel_suggestions.max_channels"
 #: Named in the skip message when the feature is switched off explicitly.
 ENABLED_CONFIG_KEY = "web.channel_suggestions.enabled"
 
+#: The ``narad_p:fullPv`` predicate every ``ChannelBinding`` carries — the
+#: control-system address of that binding, and the only thing the graph-mode
+#: snapshot reads out of a Turtle corpus.
+#:
+#: ``services/facility_knowledge/seeder/ttl_seeder.py:48-58`` spells the same
+#: IRI as ``_NARAD_P + "fullPv"``, and ``seeder/graph_seeder.py``'s
+#: ``NARAD_PREFIXES`` is the prefix table of record for the ``narad_p:``
+#: namespace. This is a plain string here deliberately rather than an import of
+#: either module: importing anything from ``osprey.services.facility_knowledge``
+#: executes that package's ``__init__``, which pulls ``okf/bundle.py`` and with
+#: it ``osprey.services.qmd`` into the deployment import graph.
+_FULL_PV_IRI = "https://narad.example.org/property/fullPv"
+
 
 @dataclass(frozen=True)
 class SnapshotDecision:
@@ -55,16 +75,23 @@ class SnapshotDecision:
         emit: True when a snapshot file should be written.
         channels: Sorted, deduplicated control-system addresses. Empty unless
             ``emit`` is True — a decision not to emit carries no payload.
-        count: How many distinct addresses the database yielded. Reported even
+        count: How many distinct addresses the source yielded. Reported even
             when ``emit`` is False, so a caller can say why nothing was written.
-        source_path: Resolved path of the database the addresses came from, or
-            None when no database was configured or reachable.
+        source_path: Resolved path of the database or corpus the addresses came
+            from, or None when no source was configured.
     """
 
     emit: bool
     channels: list[str] = field(default_factory=list)
     count: int = 0
     source_path: Path | None = None
+
+
+#: What one source branch hands back: the addresses it found and the path they
+#: came from, or the no-emit decision that stands in their place. Each branch
+#: owns its own fail-soft exits that way, leaving the caller only the guards
+#: that apply to every source alike.
+_SourcedChannels = tuple[list[str], Path] | SnapshotDecision
 
 
 def _suggestions_section(config: dict) -> dict:
@@ -97,6 +124,38 @@ def _max_channels(section: dict) -> int:
             f"using the default of {DEFAULT_MAX_CHANNELS}."
         )
         return DEFAULT_MAX_CHANNELS
+
+
+def _render_dir(config: dict) -> Path | None:
+    """Directory a render-relative configured path is authored against.
+
+    :func:`osprey.deployment.compose_generator.prepare_compose_files`
+    (``compose_generator.py:2832``) records ``config_dir`` — the directory the
+    loaded ``config.yml`` sits in — before any render helper runs, and that is
+    what ``services.graphdb.ttl_path`` resolves against: the one render-relative
+    key (see ``osprey/utils/config_paths.py:30-38``).
+
+    Returning None lets :func:`~osprey.utils.config_paths.resolve_render_relative_path`
+    fall back to the ``config.yml`` this process runs against — ``OSPREY_CONFIG``
+    when set, else ``build/config.yml`` under the working directory when that
+    file exists, else the working directory itself
+    (:func:`osprey_connectors.workspace.resolve_config_path`).
+
+    Deliberately NOT the ``project_root`` rung of
+    :func:`~osprey.deployment.compose_generator._render_anchor_dir`:
+    ``project_root`` is the repo root, which is the wrong anchor for a
+    render-relative key.
+
+    Args:
+        config: Full project configuration dictionary.
+
+    Returns:
+        The recorded config directory, or None when the config carries none.
+    """
+    raw = config.get("config_dir")
+    if isinstance(raw, str) and raw.strip():
+        return Path(raw)
+    return None
 
 
 def _load_channel_records(pipeline_type: str, db_config: dict, db_path: Path) -> list[dict]:
@@ -149,54 +208,97 @@ def _load_channel_records(pipeline_type: str, db_config: dict, db_path: Path) ->
     return records
 
 
-def compute_channel_snapshot(config: dict) -> SnapshotDecision:
-    """Decide whether the build should emit a channel snapshot, and with what.
+def _graph_channels(config: dict) -> _SourcedChannels:
+    """Read the graph paradigm's addresses out of the Turtle corpus it stages.
 
-    A snapshot is emitted when the project configures a Channel Finder database,
-    ``web.channel_suggestions.enabled`` is not switched off, the database is
-    readable, and it holds at least one and at most
-    ``web.channel_suggestions.max_channels`` distinct addresses.
-
-    The addresses — not the human-facing channel names — are what a panel writes
-    into a control-system request, so those are what the snapshot carries. A
-    database whose records name both keeps its ``address``; one that names only
-    ``channel`` (the hierarchical and middle-layer pipelines synthesize an
-    address from the channel name) contributes that instead.
-
-    The graph paradigm has no database file at all — its channels are served by
-    a graph database the browser cannot reach and the build cannot copy — so it
-    gets no snapshot and the typeahead stays quiet.
+    The graph store is a disposable mirror of a Turtle corpus that sits on the
+    build host under ``services.graphdb.ttl_path``, so the addresses are read
+    out of that file. Nothing here dials the store: the corpus is the source of
+    truth the deploy seeds it from.
 
     Args:
-        config: Full project configuration dictionary, as the build already
-            holds it.
+        config: Full project configuration dictionary.
 
     Returns:
-        The decision. An unreadable or malformed database is logged as a warning
-        and yields ``emit=False`` rather than raising.
-
-    Raises:
-        PipelineModeError: If ``channel_finder.pipeline_mode`` names a paradigm
-            that does not exist.
+        The sorted addresses and the resolved corpus path, or a no-emit
+        decision: quietly for a project that configures no ``ttl_path``,
+        because its graph store is external, and with a warning for a malformed
+        ``services.graphdb`` block, a corpus that cannot be read, or an rdflib
+        that will not import.
     """
-    section = _suggestions_section(config)
+    from osprey.deployment.graphdb_service import resolve_graphdb_service_config
 
-    if not section.get("enabled", True):
-        logger.debug(f"{ENABLED_CONFIG_KEY} is off; not emitting a channel snapshot.")
-        return SnapshotDecision(emit=False)
-
-    from osprey.services.channel_finder.utils.detection import detect_pipeline_config
-
-    pipeline_type, db_config = detect_pipeline_config(config)
-
-    if pipeline_type == "graph":
+    try:
+        settings = resolve_graphdb_service_config(config)
+    except ValueError as e:
         logger.warning(
-            "The graph paradigm serves its channels from a graph database rather than a "
-            "file on the build host, so there are no records to snapshot; the web "
-            "channel-suggestion typeahead is disabled for this project."
+            f"The services.graphdb block is malformed ({e}); not emitting a channel snapshot."
         )
         return SnapshotDecision(emit=False)
 
+    if settings is None or settings.ttl_path is None:
+        logger.debug(
+            "No services.graphdb.ttl_path is configured; the graph corpus is what a "
+            "channel snapshot would be derived from, so not emitting one."
+        )
+        return SnapshotDecision(emit=False)
+
+    from osprey.utils.config_paths import resolve_render_relative_path
+
+    ttl_path = resolve_render_relative_path(settings.ttl_path, _render_dir(config))
+
+    try:
+        from rdflib import Graph, Literal, URIRef
+    except ImportError:
+        logger.warning(
+            f"rdflib is not importable, so the graph corpus at {ttl_path} cannot be read; "
+            "not emitting a channel snapshot. rdflib is a core dependency, so this "
+            "environment is incomplete — reinstall it with: "
+            "pip install --upgrade osprey-framework."
+        )
+        return SnapshotDecision(emit=False, source_path=ttl_path)
+
+    try:
+        graph = Graph()
+        # The format is forced rather than guessed from the extension, as both
+        # other readers of this key force it — the deploy's n10s import and the
+        # TTL seeder — and rdflib would otherwise hand a corpus named ``.rdf``
+        # to its XML parser.
+        graph.parse(str(ttl_path), format="turtle")
+        channels = sorted(
+            {
+                str(o)
+                for o in graph.objects(None, URIRef(_FULL_PV_IRI))
+                if isinstance(o, Literal) and str(o)
+            }
+        )
+    except Exception as e:
+        logger.warning(
+            f"Could not read the graph corpus at {ttl_path} ({e}); not emitting a channel snapshot."
+        )
+        return SnapshotDecision(emit=False, source_path=ttl_path)
+
+    return channels, ttl_path
+
+
+def _database_channels(pipeline_type: str | None, db_config: dict | None) -> _SourcedChannels:
+    """Read a Channel Finder paradigm's addresses out of its database file.
+
+    A database whose records name both an address and a channel keeps its
+    ``address``; one that names only ``channel`` (the hierarchical and
+    middle-layer pipelines synthesize an address from the channel name)
+    contributes that instead.
+
+    Args:
+        pipeline_type: Pipeline name from ``detect_pipeline_config``, or falsy
+            when the project configures no channel finder database.
+        db_config: That pipeline's ``database`` block, or falsy likewise.
+
+    Returns:
+        The sorted addresses and the resolved database path, or a no-emit
+        decision: quietly when no database is configured, and with a warning
+        when the configured one cannot be read.
+    """
     if not pipeline_type or not db_config:
         logger.debug("No channel finder database is configured; not emitting a channel snapshot.")
         return SnapshotDecision(emit=False)
@@ -216,24 +318,85 @@ def compute_channel_snapshot(config: dict) -> SnapshotDecision:
         )
         return SnapshotDecision(emit=False, source_path=db_path)
 
+    return channels, db_path
+
+
+def compute_channel_snapshot(config: dict) -> SnapshotDecision:
+    """Decide whether the build should emit a channel snapshot, and with what.
+
+    A snapshot is emitted when the project configures a channel source — a
+    Channel Finder database, or the Turtle corpus of the graph paradigm —
+    ``web.channel_suggestions.enabled`` is not switched off, that source is
+    readable, and it holds at least one and at most
+    ``web.channel_suggestions.max_channels`` distinct addresses.
+
+    The addresses — not the human-facing channel names — are what a panel writes
+    into a control-system request, so those are what the snapshot carries. A
+    database whose records name both keeps its ``address``; one that names only
+    ``channel`` (the hierarchical and middle-layer pipelines synthesize an
+    address from the channel name) contributes that instead.
+
+    On the graph paradigm the addresses come from the corpus named by
+    ``services.graphdb.ttl_path``, which the build stages for the graph store.
+    That file is parsed as Turtle — the format is forced, exactly as the
+    deploy's import of the same corpus forces it — and every ``narad_p:fullPv``
+    literal in it is one address. The feature switch, the emptiness check and
+    the size guard then apply as they do to a database file. A project that
+    configures no ``ttl_path``, because its graph store is external, gets no
+    snapshot quietly; a corpus that cannot be read, a malformed
+    ``services.graphdb`` block, or an rdflib that will not import degrades to no
+    snapshot with a warning.
+
+    Args:
+        config: Full project configuration dictionary, as the build already
+            holds it.
+
+    Returns:
+        The decision. An unreadable or malformed source is logged as a warning
+        and yields ``emit=False`` rather than raising.
+
+    Raises:
+        PipelineModeError: If ``channel_finder.pipeline_mode`` names a paradigm
+            that does not exist.
+    """
+    section = _suggestions_section(config)
+
+    if not section.get("enabled", True):
+        logger.debug(f"{ENABLED_CONFIG_KEY} is off; not emitting a channel snapshot.")
+        return SnapshotDecision(emit=False)
+
+    from osprey.services.channel_finder.utils.detection import detect_pipeline_config
+
+    pipeline_type, db_config = detect_pipeline_config(config)
+
+    sourced = (
+        _graph_channels(config)
+        if pipeline_type == "graph"
+        else _database_channels(pipeline_type, db_config)
+    )
+    if isinstance(sourced, SnapshotDecision):
+        return sourced
+
+    channels, source_path = sourced
     count = len(channels)
 
     if count == 0:
         # An empty snapshot is not a smaller suggestion list, it is a typeahead
         # that never suggests anything — so there is nothing worth writing.
         logger.debug(
-            f"The channel database at {db_path} holds no channels; not emitting a channel snapshot."
+            f"The channel source at {source_path} holds no channels; "
+            "not emitting a channel snapshot."
         )
-        return SnapshotDecision(emit=False, source_path=db_path)
+        return SnapshotDecision(emit=False, source_path=source_path)
 
     max_channels = _max_channels(section)
     if count > max_channels:
         logger.warning(
-            f"The channel database at {db_path} holds {count} channels, above the "
+            f"The channel source at {source_path} holds {count} channels, above the "
             f"{MAX_CHANNELS_CONFIG_KEY} limit of {max_channels}; not emitting a channel "
             "snapshot. Raise that limit to include it."
         )
-        return SnapshotDecision(emit=False, count=count, source_path=db_path)
+        return SnapshotDecision(emit=False, count=count, source_path=source_path)
 
-    logger.debug(f"Channel snapshot: {count} channels from {db_path}.")
-    return SnapshotDecision(emit=True, channels=channels, count=count, source_path=db_path)
+    logger.debug(f"Channel snapshot: {count} channels from {source_path}.")
+    return SnapshotDecision(emit=True, channels=channels, count=count, source_path=source_path)

--- a/src/osprey/services/facility_knowledge/__init__.py
+++ b/src/osprey/services/facility_knowledge/__init__.py
@@ -6,8 +6,8 @@ utilities for parsing, validating, and serializing facility knowledge documents.
 
 Note: the seeder subpackage is intentionally excluded from this namespace — import it
 directly from ``osprey.services.facility_knowledge.seeder``.  Keeping it out of the
-package ``__init__`` ensures this module stays importable without the optional
-``knowledge`` extra (rdflib), which the seeder needs but the document model does not.
+package ``__init__`` keeps ``rdflib`` out of this module's import graph — the seeder
+needs it, the document model does not.
 """
 
 from .okf import OKFDocument, OKFDocumentError

--- a/src/osprey/services/facility_knowledge/seeder/__init__.py
+++ b/src/osprey/services/facility_knowledge/seeder/__init__.py
@@ -9,8 +9,9 @@ Two seeders, both offline and both driven from ``osprey knowledge``:
 
 Import this subpackage directly — it is intentionally excluded from the parent
 ``facility_knowledge`` namespace so that the runtime read path pulls in neither
-``rdflib`` (the ``knowledge`` extra) nor the ``neo4j`` driver.  Both are
-imported lazily inside the functions that need them.
+``rdflib`` nor the ``neo4j`` driver.  Both are core dependencies, so this is an
+import-graph boundary rather than an optional-install one; both are imported
+lazily inside the functions that need them.
 
 Example::
 

--- a/src/osprey/services/facility_knowledge/seeder/ttl_seeder.py
+++ b/src/osprey/services/facility_knowledge/seeder/ttl_seeder.py
@@ -4,9 +4,10 @@ Reads a canonical NARAD/als-ontology RDF/Turtle file and emits one
 :class:`DeviceStub` per device node (``?d a narad_sem:<Class>``).
 
 **rdflib is imported lazily inside each public function** — never at module
-top — so that importing this module does not require the ``knowledge`` extra.
-Callers that invoke :func:`seed_from_ttl` without rdflib installed receive an
-:class:`ImportError` with a clear message.
+top — so that importing this module keeps rdflib out of the import graph.
+rdflib is a core dependency, so an absent one means a broken environment:
+callers that invoke :func:`seed_from_ttl` without it receive an
+:class:`ImportError` saying how to repair the installation.
 
 Stub document format (OKF §9)::
 
@@ -259,7 +260,8 @@ def seed_from_ttl(ttl_path: Path | str | None) -> list[DeviceStub]:
         ``None`` or the file contains no device nodes.
 
     Raises:
-        ImportError: If ``rdflib`` is not installed (``knowledge`` extra required).
+        ImportError: If ``rdflib`` is not importable, which means the
+            installation is incomplete.
         FileNotFoundError: If *ttl_path* does not exist.
     """
     if not ttl_path:
@@ -267,13 +269,14 @@ def seed_from_ttl(ttl_path: Path | str | None) -> list[DeviceStub]:
 
     ttl_path = Path(ttl_path)
 
-    # Lazy import — keeps this module importable without the knowledge extra.
+    # Lazy import — keeps rdflib out of this module's import graph.
     try:
         from rdflib import Graph, URIRef
     except ImportError as exc:  # pragma: no cover
         raise ImportError(
-            "rdflib is required for seed_from_ttl(); "
-            "install it with: pip install 'osprey-framework[knowledge]'"
+            f"rdflib is not importable: {exc}\n"
+            "It is a core dependency, so this environment is incomplete. "
+            "Reinstall it with: pip install --upgrade osprey-framework"
         ) from exc
 
     g = Graph()

--- a/src/osprey/services/facility_knowledge/ttl_generator/__init__.py
+++ b/src/osprey/services/facility_knowledge/ttl_generator/__init__.py
@@ -3,8 +3,8 @@
 Derives a NARAD-convention knowledge graph from the control_assistant channel
 database.  The subpackage is deliberately **not** re-exported from
 :mod:`osprey.services.facility_knowledge` and this ``__init__`` re-exports
-nothing, so importing the parent package never pulls in ``rdflib`` (the
-optional ``knowledge`` extra).  Import the modules you need directly::
+nothing, so importing the parent package never pulls in ``rdflib``.  Import the
+modules you need directly::
 
     from osprey.services.facility_knowledge.ttl_generator.model import build_model
 

--- a/src/osprey/services/facility_knowledge/ttl_generator/emitter.py
+++ b/src/osprey/services/facility_knowledge/ttl_generator/emitter.py
@@ -568,7 +568,8 @@ def build_graph(model: GraphModel, ontology: OntologyMap) -> rdflib.Graph:
     Raises:
         UndirectedSignalError: If any signal group is still undirected.
         UnknownFamilyError: If a device family has no class in the table.
-        ImportError: If ``rdflib`` is not installed.
+        ImportError: If ``rdflib`` is not importable, which means the
+            installation is incomplete.
     """
     from rdflib import Graph, URIRef
 
@@ -583,9 +584,9 @@ def build_graph(model: GraphModel, ontology: OntologyMap) -> rdflib.Graph:
 def serialize_turtle(model: GraphModel, ontology: OntologyMap) -> str:
     """Serialise the corpus as deterministic Turtle text.
 
-    Pure text assembly — no ``rdflib`` involved, so this works in an
-    installation without the ``knowledge`` extra.  Identical input always yields
-    identical output, byte for byte.
+    Pure text assembly — no ``rdflib`` involved, so this keeps rdflib out of
+    the emitter's import graph.  Identical input always yields identical output,
+    byte for byte.
 
     Args:
         model: The derived graph, with directions already assigned.

--- a/tests/cli/test_knowledge_build_ttl.py
+++ b/tests/cli/test_knowledge_build_ttl.py
@@ -228,9 +228,9 @@ def _flat(result: Any) -> str:
 def _parse(ttl_path: Path) -> Any:
     """Parse *ttl_path* as Turtle.
 
-    rdflib is imported outright rather than skipped past: it is a CI
-    dependency (the ``dev`` extra), so an absent one is a broken environment
-    and four of these tests would otherwise pass by not running.
+    rdflib is imported outright rather than skipped past: it is a core
+    dependency, so an absent one is a broken environment and four of these
+    tests would otherwise pass by not running.
     """
     import rdflib
 

--- a/tests/cli/test_knowledge_cmd.py
+++ b/tests/cli/test_knowledge_cmd.py
@@ -345,7 +345,7 @@ def test_seed_from_ttl_no_rdflib_clean_error(
         runner = CliRunner()
         result = runner.invoke(knowledge, ["seed-from-ttl", str(mini_ttl), str(seed_bundle)])
 
-    # Exit code must be non-zero; output must mention the knowledge extra.
+    # Exit code must be non-zero; the message must name rdflib.
     assert result.exit_code != 0
     assert "knowledge" in result.output.lower() or "rdflib" in result.output.lower()
     # No Python traceback should appear.
@@ -354,7 +354,7 @@ def test_seed_from_ttl_no_rdflib_clean_error(
 
 @pytest.mark.skipif(
     __import__("importlib").util.find_spec("rdflib") is None,
-    reason="rdflib not installed (knowledge extra required)",
+    reason="rdflib not importable (core dependency; broken environment)",
 )
 def test_seed_from_ttl_writes_stubs(mini_ttl: Path, seed_bundle: Path) -> None:
     """Fresh seed writes one stub per device node and exits 0."""
@@ -368,7 +368,7 @@ def test_seed_from_ttl_writes_stubs(mini_ttl: Path, seed_bundle: Path) -> None:
 
 @pytest.mark.skipif(
     __import__("importlib").util.find_spec("rdflib") is None,
-    reason="rdflib not installed (knowledge extra required)",
+    reason="rdflib not importable (core dependency; broken environment)",
 )
 def test_seed_from_ttl_idempotent(mini_ttl: Path, seed_bundle: Path) -> None:
     """Re-running seed-from-ttl on an unchanged TTL produces no new writes."""
@@ -388,7 +388,7 @@ def test_seed_from_ttl_idempotent(mini_ttl: Path, seed_bundle: Path) -> None:
 
 @pytest.mark.skipif(
     __import__("importlib").util.find_spec("rdflib") is None,
-    reason="rdflib not installed (knowledge extra required)",
+    reason="rdflib not importable (core dependency; broken environment)",
 )
 def test_seed_from_ttl_skips_diff_without_force(mini_ttl: Path, seed_bundle: Path) -> None:
     """Existing stub with different body is NOT overwritten without --force."""
@@ -412,7 +412,7 @@ def test_seed_from_ttl_skips_diff_without_force(mini_ttl: Path, seed_bundle: Pat
 
 @pytest.mark.skipif(
     __import__("importlib").util.find_spec("rdflib") is None,
-    reason="rdflib not installed (knowledge extra required)",
+    reason="rdflib not importable (core dependency; broken environment)",
 )
 def test_seed_from_ttl_force_overwrites(mini_ttl: Path, seed_bundle: Path) -> None:
     """--force causes an existing stub with a different body to be overwritten."""

--- a/tests/cli/test_preset_dependency_pin.py
+++ b/tests/cli/test_preset_dependency_pin.py
@@ -54,12 +54,17 @@ PINNED_PRESET_DEPENDENCIES: dict[str, list[str]] = {
     "hello-world": [],
 }
 
-#: Packages a deploy imports in the CLI's own process, which therefore cannot be
-#: supplied by any profile. Each must be a core dependency of the framework.
+#: Packages a build or deploy imports in the CLI's own process, which therefore
+#: cannot be supplied by any profile. Each must be a core dependency of the
+#: framework.
 HOST_SIDE_PACKAGES = {
     # container_lifecycle._preflight_archiver_pymongo and, behind it,
     # _stage_archiver_store -> simulation.apply.archiver_collection.
     "pymongo",
+    # deployment.channel_snapshot.compute_channel_snapshot parses the graph
+    # corpus in the CLI's own process — on `osprey build` and on the
+    # deploy-time compose re-render.
+    "rdflib",
 }
 
 
@@ -95,7 +100,7 @@ def test_every_bundled_preset_declares_the_dependencies_it_is_pinned_to():
 
 
 def test_host_side_packages_are_core_dependencies():
-    """A package the CLI imports during a deploy cannot live behind an extra.
+    """A package the CLI imports during a build or a deploy cannot live behind an extra.
 
     This is the check that would have caught the original mistake at the commit
     that made it, rather than at a deploy months later: pymongo was reachable

--- a/tests/deployment/test_channel_snapshot.py
+++ b/tests/deployment/test_channel_snapshot.py
@@ -2,13 +2,14 @@
 
 Covers every pipeline backend the Channel Finder supports, the emission
 predicate (feature switch, absent database, empty database, size guard), the
-graph paradigm that has no file to snapshot at all, and the fail-soft behaviour
-that keeps an unreadable database from blocking a build.
+graph paradigm, whose snapshot is derived from the Turtle corpus, and the
+fail-soft behaviour that keeps an unreadable database from blocking a build.
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,7 @@ from osprey.deployment.channel_snapshot import (
     DEFAULT_MAX_CHANNELS,
     MAX_CHANNELS_CONFIG_KEY,
     _load_channel_records,
+    _render_dir,
     compute_channel_snapshot,
 )
 from osprey.services.channel_finder.core.exceptions import PipelineModeError
@@ -43,6 +45,59 @@ def _config(
     config: dict = {"channel_finder": {"pipelines": {pipeline: {"database": database}}}}
     if suggestions is not None:
         config["web"] = {"channel_suggestions": suggestions}
+    return config
+
+
+def _write_ttl(path: Path, bindings: list[tuple[str, str]] | str) -> Path:
+    """Write a Turtle corpus fixture and return its path.
+
+    A list of ``(binding id, address)`` pairs becomes one ``ChannelBinding`` per
+    pair; a string is written verbatim, for the corpora whose object terms are
+    the point of the test.
+    """
+    if isinstance(bindings, str):
+        path.write_text(bindings)
+        return path
+
+    lines = [
+        "@prefix narad_p: <https://narad.example.org/property/> .",
+        "@prefix narad_sem: <https://narad.example.org/schema/shared_semantics/> .",
+        "",
+    ]
+    lines += [
+        f"<https://example.org/binding/{binding_id}> a narad_sem:ChannelBinding ; "
+        f'narad_p:fullPv "{address}" .'
+        for binding_id, address in bindings
+    ]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _graph_config(
+    ttl_path: Path | str | None = None,
+    *,
+    suggestions: dict | None = None,
+    config_dir: Path | str | None = None,
+    graphdb_block: dict | None = None,
+) -> dict:
+    """Build the slice of project config the graph-mode decision reads.
+
+    ``graphdb_block`` writes the ``services.graphdb`` block verbatim, for the
+    cases that need a block without a usable ``ttl_path``; with neither it nor
+    ``ttl_path`` given, the config carries no ``services`` block at all.
+    """
+    config: dict = {"channel_finder": {"pipeline_mode": "graph"}}
+
+    block = graphdb_block
+    if block is None and ttl_path is not None:
+        block = {"ttl_path": str(ttl_path)}
+    if block is not None:
+        config["services"] = {"graphdb": block}
+
+    if suggestions is not None:
+        config["web"] = {"channel_suggestions": suggestions}
+    if config_dir is not None:
+        config["config_dir"] = str(config_dir)
     return config
 
 
@@ -260,21 +315,8 @@ class TestEmissionPredicate:
         assert str(DEFAULT_MAX_CHANNELS) in caplog.text
 
 
-class TestGraphParadigm:
-    """The graph paradigm keeps its channels out of reach of the build."""
-
-    def test_the_graph_paradigm_emits_nothing_and_says_the_typeahead_is_off(self, caplog):
-        config = {"channel_finder": {"pipeline_mode": "graph"}}
-
-        with caplog.at_level("WARNING"):
-            decision = compute_channel_snapshot(config)
-
-        assert decision.emit is False
-        assert decision.channels == []
-        assert decision.count == 0
-        assert decision.source_path is None
-        assert "typeahead" in caplog.text
-        assert "graph" in caplog.text.lower()
+class TestUnknownPipelineMode:
+    """A mode naming no paradigm is a configuration mistake, not a degraded panel."""
 
     def test_an_unknown_pipeline_mode_is_rejected_rather_than_quietly_skipped(self):
         config = {"channel_finder": {"pipeline_mode": "telepathy"}}
@@ -285,6 +327,214 @@ class TestGraphParadigm:
     def test_loading_records_for_an_unknown_pipeline_raises_a_pipeline_mode_error(self, tmp_path):
         with pytest.raises(PipelineModeError, match="telepathy"):
             _load_channel_records("telepathy", {}, tmp_path / "unused.json")
+
+
+class TestGraphParadigm:
+    """The graph paradigm snapshots the Turtle corpus the build host holds."""
+
+    def test_a_graph_corpus_contributes_its_sorted_deduplicated_addresses(self, tmp_path):
+        ttl = _write_ttl(
+            tmp_path / "corpus.ttl",
+            [
+                ("b1", "SR:BPM:02:X"),
+                ("b2", "SR:BPM:01:X"),
+                # The same address bound twice — two bindings, one channel.
+                ("b3", "SR:BPM:02:X"),
+            ],
+        )
+
+        decision = compute_channel_snapshot(_graph_config(ttl))
+
+        assert decision.emit is True
+        assert decision.channels == ["SR:BPM:01:X", "SR:BPM:02:X"]
+        assert decision.count == 2
+        assert decision.source_path == ttl
+
+    def test_a_corpus_whose_name_ends_in_rdf_is_still_read_as_turtle(self, tmp_path):
+        # The format is forced, so the extension rdflib would otherwise guess
+        # an XML parser from says nothing about how the corpus is read.
+        ttl = _write_ttl(
+            tmp_path / "corpus.rdf",
+            [("b1", "SR:BPM:01:X"), ("b2", "SR:BPM:02:X")],
+        )
+
+        decision = compute_channel_snapshot(_graph_config(ttl))
+
+        assert decision.emit is True
+        assert decision.count == 2
+
+    def test_an_iri_object_is_dropped_and_a_tagged_literal_keeps_its_lexical_form(self, tmp_path):
+        ttl = _write_ttl(
+            tmp_path / "mixed.ttl",
+            "@prefix narad_p: <https://narad.example.org/property/> .\n"
+            "@prefix narad_sem: <https://narad.example.org/schema/shared_semantics/> .\n"
+            "\n"
+            "<https://example.org/binding/b1> a narad_sem:ChannelBinding ;\n"
+            "    narad_p:fullPv <urn:not-a-literal> .\n"
+            "<https://example.org/binding/b2> a narad_sem:ChannelBinding ;\n"
+            '    narad_p:fullPv "SR:BPM:01:X"@en .\n',
+        )
+
+        decision = compute_channel_snapshot(_graph_config(ttl))
+
+        assert decision.emit is True
+        assert decision.channels == ["SR:BPM:01:X"]
+        assert not any("urn:not-a-literal" in channel for channel in decision.channels)
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            pytest.param(_graph_config(), id="no-services-block"),
+            pytest.param(_graph_config(graphdb_block={"port_host": 7687}), id="no-ttl-path"),
+        ],
+    )
+    def test_graph_mode_without_a_configured_corpus_says_so_at_debug(self, config, caplog):
+        # An external store with no local corpus is a correct configuration, so
+        # this must not warn on every build.
+        with caplog.at_level("DEBUG", logger="deployment.channel_snapshot"):
+            decision = compute_channel_snapshot(config)
+
+        assert decision.emit is False
+        assert decision.count == 0
+        assert decision.source_path is None
+        assert [record.message for record in caplog.records if record.levelname == "WARNING"] == []
+        assert any(
+            record.levelname == "DEBUG" and "services.graphdb.ttl_path" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_a_blank_ttl_path_warns_rather_than_raising(self, caplog):
+        config = _graph_config(graphdb_block={"ttl_path": ""})
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(config)
+
+        assert decision.emit is False
+        assert decision.source_path is None
+        assert "services.graphdb" in caplog.text
+
+    def test_a_missing_corpus_warns_with_the_path_and_emits_nothing(self, tmp_path, caplog):
+        missing = tmp_path / "gone.ttl"
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(_graph_config(missing))
+
+        assert decision.emit is False
+        assert decision.source_path == missing
+        assert str(missing) in caplog.text
+
+    def test_a_ttl_path_naming_a_directory_warns_and_emits_nothing(self, tmp_path, caplog):
+        directory = tmp_path / "corpus_dir"
+        directory.mkdir()
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(_graph_config(directory))
+
+        assert decision.emit is False
+        assert str(directory) in caplog.text
+
+    def test_non_turtle_bytes_warn_with_the_path_and_emit_nothing(self, tmp_path, caplog):
+        ttl = _write_ttl(tmp_path / "corpus.ttl", "this is not turtle")
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(_graph_config(ttl))
+
+        assert decision.emit is False
+        assert decision.channels == []
+        assert str(ttl) in caplog.text
+
+    def test_a_corpus_without_full_pv_literals_emits_nothing(self, tmp_path):
+        ttl = _write_ttl(tmp_path / "bare.ttl", [])
+
+        decision = compute_channel_snapshot(_graph_config(ttl))
+
+        assert decision.emit is False
+        assert decision.count == 0
+        assert decision.channels == []
+
+    def test_a_corpus_above_the_size_guard_emits_nothing_and_names_the_key(self, tmp_path, caplog):
+        ttl = _write_ttl(
+            tmp_path / "corpus.ttl",
+            [("b1", "SR:BPM:01:X"), ("b2", "SR:BPM:02:X")],
+        )
+        config = _graph_config(ttl, suggestions={"max_channels": 1})
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(config)
+
+        assert decision.emit is False
+        assert decision.count == 2
+        assert MAX_CHANNELS_CONFIG_KEY in caplog.text
+
+    def test_switching_the_feature_off_never_opens_the_corpus(self, tmp_path, caplog):
+        # The corpus does not exist: reaching it at all would warn.
+        config = _graph_config(tmp_path / "gone.ttl", suggestions={"enabled": False})
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(config)
+
+        assert decision.emit is False
+        assert decision.source_path is None
+        assert caplog.records == []
+
+    def test_an_unimportable_rdflib_warns_with_the_reinstall_hint(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        ttl = _write_ttl(tmp_path / "corpus.ttl", [("b1", "SR:BPM:01:X")])
+        monkeypatch.setitem(sys.modules, "rdflib", None)
+
+        with caplog.at_level("WARNING"):
+            decision = compute_channel_snapshot(_graph_config(ttl))
+
+        assert decision.emit is False
+        assert decision.source_path == ttl
+        assert "rdflib" in caplog.text
+        assert "pip install --upgrade osprey-framework" in caplog.text
+
+    def test_a_relative_ttl_path_resolves_against_the_recorded_config_dir(
+        self, tmp_path, monkeypatch
+    ):
+        render = tmp_path / "render"
+        (render / "data").mkdir(parents=True)
+        _write_ttl(render / "data" / "corpus.ttl", [("b1", "SR:BPM:01:X")])
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        decision = compute_channel_snapshot(_graph_config("data/corpus.ttl", config_dir=render))
+
+        assert decision.emit is True
+        assert decision.source_path == (render / "data" / "corpus.ttl").resolve()
+
+    def test_a_relative_ttl_path_without_a_config_dir_follows_the_running_config(
+        self, tmp_path, monkeypatch
+    ):
+        # No ``config_dir`` and no ``OSPREY_CONFIG`` (the suite clears it): the
+        # corpus is resolved against the config.yml this process runs against,
+        # which with no render in the working directory is that directory.
+        (tmp_path / "data").mkdir()
+        _write_ttl(tmp_path / "data" / "corpus.ttl", [("b1", "SR:BPM:01:X")])
+        monkeypatch.chdir(tmp_path)
+
+        decision = compute_channel_snapshot(_graph_config("data/corpus.ttl"))
+
+        assert decision.emit is True
+        assert decision.source_path == (tmp_path / "data" / "corpus.ttl").resolve()
+
+        # With a render in place, ``build/config.yml`` is that config, so the
+        # same configured string now names the corpus inside the render.
+        build = tmp_path / "build"
+        (build / "data").mkdir(parents=True)
+        (build / "config.yml").write_text("")
+        _write_ttl(
+            build / "data" / "corpus.ttl",
+            [("b1", "SR:BPM:01:X"), ("b2", "SR:BPM:02:X")],
+        )
+
+        decision = compute_channel_snapshot(_graph_config("data/corpus.ttl"))
+
+        assert decision.source_path == (build / "data" / "corpus.ttl").resolve()
+        assert decision.count == 2
 
 
 class TestFailSoft:
@@ -337,3 +587,27 @@ class TestFailSoft:
 
         assert decision.emit is True
         assert decision.source_path == tmp_path / "data" / "channel_databases" / "als.json"
+
+
+class TestRenderDir:
+    """The anchor a relative render-relative path is resolved against."""
+
+    def test_a_set_config_dir_is_returned_as_a_path(self, tmp_path):
+        assert _render_dir({"config_dir": str(tmp_path)}) == tmp_path
+
+    def test_an_empty_config_dir_is_no_anchor(self):
+        assert _render_dir({"config_dir": ""}) is None
+
+    def test_a_blank_config_dir_is_no_anchor(self):
+        assert _render_dir({"config_dir": "   "}) is None
+
+    def test_an_absent_config_dir_is_no_anchor(self):
+        assert _render_dir({}) is None
+
+    def test_a_non_string_config_dir_is_no_anchor(self, tmp_path):
+        assert _render_dir({"config_dir": 123}) is None
+        assert _render_dir({"config_dir": tmp_path}) is None
+
+    def test_project_root_is_not_consulted(self, tmp_path):
+        """``project_root`` is the repo root — the wrong anchor for this key."""
+        assert _render_dir({"project_root": str(tmp_path)}) is None

--- a/tests/deployment/test_channel_snapshot_render.py
+++ b/tests/deployment/test_channel_snapshot_render.py
@@ -4,7 +4,9 @@ Two artifacts are staged by the render and gated the same way — the
 bluesky_web sidecar's ``channels.json`` behind ``channel_snapshot``, and the
 queueserver worker's ``bluesky_devices.yml`` behind ``bluesky_devices``. Each
 is one decision reaching three consumers: a render-context boolean, a file in
-the service's build context, and the compose fragment's conditional mount.
+the service's build context, and the compose fragment's conditional mount —
+and for the snapshot that decision reads either the project's channel database
+or, on the graph paradigm, the Turtle corpus at ``services.graphdb.ttl_path``.
 
 Both are pinned across BOTH render paths — the full :func:`setup_build_dir` and
 the incremental :func:`_incremental_setup_build_dir` — because a project's
@@ -91,6 +93,10 @@ def _config(repo: Path, db_path: Path | None = None) -> dict:
     config: dict = {
         "project_name": "demo",
         "project_root": str(repo),
+        # What prepare_compose_files records before either render helper runs;
+        # the repo IS the working directory here, so it changes nothing the
+        # database paradigms see and gives the graph corpus its real anchor.
+        "config_dir": str(repo),
         "build_dir": "./build",
         "services": {"bluesky_web": {}, "bluesky": {}},
         "deployment": {},
@@ -101,6 +107,41 @@ def _config(repo: Path, db_path: Path | None = None) -> dict:
         config["channel_finder"] = {
             "pipelines": {"in_context": {"database": {"path": str(db_path), "type": "flat"}}}
         }
+    return config
+
+
+#: Two bindings, deliberately out of order, so a sorted snapshot is visible as
+#: a reordering rather than as a copy of the file's own sequence.
+CORPUS = """\
+@prefix narad_p: <https://narad.example.org/property/> .
+@prefix narad_sem: <https://narad.example.org/schema/shared_semantics/> .
+
+<https://narad.example.org/binding/sr-bpm-02-x> a narad_sem:ChannelBinding ;
+    narad_p:fullPv "SR:BPM:02:X" .
+
+<https://narad.example.org/binding/sr-bpm-01-x> a narad_sem:ChannelBinding ;
+    narad_p:fullPv "SR:BPM:01:X" .
+"""
+
+
+def _corpus(directory: Path) -> Path:
+    """Write a small Turtle corpus of channel bindings into ``directory``."""
+    path = directory / "corpus.ttl"
+    path.write_text(CORPUS, encoding="utf-8")
+    return path
+
+
+def _graph_config(repo: Path, *, ttl: bool = True) -> dict:
+    """The config slice a graph-paradigm project renders with.
+
+    ``ttl_path`` is kept RELATIVE on purpose: the only thing that makes the
+    corpus findable is the ``config_dir`` anchor, so a resolution that quietly
+    fell back to something else would show up here as a missing snapshot.
+    """
+    config = _config(repo)
+    config["channel_finder"] = {"pipeline_mode": "graph"}
+    if ttl:
+        config["services"]["graphdb"] = {"ttl_path": "./corpus.ttl"}
     return config
 
 
@@ -131,6 +172,30 @@ def test_paths_agree_when_the_database_emits(repo, rendered_contexts):
 
     # The artifact is what the sidecar's /channels route serves: the sorted
     # addresses, not the human-facing channel names.
+    assert json.loads(full_bytes) == ["SR:BPM:01:X", "SR:BPM:02:X"]
+
+
+def test_paths_agree_when_the_graph_corpus_emits(repo, rendered_contexts):
+    """A graph-mode project gets the same snapshot from either renderer.
+
+    The corpus reaches the panel exactly as a database file does — the graph
+    paradigm differs only in where the addresses are read from, never in what
+    the build writes or which render path wrote it.
+    """
+    _corpus(repo)
+    config = _graph_config(repo)
+
+    _run_full(config)
+    assert rendered_contexts[0]["channel_snapshot"] is True
+    full_bytes = SNAPSHOT.read_bytes()
+
+    shutil.rmtree("build")
+    _run_incremental(config)
+    assert rendered_contexts[1]["channel_snapshot"] is True
+    assert SNAPSHOT.read_bytes() == full_bytes
+
+    # The bindings' fullPv literals, sorted — the same artifact shape the
+    # database paradigms produce, not the corpus's own ordering.
     assert json.loads(full_bytes) == ["SR:BPM:01:X", "SR:BPM:02:X"]
 
 
@@ -219,6 +284,98 @@ def test_mount_absent_when_the_decision_is_false(repo, web_block, with_database)
     volumes = _rendered_volumes()
     assert not any("channels.json" in volume for volume in volumes)
     assert CONFIG_MOUNT in volumes
+
+
+def test_mount_present_when_the_graph_snapshot_emits(repo):
+    """A corpus-derived snapshot is mounted like any other."""
+    _corpus(repo)
+
+    _run_full(_graph_config(repo))
+
+    volumes = _rendered_volumes()
+    assert SNAPSHOT_MOUNT in volumes
+    assert CONFIG_MOUNT in volumes
+
+
+@pytest.mark.parametrize(
+    ("web_block", "with_corpus", "ttl"),
+    [
+        pytest.param({"channel_suggestions": {"enabled": False}}, True, True, id="graph-disabled"),
+        pytest.param(
+            {"channel_suggestions": {"max_channels": 1}}, True, True, id="graph-over-guard"
+        ),
+        pytest.param(None, True, False, id="graph-no-ttl-path"),
+    ],
+)
+def test_graph_mount_absent_when_the_decision_is_false(repo, web_block, with_corpus, ttl):
+    """Graph mode degrades the panel the same way the file paradigms do.
+
+    A corpus sitting right there is not enough on its own: the switch, the size
+    guard and an unconfigured ``ttl_path`` each end in a build that renders and
+    a sidecar with nothing to suggest.
+    """
+    if with_corpus:
+        _corpus(repo)
+    config = _graph_config(repo, ttl=ttl)
+    if web_block is not None:
+        config["web"] = web_block
+
+    _run_full(config)
+
+    volumes = _rendered_volumes()
+    assert not any("channels.json" in volume for volume in volumes)
+    assert CONFIG_MOUNT in volumes
+
+
+def test_a_rebuild_drops_a_stale_graph_snapshot(repo, rendered_contexts):
+    """A corpus that stops being configured takes its mount with it.
+
+    Fail-soft is by design, but it must be fail-soft all the way through: the
+    rebuild has to drop the file the previous build wrote AND the mount that
+    named it, or the deployment comes up binding a path nothing produces.
+    """
+    _corpus(repo)
+    _run_full(_graph_config(repo))
+    assert SNAPSHOT.exists()
+
+    _run_incremental(_graph_config(repo, ttl=False))
+
+    assert rendered_contexts[-1]["channel_snapshot"] is False
+    assert not SNAPSHOT.exists()
+    assert not any("channels.json" in volume for volume in _rendered_volumes())
+
+
+def test_the_graph_corpus_resolves_through_config_dir(repo, tmp_path, rendered_contexts):
+    """``config_dir`` is the anchor for a relative ``ttl_path``, not the cwd.
+
+    The two directories coincide on a real build, which is exactly why the test
+    pulls them apart: a corpus reachable only from ``config_dir`` must be found,
+    and one reachable only from the working directory must not be.
+    """
+    render_dir = tmp_path / "render"
+    render_dir.mkdir()
+    _corpus(render_dir)
+
+    config = _graph_config(repo)
+    config["config_dir"] = str(render_dir)
+    assert not (repo / "corpus.ttl").exists()
+
+    _run_full(config)
+    assert rendered_contexts[0]["channel_snapshot"] is True
+    assert json.loads(SNAPSHOT.read_bytes()) == ["SR:BPM:01:X", "SR:BPM:02:X"]
+
+    # And the inverse: the corpus in the working directory, the anchor pointing
+    # somewhere without one. Nothing is found, and the build still renders.
+    shutil.rmtree("build")
+    _corpus(repo)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    config["config_dir"] = str(elsewhere)
+
+    _run_full(config)
+    assert rendered_contexts[1]["channel_snapshot"] is False
+    assert not SNAPSHOT.exists()
+    assert not any("channels.json" in volume for volume in _rendered_volumes())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp_server/test_facility_knowledge_tools.py
+++ b/tests/mcp_server/test_facility_knowledge_tools.py
@@ -593,34 +593,3 @@ class TestToolInternalErrors:
 
         with assert_raises_error(error_type="not_found"):
             await get_tool_fn(read_concept)(concept_id="no/such")
-
-
-# ---------------------------------------------------------------------------
-# Module import safety
-# ---------------------------------------------------------------------------
-
-
-class TestModuleImportSafety:
-    """Importing the server package must not pull in rdflib."""
-
-    def test_no_rdflib_import_on_server_import(self):
-        """rdflib must not be imported as a side effect of loading server.py.
-
-        This check is only meaningful when rdflib is NOT installed at all
-        (i.e. the ``knowledge`` extra is absent).  When rdflib IS installed,
-        other tests in the suite (seeder tests) will have imported it already,
-        so the presence of ``rdflib`` in ``sys.modules`` no longer indicates
-        a side-effect from server.py — skip rather than false-fail.
-        """
-        import importlib.util
-        import sys
-
-        if importlib.util.find_spec("rdflib") is not None:
-            pytest.skip(
-                "rdflib is installed; isolation check only applies when the knowledge extra is absent"
-            )
-
-        # server.py is already imported in this session; verify rdflib is absent.
-        assert "rdflib" not in sys.modules, (
-            "rdflib was imported as a side effect of importing the facility_knowledge server"
-        )

--- a/tests/services/facility_knowledge/test_import_isolation.py
+++ b/tests/services/facility_knowledge/test_import_isolation.py
@@ -1,8 +1,11 @@
 """Import-isolation guard: rdflib and neo4j must stay OUT of sys.modules when
 the facility-knowledge runtime read path is imported.
 
-rdflib belongs exclusively to the offline TTL seeder (``knowledge`` extra) and
-the TTL generator (:mod:`osprey.services.facility_knowledge.ttl_generator`);
+rdflib is a core dependency, but inside the facility-knowledge package only
+the offline TTL seeder and the TTL generator
+(:mod:`osprey.services.facility_knowledge.ttl_generator`) import it — as does
+the graph-mode channel snapshot (:mod:`osprey.deployment.channel_snapshot`) —
+and all of them do so lazily, keeping it out of the runtime read path;
 neo4j belongs exclusively to the graph seeder (:mod:`.seeder.graph_seeder`) and
 the graph MCP server (:mod:`osprey.mcp_server.graph`), both of which import it
 lazily inside the functions that dial the store. Importing any of those modules
@@ -312,9 +315,9 @@ class TestIsolationDetectorsFire:
     """Negative controls: both detectors must fail when the driver IS imported.
 
     Without these, an uninstalled package or a broken code template would let
-    every isolation test above pass while checking nothing. rdflib ships in the
-    ``dev`` extra and neo4j in the base dependencies, so both imports below are
-    expected to succeed — and the assertion in the child is expected to trip.
+    every isolation test above pass while checking nothing. rdflib and neo4j are
+    both base dependencies, so both imports below are expected to succeed — and
+    the assertion in the child is expected to trip.
     """
 
     def test_rdflib_detector_fires_when_rdflib_is_imported(self):

--- a/tests/services/facility_knowledge/test_ttl_generator_emitter.py
+++ b/tests/services/facility_knowledge/test_ttl_generator_emitter.py
@@ -13,7 +13,7 @@ Three things are checked here, in rising order of cost:
    tier-3 channel database carries every predicate the shipped example queries
    touch, with the counts the channel database and the limits file imply.
 
-``rdflib`` is imported at module scope on purpose: it is in the ``dev`` extra, so
+``rdflib`` is imported at module scope on purpose: it is a core dependency, so
 a missing rdflib is a broken test environment rather than a reason to skip and
 report a vacuous green.  The *source* modules still import it lazily —
 ``test_import_isolation.py`` guards that.

--- a/tests/services/facility_knowledge/test_ttl_seeder.py
+++ b/tests/services/facility_knowledge/test_ttl_seeder.py
@@ -1,7 +1,8 @@
 """Tests for the TTL-based OKF stub seeder.
 
-All tests that actually invoke rdflib are guarded by ``pytest.importorskip``
-so the suite remains green when the ``knowledge`` extra is not installed.
+All tests that actually invoke rdflib are guarded by ``pytest.importorskip``,
+so they report a clear skip if rdflib is not importable — it is a core
+dependency, so that means a broken environment.
 """
 
 from __future__ import annotations
@@ -68,8 +69,10 @@ def mini_ttl(tmp_path: Path) -> Path:
 
 
 def _require_rdflib():
-    """Skip current test if rdflib is not installed."""
-    return pytest.importorskip("rdflib", reason="rdflib not installed (knowledge extra required)")
+    """Skip current test if rdflib is not importable."""
+    return pytest.importorskip(
+        "rdflib", reason="rdflib not importable (core dependency; broken environment)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -4626,6 +4626,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "questionary" },
+    { name = "rdflib" },
     { name = "requests" },
     { name = "rich" },
     { name = "ruamel-yaml" },
@@ -4671,7 +4672,6 @@ all = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "python-xlib" },
-    { name = "rdflib" },
     { name = "ruff" },
     { name = "setuptools-scm" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -4705,7 +4705,6 @@ dev = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
-    { name = "rdflib" },
     { name = "ruff" },
     { name = "setuptools-scm" },
     { name = "testcontainers", extra = ["mongodb"] },
@@ -4731,7 +4730,6 @@ gchat = [
 ]
 knowledge = [
     { name = "linkml-runtime" },
-    { name = "rdflib" },
 ]
 screen-capture-linux = [
     { name = "mss" },
@@ -4858,9 +4856,7 @@ requires-dist = [
     { name = "python-xlib", marker = "extra == 'screen-capture-linux'", specifier = ">=0.33" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "questionary", specifier = ">=2.1.1" },
-    { name = "rdflib", marker = "extra == 'all'", specifier = ">=7.0" },
-    { name = "rdflib", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "rdflib", marker = "extra == 'knowledge'", specifier = ">=7.0" },
+    { name = "rdflib", specifier = ">=7.0" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "rich", specifier = ">=15.0.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },


### PR DESCRIPTION
Graph-paradigm projects got no channel-suggestions snapshot, so the web panels' typeahead went quiet the moment a project moved to graph mode — its channels live in a graph store the build cannot copy, and the build treated that as "nothing to snapshot".

The store is only a mirror of the Turtle corpus staged under `services.graphdb.ttl_path`, so the build now reads the addresses out of that file: it is parsed as Turtle (format forced, as the deploy's import and the TTL seeder already do), every `narad_p:fullPv` literal is one address (IRIs are ignored), and the same emptiness and `max_channels` guards apply as on the database path. A relative `ttl_path` resolves against the recorded config directory, like every other render-relative key. A missing `ttl_path` (external store) stays quiet; an unreadable or malformed corpus, or an rdflib that will not import, degrades to no snapshot with a warning — never a failed build. Full and incremental renders produce identical `channels.json` bytes, and a stale snapshot is dropped when `ttl_path` is removed.

Parsing the corpus needs rdflib, which lived only in the `knowledge` extra, so it becomes a core dependency (first commit). The extra stays and keeps `linkml-runtime`; existing install commands keep working. The seeder, TTL generator and CLI still import rdflib lazily — now to keep the import graph small rather than to tolerate an optional install — and their "install the knowledge extra" hints become a reinstall hint for an incomplete environment. The server-import isolation test that could only run without rdflib is removed; the subprocess-based isolation suite covers the same guarantee.

## How it hangs together

```text
config.yml                         osprey build · compute_channel_snapshot()
┌──────────────────────────┐       ┌──────────────────────────────────────────┐
│ channel_finder            │       │ pipeline_mode == graph ?                 │
│   pipeline_mode: graph    │──────►│   yes ─► _graph_channels()               │
│ services.graphdb          │       │          resolve ttl_path (config_dir)   │
│   ttl_path: corpus.ttl    │       │          rdflib parse, format = turtle   │
└──────────────────────────┘       │          collect narad_p:fullPv literals │
                                   │   no  ─► _database_channels()            │
┌──────────────────────────┐       │          (the database read, unchanged)  │
│ corpus.ttl                │──────►│                                          │
│   narad_p:fullPv "…"      │       │ shared tail: enabled · non-empty ·       │
└──────────────────────────┘       │              ≤ max_channels ─► emit      │
                                   └────────────────────┬─────────────────────┘
                                                        ▼
                                   channels.json beside the rendered config,
                                   mounted into the web panel ─► typeahead
```

## Docs — please read for accuracy

Each paragraph must hold for both a database file and a Turtle corpus.

`use-channel-finder.rst`: "The channel-suggestion typeahead in the web panels still works in graph mode: `osprey build` reads the channel names out of the Turtle corpus named by `services.graphdb.ttl_path` and writes them into the snapshot the panels use."

`panels.rst` (source): "The names come from the project's Channel Finder catalog — the channel database, or in graph mode the Turtle corpus named by `services.graphdb.ttl_path`: `osprey build` writes a snapshot of it next to the generated config, and the panel reads that snapshot — no control-system traffic, and nothing to keep in sync at run time. A project that configures neither shows no suggestions and is otherwise unchanged."

`panels.rst` (limit): "…so a catalog holding more channels than the limit is skipped instead of shipped…"

`panels.rst` (staleness): "One staleness rule to know: editing a channel database or Turtle corpus inside the profile's `data/` tree changes the build fingerprint, so `osprey up` refuses until you rebuild — the snapshot cannot silently go stale on that path. A database or corpus referenced from *outside* the profile tree is not fingerprinted; its snapshot refreshes only on the next explicit `osprey build`."

## Follow-ups (not in this PR)

`test_ttl_generator_emitter.py` skips on a missing rdflib while `test_ttl_seeder.py` / `test_knowledge_cmd.py` hard-fail — both honest now that rdflib is core; left as is.
