### PR TITLE
ci: cut pull-request cycle time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,21 @@ on:
     # PR-gated or dispatch-gated and does NOT run on this schedule.
     - cron: '0 7 * * *'
 
+# Only one CI run per pull request stays alive. Without this, every push to a
+# branch left its predecessor's full job matrix queued rather than cancelled,
+# and on an account whose concurrent-job allowance is already saturated those
+# dead runs sat ahead of the live one in line: measured over 71 PR runs, 35%
+# were superseded-but-still-running ghosts holding 31% of all CI wall-clock.
+#
+# The `github.sha` fallback is load-bearing. `github.head_ref` is empty off
+# pull_request, so without it every push to main and every nightly would share
+# one group and cancel each other. cancel-in-progress is likewise scoped to
+# pull_request only: a superseded PR run is waste, but a superseded main or
+# schedule run is a lost signal nothing else reproduces.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Note: This workflow runs tests, linting, docs build, and package checks
 # For documentation deployment to GitHub Pages, see .github/workflows/docs.yml
 
@@ -90,6 +105,30 @@ jobs:
       matrix:
         python-version: ['3.11', '3.12']
         os: [ubuntu-latest, macos-latest]
+        # Pull requests drop the 3.11/macOS cell; every other event runs the
+        # full product.
+        #
+        # Two reasons, and neither is "macOS does not matter". The macOS
+        # concurrency ceiling is 5 jobs across the whole account and does not
+        # move on Free, Pro or Team -- only on Enterprise. At two macOS cells
+        # per PR, four in-flight PRs want 8 of those 5 slots, which is why the
+        # 3.12/macOS cell was measured sitting 24.8 minutes in the queue behind
+        # other PRs. At one cell they fit. The second reason is load: the four
+        # test cells are ~101 of the ~350 job-minutes a PR run costs, the
+        # largest single item in this file.
+        #
+        # Dropping to ZERO macOS cells on PRs was considered and rejected. The
+        # merge commit a PR creates is itself a push to main, so main-push runs
+        # do exercise macOS on every merge -- but that is detection after the
+        # fact, not prevention, and a broken main is rebased onto by every
+        # other in-flight PR. Keeping one cell costs ~23 job-minutes and buys
+        # back the pre-merge signal.
+        #
+        # 3.12 is the surviving macOS cell so it pairs with the 3.12/ubuntu
+        # coverage cell: same interpreter, different OS, so a failure isolates
+        # to the OS. 3.11 stays covered on ubuntu, and on macOS everywhere
+        # except pull requests.
+        exclude: ${{ fromJSON(github.event_name == 'pull_request' && '[{"python-version":"3.11","os":"macos-latest"}]' || '[]') }}
 
     steps:
     - name: Checkout repository
@@ -393,7 +432,7 @@ jobs:
           -v --tb=short
 
   lint:
-    name: Lint and Code Quality
+    name: Lint and Code Quality + Tier 0 config-key guard
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -430,6 +469,28 @@ jobs:
     - name: Run ruff (formatting)
       run: |
         uv run ruff format --check src/ packages/ tests/
+
+    - name: Run config-key resurrection guard (with back-test)
+      # `!cancelled()` so folding this in never costs a signal: a ruff
+      # failure above must not hide a resurrection-guard failure here and
+      # buy a second full CI cycle to discover it.
+      if: ${{ !cancelled() }}
+      # ~4.6s. Exit 0 clean, 1 on any failure record — an unmapped rendered
+      # key, a dead `evidence` regex, a deleted key resurrected in a template
+      # or preset override, an `orphan_sites` regex matching again, template
+      # parity drift, and the manifest's own consistency checks. The script's
+      # module docstring is the authoritative list.
+      #
+      # `--back-test` (one command, guard + back-test) is what makes the orphan
+      # regexes falsifiable: each must match at the recorded baseline and NOT on
+      # the branch, so a regex wired to nothing is caught instead of reporting
+      # green. tests/scripts/test_config_key_guard.py covers the same ground in
+      # the unit-test lane today — but revocably: its back-test cases skip
+      # themselves when the baseline is unreachable, so a checkout-depth or
+      # marker-deselection change over there would drop the proof with no red
+      # signal to say so. Pinning it to this lane, whose full history is its
+      # stated purpose, is what makes the coverage non-revocable.
+      run: uv run python scripts/check_config_keys.py --back-test
 
     - name: Run mypy (type checking)
       run: |
@@ -492,7 +553,7 @@ jobs:
         retention-days: 7
 
   package:
-    name: Package Build
+    name: Package Build (framework + lean connectors wheel)
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -524,23 +585,15 @@ jobs:
         path: dist/
         retention-days: 7
 
-  lean-wheel:
-    name: Lean connectors wheel
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        enable-cache: true
-
-    - name: Install Python
-      run: uv python install 3.11
-
+    # Folded in from the former `lean-wheel` job, which shared this job's whole
+    # setup -- checkout, uv, Python 3.11 -- and then ran for ~12 seconds. As a
+    # job of its own it spent a runner slot re-paying for setup already done
+    # here, and slots, not seconds, are what PR wall-clock is made of.
+    #
+    # Position is load-bearing. `uv build` above must reach `twine check` and
+    # the uploaded `package` artifact with only the framework's own artifacts in
+    # dist/, exactly as it did when these were two jobs; building the connectors
+    # wheel earlier would quietly widen both.
     - name: Build osprey-connectors wheel
       run: uv build --package osprey-connectors
 
@@ -755,55 +808,6 @@ jobs:
       with:
         name: static-checks
         engine: podman
-
-  config-key-guard:
-    name: Tier 0 — Config-key resurrection guard (manifest ↔ rendered templates)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
-      with:
-        # LOAD-BEARING for the `--back-test` run below, which extracts the
-        # baseline tree with `git archive <commit>`: a shallow clone cannot
-        # reach the baseline. It fails loudly there (RuntimeError -> exit 1)
-        # rather than skipping, so dropping this can only red the lane, never
-        # quietly hollow it out — but the fix is to restore the depth, not to
-        # drop the flag.
-        fetch-depth: 0
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        enable-cache: true
-
-    - name: Set up Python
-      run: uv python install 3.11
-
-    - name: Install dependencies
-      # The guard renders the shipped config.yml.j2 templates through Jinja and
-      # parses scripts/config_key_manifest.yml, so it needs the project deps
-      # like every other lane.
-      run: uv sync --extra dev
-
-    - name: Run config-key resurrection guard (with back-test)
-      # ~4.6s. Exit 0 clean, 1 on any failure record — an unmapped rendered
-      # key, a dead `evidence` regex, a deleted key resurrected in a template
-      # or preset override, an `orphan_sites` regex matching again, template
-      # parity drift, and the manifest's own consistency checks. The script's
-      # module docstring is the authoritative list.
-      #
-      # `--back-test` (one command, guard + back-test) is what makes the orphan
-      # regexes falsifiable: each must match at the recorded baseline and NOT on
-      # the branch, so a regex wired to nothing is caught instead of reporting
-      # green. tests/scripts/test_config_key_guard.py covers the same ground in
-      # the unit-test lane today — but revocably: its back-test cases skip
-      # themselves when the baseline is unreachable, so a checkout-depth or
-      # marker-deselection change over there would drop the proof with no red
-      # signal to say so. Pinning it to this lane, whose full history is its
-      # stated purpose, is what makes the coverage non-revocable.
-      run: uv run python scripts/check_config_keys.py --back-test
 
   visual-theming:
     name: Behavioral + Visual Theming (Playwright, design system)
@@ -4442,7 +4446,7 @@ jobs:
 
   all-checks-passed:
     name: All CI Checks Passed
-    needs: [test, dependency-floor, lint, docs, package, static-checks, config-key-guard, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, dispatch-overlay-e2e, bluesky-deploy-e2e, bluesky-web-deploy-e2e, va-substrate-equivalence-e2e, orm-roundtrip-e2e, bluesky-queue-e2e, scan-agentic-e2e, archiver-world-e2e, tiled-roundtrip-e2e, bluesky-catalog-e2e, bluesky-sandbox-escape-e2e, nextcloud-talk-bridge-e2e, gchat-bridge-e2e, dockerfile-e2e, privilege-split-e2e, execution-environment-parity-e2e, agentic-per-preset, deploy-writeback-e2e, multi-user-deploy-lifecycle-e2e, multi-user-deploy-lifecycle-e2e-podman, auth-perimeter-e2e, terminal-auth-multiuser-e2e, lean-wheel, two-shape-boot-e2e, qmd-sidecar-e2e, target-switch-e2e, target-switch-agentic-e2e]
+    needs: [test, dependency-floor, lint, docs, package, static-checks, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, dispatch-overlay-e2e, bluesky-deploy-e2e, bluesky-web-deploy-e2e, va-substrate-equivalence-e2e, orm-roundtrip-e2e, bluesky-queue-e2e, scan-agentic-e2e, archiver-world-e2e, tiled-roundtrip-e2e, bluesky-catalog-e2e, bluesky-sandbox-escape-e2e, nextcloud-talk-bridge-e2e, gchat-bridge-e2e, dockerfile-e2e, privilege-split-e2e, execution-environment-parity-e2e, agentic-per-preset, deploy-writeback-e2e, multi-user-deploy-lifecycle-e2e, multi-user-deploy-lifecycle-e2e-podman, auth-perimeter-e2e, terminal-auth-multiuser-e2e, two-shape-boot-e2e, qmd-sidecar-e2e, target-switch-e2e, target-switch-agentic-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: always()
@@ -4483,7 +4487,9 @@ jobs:
           exit 1
         fi
         if [[ "${{ needs.lint.result }}" != "success" ]]; then
-          echo "❌ Lint checks failed"
+          # Also covers the Tier 0 config-key resurrection guard, folded into
+          # that job.
+          echo "❌ Lint checks or the config-key resurrection guard failed"
           exit 1
         fi
         if [[ "${{ needs.docs.result }}" != "success" ]]; then
@@ -4491,15 +4497,12 @@ jobs:
           exit 1
         fi
         if [[ "${{ needs.package.result }}" != "success" ]]; then
-          echo "❌ Package build failed"
+          # Also covers the lean connectors wheel, folded into that job.
+          echo "❌ Package build or the lean connectors wheel check failed"
           exit 1
         fi
         if [[ "${{ needs.static-checks.result }}" != "success" ]]; then
           echo "❌ Tier 0 static checks failed"
-          exit 1
-        fi
-        if [[ "${{ needs.config-key-guard.result }}" != "success" ]]; then
-          echo "❌ Config-key resurrection guard failed"
           exit 1
         fi
         if [[ "${{ needs.visual-theming.result }}" != "success" ]]; then
@@ -4512,10 +4515,6 @@ jobs:
         fi
         if [[ "${{ needs.build-boot-smoke.result }}" != "success" ]]; then
           echo "❌ Tier 1 build + boot smoke failed"
-          exit 1
-        fi
-        if [[ "${{ needs.lean-wheel.result }}" != "success" ]]; then
-          echo "❌ Lean connectors wheel check failed"
           exit 1
         fi
         check_pr_lane() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ Compatibility is documented in release notes, not encoded in the version string.
 - `artifact_delete_all` reports one activity entry ("N artifacts (scope)") instead
   of one per deleted artifact, so clearing a large gallery no longer pushes
   everything else out of the activity history.
+- CI: pushing to a pull-request branch now cancels that branch's previous run
+  instead of leaving it queued. Pull requests run three unit-test cells rather
+  than four — Python 3.11 and 3.12 on Ubuntu, and 3.12 on macOS; the full
+  product still runs on `main`, on the nightly schedule and on manual dispatch.
+  The lean connectors wheel and the Tier 0 config-key guard now run as steps of
+  the package and lint jobs.
 
 ### Added
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -137,12 +137,13 @@ uv run python scripts/check_config_keys.py --back-test <commit>
 
 **When to use**: After editing any `config.yml.j2`, any preset under
 `src/osprey/profiles/presets/`, or code that reads configuration. Use the plain
-form for a quick local check; use `--back-test` to reproduce CI exactly. The
-`config-key-guard` CI job runs the `--back-test` form with `fetch-depth: 0`.
-`tests/scripts/test_config_key_guard.py` exercises the guard from the unit-test
-lane as well, back-test included — but those cases skip themselves when the
-baseline is unreachable, so that coverage is revocable by a checkout-depth or
-marker change. The dedicated job is what pins it down.
+form for a quick local check; use `--back-test` to reproduce CI exactly. CI runs
+the `--back-test` form as a step of the `lint` job, which checks out with
+`fetch-depth: 0`. `tests/scripts/test_config_key_guard.py` exercises the guard
+from the unit-test lane as well, back-test included — but those cases skip
+themselves when the baseline is unreachable, so that coverage is revocable by a
+checkout-depth or marker change. The step's own `!cancelled()` guard is what
+pins it down: it runs even when the lint steps before it fail.
 
 **Exit codes**:
 - `0`: No findings


### PR DESCRIPTION
## Why

PR runs have been taking 59–65 minutes. The same suite run uncontended — a push to `main`, when nothing else is queued — takes 29–30:

```
32944775591 schedule   success  30.0min  main
32934399230 push       success  29.7min  main
32909838753 push       success  29.3min  main
```

Job-level timings from a 65-minute run (47 jobs) show where the other half goes:

```
TOTAL queue-min 850   exec-min 350   jobs 47
```

**71% of job-minutes is spent waiting for a runner, not testing.** A concurrency profile across every workflow overlapping that window sits flat against a hard ceiling for half its duration:

```
peak concurrent jobs = 26
   26 jobs : 33.9 min (50.2% of window)
   25 jobs :  6.5 min ( 9.7%)
   24 jobs :  6.6 min ( 9.8%)
```

Each in-flight PR continuously occupies roughly `350 exec-min / 30 min` ≈ 12 slots, so the pool sustains about two PRs at full speed. We routinely run three to seven.

## What changed

**1. Superseded pull-request runs are cancelled.** The workflow had no `concurrency:` group, so every push to a branch left its predecessor's full 46-job matrix queued rather than cancelled. Across the last 71 pull-request runs:

```
superseded but NOT cancelled: 25  (35% of runs)
wall-clock held by them:      1420 of 4601 min (31%)
```

The group keys on the PR number with a `github.sha` fallback — `github.head_ref` is empty off `pull_request`, so without it every push to `main` and every nightly would share one group and cancel each other. `cancel-in-progress` is scoped to `pull_request` for the same reason: a superseded PR run is waste, a superseded `main` run is a lost signal.

**2. Pull requests drop the 3.11/macOS test cell.** The four test cells are ~101 of the ~350 job-minutes a run costs — the largest single item in the file. The macOS concurrency ceiling is 5 jobs account-wide and does not move on Free, Pro or Team, only on Enterprise; at two cells per PR, four in-flight branches want 8 of those 5 slots, which is why `Test Python 3.12 on macos-latest` was measured sitting 24.8 minutes in the queue.

Dropping the macOS axis entirely was considered and rejected. The merge commit a PR creates is itself a push to `main`, so macOS is exercised on every merge — but that is detection after the fact, not prevention, and a broken `main` is rebased onto by every other in-flight PR. One cell costs ~23 job-minutes and keeps the pre-merge signal. 3.12 is the surviving cell so it pairs with the 3.12/ubuntu coverage cell: same interpreter, different OS, so a failure isolates to the platform.

```
  pull_request         -> 3 cells (1 macOS): 3.11/ubuntu, 3.12/ubuntu, 3.12/macos
  push (main)          -> 4 cells (2 macOS)
  schedule (nightly)   -> 4 cells (2 macOS)
  workflow_dispatch    -> 4 cells (2 macOS)
```

**3. Two jobs folded into lanes that already paid for their setup.** The lean connectors wheel into `package`, the Tier 0 config-key guard into `lint`. Both shared their host job's checkout, uv and Python install, then ran for seconds — spending a runner slot to re-pay for setup already done.

Two details are load-bearing: the guard step carries `if: ${{ !cancelled() }}` so a ruff failure cannot hide a resurrection-guard failure and buy a second full CI cycle to discover it; and `package` builds the connectors wheel *after* the artifact upload, so `twine check` and the `package` artifact see exactly what they saw before.

`deploy-e2e` and `deploy-writeback-e2e` look like the same fold but were left alone — their `if:` gates differ on dependabot handling, so merging them would silently change which lanes run.

## Effect

| | before | after |
|---|---|---|
| Jobs per PR run | 47 | 44 |
| Exec-load per PR run | 350 min | ~324 min |
| macOS slots per PR | 2 | 1 — four PRs now fit inside the cap of 5 |
| Superseded runs left queued | 35% | 0 |

The cancellation change is the dominant one and does not appear in that table: it removes roughly a third of the load from a pool shared across all in-flight branches.

## Verification

```
actionlint .github/workflows/ci.yml           clean
tests/deployment/test_ci_workflow_wiring.py   324 passed
tests/deployment + tests/scripts              4397 passed, 1 skipped
tests/docs                                    included above
```

The gate's `needs` list has no dangling entries, and `scripts/README.md` no longer names a job that no longer exists.

## Not included

The unit lane's 28-minute critical path is untouched — nothing here shortens it. That needs a per-worker session-scoped built-project fixture for `tests/cli`, which spends 27 CPU-minutes running a full `osprey build` per test. Separate change.
