### PR TITLE
fix(web-terminal): drop Origin on the panel proxy hop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Compatibility is documented in release notes, not encoded in the version string.
   panel's sidecar, whose gate compares it against the sidecar's address. The
   proxy now drops `Origin` on that hop, as it already did the operator's
   credentials; the terminal's own gate has checked it before the proxy runs.
+- Bluesky panel: a refusal whose `detail` is a plain sentence rather than a
+  refusal record now reaches the Add-to-queue banner as that sentence, instead
+  of being flattened to a bare `HTTP <status>` the operator cannot act on.
 - The build-drift gate no longer counts material `osprey up` mints itself: the
   per-lane Bluesky CURVE certificates now live under `data/.runtime/`, a
   reserved runtime-output subpath the fingerprint never hashes and the build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 - Graph-mode builds now write the channel-suggestions snapshot from the corpus
   named by `services.graphdb.ttl_path`, so the web-panel typeahead keeps
   working after a project moves to the graph pipeline instead of going quiet.
+- Web terminal: writes from a proxied panel (the BLUESKY tab's Add to queue,
+  Start, Stop, Abort, reorder and remove) no longer fail with `HTTP 403` /
+  `cross-origin request refused` while every read still works. The terminal
+  proxy relayed the browser's `Origin` — the terminal's own address — to the
+  panel's sidecar, whose gate compares it against the sidecar's address. The
+  proxy now drops `Origin` on that hop, as it already did the operator's
+  credentials; the terminal's own gate has checked it before the proxy runs.
 - The build-drift gate no longer counts material `osprey up` mints itself: the
   per-lane Bluesky CURVE certificates now live under `data/.runtime/`, a
   reserved runtime-output subpath the fingerprint never hashes and the build

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/draft-client.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/draft-client.js
@@ -563,7 +563,11 @@ export function classifyQueueAddResponse(status, body) {
   if (code === 'queue_request_rejected' || code === 'environment_unavailable') {
     return { type: 'queue_rejected', detail: sentence };
   }
-  return { type: 'error', detail: sentence || `HTTP ${status}` };
+  // A bare-string `detail` is not a refusal record, but it is still the
+  // answer's own sentence — the sidecar's web gate speaks that way
+  // ("cross-origin request refused") — and it beats a bare status code.
+  const bare = body && typeof body === 'object' && typeof body.detail === 'string' ? body.detail : '';
+  return { type: 'error', detail: sentence || bare || `HTTP ${status}` };
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/routes/proxy.py
+++ b/src/osprey/interfaces/web_terminal/routes/proxy.py
@@ -762,11 +762,21 @@ async def proxy_panel(panel_id: str, path: str, request: Request):
     # browser attaches the operator's proof to a panel request because the
     # panel shares the terminal's origin, and the backend on the other side of
     # this hop is not entitled to it.
+    #
+    # ``Origin`` stops here as well. It names the page that made the request —
+    # the terminal — and the terminal's own gate has already held it against
+    # the terminal's origin before this route ran. Relayed onward it reaches a
+    # backend whose gate compares it against *that backend's* address
+    # (``localhost:8095`` for the bluesky sidecar), which the terminal's origin
+    # never equals: every write from a proxied panel would be refused as
+    # cross-origin while every read succeeds. On this hop the proxy is a new
+    # client, and a client that sends no ``Origin`` is what a gated backend
+    # admits on the operator secret injected below.
     fwd_headers = {
         k: v
         for k, v in request.headers.items()
         if k.lower() not in HOP_BY_HOP
-        and k.lower() not in ("host", "accept-encoding")
+        and k.lower() not in ("host", "accept-encoding", "origin")
         and not _is_stripped_header(k)
     }
     fwd_headers["x-forwarded-prefix"] = f"{outer_prefix}/panel/{panel_id}"

--- a/tests/interfaces/bluesky_web/draft-client.test.mjs
+++ b/tests/interfaces/bluesky_web/draft-client.test.mjs
@@ -2080,6 +2080,16 @@ describe('classifyQueueAddResponse', () => {
     });
   });
 
+  test("a gate refusal's bare-string detail is surfaced, not flattened to the status", () => {
+    // The sidecar's own web gate answers `403 {"detail": "cross-origin request
+    // refused"}` — a string, not a refusal record. That sentence is the whole
+    // clue the operator gets; "HTTP 403" throws it away.
+    expect(classifyQueueAddResponse(403, { detail: 'cross-origin request refused' })).toEqual({
+      type: 'error',
+      detail: 'cross-origin request refused',
+    });
+  });
+
   test('an unknown code is a generic error carrying the sentence, else the status', () => {
     expect(
       classifyQueueAddResponse(500, { detail: { code: 'something_new', detail: 'boom' } })

--- a/tests/interfaces/web_terminal/test_proxy.py
+++ b/tests/interfaces/web_terminal/test_proxy.py
@@ -312,6 +312,70 @@ class TestInboundCredentialStrip:
         assert "underscore-secret" not in " ".join(captured.values())
 
 
+class TestBrowserOriginIsNotRelayed:
+    """The browser's ``Origin`` stops at the terminal; the hop carries none.
+
+    ``Origin`` names the page that made the request — the terminal — and the
+    terminal's own gate has already held it against the terminal's origin
+    before this route runs. Relayed onward it reaches a backend whose gate
+    compares it against *that backend's* address (``localhost:8095`` for the
+    bluesky sidecar), which the terminal's origin never equals: every write
+    from a proxied panel is then refused as cross-origin while every read
+    succeeds. On this hop the proxy is a new client, and a client that sends
+    no ``Origin`` is what a gated backend admits on the operator secret (see
+    ``test_operator_header_with_no_origin_is_allowed`` in the gate's tests).
+    """
+
+    #: What the terminal's own gate demands on a write from this TestClient:
+    #: its Host is ``testserver``, so this is the terminal's origin.
+    TERMINAL_ORIGIN = "http://testserver"
+
+    def test_write_from_a_cookie_session_carries_no_origin(self, panels_app):
+        """Single-user shape: cookie-authenticated POST, Origin dropped."""
+        app, _ = panels_app
+        client = _cookie_client(app)
+        captured = _capture_request(app)
+
+        resp = client.post(
+            "/panel/trusted/queue/items",
+            json={"draft_revision": 1},
+            headers={"Origin": self.TERMINAL_ORIGIN},
+        )
+
+        assert resp.status_code == 200
+        assert "origin" not in _lower(captured)
+
+    def test_write_in_the_multi_user_shape_carries_no_origin(self, panels_app):
+        """Multi-user shape: nginx-stamped operator header, Origin dropped."""
+        app, client = panels_app
+        captured = _capture_request(app)
+
+        resp = client.post(
+            "/panel/trusted/queue/start",
+            headers={**OPERATOR_HEADERS, "Origin": self.TERMINAL_ORIGIN},
+        )
+
+        assert resp.status_code == 200
+        assert "origin" not in _lower(captured)
+
+    def test_sse_path_carries_no_origin(self, panels_app):
+        """The streaming branch builds its own request and must drop it too."""
+        app, client = panels_app
+        captured = _capture_sse(app, _FakeStreamResponse())
+
+        resp = client.get(
+            "/panel/trusted/queue/events",
+            headers={
+                **OPERATOR_HEADERS,
+                "accept": "text/event-stream",
+                "Origin": self.TERMINAL_ORIGIN,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert "origin" not in _lower(captured)
+
+
 class TestStripPredicate:
     """``_is_stripped_header`` folds ``_``→``-`` before matching."""
 


### PR DESCRIPTION
Every mutating request from a proxied web-terminal panel answered
`403 cross-origin request refused` while every read succeeded. In the
BLUESKY tab that meant the panel loaded, showed the staged draft, and
then failed on Add to queue, Start, Stop, Abort, reorder and remove.

## What was happening

The terminal proxies a panel from its own origin, so the browser attaches
`Origin: <terminal>` to the panel's requests. `proxy_panel` forwarded that
header to the backend, while httpx set `Host` to the backend's own address.
A backend behind the shared web gate resolves "my origin" from
`OSPREY_TERMINAL_EXTERNAL_ORIGIN` or, absent that, from `Host` — the
sidecar's address, never the terminal's. The two can therefore never match,
and the gate exempts safe methods, so reads pass and writes are refused.

Observed on a running deployment, in the sidecar's own log:

```
Refusing POST /queue/items: Origin 'http://127.0.0.1:9080' does not match
this app's own origin 'http://localhost:8095'.
```

This affects every deployment shape, not only multi-user: single-user
`osprey web` has no fixed external origin to configure either.

## The fix

`Origin` stops at the terminal, alongside the operator's cookie, bearer and
secret, which the proxy already strips. It is not a credential the backend is
owed:

- the terminal's own gate has already held `Origin` against the terminal's
  origin before the proxy route runs, on the strict cookie path;
- on this hop the proxy is a new client, and an absent `Origin` is precisely
  what a gated backend admits on the operator secret the proxy injects
  (`strict=False`, pinned by `test_operator_header_with_no_origin_is_allowed`).

One drop site covers the JSON, SSE and websocket paths — the websocket
handshake already built its headers from scratch.

Second commit: `classifyQueueAddResponse` read the operator-facing sentence
only out of a structured refusal record, so the gate's plain-string `detail`
was flattened to `HTTP 403` and the panel discarded the one line that said
what happened. A bare-string detail is now preferred over the status code.

## Tests

`TestBrowserOriginIsNotRelayed` pins all three request shapes (cookie
session, nginx operator header, SSE); a vitest case pins the banner. Both
fail on `main` and pass here. Full `tests/interfaces/web_terminal` +
`test_auth_middleware.py`: 2038 passed. JS lane: typecheck, lint, vitest all
green.

Verified against a live deployment: a proxied panel write that answered 403
before now reaches the sidecar and is answered on its merits.

## Relationship to #729

No overlap. #729 resolves *write posture per control target* — who may arm
which machine — and touches the bridge, the MCP tools, presets and personas.
This is a transport-layer header bug in the terminal proxy, upstream of any
posture decision, and shares no file with it. The two are orthogonal: with
#729 merged, a lane refusal will now actually reach the operator's banner
instead of being masked by a 403 that fired first.
