### PR TITLE
fix(artifacts): drop the duplicate hand-in, name categories honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ Compatibility is documented in release notes, not encoded in the version string.
 - `artifact_delete_all` reports one activity entry ("N artifacts (scope)") instead
   of one per deleted artifact, so clearing a large gallery no longer pushes
   everything else out of the activity history.
+- The pyAT specialist hands in one artifact: its answer, filed under **Lattice
+  Analysis**. It no longer owes a second JSON copy of the same numbers — that copy
+  was re-typed by the model out of its own output, so it was never more
+  authoritative than the answer itself, and the code that produced the values is
+  already saved as the notebook artifact of the run. Large arrays for plotting are
+  still saved from inside the computing call and cited by id. The
+  `results_category:` frontmatter key and the hand-in refusal that enforced it are
+  removed.
 - The facility knowledge graph agent files its answers under **Facility Knowledge**
   in the gallery, alongside the documented-knowledge agent, instead of the generic
   **Agent Response** group. That fallback group is now labelled **Uncategorized**,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ Compatibility is documented in release notes, not encoded in the version string.
 - `artifact_delete_all` reports one activity entry ("N artifacts (scope)") instead
   of one per deleted artifact, so clearing a large gallery no longer pushes
   everything else out of the activity history.
+- The facility knowledge graph agent files its answers under **Facility Knowledge**
+  in the gallery, alongside the documented-knowledge agent, instead of the generic
+  **Agent Response** group. That fallback group is now labelled **Uncategorized**,
+  which is what it means: an agent that named no category. Facility Knowledge and
+  Lattice Analysis have gallery icons of their own, and an artifact's description
+  now reads as words ("Channel Addresses — channel-finder") rather than the
+  internal key.
 
 ### Added
 
@@ -58,6 +65,8 @@ Compatibility is documented in release notes, not encoded in the version string.
   facility needs are recorded as candidates in `INTERVIEW.md`, verified against the
   installed framework by a scout, and offered to the user as a GitHub issue or email
   to the maintainers. Nothing is sent without the user approving the full text.
+- `artifact_list` takes `artifact_type=` to narrow a category to one form —
+  `artifact_type="json"` for data to load, `"markdown"` for an answer to read.
 
 ### Security
 

--- a/src/osprey/interfaces/artifacts/static/js/types.js
+++ b/src/osprey/interfaces/artifacts/static/js/types.js
@@ -89,6 +89,11 @@ const TYPE_ICONS = {
   wiki_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
   mml_research: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
   agent_response: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>',
+  // Facility knowledge — a small node graph, shared by the document-bundle and
+  // knowledge-graph agents that both file here.
+  facility_knowledge: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="5" r="2"/><circle cx="5" cy="19" r="2"/><circle cx="19" cy="19" r="2"/><path d="M12 7v3M11 11l-4.5 6M13 11l4.5 6"/></svg>',
+  // Lattice analysis — a beam envelope, for computed optics results.
+  lattice_analysis: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 12c2.5-7 5-7 7.5 0s5 7 7.5 0"/><path d="M2 12c2.5 7 5 7 7.5 0s5-7 7.5 0"/></svg>',
   user_artifact: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>',
   diagnostic_report: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2"/><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M9 14l2 2 4-4"/></svg>',
 };

--- a/src/osprey/mcp_server/agent_frontmatter.py
+++ b/src/osprey/mcp_server/agent_frontmatter.py
@@ -2,12 +2,9 @@
 
 The rendered ``<project>/.claude/agents/*.md`` files (from
 ``src/osprey/templates/claude_code/claude/agents/*.md.j2``) are the one place
-an agent says what it is: its ``name``, the ``tools`` it may use, and — for an
-agent that computes something — the ``results_category`` it owes a data
-artifact to. Two runtime readers consume that frontmatter: the dispatch worker
-(tool surfaces, :mod:`osprey.mcp_server.dispatch_worker.agent_surfaces`) and
-``submit_response`` (the results contract). They share this parser so they
-cannot disagree about which files are agents or what an agent is called.
+an agent says what it is: its ``name`` and the ``tools`` it may use. The
+dispatch worker reads that frontmatter to build tool surfaces
+(:mod:`osprey.mcp_server.dispatch_worker.agent_surfaces`).
 
 Frontmatter contract (matching what the Claude Code CLI loads):
 
@@ -33,11 +30,6 @@ from typing import Any
 import yaml
 
 logger = logging.getLogger("osprey.mcp_server.agent_frontmatter")
-
-#: Frontmatter key naming the artifact category an agent owes its computed
-#: results to. ``submit_response`` files the agent's ``data`` there and refuses
-#: a hand-in that carries none.
-RESULTS_CATEGORY_KEY = "results_category"
 
 
 def parse_agent_frontmatter(project_dir: str | Path) -> dict[str, dict[str, Any]]:
@@ -89,19 +81,3 @@ def parse_agent_frontmatter(project_dir: str | Path) -> dict[str, dict[str, Any]
         declared[name] = frontmatter
 
     return declared
-
-
-def results_category_for(agent_name: str, project_dir: str | Path) -> str | None:
-    """The artifact category *agent_name* declares it owes its results to.
-
-    ``None`` for an agent that declares nothing, for a blank or non-string
-    declaration, and for a name no agent file carries — all of which mean the
-    same thing to the caller: this agent hands in prose only.
-    """
-    frontmatter = parse_agent_frontmatter(project_dir).get(agent_name)
-    if not frontmatter:
-        return None
-    category = frontmatter.get(RESULTS_CATEGORY_KEY)
-    if not isinstance(category, str) or not category.strip():
-        return None
-    return category.strip()

--- a/src/osprey/mcp_server/workspace/tools/artifact_query.py
+++ b/src/osprey/mcp_server/workspace/tools/artifact_query.py
@@ -28,6 +28,7 @@ async def artifact_list(
     category: str | None = None,
     last_n: int | None = None,
     source_agent: str | None = None,
+    artifact_type: str | None = None,
 ) -> str:
     """List the artifacts currently available in the OSPREY workspace.
 
@@ -37,7 +38,10 @@ async def artifact_list(
     ``artifact_id``.
 
     Narrow to a data namespace with ``category`` (e.g. "archiver_data")
-    rather than reaching for a different tool.
+    rather than reaching for a different tool. A category holds whatever form
+    its subject took — prose, a table, a dataset — so add ``artifact_type``
+    when only one form is useful (e.g. ``artifact_type="json"`` for data you
+    intend to load, ``"markdown"`` for an answer to read).
 
     Args:
         tool: Only show artifacts from this tool (e.g. "archiver_read").
@@ -45,6 +49,8 @@ async def artifact_list(
         last_n: Show only the most recent N artifacts.
         source_agent: Only show artifacts from this agent
             (e.g. "logbook-search").
+        artifact_type: Only show artifacts stored in this form
+            (e.g. "json", "markdown", "plot_png").
 
     Returns:
         JSON with the list of artifacts.
@@ -58,6 +64,7 @@ async def artifact_list(
             category_filter=category,
             last_n=last_n,
             source_agent_filter=source_agent,
+            type_filter=artifact_type,
         )
 
         return json.dumps(
@@ -68,6 +75,7 @@ async def artifact_list(
                     "category": category,
                     "last_n": last_n,
                     "source_agent": source_agent,
+                    "artifact_type": artifact_type,
                 },
                 "entries": [e.to_dict() for e in entries],
             },

--- a/src/osprey/mcp_server/workspace/tools/submit_response.py
+++ b/src/osprey/mcp_server/workspace/tools/submit_response.py
@@ -26,6 +26,20 @@ from osprey.utils.workspace import resolve_config_path
 logger = logging.getLogger("osprey.mcp_server.tools.submit_response")
 
 
+def _describe(category: str, agent: str) -> str:
+    """The artifact's human-facing description line.
+
+    Uses the category's display label, not its key: the description is shown to
+    the operator, and a raw key ("agent_response from facility-knowledge-graph")
+    reads as leaked plumbing.
+    """
+    from osprey.stores.type_registry import get_categories
+
+    typedef = get_categories().get(category)
+    label = typedef.label if typedef else category
+    return f"{label} — {agent}" if agent else label
+
+
 def _declared_results_category(agent: str) -> str | None:
     """The category *agent* owes a data artifact to, per its rendered definition."""
     if not agent:
@@ -180,7 +194,7 @@ async def submit_response(
             filename=f"{tool_name}.md",
             artifact_type="markdown",
             title=title,
-            description=f"{category} from {agent}" if agent else category,
+            description=_describe(category, agent),
             mime_type="text/markdown",
             tool_source="submit_response",
             metadata={

--- a/src/osprey/mcp_server/workspace/tools/submit_response.py
+++ b/src/osprey/mcp_server/workspace/tools/submit_response.py
@@ -4,12 +4,10 @@ Sub-agents call this as their last action to save their synthesis to
 the artifact gallery so the parent session, other tools, and the gallery
 UI can all reference it.
 
-An agent that computes something hands its computed quantities in here too,
-as ``data``, and the tool files them as a JSON artifact in the category the
-agent's own definition declares (``results_category:`` in its frontmatter).
-The prose and the numbers arrive in one call, so there is no separate step
-for the agent to skip; an agent that owes data and hands in none is refused,
-with the fix in the error.
+One agent, one call, one artifact: the answer as prose, filed under the
+category the agent's own definition names in ``data_type``. An agent that
+computes an array too large to write out saves it from inside the computing
+call (``save_artifact``) and cites the id in its answer.
 """
 
 import json
@@ -17,11 +15,9 @@ import logging
 
 from fastmcp.exceptions import ToolError
 
-from osprey.mcp_server.agent_frontmatter import RESULTS_CATEGORY_KEY, results_category_for
 from osprey.mcp_server.errors import make_error
 from osprey.mcp_server.http import gallery_url
 from osprey.mcp_server.workspace.server import mcp
-from osprey.utils.workspace import resolve_config_path
 
 logger = logging.getLogger("osprey.mcp_server.tools.submit_response")
 
@@ -40,13 +36,6 @@ def _describe(category: str, agent: str) -> str:
     return f"{label} — {agent}" if agent else label
 
 
-def _declared_results_category(agent: str) -> str | None:
-    """The category *agent* owes a data artifact to, per its rendered definition."""
-    if not agent:
-        return None
-    return results_category_for(agent, resolve_config_path().parent)
-
-
 @mcp.tool()
 async def submit_response(
     title: str,
@@ -55,7 +44,6 @@ async def submit_response(
     entry_ids: list[str] | None = None,
     source_agent: str | None = None,
     skip_artifact: bool = False,
-    data: dict | None = None,
 ) -> str:
     """Submit your final synthesized response. Call this as your LAST action
     before responding. This persists your findings to the workspace so
@@ -64,35 +52,30 @@ async def submit_response(
     Include all entry IDs, channel addresses, or other identifiers you
     cited in the entry_ids parameter for cross-referencing.
 
-    If your agent definition declares a ``results_category``, you computed
-    something, and the numbers go in ``data``: a dict of native Python values
-    (floats, ints, strings, small lists) holding every quantity your prose
-    reports. It is filed as a JSON artifact in that category so the parent
-    session and other tools read exact values, never prose. A hand-in without
-    it is refused.
+    Everything your answer reports belongs in ``content``: put a handful of
+    values in a markdown table rather than leaving them out. An array too large
+    to write out is saved from inside the computing ``execute`` call with
+    ``save_artifact(...)``, and its id cited in your answer.
 
     Args:
         title: Short title for the response (e.g. "Vacuum Event Analysis").
         content: The full synthesized response text (markdown).
-        data_type: Category tag for the prose.  Must be a registered type:
-            "agent_response" (default), "channel_addresses",
-            "logbook_research", "search_results", or any other key from
-            the type registry.
+        data_type: Category tag for the answer. Must be a registered type:
+            "channel_addresses", "logbook_research", "facility_knowledge",
+            "lattice_analysis", or any other key from the type registry.
+            Name the one your agent definition tells you to; the default
+            ("agent_response") files under "Uncategorized".
         entry_ids: List of ARIEL entry IDs or channel addresses cited,
             stored as structured metadata for cross-referencing.
         source_agent: Name of the agent submitting the response
             (e.g. "logbook-search", "pyat-specialist"). Used for filtering
-            and grouping results by agent, and to look up what the agent
-            declares it owes.
+            and grouping results by agent.
         skip_artifact: If True, skip creating a new artifact (use when
             the agent already created plot/dashboard artifacts and wants
             to avoid double-registration).
-        data: The computed quantities, for an agent whose definition
-            declares a ``results_category``. Filed as a JSON artifact there.
 
     Returns:
-        JSON with artifact_id, gallery_url, and summary — plus
-        data_artifact_id when data was filed.
+        JSON with artifact_id, gallery_url, and summary.
     """
     if not title or not title.strip():
         return make_error(
@@ -119,49 +102,6 @@ async def submit_response(
         )
 
     agent = source_agent or ""
-    results_category = _declared_results_category(agent)
-
-    # The contract is checked BEFORE anything is written, so a refused hand-in
-    # leaves no half-filed prose behind for the parent to mistake for a result.
-    if results_category is not None and results_category not in valid:
-        return make_error(
-            "validation_error",
-            f"Agent '{agent}' declares {RESULTS_CATEGORY_KEY}='{results_category}', "
-            f"which is not a registered category. Valid: {sorted(valid)}",
-            [
-                f"Fix {RESULTS_CATEGORY_KEY} in the agent's definition "
-                f"(.claude/agents/{agent}.md) to a registered category."
-            ],
-        )
-    if data is not None and not isinstance(data, dict):
-        return make_error(
-            "validation_error",
-            "data must be a dict of computed quantities.",
-            ["Pass data={...} with native Python values (floats, ints, strings, lists)."],
-        )
-    if results_category is not None and not data:
-        return make_error(
-            "validation_error",
-            f"Agent '{agent}' owes its computed results in the '{results_category}' "
-            "category, and this hand-in carries none. Call submit_response again "
-            "with data={...}: a dict holding every computed quantity your prose "
-            "reports, as native Python values.",
-            [
-                "The prose alone is not the result — the parent session and other "
-                "tools read the exact values from the data artifact, never from prose.",
-            ],
-        )
-    if data and results_category is None:
-        return make_error(
-            "validation_error",
-            f"data was passed, but agent '{agent or '(none)'}' declares no "
-            f"{RESULTS_CATEGORY_KEY}, so there is no category to file it in.",
-            [
-                f"Declare `{RESULTS_CATEGORY_KEY}: <registered category>` in the agent's "
-                "definition frontmatter, or hand in prose only.",
-                "Pass source_agent=<your agent name> so the declaration can be found.",
-            ],
-        )
 
     try:
         from osprey.stores.artifact_store import get_artifact_store
@@ -180,11 +120,9 @@ async def submit_response(
                 default=str,
             )
 
-        # The category is the declared data_type, never the agent's name. An
-        # agent-derived category would put this prose in the same bucket as the
-        # structured results filed below, leaving that bucket unable to say
-        # which of the two it holds. Grouping by agent is already served by
-        # source_agent.
+        # The category is the declared data_type, never the agent's name: it
+        # says what the answer is about, so two agents answering the same kind
+        # of question land together. Grouping by agent is source_agent's job.
         category = data_type
 
         store = get_artifact_store()
@@ -217,35 +155,6 @@ async def submit_response(
         )
 
         response = artifact.to_tool_response()
-
-        if data:
-            # The data sheet: the agent's computed quantities as JSON, in the
-            # category it declared. Saved second so its metadata can name the
-            # prose it belongs to; the prose is then pointed back at it.
-            results = store.save_data(
-                tool=tool_name,
-                data=data,
-                title=title,
-                description=f"{results_category} from {agent}",
-                category=results_category,
-                source_agent=agent,
-                summary={
-                    "title": title,
-                    "keys": sorted(str(k) for k in data)[:50],
-                    "source_agent": agent,
-                },
-                metadata={
-                    "source_agent": agent,
-                    "response_artifact_id": artifact.id,
-                },
-            )
-            store.update_entry_metadata(
-                artifact.id,
-                metadata={**artifact.metadata, "data_artifact_id": results.id},
-            )
-            response["data_artifact_id"] = results.id
-            response["data_category"] = results_category
-
         response["gallery_url"] = gallery_url()
         return json.dumps(response, default=str)
 

--- a/src/osprey/stores/type_registry.py
+++ b/src/osprey/stores/type_registry.py
@@ -6,8 +6,8 @@ the artifact gallery.  Python tools, ``submit_response`` validation, and the
 fetches the registry at startup and overlays its lookup tables, so adding a
 new type here is all that's needed — no JS or CSS changes required.
 
-Icons (SVGs) remain in ``gallery.js`` where they belong; this module only
-stores display metadata (label + color).
+Icons (SVGs) remain in ``interfaces/artifacts/static/js/types.js`` where they
+belong; this module only stores display metadata (label + color).
 """
 
 from __future__ import annotations
@@ -56,7 +56,11 @@ CATEGORIES: dict[str, TypeDef] = {
     "dashboard": TypeDef("dashboard", "Dashboard", "#06b6d4"),
     "document": TypeDef("document", "Document", "#a3e635"),
     "screenshot": TypeDef("screenshot", "Screenshot", "#a78bfa"),
-    "agent_response": TypeDef("agent_response", "Agent Response", "#f472b6"),
+    # The fallback when a submitting agent names no category. "Agent Response"
+    # read as a content category, which it is not — every subagent artifact is
+    # an agent response. The honest label makes an undeclared hand-in look like
+    # what it is: something that forgot to say what it holds.
+    "agent_response": TypeDef("agent_response", "Uncategorized", "#f472b6"),
     "channel_addresses": TypeDef("channel_addresses", "Channel Addresses", "#2dd4bf"),
     "channel_finder": TypeDef("channel_finder", "Channel Finder", "#10b981"),
     "logbook_research": TypeDef("logbook_research", "Logbook Research", "#e879f9"),
@@ -65,8 +69,10 @@ CATEGORIES: dict[str, TypeDef] = {
     "user_artifact": TypeDef("user_artifact", "User Artifact", "#94a3b8"),
     "diagnostic_report": TypeDef("diagnostic_report", "Diagnostic Report", "#ef4444"),
     "lattice_analysis": TypeDef("lattice_analysis", "Lattice Analysis", "#0ea5e9"),
-    # The facility-knowledge agent has always been instructed to submit with
-    # this type; register it so submit_response accepts the instruction.
+    # Both facility-knowledge agents submit here — the document-bundle one and
+    # the knowledge-graph one. They answer different questions from different
+    # stores, but the operator asking them is after the same thing; telling the
+    # two apart is source_agent's job, not the category's.
     "facility_knowledge": TypeDef("facility_knowledge", "Facility Knowledge", "#84cc16"),
 }
 

--- a/src/osprey/templates/claude_code/claude/agents/facility-knowledge-graph.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/facility-knowledge-graph.md.j2
@@ -105,7 +105,7 @@ As your FINAL action, call `submit_response` to persist your findings:
 - `content`: Your full synthesized answer (markdown), including the facts and
   any addresses cited verbatim
 - `entry_ids`: Channel addresses your answer cites, if any
-- `data_type`: "agent_response"
+- `data_type`: "facility_knowledge"
 - `source_agent`: "facility-knowledge-graph"
 
 {% include "claude_code/claude/agents/_shared/handback.md.j2" %}

--- a/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
@@ -6,9 +6,6 @@ model: {{ claude_code_model_spec.agent_tier("pyat-specialist") if claude_code_mo
 maxTurns: 30
 tools: mcp__python__execute, mcp__osprey_workspace__submit_response, mcp__osprey_workspace__artifact_read, Read
 disallowedTools: Bash, Write, Edit, Glob, Grep, WebFetch, WebSearch, NotebookEdit, Task, Skill, Agent
-# The computed quantities this agent hands in as submit_response(data=...) are
-# filed as a JSON artifact in this category; a hand-in without them is refused.
-results_category: lattice_analysis
 ---
 
 # pyAT Specialist Agent
@@ -22,8 +19,8 @@ tools: you are an expert at writing self-contained pyAT code and running it thro
 the Python execution service.
 
 **Every answer you produce is computed from the simulated ALS-U AR design lattice.**
-Say so in prose, and carry it in provenance metadata (see "Returning Results"). Never
-present a computed value as if it were a live machine reading.
+Say so in the answer itself (see "Returning Results"). Never present a computed
+value as if it were a live machine reading.
 
 ## How You Compute
 
@@ -151,53 +148,50 @@ For chromaticity, call `at.get_optics(ring4d, get_chrom=True, dp=1e-6)` and read
 
 ## Returning Results
 
-Your last action is one `submit_response` call that carries both the prose and the
-numbers. The prose is for the parent to read; `data` is the machine-readable result
-the parent and other tools take the exact values from, so it must hold **every
-quantity your prose reports**, as native Python values:
+Your last action is one `submit_response` call carrying your answer:
 
-```
-submit_response(
-    title="AR optics at BPM01 and BPM03",
-    content="<prose: the key numbers, the recipe used (4D vs 6D), and that everything "
-            "was computed from the simulated ALS-U AR design lattice>",
-    source_agent="pyat-specialist",
-    data={
-        "tune_x": 0.2345, "tune_y": 0.1876,
-        "circumference_m": 182.0,
-        "beta_x_BPM01_m": 3.21, "beta_y_BPM01_m": 5.67,
-        "lattice": "ALS-U AR design lattice (simulated)",
-        "computed_4d": True,
-    },
-)
-```
+- `title`: Short descriptive title (e.g. "AR optics at BPM01 and BPM03")
+- `content`: The full answer (markdown) — every quantity you were asked for, the
+  recipe used (4D vs 6D), and the statement that everything was computed from the
+  simulated ALS-U AR design lattice. Put more than two or three quantities in a
+  markdown table, one row per element or plane, so the numbers stay readable and
+  unambiguous.
+- `data_type`: "lattice_analysis"
+- `source_agent`: "pyat-specialist"
 
-The tool files `data` as a JSON artifact in `lattice_analysis` and returns its id
-(see **Handing Back** below). A `submit_response` without `data` is refused — the
-prose alone is not the result.
+Report the values your code actually produced, at full useful precision — never
+rounded to look tidy, never a number your code did not print.
+
+The code you ran and everything it printed is saved automatically as a notebook
+artifact on every `mcp__python__execute` call, so the computation behind your
+answer stays inspectable without you filing it a second time.
 
 For a **large array** the operator wants plotted (beta along the whole ring, a
-response matrix), do not retype it into `data`: save it from inside the computing
-`mcp__python__execute` call with the injected `save_artifact(obj, title, description,
-artifact_type="json", category="lattice_analysis")`, coerced to native types first
-(`np.asarray(x).tolist()`), and put the returned artifact id in `data` instead.
+response matrix), do not retype it into your prose: save it from inside the
+computing `mcp__python__execute` call with the injected `save_artifact(obj, title,
+description, artifact_type="json", category="lattice_analysis")`, coerced to native
+types first (`np.asarray(x).tolist()`), and cite the returned artifact id in your
+answer so the parent can hand it to `data-visualizer`.
 
 {% include "claude_code/claude/agents/_shared/handback.md.j2" %}
 
 ## Handoff to Visualization
 
 You cannot spawn other agents. If the operator wants plots or dashboards of what you
-computed, note in your hand-back that the parent can re-delegate the results
-artifact to `data-visualizer`. Do not attempt to visualize yourself.
+computed, note in your hand-back that the parent can re-delegate your artifact — or
+the saved array, by its id — to `data-visualizer`. Do not attempt to visualize
+yourself.
 
 ## Rules
 
 - **Never fabricate numbers.** Report only values your executed code actually produced;
   on instability/non-convergence, report the instability.
-- **Hand in every computed quantity in `submit_response(data=...)`.**
+- **Report every quantity you were asked for**, in the prose you hand in.
+- **Save large arrays with `save_artifact` from the computing call** — never retype
+  an array into a tool argument.
 - **Always `execution_mode="readonly"`.**
-- **Always label answers as computed from the simulated ALS-U AR design lattice**, in
-  both prose and provenance metadata.
+- **Always label answers as computed from the simulated ALS-U AR design lattice**,
+  in the answer itself.
 - **Import only** `osprey.simulation.lattice` plus `at`/`numpy`/stdlib.
 - **Report environment limitations** (`ModuleNotFoundError`) instead of retrying or
   fabricating.

--- a/tests/e2e/claude_code/test_pyat_specialist_e2e.py
+++ b/tests/e2e/claude_code/test_pyat_specialist_e2e.py
@@ -9,12 +9,13 @@ Two halves share one deployment-build path:
   every subagent ``execute`` call is readonly-or-unset (the template pins
   ``execution_mode="readonly"`` for the in-memory simulation).
 
-- **Grounding** (:func:`test_pyat_specialist_grounding`): reads the exact
-  floats the subagent handed in as ``submit_response(data=...)`` — filed by
-  the tool as its results JSON artifact — and checks them against ground truth computed in-test from ``build_ring()`` with the
-  *identical* 4D recipe (no pinned numeric literals). An LLM judge confirms
-  provenance and simulation-derived labeling in the prose only — numbers are
-  never parsed out of prose.
+- **Grounding** (:func:`test_pyat_specialist_grounding`): grades the subagent's
+  answer — the artifact it files and returns — against ground truth computed
+  in-test from ``build_ring()`` with the *identical* 4D recipe (no pinned
+  numeric literals). One LLM judge checks both halves: every requested quantity
+  present and within tolerance, and the answer labeled as computed from the
+  simulated design lattice. The judge reads the numbers wherever the answer put
+  them, in prose or in a table.
 
 These tests use real API calls via the Claude Agent SDK — zero mocking.
 
@@ -31,7 +32,6 @@ GitHub Actions runners. To run locally you need:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
@@ -40,7 +40,6 @@ from tests.e2e.judge import LLMJudge, WorkflowResult
 from tests.e2e.sdk_helpers import (
     HAS_SDK,
     SDKWorkflowResult,
-    agent_data_dir,
     e2e_budget_scale,
     init_project,
     is_claude_code_available,
@@ -229,137 +228,6 @@ def _ground_truth() -> dict:
     }
 
 
-def _leaves(obj, prefix: str = ""):
-    """Yield ``(lowercased_path, value)`` for every scalar leaf of a JSON tree.
-
-    Nested dicts extend the path with ``.key`` and lists with ``[i]`` so a value
-    can be located by any substring of its full path — this is what makes the
-    result-key matching tolerant of how the subagent chose to nest/name keys
-    (``beta.BPM01.x`` and ``BPM01.beta_x`` both carry ``beta``/``bpm01``/``x``).
-    """
-    if isinstance(obj, dict):
-        for k, v in obj.items():
-            yield from _leaves(v, f"{prefix}.{k}".lower())
-    elif isinstance(obj, list):
-        for i, v in enumerate(obj):
-            yield from _leaves(v, f"{prefix}[{i}]")
-    else:
-        yield prefix, obj
-
-
-def _coerce_float(value, label: str) -> float:
-    """Coerce a saved value to float, failing loudly on a numpy display-repr string.
-
-    The template requires native Python values in ``submit_response(data=...)``;
-    a value like ``'np.float64(0.22)'`` means a numpy repr was handed in instead. Surface it
-    as a clear, actionable error rather than an opaque ``ValueError``.
-    """
-    if isinstance(value, bool):  # bool is an int subclass — never a physics scalar
-        raise AssertionError(f"{label}: got a boolean {value!r}, expected a number")
-    try:
-        return float(value)
-    except (TypeError, ValueError) as exc:
-        raise AssertionError(
-            f"{label}: expected a numeric value but got {value!r} — likely an "
-            "un-coerced numpy display-repr string. The subagent must hand in "
-            "native float()/int() values in submit_response(data=...) (per the "
-            "template's 'Returning Results' recipe)."
-        ) from exc
-
-
-# Quantity stems that legitimately fuse with a bare plane letter (``betax``,
-# ``nux``, ``tuney``, ``qx``). The bare-suffix clause in ``_has_token`` fires
-# only after one of these — never on an ordinary word that happens to end in a
-# plane letter (``index`` ends with ``x``, ``energy`` ends with ``y``).
-_PLANE_STEMS = ("beta", "tune", "nu", "q", "b")
-
-
-def _has_token(path: str, tokens) -> bool:
-    """True if *path* carries a plane token as a delimited segment (avoids
-    matching an incidental character inside a longer word)."""
-    for t in tokens:
-        if f".{t}" in path or f"_{t}" in path or f"[{t}]" in path:
-            return True
-        if path.endswith(t):
-            head = path[: -len(t)].split(".")[-1].split("_")[-1].rstrip("]").split("[")[-1]
-            if head in _PLANE_STEMS:
-                return True
-    return False
-
-
-def _resolve_two_plane(cands: list, label: str) -> tuple[float, float]:
-    """Resolve (x, y) from candidate ``(path, value)`` leaves.
-
-    Prefers explicit plane tokens (``_x``/``_y``, ``horizontal``/``vertical``);
-    falls back to sorted order when exactly two candidates exist (covers a
-    2-element list saved under one key, e.g. ``tune[0]``/``tune[1]``).
-    """
-    xs = [(p, v) for p, v in cands if _has_token(p, _X_TOKENS)]
-    ys = [(p, v) for p, v in cands if _has_token(p, _Y_TOKENS)]
-    if xs and ys:
-        return _coerce_float(xs[0][1], f"{label} (x)"), _coerce_float(ys[0][1], f"{label} (y)")
-    if len(cands) == 2:
-        ordered = sorted(cands)
-        return (
-            _coerce_float(ordered[0][1], f"{label} (x)"),
-            _coerce_float(ordered[1][1], f"{label} (y)"),
-        )
-    raise AssertionError(f"could not resolve horizontal/vertical {label} from saved keys: {cands}")
-
-
-def test_resolve_two_plane_ignores_metadata_keys() -> None:
-    """Regression: a sibling metadata key ending in a plane letter must not win.
-
-    In CI the subagent saved BPM01's lattice element index (7) alongside the
-    correct betas; ``.beta.bpm01.index`` ends with ``x``, so the resolver read
-    the index as the horizontal beta and failed a numerically correct artifact
-    (``got 7.0, truth 14.93``). Suffix matching must stay limited to compact
-    plane spellings (``betax``, ``nux``) and never fire on ordinary words.
-    """
-    data = {"beta": {"bpm01": {"index": 7, "s_m": 4.8, "beta_x": 14.93, "beta_y": 6.05}}}
-    cands = [(p, v) for p, v in _leaves(data) if "beta" in p and "bpm01" in p]
-    assert _resolve_two_plane(cands, "beta at BPM01") == (14.93, 6.05)
-
-    # Compact spellings without a delimiter keep resolving via the suffix path.
-    compact = {"bpm01": {"betax": 14.93, "betay": 6.05}}
-    cands = [(p, v) for p, v in _leaves(compact) if "bpm01" in p]
-    assert _resolve_two_plane(cands, "beta at BPM01") == (14.93, 6.05)
-
-
-def _load_results_artifacts(repo: Path) -> list[tuple[dict, dict]]:
-    """Return ``[(index_entry, parsed_json)]`` for the subagent's results artifacts.
-
-    SDK e2e runs the artifact store **unscoped** (``OSPREY_SESSION_ID`` unset),
-    so the shared root ``<repo>/var/agent_data/artifacts/`` holds every
-    artifact this run produced. Filter to ``artifact_type == 'json'`` AND
-    ``category != 'code_output'`` — the latter drops the executor's auto-saved
-    code+stdout wrapper (also stored as json), leaving the results dicts filed
-    by ``submit_response(data=...)`` (or by ``save_artifact`` for large arrays).
-    """
-    index_path = agent_data_dir(repo) / "artifacts" / "artifacts.json"
-    assert index_path.exists(), (
-        "No artifact index at "
-        f"{index_path} — the pyat-specialist never produced a results artifact: "
-        "its submit_response(data=...) hand-in did not complete."
-    )
-    index = json.loads(index_path.read_text(encoding="utf-8"))
-    artifacts_dir = index_path.parent
-    out: list[tuple[dict, dict]] = []
-    for entry in index.get("entries", []):
-        if entry.get("artifact_type") != "json" or entry.get("category") == "code_output":
-            continue
-        fp = artifacts_dir / entry.get("filename", "")
-        if not fp.exists():
-            continue
-        try:
-            data = json.loads(fp.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
-        if isinstance(data, (dict, list)):
-            out.append((entry, data))
-    return out
-
-
 def _to_workflow_result(query: str, sdk_result: SDKWorkflowResult) -> WorkflowResult:
     """Convert an ``SDKWorkflowResult`` into the plain-text shape the judge reads."""
     response = "\n".join(sdk_result.text_blocks).strip()
@@ -378,18 +246,19 @@ def _to_workflow_result(query: str, sdk_result: SDKWorkflowResult) -> WorkflowRe
 
 
 @pytest.mark.asyncio
-# The retries absorb the LLM's turn-to-turn variance and nothing else. The
-# results-artifact assertion below is a contract: when it fails on every
-# attempt, the subagent's save path has regressed — widen neither the retries
-# nor the match.
+# The retries absorb the LLM's turn-to-turn variance and nothing else. A verdict
+# that fails on every attempt is a real regression in what the subagent computes
+# or reports — widen neither the retries nor the tolerances.
 @pytest.mark.flaky(reruns=2)
 async def test_pyat_specialist_grounding(tmp_path: Path) -> None:
-    """The subagent's saved numbers match ground truth; prose carries provenance.
+    """The numbers in the subagent's answer match ground truth, and it says where
+    they came from.
 
-    Numeric correctness is checked against exact floats read from the results
-    JSON artifact (never parsed out of prose) versus ground truth recomputed
-    in-test with the identical 4D recipe. The LLM judge only confirms the prose
-    labels the answer as simulation-derived — it never sees or grades a number.
+    The answer is the deliverable, so the answer is what gets graded: the judge
+    is handed the reference values — recomputed in-test with the template's own
+    4D recipe, no pinned literals — and the tolerance each must hold to. It
+    fails the response for a wrong number as readily as for a missing
+    provenance statement, wherever in the prose or its tables the value appears.
     """
     repo = init_project(tmp_path, "pyat_grd", template="control_assistant", provider="als-apg")
     judge = LLMJudge(provider="als-apg")
@@ -400,7 +269,7 @@ async def test_pyat_specialist_grounding(tmp_path: Path) -> None:
     )
 
     # See the delegation test: the executor's approval "ask" hook needs the
-    # auto-approve callback, or the compute (and its saved artifact) never runs.
+    # auto-approve callback, or the compute never runs.
     result = await run_sdk_query_with_hooks(
         repo, prompt, approval_policy="auto_approve", max_turns=25, max_budget_usd=2.0
     )
@@ -410,70 +279,6 @@ async def test_pyat_specialist_grounding(tmp_path: Path) -> None:
     assert result.result is not None, "No ResultMessage received"
     assert not result.result.is_error, f"SDK query ended in error: {result.result.result}"
 
-    # --- Numeric grounding: read exact floats from the results artifact(s) ---
-
-    truth = _ground_truth()
-    results = _load_results_artifacts(repo)
-    assert results, (
-        "No results JSON artifact found (artifact_type=='json' and "
-        "category!='code_output'). The subagent must hand its computed "
-        "quantities in as submit_response(data={...}). Index entries seen: "
-        f"{[(e.get('artifact_type'), e.get('category')) for e, _ in _all_index_entries(repo)]}"
-    )
-
-    # Union the leaves across every results artifact so the check is robust to a
-    # subagent that split its output across more than one results artifact.
-    leaves: list[tuple[str, object]] = []
-    for _entry, data in results:
-        leaves.extend(_leaves(data))
-
-    def _artifact_dump() -> str:
-        return json.dumps([data for _e, data in results], indent=2, default=str)[:2000]
-
-    # Tunes — compared modulo 1 with absolute tolerance. Match "tune" only:
-    # a raw "nu" substring would false-match keys like "number_of_bpms".
-    tune_cands = [(p, v) for p, v in leaves if "tune" in p]
-    assert tune_cands, f"No tune keys in the results artifact(s):\n{_artifact_dump()}"
-    got_nux, got_nuy = _resolve_two_plane(tune_cands, "tune")
-    for label, got, ref in (
-        ("nu_x", got_nux, truth["tune"][0]),
-        ("nu_y", got_nuy, truth["tune"][1]),
-    ):
-        d = abs((got - ref) % 1.0)
-        d = min(d, 1.0 - d)  # circular distance on the unit circle
-        assert d < _TUNE_ABS_TOL, (
-            f"{label} mismatch: got {got} (frac {got % 1.0:.6f}), "
-            f"truth {ref} (frac {ref % 1.0:.6f}), |Δ mod 1| {d:.2e} ≥ {_TUNE_ABS_TOL:.0e}"
-        )
-
-    # Circumference — relative tolerance.
-    circ_cands = [(p, v) for p, v in leaves if "circ" in p]
-    assert circ_cands, f"No circumference key in the results artifact(s):\n{_artifact_dump()}"
-    got_circ = _coerce_float(circ_cands[0][1], "circumference")
-    rel = abs(got_circ - truth["circumference"]) / truth["circumference"]
-    assert rel < _CIRCUMFERENCE_REL_TOL, (
-        f"circumference mismatch: got {got_circ}, truth {truth['circumference']}, "
-        f"rel {rel:.2e} ≥ {_CIRCUMFERENCE_REL_TOL:.0e}"
-    )
-
-    # Beta at named elements — 1% relative, per plane.
-    for elem in ("BPM01", "BPM03"):
-        beta_cands = [(p, v) for p, v in leaves if "beta" in p and elem.lower() in p]
-        assert beta_cands, (
-            f"No beta keys for {elem} in the results artifact(s) — the operator "
-            f"asked for beta at {elem}.\n{_artifact_dump()}"
-        )
-        got_bx, got_by = _resolve_two_plane(beta_cands, f"beta at {elem}")
-        ref_bx, ref_by = truth["beta"][elem]
-        for label, got, ref in (
-            (f"beta_x @ {elem}", got_bx, ref_bx),
-            (f"beta_y @ {elem}", got_by, ref_by),
-        ):
-            rel = abs(got - ref) / ref
-            assert rel < _BETA_REL_TOL, (
-                f"{label} mismatch: got {got}, truth {ref}, rel {rel:.2e} ≥ {_BETA_REL_TOL:.0%}"
-            )
-
     # Cost under budget.
     if result.cost_usd is not None:
         budget = 2.0 * e2e_budget_scale()
@@ -481,32 +286,41 @@ async def test_pyat_specialist_grounding(tmp_path: Path) -> None:
             f"Test cost ${result.cost_usd:.4f} — exceeded ${budget:.2f} budget"
         )
 
-    # --- Provenance judged in PROSE only (numbers already verified above) ---
+    truth = _ground_truth()
+    nu_x, nu_y = truth["tune"]
+    bpm01_x, bpm01_y = truth["beta"]["BPM01"]
+    bpm03_x, bpm03_y = truth["beta"]["BPM03"]
 
     result_eval = await judge.evaluate(
         _to_workflow_result(prompt, result),
         expectations=(
-            "The response explicitly states that the reported quantities "
-            "(tunes, circumference, beta functions) were COMPUTED from the "
-            "simulated ALS-U Accumulator Ring (AR) design lattice — i.e. they "
-            "are simulation-derived from the lattice/optics model, not a live "
-            "machine reading or measured data. Do NOT grade the numeric values "
-            "themselves; judge only whether the answer is clearly labeled as "
-            "computed from the simulated design lattice and free of unhandled "
-            "errors."
+            "Grade the response on TWO things.\n\n"
+            "(1) NUMERIC CORRECTNESS. The reference values below were computed "
+            "from the same lattice with the same recipe and are correct. Find "
+            "each quantity in the response — it may appear in a sentence or in "
+            "a table, under any reasonable name or symbol (nu_x/Qx/horizontal "
+            "tune; beta_x/βx) and in any order — and compare it to the "
+            "reference. FAIL if any is missing, or differs by more than its "
+            "tolerance. Tunes may be reported with or without the integer part; "
+            "compare only the FRACTIONAL part, modulo 1.\n"
+            f"  - horizontal tune: {nu_x!r} (fractional part; tolerance "
+            f"{_TUNE_ABS_TOL:.0e} absolute)\n"
+            f"  - vertical tune:   {nu_y!r} (fractional part; tolerance "
+            f"{_TUNE_ABS_TOL:.0e} absolute)\n"
+            f"  - circumference:   {truth['circumference']!r} m (tolerance "
+            f"{_CIRCUMFERENCE_REL_TOL:.0e} relative)\n"
+            f"  - beta at BPM01:   x={bpm01_x!r} m, y={bpm01_y!r} m (tolerance "
+            f"{_BETA_REL_TOL:.0%} relative)\n"
+            f"  - beta at BPM03:   x={bpm03_x!r} m, y={bpm03_y!r} m (tolerance "
+            f"{_BETA_REL_TOL:.0%} relative)\n\n"
+            "(2) PROVENANCE. The response explicitly states that the reported "
+            "quantities were COMPUTED from the simulated ALS-U Accumulator Ring "
+            "(AR) design lattice — simulation-derived from the lattice/optics "
+            "model, not a live machine reading or measured data.\n\n"
+            "FAIL on an unhandled error. Do not reward a confident tone: a "
+            "number outside tolerance fails no matter how it is presented. "
+            "In your reasoning, quote each value you found and the reference "
+            "you compared it to."
         ),
     )
     assert result_eval.passed, result_eval.reasoning
-
-
-def _all_index_entries(repo: Path) -> list[tuple[dict, dict]]:
-    """Every json artifact index entry (unfiltered) — used only to enrich a
-    failure message when no results artifact is found."""
-    index_path = agent_data_dir(repo) / "artifacts" / "artifacts.json"
-    if not index_path.exists():
-        return []
-    try:
-        index = json.loads(index_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return []
-    return [(e, {}) for e in index.get("entries", [])]

--- a/tests/mcp_server/test_agent_frontmatter.py
+++ b/tests/mcp_server/test_agent_frontmatter.py
@@ -1,16 +1,12 @@
 """Tests for the shared ``.claude/agents/*.md`` frontmatter reader.
 
-The dispatch worker and ``submit_response`` both read what an agent declares
-about itself from the rendered agent file. One parser, so the two cannot
-disagree about which files are agents or what their names are.
+The dispatch worker reads what an agent declares about itself — its name and
+its tools — from the rendered agent file.
 """
 
 import logging
 
-from osprey.mcp_server.agent_frontmatter import (
-    parse_agent_frontmatter,
-    results_category_for,
-)
+from osprey.mcp_server.agent_frontmatter import parse_agent_frontmatter
 
 
 def _write_agent(agents_dir, filename, body):
@@ -51,37 +47,11 @@ class TestParseAgentFrontmatter:
 
     def test_duplicate_name_last_wins(self, tmp_path, caplog):
         agents = tmp_path / ".claude" / "agents"
-        _write_agent(agents, "a.md", "---\nname: dup\nresults_category: first\n---\n")
-        _write_agent(agents, "b.md", "---\nname: dup\nresults_category: second\n---\n")
+        _write_agent(agents, "a.md", "---\nname: dup\ntools: first\n---\n")
+        _write_agent(agents, "b.md", "---\nname: dup\ntools: second\n---\n")
 
         with caplog.at_level(logging.WARNING):
             parsed = parse_agent_frontmatter(tmp_path)
 
-        assert parsed["dup"]["results_category"] == "second"
+        assert parsed["dup"]["tools"] == "second"
         assert any("dup" in r.message for r in caplog.records)
-
-
-class TestResultsCategoryFor:
-    def test_declared(self, tmp_path):
-        agents = tmp_path / ".claude" / "agents"
-        _write_agent(
-            agents,
-            "pyat-specialist.md",
-            "---\nname: pyat-specialist\nresults_category: lattice_analysis\n---\n",
-        )
-        assert results_category_for("pyat-specialist", tmp_path) == "lattice_analysis"
-
-    def test_undeclared_agent_and_unknown_agent(self, tmp_path):
-        agents = tmp_path / ".claude" / "agents"
-        _write_agent(agents, "logbook-search.md", "---\nname: logbook-search\n---\n")
-
-        assert results_category_for("logbook-search", tmp_path) is None
-        assert results_category_for("nobody", tmp_path) is None
-
-    def test_blank_or_non_string_declaration_is_none(self, tmp_path):
-        agents = tmp_path / ".claude" / "agents"
-        _write_agent(agents, "a.md", "---\nname: a\nresults_category: ''\n---\n")
-        _write_agent(agents, "b.md", "---\nname: b\nresults_category: [x]\n---\n")
-
-        assert results_category_for("a", tmp_path) is None
-        assert results_category_for("b", tmp_path) is None

--- a/tests/mcp_server/test_artifact_list.py
+++ b/tests/mcp_server/test_artifact_list.py
@@ -55,6 +55,7 @@ async def test_list_returns_entries_and_echoes_filters(store, list_tool):
         "category": None,
         "last_n": None,
         "source_agent": None,
+        "artifact_type": None,
     }
 
     filtered = json.loads(await list_tool(tool="archiver_read", last_n=5))
@@ -75,6 +76,36 @@ async def test_list_narrows_to_a_data_category(store, list_tool):
     assert result["total_entries"] == 1
     assert result["entries"][0]["id"] == dataset.id
     assert result["filters_applied"]["category"] == "archiver_data"
+
+
+@pytest.mark.asyncio
+async def test_list_narrows_to_one_form_within_a_category(store, list_tool):
+    """``artifact_type`` separates the forms a category holds.
+
+    A category is a subject, not a format: an agent's prose answer and the
+    dataset it discusses can share one. A caller that intends to *load* the
+    data asks for the form it can load.
+    """
+    dataset = _save_entry(store, tool="pyat-specialist", category="lattice_analysis")
+    prose = store.save_file(
+        file_content=b"# AR optics\n\nTunes computed from the design lattice.",
+        filename="pyat-specialist.md",
+        artifact_type="markdown",
+        title="AR optics",
+        description="Lattice Analysis — pyat-specialist",
+        mime_type="text/markdown",
+        tool_source="submit_response",
+    )
+    # save_file takes no category; submit_response sets it the same way.
+    store.update_entry_metadata(prose.id, category="lattice_analysis")
+
+    both = json.loads(await list_tool(category="lattice_analysis"))
+    assert both["total_entries"] == 2
+
+    just_data = json.loads(await list_tool(category="lattice_analysis", artifact_type="json"))
+    assert just_data["total_entries"] == 1
+    assert just_data["entries"][0]["id"] == dataset.id
+    assert just_data["filters_applied"]["artifact_type"] == "json"
 
 
 @pytest.mark.asyncio

--- a/tests/mcp_server/test_submit_response.py
+++ b/tests/mcp_server/test_submit_response.py
@@ -281,6 +281,38 @@ class TestSubmitResponse:
         assert entry.category == "agent_response"
 
     @pytest.mark.asyncio
+    async def test_description_carries_the_label_not_the_key(self, workspace):
+        """The description is operator-facing, so it reads as words.
+
+        Storing the raw key put plumbing in front of the user
+        ("channel_addresses from channel-finder").
+        """
+        raw = await _fn(
+            title="BPM Channel Addresses",
+            content="Found 12 BPM channels.",
+            data_type="channel_addresses",
+            source_agent="channel-finder",
+        )
+        data = extract_response_dict(raw)
+
+        entry = get_artifact_store().get_entry(data["artifact_id"])
+        assert entry is not None
+        assert entry.description == "Channel Addresses — channel-finder"
+
+    @pytest.mark.asyncio
+    async def test_description_without_an_agent_is_the_bare_label(self, workspace):
+        raw = await _fn(
+            title="Ad-hoc note",
+            content="Some prose.",
+            data_type="document",
+        )
+        data = extract_response_dict(raw)
+
+        entry = get_artifact_store().get_entry(data["artifact_id"])
+        assert entry is not None
+        assert entry.description == "Document"
+
+    @pytest.mark.asyncio
     async def test_explicit_data_type_drives_the_category(self, workspace):
         """An explicit data_type is the category — the agent name never overrides it."""
         raw = await _fn(

--- a/tests/mcp_server/test_submit_response.py
+++ b/tests/mcp_server/test_submit_response.py
@@ -8,12 +8,7 @@ Covers:
   - Custom data_type passed through
   - source_agent / category mapping
   - skip_artifact mode
-  - The results-data contract: an agent whose rendered definition declares a
-    ``results_category`` hands in its computed quantities as ``data`` and the
-    tool files them as a JSON artifact there — and refuses a hand-in without them
 """
-
-import json
 
 import pytest
 
@@ -37,24 +32,12 @@ def workspace(tmp_path, monkeypatch):
     """Initialize a temporary ArtifactStore workspace.
 
     ``OSPREY_CONFIG`` is pinned into the same temp dir so the tool resolves its
-    project — and therefore its ``.claude/agents/`` declarations — there rather
-    than wherever pytest happens to run.
+    project there rather than wherever pytest happens to run.
     """
     monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
     initialize_artifact_store(workspace_root=tmp_path)
     yield tmp_path
     reset_artifact_store()
-
-
-def _declare_agent(project_dir, name, results_category=None):
-    """Render a minimal ``.claude/agents/<name>.md`` the way the build would."""
-    agents_dir = project_dir / ".claude" / "agents"
-    agents_dir.mkdir(parents=True, exist_ok=True)
-    lines = ["---", f"name: {name}"]
-    if results_category is not None:
-        lines.append(f"results_category: {results_category}")
-    lines += ["---", f"# {name}", ""]
-    (agents_dir / f"{name}.md").write_text("\n".join(lines), encoding="utf-8")
 
 
 class TestSubmitResponse:
@@ -260,12 +243,13 @@ class TestSubmitResponse:
         assert len(store.list_entries()) == 0
 
     @pytest.mark.asyncio
-    async def test_narrative_does_not_claim_a_domain_category(self, workspace):
-        """The prose artifact must not land in a domain results category.
+    async def test_unnamed_category_falls_back_to_uncategorized(self, workspace):
+        """A hand-in that names no category files under the generic fallback.
 
-        pyat-specialist's computed quantities are filed as JSON under
-        ``lattice_analysis``. If this markdown claimed the same key, that
-        category would stop identifying structured results.
+        The fallback is deliberately unhelpful — it shows as "Uncategorized" in
+        the gallery — because an agent that names nothing has told the operator
+        nothing about what its answer holds. Agent templates are gated on
+        naming one (tests/registry/test_agent_submit_categories.py).
         """
         raw = await _fn(
             title="AR Optics Summary",
@@ -277,8 +261,33 @@ class TestSubmitResponse:
         entry = get_artifact_store().get_entry(data["artifact_id"])
         assert entry is not None
         assert entry.artifact_type == "markdown"
-        assert entry.category != "lattice_analysis"
         assert entry.category == "agent_response"
+
+    @pytest.mark.asyncio
+    async def test_one_call_files_exactly_one_artifact(self, workspace):
+        """Prose is the whole deliverable: one hand-in, one artifact.
+
+        A computing agent used to owe a second JSON copy of its own numbers,
+        re-typed by the model out of its own stdout. The values live in the
+        answer; the executed code and its output are already saved as the
+        notebook artifact of the run that produced them.
+        """
+        raw = await _fn(
+            title="AR optics",
+            content="| quantity | value |\n|---|---|\n| nu_x | 0.2345 |",
+            data_type="lattice_analysis",
+            source_agent="pyat-specialist",
+        )
+        data = extract_response_dict(raw)
+
+        assert data["status"] == "success"
+        assert "data_artifact_id" not in data
+
+        entries = get_artifact_store().list_entries()
+        assert len(entries) == 1
+        assert entries[0].artifact_type == "markdown"
+        assert entries[0].category == "lattice_analysis"
+        assert entries[0].source_agent == "pyat-specialist"
 
     @pytest.mark.asyncio
     async def test_description_carries_the_label_not_the_key(self, workspace):
@@ -326,123 +335,3 @@ class TestSubmitResponse:
         entry = get_artifact_store().get_entry(data["artifact_id"])
         assert entry is not None
         assert entry.category == "channel_addresses"
-
-
-class TestResultsDataContract:
-    """An agent that declares ``results_category`` owes ``data`` at hand-in.
-
-    The declaration lives in the agent's own rendered definition — the same
-    frontmatter the dispatch worker reads for tool surfaces — so one file says
-    both what the agent may use and what it must hand back.
-    """
-
-    @pytest.mark.asyncio
-    async def test_data_is_filed_as_json_in_the_declared_category(self, workspace):
-        _declare_agent(workspace, "pyat-specialist", "lattice_analysis")
-        payload = {"tune_x": 0.2345, "tune_y": 0.1876, "circumference_m": 182.0}
-
-        raw = await _fn(
-            title="AR optics",
-            content="Tunes and circumference computed from the design lattice.",
-            source_agent="pyat-specialist",
-            data=payload,
-        )
-        data = extract_response_dict(raw)
-
-        assert data["status"] == "success"
-        store = get_artifact_store()
-
-        # The prose is still the agent_response markdown it always was.
-        prose = store.get_entry(data["artifact_id"])
-        assert prose is not None
-        assert prose.artifact_type == "markdown"
-        assert prose.category == "agent_response"
-
-        # The data sheet is a second artifact, JSON, in the declared category,
-        # attributed to the same agent, and holds exactly what was handed in.
-        results = store.get_entry(data["data_artifact_id"])
-        assert results is not None
-        assert results.artifact_type == "json"
-        assert results.category == "lattice_analysis"
-        assert results.source_agent == "pyat-specialist"
-        assert json.loads(store.get_file_path(results.id).read_text()) == payload
-        # The two know about each other.
-        assert results.metadata["response_artifact_id"] == prose.id
-        assert prose.metadata["data_artifact_id"] == results.id
-
-    @pytest.mark.asyncio
-    async def test_declared_agent_without_data_is_refused(self, workspace):
-        _declare_agent(workspace, "pyat-specialist", "lattice_analysis")
-
-        with assert_raises_error(error_type="validation_error") as ctx:
-            await _fn(
-                title="AR optics",
-                content="Tunes computed from the design lattice.",
-                source_agent="pyat-specialist",
-            )
-
-        msg = ctx["envelope"]["error_message"]
-        assert "pyat-specialist" in msg
-        assert "lattice_analysis" in msg
-        assert "data=" in msg
-        # Nothing half-filed: no prose artifact either.
-        assert get_artifact_store().list_entries() == []
-
-    @pytest.mark.asyncio
-    async def test_empty_data_counts_as_missing(self, workspace):
-        _declare_agent(workspace, "pyat-specialist", "lattice_analysis")
-
-        with assert_raises_error(error_type="validation_error"):
-            await _fn(
-                title="AR optics",
-                content="Tunes computed from the design lattice.",
-                source_agent="pyat-specialist",
-                data={},
-            )
-        assert get_artifact_store().list_entries() == []
-
-    @pytest.mark.asyncio
-    async def test_data_from_an_agent_with_no_declaration_is_refused(self, workspace):
-        _declare_agent(workspace, "logbook-search")
-
-        with assert_raises_error(error_type="validation_error") as ctx:
-            await _fn(
-                title="Vacuum events",
-                content="Three events found.",
-                source_agent="logbook-search",
-                data={"events": 3},
-            )
-
-        assert "results_category" in ctx["envelope"]["error_message"]
-        assert get_artifact_store().list_entries() == []
-
-    @pytest.mark.asyncio
-    async def test_unregistered_declared_category_is_refused(self, workspace):
-        _declare_agent(workspace, "odd-agent", "not_a_real_category")
-
-        with assert_raises_error(error_type="validation_error") as ctx:
-            await _fn(
-                title="Something",
-                content="Some prose.",
-                source_agent="odd-agent",
-                data={"x": 1},
-            )
-
-        assert "not_a_real_category" in ctx["envelope"]["error_message"]
-        assert get_artifact_store().list_entries() == []
-
-    @pytest.mark.asyncio
-    async def test_agents_with_no_declaration_are_untouched(self, workspace):
-        """A searcher hands in prose exactly as before — no data, no refusal."""
-        _declare_agent(workspace, "logbook-search")
-
-        raw = await _fn(
-            title="Vacuum events",
-            content="Three events found.",
-            source_agent="logbook-search",
-        )
-        data = extract_response_dict(raw)
-
-        assert data["status"] == "success"
-        assert "data_artifact_id" not in data
-        assert len(get_artifact_store().list_entries()) == 1

--- a/tests/registry/test_agent_submit_categories.py
+++ b/tests/registry/test_agent_submit_categories.py
@@ -1,0 +1,92 @@
+"""Every submitting agent names a real category for its answer.
+
+``submit_response`` files an agent's prose under whatever ``data_type`` the
+agent's own definition tells it to pass, and defaults to ``agent_response``
+("Uncategorized") when the definition names none. That default is a fallback,
+not a category: it says nothing about what the artifact holds, and it becomes a
+gallery group heading the operator reads.
+
+So the instruction in each agent template is a contract, and this is its gate.
+An agent whose ``tools:`` line carries ``submit_response`` must name a
+registered, non-generic category — in the bullet form the searcher agents use
+(``- `data_type`: "logbook_research"``) or the keyword form the worked examples
+use (``data_type="lattice_analysis"``). Templates are scanned as source rather
+than rendered: the instruction is static text, and every agent's file is
+checked whether or not it is enabled in some profile.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import osprey
+from osprey.stores.type_registry import valid_category_keys
+
+AGENTS_DIR = Path(osprey.__file__).parent / "templates" / "claude_code" / "claude" / "agents"
+
+#: The fallback category. Registered (so an undeclared hand-in still files),
+#: but never a legitimate declaration.
+GENERIC_CATEGORY = "agent_response"
+
+SUBMIT_TOOL = "mcp__osprey_workspace__submit_response"
+
+#: Matches both spellings of the instruction:
+#:   - `data_type`: "facility_knowledge"      (bullet, in prose)
+#:   data_type="lattice_analysis",            (kwarg, in a worked example)
+_DATA_TYPE_RE = re.compile(r'data_type`?\s*[:=]\s*"([^"]+)"')
+
+_TOOLS_LINE_RE = re.compile(r"^tools:.*$", re.MULTILINE)
+
+
+def _agent_templates() -> list[Path]:
+    """Every agent template. Partial dirs (``_shared``, ``_terminology``) are
+    directories, so a top-level glob already excludes them."""
+    return sorted(AGENTS_DIR.glob("*.md.j2"))
+
+
+def _submitting_agents() -> list[Path]:
+    """Templates whose ``tools:`` line grants ``submit_response``."""
+    out = []
+    for path in _agent_templates():
+        text = path.read_text(encoding="utf-8")
+        tools_line = _TOOLS_LINE_RE.search(text)
+        if tools_line and SUBMIT_TOOL in tools_line.group(0):
+            out.append(path)
+    return out
+
+
+def test_agent_templates_are_discoverable():
+    """Guard the guard: a moved template directory must fail loudly, not
+    silently parametrize this module to nothing."""
+    assert AGENTS_DIR.is_dir(), f"agent templates not at {AGENTS_DIR}"
+    assert _agent_templates(), f"no *.md.j2 agent templates under {AGENTS_DIR}"
+    assert _submitting_agents(), "no agent template grants submit_response"
+
+
+@pytest.mark.parametrize("path", _submitting_agents(), ids=lambda p: p.name)
+def test_submitting_agent_names_a_registered_category(path: Path):
+    text = path.read_text(encoding="utf-8")
+    declared = _DATA_TYPE_RE.findall(text)
+
+    assert declared, (
+        f"{path.name} grants {SUBMIT_TOOL} but never tells the agent which "
+        "data_type to pass, so its answers file under the generic fallback "
+        f"'{GENERIC_CATEGORY}' (shown as 'Uncategorized'). Add a data_type "
+        "naming a registered category to its submit instructions."
+    )
+
+    valid = valid_category_keys()
+    for category in declared:
+        assert category in valid, (
+            f"{path.name} instructs data_type={category!r}, which is not a "
+            f"registered category — submit_response refuses it at runtime. "
+            f"Valid: {sorted(valid)}"
+        )
+        assert category != GENERIC_CATEGORY, (
+            f"{path.name} instructs the generic fallback {GENERIC_CATEGORY!r}. "
+            "That key exists for agents that declare nothing; an agent that "
+            "names its category should name what its answer is about."
+        )

--- a/tests/registry/test_pyat_specialist_agent.py
+++ b/tests/registry/test_pyat_specialist_agent.py
@@ -195,24 +195,19 @@ class TestPyatSpecialistAgentTemplate:
         )
         assert expected in rendered
 
-    def test_frontmatter_declares_results_category(self, template_manager):
-        """The agent owes its computed quantities to lattice_analysis — declared
-        where submit_response reads it (results_category_for)."""
-        from osprey.mcp_server.agent_frontmatter import results_category_for
+    def test_frontmatter_declares_no_results_contract(self, template_manager):
+        """The agent's answer is its prose — there is no second data hand-in.
 
+        ``results_category`` was a frontmatter declaration that made
+        ``submit_response`` refuse a hand-in without a JSON copy of the numbers.
+        The copy was re-typed by the model out of its own stdout, so it was no
+        more authoritative than the prose; the run itself is preserved by the
+        automatic notebook artifact.
+        """
         ctx = self._full_ctx(enabled=True)
         rendered = self._render(template_manager, ctx)
-        assert "results_category: lattice_analysis" in rendered
-
-        # And the rendered file is what the runtime reader actually resolves.
-        import tempfile
-        from pathlib import Path
-
-        with tempfile.TemporaryDirectory() as tmp:
-            agents = Path(tmp) / ".claude" / "agents"
-            agents.mkdir(parents=True)
-            (agents / "pyat-specialist.md").write_text(rendered, encoding="utf-8")
-            assert results_category_for("pyat-specialist", tmp) == "lattice_analysis"
+        assert "results_category" not in rendered
+        assert "data={" not in rendered
 
     def test_frontmatter_disallowed_tools_exact(self, template_manager):
         """The disallowedTools: line pins exactly the eleven blocked tools, in order."""
@@ -282,26 +277,26 @@ class TestPyatSpecialistAgentTemplate:
         rendered = self._render(template_manager, ctx)
         assert "Flag heavy runs before launching them" in rendered
 
-    def test_body_hands_in_data_with_the_response(self, template_manager):
-        """The numbers travel in submit_response(data=...) — one call, prose + data.
+    def test_body_hands_in_its_answer_as_prose(self, template_manager):
+        """One submit_response call carrying the answer, filed under its category.
 
-        The agent is told the hand-in is refused without data, and that large
-        arrays go through save_artifact in the computing call instead of being
-        retyped — the one case the single-call contract deliberately leaves open.
+        The agent is told to report every quantity it was asked for in that
+        prose (a table once there are several), and that a large array goes
+        through save_artifact in the computing call instead of being retyped —
+        the one case where a second artifact earns its place.
         """
         ctx = self._full_ctx(enabled=True)
         rendered = self._render(template_manager, ctx)
         normalized = " ".join(rendered.split())
 
-        assert 'source_agent="pyat-specialist"' in rendered
-        assert "data={" in rendered
-        assert "every quantity your prose reports" in normalized
-        assert "A `submit_response` without `data` is refused" in normalized
-        assert "Hand in every computed quantity in `submit_response(data=...)`" in normalized
+        assert '`source_agent`: "pyat-specialist"' in rendered
+        assert '`data_type`: "lattice_analysis"' in rendered
+        assert "Report every quantity you were asked for" in normalized
+        assert "markdown table" in normalized
         # The large-array escape hatch names the injected helper and the category.
         assert 'category="lattice_analysis"' in rendered
         assert "np.asarray(x).tolist()" in rendered
-        # The old self-verification step is gone — the tool does it now.
+        # No self-verification step: the agent does not re-read its own filing.
         assert "artifact_list" not in rendered
 
 


### PR DESCRIPTION
Two subagent artifacts were misdescribed, in opposite directions.

The pyat-specialist owed two hand-ins per question: its answer as prose, and a
JSON dict re-stating every number in that answer, enforced by a
`results_category` frontmatter key and a `submit_response` refusal. The
contract was three days old and had fixed a real flake, but it contracted the
wrong thing — the dict was the model re-typing floats it had just read off its
own stdout, so it was no more authoritative than the prose beside it, and
nothing in the runtime read it. The executed code and everything it printed are
already saved automatically as the run's notebook artifact. The answer is the
deliverable now, as it is for every other specialist; large arrays still go
through `save_artifact` from inside the computing call and are cited by id,
which is the one case where a second artifact carries something prose cannot.

The facility-knowledge-graph agent filed under `agent_response`, the generic
fallback, so a structural machine question landed in a gallery group headed
"Agent Response" — a name for where an artifact came from, not what it holds,
and one that cannot discriminate because every subagent artifact is an agent
response. It now files under `facility_knowledge` alongside its
documented-knowledge sibling; telling those two apart is `source_agent`'s job.
The fallback is relabelled "Uncategorized" — key unchanged, so nothing migrates.

Reviewers may want to push back on two calls. First, the grounding e2e now
grades the prose answer rather than a machine-readable dict; it holds reference
values recomputed in-test from `build_ring()` with the template's own 4D recipe
plus a tolerance each, and reads them wherever the answer put them, so it still
fails a wrong tune rather than merely an implausible one — but it is parsing
prose. Second, `facility_knowledge` now covers two agents reading different
stores, on the argument that an operator asking how the machine fits together
wants the same thing either way.

A template lint test gates what started this: every agent granted
`submit_response` must name a registered, non-generic category.

## How it hangs together

```text
              agent template frontmatter
                        |  submit_response: <category>
                        v
             agent_frontmatter.py   (parses the surface;
                        |            results_category gone)
                        v
                  submit_response
                    |         |
       answer (prose)         data dict  --X removed
                    |         (floats re-typed from stdout,
                    v          read by nobody)
              artifact store ------------> artifact_list(artifact_type=)
                    |                        form filter, alongside the
                    |                        subject the category names
                    v
              type_registry.py
               display label --> gallery group + icon (types.js)
                             \-> artifact description
```
