### PR TITLE
fix: #730 fallout — extends env crash, ARIEL mirror group join, session role in the identity menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Fixed
 
+- A server spec that `extends:` a framework server and carries a malformed
+  `env:` (a list, a string, a number) no longer crashes the whole resolve;
+  the clone renders with the template's env and a warning names the spec,
+  as a custom server already did. (#748)
+- Web terminals: the ARIEL logbook mirror bound into each entitled terminal
+  is now writable by the `qmd_export` module that runs there. The mirror's
+  group was granted only through compose `group_add:`, which the
+  entrypoint's privilege drop discards; the render now names the mount to
+  the entrypoint, which joins its group before the drop, as it already did
+  for the knowledge bundle. (#747)
 - The facility-knowledge-graph agent prose and the channel-finder example
   catalogue no longer claim read/write direction comes from the limits file;
   direction is one edge per signal group, whatever produced it. (#742)
@@ -110,6 +120,9 @@ Compatibility is documented in release notes, not encoded in the version string.
 
 ### Added
 
+- Web terminals: the session menu behind the header chip shows the role the
+  login resolved to, next to the user name. Nothing is shown when the login
+  carried no role, or on a single-user terminal. (#746, part 1)
 - `osprey knowledge build-ttl --facility` (and `build_model(facility=...)`): the
   facility token minted into every graph identifier is an input the model
   carries, not a module constant a deployment had to patch in two places. (#740)

--- a/docs/source/how-to/ariel/search-sidecar.rst
+++ b/docs/source/how-to/ariel/search-sidecar.rst
@@ -165,7 +165,12 @@ Sharing it works through a Unix group, and ``osprey up`` sets both halves up:
 Both halves are needed, and this is the part that is easy to get wrong: setgid
 makes **new files inherit the directory's group**. It does *not* make any
 container process a member of that group. Without ``group_add`` the container
-is not in the group at all, and the group-write bit grants it nothing.
+is not in the group at all, and the group-write bit grants it nothing. The
+framework's own entrypoint adds a third half for the process that actually
+serves requests: it joins the ``osprey`` user to the mounted directory's group
+before dropping privileges, because ``group_add`` reaches only the container's
+initial process. The logbook mirror written by ``qmd_export`` is shared through
+exactly the same mechanism.
 
 One limit follows from how Unix works rather than from OSPREY: setgid fixes who
 *owns* a new file, not its permission bits, which come from the writing

--- a/docs/source/how-to/web-terminal/multi-user/tiers.rst
+++ b/docs/source/how-to/web-terminal/multi-user/tiers.rst
@@ -269,9 +269,10 @@ a persona pinned on every entry. That changes nothing about that mechanism:
 a role resolves to a persona before anything is built, so which persona a card
 runs and which container it opens are the same either way. What the role adds is that
 it survives the login: it travels with the session, reaches the terminal as an
-identity header, and is named on the login record in the audit trail. Where a
-facility runs single sign-on, the provider's own groups can be what decides it —
-see :ref:`Let single sign-on pick the tier <multi-user-role-from-sso>`.
+identity header, is shown beside the user's name in the terminal's session
+menu, and is named on the login record in the audit trail. Where a facility
+runs single sign-on, the provider's own groups can be what decides it — see
+:ref:`Let single sign-on pick the tier <multi-user-role-from-sso>`.
 
 What makes it hold
 ==================

--- a/src/osprey/interfaces/common_middleware.py
+++ b/src/osprey/interfaces/common_middleware.py
@@ -33,7 +33,7 @@ import html
 import json
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, parse_qsl, urlencode
 
@@ -84,6 +84,7 @@ __all__ = [
     "WebAuthMiddleware",
     "apply_url_prefix",
     "compute_url_prefix",
+    "forwarded_identity",
     "is_exempt_path",
     "session_cookie_name",
 ]
@@ -575,13 +576,20 @@ def _recordable(value: str) -> bool:
     )
 
 
-def _forwarded_identity(headers: dict[str, str]) -> tuple[str | None, str | None]:
+def forwarded_identity(headers: Mapping[str, str]) -> tuple[str | None, str | None]:
     """The ``(subject, role)`` nginx forwarded on this request, if any.
 
     Each is ``None`` when the header is absent or empty — the sidecar omits a
     header it has no value for, so absence is a state of its own and must not
     be flattened into a blank string. A value that fails :func:`_recordable`
     becomes :data:`UNSAFE_FORWARDED_VALUE`: present, and named as unusable.
+
+    Public because it is the ONE decoder for these headers: the audit
+    emitters record what it returns, and the web terminal's page shows the
+    role from it. A second reader with its own bound would let a value the
+    ledger refuses reach the screen, or the reverse. ``headers`` is read by
+    lower-cased name, so a plain dict of lower-cased keys and Starlette's
+    case-insensitive ``Headers`` both work.
     """
     resolved: list[str | None] = []
     for header in (AUDIT_SUBJECT_HEADER, AUDIT_ROLE_HEADER):
@@ -628,7 +636,7 @@ def _audit_detail(scope: Scope, headers: dict[str, str], **extra: str) -> tuple[
     be a behaviour change smuggled in under an audit heading, and the gate has
     never treated these headers as a credential.
     """
-    subject, role = _forwarded_identity(headers)
+    subject, role = forwarded_identity(headers)
     parts = [f"{key}={value}" for key, value in extra.items()]
     if subject is not None:
         container_user = _container_user()

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -22,7 +22,12 @@ from jinja2 import pass_context
 
 from osprey.cli.scaffold_cmd import ScaffoldClaimError
 from osprey.interfaces._app_setup import configure_interface_app
-from osprey.interfaces.common_middleware import apply_url_prefix, compute_url_prefix
+from osprey.interfaces.common_middleware import (
+    UNSAFE_FORWARDED_VALUE,
+    apply_url_prefix,
+    compute_url_prefix,
+    forwarded_identity,
+)
 from osprey.interfaces.vendor import vendor_url
 from osprey.interfaces.web_terminal.file_watcher import (
     FileEventBroadcaster,
@@ -1358,6 +1363,15 @@ def create_app(
         web_rail_position = getattr(request.app.state, "web_rail_position", DEFAULT_RAIL_POSITION)
         terminal_user = getattr(request.app.state, "terminal_user", "")
         landing_url = getattr(request.app.state, "landing_url", "")
+        # The role nginx forwarded on THIS request, off the header rather than
+        # app.state: a per-login fact, and the page GET is itself a gated
+        # request that carries it. Decoded by the audit ledger's own bound; a
+        # value that fails it is shown as nothing, not as the ledger's
+        # sentinel — with no nginx in front any client can send this header,
+        # and the chip is a display, not an authorization surface.
+        _, auth_role = forwarded_identity(request.headers)
+        if auth_role == UNSAFE_FORWARDED_VALUE:
+            auth_role = None
         return templates.TemplateResponse(
             request,
             "index.html",
@@ -1369,6 +1383,7 @@ def create_app(
                 "web_rail_position": web_rail_position,
                 "terminal_user": terminal_user,
                 "landing_url": landing_url,
+                "auth_role": auth_role or "",
                 "url_prefix": url_prefix,
             },
         )

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -258,6 +258,27 @@ osprey-display-menu .display-menu-logout-icon {
   text-overflow: ellipsis;
 }
 
+/* The session's role, as a small pill beside the name: it qualifies the
+   name the way a badge does, and must not compete with it. */
+.header-identity-who-role {
+  flex-shrink: 0;
+  align-self: center;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 var(--space-2);
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-relaxed);
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+}
+
 .header-identity-who-sub {
   min-width: 0;
   font-family: var(--font-display);

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -120,6 +120,12 @@
           <div class="header-identity-who">
             <span class="header-identity-avatar" aria-hidden="true">{{ terminal_user[0]|upper }}</span>
             <span class="header-identity-who-name">{{ terminal_user }}</span>
+            {#- The tier this login resolved to (a roster `role:` or the
+                provider's claim), forwarded by nginx on this request. Absent
+                when the login carried none, or when nothing sits in front of
+                the terminal to forward it: a fact stated where it is known,
+                never a default. -#}
+            {% if auth_role %}<span class="header-identity-who-role" title="Role for this session">{{ auth_role }}</span>{% endif %}
             {% if app_name %}<span class="header-identity-who-sub">{{ app_name }}</span>{% endif %}
           </div>
           {#- Only the ACTION depends on landing_url. A user with nowhere to

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -882,6 +882,38 @@ _FRAMEWORK_OWNED_SPEC_ENV: tuple[str, ...] = (TOOL_PREFIX_ENV, *NON_PINNABLE_AUD
 _REMOVED_SPEC_ENV: frozenset[str] = frozenset(NON_PINNABLE_AUDIT_MARKERS)
 
 
+def _spec_env(name: str, spec: dict, *, warn: bool = True) -> dict:
+    """The ``env:`` mapping a server spec carries, or ``{}`` when it has none.
+
+    One reader for every path that merges or inspects a spec's env — the
+    custom-server build, the extends clone and the framework-owned-marker
+    lint — so the shape check cannot drift between them. ``env: null`` is
+    absent, not malformed: it returns ``{}`` silently. Any other non-mapping
+    (a list, a string, a number) used to crash the WHOLE resolve at the merge
+    (``.update()`` on the clone, ``.items()`` on the custom server) — every
+    server in the deployment, not just the malformed one. It now fails closed
+    on the SPEC (no env) with a warning naming the server, matching how every
+    other malformed-spec branch in :func:`resolve_servers` warns and moves on.
+
+    ``warn=False`` is for a caller that only inspects the env and knows the
+    build path reading the same spec next will report the shape — so the
+    operator sees one warning per server, not one per reader.
+    """
+    spec_env = spec.get("env")
+    if spec_env is None:
+        return {}
+    if not isinstance(spec_env, dict):
+        if not warn:
+            return {}
+        logger.warning(
+            "Server %r has a malformed env: (expected a mapping, got %s) — ignoring it",
+            name,
+            type(spec_env).__name__,
+        )
+        return {}
+    return spec_env
+
+
 def _lint_framework_owned_env(name: str, spec: dict) -> None:
     """Warn when a server spec tries to pin a framework-owned env marker.
 
@@ -894,11 +926,9 @@ def _lint_framework_owned_env(name: str, spec: dict) -> None:
         name: The server name the spec is keyed under.
         spec: The raw config spec (already known to be a dict).
     """
-    spec_env = spec.get("env")
-    if not isinstance(spec_env, dict):
-        # A malformed ``env:`` (list, string, null) is not this lint's problem;
-        # it has nothing to pin.
-        return
+    # A malformed ``env:`` has nothing to pin; the build path that reads it
+    # next is where the operator hears about the shape, not here.
+    spec_env = _spec_env(name, spec, warn=False)
     for marker in _FRAMEWORK_OWNED_SPEC_ENV:
         if marker in spec_env:
             settlement = (
@@ -1132,13 +1162,14 @@ def build_extended_server(name: str, spec: dict) -> ServerDefinition | None:
     ]
 
     # Spec env merges over template env (spec keys win).
+    spec_env = _spec_env(name, spec)
     merged_env = dict(clone.env)
-    merged_env.update(spec.get("env") or {})
+    merged_env.update(spec_env)
     # Instance identity follows the clone, like the matcher rewrite: unless the
     # spec pins OSPREY_SERVER_NAME explicitly, the clone advertises its OWN
     # name (inheriting the template's would make every instance signal the
     # template's web-terminal panel, e.g. phoebus2 focusing the phoebus tab).
-    if "OSPREY_SERVER_NAME" not in (spec.get("env") or {}):
+    if "OSPREY_SERVER_NAME" not in spec_env:
         merged_env["OSPREY_SERVER_NAME"] = name
     clone.env = merged_env
 
@@ -1227,24 +1258,10 @@ def _custom_server_from_spec(name: str, spec: dict) -> ServerDefinition | None:
         if resolved:
             hooks_pre = [HookRule(matcher=f"mcp__{name}__.*", hooks=resolved)]
 
-    spec_env = spec.get("env")
-    if spec_env is None:
-        spec_env = {}
-    elif not isinstance(spec_env, dict):
-        # ``env: null`` or a list/scalar used to reach ``_server_to_dict``'s
-        # ``.items()`` and crash the whole resolve. Fail closed on the SPEC
-        # (no env) rather than on every server in the deployment.
-        logger.warning(
-            "Server %r has a malformed env: (expected a mapping, got %s) — ignoring it",
-            name,
-            type(spec_env).__name__,
-        )
-        spec_env = {}
-
     return ServerDefinition(
         name=name,
         module="",
-        env=spec_env,
+        env=_spec_env(name, spec),
         is_external=True,
         external_command=spec.get("command", ""),
         external_args=spec.get("args", []),

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -125,7 +125,9 @@
 
     ariel_mirror_gid: str, required (may be "")
       Group id of that host directory, for the same `group_add:` reason as
-      `facility_bundle_gid` below.
+      `facility_bundle_gid` below. Like the bundle, the mirror is ALSO named
+      to the entrypoint (OSPREY_ARIEL_MIRROR_DIR) so its group is joined
+      before the privilege drop, which `group_add:` alone does not survive.
 
     facility_bundle_gid: str, required (may be "")
       Group id of that host directory, read off disk by the deploy and emitted as
@@ -775,6 +777,15 @@ services:
          directory to name, and the step skips what is unset. #}
       - OSPREY_FACILITY_BUNDLE_DIR={{ svc.container_bundle_dir }}
 {%- endif %}
+{%- if ariel_mirror_source and svc.container_mirror_dir %}
+      {#- The mirror mount's target, for the same contract: the qmd_export
+         module writing it runs as the DROPPED user, and `group_add:` (below)
+         reaches only the initial process. Gated on the same pair as the mount
+         itself, never on the gid — a platform that reads no gid back still
+         binds the directory, and the entrypoint stats the group off what it
+         can see. #}
+      - OSPREY_ARIEL_MIRROR_DIR={{ svc.container_mirror_dir }}
+{%- endif %}
       - OSPREY_TERMINAL_LANDING_URL={{ landing_url }}
       - OSPREY_TERMINAL_BIND_HOST={{ bind_host }}
       - OSPREY_TERMINAL_WEB_PORT={{ svc.web }}
@@ -1100,7 +1111,9 @@ services:
          own exporter, so the sidecar's corpus is the union of everything any
          process enhanced. Read-write, like the bundle and unlike the sidecar's
          `:ro` mount of the same directory; shared through the same setgid group
-         (see `group_add` below). #}
+         (see `group_add` below) and named to the entrypoint as
+         OSPREY_ARIEL_MIRROR_DIR (in `environment:` above) for the join that
+         survives the privilege drop. #}
       # The DEPLOYMENT's ARIEL qmd mirror, written by this container's own
       # qmd_export module and indexed by the qmd sidecar. Bound here so an entry
       # enhanced from this terminal reaches the sidecar's corpus instead of a

--- a/src/osprey/templates/project/entrypoint.sh
+++ b/src/osprey/templates/project/entrypoint.sh
@@ -170,11 +170,13 @@ PY
 #
 # Which directories: exactly the ones the render NAMED, never guessed. This
 # script is POSIX sh and reads no config; each service's compose
-# `environment:` carries OSPREY_AUDIT_DIR (its own audit subdir) and, where a
-# bundle is mounted, OSPREY_FACILITY_BUNDLE_DIR. Iterating what those name and
-# skipping any that is unset or not a directory is what lets one script serve a
-# web terminal, a dispatch worker with no bundle mount, and a bare
-# `docker run` with neither, without a single special case.
+# `environment:` carries OSPREY_AUDIT_DIR (its own audit subdir) and, where
+# they are mounted, OSPREY_FACILITY_BUNDLE_DIR (the knowledge bundle) and
+# OSPREY_ARIEL_MIRROR_DIR (the ARIEL qmd mirror this container's own exporter
+# writes). Iterating what those name and skipping any that is unset or not a
+# directory is what lets one script serve a web terminal, a dispatch worker
+# with no bundle mount, and a bare `docker run` with none, without a single
+# special case.
 #
 # The gid is STATted off the mounted directory rather than passed in as env: a
 # gid chosen at render time is the host's gid THEN, while the mount's is the
@@ -305,6 +307,7 @@ join_mounted_groups() {
     JOINED_GIDS=''
     join_mounted_group OSPREY_AUDIT_DIR "${OSPREY_AUDIT_DIR:-}"
     join_mounted_group OSPREY_FACILITY_BUNDLE_DIR "${OSPREY_FACILITY_BUNDLE_DIR:-}"
+    join_mounted_group OSPREY_ARIEL_MIRROR_DIR "${OSPREY_ARIEL_MIRROR_DIR:-}"
 }
 
 # ── state-zone hand-back ─────────────────────────────────────────────────────

--- a/tests/deployment/test_audit_mounts.py
+++ b/tests/deployment/test_audit_mounts.py
@@ -65,13 +65,18 @@ from .web_terminals.test_golden_render import EXAMPLE_CONFIG
 #: The bundle the reference config mounts when a test needs the bundle half.
 BUNDLE_PATH = "data/facility_knowledge"
 
+#: The ARIEL qmd mirror the reference config mounts when a test needs that half.
+MIRROR_PATH = "var/ariel_mirror"
+
 
 # ---------------------------------------------------------------------------
 # Rendering helpers
 # ---------------------------------------------------------------------------
 
 
-def _web_config(*, auth: bool = False, bundle: bool = False, personas: bool = False) -> dict:
+def _web_config(
+    *, auth: bool = False, bundle: bool = False, mirror: bool = False, personas: bool = False
+) -> dict:
     """The reference roster, with the optional halves this file exercises."""
     config = copy.deepcopy(EXAMPLE_CONFIG)
     web_terminals = config["modules"]["web_terminals"]
@@ -82,6 +87,12 @@ def _web_config(*, auth: bool = False, bundle: bool = False, personas: bool = Fa
         web_terminals["auth"] = {"method": "password", "allow_insecure_http": True}
     if bundle:
         config["facility_knowledge"] = {"bundle_path": BUNDLE_PATH}
+    if mirror:
+        config["ariel"] = {
+            "enhancement_modules": {
+                "qmd_export": {"enabled": True, "settings": {"mirror_path": MIRROR_PATH}}
+            }
+        }
     if personas:
         web_terminals["personas"] = {
             "operator": {"project": "dls-operator", "project_path": "../dls-operator"},
@@ -326,6 +337,32 @@ def test_no_bundle_dir_without_a_bundle_mount():
     services = _web_services()
 
     assert "OSPREY_FACILITY_BUNDLE_DIR" not in _env(services["web-alice"])
+
+
+# ---------------------------------------------------------------------------
+# The mirror directory, named for the same step
+# ---------------------------------------------------------------------------
+
+
+def test_the_mirror_dir_is_named_when_a_mirror_is_mounted():
+    """The ARIEL qmd mirror is the third directory the entrypoint's root phase
+    joins — the exporter writing it runs as the dropped user, which `group_add:`
+    alone never reaches. Named by the mount's actual target, like the bundle."""
+    services = _web_services(mirror=True)
+
+    service = services["web-alice"]
+    mirror_targets = [
+        mount.split(":")[1] for mount in service["volumes"] if MIRROR_PATH in mount.split(":")[0]
+    ]
+    assert len(mirror_targets) == 1, service["volumes"]
+    assert _env(service)["OSPREY_ARIEL_MIRROR_DIR"] == mirror_targets[0]
+
+
+def test_no_mirror_dir_without_a_mirror_mount():
+    """A deployment running no qmd export binds no mirror and names none."""
+    services = _web_services()
+
+    assert "OSPREY_ARIEL_MIRROR_DIR" not in _env(services["web-alice"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_entrypoint_script.py
+++ b/tests/deployment/test_entrypoint_script.py
@@ -11,8 +11,8 @@ drop. The bind-mounted audit subdir and facility bundle are owned by a HOST
 group, and the dropped process reaches them through membership rather than
 ownership — so the group has to be in ``/etc/group`` and ``osprey`` has to be
 in it before ``exec gosu``. The set of directories is named by the render
-(``OSPREY_AUDIT_DIR``, ``OSPREY_FACILITY_BUNDLE_DIR``) and the gid is stat'd off
-the mount, never passed in. Root and system gids are refused, because a mount
+(``OSPREY_AUDIT_DIR``, ``OSPREY_FACILITY_BUNDLE_DIR``, ``OSPREY_ARIEL_MIRROR_DIR``)
+and the gid is stat'd off the mount, never passed in. Root and system gids are refused, because a mount
 that presents one must not hand the agent's user a privileged group. And a
 join is not claimed until it is VERIFIED: membership is the mechanism, while
 write access to the mount is the property the audit trail depends on, so the
@@ -53,9 +53,11 @@ TEMPLATE = (
     / "entrypoint.sh"
 )
 
-#: The two variables the render names, and the only two the join may read.
+#: The variables the render names, and the only ones the join may read.
 AUDIT_VAR = "OSPREY_AUDIT_DIR"
 BUNDLE_VAR = "OSPREY_FACILITY_BUNDLE_DIR"
+MIRROR_VAR = "OSPREY_ARIEL_MIRROR_DIR"
+RENDER_NAMED_VARS = frozenset({AUDIT_VAR, BUNDLE_VAR, MIRROR_VAR})
 
 #: The marker that routes the root phase's records to their own file.
 WRITER_VAR = "OSPREY_AUDIT_WRITER"
@@ -133,21 +135,23 @@ class TestScriptShape:
         drop = text.index('exec gosu osprey "$@"')
         assert join < drop, "the group join runs after gosu, where it grants nothing"
 
-    def test_the_join_reads_only_the_two_render_named_variables(self, text: str):
+    def test_the_join_reads_only_the_render_named_variables(self, text: str):
         """Named by the render, never guessed: this script reads no config.
 
         Scanned over the WHOLE mounted-group section — both the dispatcher and
         ``join_mounted_group``, which is where every read that decides what
         gets stat'd and joined actually lives. A slice of the dispatcher alone
-        would let a third variable steer the join from inside the worker."""
+        would let a fourth variable steer the join from inside the worker.
+        The set is a deliberate allowlist: widening it means adding exactly
+        one name here, never loosening the scan."""
         start = text.index("join_mounted_group() {")
         end = text.index("# \u2500\u2500 state-zone hand-back")
         section = text[start:end]
         assert "join_mounted_groups() {" in section, "the slice lost the dispatcher"
         code = "\n".join(line for line in section.splitlines() if not line.lstrip().startswith("#"))
-        assert AUDIT_VAR in code
-        assert BUNDLE_VAR in code
-        others = set(re.findall(r"\bOSPREY_[A-Z_]+\b", code)) - {AUDIT_VAR, BUNDLE_VAR}
+        read = set(re.findall(r"\bOSPREY_[A-Z_]+\b", code))
+        assert RENDER_NAMED_VARS <= read, f"a render-named mount is never joined: {read}"
+        others = read - RENDER_NAMED_VARS
         assert not others, f"the join reads variables the render does not name: {others}"
 
     def test_the_gid_is_stat_ed_off_the_mount(self, text: str):
@@ -237,6 +241,12 @@ class Sandbox:
         character — and the one these tests use to pin quoting."""
         return self._mount(self.tmp / name, gid)
 
+    def mirror_mount(self, gid: int, name: str = "mirror") -> Path:
+        """The deployment's ARIEL qmd mirror: a host-group mount for exactly
+        the reason the bundle is, written by this container's own exporter
+        after the drop and indexed by the sidecar on the host."""
+        return self._mount(self.tmp / name, gid)
+
     def _mount(self, path: Path, gid: int) -> Path:
         path.mkdir(parents=True, exist_ok=True)
         with self.gid_map.open("a") as handle:
@@ -255,6 +265,7 @@ class Sandbox:
         uid: int = 0,
         audit_dir: Path | str | None = None,
         bundle_dir: Path | str | None = None,
+        mirror_dir: Path | str | None = None,
         groupadd_rc: int = 0,
         usermod_rc: int = 0,
         stat_rc: int | None = None,
@@ -294,6 +305,8 @@ class Sandbox:
             env[AUDIT_VAR] = str(audit_dir)
         if bundle_dir is not None:
             env[BUNDLE_VAR] = str(bundle_dir)
+        if mirror_dir is not None:
+            env[MIRROR_VAR] = str(mirror_dir)
 
         command = ["/bin/sh", "-c", f'printf "cmd\\n" >> "{order_log}"']
         result = subprocess.run(
@@ -527,6 +540,46 @@ class TestTheGroupJoin:
         assert run.returncode == 0, run.stderr
         assert _groupadds(run) == ["groupadd 3000 osprey-mount-3000"]
         assert _usermods(run) == ["usermod osprey-mount-3000 osprey"]
+
+    def test_the_mirror_mount_is_joined_too(self, sandbox: Sandbox):
+        """The ARIEL mirror is the third host-group mount: the exporter that
+        writes it runs as the DROPPED user, so a `group_add:` alone (which
+        gosu discards) left every entry enhanced from a terminal unwritable
+        or root-owned on the host."""
+        audit = sandbox.audit_mount(gid=3000)
+        mirror = sandbox.mirror_mount(gid=5000)
+
+        run = sandbox.run(audit_dir=audit, mirror_dir=mirror)
+
+        assert run.returncode == 0, run.stderr
+        assert _groupadds(run) == [
+            "groupadd 3000 osprey-mount-3000",
+            "groupadd 5000 osprey-mount-5000",
+        ]
+        assert _usermods(run) == [
+            "usermod osprey-mount-3000 osprey",
+            "usermod osprey-mount-5000 osprey",
+        ]
+        assert f"for {MIRROR_VAR}={mirror}" in run.stderr, run.stderr
+
+    def test_mirror_and_bundle_on_one_gid_join_once(self, sandbox: Sandbox):
+        """The deploy provisions both shared directories as the same user, so
+        they usually carry one group; the dedup covers the third mount too."""
+        audit = sandbox.audit_mount(gid=3000)
+        bundle = sandbox.bundle_mount(gid=4000)
+        mirror = sandbox.mirror_mount(gid=4000)
+
+        run = sandbox.run(audit_dir=audit, bundle_dir=bundle, mirror_dir=mirror)
+
+        assert run.returncode == 0, run.stderr
+        assert _groupadds(run) == [
+            "groupadd 3000 osprey-mount-3000",
+            "groupadd 4000 osprey-mount-4000",
+        ]
+        assert _usermods(run) == [
+            "usermod osprey-mount-3000 osprey",
+            "usermod osprey-mount-4000 osprey",
+        ]
 
 
 class TestTheJoinIsVerifiedNotAssumed:

--- a/tests/deployment/web_terminals/test_mirror_mount.py
+++ b/tests/deployment/web_terminals/test_mirror_mount.py
@@ -168,6 +168,25 @@ def test_mirror_gid_reaches_only_entitled_services():
     assert groups == {"web-alice": ["21"], "web-bob": []}
 
 
+def _mirror_dir_env(config: dict, **kwargs) -> dict[str, str | None]:
+    return {
+        name: dict(item.split("=", 1) for item in svc["environment"]).get("OSPREY_ARIEL_MIRROR_DIR")
+        for name, svc in _services(config, **kwargs).items()
+    }
+
+
+def test_mirror_dir_is_named_for_entitled_services_only():
+    """`group_add:` reaches the container's initial process and is discarded by
+    the entrypoint's privilege drop; the join that survives it reads
+    ``OSPREY_ARIEL_MIRROR_DIR``. Gated on the MOUNT, not on the gid: a platform
+    that reads no gid back still binds the directory, and the entrypoint stats
+    the group off what it can see."""
+    config = _config(personas=True)
+    mounts = _mirror_mounts(config, ariel_mirror_personas={"operator"})
+    named = _mirror_dir_env(config, ariel_mirror_personas={"operator"})
+    assert named == {"web-alice": mounts["web-alice"][0].split(":")[1], "web-bob": None}
+
+
 # ---------------------------------------------------------------------------
 # Entitlement
 # ---------------------------------------------------------------------------

--- a/tests/interfaces/web_terminal/test_terminal_user.py
+++ b/tests/interfaces/web_terminal/test_terminal_user.py
@@ -211,3 +211,110 @@ class TestSessionFooter:
         assert "header-deployment" in body
         assert 'class="header-identity-who-sub">Control Assistant<' in body
         assert "header-app-name" not in body
+
+
+class TestAuthRole:
+    """``X-Osprey-Auth-Role`` -> the identity menu's who-line.
+
+    nginx forwards the role the auth sidecar resolved on every gated request,
+    the page GET included, so ``root()`` reads it off the request rather than
+    off ``app.state``: it is a per-login fact, not a render-time one. The
+    header is decoded by the same bound the audit ledger applies, and a value
+    that fails it renders NOTHING — in a topology with no nginx in front, any
+    client can send the header, and the chip is a display, not an
+    authorization surface.
+    """
+
+    ENV = {"OSPREY_TERMINAL_USER": "alice"}
+
+    def _body(self, workspace_dir, headers, env=None):
+        cfg = {"watch_dir": str(workspace_dir)}
+        with (
+            patch("osprey.interfaces.web_terminal.app._load_web_config", return_value=cfg),
+            patch.dict("os.environ", env if env is not None else self.ENV),
+        ):
+            with TestClient(create_app(shell_command="echo")) as c:
+                return c.get("/", headers=headers).text
+
+    def test_the_role_is_shown_in_the_who_line(self, workspace_dir):
+        body = self._body(workspace_dir, {"X-Osprey-Auth-Role": "operator"})
+
+        assert 'class="header-identity-who-name">alice<' in body
+        assert 'class="header-identity-who-role" title="Role for this session">operator<' in body
+
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            pytest.param({}, id="absent"),
+            pytest.param({"X-Osprey-Auth-Role": ""}, id="empty"),
+        ],
+    )
+    def test_no_role_header_renders_no_role(self, workspace_dir, headers):
+        """The sidecar omits the header when the login carried no role, a
+        deployment with no sidecar never sends one, and an ungated nginx
+        location clears it to ``""``: absence is a state, not a blank to fill
+        with a default."""
+        body = self._body(workspace_dir, headers)
+
+        assert 'class="header-identity-who-name">alice<' in body
+        assert "header-identity-who-role" not in body
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("op erator", id="interior-space"),
+            pytest.param("a" * 129, id="over-long"),
+            pytest.param("oper\x7fator", id="control-char"),
+        ],
+    )
+    def test_a_value_the_sidecar_could_not_have_sent_renders_nothing(self, workspace_dir, value):
+        """Same bound as the audit ledger's ``_recordable``: printable ASCII,
+        no interior space, at most 128 characters. The ledger records such a value as
+        its ``<unsafe>`` sentinel because a record must say something was
+        there; a chip has no such duty and shows nothing rather than a marker
+        an operator would have to interpret."""
+        body = self._body(workspace_dir, {"X-Osprey-Auth-Role": value})
+
+        assert "header-identity-who-role" not in body
+        # Autoescape would spell the sentinel as an entity; pin the escaped form
+        # so this line still fails if the suppression in root() is removed.
+        assert "&lt;unsafe&gt;" not in body
+
+    def test_a_markup_shaped_role_is_escaped(self, workspace_dir):
+        """``<script>…</script>`` carries no space and is printable ASCII, so
+        it clears the bound and reaches the template. Autoescape is what makes
+        the chip safe; nothing else here would notice if it were turned off."""
+        body = self._body(workspace_dir, {"X-Osprey-Auth-Role": "<script>alert(1)</script>"})
+
+        assert "<script>alert(1)</script>" not in body
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+
+    def test_a_role_without_a_user_renders_no_chip(self, workspace_dir):
+        """Single-user terminals render no identity chip at all; a stray role
+        header must not conjure one."""
+        body = self._body(workspace_dir, {"X-Osprey-Auth-Role": "operator"}, env={})
+
+        assert 'class="header-identity"' not in body
+        assert "header-identity-who-role" not in body
+
+    def test_the_context_carries_the_role(self, workspace_dir):
+        cfg = {"watch_dir": str(workspace_dir)}
+        with (
+            patch("osprey.interfaces.web_terminal.app._load_web_config", return_value=cfg),
+            patch.dict("os.environ", self.ENV),
+        ):
+            app = create_app(shell_command="echo")
+            with TestClient(app) as c:
+                captured = {}
+                original = app_module.templates.TemplateResponse
+
+                def _capture(request, name, context=None, *args, **kwargs):
+                    captured.update(context or {})
+                    return original(request, name, context, *args, **kwargs)
+
+                with patch.object(app_module.templates, "TemplateResponse", side_effect=_capture):
+                    assert c.get("/", headers={"X-Osprey-Auth-Role": "operator"}).status_code == 200
+                    assert captured["auth_role"] == "operator"
+                    captured.clear()
+                    assert c.get("/").status_code == 200
+                    assert captured["auth_role"] == ""

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -656,6 +656,29 @@ class TestExtendsServers:
         assert "phoebus2" not in {s["name"] for s in servers}
         assert any("Unknown extends target" in r.message for r in caplog.records)
 
+    @pytest.mark.parametrize(
+        "bad_env", [None, ["A=1"], "A=1", 7], ids=["null", "list", "str", "int"]
+    )
+    def test_extends_clone_malformed_env_is_dropped_not_fatal(self, caplog, bad_env):
+        """The extends mirror of the custom-server case: a non-mapping ``env:``
+        on a clone used to reach ``merged_env.update()`` and crash the WHOLE
+        resolve (``ValueError`` for a list/str, ``TypeError`` for an int). The
+        clone now renders with the template's env alone and the warning names
+        the spec, exactly as a custom server does. ``env: null`` stays valid
+        and warning-free on both paths: absent, not malformed."""
+        cfg = {"servers": {"phoebus2": {"extends": "phoebus", "env": bad_env}}}
+        with caplog.at_level(logging.WARNING):
+            p2 = _resolve_one(cfg, "phoebus2")
+        template = _resolve_one({"servers": {"phoebus": {"enabled": True}}}, "phoebus")
+        expected = dict(template["env"])
+        expected["OSPREY_SERVER_NAME"] = "phoebus2"
+        expected["OSPREY_MCP_TOOL_PREFIX"] = "phoebus2"
+        assert p2["env"] == expected
+        if bad_env is None:
+            assert "malformed env" not in caplog.text
+        else:
+            assert "malformed env" in caplog.text and "phoebus2" in caplog.text
+
     def test_duplicate_allow_override_cannot_defeat_ask_union(self, caplog):
         """Duplicated entries in an override's permissions.allow must not defeat
         the single-.remove() ask-union guard: drive ends ONLY in ask."""


### PR DESCRIPTION
Three small fallouts from #730, one commit each.

**#748 — malformed `env:` on an `extends:` clone.** The headline crash in the issue (a custom server with `env: null`) was already fixed on main by #730 (987ecde5e). What survived was the sibling on the extends path: a list, string or number in a clone's `env:` reached `merged_env.update()` and took the whole resolve down. Both builds and the framework-owned-marker lint now read the spec env through one `_spec_env` helper, keeping the warn-and-drop convention every other malformed-spec branch in `resolve_servers` follows. Mirror test added under `TestExtendsServers`. This closes #748.

**#747 — ARIEL mirror unwritable after the privilege drop.** The mirror's group reached each terminal only through compose `group_add:`, which gosu discards. The render now names the mount as `OSPREY_ARIEL_MIRROR_DIR` under the same gate as the bind, and the entrypoint joins its group before the drop, exactly as it already did for the knowledge bundle. The allowlist pin on what the join may read grows by that one name. Verified stub-side; the setgid write after gosu itself needs a Linux container and is not covered by the unit harness.

**#746, part 1 (role only).** The identity menu behind the header chip now shows the role nginx forwards as `X-Osprey-Auth-Role`, read off the page GET (itself a gated request) via the audit ledger's own decoder, promoted to a public `forwarded_identity()`. Absent/empty renders nothing; a value the sidecar could not have sent renders nothing; markup is autoescaped and pinned by test. `posture-badge.js` is untouched (per-session posture, not per-login role).

**Deliberately not in this PR:** the second half of #746 — *where* the role came from (roster `role:` vs ID-token claim). Nothing the terminal receives today carries that; it is a new sidecar→nginx→terminal header contract and gets its own cycle (PR-F). #746 stays open for it.

Fixes #747
Fixes #748
Part 1 of #746

https://claude.ai/code/session_01D4tHLi3DbYmsUmDtazGkh1
