### PR TITLE
feat(changelog): keep unreleased entries as fragments in changelog.d/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,6 +518,34 @@ jobs:
       # stated purpose, is what makes the coverage non-revocable.
       run: uv run python scripts/check_config_keys.py --back-test
 
+    - name: Run changelog-fragment guard
+      # A PR that touches src/ or packages/ must carry a fragment in
+      # changelog.d/, and nobody may hand-edit CHANGELOG.md's [Unreleased]
+      # block — the release fold owns it. scripts/premerge_check.sh runs the
+      # same command locally.
+      #
+      # `python3`, not `uv run`: the script is stdlib-only and standalone by
+      # design, the same reason scripts/ci/diag_summary.py runs bare above
+      # (ci.yml:330-334) — it still reports when the dependency install is
+      # what broke.
+      #
+      # `!cancelled()` for the reason given on the step above: a ruff or
+      # resurrection-guard failure must not hide a missing fragment and buy a
+      # second full CI cycle to discover it.
+      #
+      # The base comes from the event, not a hardcoded `main`, so a PR onto a
+      # release branch is diffed against that branch. It reaches the command
+      # through `env:` and never through `${{ }}` inside `run:`: a branch name
+      # is attacker-controlled text, and interpolating it into the shell line
+      # would execute it. By the time the shell sees `$BASE_REF` it is a
+      # variable, so the quoting holds. Pull requests only — on a push there
+      # is no base ref to diff against. The checkout above is fetch-depth: 0,
+      # which is what makes `origin/$BASE_REF` and the merge-base resolvable.
+      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: python3 scripts/changelog_fragments.py check --base "origin/$BASE_REF"
+
     - name: Run mypy (type checking)
       run: |
         uv run mypy src/ packages/osprey-connectors/src/ --no-error-summary || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow `YYYY.MM.MICRO`. Year and month identify the release window;
 the micro segment increments for hotfixes and same-month follow-up releases.
 Compatibility is documented in release notes, not encoded in the version string.
 
+Unreleased changes are written as fragments in `changelog.d/` and folded into
+the `[Unreleased]` section below when a release is cut.
+
 ## [Unreleased]
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,12 @@ ruff check src/ tests/
 ruff format --check src/ tests/
 ```
 
+**Changelog.** If your change touches `src/` or `packages/`, add a fragment — a
+small file such as `changelog.d/1234.fixed.md` describing the change for users.
+CI checks for it; see [`changelog.d/README.md`](changelog.d/README.md). Don't
+add entries to `CHANGELOG.md` by hand — fragments are folded in when a release
+is cut.
+
 ### 5. Submit Pull Request
 
 - Push your branch to GitHub

--- a/changelog.d/745.changed.md
+++ b/changelog.d/745.changed.md
@@ -1,0 +1,3 @@
+Changelog entries are now one small file per change under `changelog.d/`
+instead of edits to `CHANGELOG.md`. CI requires one for any change under
+`src/` or `packages/`, and the release fold assembles them into the changelog.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,62 @@
+# Changelog fragments
+
+Changelog entries live here, one small file per change, instead of being written
+straight into `CHANGELOG.md`. Two pull requests that both edit `CHANGELOG.md`
+collide on the same lines; two pull requests that each add their own file here
+never do.
+
+## Adding one
+
+Create a file named `changelog.d/<name>.<type>.md`:
+
+- **`<name>`** — the issue number when there is one (`745.changed.md`,
+  `745-gate.fixed.md`). A leading number *is* the issue number: it becomes a
+  `(#745)` reference at the end of the entry, so never start a name with a date
+  or any other number that is not an issue number — and do not repeat the
+  number in the text; a trailing `(#745)` fails the check. With no issue, use a
+  short slug (`gate.fixed.md`); no reference is added, and writing one yourself
+  at the end of the text (`(#735, #737)`) is fine.
+- **`<type>`** — one of:
+
+  | Type | File | Use it for |
+  | --- | --- | --- |
+  | added | `745.added.md` | New capability |
+  | changed | `745.changed.md` | Different behaviour of something that existed |
+  | deprecated | `745.deprecated.md` | Still works, will go away |
+  | removed | `745.removed.md` | Gone |
+  | fixed | `745.fixed.md` | Bug fix |
+  | security | `745.security.md` | Security fix |
+  | internal | `745.internal.md` | Work users never see — satisfies the check, renders nothing |
+
+The body is the changelog bullet's text *without* the leading `- `: one or two
+sentences in present tense, written for someone using OSPREY, wrapped at about
+78 columns. A bold opener (`**Breaking change:** …`) is fine. Do not start the
+file with a list marker, a heading, or a code fence — sub-bullets and fenced
+blocks further down are fine.
+
+```
+Web terminal writes from a proxied panel no longer fail with `HTTP 403`. The
+proxy now drops the browser's `Origin` header on the hop to the panel's
+sidecar, as it already did for the operator's credentials.
+```
+
+## The check
+
+A pull request that touches `src/` or `packages/` needs a fragment. To check
+before pushing:
+
+```bash
+uv run python scripts/changelog_fragments.py check --base origin/main
+```
+
+`./scripts/premerge_check.sh main` runs the same check, and the `lint` CI job
+enforces it.
+
+## Hands off CHANGELOG.md
+
+The `[Unreleased]` section of `CHANGELOG.md` is written only by the release
+fold, which turns every fragment here into a bullet and deletes the file. Adding
+a bullet by hand fails the check. To correct an entry that is already in
+`CHANGELOG.md`, open a pull request that changes nothing but that file.
+
+This README is the only permanent file in this directory.

--- a/docs/source/contributing/workflow.rst
+++ b/docs/source/contributing/workflow.rst
@@ -75,14 +75,19 @@ Commit Message Format
 - ``test:`` -- Tests
 - ``chore:`` -- Dependencies, build
 
-Every commit needs a corresponding CHANGELOG entry added **before** committing.
+Every pull request that touches ``src/`` or ``packages/`` needs a changelog
+fragment: a small file in ``changelog.d/`` named ``<name>.<type>.md`` (use the
+issue number as the name when there is one). The ``lint`` CI job checks for one,
+and ``./scripts/premerge_check.sh main`` checks the same thing locally. Fragments
+are folded into ``CHANGELOG.md`` when a release is cut — never add entries to
+``CHANGELOG.md`` by hand. See ``changelog.d/README.md`` for the type list.
 
 Pull Request Process
 ^^^^^^^^^^^^^^^^^^^^
 
 1. Push your branch: ``git push origin feature/your-feature-name``
 2. Open a PR on GitHub with a description, related issues, and testing performed.
-3. PR requirements: pass all required CI checks, include a ``CHANGELOG.md`` entry for any user-visible change, and add appropriate tests. Internal-mode contributors with push access self-merge after CI is green (the ruleset does not require human approval); fork-mode contributions wait for a maintainer to merge.
+3. PR requirements: pass all required CI checks, include a changelog fragment in ``changelog.d/`` for any change under ``src/`` or ``packages/``, and add appropriate tests. Internal-mode contributors with push access self-merge after CI is green (branch protection requires zero approving reviews); fork-mode contributions wait for a maintainer to merge.
 4. During review: respond to feedback promptly, make requested changes, ask questions if unclear.
 
 Branch Protection on ``main``

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ This directory contains testing and validation scripts for the Osprey Framework 
 | `ci_check.sh` | Full CI replication | 2-3 min | Before pushing |
 | `premerge_check.sh` | Pre-merge validation | 1-2 min | Before creating PR |
 | `check_config_keys.py` | Config-key resurrection guard | 2-5s | After touching a `config.yml.j2`, a preset, or config-reading code |
+| `changelog_fragments.py` | Changelog-fragment gate and release fold | < 1s | After touching `src/` or `packages/`; when cutting a release |
 
 ## Scripts
 
@@ -75,7 +76,7 @@ This directory contains testing and validation scripts for the Osprey Framework 
 - Detects debug code (print, breakpoint, pdb)
 - Finds commented-out code
 - Checks for hardcoded secrets
-- Validates CHANGELOG updates
+- Validates that a changelog fragment was added (runs `changelog_fragments.py check`)
 - Checks type hints
 - Validates TODO/FIXME comments have issue links
 - Runs code formatters and linters
@@ -98,7 +99,7 @@ This directory contains testing and validation scripts for the Osprey Framework 
 
 **Severity levels**:
 - **BLOCKERS**: Must fix (debug code, secrets, test failures)
-- **CRITICAL**: Should fix (missing CHANGELOG, missing type hints)
+- **CRITICAL**: Should fix (missing changelog fragment, missing type hints)
 - **HIGH**: Address before merge (unlinked TODOs)
 - **MEDIUM**: Good to fix (formatting issues)
 
@@ -150,6 +151,42 @@ pins it down: it runs even when the lint steps before it fail.
 - `1`: One or more failure records (each is printed with its key and location),
   or a hard error — notably an unreachable `--back-test` baseline, which raises
   a traceback rather than skipping
+
+---
+
+### changelog_fragments.py
+
+**Purpose**: Make sure a change under `src/` or `packages/` ships a changelog
+fragment, and fold the fragments into `CHANGELOG.md` when a release is cut.
+
+**What it does**: `check` validates every fragment in `changelog.d/` (`README.md` is skipped) — the filename
+grammar `<name>.<type>.md` and the body rules — and then compares the branch
+against its base: a change under `src/` or `packages/` must add a fragment, and
+`## [Unreleased]` in `CHANGELOG.md` must not be edited by hand. `apply` inserts
+each fragment as a bullet under its `### <Type>` heading in `## [Unreleased]`
+and deletes the fragment files.
+
+**Usage**:
+```bash
+# What the `lint` CI job and premerge_check.sh run
+uv run python scripts/changelog_fragments.py check --base origin/main
+
+# The release fold — run once while cutting a release
+uv run python scripts/changelog_fragments.py apply
+```
+
+**When to use**: `check` after touching `src/` or `packages/`, though CI and
+`./scripts/premerge_check.sh` already run it for you. `apply` only when cutting
+a release.
+
+**Exit codes**:
+- `0`: No findings
+- `1`: Something you can fix — a missing fragment, a malformed fragment, a
+  hand-written entry in `## [Unreleased]`, or a deleted fragment
+- `2`: Environment problem — the base ref was not found, or the clone is too
+  shallow to find a common ancestor
+
+See `changelog.d/README.md` for the fragment format and the list of types.
 
 ---
 

--- a/scripts/changelog_fragments.py
+++ b/scripts/changelog_fragments.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+r"""Changelog fragments — one small file per change instead of one shared section.
+
+Two pull requests that both append a bullet to ``CHANGELOG.md``'s
+``## [Unreleased]`` section collide on the same lines, whichever merges first.
+So no pull request writes that section any more. Each writes one small file
+under ``changelog.d/`` instead, and the release fold collects them.
+
+This module is both halves of that arrangement: ``check`` is the gate CI and
+``premerge_check.sh`` run, ``apply`` is the fold the release skill runs. It
+imports nothing outside the standard library and shells out to git only from
+``main``, through an injectable runner.
+
+Fragment files
+--------------
+``changelog.d/<name>.<type>.md``, matching::
+
+    ^(?P<name>[A-Za-z0-9][A-Za-z0-9_-]*)\.(?P<type>[a-z]+)\.md$
+
+``<name>`` is the issue number when the change has one (``745.fixed.md``,
+``745-gate.fixed.md``) and a short slug otherwise (``gate.fixed.md``). A name
+whose leading digits are followed by ``-`` or by the end of the name IS an
+issue reference: ``apply`` appends `` (#745)`` to the rendered bullet. That
+rule has one sharp edge, and it is deliberate — ``2026-cleanup.changed.md``
+renders ``(#2026)``, so a name must never begin with a date or any other
+number that is not an issue. A slug name gets no reference appended and may
+end its own text with a hand-written ``(#735, #737)``.
+
+``<type>`` is one of:
+
+===============  ==========================================================
+``added``        new capability
+``changed``      behaviour of something that already existed
+``deprecated``   still works, on its way out
+``removed``      gone
+``fixed``        a bug
+``security``     a vulnerability or a hardening change
+``internal``     work users never see — satisfies the gate, renders nothing
+===============  ==========================================================
+
+The first six become ``### Added`` … ``### Security`` headings in
+Keep-a-Changelog order. ``internal`` renders nothing at all: it exists so a
+refactor that touches shipped code can pass the gate honestly instead of
+inventing a user-facing sentence.
+
+Body
+----
+The body is the bullet's text *without* the leading ``- ``: one or two
+user-facing sentences, present tense, hand-wrapped. It is copied verbatim, so
+blank lines, sub-bullets and fenced blocks written at column 0 all survive the
+fold, and a bold opener (``**Breaking change:** …``) is fine. Rejected: an
+empty body, a first line that already carries a list marker, a heading or a
+fence, and — for a name that already supplies the issue reference — a trailing
+``(#745)`` at the end of the opening paragraph, which would render twice.
+
+Text is read as UTF-8 — a byte-order mark, which some Windows editors write
+by default, is stripped rather than shipped as an invisible first character —
+with ``\r\n`` and ``\r`` normalized to ``\n``, and leading and trailing blank
+lines are stripped before anything else looks at it.
+``README.md`` is skipped by name and is the only permanent resident of the
+directory, which is flat.
+
+Apply
+-----
+``apply`` validates every fragment, then folds them into ``## [Unreleased]``
+in filename order: each bullet goes directly under its own ``### <Type>``
+heading and that heading's single blank line, and headings that do not exist
+yet are created at the top of the block in Keep-a-Changelog order. Existing
+headings are never merged or reordered — the file is 6000 lines old and
+rewriting it is not this tool's business. The whole text is built in memory
+and written once; then the fragment files are deleted, ``internal`` ones
+included, and the report says what to stage.
+
+Usage
+-----
+    python scripts/changelog_fragments.py check [--base origin/main]
+    python scripts/changelog_fragments.py apply
+
+Exit codes
+----------
+0   nothing to report
+1   something a contributor fixes: a malformed fragment, a missing one, a
+    hand-written bullet in ``## [Unreleased]``, a deleted fragment
+2   something the environment has to fix: an unresolvable base ref, no common
+    ancestor, a git call that failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+TYPES = ("added", "changed", "deprecated", "removed", "fixed", "security", "internal")
+RENDERED_TYPES = TYPES[:6]
+# Both derived from RENDERED_TYPES so none of the three can drift: a type added
+# to TYPES ahead of `internal` gets its heading, and its place in the fold's
+# order, for free; one that renders nothing never gets either.
+HEADING_FOR = {type_: type_.capitalize() for type_ in RENDERED_TYPES}
+HEADING_ORDER = tuple(HEADING_FOR.values())
+GATED_PREFIXES = ("src/", "packages/")
+FRAGMENT_DIR = "changelog.d"
+KEEP = "README.md"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+NAME_RE = re.compile(r"^(?P<name>[A-Za-z0-9][A-Za-z0-9_-]*)\.(?P<type>[a-z]+)\.md$")
+REF_RE = re.compile(r"^(\d+)(?:-|$)")
+FIRST_LINE_REJECT_RE = re.compile(r"^(?:[-*+]\s|#{1,6}\s|```|~~~)")
+PARAGRAPH_END_RE = re.compile(r"^(?:[-*+]\s|```)")
+TRAILING_REF_RE = re.compile(r"\(#\d+\)\s*$")
+UNRELEASED_RE = re.compile(r"^## \[Unreleased\]\s*$")
+SECTION_END_RE = re.compile(r"^## \[")
+TYPE_HEADING_RE = re.compile(r"^### (Added|Changed|Deprecated|Removed|Fixed|Security)\s*$")
+BULLET_RE = re.compile(r"^- ")
+PLAIN_REF_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+#: One git invocation: argv in, a finished process out. ``main`` takes one so
+#: the tests can answer git from a table instead of building a repository.
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+# Every rejection that has anything to do with the type names spells all seven
+# out. A contributor who has just been told "no" should not have to open this
+# file, or the README, to find out what "yes" looks like.
+_VOCABULARY = f"use one of {', '.join(TYPES)} ({TYPES[-1]} satisfies the gate and renders nothing)"
+
+
+class FragmentError(ValueError):
+    """Something a contributor can fix in the fragment itself.
+
+    Raised for every malformed name, encoding and body. ``validate_dir``
+    collects these rather than stopping at the first, so one run of the gate
+    reports every offender.
+    """
+
+
+@dataclass(frozen=True)
+class Fragment:
+    """One validated fragment file.
+
+    ``lines`` is the body already normalized to LF and trimmed of leading and
+    trailing blank lines, so everything downstream — the ref placement, the
+    rendered bullet — can index it without re-deriving that.
+    """
+
+    path: Path
+    name: str
+    type: str
+    ref: str | None
+    lines: tuple[str, ...]
+
+
+def parse_fragment_name(filename: str) -> tuple[str, str, str | None]:
+    """Split ``<name>.<type>.md`` into ``(name, type, ref)``.
+
+    ``ref`` is the leading digit run of ``<name>`` when that run is followed by
+    ``-`` or ends the name, and ``None`` otherwise. It is a string because it
+    goes straight back into text as ``(#745)``.
+
+    Raises ``FragmentError`` on a name that does not match the grammar or that
+    carries a type outside the vocabulary.
+    """
+    match = NAME_RE.match(filename)
+    if match is None:
+        raise FragmentError(
+            f"{filename}: not a fragment name — use <name>.<type>.md, such as "
+            f"745.fixed.md (the issue number) or gate.fixed.md (a slug); for <type>, "
+            f"{_VOCABULARY}"
+        )
+    name, type_ = match.group("name"), match.group("type")
+    if type_ not in TYPES:
+        raise FragmentError(f'{filename}: unknown type "{type_}" — {_VOCABULARY}')
+    ref_match = REF_RE.match(name)
+    return name, type_, ref_match.group(1) if ref_match else None
+
+
+def _split_lines(text: str) -> list[str]:
+    """Split *text* into LF lines, keeping leading and trailing blanks.
+
+    The one place line endings are normalized. The gate compares two versions
+    of ``CHANGELOG.md`` line for line, and a blank line that one side has and
+    the other does not is exactly the kind of edit it is looking at, so this
+    trims nothing; ``normalize_lines`` is the trimming variant for fragments.
+    """
+    return text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+
+def normalize_lines(text: str) -> list[str]:
+    """Split *text* into LF lines with leading and trailing blank lines dropped.
+
+    Editors and platforms disagree about line endings and about whether a file
+    ends with a newline; none of that is allowed to reach the rendered bullet,
+    where it would show up as a stray blank line inside ``CHANGELOG.md``.
+    """
+    lines = _split_lines(text)
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return lines
+
+
+def opening_paragraph_end(lines: Sequence[str]) -> int:
+    """Index of the last line of the opening paragraph.
+
+    The opening paragraph is the run of lines that make up the bullet's own
+    sentence, which is where the issue reference belongs — appending it to the
+    body's last line would park ``(#745)`` after a sub-bullet or inside a
+    fenced block. The paragraph ends at the first blank line or at the first
+    column-0 list marker or fence; a hand-wrapped continuation line, including
+    one that opens with ``**``, does not end it.
+
+    An empty body has no opening paragraph and yields 0, so no caller ever
+    receives ``-1`` and indexes from the wrong end.
+    """
+    for index in range(1, len(lines)):
+        line = lines[index]
+        if not line.strip() or PARAGRAPH_END_RE.match(line):
+            return index - 1
+    return max(len(lines) - 1, 0)
+
+
+def load_fragment(path: Path) -> Fragment:
+    """Read and validate one fragment file.
+
+    Read as ``utf-8-sig``, so a byte-order mark is dropped instead of becoming
+    the bullet's invisible first character; plain UTF-8 decodes unchanged.
+
+    Raises ``FragmentError`` naming the file for: a name outside the grammar or
+    vocabulary, a file that cannot be read, bytes that are not UTF-8, an empty
+    body, a body that opens with a list marker/heading/fence, and a duplicated
+    issue reference (only for a name that already supplies one — a slug
+    fragment is free to end its own text with ``(#735, #737)``).
+    """
+    name, type_, ref = parse_fragment_name(path.name)
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise FragmentError(f"{path.name}: not valid UTF-8 — save the file as UTF-8 text") from exc
+    except OSError as exc:
+        # An unreadable fragment is the contributor's to fix like any other
+        # malformed one, and ``validate_dir`` should list it with the rest
+        # rather than the gate dying on it with a traceback.
+        raise FragmentError(f"{path.name}: cannot read — {exc.strerror or exc}") from exc
+    lines = normalize_lines(text)
+    if not lines:
+        raise FragmentError(f"{path.name}: empty — write one user-facing sentence")
+    if FIRST_LINE_REJECT_RE.match(lines[0]):
+        raise FragmentError(
+            f"{path.name}: a fragment must open with prose — drop the leading marker "
+            f"(the fold writes the '- ' itself)"
+        )
+    if ref is not None and TRAILING_REF_RE.search(lines[opening_paragraph_end(lines)]):
+        raise FragmentError(
+            f"{path.name}: the issue ref comes from the filename — drop it from the text "
+            f"(the fold appends ' (#{ref})')"
+        )
+    return Fragment(path=path, name=name, type=type_, ref=ref, lines=tuple(lines))
+
+
+def validate_dir(directory: Path) -> tuple[list[Fragment], list[str]]:
+    """Load every fragment in *directory*, returning the good and the bad.
+
+    Errors are collected, never raised, so one run reports every offender.
+    ``README.md`` is skipped by name — it is the directory's own documentation
+    and the only file that stays. Files that are not ``*.md`` are ignored
+    (editor droppings, ``.DS_Store``); subdirectories are an error, because the
+    directory is flat and a fragment hiding in one would silently never ship.
+    A directory that does not exist is empty, not an error: a checkout from
+    before this landed still has to pass the gate.
+    """
+    fragments: list[Fragment] = []
+    errors: list[str] = []
+    if not directory.is_dir():
+        return fragments, errors
+    for entry in sorted(directory.iterdir()):
+        if entry.name == KEEP:
+            continue
+        if entry.is_dir():
+            errors.append(f"{entry.name}/: {FRAGMENT_DIR}/ is flat — no subdirectories")
+            continue
+        if entry.suffix != ".md":
+            continue
+        try:
+            fragments.append(load_fragment(entry))
+        except FragmentError as exc:
+            errors.append(str(exc))
+    return fragments, errors
+
+
+def unreleased_span(lines: Sequence[str]) -> tuple[int, int] | None:
+    r"""Locate the ``## [Unreleased]`` section as ``(heading, end)`` indices.
+
+    ``lines[heading]`` is the heading itself and ``end`` is exclusive, so the
+    block both the gate and the fold work on is ``lines[heading + 1:end]``. The
+    section ends at the next release heading — ``^## \[`` and nothing else, the
+    same terminator ``release.yml`` uses — so a bracket-less ``## Notes``
+    written inside the block is part of it, while ``## [2026.8.0]`` closes it
+    even before the release date has been filled in. An ``[Unreleased]`` that is
+    the last section runs to the end of the file.
+
+    Returns ``None`` when the heading is absent; every caller has something
+    different to say about that, so this one says nothing.
+    """
+    for heading in range(len(lines)):
+        if UNRELEASED_RE.match(lines[heading]):
+            for end in range(heading + 1, len(lines)):
+                if SECTION_END_RE.match(lines[end]):
+                    return heading, end
+            return heading, len(lines)
+    return None
+
+
+def _unreleased_block(lines: Sequence[str]) -> list[str] | None:
+    """The lines inside ``## [Unreleased]``, or ``None`` when the heading is absent."""
+    span = unreleased_span(lines)
+    if span is None:
+        return None
+    return list(lines[span[0] + 1 : span[1]])
+
+
+def is_empty_block(block: Sequence[str]) -> bool:
+    """True when *block* holds no non-blank line.
+
+    That is the state a release rotation leaves behind — the section is emptied
+    down to a single blank line — and it is what tells the gate that a pull
+    request which touched ``## [Unreleased]`` or deleted fragments is the
+    release, not a contributor writing a bullet by hand.
+    """
+    return not any(line.strip() for line in block)
+
+
+def render_bullet(frag: Fragment) -> list[str]:
+    """Render *frag* as the lines of one ``CHANGELOG.md`` bullet.
+
+    The first line gets ``- `` and every line after it two spaces. That indent
+    is what keeps a sub-bullet a sub-bullet and a fenced block fenced once the
+    body sits inside a list item; apart from it the body is copied unchanged,
+    so a fence survives byte for byte. A blank line stays blank rather than
+    becoming two spaces, because trailing whitespace in ``CHANGELOG.md`` is
+    somebody else's diff noise later.
+
+    The issue reference, when the filename supplies one, is appended to the end
+    of the opening paragraph *before* any prefixing — ``opening_paragraph_end``
+    explains why that is not simply the body's last line.
+
+    Raises ``FragmentError`` for an ``internal`` fragment. It renders nothing
+    at all, so a caller asking for its bullet has skipped the check that keeps
+    it out of the changelog, and rendering one anyway would ship exactly the
+    sentence the type exists to avoid writing.
+    """
+    if frag.type == "internal":
+        raise FragmentError(
+            f"{frag.path.name}: an internal fragment renders nothing — "
+            f"the fold skips it and deletes the file"
+        )
+    lines = list(frag.lines)
+    if frag.ref is not None:
+        end = opening_paragraph_end(lines)
+        lines[end] = f"{lines[end]} (#{frag.ref})"
+    return ["- " + lines[0]] + ["  " + line if line else "" for line in lines[1:]]
+
+
+def _type_heading_index(lines: Sequence[str], heading: str) -> int | None:
+    """Index of the first ``### <heading>`` line inside ``## [Unreleased]``.
+
+    The search is confined to that block, so the identically named heading of
+    an already-released section — the file has one ``### Fixed`` per release —
+    is never touched. It stops at the first match, so a block that has somehow
+    grown two ``### Fixed`` headings gets its bullets in the one a reader
+    reaches first rather than in whichever came last.
+    """
+    span = unreleased_span(lines)
+    if span is None:
+        return None
+    start, end = span
+    for index in range(start + 1, end):
+        match = TYPE_HEADING_RE.match(lines[index])
+        if match is not None and match.group(1) == heading:
+            return index
+    return None
+
+
+def _insert_after_heading(lines: list[str], index: int, block: Sequence[str]) -> None:
+    """Insert *block* after ``lines[index]`` and that heading's single blank line.
+
+    Headings in this file are followed by one blank line; where one is missing
+    it is supplied rather than the bullets being welded onto the heading text.
+    New bullets sit directly on top of whatever bullet was already there — the
+    same shape a hand-written entry would have had. A blank line is added below
+    them only when the block would otherwise run straight into a heading, which
+    happens when the type heading being written to had no bullets at all; a
+    bullet already under that heading needs no separator and must not get one,
+    and a block that already ends blank — the created-headings block does —
+    must not get a second.
+    """
+    at = index + 1
+    if at < len(lines) and not lines[at].strip():
+        at += 1
+    else:
+        lines.insert(at, "")
+        at += 1
+    lines[at:at] = block
+    below = at + len(block)
+    if below < len(lines) and lines[below].startswith("#") and block and block[-1].strip():
+        lines.insert(below, "")
+
+
+def apply_fragments(text: str, fragments: Sequence[Fragment]) -> tuple[str, list[str]]:
+    """Fold *fragments* into the ``## [Unreleased]`` section of *text*.
+
+    Bullets are grouped by their type's heading and ordered within a group by
+    filename — a plain string sort, so ``115`` precedes ``745`` and a slug
+    sorts after both. A heading that already exists receives its bullets in
+    place, wherever in the block it sits; one that does not is created at the
+    top of the block in Keep-a-Changelog order. Existing headings are never
+    merged, moved or reordered: this runs once per release against a file whose
+    history is 6000 lines long, and rewriting that is not its business.
+
+    ``internal`` fragments render nothing. They still appear in the report,
+    because the release still has to delete their files.
+
+    Returns the new text — LF throughout, exactly one trailing newline — and
+    one report line per fragment, in the order the fold used, with the
+    ``internal`` ones last. An empty *fragments* hands *text* back untouched.
+
+    Raises ``FragmentError`` when *text* has no ``## [Unreleased]`` heading,
+    which means the rotation has already happened and the fold has nowhere to
+    write; that check runs before the empty-*fragments* shortcut, because a
+    changelog in that state is worth hearing about either way.
+    """
+    lines = _split_lines(text)
+    if lines and lines[-1] == "":
+        lines.pop()
+    span = unreleased_span(lines)
+    if span is None:
+        raise FragmentError("no ## [Unreleased] heading — run apply before the release rotation")
+    # Every insertion below lands after this line, so its index never moves and
+    # the creation pass can use it without re-locating the section.
+    unreleased_index = span[0]
+    if not fragments:
+        return text, []
+
+    grouped: dict[str, list[Fragment]] = {}
+    internal: list[Fragment] = []
+    for frag in fragments:
+        if frag.type == "internal":
+            internal.append(frag)
+        else:
+            grouped.setdefault(HEADING_FOR[frag.type], []).append(frag)
+    for bucket in grouped.values():
+        bucket.sort(key=lambda frag: frag.path.name)
+    internal.sort(key=lambda frag: frag.path.name)
+
+    report = [
+        f"{FRAGMENT_DIR}/{frag.path.name} -> ### {heading}"
+        + (f" (#{frag.ref})" if frag.ref is not None else "")
+        for heading in HEADING_ORDER
+        for frag in grouped.get(heading, ())
+    ]
+    report += [f"{FRAGMENT_DIR}/{frag.path.name} -> internal, not rendered" for frag in internal]
+    if not grouped:
+        return text, report
+
+    # Existing headings first: creating the new ones afterwards puts them at the
+    # top of the block without having to track how far the earlier inserts moved
+    # everything below them.
+    pending: list[tuple[str, list[str]]] = []
+    for heading in HEADING_ORDER:
+        group = grouped.get(heading)
+        if not group:
+            continue
+        bullets = [line for frag in group for line in render_bullet(frag)]
+        index = _type_heading_index(lines, heading)
+        if index is None:
+            pending.append((heading, bullets))
+        else:
+            _insert_after_heading(lines, index, bullets)
+
+    if pending:
+        created: list[str] = []
+        for heading, bullets in pending:
+            created += [f"### {heading}", "", *bullets, ""]
+        _insert_after_heading(lines, unreleased_index, created)
+
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return "\n".join(lines) + "\n", report
+
+
+def needs_fragment(changed: Iterable[str]) -> bool:
+    """True when any changed path lives under a gated directory.
+
+    The prefixes carry their trailing slash, so the test is directory-scoped:
+    ``src/osprey/cli.py`` is gated, ``srcs/x.py`` and ``docs/source/x.rst`` are
+    not, and neither is a ``src/`` nested somewhere below the repo root.
+    """
+    return any(path.startswith(GATED_PREFIXES) for path in changed)
+
+
+def _fragment_dir_paths(paths: Iterable[str]) -> list[str]:
+    """Every path under ``changelog.d/`` that is not its README."""
+    prefix = f"{FRAGMENT_DIR}/"
+    keep = f"{prefix}{KEEP}"
+    return [path for path in paths if path.startswith(prefix) and path != keep]
+
+
+def _named_fragment_paths(paths: Iterable[str]) -> list[str]:
+    """Fragment-directory paths whose filename is a valid fragment name.
+
+    ``NAME_RE`` admits no ``/``, so a file smuggled into a subdirectory fails
+    here too — which is what the flat-directory rule wants, since such a file
+    would never be folded in.
+    """
+    prefix = f"{FRAGMENT_DIR}/"
+    return [path for path in _fragment_dir_paths(paths) if NAME_RE.match(path[len(prefix) :])]
+
+
+def _listed(paths: Sequence[str], limit: int = 5) -> list[str]:
+    """*paths* as detail lines, truncated to *limit* with a count of the rest.
+
+    A refactor can touch a hundred files; the point of the list is to show the
+    contributor which change tripped the gate, and five is enough for that.
+    """
+    shown = list(paths[:limit])
+    if len(paths) > limit:
+        shown.append(f"+{len(paths) - limit} more")
+    return shown
+
+
+def _bullet_count(block: Sequence[str]) -> int:
+    """Number of top-level bullets in *block*."""
+    return sum(1 for line in block if BULLET_RE.match(line))
+
+
+def _release_count(lines: Sequence[str]) -> int:
+    """Number of ``## [`` headings in *lines*, ``[Unreleased]`` included.
+
+    This is how the gate recognizes the release pull request, and it has to be
+    a *transition*: once fragments are carrying the changelog, ``[Unreleased]``
+    is empty on every ordinary pull request too, so an empty block on its own
+    says nothing. Cutting a release is the one thing that adds a heading —
+    compare the count on both sides and only the release moves.
+    """
+    return sum(1 for line in lines if SECTION_END_RE.match(line))
+
+
+def gate_failures(
+    changed: Sequence[str],
+    added: Sequence[str],
+    deleted: Sequence[str],
+    head_text: str,
+    base_text: str,
+) -> tuple[list[str], list[str]]:
+    """Apply the three pull-request rules to one diff.
+
+    *changed*, *added* and *deleted* are repository-relative paths from
+    ``git diff --name-status`` between the merge base and HEAD; *head_text* and
+    *base_text* are the two versions of ``CHANGELOG.md``. Nothing here touches
+    the filesystem or git, so the caller decides where the diff came from.
+
+    The rules:
+
+    1. A change under ``src/`` or ``packages/`` needs a fragment *added* by
+       this pull request. One already in the tree does not count — the gate
+       reads committed history, so neither does one that is merely written.
+    2. ``## [Unreleased]`` must come out of the merge base unchanged. Three
+       shapes are allowed through: the release rotation, which empties it; a
+       pull request that changes ``CHANGELOG.md`` and nothing else without
+       growing the bullet count, which is a correction; and a head whose block
+       is byte-identical to the base's.
+    3. Only that rotation deletes fragments.
+
+    The rotation is a *transition*, not a state: an empty ``[Unreleased]`` is
+    what every pull request sees once fragments are carrying the changelog, so
+    it is recognized by the release heading the release pull request adds
+    (``_release_count``). Reading the head alone would exempt every pull
+    request from rule 3 for the whole cycle between releases.
+
+    Returns ``(failures, ok_lines)``. Each failure is a headline followed by
+    detail lines — the caller prints the headline after ``✗ `` and indents the
+    rest — and every ok line already carries its own ``✓``. Both lists are in
+    rule order, so a run that trips everything reads top to bottom.
+
+    A *base_text* of ``""`` (no ``CHANGELOG.md`` at the merge base) is read as
+    a base with no heading, so its block is empty and the comparison proceeds
+    normally rather than the gate having a special opinion about it. That path
+    is for direct callers only: ``check`` treats a failing
+    ``git show <base>:CHANGELOG.md`` as an environment error and never reaches
+    here with an empty *base_text*.
+    """
+    failures: list[str] = []
+    ok_lines: list[str] = []
+    prefixes = ", ".join(GATED_PREFIXES)
+
+    gated = [path for path in changed if needs_fragment((path,))]
+    if not gated:
+        ok_lines.append(
+            f"✓ changelog gate: no {' or '.join(GATED_PREFIXES)} changes — no fragment required"
+        )
+    else:
+        fragments = sorted(_named_fragment_paths(added))
+        if fragments:
+            ok_lines.append(
+                f"✓ changelog gate: {fragments[0]} added for "
+                f"{len(gated)} changed file(s) under {prefixes}"
+            )
+        else:
+            failures.append(
+                "\n".join(
+                    [
+                        f"no changelog fragment for {len(gated)} changed file(s) under {prefixes}",
+                        *_listed(gated),
+                        f"add {FRAGMENT_DIR}/<name>.<type>.md — <name> is the issue number when "
+                        f"there is one, a short slug otherwise; for <type>, {_VOCABULARY}",
+                        "the gate reads committed history — an unstaged fragment does not count",
+                    ]
+                )
+            )
+
+    base_lines = _split_lines(base_text)
+    base_block = _unreleased_block(base_lines) or []
+    head_lines = _split_lines(head_text)
+    head_block = _unreleased_block(head_lines)
+    rotation = False
+    if head_block is None:
+        failures.append(
+            "CHANGELOG.md has no ## [Unreleased] heading — the heading must exist, "
+            "because apply folds the fragments into it"
+        )
+    else:
+        rotation = is_empty_block(head_block) and _release_count(head_lines) > _release_count(
+            base_lines
+        )
+        if head_block == base_block:
+            ok_lines.append("✓ [Unreleased]: untouched")
+        elif rotation:
+            ok_lines.append("✓ [Unreleased]: empty (rotation)")
+        elif set(changed) == {"CHANGELOG.md"} and _bullet_count(head_block) <= _bullet_count(
+            base_block
+        ):
+            # Editing or dropping a bullet that is already there is a correction,
+            # and a correction has nowhere else to go. Counting bullets cannot
+            # tell a reworded one from a swapped one, which is accepted: a pull
+            # request that touches no other file cannot collide with a feature.
+            ok_lines.append("✓ [Unreleased]: changelog-only correction")
+        else:
+            failures.append(
+                "this PR adds to ## [Unreleased] by hand — move the entry into "
+                f"{FRAGMENT_DIR}/<name>.<type>.md; corrections to existing bullets go in a "
+                "CHANGELOG-only PR"
+            )
+
+    # A head with no heading is not a rotation, whatever the empty block would
+    # otherwise suggest: the fold writes into that heading, so a diff that has
+    # removed it has not folded anything.
+    gone = _fragment_dir_paths(deleted)
+    if gone and not rotation:
+        failures.append(
+            "\n".join(
+                [
+                    f"{len(gone)} fragment(s) deleted — only the release PR's apply removes "
+                    f"fragments",
+                    *_listed(gone),
+                    "restore them; they are folded in and deleted when a release is cut",
+                ]
+            )
+        )
+    return failures, ok_lines
+
+
+def _run(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run *argv* at the repository root and capture its text output.
+
+    The default runner, and the only place in this module that starts a
+    process. ``check`` is often invoked from a subdirectory — a pre-merge
+    script, an editor task — so the working directory is pinned to the
+    repository rather than inherited.
+    """
+    return subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", cwd=REPO_ROOT)
+
+
+def _emit(message: str, *, mark: str = "✗", stream: TextIO | None = None) -> None:
+    """Print *message* as one marked headline plus indented detail lines.
+
+    Every failure this tool reports is a headline a reader can scan and detail
+    they only need once they have stopped scanning, so the two are formatted
+    differently rather than run together.
+    """
+    headline, *detail = message.split("\n")
+    target = stream if stream is not None else sys.stdout
+    print(f"{mark} {headline}", file=target)
+    for line in detail:
+        print(f"  {line}", file=target)
+
+
+def _environment_error(message: str) -> int:
+    """Report *message* on stderr and hand back the environment exit code.
+
+    Exit 2 is the code that says "not your fault": an unfetched base ref, a
+    shallow clone, a git call that failed. It goes to stderr because it is not
+    part of the gate's report — there is no report, the gate never ran.
+    """
+    _emit(message, stream=sys.stderr)
+    return 2
+
+
+def resolve_base(ref: str, run: Runner) -> str | None:
+    """Resolve *ref* to a commit, preferring the remote for a plain branch name.
+
+    A plain name — letters, digits, ``.``, ``_``, ``-`` and nothing else, and
+    not ``HEAD`` — is almost always a branch, and in a fresh CI checkout the
+    only copy of that branch is the remote one, so ``origin/<ref>`` is tried
+    first and the local name second. Anything else (``HEAD~1``, a sha, a
+    ``refs/`` path, a name that already says ``origin/``) is taken at its word
+    first and only then looked for under ``origin/``.
+
+    Returns the commit sha, or ``None`` when neither spelling resolves.
+    """
+    plain = PLAIN_REF_RE.match(ref) is not None and ref != "HEAD"
+    candidates = [f"origin/{ref}", ref] if plain else [ref, f"origin/{ref}"]
+    for candidate in candidates:
+        result = run(["git", "rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"])
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    return None
+
+
+def parse_name_status(stdout: str) -> list[tuple[str, str]]:
+    """Parse ``git diff --name-status -z`` output into ``(status, path)`` pairs.
+
+    ``-z`` is not a convenience here: a path with a space in it is ambiguous in
+    the default output and this repository has such paths. The NUL-separated
+    form alternates status and path, so the split list is read two at a time
+    and a trailing empty element (every record is NUL-*terminated*) is ignored.
+    """
+    fields = [field for field in stdout.split("\0") if field != ""]
+    return [(fields[index], fields[index + 1]) for index in range(0, len(fields) - 1, 2)]
+
+
+def _check(directory: Path, changelog: Path, base: str, run: Runner) -> int:
+    """Run the gate against the diff between *base*'s merge base and HEAD."""
+    fragments, errors = validate_dir(directory)
+    for error in errors:
+        _emit(error)
+    if not errors:
+        print(f"✓ {FRAGMENT_DIR}: {len(fragments)} fragment(s) valid")
+
+    def environment_error(message: str) -> int:
+        """Exit 2, saying so without hiding the fragment errors already printed.
+
+        The two codes answer different questions and only one can be returned,
+        so the one that is not returned is spelled out instead of being left
+        for the contributor to infer from output that scrolled past.
+        """
+        if errors:
+            message += (
+                f"\n{len(errors)} fragment error(s) reported above are separate "
+                f"and still have to be fixed"
+            )
+        return _environment_error(message)
+
+    base_sha = resolve_base(base, run)
+    if base_sha is None:
+        return environment_error(
+            f"base ref {base} not found — git fetch origin <branch>\n"
+            f"in CI, actions/checkout needs fetch-depth: 0"
+        )
+
+    merge_base = run(["git", "merge-base", base_sha, "HEAD"])
+    if merge_base.returncode != 0 or not merge_base.stdout.strip():
+        return environment_error(
+            f"git merge-base {base_sha} HEAD found no common ancestor — shallow clone? "
+            f"git fetch --unshallow\n{merge_base.stderr.strip()}"
+        )
+    point = merge_base.stdout.strip()
+
+    diff_argv = ["git", "diff", "--name-status", "-z", "--no-renames", point, "HEAD"]
+    diff = run(diff_argv)
+    if diff.returncode != 0:
+        return environment_error(f"{' '.join(diff_argv)} failed\n{diff.stderr.strip()}")
+    pairs = parse_name_status(diff.stdout)
+    # "changed" is every path the pull request touched, whatever git did to it:
+    # deleting a module is as much a user-visible change as editing one.
+    changed = [path for _, path in pairs]
+    added = [path for status, path in pairs if status.startswith("A")]
+    deleted = [path for status, path in pairs if status.startswith("D")]
+
+    show_argv = ["git", "show", f"{point}:CHANGELOG.md"]
+    show = run(show_argv)
+    if show.returncode != 0:
+        return environment_error(f"{' '.join(show_argv)} failed\n{show.stderr.strip()}")
+
+    try:
+        head_text = changelog.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return environment_error(f"cannot read {changelog}\n{exc}")
+
+    failures, ok_lines = gate_failures(changed, added, deleted, head_text, show.stdout)
+    for line in ok_lines:
+        print(line)
+    for failure in failures:
+        _emit(failure)
+    return 1 if errors or failures else 0
+
+
+def _apply(directory: Path, changelog: Path) -> int:
+    """Fold every fragment in *directory* into *changelog* and delete them."""
+    fragments, errors = validate_dir(directory)
+    if errors:
+        for error in errors:
+            _emit(error)
+        return 1
+
+    try:
+        text = changelog.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return _environment_error(f"cannot read {changelog}\n{exc}")
+
+    # Run the fold even with nothing to fold: it is what notices that the
+    # ## [Unreleased] heading is gone, and a release that has already rotated
+    # is worth hearing about before anyone writes the next fragment.
+    try:
+        new_text, report = apply_fragments(text, fragments)
+    except FragmentError as exc:
+        _emit(str(exc))
+        return 1
+
+    if not fragments:
+        print(f"{FRAGMENT_DIR}: no fragments; nothing to do")
+        return 0
+
+    try:
+        changelog.write_text(new_text, encoding="utf-8")
+    except OSError as exc:
+        return _environment_error(f"cannot write {changelog}\n{exc}")
+
+    # The changelog is already written, so a fragment left on disk would be
+    # folded in twice by the next run. Name the survivors rather than leaving
+    # that to be discovered in the release diff.
+    survivors: list[str] = []
+    for fragment in fragments:
+        try:
+            fragment.path.unlink()
+        except OSError as exc:
+            survivors.append(f"{fragment.path}: {exc}")
+    if survivors:
+        return _environment_error(
+            "\n".join(
+                [
+                    f"{changelog} is written, but {len(survivors)} fragment(s) could not "
+                    f"be deleted — remove them by hand or the next apply folds them again",
+                    *survivors,
+                ]
+            )
+        )
+
+    for line in report:
+        print(line)
+    print(f"stage with: git add -A {FRAGMENT_DIR}/ CHANGELOG.md")
+    return 0
+
+
+def main(argv: list[str] | None = None, run: Runner | None = None) -> int:
+    """Entry point for ``check`` and ``apply``.
+
+    *run* is the git runner, injected by the tests so that none of them has to
+    build a repository. Exit codes: 0 clean, 1 something a contributor fixes,
+    2 something the environment has to fix.
+    """
+    parser = argparse.ArgumentParser(
+        prog="changelog_fragments.py",
+        description="Check for a changelog fragment, or fold the fragments into CHANGELOG.md.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = subcommands.add_parser("check", help="gate one pull request (CI, pre-merge)")
+    check_parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="branch this pull request merges into (default: origin/main)",
+    )
+    check_parser.add_argument("--dir", help=f"fragment directory (default: {FRAGMENT_DIR}/)")
+    check_parser.add_argument("--changelog", help="changelog to read (default: CHANGELOG.md)")
+
+    apply_parser = subcommands.add_parser("apply", help="fold the fragments in (release)")
+    apply_parser.add_argument("--changelog", help="changelog to write (default: CHANGELOG.md)")
+    apply_parser.add_argument("--dir", help=f"fragment directory (default: {FRAGMENT_DIR}/)")
+
+    args = parser.parse_args(argv)
+    directory = Path(args.dir) if args.dir else REPO_ROOT / FRAGMENT_DIR
+    changelog = Path(args.changelog) if args.changelog else REPO_ROOT / "CHANGELOG.md"
+    if args.command == "apply":
+        return _apply(directory, changelog)
+    return _check(directory, changelog, args.base, run or _run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/premerge_check.sh
+++ b/scripts/premerge_check.sh
@@ -55,12 +55,15 @@ fi
 
 # CRITICAL checks
 echo -e "\n=== CRITICAL ==="
-if git diff $BASE...HEAD --name-only | grep -q CHANGELOG.md; then
-  echo "✓ CHANGELOG updated"
-else
-  echo "✗ CHANGELOG not updated"
-  ERRORS=$((ERRORS + 1))
-fi
+# The changelog gate — the same command the `lint` CI job runs, so this sweep
+# and the lane agree: a fragment in changelog.d/ for any change under src/ or
+# packages/, and no hand-written entry in CHANGELOG.md's [Unreleased] block.
+# It replaces a `grep CHANGELOG.md` over the diff, which under the fragment
+# workflow was wrong in both directions — red on every ordinary PR (fragments
+# are the entry) and green on one that hand-edited [Unreleased].
+# `uv run python` here, bare `python3` in CI; the script is stdlib-only either
+# way. It prints its own ✓/✗ lines, so this block only counts the failure.
+if uv run python scripts/changelog_fragments.py check --base "$BASE"; then :; else ERRORS=$((ERRORS + 1)); fi
 
 # Type hints (fixed: only count functions, not classes; exclude methods)
 # The `|| true` is inside the group so a no-match grep (exit 1) can't abort the

--- a/src/osprey/templates/skills/osprey-contribute/SKILL.md
+++ b/src/osprey/templates/skills/osprey-contribute/SKILL.md
@@ -130,10 +130,20 @@ Tell the contributor what you observed and which phase you're entering.
 
 The contributor edits code; the skill is mostly absent. Two reminders:
 
-- **Update `CHANGELOG.md` as you go**, not at the end. Add a bullet under the
-  relevant heading (`### Added`, `### Changed`, `### Fixed`) in the
-  `## [Unreleased]` section. Doing this concurrently keeps it accurate and
-  turns the per-commit CHANGELOG check into a non-event.
+- **Add a changelog fragment as you go**, not at the end. One file per change
+  that touches `src/` or `packages/`, in `changelog.d/`, named
+  `<name>.<type>.md` — user-visible work gets a real type, work users never see
+  gets `internal`. Use the issue number as the name when there is one —
+  `745.fixed.md`, where the leading number becomes the `(#745)` reference in
+  the released entry, so never start a name with a date and do not write
+  `(#745)` in the body yourself (the check rejects a repeated reference).
+  Otherwise use a short slug (`gate.fixed.md`). The
+  seven types, as example filenames: `745.added.md`, `745.changed.md`,
+  `745.deprecated.md`, `745.removed.md`, `745.fixed.md`, `745.security.md`,
+  `745.internal.md` — `internal` is for work users never see. The body is the
+  bullet's text: one or two user-facing sentences, without the leading `- `.
+  Never add entries to `CHANGELOG.md` by hand — the release fold owns that
+  file. `changelog.d/README.md` has the full rules.
 - Keep the change focused. If the working tree starts to span unrelated
   concerns (e.g., "fix bug X" plus an unrelated refactor), suggest invoking
   `commit-organize` to split it before committing.
@@ -171,9 +181,10 @@ The contributor edits code; the skill is mostly absent. Two reminders:
    **Soft prompt**: if the contributor's preferred message doesn't match the
    conventional form, propose a rewrite once. Accept their version on insist.
 
-5. **Soft prompt — CHANGELOG**: if `CHANGELOG.md` isn't in the staged set, ask
-   whether this commit needs an entry. Some genuinely don't (pure ruff
-   renames, internal refactors invisible to users). Don't block.
+5. **Soft prompt — changelog fragment**: if the commit touches `src/` or
+   `packages/` and nothing under `changelog.d/` is staged, ask whether it needs
+   a fragment. Pure internal work takes an `internal` fragment. Don't block
+   here; CI is the gate.
 
 6. Commit, then `git log -1 --stat` so the contributor sees what was recorded.
 
@@ -210,8 +221,8 @@ The contributor edits code; the skill is mostly absent. Two reminders:
 
    - **Title** — short (≤70 chars), conventional-style summary of the branch
      theme. If there's only one commit, that subject line is usually right.
-   - **Body** — pull from the commit messages and the CHANGELOG entries.
-     Sections:
+   - **Body** — pull from the commit messages and the fragments in
+     `changelog.d/`. Sections:
      - `## Summary` — 1-3 bullets, *why* this change.
      - `## Changes` — what landed.
      - `## Test plan` — bulleted checklist of how this was validated.

--- a/src/osprey/templates/skills/osprey-design-philosophy/SKILL.md
+++ b/src/osprey/templates/skills/osprey-design-philosophy/SKILL.md
@@ -79,8 +79,8 @@ fast-moving field, tight coupling to a volatile dependency is technical risk, no
 ## 5. A user-facing feature isn't done until it's discoverable
 
 If a change alters what an operator or deployer sees or does, the user-facing surface ships with it: a
-docs how-to, CLI `--help` text, and a changelog entry. Code that works but cannot be found is
-incomplete, not done.
+docs how-to, CLI `--help` text, and a changelog fragment in `changelog.d/`. Code that works but cannot
+be found is incomplete, not done.
 
 - Test each change against: "Could a user discover and use this without reading the source?" If no,
   the feature is unfinished.

--- a/src/osprey/templates/skills/osprey-release/SKILL.md
+++ b/src/osprey/templates/skills/osprey-release/SKILL.md
@@ -54,7 +54,7 @@ distinguishable from the release it descends from.
 | File | Purpose | Updated by |
 | --- | --- | --- |
 | `RELEASE_NOTES.md` | First-line title with the release version | This skill |
-| `CHANGELOG.md` | Add `## [vYYYY.M.P] - YYYY-MM-DD` heading; rotate `## [Unreleased]` content | This skill |
+| `CHANGELOG.md` | Fold `changelog.d/` fragments into `## [Unreleased]` (`changelog_fragments.py apply`), then rotate it to `## [YYYY.M.P] - YYYY-MM-DD` | This skill |
 | `README.md` | "Latest Release" line with version + theme | This skill |
 | `pyproject.toml` | `[tool.hatch.version] source = "vcs"` | **Do not edit** |
 | `src/osprey/_version.py` | Build-time stamp, gitignored | **Never commit** |
@@ -68,8 +68,9 @@ when the tag is not on the commit being built, or when the checkout is shallow
 
 ## Step 0: Read the CHANGELOG and decide the theme
 
-Open `CHANGELOG.md`, read the `## [Unreleased]` section, and answer three
-questions before doing anything else:
+Open `CHANGELOG.md` and read the `## [Unreleased]` section together with the
+pending fragments in `changelog.d/` — both are this release's content. Then
+answer three questions before doing anything else:
 
 1. **What is this release about?** Pick a short theme (e.g., "plan
    authoring & branch-protection enforcement"). It goes into the release
@@ -148,6 +149,17 @@ git checkout main && git pull --ff-only origin main
 git checkout -b release/vYYYY.M.P
 ```
 
+First fold the fragments in, so the rotation below has the full section to
+rotate:
+
+```bash
+uv run python scripts/changelog_fragments.py apply
+```
+
+This inserts each fragment under its `### <Type>` heading in `## [Unreleased]`
+and deletes the fragment files. Show the maintainer the resulting
+`CHANGELOG.md` diff before continuing.
+
 There is **no version literal to edit** — the tag in Step 5 sets the version.
 This PR carries only the human-facing notes. Show the maintainer each diff
 before applying:
@@ -155,17 +167,24 @@ before applying:
 | File | Change |
 | --- | --- |
 | `RELEASE_NOTES.md` | First line: `# Osprey Framework - Latest Release (vYYYY.M.P)` followed by the theme tagline |
-| `CHANGELOG.md` | Convert `## [Unreleased]` to `## [YYYY.M.P] - YYYY-MM-DD`; insert a fresh empty `## [Unreleased]` above it |
+| `CHANGELOG.md` | After the fold, convert `## [Unreleased]` to `## [YYYY.M.P] - YYYY-MM-DD`; insert a fresh empty `## [Unreleased]` above it |
+| `changelog.d/` | Fragment files deleted by `apply`; only `README.md` remains |
 | `README.md` | Update the "Latest Release" line with version + theme |
 | `docs/source/_static/screenshots/` | Any images re-captured in Step 2, plus the updated `manifest.json` |
 
-Then run a consistency check — every line should mention the same version:
+Stage the fold and the rotation together — `git add -A changelog.d/ CHANGELOG.md`
+(pathspec-scoped, so the fragment deletions are included).
+
+Then run a consistency check — every line should mention the same version, and
+no fragment should be left behind:
 
 ```bash
 echo "=== VERSION CONSISTENCY CHECK ==="
 echo "RELEASE_NOTES:  $(head -1 RELEASE_NOTES.md)"
 echo "README.md:      $(grep 'Latest Release:' README.md)"
 echo "CHANGELOG.md:   $(grep -m1 '^## \[' CHANGELOG.md)"
+echo "changelog.d/:   $(ls changelog.d | grep -vc '^README.md$') fragment(s) on disk (must be 0)"
+echo "staged:         $(git diff --cached --name-only -- changelog.d/ CHANGELOG.md | tr '\n' ' ')"
 ```
 
 Now hand off to `osprey-contribute` for the rest of the PR mechanics:
@@ -269,6 +288,8 @@ This is a fallback. The default path is the automated workflow.
 | PyPI rejects the upload as a duplicate | This version was already published | CalVer means version numbers are unique; you cannot republish. Bump the patch counter and try again |
 | `gh pr merge --rebase` fails with "not mergeable" | Stale checks because `main` moved | `git rebase origin/main` on the release branch, force-push with lease, wait for CI to re-run |
 | GitHub Release body is empty or wrong | CHANGELOG section heading didn't match the regex `release.yml` uses | Make sure the CHANGELOG heading is exactly `## [YYYY.M.P] - YYYY-MM-DD` |
+| `changelog_fragments.py apply` exits 1 | A fragment filename is malformed or carries an unrecognized type | Rename it `<name>.<type>.md` using one of added/changed/deprecated/removed/fixed/security/internal |
+| Released section is missing entries, or fragments are still on `main` after the release | `apply` was not run before the rotation, or its deletions were not staged | Fold the leftover fragments into the released section by hand, delete them, and open a PR carrying just `CHANGELOG.md` and the fragment deletions (`git add -A changelog.d/ CHANGELOG.md`) |
 
 ## Out of Scope
 

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -4608,6 +4608,93 @@ def test_lint_checks_the_lockfile__mutation_moves_it_after_sync() -> None:
 
 
 # ---------------------------------------------------------------------------
+# the changelog-fragment gate runs in lint, and premerge_check.sh runs the same
+# ---------------------------------------------------------------------------
+#
+# One rule, two callers: `scripts/changelog_fragments.py check` decides whether
+# a PR that touches src/ or packages/ carries a fragment in changelog.d/ and
+# whether anyone hand-edited CHANGELOG.md's [Unreleased] block. The local script
+# has to run the *same command* as the lane, or the pre-PR sweep goes green on
+# work CI then rejects.
+
+CHANGELOG_STEP = "Run changelog-fragment guard"
+CHANGELOG_SCRIPT = "scripts/changelog_fragments.py"
+PREMERGE_SCRIPT = "scripts/premerge_check.sh"
+#: What the CRITICAL block used to be: proof that CHANGELOG.md was *touched*,
+#: which the fragment workflow makes both unsatisfiable (fragments are the
+#: entry) and meaningless (touching the file proves nothing about content).
+_CHANGELOG_TOUCH_GREP = "grep -q CHANGELOG.md"
+
+
+@pytest.fixture()
+def premerge_source() -> str:
+    return _script_source(PREMERGE_SCRIPT)
+
+
+def test_lint_runs_the_changelog_fragment_guard(workflow: dict[str, Any]) -> None:
+    """Four things at once, because each has its own way of silently going
+    missing: the step exists and calls `check`; the base ref reaches the shell
+    through ``env:`` and never through ``${{ }}`` inside ``run:`` (a branch
+    name is attacker-controlled text — interpolated into the run line it is
+    executed); the env value comes from the pull-request event rather than a
+    hardcoded ``main``; and ``!cancelled()`` keeps a ruff failure above from
+    hiding a missing fragment and buying a second full CI cycle."""
+    step = _find_named_step(workflow, LINT_JOB, CHANGELOG_STEP)
+    assert CHANGELOG_SCRIPT + " check --base" in step["run"]
+    assert "${{" not in step["run"], (
+        f"{CHANGELOG_STEP} interpolates an expression into `run:`: {step['run']!r}"
+    )
+    assert "github.event.pull_request.base.ref" in step["env"]["BASE_REF"]
+    assert "!cancelled()" in step["if"]
+    assert "pull_request" in step["if"]
+
+
+def test_lint_runs_the_changelog_fragment_guard__mutation_drops_the_step() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    steps = _jobs(mutated)[LINT_JOB]["steps"]
+    steps[:] = [s for s in steps if s.get("name") != CHANGELOG_STEP]
+    with pytest.raises(AssertionError):
+        test_lint_runs_the_changelog_fragment_guard(mutated)
+
+
+def test_lint_runs_the_changelog_fragment_guard__mutation_interpolates_the_base_ref_into_run() -> (
+    None
+):
+    """The regression the ``env:`` indirection exists to prevent: the same
+    command, written the obvious way. A PR from a branch named with shell
+    metacharacters then runs them on the lint runner."""
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, LINT_JOB, CHANGELOG_STEP)
+    step["run"] = step["run"].replace(
+        '"origin/$BASE_REF"', '"origin/${{ github.event.pull_request.base.ref }}"'
+    )
+    assert "${{" in step["run"], "the run line no longer uses $BASE_REF; this mutation is stale"
+    with pytest.raises(AssertionError):
+        test_lint_runs_the_changelog_fragment_guard(mutated)
+
+
+def test_premerge_check_runs_the_same_gate(premerge_source: str) -> None:
+    """The local sweep must run the gate itself, not a proxy for it. Its old
+    CRITICAL check grepped the diff for CHANGELOG.md, which under the fragment
+    workflow is red on every ordinary PR and green on a PR that hand-edited
+    [Unreleased] — wrong in both directions."""
+    assert CHANGELOG_SCRIPT in premerge_source
+    assert "check --base" in premerge_source
+    assert _CHANGELOG_TOUCH_GREP not in premerge_source
+
+
+def test_premerge_check_runs_the_same_gate__mutation_restores_the_grep() -> None:
+    source = _script_source(PREMERGE_SCRIPT)
+    mutated = source.replace(
+        f'uv run python {CHANGELOG_SCRIPT} check --base "$BASE"',
+        f"git diff $BASE...HEAD --name-only | {_CHANGELOG_TOUCH_GREP}",
+    )
+    assert mutated != source, "the gate invocation moved; this mutation is stale"
+    with pytest.raises(AssertionError):
+        test_premerge_check_runs_the_same_gate(mutated)
+
+
+# ---------------------------------------------------------------------------
 # (j) every dockerbuild-marked module reaches a lane that gates the merge
 # ---------------------------------------------------------------------------
 #

--- a/tests/infrastructure/test_import_time_audit.py
+++ b/tests/infrastructure/test_import_time_audit.py
@@ -38,6 +38,7 @@ WHITELIST: dict[str, set[str]] = {
     "benchmark/test_matrix_dashboard.py": {"sys.modules"},
     "benchmark/test_matrix_lanes.py": {"sys.modules"},
     "scripts/test_config_key_guard.py": {"sys.modules"},
+    "scripts/test_changelog_fragments.py": {"sys.modules"},
     "scripts/test_docs_publish.py": {"sys.modules"},
     "va/e2e/conftest.py": {"sys.modules"},
     # the root conftest scrubs FORCE_COLOR/CLICOLOR_FORCE before collection

--- a/tests/scripts/test_changelog_fragments.py
+++ b/tests/scripts/test_changelog_fragments.py
@@ -1,0 +1,1845 @@
+"""Tests for the changelog-fragment gate and fold.
+
+The fragment file's *name* carries meaning — its leading digits become the
+issue reference in the shipped changelog — so most of what can go wrong here
+goes wrong quietly: a fragment nobody can parse, a reference printed twice, a
+date read as an issue number. Every rule therefore has a negative control, and
+the sharp edges (``2026-cleanup.changed.md`` → ``(#2026)``; a slug fragment
+allowed to write its own ``(#735, #737)``) are pinned as behaviour rather than
+left to be rediscovered.
+
+No test here creates a git repository.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "changelog_fragments.py"
+_spec = importlib.util.spec_from_file_location("changelog_fragments", _MODULE_PATH)
+assert _spec and _spec.loader
+cf = importlib.util.module_from_spec(_spec)
+# import-time required because scripts/ is not a package: changelog_fragments.py is
+# loaded by path and registered in sys.modules before exec so @dataclass can resolve
+# annotations through cls.__module__.
+sys.modules[_spec.name] = cf
+_spec.loader.exec_module(cf)
+
+
+def write(directory: Path, name: str, text: str) -> Path:
+    """Drop a fragment into *directory* and hand back its path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def refuse_io(self, *args, **kwargs):
+    """A `Path` method stand-in that fails the way a read-only file does."""
+    raise PermissionError(13, "Permission denied")
+
+
+class TestParseFragmentName:
+    def test_an_issue_number_name_carries_the_ref(self):
+        assert cf.parse_fragment_name("745.fixed.md") == ("745", "fixed", "745")
+
+    def test_an_issue_number_with_a_slug_suffix_still_carries_the_ref(self):
+        """`745-gate` names the issue and says which of its fixes this is."""
+        assert cf.parse_fragment_name("745-gate.fixed.md") == ("745-gate", "fixed", "745")
+
+    def test_a_slug_name_has_no_ref(self):
+        assert cf.parse_fragment_name("gate.fixed.md") == ("gate", "fixed", None)
+
+    def test_a_leading_date_is_read_as_an_issue_number(self):
+        """Documented sharp edge: the leading digits ARE the issue reference.
+
+        `2026-cleanup.changed.md` renders `(#2026)`. The rule cannot tell a
+        year from an issue, so the README tells contributors not to start a
+        name with a date.
+        """
+        assert cf.parse_fragment_name("2026-cleanup.changed.md") == (
+            "2026-cleanup",
+            "changed",
+            "2026",
+        )
+
+    def test_underscores_and_digits_inside_a_slug_are_fine(self):
+        assert cf.parse_fragment_name("web_terminal2.added.md") == (
+            "web_terminal2",
+            "added",
+            None,
+        )
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "745.Fixed.md",  # the type is lower-case only
+            "issue.745.md",  # digits are not a type
+            "745.fixed.txt",  # not markdown
+            "745.fixed.md.bak",
+            "-745.fixed.md",  # a name starts with a letter or a digit
+            ".fixed.md",  # no name at all
+            "745.md",  # no type segment
+            "README.md",  # skipped by name, never parsed
+        ],
+    )
+    def test_names_outside_the_grammar_are_rejected(self, filename):
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.parse_fragment_name(filename)
+        message = str(excinfo.value)
+        assert message.startswith(f"{filename}: ")
+        assert "<name>.<type>.md" in message
+
+    def test_an_unknown_type_names_every_type(self):
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.parse_fragment_name("745.tweaked.md")
+        message = str(excinfo.value)
+        assert 'unknown type "tweaked"' in message
+        for type_ in cf.TYPES:
+            assert type_ in message
+        assert "renders nothing" in message
+
+    @pytest.mark.parametrize("type_", cf.TYPES)
+    def test_every_type_in_the_vocabulary_parses(self, type_):
+        assert cf.parse_fragment_name(f"745.{type_}.md") == ("745", type_, "745")
+
+
+class TestHeadingVocabulary:
+    """`TYPE_HEADING_RE` spells the headings out by hand — it is part of the
+    module contract — so it is the one place the rendered vocabulary can still
+    drift from `TYPES`. Pin it to the derived tables."""
+
+    def test_the_heading_regex_matches_exactly_the_rendered_headings(self):
+        assert cf.HEADING_ORDER == (
+            "Added",
+            "Changed",
+            "Deprecated",
+            "Removed",
+            "Fixed",
+            "Security",
+        )
+        for heading in cf.HEADING_ORDER:
+            assert cf.TYPE_HEADING_RE.match(f"### {heading}")
+        assert not cf.TYPE_HEADING_RE.match("### Internal")
+        assert cf.TYPE_HEADING_RE.pattern.count("|") == len(cf.HEADING_ORDER) - 1
+
+
+class TestNormalizeLines:
+    def test_crlf_becomes_lf(self):
+        assert cf.normalize_lines("first\r\nsecond\r\n") == ["first", "second"]
+
+    def test_a_lone_cr_becomes_lf(self):
+        assert cf.normalize_lines("first\rsecond\r") == ["first", "second"]
+
+    def test_leading_and_trailing_blank_lines_are_stripped(self):
+        assert cf.normalize_lines("\n\n  \nbody\n\n   \n") == ["body"]
+
+    def test_interior_blank_lines_survive(self):
+        assert cf.normalize_lines("lead-in\n\n- sub\n") == ["lead-in", "", "- sub"]
+
+    def test_interior_indentation_survives(self):
+        assert cf.normalize_lines("lead-in\n    indented\n") == ["lead-in", "    indented"]
+
+    def test_a_blank_file_is_no_lines(self):
+        assert cf.normalize_lines("\n  \n\t\n") == []
+        assert cf.normalize_lines("") == []
+
+
+class TestOpeningParagraphEnd:
+    def test_a_single_line_ends_at_itself(self):
+        assert cf.opening_paragraph_end(["one sentence."]) == 0
+
+    def test_a_hand_wrapped_paragraph_ends_at_its_last_line(self):
+        assert cf.opening_paragraph_end(["wrapped at about", "seventy-eight columns."]) == 1
+
+    def test_a_blank_line_ends_the_paragraph(self):
+        lines = ["lead-in:", "", "- one", "- two"]
+        assert cf.opening_paragraph_end(lines) == 0
+
+    def test_a_column_zero_sub_bullet_ends_the_paragraph_without_a_blank_line(self):
+        lines = ["lead-in:", "- one", "- two"]
+        assert cf.opening_paragraph_end(lines) == 0
+
+    @pytest.mark.parametrize("marker", ["- item", "* item", "+ item", "```python"])
+    def test_every_column_zero_marker_ends_the_paragraph(self, marker):
+        assert cf.opening_paragraph_end(["lead-in:", marker]) == 0
+
+    def test_a_continuation_line_opening_with_bold_does_not_end_the_paragraph(self):
+        """`**` is not a list marker — `[-*+]\\s` needs whitespace after it."""
+        lines = ["A wrapped sentence that continues with", "**emphasis** and keeps going."]
+        assert cf.opening_paragraph_end(lines) == 1
+
+    def test_an_indented_sub_bullet_does_not_end_the_paragraph(self):
+        """The patterns are anchored at column 0; an indented line is prose."""
+        assert cf.opening_paragraph_end(["lead-in:", "  - indented"]) == 1
+
+    def test_an_empty_body_yields_zero(self):
+        assert cf.opening_paragraph_end([]) == 0
+
+
+class TestLoadFragment:
+    def test_a_plain_fragment_loads(self, tmp_path):
+        path = write(tmp_path, "745.changed.md", "Changelog entries now live in fragments.\n")
+        fragment = cf.load_fragment(path)
+        assert (fragment.name, fragment.type, fragment.ref) == ("745", "changed", "745")
+        assert fragment.lines == ("Changelog entries now live in fragments.",)
+        assert fragment.path == path
+
+    def test_the_body_is_normalized_on_the_way_in(self, tmp_path):
+        path = write(tmp_path, "gate.fixed.md", "\r\n\r\nWindows wrote this.\r\n\r\n")
+        assert cf.load_fragment(path).lines == ("Windows wrote this.",)
+
+    def test_a_bold_opener_is_prose(self, tmp_path):
+        path = write(tmp_path, "745.changed.md", "**Breaking change:** the flag is gone.\n")
+        assert cf.load_fragment(path).lines[0] == "**Breaking change:** the flag is gone."
+
+    def test_sub_bullets_and_fences_survive(self, tmp_path):
+        body = "The gate now checks two things:\n\n- a fragment exists\n- nobody hand-edited\n"
+        fragment = cf.load_fragment(write(tmp_path, "745.added.md", body))
+        assert fragment.lines == (
+            "The gate now checks two things:",
+            "",
+            "- a fragment exists",
+            "- nobody hand-edited",
+        )
+        assert cf.opening_paragraph_end(fragment.lines) == 0
+
+    @pytest.mark.parametrize(
+        "first_line",
+        ["- a bullet", "* a bullet", "+ a bullet", "# a heading", "###### a heading", "```", "~~~"],
+    )
+    def test_a_marker_on_the_first_line_is_rejected(self, tmp_path, first_line):
+        path = write(tmp_path, "745.fixed.md", f"{first_line}\nrest\n")
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.load_fragment(path)
+        assert "must open with prose" in str(excinfo.value)
+
+    @pytest.mark.parametrize("text", ["", "\n\n", "   \n\t\n"])
+    def test_an_empty_body_is_rejected(self, tmp_path, text):
+        path = write(tmp_path, "745.fixed.md", text)
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.load_fragment(path)
+        assert "write one user-facing sentence" in str(excinfo.value)
+
+    def test_bytes_that_are_not_utf8_are_rejected(self, tmp_path):
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        path = tmp_path / "745.fixed.md"
+        path.write_bytes(b"caf\xe9 au lait\n")
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.load_fragment(path)
+        assert "not valid UTF-8" in str(excinfo.value)
+        assert "745.fixed.md" in str(excinfo.value)
+
+    def test_a_file_that_cannot_be_read_is_a_fragment_error(self, tmp_path, monkeypatch):
+        """Contributor-fixable like every other malformed fragment, so
+        `validate_dir` lists it instead of the gate dying on a traceback."""
+        path = write(tmp_path, "745.fixed.md", "A bug.\n")
+        monkeypatch.setattr(Path, "read_text", refuse_io)
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.load_fragment(path)
+        assert str(excinfo.value).startswith("745.fixed.md: cannot read")
+        assert "Permission denied" in str(excinfo.value)
+
+    def test_a_ref_bearing_name_may_not_repeat_the_ref(self, tmp_path):
+        path = write(tmp_path, "745.fixed.md", "The gate no longer double-counts. (#745)\n")
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.load_fragment(path)
+        assert "comes from the filename" in str(excinfo.value)
+
+    def test_the_ref_check_reads_the_opening_paragraph_not_the_last_line(self, tmp_path):
+        body = "A wrapped sentence that runs on\nand ends with the reference. (#745)\n\n- detail\n"
+        with pytest.raises(cf.FragmentError):
+            cf.load_fragment(write(tmp_path, "745.fixed.md", body))
+
+    def test_a_ref_further_down_the_body_is_left_alone(self, tmp_path):
+        """Only the line the fold would append to is checked."""
+        body = "The gate landed.\n\n- it supersedes the union driver (#729)\n"
+        assert cf.load_fragment(write(tmp_path, "745.fixed.md", body)).ref == "745"
+
+    def test_a_slug_fragment_may_write_its_own_refs(self, tmp_path):
+        """No ref comes from `gate`, so the text has to supply one itself."""
+        path = write(tmp_path, "gate.fixed.md", "Seven issues from the wave. (#735, #737)\n")
+        fragment = cf.load_fragment(path)
+        assert fragment.ref is None
+        assert fragment.lines[-1].endswith("(#735, #737)")
+
+    def test_a_slug_fragment_may_even_write_a_single_ref(self, tmp_path):
+        path = write(tmp_path, "gate.fixed.md", "One issue, named by hand. (#735)\n")
+        assert cf.load_fragment(path).ref is None
+
+    def test_a_bad_name_is_rejected_before_the_file_is_read(self, tmp_path):
+        path = write(tmp_path, "745.tweaked.md", "body\n")
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.load_fragment(path)
+        assert 'unknown type "tweaked"' in str(excinfo.value)
+
+    def test_a_byte_order_mark_is_stripped(self, tmp_path):
+        """Windows editors write one by default; it is invisible in the changelog."""
+        path = tmp_path / "745.fixed.md"
+        path.write_bytes("\ufeffThe gate no longer eats the last line.\n".encode("utf-8"))
+        fragment = cf.load_fragment(path)
+        assert fragment.lines[0] == "The gate no longer eats the last line."
+        assert "\ufeff" not in "".join(cf.render_bullet(fragment))
+
+
+class TestValidateDir:
+    def test_a_missing_directory_is_empty_not_an_error(self, tmp_path):
+        assert cf.validate_dir(tmp_path / "nope") == ([], [])
+
+    def test_an_empty_directory_is_empty(self, tmp_path):
+        (tmp_path / "changelog.d").mkdir()
+        assert cf.validate_dir(tmp_path / "changelog.d") == ([], [])
+
+    def test_the_readme_is_never_validated(self, tmp_path):
+        """It opens with a heading, which would fail every body rule."""
+        write(tmp_path, cf.KEEP, "# Changelog fragments\n\nHow to write one.\n")
+        assert cf.validate_dir(tmp_path) == ([], [])
+
+    def test_fragments_come_back_in_filename_order(self, tmp_path):
+        write(tmp_path, "745.fixed.md", "Second alphabetically.\n")
+        write(tmp_path, "100.added.md", "First alphabetically.\n")
+        write(tmp_path, "gate.changed.md", "Last alphabetically.\n")
+        fragments, errors = cf.validate_dir(tmp_path)
+        assert errors == []
+        assert [f.path.name for f in fragments] == [
+            "100.added.md",
+            "745.fixed.md",
+            "gate.changed.md",
+        ]
+
+    def test_every_offender_is_reported_not_just_the_first(self, tmp_path):
+        write(tmp_path, "745.tweaked.md", "bad type\n")
+        write(tmp_path, "746.fixed.md", "- bad body\n")
+        write(tmp_path, "747.fixed.md", "")
+        write(tmp_path, "good.added.md", "This one is fine.\n")
+        fragments, errors = cf.validate_dir(tmp_path)
+        assert [f.path.name for f in fragments] == ["good.added.md"]
+        assert len(errors) == 3
+        assert [e.split(":")[0] for e in errors] == [
+            "745.tweaked.md",
+            "746.fixed.md",
+            "747.fixed.md",
+        ]
+
+    def test_a_name_outside_the_grammar_is_an_error(self, tmp_path):
+        write(tmp_path, "notes.md", "This is not a fragment.\n")
+        fragments, errors = cf.validate_dir(tmp_path)
+        assert fragments == []
+        assert len(errors) == 1
+        assert "<name>.<type>.md" in errors[0]
+        for type_ in cf.TYPES:
+            assert type_ in errors[0]
+
+    def test_a_subdirectory_is_an_error(self, tmp_path):
+        (tmp_path / "drafts").mkdir()
+        write(tmp_path / "drafts", "745.fixed.md", "Hidden away.\n")
+        fragments, errors = cf.validate_dir(tmp_path)
+        assert fragments == []
+        assert errors == [f"drafts/: {cf.FRAGMENT_DIR}/ is flat — no subdirectories"]
+
+    def test_files_that_are_not_markdown_are_ignored(self, tmp_path):
+        (tmp_path / ".DS_Store").write_bytes(b"\x00\x01")
+        write(tmp_path, "notes.txt", "scratch\n")
+        write(tmp_path, "745.fixed.md", "The one real fragment.\n")
+        fragments, errors = cf.validate_dir(tmp_path)
+        assert [f.path.name for f in fragments] == ["745.fixed.md"]
+        assert errors == []
+
+    def test_an_internal_fragment_is_valid(self, tmp_path):
+        write(tmp_path, "745.internal.md", "Refactored the loader; nobody sees this.\n")
+        fragments, errors = cf.validate_dir(tmp_path)
+        assert errors == []
+        assert fragments[0].type == "internal"
+
+
+class TestUnreleasedSpan:
+    """`## [Unreleased]` is located the same way by both subcommands."""
+
+    CHANGELOG = [
+        "# Changelog",
+        "",
+        "All notable changes are recorded here.",
+        "",
+        "## [Unreleased]",
+        "",
+        "### Fixed",
+        "",
+        "- the gate no longer double-counts (#745)",
+        "",
+        "## [2026.8.0] - 2026-08-20",
+        "",
+        "### Added",
+        "",
+        "- the first release",
+    ]
+
+    def test_the_span_brackets_the_block(self):
+        heading, end = cf.unreleased_span(self.CHANGELOG)
+        assert (heading, end) == (4, 10)
+        assert self.CHANGELOG[heading] == "## [Unreleased]"
+        assert self.CHANGELOG[heading + 1 : end] == [
+            "",
+            "### Fixed",
+            "",
+            "- the gate no longer double-counts (#745)",
+            "",
+        ]
+
+    def test_a_heading_on_the_first_line_is_found(self):
+        lines = ["## [Unreleased]", "", "- a bullet", "", "## [2026.8.0] - 2026-08-20"]
+        assert cf.unreleased_span(lines) == (0, 4)
+
+    def test_a_bracket_less_heading_does_not_end_the_block(self):
+        """`## Notes` is prose inside the section — the terminator needs `[`."""
+        lines = ["## [Unreleased]", "", "## Notes", "", "- still unreleased"]
+        assert cf.unreleased_span(lines) == (0, 5)
+
+    def test_a_release_heading_without_a_date_ends_the_block(self):
+        """A release in preparation has no date yet; it still closes the section."""
+        lines = ["## [Unreleased]", "", "## [2026.8.0]", "", "- shipped"]
+        assert cf.unreleased_span(lines) == (0, 2)
+
+    def test_the_last_section_runs_to_the_end_of_the_file(self):
+        lines = ["# Changelog", "", "## [Unreleased]", "", "### Fixed", "", "- one"]
+        assert cf.unreleased_span(lines) == (2, len(lines))
+
+    def test_an_empty_block_still_has_a_span(self):
+        lines = ["## [Unreleased]", "", "## [2026.8.0] - 2026-08-20"]
+        heading, end = cf.unreleased_span(lines)
+        assert (heading, end) == (0, 2)
+        assert lines[heading + 1 : end] == [""]
+
+    def test_a_heading_with_trailing_spaces_matches(self):
+        lines = ["## [Unreleased]   ", "", "- a bullet"]
+        assert cf.unreleased_span(lines) == (0, 3)
+
+    def test_the_first_heading_wins(self):
+        lines = ["## [Unreleased]", "", "## [2026.8.0]", "", "## [Unreleased]"]
+        assert cf.unreleased_span(lines) == (0, 2)
+
+    @pytest.mark.parametrize(
+        "lines",
+        [
+            [],
+            ["# Changelog", "", "## [2026.8.0] - 2026-08-20"],
+            ["## [Unreleased] - 2026-08-20"],  # a date makes it a release heading
+            ["### [Unreleased]"],  # wrong level
+            ["## Unreleased"],  # no brackets
+            ["  ## [Unreleased]"],  # not at column 0
+        ],
+    )
+    def test_a_missing_heading_is_none(self, lines):
+        assert cf.unreleased_span(lines) is None
+
+
+class TestIsEmptyBlock:
+    @pytest.mark.parametrize("block", [[], [""], ["", "  "], ["\t", "", "   "]])
+    def test_blank_lines_only_is_empty(self, block):
+        assert cf.is_empty_block(block) is True
+
+    @pytest.mark.parametrize("block", [["### Fixed"], ["", "- a bullet", ""], ["  indented"]])
+    def test_any_content_at_all_is_not_empty(self, block):
+        assert cf.is_empty_block(block) is False
+
+    def test_the_post_rotation_state_is_empty(self):
+        """A release rotation leaves the section as exactly one blank line."""
+        lines = ["## [Unreleased]", "", "## [2026.8.0] - 2026-08-20", "", "### Fixed", "", "- one"]
+        heading, end = cf.unreleased_span(lines)
+        assert cf.is_empty_block(lines[heading + 1 : end]) is True
+
+    def test_a_populated_block_is_not_empty(self):
+        lines = ["## [Unreleased]", "", "### Fixed", "", "- one", "", "## [2026.8.0] - 2026-08-20"]
+        heading, end = cf.unreleased_span(lines)
+        assert cf.is_empty_block(lines[heading + 1 : end]) is False
+
+
+class TestRenderBullet:
+    """The bullet is what ships, so its shape is pinned line by line.
+
+    The shapes below are the ones `CHANGELOG.md` already contains: a one-line
+    bullet, a hand-wrapped one, a lead-in with sub-bullets, and a bullet with a
+    fenced block inside it (modelled on the `osprey profile new` entry under
+    `## [2026.8.0]`). Each is checked as a whole list rather than by substring —
+    a stray blank line or a lost indent is exactly the failure that would
+    otherwise reach the changelog unnoticed.
+    """
+
+    @staticmethod
+    def make(tmp_path, name: str, body: str) -> cf.Fragment:
+        """Load a real fragment, so the ref comes from the name the fold sees."""
+        return cf.load_fragment(write(tmp_path, name, body))
+
+    def test_a_single_line_bullet_carries_its_ref(self, tmp_path):
+        frag = self.make(tmp_path, "745.fixed.md", "The gate no longer double-counts.\n")
+        assert cf.render_bullet(frag) == ["- The gate no longer double-counts. (#745)"]
+
+    def test_a_hand_wrapped_bullet_indents_the_continuation_and_ends_with_the_ref(self, tmp_path):
+        body = "Changelog entries now live in one small file per change instead of\nthe shared section.\n"
+        frag = self.make(tmp_path, "745.changed.md", body)
+        assert cf.render_bullet(frag) == [
+            "- Changelog entries now live in one small file per change instead of",
+            "  the shared section. (#745)",
+        ]
+
+    def test_a_lead_in_with_sub_bullets_puts_the_ref_on_the_lead_in(self, tmp_path):
+        body = (
+            "The gate now checks two things before a pull request can\n"
+            "merge.\n"
+            "\n"
+            "- a fragment exists for the change\n"
+            "- nobody wrote a bullet into the block by hand\n"
+        )
+        frag = self.make(tmp_path, "745.added.md", body)
+        assert cf.render_bullet(frag) == [
+            "- The gate now checks two things before a pull request can",
+            "  merge. (#745)",
+            "",
+            "  - a fragment exists for the change",
+            "  - nobody wrote a bullet into the block by hand",
+        ]
+
+    def test_a_blank_line_renders_as_an_empty_line(self, tmp_path):
+        """Not two spaces — trailing whitespace is somebody's diff noise later."""
+        frag = self.make(tmp_path, "745.added.md", "Lead-in.\n\n- one\n")
+        assert cf.render_bullet(frag)[1] == ""
+
+    def test_a_fenced_block_survives_apart_from_the_indent(self, tmp_path):
+        body = (
+            "`osprey build --emit-profile` is gone, with no alias — the build command\n"
+            "builds projects, and profile authoring now has its own verb. Materialize a\n"
+            "profile directory with:\n"
+            "\n"
+            "```\n"
+            "osprey profile new DIR --preset X\n"
+            "```\n"
+            "\n"
+            "It writes everything the flag wrote, plus the preset's `data/` tree.\n"
+        )
+        frag = self.make(tmp_path, "745.removed.md", body)
+        assert cf.render_bullet(frag) == [
+            "- `osprey build --emit-profile` is gone, with no alias — the build command",
+            "  builds projects, and profile authoring now has its own verb. Materialize a",
+            "  profile directory with: (#745)",
+            "",
+            "  ```",
+            "  osprey profile new DIR --preset X",
+            "  ```",
+            "",
+            "  It writes everything the flag wrote, plus the preset's `data/` tree.",
+        ]
+
+    def test_the_fence_body_is_copied_byte_for_byte(self, tmp_path):
+        """Whatever is inside the fence is content, not prose to be reflowed."""
+        body = "Run it with:\n\n```\n  osprey up --detach   # two leading spaces stay\n```\n"
+        frag = self.make(tmp_path, "gate.added.md", body)
+        assert cf.render_bullet(frag)[3] == "    osprey up --detach   # two leading spaces stay"
+
+    def test_a_bold_continuation_line_does_not_end_the_paragraph(self, tmp_path):
+        """`**` is not a list marker, so the ref still lands on the wrapped line."""
+        body = "A wrapped sentence that continues with\n**emphasis** and keeps going.\n"
+        frag = self.make(tmp_path, "745.changed.md", body)
+        assert cf.render_bullet(frag) == [
+            "- A wrapped sentence that continues with",
+            "  **emphasis** and keeps going. (#745)",
+        ]
+
+    def test_a_bold_opener_is_rendered_as_written(self, tmp_path):
+        frag = self.make(tmp_path, "745.changed.md", "**Breaking change:** the flag is gone.\n")
+        assert cf.render_bullet(frag) == ["- **Breaking change:** the flag is gone. (#745)"]
+
+    def test_a_slug_name_appends_nothing(self, tmp_path):
+        frag = self.make(tmp_path, "gate.fixed.md", "A change with no issue behind it.\n")
+        assert frag.ref is None
+        assert cf.render_bullet(frag) == ["- A change with no issue behind it."]
+
+    def test_a_slug_fragment_keeps_its_hand_written_refs(self, tmp_path):
+        """The text supplies what the name cannot — verbatim, and only once."""
+        body = "Seven issues from the wave landed together. (#735, #737)\n"
+        frag = self.make(tmp_path, "gate.fixed.md", body)
+        assert cf.render_bullet(frag) == [
+            "- Seven issues from the wave landed together. (#735, #737)"
+        ]
+
+    def test_a_name_with_an_issue_and_a_slug_still_appends_the_issue(self, tmp_path):
+        frag = self.make(tmp_path, "745-gate.fixed.md", "One of several fixes for the wave.\n")
+        assert cf.render_bullet(frag) == ["- One of several fixes for the wave. (#745)"]
+
+    def test_an_internal_fragment_is_never_rendered(self, tmp_path):
+        frag = self.make(tmp_path, "745.internal.md", "Refactored the loader; nobody sees this.\n")
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.render_bullet(frag)
+        message = str(excinfo.value)
+        assert message.startswith("745.internal.md: ")
+        assert "renders nothing" in message
+
+    def test_rendering_does_not_touch_the_fragment(self, tmp_path):
+        """The ref is appended to a copy — `apply` may not mutate what it loaded."""
+        frag = self.make(tmp_path, "745.fixed.md", "The gate no longer double-counts.\n")
+        cf.render_bullet(frag)
+        assert frag.lines == ("The gate no longer double-counts.",)
+
+
+class TestApplyFragments:
+    """The fold rewrites one section of a file nobody wants to re-read by hand.
+
+    `CHANGELOG.md` is 6000 lines old and every release below `## [Unreleased]`
+    is history, so the whole result is asserted rather than sampled: the
+    interesting failures are a blank line gained or lost, a bullet landing
+    under a released heading, and an existing heading being quietly moved.
+    """
+
+    CHANGELOG = (
+        "# Changelog\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+        "### Changed\n"
+        "\n"
+        "- an entry that was already here\n"
+        "\n"
+        "## [2026.8.0] - 2026-08-20\n"
+        "\n"
+        "### Fixed\n"
+        "\n"
+        "- something in the last release\n"
+    )
+
+    @staticmethod
+    def make(tmp_path, name: str, body: str) -> cf.Fragment:
+        """Load a real fragment, so the ref and body come from the file itself."""
+        return cf.load_fragment(write(tmp_path, name, body))
+
+    def test_a_bullet_goes_under_an_existing_heading(self, tmp_path):
+        frag = self.make(tmp_path, "745.changed.md", "The fold writes the bullet.\n")
+        new_text, report = cf.apply_fragments(self.CHANGELOG, [frag])
+        assert new_text == (
+            "# Changelog\n"
+            "\n"
+            "## [Unreleased]\n"
+            "\n"
+            "### Changed\n"
+            "\n"
+            "- The fold writes the bullet. (#745)\n"
+            "- an entry that was already here\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- something in the last release\n"
+        )
+        assert report == ["changelog.d/745.changed.md -> ### Changed (#745)"]
+
+    def test_a_missing_heading_is_created_at_the_top_of_the_block(self, tmp_path):
+        frag = self.make(tmp_path, "745.added.md", "A new capability.\n")
+        new_text, report = cf.apply_fragments(self.CHANGELOG, [frag])
+        assert new_text == (
+            "# Changelog\n"
+            "\n"
+            "## [Unreleased]\n"
+            "\n"
+            "### Added\n"
+            "\n"
+            "- A new capability. (#745)\n"
+            "\n"
+            "### Changed\n"
+            "\n"
+            "- an entry that was already here\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- something in the last release\n"
+        )
+        assert report == ["changelog.d/745.added.md -> ### Added (#745)"]
+
+    def test_created_headings_go_above_an_existing_one_that_is_never_moved(self, tmp_path):
+        """`### Changed` stays where it is, so the block ends up Added, Fixed, Changed.
+
+        Keep-a-Changelog order applies to headings this run creates. Reordering
+        what is already in the file would turn one release's fold into a diff
+        across the whole section.
+        """
+        frags = [
+            self.make(tmp_path, "745.added.md", "A new capability.\n"),
+            self.make(tmp_path, "746.changed.md", "Different behaviour.\n"),
+            self.make(tmp_path, "747.fixed.md", "A bug.\n"),
+        ]
+        new_text, report = cf.apply_fragments(self.CHANGELOG, frags)
+        assert new_text == (
+            "# Changelog\n"
+            "\n"
+            "## [Unreleased]\n"
+            "\n"
+            "### Added\n"
+            "\n"
+            "- A new capability. (#745)\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- A bug. (#747)\n"
+            "\n"
+            "### Changed\n"
+            "\n"
+            "- Different behaviour. (#746)\n"
+            "- an entry that was already here\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- something in the last release\n"
+        )
+        assert report == [
+            "changelog.d/745.added.md -> ### Added (#745)",
+            "changelog.d/746.changed.md -> ### Changed (#746)",
+            "changelog.d/747.fixed.md -> ### Fixed (#747)",
+        ]
+
+    def test_a_heading_far_down_the_block_still_receives_its_own_bullet(self, tmp_path):
+        text = (
+            "## [Unreleased]\n"
+            "\n"
+            "### Added\n"
+            "\n"
+            "- one\n"
+            "\n"
+            "### Changed\n"
+            "\n"
+            "- two\n"
+            "\n"
+            "### Security\n"
+            "\n"
+            "- three\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+        )
+        frag = self.make(tmp_path, "745.security.md", "A hardening change.\n")
+        new_text, _ = cf.apply_fragments(text, [frag])
+        assert new_text == (
+            "## [Unreleased]\n"
+            "\n"
+            "### Added\n"
+            "\n"
+            "- one\n"
+            "\n"
+            "### Changed\n"
+            "\n"
+            "- two\n"
+            "\n"
+            "### Security\n"
+            "\n"
+            "- A hardening change. (#745)\n"
+            "- three\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+        )
+
+    def test_a_released_section_with_the_same_heading_is_byte_identical(self, tmp_path):
+        """The search is confined to the block — history is not editable."""
+        frag = self.make(tmp_path, "745.fixed.md", "A bug.\n")
+        new_text, _ = cf.apply_fragments(self.CHANGELOG, [frag])
+        tail = "## [2026.8.0] - 2026-08-20\n\n### Fixed\n\n- something in the last release\n"
+        assert new_text.endswith(tail)
+        assert new_text.count("### Fixed") == 2
+        assert "- A bug. (#745)" in new_text.split("## [2026.8.0]")[0]
+
+    def test_the_first_of_several_duplicate_headings_wins(self, tmp_path):
+        text = "## [Unreleased]\n"
+        for ordinal in ("first", "second", "third", "fourth", "fifth"):
+            text += f"\n### Fixed\n\n- the {ordinal} block\n"
+        text += "\n## [2026.8.0] - 2026-08-20\n"
+        frag = self.make(tmp_path, "745.fixed.md", "A bug.\n")
+        new_text, _ = cf.apply_fragments(text, [frag])
+        assert new_text.count("### Fixed") == 5
+        assert "### Fixed\n\n- A bug. (#745)\n- the first block\n" in new_text
+        assert "- the second block" in new_text
+
+    def test_an_empty_unreleased_section_gains_headings_without_double_blanks(self, tmp_path):
+        """The post-rotation state is exactly one blank line; the fold reuses it."""
+        text = (
+            "# Changelog\n\n## [Unreleased]\n\n## [2026.8.0] - 2026-08-20\n\n### Fixed\n\n- old\n"
+        )
+        frags = [
+            self.make(tmp_path, "745.added.md", "A new capability.\n"),
+            self.make(tmp_path, "746.fixed.md", "A bug.\n"),
+        ]
+        new_text, _ = cf.apply_fragments(text, frags)
+        assert new_text == (
+            "# Changelog\n"
+            "\n"
+            "## [Unreleased]\n"
+            "\n"
+            "### Added\n"
+            "\n"
+            "- A new capability. (#745)\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- A bug. (#746)\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- old\n"
+        )
+        assert "\n\n\n" not in new_text
+
+    def test_an_unreleased_section_at_the_end_of_the_file_is_folded(self, tmp_path):
+        """Nothing follows the block, so the fold supplies the blank line itself."""
+        frag = self.make(tmp_path, "745.fixed.md", "A bug.\n")
+        new_text, _ = cf.apply_fragments("# Changelog\n\n## [Unreleased]\n", [frag])
+        assert new_text == "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- A bug. (#745)\n"
+
+    def test_a_heading_with_no_blank_line_after_it_gets_one(self, tmp_path):
+        text = "## [Unreleased]\n### Fixed\n- an entry that was already here\n"
+        frag = self.make(tmp_path, "745.fixed.md", "A bug.\n")
+        new_text, _ = cf.apply_fragments(text, [frag])
+        assert new_text == (
+            "## [Unreleased]\n### Fixed\n\n- A bug. (#745)\n- an entry that was already here\n"
+        )
+
+    def test_an_internal_fragment_renders_nothing_and_creates_no_heading(self, tmp_path):
+        frag = self.make(tmp_path, "745.internal.md", "Refactored the loader.\n")
+        new_text, report = cf.apply_fragments(self.CHANGELOG, [frag])
+        assert new_text == self.CHANGELOG
+        assert report == ["changelog.d/745.internal.md -> internal, not rendered"]
+
+    def test_an_internal_fragment_is_reported_alongside_the_rendered_ones(self, tmp_path):
+        frags = [
+            self.make(tmp_path, "745.internal.md", "Refactored the loader.\n"),
+            self.make(tmp_path, "746.changed.md", "Different behaviour.\n"),
+        ]
+        new_text, report = cf.apply_fragments(self.CHANGELOG, frags)
+        assert "Refactored the loader" not in new_text
+        assert report == [
+            "changelog.d/746.changed.md -> ### Changed (#746)",
+            "changelog.d/745.internal.md -> internal, not rendered",
+        ]
+
+    def test_a_slug_fragment_is_reported_without_a_ref(self, tmp_path):
+        frag = self.make(tmp_path, "gate.changed.md", "Something with no issue behind it.\n")
+        _, report = cf.apply_fragments(self.CHANGELOG, [frag])
+        assert report == ["changelog.d/gate.changed.md -> ### Changed"]
+
+    def test_an_empty_fragment_list_changes_nothing(self):
+        assert cf.apply_fragments(self.CHANGELOG, []) == (self.CHANGELOG, [])
+
+    def test_a_changelog_without_the_unreleased_heading_raises(self, tmp_path):
+        frag = self.make(tmp_path, "745.fixed.md", "A bug.\n")
+        with pytest.raises(cf.FragmentError) as excinfo:
+            cf.apply_fragments("# Changelog\n\n## [2026.8.0] - 2026-08-20\n", [frag])
+        assert "no ## [Unreleased] heading" in str(excinfo.value)
+
+    def test_bullets_within_a_heading_are_ordered_by_filename(self, tmp_path):
+        """A plain string sort — `115` before `745`, digits before letters."""
+        frags = [
+            self.make(tmp_path, "802.fixed.md", "Third.\n"),
+            self.make(tmp_path, "745.fixed.md", "Second.\n"),
+            self.make(tmp_path, "gate.fixed.md", "Fourth.\n"),
+            self.make(tmp_path, "115.fixed.md", "First.\n"),
+        ]
+        new_text, report = cf.apply_fragments(self.CHANGELOG, frags)
+        assert "### Fixed\n\n- First. (#115)\n- Second. (#745)\n- Third. (#802)\n- Fourth.\n" in (
+            new_text
+        )
+        assert report == [
+            "changelog.d/115.fixed.md -> ### Fixed (#115)",
+            "changelog.d/745.fixed.md -> ### Fixed (#745)",
+            "changelog.d/802.fixed.md -> ### Fixed (#802)",
+            "changelog.d/gate.fixed.md -> ### Fixed",
+        ]
+
+    def test_a_trailing_newline_does_not_separate_two_bullets(self, tmp_path):
+        """`normalize_lines` already trimmed it; the fold must not put it back."""
+        frags = [
+            self.make(tmp_path, "745.changed.md", "First.\n\n\n"),
+            self.make(tmp_path, "746.changed.md", "Second.\n"),
+        ]
+        new_text, _ = cf.apply_fragments(self.CHANGELOG, frags)
+        assert "- First. (#745)\n- Second. (#746)\n- an entry that was already here\n" in new_text
+
+    def test_a_multi_line_body_keeps_its_shape_inside_the_block(self, tmp_path):
+        body = "A lead-in that wraps onto\na second line.\n\n- a sub-bullet\n"
+        frag = self.make(tmp_path, "745.changed.md", body)
+        new_text, _ = cf.apply_fragments(self.CHANGELOG, [frag])
+        assert new_text == (
+            "# Changelog\n"
+            "\n"
+            "## [Unreleased]\n"
+            "\n"
+            "### Changed\n"
+            "\n"
+            "- A lead-in that wraps onto\n"
+            "  a second line. (#745)\n"
+            "\n"
+            "  - a sub-bullet\n"
+            "- an entry that was already here\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- something in the last release\n"
+        )
+
+    def test_crlf_input_comes_back_as_lf(self, tmp_path):
+        frag = self.make(tmp_path, "745.changed.md", "The fold writes the bullet.\n")
+        new_text, _ = cf.apply_fragments(self.CHANGELOG.replace("\n", "\r\n"), [frag])
+        assert "\r" not in new_text
+        assert new_text.endswith("- something in the last release\n")
+
+    EMPTY_HEADING = (
+        "# Changelog\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+        "### Fixed\n"
+        "\n"
+        "## [2026.8.0] - 2026-08-20\n"
+        "\n"
+        "### Fixed\n"
+        "\n"
+        "- something in the last release\n"
+    )
+
+    def test_a_heading_with_no_bullets_keeps_its_blank_line_below(self, tmp_path):
+        """A shape the fold never creates but a hand-edit can leave behind."""
+        fragment = self.make(tmp_path, "745.fixed.md", "A bug.\n")
+        new_text, _ = cf.apply_fragments(self.EMPTY_HEADING, [fragment])
+        assert new_text == (
+            "# Changelog\n"
+            "\n"
+            "## [Unreleased]\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- A bug. (#745)\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- something in the last release\n"
+        )
+
+
+class TestNeedsFragment:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/osprey/cli/build.py",
+            "packages/osprey-edu/pyproject.toml",
+            "src/",
+            "packages/deep/nested/file.py",
+        ],
+    )
+    def test_a_path_under_a_gated_directory_needs_one(self, path):
+        assert cf.needs_fragment([path]) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "srcs/x.py",  # the prefix is a directory, not a string
+            "docs/source/x.rst",  # `source` is not `src/`
+            "src",  # the directory itself, unslashed
+            "packages",
+            "tests/src/x.py",  # gated only at the repo root
+            "CHANGELOG.md",
+        ],
+    )
+    def test_a_path_outside_them_does_not(self, path):
+        assert cf.needs_fragment([path]) is False
+
+    def test_one_gated_path_among_many_is_enough(self):
+        assert cf.needs_fragment(["docs/a.rst", "tests/b.py", "src/c.py"]) is True
+
+    def test_an_empty_diff_needs_nothing(self):
+        assert cf.needs_fragment([]) is False
+
+
+class TestGateFailures:
+    """The three PR-shape rules, exercised without a git repository.
+
+    Every case is a diff shape the gate will actually meet: a normal PR, a
+    correction PR, the release PR's own rotation. The messages are pinned by
+    substring rather than in full — they are prose meant for a human who is
+    already stuck, and the parts that matter are the ones that tell them what
+    to do next.
+    """
+
+    EXISTING = "\n### Fixed\n\n- an entry that was already here\n\n"
+    EMPTY = "\n"
+
+    @staticmethod
+    def changelog(block: str) -> str:
+        """A changelog whose ``[Unreleased]`` block is exactly *block*."""
+        return (
+            "# Changelog\n"
+            "\n"
+            "## [Unreleased]\n"
+            f"{block}"
+            "## [2026.8.0] - 2026-08-20\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- something in the last release\n"
+        )
+
+    @staticmethod
+    def rotated() -> str:
+        """The head of a release PR: `[Unreleased]` emptied INTO a new section.
+
+        This is the shape the deletion exemption keys on. An empty block by
+        itself is the steady state of every PR once fragments carry the
+        changelog, so what marks the release is the dated heading it cuts.
+        """
+        return (
+            "# Changelog\n"
+            "\n"
+            "## [Unreleased]\n"
+            "\n"
+            "## [2026.9.0] - 2026-09-01\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- an entry that was already here\n"
+            "\n"
+            "## [2026.8.0] - 2026-08-20\n"
+            "\n"
+            "### Fixed\n"
+            "\n"
+            "- something in the last release\n"
+        )
+
+    # ---- rule 3: a gated change needs a fragment -------------------------
+
+    def test_a_gated_change_with_a_fragment_passes(self):
+        text = self.changelog(self.EXISTING)
+        failures, ok_lines = cf.gate_failures(
+            ["src/osprey/cli/build.py", "changelog.d/745.fixed.md"],
+            ["changelog.d/745.fixed.md"],
+            [],
+            text,
+            text,
+        )
+        assert failures == []
+        assert ok_lines == [
+            "✓ changelog gate: changelog.d/745.fixed.md added for 1 changed file(s) "
+            "under src/, packages/",
+            "✓ [Unreleased]: untouched",
+        ]
+
+    def test_a_gated_change_without_a_fragment_fails(self):
+        text = self.changelog(self.EXISTING)
+        failures, ok_lines = cf.gate_failures(["src/osprey/cli/build.py"], [], [], text, text)
+        assert len(failures) == 1
+        message = failures[0]
+        assert "src/osprey/cli/build.py" in message
+        assert "changelog.d/<name>.<type>.md" in message
+        for type_ in cf.TYPES:
+            assert type_ in message
+        assert "the gate reads committed history — an unstaged fragment does not count" in message
+        assert ok_lines == ["✓ [Unreleased]: untouched"]
+
+    def test_the_failure_lists_five_paths_and_counts_the_rest(self):
+        text = self.changelog(self.EXISTING)
+        changed = [f"src/osprey/mod{index}.py" for index in range(8)]
+        failures, _ = cf.gate_failures(changed, [], [], text, text)
+        message = failures[0]
+        assert "8 changed file(s)" in message
+        for path in changed[:5]:
+            assert path in message
+        assert changed[5] not in message
+        assert "+3 more" in message
+
+    def test_a_pre_existing_fragment_does_not_satisfy_the_gate(self):
+        """The fragment has to be *added* by this PR, not merely present."""
+        text = self.changelog(self.EXISTING)
+        failures, _ = cf.gate_failures(["src/osprey/a.py"], [], [], text, text)
+        assert len(failures) == 1
+        assert "no changelog fragment" in failures[0]
+
+    def test_a_modified_fragment_does_not_satisfy_the_gate(self):
+        text = self.changelog(self.EXISTING)
+        failures, _ = cf.gate_failures(
+            ["src/osprey/a.py", "changelog.d/745.fixed.md"], [], [], text, text
+        )
+        assert len(failures) == 1
+
+    @pytest.mark.parametrize(
+        "added",
+        [
+            ["changelog.d/745.Fixed.md"],  # the type is lower-case only
+            ["changelog.d/README.md"],  # never a fragment
+            ["changelog.d/sub/745.fixed.md"],  # the directory is flat
+            ["changelog.doc/745.fixed.md"],  # a different directory
+            ["745.fixed.md"],  # not in changelog.d/ at all
+        ],
+    )
+    def test_an_added_file_that_is_not_a_fragment_does_not_satisfy_the_gate(self, added):
+        text = self.changelog(self.EXISTING)
+        failures, _ = cf.gate_failures(["src/osprey/a.py"], added, [], text, text)
+        assert len(failures) == 1
+        assert "no changelog fragment" in failures[0]
+
+    def test_an_unknown_type_is_left_to_the_validator(self):
+        """Rule 3 asks only that the *name* be a fragment name.
+
+        `745.tweaked.md` matches the grammar, so the gate stops complaining
+        about a missing fragment — and `validate_dir` fails the same run with
+        the vocabulary, which is the message the contributor needs. Checking
+        the type here as well would print two failures for one typo.
+        """
+        text = self.changelog(self.EXISTING)
+        failures, ok_lines = cf.gate_failures(
+            ["src/osprey/a.py"], ["changelog.d/745.tweaked.md"], [], text, text
+        )
+        assert failures == []
+        assert ok_lines[0].startswith("✓ changelog gate: changelog.d/745.tweaked.md added")
+
+    def test_an_internal_fragment_satisfies_the_gate(self):
+        """A refactor passes honestly instead of inventing a user-facing sentence."""
+        text = self.changelog(self.EXISTING)
+        failures, ok_lines = cf.gate_failures(
+            ["src/osprey/a.py"], ["changelog.d/745.internal.md"], [], text, text
+        )
+        assert failures == []
+        assert ok_lines[0].startswith("✓ changelog gate: changelog.d/745.internal.md added")
+
+    def test_the_ok_line_names_the_first_fragment_in_filename_order(self):
+        text = self.changelog(self.EXISTING)
+        _, ok_lines = cf.gate_failures(
+            ["src/a.py", "packages/b.py"],
+            ["changelog.d/746.added.md", "changelog.d/115.fixed.md"],
+            [],
+            text,
+            text,
+        )
+        assert ok_lines[0] == (
+            "✓ changelog gate: changelog.d/115.fixed.md added for 2 changed file(s) "
+            "under src/, packages/"
+        )
+
+    def test_no_gated_change_requires_no_fragment(self):
+        text = self.changelog(self.EXISTING)
+        failures, ok_lines = cf.gate_failures(
+            ["docs/source/index.rst", "tests/a.py"], [], [], text, text
+        )
+        assert failures == []
+        assert ok_lines == [
+            "✓ changelog gate: no src/ or packages/ changes — no fragment required",
+            "✓ [Unreleased]: untouched",
+        ]
+
+    # ---- rule 4: nobody writes [Unreleased] by hand -----------------------
+
+    def test_a_hand_written_bullet_fails(self):
+        base = self.changelog(self.EXISTING)
+        head = self.changelog(
+            "\n### Fixed\n\n- a bullet added by hand\n- an entry that was already here\n\n"
+        )
+        failures, _ = cf.gate_failures(
+            ["src/osprey/a.py", "CHANGELOG.md"],
+            ["changelog.d/745.fixed.md"],
+            [],
+            head,
+            base,
+        )
+        assert len(failures) == 1
+        assert "adds to ## [Unreleased] by hand" in failures[0]
+        assert "changelog.d/<name>.<type>.md" in failures[0]
+        assert "CHANGELOG-only PR" in failures[0]
+
+    def test_an_edit_outside_the_block_passes(self):
+        """The preamble sentence this feature adds is outside the block."""
+        base = self.changelog(self.EXISTING)
+        head = base.replace("# Changelog\n", "# Changelog\n\nFragments live in changelog.d/.\n")
+        failures, ok_lines = cf.gate_failures(
+            ["src/osprey/a.py", "CHANGELOG.md"],
+            ["changelog.d/745.fixed.md"],
+            [],
+            head,
+            base,
+        )
+        assert failures == []
+        assert ok_lines[1] == "✓ [Unreleased]: untouched"
+
+    def test_a_head_without_the_heading_fails(self):
+        base = self.changelog(self.EXISTING)
+        head = "# Changelog\n\n## [2026.8.0] - 2026-08-20\n\n- something\n"
+        failures, ok_lines = cf.gate_failures(["docs/a.rst"], [], [], head, base)
+        assert len(failures) == 1
+        assert "## [Unreleased]" in failures[0]
+        assert not any("[Unreleased]:" in line for line in ok_lines)
+
+    def test_an_emptied_block_is_the_release_rotation(self):
+        base = self.changelog(self.EXISTING)
+        head = self.rotated()
+        failures, ok_lines = cf.gate_failures(["CHANGELOG.md"], [], [], head, base)
+        assert failures == []
+        assert ok_lines[1] == "✓ [Unreleased]: empty (rotation)"
+
+    def test_emptying_the_block_without_cutting_a_release_is_not_a_rotation(self):
+        """An empty block alone proves nothing — every PR has one between releases."""
+        base = self.changelog(self.EXISTING)
+        head = self.changelog(self.EMPTY)
+        failures, _ = cf.gate_failures(
+            ["CHANGELOG.md", "src/osprey/a.py"],
+            ["changelog.d/745.fixed.md"],
+            [],
+            head,
+            base,
+        )
+        assert len(failures) == 1
+        assert "adds to ## [Unreleased] by hand" in failures[0]
+
+    def test_a_changelog_only_correction_passes(self):
+        base = self.changelog(self.EXISTING)
+        head = self.changelog("\n### Fixed\n\n- an entry that was already here, reworded\n\n")
+        failures, ok_lines = cf.gate_failures(["CHANGELOG.md"], [], [], head, base)
+        assert failures == []
+        assert ok_lines[1] == "✓ [Unreleased]: changelog-only correction"
+
+    def test_a_changelog_only_removal_passes(self):
+        base = self.changelog(self.EXISTING)
+        head = self.changelog("\n### Fixed\n\n")
+        failures, ok_lines = cf.gate_failures(["CHANGELOG.md"], [], [], head, base)
+        assert failures == []
+        assert ok_lines[1] == "✓ [Unreleased]: changelog-only correction"
+
+    def test_a_changelog_only_addition_fails(self):
+        base = self.changelog(self.EXISTING)
+        head = self.changelog("\n### Fixed\n\n- an entry that was already here\n- a new one\n\n")
+        failures, _ = cf.gate_failures(["CHANGELOG.md"], [], [], head, base)
+        assert len(failures) == 1
+        assert "adds to ## [Unreleased] by hand" in failures[0]
+
+    def test_delete_one_add_one_in_a_changelog_only_pr_passes(self):
+        """Named residual: a correction-shaped edit the bullet count cannot tell apart."""
+        base = self.changelog(self.EXISTING)
+        head = self.changelog("\n### Fixed\n\n- an entirely different entry\n\n")
+        failures, ok_lines = cf.gate_failures(["CHANGELOG.md"], [], [], head, base)
+        assert failures == []
+        assert ok_lines[1] == "✓ [Unreleased]: changelog-only correction"
+
+    def test_a_correction_alongside_another_file_fails(self):
+        """The exemption is for a CHANGELOG-only PR, and nothing else."""
+        base = self.changelog(self.EXISTING)
+        head = self.changelog("\n### Fixed\n\n- an entry that was already here, reworded\n\n")
+        failures, _ = cf.gate_failures(
+            ["CHANGELOG.md", "src/osprey/a.py"],
+            ["changelog.d/745.fixed.md"],
+            [],
+            head,
+            base,
+        )
+        assert len(failures) == 1
+        assert "adds to ## [Unreleased] by hand" in failures[0]
+
+    def test_an_absent_base_changelog_compares_against_an_empty_block(self):
+        head = self.changelog(self.EXISTING)
+        failures, _ = cf.gate_failures(
+            ["src/osprey/a.py"], ["changelog.d/745.fixed.md"], [], head, ""
+        )
+        assert len(failures) == 1
+        assert "adds to ## [Unreleased] by hand" in failures[0]
+
+    def test_an_absent_base_changelog_still_recognizes_a_rotation(self):
+        head = self.changelog(self.EMPTY)
+        failures, ok_lines = cf.gate_failures(["CHANGELOG.md"], [], [], head, "")
+        assert failures == []
+        assert ok_lines[1] == "✓ [Unreleased]: empty (rotation)"
+
+    # ---- rule 5: only the release fold deletes fragments -------------------
+
+    def test_deleting_a_fragment_fails(self):
+        text = self.changelog(self.EXISTING)
+        failures, _ = cf.gate_failures(
+            ["changelog.d/745.fixed.md"], [], ["changelog.d/745.fixed.md"], text, text
+        )
+        assert len(failures) == 1
+        assert "only the release PR's apply removes fragments" in failures[0]
+        assert "changelog.d/745.fixed.md" in failures[0]
+
+    def test_deleting_the_readme_is_not_a_fragment_deletion(self):
+        text = self.changelog(self.EXISTING)
+        failures, _ = cf.gate_failures(
+            ["changelog.d/README.md"], [], ["changelog.d/README.md"], text, text
+        )
+        assert failures == []
+
+    def test_the_release_pr_may_delete_fragments(self):
+        base = self.changelog(self.EXISTING)
+        head = self.rotated()
+        changed = [
+            "CHANGELOG.md",
+            "RELEASE_NOTES.md",
+            "README.md",
+            "changelog.d/745.fixed.md",
+            "changelog.d/gate.security.md",
+        ]
+        deleted = ["changelog.d/745.fixed.md", "changelog.d/gate.security.md"]
+        failures, ok_lines = cf.gate_failures(changed, [], deleted, head, base)
+        assert failures == []
+        assert ok_lines == [
+            "✓ changelog gate: no src/ or packages/ changes — no fragment required",
+            "✓ [Unreleased]: empty (rotation)",
+        ]
+
+    def test_an_empty_unreleased_does_not_exempt_a_deletion(self):
+        """The steady state, and the one the old head-only predicate let through.
+
+        Once fragments carry the changelog, `[Unreleased]` is empty on every
+        PR. A feature PR that also deletes somebody else's fragment must not
+        be read as the release.
+        """
+        text = self.changelog(self.EMPTY)
+        failures, ok_lines = cf.gate_failures(
+            ["src/osprey/a.py", "changelog.d/745.fixed.md", "changelog.d/other.fixed.md"],
+            ["changelog.d/745.fixed.md"],
+            ["changelog.d/other.fixed.md"],
+            text,
+            text,
+        )
+        assert len(failures) == 1
+        assert "only the release PR's apply removes fragments" in failures[0]
+        assert "changelog.d/other.fixed.md" in failures[0]
+        assert ok_lines[1] == "✓ [Unreleased]: untouched"
+
+    def test_the_release_pr_passes_when_the_base_block_is_already_empty(self):
+        """The release cut from the steady state: both blocks empty, one new section."""
+        base = self.changelog(self.EMPTY)
+        head = self.rotated()
+        deleted = ["changelog.d/745.fixed.md", "changelog.d/gate.security.md"]
+        failures, ok_lines = cf.gate_failures(["CHANGELOG.md", *deleted], [], deleted, head, base)
+        assert failures == []
+        # The blocks are byte-identical, so rule 4 says "untouched" — but the
+        # new release heading is what lets rule 5 through.
+        assert ok_lines[1] == "✓ [Unreleased]: untouched"
+
+    def test_all_three_rules_can_fail_at_once(self):
+        base = self.changelog(self.EXISTING)
+        head = self.changelog(
+            "\n### Fixed\n\n- a bullet added by hand\n- an entry that was already here\n\n"
+        )
+        failures, _ = cf.gate_failures(
+            ["src/osprey/a.py", "CHANGELOG.md", "changelog.d/745.fixed.md"],
+            [],
+            ["changelog.d/745.fixed.md"],
+            head,
+            base,
+        )
+        assert len(failures) == 3
+        assert "no changelog fragment" in failures[0]
+        assert "adds to ## [Unreleased] by hand" in failures[1]
+        assert "only the release PR's apply removes fragments" in failures[2]
+
+
+# ---------------------------------------------------------------------------
+# The CLI. Git is answered from a table, so nothing below builds a repository.
+# ---------------------------------------------------------------------------
+
+BASE_SHA = "a" * 40
+MERGE_BASE = "b" * 40
+
+CHANGELOG = (
+    "# Changelog\n"
+    "\n"
+    "## [Unreleased]\n"
+    "\n"
+    "### Fixed\n"
+    "\n"
+    "- an entry that was already here\n"
+    "\n"
+    "## [2026.8.0] - 2026-08-20\n"
+    "\n"
+    "### Fixed\n"
+    "\n"
+    "- something in the last release\n"
+)
+
+
+def completed(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    """One finished git call."""
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+
+class FakeGit:
+    """git as a lookup table, recording what it was asked.
+
+    Anything the table does not answer comes back the way git does for a
+    revision it cannot resolve, so a test that forgets an entry fails on the
+    exit code rather than on a KeyError.
+    """
+
+    def __init__(self, table: dict[tuple[str, ...], subprocess.CompletedProcess[str]]):
+        self.table = table
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(argv))
+        return self.table.get(tuple(argv), completed(returncode=128, stderr="fatal: bad revision"))
+
+
+def git_table(
+    *,
+    diff: str = "",
+    base_text: str = CHANGELOG,
+    ref: str = "origin/main",
+) -> dict[tuple[str, ...], subprocess.CompletedProcess[str]]:
+    """A table for one green ``check``: base resolves, merge base, diff, show."""
+    return {
+        ("git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"): completed(
+            f"{BASE_SHA}\n"
+        ),
+        ("git", "merge-base", BASE_SHA, "HEAD"): completed(f"{MERGE_BASE}\n"),
+        ("git", "diff", "--name-status", "-z", "--no-renames", MERGE_BASE, "HEAD"): completed(diff),
+        ("git", "show", f"{MERGE_BASE}:CHANGELOG.md"): completed(base_text),
+    }
+
+
+def diff_z(*pairs: tuple[str, str]) -> str:
+    """``git diff --name-status -z`` output for *pairs* of ``(status, path)``."""
+    return "".join(f"{status}\0{path}\0" for status, path in pairs)
+
+
+class TestResolveBase:
+    """Which spelling of the base ref is tried, and in which order.
+
+    In a fresh CI checkout the only copy of `main` is `origin/main`, and on a
+    developer's machine `HEAD~1` must not be looked for under `origin/`. One
+    rule covers both, and its edges are what these tests pin.
+    """
+
+    @staticmethod
+    def rev_parse(ref: str) -> tuple[str, ...]:
+        return ("git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}")
+
+    def test_a_plain_name_is_looked_for_under_origin_first(self):
+        git = FakeGit({self.rev_parse("origin/main"): completed(f"{BASE_SHA}\n")})
+        assert cf.resolve_base("main", git) == BASE_SHA
+        assert git.calls == [list(self.rev_parse("origin/main"))]
+
+    def test_a_plain_name_falls_back_to_the_local_branch(self):
+        git = FakeGit({self.rev_parse("main"): completed(f"{BASE_SHA}\n")})
+        assert cf.resolve_base("main", git) == BASE_SHA
+        assert [call[-1] for call in git.calls] == ["origin/main^{commit}", "main^{commit}"]
+
+    def test_an_already_qualified_ref_is_tried_as_given(self):
+        git = FakeGit({self.rev_parse("origin/main"): completed(f"{BASE_SHA}\n")})
+        assert cf.resolve_base("origin/main", git) == BASE_SHA
+        assert git.calls == [list(self.rev_parse("origin/main"))]
+
+    def test_a_revision_expression_is_tried_as_given(self):
+        """`HEAD~1` is not a branch name; `origin/HEAD~1` must not come first."""
+        git = FakeGit({self.rev_parse("HEAD~1"): completed(f"{BASE_SHA}\n")})
+        assert cf.resolve_base("HEAD~1", git) == BASE_SHA
+        assert git.calls == [list(self.rev_parse("HEAD~1"))]
+
+    def test_head_itself_is_not_treated_as_a_branch_name(self):
+        git = FakeGit({self.rev_parse("HEAD"): completed(f"{BASE_SHA}\n")})
+        assert cf.resolve_base("HEAD", git) == BASE_SHA
+        assert git.calls == [list(self.rev_parse("HEAD"))]
+
+    def test_an_unresolvable_ref_is_none_after_both_spellings(self):
+        git = FakeGit({})
+        assert cf.resolve_base("nope", git) is None
+        assert [call[-1] for call in git.calls] == ["origin/nope^{commit}", "nope^{commit}"]
+
+    def test_a_success_with_no_output_is_not_a_resolution(self):
+        """`--quiet` says nothing when it finds nothing; an empty sha is not one."""
+        git = FakeGit({self.rev_parse("origin/main"): completed("\n")})
+        assert cf.resolve_base("main", git) is None
+
+
+class TestParseNameStatus:
+    def test_pairs_are_read_two_fields_at_a_time(self):
+        assert cf.parse_name_status(diff_z(("M", "a.py"), ("A", "b.py"))) == [
+            ("M", "a.py"),
+            ("A", "b.py"),
+        ]
+
+    def test_a_path_with_a_space_survives(self):
+        """The whole reason the diff is asked for with `-z`."""
+        assert cf.parse_name_status(diff_z(("M", "src/osprey/a b.py"))) == [
+            ("M", "src/osprey/a b.py")
+        ]
+
+    def test_an_empty_diff_is_no_pairs(self):
+        assert cf.parse_name_status("") == []
+
+
+class TestMain:
+    """The two subcommands end to end, with git faked and files in tmp_path."""
+
+    @staticmethod
+    def fixture(tmp_path: Path, head_text: str = CHANGELOG) -> tuple[Path, Path]:
+        """A fragment directory and a changelog file to point the CLI at."""
+        directory = tmp_path / "changelog.d"
+        directory.mkdir()
+        (directory / "README.md").write_text("how to write one\n", encoding="utf-8")
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text(head_text, encoding="utf-8")
+        return directory, changelog
+
+    @staticmethod
+    def check_argv(directory: Path, changelog: Path, *extra: str) -> list[str]:
+        return ["check", "--dir", str(directory), "--changelog", str(changelog), *extra]
+
+    # ---- check: the environment exit code --------------------------------
+
+    def test_an_unresolvable_base_is_an_environment_error(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        code = cf.main(self.check_argv(directory, changelog), FakeGit({}))
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "base ref origin/main not found" in err
+        assert "git fetch origin <branch>" in err
+        assert "fetch-depth: 0" in err
+
+    def test_an_empty_merge_base_is_an_environment_error(self, tmp_path, capsys):
+        """A shallow clone answers `merge-base` with success and nothing else."""
+        directory, changelog = self.fixture(tmp_path)
+        table = git_table()
+        table[("git", "merge-base", BASE_SHA, "HEAD")] = completed("\n")
+        code = cf.main(self.check_argv(directory, changelog), FakeGit(table))
+        assert code == 2
+        assert (
+            "no common ancestor — shallow clone? git fetch --unshallow" in capsys.readouterr().err
+        )
+
+    def test_a_failing_merge_base_is_an_environment_error(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        table = git_table()
+        table[("git", "merge-base", BASE_SHA, "HEAD")] = completed(
+            returncode=1, stderr="fatal: refusing"
+        )
+        code = cf.main(self.check_argv(directory, changelog), FakeGit(table))
+        assert code == 2
+        assert "no common ancestor" in capsys.readouterr().err
+
+    def test_a_failing_diff_names_the_command(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        table = git_table()
+        table[("git", "diff", "--name-status", "-z", "--no-renames", MERGE_BASE, "HEAD")] = (
+            completed(returncode=128, stderr="fatal: bad object")
+        )
+        code = cf.main(self.check_argv(directory, changelog), FakeGit(table))
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "git diff --name-status -z --no-renames" in err
+        assert "fatal: bad object" in err
+
+    def test_a_failing_show_names_the_command(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        table = git_table()
+        table[("git", "show", f"{MERGE_BASE}:CHANGELOG.md")] = completed(
+            returncode=128, stderr="fatal: path does not exist"
+        )
+        code = cf.main(self.check_argv(directory, changelog), FakeGit(table))
+        assert code == 2
+        err = capsys.readouterr().err
+        assert f"git show {MERGE_BASE}:CHANGELOG.md" in err
+        assert "fatal: path does not exist" in err
+
+    # ---- check: the report -----------------------------------------------
+
+    def test_a_green_run_prints_three_lines_and_exits_zero(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        write(directory, "745.fixed.md", "the gate no longer eats the last line.\n")
+        git = FakeGit(
+            git_table(
+                diff=diff_z(("M", "src/osprey/cli/build.py"), ("A", "changelog.d/745.fixed.md"))
+            )
+        )
+        code = cf.main(self.check_argv(directory, changelog), git)
+        assert code == 0
+        assert capsys.readouterr().out.splitlines() == [
+            "✓ changelog.d: 1 fragment(s) valid",
+            "✓ changelog gate: changelog.d/745.fixed.md added for 1 changed file(s) "
+            "under src/, packages/",
+            "✓ [Unreleased]: untouched",
+        ]
+
+    def test_a_documentation_only_pull_request_needs_no_fragment(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        git = FakeGit(git_table(diff=diff_z(("M", "docs/source/index.rst"))))
+        code = cf.main(self.check_argv(directory, changelog), git)
+        assert code == 0
+        assert capsys.readouterr().out.splitlines() == [
+            "✓ changelog.d: 0 fragment(s) valid",
+            "✓ changelog gate: no src/ or packages/ changes — no fragment required",
+            "✓ [Unreleased]: untouched",
+        ]
+
+    def test_a_red_run_reports_every_offender_at_once(self, tmp_path, capsys):
+        """Four problems, one run: a contributor should not fix them one per push."""
+        head_text = CHANGELOG.replace(
+            "- an entry that was already here\n",
+            "- an entry that was already here\n- one written by hand\n",
+        )
+        directory, changelog = self.fixture(tmp_path, head_text)
+        write(directory, "745.tweaked.md", "an unknown type.\n")
+        git = FakeGit(
+            git_table(
+                diff=diff_z(("M", "src/osprey/a b.py"), ("D", "changelog.d/old.fixed.md")),
+            )
+        )
+        code = cf.main(self.check_argv(directory, changelog), git)
+        assert code == 1
+        out = capsys.readouterr().out
+        assert '✗ 745.tweaked.md: unknown type "tweaked"' in out
+        assert "✗ no changelog fragment for 1 changed file(s)" in out
+        assert "✗ this PR adds to ## [Unreleased] by hand" in out
+        assert "✗ 1 fragment(s) deleted" in out
+        # The gated path came through `-z`, and detail lines are indented by two.
+        assert "  src/osprey/a b.py" in out.splitlines()
+        assert "  changelog.d/old.fixed.md" in out.splitlines()
+
+    def test_a_malformed_fragment_fails_a_run_whose_gate_is_green(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        write(directory, "745.fixed.md", "- already a bullet\n")
+        git = FakeGit(git_table(diff=diff_z(("M", "docs/source/index.rst"))))
+        code = cf.main(self.check_argv(directory, changelog), git)
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "✗ 745.fixed.md: a fragment must open with prose" in out
+        assert "fragment(s) valid" not in out
+        assert "✓ [Unreleased]: untouched" in out
+
+    def test_the_base_ref_can_be_a_revision_expression(self, tmp_path):
+        directory, changelog = self.fixture(tmp_path)
+        git = FakeGit(git_table(ref="HEAD~1"))
+        code = cf.main(self.check_argv(directory, changelog, "--base", "HEAD~1"), git)
+        assert code == 0
+        assert git.calls[0][-1] == "HEAD~1^{commit}"
+
+    def test_a_missing_fragment_directory_is_not_an_error(self, tmp_path, capsys):
+        """A branch cut before this landed still has to be able to pass."""
+        _, changelog = self.fixture(tmp_path)
+        git = FakeGit(git_table(diff=diff_z(("M", "README.md"))))
+        code = cf.main(self.check_argv(tmp_path / "absent", changelog), git)
+        assert code == 0
+        assert "✓ changelog.d: 0 fragment(s) valid" in capsys.readouterr().out
+
+    # ---- apply ------------------------------------------------------------
+
+    def test_apply_folds_deletes_and_says_what_to_stage(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        write(directory, "745.fixed.md", "the gate no longer eats the last line.\n")
+        write(directory, "banner.added.md", "a banner naming the control target.\n")
+        write(directory, "cleanup.internal.md", "moved a helper.\n")
+
+        assert cf.main(["apply", "--changelog", str(changelog), "--dir", str(directory)]) == 0
+
+        text = changelog.read_text(encoding="utf-8")
+        assert "- the gate no longer eats the last line. (#745)" in text
+        assert "### Added\n\n- a banner naming the control target." in text
+        assert "moved a helper" not in text
+        assert sorted(path.name for path in directory.iterdir()) == ["README.md"]
+        assert capsys.readouterr().out.splitlines() == [
+            "changelog.d/banner.added.md -> ### Added",
+            "changelog.d/745.fixed.md -> ### Fixed (#745)",
+            "changelog.d/cleanup.internal.md -> internal, not rendered",
+            "stage with: git add -A changelog.d/ CHANGELOG.md",
+        ]
+
+    def test_a_second_apply_has_nothing_to_do(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        write(directory, "745.fixed.md", "the gate no longer eats the last line.\n")
+        argv = ["apply", "--changelog", str(changelog), "--dir", str(directory)]
+        assert cf.main(argv) == 0
+        before = changelog.read_text(encoding="utf-8")
+        capsys.readouterr()
+
+        assert cf.main(argv) == 0
+        assert capsys.readouterr().out == "changelog.d: no fragments; nothing to do\n"
+        assert changelog.read_text(encoding="utf-8") == before
+
+    def test_apply_refuses_a_directory_that_does_not_validate(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        bad = write(directory, "745.tweaked.md", "an unknown type.\n")
+        code = cf.main(["apply", "--changelog", str(changelog), "--dir", str(directory)])
+        assert code == 1
+        assert '✗ 745.tweaked.md: unknown type "tweaked"' in capsys.readouterr().out
+        assert bad.exists()
+        assert changelog.read_text(encoding="utf-8") == CHANGELOG
+
+    def test_apply_refuses_a_changelog_with_no_unreleased_heading(self, tmp_path, capsys):
+        """After the rotation there is nowhere to fold into — say so, keep the files."""
+        rotated = CHANGELOG.replace("## [Unreleased]\n", "## [2026.9.0] - 2026-09-01\n")
+        directory, changelog = self.fixture(tmp_path, rotated)
+        fragment = write(directory, "745.fixed.md", "the gate no longer eats the last line.\n")
+        code = cf.main(["apply", "--changelog", str(changelog), "--dir", str(directory)])
+        assert code == 1
+        assert "✗ no ## [Unreleased] heading" in capsys.readouterr().out
+        assert fragment.exists()
+        assert changelog.read_text(encoding="utf-8") == rotated
+
+    # ---- the runner, and failures that belong to the environment ----------
+
+    def test_the_default_runner_pins_utf8_and_the_repository_root(self, monkeypatch):
+        """git output carries em dashes and ✓; the ambient locale must not decide."""
+        captured: dict[str, object] = {}
+
+        def fake_run(argv, **kwargs):
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        monkeypatch.setattr(cf.subprocess, "run", fake_run)
+        cf._run(["git", "status"])
+        assert captured["encoding"] == "utf-8"
+        assert captured["text"] is True
+        assert captured["capture_output"] is True
+        assert captured["cwd"] == cf.REPO_ROOT
+
+    def test_an_environment_error_does_not_hide_the_fragment_errors(self, tmp_path, capsys):
+        """Exit 2 answers a different question; say the exit-1 problems are still there."""
+        directory, changelog = self.fixture(tmp_path)
+        write(directory, "745.tweaked.md", "an unknown type.\n")
+        code = cf.main(self.check_argv(directory, changelog), FakeGit({}))
+        assert code == 2
+        captured = capsys.readouterr()
+        assert '✗ 745.tweaked.md: unknown type "tweaked"' in captured.out
+        assert "1 fragment error(s) reported above are separate" in captured.err
+
+    def test_check_reports_a_changelog_it_cannot_decode(self, tmp_path, capsys):
+        """A changelog that is not UTF-8 is the environment's problem, not a
+        traceback — the same exit the unreadable-file case gets."""
+        directory, changelog = self.fixture(tmp_path)
+        changelog.write_bytes(b"# Changelog\n\n## [Unreleased]\n\ncaf\xe9\n")
+        code = cf.main(self.check_argv(directory, changelog), FakeGit(git_table()))
+        assert code == 2
+        assert f"cannot read {changelog}" in capsys.readouterr().err
+
+    def test_apply_reports_a_changelog_it_cannot_decode(self, tmp_path, capsys):
+        directory, changelog = self.fixture(tmp_path)
+        fragment = write(directory, "745.fixed.md", "A bug.\n")
+        changelog.write_bytes(b"# Changelog\n\n## [Unreleased]\n\ncaf\xe9\n")
+        code = cf.main(["apply", "--changelog", str(changelog), "--dir", str(directory)])
+        assert code == 2
+        assert f"cannot read {changelog}" in capsys.readouterr().err
+        assert fragment.exists()
+
+    def test_a_changelog_that_cannot_be_written_is_an_environment_error(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        directory, changelog = self.fixture(tmp_path)
+        fragment = write(directory, "745.fixed.md", "A bug.\n")
+        monkeypatch.setattr(Path, "write_text", refuse_io)
+        code = cf.main(["apply", "--changelog", str(changelog), "--dir", str(directory)])
+        assert code == 2
+        assert f"cannot write {changelog}" in capsys.readouterr().err
+        assert fragment.exists()
+
+    def test_a_fragment_that_cannot_be_deleted_is_named(self, tmp_path, capsys, monkeypatch):
+        """The changelog is already written, so a survivor would be folded in twice."""
+        directory, changelog = self.fixture(tmp_path)
+        fragment = write(directory, "745.fixed.md", "A bug.\n")
+        monkeypatch.setattr(Path, "unlink", refuse_io)
+        code = cf.main(["apply", "--changelog", str(changelog), "--dir", str(directory)])
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "1 fragment(s) could not be deleted" in err
+        assert str(fragment) in err
+        assert "- A bug. (#745)" in changelog.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The live tree. Everything below reads the real repository and writes nothing.
+# ---------------------------------------------------------------------------
+
+#: Surfaces that spell out the whole type vocabulary. A type added to `TYPES`
+#: without being documented in both of these is a type nobody knows exists.
+VOCABULARY_SURFACES = (
+    "changelog.d/README.md",
+    "src/osprey/templates/skills/osprey-contribute/SKILL.md",
+)
+
+#: Surfaces that have to send a contributor to the directory. Each one is a
+#: place where someone reads "how do I record this change?" and must not be
+#: told to edit `## [Unreleased]` by hand.
+POINTER_SURFACES = (
+    "docs/source/contributing/workflow.rst",
+    "CONTRIBUTING.md",
+    "scripts/README.md",
+    "src/osprey/templates/skills/osprey-design-philosophy/SKILL.md",
+    "src/osprey/templates/skills/osprey-release/SKILL.md",
+)
+
+
+def _surface_has(text: str, tokens: list[str]) -> bool:
+    """True when *text* contains every token in *tokens*."""
+    return all(token in text for token in tokens)
+
+
+class TestLiveTree:
+    """The documentation and the vocabulary move in lockstep, or this fails.
+
+    The gate's messages name all seven types; so must the two surfaces a
+    contributor actually reads. These assertions derive their expectations
+    from `cf.TYPES` rather than repeating it, so adding a type turns into a
+    failing test in the same commit instead of a stale README a year later.
+    Each one has a negative control, because an assertion over a 200-line
+    document passes by accident easily.
+    """
+
+    @staticmethod
+    def read(relative: str) -> str:
+        """Text of a repository file, failing by name when it has moved."""
+        path = cf.REPO_ROOT / relative
+        assert path.is_file(), f"{relative} is missing"
+        return path.read_text(encoding="utf-8")
+
+    @staticmethod
+    def vocabulary() -> list[str]:
+        """The filename token every type is documented by: `.<type>.md`."""
+        return [f".{type_}.md" for type_ in cf.TYPES]
+
+    def test_the_repositorys_own_fragments_validate(self):
+        """The directory this branch ships passes its own validator."""
+        _, errors = cf.validate_dir(cf.REPO_ROOT / cf.FRAGMENT_DIR)
+        assert errors == []
+        assert (cf.REPO_ROOT / cf.FRAGMENT_DIR / cf.KEEP).is_file()
+
+    @pytest.mark.parametrize("relative", VOCABULARY_SURFACES)
+    def test_a_vocabulary_surface_spells_out_every_type(self, relative):
+        assert _surface_has(self.read(relative), self.vocabulary())
+
+    @pytest.mark.parametrize("relative", VOCABULARY_SURFACES)
+    def test_dropping_one_type_from_a_vocabulary_surface_would_fail(self, relative):
+        text = self.read(relative)
+        for token in self.vocabulary():
+            assert _surface_has(text.replace(token, ""), self.vocabulary()) is False
+
+    @pytest.mark.parametrize("relative", POINTER_SURFACES)
+    def test_a_pointer_surface_sends_the_reader_to_the_directory(self, relative):
+        assert _surface_has(self.read(relative), [f"{cf.FRAGMENT_DIR}/"])
+
+    @pytest.mark.parametrize("relative", POINTER_SURFACES)
+    def test_dropping_the_directory_from_a_pointer_surface_would_fail(self, relative):
+        text = self.read(relative).replace(f"{cf.FRAGMENT_DIR}/", "")
+        assert _surface_has(text, [f"{cf.FRAGMENT_DIR}/"]) is False
+
+    def test_the_release_skill_folds_and_counts_what_is_on_disk(self):
+        """Step 3 has to run `apply`, and the release has to see the count."""
+        tokens = ["changelog_fragments.py apply", "fragment(s) on disk"]
+        assert _surface_has(
+            self.read("src/osprey/templates/skills/osprey-release/SKILL.md"), tokens
+        )
+
+    def test_dropping_either_release_token_would_fail(self):
+        text = self.read("src/osprey/templates/skills/osprey-release/SKILL.md")
+        tokens = ["changelog_fragments.py apply", "fragment(s) on disk"]
+        for token in tokens:
+            assert _surface_has(text.replace(token, ""), tokens) is False


### PR DESCRIPTION
Every pull request appended bullets under the single `## [Unreleased]` heading of `CHANGELOG.md`, so any two open PRs conflicted there whichever merged first. The `merge=union` driver added in #749 hides the conflict but not the class, and GitHub's server-side merge does not honor it at all.

Each change now ships one small file, `changelog.d/<ref>.<type>.md`, and `CHANGELOG.md` is never edited by hand between releases. `scripts/changelog_fragments.py check` runs in the `lint` job and in `premerge_check.sh` and enforces three rules against the PR's committed diff: a change under `src/` or `packages/` needs a fragment; `[Unreleased]` is not added to by hand (a CHANGELOG-only PR may still correct an existing bullet); and only the release removes fragments. The release is recognised by the dated section it cuts, not by an empty block — an empty block is the steady state now. `apply` folds the fragments under their `###` headings, creating missing headings at the top of the block, and deletes them; the release skill runs it right before the rotation it already performs. The script is stdlib-only so CI runs it with bare `python3` even when the dependency install is what broke.

The base ref reaches the CI step through `env:` rather than `${{ }}` inside `run:`, because a branch name is attacker-controlled text. The contributor guide, workflow page, scripts README and the bundled contribute / release / design-philosophy skills now describe the fragment instead of the hand bullet; lockstep tests derive the expected vocabulary from the script's `TYPES` so the docs cannot drift from it.

Out of scope, each named so it is not mistaken for an omission: `release.yml` (it only reads the rotated `## [VERSION]` section); the `.gitattributes` union driver, which stays until the in-flight branches that still carry hand bullets have landed and is removed in the first release PR after that; the existing `[Unreleased]` backlog with its duplicate `###` headings, the untagged `## [2026.8.0]` / `## [2026.6.3]` sections and `RELEASE_NOTES.md` at v2026.6.2; the stale "ruleset enforces checks" claim in `workflow.rst`. In-flight branches with hand-written bullets will fail the gate on rebase and must move their bullets into fragments — intended.

Fixes #745

## How it hangs together

```text
 contributor PR                          release PR
 ──────────────                          ──────────
 changelog.d/<ref>.<type>.md             osprey-release skill
        │                                       │
        ▼                                       ▼
 changelog_fragments.py check            changelog_fragments.py apply
   ├─ validate_dir  (name, type, body)     ├─ fold bullets under ### headings
   ├─ rule: src/|packages/ ⇒ fragment      ├─ create missing headings at top
   ├─ rule: [Unreleased] not hand-edited   └─ delete the fragments
   └─ rule: fragments deleted only by              │
            the release (new ## [x.y.z])           ▼
        │                                  CHANGELOG.md  ## [Unreleased]
        ├── ci.yml  lint job  (python3)            │
        └── scripts/premerge_check.sh              ▼ rotation (unchanged)
                                            ## [YYYY.MM.MICRO]
```
