### PR TITLE
feat(health): plugin runtime access and a boot hook for network homes

### DIFF
--- a/changelog.d/735.added.md
+++ b/changelog.d/735.added.md
@@ -1,0 +1,7 @@
+A health plugin category can now share the suite's control-system connector
+instead of opening its own. An `async def` category callable that declares a
+`runtime` parameter receives the run's `HealthRuntime`, so
+`await runtime.get_connector()` returns the one connector every built-in check
+already uses. Zero-argument callables are unchanged; a sync callable that
+declares `runtime` is refused with an `error` row rather than handed a
+connector it could not use.

--- a/changelog.d/738.added.md
+++ b/changelog.d/738.added.md
@@ -1,0 +1,7 @@
+`osprey scaffold systemd` also writes `scripts/osprey-boot-hook.sh`, a no-root
+fallback for hosts whose home directory is an NFS or autofs mount: it waits for
+the home and the user manager, then reloads the unit files and starts the unit.
+On such a host the command shows the `@reboot` crontab line that wires it up.
+A new `systemd_unit` health category reports a scaffolded unit the user manager
+cannot see (`not-found` after a reboot) as an `error`, and one never installed
+as a `warning`.

--- a/changelog.d/738.added.md
+++ b/changelog.d/738.added.md
@@ -1,7 +1,9 @@
-`osprey scaffold systemd` also writes `scripts/osprey-boot-hook.sh`, a no-root
-fallback for hosts whose home directory is an NFS or autofs mount: it waits for
-the home and the user manager, then reloads the unit files and starts the unit.
-On such a host the command shows the `@reboot` crontab line that wires it up.
+`osprey scaffold systemd` also writes `scripts/osprey-boot-hook.sh` for hosts
+whose home directory is an NFS or autofs mount: it waits for the home and the
+user manager, then reloads the unit files and starts the unit. On such a host
+the command prints the two crontab lines that run it at boot — `HOME=/`, so
+cron can start the job before the home is mounted, and an `@reboot` job that
+records that it fired in `/tmp` and waits for the script to become readable.
 A new `systemd_unit` health category reports a scaffolded unit the user manager
 cannot see (`not-found` after a reboot) as an `error`, and one never installed
 as a `warning`.

--- a/changelog.d/health-runtime-lock.fixed.md
+++ b/changelog.d/health-runtime-lock.fixed.md
@@ -1,0 +1,4 @@
+Two health checks that both needed the control-system connector at the same
+moment could each build one, leaving the loser of the race connected until the
+process exited. `HealthRuntime` now serializes construction so a run holds
+exactly one connector.

--- a/docs/source/contributing/extending-osprey.rst
+++ b/docs/source/contributing/extending-osprey.rst
@@ -116,9 +116,9 @@ Health plugin
 -------------
 
 Most health checks are declarative YAML. A plugin is for the ones that need
-real Python --- querying a facility service, computing a derived state. Write
-a module that exposes ``get_health_categories()``, returning a mapping of
-category name to a no-argument callable (sync or async) that produces a list of
+real Python --- querying a facility service, computing a derived state. Write a
+module that exposes ``get_health_categories()``, returning a mapping of
+category name to a callable (sync or async) that produces a list of
 ``osprey.health.models.CheckResult``, then name it under ``health.plugins`` —
 either as a dotted path to an importable module (``my_package.health_checks``)
 or as a path to a ``.py`` file (``./health/facility_checks.py``). A relative
@@ -127,10 +127,17 @@ file path is resolved against the project root, the same anchor ``data/`` and
 packaging them or setting ``PYTHONPATH``. A file loaded that way is given a
 synthetic module name derived from its path and is **re-executed** every time
 the health config is reloaded, so it must not keep state at module level.
-``osprey.health.plugins.load_plugin_categories``
-loads it, and does so fail-safe: a plugin that will not import, returns the
-wrong type, or collides with an existing category name becomes one ``error``
-row rather than a crashed suite. Pinning test:
+``osprey.health.plugins.load_plugin_categories`` loads it, and does so
+fail-safe: a plugin that will not import, returns the wrong type, or collides
+with an existing category name becomes one ``error`` row rather than a crashed
+suite. A category callable normally takes no arguments. An ``async def`` one
+may instead declare a ``runtime`` parameter and receive the suite's shared
+``osprey.health.runtime.HealthRuntime``, so ``await runtime.get_connector()``
+hands back the one control-system connector the whole run shares instead of
+opening a second Channel Access context. The runtime is valid only for that
+call. A sync callable cannot take it — it runs on a worker thread with no event
+loop — and one that declares ``runtime`` is refused with an ``error`` row
+saying to make it ``async def``. Pinning test:
 ``tests/health/test_plugins.py``. Config side:
 :doc:`/how-to/health-and-monitoring/configure-health-checks`.
 

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -710,26 +710,28 @@ root is available, the same run has already written the other route:
 ``scripts/osprey-boot-hook.sh``, beside the unit. It waits for the home, the
 deployment and the user manager to appear, then reloads the unit files and
 starts the unit — the script an affected site otherwise ends up writing by
-hand. Wire it into the account's own crontab with the two lines the command
-prints, pasted whole:
+hand. Wire it into the account's own crontab with the lines the command
+prints, all of them, pasted whole:
 
 .. code-block:: bash
 
    crontab -e
+   SHELL=/bin/sh
    HOME=/
-   @reboot echo "$(date) osprey-boot-hook: cron fired" >> /tmp/osprey-boot-hook.$(id -u).log; n=0; until [ -x /path/to/repo/scripts/osprey-boot-hook.sh ] || [ $n -ge 120 ]; do sleep 5; n=$((n+1)); done; if [ -x /path/to/repo/scripts/osprey-boot-hook.sh ]; then exec /path/to/repo/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /path/to/repo/scripts/osprey-boot-hook.sh never appeared" | tee -a /tmp/osprey-boot-hook.$(id -u).log
+   @reboot d=/tmp/osprey-boot-hook.$(id -u); mkdir -m 700 "$d" 2>/dev/null; if [ -d "$d" ] && [ ! -L "$d" ] && [ -O "$d" ]; then log=/tmp/osprey-boot-hook.$(id -u)/boot.log; else log=/dev/null; fi; echo "$(date) osprey-boot-hook: cron fired" >> "$log"; n=0; until [ -x /path/to/repo/scripts/osprey-boot-hook.sh ] || [ $n -ge 120 ]; do sleep 5; n=$((n+1)); done; if [ -x /path/to/repo/scripts/osprey-boot-hook.sh ]; then exec /path/to/repo/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /path/to/repo/scripts/osprey-boot-hook.sh never appeared" | tee -a "$log"
 
 The job is deliberately not a bare ``@reboot`` with the script's path, because
 two things happen before a cron job's command runs and each one kills the job
 silently on this kind of host. cron changes into the crontab's ``HOME`` first
 and dies, with no mail, when that directory is not there yet — ``HOME=/``
-gives it one that is, and the script restores the real home as its first act.
-Then ``sh`` has to read the script, which sits on the same late mount; so the
+gives it one that is, ``SHELL=/bin/sh`` names the shell the job is written
+for whatever an existing crontab set above, and the script restores the real
+home as its first act. Then ``sh`` has to read the script, which sits on the same late mount; so the
 job, which lives in the crontab on the local disk, notes that cron fired it in
-``/tmp/osprey-boot-hook.<uid>.log`` and waits for the script to become
+``/tmp/osprey-boot-hook.<uid>/boot.log`` and waits for the script to become
 readable before running it. That log is the first place to look after a boot
 that did not come back: it splits "cron never fired" from "still waiting for
-the home" from "the hook ran and said why". Put the two lines last in the
+the home" from "the hook ran and said why". Put the lines last in the
 crontab: every job below them runs from ``/`` and sees ``HOME=/`` in its
 environment, so a job body that expands ``$HOME`` breaks silently unless it
 starts with its own ``export HOME=<the real home>``.

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -683,8 +683,10 @@ reads as ``not-found``, and ``podman.socket`` with it, until somebody runs
 ``systemctl --user daemon-reload`` by hand. It looks like a broken unit and it
 is a mount-ordering problem.
 
-Ordering the user manager after the mount is a drop-in on ``user@<uid>.service``,
-which OSPREY cannot install for you because it needs root:
+When systemd manages the mount itself — an fstab entry, or a ``.mount`` or
+``.automount`` unit — ordering the user manager after it is a drop-in on
+``user@<uid>.service``, which OSPREY cannot install for you because it needs
+root:
 
 .. code-block:: ini
 
@@ -698,21 +700,41 @@ your own uid and home directory already filled in, ready to hand to whoever
 administers the host. On a local home — or on a host with no ``findmnt``, where
 there is no way to tell — it prints nothing extra.
 
-When nobody with root is available, the same run has already written the
-fallback: ``scripts/osprey-boot-hook.sh``, beside the unit. It waits for the
-home, the deployment and the user manager to appear, then reloads the unit
-files and starts the unit — the script an affected site otherwise ends up
-writing by hand. Wire it into the account's own crontab:
+That drop-in does nothing for a home served by the autofs daemon
+(``automount(8)``): there is no systemd mount unit for ``RequiresMountsFor`` to
+order against, so the manager starts exactly as before. ``findmnt`` reports
+``autofs`` for a systemd automount as well, so the command cannot tell the two
+apart — check ``systemctl list-units -t mount,automount`` for your home to know
+which you have. For a daemon-managed home, and for any host where nobody with
+root is available, the same run has already written the other route:
+``scripts/osprey-boot-hook.sh``, beside the unit. It waits for the home, the
+deployment and the user manager to appear, then reloads the unit files and
+starts the unit — the script an affected site otherwise ends up writing by
+hand. Wire it into the account's own crontab with the two lines the command
+prints, pasted whole:
 
 .. code-block:: bash
 
    crontab -e
-   @reboot /path/to/repo/scripts/osprey-boot-hook.sh
+   HOME=/
+   @reboot echo "$(date) osprey-boot-hook: cron fired" >> /tmp/osprey-boot-hook.$(id -u).log; n=0; until [ -x /path/to/repo/scripts/osprey-boot-hook.sh ] || [ $n -ge 60 ]; do sleep 5; n=$((n+1)); done; if [ -x /path/to/repo/scripts/osprey-boot-hook.sh ]; then exec /path/to/repo/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /path/to/repo/scripts/osprey-boot-hook.sh never appeared" >> /tmp/osprey-boot-hook.$(id -u).log
 
-It repairs each boot after the fact rather than ordering the manager
-correctly in the first place, so it is a fallback, not a replacement for the
-drop-in. cron mails the account whatever the hook prints, so a boot that
-did not come back says why.
+The job is deliberately not a bare ``@reboot`` with the script's path, because
+two things happen before a cron job's command runs and each one kills the job
+silently on this kind of host. cron changes into the crontab's ``HOME`` first
+and dies, with no mail, when that directory is not there yet — ``HOME=/``
+gives it one that is, and the script restores the real home as its first act.
+Then ``sh`` has to read the script, which sits on the same late mount; so the
+job, which lives in the crontab on the local disk, notes that cron fired it in
+``/tmp/osprey-boot-hook.<uid>.log`` and waits for the script to become
+readable before running it. That log is the first place to look after a boot
+that did not come back: it splits "cron never fired" from "still waiting for
+the home" from "the hook ran and said why". Put the two lines last in the
+crontab, or every job below them runs from ``/`` too.
+
+Where the drop-in applies, the hook repairs each boot after the fact rather
+than ordering the manager correctly in the first place, so there it is a
+fallback, not a replacement.
 
 ``osprey health`` reports this condition too: the ``systemd_unit`` category
 is ``error`` when the unit is installed but the user manager reports it

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -623,8 +623,9 @@ systemd user unit that does it for you.
 
    osprey scaffold systemd
 
-It writes ``osprey.service`` at the repository root and prints the commands that
-install it on this machine:
+It writes ``osprey.service`` at the repository root — and, beside it,
+``scripts/osprey-boot-hook.sh``, covered below — and prints the commands that
+install the unit on this machine:
 
 .. code-block:: bash
 
@@ -696,6 +697,27 @@ Followed by ``sudo systemctl daemon-reload``. The command prints that file with
 your own uid and home directory already filled in, ready to hand to whoever
 administers the host. On a local home — or on a host with no ``findmnt``, where
 there is no way to tell — it prints nothing extra.
+
+When nobody with root is available, the same run has already written the
+fallback: ``scripts/osprey-boot-hook.sh``, beside the unit. It waits for the
+home, the deployment and the user manager to appear, then reloads the unit
+files and starts the unit — the script an affected site otherwise ends up
+writing by hand. Wire it into the account's own crontab:
+
+.. code-block:: bash
+
+   crontab -e
+   @reboot /path/to/repo/scripts/osprey-boot-hook.sh
+
+It repairs each boot after the fact rather than ordering the manager
+correctly in the first place, so it is a fallback, not a replacement for the
+drop-in. cron mails the account whatever the hook prints, so a boot that
+did not come back says why.
+
+``osprey health`` reports this condition too: the ``systemd_unit`` category
+is ``error`` when the unit is installed but the user manager reports it
+``not-found``, ``warning`` when it was scaffolded but never installed, and
+a skip on any host without a scaffolded unit or a user manager.
 
 Why the unit runs ``osprey`` and not compose
 --------------------------------------------

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -717,7 +717,7 @@ prints, pasted whole:
 
    crontab -e
    HOME=/
-   @reboot echo "$(date) osprey-boot-hook: cron fired" >> /tmp/osprey-boot-hook.$(id -u).log; n=0; until [ -x /path/to/repo/scripts/osprey-boot-hook.sh ] || [ $n -ge 60 ]; do sleep 5; n=$((n+1)); done; if [ -x /path/to/repo/scripts/osprey-boot-hook.sh ]; then exec /path/to/repo/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /path/to/repo/scripts/osprey-boot-hook.sh never appeared" >> /tmp/osprey-boot-hook.$(id -u).log
+   @reboot echo "$(date) osprey-boot-hook: cron fired" >> /tmp/osprey-boot-hook.$(id -u).log; n=0; until [ -x /path/to/repo/scripts/osprey-boot-hook.sh ] || [ $n -ge 120 ]; do sleep 5; n=$((n+1)); done; if [ -x /path/to/repo/scripts/osprey-boot-hook.sh ]; then exec /path/to/repo/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /path/to/repo/scripts/osprey-boot-hook.sh never appeared" | tee -a /tmp/osprey-boot-hook.$(id -u).log
 
 The job is deliberately not a bare ``@reboot`` with the script's path, because
 two things happen before a cron job's command runs and each one kills the job
@@ -730,7 +730,9 @@ job, which lives in the crontab on the local disk, notes that cron fired it in
 readable before running it. That log is the first place to look after a boot
 that did not come back: it splits "cron never fired" from "still waiting for
 the home" from "the hook ran and said why". Put the two lines last in the
-crontab, or every job below them runs from ``/`` too.
+crontab: every job below them runs from ``/`` and sees ``HOME=/`` in its
+environment, so a job body that expands ``$HOME`` breaks silently unless it
+starts with its own ``export HOME=<the real home>``.
 
 Where the drop-in applies, the hook repairs each boot after the fact rather
 than ordering the manager correctly in the first place, so there it is a

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -1046,8 +1046,9 @@ All subcommands accept a common flag:
    pipeline includes it.
 
 ``osprey scaffold systemd [--force]``
-   Emit a systemd user unit that starts this deployment at boot: ``osprey.service``
-   at the repository root, plus the commands to install it. The unit runs
+   Emit the files that start this deployment at boot: a systemd user unit,
+   ``osprey.service`` at the repository root, and a boot hook,
+   ``scripts/osprey-boot-hook.sh``, plus the commands to install the unit. The unit runs
    ``osprey up -d`` from this repository and ``osprey down`` on stop, with both
    the repository and the ``osprey`` program written in as full paths — systemd
    starts a unit with no working directory and a short ``PATH``. Run it on the
@@ -1057,9 +1058,10 @@ All subcommands accept a common flag:
    write needs ``--force``. Refuses when no ``osprey`` program can be found to
    name. Starting at boot also needs ``loginctl enable-linger $USER`` once —
    see :doc:`/how-to/deploy-a-facility`. When ``$HOME`` is on an NFS or autofs
-   mount it also warns that linger alone will not survive a reboot there, and
-   prints the root-only ``user@<uid>.service`` drop-in that orders the user
-   manager after the mount.
+   mount it also warns that linger alone will not survive a reboot there, prints
+   the root-only ``user@<uid>.service`` drop-in that orders the user manager
+   after the mount, and shows how to wire the boot hook into the account's
+   crontab as the no-root fallback.
 
 ``osprey scaffold list``
    List all build artifacts and their ownership status (framework vs.

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -1060,8 +1060,9 @@ All subcommands accept a common flag:
    see :doc:`/how-to/deploy-a-facility`. When ``$HOME`` is on an NFS or autofs
    mount it also warns that linger alone will not survive a reboot there, prints
    the root-only ``user@<uid>.service`` drop-in that orders the user manager
-   after the mount, and shows how to wire the boot hook into the account's
-   crontab as the no-root fallback.
+   after a systemd-managed mount, and shows the two crontab lines that run the
+   boot hook at boot — the route for a daemon-managed autofs home, and the
+   no-root fallback elsewhere.
 
 ``osprey scaffold list``
    List all build artifacts and their ownership status (framework vs.

--- a/src/osprey/cli/deploy_scaffold.py
+++ b/src/osprey/cli/deploy_scaffold.py
@@ -12,12 +12,13 @@ to key them off.
 time. One engine, called twice, so a repo created today and a repo
 re-scaffolded a year later carry the same two files.
 
-``osprey scaffold systemd`` emits a third file through the same engine: the
-boot unit at :data:`SYSTEMD_OUTPUT_NAME`. It is not part of what ``init``
-writes, because it is rendered for a HOST rather than for the repo — the two
-absolute paths in it are properties of the machine that will run the
-deployment, so it is emitted when an operator is standing on that machine and
-asks for it.
+``osprey scaffold systemd`` emits two more files through the same engine: the
+boot unit at :data:`SYSTEMD_OUTPUT_NAME`, and the boot hook at
+:data:`BOOT_HOOK_OUTPUT_PATH` that starts that unit on a host whose home is a
+late mount. Neither is part of what ``init`` writes, because both are rendered
+for a HOST rather than for the repo — the two absolute paths in them are
+properties of the machine that will run the deployment, so they are emitted
+when an operator is standing on that machine and asks for them.
 
 Re-emission is the whole difficulty. A generated file that lands in a git
 repository is read, diffed and eventually edited by people, so the engine has
@@ -54,6 +55,9 @@ from .build_profile_deploy import SUPPORTED_CI_PLATFORMS, DeployConfig, parse_de
 from .build_profile_document import _read_profile_document
 from .build_profile_merge import resolve_profile_document
 from .deploy_scaffold_templates import (
+    BOOT_HOOK_MARKER,
+    BOOT_HOOK_PATH,
+    BOOT_HOOK_TEMPLATE,
     CI_MARKER,
     CI_TEMPLATES,
     SYSTEMD_MARKER,
@@ -62,6 +66,7 @@ from .deploy_scaffold_templates import (
     VERIFY_MARKER,
     VERIFY_PATH,
     VERIFY_TEMPLATE,
+    build_boot_hook_context,
     build_ci_context,
     build_systemd_context,
     build_verify_context,
@@ -97,9 +102,30 @@ VERIFY_OUTPUT_PATH: tuple[str, ...] = tuple(VERIFY_PATH.split("/"))
 #: the emitted header plus the verb's own output say to copy it across.
 SYSTEMD_OUTPUT_NAME: str = SYSTEMD_UNIT_NAME
 
+#: Where the boot hook is emitted, as path segments relative to the repo root.
+#: Derived from the emitted script's own spelling of it
+#: (:data:`~.deploy_scaffold_templates.BOOT_HOOK_PATH`), the same way
+#: :data:`VERIFY_OUTPUT_PATH` is: the hook's header prints the ``@reboot``
+#: crontab line an operator pastes, and that line is this path under the repo
+#: root, so a second literal here could move the file out from under the line
+#: that installs it.
+#:
+#: Under ``scripts/`` rather than at the repo root, and deliberately so.
+#: :mod:`osprey.cli.profile_conventions` keeps ``_SOURCE_ZONE_ENTRIES``, the set
+#: of repo-root entries ``osprey build``'s unknown-root-entry warning knows
+#: about. A new root file would not be in it, so a build would warn about a file
+#: OSPREY itself told the operator to create — the exact thing that module's
+#: docstring says must not happen. ``scripts`` is already covered (it is where
+#: ``verify.sh`` lands), so emitting the hook there needs no edit to that table,
+#: nor to the python-executor write-guard that mirrors it.
+BOOT_HOOK_OUTPUT_PATH: tuple[str, ...] = tuple(BOOT_HOOK_PATH.split("/"))
+
 #: The health check is meant to be runnable by hand (``./scripts/verify.sh``),
 #: as its own header advertises. The post-up hook runs it through ``bash`` and
-#: would not care, but an operator following the header would.
+#: would not care, but an operator following the header would. The boot hook is
+#: the same case one directory over: cron invokes the ``@reboot`` line its
+#: header prints as a command, not through an interpreter, so a hook without
+#: the bit set is a boot that silently never happens.
 _EXECUTABLE_MODE = 0o755
 _REGULAR_MODE = 0o644
 
@@ -241,48 +267,75 @@ def scaffold_systemd_unit(
     force: bool = False,
     osprey_bin: str | None = None,
     osprey_version: str | None = None,
-) -> ScaffoldedFile:
-    """Emit the boot unit that brings this deployment up after a reboot.
+) -> list[ScaffoldedFile]:
+    """Emit the boot unit that brings this deployment up after a reboot, and
+    the hook that starts that unit on a host whose home is a late mount.
 
-    Rendered from the profile's ``name:`` and from two paths on the machine the
-    unit will run on: the repo, and the ``osprey`` executable. No ``deploy:``
-    block is read, because none of it applies — a unit runs the deployment where
-    it already is, rather than shipping it anywhere.
+    Both are rendered from the profile's ``name:`` and from two paths on the
+    machine they will run on: the repo, and the ``osprey`` executable. No
+    ``deploy:`` block is read, because none of it applies — a unit runs the
+    deployment where it already is, rather than shipping it anywhere.
+
+    The hook is emitted beside the unit rather than on request, because the
+    situation it exists for is not one an operator can see while scaffolding:
+    it is a boot that does not come back, several reboots from now. A file
+    already sitting in the repo is one somebody can read when that happens.
 
     Args:
         repo_root: The deployment repo. Also the unit's ``WorkingDirectory``,
-            resolved absolute.
-        force: Overwrite a file that carries no marker of ours.
+            resolved absolute, and the path the hook waits for.
+        force: Overwrite files that carry no marker of ours.
         osprey_bin: Absolute path to the ``osprey`` executable the unit invokes.
             Defaults to the one resolvable here.
         osprey_version: Version for the provenance stamp. Defaults to the
             installed framework's; tests pass a frozen value.
 
     Returns:
-        What the emission did to the one file it writes.
+        One :class:`ScaffoldedFile` per emitted file, in emission order — the
+        unit at :data:`SYSTEMD_OUTPUT_NAME`, then the hook at
+        :data:`BOOT_HOOK_OUTPUT_PATH`. A refusal is reported here rather than
+        raised, for the same reason the CI pair reports one: the two files have
+        independent histories, and a hand-edited unit is no reason to leave the
+        hook stale.
 
     Raises:
         ConfigurationError: If the repo holds no profile, or holds one that is
             not a YAML mapping.
         FileNotFoundError: If no ``osprey`` executable can be found and none was
-            given. A unit naming a command that is not there fails at boot,
-            where nobody is watching, so it is not written.
+            given. A unit naming a command that is not there fails at boot, and
+            a hook waiting on a path that will never exist gives up every boot
+            — both where nobody is watching, so neither file is written.
     """
     repo_root = repo_root.resolve()
     profile, _ = _load_profile(repo_root / PROFILE_FILENAME, command="osprey scaffold systemd")
 
-    text = render(
+    unit_text = render(
         SYSTEMD_TEMPLATE,
         build_systemd_context(profile, repo_root, osprey_bin, osprey_version),
     )
-    return _emit(
-        repo_root / SYSTEMD_OUTPUT_NAME,
-        text,
-        SYSTEMD_MARKER,
-        mode=_REGULAR_MODE,
-        force=force,
-        command="osprey scaffold systemd",
+    hook_text = render(
+        BOOT_HOOK_TEMPLATE,
+        build_boot_hook_context(profile, repo_root, osprey_bin, osprey_version),
     )
+
+    return [
+        _emit(
+            repo_root / SYSTEMD_OUTPUT_NAME,
+            unit_text,
+            SYSTEMD_MARKER,
+            mode=_REGULAR_MODE,
+            force=force,
+            command="osprey scaffold systemd",
+        ),
+        _emit(
+            repo_root.joinpath(*BOOT_HOOK_OUTPUT_PATH),
+            hook_text,
+            BOOT_HOOK_MARKER,
+            mode=_EXECUTABLE_MODE,
+            force=force,
+            command="osprey scaffold systemd",
+        ),
+    ]
 
 
 def detect_network_home(home: Path) -> str | None:

--- a/src/osprey/cli/deploy_scaffold_templates.py
+++ b/src/osprey/cli/deploy_scaffold_templates.py
@@ -1,10 +1,11 @@
 """Templates and render contexts for the ``osprey scaffold`` verbs.
 
 Scaffolding emits generated files into a deployment repo — a CI pipeline, a
-post-deploy health check, a systemd unit — and every one of them is a Jinja
-template under ``osprey/templates/deploy/``. This module owns three things the
-verbs need and nothing else: which template a platform selects, what context
-each template expects, and how to turn a profile into that context.
+post-deploy health check, a systemd unit and its boot hook — and every one of
+them is a Jinja template under ``osprey/templates/deploy/``. This module owns
+three things the verbs need and nothing else: which template a platform
+selects, what context each template expects, and how to turn a profile into
+that context.
 
 The split matters because the templates are held to a byte-for-byte golden
 (``tests/deployment/goldens/``). Layout decisions — column alignment, comment
@@ -52,12 +53,22 @@ VERIFY_TEMPLATE: str = "verify.sh.j2"
 #: The systemd unit that brings a deployment up at boot.
 SYSTEMD_TEMPLATE: str = "osprey.service.j2"
 
+#: The no-root fallback for a host whose home is a late mount. A lingering user
+#: manager resolves its unit search path once, at boot, before an NFS or autofs
+#: home is there — and never looks again, so the unit reads ``not-found`` until
+#: someone reloads by hand. The supported fix is a ``RequiresMountsFor``
+#: drop-in on ``user@<uid>.service``, which needs root; this script is what an
+#: operator without root ends up writing instead, so it is shipped rather than
+#: left to be rediscovered.
+BOOT_HOOK_TEMPLATE: str = "osprey-boot-hook.sh.j2"
+
 #: Provenance markers the emitted files carry. A file whose first lines name one
 #: of these was written by the scaffolder and may be re-emitted; anything else is
 #: treated as hand-written.
 CI_MARKER: str = "deploy/gitlab-ci"
 VERIFY_MARKER: str = "deploy/verify"
 SYSTEMD_MARKER: str = "deploy/systemd"
+BOOT_HOOK_MARKER: str = "deploy/boot-hook"
 
 #: What the emitted unit is called. Fixed rather than chosen at emission time:
 #: the unit's own header tells the operator which file to copy and which name to
@@ -65,12 +76,29 @@ SYSTEMD_MARKER: str = "deploy/systemd"
 #: could get wrong.
 SYSTEMD_UNIT_NAME: str = "osprey.service"
 
+#: What the emitted boot hook is called, fixed for the same reason the unit's
+#: name is: the script's own header tells the operator the ``@reboot`` line to
+#: paste into their crontab, and a name the caller could change is a name that
+#: line could get wrong.
+BOOT_HOOK_OUTPUT_NAME: str = "osprey-boot-hook.sh"
+
 #: How long systemd may wait for ``osprey up -d``. A oneshot gets 90 seconds by
 #: default, which a start that pulls images first will exceed — and a start
 #: timeout kills the deploy halfway through. Fifteen minutes is long enough for
 #: a cold pull on a slow link and still short enough to end a genuinely wedged
 #: start rather than hang the boot on it.
 SYSTEMD_START_TIMEOUT_SEC: int = 900
+
+#: How long the boot hook waits, in total, for the pieces it needs — the home
+#: mount, the deployment, and the user manager's runtime directory. An automount
+#: that has not answered in five minutes is not slow, it is broken, and a hook
+#: that waits past that holds a cron slot open on a host nobody is watching.
+BOOT_HOOK_TOTAL_WAIT_SEC: int = 300
+
+#: Seconds between the hook's attempts. Short enough that a mount landing two
+#: seconds after boot does not cost the deployment a visible delay, long enough
+#: that the wait is not a spin.
+BOOT_HOOK_POLL_SEC: int = 5
 
 #: Where the unit's ``Documentation=`` points. The deployment how-to is the page
 #: that covers what a host needs before the unit can bring a stack up.
@@ -91,10 +119,15 @@ DEPLOY_SSH_KEY_VAR: str = "DEPLOY_SSH_KEY"
 #: the engine derives its output path from it, and ``test_scaffold_ci`` asks
 #: every reader (engine, rendered pipeline, init, post-up hook) about the file
 #: that was actually written, so the spellings cannot drift apart in silence.
+#: ``BOOT_HOOK_PATH`` is the same idea one directory over: the hook's header
+#: prints the ``@reboot`` crontab line an operator pastes, and that line is this
+#: path under the repo root, so the spelling the script shows and the spelling
+#: the emitter writes to have to be one constant.
 PROFILE_PATH: str = PROFILE_FILENAME
 BUILD_DIR: str = BUILD_OUTPUT_DIR
 STATE_DIR_PATH: str = STATE_DIR
 VERIFY_PATH: str = "scripts/verify.sh"
+BOOT_HOOK_PATH: str = f"scripts/{BOOT_HOOK_OUTPUT_NAME}"
 
 #: What ``osprey users env --output`` writes on the deploy host, at the repo
 #: root where compose reads it. Aliased from the writer's own constant rather
@@ -272,7 +305,46 @@ class SystemdContext:
     timeout_start_sec: int = SYSTEMD_START_TIMEOUT_SEC
 
 
-def render(template_name: str, context: CIContext | VerifyContext | SystemdContext) -> str:
+@dataclass(frozen=True)
+class BootHookContext:
+    """Everything ``osprey-boot-hook.sh.j2`` renders from.
+
+    Frozen, and every field a plain string or integer, for the same reason
+    :class:`SystemdContext` is: the script runs at boot on a host the
+    scaffolder may never see, so nothing here may be recomputed from the local
+    machine after the caller has decided what it says.
+
+    Attributes:
+        facility_name: The profile's ``name:`` — the script's title. One host
+            can carry a hook per deployment, and cron mails their output to the
+            same account.
+        osprey_version: Installed framework version, for the provenance header.
+        repo_root: Absolute path of the deployment repo on the deploy host. The
+            hook waits for it, because on the host this exists for it sits under
+            the same late mount as the home; it is also what makes the
+            ``@reboot`` line in the header absolute.
+        osprey_bin: Absolute path to the ``osprey`` executable on that host. The
+            hook waits for this too: a pip install under the home directory is
+            just as absent as the repo until the mount lands, and a unit started
+            without it fails where nobody is looking.
+        poll_seconds: Seconds between attempts — see :data:`BOOT_HOOK_POLL_SEC`.
+        total_wait_seconds: Seconds the hook waits in total before giving up and
+            saying which piece never arrived — see
+            :data:`BOOT_HOOK_TOTAL_WAIT_SEC`.
+    """
+
+    facility_name: str
+    osprey_version: str
+    repo_root: str
+    osprey_bin: str
+    poll_seconds: int = BOOT_HOOK_POLL_SEC
+    total_wait_seconds: int = BOOT_HOOK_TOTAL_WAIT_SEC
+
+
+def render(
+    template_name: str,
+    context: CIContext | VerifyContext | SystemdContext | BootHookContext,
+) -> str:
     """Render one deploy template.
 
     Args:
@@ -296,6 +368,7 @@ def render(template_name: str, context: CIContext | VerifyContext | SystemdConte
         build_dir=BUILD_DIR,
         state_dir=STATE_DIR_PATH,
         verify_path=VERIFY_PATH,
+        boot_hook_path=BOOT_HOOK_PATH,
         users_env_name=USERS_ENV_NAME,
         unit_name=SYSTEMD_UNIT_NAME,
         docs_url=DEPLOY_DOCS_URL,
@@ -445,6 +518,49 @@ def build_systemd_context(
             there would fail at boot, where nobody is watching.
     """
     return SystemdContext(
+        facility_name=str(profile.get("name", repo_root.name)),
+        osprey_version=osprey_version or osprey.__version__,
+        repo_root=str(repo_root.resolve()),
+        osprey_bin=osprey_bin or resolve_shell_command("osprey"),
+    )
+
+
+def build_boot_hook_context(
+    profile: dict[str, Any],
+    repo_root: Path,
+    osprey_bin: str | None = None,
+    osprey_version: str | None = None,
+) -> BootHookContext:
+    """Derive the boot hook's context from a profile and a machine.
+
+    Takes the same arguments as :func:`build_systemd_context`, and for the same
+    reasons: the hook exists to start the unit that function's template
+    describes, so the two are emitted from one set of host coordinates or they
+    describe two different machines.
+
+    Args:
+        profile: The resolved raw profile dict.
+        repo_root: The deployment repo's root. Resolved to an absolute path — a
+            crontab entry is run from the account's home with no context, and
+            the hook waits on this path by name; a caller emitting a hook for a
+            *different* host passes that host's path, which is absolute already
+            and travels through untouched.
+        osprey_bin: Absolute path to the ``osprey`` executable on the host that
+            will run the unit. Defaults to the one that would answer here,
+            resolved through the same helper the web terminal uses for a
+            stripped ``PATH``.
+        osprey_version: Version for the provenance header; defaults to the
+            installed framework's.
+
+    Returns:
+        The context :data:`BOOT_HOOK_TEMPLATE` renders against.
+
+    Raises:
+        FileNotFoundError: If no ``osprey_bin`` was given and no ``osprey``
+            executable can be found — a hook waiting for a path that will never
+            exist would time out every boot.
+    """
+    return BootHookContext(
         facility_name=str(profile.get("name", repo_root.name)),
         osprey_version=osprey_version or osprey.__version__,
         repo_root=str(repo_root.resolve()),

--- a/src/osprey/cli/deploy_scaffold_templates.py
+++ b/src/osprey/cli/deploy_scaffold_templates.py
@@ -89,11 +89,16 @@ BOOT_HOOK_OUTPUT_NAME: str = "osprey-boot-hook.sh"
 #: start rather than hang the boot on it.
 SYSTEMD_START_TIMEOUT_SEC: int = 900
 
-#: How long the boot hook waits, in total, for the pieces it needs — the home
-#: mount, the deployment, and the user manager's runtime directory. An automount
-#: that has not answered in five minutes is not slow, it is broken, and a hook
-#: that waits past that holds a cron slot open on a host nobody is watching.
-BOOT_HOOK_TOTAL_WAIT_SEC: int = 300
+#: How long the crontab job waits for the hook to become readable — in practice
+#: how long the home may take to arrive — and, separately, how long the hook
+#: then waits for the deployment and the user manager. On a normal boot the
+#: automounter followed cron by under twenty seconds; the boot that matters is
+#: the messy one, a site power event with the filer coming up after the compute
+#: host, where the home can be minutes late and giving up recreates the silent
+#: dead stack the hook exists to prevent. Ten minutes of a sleeping shell costs
+#: nothing; a hook that waits past that holds a cron slot open on a host nobody
+#: is watching.
+BOOT_HOOK_TOTAL_WAIT_SEC: int = 600
 
 #: Seconds between the hook's attempts. Short enough that a mount landing two
 #: seconds after boot does not cost the deployment a visible delay, long enough
@@ -374,7 +379,9 @@ def boot_hook_crontab_lines(hook: str) -> tuple[str, str]:
     for itself: it writes a launch marker to :data:`BOOT_HOOK_LOG` before
     anything else, waits up to :data:`BOOT_HOOK_TOTAL_WAIT_SEC` for the script
     to become readable, and only then runs it. The script restores the real
-    ``HOME`` as its first act.
+    ``HOME`` as its first act. Giving up is said on stdout as well as in the
+    log: cron mails what a job prints, and this is the one branch where that
+    mail is the whole point.
 
     No ``%`` anywhere: cron reads it as a newline.
 
@@ -391,7 +398,7 @@ def boot_hook_crontab_lines(hook: str) -> tuple[str, str]:
         f"n=0; until [ -x {hook} ] || [ $n -ge {attempts} ]; "
         f"do sleep {BOOT_HOOK_POLL_SEC}; n=$((n+1)); done; "
         f"if [ -x {hook} ]; then exec {hook}; fi; "
-        f'echo "$(date) osprey-boot-hook: gave up, {hook} never appeared" >> {BOOT_HOOK_LOG}'
+        f'echo "$(date) osprey-boot-hook: gave up, {hook} never appeared" | tee -a {BOOT_HOOK_LOG}'
     )
     return ("HOME=/", job)
 

--- a/src/osprey/cli/deploy_scaffold_templates.py
+++ b/src/osprey/cli/deploy_scaffold_templates.py
@@ -106,13 +106,22 @@ BOOT_HOOK_TOTAL_WAIT_SEC: int = 600
 BOOT_HOOK_POLL_SEC: int = 5
 
 #: Where the boot hook and the crontab job that launches it record their
-#: progress: ``/tmp``, on the local disk, because on the host this exists for
-#: the home is the thing that has not arrived yet. Written before any wait, so
-#: a boot that never mounted the home still shows whether cron fired the job at
-#: all — the one question a mail that never came cannot answer. ``$(id -u)`` is
-#: expanded by the shell that runs the line, so the same spelling serves the
+#: progress: under ``/tmp``, on the local disk, because on the host this exists
+#: for the home is the thing that has not arrived yet. Written before any wait,
+#: so a boot that never mounted the home still shows whether cron fired the job
+#: at all — the one question a mail that never came cannot answer. ``$(id -u)``
+#: is expanded by the shell that runs the line, so the same spelling serves the
 #: crontab and the script.
-BOOT_HOOK_LOG: str = "/tmp/osprey-boot-hook.$(id -u).log"
+#:
+#: A directory rather than a bare file, because ``/tmp`` is world-writable and
+#: the name is predictable: appending to a file there follows a symlink any
+#: local user could have planted, turning the log into an append to a file of
+#: their choosing, as the deploying account. Both writers create the directory
+#: with mode 700 and use it only if it is a real directory they own — otherwise
+#: they log to ``/dev/null`` — and ``/tmp``'s sticky bit keeps anyone else from
+#: swapping it out afterwards.
+BOOT_HOOK_LOG_DIR: str = "/tmp/osprey-boot-hook.$(id -u)"
+BOOT_HOOK_LOG: str = f"{BOOT_HOOK_LOG_DIR}/boot.log"
 
 #: Where the unit's ``Documentation=`` points. The deployment how-to is the page
 #: that covers what a host needs before the unit can bring a stack up.
@@ -347,7 +356,7 @@ class BootHookContext:
             :func:`boot_hook_crontab_lines`), and asking the identity stack
             with ``getent`` at that moment depends on a service that may have
             started seconds earlier, or not yet.
-        crontab_job: The ``@reboot`` line the header shows, from
+        crontab_lines: Every line the header tells the operator to paste, from
             :func:`boot_hook_crontab_lines` — one spelling for the header and
             the console.
         poll_seconds: Seconds between attempts — see :data:`BOOT_HOOK_POLL_SEC`.
@@ -361,20 +370,23 @@ class BootHookContext:
     repo_root: str
     osprey_bin: str
     home: str
-    crontab_job: str
+    crontab_lines: tuple[str, ...]
     poll_seconds: int = BOOT_HOOK_POLL_SEC
     total_wait_seconds: int = BOOT_HOOK_TOTAL_WAIT_SEC
 
 
-def boot_hook_crontab_lines(hook: str) -> tuple[str, str]:
-    """The two crontab lines that run the boot hook at every boot.
+def boot_hook_crontab_lines(hook: str) -> tuple[str, ...]:
+    """The crontab lines that run the boot hook at every boot.
 
-    Both are needed, and the job is deliberately not a bare ``@reboot <hook>``.
-    Two things happen before a cron job's command runs, and on a host whose
-    home is a late mount each one kills the job silently: cron changes into the
-    crontab's ``HOME`` first, and dies if that directory is not there yet; then
-    ``sh`` has to read the script, which sits on the same mount. The first line
-    gives cron a directory that exists at boot. The job itself lives in the
+    All of them are needed, and the job is deliberately not a bare
+    ``@reboot <hook>``. Two things happen before a cron job's command runs,
+    and on a host whose home is a late mount each one kills the job silently:
+    cron changes into the crontab's ``HOME`` first, and dies if that directory
+    is not there yet; then ``sh`` has to read the script, which sits on the
+    same mount. ``HOME=/`` gives cron a directory that exists at boot.
+    ``SHELL=/bin/sh`` makes the job's shell a property of these lines rather
+    than of whatever an existing crontab set above them — the job is POSIX
+    ``sh`` and would not parse under a ``csh``. The job itself lives in the
     crontab — on the local disk — and does the waiting the script cannot do
     for itself: it writes a launch marker to :data:`BOOT_HOOK_LOG` before
     anything else, waits up to :data:`BOOT_HOOK_TOTAL_WAIT_SEC` for the script
@@ -383,24 +395,30 @@ def boot_hook_crontab_lines(hook: str) -> tuple[str, str]:
     log: cron mails what a job prints, and this is the one branch where that
     mail is the whole point.
 
+    The log directory is created and checked the way :data:`BOOT_HOOK_LOG`
+    describes, in the job as well as in the script: the job writes first.
+
     No ``%`` anywhere: cron reads it as a newline.
 
     Args:
         hook: Absolute path of the emitted boot hook on the deploy host.
 
     Returns:
-        The ``HOME=/`` line and the ``@reboot`` line, in the order they go
-        into the crontab.
+        The lines in the order they go into the crontab: the two preamble
+        assignments, then the ``@reboot`` job.
     """
     attempts = BOOT_HOOK_TOTAL_WAIT_SEC // BOOT_HOOK_POLL_SEC
     job = (
-        f'@reboot echo "$(date) osprey-boot-hook: cron fired" >> {BOOT_HOOK_LOG}; '
+        f'@reboot d={BOOT_HOOK_LOG_DIR}; mkdir -m 700 "$d" 2>/dev/null; '
+        f'if [ -d "$d" ] && [ ! -L "$d" ] && [ -O "$d" ]; then log={BOOT_HOOK_LOG}; '
+        f"else log=/dev/null; fi; "
+        f'echo "$(date) osprey-boot-hook: cron fired" >> "$log"; '
         f"n=0; until [ -x {hook} ] || [ $n -ge {attempts} ]; "
         f"do sleep {BOOT_HOOK_POLL_SEC}; n=$((n+1)); done; "
         f"if [ -x {hook} ]; then exec {hook}; fi; "
-        f'echo "$(date) osprey-boot-hook: gave up, {hook} never appeared" | tee -a {BOOT_HOOK_LOG}'
+        f'echo "$(date) osprey-boot-hook: gave up, {hook} never appeared" | tee -a "$log"'
     )
-    return ("HOME=/", job)
+    return ("SHELL=/bin/sh", "HOME=/", job)
 
 
 def render(
@@ -432,6 +450,7 @@ def render(
         verify_path=VERIFY_PATH,
         boot_hook_path=BOOT_HOOK_PATH,
         boot_hook_log=BOOT_HOOK_LOG,
+        boot_hook_log_dir=BOOT_HOOK_LOG_DIR,
         users_env_name=USERS_ENV_NAME,
         unit_name=SYSTEMD_UNIT_NAME,
         docs_url=DEPLOY_DOCS_URL,
@@ -626,16 +645,18 @@ def build_boot_hook_context(
         FileNotFoundError: If no ``osprey_bin`` was given and no ``osprey``
             executable can be found — a hook waiting for a path that will never
             exist would time out every boot.
+        RuntimeError: If no ``home`` was given and this machine cannot resolve
+            one (``Path.home()``'s own failure) — a user unit has no account to
+            belong to there.
     """
     resolved_root = repo_root.resolve()
-    _, crontab_job = boot_hook_crontab_lines(str(resolved_root / BOOT_HOOK_PATH))
     return BootHookContext(
         facility_name=str(profile.get("name", repo_root.name)),
         osprey_version=osprey_version or osprey.__version__,
         repo_root=str(resolved_root),
         osprey_bin=osprey_bin or resolve_shell_command("osprey"),
         home=str(home if home is not None else Path.home()),
-        crontab_job=crontab_job,
+        crontab_lines=boot_hook_crontab_lines(str(resolved_root / BOOT_HOOK_PATH)),
     )
 
 

--- a/src/osprey/cli/deploy_scaffold_templates.py
+++ b/src/osprey/cli/deploy_scaffold_templates.py
@@ -100,6 +100,15 @@ BOOT_HOOK_TOTAL_WAIT_SEC: int = 300
 #: that the wait is not a spin.
 BOOT_HOOK_POLL_SEC: int = 5
 
+#: Where the boot hook and the crontab job that launches it record their
+#: progress: ``/tmp``, on the local disk, because on the host this exists for
+#: the home is the thing that has not arrived yet. Written before any wait, so
+#: a boot that never mounted the home still shows whether cron fired the job at
+#: all — the one question a mail that never came cannot answer. ``$(id -u)`` is
+#: expanded by the shell that runs the line, so the same spelling serves the
+#: crontab and the script.
+BOOT_HOOK_LOG: str = "/tmp/osprey-boot-hook.$(id -u).log"
+
 #: Where the unit's ``Documentation=`` points. The deployment how-to is the page
 #: that covers what a host needs before the unit can bring a stack up.
 DEPLOY_DOCS_URL: str = "https://als-apg.github.io/osprey/how-to/deploy-a-facility.html"
@@ -327,6 +336,15 @@ class BootHookContext:
             hook waits for this too: a pip install under the home directory is
             just as absent as the repo until the mount lands, and a unit started
             without it fails where nobody is looking.
+        home: Absolute path of the account's home on that host, written into
+            the script rather than read from ``$HOME`` at boot: the crontab
+            that launches it sets ``HOME=/`` (see
+            :func:`boot_hook_crontab_lines`), and asking the identity stack
+            with ``getent`` at that moment depends on a service that may have
+            started seconds earlier, or not yet.
+        crontab_job: The ``@reboot`` line the header shows, from
+            :func:`boot_hook_crontab_lines` — one spelling for the header and
+            the console.
         poll_seconds: Seconds between attempts — see :data:`BOOT_HOOK_POLL_SEC`.
         total_wait_seconds: Seconds the hook waits in total before giving up and
             saying which piece never arrived — see
@@ -337,8 +355,45 @@ class BootHookContext:
     osprey_version: str
     repo_root: str
     osprey_bin: str
+    home: str
+    crontab_job: str
     poll_seconds: int = BOOT_HOOK_POLL_SEC
     total_wait_seconds: int = BOOT_HOOK_TOTAL_WAIT_SEC
+
+
+def boot_hook_crontab_lines(hook: str) -> tuple[str, str]:
+    """The two crontab lines that run the boot hook at every boot.
+
+    Both are needed, and the job is deliberately not a bare ``@reboot <hook>``.
+    Two things happen before a cron job's command runs, and on a host whose
+    home is a late mount each one kills the job silently: cron changes into the
+    crontab's ``HOME`` first, and dies if that directory is not there yet; then
+    ``sh`` has to read the script, which sits on the same mount. The first line
+    gives cron a directory that exists at boot. The job itself lives in the
+    crontab — on the local disk — and does the waiting the script cannot do
+    for itself: it writes a launch marker to :data:`BOOT_HOOK_LOG` before
+    anything else, waits up to :data:`BOOT_HOOK_TOTAL_WAIT_SEC` for the script
+    to become readable, and only then runs it. The script restores the real
+    ``HOME`` as its first act.
+
+    No ``%`` anywhere: cron reads it as a newline.
+
+    Args:
+        hook: Absolute path of the emitted boot hook on the deploy host.
+
+    Returns:
+        The ``HOME=/`` line and the ``@reboot`` line, in the order they go
+        into the crontab.
+    """
+    attempts = BOOT_HOOK_TOTAL_WAIT_SEC // BOOT_HOOK_POLL_SEC
+    job = (
+        f'@reboot echo "$(date) osprey-boot-hook: cron fired" >> {BOOT_HOOK_LOG}; '
+        f"n=0; until [ -x {hook} ] || [ $n -ge {attempts} ]; "
+        f"do sleep {BOOT_HOOK_POLL_SEC}; n=$((n+1)); done; "
+        f"if [ -x {hook} ]; then exec {hook}; fi; "
+        f'echo "$(date) osprey-boot-hook: gave up, {hook} never appeared" >> {BOOT_HOOK_LOG}'
+    )
+    return ("HOME=/", job)
 
 
 def render(
@@ -369,6 +424,7 @@ def render(
         state_dir=STATE_DIR_PATH,
         verify_path=VERIFY_PATH,
         boot_hook_path=BOOT_HOOK_PATH,
+        boot_hook_log=BOOT_HOOK_LOG,
         users_env_name=USERS_ENV_NAME,
         unit_name=SYSTEMD_UNIT_NAME,
         docs_url=DEPLOY_DOCS_URL,
@@ -530,13 +586,14 @@ def build_boot_hook_context(
     repo_root: Path,
     osprey_bin: str | None = None,
     osprey_version: str | None = None,
+    home: Path | None = None,
 ) -> BootHookContext:
     """Derive the boot hook's context from a profile and a machine.
 
     Takes the same arguments as :func:`build_systemd_context`, and for the same
     reasons: the hook exists to start the unit that function's template
     describes, so the two are emitted from one set of host coordinates or they
-    describe two different machines.
+    describe two different machines. The home is one more such coordinate.
 
     Args:
         profile: The resolved raw profile dict.
@@ -551,6 +608,9 @@ def build_boot_hook_context(
             stripped ``PATH``.
         osprey_version: Version for the provenance header; defaults to the
             installed framework's.
+        home: The account's home on the host that will run the unit. Defaults
+            to this machine's, which is the right answer on the machine the
+            verb is meant to be run on.
 
     Returns:
         The context :data:`BOOT_HOOK_TEMPLATE` renders against.
@@ -560,11 +620,15 @@ def build_boot_hook_context(
             executable can be found — a hook waiting for a path that will never
             exist would time out every boot.
     """
+    resolved_root = repo_root.resolve()
+    _, crontab_job = boot_hook_crontab_lines(str(resolved_root / BOOT_HOOK_PATH))
     return BootHookContext(
         facility_name=str(profile.get("name", repo_root.name)),
         osprey_version=osprey_version or osprey.__version__,
-        repo_root=str(repo_root.resolve()),
+        repo_root=str(resolved_root),
         osprey_bin=osprey_bin or resolve_shell_command("osprey"),
+        home=str(home if home is not None else Path.home()),
+        crontab_job=crontab_job,
     )
 
 

--- a/src/osprey/cli/scaffold_cmd.py
+++ b/src/osprey/cli/scaffold_cmd.py
@@ -961,16 +961,20 @@ def _warn_about_a_network_home(home: Path, fstype: str | None, hook: Path) -> No
 
     Printed after the install instructions rather than instead of them: those
     lines are still exactly what the operator has to run. What they do not do
-    is survive a reboot on this host, and the fix for that needs root — a
-    drop-in on ``user@<uid>.service`` ordering the user manager after the
-    mount. So the drop-in is printed verbatim, for the operator to hand to
-    whoever has root, and nothing here is refused or withheld.
+    is survive a reboot on this host. When systemd manages the mount the fix
+    needs root — a drop-in on ``user@<uid>.service`` ordering the user manager
+    after the mount — so the drop-in is printed verbatim, for the operator to
+    hand to whoever has root, and nothing here is refused or withheld. A home
+    served by the autofs daemon has no mount unit for it to order against;
+    ``findmnt`` reports ``autofs`` for a systemd automount too, so the two
+    cannot be told apart here and the scope is stated rather than detected.
 
-    Then the fallback for an operator who has nobody to hand it to: the boot
-    hook this verb already wrote, and the crontab line that runs it. That is
-    the only reason the hook exists, and this is the only place its path is
-    named — an operator on a local home never needs it. OSPREY prints the
-    ``@reboot`` line rather than installing it; the crontab is the account's.
+    Then the boot hook this verb already wrote, and the two crontab lines that
+    run it — the only route on a daemon-managed autofs home, and the fallback
+    for an operator who has nobody to hand the drop-in to. That is the only
+    reason the hook exists, and this is the only place its path is named — an
+    operator on a local home never needs it. OSPREY prints the lines rather
+    than installing them; the crontab is the account's.
 
     Silent when *fstype* is ``None``, which covers both a local home and a host
     the detection could not read.
@@ -985,6 +989,9 @@ def _warn_about_a_network_home(home: Path, fstype: str | None, hook: Path) -> No
     if fstype is None:
         return
 
+    # Local for the same reason the verb's own imports are.
+    from .deploy_scaffold_templates import BOOT_HOOK_LOG, boot_hook_crontab_lines
+
     console.print()
     console.print(
         f"  [warning]\u26a0[/warning] $HOME is on an {fstype} mount, so linger alone will "
@@ -998,7 +1005,9 @@ def _warn_about_a_network_home(home: Path, fstype: str | None, hook: Path) -> No
     console.print("    look again, so after every reboot the unit reads as not-found")
     console.print("    until someone runs 'systemctl --user daemon-reload' by hand.")
     console.print()
-    console.print("    Ordering it after the mount needs root. Whoever has it can write:")
+    console.print("    When systemd manages the mount — an fstab entry, or a .mount or")
+    console.print("    .automount unit — ordering the manager after it needs root. Whoever")
+    console.print("    has it can write:")
     # markup=False for the whole drop-in: '[Unit]' is a systemd section header,
     # and Rich would read it as a style tag and swallow it. soft_wrap keeps a
     # long home path on one line for whoever copies it.
@@ -1014,16 +1023,26 @@ def _warn_about_a_network_home(home: Path, fstype: str | None, hook: Path) -> No
     console.print("    and then run:")
     console.print("      sudo systemctl daemon-reload")
     console.print()
-    console.print("    If nobody with root is available, this run also wrote a boot hook:")
+    console.print("    A home served by the autofs daemon has no mount unit for that drop-in")
+    console.print("    to order against, so there it changes nothing. For that host, and")
+    console.print("    for one where nobody has root, this run also wrote a boot hook:")
     console.print(f"      {hook}", soft_wrap=True)
     console.print("    It waits for the home, this deployment and the user manager to show")
     console.print("    up, then reloads the unit files and starts the unit. Run it once per")
-    console.print("    boot from the account's own crontab:")
+    console.print("    boot from the account's own crontab — both lines, pasted whole:")
     console.print("      crontab -e")
-    console.print(f"      @reboot {hook}", soft_wrap=True)
-    console.print("    That is a fallback, not a replacement for the drop-in above: it")
-    console.print("    repairs each boot after the fact rather than ordering the manager")
-    console.print("    correctly in the first place.")
+    # markup=False: the job holds `[ -x ... ]` tests that Rich would read as
+    # style tags. soft_wrap keeps it one line for whoever pastes it.
+    home_line, job = boot_hook_crontab_lines(str(hook))
+    console.print(f"      {home_line}", markup=False)
+    console.print(f"      {job}", markup=False, soft_wrap=True)
+    console.print("    HOME=/ is what lets the job start at all: cron changes into the")
+    console.print("    crontab's HOME before it runs a job, and on this host the home is")
+    console.print("    not there yet. The job restores the real home itself, and notes in")
+    console.print(f"    {BOOT_HOOK_LOG} that it fired before it waits for anything.")
+    console.print("    Where the drop-in applies, the hook repairs each boot after the")
+    console.print("    fact rather than ordering the manager correctly in the first place,")
+    console.print("    so it is a fallback there, not a replacement.")
 
 
 def _owned_row(profile_root: Path | None, name: str) -> tuple[str, str, str]:

--- a/src/osprey/cli/scaffold_cmd.py
+++ b/src/osprey/cli/scaffold_cmd.py
@@ -1026,8 +1026,8 @@ def _warn_about_a_network_home(
     console.print("    look again, so after every reboot the unit reads as not-found")
     console.print("    until someone runs 'systemctl --user daemon-reload' by hand.")
     console.print()
-    console.print("    When systemd manages the mount — an fstab entry, or a .mount or")
-    console.print("    .automount unit — ordering the manager after it needs root. Whoever")
+    console.print("    When systemd manages the mount, from an fstab entry or a .mount or")
+    console.print("    .automount unit, ordering the manager after it needs root. Whoever")
     console.print("    has it can write:")
     # markup=False for the whole drop-in: '[Unit]' is a systemd section header,
     # and Rich would read it as a style tag and swallow it. soft_wrap keeps a
@@ -1047,7 +1047,7 @@ def _warn_about_a_network_home(
     console.print("    A home served by the autofs daemon has no mount unit for that drop-in")
     console.print("    to order against, so there it changes nothing. For that host, and")
     if not hook_written:
-        console.print("    for one where nobody has root, this verb writes a boot hook — but")
+        console.print("    for one where nobody has root, this verb writes a boot hook, but")
         console.print("    this run did not (see above): a file it did not write is already at")
         console.print(f"      {hook}", soft_wrap=True)
         console.print("    Re-run with --force to replace it; that run prints the crontab lines")
@@ -1057,7 +1057,7 @@ def _warn_about_a_network_home(
     console.print(f"      {hook}", soft_wrap=True)
     console.print("    It waits for the home, this deployment and the user manager to show")
     console.print("    up, then reloads the unit files and starts the unit. Run it once per")
-    console.print("    boot from the account's own crontab — all of these lines, pasted whole:")
+    console.print("    boot from the account's own crontab, all of these lines pasted whole:")
     console.print("      crontab -e")
     # markup=False: the job holds `[ -x ... ]` tests that Rich would read as
     # style tags. soft_wrap keeps it one line for whoever pastes it.

--- a/src/osprey/cli/scaffold_cmd.py
+++ b/src/osprey/cli/scaffold_cmd.py
@@ -899,6 +899,17 @@ def systemd(repo: Path | None, force: bool) -> None:
         emitted = scaffold_systemd_unit(repo_root, force=force)
     except ConfigurationError as exc:
         raise click.ClickException(str(exc)) from None
+    except RuntimeError as exc:
+        # `Path.home()` — the boot hook writes the account's home in as a
+        # literal, and a host with no resolvable home has no account for a
+        # user unit to belong to. Reported rather than traced for the same
+        # reason as the missing program below: it is the host, not OSPREY.
+        raise click.ClickException(
+            f"cannot resolve this account's home directory: {exc}\n\n"
+            "The boot hook names the home in full, and a systemd user unit "
+            "belongs to an account. Set HOME, or run this on the account that "
+            "will run the deployment."
+        ) from None
     except FileNotFoundError as exc:
         # The unit names the program in full, so there is nothing to write
         # until one can be found. Reported as a refusal rather than a
@@ -946,7 +957,9 @@ def systemd(repo: Path | None, force: bool) -> None:
         console.print("    loginctl enable-linger $USER")
 
         home = Path.home()
-        _warn_about_a_network_home(home, detect_network_home(home), hook.path)
+        _warn_about_a_network_home(
+            home, detect_network_home(home), hook.path, hook_written=not hook.refused
+        )
 
     if any(result.refused for result in emitted):
         # Last, after everything above has been said. Non-zero for the same
@@ -956,7 +969,9 @@ def systemd(repo: Path | None, force: bool) -> None:
         raise SystemExit(1)
 
 
-def _warn_about_a_network_home(home: Path, fstype: str | None, hook: Path) -> None:
+def _warn_about_a_network_home(
+    home: Path, fstype: str | None, hook: Path, *, hook_written: bool
+) -> None:
     """Say what linger does not cover when ``$HOME`` is a network mount.
 
     Printed after the install instructions rather than instead of them: those
@@ -985,6 +1000,12 @@ def _warn_about_a_network_home(home: Path, fstype: str | None, hook: Path) -> No
         fstype: What :func:`~.deploy_scaffold.detect_network_home` reported.
         hook: Absolute path to the emitted boot hook, as the crontab line has
             to name it.
+        hook_written: Whether this run wrote (or found unchanged) the hook at
+            that path. When it refused — a hand-written file sits there — the
+            crontab lines are withheld: printing them would wire cron to the
+            operator's own script, which is most likely the very hook that
+            "does nothing", and the sentence saying this run wrote one would
+            be false.
     """
     if fstype is None:
         return
@@ -1025,21 +1046,30 @@ def _warn_about_a_network_home(home: Path, fstype: str | None, hook: Path) -> No
     console.print()
     console.print("    A home served by the autofs daemon has no mount unit for that drop-in")
     console.print("    to order against, so there it changes nothing. For that host, and")
+    if not hook_written:
+        console.print("    for one where nobody has root, this verb writes a boot hook — but")
+        console.print("    this run did not (see above): a file it did not write is already at")
+        console.print(f"      {hook}", soft_wrap=True)
+        console.print("    Re-run with --force to replace it; that run prints the crontab lines")
+        console.print("    that wire it up. Do not wire the existing file up as it is.")
+        return
     console.print("    for one where nobody has root, this run also wrote a boot hook:")
     console.print(f"      {hook}", soft_wrap=True)
     console.print("    It waits for the home, this deployment and the user manager to show")
     console.print("    up, then reloads the unit files and starts the unit. Run it once per")
-    console.print("    boot from the account's own crontab — both lines, pasted whole:")
+    console.print("    boot from the account's own crontab — all of these lines, pasted whole:")
     console.print("      crontab -e")
     # markup=False: the job holds `[ -x ... ]` tests that Rich would read as
     # style tags. soft_wrap keeps it one line for whoever pastes it.
-    home_line, job = boot_hook_crontab_lines(str(hook))
-    console.print(f"      {home_line}", markup=False)
-    console.print(f"      {job}", markup=False, soft_wrap=True)
+    for line in boot_hook_crontab_lines(str(hook)):
+        console.print(f"      {line}", markup=False, soft_wrap=True)
     console.print("    HOME=/ is what lets the job start at all: cron changes into the")
     console.print("    crontab's HOME before it runs a job, and on this host the home is")
-    console.print("    not there yet. The job restores the real home itself, and notes in")
-    console.print(f"    {BOOT_HOOK_LOG} that it fired before it waits for anything.")
+    console.print("    not there yet. The script restores the real home itself; the job")
+    console.print(f"    first notes in {BOOT_HOOK_LOG} that it fired, then waits for the")
+    console.print("    script to be readable. Put these lines LAST in the crontab: every job")
+    console.print("    below them runs from / with HOME=/ in its environment, so a job that")
+    console.print("    expands $HOME breaks unless it starts with its own export HOME=... .")
     console.print("    Where the drop-in applies, the hook repairs each boot after the")
     console.print("    fact rather than ordering the manager correctly in the first place,")
     console.print("    so it is a fallback there, not a replacement.")

--- a/src/osprey/cli/scaffold_cmd.py
+++ b/src/osprey/cli/scaffold_cmd.py
@@ -863,12 +863,15 @@ def ci(repo: Path | None, force: bool) -> None:
 def systemd(repo: Path | None, force: bool) -> None:
     """Emit a systemd unit that starts this deployment at boot.
 
-    Writes osprey.service at the repo root and prints how to install it. The
-    unit runs 'osprey up -d' from this repo and 'osprey down' on stop; both the
-    repo and the osprey program are written into it as full paths, because
-    systemd starts a unit with no working directory and a short PATH. Run it on
-    the machine that will run the deployment, and again after the repo moves or
-    OSPREY is reinstalled somewhere else.
+    Writes two files and prints how to install them: osprey.service at the repo
+    root, and scripts/osprey-boot-hook.sh beside it. The unit runs
+    'osprey up -d' from this repo and 'osprey down' on stop; both the repo and
+    the osprey program are written into it as full paths, because systemd
+    starts a unit with no working directory and a short PATH. The hook is for
+    one situation only — a home directory that arrives after the user manager
+    does — and this verb says so when it finds one. Run it on the machine that
+    will run the deployment, and again after the repo moves or OSPREY is
+    reinstalled somewhere else.
 
     Re-running is safe. A file whose content already matches is left untouched,
     stamp included, so an OSPREY upgrade alone produces no diff. A file the
@@ -884,12 +887,16 @@ def systemd(repo: Path | None, force: bool) -> None:
     # Imported here for the same reason `ci` does it: the build-profile chain
     # behind these two verbs is not loaded for any of the ownership ones.
     from .deploy_scaffold import detect_network_home, scaffold_systemd_unit
-    from .deploy_scaffold_templates import SYSTEMD_UNIT_NAME
+    from .deploy_scaffold_templates import (
+        BOOT_HOOK_MARKER,
+        SYSTEMD_MARKER,
+        SYSTEMD_UNIT_NAME,
+    )
 
     repo_root = find_repo_root(repo)
 
     try:
-        result = scaffold_systemd_unit(repo_root, force=force)
+        emitted = scaffold_systemd_unit(repo_root, force=force)
     except ConfigurationError as exc:
         raise click.ClickException(str(exc)) from None
     except FileNotFoundError as exc:
@@ -906,34 +913,50 @@ def systemd(repo: Path | None, force: bool) -> None:
             "environment, activate it and re-run."
         ) from None
 
-    shown = result.path.relative_to(repo_root)
-    if result.refused:
-        console.print(f"  [error]✗[/error] {shown} not written: {result.reason}")
-        # Non-zero for the same reason `ci` exits non-zero on a refusal: the
-        # operator asked for a file and did not get one.
+    for result in emitted:
+        shown = result.path.relative_to(repo_root)
+        if result.refused:
+            console.print(f"  [error]✗[/error] {shown} not written: {result.reason}")
+        elif result.action == "unchanged":
+            console.print(f"  [dim]= {shown} (unchanged)[/dim]")
+        else:
+            console.print(f"  [success]✓[/success] {shown} ({result.action})")
+
+    # Found by marker rather than by position: the emission order is the
+    # engine's business, and the two files below are told apart by what they
+    # are, not by where they happened to land in the list.
+    unit = next(f for f in emitted if f.marker == SYSTEMD_MARKER)
+    hook = next(f for f in emitted if f.marker == BOOT_HOOK_MARKER)
+
+    # Gated on the unit alone. A hand-written boot hook already sitting in the
+    # repo is refused, and rightly — but the unit beside it may have been
+    # written perfectly, and an operator who just got one still needs to be
+    # told how to install it and what a late-mounting home does to it.
+    if not unit.refused:
+        console.print()
+        console.print("  Install it on this machine:")
+        # The full path, not the one reported above: --repo and any subdirectory
+        # both put the operator somewhere this line has to work from anyway. Soft
+        # wrapped, so a deep repo path stays one line for whoever copies it.
+        console.print(f"    cp {unit.path} ~/.config/systemd/user/", soft_wrap=True)
+        console.print("    systemctl --user daemon-reload")
+        console.print(f"    systemctl --user enable --now {SYSTEMD_UNIT_NAME}")
+        console.print()
+        console.print("  For it to start at boot, the account also needs:")
+        console.print("    loginctl enable-linger $USER")
+
+        home = Path.home()
+        _warn_about_a_network_home(home, detect_network_home(home), hook.path)
+
+    if any(result.refused for result in emitted):
+        # Last, after everything above has been said. Non-zero for the same
+        # reason `ci` exits non-zero on a refusal: the operator asked for a file
+        # and did not get one. The reason printed above names the overriding
+        # flag.
         raise SystemExit(1)
-    if result.action == "unchanged":
-        console.print(f"  [dim]= {shown} (unchanged)[/dim]")
-    else:
-        console.print(f"  [success]✓[/success] {shown} ({result.action})")
-
-    console.print()
-    console.print("  Install it on this machine:")
-    # The full path, not the one reported above: --repo and any subdirectory
-    # both put the operator somewhere this line has to work from anyway. Soft
-    # wrapped, so a deep repo path stays one line for whoever copies it.
-    console.print(f"    cp {result.path} ~/.config/systemd/user/", soft_wrap=True)
-    console.print("    systemctl --user daemon-reload")
-    console.print(f"    systemctl --user enable --now {SYSTEMD_UNIT_NAME}")
-    console.print()
-    console.print("  For it to start at boot, the account also needs:")
-    console.print("    loginctl enable-linger $USER")
-
-    home = Path.home()
-    _warn_about_a_network_home(home, detect_network_home(home))
 
 
-def _warn_about_a_network_home(home: Path, fstype: str | None) -> None:
+def _warn_about_a_network_home(home: Path, fstype: str | None, hook: Path) -> None:
     """Say what linger does not cover when ``$HOME`` is a network mount.
 
     Printed after the install instructions rather than instead of them: those
@@ -943,6 +966,12 @@ def _warn_about_a_network_home(home: Path, fstype: str | None) -> None:
     mount. So the drop-in is printed verbatim, for the operator to hand to
     whoever has root, and nothing here is refused or withheld.
 
+    Then the fallback for an operator who has nobody to hand it to: the boot
+    hook this verb already wrote, and the crontab line that runs it. That is
+    the only reason the hook exists, and this is the only place its path is
+    named — an operator on a local home never needs it. OSPREY prints the
+    ``@reboot`` line rather than installing it; the crontab is the account's.
+
     Silent when *fstype* is ``None``, which covers both a local home and a host
     the detection could not read.
 
@@ -950,6 +979,8 @@ def _warn_about_a_network_home(home: Path, fstype: str | None) -> None:
         home: The home directory that was inspected, and the one the drop-in
             has to name.
         fstype: What :func:`~.deploy_scaffold.detect_network_home` reported.
+        hook: Absolute path to the emitted boot hook, as the crontab line has
+            to name it.
     """
     if fstype is None:
         return
@@ -982,6 +1013,17 @@ def _warn_about_a_network_home(home: Path, fstype: str | None) -> None:
     console.print("      After=remote-fs.target autofs.service", markup=False)
     console.print("    and then run:")
     console.print("      sudo systemctl daemon-reload")
+    console.print()
+    console.print("    If nobody with root is available, this run also wrote a boot hook:")
+    console.print(f"      {hook}", soft_wrap=True)
+    console.print("    It waits for the home, this deployment and the user manager to show")
+    console.print("    up, then reloads the unit files and starts the unit. Run it once per")
+    console.print("    boot from the account's own crontab:")
+    console.print("      crontab -e")
+    console.print(f"      @reboot {hook}", soft_wrap=True)
+    console.print("    That is a fallback, not a replacement for the drop-in above: it")
+    console.print("    repairs each boot after the fact rather than ordering the manager")
+    console.print("    correctly in the first place.")
 
 
 def _owned_row(profile_root: Path | None, name: str) -> tuple[str, str, str]:

--- a/src/osprey/health/core/__init__.py
+++ b/src/osprey/health/core/__init__.py
@@ -20,15 +20,24 @@ where
   the load outcome, since it is the category that *reports* on config loading.
 * ``context`` is the opaque health runtime (see ``osprey.health.runtime``),
   providing lazy access to a control-system connector via
-  ``await context.get_connector()``. Categories that need no connector ignore
-  it. It defaults to ``None`` so config-only categories can be called without
-  a runtime.
+  ``await context.get_connector()``. It defaults to ``None`` so config-only
+  categories can be called without a runtime — and ``None`` is all it ever is
+  today: ``build_records`` passes ``context=None`` at every call site, and a
+  category that needs the runtime now reaches it through its *callable*
+  instead (see below).
 
-The factory returns a ``CategoryCallable``: a **no-argument** callable that
-returns ``list[CheckResult]`` (sync) or an awaitable of it (async). Anything
-the callable needs (config, runtime, resolved timeouts) is captured by closure
-at registration time — this keeps the runner's execution path uniform across
-core, YAML and plugin categories.
+The factory returns a ``CategoryCallable``: a callable returning
+``list[CheckResult]`` (sync) or an awaitable of it (async). It normally takes
+no arguments — config and resolved timeouts are captured by closure at
+registration time, which keeps the runner's execution path uniform across
+core, YAML and plugin categories. An ``async def`` callable may instead
+declare a ``runtime`` parameter and be handed the suite's shared
+``osprey.health.runtime.HealthRuntime`` by keyword, so it reuses the one
+control-system connector the whole run shares rather than opening a second
+one; that runtime is valid only for the duration of the call. A sync callable
+cannot take it — it runs on a worker thread with no event loop — and one that
+declares ``runtime`` is refused with an ``error`` row saying to make it
+``async def``.
 
 Lazy resolution
 ----------------
@@ -49,9 +58,12 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from osprey.health.models import CheckResult
 
-# A category callable takes no arguments and returns results, sync or async.
-CategoryCallable = Callable[[], "list[CheckResult] | Awaitable[list[CheckResult]]"]
-# A factory binds config/runtime and returns the category callable.
+# A category callable returns results, sync or async. Its parameter list is open
+# rather than empty because an ``async def`` one may declare ``runtime`` and be
+# called by keyword — see the factory contract above.
+CategoryCallable = Callable[..., "list[CheckResult] | Awaitable[list[CheckResult]]"]
+# A factory binds the config state (and, where a category takes one, a `cwd`)
+# and returns the category callable.
 CategoryFactory = Callable[..., CategoryCallable]
 
 # Canonical category name -> (sibling module name, factory attribute) within

--- a/src/osprey/health/core/__init__.py
+++ b/src/osprey/health/core/__init__.py
@@ -41,7 +41,7 @@ declares ``runtime`` is refused with an ``error`` row saying to make it
 
 Lazy resolution
 ----------------
-``CORE_CATEGORIES`` is a lazy mapping: iterating it yields the fourteen canonical
+``CORE_CATEGORIES`` is a lazy mapping: iterating it yields the fifteen canonical
 names without importing anything, and indexing a name imports only that one
 sibling module on demand. Sibling category modules are authored independently
 and must never edit this file; a not-yet-written or import-failing module
@@ -67,13 +67,14 @@ CategoryCallable = Callable[..., "list[CheckResult] | Awaitable[list[CheckResult
 CategoryFactory = Callable[..., CategoryCallable]
 
 # Canonical category name -> (sibling module name, factory attribute) within
-# this package. Static so the fourteen valid names are known without importing any
+# this package. Static so the fifteen valid names are known without importing any
 # sibling module; resolution imports the module lazily on first access.
 _CORE_CATEGORY_SPECS: dict[str, tuple[str, str]] = {
     "configuration": ("configuration", "configuration"),
     "file_system": ("file_system", "file_system"),
     "python_environment": ("python_environment", "python_environment"),
     "containers": ("containers", "containers"),
+    "systemd_unit": ("systemd_unit", "systemd_unit"),
     "openobserve": ("openobserve", "openobserve"),
     "providers": ("providers", "providers"),
     "claude_cli": ("claude_cli", "claude_cli"),
@@ -115,7 +116,7 @@ class _LazyCoreCategoryRegistry(Mapping[str, CategoryFactory]):
 
 CORE_CATEGORIES: Mapping[str, CategoryFactory] = _LazyCoreCategoryRegistry()
 
-# The fourteen canonical core category names, without importing any sibling module.
+# The fifteen canonical core category names, without importing any sibling module.
 CORE_CATEGORY_NAMES: tuple[str, ...] = tuple(_CORE_CATEGORY_SPECS)
 
 

--- a/src/osprey/health/core/systemd_unit.py
+++ b/src/osprey/health/core/systemd_unit.py
@@ -1,0 +1,265 @@
+"""Core ``systemd_unit`` health category.
+
+Reports whether the ``systemd --user`` manager can actually *see* the boot unit
+``osprey scaffold systemd`` wrote, which is a different question from whether
+the unit file exists.
+
+The failure this row exists for: when ``$HOME`` lives on NFS/autofs, a lingering
+``systemd --user`` manager is started at boot — before the home is mounted. That
+manager resolves its unit search path exactly once, finds an empty (or absent)
+``~/.config/systemd/user``, and never looks again. The scaffolded unit is then
+installed on disk and perfectly well-formed, yet ``systemctl --user`` answers
+``not-found`` for it, and the deployment silently fails to come back after every
+reboot. Read from the outside it looks like a broken unit; it is really a
+mount-ordering problem, and the fix is a ``systemctl --user daemon-reload``
+(plus, durably, making the manager start after the home is mounted). Nothing
+else in the health suite would notice: the file is on disk, the build is clean,
+and the only witness is the manager's own answer.
+
+The category emits exactly one row, ``systemd_unit``, from a deliberate
+trigger/report split:
+
+* the **repo** copy (``<project>/osprey.service``) decides whether this
+  deployment uses the systemd boot path at all. No repo unit means the operator
+  never asked for one, so the row is ``skip`` — not a warning about a missing
+  file nobody wanted;
+* the **installed** copy plus the manager's ``LoadState`` decide the verdict:
+  ``warning`` when the unit was scaffolded but never installed, ``error`` when
+  it is installed and the manager still reports ``not-found``, ``ok`` for any
+  other ``LoadState`` (``loaded``, ``masked``, ``error``, ``bad-setting`` — all
+  states in which the manager can see the unit, which is what this row asks).
+
+Keying off only one of the two produces a false alarm in one direction or the
+other: repo-only would warn about every host that deliberately runs OSPREY some
+other way, and install-only would stay silent on exactly the host where the
+manager has gone blind.
+
+Everything that is not a verdict degrades to ``skip``: no ``systemctl`` on
+``PATH`` (macOS, containers), a ``systemctl --user`` that cannot reach a bus, a
+timed-out query, or a home directory that cannot be resolved at all. A host with
+no user manager is not an unhealthy host.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from osprey.health.models import CheckResult, Status
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from osprey.health.core import CategoryCallable
+    from osprey.health.runtime import HealthRuntime
+
+CATEGORY = "systemd_unit"
+
+#: Wall-clock budget for the ``systemctl --user show`` query. Its own constant
+#: rather than a share of the poll budget: the query is a single D-Bus
+#: round-trip against a local manager, so anything slower than this is a wedged
+#: or unreachable bus, and waiting longer only delays the ``skip``.
+_SYSTEMCTL_TIMEOUT_S = 5.0
+
+#: The boot unit ``osprey scaffold systemd`` writes, spelled as a literal rather
+#: than imported from :mod:`~osprey.cli.deploy_scaffold_templates` (which owns
+#: the name as ``SYSTEMD_UNIT_NAME``). Importing it would pull the CLI package
+#: into the web and MCP health surfaces, which import this module. This is the
+#: same choice :mod:`~osprey.cli.profile_conventions` made for its own copy of
+#: the name, and the same answer: the two spellings are pinned to each other by
+#: a test rather than by an import.
+_UNIT_NAME = "osprey.service"
+
+_LOAD_STATE_NOT_FOUND = "not-found"
+
+
+def systemd_unit(
+    config: Mapping[str, Any] | None = None,
+    context: HealthRuntime | None = None,
+    *,
+    cwd: Path | None = None,
+) -> CategoryCallable:
+    """Build the ``systemd_unit`` category callable.
+
+    Args:
+        config: Loaded config mapping. Unused — the check reads the deployment
+            repo and the user manager, not the rendered config.
+        context: Health runtime. Unused — no control-system connector is needed.
+        cwd: Deployment repo root, where the scaffolded ``osprey.service`` lives.
+            Defaults to :func:`Path.cwd`, resolved when the callable runs so the
+            CLI can thread a ``--project-path`` override; ``build_records``
+            passes the project path here just as it does for ``file_system``.
+
+    Returns:
+        A no-argument async callable returning the category's single row.
+    """
+    base_dir = cwd
+
+    async def _run() -> list[CheckResult]:
+        return await _check_systemd_unit(base_dir or Path.cwd())
+
+    return _run
+
+
+async def _run_systemctl(argv: list[str], timeout_s: float) -> tuple[int | None, str, str]:
+    """Run ``argv`` and return ``(returncode, stdout, stderr)``.
+
+    Args:
+        argv: Command and arguments to execute.
+        timeout_s: Wall-clock budget; on expiry the child is killed and reaped.
+
+    Returns:
+        The exit code and decoded stdout/stderr.
+
+    Raises:
+        FileNotFoundError: If the executable is not on ``PATH``.
+        TimeoutError: If the command exceeds ``timeout_s``.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+    except TimeoutError:
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        raise
+    return (
+        proc.returncode,
+        stdout.decode(errors="replace"),
+        stderr.decode(errors="replace"),
+    )
+
+
+def _user_unit_dir() -> Path:
+    """Resolve the directory the user manager loads units from.
+
+    ``$XDG_CONFIG_HOME/systemd/user`` when that variable is set and non-empty,
+    otherwise ``~/.config/systemd/user``. Honouring ``XDG_CONFIG_HOME`` matters:
+    the user manager reads it when set, so hardcoding ``~/.config`` would report
+    a properly installed unit as missing on every host that sets it.
+
+    Raises:
+        RuntimeError: If ``Path.home()`` cannot resolve a home directory.
+        OSError: If the environment or path expansion fails.
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "systemd" / "user"
+
+
+def _row(status: Status, message: str, details: str = "", value: str = "") -> CheckResult:
+    """Build this category's single row."""
+    return CheckResult(
+        name=CATEGORY,
+        category=CATEGORY,
+        status=status,
+        message=message,
+        value=value,
+        details=details,
+    )
+
+
+async def _check_systemd_unit(repo_root: Path) -> list[CheckResult]:
+    """Produce the one ``systemd_unit`` row for the deployment at ``repo_root``."""
+    repo_unit = repo_root / _UNIT_NAME
+    if not repo_unit.exists():
+        return [
+            _row(
+                Status.SKIP,
+                f"no scaffolded {_UNIT_NAME} in this deployment",
+                details=(
+                    f"Run `osprey scaffold systemd` if this deployment should "
+                    f"start at boot; expected {repo_unit}."
+                ),
+            )
+        ]
+
+    if shutil.which("systemctl") is None:
+        return [_row(Status.SKIP, "systemctl not found in PATH")]
+
+    try:
+        installed_unit = _user_unit_dir() / _UNIT_NAME
+        installed = installed_unit.exists()
+    except (RuntimeError, OSError) as exc:
+        # Path.home() raises RuntimeError when neither $HOME nor a passwd entry
+        # resolves (containers, some CI). Nothing to report against.
+        return [
+            _row(
+                Status.SKIP,
+                "cannot resolve the user unit directory",
+                details=f"{type(exc).__name__}: {exc}",
+            )
+        ]
+
+    if not installed:
+        return [
+            _row(
+                Status.WARNING,
+                f"{_UNIT_NAME} is scaffolded but not installed",
+                details=(
+                    f"Copy or symlink {repo_unit} to {installed_unit}, then run "
+                    f"`systemctl --user daemon-reload` and "
+                    f"`systemctl --user enable --now {_UNIT_NAME}`."
+                ),
+            )
+        ]
+
+    argv = ["systemctl", "--user", "show", "-p", "LoadState", "--value", _UNIT_NAME]
+    try:
+        returncode, stdout, stderr = await _run_systemctl(argv, _SYSTEMCTL_TIMEOUT_S)
+    except FileNotFoundError:
+        return [_row(Status.SKIP, "systemctl not found in PATH")]
+    except TimeoutError:
+        return [
+            _row(
+                Status.SKIP,
+                f"`systemctl --user show` timed out ({_SYSTEMCTL_TIMEOUT_S:.0f}s)",
+                details="The user manager did not answer; not treated as a fault.",
+            )
+        ]
+
+    if returncode != 0:
+        return [
+            _row(
+                Status.SKIP,
+                "no reachable systemd --user manager",
+                details=stderr.strip() or "systemctl --user exited non-zero with no stderr.",
+            )
+        ]
+
+    load_state = stdout.strip() or "unknown"
+    if load_state == _LOAD_STATE_NOT_FOUND:
+        return [
+            _row(
+                Status.ERROR,
+                f"{_UNIT_NAME} is installed but the user manager reports not-found",
+                details=(
+                    f"{installed_unit} exists, yet `systemctl --user` cannot see it. "
+                    "This is the network-home failure: when $HOME is on NFS/autofs, "
+                    "a systemd --user manager started before the home was mounted "
+                    "resolved its unit search path once and never looked again, so "
+                    "the deployment does not come back after a reboot. Run "
+                    "`systemctl --user daemon-reload` to recover now, and order the "
+                    "user manager after the home mount so it does not recur."
+                ),
+            )
+        ]
+
+    return [
+        _row(
+            Status.OK,
+            f"{_UNIT_NAME} is installed and visible to the user manager",
+            value=load_state,
+        )
+    ]
+
+
+__all__ = ["CATEGORY", "systemd_unit"]

--- a/src/osprey/health/core/systemd_unit.py
+++ b/src/osprey/health/core/systemd_unit.py
@@ -141,17 +141,20 @@ async def _run_systemctl(argv: list[str], timeout_s: float) -> tuple[int | None,
 def _user_unit_dir() -> Path:
     """Resolve the directory the user manager loads units from.
 
-    ``$XDG_CONFIG_HOME/systemd/user`` when that variable is set and non-empty,
-    otherwise ``~/.config/systemd/user``. Honouring ``XDG_CONFIG_HOME`` matters:
-    the user manager reads it when set, so hardcoding ``~/.config`` would report
-    a properly installed unit as missing on every host that sets it.
+    ``$XDG_CONFIG_HOME/systemd/user`` when that variable is set, non-empty and
+    absolute, otherwise ``~/.config/systemd/user``. Honouring ``XDG_CONFIG_HOME``
+    matters: the user manager reads it when set, so hardcoding ``~/.config``
+    would report a properly installed unit as missing on every host that sets
+    it. A relative value is ignored the way systemd and the basedir spec ignore
+    it — read literally it would resolve against this process's cwd and report
+    an installed unit as missing.
 
     Raises:
         RuntimeError: If ``Path.home()`` cannot resolve a home directory.
         OSError: If the environment or path expansion fails.
     """
     xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
-    base = Path(xdg) if xdg else Path.home() / ".config"
+    base = Path(xdg) if xdg and Path(xdg).is_absolute() else Path.home() / ".config"
     return base / "systemd" / "user"
 
 

--- a/src/osprey/health/plugins.py
+++ b/src/osprey/health/plugins.py
@@ -29,8 +29,9 @@ surfaces do on every config-change refresh — **re-executes** the file and
 replaces that ``sys.modules`` entry. Module-level state in a plugin therefore
 does not survive a refresh, and a plugin must not rely on it doing so.
 
-Loading is defensive: no plugin failure ever crashes the suite. An import error,
-a missing/non-callable ``get_health_categories``, a bad return type, or a name
+Loading is defensive: no plugin failure ever crashes the suite. A file-path
+entry that cannot even be resolved to an absolute path, an import error, a
+missing/non-callable ``get_health_categories``, a bad return type, or a name
 that collides with a core/YAML/earlier-plugin category each yields a single
 ``error`` :class:`~osprey.health.models.CheckResult` in the diagnostic
 ``plugins`` category — never an exception. Successfully loaded plugin categories
@@ -203,7 +204,13 @@ def _import_plugin_file(
     entry: str, errors: list[CheckResult], *, project_root: Path | None
 ) -> ModuleType | None:
     """Load a ``.py`` plugin entry off disk under its synthetic module name."""
-    resolved = _resolve_plugin_file(entry, project_root)
+    try:
+        resolved = _resolve_plugin_file(entry, project_root)
+    except Exception as exc:  # noqa: BLE001 - an unresolvable path is a reported error row
+        # ``~`` with no resolvable home, a symlink cycle, an over-long name: the
+        # entry never becomes a path, and that must degrade the suite by one row.
+        errors.append(_error_row(entry, f"could not resolve health plugin path '{entry}': {exc}"))
+        return None
     if not resolved.is_file():
         errors.append(_error_row(entry, f"health plugin file '{entry}' not found: {resolved}"))
         return None

--- a/src/osprey/health/plugins.py
+++ b/src/osprey/health/plugins.py
@@ -1,10 +1,14 @@
 """Load facility health categories from ``health.plugins`` entries.
 
 A plugin exposes ``get_health_categories() -> dict[str, CategoryCallable]`` — a
-mapping of category name to a no-argument callable returning
-``list[CheckResult]`` (sync or async), the same callable shape core and YAML
-categories use. Plugin categories run alongside core and YAML categories through
-the identical runner path.
+mapping of category name to a callable returning ``list[CheckResult]`` (sync or
+async), the same callable shape core and YAML categories use. The callable
+normally takes no arguments; an ``async def`` one may declare a ``runtime``
+parameter and be handed the suite's shared
+:class:`~osprey.health.runtime.HealthRuntime` by keyword, while a sync one that
+declares it is refused with an ``error`` row. The full contract is on the
+``contributing/extending-osprey`` page. Plugin categories run alongside core and
+YAML categories through the identical runner path.
 
 An entry under ``health.plugins`` names that plugin in one of two ways:
 

--- a/src/osprey/health/records.py
+++ b/src/osprey/health/records.py
@@ -258,16 +258,23 @@ def build_records(
             continue
 
         factory = get_core_category_factory(name)
-        if name == "file_system":
-            # Repo-root things: the `.env`, a `registry_path` the config states
-            # relative to project_root, the disk the deployment lives on.
+        # Three categories take a `cwd`, and the anchor follows the ZONE the
+        # material they look for lives in — not a house style. Getting it wrong
+        # is silent: the check reports a present file as missing.
+        if name in ("file_system", "systemd_unit"):
+            # Repo-root things. `file_system`: the `.env`, a `registry_path` the
+            # config states relative to project_root, the disk the deployment
+            # lives on. `systemd_unit`: `osprey scaffold systemd` writes
+            # `osprey.service` beside the profile, in the tracked source zone —
+            # it is not build output, so the render zone would never hold it and
+            # the row would skip on every deployment that has one.
             func = factory(expanded, context=None, cwd=project_path)
         elif name == "channel_finder":
             # NOT the repo root. A channel database is build-owned output, and
             # the rendered config states its path relative to the config's own
             # directory (`<repo>/build`), so anchoring it on the repo root looks
             # one zone too high and reports a present database as missing. The
-            # two categories take DIFFERENT anchors on purpose.
+            # three categories do not all take the same anchor on purpose.
             func = factory(expanded, context=None, cwd=render_path)
         else:
             func = factory(expanded, context=None)

--- a/src/osprey/health/runner.py
+++ b/src/osprey/health/runner.py
@@ -24,7 +24,11 @@ Execution model
   first). A backstop expiry synthesizes the check's ``timeout_status``.
 * **Sync off-loading.** Callable categories that are plain functions run on a
   daemon thread via :func:`osprey.health.offload.run_sync`, so a hung sync check
-  can never wedge process exit.
+  can never wedge process exit. That thread has no event loop, so only an
+  ``async def`` callable may be handed the suite's shared
+  :class:`~osprey.health.runtime.HealthRuntime`; a sync one that asks for it is
+  refused with an ``error`` row, and a zero-argument callable of either kind is
+  unaffected. See :func:`_run_callable`.
 * **Cost gating.** ``on_demand`` categories run only when ``full`` is set;
   otherwise they are emitted as ``skip`` rows carrying a "run with --full" hint.
   ``--category`` selection never elevates cost class — ``full`` is the sole gate.
@@ -49,6 +53,7 @@ Execution model
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Iterable, Mapping, Sequence
 from time import perf_counter
 from typing import Any
@@ -228,9 +233,31 @@ async def _run_declarative(
     return [results[c.name] for c in checks], deadline_hit
 
 
+def _accepts_runtime(func: Any) -> bool:
+    """Whether a category callable asks for the suite's shared ``HealthRuntime``.
+
+    The parameter must be nameable as a keyword — ``POSITIONAL_OR_KEYWORD`` or
+    ``KEYWORD_ONLY`` — because the runtime is bound *by keyword*. Matching on
+    the parameter's kind rather than only its name lets the natural
+    ``def check(*, runtime)`` spelling work, while keyword binding makes
+    ``def check(cache=None, runtime=None)`` impossible to misbind (a positional
+    call would hand the runtime to ``cache``). A callable whose signature cannot
+    be read at all is treated as zero-argument, the older and safer shape.
+    """
+    try:
+        param = inspect.signature(func).parameters.get("runtime")
+    except (TypeError, ValueError):
+        return False
+    return param is not None and param.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
+
+
 async def _run_callable(
     record: CategoryRecord,
     deadline: float | None,
+    runtime: HealthRuntime,
 ) -> tuple[list[CheckResult], bool]:
     """Execute a callable-backed category (core/plugin), off-loading sync funcs.
 
@@ -238,6 +265,17 @@ async def _run_callable(
     time left before the cost-class deadline. A budget expiry synthesizes one
     ``error`` row named after the category and flags a deadline hit; a raise
     synthesizes one ``error`` row without flagging a deadline (isolation).
+
+    A callable that names a ``runtime`` parameter (see :func:`_accepts_runtime`)
+    receives the suite's shared :class:`~osprey.health.runtime.HealthRuntime` by
+    keyword, so a facility plugin reuses the one lazily-built connector instead
+    of standing up a second one. Only coroutine functions are eligible: a sync
+    category runs on a bare thread with no event loop, whose only route into the
+    async connector would be :func:`asyncio.run` — a connector built on a loop
+    that then dies, violating the single-ownership invariant
+    :mod:`osprey.health.runtime` exists to protect. A sync callable that asks for
+    the runtime is therefore refused loudly with one ``error`` row rather than
+    served a cross-loop connector.
     """
     func = record.func
     if deadline is None:
@@ -245,9 +283,29 @@ async def _run_callable(
     else:
         effective = min(record.timeout_s, max(deadline - perf_counter(), 0.0))
 
+    wants_runtime = _accepts_runtime(func)
+    if wants_runtime and not asyncio.iscoroutinefunction(func):
+        return (
+            [
+                CheckResult(
+                    record.name,
+                    record.name,
+                    Status.ERROR,
+                    f"{record.name} must be `async def` to receive `runtime`",
+                    details=(
+                        "A sync category callable runs on a worker thread with no event "
+                        "loop and cannot use the shared HealthRuntime; declare the "
+                        "category `async def` or drop its `runtime` parameter."
+                    ),
+                )
+            ],
+            False,
+        )
+
     try:
         if asyncio.iscoroutinefunction(func):
-            result = await asyncio.wait_for(func(), timeout=effective)
+            call = func(runtime=runtime) if wants_runtime else func()
+            result = await asyncio.wait_for(call, timeout=effective)
         else:
             result = await run_sync(func, timeout_s=effective)
         return list(result), False
@@ -294,7 +352,9 @@ async def run_health_suite(
         records: The merged category set (core + YAML + plugin), already
             resolved to :class:`~osprey.health.config.CategoryRecord`\\ s.
         runtime: The suite's :class:`~osprey.health.runtime.HealthRuntime`,
-            passed to every probe via :class:`~osprey.health.probes.ProbeContext`.
+            passed to every probe via :class:`~osprey.health.probes.ProbeContext`
+            and, for an ``async def`` category callable that names a ``runtime``
+            parameter, injected into the call by keyword.
         config: Optional per-run configuration mapping forwarded to every probe
             via :class:`~osprey.health.probes.ProbeContext`. When ``None`` (the
             CLI/standalone default) probes fall back to the global config
@@ -336,7 +396,7 @@ async def run_health_suite(
             return _skip_on_demand(record), False
         deadline = on_demand_deadline if record.cost is Cost.ON_DEMAND else suite_deadline
         if record.func is not None:
-            return await _run_callable(record, deadline)
+            return await _run_callable(record, deadline, runtime)
         return await _run_declarative(record, ctx, deadline)
 
     grouped = await asyncio.gather(*(_run_category(r) for r in selected))

--- a/src/osprey/health/runner.py
+++ b/src/osprey/health/runner.py
@@ -246,7 +246,11 @@ def _accepts_runtime(func: Any) -> bool:
     """
     try:
         param = inspect.signature(func).parameters.get("runtime")
-    except (TypeError, ValueError):
+    except Exception:  # noqa: BLE001 - an unreadable signature is the zero-arg shape
+        # ``signature()`` documents TypeError and ValueError, but it also reads
+        # ``__signature__`` and follows ``__wrapped__``, and plugin code owns
+        # both. This runs outside the per-callable isolation, so anything it
+        # raised would abort the whole suite against the module's promise.
         return False
     return param is not None and param.kind in (
         inspect.Parameter.POSITIONAL_OR_KEYWORD,

--- a/src/osprey/health/runtime.py
+++ b/src/osprey/health/runtime.py
@@ -165,9 +165,16 @@ class HealthRuntime:
                 )
 
                 register_builtin_connectors()  # idempotent; must run before create
-                self._connector = await ConnectorFactory.create_control_system_connector(
-                    self._config
-                )
+                connector = await ConnectorFactory.create_control_system_connector(self._config)
+                if self._closed:
+                    # shutdown() ran during construction: it found the slot
+                    # empty and disconnected nothing, so this one is ours to
+                    # close — installing it would orphan it.
+                    await self._disconnect_one("connector", connector)
+                    raise RuntimeError(
+                        "HealthRuntime was closed while its connector was being constructed"
+                    )
+                self._connector = connector
                 self._ever_constructed = True
                 logger.info(
                     "HealthRuntime: constructed control-system connector (%s)",
@@ -212,7 +219,14 @@ class HealthRuntime:
                 )
 
                 register_builtin_connectors()  # idempotent; must run before create
-                self._archiver = await ConnectorFactory.create_archiver_connector(archiver_config)
+                archiver = await ConnectorFactory.create_archiver_connector(archiver_config)
+                if self._closed:
+                    # Same window as get_connector: closed mid-construction.
+                    await self._disconnect_one("archiver connector", archiver)
+                    raise RuntimeError(
+                        "HealthRuntime was closed while its archiver connector was being constructed"
+                    )
+                self._archiver = archiver
                 self._archiver_ever_constructed = True
                 logger.info(
                     "HealthRuntime: constructed archiver connector (%s)",

--- a/src/osprey/health/runtime.py
+++ b/src/osprey/health/runtime.py
@@ -32,6 +32,7 @@ this class without API changes.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
@@ -66,6 +67,19 @@ class HealthRuntime:
     ``disconnect()`` that raises is swallowed so a failing connector can never
     mask the suite's own result.
 
+    Construction is serialized. Health checks run concurrently — probes within
+    a category are awaited together, and the categories themselves run under a
+    single ``gather`` — so several probes can reach an accessor while the
+    connector is still ``None``. Without a guard each of them would see the
+    empty slot, each would build a connector, and every assignment but the last
+    would orphan one: an unreferenced Channel Access client that :meth:`shutdown`
+    never disconnects, because it only ever knew about the instance that won the
+    race. Both accessors therefore take a single :class:`asyncio.Lock` and
+    re-test the cache inside it, so exactly one caller constructs and every
+    other waiter returns that same instance. The ``closed`` refusal stays
+    outside the lock: a runtime that has already torn its connectors down must
+    say so immediately rather than queue behind an in-flight construction.
+
     Args:
         control_system_config: The ``control_system`` config section passed
             straight to
@@ -79,6 +93,9 @@ class HealthRuntime:
         self._archiver: ArchiverConnector | None = None
         self._archiver_ever_constructed = False
         self._closed = False
+        #: Guards lazy construction in both accessors (see the class docstring).
+        #: Held only across construction, never across teardown.
+        self._lock = asyncio.Lock()
 
     @property
     def ever_constructed(self) -> bool:
@@ -130,26 +147,33 @@ class HealthRuntime:
         calls return the same cached instance. After :meth:`shutdown` the
         runtime is closed and this refuses with :class:`RuntimeError` rather
         than reconstructing a connector the suite already tore down.
+
+        Concurrent callers are serialized, so two probes that both find the slot
+        empty still produce one connector between them; the closed check runs
+        before the lock, so a closed runtime refuses at once.
         """
         if self._closed:
             raise RuntimeError(
                 "HealthRuntime is closed; get_connector() cannot reconstruct "
                 "a connector after shutdown()"
             )
-        if self._connector is None:
-            from osprey.connectors.factory import (
-                ConnectorFactory,
-                register_builtin_connectors,
-            )
+        async with self._lock:
+            if self._connector is None:
+                from osprey.connectors.factory import (
+                    ConnectorFactory,
+                    register_builtin_connectors,
+                )
 
-            register_builtin_connectors()  # idempotent; must run before create
-            self._connector = await ConnectorFactory.create_control_system_connector(self._config)
-            self._ever_constructed = True
-            logger.info(
-                "HealthRuntime: constructed control-system connector (%s)",
-                type(self._connector).__name__,
-            )
-        return self._connector
+                register_builtin_connectors()  # idempotent; must run before create
+                self._connector = await ConnectorFactory.create_control_system_connector(
+                    self._config
+                )
+                self._ever_constructed = True
+                logger.info(
+                    "HealthRuntime: constructed control-system connector (%s)",
+                    type(self._connector).__name__,
+                )
+            return self._connector
 
     async def get_archiver(self, archiver_config: dict[str, Any]) -> ArchiverConnector:
         """Return the cached archiver connector, constructing it on first call.
@@ -167,6 +191,10 @@ class HealthRuntime:
         :class:`RuntimeError` rather than reconstructing a connector the suite
         already tore down.
 
+        Construction is serialized on the same lock as :meth:`get_connector`, so
+        concurrent archiver probes build one connector between them rather than
+        one apiece.
+
         Args:
             archiver_config: The ``archiver`` config block passed straight to
                 :meth:`ConnectorFactory.create_archiver_connector`.
@@ -176,20 +204,21 @@ class HealthRuntime:
                 "HealthRuntime is closed; get_archiver() cannot reconstruct "
                 "an archiver connector after shutdown()"
             )
-        if self._archiver is None:
-            from osprey.connectors.factory import (
-                ConnectorFactory,
-                register_builtin_connectors,
-            )
+        async with self._lock:
+            if self._archiver is None:
+                from osprey.connectors.factory import (
+                    ConnectorFactory,
+                    register_builtin_connectors,
+                )
 
-            register_builtin_connectors()  # idempotent; must run before create
-            self._archiver = await ConnectorFactory.create_archiver_connector(archiver_config)
-            self._archiver_ever_constructed = True
-            logger.info(
-                "HealthRuntime: constructed archiver connector (%s)",
-                type(self._archiver).__name__,
-            )
-        return self._archiver
+                register_builtin_connectors()  # idempotent; must run before create
+                self._archiver = await ConnectorFactory.create_archiver_connector(archiver_config)
+                self._archiver_ever_constructed = True
+                logger.info(
+                    "HealthRuntime: constructed archiver connector (%s)",
+                    type(self._archiver).__name__,
+                )
+            return self._archiver
 
     @staticmethod
     def baseline_pinned_row() -> CheckResult | None:

--- a/src/osprey/templates/deploy/osprey-boot-hook.sh.j2
+++ b/src/osprey/templates/deploy/osprey-boot-hook.sh.j2
@@ -1,0 +1,102 @@
+#!/bin/sh
+# =============================================================================
+# {{ ctx.facility_name }} — OSPREY boot hook
+# =============================================================================
+# osprey-scaffold: deploy/boot-hook
+# osprey-version: {{ ctx.osprey_version }}
+#
+# Emitted by `osprey scaffold systemd` beside the user unit, for one situation:
+# a deploy host whose home directory is an NFS or autofs mount.
+#
+# A lingering `systemd --user` manager starts at boot, before that mount lands.
+# It resolves its unit search path once, finds nothing under the not-yet-
+# mounted home, and never looks again — so `systemctl --user status
+# {{ unit_name }}` reads `not-found` after every reboot and the stack sits
+# there until somebody runs `daemon-reload` by hand.
+#
+# The proper fix is a `RequiresMountsFor` drop-in on `user@<uid>.service`,
+# which needs root. This script is the fallback that does not: it waits for the
+# home, the deployment and the user manager to appear, then reloads the unit
+# files and starts the unit. Wire it into the account's own crontab:
+#
+#   crontab -e
+#   @reboot {{ ctx.repo_root }}/{{ boot_hook_path }}
+#
+# cron mails the account whatever this prints, so a boot that did not come back
+# says why in that mail. Running it again by hand is harmless: an already
+# active unit is left alone.
+#
+# Deployment how-to: {{ docs_url }}
+#
+# Re-run `osprey scaffold systemd` after the repo moves or OSPREY is
+# reinstalled elsewhere — the paths below are absolute. The marker line above
+# is what makes re-emission safe, so a file without it is treated as
+# hand-written and left alone unless you pass --force.
+# =============================================================================
+set -u
+
+# The one line that makes a cron job able to talk to the user manager at all.
+# `@reboot` runs with no session and no bus address, and `systemctl --user`
+# with no XDG_RUNTIME_DIR does not fail loudly — it just fails. Every hook of
+# this kind that "does nothing" is missing this.
+XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export XDG_RUNTIME_DIR
+
+# Seconds between attempts, and the budget shared by every wait below. Past
+# the budget the hook gives up and says which thing never showed, rather than
+# holding a cron slot open forever.
+POLL_SECONDS={{ ctx.poll_seconds }}
+TOTAL_WAIT_SECONDS={{ ctx.total_wait_seconds }}
+WAITED=0
+
+say() { printf 'osprey-boot-hook: %s\n' "$1"; }
+die() { printf 'osprey-boot-hook: %s\n' "$1" >&2; exit 1; }
+
+# Block until a path exists, spending from the shared budget. POSIX sh has no
+# `local`, so WAITED is deliberately global: the budget covers the whole boot,
+# not each path in turn.
+wait_for() {
+  while [ ! -e "$1" ]; do
+    if [ "$WAITED" -ge "$TOTAL_WAIT_SECONDS" ]; then
+      die "gave up after ${TOTAL_WAIT_SECONDS}s waiting for $2 ($1) — the unit was not started"
+    fi
+    sleep "$POLL_SECONDS"
+    WAITED=$((WAITED + POLL_SECONDS))
+  done
+  say "$2 is there: $1"
+}
+
+if [ -z "${HOME:-}" ]; then
+  die "HOME is unset — cron gives a job the account's home, so this ran from somewhere unexpected"
+fi
+
+# The home carries the unit file, and on this kind of host it is the mount
+# everything else is waiting on.
+wait_for "$HOME" "the home directory"
+
+# Both absolute, and both may live under that same mount: the unit's
+# WorkingDirectory, and the executable it runs.
+wait_for "{{ ctx.repo_root }}" "the deployment repo"
+wait_for "{{ ctx.osprey_bin }}" "the osprey executable"
+
+# The runtime directory is created by the user manager itself, so it appearing
+# is the signal that there is a manager to talk to — checking for the mount
+# alone would race a manager that has not started yet.
+wait_for "$XDG_RUNTIME_DIR" "the user manager's runtime directory"
+
+# Re-resolve the unit search path, which is the whole point: the manager read
+# it once, before the home was there.
+if ! systemctl --user daemon-reload; then
+  die "systemctl --user daemon-reload failed — the manager is up but not answering this account"
+fi
+say "reloaded the user manager's unit files"
+
+if systemctl --user is-active --quiet {{ unit_name }}; then
+  say "{{ unit_name }} is already active — nothing to start"
+  exit 0
+fi
+
+if ! systemctl --user start {{ unit_name }}; then
+  die "systemctl --user start {{ unit_name }} failed — see: systemctl --user status {{ unit_name }}"
+fi
+say "started {{ unit_name }}"

--- a/src/osprey/templates/deploy/osprey-boot-hook.sh.j2
+++ b/src/osprey/templates/deploy/osprey-boot-hook.sh.j2
@@ -35,7 +35,9 @@
 # the same late mount, so the job — which lives in the crontab, on the local
 # disk — first notes that cron fired it in `{{ boot_hook_log }}`, waits for
 # this file to become readable, and only then runs it. Put the two lines last
-# in the crontab, or any job below them runs from `/` too.
+# in the crontab: every job below them runs from `/` and sees HOME=/ in its
+# environment, so a job body that expands $HOME breaks silently unless it
+# starts with its own `export HOME=<the real home>`.
 #
 # Everything this script prints lands in that same log, on the local disk
 # rather than the home, so a boot on which the home never came still says

--- a/src/osprey/templates/deploy/osprey-boot-hook.sh.j2
+++ b/src/osprey/templates/deploy/osprey-boot-hook.sh.j2
@@ -14,16 +14,33 @@
 # {{ unit_name }}` reads `not-found` after every reboot and the stack sits
 # there until somebody runs `daemon-reload` by hand.
 #
-# The proper fix is a `RequiresMountsFor` drop-in on `user@<uid>.service`,
-# which needs root. This script is the fallback that does not: it waits for the
-# home, the deployment and the user manager to appear, then reloads the unit
-# files and starts the unit. Wire it into the account's own crontab:
+# When systemd manages the mount itself — an fstab entry, or a .mount or
+# .automount unit — a `RequiresMountsFor` drop-in on `user@<uid>.service`
+# orders the manager after it, and needs root. A home served by the autofs
+# daemon has no mount unit for that drop-in to order against, so there it
+# changes nothing, and this script is the fix rather than the fallback. It
+# waits for the home, the deployment and the user manager to appear, then
+# reloads the unit files and starts the unit. Wire it into the account's own
+# crontab, both lines, pasted whole:
 #
 #   crontab -e
-#   @reboot {{ ctx.repo_root }}/{{ boot_hook_path }}
+#   HOME=/
+#   {{ ctx.crontab_job }}
 #
-# cron mails the account whatever this prints, so a boot that did not come back
-# says why in that mail. Running it again by hand is harmless: an already
+# Neither line is optional, and the job is deliberately not a bare `@reboot`
+# with this script's path. cron changes into the crontab's HOME before it runs
+# a job, and on this host the home is not there yet when cron starts, so the
+# job dies before anything runs — silently, with no mail. `HOME=/` gives cron
+# a directory that exists. Then `sh` has to read this script, which sits on
+# the same late mount, so the job — which lives in the crontab, on the local
+# disk — first notes that cron fired it in `{{ boot_hook_log }}`, waits for
+# this file to become readable, and only then runs it. Put the two lines last
+# in the crontab, or any job below them runs from `/` too.
+#
+# Everything this script prints lands in that same log, on the local disk
+# rather than the home, so a boot on which the home never came still says
+# how far things got; cron mails the account the same lines if the host
+# delivers mail. Running the script again by hand is harmless: an already
 # active unit is left alone.
 #
 # Deployment how-to: {{ docs_url }}
@@ -35,12 +52,27 @@
 # =============================================================================
 set -u
 
+# cron ran this with HOME=/ (see the header), so the real home goes back first:
+# the unit file lives under it, and on this host it is the mount everything
+# else waits on. Written in as a full path like the repo and the executable —
+# until the home is mounted nothing on this host can be asked where it is.
+HOME="{{ ctx.home }}"
+export HOME
+
 # The one line that makes a cron job able to talk to the user manager at all.
 # `@reboot` runs with no session and no bus address, and `systemctl --user`
 # with no XDG_RUNTIME_DIR does not fail loudly — it just fails. Every hook of
 # this kind that "does nothing" is missing this.
 XDG_RUNTIME_DIR="/run/user/$(id -u)"
 export XDG_RUNTIME_DIR
+
+# Proof of launch, before any wait, on a disk that is there at boot. Appended:
+# the crontab job wrote the line before this one, and the two together say
+# whether cron fired, whether this file was reachable, and how far it got.
+LOG="{{ boot_hook_log }}"
+if ! printf 'osprey-boot-hook: launched %s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')" >> "$LOG" 2>/dev/null; then
+  LOG=/dev/null
+fi
 
 # Seconds between attempts, and the budget shared by every wait below. Past
 # the budget the hook gives up and says which thing never showed, rather than
@@ -49,8 +81,8 @@ POLL_SECONDS={{ ctx.poll_seconds }}
 TOTAL_WAIT_SECONDS={{ ctx.total_wait_seconds }}
 WAITED=0
 
-say() { printf 'osprey-boot-hook: %s\n' "$1"; }
-die() { printf 'osprey-boot-hook: %s\n' "$1" >&2; exit 1; }
+say() { printf 'osprey-boot-hook: %s\n' "$1" | tee -a "$LOG"; }
+die() { printf 'osprey-boot-hook: %s\n' "$1" | tee -a "$LOG" >&2; exit 1; }
 
 # Block until a path exists, spending from the shared budget. POSIX sh has no
 # `local`, so WAITED is deliberately global: the budget covers the whole boot,
@@ -66,12 +98,9 @@ wait_for() {
   say "$2 is there: $1"
 }
 
-if [ -z "${HOME:-}" ]; then
-  die "HOME is unset — cron gives a job the account's home, so this ran from somewhere unexpected"
-fi
-
 # The home carries the unit file, and on this kind of host it is the mount
-# everything else is waiting on.
+# everything else is waiting on. On an autofs home the test itself is what
+# triggers the mount.
 wait_for "$HOME" "the home directory"
 
 # Both absolute, and both may live under that same mount: the unit's

--- a/src/osprey/templates/deploy/osprey-boot-hook.sh.j2
+++ b/src/osprey/templates/deploy/osprey-boot-hook.sh.j2
@@ -21,23 +21,26 @@
 # changes nothing, and this script is the fix rather than the fallback. It
 # waits for the home, the deployment and the user manager to appear, then
 # reloads the unit files and starts the unit. Wire it into the account's own
-# crontab, both lines, pasted whole:
+# crontab — all of these lines, pasted whole:
 #
 #   crontab -e
-#   HOME=/
-#   {{ ctx.crontab_job }}
+{% for line in ctx.crontab_lines %}
+#   {{ line }}
+{% endfor %}
 #
-# Neither line is optional, and the job is deliberately not a bare `@reboot`
+# None of them is optional, and the job is deliberately not a bare `@reboot`
 # with this script's path. cron changes into the crontab's HOME before it runs
 # a job, and on this host the home is not there yet when cron starts, so the
 # job dies before anything runs — silently, with no mail. `HOME=/` gives cron
-# a directory that exists. Then `sh` has to read this script, which sits on
-# the same late mount, so the job — which lives in the crontab, on the local
-# disk — first notes that cron fired it in `{{ boot_hook_log }}`, waits for
-# this file to become readable, and only then runs it. Put the two lines last
-# in the crontab: every job below them runs from `/` and sees HOME=/ in its
-# environment, so a job body that expands $HOME breaks silently unless it
-# starts with its own `export HOME=<the real home>`.
+# a directory that exists; `SHELL=/bin/sh` is the shell the job is written
+# for, whatever an existing crontab set above. Then `sh` has to read this
+# script, which sits on the same late mount, so the job — which lives in the
+# crontab, on the local disk — first notes that cron fired it in
+# `{{ boot_hook_log }}`, waits for this file to become readable, and only
+# then runs it. Put the lines last in the crontab: every job below them runs
+# from `/` and sees HOME=/ in its environment, so a job body that expands
+# $HOME breaks silently unless it starts with its own
+# `export HOME=<the real home>`.
 #
 # Everything this script prints lands in that same log, on the local disk
 # rather than the home, so a boot on which the home never came still says
@@ -71,7 +74,17 @@ export XDG_RUNTIME_DIR
 # Proof of launch, before any wait, on a disk that is there at boot. Appended:
 # the crontab job wrote the line before this one, and the two together say
 # whether cron fired, whether this file was reachable, and how far it got.
-LOG="{{ boot_hook_log }}"
+# The directory, not a bare file, because /tmp is shared and the name is
+# predictable: appending would follow a symlink anyone could have planted
+# there. Only a real directory this account owns is used; otherwise nothing
+# is logged rather than something written where a stranger pointed.
+LOG_DIR="{{ boot_hook_log_dir }}"
+mkdir -m 700 "$LOG_DIR" 2>/dev/null
+if [ -d "$LOG_DIR" ] && [ ! -L "$LOG_DIR" ] && [ -O "$LOG_DIR" ]; then
+  LOG="{{ boot_hook_log }}"
+else
+  LOG=/dev/null
+fi
 if ! printf 'osprey-boot-hook: launched %s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')" >> "$LOG" 2>/dev/null; then
   LOG=/dev/null
 fi

--- a/tests/cli/test_scaffold_systemd.py
+++ b/tests/cli/test_scaffold_systemd.py
@@ -527,7 +527,12 @@ def test_a_findmnt_that_fails_says_nothing_extra(
 def test_a_refusal_prints_no_drop_in_either(
     runner: CliRunner, repo: Path, home: Path, findmnt
 ) -> None:
-    """Nothing was written, so there is nothing for a mount to hide."""
+    """The unit was refused, so there is no install for a mount to undo.
+
+    The hook beside it is still written — the two files have independent
+    histories — but the whole install-and-linger block, drop-in included,
+    hangs off the unit alone.
+    """
     findmnt("nfs")
     unit_of(repo).write_text("[Unit]\nDescription=mine\n", encoding="utf-8")
 
@@ -547,6 +552,11 @@ def test_a_hand_written_hook_still_leaves_the_unit_fully_explained(
     perfectly — and on a network home the drop-in is the whole reason this
     warning exists. Gating any of that on "did anything refuse" would hide the
     drop-in from exactly the operator who needs it.
+
+    What the run must NOT do is claim it wrote the hook and print the crontab
+    lines: those would wire cron to the operator's own script — most likely
+    the very hook that "does nothing" — with HOME=/ set and never restored,
+    because the restore lives in the script that was refused.
     """
     findmnt("nfs")
     hook = hook_of(repo)
@@ -563,6 +573,11 @@ def test_a_hand_written_hook_still_leaves_the_unit_fully_explained(
     assert "systemctl --user enable --now osprey.service" in text
     assert "loginctl enable-linger" in text
     assert f"RequiresMountsFor={home}" in text
+    assert "this run did not" in text
+    assert "Do not wire the existing file up" in text
+    assert "also wrote a boot hook" not in text
+    assert "@reboot" not in text
+    assert "HOME=/" not in text
 
 
 def test_a_network_home_says_how_to_wire_the_hook_up(
@@ -580,12 +595,15 @@ def test_a_network_home_says_how_to_wire_the_hook_up(
 
     assert result.exit_code == 0, result.output
     text = flat(result)
-    home_line, job = boot_hook_crontab_lines(str(hook_of(repo)))
+    lines = boot_hook_crontab_lines(str(hook_of(repo)))
     assert str(hook_of(repo)) in text
     assert "crontab -e" in text
-    assert home_line in text
-    assert job in text
-    assert text.index("HOME=/") < text.index("@reboot")
+    for line in lines:
+        assert line in text
+    assert text.index("SHELL=/bin/sh") < text.index("HOME=/") < text.index("@reboot")
+    # Placement is part of the instruction: HOME=/ applies to every line below.
+    assert "Put these lines LAST in the crontab" in text
+    assert "export HOME=" in text
 
 
 def test_the_drop_in_is_scoped_to_mounts_systemd_manages(

--- a/tests/cli/test_scaffold_systemd.py
+++ b/tests/cli/test_scaffold_systemd.py
@@ -20,9 +20,14 @@ full. The executable is resolved through a helper that reads the machine, so
 every test here freezes it: a unit whose contents depend on the developer's
 PATH is a unit nobody can pin.
 
-*The instruction.* The file is written to the repo root and takes effect from
+*The instruction.* The unit is written to the repo root and takes effect from
 ``~/.config/systemd/user/``, so the verb's output is the only thing standing
 between "emitted" and "installed".
+
+*The pair.* The verb emits two files with independent histories — the unit, and
+the boot hook under ``scripts/`` — and the printing has to keep them apart. A
+hand-written hook is a refusal, but it is not a reason to stop telling an
+operator how to install the unit they did just get.
 """
 
 from __future__ import annotations
@@ -35,11 +40,12 @@ import pytest
 from click.testing import CliRunner
 
 from osprey.cli.deploy_scaffold import (
+    BOOT_HOOK_OUTPUT_PATH,
     SYSTEMD_OUTPUT_NAME,
     detect_network_home,
     scaffold_systemd_unit,
 )
-from osprey.cli.deploy_scaffold_templates import SYSTEMD_MARKER
+from osprey.cli.deploy_scaffold_templates import BOOT_HOOK_MARKER, SYSTEMD_MARKER
 from osprey.cli.main import cli
 from osprey.cli.scaffold_cmd import scaffold
 from osprey.errors import ConfigurationError
@@ -82,6 +88,10 @@ def emit(runner: CliRunner, repo: Path, *args: str):
 
 def unit_of(repo: Path) -> Path:
     return repo / SYSTEMD_OUTPUT_NAME
+
+
+def hook_of(repo: Path) -> Path:
+    return repo.joinpath(*BOOT_HOOK_OUTPUT_PATH)
 
 
 # ── What it writes, and where ────────────────────────────────────────────────
@@ -130,6 +140,35 @@ def test_no_temporary_file_is_left_behind(runner: CliRunner, repo: Path) -> None
 
     assert not list(repo.glob("*.tmp"))
     assert not list(repo.glob(".osprey.service.*"))
+
+
+def test_the_hook_lands_under_scripts(runner: CliRunner, repo: Path) -> None:
+    """One run, two files: the unit at the root and the hook beside it."""
+    result = emit(runner, repo)
+
+    assert result.exit_code == 0, result.output
+    hook = hook_of(repo)
+    assert hook.is_file()
+    assert hook.parent == repo / "scripts"
+    assert hook.name == "osprey-boot-hook.sh"
+    assert f"osprey-scaffold: {BOOT_HOOK_MARKER}" in hook.read_text(encoding="utf-8")
+
+
+def test_both_files_are_reported(runner: CliRunner, repo: Path) -> None:
+    """Each emitted file gets its own status line, named repo-relative."""
+    result = emit(runner, repo)
+
+    text = flat(result)
+    assert f"{SYSTEMD_OUTPUT_NAME} (created)" in text
+    assert "scripts/osprey-boot-hook.sh (created)" in text
+
+
+def test_the_hook_is_executable_and_the_unit_is_not(runner: CliRunner, repo: Path) -> None:
+    """cron runs the hook directly; systemd only reads the unit."""
+    emit(runner, repo)
+
+    assert hook_of(repo).stat().st_mode & 0o777 == 0o755
+    assert unit_of(repo).stat().st_mode & 0o777 == 0o644
 
 
 # ── Which repo it acts on ────────────────────────────────────────────────────
@@ -189,6 +228,20 @@ def test_a_second_run_writes_nothing(runner: CliRunner, repo: Path) -> None:
     assert result.exit_code == 0, result.output
     assert unit.read_bytes() == first
     assert "unchanged" in result.output
+
+
+def test_a_second_run_reports_both_files_as_unchanged(runner: CliRunner, repo: Path) -> None:
+    """Neither file may drift on a re-run, and both have to say so."""
+    emit(runner, repo)
+    before = (unit_of(repo).read_bytes(), hook_of(repo).read_bytes())
+
+    result = emit(runner, repo)
+
+    assert result.exit_code == 0, result.output
+    assert (unit_of(repo).read_bytes(), hook_of(repo).read_bytes()) == before
+    text = flat(result)
+    assert f"{SYSTEMD_OUTPUT_NAME} (unchanged)" in text
+    assert "scripts/osprey-boot-hook.sh (unchanged)" in text
 
 
 def test_a_stale_version_stamp_alone_is_not_a_change(runner: CliRunner, repo: Path) -> None:
@@ -325,15 +378,38 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return account
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def findmnt(monkeypatch: pytest.MonkeyPatch):
-    """Drive the detection seam: is ``findmnt`` there, and what does it say.
+    """Own the detection seam: is ``findmnt`` there, and what does it say.
 
     Both halves are patched in the module that reaches for them — the binary
     lookup as well as the call — because the tests run on macOS too, where
     ``findmnt`` does not exist and an unpatched lookup would answer for every
     case at once.
+
+    Autouse, so the seam is closed from setup even for the tests that never
+    mention it: ``shutil.which`` answers ``None``, which is the quiet default
+    (no binary, no warning, and the answer those tests already expect), and
+    ``subprocess.run`` is replaced by a callable that raises rather than
+    letting an unpatched path shell out. Without that, every test that calls
+    ``emit`` would run the real detection against the machine's own ``$HOME``
+    — a live ``findmnt`` per test on Linux, with a two-second timeout hanging
+    off it. No assertion here depends on the outcome, so nothing was failing;
+    what the default removes is the subprocess and the machine-dependence.
+
+    The returned ``install`` is how a test opts into a specific answer, exactly
+    as before; it patches over the default and returns a fresh list of the
+    argv the seam is called with. A test that patches the same two names by
+    hand also wins, because its patches land after this setup.
     """
+
+    def unexpected_run(argv, **kwargs):
+        raise AssertionError(
+            f"the findmnt seam was called without an answer installed: argv={list(argv)}"
+        )
+
+    monkeypatch.setattr("osprey.cli.deploy_scaffold.shutil.which", lambda name: None)
+    monkeypatch.setattr("osprey.cli.deploy_scaffold.subprocess.run", unexpected_run)
 
     def install(fstype: str = "", *, present: bool = True, returncode: int = 0) -> list[list[str]]:
         calls: list[list[str]] = []
@@ -455,6 +531,79 @@ def test_a_refusal_prints_no_drop_in_either(
 
     assert result.exit_code == 1
     assert "RequiresMountsFor" not in flat(result)
+
+
+def test_a_hand_written_hook_still_leaves_the_unit_fully_explained(
+    runner: CliRunner, repo: Path, home: Path, findmnt
+) -> None:
+    """A refused hook must not swallow the unit's instructions.
+
+    The two files have independent histories. A hook somebody wrote by hand is
+    refused and makes the run non-zero, but the unit beside it was written
+    perfectly — and on a network home the drop-in is the whole reason this
+    warning exists. Gating any of that on "did anything refuse" would hide the
+    drop-in from exactly the operator who needs it.
+    """
+    findmnt("nfs")
+    hook = hook_of(repo)
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\necho mine\n", encoding="utf-8")
+
+    result = emit(runner, repo)
+
+    assert result.exit_code == 1
+    assert hook.read_text(encoding="utf-8") == "#!/bin/sh\necho mine\n"
+    text = flat(result)
+    assert "osprey scaffold systemd --force" in text
+    assert f"cp {unit_of(repo)} ~/.config/systemd/user/" in text
+    assert "systemctl --user enable --now osprey.service" in text
+    assert "loginctl enable-linger" in text
+    assert f"RequiresMountsFor={home}" in text
+
+
+def test_a_network_home_says_how_to_wire_the_hook_up(
+    runner: CliRunner, repo: Path, home: Path, findmnt
+) -> None:
+    """The no-root fallback: the hook's full path, and the crontab line."""
+    findmnt("nfs")
+
+    result = emit(runner, repo)
+
+    assert result.exit_code == 0, result.output
+    text = flat(result)
+    assert str(hook_of(repo)) in text
+    assert "crontab -e" in text
+    assert f"@reboot {hook_of(repo)}" in text
+
+
+def test_the_hook_is_named_as_a_fallback_not_a_replacement(
+    runner: CliRunner, repo: Path, home: Path, findmnt
+) -> None:
+    """The drop-in is still the fix; cron only repairs each boot after it."""
+    findmnt("autofs")
+
+    result = emit(runner, repo)
+
+    text = flat(result)
+    assert "fallback" in text
+    assert "not a replacement for the drop-in" in text
+    # Said in the order an operator reads it: root first, cron only after.
+    assert text.index("RequiresMountsFor") < text.index("@reboot")
+
+
+def test_a_local_home_never_mentions_the_hook(
+    runner: CliRunner, repo: Path, home: Path, findmnt
+) -> None:
+    """The hook is written either way, but wiring it up here is noise."""
+    findmnt("ext4")
+
+    result = emit(runner, repo)
+
+    assert result.exit_code == 0, result.output
+    text = flat(result)
+    assert "@reboot" not in text
+    assert "crontab" not in text
+    assert str(hook_of(repo)) not in text
 
 
 # ── The detection itself ─────────────────────────────────────────────────────

--- a/tests/cli/test_scaffold_systemd.py
+++ b/tests/cli/test_scaffold_systemd.py
@@ -45,7 +45,11 @@ from osprey.cli.deploy_scaffold import (
     detect_network_home,
     scaffold_systemd_unit,
 )
-from osprey.cli.deploy_scaffold_templates import BOOT_HOOK_MARKER, SYSTEMD_MARKER
+from osprey.cli.deploy_scaffold_templates import (
+    BOOT_HOOK_MARKER,
+    SYSTEMD_MARKER,
+    boot_hook_crontab_lines,
+)
 from osprey.cli.main import cli
 from osprey.cli.scaffold_cmd import scaffold
 from osprey.errors import ConfigurationError
@@ -564,30 +568,45 @@ def test_a_hand_written_hook_still_leaves_the_unit_fully_explained(
 def test_a_network_home_says_how_to_wire_the_hook_up(
     runner: CliRunner, repo: Path, home: Path, findmnt
 ) -> None:
-    """The no-root fallback: the hook's full path, and the crontab line."""
+    """The no-root route: the hook's full path, and both crontab lines.
+
+    The job is the one :func:`boot_hook_crontab_lines` builds — the same
+    spelling the hook's own header carries — printed without Rich reading its
+    ``[ -x ... ]`` tests as style tags.
+    """
     findmnt("nfs")
 
     result = emit(runner, repo)
 
     assert result.exit_code == 0, result.output
     text = flat(result)
+    home_line, job = boot_hook_crontab_lines(str(hook_of(repo)))
     assert str(hook_of(repo)) in text
     assert "crontab -e" in text
-    assert f"@reboot {hook_of(repo)}" in text
+    assert home_line in text
+    assert job in text
+    assert text.index("HOME=/") < text.index("@reboot")
 
 
-def test_the_hook_is_named_as_a_fallback_not_a_replacement(
+def test_the_drop_in_is_scoped_to_mounts_systemd_manages(
     runner: CliRunner, repo: Path, home: Path, findmnt
 ) -> None:
-    """The drop-in is still the fix; cron only repairs each boot after it."""
+    """A home served by the autofs daemon has no mount unit to order against.
+
+    ``findmnt`` says ``autofs`` for a systemd automount too, so the verb cannot
+    tell the two apart and has to say where the drop-in applies rather than
+    pretend it always does. Where it does apply, cron only repairs each boot
+    after it — and that is still said, in the order an operator reads it: root
+    first, cron after.
+    """
     findmnt("autofs")
 
     result = emit(runner, repo)
 
     text = flat(result)
-    assert "fallback" in text
-    assert "not a replacement for the drop-in" in text
-    # Said in the order an operator reads it: root first, cron only after.
+    assert "When systemd manages the mount" in text
+    assert "autofs daemon has no mount unit" in text
+    assert "fallback there, not a replacement" in text
     assert text.index("RequiresMountsFor") < text.index("@reboot")
 
 

--- a/tests/deployment/goldens/osprey-boot-hook.sh
+++ b/tests/deployment/goldens/osprey-boot-hook.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# =============================================================================
+# Demo Facility — OSPREY boot hook
+# =============================================================================
+# osprey-scaffold: deploy/boot-hook
+# osprey-version: OSPREY_VERSION
+#
+# Emitted by `osprey scaffold systemd` beside the user unit, for one situation:
+# a deploy host whose home directory is an NFS or autofs mount.
+#
+# A lingering `systemd --user` manager starts at boot, before that mount lands.
+# It resolves its unit search path once, finds nothing under the not-yet-
+# mounted home, and never looks again — so `systemctl --user status
+# osprey.service` reads `not-found` after every reboot and the stack sits
+# there until somebody runs `daemon-reload` by hand.
+#
+# The proper fix is a `RequiresMountsFor` drop-in on `user@<uid>.service`,
+# which needs root. This script is the fallback that does not: it waits for the
+# home, the deployment and the user manager to appear, then reloads the unit
+# files and starts the unit. Wire it into the account's own crontab:
+#
+#   crontab -e
+#   @reboot /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh
+#
+# cron mails the account whatever this prints, so a boot that did not come back
+# says why in that mail. Running it again by hand is harmless: an already
+# active unit is left alone.
+#
+# Deployment how-to: https://als-apg.github.io/osprey/how-to/deploy-a-facility.html
+#
+# Re-run `osprey scaffold systemd` after the repo moves or OSPREY is
+# reinstalled elsewhere — the paths below are absolute. The marker line above
+# is what makes re-emission safe, so a file without it is treated as
+# hand-written and left alone unless you pass --force.
+# =============================================================================
+set -u
+
+# The one line that makes a cron job able to talk to the user manager at all.
+# `@reboot` runs with no session and no bus address, and `systemctl --user`
+# with no XDG_RUNTIME_DIR does not fail loudly — it just fails. Every hook of
+# this kind that "does nothing" is missing this.
+XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export XDG_RUNTIME_DIR
+
+# Seconds between attempts, and the budget shared by every wait below. Past
+# the budget the hook gives up and says which thing never showed, rather than
+# holding a cron slot open forever.
+POLL_SECONDS=5
+TOTAL_WAIT_SECONDS=300
+WAITED=0
+
+say() { printf 'osprey-boot-hook: %s\n' "$1"; }
+die() { printf 'osprey-boot-hook: %s\n' "$1" >&2; exit 1; }
+
+# Block until a path exists, spending from the shared budget. POSIX sh has no
+# `local`, so WAITED is deliberately global: the budget covers the whole boot,
+# not each path in turn.
+wait_for() {
+  while [ ! -e "$1" ]; do
+    if [ "$WAITED" -ge "$TOTAL_WAIT_SECONDS" ]; then
+      die "gave up after ${TOTAL_WAIT_SECONDS}s waiting for $2 ($1) — the unit was not started"
+    fi
+    sleep "$POLL_SECONDS"
+    WAITED=$((WAITED + POLL_SECONDS))
+  done
+  say "$2 is there: $1"
+}
+
+if [ -z "${HOME:-}" ]; then
+  die "HOME is unset — cron gives a job the account's home, so this ran from somewhere unexpected"
+fi
+
+# The home carries the unit file, and on this kind of host it is the mount
+# everything else is waiting on.
+wait_for "$HOME" "the home directory"
+
+# Both absolute, and both may live under that same mount: the unit's
+# WorkingDirectory, and the executable it runs.
+wait_for "/srv/osprey/demo-facility" "the deployment repo"
+wait_for "/usr/local/bin/osprey" "the osprey executable"
+
+# The runtime directory is created by the user manager itself, so it appearing
+# is the signal that there is a manager to talk to — checking for the mount
+# alone would race a manager that has not started yet.
+wait_for "$XDG_RUNTIME_DIR" "the user manager's runtime directory"
+
+# Re-resolve the unit search path, which is the whole point: the manager read
+# it once, before the home was there.
+if ! systemctl --user daemon-reload; then
+  die "systemctl --user daemon-reload failed — the manager is up but not answering this account"
+fi
+say "reloaded the user manager's unit files"
+
+if systemctl --user is-active --quiet osprey.service; then
+  say "osprey.service is already active — nothing to start"
+  exit 0
+fi
+
+if ! systemctl --user start osprey.service; then
+  die "systemctl --user start osprey.service failed — see: systemctl --user status osprey.service"
+fi
+say "started osprey.service"

--- a/tests/deployment/goldens/osprey-boot-hook.sh
+++ b/tests/deployment/goldens/osprey-boot-hook.sh
@@ -21,23 +21,26 @@
 # changes nothing, and this script is the fix rather than the fallback. It
 # waits for the home, the deployment and the user manager to appear, then
 # reloads the unit files and starts the unit. Wire it into the account's own
-# crontab, both lines, pasted whole:
+# crontab — all of these lines, pasted whole:
 #
 #   crontab -e
+#   SHELL=/bin/sh
 #   HOME=/
-#   @reboot echo "$(date) osprey-boot-hook: cron fired" >> /tmp/osprey-boot-hook.$(id -u).log; n=0; until [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ] || [ $n -ge 120 ]; do sleep 5; n=$((n+1)); done; if [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ]; then exec /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh never appeared" | tee -a /tmp/osprey-boot-hook.$(id -u).log
+#   @reboot d=/tmp/osprey-boot-hook.$(id -u); mkdir -m 700 "$d" 2>/dev/null; if [ -d "$d" ] && [ ! -L "$d" ] && [ -O "$d" ]; then log=/tmp/osprey-boot-hook.$(id -u)/boot.log; else log=/dev/null; fi; echo "$(date) osprey-boot-hook: cron fired" >> "$log"; n=0; until [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ] || [ $n -ge 120 ]; do sleep 5; n=$((n+1)); done; if [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ]; then exec /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh never appeared" | tee -a "$log"
 #
-# Neither line is optional, and the job is deliberately not a bare `@reboot`
+# None of them is optional, and the job is deliberately not a bare `@reboot`
 # with this script's path. cron changes into the crontab's HOME before it runs
 # a job, and on this host the home is not there yet when cron starts, so the
 # job dies before anything runs — silently, with no mail. `HOME=/` gives cron
-# a directory that exists. Then `sh` has to read this script, which sits on
-# the same late mount, so the job — which lives in the crontab, on the local
-# disk — first notes that cron fired it in `/tmp/osprey-boot-hook.$(id -u).log`, waits for
-# this file to become readable, and only then runs it. Put the two lines last
-# in the crontab: every job below them runs from `/` and sees HOME=/ in its
-# environment, so a job body that expands $HOME breaks silently unless it
-# starts with its own `export HOME=<the real home>`.
+# a directory that exists; `SHELL=/bin/sh` is the shell the job is written
+# for, whatever an existing crontab set above. Then `sh` has to read this
+# script, which sits on the same late mount, so the job — which lives in the
+# crontab, on the local disk — first notes that cron fired it in
+# `/tmp/osprey-boot-hook.$(id -u)/boot.log`, waits for this file to become readable, and only
+# then runs it. Put the lines last in the crontab: every job below them runs
+# from `/` and sees HOME=/ in its environment, so a job body that expands
+# $HOME breaks silently unless it starts with its own
+# `export HOME=<the real home>`.
 #
 # Everything this script prints lands in that same log, on the local disk
 # rather than the home, so a boot on which the home never came still says
@@ -71,7 +74,17 @@ export XDG_RUNTIME_DIR
 # Proof of launch, before any wait, on a disk that is there at boot. Appended:
 # the crontab job wrote the line before this one, and the two together say
 # whether cron fired, whether this file was reachable, and how far it got.
-LOG="/tmp/osprey-boot-hook.$(id -u).log"
+# The directory, not a bare file, because /tmp is shared and the name is
+# predictable: appending would follow a symlink anyone could have planted
+# there. Only a real directory this account owns is used; otherwise nothing
+# is logged rather than something written where a stranger pointed.
+LOG_DIR="/tmp/osprey-boot-hook.$(id -u)"
+mkdir -m 700 "$LOG_DIR" 2>/dev/null
+if [ -d "$LOG_DIR" ] && [ ! -L "$LOG_DIR" ] && [ -O "$LOG_DIR" ]; then
+  LOG="/tmp/osprey-boot-hook.$(id -u)/boot.log"
+else
+  LOG=/dev/null
+fi
 if ! printf 'osprey-boot-hook: launched %s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')" >> "$LOG" 2>/dev/null; then
   LOG=/dev/null
 fi

--- a/tests/deployment/goldens/osprey-boot-hook.sh
+++ b/tests/deployment/goldens/osprey-boot-hook.sh
@@ -14,16 +14,33 @@
 # osprey.service` reads `not-found` after every reboot and the stack sits
 # there until somebody runs `daemon-reload` by hand.
 #
-# The proper fix is a `RequiresMountsFor` drop-in on `user@<uid>.service`,
-# which needs root. This script is the fallback that does not: it waits for the
-# home, the deployment and the user manager to appear, then reloads the unit
-# files and starts the unit. Wire it into the account's own crontab:
+# When systemd manages the mount itself — an fstab entry, or a .mount or
+# .automount unit — a `RequiresMountsFor` drop-in on `user@<uid>.service`
+# orders the manager after it, and needs root. A home served by the autofs
+# daemon has no mount unit for that drop-in to order against, so there it
+# changes nothing, and this script is the fix rather than the fallback. It
+# waits for the home, the deployment and the user manager to appear, then
+# reloads the unit files and starts the unit. Wire it into the account's own
+# crontab, both lines, pasted whole:
 #
 #   crontab -e
-#   @reboot /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh
+#   HOME=/
+#   @reboot echo "$(date) osprey-boot-hook: cron fired" >> /tmp/osprey-boot-hook.$(id -u).log; n=0; until [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ] || [ $n -ge 60 ]; do sleep 5; n=$((n+1)); done; if [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ]; then exec /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh never appeared" >> /tmp/osprey-boot-hook.$(id -u).log
 #
-# cron mails the account whatever this prints, so a boot that did not come back
-# says why in that mail. Running it again by hand is harmless: an already
+# Neither line is optional, and the job is deliberately not a bare `@reboot`
+# with this script's path. cron changes into the crontab's HOME before it runs
+# a job, and on this host the home is not there yet when cron starts, so the
+# job dies before anything runs — silently, with no mail. `HOME=/` gives cron
+# a directory that exists. Then `sh` has to read this script, which sits on
+# the same late mount, so the job — which lives in the crontab, on the local
+# disk — first notes that cron fired it in `/tmp/osprey-boot-hook.$(id -u).log`, waits for
+# this file to become readable, and only then runs it. Put the two lines last
+# in the crontab, or any job below them runs from `/` too.
+#
+# Everything this script prints lands in that same log, on the local disk
+# rather than the home, so a boot on which the home never came still says
+# how far things got; cron mails the account the same lines if the host
+# delivers mail. Running the script again by hand is harmless: an already
 # active unit is left alone.
 #
 # Deployment how-to: https://als-apg.github.io/osprey/how-to/deploy-a-facility.html
@@ -35,12 +52,27 @@
 # =============================================================================
 set -u
 
+# cron ran this with HOME=/ (see the header), so the real home goes back first:
+# the unit file lives under it, and on this host it is the mount everything
+# else waits on. Written in as a full path like the repo and the executable —
+# until the home is mounted nothing on this host can be asked where it is.
+HOME="/home/osprey"
+export HOME
+
 # The one line that makes a cron job able to talk to the user manager at all.
 # `@reboot` runs with no session and no bus address, and `systemctl --user`
 # with no XDG_RUNTIME_DIR does not fail loudly — it just fails. Every hook of
 # this kind that "does nothing" is missing this.
 XDG_RUNTIME_DIR="/run/user/$(id -u)"
 export XDG_RUNTIME_DIR
+
+# Proof of launch, before any wait, on a disk that is there at boot. Appended:
+# the crontab job wrote the line before this one, and the two together say
+# whether cron fired, whether this file was reachable, and how far it got.
+LOG="/tmp/osprey-boot-hook.$(id -u).log"
+if ! printf 'osprey-boot-hook: launched %s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')" >> "$LOG" 2>/dev/null; then
+  LOG=/dev/null
+fi
 
 # Seconds between attempts, and the budget shared by every wait below. Past
 # the budget the hook gives up and says which thing never showed, rather than
@@ -49,8 +81,8 @@ POLL_SECONDS=5
 TOTAL_WAIT_SECONDS=300
 WAITED=0
 
-say() { printf 'osprey-boot-hook: %s\n' "$1"; }
-die() { printf 'osprey-boot-hook: %s\n' "$1" >&2; exit 1; }
+say() { printf 'osprey-boot-hook: %s\n' "$1" | tee -a "$LOG"; }
+die() { printf 'osprey-boot-hook: %s\n' "$1" | tee -a "$LOG" >&2; exit 1; }
 
 # Block until a path exists, spending from the shared budget. POSIX sh has no
 # `local`, so WAITED is deliberately global: the budget covers the whole boot,
@@ -66,12 +98,9 @@ wait_for() {
   say "$2 is there: $1"
 }
 
-if [ -z "${HOME:-}" ]; then
-  die "HOME is unset — cron gives a job the account's home, so this ran from somewhere unexpected"
-fi
-
 # The home carries the unit file, and on this kind of host it is the mount
-# everything else is waiting on.
+# everything else is waiting on. On an autofs home the test itself is what
+# triggers the mount.
 wait_for "$HOME" "the home directory"
 
 # Both absolute, and both may live under that same mount: the unit's

--- a/tests/deployment/goldens/osprey-boot-hook.sh
+++ b/tests/deployment/goldens/osprey-boot-hook.sh
@@ -25,7 +25,7 @@
 #
 #   crontab -e
 #   HOME=/
-#   @reboot echo "$(date) osprey-boot-hook: cron fired" >> /tmp/osprey-boot-hook.$(id -u).log; n=0; until [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ] || [ $n -ge 60 ]; do sleep 5; n=$((n+1)); done; if [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ]; then exec /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh never appeared" >> /tmp/osprey-boot-hook.$(id -u).log
+#   @reboot echo "$(date) osprey-boot-hook: cron fired" >> /tmp/osprey-boot-hook.$(id -u).log; n=0; until [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ] || [ $n -ge 120 ]; do sleep 5; n=$((n+1)); done; if [ -x /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh ]; then exec /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh; fi; echo "$(date) osprey-boot-hook: gave up, /srv/osprey/demo-facility/scripts/osprey-boot-hook.sh never appeared" | tee -a /tmp/osprey-boot-hook.$(id -u).log
 #
 # Neither line is optional, and the job is deliberately not a bare `@reboot`
 # with this script's path. cron changes into the crontab's HOME before it runs
@@ -35,7 +35,9 @@
 # the same late mount, so the job — which lives in the crontab, on the local
 # disk — first notes that cron fired it in `/tmp/osprey-boot-hook.$(id -u).log`, waits for
 # this file to become readable, and only then runs it. Put the two lines last
-# in the crontab, or any job below them runs from `/` too.
+# in the crontab: every job below them runs from `/` and sees HOME=/ in its
+# environment, so a job body that expands $HOME breaks silently unless it
+# starts with its own `export HOME=<the real home>`.
 #
 # Everything this script prints lands in that same log, on the local disk
 # rather than the home, so a boot on which the home never came still says
@@ -78,7 +80,7 @@ fi
 # the budget the hook gives up and says which thing never showed, rather than
 # holding a cron slot open forever.
 POLL_SECONDS=5
-TOTAL_WAIT_SECONDS=300
+TOTAL_WAIT_SECONDS=600
 WAITED=0
 
 say() { printf 'osprey-boot-hook: %s\n' "$1" | tee -a "$LOG"; }

--- a/tests/deployment/test_scaffold_boot_hook.py
+++ b/tests/deployment/test_scaffold_boot_hook.py
@@ -38,6 +38,7 @@ import yaml
 import osprey
 from osprey.cli.deploy_scaffold_templates import (
     BOOT_HOOK_LOG,
+    BOOT_HOOK_LOG_DIR,
     BOOT_HOOK_MARKER,
     BOOT_HOOK_OUTPUT_NAME,
     BOOT_HOOK_PATH,
@@ -225,17 +226,17 @@ def test_running_it_twice_is_harmless(code: str) -> None:
 
 
 def test_the_header_shows_the_crontab_lines_that_install_it(rendered: str) -> None:
-    """The hook is wired up by hand, so the file has to say how — both lines.
+    """The hook is wired up by hand, so the file has to say how — every line.
 
-    The job comes from the same function the console prints it from, and it
-    names the hook by the same constant the emitter writes to, so the lines an
-    operator pastes cannot drift from where the file lands or from what the
+    The lines come from the same function the console prints them from, and
+    the job names the hook by the same constant the emitter writes to, so what
+    an operator pastes cannot drift from where the file lands or from what the
     verb told them.
     """
     header = rendered[: rendered.index("set -u")]
-    home_line, job = boot_hook_crontab_lines(FROZEN_HOOK)
+    lines = boot_hook_crontab_lines(FROZEN_HOOK)
     assert "crontab -e" in header
-    assert f"#   {home_line}\n#   {job}\n" in header
+    assert "".join(f"#   {line}\n" for line in lines) in header
 
 
 def test_the_crontab_job_survives_a_home_that_is_not_there_yet() -> None:
@@ -249,12 +250,14 @@ def test_the_crontab_job_survives_a_home_that_is_not_there_yet() -> None:
     home before it waits. Both were learned from real reboots, where a bare
     ``@reboot <hook>`` never launched at all.
     """
-    home_line, job = boot_hook_crontab_lines(FROZEN_HOOK)
+    shell_line, home_line, job = boot_hook_crontab_lines(FROZEN_HOOK)
+    # The job is POSIX sh; an existing crontab may have set SHELL to a csh.
+    assert shell_line == "SHELL=/bin/sh"
     assert home_line == "HOME=/"
     assert job.startswith("@reboot ")
     # cron reads a `%` as a newline, and the job would be cut there.
     assert "%" not in job
-    fired_at = job.index(f'cron fired" >> {BOOT_HOOK_LOG}')
+    fired_at = job.index('cron fired" >> "$log"')
     wait_at = job.index(f"until [ -x {FROZEN_HOOK} ]")
     run_at = job.index(f"exec {FROZEN_HOOK}")
     assert fired_at < wait_at < run_at
@@ -262,7 +265,33 @@ def test_the_crontab_job_survives_a_home_that_is_not_there_yet() -> None:
     assert f"[ $n -ge {BOOT_HOOK_TOTAL_WAIT_SEC // BOOT_HOOK_POLL_SEC} ]" in job
     assert f"sleep {BOOT_HOOK_POLL_SEC}" in job
     # On stdout as well as in the log: this is the branch cron's mail is for.
-    assert f'never appeared" | tee -a {BOOT_HOOK_LOG}' in job
+    assert 'never appeared" | tee -a "$log"' in job
+
+
+def test_both_writers_refuse_a_log_directory_they_do_not_own() -> None:
+    """``/tmp`` is shared and the name is predictable.
+
+    Appending to a bare file there follows a symlink any local user could
+    have planted, turning the log into an append to a file of their choosing
+    as the deploying account. So the log lives in a directory each writer
+    creates with mode 700 and uses only if it is a real directory it owns —
+    ``/tmp``'s sticky bit keeps anyone else from swapping it out afterwards.
+    """
+    *_, job = boot_hook_crontab_lines(FROZEN_HOOK)
+    assert BOOT_HOOK_LOG == f"{BOOT_HOOK_LOG_DIR}/boot.log"
+    assert f'd={BOOT_HOOK_LOG_DIR}; mkdir -m 700 "$d"' in job
+    assert 'if [ -d "$d" ] && [ ! -L "$d" ] && [ -O "$d" ]; then log=' in job
+    assert "else log=/dev/null; fi" in job
+    assert job.index("mkdir -m 700") < job.index("cron fired")
+
+
+def test_the_script_guards_its_log_directory_the_same_way(code: str) -> None:
+    """Same directory, same ownership check, before the first write."""
+    assert f'LOG_DIR="{BOOT_HOOK_LOG_DIR}"' in code
+    assert 'mkdir -m 700 "$LOG_DIR"' in code
+    guard = 'if [ -d "$LOG_DIR" ] && [ ! -L "$LOG_DIR" ] && [ -O "$LOG_DIR" ]; then'
+    assert guard in code
+    assert code.index(guard) < code.index(f'LOG="{BOOT_HOOK_LOG}"') < code.index("launched")
 
 
 def test_the_script_restores_the_real_home_before_anything_else(code: str) -> None:
@@ -301,8 +330,8 @@ def test_the_how_to_shows_the_same_crontab_job() -> None:
     job the field evidence says does not launch.
     """
     docs = DEPLOY_HOWTO.read_text(encoding="utf-8")
-    home_line, job = boot_hook_crontab_lines(f"/path/to/repo/{BOOT_HOOK_PATH}")
-    assert f"   {home_line}\n   {job}\n" in docs
+    lines = boot_hook_crontab_lines(f"/path/to/repo/{BOOT_HOOK_PATH}")
+    assert "".join(f"   {line}\n" for line in lines) in docs
 
 
 def test_the_header_names_the_facility_and_the_unit(rendered: str) -> None:

--- a/tests/deployment/test_scaffold_boot_hook.py
+++ b/tests/deployment/test_scaffold_boot_hook.py
@@ -37,6 +37,7 @@ import yaml
 
 import osprey
 from osprey.cli.deploy_scaffold_templates import (
+    BOOT_HOOK_LOG,
     BOOT_HOOK_MARKER,
     BOOT_HOOK_OUTPUT_NAME,
     BOOT_HOOK_PATH,
@@ -44,6 +45,7 @@ from osprey.cli.deploy_scaffold_templates import (
     BOOT_HOOK_TEMPLATE,
     BOOT_HOOK_TOTAL_WAIT_SEC,
     SYSTEMD_UNIT_NAME,
+    boot_hook_crontab_lines,
     build_boot_hook_context,
     render,
 )
@@ -51,23 +53,30 @@ from osprey.cli.deploy_scaffold_templates import (
 GOLDENS = Path(__file__).parent / "goldens"
 EXEMPLAR_DIR = GOLDENS / "exemplar-profile"
 GOLDEN_PATH = GOLDENS / BOOT_HOOK_OUTPUT_NAME
+DEPLOY_HOWTO = Path(__file__).parents[2] / "docs" / "source" / "how-to" / "deploy-a-facility.rst"
 
 #: Passed in place of the installed version so the golden does not change with
 #: the release the test happens to run under.
 FROZEN_VERSION = "OSPREY_VERSION"
 
-#: The deploy host's coordinates, frozen. Both are properties of a machine
+#: The deploy host's coordinates, frozen. All three are properties of a machine
 #: rather than of the profile, so a render that read them off the host running
 #: the tests would produce a different hook on every checkout.
 FROZEN_REPO_ROOT = Path("/srv/osprey/demo-facility")
 FROZEN_OSPREY_BIN = "/usr/local/bin/osprey"
+FROZEN_HOME = Path("/home/osprey")
+
+#: Where the frozen host's hook lands, as the crontab has to name it.
+FROZEN_HOOK = f"{FROZEN_REPO_ROOT}/{BOOT_HOOK_PATH}"
 
 
 def render_hook(profile: dict[str, Any] | None = None) -> str:
     """Render the hook for a profile, with the host's half held fixed."""
     if profile is None:
         profile = yaml.safe_load((EXEMPLAR_DIR / "profile.yml").read_text(encoding="utf-8"))
-    context = build_boot_hook_context(profile, FROZEN_REPO_ROOT, FROZEN_OSPREY_BIN, FROZEN_VERSION)
+    context = build_boot_hook_context(
+        profile, FROZEN_REPO_ROOT, FROZEN_OSPREY_BIN, FROZEN_VERSION, home=FROZEN_HOME
+    )
     return render(BOOT_HOOK_TEMPLATE, context)
 
 
@@ -106,7 +115,7 @@ def test_installed_version_is_the_only_value_that_moves_with_a_release(
     """
     profile = yaml.safe_load((EXEMPLAR_DIR / "profile.yml").read_text(encoding="utf-8"))
     context = build_boot_hook_context(
-        profile, FROZEN_REPO_ROOT, FROZEN_OSPREY_BIN, osprey.__version__
+        profile, FROZEN_REPO_ROOT, FROZEN_OSPREY_BIN, osprey.__version__, home=FROZEN_HOME
     )
     current = render(BOOT_HOOK_TEMPLATE, context)
 
@@ -215,15 +224,84 @@ def test_running_it_twice_is_harmless(code: str) -> None:
     assert guard_at < start_at
 
 
-def test_the_header_shows_the_crontab_line_that_installs_it(rendered: str) -> None:
-    """The hook is wired up by hand, so the file has to say how.
+def test_the_header_shows_the_crontab_lines_that_install_it(rendered: str) -> None:
+    """The hook is wired up by hand, so the file has to say how — both lines.
 
-    The path is absolute and derived from the same constant the emitter writes
-    to, so the line an operator pastes cannot drift from where the file lands.
+    The job comes from the same function the console prints it from, and it
+    names the hook by the same constant the emitter writes to, so the lines an
+    operator pastes cannot drift from where the file lands or from what the
+    verb told them.
     """
     header = rendered[: rendered.index("set -u")]
+    home_line, job = boot_hook_crontab_lines(FROZEN_HOOK)
     assert "crontab -e" in header
-    assert f"@reboot {FROZEN_REPO_ROOT}/{BOOT_HOOK_PATH}" in header
+    assert f"#   {home_line}\n#   {job}\n" in header
+
+
+def test_the_crontab_job_survives_a_home_that_is_not_there_yet() -> None:
+    """Two things kill a cron job before its command runs on this host.
+
+    cron changes into the crontab's ``HOME`` first and dies silently when it is
+    missing, so the preamble has to hand it a directory that exists at boot.
+    Then ``sh`` has to read the script, which sits on the same late mount, so
+    the job — on the local disk, in the crontab — must wait for the file
+    itself before running it, and must say it fired somewhere that is not the
+    home before it waits. Both were learned from real reboots, where a bare
+    ``@reboot <hook>`` never launched at all.
+    """
+    home_line, job = boot_hook_crontab_lines(FROZEN_HOOK)
+    assert home_line == "HOME=/"
+    assert job.startswith("@reboot ")
+    # cron reads a `%` as a newline, and the job would be cut there.
+    assert "%" not in job
+    fired_at = job.index(f'cron fired" >> {BOOT_HOOK_LOG}')
+    wait_at = job.index(f"until [ -x {FROZEN_HOOK} ]")
+    run_at = job.index(f"exec {FROZEN_HOOK}")
+    assert fired_at < wait_at < run_at
+    # Bounded by the same budget the script uses, and loud when it runs out.
+    assert f"[ $n -ge {BOOT_HOOK_TOTAL_WAIT_SEC // BOOT_HOOK_POLL_SEC} ]" in job
+    assert f"sleep {BOOT_HOOK_POLL_SEC}" in job
+    assert f'never appeared" >> {BOOT_HOOK_LOG}' in job
+
+
+def test_the_script_restores_the_real_home_before_anything_else(code: str) -> None:
+    """The crontab sets ``HOME=/`` so cron can start the job at all.
+
+    Everything the script waits for sits under the real home, so it has to
+    put that back first — from a literal the scaffolder knew, not from
+    ``$HOME`` (which is ``/``) or from ``getent`` (which asks an identity
+    service that may not be up yet).
+    """
+    restore_at = code.index(f'HOME="{FROZEN_HOME}"')
+    assert "export HOME" in code
+    assert restore_at < code.index("export HOME") < code.index("wait_for ")
+
+
+def test_the_launch_marker_is_written_before_the_first_wait(code: str) -> None:
+    """A boot on which the home never came leaves no other trace.
+
+    The marker goes to the local disk, appended after the line the crontab job
+    already wrote, and before the script waits for anything — so the log
+    splits "cron never fired" from "still waiting" from "ran and said why".
+    """
+    assert f'LOG="{BOOT_HOOK_LOG}"' in code
+    marker_at = code.index("launched")
+    assert '>> "$LOG"' in code[marker_at : marker_at + 120]
+    assert marker_at < code.index('wait_for "$HOME"')
+    # Every later line lands in the same file.
+    assert 'tee -a "$LOG"' in code
+
+
+def test_the_how_to_shows_the_same_crontab_job() -> None:
+    """The docs cannot render the line, so they carry a copy — pinned here.
+
+    The how-to spells the hook as ``/path/to/repo/...``; the job around it has
+    to be the one the verb prints, or an operator following the page gets a
+    job the field evidence says does not launch.
+    """
+    docs = DEPLOY_HOWTO.read_text(encoding="utf-8")
+    home_line, job = boot_hook_crontab_lines(f"/path/to/repo/{BOOT_HOOK_PATH}")
+    assert f"   {home_line}\n   {job}\n" in docs
 
 
 def test_the_header_names_the_facility_and_the_unit(rendered: str) -> None:

--- a/tests/deployment/test_scaffold_boot_hook.py
+++ b/tests/deployment/test_scaffold_boot_hook.py
@@ -261,7 +261,8 @@ def test_the_crontab_job_survives_a_home_that_is_not_there_yet() -> None:
     # Bounded by the same budget the script uses, and loud when it runs out.
     assert f"[ $n -ge {BOOT_HOOK_TOTAL_WAIT_SEC // BOOT_HOOK_POLL_SEC} ]" in job
     assert f"sleep {BOOT_HOOK_POLL_SEC}" in job
-    assert f'never appeared" >> {BOOT_HOOK_LOG}' in job
+    # On stdout as well as in the log: this is the branch cron's mail is for.
+    assert f'never appeared" | tee -a {BOOT_HOOK_LOG}' in job
 
 
 def test_the_script_restores_the_real_home_before_anything_else(code: str) -> None:

--- a/tests/deployment/test_scaffold_boot_hook.py
+++ b/tests/deployment/test_scaffold_boot_hook.py
@@ -1,0 +1,242 @@
+"""The boot-hook template, pinned to the bytes it emits.
+
+The hook runs from cron at boot, on a host nobody is watching, in a shell with
+no session and no bus — the one context where a mistake is both silent and
+permanent until the next reboot. It is also a shell script, where a lost quote
+or an unbalanced ``if`` is not a style problem but a job that does nothing and
+mails a parse error to an account nobody reads. So this template is held to its
+output byte for byte, against ``goldens/osprey-boot-hook.sh``, and the render
+is additionally parsed by a real shell.
+
+The byte specification lives here for the same reason the unit's does (see
+``test_scaffold_systemd_unit``): the hook is not part of what a deployment repo
+carries — it is emitted for a host, from absolute paths the repo does not know,
+and wired into that account's crontab outside the repo entirely.
+
+**Update discipline.** The golden is renderer output, never hand-edited. When a
+template change is deliberate, regenerate it in the same reviewed change::
+
+    PYTHONPATH=src .venv/bin/python -c "
+    from pathlib import Path
+    from tests.deployment.test_scaffold_boot_hook import GOLDEN_PATH, render_hook
+    GOLDEN_PATH.write_text(render_hook(), encoding='utf-8')"
+
+so the diff a reviewer reads is the template edit and its consequence, side by
+side.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+import osprey
+from osprey.cli.deploy_scaffold_templates import (
+    BOOT_HOOK_MARKER,
+    BOOT_HOOK_OUTPUT_NAME,
+    BOOT_HOOK_PATH,
+    BOOT_HOOK_POLL_SEC,
+    BOOT_HOOK_TEMPLATE,
+    BOOT_HOOK_TOTAL_WAIT_SEC,
+    SYSTEMD_UNIT_NAME,
+    build_boot_hook_context,
+    render,
+)
+
+GOLDENS = Path(__file__).parent / "goldens"
+EXEMPLAR_DIR = GOLDENS / "exemplar-profile"
+GOLDEN_PATH = GOLDENS / BOOT_HOOK_OUTPUT_NAME
+
+#: Passed in place of the installed version so the golden does not change with
+#: the release the test happens to run under.
+FROZEN_VERSION = "OSPREY_VERSION"
+
+#: The deploy host's coordinates, frozen. Both are properties of a machine
+#: rather than of the profile, so a render that read them off the host running
+#: the tests would produce a different hook on every checkout.
+FROZEN_REPO_ROOT = Path("/srv/osprey/demo-facility")
+FROZEN_OSPREY_BIN = "/usr/local/bin/osprey"
+
+
+def render_hook(profile: dict[str, Any] | None = None) -> str:
+    """Render the hook for a profile, with the host's half held fixed."""
+    if profile is None:
+        profile = yaml.safe_load((EXEMPLAR_DIR / "profile.yml").read_text(encoding="utf-8"))
+    context = build_boot_hook_context(profile, FROZEN_REPO_ROOT, FROZEN_OSPREY_BIN, FROZEN_VERSION)
+    return render(BOOT_HOOK_TEMPLATE, context)
+
+
+@pytest.fixture(scope="module")
+def rendered() -> str:
+    """The hook the exemplar renders."""
+    return render_hook()
+
+
+@pytest.fixture(scope="module")
+def code(rendered: str) -> str:
+    """The hook with its comments stripped — the lines a shell acts on.
+
+    Asserting against the whole file would let a promise made only in a comment
+    pass for the behaviour itself, which is exactly the failure mode this hook
+    exists to fix.
+    """
+    return "\n".join(line for line in rendered.splitlines() if not line.lstrip().startswith("#"))
+
+
+def test_render_matches_the_golden_byte_for_byte(rendered: str) -> None:
+    """The template emits exactly what is committed under ``goldens/``."""
+    assert GOLDEN_PATH.is_file(), f"missing golden fixture: {GOLDEN_PATH}"
+    assert rendered == GOLDEN_PATH.read_text(encoding="utf-8")
+
+
+def test_installed_version_is_the_only_value_that_moves_with_a_release(
+    rendered: str,
+) -> None:
+    """Two renders of one profile differ in exactly the ``osprey-version:`` line.
+
+    The scaffolder normalizes that line away before deciding whether a re-emit
+    would change anything, so an upgrade rewrites no hook. A second
+    release-dependent value would be masked by the same normalization and would
+    silently stop re-emission from noticing a real change.
+    """
+    profile = yaml.safe_load((EXEMPLAR_DIR / "profile.yml").read_text(encoding="utf-8"))
+    context = build_boot_hook_context(
+        profile, FROZEN_REPO_ROOT, FROZEN_OSPREY_BIN, osprey.__version__
+    )
+    current = render(BOOT_HOOK_TEMPLATE, context)
+
+    differing = [
+        (left, right)
+        for left, right in zip(rendered.splitlines(), current.splitlines(), strict=True)
+        if left != right
+    ]
+    assert differing == [
+        (f"# osprey-version: {FROZEN_VERSION}", f"# osprey-version: {osprey.__version__}")
+    ]
+
+
+def test_the_hook_carries_the_provenance_marker_in_its_header(rendered: str) -> None:
+    """Re-emission is only safe for a file the scaffolder can recognize.
+
+    The marker is looked for in the first twenty lines alone, so it has to be
+    there — a hook that lost it would be treated as hand-written and never
+    updated again.
+    """
+    header = rendered.splitlines()[:20]
+    assert f"# osprey-scaffold: {BOOT_HOOK_MARKER}" in header
+
+
+@pytest.mark.parametrize("shell", ["sh", "bash"])
+def test_the_rendered_script_parses(rendered: str, tmp_path: Path, shell: str) -> None:
+    """A rendered-string assertion cannot catch a shell syntax error.
+
+    The hook's only reader is cron, which will not tell anybody the job failed
+    to parse, so the emitted text is handed to a real shell here. Both are
+    checked: ``sh`` because that is the interpreter the shebang names, and
+    ``bash`` because on many hosts ``/bin/sh`` *is* bash and would quietly
+    accept a bashism that a dash-based host rejects at boot.
+    """
+    binary = shutil.which(shell)
+    if binary is None:
+        pytest.skip(f"{shell} is not installed on this host")
+
+    script = tmp_path / BOOT_HOOK_OUTPUT_NAME
+    script.write_text(rendered, encoding="utf-8")
+    result = subprocess.run(
+        [binary, "-n", str(script)], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_the_hook_exports_the_user_managers_runtime_directory(code: str) -> None:
+    """The one line without which the whole script is a no-op.
+
+    A ``cron @reboot`` job inherits no ``XDG_RUNTIME_DIR`` and no session bus,
+    and ``systemctl --user`` without one does not fail loudly — it just fails.
+    This is the classic reason a hand-written boot hook appears to run and
+    changes nothing, so it gets its own pin rather than riding on the golden.
+    """
+    assert 'XDG_RUNTIME_DIR="/run/user/$(id -u)"' in code
+    assert "export XDG_RUNTIME_DIR" in code
+
+
+def test_the_hook_waits_for_every_late_path_before_touching_systemd(code: str) -> None:
+    """The mount, the deployment, the executable, and the manager itself.
+
+    All four can be absent when cron fires: the first three sit under the home
+    that has not been mounted yet, and the runtime directory is created by the
+    user manager, so its appearance is the only signal that there is a manager
+    to talk to.
+    """
+    waits = [line.strip() for line in code.splitlines() if line.strip().startswith("wait_for ")]
+    assert waits == [
+        'wait_for "$HOME" "the home directory"',
+        f'wait_for "{FROZEN_REPO_ROOT}" "the deployment repo"',
+        f'wait_for "{FROZEN_OSPREY_BIN}" "the osprey executable"',
+        'wait_for "$XDG_RUNTIME_DIR" "the user manager\'s runtime directory"',
+    ]
+    assert code.index('wait_for "$XDG_RUNTIME_DIR"') < code.index("systemctl --user daemon-reload")
+
+
+def test_the_wait_is_bounded_and_says_what_never_arrived(code: str) -> None:
+    """An unbounded wait holds a cron slot open on a host nobody is watching.
+
+    Giving up has to be loud: cron mails what the job prints, and that mail is
+    the only account of a boot that did not come back.
+    """
+    assert f"POLL_SECONDS={BOOT_HOOK_POLL_SEC}" in code
+    assert f"TOTAL_WAIT_SECONDS={BOOT_HOOK_TOTAL_WAIT_SEC}" in code
+    assert 'sleep "$POLL_SECONDS"' in code
+    assert "die " in code and "gave up after" in code
+    assert BOOT_HOOK_POLL_SEC < BOOT_HOOK_TOTAL_WAIT_SEC
+
+
+def test_the_hook_reloads_before_it_starts(code: str) -> None:
+    """Reloading is the entire point: the manager read its unit search path
+    once, before the home was there, so without this the start command finds no
+    such unit."""
+    reload_at = code.index("systemctl --user daemon-reload")
+    start_at = code.index(f"systemctl --user start {SYSTEMD_UNIT_NAME}")
+    assert reload_at < start_at
+
+
+def test_running_it_twice_is_harmless(code: str) -> None:
+    """An operator debugging a failed boot runs the hook by hand, on a host
+    where the unit may already be up. It has to leave an active deployment
+    alone rather than restart it underneath its users."""
+    assert f"systemctl --user is-active --quiet {SYSTEMD_UNIT_NAME}" in code
+    guard_at = code.index("is-active")
+    start_at = code.index(f"systemctl --user start {SYSTEMD_UNIT_NAME}")
+    assert guard_at < start_at
+
+
+def test_the_header_shows_the_crontab_line_that_installs_it(rendered: str) -> None:
+    """The hook is wired up by hand, so the file has to say how.
+
+    The path is absolute and derived from the same constant the emitter writes
+    to, so the line an operator pastes cannot drift from where the file lands.
+    """
+    header = rendered[: rendered.index("set -u")]
+    assert "crontab -e" in header
+    assert f"@reboot {FROZEN_REPO_ROOT}/{BOOT_HOOK_PATH}" in header
+
+
+def test_the_header_names_the_facility_and_the_unit(rendered: str) -> None:
+    """One host can carry a hook per deployment, and cron mails all of their
+    output to the same account."""
+    header = rendered[: rendered.index("set -u")]
+    assert "Demo Facility" in header
+    assert SYSTEMD_UNIT_NAME in header
+
+
+def test_the_script_stays_posix(code: str) -> None:
+    """``sh -n`` under a shell that happens to be bash would accept several of
+    these, so they are named explicitly. The shebang promises ``/bin/sh``, which
+    on a Debian-family deploy host is dash."""
+    for bashism in ("[[", "declare ", "local ", "function ", "+=("):
+        assert bashism not in code, f"bashism in a POSIX sh script: {bashism!r}"

--- a/tests/health/core/test_configuration.py
+++ b/tests/health/core/test_configuration.py
@@ -23,6 +23,7 @@ _CANONICAL_NAMES = (
     "file_system",
     "python_environment",
     "containers",
+    "systemd_unit",
     "openobserve",
     "providers",
     "claude_cli",
@@ -66,7 +67,7 @@ class TestCoreRegistry:
     def test_canonical_names_present_without_import(self):
         assert set(CORE_CATEGORY_NAMES) == set(_CANONICAL_NAMES)
         assert set(CORE_CATEGORIES) == set(_CANONICAL_NAMES)
-        assert len(CORE_CATEGORIES) == 14
+        assert len(CORE_CATEGORIES) == 15
 
     def test_contains(self):
         assert "configuration" in CORE_CATEGORIES

--- a/tests/health/core/test_systemd_unit.py
+++ b/tests/health/core/test_systemd_unit.py
@@ -204,6 +204,25 @@ class TestInstallDirResolution:
         results = await systemd_unit({}, cwd=repo)()
         assert results[0].status == Status.OK
 
+    async def test_relative_xdg_config_home_is_ignored(self, monkeypatch, tmp_path):
+        """systemd and the basedir spec ignore a non-absolute value.
+
+        Read literally it would resolve against this process's cwd, and a unit
+        correctly installed under ``~/.config`` would be reported as missing.
+        """
+        _stub_run(monkeypatch, returncode=0, stdout="loaded\n")
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        monkeypatch.setenv("XDG_CONFIG_HOME", "relative/config")
+        monkeypatch.chdir(tmp_path)
+        home = tmp_path / "home"
+        unit_dir = home / ".config" / "systemd" / "user"
+        unit_dir.mkdir(parents=True)
+        (unit_dir / _UNIT).write_text("[Unit]\n")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.OK
+
     async def test_unset_xdg_config_home_uses_home(self, monkeypatch, tmp_path):
         _stub_run(monkeypatch, raises=AssertionError("must not run systemctl"))
         _have_systemctl(monkeypatch)

--- a/tests/health/core/test_systemd_unit.py
+++ b/tests/health/core/test_systemd_unit.py
@@ -1,0 +1,324 @@
+"""Tests for the core ``systemd_unit`` category.
+
+Branch coverage patches the module's ``_run_systemctl`` helper and its
+``shutil.which``/``Path.home`` seams; a few tests patch
+``asyncio.create_subprocess_exec`` directly to exercise the real subprocess
+helper (success, timeout-kill, missing executable).
+
+Every seam is patched, so the suite passes on hosts with no systemd at all
+(macOS, containers) as well as on Linux.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from osprey.health.core import systemd_unit as mod
+from osprey.health.core.systemd_unit import systemd_unit
+from osprey.health.models import Status
+
+_UNIT = "osprey.service"
+
+
+def _stub_run(monkeypatch, *, returncode=0, stdout="", stderr="", raises=None):
+    """Patch ``_run_systemctl`` to return canned output or raise."""
+
+    async def _fake(argv, timeout_s):
+        if raises is not None:
+            raise raises
+        return (returncode, stdout, stderr)
+
+    monkeypatch.setattr(mod, "_run_systemctl", _fake)
+
+
+def _have_systemctl(monkeypatch, present=True):
+    """Patch ``shutil.which`` as seen by the module."""
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/systemctl" if present else None)
+
+
+def _repo_with_unit(tmp_path: Path) -> Path:
+    """Create a deployment repo root holding a scaffolded unit file."""
+    (tmp_path / _UNIT).write_text("[Unit]\n")
+    return tmp_path
+
+
+def _install_dir(monkeypatch, tmp_path: Path, *, installed: bool) -> Path:
+    """Point ``XDG_CONFIG_HOME`` at ``tmp_path`` and optionally install the unit."""
+    xdg = tmp_path / "xdg"
+    unit_dir = xdg / "systemd" / "user"
+    unit_dir.mkdir(parents=True)
+    if installed:
+        (unit_dir / _UNIT).write_text("[Unit]\n")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    return unit_dir
+
+
+# --------------------------------------------------------------------------- #
+# state table
+# --------------------------------------------------------------------------- #
+
+
+class TestStateTable:
+    async def test_no_repo_unit_is_skip(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, raises=AssertionError("must not run systemctl"))
+        _have_systemctl(monkeypatch)
+        results = await systemd_unit(None, cwd=tmp_path)()
+        assert len(results) == 1
+        row = results[0]
+        assert row.name == "systemd_unit"
+        assert row.category == "systemd_unit"
+        assert row.status == Status.SKIP
+        assert "no scaffolded" in row.message
+
+    async def test_no_systemctl_is_skip(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, raises=AssertionError("must not run systemctl"))
+        _have_systemctl(monkeypatch, present=False)
+        results = await systemd_unit({}, cwd=_repo_with_unit(tmp_path))()
+        assert len(results) == 1
+        assert results[0].status == Status.SKIP
+        assert "systemctl not found" in results[0].message
+
+    async def test_scaffolded_but_not_installed_is_warning(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, raises=AssertionError("must not run systemctl"))
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=False)
+        results = await systemd_unit({}, cwd=repo)()
+        assert len(results) == 1
+        row = results[0]
+        assert row.status == Status.WARNING
+        assert "not installed" in row.message
+        assert "daemon-reload" in row.details
+
+    async def test_installed_but_not_found_is_error(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, returncode=0, stdout="not-found\n")
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        results = await systemd_unit({}, cwd=repo)()
+        assert len(results) == 1
+        row = results[0]
+        assert row.status == Status.ERROR
+        assert "not-found" in row.message
+        assert "systemctl --user daemon-reload" in row.details
+        assert "NFS/autofs" in row.details
+
+    @pytest.mark.parametrize("load_state", ["loaded", "masked", "error", "bad-setting"])
+    async def test_installed_and_visible_is_ok(self, monkeypatch, tmp_path, load_state):
+        _stub_run(monkeypatch, returncode=0, stdout=f"{load_state}\n")
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        results = await systemd_unit({}, cwd=repo)()
+        assert len(results) == 1
+        assert results[0].status == Status.OK
+        assert results[0].value == load_state
+
+    async def test_bus_unreachable_is_skip(self, monkeypatch, tmp_path):
+        _stub_run(
+            monkeypatch,
+            returncode=1,
+            stderr="Failed to connect to bus: No such file or directory",
+        )
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.SKIP
+        assert "no reachable systemd" in results[0].message
+        assert "Failed to connect to bus" in results[0].details
+
+    async def test_bus_unreachable_without_stderr_still_skips(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, returncode=1, stderr="")
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.SKIP
+        assert results[0].details
+
+    async def test_query_timeout_is_skip(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, raises=TimeoutError())
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.SKIP
+        assert "timed out" in results[0].message
+
+    async def test_systemctl_vanishing_between_which_and_exec_is_skip(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, raises=FileNotFoundError())
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.SKIP
+        assert "systemctl not found" in results[0].message
+
+    async def test_empty_load_state_is_ok_unknown(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, returncode=0, stdout="   \n")
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.OK
+        assert results[0].value == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# install-directory resolution
+# --------------------------------------------------------------------------- #
+
+
+class TestInstallDirResolution:
+    async def test_xdg_config_home_directory_reports_ok(self, monkeypatch, tmp_path):
+        """The regression a hardcoded ``~/.config`` would cause.
+
+        With ``XDG_CONFIG_HOME`` set and the unit installed underneath it, the
+        row must be OK — not the WARNING a ``~/.config``-only lookup would give.
+        """
+        _stub_run(monkeypatch, returncode=0, stdout="loaded\n")
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        # A home that holds nothing, to prove the XDG path is what was read.
+        empty_home = tmp_path / "home"
+        (empty_home / ".config" / "systemd" / "user").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: empty_home))
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.OK
+
+    async def test_blank_xdg_config_home_falls_back_to_home(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, returncode=0, stdout="loaded\n")
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        monkeypatch.setenv("XDG_CONFIG_HOME", "   ")
+        home = tmp_path / "home"
+        unit_dir = home / ".config" / "systemd" / "user"
+        unit_dir.mkdir(parents=True)
+        (unit_dir / _UNIT).write_text("[Unit]\n")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.OK
+
+    async def test_unset_xdg_config_home_uses_home(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, raises=AssertionError("must not run systemctl"))
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        home = tmp_path / "home"
+        (home / ".config" / "systemd" / "user").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.WARNING
+
+    async def test_unresolvable_home_is_skip(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, raises=AssertionError("must not run systemctl"))
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        def _boom(cls):
+            raise RuntimeError("Could not determine home directory")
+
+        monkeypatch.setattr(Path, "home", classmethod(_boom))
+        results = await systemd_unit({}, cwd=repo)()
+        assert len(results) == 1
+        assert results[0].status == Status.SKIP
+        assert "cannot resolve" in results[0].message
+        assert "RuntimeError" in results[0].details
+
+    async def test_oserror_resolving_install_dir_is_skip(self, monkeypatch, tmp_path):
+        _stub_run(monkeypatch, raises=AssertionError("must not run systemctl"))
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+
+        def _boom() -> Path:
+            raise OSError("ENAMETOOLONG")
+
+        monkeypatch.setattr(mod, "_user_unit_dir", _boom)
+        results = await systemd_unit({}, cwd=repo)()
+        assert results[0].status == Status.SKIP
+        assert "OSError" in results[0].details
+
+
+# --------------------------------------------------------------------------- #
+# cwd defaulting
+# --------------------------------------------------------------------------- #
+
+
+class TestCwdDefault:
+    async def test_cwd_defaults_at_call_time(self, monkeypatch, tmp_path):
+        """No ``cwd=`` => ``Path.cwd()`` resolved when the callable runs."""
+        _stub_run(monkeypatch, returncode=0, stdout="loaded\n")
+        _have_systemctl(monkeypatch)
+        repo = _repo_with_unit(tmp_path)
+        _install_dir(monkeypatch, tmp_path, installed=True)
+        callable_ = systemd_unit({})
+        monkeypatch.chdir(repo)
+        results = await callable_()
+        assert results[0].status == Status.OK
+
+
+# --------------------------------------------------------------------------- #
+# _run_systemctl against a fake asyncio subprocess
+# --------------------------------------------------------------------------- #
+
+
+class _FakeProc:
+    def __init__(self, stdout=b"", stderr=b"", returncode=0, hang=False):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self._hang = hang
+        self.killed = False
+        self.reaped = False
+
+    async def communicate(self):
+        if self._hang:
+            await asyncio.sleep(10)
+        return (self._stdout, self._stderr)
+
+    def kill(self):
+        self.killed = True
+
+    async def wait(self):
+        self.reaped = True
+        return self.returncode
+
+
+class TestRunSystemctl:
+    async def test_success_decodes_output(self, monkeypatch):
+        proc = _FakeProc(stdout=b"loaded\n", stderr=b"", returncode=0)
+
+        async def _fake_exec(*argv, **kwargs):
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        rc, out, err = await mod._run_systemctl(["systemctl", "--user", "show"], 5.0)
+        assert rc == 0
+        assert out == "loaded\n"
+        assert err == ""
+
+    async def test_timeout_kills_and_reaps_process(self, monkeypatch):
+        proc = _FakeProc(hang=True)
+
+        async def _fake_exec(*argv, **kwargs):
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await mod._run_systemctl(["systemctl", "--user", "show"], 0.01)
+        assert proc.killed is True
+        assert proc.reaped is True
+
+    async def test_missing_executable_propagates(self, monkeypatch):
+        async def _fake_exec(*argv, **kwargs):
+            raise FileNotFoundError()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        with pytest.raises(FileNotFoundError):
+            await mod._run_systemctl(["nope"], 5.0)

--- a/tests/health/test_config.py
+++ b/tests/health/test_config.py
@@ -372,7 +372,7 @@ def test_empty_metadata_override_block() -> None:
 def test_core_category_names_content() -> None:
     assert "providers" in CORE_CATEGORY_NAMES
     assert "claude_cli_pinned" in CORE_CATEGORY_NAMES
-    assert len(CORE_CATEGORY_NAMES) == 14
+    assert len(CORE_CATEGORY_NAMES) == 15
 
 
 # --- timeout resolution helpers ---------------------------------------------

--- a/tests/health/test_plugins.py
+++ b/tests/health/test_plugins.py
@@ -411,3 +411,84 @@ def test_path_entry_collision_is_error_row(tmp_path: Path) -> None:
     assert len(result.errors) == 1
     assert "collides" in result.errors[0].message
     assert "./b.py" in result.errors[0].message
+
+
+def test_unresolvable_home_entry_is_error_row(tmp_path: Path, monkeypatch) -> None:
+    """A ``~`` entry on a host with no resolvable home degrades by one row, not a crash.
+
+    ``Path.expanduser()`` raises ``RuntimeError`` when neither ``$HOME`` nor a
+    passwd entry answers — containers and some CI runners. Resolution happens
+    outside the import ``try``, so nothing else would catch it.
+    """
+
+    def _no_home(self):
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr(Path, "expanduser", _no_home)
+
+    result = load_plugin_categories(
+        _settings(plugins=["~/health/facility_checks.py"]), project_root=tmp_path
+    )
+
+    assert result.categories == {}
+    assert len(result.errors) == 1
+    row = result.errors[0]
+    assert row.status is Status.ERROR
+    assert row.category == PLUGINS_DIAGNOSTIC_CATEGORY
+    assert "could not resolve" in row.message
+    assert "~/health/facility_checks.py" in row.message
+    assert "Could not determine home directory." in row.message
+
+
+def test_unresolvable_home_entry_without_anchor_is_error_row(monkeypatch) -> None:
+    """Same on the anchorless path, where the shared config-path rule expands ``~``."""
+
+    def _no_home(self):
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr(Path, "expanduser", _no_home)
+
+    result = load_plugin_categories(_settings(plugins=["~/checks.py"]))
+
+    assert result.categories == {}
+    assert len(result.errors) == 1
+    assert "could not resolve" in result.errors[0].message
+
+
+def test_resolution_oserror_is_error_row(tmp_path: Path, monkeypatch) -> None:
+    """A path that cannot be resolved (symlink cycle, over-long name) is a row too."""
+
+    def _boom(self, *args, **kwargs):
+        raise OSError("Too many levels of symbolic links")
+
+    monkeypatch.setattr(Path, "resolve", _boom)
+
+    result = load_plugin_categories(
+        _settings(plugins=["./health/facility_checks.py"]), project_root=tmp_path
+    )
+
+    assert result.categories == {}
+    assert len(result.errors) == 1
+    assert "could not resolve" in result.errors[0].message
+    assert "symbolic links" in result.errors[0].message
+
+
+def test_unresolvable_entry_does_not_stop_later_plugins(tmp_path: Path, monkeypatch) -> None:
+    """One bad entry costs one row; the rest of the plugin list still loads."""
+    _write_plugin(tmp_path, "checks.py")
+    real_expanduser = Path.expanduser
+
+    def _no_home_for_tilde(self):
+        if str(self).startswith("~"):
+            raise RuntimeError("Could not determine home directory.")
+        return real_expanduser(self)
+
+    monkeypatch.setattr(Path, "expanduser", _no_home_for_tilde)
+
+    result = load_plugin_categories(
+        _settings(plugins=["~/broken.py", "./checks.py"]), project_root=tmp_path
+    )
+
+    assert set(result.categories) == {"facility"}
+    assert len(result.errors) == 1
+    assert "could not resolve" in result.errors[0].message

--- a/tests/health/test_records.py
+++ b/tests/health/test_records.py
@@ -369,7 +369,7 @@ class TestBuildRecords:
         env_row = next(r for r in by_name["file_system"].func() if r.name == "env_file")
         assert env_row.status is Status.WARNING  # no .env at the repo root
 
-    def test_systemd_unit_is_assembled_and_anchored_on_the_repo_root(self, tmp_path):
+    def test_systemd_unit_is_assembled_and_anchored_on_the_repo_root(self, tmp_path, monkeypatch):
         """The boot unit is looked for beside the profile, not under the render.
 
         ``osprey scaffold systemd`` writes ``osprey.service`` into the tracked
@@ -384,6 +384,11 @@ class TestBuildRecords:
         root, so a render anchor cannot find it.
         """
         import asyncio
+
+        # The category is run for real below; without `systemctl` it skips at
+        # the install-directory step, so a developer host that happens to have
+        # the unit installed never spawns a real `systemctl --user show`.
+        monkeypatch.setattr("osprey.health.core.systemd_unit.shutil.which", lambda _name: None)
 
         repo = tmp_path / "repo"
         build = repo / "build"

--- a/tests/health/test_records.py
+++ b/tests/health/test_records.py
@@ -369,6 +369,82 @@ class TestBuildRecords:
         env_row = next(r for r in by_name["file_system"].func() if r.name == "env_file")
         assert env_row.status is Status.WARNING  # no .env at the repo root
 
+    def test_systemd_unit_is_assembled_and_anchored_on_the_repo_root(self, tmp_path):
+        """The boot unit is looked for beside the profile, not under the render.
+
+        ``osprey scaffold systemd`` writes ``osprey.service`` into the tracked
+        source zone at the repo root. The category's trigger is that repo copy:
+        no repo unit means the operator never asked for the systemd boot path
+        and the row skips. Anchored on ``render_path`` instead, the unit would
+        be invisible on every deployment that HAS one, and the category would
+        skip permanently — silently, since a skip is what a deployment without
+        a unit is supposed to produce.
+
+        Written as the discriminating case: the unit exists ONLY at the repo
+        root, so a render anchor cannot find it.
+        """
+        import asyncio
+
+        repo = tmp_path / "repo"
+        build = repo / "build"
+        config_path = _write_config(build, _VALID_CONFIG)
+        (repo / "osprey.service").write_text("[Unit]\n")
+        assert not (build / "osprey.service").exists()
+
+        state, expanded, settings, config_ok = load_config(config_path, repo)
+        records, _ = build_records(
+            state, expanded, settings, config_ok, repo, 30.0, render_path=state.config_path.parent
+        )
+        by_name = {r.name: r for r in records}
+
+        # The category is in the assembled record set, at plain poll cost: it
+        # reads no config and is cheap, so it is neither config-dependent nor
+        # gated behind ``--full``.
+        assert "systemd_unit" in by_name
+        assert by_name["systemd_unit"].cost is Cost.POLL
+
+        no_unit_message = "no scaffolded osprey.service in this deployment"
+        rows = asyncio.run(by_name["systemd_unit"].func())
+        assert len(rows) == 1
+        assert rows[0].name == "systemd_unit"
+        # The repo unit was seen, so the row got past the trigger. What it
+        # reports next depends on the host (no systemctl on macOS/containers),
+        # which is not what this pin is about.
+        assert rows[0].message != no_unit_message
+
+        # The discrimination, in the same test: anchored on the render zone,
+        # the identical deployment reports no unit at all.
+        from osprey.health.core import get_core_category_factory
+
+        render_anchored = get_core_category_factory("systemd_unit")(
+            expanded, context=None, cwd=state.config_path.parent
+        )
+        render_rows = asyncio.run(render_anchored())
+        assert render_rows[0].status is Status.SKIP
+        assert render_rows[0].message == no_unit_message
+
+
+# --------------------------------------------------------------------------- #
+# systemd_unit: the unit-name spelling pin
+# --------------------------------------------------------------------------- #
+
+
+def test_systemd_unit_spelling_matches_the_verb_that_writes_it():
+    """The two literals cannot drift apart.
+
+    ``osprey.health.core.systemd_unit`` spells the unit filename itself rather
+    than importing ``SYSTEMD_UNIT_NAME``, because importing it would pull the
+    CLI package into the web and MCP health surfaces that import the category.
+    A rename on either side that missed the other would leave the check looking
+    for a file the scaffolder no longer writes — and it would fail silently, as
+    a permanent "no scaffolded unit" skip that reads exactly like a deployment
+    which never asked for one. So the equality is asserted, not assumed.
+    """
+    from osprey.cli.deploy_scaffold_templates import SYSTEMD_UNIT_NAME
+    from osprey.health.core.systemd_unit import _UNIT_NAME
+
+    assert _UNIT_NAME == SYSTEMD_UNIT_NAME
+
 
 # --------------------------------------------------------------------------- #
 # build_records: auto-derived mcp_servers category

--- a/tests/health/test_runner.py
+++ b/tests/health/test_runner.py
@@ -415,6 +415,33 @@ async def test_unreadable_signature_is_called_with_zero_arguments(runtime) -> No
     assert report.results[0].status is Status.OK
 
 
+async def test_signature_raising_anything_else_is_still_zero_arguments(runtime) -> None:
+    """``signature()`` reads ``__signature__``, which plugin code owns.
+
+    The signature probe runs outside the per-callable isolation, so an
+    exception it let through would abort the whole suite — against the
+    module's promise — rather than cost one row. Only ``TypeError`` and
+    ``ValueError`` are documented; a property that raises something else is
+    the case that has to be absorbed too.
+    """
+
+    class _Opaque:
+        @property
+        def __signature__(self):
+            raise RuntimeError("signature unavailable")
+
+        def __call__(self):
+            return [CheckResult("o1", "mycat", Status.OK, "opaque ok")]
+
+    with pytest.raises(RuntimeError):
+        inspect.signature(_Opaque())
+
+    report = await run_health_suite([_call("mycat", _Opaque())], runtime=runtime)
+
+    assert report.results[0].name == "o1"
+    assert report.results[0].status is Status.OK
+
+
 # --- Report shape -----------------------------------------------------------
 
 

--- a/tests/health/test_runner.py
+++ b/tests/health/test_runner.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
+import threading
 from time import perf_counter
 
 import pytest
@@ -305,6 +307,112 @@ async def test_on_demand_callable_skip_row_named_after_category(runtime) -> None
     assert len(report.results) == 1
     assert report.results[0].name == "mycat"
     assert report.results[0].status is Status.SKIP
+
+
+# --- Runtime injection into category callables ------------------------------
+
+
+async def test_async_callable_receives_runtime_positional_or_keyword(runtime) -> None:
+    """An ``async def check(runtime)`` gets the suite's own HealthRuntime."""
+    seen: dict[str, object] = {}
+
+    async def _cat(runtime):
+        seen["runtime"] = runtime
+        return [CheckResult("r1", "mycat", Status.OK, "ok")]
+
+    report = await run_health_suite([_call("mycat", _cat)], runtime=runtime)
+
+    assert seen["runtime"] is runtime
+    assert report.results[0].name == "r1"
+
+
+async def test_async_callable_receives_runtime_keyword_only(runtime) -> None:
+    """``async def check(*, runtime)`` is a natural spelling and must work."""
+    seen: dict[str, object] = {}
+
+    async def _cat(*, runtime):
+        seen["runtime"] = runtime
+        return [CheckResult("r1", "mycat", Status.OK, "ok")]
+
+    report = await run_health_suite([_call("mycat", _cat)], runtime=runtime)
+
+    assert seen["runtime"] is runtime
+    assert report.results[0].status is Status.OK
+
+
+async def test_runtime_bound_by_keyword_not_position(runtime) -> None:
+    """A leading unrelated parameter must not receive the runtime."""
+    seen: dict[str, object] = {}
+
+    async def _cat(cache=None, runtime=None):
+        seen["cache"] = cache
+        seen["runtime"] = runtime
+        return [CheckResult("r1", "mycat", Status.OK, "ok")]
+
+    await run_health_suite([_call("mycat", _cat)], runtime=runtime)
+
+    assert seen["runtime"] is runtime
+    assert seen["cache"] is None
+
+
+async def test_zero_arg_async_callable_unchanged(runtime) -> None:
+    async def _cat():
+        return [CheckResult("a1", "mycat", Status.WARNING, "async warn")]
+
+    report = await run_health_suite([_call("mycat", _cat)], runtime=runtime)
+    assert report.results[0].name == "a1"
+    assert report.results[0].status is Status.WARNING
+
+
+async def test_zero_arg_sync_callable_still_offloaded(runtime) -> None:
+    seen: dict[str, object] = {}
+
+    def _cat():
+        seen["thread"] = threading.current_thread()
+        return [CheckResult("s1", "mycat", Status.OK, "sync ok")]
+
+    report = await run_health_suite([_call("mycat", _cat)], runtime=runtime)
+
+    assert report.results[0].name == "s1"
+    assert report.results[0].status is Status.OK
+    assert seen["thread"] is not threading.current_thread()
+
+
+async def test_sync_callable_asking_for_runtime_is_refused(runtime) -> None:
+    """A sync category cannot own the connector's loop, so it is not invoked."""
+    called = False
+
+    def _cat(runtime):
+        nonlocal called
+        called = True
+        return []
+
+    report = await run_health_suite([_call("mycat", _cat)], runtime=runtime)
+
+    assert called is False
+    assert len(report.results) == 1
+    row = report.results[0]
+    assert row.name == "mycat"
+    assert row.category == "mycat"
+    assert row.status is Status.ERROR
+    assert "async def" in row.message
+    assert report.deadline_hit is False
+
+
+async def test_unreadable_signature_is_called_with_zero_arguments(runtime) -> None:
+    """An unreadable signature falls back to the older, safer zero-arg shape."""
+
+    async def _cat():
+        return [CheckResult("o1", "mycat", Status.OK, "opaque ok")]
+
+    _cat.__signature__ = "not a signature"
+    with pytest.raises((TypeError, ValueError)):  # which one is version-dependent
+        inspect.signature(_cat)
+
+    report = await run_health_suite([_call("mycat", _cat)], runtime=runtime)
+
+    assert report.results[0].name == "o1"
+    assert report.results[0].status is Status.OK
 
 
 # --- Report shape -----------------------------------------------------------

--- a/tests/health/test_runtime.py
+++ b/tests/health/test_runtime.py
@@ -340,6 +340,32 @@ async def test_many_concurrent_get_connector_calls_construct_exactly_one(
     assert all(result is spy for result in results)
 
 
+async def test_shutdown_during_construction_does_not_orphan_the_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The closed check runs before the lock, so it can be passed and then
+    overtaken: ``shutdown()`` finds the slot still empty, disconnects nothing,
+    and the construction completes into a runtime that has already torn down.
+    Nothing would ever disconnect that connector — the orphan the lock exists
+    to prevent, reached through a different window. The construction has to
+    re-check inside the lock and close what it just built."""
+    construct_calls: list[Any] = []
+    spy = _SpyConnector()
+    _patch_slow_factory(monkeypatch, spy, construct_calls)
+    runtime = HealthRuntime({"type": "mock"})
+
+    getter = asyncio.create_task(runtime.get_connector())
+    await asyncio.sleep(0)  # getter passes the closed check and enters construction
+    assert construct_calls == [{"type": "mock"}]
+    await runtime.shutdown()
+
+    with pytest.raises(RuntimeError, match="closed while its connector was being constructed"):
+        await getter
+    assert spy.disconnect_calls == 1
+    assert runtime.closed
+    assert not runtime.ever_constructed
+
+
 async def test_concurrent_get_archiver_constructs_exactly_one(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/health/test_runtime.py
+++ b/tests/health/test_runtime.py
@@ -9,11 +9,15 @@ disconnects it exactly once on exit. Mirrors the spy-connector shape from
 - never-constructed: a runtime whose ``get_connector`` is never called neither
   registers connector types nor constructs anything, and disconnects nothing;
 - best-effort teardown: a ``disconnect()`` that raises is swallowed so context
-  exit never propagates it.
+  exit never propagates it;
+- serialized construction: probes run concurrently inside a health category, so
+  two gathered ``get_connector``/``get_archiver`` calls must still construct a
+  single connector rather than orphaning the loser of the race.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -240,3 +244,144 @@ async def test_double_shutdown_is_safe_after_construction(
     assert runtime.closed is True
     assert runtime.ever_constructed is True
     assert spy.disconnect_calls == 1
+
+
+class _SpyArchiver:
+    """Minimal async-``disconnect``-only stand-in for an archiver connector."""
+
+    def __init__(self) -> None:
+        self.disconnect_calls = 0
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+
+
+def _patch_archiver_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    connector: Any,
+    construct_calls: list[Any],
+) -> None:
+    """Spy `create_archiver_connector`, yielding once inside the construction.
+
+    The ``await asyncio.sleep(0)`` is the whole point: it hands control back to
+    the event loop while the cache slot is still empty, which is exactly the
+    window a second concurrent probe used to slip through.
+    """
+
+    async def fake_create(config: dict[str, Any]) -> Any:
+        construct_calls.append(config)
+        await asyncio.sleep(0)
+        return connector
+
+    monkeypatch.setattr(factory.ConnectorFactory, "create_archiver_connector", fake_create)
+    monkeypatch.setattr(factory, "register_builtin_connectors", lambda: None)
+
+
+def _patch_slow_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    connector: Any,
+    construct_calls: list[Any],
+) -> None:
+    """Like `_patch_factory`, but yields to the loop mid-construction.
+
+    Without the runtime's lock, the yield lets a second gathered caller observe
+    the still-empty cache and build a connector of its own — the orphan
+    ``shutdown()`` would never disconnect.
+    """
+
+    async def fake_create(config: dict[str, Any]) -> Any:
+        construct_calls.append(config)
+        await asyncio.sleep(0)
+        return connector
+
+    monkeypatch.setattr(
+        factory.ConnectorFactory,
+        "create_control_system_connector",
+        fake_create,
+    )
+    monkeypatch.setattr(factory, "register_builtin_connectors", lambda: None)
+
+
+async def test_concurrent_get_connector_constructs_exactly_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    construct_calls: list[Any] = []
+    spy = _SpyConnector()
+    _patch_slow_factory(monkeypatch, spy, construct_calls)
+
+    async with HealthRuntime({"type": "mock"}) as runtime:
+        first, second = await asyncio.gather(
+            runtime.get_connector(),
+            runtime.get_connector(),
+        )
+
+        # One construction between them, and the waiter got the winner's
+        # instance rather than an orphan of its own.
+        assert construct_calls == [{"type": "mock"}]
+        assert first is spy
+        assert second is spy
+
+    # The single connector is disconnected once; nothing was left behind.
+    assert spy.disconnect_calls == 1
+
+
+async def test_many_concurrent_get_connector_calls_construct_exactly_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    construct_calls: list[Any] = []
+    spy = _SpyConnector()
+    _patch_slow_factory(monkeypatch, spy, construct_calls)
+
+    # A realistic category fan-out: several channel_read-style probes at once.
+    async with HealthRuntime({"type": "mock"}) as runtime:
+        results = await asyncio.gather(*(runtime.get_connector() for _ in range(8)))
+
+    assert len(construct_calls) == 1
+    assert all(result is spy for result in results)
+
+
+async def test_concurrent_get_archiver_constructs_exactly_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    construct_calls: list[Any] = []
+    spy = _SpyArchiver()
+    _patch_archiver_factory(monkeypatch, spy, construct_calls)
+
+    archiver_config = {"type": "epics_archiver", "epics_archiver": {}}
+
+    async with HealthRuntime({"type": "mock"}) as runtime:
+        first, second = await asyncio.gather(
+            runtime.get_archiver(archiver_config),
+            runtime.get_archiver(archiver_config),
+        )
+
+        assert construct_calls == [archiver_config]
+        assert first is spy
+        assert second is spy
+        assert runtime.archiver_ever_constructed is True
+
+    assert spy.disconnect_calls == 1
+
+
+async def test_closed_runtime_refuses_without_waiting_on_the_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    construct_calls: list[Any] = []
+    spy = _SpyConnector()
+    _patch_slow_factory(monkeypatch, spy, construct_calls)
+
+    runtime = HealthRuntime({"type": "mock"})
+    await runtime.shutdown()
+
+    # The closed guard sits outside the lock, so the refusal does not depend on
+    # the lock being free: it is raised even while another task holds it.
+    await runtime._lock.acquire()
+    try:
+        with pytest.raises(RuntimeError):
+            await asyncio.wait_for(runtime.get_connector(), timeout=1)
+        with pytest.raises(RuntimeError):
+            await asyncio.wait_for(runtime.get_archiver({"type": "mock"}), timeout=1)
+    finally:
+        runtime._lock.release()
+
+    assert construct_calls == []


### PR DESCRIPTION
Two extension points in `src/osprey/health/`, bundled because both move the
same core-category pin.

**Plugin categories reach the suite's connector.** A facility health plugin that
wanted to read a channel had to build its own connector, while `HealthRuntime`
already held one lazily-built connector that every core check shares. That meant
a second Channel Access context per check, outside the run's fail-closed readonly
posture. An `async def` category callable may now declare a `runtime` parameter
and is handed the run's `HealthRuntime` by keyword; acceptance is decided on the
parameter's kind rather than its bare name so `check(cache=None, runtime=None)`
cannot receive it as `cache`. A sync callable declaring `runtime` is refused with
one `error` row — it runs on a worker thread with no event loop, and the only
route to a connector from there would build one on a loop that dies. This lands
at the callable, not at `get_health_categories(runtime)` as the issue spelled it:
the entrypoint runs before any runtime exists, and category names must be known
at load time for collision detection and `--category` validation.

Two things surfaced on the way. `get_connector`/`get_archiver` built behind an
unguarded `is None` test while checks run concurrently, so two callers could each
build one and orphan the loser until process exit — construction is now behind an
`asyncio.Lock`. And an unresolvable `health.plugins` path raised outside the
loader's try and crashed the suite; it now degrades to one `error` row.

**A boot path that survives a network home.** When `$HOME` is on NFS or autofs, a
lingering user manager reaches `default.target` before the home is mounted,
resolves its unit search path once, and never looks again. After every reboot the
scaffolded unit reads `not-found` and the stack sits in `Created` until someone
runs `daemon-reload` by hand. The root-only drop-in guidance already ships; an
operator without root had nothing, and `osprey health` showed the condition as an
unremarkable broken unit. `osprey scaffold systemd` now also writes
`scripts/osprey-boot-hook.sh` (waits for the home and the user manager, reloads,
starts; idempotent) and prints the `@reboot` crontab line only when `findmnt`
reports a network home — OSPREY writes the file and never edits a crontab. A new
`systemd_unit` core category names the condition. `osprey.service` and its golden
are untouched: per the issue, `RequiresMountsFor` belongs on `user@<uid>.service`.

Fixes #735
Fixes #738

## How it hangs together

```text
 plugin runtime access (#735)

   osprey health ──► build_records() ──► HealthRuntime  (one per run)
                                              │ get_connector() / get_archiver()
                                              │ construction behind asyncio.Lock
                                              ▼
                     runner._run_callable(func, runtime)
                       ├─ async def check(runtime) / check(*, runtime) ──► func(runtime=runtime)
                       ├─ async def check()  /  def check()             ──► func()
                       └─ def check(runtime)                            ──► one `error` row: needs async def

 boot path for a network home (#738)

   osprey scaffold systemd
     ├─► osprey.service                 (unchanged, golden byte-identical)
     └─► scripts/osprey-boot-hook.sh    (new, 0755)
            wait $HOME + /run/user/$UID ──► systemctl --user daemon-reload ──► start osprey.service
            printed only when findmnt says nfs/autofs:
              @reboot <repo>/scripts/osprey-boot-hook.sh

   osprey health ──► systemd_unit category ──► one row
     no <repo>/osprey.service, no systemctl, no user bus ──► SKIP
     not in $XDG_CONFIG_HOME/systemd/user (~/.config/…) ──► WARNING  scaffolded, not installed
     installed, manager reports not-found                ──► ERROR    manager cannot see it
     installed, manager knows it                         ──► OK
```
