### PR TITLE
Show the channel-finder capture queue in graph mode, and publish the panel theming contract

### DIFF
--- a/changelog.d/cf-feedback-graph.fixed.md
+++ b/changelog.d/cf-feedback-graph.fixed.md
@@ -1,0 +1,7 @@
+The channel finder's Feedback tab no longer shows a lock screen naming a
+hierarchical-only config key on a deployment that answers channel searches
+from the facility graph. That deployment keeps no hint store by design, but
+the agent's searches are captured all the same, so the tab now lists them for
+review and offers Dismiss — promotion is withheld rather than offered and
+refused. Where feedback is simply switched off, the pane says so in operator
+language instead of quoting a config key.

--- a/changelog.d/panel-theming-contract.added.md
+++ b/changelog.d/panel-theming-contract.added.md
@@ -1,0 +1,3 @@
+The panels how-to now documents how a URL-backed panel follows the operator's
+theme: the parameters the terminal opens it with, the message it sends when
+the theme changes, and how to load the terminal's own design tokens.

--- a/docs/source/how-to/web-terminal/panels.rst
+++ b/docs/source/how-to/web-terminal/panels.rst
@@ -4,8 +4,11 @@ Panels
 A **panel** is a self-contained, themed mini-app the Web Terminal shows as a tab
 beside the chat. OSPREY's own tools — Channel Finder, ARIEL, the lattice
 dashboard, the artifact gallery — are all panels, and you can add your own.
-Because panels use the shared design tokens (:doc:`theming`), they match your
-theme automatically, in light and dark, with no extra work.
+A panel that takes its colors from the shared design tokens (:doc:`theming`)
+matches your theme automatically, in light and dark, with no extra work. A
+service that brings its own colors — most facility dashboards do — follows
+the theme only once it opts in; `Theming a URL-backed panel`_ is what it needs
+to do.
 
 Enable OSPREY's built-in panels in ``config.yml``:
 
@@ -48,6 +51,76 @@ the entries for you):
 
 The hub shows the service as a tab and proxies requests to it from the same
 origin, so the browser never needs direct access to the backing port.
+
+Theming a URL-backed panel
+--------------------------
+
+A service you did not write for OSPREY keeps its own colors when you hang it
+in a tab, and the terminal will not restyle it for you. What the terminal does
+do is tell the service, at every moment, which theme the operator is looking
+at — and it is then a small change in the service to follow along. This is the
+whole of what it is told. Everything below is **version 1** of the contract
+(``CONTRACT_VERSION`` in the design system's ``frame-params.js``), so a service
+that follows it keeps working as later versions add to it.
+
+**The theme arrives in the address.** The terminal opens the panel at the URL
+you configured with three parameters added:
+
+.. code-block:: text
+
+   ?embedded=true&theme=retro-dark&mode=expert
+
+``theme`` is the theme to paint with. ``embedded=true`` says the page is
+running inside the terminal rather than on its own, which is the cue to hide
+your own logo and page chrome — the terminal already draws a header around the
+tab, and without this you get two. ``mode`` is the operator's Expert or Simple
+preference. Read all three *before the page first paints*, or the operator sees
+your default colors flash before yours settle on theirs.
+
+**The theme is one of eight names.** ``light`` and ``dark`` for the main
+family, then ``desy-light``, ``desy-dark``, ``high-contrast-light``,
+``high-contrast-dark``, ``retro-light`` and ``retro-dark`` (:doc:`theming`
+describes the families). OSPREY's own pages put the name on the ``<html>``
+element as ``data-theme="retro-dark"`` and let their stylesheet key off it;
+a service is free to map the eight names onto whatever its own styling
+expects, and to treat an unfamiliar name as its nearest light or dark default.
+
+**A change while the tab is open arrives as a message.** When the operator
+switches theme, the terminal posts to the panel's frame:
+
+.. code-block:: javascript
+
+   { type: 'osprey-theme-change', theme: 'high-contrast-dark' }
+
+A panel is always served from the terminal's own address, so the message is
+same-origin. Check that before acting on it — ``if (event.origin !==
+window.location.origin) return;`` — and repaint. The Expert/Simple toggle
+broadcasts the same way, as ``{ type: 'osprey-mode-change', mode }``.
+
+**The tokens come from the terminal, not from your copy.** A page embedded as
+a panel can load OSPREY's design tokens with a plain root-absolute reference:
+
+.. code-block:: html
+
+   <link rel="stylesheet" href="/design-system/css/tokens.css">
+
+The proxy rewrites that to the terminal's own copy of the design system, so
+the colors a panel paints with are the ones the terminal is running — not
+whichever ones the service's own build happened to ship. Every OSPREY color is
+a CSS variable there, and all eight themes are defined in that one file, so a
+service that restates its colors in terms of those variables gets the whole
+theme switch for free.
+
+Two boundaries are worth saying out loud:
+
+- **Nothing happens on its own.** The terminal only *tells* the panel the
+  theme. A service that never reads the parameter, the message, or the tokens
+  is embedded successfully and stays exactly the color it always was.
+- **No credentials cross the proxy.** The terminal strips the operator's
+  cookies and ``Authorization`` header on the way to your service, and strips
+  headers that would act on the terminal's address on the way back — see the
+  note under `Adding your own panel`_. A service that authenticates its own
+  callers that way cannot be driven as a panel, themed or not.
 
 The Bluesky panel
 -----------------

--- a/src/osprey/interfaces/channel_finder/feedback_api.py
+++ b/src/osprey/interfaces/channel_finder/feedback_api.py
@@ -82,12 +82,28 @@ class DeleteRecordRequest(BaseModel):
 
 @router.get("/feedback/status")
 async def feedback_status(request: Request):
-    """Check feedback store availability. Always returns 200."""
+    """Check feedback store availability. Always returns 200.
+
+    ``paradigm`` names the pipeline being served, and it is what makes
+    ``available: false`` actionable. There are two unrelated reasons for that
+    answer — the operator has not switched feedback on for a pipeline that
+    supports it, and the served paradigm keeps no feedback store at all — and
+    a bare boolean cannot tell them apart. The UI that had only the boolean
+    answered both with the same lock screen quoting a hierarchical-only config
+    key, which is wrong advice for an operator running the graph paradigm.
+    """
+    paradigm = getattr(request.app.state, "pipeline_type", None)
     store = getattr(request.app.state, "feedback_store", None)
     if store is None:
-        return {"available": False, "entry_count": 0, "store_path": None}
+        return {
+            "available": False,
+            "paradigm": paradigm,
+            "entry_count": 0,
+            "store_path": None,
+        }
     return {
         "available": True,
+        "paradigm": paradigm,
         "entry_count": len(store.list_keys()),
         "store_path": str(store._path),
     }

--- a/src/osprey/interfaces/channel_finder/pending_review_api.py
+++ b/src/osprey/interfaces/channel_finder/pending_review_api.py
@@ -57,11 +57,27 @@ def _get_pending_store(request: Request):
 
 
 def _get_feedback_store(request: Request):
-    """Get the feedback store from app state, or raise 404."""
+    """Get the feedback store from app state, or raise 404.
+
+    Approving and rejecting both *write* — they promote a captured search into
+    the navigation hints the hierarchical pipeline reads back. A deployment
+    with no feedback store has nowhere to put them, and the reason differs by
+    paradigm, so the refusal says which one it is rather than leaving the
+    operator with a bare "not available" against a queue that visibly has items
+    in it. Dismissing a captured item needs no feedback store and is not routed
+    through here.
+    """
     from osprey.services.channel_finder.feedback.store import FeedbackStore
 
     store: FeedbackStore | None = getattr(request.app.state, "feedback_store", None)
     if store is None:
+        if getattr(request.app.state, "pipeline_type", None) == "graph":
+            raise HTTPException(
+                404,
+                "Approving or rejecting records a navigation hint for a pipeline that "
+                "reads them back; this deployment answers channel searches by querying "
+                "the facility graph and keeps no hint store. Dismiss the item instead.",
+            )
         raise HTTPException(404, "Feedback store not available")
     return store
 
@@ -180,13 +196,22 @@ class RejectRequest(BaseModel):
 
 @router.get("/pending-reviews/status")
 async def pending_reviews_status(request: Request):
-    """Check pending review store availability. Always returns 200."""
+    """Check pending review store availability. Always returns 200.
+
+    ``can_promote`` is a second, independent axis: the capture queue is filled
+    by the agent hook for every pipeline, while approve/reject write into the
+    feedback store, which only some deployments have. Reporting the two
+    separately is what lets a client offer the queue without offering buttons
+    the server would refuse (see :func:`_get_feedback_store`).
+    """
     store = getattr(request.app.state, "pending_review_store", None)
+    can_promote = getattr(request.app.state, "feedback_store", None) is not None
     if store is None:
-        return {"available": False, "item_count": 0}
+        return {"available": False, "item_count": 0, "can_promote": can_promote}
     return {
         "available": True,
         "item_count": len(store.list_items()),
+        "can_promote": can_promote,
     }
 
 

--- a/src/osprey/interfaces/channel_finder/static/css/channel-finder.css
+++ b/src/osprey/interfaces/channel_finder/static/css/channel-finder.css
@@ -1522,12 +1522,29 @@ textarea.form-input {
   margin: 0 auto;
 }
 
-.fb-disabled-hint code {
-  font-family: var(--font-mono);
-  font-size: var(--cf-text-xs);
-  background: var(--bg-elevated);
-  padding: 1px 4px;
-  border-radius: 2px;
+/* Informational posture, matching .explore-unknown--info: the graph paradigm
+   keeps no feedback store by design, so the pane that says so must not be
+   tinted like a failure. Sized to sit above the capture queue rather than
+   alone on the view, which is what separates it from .fb-disabled. */
+.fb-paradigm-note {
+  background: var(--accent-tint-08);
+  border: 1px solid var(--accent-tint-30);
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--cf-radius-md);
+  padding: var(--cf-space-3) var(--cf-space-4);
+}
+
+.fb-paradigm-note-title {
+  color: var(--text-accent);
+  font-size: var(--cf-text-base);
+  font-weight: 600;
+}
+
+.fb-paradigm-note-body {
+  margin-top: var(--cf-space-2);
+  color: var(--text-secondary);
+  font-size: var(--cf-text-sm);
+  line-height: 1.5;
 }
 
 .fb-table-row {

--- a/src/osprey/interfaces/channel_finder/static/js/feedback-render.js
+++ b/src/osprey/interfaces/channel_finder/static/js/feedback-render.js
@@ -186,3 +186,80 @@ export function _formatTime(isoStr) {
     return isoStr;
   }
 }
+
+/**
+ * Render the "Pending Reviews" section: the searches the agent ran, captured
+ * by the PostToolUse hook and waiting for an operator to look at them.
+ *
+ * Shared by both feedback views, and `canPromote` is the entire difference
+ * between them. Approving promotes a captured search into the navigation
+ * hints a pipeline reads back on its next search; a deployment with no
+ * feedback store has nowhere to put one, and the server refuses the call
+ * (`pending_review_api._get_feedback_store`). So the button is not drawn
+ * there rather than drawn and answered with an error. Dismiss stays in both:
+ * it only deletes from the capture queue and needs no feedback store.
+ *
+ * @param {any[]} items - pending review items, newest first.
+ * @param {{canPromote?: boolean}} [options]
+ * @returns {string}
+ */
+export function _renderPendingSection(items, options = {}) {
+  const canPromote = options.canPromote !== false;
+  const pendingItems = items || [];
+
+  if (pendingItems.length === 0) {
+    return `
+      <div class="fb-pending-section">
+        <div class="fb-pending-header">
+          <span>Pending Reviews</span>
+          <span class="fb-pending-subtitle">Agent-captured searches awaiting review</span>
+        </div>
+        <div class="fb-pending-empty">No pending reviews</div>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="fb-pending-section">
+      <div class="fb-pending-header">
+        <span>Pending Reviews <span class="fb-pending-badge">${pendingItems.length}</span></span>
+        <span class="fb-pending-subtitle">Agent-captured searches awaiting review</span>
+      </div>
+      ${pendingItems.map((/** @type {any} */ item) => {
+        const summary = _buildCardSummary(item);
+        const label = _toolLabel(item.tool_name);
+        const channels = _parseChannelsFromResponse(item.tool_response);
+        const selHtml = item.selections && Object.keys(item.selections).length > 0
+          ? `<div class="fb-selections">${_renderSelections(item.selections)}</div>` : '';
+        const chHtml = _renderChannelList(channels);
+        const taskHtml = item.agent_task && item.agent_task !== summary
+          ? `<div class="fb-pending-agent-task">${esc(item.agent_task)}</div>` : '';
+        const artifactHtml = item.artifact && item.artifact.filename
+          ? `<a class="fb-pending-artifact-link" href="/api/artifacts/${esc(item.artifact.filename)}" target="_blank">View Result</a>` : '';
+        const approveHtml = canPromote
+          ? `<button class="btn btn-sm btn-primary fb-pending-approve" data-id="${esc(item.id)}">Approve &amp; Update Prompt</button>` : '';
+        return `
+        <div class="fb-pending-card" data-id="${esc(item.id)}">
+          ${taskHtml}
+          <div class="fb-pending-header">
+            <div class="fb-pending-summary">${esc(summary)}</div>
+            ${label ? `<span class="fb-pending-tool-badge">${esc(label)}</span>` : ''}
+          </div>
+          ${selHtml}
+          ${chHtml}
+          <div class="fb-pending-footer">
+            <div class="fb-pending-meta">
+              <span>${item.channel_count || 0} channels</span>
+              <span>${_formatTime(item.captured_at)}</span>
+            </div>
+            ${artifactHtml}
+            <div class="fb-pending-actions">
+              ${approveHtml}
+              <button class="btn btn-sm btn-danger fb-pending-dismiss" data-id="${esc(item.id)}">Dismiss</button>
+            </div>
+          </div>
+        </div>`;
+      }).join('')}
+    </div>
+  `;
+}

--- a/src/osprey/interfaces/channel_finder/static/js/feedback.js
+++ b/src/osprey/interfaces/channel_finder/static/js/feedback.js
@@ -15,13 +15,9 @@ import { showToast } from './app.js';
 import { getContainer, setContainer, getCurrentKey, setCurrentKey, setRerender, setRenderList } from './feedback-state.js';
 import { _renderDetail } from './feedback-detail.js';
 import {
-  _toolLabel,
-  _buildCardSummary,
-  _parseChannelsFromResponse,
-  _renderChannelList,
-  _renderSelections,
   _parseSelections,
   _formatTime,
+  _renderPendingSection,
 } from './feedback-render.js';
 
 // ---- Public API ----
@@ -50,7 +46,16 @@ async function _render() {
   try {
     const status = await fetchJSON('/api/feedback/status');
     if (!status.available) {
-      _renderDisabled();
+      // Two different "no feedback store" answers, and only the paradigm tells
+      // them apart. The graph paradigm keeps no hint store by design, yet the
+      // capture hook fills the pending queue there like anywhere else — so
+      // showing the lock screen hid real captured searches behind advice to
+      // switch on a setting that paradigm does not have.
+      if (status.paradigm === 'graph') {
+        await _renderGraphReviews();
+      } else {
+        _renderDisabled();
+      }
       return;
     }
     if (getCurrentKey()) {
@@ -63,19 +68,58 @@ async function _render() {
   }
 }
 
+/**
+ * Feedback is switched off for a paradigm that supports it. Operator language,
+ * and deliberately no dotted config key: the pane names the setting the way
+ * the Explore view's panes do, because the key that was printed here is
+ * hierarchical-only and this pane is reached from several paradigms.
+ */
 function _renderDisabled() {
   const container = getContainer();
   if (!container) return;
   container.innerHTML = `
     <div class="fb-disabled">
       <div class="fb-disabled-icon">&#128274;</div>
-      <div class="fb-disabled-title">Feedback Store Not Available</div>
+      <div class="fb-disabled-title">Feedback is switched off for this deployment</div>
       <div class="fb-disabled-hint">
-        Enable feedback in your config to start recording navigation hints:<br>
-        <code>channel_finder.pipelines.hierarchical.feedback.enabled: true</code>
+        Feedback records the paths that answered a channel search so the agent
+        can reuse them. Check the channel finder feedback setting in your
+        configuration, then reload this panel.
       </div>
     </div>
   `;
+}
+
+/**
+ * The graph paradigm's feedback view: the capture queue on its own.
+ *
+ * Nothing is hidden here and nothing is broken — there is simply no hint
+ * store to browse, because the graph agent answers each question by querying
+ * the facility graph rather than by replaying a saved path. What the hook
+ * captures is still worth an operator's eye, so the queue is rendered with
+ * Dismiss only; approving would write a hint nothing reads back.
+ */
+async function _renderGraphReviews() {
+  const container = getContainer();
+  if (!container) return;
+
+  const pendingData = await fetchJSON('/api/pending-reviews/status')
+    .then((/** @type {any} */ s) => s.available ? fetchJSON('/api/pending-reviews') : { items: [] })
+    .catch(() => ({ items: [] }));
+
+  container.innerHTML = `
+    <div class="fb-paradigm-note">
+      <div class="fb-paradigm-note-title">Reviewing graph answers</div>
+      <div class="fb-paradigm-note-body">
+        This deployment answers channel searches by querying the facility graph,
+        so there are no saved navigation hints to browse or edit. The searches
+        the agent ran are still captured below for review &mdash; look them over,
+        then dismiss the ones you are done with.
+      </div>
+    </div>
+    ${_renderPendingSection(pendingData.items || [], { canPromote: false })}
+  `;
+  _bindPendingEvents();
 }
 
 // ---- List View ----
@@ -159,59 +203,9 @@ async function _renderList() {
   }
 
   // ---- Pending Reviews Section ----
-  if (pendingItems.length > 0) {
-    html += `
-      <div class="fb-pending-section">
-        <div class="fb-pending-header">
-          <span>Pending Reviews <span class="fb-pending-badge">${pendingItems.length}</span></span>
-          <span class="fb-pending-subtitle">Agent-captured searches awaiting review</span>
-        </div>
-        ${pendingItems.map((/** @type {any} */ item) => {
-          const summary = _buildCardSummary(item);
-          const label = _toolLabel(item.tool_name);
-          const channels = _parseChannelsFromResponse(item.tool_response);
-          const selHtml = item.selections && Object.keys(item.selections).length > 0
-            ? `<div class="fb-selections">${_renderSelections(item.selections)}</div>` : '';
-          const chHtml = _renderChannelList(channels);
-          const taskHtml = item.agent_task && item.agent_task !== summary
-            ? `<div class="fb-pending-agent-task">${esc(item.agent_task)}</div>` : '';
-          const artifactHtml = item.artifact && item.artifact.filename
-            ? `<a class="fb-pending-artifact-link" href="/api/artifacts/${esc(item.artifact.filename)}" target="_blank">View Result</a>` : '';
-          return `
-          <div class="fb-pending-card" data-id="${esc(item.id)}">
-            ${taskHtml}
-            <div class="fb-pending-header">
-              <div class="fb-pending-summary">${esc(summary)}</div>
-              ${label ? `<span class="fb-pending-tool-badge">${esc(label)}</span>` : ''}
-            </div>
-            ${selHtml}
-            ${chHtml}
-            <div class="fb-pending-footer">
-              <div class="fb-pending-meta">
-                <span>${item.channel_count || 0} channels</span>
-                <span>${_formatTime(item.captured_at)}</span>
-              </div>
-              ${artifactHtml}
-              <div class="fb-pending-actions">
-                <button class="btn btn-sm btn-primary fb-pending-approve" data-id="${esc(item.id)}">Approve &amp; Update Prompt</button>
-                <button class="btn btn-sm btn-danger fb-pending-dismiss" data-id="${esc(item.id)}">Dismiss</button>
-              </div>
-            </div>
-          </div>`;
-        }).join('')}
-      </div>
-    `;
-  } else {
-    html += `
-      <div class="fb-pending-section">
-        <div class="fb-pending-header">
-          <span>Pending Reviews</span>
-          <span class="fb-pending-subtitle">Agent-captured searches awaiting review</span>
-        </div>
-        <div class="fb-pending-empty">No pending reviews</div>
-      </div>
-    `;
-  }
+  // Shared with the graph view (see _renderGraphReviews); here the deployment
+  // has a feedback store, so promotion is on offer.
+  html += _renderPendingSection(pendingItems, { canPromote: true });
 
   container.innerHTML = html;
   _bindListEvents();

--- a/tests/interfaces/channel_finder/feedback-graph-mode.test.mjs
+++ b/tests/interfaces/channel_finder/feedback-graph-mode.test.mjs
@@ -1,0 +1,132 @@
+// @ts-check
+/**
+ * Paradigm dispatch for the Feedback view (feedback.js).
+ *
+ * `/api/feedback/status` answering `available: false` has two unrelated
+ * causes, and the view must not answer both the same way. Under the graph
+ * paradigm there is no hint store by design, yet the capture hook still fills
+ * the pending queue — so the view shows that queue instead of a lock screen,
+ * and offers Dismiss without Approve (the server refuses promotion where there
+ * is no feedback store). Under any other paradigm the store is simply switched
+ * off, and the pane says so in operator language, naming no dotted config key.
+ *   npx vitest run tests/interfaces/channel_finder/feedback-graph-mode.test.mjs
+ *
+ * Runs under happy-dom (vitest.config.js). app.js is mocked so importing the
+ * view does not boot the whole panel; feedback.js wants only `showToast`.
+ */
+
+import { test, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../../src/osprey/interfaces/channel_finder/static/js/app.js', () => ({
+  showToast: vi.fn(),
+}));
+
+import { mountFeedback, unmountFeedback } from '../../../src/osprey/interfaces/channel_finder/static/js/feedback.js';
+
+afterEach(() => {
+  unmountFeedback();
+  vi.unstubAllGlobals();
+});
+
+/**
+ * Answer each GET with the payload registered for its path. An unregistered
+ * path resolves not-ok, so a view that reaches for an endpoint this fixture
+ * did not intend to offer fails loudly rather than silently reading `{}`.
+ * @param {Record<string, any>} routes
+ */
+function stubApi(routes) {
+  vi.stubGlobal('fetch', vi.fn(async (/** @type {string} */ path) => {
+    if (path in routes) return { ok: true, json: async () => routes[path] };
+    return { ok: false, status: 404, statusText: 'Not Found', json: async () => ({ detail: `no stub: ${path}` }) };
+  }));
+}
+
+/** @returns {HTMLElement} a fresh mount point. */
+function freshContainer() {
+  document.body.innerHTML = '<div id="view"></div>';
+  return /** @type {HTMLElement} */ (document.getElementById('view'));
+}
+
+const PENDING_ITEM = {
+  id: 'item-1',
+  query: 'all horizontal correctors',
+  tool_name: 'mcp__channel-finder__read_cypher',
+  tool_response: JSON.stringify({ row_count: 2, channels: ['SR:C01:BPM1', 'SR:C02:BPM1'] }),
+  channel_count: 2,
+  selections: {},
+  captured_at: '2026-08-27T10:00:00Z',
+};
+
+test('graph mode shows the capture queue, not the lock screen', async () => {
+  const container = freshContainer();
+  stubApi({
+    '/api/feedback/status': { available: false, paradigm: 'graph', entry_count: 0, store_path: null },
+    '/api/pending-reviews/status': { available: true, item_count: 1, can_promote: false },
+    '/api/pending-reviews': { items: [PENDING_ITEM] },
+  });
+
+  mountFeedback(container);
+  await vi.waitFor(() => expect(container.querySelector('.fb-pending-card')).not.toBeNull());
+
+  // The captured search is on screen...
+  expect(container.innerHTML).toContain('all horizontal correctors');
+  expect(container.innerHTML).toContain('SR:C01:BPM1');
+  // ...with Dismiss offered and Approve withheld: promotion would 404.
+  expect(container.querySelector('.fb-pending-dismiss')).not.toBeNull();
+  expect(container.querySelector('.fb-pending-approve')).toBeNull();
+  // The lock screen and its hierarchical-only config key are both gone.
+  expect(container.querySelector('.fb-disabled')).toBeNull();
+  expect(container.innerHTML).not.toMatch(/channel_finder\./);
+});
+
+test('graph mode with an empty queue still explains itself', async () => {
+  const container = freshContainer();
+  stubApi({
+    '/api/feedback/status': { available: false, paradigm: 'graph', entry_count: 0, store_path: null },
+    '/api/pending-reviews/status': { available: true, item_count: 0, can_promote: false },
+    '/api/pending-reviews': { items: [] },
+  });
+
+  mountFeedback(container);
+  await vi.waitFor(() => expect(container.querySelector('.fb-paradigm-note')).not.toBeNull());
+
+  expect(container.innerHTML).toContain('No pending reviews');
+  expect(container.querySelector('.fb-disabled')).toBeNull();
+  expect(container.innerHTML).not.toMatch(/channel_finder\./);
+});
+
+test('a store-backed paradigm with feedback off gets the operator pane, no config key', async () => {
+  const container = freshContainer();
+  stubApi({
+    '/api/feedback/status': { available: false, paradigm: 'hierarchical', entry_count: 0, store_path: null },
+  });
+
+  mountFeedback(container);
+  await vi.waitFor(() => expect(container.querySelector('.fb-disabled')).not.toBeNull());
+
+  expect(container.innerHTML).not.toMatch(/channel_finder\./);
+  expect(container.innerHTML).not.toContain('<code>');
+  expect(container.querySelector('.fb-paradigm-note')).toBeNull();
+});
+
+test('an available store still lists entries and offers promotion', async () => {
+  const container = freshContainer();
+  stubApi({
+    '/api/feedback/status': { available: true, paradigm: 'hierarchical', entry_count: 1, store_path: '/tmp/fb.json' },
+    '/api/feedback': {
+      entries: [{
+        key: 'k1', query: 'bpms', facility: 'ALS',
+        success_count: 3, failure_count: 1, last_activity: '2026-08-27T10:00:00Z',
+      }],
+    },
+    '/api/pending-reviews/status': { available: true, item_count: 1, can_promote: true },
+    '/api/pending-reviews': { items: [PENDING_ITEM] },
+  });
+
+  mountFeedback(container);
+  await vi.waitFor(() => expect(container.querySelector('.fb-table-row')).not.toBeNull());
+
+  expect(container.innerHTML).toContain('bpms');
+  expect(container.querySelector('.fb-pending-approve')).not.toBeNull();
+  expect(container.querySelector('.fb-pending-dismiss')).not.toBeNull();
+});

--- a/tests/interfaces/channel_finder/test_feedback_api.py
+++ b/tests/interfaces/channel_finder/test_feedback_api.py
@@ -23,6 +23,24 @@ class TestFeedbackStatus:
         data = resp.json()
         assert data["available"] is False
 
+    def test_available_reports_the_paradigm(self, feedback_client):
+        """The served paradigm rides along on the available answer too."""
+        data = feedback_client.get("/api/feedback/status").json()
+        assert data["paradigm"] == "in_context"
+
+    def test_unavailable_reports_the_paradigm(self, client):
+        """``available: false`` alone cannot be acted on.
+
+        A paradigm that keeps no feedback store and one whose operator has not
+        switched feedback on both answer false, and the advice differs: the
+        first has no setting to switch. The UI needs the paradigm to tell them
+        apart, so it is reported on the unavailable answer as well.
+        """
+        client.app.state.pipeline_type = "graph"
+        data = client.get("/api/feedback/status").json()
+        assert data["available"] is False
+        assert data["paradigm"] == "graph"
+
 
 # ------------------------------------------------------------------
 # List entries

--- a/tests/interfaces/channel_finder/test_pending_review_api.py
+++ b/tests/interfaces/channel_finder/test_pending_review_api.py
@@ -26,6 +26,40 @@ def test_status_unavailable(client):
     assert data["available"] is False
 
 
+def test_status_reports_whether_items_can_be_promoted(pending_review_client):
+    """The queue and the ability to promote out of it are separate axes.
+
+    The capture hook fills this queue for every paradigm; approve and reject
+    write into the feedback store, which not every deployment has. A client
+    that could only see ``available`` had to either hide a queue that has real
+    items in it or draw buttons the server refuses.
+    """
+    data = pending_review_client.get("/api/pending-reviews/status").json()
+    assert data["available"] is True
+    assert data["can_promote"] is True
+
+    pending_review_client.app.state.feedback_store = None
+    data = pending_review_client.get("/api/pending-reviews/status").json()
+    assert data["available"] is True
+    assert data["can_promote"] is False
+
+
+def test_approve_without_a_feedback_store_says_why_under_graph(pending_review_client):
+    """The refusal names the paradigm's reason, not just "not available"."""
+    pending_review_client.app.state.feedback_store = None
+    pending_review_client.app.state.pipeline_type = "graph"
+    store = pending_review_client.app.state.pending_review_store
+    item_id = store.capture({"query": "correctors", "facility": "ALS"})
+
+    resp = pending_review_client.post(f"/api/pending-reviews/{item_id}/approve")
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert "facility graph" in detail
+    assert "Dismiss" in detail
+    # Operator language throughout: no dotted config key in a user-facing error.
+    assert "channel_finder." not in detail
+
+
 # ------------------------------------------------------------------
 # 2. List endpoint
 # ------------------------------------------------------------------


### PR DESCRIPTION
Two operator-facing gaps, both about a surface saying something that is not true
of the deployment in front of it.

**The Feedback tab was locked under the graph paradigm.** It showed a lock
screen telling the operator to switch on
`channel_finder.pipelines.hierarchical.feedback.enabled` — a key that paradigm
does not have. Behind that screen sat real work: the capture hook matches
`read_cypher` as well, so the pending-review queue fills in graph mode like
anywhere else, and every captured search was hidden by advice that could not be
followed. The cause is that `/api/feedback/status` answered a boolean to a
question with two unrelated negative answers — feedback switched off, and a
paradigm that keeps no feedback store at all — so the view had one pane for
both. The endpoint now reports the served paradigm, and `/api/pending-reviews/status`
reports `can_promote` beside it, because the queue is filled for every paradigm
while approve and reject write into the feedback store that only some
deployments have. Graph mode then renders the queue with Dismiss offered and
Approve withheld rather than drawn and refused; every other paradigm keeps the
switched-off pane, now in operator language naming no dotted key.

**The theming contract for URL-backed panels was unpublished.** The mechanism
has shipped for a while but was written down only in a browser test and a
skill, so a facility hanging its own dashboard in a tab had no way to learn it —
and the panels page claimed panels theme themselves "with no extra work", which
holds only for panels styled against the design tokens. The new section states
the four wire facts and the two boundaries, versioned against `CONTRACT_VERSION`.

## How it hangs together

```text
                     GET /api/feedback/status
                       { available, paradigm }
                                 │
                available:false  │  available:true
              ┌──────────────────┴──────────────────┐
              │                                     │
      paradigm == "graph" ?                    _renderList
         ┌────┴─────┐                        (entries table)
        yes         no                              │
         │           │                              │
_renderGraphReviews  _renderDisabled                 │
 "no hint store to   "feedback is switched          │
  browse — here is    off" (operator words,          │
  what was captured"  no dotted key)                 │
         │                                           │
         └─────────────────┬───────────────────────-─┘
                           │
         _renderPendingSection(items, { canPromote })
                           │
              ┌────────────┴────────────┐
        canPromote: false          canPromote: true
          Dismiss only            Approve + Dismiss
                │                        │
                │                        └─► POST /pending-reviews/{id}/approve
                │
                └─► DELETE /pending-reviews/{id}   (needs no feedback store)
```

`can_promote` on `/api/pending-reviews/status` is the server-side half of that
same switch: a client can offer the queue without offering a button the server
would refuse, and a refusal that does happen now names the paradigm's reason.
