### PR TITLE
feat(dispatch): clear finished runs from the dashboard's history

### DIFF
--- a/changelog.d/dispatch-clear-history.added.md
+++ b/changelog.d/dispatch-clear-history.added.md
@@ -1,0 +1,7 @@
+The dispatcher dashboard can clear its run history. A **Clear history** button
+beside the Activity filters deletes every finished run — both the persisted
+record and the in-memory entry, so the list stays empty after a reload — while
+runs still in flight are kept. The button asks twice before it fires, and it
+uses the same "is this run finished" rule as the optional `RETENTION_DAYS`
+sweep, so the two can never disagree. Artifacts the cleared runs produced are
+left alone; ageing those out remains the retention sweep's job.

--- a/changelog.d/qmd-model-fetch-retry.fixed.md
+++ b/changelog.d/qmd-model-fetch-retry.fixed.md
@@ -1,0 +1,4 @@
+Building the qmd search sidecar no longer fails when a model download is cut
+short. The three GGUF fetches now pass `curl --retry-all-errors`, so a stream
+the CDN drops mid-transfer is retried like any other transient failure instead
+of failing the image build outright.

--- a/src/osprey/dispatch/dashboard.html
+++ b/src/osprey/dispatch/dashboard.html
@@ -798,6 +798,7 @@ a.btn {
         <span class="search-box">
           <input class="text-input" id="run-search" placeholder="Search runs…" spellcheck="false" autocomplete="off">
         </span>
+        <button class="btn danger" id="clear-history" title="Delete every finished run from the dispatcher's history. Runs still in flight are kept.">Clear history</button>
       </div>
     </div>
     <div id="run-list"></div>
@@ -1991,6 +1992,49 @@ async function cancelRun(runId) {
   }
 }
 
+/* Clearing the history is destructive and cannot be undone, so the button asks
+ * twice: the first click arms it, the second fires, and it disarms itself after
+ * a few seconds. Deliberately NOT `confirm()` — a modal inside the web
+ * terminal's panel iframe blocks the whole terminal tab (see the note above
+ * `bearer()`), so the confirmation lives in the button instead. */
+const CLEAR_ARM_MS = 5000;
+let clearArmTimer = null;
+
+function disarmClearHistory() {
+  clearTimeout(clearArmTimer);
+  clearArmTimer = null;
+  const btn = $('#clear-history');
+  if (!btn) return;
+  delete btn.dataset.armed;
+  btn.textContent = 'Clear history';
+}
+
+async function clearHistory() {
+  const btn = $('#clear-history');
+  if (btn && !btn.dataset.armed) {
+    btn.dataset.armed = '1';
+    btn.textContent = 'Delete finished runs?';
+    clearArmTimer = setTimeout(disarmClearHistory, CLEAR_ARM_MS);
+    return;
+  }
+  disarmClearHistory();
+  if (btn) btn.disabled = true;
+  try {
+    const res = await apiPost('/dashboard/clear-history', {}, bearer());
+    if (res.ok) {
+      const n = res.data?.cleared ?? 0;
+      showToast(n ? `Cleared ${n} finished run${n === 1 ? '' : 's'}` : 'No finished runs to clear', n ? 'ok' : '');
+      fetchState();
+    } else if (!explainIfUnauthorized(res)) {
+      showToast(`Clear failed: ${res.data?.detail || res.status}`, 'err');
+    }
+  } catch (e) {
+    showToast('Clear error: ' + e.message, 'err');
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
 async function toggleTrigger(name, currentStatus) {
   const next = currentStatus === 'disabled' ? 'active' : 'disabled';
   try {
@@ -2052,6 +2096,8 @@ function wire() {
     clearTimeout(searchTimer);
     searchTimer = setTimeout(() => { filters.search = search.value; saveUrl(); renderRunList(); }, 180);
   });
+
+  $('#clear-history').addEventListener('click', clearHistory);
 
   $('#trigger-filter').addEventListener('input', () => renderTriggerList());
 

--- a/src/osprey/dispatch/server.py
+++ b/src/osprey/dispatch/server.py
@@ -41,6 +41,7 @@ from osprey.dispatch.worker_client import (
     WorkerAuthRejectedError,
     WorkerRequestError,
     cancel_worker_run,
+    clear_worker_history,
     dispatch_to_worker,
     fetch_worker_runs,
     proxy_worker_stream,
@@ -500,11 +501,12 @@ def create_server() -> FastMCP:
     #     header-gated too, so it is unavailable on the standalone path (EventSource
     #     cannot set headers, and we deliberately do NOT accept a ``?token=`` query
     #     that would leak the bearer into access logs); polled state still renders.
-    # WRITE endpoints (/retry, /dashboard/cancel, /trigger/.../status) are gated the
-    # same way. The /dashboard HTML SHELL itself stays ungated on purpose: it carries
-    # no agent data, and the standalone token handoff requires the page to load so
-    # its JS can read the fragment. Secret-like source_config keys are still redacted
-    # in /dashboard/state. Production deployments should still network-isolate the port.
+    # WRITE endpoints (/retry, /dashboard/cancel, /dashboard/clear-history and
+    # /trigger/.../status) are gated the same way. The /dashboard HTML SHELL itself
+    # stays ungated on purpose: it carries no agent data, and the standalone token
+    # handoff requires the page to load so its JS can read the fragment. Secret-like
+    # source_config keys are still redacted in /dashboard/state. Production
+    # deployments should still network-isolate the port.
     # -----------------------------------------------------------------------
 
     @mcp.custom_route("/dashboard", methods=["GET"])
@@ -749,6 +751,45 @@ def create_server() -> FastMCP:
         run_id = request.path_params["run_id"]
         try:
             result = await cancel_worker_run(dispatch_target, dispatch_token, run_id)
+        except WorkerAuthRejectedError:
+            return JSONResponse({"detail": "worker auth failed"}, status_code=502)
+        except WorkerRequestError as exc:
+            return JSONResponse({"detail": str(exc)}, status_code=502)
+        return JSONResponse(result)
+
+    @mcp.custom_route("/dashboard/clear-history", methods=["POST"])
+    async def dashboard_clear_history(request: Request) -> JSONResponse:
+        """Proxy a clear-history request to the worker.
+
+        Bearer-auth against the dispatcher's own token, like the cancel proxy;
+        the dispatcher holds the worker token itself so the browser never sees
+        it. POST rather than DELETE because this is the browser-facing hop and
+        the dashboard already speaks POST for every write.
+
+        Body is optional: ``{"older_than_days": N}`` keeps runs younger than N
+        days, and anything else (absent, empty, ``0``) clears every finished run.
+        """
+        unauth = _check_auth(request)
+        if unauth is not None:
+            return unauth
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict):
+            return JSONResponse({"detail": "body must be an object"}, status_code=400)
+
+        raw = body.get("older_than_days") or 0
+        try:
+            older_than_days = int(raw)
+        except (TypeError, ValueError):
+            return JSONResponse({"detail": "older_than_days must be an integer"}, status_code=400)
+        if older_than_days < 0:
+            return JSONResponse({"detail": "older_than_days must not be negative"}, status_code=400)
+
+        try:
+            result = await clear_worker_history(dispatch_target, dispatch_token, older_than_days)
         except WorkerAuthRejectedError:
             return JSONResponse({"detail": "worker auth failed"}, status_code=502)
         except WorkerRequestError as exc:

--- a/src/osprey/dispatch/worker_client.py
+++ b/src/osprey/dispatch/worker_client.py
@@ -271,6 +271,54 @@ async def cancel_worker_run(
     return cast(dict[str, Any], response.json())
 
 
+async def clear_worker_history(
+    url: str, token: str, older_than_days: int = 0, timeout: float = 30.0
+) -> dict[str, Any]:
+    """DELETE /dispatch/runs on the worker to drop finished run records.
+
+    Args:
+        url: Base URL of the worker service (e.g. "http://dispatch-worker-1:9190").
+        token: Bearer token for authentication.
+        older_than_days: Age floor in days. ``0`` (the default) clears every
+            finished run; a positive value clears only those older than it,
+            which is the retention sweep's horizon applied on demand.
+        timeout: Request timeout in seconds. Longer than the cancel path's: this
+            unlinks up to a full history's worth of records in one call.
+
+    Returns:
+        Worker's response dict (``{"cleared": int, "records_deleted": int,
+        "older_than_days": int}``).
+
+    Raises:
+        WorkerAuthRejectedError: If the worker returns HTTP 401.
+        WorkerUnreachableError: On connection errors or timeouts.
+    """
+    clear_url = url.rstrip("/") + "/dispatch/runs"
+    headers = {"Authorization": f"Bearer {token}"}
+    payload = {"older_than_days": older_than_days}
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            # ``client.delete`` takes no body, so go through ``request``: the age
+            # floor rides in the body rather than the URL, keeping it out of
+            # access logs alongside the rest of the worker's write surface.
+            response = await client.request("DELETE", clear_url, headers=headers, json=payload)
+    except httpx.TimeoutException as exc:
+        raise WorkerUnreachableError(f"Timeout clearing history at {clear_url}: {exc}") from exc
+    except httpx.ConnectError as exc:
+        raise WorkerUnreachableError(
+            f"Connection error clearing history at {clear_url}: {exc}"
+        ) from exc
+    except httpx.RequestError as exc:
+        raise WorkerUnreachableError(
+            f"Request error clearing history at {clear_url}: {exc}"
+        ) from exc
+
+    if response.status_code == 401:
+        raise WorkerAuthRejectedError(f"Unauthorized (401) from {clear_url}")
+    response.raise_for_status()
+    return cast(dict[str, Any], response.json())
+
+
 async def proxy_worker_stream(url: str, token: str, run_id: str) -> AsyncIterator[bytes]:
     """Proxy an SSE stream from a worker's /dispatch/{run_id}/stream endpoint.
 

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -6,6 +6,8 @@ Exposes:
   GET  /dispatch/{id}/stream          — SSE stream of run events
   GET  /dispatch/{id}/artifacts       — descriptors of the artifacts the run produced
   GET  /dispatch/{id}/artifacts/{aid} — resolved (renderable) bytes of one artifact the run produced
+  DELETE /dispatch/{id}               — cancel an in-flight run
+  DELETE /dispatch/runs               — delete finished runs from the history
   GET  /health                        — liveness check with run statistics
   GET  /dashboard/runs                — JSON feed consumed by the dispatcher dashboard (token-gated)
 
@@ -31,7 +33,7 @@ from typing import Any
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from osprey.agent_runner.artifact_resolve import (
     deployed_config_path,
@@ -770,6 +772,73 @@ async def dispatch(request: DispatchRequest) -> DispatchResponse:
     # Use create_task (not BackgroundTasks) so we retain a handle for cancellation.
     _tasks[run_id] = asyncio.create_task(_run_dispatch_task(run_id, request))
     return DispatchResponse(status="accepted", run_id=run_id)
+
+
+class ClearRunsRequest(BaseModel):
+    """Body of ``DELETE /dispatch/runs``. Optional; an absent body clears all."""
+
+    older_than_days: int = Field(default=0, ge=0)
+
+
+# Declared BEFORE ``/dispatch/{run_id}``: Starlette matches routes in
+# registration order, so the parameterised cancel route below would otherwise
+# swallow this path as a cancel of a run literally named "runs".
+@app.delete("/dispatch/runs", dependencies=[Depends(_verify_token)])
+async def clear_dispatch_runs(body: ClearRunsRequest | None = None) -> dict[str, Any]:
+    """Delete finished runs from the history — the dashboard's clear action.
+
+    Unlinks every persisted ``{run_id}.json`` the retention sweep would consider
+    eligible AND drops the matching in-memory entries, so the run list comes
+    back empty instead of repopulating from disk on the next reload.
+
+    Both layers are cleared against the same predicate rather than against each
+    other's results: a run can live in ``_runs`` with no file (a persist that
+    failed) and on disk with no ``_runs`` entry (evicted by the cap), and either
+    one left behind would keep showing up.
+
+    A run still in flight is never touched, at either layer. Eligibility is
+    ``retention.record_is_deletable`` plus the worker's own pending set — the
+    same pair the periodic sweep uses. With ``older_than_days`` set this is that
+    sweep's horizon on demand; without it there is no age floor.
+
+    Run records only. The artifacts those runs produced stay in the artifact
+    store — clearing a history should not silently delete a plot someone is
+    still looking at. Ageing artifacts out is the retention sweep's job.
+    """
+    older_than_days = body.older_than_days if body is not None else 0
+    in_flight = _in_flight_run_ids()
+    now = time.time()
+
+    cleared_ids = set(
+        retention.delete_run_records(
+            _log_dir(),
+            now,
+            older_than_days=older_than_days,
+            in_flight_run_ids=in_flight,
+        )
+    )
+    records_deleted = len(cleared_ids)
+
+    for run_id, run in list(_runs.items()):
+        if run_id in in_flight:
+            continue
+        if not retention.record_is_deletable(run, now, older_than_days):
+            continue
+        del _runs[run_id]
+        _queues.pop(run_id, None)
+        cleared_ids.add(run_id)
+
+    logger.info(
+        "Cleared %d finished run(s) from history (%d persisted record(s), older_than_days=%d)",
+        len(cleared_ids),
+        records_deleted,
+        older_than_days,
+    )
+    return {
+        "cleared": len(cleared_ids),
+        "records_deleted": records_deleted,
+        "older_than_days": older_than_days,
+    }
 
 
 @app.delete("/dispatch/{run_id}", dependencies=[Depends(_verify_token)])

--- a/src/osprey/mcp_server/dispatch_worker/retention.py
+++ b/src/osprey/mcp_server/dispatch_worker/retention.py
@@ -17,6 +17,11 @@ In-flight runs are never swept regardless of age: a run record whose status is
 not terminal is skipped, and any run id currently pending in the worker (passed
 in as ``in_flight_run_ids``) is skipped along with the artifacts it produced.
 
+The same eligibility rule (:func:`record_is_deletable`) also backs the
+dashboard's on-demand *clear history* action, which runs it with no age floor —
+so a button click and a scheduled sweep agree, by construction, on what counts
+as a finished run.
+
 This is a generic OSPREY-core capability with no channel awareness. The sweep
 functions are pure (they take the log dir, an ``ArtifactStore``, and an injected
 ``now``) so they can be driven directly in tests without a clock or sleeps.
@@ -28,10 +33,10 @@ import json
 import logging
 import os
 import time
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from osprey.stores.artifact_store import ArtifactStore
@@ -77,6 +82,87 @@ def _parse_iso_timestamp(value: str) -> float | None:
         return None
 
 
+def record_is_deletable(
+    record: Mapping[str, Any],
+    now: float,
+    older_than_days: int = 0,
+) -> bool:
+    """True when a run record may be deleted. The one eligibility rule.
+
+    Shared by the periodic retention sweep and the dashboard's clear-history
+    action, so the two can never disagree about which runs are finished and safe
+    to drop.
+
+    A record qualifies when its status is terminal and — when ``older_than_days``
+    is positive — its completion is strictly older than that window (a record
+    aged exactly N days survives). ``older_than_days <= 0`` means *no age floor*:
+    every terminal record qualifies, which is what the clear-history button
+    asks for. A record whose timestamp cannot be read is never deletable under
+    an age floor.
+
+    In-flight protection is the caller's: a run the worker still holds as
+    pending is filtered out by run id before this is consulted, because a
+    pending run's record is not always on disk yet.
+    """
+    if record.get("status") not in _TERMINAL_STATUSES:
+        return False
+    if older_than_days <= 0:
+        return True
+
+    ts = record.get("completed_at")
+    if ts is None:
+        ts = record.get("created_at")
+    try:
+        ts = float(ts)
+    except (TypeError, ValueError):
+        return False
+
+    # Strictly older than the window: age exactly N days survives (ts == cutoff).
+    return ts < now - older_than_days * _SECONDS_PER_DAY
+
+
+def delete_run_records(
+    log_dir: str | Path,
+    now: float,
+    older_than_days: int = 0,
+    in_flight_run_ids: Iterable[str] = (),
+) -> list[str]:
+    """Delete every eligible persisted run record. Returns the deleted run ids.
+
+    Eligibility is :func:`record_is_deletable` plus the in-flight guard. With
+    ``older_than_days`` unset there is no age floor and every terminal record
+    goes. Unreadable files are left in place, as is any file whose unlink fails
+    — a partial deletion is reported honestly rather than raising.
+    """
+    log_dir = Path(log_dir)
+    if not log_dir.is_dir():
+        return []
+
+    in_flight = frozenset(in_flight_run_ids)
+    deleted: list[str] = []
+
+    for path in sorted(log_dir.glob("*.json")):
+        run_id = path.name.removesuffix(".json")
+        if run_id in in_flight:
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            logger.warning("Could not read %s — leaving it in place", path, exc_info=True)
+            continue
+
+        if not record_is_deletable(data, now, older_than_days):
+            continue
+
+        try:
+            path.unlink()
+            deleted.append(run_id)
+        except OSError:
+            logger.warning("Failed to delete %s", path, exc_info=True)
+
+    return deleted
+
+
 def sweep_dispatch_runs(
     log_dir: str | Path,
     retention_days: int,
@@ -85,53 +171,13 @@ def sweep_dispatch_runs(
 ) -> int:
     """Delete persisted run records older than the threshold. Returns the count.
 
-    Skips any record that is non-terminal or whose run id is in
-    ``in_flight_run_ids`` (an in-flight run is never swept). Unreadable files are
-    left in place. A no-op when ``retention_days <= 0`` or the dir is absent.
+    The age-based face of :func:`delete_run_records`: skips any record that is
+    non-terminal or whose run id is in ``in_flight_run_ids`` (an in-flight run is
+    never swept). A no-op when ``retention_days <= 0`` or the dir is absent.
     """
     if retention_days <= 0:
         return 0
-    log_dir = Path(log_dir)
-    if not log_dir.is_dir():
-        return 0
-
-    in_flight = frozenset(in_flight_run_ids)
-    cutoff = now - retention_days * _SECONDS_PER_DAY
-    deleted = 0
-
-    for path in log_dir.glob("*.json"):
-        run_id = path.name.removesuffix(".json")
-        if run_id in in_flight:
-            continue
-        try:
-            data = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            logger.warning("Retention: could not read %s — skipping", path, exc_info=True)
-            continue
-
-        if data.get("status") not in _TERMINAL_STATUSES:
-            # In-flight / non-terminal record — never sweep it.
-            continue
-
-        ts = data.get("completed_at")
-        if ts is None:
-            ts = data.get("created_at")
-        try:
-            ts = float(ts)
-        except (TypeError, ValueError):
-            continue
-
-        # Strictly older than the window: age exactly N days survives (ts == cutoff).
-        if ts >= cutoff:
-            continue
-
-        try:
-            path.unlink()
-            deleted += 1
-        except OSError:
-            logger.warning("Retention: failed to delete %s", path, exc_info=True)
-
-    return deleted
+    return len(delete_run_records(log_dir, now, retention_days, in_flight_run_ids))
 
 
 def sweep_artifacts(

--- a/src/osprey/templates/services/qmd/Dockerfile
+++ b/src/osprey/templates/services/qmd/Dockerfile
@@ -138,6 +138,14 @@ ENV OSPREY_QMD_EMBED_SHA256=${OSPREY_QMD_EMBED_SHA256} \
 #
 # One RUN per model so a network failure on the 1.2 GB file does not discard the
 # two already-verified layers.
+#
+# ``--retry-all-errors`` is load-bearing, not belt-and-braces. The CDN drops a
+# stream mid-transfer often enough to redden a lane (``curl: (92) HTTP/2 stream
+# was not closed cleanly``), and curl retries neither that nor an HTTP error
+# body by default — ``--retry`` covers transient *transfer* failures and
+# ``--retry-connrefused`` only adds a refused connection, so without this flag
+# the retry budget is never spent on the failure that actually happens and a
+# 318 MB download that dies at 62% fails the whole image build on the spot.
 
 # Embeddings (318 MB). Needed to BUILD an index — the fail-closed startup pass
 # in the entrypoint depends on this one.
@@ -147,7 +155,7 @@ RUN set -eu; \
     fi; \
     dest="$OSPREY_QMD_MODEL_DIR/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf"; \
     want="$OSPREY_QMD_EMBED_SHA256"; \
-    curl -fSL --retry 5 --retry-delay 5 --retry-connrefused -o "$dest" \
+    curl -fSL --retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors -o "$dest" \
       "https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/0f741b5a6585bd53aeb15cd1372c56f2a0f65e12/embeddinggemma-300M-Q8_0.gguf"; \
     got="$(sha256sum "$dest" | cut -d' ' -f1)"; \
     [ "$got" = "$want" ] || { echo "ERROR: SHA256 mismatch for embedding model: want $want, got $got" >&2; exit 1; }; \
@@ -160,7 +168,7 @@ RUN set -eu; \
     fi; \
     dest="$OSPREY_QMD_MODEL_DIR/hf_ggml-org_qwen3-reranker-0.6b-q8_0.gguf"; \
     want="$OSPREY_QMD_RERANK_SHA256"; \
-    curl -fSL --retry 5 --retry-delay 5 --retry-connrefused -o "$dest" \
+    curl -fSL --retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors -o "$dest" \
       "https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/a02f48bb4f057028298c21fa033da2b30d7742d5/qwen3-reranker-0.6b-q8_0.gguf"; \
     got="$(sha256sum "$dest" | cut -d' ' -f1)"; \
     [ "$got" = "$want" ] || { echo "ERROR: SHA256 mismatch for rerank model: want $want, got $got" >&2; exit 1; }; \
@@ -173,7 +181,7 @@ RUN set -eu; \
     fi; \
     dest="$OSPREY_QMD_MODEL_DIR/hf_tobil_qmd-query-expansion-1.7B-q4_k_m.gguf"; \
     want="$OSPREY_QMD_GENERATE_SHA256"; \
-    curl -fSL --retry 5 --retry-delay 5 --retry-connrefused -o "$dest" \
+    curl -fSL --retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors -o "$dest" \
       "https://huggingface.co/tobil/qmd-query-expansion-1.7B-gguf/resolve/7816de0b72572c6c860ca1eddf97ba9e7fb8cc65/qmd-query-expansion-1.7B-q4_k_m.gguf"; \
     got="$(sha256sum "$dest" | cut -d' ' -f1)"; \
     [ "$got" = "$want" ] || { echo "ERROR: SHA256 mismatch for generate model: want $want, got $got" >&2; exit 1; }; \

--- a/tests/deployment/test_qmd_service_config.py
+++ b/tests/deployment/test_qmd_service_config.py
@@ -267,6 +267,27 @@ def test_model_filenames_match_the_dockerfile_pins() -> None:
         assert name in text, f"{name} is not the cache name the Dockerfile writes"
 
 
+def test_model_fetches_retry_a_dropped_stream() -> None:
+    """Every model fetch carries ``--retry-all-errors``.
+
+    The three GGUF downloads total ~2.1 GB, and the CDN drops a stream
+    mid-transfer often enough to fail a whole image build (``curl: (92) HTTP/2
+    stream was not closed cleanly``). curl retries neither that nor an HTTP
+    error body unless asked: ``--retry`` covers transient transfer failures and
+    ``--retry-connrefused`` only adds a refused connection, so without this flag
+    the configured retry budget is never spent on the failure that actually
+    happens. Pinned as text because the fetch only runs during a real image
+    build — no unit test can reach it.
+    """
+    dockerfile = (
+        Path(__file__).resolve().parents[2] / "src/osprey/templates/services/qmd/Dockerfile"
+    )
+    fetches = [line for line in dockerfile.read_text().splitlines() if "curl -fSL" in line]
+    assert len(fetches) == len(MODEL_FILENAMES), "one fetch per pinned model"
+    for line in fetches:
+        assert "--retry-all-errors" in line, f"fetch retries only some errors: {line.strip()}"
+
+
 def test_port_conflict_preflight_knows_the_sidecar() -> None:
     """The deploy-time port sweep can name the key that moves the qmd port."""
     assert _SERVICE_REMEDY_KEYS["qmd"] == PORT_CONFIG_KEY == "services.qmd.port"

--- a/tests/dispatch_worker/test_retention.py
+++ b/tests/dispatch_worker/test_retention.py
@@ -393,3 +393,89 @@ def test_retention_loop_re_resolves_a_callable_log_dir(tmp_path, monkeypatch):
 
     assert resolved == [stale_root, real_root]
     assert not (real_root / "old.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# record_is_deletable / delete_run_records — the shared eligibility rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["completed", "error"])
+def test_record_is_deletable_terminal_without_age_floor(status):
+    """No age floor: a terminal record qualifies however young it is."""
+    record = {"status": status, "completed_at": _NOW}
+    assert retention.record_is_deletable(record, _NOW) is True
+
+
+@pytest.mark.parametrize("status", ["pending", "unknown", None])
+def test_record_is_deletable_rejects_non_terminal(status):
+    """A non-terminal record is never deletable, at any age or floor."""
+    record = {"status": status, "completed_at": _NOW - 100 * _DAY}
+    assert retention.record_is_deletable(record, _NOW) is False
+    assert retention.record_is_deletable(record, _NOW, older_than_days=1) is False
+
+
+def test_record_is_deletable_age_floor_matches_sweep_boundary():
+    """Same boundary as the sweep: N-1 and exactly N survive, N+1 goes."""
+    for days, expected in ((4, False), (5, False), (6, True)):
+        record = {"status": "completed", "completed_at": _NOW - days * _DAY}
+        assert retention.record_is_deletable(record, _NOW, older_than_days=5) is expected
+
+
+def test_record_is_deletable_unreadable_timestamp_under_age_floor():
+    """A record with no usable timestamp is kept when an age floor is asked for."""
+    record = {"status": "completed"}
+    assert retention.record_is_deletable(record, _NOW, older_than_days=5) is False
+    # …but it is still clearable when the caller asks for no floor at all.
+    assert retention.record_is_deletable(record, _NOW) is True
+
+
+def test_delete_run_records_clears_every_terminal_record(tmp_path):
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "fresh", completed_at=_NOW)
+    _write_run(log_dir, "failed", status="error", completed_at=_NOW - _DAY)
+    _write_run(log_dir, "running", status="pending", created_at=_NOW)
+
+    deleted = retention.delete_run_records(log_dir, _NOW)
+
+    assert sorted(deleted) == ["failed", "fresh"]
+    assert not (log_dir / "fresh.json").exists()
+    assert not (log_dir / "failed.json").exists()
+    assert (log_dir / "running.json").exists()
+
+
+def test_delete_run_records_honours_in_flight_ids(tmp_path):
+    """A run the worker still holds as pending survives even if its record says done."""
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "in-flight", completed_at=_NOW)
+    _write_run(log_dir, "done", completed_at=_NOW)
+
+    deleted = retention.delete_run_records(log_dir, _NOW, in_flight_run_ids=["in-flight"])
+
+    assert deleted == ["done"]
+    assert (log_dir / "in-flight.json").exists()
+
+
+def test_delete_run_records_age_floor_is_the_sweep_horizon(tmp_path):
+    """With a floor, delete_run_records deletes exactly what the sweep would."""
+    log_dir = tmp_path / "dispatch"
+    _write_run(log_dir, "young", completed_at=_NOW - 2 * _DAY)
+    _write_run(log_dir, "old", completed_at=_NOW - 20 * _DAY)
+
+    deleted = retention.delete_run_records(log_dir, _NOW, older_than_days=5)
+
+    assert deleted == ["old"]
+    assert (log_dir / "young.json").exists()
+
+
+def test_delete_run_records_missing_dir_is_a_noop(tmp_path):
+    assert retention.delete_run_records(tmp_path / "nope", _NOW) == []
+
+
+def test_delete_run_records_leaves_unreadable_files(tmp_path):
+    log_dir = tmp_path / "dispatch"
+    log_dir.mkdir(parents=True)
+    (log_dir / "corrupt.json").write_text("{not json")
+
+    assert retention.delete_run_records(log_dir, _NOW) == []
+    assert (log_dir / "corrupt.json").exists()

--- a/tests/unit/dispatch/test_server_routes.py
+++ b/tests/unit/dispatch/test_server_routes.py
@@ -727,6 +727,75 @@ def test_dashboard_cancel_proxies_to_worker(app, monkeypatch):
     assert resp.json()["cancelled"] is True
 
 
+def test_dashboard_clear_history_requires_auth(app):
+    with TestClient(app) as client:
+        resp = client.post("/dashboard/clear-history", json={})
+    assert resp.status_code == 401
+
+
+def test_dashboard_clear_history_proxies_to_worker(app, monkeypatch):
+    """A bodyless clear proxies through with no age floor."""
+    seen = {}
+
+    async def fake_clear(url, token, older_than_days):
+        seen["older_than_days"] = older_than_days
+        return {"cleared": 4, "records_deleted": 4, "older_than_days": older_than_days}
+
+    monkeypatch.setattr(server, "clear_worker_history", fake_clear)
+    with TestClient(app) as client:
+        resp = client.post("/dashboard/clear-history", headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] == 4
+    assert seen["older_than_days"] == 0
+
+
+def test_dashboard_clear_history_forwards_the_age_floor(app, monkeypatch):
+    seen = {}
+
+    async def fake_clear(url, token, older_than_days):
+        seen["older_than_days"] = older_than_days
+        return {"cleared": 1}
+
+    monkeypatch.setattr(server, "clear_worker_history", fake_clear)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/dashboard/clear-history",
+            json={"older_than_days": 30},
+            headers={"Authorization": "Bearer secret"},
+        )
+    assert resp.status_code == 200
+    assert seen["older_than_days"] == 30
+
+
+@pytest.mark.parametrize("bad", [-1, "soon"])
+def test_dashboard_clear_history_rejects_a_bad_age_floor(app, monkeypatch, bad):
+    """A nonsense horizon is a 400, never a silent clear-everything."""
+
+    async def fake_clear(url, token, older_than_days):  # pragma: no cover - must not run
+        raise AssertionError("worker should not be called")
+
+    monkeypatch.setattr(server, "clear_worker_history", fake_clear)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/dashboard/clear-history",
+            json={"older_than_days": bad},
+            headers={"Authorization": "Bearer secret"},
+        )
+    assert resp.status_code == 400
+
+
+def test_dashboard_clear_history_worker_auth_failure_returns_502(app, monkeypatch):
+    from osprey.dispatch.worker_client import WorkerAuthRejectedError
+
+    async def fake_clear(url, token, older_than_days):
+        raise WorkerAuthRejectedError("nope")
+
+    monkeypatch.setattr(server, "clear_worker_history", fake_clear)
+    with TestClient(app) as client:
+        resp = client.post("/dashboard/clear-history", headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 502
+
+
 def test_dashboard_cancel_worker_auth_failure_returns_502(app, monkeypatch):
     from osprey.dispatch.worker_client import WorkerAuthRejectedError
 

--- a/tests/unit/dispatch/test_worker_client.py
+++ b/tests/unit/dispatch/test_worker_client.py
@@ -14,6 +14,7 @@ from osprey.dispatch.worker_client import (
     WorkerUnavailableError,
     WorkerUnreachableError,
     cancel_worker_run,
+    clear_worker_history,
     dispatch_to_worker,
     fetch_worker_runs,
     proxy_worker_stream,
@@ -301,6 +302,46 @@ async def test_cancel_worker_run_404_raises_dispatch_error():
     with _patched_client(transport):
         with pytest.raises(WorkerRejectedRequestError, match="not found"):
             await cancel_worker_run("http://worker:9190", token="tok", run_id="ghost")
+
+
+# ---------------------------------------------------------------------------
+# clear_worker_history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_worker_history_success():
+    transport = _mock_transport(200, body={"cleared": 3, "records_deleted": 3})
+    with _patched_client(transport):
+        result = await clear_worker_history("http://worker:9190", token="tok")
+    assert result["cleared"] == 3
+
+
+@pytest.mark.asyncio
+async def test_clear_worker_history_sends_delete_with_the_age_floor():
+    """The horizon rides in the body, not the URL — DELETE /dispatch/runs."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"cleared": 0}, request=request)
+
+    with _patched_client(httpx.MockTransport(handler)):
+        await clear_worker_history("http://worker:9190/", token="tok", older_than_days=7)
+
+    assert seen["method"] == "DELETE"
+    assert seen["url"] == "http://worker:9190/dispatch/runs"
+    assert seen["body"] == {"older_than_days": 7}
+
+
+@pytest.mark.asyncio
+async def test_clear_worker_history_401_raises_auth_error():
+    transport = _mock_transport(401, body={"detail": "no"})
+    with _patched_client(transport):
+        with pytest.raises(WorkerAuthRejectedError):
+            await clear_worker_history("http://worker:9190", token="bad")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/dispatch_worker/test_dispatch_api.py
+++ b/tests/unit/dispatch_worker/test_dispatch_api.py
@@ -9,6 +9,7 @@ SDK and tests never assert a timing-dependent terminal status.
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from typing import Any
@@ -251,6 +252,115 @@ def test_cancel_finished_run(client):
     assert "cancelled" in body
     # A finished run cannot be cancelled.
     assert body["cancelled"] is False
+
+
+# ---------------------------------------------------------------------------
+# DELETE /dispatch/runs — clear finished history
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def log_dir(tmp_path, monkeypatch):
+    """Point the worker's persisted-record directory at a tmp dir."""
+    d = tmp_path / "dispatch"
+    d.mkdir()
+    monkeypatch.setattr(dispatch_api, "_log_dir", lambda: str(d))
+    return d
+
+
+def _write_record(log_dir, run_id: str, **fields: Any) -> None:
+    """Write a persisted record the way ``_persist_run`` would."""
+    record = {"run_id": run_id, "status": "completed", "completed_at": time.time()}
+    record.update(fields)
+    (log_dir / f"{run_id}.json").write_text(json.dumps(record))
+
+
+def test_clear_runs_requires_auth(client, log_dir):
+    resp = client.delete("/dispatch/runs")
+    assert resp.status_code in (401, 403)
+
+
+def test_clear_runs_deletes_records_and_memory(client, log_dir):
+    """Both layers go: the persisted file AND the in-memory entry."""
+    _write_record(log_dir, "on-disk-only")
+    dispatch_api._runs["in-ram-only"] = {"status": "error", "completed_at": time.time()}
+    _write_record(log_dir, "both")
+    dispatch_api._runs["both"] = {"status": "completed", "completed_at": time.time()}
+
+    resp = client.delete("/dispatch/runs", headers=_auth())
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cleared"] == 3
+    assert body["records_deleted"] == 2
+    assert list(log_dir.glob("*.json")) == []
+    assert dispatch_api._runs == {}
+
+
+def test_clear_runs_route_is_not_swallowed_by_the_cancel_route(client, log_dir):
+    """``/dispatch/runs`` must not be read as a cancel of run id "runs".
+
+    Starlette matches in registration order, so this only holds while the
+    literal route is declared above ``DELETE /dispatch/{run_id}``.
+    """
+    resp = client.delete("/dispatch/runs", headers=_auth())
+    assert resp.status_code == 200
+    assert "cancelled" not in resp.json()
+
+
+def test_clear_runs_keeps_in_flight_runs(client, log_dir):
+    """A pending run survives — in memory and on disk — however the record reads."""
+    dispatch_api._runs["running"] = {"status": "pending", "created_at": time.time()}
+    # A stale record claiming the run finished must still be protected by the
+    # worker's live pending set.
+    _write_record(log_dir, "running")
+    _write_record(log_dir, "done")
+
+    resp = client.delete("/dispatch/runs", headers=_auth())
+
+    assert resp.json()["cleared"] == 1
+    assert (log_dir / "running.json").exists()
+    assert not (log_dir / "done.json").exists()
+    assert "running" in dispatch_api._runs
+
+
+def test_clear_runs_honours_older_than_days(client, log_dir):
+    """With an age floor, only runs past the horizon go — the sweep on demand."""
+    day = 86400.0
+    now = time.time()
+    _write_record(log_dir, "recent", completed_at=now - day)
+    _write_record(log_dir, "ancient", completed_at=now - 30 * day)
+    dispatch_api._runs["recent"] = {"status": "completed", "completed_at": now - day}
+    dispatch_api._runs["ancient"] = {"status": "completed", "completed_at": now - 30 * day}
+
+    # ``TestClient.delete`` takes no body (httpx's API); the age floor rides in
+    # one, as it does from the dispatcher's proxy.
+    resp = client.request("DELETE", "/dispatch/runs", headers=_auth(), json={"older_than_days": 7})
+
+    assert resp.json() == {"cleared": 1, "records_deleted": 1, "older_than_days": 7}
+    assert (log_dir / "recent.json").exists()
+    assert not (log_dir / "ancient.json").exists()
+    assert set(dispatch_api._runs) == {"recent"}
+
+
+def test_clear_runs_rejects_a_negative_horizon(client, log_dir):
+    """A negative floor is a typo, not a request to delete everything."""
+    _write_record(log_dir, "done")
+
+    resp = client.request("DELETE", "/dispatch/runs", headers=_auth(), json={"older_than_days": -1})
+
+    assert resp.status_code == 422
+    assert (log_dir / "done.json").exists()
+
+
+def test_clear_runs_drops_the_stream_queue(client, log_dir):
+    """A cleared run's SSE queue goes with it rather than leaking."""
+    dispatch_api._runs["done"] = {"status": "completed", "completed_at": time.time()}
+    dispatch_api._queues["done"] = MagicMock()
+
+    client.delete("/dispatch/runs", headers=_auth())
+
+    assert "done" not in dispatch_api._queues
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The dashboard could cancel a run but never remove one. Every finished run stayed
on the Activity list forever: the worker persists one JSON record per run on the
durable volume and reloads them at startup, so even a run evicted from the
in-memory cap came back on the next restart. The only way to prune was
`RETENTION_DAYS`, an age-based sweep an operator cannot reach on demand — and
the only `DELETE` route was cancel, which answers *"already finished"* for
exactly the runs an operator wants gone.

`DELETE /dispatch/runs` on the worker unlinks the eligible persisted records and
drops the matching `_runs`/`_queues` entries. **Both layers are cleared against
the same predicate rather than against each other's results**: a run can live in
memory with no file (a persist that failed) or on disk with no memory entry
(evicted by the cap), and either one left behind keeps showing up. Eligibility is
now one function, `retention.record_is_deletable`, shared with
`sweep_dispatch_runs`, so a button click and a scheduled sweep cannot disagree
about which runs are finished. An optional `older_than_days` runs the sweep's own
horizon on demand.

In-flight runs are protected at both layers by the worker's live pending set, not
by what a record claims — a stale record saying `completed` for a run the worker
still holds as pending does not get it deleted. Artifacts are deliberately left
alone: clearing a history should not delete a plot someone is still reading;
ageing those out remains the retention sweep's job.

Two details worth disagreeing with if you see it differently:

- The route is declared **above** `DELETE /dispatch/{run_id}`. Starlette matches
  in registration order, so the parameterised cancel route would otherwise
  swallow the path as a cancel of a run literally named `runs`. There is a test
  pinning this, because the failure mode is silent.
- The button asks twice rather than opening a `confirm()`. Inside the web
  terminal's panel iframe a modal blocks the whole terminal tab — the same
  reason the token prompt was removed from the write path.

## How it hangs together

```text
  browser — dashboard.html
  ┌──────────────────────────────┐
  │ Activity ▸ [ Clear history ] │   click 1 arms · click 2 fires · disarms in 5s
  └───────────────┬──────────────┘
                  │  POST /dashboard/clear-history        (dispatcher token)
                  ▼
  dispatcher — dispatch/server.py
  ┌──────────────────────────────┐
  │ _check_auth                  │
  │ validate older_than_days     │   400 on a negative / non-integer horizon
  └───────────────┬──────────────┘
                  │  clear_worker_history()               (worker token — never in the browser)
                  ▼  DELETE /dispatch/runs
  worker — dispatch_worker/dispatch_api.py
  ┌───────────────────────────────────────────────┐
  │ clear_dispatch_runs                           │
  │   in_flight = _in_flight_run_ids()  ← pending │
  └────────┬──────────────────────────┬───────────┘
           │                          │
  ┌────────▼─────────┐      ┌─────────▼──────────┐
  │ {run_id}.json    │      │  _runs / _queues   │
  │ on the data vol  │      │  in memory         │
  └────────┬─────────┘      └─────────┬──────────┘
           └───────────┬──────────────┘
                       ▼
        retention.record_is_deletable(record, now, older_than_days)
                       ▲
                       │  one predicate, two callers
        retention.sweep_dispatch_runs   ← RETENTION_DAYS, hourly
```
