### PR TITLE
feat(bluesky): let the panel drive the second plan lane

### DIFF
--- a/changelog.d/736.added.md
+++ b/changelog.d/736.added.md
@@ -1,0 +1,5 @@
+The BLUESKY panel can now drive the second plan lane. On a two-lane
+deployment the panel sidecar reaches each lane's bridge and arms with that
+lane's own launch token, and the panel carries a lane picker in its status
+strip — plans, shared draft, queue and results all follow the picked lane.
+Single-lane deployments are unchanged.

--- a/docs/source/how-to/bluesky/queue.rst
+++ b/docs/source/how-to/bluesky/queue.rst
@@ -141,6 +141,13 @@ quirks worth knowing:
    ``launch_token_required`` and the start stays with you, from the BLUESKY
    queue panel's own **Start queue** button.
 
+   On a two-lane deployment the BLUESKY panel carries a **lane picker** in its
+   status strip, labelled by the machine each lane drives. The panel is bound
+   to one lane at a time — plans, shared draft, queue and results all follow
+   the picked lane, and its Start queue button arms with that lane's own
+   token — so what you see and what a click starts can never belong to two
+   different machines.
+
 .. dropdown:: When something is refused
    :color: info
    :icon: alert

--- a/docs/source/how-to/control-systems/switch-control-target.rst
+++ b/docs/source/how-to/control-systems/switch-control-target.rst
@@ -348,6 +348,14 @@ so a plan composed for the simulator cannot be started on the machine because
 the session moved in between. See :doc:`../bluesky/index` for the plan stack
 itself.
 
+The **BLUESKY panel** follows the same two-lane deployment with a picker of its
+own. A panel is shared by every session, so it cannot follow any one session's
+target; instead it shows which machine it is pointed at in its status strip —
+labelled by target, ``live`` / ``va`` — and switching lanes there reloads the
+panel onto the other lane's bridge: its plans, shared draft, queue and results
+all move together, and starting the queue uses that lane's own launch token. A
+single-lane deployment shows no picker and nothing about its panel changes.
+
 Rehearse with a stand-in live machine
 =====================================
 

--- a/src/osprey/interfaces/bluesky_web/app.py
+++ b/src/osprey/interfaces/bluesky_web/app.py
@@ -37,7 +37,12 @@ from fastapi.templating import Jinja2Templates
 from starlette.responses import Response
 from starlette.staticfiles import StaticFiles
 
-from osprey.bluesky_bridge_connection import resolve_bridge_url, resolve_lane_bridge_urls
+from osprey.bluesky_bridge_connection import (
+    LANE_ONE,
+    lane_declared_target,
+    resolve_bridge_url,
+    resolve_lane_bridge_urls,
+)
 from osprey.interfaces._app_setup import configure_interface_app
 from osprey.interfaces.bluesky_web import channels, draft_relay, queue_relay, read_proxy
 from osprey.interfaces.vendor import vendor_url
@@ -53,6 +58,29 @@ _BLUESKY_PANEL_DIR = "bluesky"
 
 # (mount path, bundle directory).
 _PANEL_MOUNTS: tuple[tuple[str, str], ...] = (("/bluesky", _BLUESKY_PANEL_DIR),)
+
+#: The roster ``GET /lanes`` answers before the lifespan has resolved one —
+#: and the roster every single-lane deployment keeps: the one lane every
+#: deployment has had since the bridge shipped, declaring no target because
+#: its config block has never carried one (the panel labels it by the
+#: capability record its bridge publishes instead).
+_SINGLE_LANE_ROSTER: tuple[dict, ...] = ({"lane": LANE_ONE, "lane_target": None},)
+
+
+def _lane_roster(lane_urls: dict[str, str]) -> tuple[dict, ...]:
+    """The plan lanes this sidecar can address, as ``GET /lanes`` reports them.
+
+    One entry per lane the sidecar holds a bridge URL for — the same mapping
+    the read proxy and both relays route ``?lane=`` by, so the roster can
+    never claim a lane a request would then 404 on. ``lane_target`` is the
+    control target the lane's own ``services.<lane>`` block declares
+    (:func:`~osprey.bluesky_bridge_connection.lane_declared_target`), which a
+    two-lane render writes on every lane; ``None`` is the single-lane
+    deployment, whose block has never carried one.
+    """
+    if not lane_urls:
+        return _SINGLE_LANE_ROSTER
+    return tuple({"lane": key, "lane_target": lane_declared_target(key)} for key in lane_urls)
 
 
 @asynccontextmanager
@@ -79,6 +107,10 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     lane_urls = resolve_lane_bridge_urls()
     if lane_urls:
         _app.state.bridge_urls = lane_urls
+    # The roster the panel builds its lane picker from — computed once here,
+    # beside the URL map it mirrors, so the two cannot disagree at request
+    # time about which lanes exist.
+    _app.state.lanes = _lane_roster(lane_urls)
     try:
         yield
     finally:
@@ -114,6 +146,21 @@ async def _no_cache(request, call_next):  # type: ignore[no-untyped-def]
 @app.get("/health")
 def health() -> dict:
     return {"status": "ok"}
+
+
+@app.get("/lanes")
+def lanes(request: Request) -> dict:
+    """The plan lanes this sidecar can address, in render order.
+
+    The panel builds its lane picker from this roster — lane keys plus the
+    control target each lane's own config block declares — and shows the
+    picker only when there is more than one entry, so a single-lane deployment
+    (every deployment until a second lane is opted in) renders exactly the
+    panel it always has. Whether a lane can *execute* is deliberately not
+    answered here: that is the bridge's own capability record, read per lane
+    through ``GET /bridge/health?lane=``.
+    """
+    return {"lanes": list(getattr(request.app.state, "lanes", _SINGLE_LANE_ROSTER))}
 
 
 # Wire the bridge read-proxy, the plan-draft relay, and the plan-queue relay

--- a/src/osprey/interfaces/bluesky_web/draft_relay.py
+++ b/src/osprey/interfaces/bluesky_web/draft_relay.py
@@ -29,6 +29,13 @@ body ``read_proxy`` uses for its own bridge-unreachable case -- it never
 surfaces here as an uncaught 500. HTTP-level error responses from the bridge
 itself (404, 409, 422, ...) are not exceptions to httpx at all; they flow
 straight through and are relayed as-is.
+
+Every route takes the read proxy's optional ``lane`` query parameter naming
+which PLAN LANE's bridge holds the draft being read or edited -- each bridge
+keeps its own shared draft, so a second-lane plan cannot even be composed
+unless the draft surface takes the lane too. Consumed here and never
+forwarded, defaults to lane 1, and an unknown lane is the read proxy's 404
+rather than a relay from the other lane's draft.
 """
 
 from __future__ import annotations
@@ -40,6 +47,16 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from osprey.interfaces.bluesky_web._shared import UNREACHABLE_BODY, safe_json
+
+# One lane vocabulary for the whole sidecar: the read proxy's query-param
+# name, resolver and unknown-lane refusal body, imported rather than restated
+# so the draft surface cannot drift from the read surface on how a lane is
+# addressed or refused (the same sharing ``queue_relay`` does).
+from osprey.interfaces.bluesky_web.read_proxy import (
+    LANE_QUERY_PARAM,
+    UNKNOWN_LANE_BODY,
+    resolve_lane_bridge_url,
+)
 from osprey.utils.http_proxy import HOP_BY_HOP
 
 router = APIRouter()
@@ -49,13 +66,20 @@ async def _relay(request: Request, method: str) -> JSONResponse:
     """Relay ``method /draft`` onto the bridge and return its body/status verbatim.
 
     For ``PATCH``, the incoming request's raw JSON body is forwarded to the
-    bridge unchanged (byte-for-byte, not re-serialized). Query params (none
-    in the current bridge contract) are forwarded verbatim for the same
+    bridge unchanged (byte-for-byte, not re-serialized). Query params
+    (``client_id`` on the panel's PATCH) are forwarded verbatim for the same
     reason ``read_proxy._forward_get`` does: forward-compatibility without
-    special-casing.
+    special-casing -- except :data:`LANE_QUERY_PARAM`, which selects WHICH
+    lane's bridge holds the draft and is consumed here.
     """
     client: httpx.AsyncClient = request.app.state.client
-    bridge_url: str = request.app.state.bridge_url
+
+    # `or None`: an empty `?lane=` names no lane at all, exactly as the read
+    # proxy reads it -- see `_forward_get`.
+    lane = request.query_params.get(LANE_QUERY_PARAM) or None
+    bridge_url = resolve_lane_bridge_url(request, lane)
+    if bridge_url is None:
+        return JSONResponse(content=UNKNOWN_LANE_BODY, status_code=404)
 
     content: bytes | None = None
     headers: dict[str, str] | None = None
@@ -63,11 +87,15 @@ async def _relay(request: Request, method: str) -> JSONResponse:
         content = await request.body()
         headers = {"content-type": request.headers.get("content-type", "application/json")}
 
+    # multi_items(), not a dict: repeated query keys are preserved exactly as
+    # they arrived. The lane addresses the sidecar and is stripped.
+    params = [(k, v) for k, v in request.query_params.multi_items() if k != LANE_QUERY_PARAM]
+
     try:
         response = await client.request(
             method,
             f"{bridge_url}/draft",
-            params=request.query_params,
+            params=params,
             content=content,
             headers=headers,
         )
@@ -110,9 +138,18 @@ async def draft_events(request: Request) -> Response:
     sole hop. Uses a per-request ``httpx.Timeout(None, connect=5.0)`` to
     disable the shared client's 15s default read timeout, since the stream
     idles between the bridge's ~15s heartbeat comment frames.
+
+    Takes the lane parameter exactly as the other draft routes do: a draft
+    stream labelled with the wrong machine is the same wrong-machine
+    confusion as an edit to it, so an unknown lane is the read proxy's 404,
+    never the other lane's stream.
     """
     client: httpx.AsyncClient = request.app.state.client
-    bridge_url: str = request.app.state.bridge_url
+
+    lane = request.query_params.get(LANE_QUERY_PARAM) or None
+    bridge_url = resolve_lane_bridge_url(request, lane)
+    if bridge_url is None:
+        return JSONResponse(content=UNKNOWN_LANE_BODY, status_code=404)
 
     try:
         upstream = await client.send(

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/index.html
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/index.html
@@ -90,6 +90,15 @@
     because arming a queue is a deliberate act, not an always-at-hand one.
   -->
   <div class="status-strip">
+    <!-- Plan-lane picker, hidden unless this deployment renders more than one
+         lane (panel.js fills it from GET /lanes). It lives HERE, beside the
+         queue badge and the two halts, because which machine this panel is
+         pointed at is safety-bearing context for all three: it must be
+         visible from every tab and in every UI mode, and the tile bar
+         survives neither. Switching lanes navigates to a fresh document — a
+         lane is a different machine, and one document never shows two (see
+         lane-client.js). -->
+    <span id="lane-strip" class="lane-strip" role="group" aria-label="Bluesky plan lane" hidden></span>
     <span id="queue-state-badge" class="badge warn">connecting&hellip;</span>
     <span class="status-strip-spacer"></span>
     <!-- NEVER add `disabled` here. The halt has no disabled state (see
@@ -118,6 +127,12 @@
        tab — a refusal sentence the operator cannot see is a refusal that did
        not happen as far as they know. -->
   <div id="queue-banner" class="banner" hidden></div>
+  <!-- Raised only when this document's URL names a lane the deployment does
+       not render: the sidecar is 404ing every request, and this is the one
+       place that says why (panel.js loadLaneRoster). Never auto-rerouted to
+       lane 1 — a silent wrong-machine reroute is the failure the lane axis
+       exists to remove. -->
+  <div id="lane-banner" class="banner banner-err" hidden></div>
 
   <!-- ==== Plans ==== -->
   <!--

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/lane-client.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/lane-client.js
@@ -1,0 +1,162 @@
+// @ts-check
+/**
+ * BLUESKY panel — plan-lane addressing.
+ *
+ * A PLAN LANE is a whole bridge stack bound at render time to one
+ * control-system target; a two-lane deployment runs two of them about two
+ * different machines, and the sidecar addresses them by a `?lane=` query
+ * parameter on every route (reads, draft, queue, both SSE streams). This
+ * module owns the panel's half of that contract as pure functions — parsing
+ * the sidecar's `GET /lanes` roster, resolving which lane this document
+ * addresses, and spelling the lane onto a request path — so the whole
+ * contract is unit-testable with plain strings.
+ *
+ * The panel binds to exactly ONE lane per document: the lane is read from the
+ * document's own URL (`?lane=`), every request the panel makes carries it,
+ * and switching lanes navigates to a new document. A lane is a different
+ * MACHINE, and an in-place switch would leave a window where the queue view
+ * shows one machine's plans beside the other machine's results — the exact
+ * wrong-machine confusion the lane axis exists to remove. A fresh document
+ * per lane makes that state unrepresentable.
+ *
+ * The panel never decides what a lane may do. An unknown lane is pinned, not
+ * silently rerouted to lane 1 — the sidecar answers every request about it
+ * with its 404 and the panel says so — and whether a lane can execute is the
+ * bridge's own capability record, read per lane through the existing
+ * `/bridge/health` fetch (which this module's addressing scopes like every
+ * other request).
+ */
+
+/**
+ * Service key of the plan lane every deployment has. Mirrors
+ * `bluesky_bridge_connection.LANE_ONE`; requests addressed to it stay bare
+ * (no `lane` parameter), so a single-lane deployment's requests are
+ * byte-identical to what the panel has always sent.
+ * @type {string}
+ */
+export const LANE_ONE = 'bluesky';
+
+/**
+ * The sidecar's lane query parameter (`read_proxy.LANE_QUERY_PARAM`).
+ * @type {string}
+ */
+export const LANE_QUERY_PARAM = 'lane';
+
+/** @typedef {{lane: string, laneTarget: string|null}} LaneEntry */
+
+/** The roster a single-lane deployment has, and the fallback when the
+ *  sidecar's answer cannot be read: one lane, no declared target.
+ * @returns {LaneEntry[]}
+ */
+function singleLaneRoster() {
+  return [{ lane: LANE_ONE, laneTarget: null }];
+}
+
+/**
+ * Parse the sidecar's `GET /lanes` body into a roster.
+ *
+ * Malformed or empty answers collapse to the single-lane roster rather than
+ * to an empty one: the panel must render regardless, and "one lane" is the
+ * shape every deployment had before the lane axis existed. Entries without a
+ * usable `lane` key are dropped, not guessed at.
+ *
+ * @param {any} body
+ * @returns {LaneEntry[]}
+ */
+export function parseLaneRoster(body) {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.lanes)) return singleLaneRoster();
+  const lanes = body.lanes
+    .filter(
+      (/** @type {any} */ entry) =>
+        entry && typeof entry === 'object' && typeof entry.lane === 'string' && entry.lane !== ''
+    )
+    .map((/** @type {{lane: string, lane_target?: unknown}} */ entry) => ({
+      lane: entry.lane,
+      laneTarget:
+        typeof entry.lane_target === 'string' && entry.lane_target ? entry.lane_target : null,
+    }));
+  return lanes.length ? lanes : singleLaneRoster();
+}
+
+/**
+ * The lane this document's own URL addresses.
+ *
+ * No parameter (or an empty one) is lane 1 — the only lane a single-lane
+ * deployment has, so nothing about those documents changes. A named lane is
+ * returned VERBATIM, whether or not the roster knows it: rerouting an unknown
+ * lane to lane 1 silently would point the operator at a different machine
+ * than the URL names, which is worse than the honest alternative — every
+ * request 404s at the sidecar and `laneIsKnown` lets the shell say why.
+ *
+ * @param {string} search  the document's `location.search`
+ * @returns {string}
+ */
+export function resolveLaneFromSearch(search) {
+  return new URLSearchParams(search).get(LANE_QUERY_PARAM) || LANE_ONE;
+}
+
+/**
+ * Whether the roster renders `lane`.
+ *
+ * @param {LaneEntry[]} roster
+ * @param {string} lane
+ * @returns {boolean}
+ */
+export function laneIsKnown(roster, lane) {
+  return roster.some((entry) => entry.lane === lane);
+}
+
+/**
+ * Spell the lane axis onto a sidecar-relative request path.
+ *
+ * Lane 1 stays bare — the parameter defaults there sidecar-side, and keeping
+ * it off the wire makes a single-lane deployment's requests byte-identical
+ * to what the panel has always sent. Composes with paths that already carry
+ * a query string (`/draft?client_id=…`).
+ *
+ * @param {string} path
+ * @param {string} lane
+ * @returns {string}
+ */
+export function withLane(path, lane) {
+  if (!lane || lane === LANE_ONE) return path;
+  const separator = path.includes('?') ? '&' : '?';
+  return `${path}${separator}${LANE_QUERY_PARAM}=${encodeURIComponent(lane)}`;
+}
+
+/**
+ * The picker label for one lane: the control target it drives.
+ *
+ * A lane is named for its target, never for its index — "va" / "live" is
+ * what tells an operator which machine a click arms. The service key is the
+ * fallback for a roster entry that declared none (lane 1 on rosters written
+ * before targets were declared), so the picker never renders a blank button.
+ *
+ * @param {LaneEntry} entry
+ * @returns {string}
+ */
+export function laneLabel(entry) {
+  return entry.laneTarget || entry.lane;
+}
+
+/**
+ * The `location.search` string addressing `lane`, with every other parameter
+ * (the host's `?embedded=`, `?mode=`, `?theme=`) preserved — dropping those
+ * on a lane switch would un-embed the panel or flash it into the wrong
+ * theme. Lane 1 removes the parameter rather than naming it, mirroring
+ * `withLane`.
+ *
+ * @param {string} search  the document's current `location.search`
+ * @param {string} lane
+ * @returns {string}  a search string (`?…`), or `''` for no query at all
+ */
+export function laneSearch(search, lane) {
+  const params = new URLSearchParams(search);
+  if (!lane || lane === LANE_ONE) {
+    params.delete(LANE_QUERY_PARAM);
+  } else {
+    params.set(LANE_QUERY_PARAM, lane);
+  }
+  const spelled = params.toString();
+  return spelled ? `?${spelled}` : '';
+}

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.css
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.css
@@ -145,6 +145,42 @@ html:not([data-ui-mode="simple"]) body.embedded .panel-tabs { display: none; }
 }
 .status-strip-spacer { flex: 1 1 auto; }
 
+/* ---- Plan-lane picker ----
+ * Hidden unless the deployment renders more than one plan lane (panel.js).
+ * A segmented group rather than tabs: it sits inside the status strip and
+ * names WHICH MACHINE this panel is pointed at, so the current lane reads as
+ * a held-down state (`aria-pressed`), not as navigation chrome. Clicking the
+ * other lane navigates to a fresh document — see lane-client.js. */
+.lane-strip {
+  display: inline-flex;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.lane-tab {
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  padding: 4px 10px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.lane-tab + .lane-tab { border-left: 1px solid var(--border-default); }
+.lane-tab:hover { color: var(--text-primary); }
+.lane-tab.active {
+  color: var(--color-accent-light);
+  background: var(--bg-inset, transparent);
+  cursor: default;
+}
+.lane-tab:focus-visible {
+  outline: none;
+  color: var(--text-primary);
+}
+
 /* WIDTH FLOORS on the two halt buttons. The strip is a right-anchored cluster
  * (leading spacer), so a member's position depends only on the widths of the
  * members AFTER it — which makes the rightmost button, Abort, the thing that

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/panel.js
@@ -43,6 +43,14 @@ import { panelApiPrefix } from '/design-system/js/dom.js';
 import { onModeChange } from '/design-system/js/frame-params.js';
 import { contributeHeader, isSimpleMode, onHeaderAction } from '/design-system/js/header-contrib.js';
 
+import {
+  laneIsKnown,
+  laneLabel,
+  laneSearch,
+  parseLaneRoster,
+  resolveLaneFromSearch,
+  withLane,
+} from './lane-client.js';
 import { createPlansView } from './plans-view.js';
 import { createQueueView } from './queue-view.js';
 import { createResultsView } from './results-view.js';
@@ -66,11 +74,28 @@ const ACTIVITY_MARKER = ' •';
 const PREFIX = panelApiPrefix();
 
 /**
+ * The PLAN LANE this document is bound to, read from its own URL once at
+ * boot. One lane per document, deliberately (see lane-client.js): every
+ * request `api()` builds carries it, so the three views, both SSE streams and
+ * the channel catalog can never mix two machines' state, and a lane switch is
+ * a navigation rather than an in-place mutation.
+ *
+ * @type {string}
+ */
+const CURRENT_LANE = (() => {
+  try {
+    return resolveLaneFromSearch(window.location.search);
+  } catch {
+    return resolveLaneFromSearch('');
+  }
+})();
+
+/**
  * @param {string} path
  * @returns {string}
  */
 function api(path) {
-  return `${PREFIX}${path}`;
+  return `${PREFIX}${withLane(path, CURRENT_LANE)}`;
 }
 
 /**
@@ -375,3 +400,81 @@ async function loadChannelCatalog() {
     // Optional endpoint: absence is a normal deployment state, not an error.
   }
 }
+
+/**
+ * Render the lane picker from one roster: a button per lane, labelled by the
+ * control target it drives, the current one marked. Clicking another lane
+ * NAVIGATES — `laneSearch` rewrites only the `lane` parameter, so the host's
+ * `?embedded=`/`?mode=`/`?theme=` survive — because a lane is a different
+ * machine and this panel binds one lane per document (see lane-client.js).
+ *
+ * In the persistent status strip, deliberately: which machine this panel is
+ * pointed at is safety-bearing context for the queue badge and the two halts
+ * beside it, must be visible from every tab and in every UI mode, and the
+ * tile bar survives neither Simple mode nor standalone serving.
+ *
+ * @param {import('./lane-client.js').LaneEntry[]} roster
+ */
+function renderLaneStrip(roster) {
+  const strip = byId('lane-strip');
+  strip.textContent = '';
+  for (const entry of roster) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'lane-tab';
+    const current = entry.lane === CURRENT_LANE;
+    button.classList.toggle('active', current);
+    button.setAttribute('aria-pressed', current ? 'true' : 'false');
+    // Text node, never markup: the label originates in deployment config,
+    // which is off-panel input like everything else this bundle renders.
+    button.textContent = laneLabel(entry);
+    button.title = current
+      ? `This panel is on the '${entry.lane}' plan lane.`
+      : `Switch this panel to the '${entry.lane}' plan lane.`;
+    if (!current) {
+      button.addEventListener('click', () => {
+        window.location.search = laneSearch(window.location.search, entry.lane);
+      });
+    }
+    strip.appendChild(button);
+  }
+  strip.hidden = false;
+}
+
+/**
+ * Fetch the sidecar's lane roster — once per panel load — and show the lane
+ * picker when there is more than one lane to pick. A single-lane deployment
+ * (every deployment until a second lane is opted in) takes the early return
+ * and renders exactly the panel it always has; so does any failure to read
+ * the roster, which is the direction that cannot invent a lane.
+ *
+ * A document pinned to a lane the roster does not know is said out loud
+ * instead of being silently rerouted: every request is already 404ing at the
+ * sidecar (`unknown bluesky lane`), and this banner is the one place that
+ * explains why. Wrong-machine silence is the failure mode; a loud refusal is
+ * recoverable.
+ *
+ * @returns {Promise<void>}
+ */
+async function loadLaneRoster() {
+  let roster;
+  try {
+    const response = await fetch(`${PREFIX}/lanes`);
+    if (!response.ok) return;
+    roster = parseLaneRoster(await response.json());
+  } catch {
+    return;
+  }
+  if (!laneIsKnown(roster, CURRENT_LANE)) {
+    const banner = byId('lane-banner');
+    banner.textContent =
+      `This deployment renders no '${CURRENT_LANE}' plan lane — every request from ` +
+      'this panel is being refused. Pick a rendered lane below.';
+    banner.hidden = false;
+  } else if (roster.length < 2) {
+    return;
+  }
+  renderLaneStrip(roster);
+}
+
+void loadLaneRoster();

--- a/src/osprey/interfaces/bluesky_web/queue_relay.py
+++ b/src/osprey/interfaces/bluesky_web/queue_relay.py
@@ -30,11 +30,22 @@ classifies on ``detail.code`` (``launch_token_required``,
 is the bridge's, and a relay that reshaped it would be a second, drifting copy
 of the contract.
 
+Every route takes the read proxy's optional ``lane`` query parameter naming
+which PLAN LANE the request is addressed to -- a two-lane deployment runs two
+bridges answering these same paths about two different machines. It is
+consumed here and never forwarded, defaults to lane 1, and a lane this
+deployment does not render is answered with the read proxy's 404 rather than
+relayed from the other lane: a write armed against the wrong machine is the
+confusion the lane axis exists to remove, and this refusal is addressing, not
+policy.
+
 The launch token is the one thing this module adds to a request. It is
 resolved in-process on every write via the shared
 ``osprey.bluesky_bridge_connection.resolve_launch_token`` -- the same resolver
 the Bluesky MCP server uses, so the two agent-facing paths to a bridge never
-drift on which token arms which one. It is never accepted from the incoming request
+drift on which token arms which one -- and it is resolved FOR THE LANE the
+write is addressed to, so a second lane's write carries that lane's own token
+and never lane 1's. It is never accepted from the incoming request
 (the forwarded header set is built from scratch, so a browser-supplied
 ``X-Launch-Token`` is dropped, not proxied) and never echoed back.
 
@@ -92,8 +103,16 @@ from osprey.interfaces.bluesky_web._shared import UNREACHABLE_BODY, safe_json
 # (verbatim body + status, query params forwarded, 502 on an unreachable
 # bridge), and a private-but-same-package import keeps the two from drifting.
 # The write routes live here instead of there because ``read_proxy`` is
-# GET-only by documented invariant.
-from osprey.interfaces.bluesky_web.read_proxy import _forward_get
+# GET-only by documented invariant. The lane vocabulary is shared the same
+# way: one query-param name, one resolver, one unknown-lane refusal body, so
+# the write surface cannot drift from the read surface on how a lane is
+# addressed or refused.
+from osprey.interfaces.bluesky_web.read_proxy import (
+    LANE_QUERY_PARAM,
+    UNKNOWN_LANE_BODY,
+    _forward_get,
+    resolve_lane_bridge_url,
+)
 from osprey.utils.http_proxy import HOP_BY_HOP
 
 router = APIRouter()
@@ -103,7 +122,7 @@ _LAUNCH_TOKEN_HEADER = "X-Launch-Token"
 logger = logging.getLogger("osprey.interfaces.bluesky_web.queue_relay")
 
 
-def _resolve_token_or_none() -> str | None:
+def _resolve_token_or_none(lane: str | None = None) -> str | None:
     """``resolve_launch_token`` that degrades to "no token" instead of raising.
 
     The resolver reads the project config on the miss path, so an unreadable or
@@ -112,9 +131,16 @@ def _resolve_token_or_none() -> str | None:
     which needs no token at all. Omitting the header is the already-documented
     unarmed path: the bridge refuses what needs arming and permits what does
     not, which is the correct answer either way.
+
+    Per lane, because the token is what ARMS a launch and each lane carries
+    its own: the caller passes the lane the write is addressed to (already
+    held against the sidecar's lane map, so an unknown lane never gets here)
+    and the shared resolver answers with THAT lane's token -- env-first
+    (``<PREFIX>_LAUNCH_TOKEN``, the compose-injected spelling), never another
+    lane's.
     """
     try:
-        return resolve_launch_token()
+        return resolve_launch_token(lane)
     except Exception:
         logger.warning(
             "could not resolve the bridge launch token; relaying this queue write "
@@ -174,17 +200,39 @@ async def _forward_write(
     ``timeout`` overrides the shared client's default for this one request, the
     way ``queue_events`` does for the SSE stream. Only the abort needs it; every
     other queue write is a single manager call and keeps the shared 15s.
+
+    The optional :data:`~osprey.interfaces.bluesky_web.read_proxy.LANE_QUERY_PARAM`
+    names which PLAN LANE's bridge the write is addressed to, exactly as it
+    does on every read: consumed here (the bridge has no parameter by that
+    name), resolved through the read proxy's own resolver, and answered with
+    the read proxy's 404 for a lane this deployment does not render -- never
+    relayed to another lane's bridge, because a write armed against the wrong
+    machine is the failure the lane axis exists to prevent. The launch token
+    is then THAT lane's token: URL and credential travel as one decision, so
+    the request can never reach one lane's bridge carrying another lane's
+    arming proof. This refusal is addressing, not policy -- which writes need
+    arming, and whether this one is permitted, stays entirely the bridge's.
     """
     client: httpx.AsyncClient = request.app.state.client
-    bridge_url: str = request.app.state.bridge_url
+
+    # `or None`: an empty `?lane=` names no lane at all, exactly as the read
+    # proxy reads it -- see `_forward_get`.
+    lane = request.query_params.get(LANE_QUERY_PARAM) or None
+    bridge_url = resolve_lane_bridge_url(request, lane)
+    if bridge_url is None:
+        return JSONResponse(content=UNKNOWN_LANE_BODY, status_code=404)
 
     content = await request.body()
     headers: dict[str, str] = {}
     if content:
         headers["content-type"] = request.headers.get("content-type", "application/json")
-    token = _resolve_token_or_none()
+    token = _resolve_token_or_none(lane)
     if token:
         headers[_LAUNCH_TOKEN_HEADER] = token
+
+    # multi_items(), not a dict: repeated query keys are preserved exactly as
+    # they arrived. The lane addresses the sidecar and is stripped.
+    params = [(k, v) for k, v in request.query_params.multi_items() if k != LANE_QUERY_PARAM]
 
     # Passed through only when set: httpx reads an explicit ``timeout=None`` as
     # "no timeout at all", not as "use the client's default".
@@ -194,7 +242,7 @@ async def _forward_write(
         response = await client.request(
             method,
             f"{bridge_url}{path}",
-            params=request.query_params,
+            params=params,
             content=content or None,
             headers=headers,
             **overrides,
@@ -287,9 +335,18 @@ async def queue_events(request: Request) -> Response:
     shared client's 15s default read timeout, since the stream idles between
     the bridge's ~15s heartbeat comment frames. Mirrors
     ``draft_relay.draft_events``; a buffering relay would defeat the stream.
+
+    Takes the lane parameter exactly as the writes do: a queue stream labelled
+    with the wrong machine is the same wrong-machine confusion as a write to
+    it, so an unknown lane is the read proxy's 404, never the other lane's
+    stream.
     """
     client: httpx.AsyncClient = request.app.state.client
-    bridge_url: str = request.app.state.bridge_url
+
+    lane = request.query_params.get(LANE_QUERY_PARAM) or None
+    bridge_url = resolve_lane_bridge_url(request, lane)
+    if bridge_url is None:
+        return JSONResponse(content=UNKNOWN_LANE_BODY, status_code=404)
 
     try:
         upstream = await client.send(

--- a/src/osprey/templates/services/bluesky_web/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky_web/docker-compose.yml.j2
@@ -39,6 +39,16 @@ services:
     depends_on:
       bluesky-bridge:
         condition: service_healthy
+{%- for lane_key in ['bluesky_va', 'bluesky_live'] %}
+{%- if lane_key in deployed_services %}
+      # The second plan lane's own bridge, for the same reason: the sidecar
+      # relays this lane's reads, draft and queue too, and must not race its
+      # startup either. Gated on deployed_services exactly like the lane's
+      # whole stack, so a single-lane render carries no second entry.
+      {{ lane_key | replace('_', '-') }}-bridge:
+        condition: service_healthy
+{%- endif %}
+{%- endfor %}
 {% endif %}
     # container_name is a HOST-GLOBAL docker identifier: namespace it per-project
     # so two OSPREY projects can deploy the sidecar on one host without colliding
@@ -91,6 +101,21 @@ services:
       # project .env when unset (see container_lifecycle.py's per-service
       # token-mint map).
       BLUESKY_LAUNCH_TOKEN: ${BLUESKY_LAUNCH_TOKEN}
+{%- for lane_key in ['bluesky_va', 'bluesky_live'] %}
+{%- if lane_key in deployed_services %}
+      # The SECOND plan lane, when this deployment renders one: its own
+      # bridge by its own in-network service key, and its own launch token —
+      # one token shared across two lanes would let a launch a human approved
+      # against one machine be replayed against the other. Spelled under the
+      # lane's env prefix (bluesky_bridge_connection.lane_env_prefix), the
+      # same three-way contract the mint (container_lifecycle) and the shared
+      # resolvers already speak, so the sidecar's per-lane resolution needs no
+      # new parser. Gated on deployed_services so a single-lane deployment
+      # renders byte-for-byte what it always rendered.
+      {{ lane_key | upper }}_BRIDGE_URL: http://{{ lane_key | replace('_', '-') }}-bridge:{{ services[lane_key].port }}
+      {{ lane_key | upper }}_LAUNCH_TOKEN: ${{ '{' }}{{ lane_key | upper }}_LAUNCH_TOKEN}
+{%- endif %}
+{%- endfor %}
       # The operator credential for this sidecar's own web gate
       # (WebAuthMiddleware): a browser logs in through the `?token=` exchange,
       # a non-browser client sends it as `X-Osprey-Terminal-Secret`. No

--- a/tests/deployment/test_lane_compose.py
+++ b/tests/deployment/test_lane_compose.py
@@ -1161,6 +1161,108 @@ def test_the_read_proxy_refuses_a_lane_it_does_not_serve() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# The sidecar's half of the lane axis: the bluesky-web compose template
+# ---------------------------------------------------------------------------
+#
+# The panel path's sibling of the per-lane resources above. The sidecar is the
+# one service that relays every terminal's BLUESKY tab, and on a two-lane
+# deployment it must be able to reach the second bridge AND present that
+# lane's own token -- so its compose environment carries a `<PREFIX>_` pair
+# per second lane, spelled under the same env-prefix contract the mint and
+# the shared resolvers already speak. The single-lane render's byte identity
+# is pinned separately (tests/templates render_defaults + render_axis_shapes
+# goldens); here the claims are the two-lane additions and their gating.
+
+BLUESKY_WEB_TEMPLATE = "bluesky_web/docker-compose.yml.j2"
+
+
+def _web_context(
+    *,
+    deployed_services: list[str],
+    lanes: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """The bluesky_web render context, mirroring the generator's contract."""
+    return {
+        "services": {"bluesky_web": {}, **(lanes or {})},
+        "deployed_services": deployed_services,
+        "deployment": {},
+        "system": {"timezone": "UTC"},
+        "osprey_labels": {
+            "project_name": "proj",
+            "repo_id": "abc",
+            "project_root": "/deploy/proj",
+        },
+        "osprey_images": _image_defaults("proj"),
+        "osprey_audit_mount_source": "./var/audit",
+        "osprey_service_container_audit_dir": "/app/var/audit",
+    }
+
+
+def _render_web(context: dict[str, Any]) -> dict[str, Any]:
+    env = Environment(loader=FileSystemLoader(_LOADER_ROOTS), keep_trailing_newline=True)
+    return yaml.safe_load(env.get_template(BLUESKY_WEB_TEMPLATE).render(context))
+
+
+@pytest.mark.parametrize(("lane_key", "port"), [("bluesky_va", 8190), ("bluesky_live", 8190)])
+def test_a_two_lane_sidecar_render_carries_the_second_lanes_url_and_token(
+    lane_key: str, port: int
+) -> None:
+    """The gap the panel path had: the sidecar could neither reach the second
+    bridge nor present its token. The pair is spelled under the lane's env
+    prefix, so the shared resolvers pick both up env-first with no new
+    parser, and the URL names the lane's own in-network bridge service."""
+    rendered = _render_web(
+        _web_context(
+            deployed_services=["bluesky", lane_key, "bluesky_web"],
+            lanes={
+                "bluesky": _lane_block(8090, target="live"),
+                lane_key: _lane_block(port, target="va"),
+            },
+        )
+    )
+    environment = rendered["services"]["bluesky-web"]["environment"]
+    prefix = lane_key.upper()
+    lane_service = lane_key.replace("_", "-")
+
+    assert environment["BLUESKY_BRIDGE_URL"] == "http://bluesky-bridge:8090"
+    assert environment[f"{prefix}_BRIDGE_URL"] == f"http://{lane_service}-bridge:{port}"
+    assert environment[f"{prefix}_LAUNCH_TOKEN"] == f"${{{prefix}_LAUNCH_TOKEN}}"
+
+
+def test_a_two_lane_sidecar_waits_on_both_bridges() -> None:
+    """`depends_on: service_healthy` covered lane 1 only; a sidecar racing the
+    second bridge's startup would 502 that lane's panel reads."""
+    rendered = _render_web(
+        _web_context(
+            deployed_services=["bluesky", "bluesky_va", "bluesky_web"],
+            lanes={
+                "bluesky": _lane_block(8090, target="live"),
+                "bluesky_va": _lane_block(8190, target="va"),
+            },
+        )
+    )
+    depends = rendered["services"]["bluesky-web"]["depends_on"]
+    assert depends["bluesky-bridge"] == {"condition": "service_healthy"}
+    assert depends["bluesky-va-bridge"] == {"condition": "service_healthy"}
+
+
+def test_a_single_lane_sidecar_render_carries_no_second_lane_names() -> None:
+    """The gate: an undeployed lane leaves no trace -- no env pair, no
+    depends_on entry -- which is what keeps the byte-identity pins on the
+    single-lane goldens standing."""
+    rendered = _render_web(
+        _web_context(
+            deployed_services=["bluesky", "bluesky_web"],
+            lanes={"bluesky": _lane_block(8090)},
+        )
+    )
+    service = rendered["services"]["bluesky-web"]
+    assert list(service["depends_on"]) == ["bluesky-bridge"]
+    for name in service["environment"]:
+        assert not name.startswith(("BLUESKY_VA_", "BLUESKY_LIVE_"))
+
+
 def _regenerate() -> None:
     """Overwrite the single-lane goldens from today's template.
 

--- a/tests/interfaces/bluesky_web/lane-client.test.mjs
+++ b/tests/interfaces/bluesky_web/lane-client.test.mjs
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the BLUESKY panel's plan-lane addressing (lane-client.js).
+ *
+ * Everything under test is pure — roster parsing, lane resolution from the
+ * document URL, the `?lane=` spelling on request paths, and the search-string
+ * rewrite a lane switch navigates to — so the whole panel half of the
+ * sidecar's lane contract is pinned with plain strings, no DOM and no
+ * network.
+ *
+ * The one invariant stated twice on purpose: lane 1 stays OFF the wire. A
+ * single-lane deployment's requests and document URLs must be byte-identical
+ * to what the panel produced before the lane axis existed, and an unknown
+ * lane is pinned loudly, never silently rerouted to lane 1 — the sidecar
+ * refuses it (404 `unknown bluesky lane`) and the panel says why.
+ */
+
+import { test, expect, describe } from 'vitest';
+
+import {
+  LANE_ONE,
+  LANE_QUERY_PARAM,
+  laneIsKnown,
+  laneLabel,
+  laneSearch,
+  parseLaneRoster,
+  resolveLaneFromSearch,
+  withLane,
+} from '../../../src/osprey/interfaces/bluesky_web/panels/bluesky/lane-client.js';
+
+const TWO_LANES = [
+  { lane: 'bluesky', laneTarget: 'live' },
+  { lane: 'bluesky_va', laneTarget: 'va' },
+];
+
+describe('parseLaneRoster', () => {
+  test('parses the sidecar roster, lane_target and all', () => {
+    expect(
+      parseLaneRoster({
+        lanes: [
+          { lane: 'bluesky', lane_target: 'live' },
+          { lane: 'bluesky_va', lane_target: 'va' },
+        ],
+      })
+    ).toEqual(TWO_LANES);
+  });
+
+  test('a declared-nothing target is null, not a guess', () => {
+    expect(parseLaneRoster({ lanes: [{ lane: 'bluesky' }] })).toEqual([
+      { lane: 'bluesky', laneTarget: null },
+    ]);
+    expect(parseLaneRoster({ lanes: [{ lane: 'bluesky', lane_target: '' }] })).toEqual([
+      { lane: 'bluesky', laneTarget: null },
+    ]);
+  });
+
+  test.each([null, undefined, 'nope', {}, { lanes: 'x' }, { lanes: [] }])(
+    'a malformed or empty answer collapses to the single-lane roster (%j)',
+    (body) => {
+      // The panel must render regardless, and one lane is the shape every
+      // deployment had before the axis existed — never zero lanes.
+      expect(parseLaneRoster(body)).toEqual([{ lane: LANE_ONE, laneTarget: null }]);
+    }
+  );
+
+  test('entries without a usable lane key are dropped, not guessed at', () => {
+    expect(
+      parseLaneRoster({ lanes: [{ lane: 'bluesky' }, { lane: '' }, { nope: 1 }, null] })
+    ).toEqual([{ lane: 'bluesky', laneTarget: null }]);
+  });
+});
+
+describe('resolveLaneFromSearch', () => {
+  test('no parameter is lane 1 — the only lane a single-lane deployment has', () => {
+    expect(resolveLaneFromSearch('')).toBe(LANE_ONE);
+    expect(resolveLaneFromSearch('?embedded=true&mode=simple')).toBe(LANE_ONE);
+  });
+
+  test('an empty parameter names no lane, matching the sidecar', () => {
+    expect(resolveLaneFromSearch('?lane=')).toBe(LANE_ONE);
+  });
+
+  test('a named lane is returned verbatim, known to the roster or not', () => {
+    // Rerouting an unknown lane to lane 1 silently would point the operator
+    // at a different machine than the URL names; the sidecar 404s instead.
+    expect(resolveLaneFromSearch('?lane=bluesky_va')).toBe('bluesky_va');
+    expect(resolveLaneFromSearch('?lane=not-a-lane')).toBe('not-a-lane');
+  });
+});
+
+describe('laneIsKnown', () => {
+  test('holds a lane against the roster', () => {
+    expect(laneIsKnown(TWO_LANES, 'bluesky_va')).toBe(true);
+    expect(laneIsKnown(TWO_LANES, 'bluesky_live')).toBe(false);
+  });
+});
+
+describe('withLane', () => {
+  test('lane 1 stays bare — single-lane requests are byte-identical', () => {
+    expect(withLane('/queue/events', LANE_ONE)).toBe('/queue/events');
+    expect(withLane('/draft?client_id=abc', LANE_ONE)).toBe('/draft?client_id=abc');
+  });
+
+  test('a second lane rides every path as ?lane=', () => {
+    expect(withLane('/queue/start', 'bluesky_va')).toBe('/queue/start?lane=bluesky_va');
+    expect(withLane('/bridge/health', 'bluesky_va')).toBe('/bridge/health?lane=bluesky_va');
+  });
+
+  test('composes with a path that already carries a query string', () => {
+    expect(withLane('/draft?client_id=abc', 'bluesky_va')).toBe(
+      '/draft?client_id=abc&lane=bluesky_va'
+    );
+  });
+
+  test('the parameter name is the shared contract spelling', () => {
+    // read_proxy.LANE_QUERY_PARAM — one axis, one spelling, panel included.
+    expect(LANE_QUERY_PARAM).toBe('lane');
+  });
+});
+
+describe('laneLabel', () => {
+  test('a lane is labelled by the target it drives', () => {
+    expect(laneLabel({ lane: 'bluesky_va', laneTarget: 'va' })).toBe('va');
+  });
+
+  test('a target-less entry falls back to the service key, never blank', () => {
+    expect(laneLabel({ lane: 'bluesky', laneTarget: null })).toBe('bluesky');
+  });
+});
+
+describe('laneSearch', () => {
+  test('switching to a second lane preserves every host parameter', () => {
+    // Dropping ?embedded/?mode/?theme on a lane switch would un-embed the
+    // panel or flash it into the wrong theme mid-shift.
+    expect(laneSearch('?embedded=true&mode=simple', 'bluesky_va')).toBe(
+      '?embedded=true&mode=simple&lane=bluesky_va'
+    );
+  });
+
+  test('switching back to lane 1 removes the parameter rather than naming it', () => {
+    expect(laneSearch('?embedded=true&lane=bluesky_va', LANE_ONE)).toBe('?embedded=true');
+    expect(laneSearch('?lane=bluesky_va', LANE_ONE)).toBe('');
+  });
+
+  test('replaces an existing lane instead of stacking a second one', () => {
+    expect(laneSearch('?lane=bluesky_va', 'bluesky_live')).toBe('?lane=bluesky_live');
+  });
+});

--- a/tests/interfaces/bluesky_web/test_app_integration.py
+++ b/tests/interfaces/bluesky_web/test_app_integration.py
@@ -406,3 +406,48 @@ def test_panel_index_renders_at_every_bundle_root_spelling() -> None:
             assert response.status_code == 200, path
             assert "{{" not in response.text, path
             assert 'id="hljs-theme"' in response.text, path
+
+
+# ---------------------------------------------------------------------------
+# GET /lanes -- the roster the panel builds its lane picker from
+# ---------------------------------------------------------------------------
+
+
+def test_lanes_reports_the_single_lane_on_a_single_lane_deployment() -> None:
+    """The isolated config renders one lane, so the roster is lane 1 alone --
+    which is what keeps the panel's picker hidden on every deployment that
+    never opted into a second lane."""
+    with TestClient(app) as client:
+        response = client.get("/lanes")
+
+    assert response.status_code == 200
+    assert response.json() == {"lanes": [{"lane": "bluesky", "lane_target": None}]}
+
+
+def test_lanes_reports_every_lane_the_lifespan_resolved(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A two-lane render's roster: both lanes, each with its declared target,
+    in render order -- read from the same config the URL map is resolved from,
+    so the picker can never offer a lane a request would then 404 on."""
+    (tmp_path / "config.yml").write_text(
+        "services:\n"
+        "  bluesky:\n"
+        "    port: 8090\n"
+        "    target: live\n"
+        "  bluesky_va:\n"
+        "    port: 8190\n"
+        "    target: va\n"
+    )
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "config.yml"))
+
+    with TestClient(app) as client:
+        response = client.get("/lanes")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "lanes": [
+            {"lane": "bluesky", "lane_target": "live"},
+            {"lane": "bluesky_va", "lane_target": "va"},
+        ]
+    }

--- a/tests/interfaces/bluesky_web/test_draft_relay.py
+++ b/tests/interfaces/bluesky_web/test_draft_relay.py
@@ -361,3 +361,113 @@ def test_all_verbs_present_on_draft_path(path: str) -> None:
     app.include_router(draft_relay.router)
     operations = app.openapi()["paths"][path]
     assert {"get", "patch", "delete"} <= set(operations.keys())
+
+
+# ---------------------------------------------------------------------------
+# The PLAN LANE axis on the draft surface
+# ---------------------------------------------------------------------------
+#
+# Each bridge keeps its own shared draft, so a second-lane plan cannot even
+# be composed unless the draft surface takes the lane too. Same vocabulary as
+# the read proxy and the queue relay, by import: `?lane=` consumed here, an
+# unknown lane answered 404 -- never the other lane's draft, which would show
+# an operator (and hand the enqueue path) a plan composed for a different
+# machine.
+
+_VA_BRIDGE_URL = "http://bridge-va.test"
+
+
+def _two_lane_recording_app() -> tuple[FastAPI, list[httpx.Request]]:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"draft": None, "revision": 0})
+
+    app = _build_app(handler)
+    app.state.bridge_urls = {"bluesky": _BRIDGE_URL, "bluesky_va": _VA_BRIDGE_URL}
+    return app, seen
+
+
+def test_a_draft_read_addressed_to_a_lane_reaches_that_lanes_bridge() -> None:
+    app, seen = _two_lane_recording_app()
+    with TestClient(app) as client:
+        response = client.get("/draft?lane=bluesky_va")
+
+    assert response.status_code == 200
+    assert str(seen[0].url).startswith(_VA_BRIDGE_URL)
+
+
+def test_a_draft_patch_keeps_its_own_params_and_sheds_the_lane() -> None:
+    """`client_id` is the bridge's parameter and survives; `lane` is the
+    sidecar's address and must not leak onto a bridge that has no such name."""
+    app, seen = _two_lane_recording_app()
+    with TestClient(app) as client:
+        response = client.patch(
+            "/draft?client_id=abc&lane=bluesky_va",
+            json={"plan_name": "grid_scan"},
+        )
+
+    assert response.status_code == 200
+    assert str(seen[0].url).startswith(_VA_BRIDGE_URL)
+    assert seen[0].url.params.get("client_id") == "abc"
+    assert "lane" not in seen[0].url.params
+
+
+@pytest.mark.parametrize("method", ["GET", "PATCH", "DELETE"])
+def test_every_draft_verb_refuses_an_unknown_lane_without_touching_a_bridge(
+    method: str,
+) -> None:
+    from osprey.interfaces.bluesky_web.read_proxy import UNKNOWN_LANE_BODY
+
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={})
+
+    app = _build_app(handler)
+    with TestClient(app) as client:
+        response = client.request(method, "/draft?lane=bluesky_va")
+
+    assert response.status_code == 404
+    assert response.json() == UNKNOWN_LANE_BODY
+    assert seen == []
+
+
+def test_draft_events_streams_from_the_named_lanes_bridge() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=b'data: {"type": "hello"}\n\n',
+        )
+
+    app = _build_app(handler)
+    app.state.bridge_urls = {"bluesky": _BRIDGE_URL, "bluesky_va": _VA_BRIDGE_URL}
+    with TestClient(app) as client:
+        response = client.get("/draft/events?lane=bluesky_va")
+
+    assert response.status_code == 200
+    assert str(seen[0].url) == f"{_VA_BRIDGE_URL}/draft/events"
+
+
+def test_draft_events_refuses_an_unknown_lane() -> None:
+    from osprey.interfaces.bluesky_web.read_proxy import UNKNOWN_LANE_BODY
+
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={})
+
+    app = _build_app(handler)
+    with TestClient(app) as client:
+        response = client.get("/draft/events?lane=bluesky_va")
+
+    assert response.status_code == 404
+    assert response.json() == UNKNOWN_LANE_BODY
+    assert seen == []

--- a/tests/interfaces/bluesky_web/test_lane_picker_browser.py
+++ b/tests/interfaces/bluesky_web/test_lane_picker_browser.py
@@ -1,0 +1,145 @@
+"""Real-browser tests for the BLUESKY panel's plan-lane picker.
+
+The vitest suite (``lane-client.test.mjs``) pins the pure half — roster
+parsing, the ``?lane=`` spelling, the search-string rewrite. What only a real
+browser can prove is the composed behaviour this feature exists for: a panel
+document pinned to the second lane sends EVERY bridge-bound request — boot
+fetches and both SSE streams alike — to that lane's bridge and none to lane
+1's, the picker renders from the sidecar's roster with the current lane held
+down, and a single-lane deployment shows no picker at all.
+
+Runs the composed sidecar for real (``bluesky_live_server``), then swaps in a
+two-lane world the way every suite in this directory swaps the bridge: a
+recording ``httpx.MockTransport`` answering for BOTH bridge hosts, plus the
+``app.state`` lane map/roster the lifespan would have resolved from a
+two-lane render.
+
+Skips cleanly when the chromium headless binary is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from osprey.interfaces.bluesky_web.app import app
+from tests.interfaces.bluesky_web.conftest import STUB_BRIDGE_URL, _stub_bridge
+
+try:
+    from playwright.sync_api import expect
+
+    _PLAYWRIGHT_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PLAYWRIGHT_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Browser
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+VA_BRIDGE_URL = "http://bridge-va.test"
+
+_PANEL_SETTLE_MS = 15_000
+
+
+def _wire_two_lanes() -> list[str]:
+    """Swap the served app into a two-lane shape; return the recorded hosts.
+
+    Must be called inside a ``bluesky_live_server()`` context (the lifespan
+    has run). The recording handler answers for both bridge hosts with the
+    same stub answers, so which HOST each request reached is the entire
+    routing claim.
+    """
+    hosts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hosts.append(request.url.host)
+        return _stub_bridge(request)
+
+    app.state.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app.state.bridge_url = STUB_BRIDGE_URL
+    app.state.bridge_urls = {"bluesky": STUB_BRIDGE_URL, "bluesky_va": VA_BRIDGE_URL}
+    app.state.lanes = [
+        {"lane": "bluesky", "lane_target": "live"},
+        {"lane": "bluesky_va", "lane_target": "va"},
+    ]
+    return hosts
+
+
+def test_single_lane_deployment_shows_no_picker(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    """Every deployment until a second lane is opted in: panel unchanged."""
+    with bluesky_live_server() as base_url:
+        page = chromium_browser.new_page()
+        try:
+            page.goto(f"{base_url}/bluesky/", wait_until="load")
+            expect(page.locator("#queue-state-badge")).to_be_visible(timeout=_PANEL_SETTLE_MS)
+            expect(page.locator("#lane-strip")).to_be_hidden()
+            expect(page.locator("#lane-banner")).to_be_hidden()
+        finally:
+            page.close()
+
+
+def test_second_lane_document_routes_every_bridge_request_to_that_lane(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    """The claim the feature exists for, end to end.
+
+    A panel opened on ``?lane=bluesky_va`` boots its plans, draft, queue,
+    runs, capability read and both SSE streams against the VA bridge and
+    touches lane 1's bridge not once — the wrong-machine mixture the one-lane-
+    per-document design makes unrepresentable.
+    """
+    with bluesky_live_server() as base_url:
+        hosts = _wire_two_lanes()
+        page = chromium_browser.new_page()
+        try:
+            page.goto(f"{base_url}/bluesky/?lane=bluesky_va", wait_until="load")
+
+            strip = page.locator("#lane-strip")
+            expect(strip).to_be_visible(timeout=_PANEL_SETTLE_MS)
+            buttons = strip.locator("button")
+            expect(buttons).to_have_count(2)
+            # Labelled by target — which machine, not which index.
+            expect(buttons.nth(0)).to_have_text("live")
+            expect(buttons.nth(1)).to_have_text("va")
+            expect(buttons.nth(1)).to_have_attribute("aria-pressed", "true")
+            expect(page.locator("#lane-banner")).to_be_hidden()
+
+            # The boot fetches have long since landed once the strip rendered;
+            # the routing claim is over everything recorded.
+            assert hosts, "the panel booted without a single bridge fetch"
+            assert set(hosts) == {"bridge-va.test"}
+        finally:
+            page.close()
+
+
+def test_picker_switches_back_to_lane_one_by_navigation(
+    chromium_browser: Browser, bluesky_live_server
+) -> None:
+    """Clicking the other lane is a navigation to a fresh document whose URL
+    no longer names a lane — lane 1 stays off the wire, as it always was."""
+    with bluesky_live_server() as base_url:
+        hosts = _wire_two_lanes()
+        page = chromium_browser.new_page()
+        try:
+            page.goto(f"{base_url}/bluesky/?lane=bluesky_va", wait_until="load")
+            strip = page.locator("#lane-strip")
+            expect(strip).to_be_visible(timeout=_PANEL_SETTLE_MS)
+
+            hosts.clear()
+            with page.expect_navigation(wait_until="load"):
+                strip.locator("button", has_text="live").click()
+
+            assert "lane=" not in page.url
+            expect(page.locator("#lane-strip")).to_be_visible(timeout=_PANEL_SETTLE_MS)
+            expect(page.locator("#lane-strip button", has_text="live")).to_have_attribute(
+                "aria-pressed", "true"
+            )
+            assert hosts, "the reloaded panel booted without a single bridge fetch"
+            assert set(hosts) == {"bridge.test"}
+        finally:
+            page.close()

--- a/tests/interfaces/bluesky_web/test_queue_relay.py
+++ b/tests/interfaces/bluesky_web/test_queue_relay.py
@@ -939,3 +939,175 @@ def test_the_queue_relay_shadows_no_pre_existing_sidecar_route() -> None:
     for path in ("/health", "/bridge/health", "/plans", "/runs", "/draft"):
         assert path in paths, f"queue relay displaced a pre-existing route: {path}"
     assert set(paths["/health"].keys()) == {"get"}
+
+
+# ---------------------------------------------------------------------------
+# The PLAN LANE axis on the write surface and the SSE stream
+# ---------------------------------------------------------------------------
+#
+# One vocabulary with the read proxy, by import: the same `?lane=` parameter,
+# the same resolver against `app.state.bridge_urls`, the same 404 body for a
+# lane this deployment does not render. The claims pinned here are the two
+# that matter for arming hardware: a write addressed to a lane reaches THAT
+# lane's bridge carrying THAT lane's token (URL and credential travel as one
+# decision), and an unknown lane is refused without ever falling back to lane
+# 1 -- the wrong-machine relay the axis exists to remove.
+
+_VA_BRIDGE_URL = "http://bridge-va.test"
+VA_TOKEN = "va-launch-token"  # noqa: S105 - test fixture value, not a real secret
+
+
+def _two_lane_app(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> FastAPI:
+    """A sidecar app shaped like a two-lane deployment's after its lifespan."""
+    app = _build_app(handler)
+    app.state.bridge_urls = {"bluesky": _BRIDGE_URL, "bluesky_va": _VA_BRIDGE_URL}
+    return app
+
+
+def _two_lane_recording_app() -> tuple[FastAPI, list[httpx.Request]]:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"success": True})
+
+    return _two_lane_app(handler), seen
+
+
+def test_a_write_addressed_to_a_lane_reaches_that_lanes_bridge_with_its_own_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """URL and credential travel as one decision.
+
+    The request must never reach one lane's bridge carrying another lane's
+    arming proof -- a launch a human approved against one machine, replayed
+    against the other, is exactly what per-lane tokens exist to prevent.
+    """
+    monkeypatch.setenv("BLUESKY_LAUNCH_TOKEN", TOKEN)
+    monkeypatch.setenv("BLUESKY_VA_LAUNCH_TOKEN", VA_TOKEN)
+    app, seen = _two_lane_recording_app()
+
+    with TestClient(app) as client:
+        response = client.post("/queue/start?lane=bluesky_va")
+
+    assert response.status_code == 200
+    assert len(seen) == 1
+    assert str(seen[0].url).startswith(_VA_BRIDGE_URL)
+    assert seen[0].headers["X-Launch-Token"] == VA_TOKEN
+
+
+def test_a_lane_one_write_still_carries_lane_ones_token_on_a_two_lane_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BLUESKY_LAUNCH_TOKEN", TOKEN)
+    monkeypatch.setenv("BLUESKY_VA_LAUNCH_TOKEN", VA_TOKEN)
+    app, seen = _two_lane_recording_app()
+
+    with TestClient(app) as client:
+        bare = client.post("/queue/start")
+        named = client.post("/queue/start?lane=bluesky")
+
+    assert bare.status_code == named.status_code == 200
+    for request in seen:
+        assert str(request.url).startswith(_BRIDGE_URL)
+        assert request.headers["X-Launch-Token"] == TOKEN
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/queue/items"),
+        ("POST", "/queue/items/item-a/move"),
+        ("DELETE", "/queue/items/item-a"),
+        ("POST", "/queue/start"),
+        ("POST", "/queue/stop"),
+        ("POST", "/queue/abort"),
+    ],
+)
+def test_every_write_refuses_an_unknown_lane_without_touching_a_bridge(
+    method: str, path: str
+) -> None:
+    """404 with the read proxy's body -- never a relay from lane 1.
+
+    The emergency abort is deliberately in this list: an abort addressed to a
+    lane that does not exist aborts NOTHING, and relaying it to lane 1 would
+    halt a different machine than the caller named.
+    """
+    from osprey.interfaces.bluesky_web.read_proxy import UNKNOWN_LANE_BODY
+
+    app, seen, _ = _recording_app(200, {"success": True})
+    with TestClient(app) as client:
+        response = client.request(method, f"{path}?lane=bluesky_va")
+
+    assert response.status_code == 404
+    assert response.json() == UNKNOWN_LANE_BODY
+    assert seen == []
+
+
+def test_a_two_lane_app_still_refuses_the_lane_it_does_not_render() -> None:
+    from osprey.interfaces.bluesky_web.read_proxy import UNKNOWN_LANE_BODY
+
+    app, seen = _two_lane_recording_app()
+    with TestClient(app) as client:
+        response = client.post("/queue/start?lane=bluesky_live")
+
+    assert response.status_code == 404
+    assert response.json() == UNKNOWN_LANE_BODY
+    assert seen == []
+
+
+def test_the_lane_parameter_is_consumed_never_forwarded_to_the_bridge() -> None:
+    """The bridge has no parameter by that name; every other param survives."""
+    app, seen = _two_lane_recording_app()
+
+    with TestClient(app) as client:
+        response = client.post("/queue/stop?lane=bluesky_va&foo=1")
+
+    assert response.status_code == 200
+    assert seen[0].url.params.get("foo") == "1"
+    assert "lane" not in seen[0].url.params
+
+
+def test_an_empty_lane_parameter_names_no_lane_on_the_write_surface() -> None:
+    """``?lane=`` behaves as ``?lane`` omitted, exactly as the read proxy reads it."""
+    app, seen, _ = _recording_app(200, {"success": True})
+    with TestClient(app) as client:
+        response = client.post("/queue/start?lane=")
+
+    assert response.status_code == 200
+    assert str(seen[0].url).startswith(_BRIDGE_URL)
+
+
+def test_queue_events_streams_from_the_named_lanes_bridge() -> None:
+    """A queue stream labelled with the wrong machine is a wrong-machine write
+    waiting to happen -- the SSE hop takes the lane like every write does."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=b'data: {"type": "hello"}\n\n',
+        )
+
+    app = _two_lane_app(handler)
+    with TestClient(app) as client:
+        response = client.get("/queue/events?lane=bluesky_va")
+
+    assert response.status_code == 200
+    assert str(seen[0].url) == f"{_VA_BRIDGE_URL}/queue/events"
+
+
+def test_queue_events_refuses_an_unknown_lane() -> None:
+    from osprey.interfaces.bluesky_web.read_proxy import UNKNOWN_LANE_BODY
+
+    app, seen, _ = _recording_app(200, {})
+    with TestClient(app) as client:
+        response = client.get("/queue/events?lane=bluesky_va")
+
+    assert response.status_code == 404
+    assert response.json() == UNKNOWN_LANE_BODY
+    assert seen == []


### PR DESCRIPTION
Closes #736

On a two-lane deployment the BLUESKY panel could only reach lane 1: the sidecar held one bridge URL and one launch token. Now the sidecar reaches each lane's bridge and arms with that lane's own token, and the panel carries a lane picker in its status strip — plans, shared draft, queue and results all follow the picked lane. Single-lane deployments render byte-identically.

## Design decisions

| Fork | Decision |
|---|---|
| How the sidecar learns the lane | Explicit `?lane=`, panel-driven; one lane per document (a switch navigates). Not a proxy header, not `_bind_lane` (it reads per-process state the shared sidecar cannot see). |
| Per-user entitlement | Parity kept: one token per lane, deployment-wide; the terminal stays the gate. `web_auth.py` and `web_terminal/routes/proxy.py` untouched, so #733's Origin-stripping is preserved. |
| Compose spelling | Per-prefix `BLUESKY_VA_BRIDGE_URL` / `BLUESKY_VA_LAUNCH_TOKEN`, second bridge in `depends_on`, both gated on `deployed_services`. |
| Lane scope | Queue writes + draft relay + both SSE streams (`/queue/events`, `/draft/events`). |
| Unknown lane | The read proxy's existing 404, imported not restated — never a fallback to lane 1. |

New `GET /lanes` roster endpoint (OPERATOR tier, no URLs/ports/tokens) feeds the picker, which stays hidden on single-lane deployments.

Not in scope: the per-user "read-only for a lane the persona is not entitled to" nuance from the issue — that needs a roster-secret→identity contract in `web_auth.py` and is better as its own issue.

## Verification

- `tests/interfaces/bluesky_web/` incl. `-m browser` (3 new Playwright lane-picker tests)
- `tests/deployment/` + `tests/interfaces/web_terminal/` — 6637 passed
- `tests/templates/` — single-lane renders byte-identical, all golden pins unmoved
- `npm run typecheck` / `lint` / `test:js` — 2533 (22 new vitest for `lane-client.js`)
- Security review of the `?lane=` boundary: lane is only ever a dict key into `app.state.bridge_urls`, never a URL; URL and token are one decision in `_forward_write`; no HTML sinks for lane-supplied strings.
