### PR TITLE
feat(web-terminal): make `none` open and `token` the default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3385,9 +3385,23 @@ jobs:
         docker rmi -f authe2e-operator:local || true
 
   terminal-auth-multiuser-e2e:
-    name: Terminal Auth Multi-User E2E (auth.method none, real persona image)
+    name: Terminal Auth Multi-User E2E (auth.method token + none, real persona image)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Raised from the 60 this lane carried while it stood up ONE deployment.
+    # What the second posture adds is a second render and a second `osprey up`
+    # — NOT a second image build, which the two lanes share — plus a third
+    # container to boot and the in-container guard probe. Measured on a
+    # developer machine with a warm layer cache: 6m55s for the whole module,
+    # of which the second deployment and its four assertions were well under a
+    # minute. That number does not size the cap on its own, because the runner
+    # builds cold and its neighbours measure a single such build at 7-11
+    # minutes; the +10 here is that estimate plus headroom, and the first cold
+    # runner wall clock should be recorded in the PR body so the margin gets
+    # resized from a measurement rather than from this estimate. Stays under
+    # full-chain-auth-e2e's 85/75, which the sibling relation
+    # `test_full_chain_auth_lane_outbudgets_the_single_build_lanes` pins: that
+    # lane builds two real images where this one builds one.
+    timeout-minutes: 70
     # Same PR scoping as the lifecycle and auth-perimeter lanes above: same-repo
     # PRs into main only, since this drives a real `osprey up` (container and
     # volume lifecycle) against the runtime.
@@ -3401,11 +3415,21 @@ jobs:
     # lane (which is why the module carries the `dockerbuild` marker and is
     # --ignore'd there).
     #
+    # TWO deployments, ONE build. The module proves both sidecar-less postures:
+    # `auth.method: token` (the DEFAULT, and what an absent `auth:` block
+    # renders) where nginx injects nothing and each terminal's own `?token=`
+    # exchange is the gate; and `auth.method: none` (OPEN, navigation-only)
+    # where nginx injects each user's operator secret, a `login: false` entry is
+    # left out of that injection, and executed code is refused the deployment's
+    # own web ports. Both lanes share one persona project and therefore one
+    # `:local` image, so the second `osprey up` re-runs the build against a
+    # byte-identical context and hits the runtime cache: the added cost over the
+    # single-posture lane this replaces is a second render plus a second deploy,
+    # not a second image build.
+    #
     # Complement, not duplicate, of auth-perimeter-e2e: that lane proves the
-    # AUTHENTICATED perimeter (sidecar + nginx auth_request + header injection);
-    # this one proves the DEFAULT posture `auth.method: none`, where nginx
-    # authenticates nothing and the terminal app's own WebAuthMiddleware is the
-    # only gate.
+    # AUTHENTICATED perimeter (sidecar + nginx auth_request + header injection),
+    # which is the one posture family this lane does not stand up.
     # Base-ref clause matches two-shape-boot-e2e below rather than the
     # lifecycle lanes above, and for the same reason: this lane certifies the
     # auth perimeter, which is built on epic phase branches whose PRs target an
@@ -3444,7 +3468,7 @@ jobs:
     # published release. No provider secret is needed: the fixture writes a fake
     # ANTHROPIC_API_KEY and the PTY never contacts a model.
     - name: Run terminal auth multi-user E2E
-      timeout-minutes: 55
+      timeout-minutes: 65
       run: |
         uv run pytest tests/e2e/web_terminals/test_terminal_auth_multiuser_e2e.py -v --tb=short
 
@@ -3465,13 +3489,22 @@ jobs:
       if: always()
       run: |
         for user in alice; do
-          docker rm -f "authoff-web-${user}" || true
-          docker volume rm "osprey-e2e-authoff-multiuser_${user}-claude-config" || true
-          docker volume rm "osprey-e2e-authoff-multiuser_${user}-agent-data" || true
+          docker rm -f "authtok-web-${user}" || true
+          docker volume rm "osprey-e2e-token-multiuser_${user}-claude-config" || true
+          docker volume rm "osprey-e2e-token-multiuser_${user}-agent-data" || true
         done
-        docker rm -f authoff-nginx || true
-        docker compose -p osprey-e2e-authoff-multiuser down || true
-        docker rmi -f authoff-operator-operator:local || true
+        docker rm -f authtok-nginx || true
+        docker compose -p osprey-e2e-token-multiuser down || true
+        for user in alice kiosk; do
+          docker rm -f "authopen-web-${user}" || true
+          docker volume rm "osprey-e2e-open-multiuser_${user}-claude-config" || true
+          docker volume rm "osprey-e2e-open-multiuser_${user}-agent-data" || true
+        done
+        docker rm -f authopen-nginx || true
+        docker compose -p osprey-e2e-open-multiuser down || true
+        # ONE image for both lanes: the persona catalog entry names its own
+        # `project`, so the tag is `<project>:local` with no persona suffix.
+        docker rmi -f authmulti-operator:local || true
 
   full-chain-auth-e2e:
     name: Full-Chain Auth E2E (real sidecar + role-resolved persona + audit ledgers)

--- a/changelog.d/auth-open-navigation.changed.md
+++ b/changelog.d/auth-open-navigation.changed.md
@@ -1,0 +1,9 @@
+**Upgrade note:** ``modules.web_terminals.auth.method: none`` now means an
+**open** deployment. nginx stamps each user's operator secret onto every
+request it proxies, so the landing page is pure navigation — a card opens its
+terminal, with no login page and no per-user login URL. The posture that value
+used to select is now spelled ``token``, and is still what an absent ``auth``
+stanza means, so only a config that writes ``method: none`` explicitly changes
+behaviour on upgrade. An open deployment is refused unless every persona denies
+``Bash``, ``WebFetch``, ``WebSearch`` and Playwright, and the refusal names
+``token`` as the way back.

--- a/changelog.d/auth-open-navigation.security.md
+++ b/changelog.d/auth-open-navigation.security.md
@@ -1,0 +1,5 @@
+``osprey up``, the render step and the new ``web_terminals.open_mode_egress``
+lint rule refuse an open deployment whose personas can still reach the host
+network, naming the offending persona and the deny entries it is missing. Under
+that posture the python executor also refuses connections from executed code to
+the deployment's own web ports.

--- a/changelog.d/panel-url-own-host.changed.md
+++ b/changelog.d/panel-url-own-host.changed.md
@@ -1,0 +1,4 @@
+A custom web panel may no longer point at a URL that resolves to the deployment
+host's own address. The panel proxy fetches server-side, so such a panel is a
+route back into the deployment's own web terminals; host the dashboard on
+another machine, or reach it from the landing page instead.

--- a/changelog.d/python-execute-file-gate.fixed.md
+++ b/changelog.d/python-execute-file-gate.fixed.md
@@ -1,0 +1,4 @@
+``mcp__python__execute_file`` now carries the same permission placement and
+pre-tool hooks as ``mcp__python__execute``. The file form previously fell
+through to an interactive prompt with no write check or approval behind it, so
+a profile that gated one did not gate the other.

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -4,18 +4,37 @@
 Require a Login
 ===============
 
-The landing page lists the roster; a login decides who may open a card. This
-page covers the two ways to require one — passwords OSPREY manages, or the
-single sign-on your facility already runs — the HTTPS that either needs, how a
-provider's groups can pick which tier a login lands on, where passwords live,
-what a login leaves in the audit trail, and what to do when someone leaves.
+The landing page lists the roster; ``modules.web_terminals.auth.method``
+decides what stands between a card and the terminal behind it. There are four
+postures:
 
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
 
-With no ``auth`` stanza nginx asks for no credentials and speaks plain HTTP —
-but the terminals behind it are not open. Each one authenticates every request
-against its own operator secret, which ``osprey up`` mints into the
-deployment's ``.env`` for every roster user whether or not authentication is
-on. Clicking a card on the landing page therefore reaches a terminal that
+   * - ``method``
+     - What a person meets
+   * - ``token``
+     - **The default**, and what an absent ``auth`` stanza means. No login
+       page; each terminal is opened once from that user's own login URL.
+   * - ``none``
+     - **Open.** No login page and no URL either: the landing page is pure
+       navigation, and a card opens its terminal. Only for a room where
+       everyone who can reach the page is trusted.
+   * - ``password``
+     - A login page, against passwords OSPREY manages.
+   * - ``oidc``
+     - A login page, against the single sign-on your facility already runs.
+
+This page covers all four: what ``open`` requires before OSPREY will start it,
+the HTTPS a login page needs, how a provider's groups can pick which tier a
+login lands on, where passwords live, and what to do when someone leaves.
+
+With no ``auth`` stanza the method is ``token``: nginx asks for no credentials
+and speaks plain HTTP, but the terminals behind it are not open. Each one
+authenticates every request against its own operator secret, which ``osprey
+up`` mints into the deployment's ``.env`` for every roster user in every
+posture. Clicking a card on the landing page therefore reaches a terminal that
 refuses you until you have opened that user's login URL once:
 
 .. code-block:: bash
@@ -28,7 +47,7 @@ you rotate it, which means deleting that user's ``OSPREY_TERMINAL_SECRET_*``
 line from ``.env`` and running ``osprey up`` again. (``osprey up`` names the
 verb in its summary but never prints the URLs.)
 
-What this posture does *not* do is tell one person from another at the front
+What ``token`` does *not* do is tell one person from another at the front
 door: whoever holds a URL is that user. It suits a **single trusted host** —
 a workstation or control-room machine you already trust — and nothing beyond
 it.
@@ -42,11 +61,12 @@ via ``login: false`` (see below), and ``allow_insecure_http: true`` keeps the
 demo on plain HTTP. Those passwords authenticate a demo, not a facility: for
 any reachable host, set real passwords and serve TLS as described here.
 
-Set ``auth.method`` and every request under ``/u/<name>/`` — pages, APIs and
-the terminal's live connection alike — is refused unless the browser holds a
-valid session for *that* user. The check happens at the front door: a small
-authentication service joins the stack in its own container, and nginx asks it
-about each request before proxying anything. Nothing depends on the per-user
+Set ``auth.method`` to ``password`` or ``oidc`` and every request under
+``/u/<name>/`` — pages, APIs and the terminal's live connection alike — is
+refused unless the browser holds a valid session for *that* user. The check
+happens at the front door: a small authentication service joins the stack in
+its own container, and nginx asks it about each request before proxying
+anything. Nothing depends on the per-user
 containers policing themselves.
 
 Note that the persona split is a *capability* boundary, enforced per project —
@@ -58,6 +78,60 @@ at startup, so "no login" is never the single-user default either.
 
 Choose a method
 ---------------
+
+``token`` is described above and needs no stanza. The other three are here.
+
+.. _multi-user-open-mode:
+
+**Open** — no credential anywhere. For a control room whose console is already
+behind a locked door, and which may have no route to the internet to send a
+per-user link over:
+
+.. code-block:: yaml
+
+   modules:
+     web_terminals:
+       auth:
+         method: none
+
+The landing page becomes pure navigation: click a card and the terminal opens.
+nginx vouches for the request itself, stamping that user's operator secret onto
+every request it proxies, so no token URL exists — ``osprey users login-url``
+refuses for those users and prints the terminal's plain address instead.
+
+Open mode is only safe where nothing inside the deployment can reach it back.
+An agent's own tools reach nginx over loopback and look exactly like the
+operator's browser from there, so they would be served whichever terminal they
+asked for. ``osprey up`` therefore refuses to start an open deployment unless
+**every** persona's shipped ``.claude/settings.json`` denies all four of
+``Bash``, ``WebFetch``, ``WebSearch`` and
+``mcp__plugin_playwright_playwright__*``; ``osprey build`` and ``osprey
+profile validate`` report the same thing earlier, as the error
+``web_terminals.open_mode_egress``. Either way the message names the persona
+and the entries it is missing.
+
+All four are in OSPREY's deny defaults, so a refusal almost always means a
+persona lifted one. Put it back in that persona's ``config:`` block —
+
+.. code-block:: yaml
+
+   config:
+     # and nothing under remove_deny may name one of these four
+     claude_code.permissions.deny:
+       ["Bash", "WebFetch", "WebSearch", "mcp__plugin_playwright_playwright__*"]
+
+— then ``osprey build`` to render it and rebuild that persona's image, because
+the settings file that runs is the one baked into the image. Where a persona
+genuinely needs one of the four, use ``method: token`` instead and keep the
+per-user login URLs.
+
+.. warning::
+
+   The python executor refuses connections from executed code to this
+   deployment's own web ports under ``none``, but that guard runs inside the
+   agent's own process and is defence in depth rather than a boundary: an agent
+   process determined enough to defeat it could still reach a terminal, so
+   ``none`` is for rooms where everyone — the agents included — is trusted.
 
 **Passwords**, managed by OSPREY. Nothing extra to run or operate:
 
@@ -302,18 +376,20 @@ opt out of the login wall:
        persona: ariel
        login: false
 
-With authentication on, that entry sits outside the login wall: nginx never
-asks the authentication service about it, and no password is provisioned for it
-(``osprey users passwd`` refuses the name and says why). Outside the wall is not
-the same as open — the entry is gated exactly as the whole deployment is with
-authentication off, by its own operator secret, so a browser still has to open
+Under ``password`` or ``oidc`` that entry sits outside the login wall: nginx
+never asks the authentication service about it, and no password is provisioned
+for it (``osprey users passwd`` refuses the name and says why). Under ``none``
+it is the one entry nginx does *not* vouch for. Outside is not the same as
+open, in either posture — the entry is gated the way every terminal is under
+``token``, by its own operator secret, so a browser still has to open
 ``osprey users login-url ariel`` once. Cookies from the login wall never reach
 its container.
 
 Only the literal ``false`` opts an entry out. Absence, ``true``, and any typo
 all mean "login required" — a misspelling can lock an entry down, never open it
 up — and lint reports a non-boolean value. The key is inert while
-``auth.method`` is ``none``, which lint points out as well.
+``auth.method`` is ``token``, where nginx stamps nothing for an entry to be
+exempt from; lint points that out as well.
 
 Opting out is for entries whose *content* is public by design. Anything that
 can reach a control system, write anywhere, or spend provider tokens belongs
@@ -336,8 +412,9 @@ Serve it over HTTPS
 -------------------
 
 A session cookie sent over plain HTTP is readable by anything on the path, so a
-deployment with ``auth.method`` other than ``none`` and ``tls.enabled: false``
-**refuses to render at all** rather than hand out cookies in the clear. You
+deployment with a login page — ``auth.method`` of ``password`` or ``oidc`` —
+and ``tls.enabled: false`` **refuses to render at all** rather than hand out
+cookies in the clear. You
 therefore have to pick one of two ways to get the connection encrypted.
 
 **Let this nginx terminate TLS.** Set ``tls.enabled: true`` with a certificate
@@ -462,10 +539,14 @@ nobody else's are touched.
 Sessions, logging out, and rolling back
 ---------------------------------------
 
+This section is about the login page, so it applies to ``password`` and
+``oidc``; under ``none`` a card *is* the door, which is that posture's whole
+point.
+
 The landing page stays public — it lists the roster so people can find their own
-card, and a card is a prompt, not a door. One browser may hold several unlocked
-users at once, which is what a shared control-room machine needs; logging out
-ends that one user's session and leaves the others alone.
+card, and behind a login page a card is a prompt, not a door. One browser may
+hold several unlocked users at once, which is what a shared control-room machine
+needs; logging out ends that one user's session and leaves the others alone.
 
 .. note::
 
@@ -515,8 +596,11 @@ user has none. Their container is gone either way, so the stale route just
 fails; but if what you need is that person's *session* closed now, run
 ``decommission``.
 
-To turn login back off, set ``auth.method: none`` and run ``osprey up``.
-That re-renders nginx and the compose file, drops the authentication service,
-and returns the stack to the open posture described at the top of this section.
-``.env.auth`` is left in place, so turning login on again keeps everyone's
-existing password.
+To turn the login page back off, set ``auth.method: token`` and run ``osprey
+up``. That re-renders nginx and the compose file, drops the authentication
+service, and returns the stack to the per-user login URLs described at the top
+of this page. ``.env.auth`` is left in place, so turning login on again keeps
+everyone's existing password. ``auth.method: none`` goes one step further and
+drops the URLs too — it is refused unless every persona denies the four egress
+tools, so read :ref:`the open posture <multi-user-open-mode>` before you switch
+to it.

--- a/docs/source/how-to/web-terminal/multi-user/tiers.rst
+++ b/docs/source/how-to/web-terminal/multi-user/tiers.rst
@@ -449,10 +449,11 @@ starts anything. Each refusal names the user, or the persona, and the remedy.
    whatever the profile floors, so long as the deployment has a login wall for
    the entry to have opted out of.
 
-   With ``auth.method: none`` there is no wall for an entry to be exempt from,
-   so the exposure belongs to the deployment rather than to any one entry: it
-   is reported as an advisory naming every privileged terminal instead of
-   failing the build, and it is the one of these rules measured against the
+   Where the deployment has no login page at all — ``auth.method`` of
+   ``token`` (the default) or ``none`` — there is no wall for an entry to be
+   exempt from, so the exposure belongs to the deployment rather than to any
+   one entry: it is reported as an advisory naming every privileged terminal
+   instead of failing the build, and it is the one of these rules measured against the
    profile's own floor — a deployment that never drew a split would otherwise
    hear about every terminal it has, every time, for a posture it has always
    had. Both commands print advisories like this one with a ``⚠``, above their

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -459,7 +459,7 @@ these verbs act on that roster, which lives in the profile. Every verb takes
    * - ``login-url USER``
      - Print the URL that opens that user's terminal. Only the URL goes to
        stdout, so it can be piped or copied. Refuses for a user who signs in
-       through the login page.
+       through a login page, and for every user of an open deployment.
      - —
    * - ``env``
      - Render ``.env.users``, the env file every per-user container runs
@@ -477,15 +477,19 @@ these verbs act on that roster, which lives in the profile. Every verb takes
 ``osprey users login-url`` builds the URL from that user's operator secret in
 the repository's ``.env``, which ``osprey up`` mints for every roster user in
 every auth mode. Opening it once trades the token for a session cookie. It is
-how someone gets in when nginx authenticates nobody — ``auth.method: none``, or
-a roster entry with ``login: false`` — and it is a password: send each person
-only their own. Rotate one by deleting that user's ``OSPREY_TERMINAL_SECRET_*``
-line from ``.env`` and running ``osprey up`` again.
+how someone gets in when nginx stamps no credential on the request —
+``auth.method: token``, the default, or a roster entry with ``login: false``
+— and it is a password: send each person only their own. Rotate one by deleting
+that user's ``OSPREY_TERMINAL_SECRET_*`` line from ``.env`` and running
+``osprey up`` again.
 
-For a user who *is* behind the login wall the command refuses and names their
-login page instead. The URL would not work for them — the authentication
-service turns the request away before the terminal can read the token — and
-printing it would put a live credential in someone's inbox for nothing.
+The command refuses in the two cases where the URL would accomplish nothing,
+rather than putting a live credential in someone's inbox for it. A user behind
+a login page (``password``/``oidc``) is named their login page instead: the
+authentication service turns the request away before the terminal can read the
+token. A user of an open deployment (``auth.method: none``) is named their
+terminal's plain address instead, because nginx vouches for that terminal on
+every request and there is no token to trade.
 
 ``osprey users env`` renders the same subset a deploy would generate, from the
 same two inputs — the rendered deploy config and the repository root's env

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -412,9 +412,10 @@ move anything".
    persona is the single delta that removes that deny. Writing the floor is
    not only a convention. A web terminal served without a login by a persona
    that can edit the deployment is refused by ``osprey validate``, ``osprey
-   build`` and ``osprey up`` alike, wherever the deployment has a login wall
-   at all — with ``auth.method: none`` there is no wall to be exempt from, and
-   the same exposure is reported as an advisory instead. On a profile that
+   build`` and ``osprey up`` alike, wherever the deployment has a login page
+   at all — with ``auth.method`` at ``token`` (the default) or ``none`` there
+   is no wall to be exempt from, and the same exposure is reported as an
+   advisory instead. On a profile that
    wrote no floor at all, where every persona holds everything, the only
    remedy that refusal can offer is to write one. See
    :doc:`/how-to/web-terminal/multi-user/tiers`.

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -1460,10 +1460,12 @@ governed_sets:
     note: >-
       Not exhaustive claims in any shipped comment — recorded so a future
       change to the default-enabled server set is visible. Re-derived
-      2026-08-02 with the method above.
-    project: [channel_write, channel_read, archiver_read, control_target_set, execute, setup_patch, entry_create, draft_concept]
-    control_assistant: [channel_write, channel_read, archiver_read, control_target_set, execute, setup_patch, entry_create, draft_concept]
-    hello_world: [channel_write, channel_read, archiver_read, control_target_set, execute, setup_patch, draft_concept]
+      2026-08-27 with the method above: execute_file joined every set when the
+      policy-unit rescue gave it the same approval hook as execute (they share
+      one gate on the python server, so the pair moves together).
+    project: [channel_write, channel_read, archiver_read, control_target_set, execute, execute_file, setup_patch, entry_create, draft_concept]
+    control_assistant: [channel_write, channel_read, archiver_read, control_target_set, execute, execute_file, setup_patch, entry_create, draft_concept]
+    hello_world: [channel_write, channel_read, archiver_read, control_target_set, execute, execute_file, setup_patch, draft_concept]
   draft_concept_note: >-
     draft_concept is approval-governed in project, control_assistant and
     hello_world (osprey_facility_knowledge is enabled by default and carries the
@@ -1473,8 +1475,10 @@ governed_sets:
     approval.tools LISTS are 6/6/6 — do not "fix" one to match the other.
     control_target_set is governed the same way and for the same reason: the
     controls server carries the approval hook on it, and it appears in no
-    approval.tools block, so it too falls to default_policy. That is what
-    makes the governed set 8/8/7 rather than 7/7/6.
+    approval.tools block, so it too falls to default_policy. execute_file is
+    the third of this kind: it shares execute's policy unit (same server, same
+    hooks) but no approval.tools block names it. That is what makes the
+    governed set 9/9/8 rather than 7/7/6.
 
 # ---------------------------------------------------------------------------
 # kept_readers — code that legitimately still mentions a DELETED key. These are

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -483,7 +483,13 @@ keys:
   control_system.connector.mock.noise_level: {evidence: 'noise_level'}
   control_system.connector.epics: {covered-by: control_system.connector}
   control_system.connector.epics.timeout: {covered-by: control_system.connector.epics}
-  control_system.connector.epics.gateways: {evidence: 'gateways'}
+  control_system.connector.epics.gateways:
+    evidence: 'gateways = config\.get\("gateways", \{\}\)'
+    note: >-
+      Anchored on the EPICS connector's read of the block: the bare word
+      `gateways` is past the vacuity cap (31 files under the evidence roots)
+      and would have kept the entry green with no reader left — the same
+      reason the `read_only` entry below is anchored.
   control_system.connector.epics.gateways.read_only:
     evidence: 'gateways\.get\("read_only", \{\}\)'
     note: >-
@@ -504,7 +510,12 @@ keys:
   control_system.connector.virtual_accelerator: {covered-by: control_system.connector}
   control_system.connector.virtual_accelerator.timeout: {covered-by: control_system.connector.virtual_accelerator}
   control_system.connector.virtual_accelerator.simulation_file: {evidence: 'simulation_file'}
-  control_system.connector.virtual_accelerator.gateways: {evidence: 'gateways'}
+  control_system.connector.virtual_accelerator.gateways:
+    evidence: 'gateways = config\.get\("gateways"\)'
+    note: >-
+      Anchored on the VA connector's own read of the block — no default in the
+      call, so the pattern is disjoint from the EPICS site above and each dies
+      with exactly its own reader. Same vacuity-cap reason as the EPICS entry.
   control_system.connector.virtual_accelerator.gateways.read_only:
     evidence: 'gateways\.get\("read_only", \{\}\)'
     note: >-

--- a/src/osprey/agent_runner/write_tools.py
+++ b/src/osprey/agent_runner/write_tools.py
@@ -29,6 +29,7 @@ _FALLBACK_WRITE_TOOLS = [
     "mcp__bluesky__queue_start",
     "mcp__controls__channel_write",
     "mcp__python__execute",
+    "mcp__python__execute_file",
 ]
 
 # Built-in (non-MCP) Claude Code tools that can write to disk, execute shell
@@ -136,18 +137,6 @@ def load_write_tools(project_dir: Path) -> list[str]:
 # clear_plan_draft → clear_draft) cannot silently detach a tool from this floor.
 _DESTRUCTIVE_MARKERS = DESTRUCTIVE_MARKERS
 
-# Side-effecting MCP tools the registry walk below cannot see because they are
-# in NO registry permission list at all: the python server registers both
-# ``execute`` (gated) and ``execute_file`` (unlisted), and SDK disallow matching
-# is by exact tool name — so disallowing ``mcp__python__execute`` does NOT cover
-# ``execute_file``, which runs arbitrary Python. (Destructive auto-allowed tools
-# such as the workspace deletes are handled generically by the destructive-name
-# scan in ``_registry_side_effect_tools``, not hard-coded here.) Keep this in
-# sync with server tool modules; test_write_tools.py pins it.
-_EXTRA_SIDE_EFFECT_TOOLS = [
-    "mcp__python__execute_file",
-]
-
 
 def _is_destructive(tool: str) -> bool:
     """True if a tool's name implies it removes/destroys stored state."""
@@ -176,10 +165,12 @@ def _server_side_effect_tools(server) -> list[str]:
     *reads* (``channel_read``, ``archiver_read``), which a read-only query must
     still be able to call.
 
-    Does NOT include ``_EXTRA_SIDE_EFFECT_TOOLS`` (tools in no permission list
-    at all) — callers union those separately: the framework walk via
-    :func:`read_only_disallowed_tools`, extends clones via
-    :func:`_extra_side_effect_tools_for`.
+    This is the whole side-effect surface of a server: the python executor's
+    ``execute_file`` used to sit outside every registry list and needed a
+    hard-coded companion list here, which is exactly how one spelling of a
+    tool drifts from the other. It is now in the registry's ``permissions_ask``
+    and writes-check hooks alongside ``execute``, so this walk sees it — for
+    the template and, unchanged, for an ``extends`` clone.
 
     Returns names as ``mcp__<server>__<tool>`` (writes-check matchers verbatim).
     """
@@ -195,21 +186,6 @@ def _server_side_effect_tools(server) -> list[str]:
         if _WRITES_CHECK in rule.hooks:
             out.append(rule.matcher)
     return out
-
-
-def _extra_side_effect_tools_for(instance_name: str, template_name: str) -> list[str]:
-    """``_EXTRA_SIDE_EFFECT_TOOLS`` entries owned by one framework template,
-    rewritten to an instance's prefix.
-
-    The extras list is keyed by framework-server name (``mcp__python__…``), but
-    SDK disallow matching is by EXACT tool name — an ``extends`` clone launches
-    the SAME tool module under a new prefix, so the template's extras must
-    follow the clone as ``mcp__<instance>__<tool>`` or the clone would keep an
-    unlisted exec tool (e.g. ``execute_file``) callable in read-only mode.
-    """
-    old = f"mcp__{template_name}__"
-    new = f"mcp__{instance_name}__"
-    return [new + tool[len(old) :] for tool in _EXTRA_SIDE_EFFECT_TOOLS if tool.startswith(old)]
 
 
 def _registry_side_effect_tools() -> list[str]:
@@ -253,9 +229,7 @@ def _custom_server_side_effect_tools(project_dir: Path) -> list[str]:
     An ``extends`` spec (second instance of a framework server) is classified
     from the RESOLVED clone via :func:`_server_side_effect_tools`, so it
     inherits the template's ask/destructive-allow/writes-check surface with the
-    ``mcp__<template>__`` → ``mcp__<name>__`` matcher rewrite, plus the
-    template's ``_EXTRA_SIDE_EFFECT_TOOLS`` entries rewritten the same way
-    (:func:`_extra_side_effect_tools_for`). If the extends
+    ``mcp__<template>__`` → ``mcp__<name>__`` matcher rewrite. If the extends
     target cannot be resolved (typo, version skew, config edited after build)
     this fails CLOSED with a server-level ``mcp__<name>`` disallow — a stale
     ``.mcp.json`` from a previous build can still launch the server
@@ -289,12 +263,6 @@ def _custom_server_side_effect_tools(project_dir: Path) -> list[str]:
                 out.append(f"mcp__{name}")  # fail closed (see docstring)
             else:
                 out.extend(_server_side_effect_tools(clone))
-                # The template's hard-coded extras (side-effect tools in NO
-                # registry list, e.g. python's execute_file) must follow the
-                # clone with the rewritten prefix — the registry classifier
-                # cannot see them, and exact-name disallow matching means the
-                # template's own entry does not cover the clone.
-                out.extend(_extra_side_effect_tools_for(name, spec["extends"]))
             continue
         if not spec.get("command") and not spec.get("url"):
             # NONE of extends/command/url (e.g. 'phoebus2: {enabled: true}'):
@@ -340,10 +308,6 @@ def read_only_disallowed_tools(project_dir: Path) -> list[str]:
       destructive auto-allowed tools, and writes-check-gated tools (so the
       side-effect surface tracks the registry as the single source of truth, not
       a hand-maintained copy).
-    * ``_EXTRA_SIDE_EFFECT_TOOLS`` — side-effecting tools in NO registry
-      permission list (currently ``mcp__python__execute_file``); ``extends``
-      clones of the owning template get these rewritten to their own prefix
-      via the custom-server path below.
     * :func:`_custom_server_side_effect_tools` — write tools of facility-defined
       custom MCP servers declared in the project's ``config.yml``.
 
@@ -358,7 +322,6 @@ def read_only_disallowed_tools(project_dir: Path) -> list[str]:
     for tool in (
         *_BUILTIN_UNSAFE_TOOLS,
         *_registry_side_effect_tools(),
-        *_EXTRA_SIDE_EFFECT_TOOLS,
         *_custom_server_side_effect_tools(project_dir),
     ):
         if tool not in result:

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2411,8 +2411,9 @@ def _build_repo(
             )
 
         # Advisory lint findings — real exposures that are deliberately not
-        # build-failing (a privileged terminal in front of `auth.method: none`
-        # is the shipped loopback posture, not a mistake). Printed here, beside
+        # build-failing (a privileged terminal with no login wall — `auth.method:
+        # token` or `none` — is the shipped loopback posture, not a mistake).
+        # Printed here, beside
         # the profile identity, because a finding nobody prints is a finding
         # nobody has: every surface that gates on the errors discards these.
         for web_warning in web_warnings:

--- a/src/osprey/cli/build_profile_deploy.py
+++ b/src/osprey/cli/build_profile_deploy.py
@@ -308,9 +308,9 @@ def deploy_aware_config_warnings(
     validates must build, and a profile that draws an advisory from one command
     must draw the same one from the other. Both command surfaces print these
     above their success line — an exposure nobody prints is an exposure nobody
-    has, and the whole-deployment one (``auth.method: none`` in front of a
-    privileged terminal) is deliberately not an error, so printing is the only
-    way it reaches an operator at all.
+    has, and the whole-deployment one (no login wall — ``auth.method: token`` or
+    ``none`` — in front of a privileged terminal) is deliberately not an error,
+    so printing is the only way it reaches an operator at all.
     """
     from osprey.deployment.web_terminals.lint import profile_config_warnings
 

--- a/src/osprey/cli/scaffold_cmd.py
+++ b/src/osprey/cli/scaffold_cmd.py
@@ -1396,9 +1396,10 @@ def _print_web_terminals_lint_warnings(warnings: list[Any]) -> None:
     The sibling of :func:`_print_web_terminals_lint_errors`, and it exists
     because the render gate used to filter the findings to errors and drop the
     rest on the floor. Some of what it dropped is the only report an operator
-    ever gets: a privileged terminal in front of ``auth.method: none`` is
-    deliberately not build-failing (it is the shipped loopback posture, not a
-    mistake), so discarding it means the exposure is never named anywhere.
+    ever gets: a privileged terminal with no login wall (``auth.method: token``,
+    the default, or ``none``) is deliberately not build-failing (it is the
+    shipped loopback posture, not a mistake), so discarding it means the
+    exposure is never named anywhere.
     Advisory, never fatal \u2014 the caller decides what blocks.
     """
     console.print("  [dim]Warnings:[/dim]")

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -469,6 +469,43 @@ def _renders_the_target_switch(control_system: dict) -> bool:
     return switch_capable(control_system)
 
 
+def _policy_unit_of(tool: str, units: dict[str, tuple[str, frozenset[str]]]) -> list[str]:
+    """Every matcher that shares *tool*'s policy unit: same server, same gate.
+
+    Two matchers belong to one policy unit when they come from the same server
+    **instance** — the same ``mcp__<server>__`` prefix, after clone rewriting,
+    so a ``python2`` clone is its own unit — and are gated by exactly the same
+    PreToolUse hooks. Past that point the permission layer has no way to tell
+    them apart: the hooks, not the prompt, are what actually decides each call,
+    and they run identically for both.
+
+    WHY the unit has to move together. The writes-off / mixed render pulls
+    these matchers out of ``ask`` and the rescue puts back, via ``allow``, the
+    ones an enabled agent hard-requires. But ``requires_ask_tools`` is an honest
+    declaration of what an agent calls, not of what shares its gate: the
+    pyat-specialist names ``mcp__python__execute`` and genuinely never calls
+    ``mcp__python__execute_file``, though both run arbitrary Python through the
+    same kernels behind the same writes-check + approval pair. Promoting only
+    the declared half would leave the other pulled from ``ask`` and in no list
+    at all — which is not a policy but a fall-through to the SDK's interactive
+    ``can_use_tool`` prompt, the very prompt this block exists to close.
+    Splitting the pair reopens it.
+
+    Args:
+        tool: A matcher already known to be a key of *units*.
+        units: matcher -> (server-instance prefix, hook-command set). Built
+            over the read/write-mixed matchers only, so no pure-write matcher
+            is in scope and none can be dragged into ``allow`` as a companion.
+
+    Returns:
+        The matchers to promote, *tool* included, sorted for a stable render.
+    """
+    prefix, gate = units[tool]
+    return sorted(
+        m for m, (m_prefix, m_gate) in units.items() if m_prefix == prefix and m_gate == gate
+    )
+
+
 def build_claude_code_context(
     template_root: Path,
     jinja_env,
@@ -807,7 +844,11 @@ def build_claude_code_context(
         # also holds the pure-write matchers (and which a profile can seed with
         # anything at all): a pure-write tool in `allow` is an unguarded write,
         # so the rescue must never be able to reach one.
-        mixed_remove_ask: set[str] = set()
+        #
+        # Keyed matcher -> (server-instance prefix, hook-command set) rather
+        # than a bare set, because the rescue promotes whole policy units and
+        # needs both halves of that identity — see `_policy_unit_of`.
+        mixed_policy_units: dict[str, tuple[str, frozenset[str]]] = {}
         # Cover extends clones too, not just the literal template names: the
         # runtime hook templates (osprey_writes_check.py, osprey_approval.py)
         # exact-match template tool names and are clone-unaware — they are the
@@ -828,7 +869,10 @@ def build_claude_code_context(
                 if matcher.startswith(old_prefix):
                     matcher = new_prefix + matcher[len(old_prefix) :]
                 if template in MIXED_READ_WRITE_TEMPLATES:
-                    mixed_remove_ask.add(matcher)
+                    mixed_policy_units[matcher] = (
+                        new_prefix,
+                        frozenset(h.command for h in rule.hooks),
+                    )
                     if matcher not in remove_ask:
                         remove_ask.append(matcher)
                 elif mixed:
@@ -840,12 +884,18 @@ def build_claude_code_context(
         # hard-requires that the kill-switch just pulled from `ask`. `allow`
         # (not `ask`) keeps it off the approval-prompt path the writes-check
         # kill switch guards, so the read-only agent keeps its compute without
-        # reopening a write-access bypass. Drawn from `mixed_remove_ask` and not
-        # from `remove_ask`: a pure-write tool is denied on an all-off render and
-        # hook-gated on a mixed one, and must reach `allow` from neither.
+        # reopening a write-access bypass. Drawn from `mixed_policy_units` and
+        # not from `remove_ask`: a pure-write tool is denied on an all-off render
+        # and hook-gated on a mixed one, and must reach `allow` from neither.
+        #
+        # Promoted a whole policy unit at a time — `_policy_unit_of` says why a
+        # tool the agent never names still has to travel with the one it does.
         for tool in sorted(required_ask):
-            if tool in mixed_remove_ask and tool not in allow:
-                allow.append(tool)
+            if tool not in mixed_policy_units:
+                continue
+            for matcher in _policy_unit_of(tool, mixed_policy_units):
+                if matcher not in allow:
+                    allow.append(matcher)
         facility_perms["remove_ask"] = remove_ask
         facility_perms["allow"] = allow
         ctx["facility_permissions"] = facility_perms

--- a/src/osprey/cli/users_cmd.py
+++ b/src/osprey/cli/users_cmd.py
@@ -708,16 +708,19 @@ def login_url(user: str, repo: Path | None) -> None:
 
     Every web terminal authenticates each request against that user's own
     operator secret, which nginx stamps on requests it has authenticated. With
-    web_terminals.auth.method at 'none' — the default — nginx authenticates
+    web_terminals.auth.method at 'token' — the default — nginx authenticates
     nobody and stamps nothing, so the terminal's own gate is the only one: a
     browser gets in by opening this URL once, which trades the token for a
     session cookie and redirects to the plain address. The same is true for a
     roster entry that set 'login: false' while auth is on.
 
-    A user who signs in through the login page has no token URL, and this verb
-    refuses for them: nginx denies the request before the app can read the
-    token, so the URL would only bounce them to that page. It names the login
-    page instead of printing a live secret that accomplishes nothing.
+    A user behind a login wall ('password'/'oidc') has no token URL, and this
+    verb refuses for them: nginx denies the request before the app can read
+    the token, so the URL would only bounce them to that page. Under 'none',
+    nginx vouches for every non-exempt terminal itself, so there is no login
+    page and no token URL either; this verb refuses and names the terminal's
+    plain address instead. Either way, it names the real address rather than
+    printing a live secret that accomplishes nothing.
 
     The URL carries that user's secret. Treat it like a password: send it to the
     person it belongs to, over something you would send a password over, and
@@ -739,6 +742,7 @@ def login_url(user: str, repo: Path | None) -> None:
         from osprey.deployment.deploy_summary import token_login_users
         from osprey.deployment.web_terminals.auth_credentials import terminal_secret_var
         from osprey.deployment.web_terminals.render import (
+            _auth_tls_context,
             deployment_external_origin,
             terminal_login_url,
         )
@@ -761,31 +765,47 @@ def login_url(user: str, repo: Path | None) -> None:
             )
             raise click.Abort()
 
-        # A user BEHIND the login wall has no use for this URL, and the URL
-        # would not work if they tried it: nginx's `auth_request` denies the
-        # request before the app ever sees the `?token=`, and even after a
-        # successful sidecar login the gated location forwards `Cookie ""`, so
-        # the token->cookie exchange the URL exists to trigger can never apply.
-        # Refused rather than caveated: a live operator secret should not leave
-        # the deployment to accomplish nothing. The predicate is the deploy
-        # summary's own, so the verb and the closing card cannot disagree about
-        # who has a login page.
+        # A user with no use for this URL has no use for it in one of two
+        # shapes, and the URL would not work if they tried it either way:
+        # nginx's `auth_request` denies the request before the app ever sees
+        # the `?token=` under a login wall, and even after a successful
+        # sidecar login the gated location forwards `Cookie ""`, so the
+        # token->cookie exchange the URL exists to trigger can never apply.
+        # Under `none`, nginx vouches for the terminal itself before the app
+        # sees the request, so the same exchange is equally moot -- there is
+        # no login page to name instead, only the terminal's own address.
+        # Refused rather than caveated either way: a live operator secret
+        # should not leave the deployment to accomplish nothing. The
+        # predicate is the deploy summary's own, so the verb and the closing
+        # card cannot disagree about who has a login page.
         config = load_project_config(session.config)
         if user not in token_login_users(config):
             try:
                 origin = deployment_external_origin(config)
             except ValueError:
                 origin = ""
-            login_page = f"{origin}/auth/login" if origin else "this deployment's /auth/login"
-            fail(
-                f"{user} signs in through the login page, so no token URL applies",
-                f"This deployment authenticates {user} at {login_page}; nginx refuses "
-                "the request before the app can read a ?token=, so the URL would only "
-                "land them back on that page. Set their password with "
-                f"`osprey users passwd {user}` (or, under OIDC, have them sign in "
-                "with the identity their roster entry names).",
-                "send them the login page, not a token URL",
-            )
+            web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+            walled = _auth_tls_context(web_terminals)["walled"]
+            if walled:
+                login_page = f"{origin}/auth/login" if origin else "this deployment's /auth/login"
+                fail(
+                    f"{user} signs in through the login page, so no token URL applies",
+                    f"This deployment authenticates {user} at {login_page}; nginx refuses "
+                    "the request before the app can read a ?token=, so the URL would only "
+                    "land them back on that page. Set their password with "
+                    f"`osprey users passwd {user}` (or, under OIDC, have them sign in "
+                    "with the identity their roster entry names).",
+                    "send them the login page, not a token URL",
+                )
+            else:
+                terminal_url = f"{origin}/u/{user}/" if origin else f"this deployment's /u/{user}/"
+                fail(
+                    f"{user} is reached directly, so no token URL applies",
+                    f"This deployment is open (auth.method: none): nginx vouches for "
+                    f"{user}'s terminal on every request, so there is no login page and "
+                    f"no ?token= to trade. Open {terminal_url} directly.",
+                    "open the terminal's own address, not a token URL",
+                )
             raise click.Abort()
 
         variable = terminal_secret_var(user)

--- a/src/osprey/cli/validate_cmd.py
+++ b/src/osprey/cli/validate_cmd.py
@@ -120,7 +120,7 @@ def check_profile_file(profile_file: Path) -> None:
         raise click.UsageError("Profile validation failed:\n  - " + "\n  - ".join(web_errors))
 
     # Advisory findings are printed rather than raised: they name real exposures
-    # (a privileged terminal in front of `auth.method: none`) that are not
+    # (a privileged terminal with no login wall — `auth.method: token` or `none`) that are not
     # mistakes every deployment has made, so they must not fail a CI gate — but
     # a finding nobody prints is a finding nobody has.
     for warning in deploy_aware_config_warnings(

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -218,10 +218,11 @@ class ClosingFacts:
         :func:`~osprey.deployment.web_terminals.auth_credentials.seeded_logins`.
     :param token_login_users: Roster users who can only be reached by opening
         their own ``?token=`` URL, in roster order. These are the entries no
-        login wall stands in front of -- the whole roster when
-        ``auth.method`` is ``none``, and the ``login: false`` entries otherwise
-        -- so the terminal's own gate is the only one and the URL is the only
-        way through it. NOT the URLs themselves: each carries that user's
+        login wall stands in front of -- the whole roster when ``auth.method``
+        is ``token`` (the default), and the ``login: false`` entries under
+        ``password``, ``oidc``, or ``none`` -- so the terminal's own gate is
+        the only one and the URL is the only way through it. NOT the URLs
+        themselves: each carries that user's
         operator secret, and a deploy's closing output is read over shoulders,
         pasted into tickets and captured by CI logs. The verb that prints one
         (``osprey users login-url <user>``) is what goes here instead.
@@ -288,8 +289,9 @@ def _seeded_logins(root: Path, config: dict) -> list[tuple[str, str]]:
     """The profile-seeded logins of this deployment's roster, in roster order.
 
     Gated on there being a login to have: with ``auth.method`` at anything but
-    ``password`` no OSPREY-held credential exists (``none`` has none at all, and
-    under ``oidc`` the facility's identity provider holds them), so a password
+    ``password`` no OSPREY-held credential exists (``none``/``token`` have no
+    login at all, and under ``oidc`` the facility's identity provider holds
+    them), so a password
     named here would be one nothing ever checks. Roster entries carrying
     ``login: false`` sit outside the wall and are skipped for the same reason --
     the same predicate credential provisioning itself uses.
@@ -312,20 +314,22 @@ def _seeded_logins(root: Path, config: dict) -> list[tuple[str, str]]:
 
 
 def token_login_users(config: dict) -> list[str]:
-    """The roster users whose terminal has no login wall in front of it.
+    """The roster users whose terminal is entered through its ``?token=`` URL.
 
-    The complement of :func:`_seeded_logins`, and derived from the same two
-    predicates so the two cannot disagree about who has a login. Public because
-    ``osprey users login-url`` asks the same question before it prints anything:
-    the URL is inert for a user behind the wall, so the verb refuses there, and
-    a second spelling of "who has a login page" could send an operator a live
-    secret the deployment would then ignore. With
-    ``auth.method`` at ``none`` that is everybody: nginx runs no login flow and
-    injects no operator secret, so the per-user app's own token->cookie gate is
-    the only one and a browser gets past it exactly once, by opening that user's
-    ``?token=`` URL. With authentication on it is the ``login: false`` entries,
-    which sit outside the wall for the same reason and reach their terminal the
-    same way.
+    The complement of :func:`_seeded_logins`, and derived from the same
+    predicates nginx renders under so the two cannot disagree about who needs a
+    login URL. Public because ``osprey users login-url`` asks the same question
+    before it prints anything: the URL is inert for a user nginx vouches for, so
+    the verb refuses there, and a second spelling of "who has a login page"
+    could send an operator a live secret the deployment would then ignore.
+    Exactly the users whose location nginx injects no operator secret into:
+    with ``auth.method`` at ``token`` that is everybody — nginx runs no login
+    flow and injects nothing, so the per-user app's own token->cookie gate is
+    the only one and a browser gets past it exactly once, by opening that
+    user's ``?token=`` URL. Under every other method it is the ``login: false``
+    entries, which sit outside nginx's vouching for the same reason and reach
+    their terminal the same way; under ``none`` (open) a non-exempt terminal
+    needs no URL at all, which is the point of that posture.
 
     Returns names, never URLs. The URL carries a live credential; the closing
     card is not a place to put one.
@@ -336,11 +340,11 @@ def token_login_users(config: dict) -> list[str]:
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
     if not web_terminals.get("enabled"):
         return []
-    walled = _auth_tls_context(web_terminals).get("auth_method") != "none"
+    inject_secret = _auth_tls_context(web_terminals)["inject_secret"]
     return [
         entry["name"]
         for entry in normalize_users(web_terminals.get("users"))
-        if not (walled and entry_requires_login(entry))
+        if not (inject_secret and entry_requires_login(entry))
     ]
 
 

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -1150,7 +1150,7 @@ def _candidate_image_tags(repo_root: Path, project: str) -> list[str]:
 
         auth_ctx = _auth_tls_context(web_terminals)
         if (
-            auth_ctx["auth_method"] != "none"
+            auth_ctx["sidecar_active"]
             and effective_image_source(web_terminals) == "local"
             and not auth_ctx["auth_image"]
         ):

--- a/src/osprey/deployment/web_terminals/artifacts.py
+++ b/src/osprey/deployment/web_terminals/artifacts.py
@@ -44,10 +44,14 @@ from osprey.deployment.web_terminals.personas import (
     personas_needing_graphdb_password,
     personas_needing_launch_token_by_lane,
     personas_not_denying_bash,
+    referenced_persona_project_dirs,
     rendered_persona_configs,
     settings_json_denies_bash,
+    settings_json_deny_entries,
+    settings_json_is_rendered,
 )
 from osprey.deployment.web_terminals.render import (
+    _auth_tls_context,
     clear_nginx_templates_dir,
     render_web_terminals,
 )
@@ -59,8 +63,9 @@ from osprey_connectors.types import WRITES_ENABLED_KEY
 #: :func:`~osprey.deployment.web_terminals.render.render_web_terminals` keys it.
 WEB_COMPOSE_FILENAME = "docker-compose.web.yml"
 
-#: The offender :class:`BashLaunchTokenConflictError` names for the roster
-#: entries that run no persona (the zero-migration path). Those entries share
+#: The offender :class:`BashLaunchTokenConflictError` and
+#: :class:`OpenModeEgressError` name for the roster entries that run no persona
+#: (the zero-migration path). Those entries share
 #: the deploy project's own image, config and ``.claude/settings.json``, so
 #: they are one offender however many of them there are — and a spelling no
 #: persona catalog key can collide with.
@@ -401,6 +406,403 @@ def _roster_has_personaless_entries(config: Any) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# The OPEN-mode egress gate
+#
+# A twin of the Bash/launch-token guard above, and deliberately shaped like it:
+# same fail-closed read of the same image-baked artifact, same non-raising twin
+# for the collect-all preflight, same persona-less sentinel, same call sites.
+# The question it asks is different — not "may this persona arm hardware from a
+# shell?" but "may this persona reach the deployment's own terminals?" — but a
+# second shape for a second gate is how two guards drift into disagreeing about
+# what a rendered settings.json says.
+# ---------------------------------------------------------------------------
+
+
+#: The ``permissions.deny`` entries every persona must ship before a deployment
+#: may run OPEN (``modules.web_terminals.auth.method: none``). Each is a
+#: host-network egress path an agent can take from *outside* the python
+#: executor, which is where the open-mode socket guard sits: a shell, the two
+#: web tools, and the Playwright browser server.
+#:
+#: Every entry is spelled exactly as
+#: :data:`~osprey.cli.templates.claude_code.DENY_DEFAULTS` spells it — that
+#: tuple is what ``settings.json.j2`` writes into the artifact this gate reads,
+#: and the comparison is literal (see
+#: :func:`~osprey.deployment.web_terminals.personas.settings_json_denies`).
+#: A strict subset of it, deliberately: ``Edit`` writes files rather than
+#: reaching the network, and the context7 MCP server reaches a documentation
+#: host rather than this deployment's own terminals. Written out rather than
+#: derived by filtering ``DENY_DEFAULTS``, so that a rename there fails a test
+#: loudly instead of silently dropping an entry from this gate and weakening it
+#: (``test_the_open_mode_egress_tools_are_spelled_as_the_template_ships_them``).
+OPEN_MODE_EGRESS_TOOLS: tuple[str, ...] = (
+    "Bash",
+    "WebFetch",
+    "WebSearch",
+    "mcp__plugin_playwright_playwright__*",
+)
+
+#: The :func:`open_mode_missing_by_persona` value meaning "there is no rendered
+#: ``.claude/settings.json`` for this offender on this host at all" — as opposed
+#: to a rendered artifact that lifts particular entries, which is reported as
+#: the tuple of entries it lifts.
+#:
+#: Empty rather than a marker string, so the two cases can never be confused for
+#: a tool name and the ordinary "which tools are missing" read stays a plain
+#: tuple. The distinction exists because the two states have different remedies:
+#: a lifted entry is fixed by restoring it and rebuilding, while a missing
+#: render is fixed by rendering the project first (``osprey build``) — and an
+#: operator told to add a deny entry to a file that does not exist is told
+#: nothing they can act on.
+UNRENDERED_SETTINGS: tuple[str, ...] = ()
+
+
+class OpenModeEgressError(DeploymentError):
+    """An OPEN deployment ships a persona that may still reach the host network.
+
+    Under ``auth.method: none`` nginx vouches for every request it proxies: it
+    injects each user's operator secret on every non-exempt location, so
+    *anything* that can reach nginx is served that user's terminal. That is the
+    posture's whole point for a human — no login, no magic link — and its whole
+    danger for an agent, because the agent's own tools reach nginx from inside
+    the deployment, over loopback, indistinguishable by source address from the
+    operator's browser.
+
+    The python executor's open-mode socket guard refuses the deployment's own
+    web ports from executed code, but it covers exactly that one path. A shell,
+    ``WebFetch``/``WebSearch`` or a Playwright browser reaches those ports
+    straight past it, in-process guard or not. So open mode is refused unless
+    every persona's shipped settings deny all of
+    :data:`OPEN_MODE_EGRESS_TOOLS` — the deploy stops before a single
+    web-terminal artifact is written, while the operator still has the context
+    to choose between the two real remedies.
+
+    Deliberately not a ``ValueError``, for the reason
+    :class:`BashLaunchTokenConflictError` spells out:
+    ``force_recreate_auth_sidecar`` catches ``(ValueError, OSError)`` around its
+    best-effort re-render and downgrades it to a warning, and a safety refusal a
+    credential rotation can swallow is not a refusal.
+
+    Persona-less roster entries are bound the same way they are there: an entry
+    naming no persona runs the deploy project itself, so the settings artifact
+    read for it is the deploy project's own ``.claude/settings.json`` and it is
+    reported under :data:`ZERO_MIGRATION_OFFENDER`.
+
+    Two boundaries carried forward from the Bash guard unchanged, because this
+    gate reads the same artifact:
+
+    * **The check is render-scoped, not image-scoped.** It reads the rendered
+      project directory, which equals the image's ``.claude/settings.json``
+      only as of that image's last build: ``COPY . /app/<project>/`` bakes the
+      directory in, and the per-user compose services declare only ``image:``,
+      with no ``build:`` stanza to rebuild one at start. A render that *adds*
+      the denies without an image rebuild therefore passes this gate while the
+      running image is still permissive — which is why the remedy says rebuild.
+    * **It assumes the agent does not run in bypass-permissions mode**, where a
+      deny list is ignored wholesale and proves nothing. No such flag appears
+      on the web-terminal launch path today.
+
+    Args:
+        missing_by_persona: :func:`open_mode_missing_by_persona`'s answer — the
+            subset of :data:`OPEN_MODE_EGRESS_TOOLS` each offender fails to
+            deny, keyed by offender, with :data:`ZERO_MIGRATION_OFFENDER`
+            standing for the persona-less entries and
+            :data:`UNRENDERED_SETTINGS` for an offender with no rendered
+            artifact at all (which gets the render remedy instead of a deny
+            list it cannot edit). Every offender is named, so an operator
+            fixing one at a time does not redeploy once per offender to
+            discover the next, and each is named with the entry it actually
+            lifted rather than the whole set. :attr:`personas` is its key set,
+            exposed because that is the shape callers compare against.
+    """
+
+    def __init__(self, missing_by_persona: Mapping[str, Iterable[str]]) -> None:
+        self.missing_by_persona = {
+            persona: list(tools) for persona, tools in sorted(missing_by_persona.items())
+        }
+        self.personas = sorted(self.missing_by_persona)
+        named = ", ".join(repr(name) for name in self.personas)
+        # The union of what the offenders are actually missing, so the tools
+        # named in the headline are the tools named in the remedy.
+        reaching = [
+            tool
+            for tool in OPEN_MODE_EGRESS_TOOLS
+            # An offender with no rendered artifact denies nothing, so it puts
+            # the WHOLE set back in reach rather than none of it.
+            if any(not tools or tool in tools for tools in self.missing_by_persona.values())
+        ]
+        tools_named = ", ".join(repr(tool) for tool in reaching)
+        breakdown = "".join(
+            (
+                f"\n  - {persona!r} does not deny: {', '.join(repr(tool) for tool in tools)}"
+                if tools
+                else (
+                    f"\n  - {persona!r} has no rendered .claude/settings.json on this "
+                    f"host — run `osprey build` to render it, then rebuild its image"
+                )
+            )
+            for persona, tools in self.missing_by_persona.items()
+        )
+        zero_migration_note = (
+            (
+                f" {ZERO_MIGRATION_OFFENDER!r} stands for the roster entries that run "
+                f"no persona at all: they run the deploy project itself, so the "
+                f"settings.json read for them is the deploy project's own "
+                f".claude/settings.json."
+            )
+            if ZERO_MIGRATION_OFFENDER in self.personas
+            else ""
+        )
+        super().__init__(
+            f"Refusing to deploy: auth.method 'none' (open) lets nginx vouch for every "
+            f"terminal, and persona(s) {named} may still reach the host network via "
+            f"{tools_named}.{breakdown}\n"
+            f"Open mode injects each user's operator secret on every non-exempt "
+            f"location, so anything that reaches nginx is served that user's terminal "
+            f"— including an agent running inside another user's terminal, which "
+            f"arrives over loopback and is indistinguishable from the operator's own "
+            f"browser. The python executor refuses the deployment's own web ports from "
+            f"executed code, but that guard covers only executed code: a shell, a web "
+            f"fetch or a Playwright browser reaches those ports straight past it. Every "
+            f"persona's shipped .claude/settings.json must therefore list all of "
+            f"{', '.join(repr(tool) for tool in OPEN_MODE_EGRESS_TOOLS)} in "
+            f"permissions.deny (a missing or unparseable settings.json counts the same "
+            f"— it is not evidence of a deny). Set "
+            f"modules.web_terminals.auth.method to 'token' to keep the magic-link wall, "
+            f"or deny {tools_named} in those personas, RENDER them on this host "
+            f"(`osprey build`) and rebuild their images — in registry mode, republish "
+            f"the images from a render that carries the denies and re-pull them, and "
+            f"keep this host's render in step. A re-render alone is not enough, "
+            f"because the settings.json that RUNS is the one baked into the image and "
+            f"the per-user services declare only `image:`, so nothing rebuilds at "
+            f"start; a re-pull alone is not enough either, because the settings.json "
+            f"read HERE is this host's render, which open mode requires in both "
+            f"image-source modes.{zero_migration_note}"
+        )
+
+
+def check_open_mode_requirements(config: Any, project_root: Path | str) -> None:
+    """Refuse an OPEN deploy whose personas can still reach the host network.
+
+    The twin of :func:`check_bash_launch_token_conflict`, wired into the same
+    three call points for the same reasons, so the two gates cannot come to
+    disagree about which deploys are allowed to start:
+
+    * :func:`~osprey.deployment.web_terminals.provision.preflight_web_terminals`
+      — the fail-fast gate, ahead of
+      :func:`~osprey.deployment.web_terminals.provision.ensure_env_production`,
+      so a deployment that will be refused never pays for the project-image
+      build or has credentials minted and printed for it.
+    * :func:`~osprey.deployment.web_terminals.lifecycle.decommission_user` —
+      ahead of its roster edit, handed the **post-removal** roster. That is
+      load-bearing rather than incidental here too: decommissioning the
+      offending persona's own last user drops it from the referenced set, so
+      that removal must still succeed. It is the one remediation that needs no
+      image rebuild.
+    * :func:`resolve_render_inputs` — the render seam, and so the cover for
+      every writer of this deployment's artifacts that reaches a render without
+      passing the preflight above: :func:`write_web_terminal_artifacts` routes
+      through it, which is how
+      :func:`~osprey.deployment.web_terminals.provision.deploy_up_web_terminals`'
+      own re-render is answered for. The Bash guard's third caller,
+      :func:`~osprey.deployment.web_terminals.provision.force_recreate_auth_sidecar`'s
+      pre-recreate re-render, is unreachable under this posture — open mode runs
+      no auth sidecar to recreate — and the gate sits at the shared seam anyway
+      rather than teaching one seam which of its two guards each caller needs.
+
+    The claim is scoped to that seam, which is the path that writes THIS
+    deployment's artifacts. ``osprey scaffold web-terminals render``
+    (:mod:`osprey.cli.scaffold_cmd`) calls
+    :func:`~osprey.deployment.web_terminals.render.render_web_terminals`
+    directly, into an output directory of the operator's choosing, and stays
+    ungated — an inspection surface, exactly as it is for the Bash twin. It is
+    not silent there: the lint rule ``web_terminals.open_mode_egress`` runs on
+    that path off the same predicate and refuses the render unless ``--no-lint``
+    is passed.
+
+    Every other auth method returns immediately: ``token`` keeps the magic-link
+    exchange, ``password``/``oidc`` put a login wall in front of the roster, and
+    in none of the three is nginx vouching for whoever reaches it. The posture is
+    read through
+    :func:`~osprey.deployment.web_terminals.render._auth_tls_context`'s derived
+    booleans rather than off the method name, so a fifth method cannot fork a
+    branch nobody updated.
+
+    Like
+    :func:`~osprey.deployment.web_terminals.personas.settings_json_denies`, this
+    reads the **rendered** project directory, which equals the image's
+    ``.claude/settings.json`` only as of that image's last build — a render
+    newer than its image can report a deny the running image does not yet
+    carry, which is why the refusal says rebuild rather than merely "add the
+    deny".
+
+    Args:
+        config: The parsed deploy config.
+        project_root: Deploy project root; relative ``project_path`` values
+            resolve against it, and it is itself the settings artifact the
+            persona-less roster entries ship.
+
+    Raises:
+        OpenModeEgressError: The deployment is open and at least one referenced
+            persona — or the deploy project itself, on behalf of the
+            persona-less entries — ships settings that do not deny every tool in
+            :data:`OPEN_MODE_EGRESS_TOOLS`.
+    """
+    if missing := open_mode_missing_by_persona(config, project_root):
+        raise OpenModeEgressError(missing)
+
+
+def open_mode_offenders(config: Any, project_root: Path | str) -> set[str]:
+    """The personas an OPEN deploy would be refused for, computed without raising.
+
+    The same predicate :func:`check_open_mode_requirements` refuses on, split
+    out so a caller can ASK the question without raising on the answer — a
+    second reader of one predicate, never a second definition of what an
+    offender is. The names alone; :func:`open_mode_missing_by_persona` is the
+    same answer with the per-offender detail attached, and this is that answer's
+    key set.
+
+    Reads rendered directories and nothing else: no file is written, no process
+    is started, and nothing about the deployment changes. That purity is what
+    licenses calling it from the middle of a start sequence, and from lint.
+
+    Args:
+        config: The parsed deploy config.
+        project_root: Deploy project root; relative ``project_path`` values
+            resolve against it.
+
+    Returns:
+        Every persona whose shipped settings do not deny the whole of
+        :data:`OPEN_MODE_EGRESS_TOOLS` — including one with no rendered
+        settings artifact at all — plus :data:`ZERO_MIGRATION_OFFENDER` when the
+        roster's persona-less entries are in that state. Empty when the
+        deployment is not open, and empty when it is open and clean.
+    """
+    return set(open_mode_missing_by_persona(config, project_root))
+
+
+def open_mode_missing_by_persona(
+    config: Any, project_root: Path | str
+) -> dict[str, tuple[str, ...]]:
+    """Per offender, the egress entries its shipped settings fail to deny.
+
+    The one place the raising gate and the ask-only readers get their answer, so
+    they cannot disagree — including about whether the deployment is open at
+    all, which is settled here rather than at each caller. It is also what a
+    caller building an :class:`OpenModeEgressError` of its own passes as
+    ``missing_by_persona`` so its message names the same entries the raising
+    gate would have named. Asking :func:`open_mode_offenders` instead and
+    phrasing the refusal against the whole set is supported, but sends the
+    operator through four entries to find the one that is lifted.
+
+    Pure in the same sense as :func:`open_mode_offenders`, which is derived from
+    this.
+
+    Args:
+        config: The parsed deploy config.
+        project_root: Deploy project root; relative ``project_path`` values
+            resolve against it, and it is itself the artifact the persona-less
+            roster entries ship.
+
+    Returns:
+        ``{offender: entries}``, each tuple in :data:`OPEN_MODE_EGRESS_TOOLS`
+        order, and :data:`UNRENDERED_SETTINGS` (the empty tuple) for an offender
+        with no rendered artifact on this host. ``{}`` when the deployment is
+        not open, or when every offender-to-be denies the whole set.
+    """
+    if not deployment_is_open(config):
+        return {}
+    missing: dict[str, tuple[str, ...]] = {}
+    # One roster walk, and one read of each persona's settings.json diffed
+    # against the whole tuple — not one walk per entry. The offender still has
+    # to be named with the entries IT is missing (a persona that lifted only
+    # `WebFetch` is a different problem, and a different remedy, from one
+    # shipping no settings.json at all), and the diff answers that from the same
+    # single read.
+    for persona, project_dir in referenced_persona_project_dirs(config, project_root).items():
+        if (gap := _open_mode_gap(project_dir)) is not None:
+            missing[persona] = gap
+    # The persona walk above is keyed on persona names and so cannot see roster
+    # entries that run no persona; they ship the deploy project's own artifact.
+    if (
+        _roster_has_personaless_entries(config)
+        and (gap := _open_mode_gap(Path(project_root))) is not None
+    ):
+        missing[ZERO_MIGRATION_OFFENDER] = gap
+    return missing
+
+
+def _open_mode_gap(project_dir: Path | None) -> tuple[str, ...] | None:
+    """What one rendered project fails to deny, or ``None`` when it denies it all.
+
+    Fails closed on every artifact it cannot read, exactly as
+    :func:`~osprey.deployment.web_terminals.personas.settings_json_denies` does,
+    and splits that failure in two so the refusal can be acted on: an artifact
+    that is simply not there on this host reports
+    :data:`UNRENDERED_SETTINGS` — render it — while one that is there and
+    unreadable, or there and permissive, reports the entries it does not deny.
+
+    Args:
+        project_dir: The rendered project directory whose
+            ``.claude/settings.json`` this offender ships, or ``None`` for a
+            persona whose catalog entry names no ``project_path`` — which ships
+            no artifact at all and is reported the same way an unrendered one
+            is.
+
+    Returns:
+        ``None`` when every entry in :data:`OPEN_MODE_EGRESS_TOOLS` is denied;
+        :data:`UNRENDERED_SETTINGS` when there is no artifact on this host; else
+        the entries that are missing, in :data:`OPEN_MODE_EGRESS_TOOLS` order.
+    """
+    if project_dir is None or not settings_json_is_rendered(project_dir):
+        return UNRENDERED_SETTINGS
+    denied = settings_json_deny_entries(project_dir)
+    gap = tuple(tool for tool in OPEN_MODE_EGRESS_TOOLS if denied is None or tool not in denied)
+    return gap or None
+
+
+def deployment_is_open(config: Any) -> bool:
+    """Whether this deployment runs OPEN — nginx vouching for every terminal.
+
+    The gate's own posture question, and exported because one other decision
+    hangs off the same answer: open mode requires a local persona render on this
+    host (it is the artifact this gate reads), so
+    :func:`~osprey.deployment.web_terminals.provision.persona_render_problem`
+    demands one in BOTH image-source modes when this returns ``True``. Routed
+    here rather than re-derived there, so the mode that requires the render and
+    the gate that reads it can never disagree about which deployments are open.
+
+    Asked through
+    :func:`~osprey.deployment.web_terminals.render._auth_tls_context`, the
+    single definition of what an ``auth`` stanza means, and off its
+    ``open_perimeter`` boolean rather than the method name — the same boolean
+    the compose render stamps the perimeter from, so the gate and the stamp
+    cannot come to disagree about which deployments are open.
+
+    Degrades to ``False`` on the one input that function rejects — an
+    ``auth.method`` naming a method that does not exist. Such a config renders
+    nothing at all: the render raises on it and lint reports
+    ``web_terminals.unknown_auth_method``, both independently of this gate. It
+    is not an open deployment, and answering the question with a ``ValueError``
+    would put a raise inside :func:`open_mode_offenders`, whose callers are
+    promised one that does not raise.
+
+    Args:
+        config: The parsed deploy config.
+
+    Returns:
+        ``True`` only for a deployment whose ``auth.method`` resolves to the
+        open posture.
+    """
+    web_terminals = as_dict(as_dict(as_dict(config).get("modules")).get("web_terminals"))
+    try:
+        context = _auth_tls_context(web_terminals)
+    except ValueError:
+        return False
+    return bool(context["open_perimeter"])
+
+
 def web_artifacts_dir(repo_root: Path | str) -> Path:
     """Where a repo's rendered web-terminal artifacts live: ``<repo>/build``.
 
@@ -540,6 +942,7 @@ def resolve_render_inputs(config: Any, repo_root: Path | str) -> dict[str, Any]:
 
     Raises:
         BashLaunchTokenConflictError: See :func:`check_bash_launch_token_conflict`.
+        OpenModeEgressError: See :func:`check_open_mode_requirements`.
     """
     from osprey.deployment.compose_generator import (
         resolve_ariel_mirror_dir,
@@ -549,6 +952,10 @@ def resolve_render_inputs(config: Any, repo_root: Path | str) -> dict[str, Any]:
 
     root = Path(repo_root)
     launch_token_personas_by_lane = check_bash_launch_token_conflict(config, root)
+    # The second fail-closed gate, in the same position and for the same reason:
+    # an open deployment whose personas can still reach its own terminals must
+    # leave no half-written artifacts behind either.
+    check_open_mode_requirements(config, root)
     return {
         "auth_env_digest": auth_env_digest(root),
         "dispatcher_personas": personas_needing_dispatcher_token(config, root),
@@ -644,6 +1051,13 @@ def write_web_terminal_artifacts(config: Any, repo_root: Path | str | None = Non
             those refuse earlier still (see
             :func:`check_bash_launch_token_conflict`); this is the backstop that
             makes the property hold for all of them.
+        OpenModeEgressError: The deployment is open (``auth.method: none``) and
+            some referenced persona's shipped ``.claude/settings.json`` does not
+            deny every tool in :data:`OPEN_MODE_EGRESS_TOOLS` — including the
+            case where there is no rendered artifact to read at all, which open
+            mode requires on this host. Raised before the render on every
+            writer, for the same reason and with the same backstop role as the
+            conflict above (see :func:`check_open_mode_requirements`).
         ValueError: From the render — including, once this deployment has any
             operator secret provisioned at all, a roster user that has none of
             its own (see :func:`_terminal_secrets`). Raised before any file is

--- a/src/osprey/deployment/web_terminals/auth_credentials.py
+++ b/src/osprey/deployment/web_terminals/auth_credentials.py
@@ -167,7 +167,7 @@ class AuthCredentialsResult:
 #: What :func:`_validate_usernames` calls the thing it was about to provision,
 #: by default. Names the auth credentials because that is what the module's
 #: original caller mints; the terminal-secret caller passes its own, because it
-#: runs on EVERY deployment — ``auth.method: none`` included — and a refusal
+#: runs on EVERY deployment — sidecar or not — and a refusal
 #: naming "auth credentials" on an auth-off deployment describes a feature the
 #: operator did not turn on.
 _AUTH_CREDENTIALS_SUBJECT = "auth credentials"
@@ -565,7 +565,7 @@ class AuthSecretsResult:
 def ensure_auth_session_secrets(project_root: str | Path) -> AuthSecretsResult:
     """Mint the sidecar's cookie-signing secrets into ``.env.auth``.
 
-    Call on the deploy preflight path whenever ``auth.method != "none"``; the
+    Call on the deploy preflight path whenever the sidecar is active; the
     method itself is the caller's to read, exactly as it decides whether to
     call :func:`ensure_auth_credentials`.
 
@@ -783,7 +783,7 @@ def ensure_terminal_secrets(
     interpolates ``${OSPREY_TERMINAL_SECRET_<USER>}`` from for both services.
 
     Called on the deploy preflight path for EVERY deployment, including one with
-    ``auth.method: none``. Authentication decides who may reach a terminal
+    one without a sidecar. Authentication decides who may reach a terminal
     through the front door; this secret decides that the front door is the only
     way in at all, which an auth-off multi-user deployment needs just as much —
     arguably more, since nothing else stands between one user's browser and

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -95,6 +95,7 @@ from osprey.deployment.runtime_helper import (
 )
 from osprey.deployment.web_terminals.artifacts import (
     check_bash_launch_token_conflict,
+    check_open_mode_requirements,
     write_web_terminal_artifacts,
 )
 from osprey.deployment.web_terminals.auth_credentials import (
@@ -244,16 +245,19 @@ def decommission_user(
     # The probe roster is the POST-removal one, which is what preserves the
     # escape hatch: decommissioning the offending persona's last user drops it
     # from the referenced set, so that removal still succeeds.
-    check_bash_launch_token_conflict(
-        {
-            **config,
-            "modules": {
-                **as_dict(config.get("modules")),
-                "web_terminals": {**web_terminals, "users": remaining},
-            },
+    post_removal_config = {
+        **config,
+        "modules": {
+            **as_dict(config.get("modules")),
+            "web_terminals": {**web_terminals, "users": remaining},
         },
-        repo_root,
-    )
+    }
+    check_bash_launch_token_conflict(post_removal_config, repo_root)
+    # The open-mode gate on the same roster, for the same reason and with the
+    # same escape hatch: removing the last user of a persona that can reach the
+    # host network drops it from the referenced set, and that removal is the
+    # remediation which needs no image rebuild.
+    check_open_mode_requirements(post_removal_config, repo_root)
 
     # Roster edit + artifact re-render happen before container/volume removal:
     # they are recoverable by re-running `osprey up`, unlike volume removal.
@@ -529,13 +533,13 @@ def nuke_stack(config_path: str | Path, *, assume_yes: bool = False) -> None:
             candidate_images.append(image)
 
     # The auth sidecar's own locally-built tag, on exactly the terms that
-    # produced it: authentication on AND local mode AND no auth.image pinning an
+    # produced it: a sidecar method AND local mode AND no auth.image pinning an
     # external image (see provision.build_auth_sidecar_image). It is a candidate
     # like any persona tag — the same com.osprey.project label verification
     # below decides whether it is really ours, since image tags are host-global.
     auth_ctx = _auth_tls_context(web_terminals)
     if (
-        auth_ctx["auth_method"] != "none"
+        auth_ctx["sidecar_active"]
         and effective_image_source(web_terminals) == "local"
         and not auth_ctx["auth_image"]
     ):
@@ -665,7 +669,7 @@ def _reconcile_auth_after_user_removal(
             users whose credentials survive.
     """
     web_terminals = as_dict(as_dict(config.get("modules")).get("web_terminals"))
-    if _auth_tls_context(web_terminals)["auth_method"] == "none":
+    if not _auth_tls_context(web_terminals)["sidecar_active"]:
         return
 
     # Deferred import for the same reason rotate_user_password defers it: a
@@ -905,11 +909,13 @@ def rotate_user_password(config_path: str | Path, user: str, password: str) -> N
 
     # Read through the same parser the render and the deploy preflight use, so
     # the three can never disagree about what this deployment's `auth` means.
-    auth_method = _auth_tls_context(web_terminals)["auth_method"]
-    if auth_method == "none":
+    auth_ctx = _auth_tls_context(web_terminals)
+    auth_method = auth_ctx["auth_method"]
+    if not auth_ctx["walled"]:
         raise ValueError(
-            "modules.web_terminals.auth.method is 'none', so this deployment has no "
-            "login passwords to change. Enable authentication first; nothing was modified."
+            f"modules.web_terminals.auth.method is {auth_method!r}, which puts no login "
+            "wall in front of the terminals, so this deployment has no login passwords "
+            "to change. Set auth.method: password first; nothing was modified."
         )
     if auth_method != "password":
         raise ValueError(

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -58,6 +58,7 @@ from osprey.deployment.web_terminals.render import (
     _RESERVED_AUDIT_IDENTITY_RE,
     AUTH_SIDECAR_AUDIT_IDENTITY,
     SUPPORTED_AUTH_METHODS,
+    TLS_LISTEN_PORT,
     _auth_tls_context,
     _authorization_context,
     _configured_external_origin,
@@ -65,11 +66,13 @@ from osprey.deployment.web_terminals.render import (
 )
 from osprey_connectors.types import TYPE_WRITES_ENABLED_LEAF, WRITES_ENABLED_KEY
 
-# The TLS seam's listener port (`listen 443 ssl` in the gated nginx block). The
-# auth sidecar's listener has no constant here: it is config-driven
+# The TLS seam's listener port (`listen 443 ssl` in the gated nginx block) is
+# `render.TLS_LISTEN_PORT`, imported above rather than restated: the render
+# stamps the same port into the perimeter deny-list, and a second literal here
+# could come to reserve a port the template does not listen on. The auth
+# sidecar's listener needs no constant at all: it is config-driven
 # (`auth.port`), and its effective value is read from render's parsed auth
-# context rather than restated.
-_TLS_LISTEN_PORT = 443
+# context.
 
 # The credential env-var stem a roster username is keyed into
 # (`OSPREY_AUTH_PW_HASH_<SUFFIX>`), quoted only inside this module's collision
@@ -219,6 +222,12 @@ def lint_web_terminals(
         # Resolves notice paths against the project directory, so it rides the
         # same gate: a profile has no rendered project to look in yet.
         findings.extend(_check_notice_docs(root, web_terminals))
+        # Reads each persona's rendered `.claude/settings.json`, so it rides the
+        # same gate for the same reason — and rides it honestly: at profile
+        # altitude there is no shipped artifact to read, and a rule that
+        # answered anyway would be guessing at the one file the deploy gate
+        # refuses on.
+        findings.extend(_check_open_mode_egress(root, project_root=project_root))
     findings.extend(_check_registry_mode_build_profile(web_terminals, users))
     findings.extend(_check_persona_extra_mounts(web_terminals))
     findings.extend(_check_unknown_mcp_topology(web_terminals))
@@ -499,8 +508,8 @@ def _check_user_theme(users: list[Any]) -> list[Finding]:
 
 
 def _check_user_login(web_terminals: dict[str, Any], users: list[Any]) -> list[Finding]:
-    """An object-form entry's optional ``login`` must be a boolean, and only
-    does anything while authentication is on.
+    """An object-form entry's optional ``login`` must be a boolean, and only does
+    anything where the perimeter puts something in front of that entry.
 
     Two findings, for the two ways the key can lie:
 
@@ -508,9 +517,11 @@ def _check_user_login(web_terminals: dict[str, Any], users: list[Any]) -> list[F
       the literal ``false`` as "login required" — deliberately fail-closed —
       so the typo can never open an entry to the world, but the author who
       wrote ``login: no-thanks`` believes the opposite of what deploys.
-    * ``login: false`` with ``auth.method: none`` is a WARN. The key is inert
-      (there is no login wall to be exempt from), so the config claims a
-      distinction the deployment does not have.
+    * ``login: false`` with ``auth.method: token`` is a WARN. That is the one
+      method whose perimeter puts nothing in front of any entry — no login
+      wall and no injected operator secret — so the key is inert and the
+      config claims a distinction the deployment does not have. Under ``none``
+      it is meaningful: it withholds the injected secret from that entry.
     """
     findings: list[Finding] = []
     login_declared = False
@@ -536,16 +547,22 @@ def _check_user_login(web_terminals: dict[str, Any], users: list[Any]) -> list[F
         )
 
     context = _auth_context(web_terminals)
-    auth_off = context is None or context["auth_method"] == "none"
-    if login_declared and auth_off:
+    # `inject_secret`, not `walled`: under `none` there is no login wall either,
+    # but the key still decides whether nginx injects that entry's operator
+    # secret — so it is inert under `token` alone.
+    inert = context is None or not context["inject_secret"]
+    if login_declared and inert:
+        method = "unset" if context is None else repr(context["auth_method"])
         findings.append(
             Finding(
                 severity="warn",
                 code="web_terminals.user_login_inert",
                 message=(
                     "a modules.web_terminals.users entry sets login: false, but "
-                    "auth.method is 'none' so no entry has a login to be exempt "
-                    "from; the key changes nothing until authentication is enabled"
+                    f"auth.method is {method} so there is nothing for an entry to be "
+                    "exempt from — no login wall, and no injected operator secret; "
+                    "the key changes nothing until auth.method is none, password "
+                    "or oidc"
                 ),
             )
         )
@@ -726,13 +743,13 @@ def _check_port_overlap(
                 entries.append((value, f"test_ioc.{field}"))
 
     # S5: the gated auth/TLS seam's port(s) — only join the collision set when
-    # the seam is actually enabled by config; the default (tls disabled, auth
-    # "none") must not reserve 443 or the sidecar port against ordinary configs.
+    # the seam is actually enabled by config; the default (tls disabled, no
+    # sidecar) must not reserve 443 or the sidecar port against ordinary configs.
     tls = as_dict(web_terminals.get("tls"))
     if bool(tls.get("enabled", False)):
-        entries.append((_TLS_LISTEN_PORT, "web_terminals.tls (listen 443 ssl)"))
+        entries.append((TLS_LISTEN_PORT, "web_terminals.tls (listen 443 ssl)"))
     auth_context = _auth_context(web_terminals)
-    if auth_context is not None and auth_context["auth_method"] != "none":
+    if auth_context is not None and auth_context["sidecar_active"]:
         # The sidecar's own listener, published on the host beside every other
         # service in the stack. Unlike `nginx_port` it has no `ports.*` mirror
         # to be covered by S3 — `auth.port` is where it is declared — so it is
@@ -1307,7 +1324,7 @@ def _check_unreadable_persona_privileges(
             [
                 f"{'users' if len(names) > 1 else 'user'} {_named_users(names)} "
                 f"{'are' if len(names) > 1 else 'is'} served with no login wall at all "
-                f"(modules.web_terminals.auth.method is 'none') and "
+                f"(modules.web_terminals.auth.method is not password or oidc) and "
                 f"{'resolve' if len(names) > 1 else 'resolves'} to it"
             ],
             f"{altitude_remedy(persona_name)}, or turn authentication on "
@@ -2602,6 +2619,91 @@ def _auth_context(web_terminals: dict[str, Any]) -> dict[str, Any] | None:
         return None
 
 
+def _check_open_mode_egress(root: dict[str, Any], *, project_root: Path | None) -> list[Finding]:
+    """An OPEN deployment whose personas can still reach the host network.
+
+    The authoring-time voice of the deploy gate
+    :func:`~osprey.deployment.web_terminals.artifacts.check_open_mode_requirements`,
+    which refuses this deployment at ``osprey up``, at ``decommission``, and at
+    the render seam. Without this rule the whole posture is discovered only when
+    a start is attempted: ``osprey build`` and ``osprey profile validate`` would
+    render and bless a deployment that cannot come up, and the operator would
+    meet the refusal one step later than the edit that caused it.
+
+    Driven by
+    :func:`~osprey.deployment.web_terminals.artifacts.open_mode_missing_by_persona`
+    — the SAME predicate the gate raises on, not a second reading of the same
+    idea. A lint rule that re-derived "which personas may reach the network"
+    would be free to clear a deployment the gate refuses, which is the worst of
+    both surfaces: a green authoring run and a start nobody can perform.
+
+    ERROR rather than WARN, and for the gate's reason rather than lint's usual
+    one: under ``auth.method: none`` nginx vouches for every terminal it
+    proxies, so a persona that keeps one of these entries is one prompt away
+    from a neighbour's session.
+
+    Imported at call time. This module is static validation of a config file,
+    and ``artifacts`` pulls the deploy-time artifact writer — and the credential
+    provisioner behind it — in with it; the same reason ``_PW_HASH_VAR_PREFIX``
+    is quoted here rather than imported.
+
+    Args:
+        root: The whole parsed config — the gate reads the ``auth`` posture off
+            ``modules.web_terminals`` itself, so it takes the config rather than
+            that stanza.
+        project_root: The deployment repo whose ``build/`` holds the renders a
+            ``project_path`` resolves against. ``None`` falls back to the
+            working directory, as everywhere else in this module.
+
+    Returns:
+        One finding naming every offender and what each is missing, or none.
+    """
+    from osprey.deployment.web_terminals.artifacts import (
+        OPEN_MODE_EGRESS_TOOLS,
+        ZERO_MIGRATION_OFFENDER,
+        open_mode_missing_by_persona,
+    )
+
+    missing = open_mode_missing_by_persona(root, project_root or Path("."))
+    if not missing:
+        return []
+    detail = "; ".join(
+        (
+            f"{persona!r} does not deny {', '.join(repr(tool) for tool in tools)}"
+            if tools
+            # The empty tuple is the gate's "there is nothing rendered here to
+            # read", whose remedy is a render rather than a deny entry.
+            else f"{persona!r} has no rendered .claude/settings.json on this host"
+        )
+        for persona, tools in sorted(missing.items())
+    )
+    zero_migration_note = (
+        f". {ZERO_MIGRATION_OFFENDER!r} stands for the roster entries that run no persona "
+        "at all: they run the deploy project itself, so the settings.json read for them "
+        "is the deploy project's own .claude/settings.json"
+        if ZERO_MIGRATION_OFFENDER in missing
+        else ""
+    )
+    return [
+        Finding(
+            severity="error",
+            code="web_terminals.open_mode_egress",
+            message=(
+                f"modules.web_terminals.auth.method is 'none' (open), so nginx vouches "
+                f"for every terminal it proxies — but {detail}. An agent in one terminal "
+                f"reaches nginx over loopback and is served a neighbour's session, and "
+                f"the python executor's socket guard covers only executed code. Every "
+                f"persona's shipped .claude/settings.json must deny all of "
+                f"{', '.join(repr(tool) for tool in OPEN_MODE_EGRESS_TOOLS)} (a missing "
+                f"or unparseable settings.json counts the same). Set auth.method to "
+                f"'token' to keep the magic-link wall, or restore those deny entries, "
+                f"render with `osprey build` and rebuild the images this deployment "
+                f"runs{zero_migration_note}"
+            ),
+        )
+    ]
+
+
 def _check_auth_method(web_terminals: dict[str, Any]) -> list[Finding]:
     """``modules.web_terminals.auth.method`` must name a supported method.
 
@@ -2648,8 +2750,8 @@ def _check_auth_method(web_terminals: dict[str, Any]) -> list[Finding]:
                 message=(
                     f"modules.web_terminals.auth.method {method!r} is not a string; "
                     f"expected one of {', '.join(SUPPORTED_AUTH_METHODS)}. A non-string "
-                    "value falls back to 'none' at render time, which would render the "
-                    "deployment with authentication silently disabled"
+                    "value falls back to 'token' at render time, which would render the "
+                    "deployment with the login wall silently disabled"
                 ),
             )
         ]
@@ -2686,7 +2788,7 @@ def _check_auth_transport(root: dict[str, Any], web_terminals: dict[str, Any]) -
     the WARN back with the config change that creates the exposure.
     """
     context = _auth_context(web_terminals)
-    if context is None or context["auth_method"] == "none":
+    if context is None or not context["sidecar_active"]:
         return []
     if context["tls_enabled"]:
         return []

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -1486,11 +1486,12 @@ def privileged_default_persona_problem(
 def auth_is_enforced(web_terminals: Any) -> bool:
     """Whether this deployment puts a login wall in front of its terminals at all.
 
-    ``auth.method: none`` (the default, and the whole ``auth`` stanza is
-    optional) means no entry has a login — which makes every terminal what
-    ``login: false`` makes one, and is why
-    :func:`unauthenticated_privileged_terminal_problems` takes this as a
-    parameter rather than reading ``login`` alone.
+    The render context's ``walled`` boolean: ``password``/``oidc`` stand a
+    sidecar in front of the roster; ``token`` (the default, and what an absent
+    ``auth`` stanza means) and ``none`` (open) do not, so under either no entry
+    has a login — which makes every terminal what ``login: false`` makes one,
+    and is why :func:`unauthenticated_privileged_terminal_problems` takes this
+    as a parameter rather than reading ``login`` alone.
 
     Routed through render's parsed auth context rather than re-reading
     ``auth.method`` here, so the guards cannot disagree with the nginx seam
@@ -1505,7 +1506,7 @@ def auth_is_enforced(web_terminals: Any) -> bool:
         context = _auth_tls_context(as_dict(web_terminals))
     except ValueError:
         return True
-    return bool(context["auth_method"] != "none")
+    return bool(context["walled"])
 
 
 def _privileged_entries(
@@ -1696,9 +1697,10 @@ def deployment_wide_privileged_exposure_problems(
         name = entry.get("name")
         problems.append(
             f"modules.web_terminals user {name!r} resolves to persona {persona!r}, which "
-            f"holds {privilege_phrase(privileges)}, and modules.web_terminals.auth.method is "
-            f"'none' — so anyone who can reach this deployment edits it. Turn "
-            f"authentication on (auth.method: password or oidc), or point {name!r} at a "
+            f"holds {privilege_phrase(privileges)}, and modules.web_terminals.auth.method "
+            f"puts no login wall in front of it — so anyone who can reach this deployment "
+            f"edits it. Turn authentication on (auth.method: password or oidc), or point "
+            f"{name!r} at a "
             f"persona that holds neither (the bundled stack's "
             f"{UNPRIVILEGED_TIER_EXAMPLE!r})"
         )
@@ -2202,8 +2204,8 @@ def resolve_personas(
 _BASH_DENY_ENTRY = "Bash"
 
 
-def settings_json_denies_bash(project_dir: Any) -> bool:
-    """True if ``<project_dir>/.claude/settings.json`` denies ``Bash`` outright.
+def settings_json_denies(project_dir: Any, tools: Iterable[str]) -> bool:
+    """True if ``<project_dir>/.claude/settings.json`` denies every tool in *tools*.
 
     Reads the **shipped build artifact**, not the ``config.yml`` that produced
     it, and that distinction is the whole point of this function. ``osprey up``
@@ -2225,7 +2227,13 @@ def settings_json_denies_bash(project_dir: Any) -> bool:
     would not close that window either — it is one step further from the image,
     not one step closer.
 
-    Only the exact ``"Bash"`` entry counts (see :data:`_BASH_DENY_ENTRY`).
+    Matching is by **exact entry**, never by tool-name resolution: a scoped deny
+    (``Bash(rm:*)``) constrains one command family and leaves the tool otherwise
+    usable, and a wildcard entry such as
+    ``mcp__plugin_playwright_playwright__*`` is compared as the literal string
+    the artifact carries. Callers therefore spell each tool exactly as
+    :data:`~osprey.cli.templates.claude_code.DENY_DEFAULTS` spells it, which is
+    what the ``settings.json.j2`` template writes.
 
     Fails **closed**: an artifact that cannot be read and parsed into a
     ``permissions.deny`` list is not evidence that anything is denied, so every
@@ -2237,12 +2245,44 @@ def settings_json_denies_bash(project_dir: Any) -> bool:
     Args:
         project_dir: The rendered persona project directory (the one holding
             ``config.yml`` and ``.claude/``).
+        tools: The ``permissions.deny`` entries that must **all** be present.
+            Asked as one question rather than one call per tool so a caller
+            wanting "denies the whole egress set" cannot accidentally accept a
+            persona that denies only part of it.
 
     Returns:
-        ``True`` only when the artifact was read, parsed, and lists ``"Bash"``
-        in ``permissions.deny``; ``False`` in every other case.
+        ``True`` only when the artifact was read, parsed, and lists every entry
+        in *tools*; ``False`` in every other case.
     """
-    settings_json = Path(project_dir) / ".claude" / "settings.json"
+    deny = settings_json_deny_entries(project_dir)
+    return deny is not None and deny.issuperset(tools)
+
+
+def settings_json_deny_entries(project_dir: Any) -> frozenset[str] | None:
+    """The ``permissions.deny`` entries the shipped artifact lists, or ``None``.
+
+    The read :func:`settings_json_denies` answers its yes/no question with, kept
+    separately for the caller that needs the whole set rather than one verdict:
+    a guard naming WHICH of several required entries a persona is missing would
+    otherwise re-read and re-parse the same small file once per entry.
+
+    Every property of the read — the shipped artifact rather than the config,
+    the BOM-tolerant decode, exact-entry matching, and failing closed on
+    anything it cannot turn into a deny list — is described on
+    :func:`settings_json_denies` and is unchanged here.
+
+    Args:
+        project_dir: The rendered persona project directory (the one holding
+            ``config.yml`` and ``.claude/``).
+
+    Returns:
+        The set of string ``permissions.deny`` entries, or ``None`` when the
+        artifact is absent, unreadable, unparseable, or carries no
+        ``permissions.deny`` list. ``None`` is deliberately distinct from an
+        empty set: "nothing is denied here" and "there is nothing to read" are
+        the same verdict for a guard but different sentences for an operator.
+    """
+    settings_json = settings_json_path(project_dir)
     try:
         # utf-8-sig, not utf-8: `json.load` does not strip a BOM, so a hand-edited
         # artifact saved with one would fail to parse and a genuinely Bash-denying
@@ -2251,11 +2291,122 @@ def settings_json_denies_bash(project_dir: Any) -> bool:
         with settings_json.open("r", encoding="utf-8-sig") as fh:
             settings = json.load(fh)
     except (OSError, ValueError):
-        return False
+        return None
     deny = as_dict(as_dict(settings).get("permissions")).get("deny")
     if not isinstance(deny, list):
-        return False
-    return _BASH_DENY_ENTRY in [entry for entry in deny if isinstance(entry, str)]
+        return None
+    return frozenset(entry for entry in deny if isinstance(entry, str))
+
+
+def settings_json_path(project_dir: Any) -> Path:
+    """Where a rendered persona project keeps the settings artifact this reads.
+
+    One spelling of ``.claude/settings.json``, so a guard asking whether the
+    artifact exists at all cannot look somewhere other than where the reads
+    above look.
+    """
+    return Path(project_dir) / ".claude" / "settings.json"
+
+
+def settings_json_is_rendered(project_dir: Any) -> bool:
+    """Whether *project_dir* holds a settings artifact at all.
+
+    Not a safety question — an artifact that exists proves nothing about what it
+    denies — but a phrasing one. A persona with no rendered project on this host
+    fails every deny check for a reason no ``permissions.deny`` edit can fix,
+    and telling that operator to add a deny entry sends them to a file that is
+    not there. Callers that fail closed ask this only to choose the sentence.
+    """
+    return settings_json_path(project_dir).is_file()
+
+
+def settings_json_denies_bash(project_dir: Any) -> bool:
+    """True if ``<project_dir>/.claude/settings.json`` denies ``Bash`` outright.
+
+    The one-tool case of :func:`settings_json_denies`, kept under its own name
+    because the Bash/launch-token guard asks exactly this question in four
+    places and reads better for saying so. Only the exact ``"Bash"`` entry
+    counts (see :data:`_BASH_DENY_ENTRY`); every other property — reading the
+    shipped artifact rather than the config, and failing closed on one it
+    cannot parse — belongs to :func:`settings_json_denies` and is described
+    there.
+
+    Args:
+        project_dir: The rendered persona project directory (the one holding
+            ``config.yml`` and ``.claude/``).
+
+    Returns:
+        ``True`` only when the artifact was read, parsed, and lists ``"Bash"``
+        in ``permissions.deny``; ``False`` in every other case.
+    """
+    return settings_json_denies(project_dir, (_BASH_DENY_ENTRY,))
+
+
+def personas_not_denying(config: Any, project_root: Any, tools: Iterable[str]) -> set[str]:
+    """Names of referenced personas whose shipped settings do **not** deny *tools*.
+
+    The roster-shaped form of :func:`settings_json_denies`, phrased as the
+    *unsafe* set so its caller can name every offending persona in one error
+    rather than re-deriving them.
+
+    Walks the roster itself rather than routing through the shared
+    ``config.yml`` engine the entitlement predicates use, because the question
+    is about the built artifact and not about intent — see
+    :func:`settings_json_denies`. Membership is inclusive for the same
+    fail-closed reason: a persona with no ``project_path``, or one whose project
+    is not rendered, is reported here as not denying anything.
+
+    Args:
+        config: The parsed deploy config.
+        project_root: Deploy project root; relative ``project_path`` values
+            resolve against it.
+        tools: The ``permissions.deny`` entries a persona must **all** ship to
+            stay out of the returned set.
+
+    Returns:
+        The subset of referenced persona names whose rendered
+        ``.claude/settings.json`` does not deny every named tool.
+    """
+    return {
+        persona_name
+        for persona_name, project_dir in referenced_persona_project_dirs(
+            config, project_root
+        ).items()
+        if project_dir is None or not settings_json_denies(project_dir, tools)
+    }
+
+
+def referenced_persona_project_dirs(config: Any, project_root: Any) -> dict[str, Path | None]:
+    """Every referenced persona's rendered project directory, ``None`` when it has none.
+
+    The roster walk behind :func:`personas_not_denying`, named on its own so a
+    caller asking several questions of the same artifact walks the roster once
+    and reads each persona's ``settings.json`` once. Both readers stay bound to
+    one definition of "referenced" and one resolution of ``project_path``, which
+    is what keeps a raising guard and an ask-only reader from disagreeing about
+    which personas a deployment even has.
+
+    Args:
+        config: The parsed deploy config.
+        project_root: Deploy project root; relative ``project_path`` values
+            resolve against it.
+
+    Returns:
+        ``{persona: directory}`` for every referenced persona, with ``None`` for
+        one whose catalog entry carries no usable ``project_path``. ``None`` is
+        not "clean": such a persona ships no artifact a guard can read, and
+        every fail-closed caller must treat it as denying nothing.
+    """
+    catalog, referenced = _referenced_personas(config)
+    dirs: dict[str, Path | None] = {}
+    for persona_name in sorted(referenced):
+        project_path = as_dict(catalog.get(persona_name)).get("project_path")
+        dirs[persona_name] = (
+            Path(project_root, project_path)
+            if isinstance(project_path, str) and project_path
+            else None
+        )
+    return dirs
 
 
 def personas_not_denying_bash(config: Any, project_root: Any) -> set[str]:
@@ -2271,14 +2422,10 @@ def personas_not_denying_bash(config: Any, project_root: Any) -> set[str]:
     :func:`personas_needing_launch_token_by_lane`
     therefore names exactly the personas a deploy must refuse.
 
-    Walks the roster itself rather than routing through the shared
-    ``config.yml`` engine the entitlement predicates use, because the question
-    is about the built artifact and not about intent — see
-    :func:`settings_json_denies_bash`. Membership is inclusive for the same
-    fail-closed reason: a persona with no ``project_path``, or one whose project
-    is not rendered, is reported here as not denying ``Bash``. That never
-    over-blocks a deploy, since a persona whose project is missing cannot
-    satisfy :func:`config_needs_launch_token` either and so drops out of the
+    The one-tool case of :func:`personas_not_denying`, which describes the walk
+    and the fail-closed membership rule. Being inclusive never over-blocks a
+    deploy here, since a persona whose project is missing cannot satisfy
+    :func:`config_needs_launch_token` either and so drops out of the
     intersection anyway.
 
     Args:
@@ -2290,14 +2437,4 @@ def personas_not_denying_bash(config: Any, project_root: Any) -> set[str]:
         The subset of referenced persona names whose rendered
         ``.claude/settings.json`` does not deny the shell.
     """
-    catalog, referenced = _referenced_personas(config)
-
-    permitting: set[str] = set()
-    for persona_name in sorted(referenced):
-        project_path = as_dict(catalog.get(persona_name)).get("project_path")
-        if not isinstance(project_path, str) or not project_path:
-            permitting.add(persona_name)
-            continue
-        if not settings_json_denies_bash(Path(project_root, project_path)):
-            permitting.add(persona_name)
-    return permitting
+    return personas_not_denying(config, project_root, (_BASH_DENY_ENTRY,))

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -48,8 +48,12 @@ from osprey.deployment.runtime_helper import (
 from osprey.deployment.subprocess_capture import run_captured
 from osprey.deployment.web_terminals.artifacts import (
     BashLaunchTokenConflictError,
+    OpenModeEgressError,
     bash_launch_token_offenders,
     check_bash_launch_token_conflict,
+    check_open_mode_requirements,
+    deployment_is_open,
+    open_mode_missing_by_persona,
     web_compose_file,
     write_web_terminal_artifacts,
 )
@@ -157,6 +161,10 @@ def preflight_web_terminals(config: dict, *, repo_root: Path | str | None = None
     # again — see check_bash_launch_token_conflict for why all three call sites
     # are load-bearing.
     check_bash_launch_token_conflict(config, root)
+    # Immediately after, and ahead of the same steps: an OPEN deployment whose
+    # personas can still reach the host network is refused on the same terms —
+    # before the image build, and before any credential is minted or printed.
+    check_open_mode_requirements(config, root)
     ensure_env_production(config, str(root))
     # BEFORE the mint, deliberately: a registry-mode deploy that forgot
     # auth.image is already doomed, and minting here first would write (and
@@ -193,16 +201,28 @@ def persona_render_problem(config: dict, repo_root: Path | str) -> str | None:
     ``config.yml`` (expanding ``${VAR}`` against the repo root's ``.env``), and
     neither writes a file, starts a process, or touches the container runtime.
 
-    Registry-mode deploys answer ``None`` unconditionally: nothing on this host
-    renders their persona projects, so there is no render to have a problem
-    with — the same gate :func:`preflight_web_terminals` applies.
+    Registry-mode deploys answer ``None`` unconditionally — nothing on this
+    host renders their persona projects, so there is no render to have a problem
+    with — with one deliberate exception: an OPEN deployment
+    (``auth.method: none``) is asked the question in registry mode too, because
+    it is refused without those renders anyway.
+    :func:`~osprey.deployment.web_terminals.artifacts.check_open_mode_requirements`
+    reads each persona's rendered ``.claude/settings.json`` to decide whether an
+    agent can reach the deployment's own terminals, and fails closed on an
+    artifact it cannot read — so on a pull-only host every open deployment meets
+    a refusal whose remedy (restore the deny entries and rebuild) cannot clear
+    it. Requiring the render here turns that dead end into the one problem the
+    operator can act on, and in the order they can act on it: render first
+    (``osprey build``), and the gate then reads what the render produced. Open
+    mode is therefore a render-requiring posture in both image-source modes,
+    which is the deliberate cost of gating on a shipped artifact.
 
     :param config: Raw deploy config.
     :param repo_root: The deployment repo whose ``build/`` holds the renders.
     :return: The refusal sentence, or ``None`` when every persona is usable.
     """
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
-    if effective_image_source(web_terminals) != "local":
+    if effective_image_source(web_terminals) != "local" and not deployment_is_open(config):
         return None
     facility_prefix = (config.get("facility") or {}).get("prefix") or ""
     registry_cfg = config.get("registry") or {}
@@ -380,6 +400,14 @@ def web_terminal_preflight_report(
     # and an operator reading top-down should meet it first.
     if offenders := bash_launch_token_offenders(config, root):
         findings.append((str(BashLaunchTokenConflictError(offenders)), ""))
+    # Next, in the gate's own order: an open deployment whose personas can reach
+    # its terminals is the other refusal an operator must see before being told
+    # about anything the deploy merely needs. Reported through the gate's own
+    # error, so the report an operator reads BEFORE the refusal names the one
+    # entry that is lifted rather than the whole egress set — and says "no
+    # render here" where that is the actual problem.
+    if open_missing := open_mode_missing_by_persona(config, root):
+        findings.append((str(OpenModeEgressError(open_missing)), ""))
     if (problem := users_env_generation_problem(config, root)) is not None:
         findings.append((problem, ""))
 
@@ -396,11 +424,11 @@ def web_terminal_preflight_report(
 def _provision_terminal_secrets(web_terminals: dict, repo_root: str) -> None:
     """Mint every roster user's terminal secret, then gate the deploy on it.
 
-    Runs in EVERY auth method, ``none`` included. The per-user secret nginx
+    Runs in EVERY auth method, sidecar or not. The per-user secret nginx
     stamps onto a proxied request is what lets a terminal refuse everything that
-    did not come through nginx; turning authentication off decides who may walk
-    through the front door, not whether the back ones are open. An auth-off
-    multi-user deployment is precisely the one with nothing else in the way.
+    did not come through nginx; the auth method decides who may walk through
+    the front door, not whether the back ones are open. A deployment with no
+    login wall is precisely the one with nothing else in the way.
 
     The whole roster is provisioned, ``login: false`` entries included — unlike
     the auth credentials, where such an entry has no login for a password to
@@ -414,7 +442,7 @@ def _provision_terminal_secrets(web_terminals: dict, repo_root: str) -> None:
 
     Because this runs in every auth method, so does the roster gate inside it:
     ``ensure_terminal_secrets`` refuses a name outside ``USERNAME_CHARSET_RE``
-    on an ``auth.method: none`` deployment as well, where nothing checked it
+    on a deployment without a sidecar as well, where nothing checked it
     before. That is a real tightening — ``Alice`` and ``alice.b`` are refused by
     a deploy that used to accept them — and it is the right one: the name is an
     nginx location key and a URL path segment whatever the auth method. The
@@ -496,9 +524,13 @@ def _provision_auth_secrets(web_terminals: dict, repo_root: str) -> None:
         usernames colliding onto one credential variable, both raised by
         ``ensure_auth_credentials``).
     """
-    auth_method = _auth_tls_context(web_terminals)["auth_method"]
-    if auth_method == "none":
+    auth_ctx = _auth_tls_context(web_terminals)
+    if not auth_ctx["sidecar_active"]:
+        # Everything below is the sidecar's: password hashes and the session
+        # signing secret it checks. Terminal secrets are minted for every
+        # method by _provision_terminal_secrets, not here.
         return
+    auth_method = auth_ctx["auth_method"]
 
     _warn_if_env_auth_not_gitignored(Path(repo_root))
 
@@ -608,7 +640,8 @@ def _raise_if_auth_provisioning_incomplete(
     sidecar answers every request with 503 and the whole deployment is locked
     out.
 
-    :param auth_method: The parsed ``auth.method`` (never ``"none"`` here).
+    :param auth_method: The parsed ``auth.method`` (a sidecar method — the
+        caller returns early otherwise).
     :param credentials: The :func:`ensure_auth_credentials` result, or ``None``
         when the method provisions no password hashes.
     :param secrets: The :func:`ensure_auth_session_secrets` result.
@@ -749,12 +782,12 @@ def _require_auth_sidecar_image(web_terminals: dict) -> None:
     Publishing the image is the facility CI's contract, exactly like
     ``.env.users``; OSPREY only checks that the deployment names one.
 
-    A no-op when authentication is off (no sidecar is rendered at all) and in
-    local mode (:func:`build_auth_sidecar_image` produces the tag there).
+    A no-op when no sidecar is rendered at all and in local mode
+    (:func:`build_auth_sidecar_image` produces the tag there).
 
-    :raises RuntimeError: Registry mode, authentication on, ``auth.image`` unset.
+    :raises RuntimeError: Registry mode, sidecar active, ``auth.image`` unset.
     """
-    if _auth_tls_context(web_terminals)["auth_method"] == "none":
+    if not _auth_tls_context(web_terminals)["sidecar_active"]:
         return
     if effective_image_source(web_terminals) == "local":
         return
@@ -818,7 +851,7 @@ def build_auth_sidecar_image(
 
     Three no-op cases, each deliberate:
 
-    * authentication off — no sidecar service is rendered, so nothing to build;
+    * no sidecar method — no sidecar service is rendered, so nothing to build;
     * registry mode — the image comes from ``auth.image`` (preflight already
       required it);
     * ``auth.image`` set in local mode — the deployment pinned an external
@@ -833,7 +866,7 @@ def build_auth_sidecar_image(
     """
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
     auth_ctx = _auth_tls_context(web_terminals)
-    if auth_ctx["auth_method"] == "none":
+    if not auth_ctx["sidecar_active"]:
         return
     if effective_image_source(web_terminals) != "local":
         return
@@ -920,7 +953,7 @@ def _audit_identities(config: dict) -> list[str]:
         entry["name"]
         for entry in resolve_personas(web_terminals, registry_cfg, facility_prefix, strict=False)
     ]
-    if _auth_tls_context(web_terminals)["auth_method"] != "none":
+    if _auth_tls_context(web_terminals)["sidecar_active"]:
         identities.append(AUTH_SIDECAR_AUDIT_IDENTITY)
     return identities
 

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -87,13 +87,26 @@ _LOOPBACK_BIND_HOST = "127.0.0.1"
 # an absent config value renders the same image from either side.
 _DEFAULT_NGINX_IMAGE = "nginx:1.27-alpine"
 
-#: The authentication methods this deployment can actually serve: ``none`` (no
-#: auth at all), ``password`` (OSPREY-managed scrypt hashes) and ``oidc``
-#: (Authlib client against a facility IdP). Anything else is a hard config
-#: error rather than a forward-compatible passthrough — nginx would emit the
-#: ``auth_request`` seam against a sidecar that cannot answer for that method,
-#: which does fail closed but only as an unactionable 403 on every request.
-SUPPORTED_AUTH_METHODS = ("none", "password", "oidc")
+#: The TLS seam's listener port. A literal because the template makes it one:
+#: there is no ``tls.port`` key to read, the ``443`` is spelled inside
+#: nginx.conf.j2's block gated on ``tls_enabled``. Defined here, beside the
+#: render that stamps it into the perimeter deny-list, and imported by ``lint``
+#: for its port-collision check — never restated there, since two spellings of
+#: one hard-coded listener is exactly how a collision check comes to reserve a
+#: port the template does not use.
+TLS_LISTEN_PORT = 443
+
+#: The authentication methods this deployment can actually serve: ``none``
+#: (open — every terminal is navigation-only, nginx vouches for every request),
+#: ``token`` (the default: no login wall, each user's terminal is entered once
+#: through its own ``?token=`` magic link), ``password`` (OSPREY-managed scrypt
+#: hashes) and ``oidc`` (Authlib client against a facility IdP). Anything else
+#: is a hard config error rather than a forward-compatible passthrough — nginx
+#: would emit the ``auth_request`` seam against a sidecar that cannot answer for
+#: that method, which does fail closed but only as an unactionable 403 on every
+#: request. Consumers never compare against these names: they read the derived
+#: booleans :func:`_auth_tls_context` returns beside ``auth_method``.
+SUPPORTED_AUTH_METHODS = ("none", "token", "password", "oidc")
 
 #: Port the auth sidecar listens on when ``auth.port`` is unset. Deliberately
 #: outside the per-user port families (which start at ``*_base_port`` and grow
@@ -288,8 +301,8 @@ def _secret_template_content(username: str) -> str:
     return (
         f"# Rendered by OSPREY (osprey.deployment.web_terminals.render).\n"
         f"# Injects {username}'s operator secret into requests proxied to that\n"
-        f"# user's terminal. Included only from that user's authenticated\n"
-        f"# location, so no terminal ever sees another user's secret. The value\n"
+        f"# user's terminal. Included only from that user's own /u/ location,\n"
+        f"# so no terminal ever sees another user's secret. The value\n"
         f"# is substituted by nginx's entrypoint at container start from\n"
         f"# {terminal_secret_env_var(username)}, and appears in no rendered artifact.\n"
         f"proxy_set_header {TERMINAL_SECRET_HEADER} "
@@ -341,23 +354,25 @@ def clear_nginx_templates_dir(dest: Path | str) -> list[Path]:
 
 
 def _terminal_secret_artifacts(
-    services: list[dict[str, Any]], terminal_secrets: dict[str, str], *, auth_method: str
+    services: list[dict[str, Any]], terminal_secrets: dict[str, str], *, inject_secret: bool
 ) -> dict[str, str]:
-    """Build one nginx template snippet per roster user with a GATED location.
+    """Build one nginx template snippet per roster user whose location injects one.
 
     Every roster user is CHECKED — the four refusals below cover the whole
     roster, because every user's container reads its own secret whatever the
     perimeter does with it — but only a user whose ``/u/<user>/`` location
     actually ``include``s a snippet gets one written. That is exactly the
-    predicate nginx.conf.j2 emits the include under (``auth_method != "none"
-    and not svc.login_exempt``), spelled here so the two cannot disagree.
+    predicate nginx.conf.j2 emits the include under (``inject_secret and not
+    svc.login_exempt``), spelled here character-for-character so the two cannot
+    disagree: a snippet with no include is a dead secret, an include with no
+    snippet is a proxy that refuses to start.
 
     A snippet for anyone else is a plaintext operator secret substituted into
-    the nginx container's filesystem for no reader: with authentication off
-    nginx injects no header at all (the browser reaches the app through that
-    user's own ``?token=`` exchange), and a ``login: false`` entry is served
-    ungated with the header explicitly CLEARED. Not written, so the invariant
-    the nginx ``-T`` tests reason about — every file under
+    the nginx container's filesystem for no reader: under ``token`` nginx
+    injects no header at all (the browser reaches the app through that user's
+    own ``?token=`` exchange), and a ``login: false`` entry is served ungated
+    with the header explicitly CLEARED whatever the method. Not written, so the
+    invariant the nginx ``-T`` tests reason about — every file under
     ``/etc/nginx/osprey`` is included by exactly one location — holds by
     construction rather than by luck.
 
@@ -367,12 +382,15 @@ def _terminal_secret_artifacts(
         terminal_secrets: ``{username: secret}`` as provisioned into the deploy
             ``.env``. Only the KEYS are used — a value is read solely to refuse
             an absent one, and is never rendered anywhere.
-        auth_method: The parsed ``auth.method`` (see :func:`_auth_tls_context`).
-            ``"none"`` means no location is gated, so no snippet is written.
+        inject_secret: Whether nginx injects the operator secret on the
+            non-exempt ``/u/<user>/`` locations at all — the ``inject_secret``
+            boolean of :func:`_auth_tls_context` (true for ``none``,
+            ``password`` and ``oidc``; false for ``token``). ``False`` means no
+            location includes anything, so no snippet is written.
 
     Returns:
-        ``{output-relative path: content}``, one entry per gated roster user —
-        empty when nothing is gated.
+        ``{output-relative path: content}``, one entry per injecting roster
+        user — empty when nothing injects.
 
     Raises:
         ValueError: On any of four fail-closed conditions — a roster name that
@@ -452,7 +470,7 @@ def _terminal_secret_artifacts(
     return {
         _secret_template_path(service["user"]): _secret_template_content(service["user"])
         for service in services
-        if auth_method != "none" and not service.get("login_exempt")
+        if inject_secret and not service.get("login_exempt")
     }
 
 
@@ -793,7 +811,7 @@ def render_web_terminals(
             reason ``auth_env_digest`` is. Supplying it adds one
             ``nginx/templates/secret-<user>.conf.template`` to the returned
             mapping (see :data:`NGINX_TEMPLATES_OUTPUT_DIR`) for each roster
-            user whose location is GATED — the only ones an ``include`` ever
+            user whose location INJECTS one — the only ones an ``include`` ever
             reads (see :func:`_terminal_secret_artifacts`); the three artifacts
             render byte-identically either way. **Only the keys are used.** A value is read solely to refuse an absent one — no
             secret value enters any rendered artifact, which is why the snippet
@@ -812,7 +830,7 @@ def render_web_terminals(
         ``docker-compose.web.yml``, ``nginx/nginx.conf`` and
         ``nginx/landing.html``, plus — only when ``terminal_secrets`` is
         supplied — one ``nginx/templates/secret-<user>.conf.template`` per
-        roster user with a gated location. The write seam clears that directory
+        roster user whose location injects one. The write seam clears that directory
         first (see
         :func:`clear_nginx_templates_dir`), so a decommissioned user's snippet
         cannot survive a re-render.
@@ -1096,7 +1114,7 @@ def render_web_terminals(
         )
     _check_tls_host_cert_dir(auth_tls_ctx)
     if (
-        auth_tls_ctx["auth_method"] != "none"
+        auth_tls_ctx["sidecar_active"]
         and not auth_tls_ctx["tls_enabled"]
         and not auth_tls_ctx["auth_allow_insecure_http"]
     ):
@@ -1111,12 +1129,12 @@ def render_web_terminals(
     # both are right about it, but they explain it differently and only one of
     # them applies in both postures: with a login wall the name is the
     # authorization identity (the nginx location key, the `?user=` value), which
-    # is the more urgent thing to say, so that gate gets first refusal; with
-    # `auth.method: none` it returns and the audit gate refuses the same name as
-    # a directory. Reversing these two would leave the charset gate unreachable.
-    _check_roster_charset(services, auth_tls_ctx["auth_method"])
+    # is the more urgent thing to say, so that gate gets first refusal; without
+    # a sidecar it returns and the audit gate refuses the same name as a
+    # directory. Reversing these two would leave the charset gate unreachable.
+    _check_roster_charset(services, auth_tls_ctx)
     _check_roster_audit_identities(services)
-    _check_roster_env_var_collisions(services, auth_tls_ctx["auth_method"])
+    _check_roster_env_var_collisions(services, auth_tls_ctx)
     # Parsed on every render, authenticated or not: `roles:` binds privileges
     # through the roster in every posture, and an incoherent stanza must stop
     # the deployment rather than render artifacts that bind the wrong ones.
@@ -1125,9 +1143,13 @@ def render_web_terminals(
     # Built (and refused) ahead of the Jinja pass so a roster user with no
     # operator secret stops the render before any artifact exists, rather than
     # after three of them have been produced.
+    # Keyed on `inject_secret`, exactly as nginx.conf.j2 keys the `include`
+    # that reads the snippet. The two predicates must never move apart: a
+    # snippet nobody includes is a plaintext secret in the container for no
+    # reader, and an include with no snippet stops nginx at start.
     secret_templates = (
         _terminal_secret_artifacts(
-            services, terminal_secrets, auth_method=auth_tls_ctx["auth_method"]
+            services, terminal_secrets, inject_secret=auth_tls_ctx["inject_secret"]
         )
         if terminal_secrets is not None
         else {}
@@ -1136,11 +1158,11 @@ def render_web_terminals(
     tls_enabled = auth_tls_ctx["tls_enabled"]
     # The one origin every absolute URL in this deployment is built from (see
     # _external_origin). Derived only when something actually needs it: a
-    # roster-less config with no auth has no absolute URL to build, and must
+    # roster-less config with no sidecar has no absolute URL to build, and must
     # keep rendering without a deploy.fqdn.
     external_origin = (
         _external_origin(root, nginx_port, tls_enabled=tls_enabled)
-        if services or auth_tls_ctx["auth_method"] != "none"
+        if services or auth_tls_ctx["sidecar_active"]
         else ""
     )
     landing_url = _landing_url(root, nginx_port, tls_enabled=tls_enabled) if services else ""
@@ -1164,6 +1186,47 @@ def render_web_terminals(
     bundle_path = raw_bundle_path.strip() if isinstance(raw_bundle_path, str) else ""
     mirror_path = configured_ariel_mirror_path(root)
 
+    # The open posture, and the deployment's own web ports, stamped onto every
+    # per-user container so the code an agent runs inside one can be told which
+    # ports it must not open a connection to. Both are derived HERE, from the
+    # roster this render already resolved: a process inside the container could
+    # not re-derive the set (it knows its own port and nothing about its
+    # neighbours), and a sandbox that derived its own deny-list could equally
+    # derive an empty one.
+    #
+    # `open` is the ONE posture that needs it. There the perimeter is nginx —
+    # it injects each user's operator secret on every proxied location, so
+    # anything that reaches nginx from the deploy host is already authenticated
+    # as whoever that location belongs to. Under `token`/`password`/`oidc` a
+    # caller still has to present a credential the sandbox does not hold, so
+    # there is nothing to deny and no stamp is emitted at all.
+    #
+    # The set is the nginx port plus every roster user's WEB port: the terminals
+    # and the front door, which is exactly what the injected secret opens.
+    # Companion panel families (artifact, ariel, ...) are deliberately NOT in
+    # it — they are not what nginx grants; the in-container panel proxy
+    # addresses them legitimately, and none of them fronts a terminal, an agent
+    # session, or an approval prompt, which is what this deny-list guards.
+    perimeter_open = auth_tls_ctx["open_perimeter"]
+    # The TLS seam's listener (`TLS_LISTEN_PORT`) joins the set only when
+    # `tls.enabled` is on. There nginx.conf.j2 renders `listen 443 ssl` as the
+    # SOLE content server and demotes `nginx_port` to a redirect — so a list
+    # carrying only `nginx_port` would name the door that redirects and miss the
+    # one that serves. `nginx_port` stays in either way: the redirect listener
+    # still accepts the connection, and the redirect it answers with is the map
+    # to everything else.
+    #
+    # Sorted and de-duplicated, so the rendered line is a function of the
+    # roster and not of dict iteration order — this file is diffed between
+    # deploys.
+    perimeter_deny_ports = sorted(
+        {
+            nginx_port,
+            *([TLS_LISTEN_PORT] if tls_enabled else []),
+            *(service["web"] for service in services),
+        }
+    )
+
     compose_ctx = {
         "facility_prefix": facility_prefix,
         "registry_url": registry.get("url") or "",
@@ -1172,6 +1235,16 @@ def render_web_terminals(
         "nginx_port": nginx_port,
         "landing_url": landing_url,
         "facility_timezone": facility.get("timezone") or "UTC",
+        # The navigation-only perimeter stamp (see the derivation above).
+        # `open_perimeter` is the ONE gate the template reads for it, rather
+        # than the template re-combining `inject_secret`/`sidecar_active`
+        # itself: the posture is interpreted once, in `_auth_tls_context`,
+        # exactly as the method name is.
+        "perimeter_open": perimeter_open,
+        # Rendered as the comma-separated literal the container reads back.
+        # Joined HERE so the template holds no list formatting and the
+        # separator the parser splits on is spelled in one place.
+        "perimeter_deny_ports": ",".join(str(port) for port in perimeter_deny_ports),
         "bind_host": _LOOPBACK_BIND_HOST,
         # Read defensively (as everywhere else in this module); the template
         # carries the same default, so an absent/blank value still renders the
@@ -1211,7 +1284,7 @@ def render_web_terminals(
         "facility_bundle_gid": str(facility_bundle_gid) if facility_bundle_gid is not None else "",
         # The sidecar's own audit subdir, both ends of it. Emitted
         # unconditionally, like every other key here; the template uses them
-        # only inside the block it already gates on `auth_method != "none"`,
+        # only inside the block it already gates on `sidecar_active`,
         # because a deployment with no sidecar service has nothing to mount them
         # into.
         "auth_audit_identity": AUTH_SIDECAR_AUDIT_IDENTITY,
@@ -1728,12 +1801,42 @@ def _auth_tls_context(web_terminals: dict[str, Any]) -> dict[str, Any]:
     the templates turn ``tls_enabled``/``auth_method`` into actual `listen 443
     ssl` / `auth_request` directives.
 
-    Both stanzas remain entirely optional and default to the inert posture: no
-    authentication, no TLS. Every value is read defensively (wrong-typed entries
+    Both stanzas remain entirely optional. ``tls`` defaults to off; ``auth``
+    defaults to ``token``, today's magic-link posture. Every value is read defensively (wrong-typed entries
     fall back to their default, as everywhere else in this module — lint is the
     authoritative gate on schema well-formedness) with one exception: an
     ``auth.method`` string naming a method that does not exist raises, because
     the resulting deployment would emit an auth seam nothing can answer.
+
+    The four methods and what they mean:
+
+    * ``none`` — OPEN, navigation-only. Everyone who can reach nginx is
+      trusted; nginx vouches for every request to a non-exempt terminal by
+      injecting that user's terminal secret, so the landing page needs no
+      login and no token. No sidecar.
+    * ``token`` — the DEFAULT. No login wall and no sidecar; nginx injects
+      nothing, so each terminal's own ``?token=`` -> cookie exchange is the one
+      gate and a browser passes it once per user via the minted login URL.
+    * ``password`` / ``oidc`` — a login wall: the auth sidecar answers every
+      ``auth_request`` and nginx injects the secret only behind it.
+
+    Every consumer decides on the derived booleans below rather than on the
+    method name, so a new method cannot fork a branch somebody forgot:
+
+    * ``sidecar_active`` — a sidecar service is rendered and every non-exempt
+      location carries an ``auth_request`` (``password``/``oidc``).
+    * ``inject_secret`` — nginx injects the per-user terminal secret on
+      non-exempt locations (``password``/``oidc``/``none``; NOT ``token``).
+    * ``walled`` — a login wall stands in front of the roster. Identical to
+      ``sidecar_active``; spelled separately because its readers ask a
+      different question (who has a login) than the sidecar's do.
+    * ``token_exchange`` — the browser reaches every terminal through the
+      per-user magic link (``token`` only).
+    * ``open_perimeter`` — nginx vouches for every non-exempt terminal with no
+      wall in front of it (``none`` only). Derived here rather than recombined
+      as ``inject_secret and not sidecar_active`` by each reader, because it is
+      the posture the perimeter stamp, the egress deploy gate and the lint rule
+      all key on and a second spelling of it is a second thing to get wrong.
 
     Args:
         web_terminals: The already-unwrapped ``modules.web_terminals`` dict (as
@@ -1741,7 +1844,10 @@ def _auth_tls_context(web_terminals: dict[str, Any]) -> dict[str, Any]:
 
     Returns:
         A dict with the auth keys ``auth_method`` (one of
-        :data:`SUPPORTED_AUTH_METHODS`, defaults to ``"none"``), ``auth_port``
+        :data:`SUPPORTED_AUTH_METHODS`, defaults to ``"token"``), the derived
+        booleans
+        ``sidecar_active``/``inject_secret``/``walled``/``token_exchange``/``open_perimeter``
+        described above, ``auth_port``
         (int, the sidecar's listen port), ``auth_session_lifetime`` (int
         seconds), ``auth_allow_insecure_http`` (bool), ``auth_image`` (str or
         ``None`` — required only in registry image-source mode),
@@ -1763,15 +1869,22 @@ def _auth_tls_context(web_terminals: dict[str, Any]) -> dict[str, Any]:
     oidc = as_dict(auth.get("oidc"))
 
     method = auth.get("method")
-    auth_method = method if isinstance(method, str) and method else "none"
+    auth_method = method if isinstance(method, str) and method else "token"
     if auth_method not in SUPPORTED_AUTH_METHODS:
         raise ValueError(
             f"modules.web_terminals.auth.method {auth_method!r} is not a supported "
             f"authentication method; expected one of {', '.join(SUPPORTED_AUTH_METHODS)}"
         )
+    sidecar_active = auth_method in ("password", "oidc")
 
     return {
         "auth_method": auth_method,
+        # The ONLY place the method name is interpreted; see the docstring.
+        "sidecar_active": sidecar_active,
+        "inject_secret": sidecar_active or auth_method == "none",
+        "walled": sidecar_active,
+        "token_exchange": auth_method == "token",
+        "open_perimeter": auth_method == "none",
         "auth_port": _positive_int(auth.get("port"), _DEFAULT_AUTH_PORT),
         "auth_session_lifetime": _positive_int(
             auth.get("session_lifetime"), _DEFAULT_SESSION_LIFETIME
@@ -2143,7 +2256,7 @@ def _check_roster_audit_identities(services: list[dict[str, Any]]) -> None:
         )
 
 
-def _check_roster_charset(services: list[dict[str, Any]], auth_method: str) -> None:
+def _check_roster_charset(services: list[dict[str, Any]], auth_tls_ctx: dict[str, Any]) -> None:
     """Fail-closed render gate: with authentication on, every roster name must
     match the username charset.
 
@@ -2158,9 +2271,9 @@ def _check_roster_charset(services: list[dict[str, Any]], auth_method: str) -> N
     rather than produce a seam whose meaning depends on how the sidecar's query
     parser breaks a tie.
 
-    Scoped to authentication being on, deliberately — but no longer the only
-    gate on the charset. With ``auth.method: none`` the username is a routing
-    label rather than an authorization identity, so none of the reasoning above
+    Scoped to the sidecar being active, deliberately — but no longer the only
+    gate on the charset. Without a sidecar the username is a routing label
+    rather than an authorization identity, so none of the reasoning above
     applies and this function returns; what still applies in that posture is
     that the name is a DIRECTORY, and
     :func:`_check_roster_audit_identities` refuses it there on those grounds and
@@ -2170,14 +2283,16 @@ def _check_roster_charset(services: list[dict[str, Any]], auth_method: str) -> N
 
     Args:
         services: The resolved per-user service entries (each with a ``user``).
-        auth_method: The parsed ``auth.method`` (see :func:`_auth_tls_context`).
+        auth_tls_ctx: The parsed auth context (see :func:`_auth_tls_context`);
+            ``sidecar_active`` decides, ``auth_method`` names the posture.
 
     Raises:
-        ValueError: If authentication is on and any roster name is outside the
+        ValueError: If the sidecar is active and any roster name is outside the
             charset. The message names every offender.
     """
-    if auth_method == "none":
+    if not auth_tls_ctx["sidecar_active"]:
         return
+    auth_method = auth_tls_ctx["auth_method"]
     # fullmatch, not match: `$` also matches *before* a trailing newline, so
     # `match` would accept "alice\n" — a name that then renders into an nginx
     # location key mid-directive.
@@ -2198,7 +2313,9 @@ def _check_roster_charset(services: list[dict[str, Any]], auth_method: str) -> N
         )
 
 
-def _check_roster_env_var_collisions(services: list[dict[str, Any]], auth_method: str) -> None:
+def _check_roster_env_var_collisions(
+    services: list[dict[str, Any]], auth_tls_ctx: dict[str, Any]
+) -> None:
     """Fail-closed render gate: with authentication on, no two roster names may
     share one per-user env-var suffix.
 
@@ -2216,14 +2333,16 @@ def _check_roster_env_var_collisions(services: list[dict[str, Any]], auth_method
 
     Args:
         services: The resolved per-user service entries (each with a ``user``).
-        auth_method: The parsed ``auth.method`` (see :func:`_auth_tls_context`).
+        auth_tls_ctx: The parsed auth context (see :func:`_auth_tls_context`);
+            ``sidecar_active`` decides, ``auth_method`` names the posture.
 
     Raises:
-        ValueError: If authentication is on and two or more names collide. The
+        ValueError: If the sidecar is active and two or more names collide. The
             message names each colliding group and the suffix they share.
     """
-    if auth_method == "none":
+    if not auth_tls_ctx["sidecar_active"]:
         return
+    auth_method = auth_tls_ctx["auth_method"]
     collisions = env_var_suffix_collisions([service["user"] for service in services])
     if collisions:
         detail = "; ".join(

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -977,6 +977,114 @@ def _allowlist_matches(host: str, port: int | None, scheme: str, allowlist: list
     return False
 
 
+def _normalize_ip(raw_addr: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Parse one resolved address into a comparable :mod:`ipaddress` object.
+
+    A scope id (``fe80::1%en0``, as ``getsockname`` reports it on a link-local
+    interface) is dropped and an IPv4-mapped IPv6 address (``::ffff:10.0.0.5``)
+    is unwrapped, so the two spellings of one address compare equal wherever
+    they meet.
+
+    Args:
+        raw_addr: The address string from a ``sockaddr``.
+
+    Returns:
+        The parsed address, or ``None`` when the string is not an IP literal.
+    """
+    try:
+        ip = ipaddress.ip_address(raw_addr.split("%", 1)[0])
+    except ValueError:
+        return None
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    return ip
+
+
+#: How long a probe result stands before the interfaces are re-read. A host's
+#: own addresses change on the timescale of a DHCP lease or a VPN coming up,
+#: not of a panel registration, so a minute is short enough to follow a real
+#: change and long enough that a burst of registrations pays for one probe.
+_HOST_ADDRS_TTL_SECONDS = 60.0
+
+#: ``(monotonic timestamp, addresses)`` of the last probe, or ``None`` before
+#: the first one. Monotonic because this is an age, not a wall-clock date: a
+#: clock step must not make a fresh entry look expired or an old one fresh.
+_host_addrs_cache: tuple[float, frozenset[ipaddress.IPv4Address | ipaddress.IPv6Address]] | None = (
+    None
+)
+
+
+def _host_interface_addresses() -> frozenset[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Best-effort, dependency-free discovery of this host's own addresses.
+
+    Two independent, zero-traffic probes (the idiom the loopback-chokepoint
+    e2e test uses, brought into production for panel validation):
+
+    1. ``getaddrinfo(gethostname(), None)`` — every address the host's own
+       name resolves to, which catches interfaces with no default route.
+    2. The UDP-connect trick — ``connect()`` on a ``SOCK_DGRAM`` socket only
+       makes the kernel pick a route and sends no packet, and
+       ``getsockname()`` then reports the local address that route would use.
+       Run once per family so a v6-only interface is seen too.
+
+    Either probe failing (offline host, no default route, unresolvable
+    hostname) is expected rather than exceptional, so both are wrapped: the
+    function fails OPEN with an empty set, and the loopback / link-local /
+    unspecified checks in :func:`_validate_panel_url` still apply.
+
+    The result is memoized for :data:`_HOST_ADDRS_TTL_SECONDS`. Probe 1 is a
+    name resolution with no timeout of its own — on a host whose resolver is
+    slow or unreachable it blocks for however long the system resolver takes —
+    and running that unconditionally on every registration would put an
+    unbounded stall in the request path. The cache lives INSIDE this function
+    rather than around it so that tests, which patch this module attribute
+    wholesale, replace the caching along with the probing.
+
+    Blocking (it resolves and opens sockets), so callers on the event loop run
+    it in a thread pool. It is a module attribute so tests patch it directly.
+
+    Returns:
+        The discovered addresses, normalized by :func:`_normalize_ip`.
+    """
+    global _host_addrs_cache
+
+    cached = _host_addrs_cache
+    if cached is not None and (time.monotonic() - cached[0]) < _HOST_ADDRS_TTL_SECONDS:
+        return cached[1]
+
+    addresses: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+
+    try:
+        for *_prefix, sockaddr in socket.getaddrinfo(socket.gethostname(), None):
+            ip = _normalize_ip(sockaddr[0])
+            if ip is not None:
+                addresses.add(ip)
+    except OSError:
+        pass
+
+    # RFC 5737 / RFC 3849 documentation addresses. Route selection works the
+    # same for them as for any off-link destination and no packet is sent, so
+    # nothing here depends on the destination existing — a documentation
+    # address just makes that explicit, where a real public resolver's address
+    # reads like traffic to a third party that never happens.
+    for family, destination in (
+        (socket.AF_INET, ("192.0.2.1", 80)),
+        (socket.AF_INET6, ("2001:db8::1", 80)),
+    ):
+        try:
+            with socket.socket(family, socket.SOCK_DGRAM) as probe:
+                probe.connect(destination)
+                ip = _normalize_ip(probe.getsockname()[0])
+            if ip is not None:
+                addresses.add(ip)
+        except OSError:
+            pass
+
+    resolved = frozenset(addresses)
+    _host_addrs_cache = (time.monotonic(), resolved)
+    return resolved
+
+
 async def _validate_panel_url(raw_url: str, allowlist: list[str] | None) -> str | None:
     """Validate a panel URL for SSRF-relevant categories.
 
@@ -990,17 +1098,31 @@ async def _validate_panel_url(raw_url: str, allowlist: list[str] | None) -> str 
     - Any resolved address that is loopback (127.0.0.0/8, ::1),
       link-local / cloud-metadata (169.254.0.0/16 incl. 169.254.169.254,
       fe80::/10), or unspecified (0.0.0.0/::).
+    - Any resolved address that is one of the deploy host's OWN interface
+      addresses (:func:`_host_interface_addresses`). The panel proxy fetches
+      server-side from inside the deployment, so a panel pointed at this
+      host's LAN address is a route back into the deployment's own web
+      terminals — nginx injects a per-user terminal secret on every request
+      under the ``open`` auth posture, which would make that a route into a
+      neighbour's terminal. The refusal is deliberately host-wide rather than
+      port-scoped: it costs an operator the ability to register an unrelated
+      dashboard that happens to be co-hosted with the deployment (the error
+      names the workarounds), and buys not having to trust a port number to
+      stay pointed at something other than the deployment's own front door.
     - IPv4-mapped IPv6 addresses (e.g. ``::ffff:169.254.169.254``) are
       unwrapped and then classified as their IPv4 equivalents.
 
-    Permits: ordinary private LAN ranges (10/8, 172.16/12, 192.168/16) —
-    real Grafana dashboards live there.
+    Permits: ordinary private LAN ranges (10/8, 172.16/12, 192.168/16) on
+    hosts other than this one — real Grafana dashboards live there.
 
     Out of scope: DNS rebinding *after* registration (host is validated at
-    registration time only; rebinding is a network-layer concern).
+    registration time only; rebinding is a network-layer concern); other
+    hosts inside the same deployment fleet, which are not distinguishable
+    from a genuine dashboard host from here.
 
-    ``getaddrinfo`` is executed in a thread pool so the async event loop is
-    not blocked.  Tests can mock ``socket.getaddrinfo`` directly.
+    ``getaddrinfo`` and the interface-address probes are executed in a thread
+    pool so the async event loop is not blocked.  Tests can mock
+    ``socket.getaddrinfo`` and ``_host_interface_addresses`` directly.
 
     Args:
         raw_url: The user-supplied URL to inspect.
@@ -1035,16 +1157,31 @@ async def _validate_panel_url(raw_url: str, allowlist: list[str] | None) -> str 
     if not results:
         return f"Could not resolve host: {host!r}"
 
+    # Probed lazily, and at most once per call: an address rejected by a
+    # categorical check below never reaches the own-address comparison, so the
+    # common refusals (loopback, metadata) cost no interface probe at all.
+    own_addresses: frozenset[ipaddress.IPv4Address | ipaddress.IPv6Address] | None = None
+
     for _family, _type, _proto, _canonname, sockaddr in results:
         raw_addr = sockaddr[0]
-        ip = ipaddress.ip_address(raw_addr)
-        # Unwrap IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254).
-        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
-            ip = ip.ipv4_mapped
+        ip = _normalize_ip(raw_addr)
+        if ip is None:
+            return f"Resolved address {raw_addr!r} for host {host!r} is not an IP address"
         if ip.is_loopback or ip.is_link_local or ip.is_unspecified:
             return (
                 f"Resolved address {raw_addr!r} for host {host!r} is not permitted "
                 "(loopback, link-local, cloud-metadata, or unspecified)"
+            )
+        if own_addresses is None:
+            # Fails open (empty set) when the host cannot be probed; the
+            # categorical checks above stand on their own.
+            own_addresses = await loop.run_in_executor(None, _host_interface_addresses)
+        if ip in own_addresses:
+            return (
+                f"Resolved address {raw_addr!r} for host {host!r} is the deployment "
+                "host itself; a panel proxied back into this deployment is not "
+                "permitted. Host the dashboard on another machine, or use the "
+                "deployment's landing page entries instead."
             )
 
     # Allowlist enforcement (after address validation so blocked IPs are always caught).

--- a/src/osprey/mcp_server/audit_middleware.py
+++ b/src/osprey/mcp_server/audit_middleware.py
@@ -182,6 +182,7 @@ _FALLBACK_WRITE_TOOLS: list[str] = [
     "mcp__bluesky__queue_start",
     "mcp__controls__channel_write",
     "mcp__python__execute",
+    "mcp__python__execute_file",
 ]
 
 #: The read/write tools excluded from the floor clamp. Task 1.8's drift guard
@@ -194,7 +195,7 @@ _FALLBACK_WRITE_TOOLS: list[str] = [
 #: list: the two always degrade together. A loaded write list minus this floor
 #: would clamp whatever the deployment renders as mixed, and a readonly
 #: ``execute`` would stop working under exactly the posture it exists for.
-_FALLBACK_MIXED_TOOLS: list[str] = ["mcp__python__execute"]
+_FALLBACK_MIXED_TOOLS: list[str] = ["mcp__python__execute", "mcp__python__execute_file"]
 
 #: The clamp set used whenever the render cannot be trusted.
 _FLOOR_CLAMP: frozenset[str] = frozenset(_FALLBACK_WRITE_TOOLS) - frozenset(_FALLBACK_MIXED_TOOLS)

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -26,35 +26,28 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from osprey.mcp_server.sandbox_env import scrub_sensitive_env
+from osprey.mcp_server.sandbox_env import (
+    PERIMETER_DENY_PORTS_ENV,
+    PERIMETER_MARKER_ENV,
+    scrub_sandbox_child_env,
+)
 from osprey.stores.artifact_manifest import collect_artifacts
 from osprey.utils.config import EXECUTION_METHOD_SUBPROCESS
 
 logger = logging.getLogger("osprey.mcp_server.python_executor.executor")
 
-# scrub_sensitive_env and its deny-list constants live in
-# osprey.mcp_server.sandbox_env (imported above), never here: this module and
-# the workspace sandbox (osprey.mcp_server.workspace.execution.sandbox_executor)
-# must share one deny-list rather than two that can drift.
+# The sandbox child's environment policy lives in osprey.mcp_server.sandbox_env
+# (imported above), never here. Two processes spawn agent-authored Python — this
+# module and the lighter visualization sandbox in
+# osprey.mcp_server.workspace.execution.sandbox_executor — and both must hand
+# their child the same environment, so the credential scrub, the web-terminal
+# address book and the perimeter-stamp names are defined once, there, and used
+# under that one spelling here.
 
-# The web-terminal address family, dropped from the sandbox child on top of the
-# shared credential scrub. The child's only callback surface is the
-# `save_artifact` helper the execution wrapper injects, which writes to the
-# filesystem: nothing in the child resolves a terminal URL or calls a
-# web-terminal route, so these names buy it nothing and only tell agent code
-# where a surface it must not reach is listening. OSPREY_TERMINAL_SECRET is
-# already gone via scrub_sensitive_env; dropping the whole family is still
-# right, because the rest of it (bind host, landing URL, external origin, the
-# per-user OSPREY_TERMINAL_SECRET_<USER> names) is the same address book.
-#
-# Deliberately local to this module rather than added to the shared deny-list
-# in osprey.utils.sensitive_env: that set is shared with the PTY child, and the
-# PTY child *is* the web terminal — it must keep these (see the sandbox_env
-# module docstring). This is a per-sandbox narrowing, not a credential policy.
-_WEB_TERMINAL_ENV_NAMES_TO_DROP: tuple[str, ...] = ("OSPREY_WEB_PORT",)
-#: Matched by prefix so a terminal variable added later is covered without a
-#: code change here — the same reasoning as SENSITIVE_ENV_SUFFIXES.
-_WEB_TERMINAL_ENV_PREFIXES_TO_DROP: tuple[str, ...] = ("OSPREY_TERMINAL_",)
+#: The one marker value that means "open"; anything else leaves the stamp inert.
+#: Local to the reader, not the shared module: this is how the stamp is PARSED,
+#: and the parse has exactly one call site.
+_PERIMETER_OPEN_VALUE = "open"
 
 #: The profile SOURCE zone, as repo-root-relative entries: ``profile.yml`` and
 #: everything a build reads to produce a project — the convention directories
@@ -541,6 +534,58 @@ def _in_flight_marker(control_target: str):
                 logger.warning("Could not remove the in-flight execution marker %s", path)
 
 
+def _perimeter_denied_ports(env: Mapping[str, str]) -> tuple[int, ...]:
+    """Read the navigation-only perimeter deny-list off the parent's environment.
+
+    The stamp is a pair (see :data:`PERIMETER_MARKER_ENV`): a marker naming the
+    posture and a comma-separated list of the deployment's own web ports. The
+    marker is what arms it — a deny-list without the posture that justifies it
+    means the container was rendered under a method whose perimeter still asks
+    callers for a credential, and denying ports there would only break panel
+    traffic that is entitled to them.
+
+    Parsed defensively rather than trusted: this is deployment-rendered input
+    read at execution time, and a malformed entry must narrow the guard, never
+    raise inside the run it is protecting. Unparseable and out-of-range entries
+    are skipped individually, so one bad token cannot empty an otherwise valid
+    list.
+
+    Args:
+        env: The parent process's environment (``os.environ``), read BEFORE the
+            sandbox scrub — the child never receives either name.
+
+    Returns:
+        The denied ports, de-duplicated and ascending. Empty when the marker is
+        absent or not ``"open"``, when no list is set, or when nothing in the
+        list parsed — an empty tuple is the inert value, and the sandbox
+        installs no port guard for it.
+
+    What this function returns is the deny-list, not the guard: the guard
+    itself is source rendered by the net-guard renderer and consumed via
+    ``ExecutionWrapper.perimeter_denied_ports``, which emits nothing at all for
+    an empty tuple. So the same caveat the wrapper documents applies here — the
+    ports named below are refused to code that goes through the emitted guard,
+    which is the sandbox's own socket layer and not a kernel-level boundary.
+    """
+    if (env.get(PERIMETER_MARKER_ENV) or "").strip() != _PERIMETER_OPEN_VALUE:
+        return ()
+    ports: set[int] = set()
+    for entry in (env.get(PERIMETER_DENY_PORTS_ENV) or "").split(","):
+        token = entry.strip()
+        if not token:
+            continue
+        try:
+            port = int(token)
+        except ValueError:
+            logger.warning("Ignoring non-numeric entry %r in %s", token, PERIMETER_DENY_PORTS_ENV)
+            continue
+        if 1 <= port <= 65535:
+            ports.add(port)
+        else:
+            logger.warning("Ignoring out-of-range port %d in %s", port, PERIMETER_DENY_PORTS_ENV)
+    return tuple(sorted(ports))
+
+
 async def _execute_via_local(
     code: str,
     execution_mode: str,
@@ -565,6 +610,19 @@ async def _execute_via_local(
         execution_mode=execution_mode,
         protected_roots=resolve_protected_roots(project_root, osprey_config),
         permitted_roots=resolve_permitted_roots(project_root, osprey_config),
+        # Resolved by the parent and passed down as literals, exactly like the
+        # guard roots above and for the same reason: the child is handed the
+        # boundary rather than left to work out for itself which ports it is
+        # sharing a network namespace with. Read from THIS process's
+        # environment, which is where the deployment stamped it; the sandbox's
+        # own environment carries neither name.
+        #
+        # This hands over the list only. The guard that enforces it is rendered
+        # by the net-guard renderer and consumed via
+        # `ExecutionWrapper.perimeter_denied_ports`, so it carries that
+        # renderer's caveat rather than any stronger one this module could
+        # claim.
+        perimeter_denied_ports=_perimeter_denied_ports(os.environ),
     )
     wrapped_code = wrapper.create_wrapper(code, execution_folder)
 
@@ -577,12 +635,9 @@ async def _execute_via_local(
 
     python_bin = str(resolve_agent_interpreter(project_root))
 
-    sandbox_env = scrub_sensitive_env(os.environ.copy())
-    for name in tuple(sandbox_env):
-        if name in _WEB_TERMINAL_ENV_NAMES_TO_DROP or name.startswith(
-            _WEB_TERMINAL_ENV_PREFIXES_TO_DROP
-        ):
-            sandbox_env.pop(name, None)
+    # Credential scrub plus the sandbox-only narrowing, in one shared helper, so
+    # this path and the visualization sandbox cannot drop different sets.
+    sandbox_env = scrub_sandbox_child_env(os.environ)
     # The declared mode becomes a runtime property of the subprocess: the
     # connector base class refuses writes and the EPICS connector stays on
     # the read_only gateway when this says readonly, so a readonly run cannot

--- a/src/osprey/mcp_server/sandbox_env.py
+++ b/src/osprey/mcp_server/sandbox_env.py
@@ -11,12 +11,20 @@ them the tokens anyway would let agent-run code call a write-gated endpoint
 directly, from outside the tool layer whose in-tool ``writes_enabled``
 re-check is the actual write-safety authority.
 
-The set of names to drop is not defined here. It lives in
+The set of CREDENTIAL names to drop is not defined here. It lives in
 :mod:`osprey.utils.sensitive_env`, the dependency-free leaf module that
 ``agent_runner`` also uses, so that the PTY child and the execution
 sandboxes cannot drift apart. This module only re-exports that set and wraps
 :func:`~osprey.utils.sensitive_env.strip_sensitive` under the name the
 sandboxes already import.
+
+What IS defined here is the second, sandbox-only narrowing: the web-terminal
+address book and the navigation-only perimeter stamp. Those are not credential
+policy - the PTY child that shares ``osprey.utils.sensitive_env`` *is* the web
+terminal and must keep them - but no execution sandbox has any use for them,
+and both spawn paths must drop exactly the same set. Hence
+:func:`scrub_sandbox_child_env`: one definition, used by every sandbox that
+spawns a child, so a name added for one path cannot go missing on the other.
 """
 
 from collections.abc import Mapping
@@ -27,7 +35,65 @@ from osprey.utils.sensitive_env import (
     strip_sensitive,
 )
 
-__all__ = ["SENSITIVE_ENV_EXACT", "SENSITIVE_ENV_SUFFIXES", "scrub_sensitive_env"]
+__all__ = [
+    "PERIMETER_DENY_PORTS_ENV",
+    "PERIMETER_MARKER_ENV",
+    "SANDBOX_CHILD_ENV_DROP_NAMES",
+    "SANDBOX_CHILD_ENV_DROP_PREFIXES",
+    "SENSITIVE_ENV_EXACT",
+    "SENSITIVE_ENV_SUFFIXES",
+    "WEB_TERMINAL_ENV_NAMES_TO_DROP",
+    "scrub_sandbox_child_env",
+    "scrub_sensitive_env",
+]
+
+# The web-terminal address family, dropped from every sandbox child on top of
+# the shared credential scrub. A sandbox's only callback surface is the
+# `save_artifact` helper its execution wrapper injects, which writes to the
+# filesystem: nothing in a child resolves a terminal URL or calls a web-terminal
+# route, so these names buy it nothing and only tell agent code where a surface
+# it must not reach is listening. OSPREY_TERMINAL_SECRET is already gone via
+# scrub_sensitive_env; dropping the whole family is still right, because the
+# rest of it (bind host, landing URL, external origin, the per-user
+# OSPREY_TERMINAL_SECRET_<USER> names) is the same address book.
+#
+# Deliberately NOT added to the shared deny-list in osprey.utils.sensitive_env:
+# that set is shared with the PTY child, and the PTY child *is* the web terminal
+# - it must keep these (see the module docstring). This is a per-sandbox
+# narrowing, not a credential policy.
+WEB_TERMINAL_ENV_NAMES_TO_DROP: tuple[str, ...] = ("OSPREY_WEB_PORT",)
+
+#: The navigation-only perimeter stamp, rendered onto every per-user web
+#: terminal container by the deployment's compose overlay when
+#: ``modules.web_terminals.auth.method`` is ``none``. The marker names the
+#: posture; the deny-list names the deployment's own web ports (nginx, the TLS
+#: listener when TLS is on, and every roster user's terminal), which under that
+#: posture are reachable from inside such a container as whoever owns them -
+#: nginx injects each user's operator secret, and these containers share the
+#: host network namespace.
+#:
+#: Read in the PARENT process and handed to the sandbox as a wrapper argument.
+#: They are NOT in the ``OSPREY_TERMINAL_`` family on purpose: that prefix is
+#: dropped from the child too, and a stamp the parent could not read back would
+#: be inert. The child never sees them either (they are in
+#: :data:`SANDBOX_CHILD_ENV_DROP_NAMES`) - executed code is told what it may not
+#: reach by the process that spawned it, and a sandbox that re-derived the list
+#: could equally derive an empty one.
+PERIMETER_MARKER_ENV = "OSPREY_WEB_PERIMETER"
+PERIMETER_DENY_PORTS_ENV = "OSPREY_WEB_PERIMETER_DENY_PORTS"
+
+#: Every exact name dropped from a sandbox child's environment: the web-terminal
+#: address book plus the perimeter stamp the parent has already consumed by the
+#: time the child is spawned.
+SANDBOX_CHILD_ENV_DROP_NAMES: tuple[str, ...] = (
+    *WEB_TERMINAL_ENV_NAMES_TO_DROP,
+    PERIMETER_MARKER_ENV,
+    PERIMETER_DENY_PORTS_ENV,
+)
+
+#: Matched by prefix so a terminal variable added later is covered without a
+#: code change here - the same reasoning as SENSITIVE_ENV_SUFFIXES.
+SANDBOX_CHILD_ENV_DROP_PREFIXES: tuple[str, ...] = ("OSPREY_TERMINAL_",)
 
 
 def scrub_sensitive_env(env: Mapping[str, str]) -> dict[str, str]:
@@ -42,3 +108,23 @@ def scrub_sensitive_env(env: Mapping[str, str]) -> dict[str, str]:
     ``os.environ`` may be passed directly.
     """
     return strip_sensitive(env)
+
+
+def scrub_sandbox_child_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Return the environment an agent-code execution child may be spawned with.
+
+    :func:`scrub_sensitive_env` first (the credential policy shared with the PTY
+    child), then the sandbox-only narrowing: every name in
+    :data:`SANDBOX_CHILD_ENV_DROP_NAMES` and every name starting with one of
+    :data:`SANDBOX_CHILD_ENV_DROP_PREFIXES`.
+
+    Both spawn paths - the general-purpose python executor and the lighter
+    visualization sandbox - call THIS function rather than each applying the
+    drop themselves, so a name added for one path cannot go missing on the
+    other. *env* is not mutated, so ``os.environ`` may be passed directly.
+    """
+    scrubbed = scrub_sensitive_env(env)
+    for name in tuple(scrubbed):
+        if name in SANDBOX_CHILD_ENV_DROP_NAMES or name.startswith(SANDBOX_CHILD_ENV_DROP_PREFIXES):
+            scrubbed.pop(name, None)
+    return scrubbed

--- a/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
+++ b/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-from osprey.mcp_server.sandbox_env import scrub_sensitive_env
+from osprey.mcp_server.sandbox_env import scrub_sandbox_child_env
 from osprey.services.python_executor.execution.fs_guard import (
     SANDBOX_PATCH_TARGETS,
     SANDBOX_WRITE_MODES_ONLY_TARGETS,
@@ -479,7 +479,12 @@ async def execute_sandbox_code(
     script_path.write_text(wrapped_code, encoding="utf-8")
 
     start_time = time.time()
-    sandbox_env = scrub_sensitive_env(os.environ.copy())
+    # The same environment the python-executor sandbox gets, built by the same
+    # shared helper: the credential scrub plus the web-terminal address book and
+    # the navigation-only perimeter stamp. This child renders visualizations and
+    # has no more business resolving a terminal URL — or reading the deny-list it
+    # is not the one enforcing — than the general-purpose sandbox does.
+    sandbox_env = scrub_sandbox_child_env(os.environ)
 
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -213,10 +213,22 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             "CONFIG_FILE": RENDERED_CONFIG_ENV_VALUE,
         },
         permissions_allow=[],
-        permissions_ask=["execute"],
+        # execute_file carries the same policy as execute, deliberately: it runs
+        # arbitrary Python through the same kernels and the same execution-mode
+        # gates, so a ladder that moves one and not the other (writes-off deny,
+        # mixed-posture remove_ask, headless read-only disallow) would leave the
+        # file form falling through to an interactive prompt with no gate behind
+        # it. Two explicit rules rather than one regex matcher: the hooks and the
+        # SDK's disallow engine match tool names exactly, so a regex would gate
+        # nothing there.
+        permissions_ask=["execute", "execute_file"],
         hooks_pre=[
             HookRule(
                 matcher="mcp__python__execute",
+                hooks=[_WRITES_CHECK, _APPROVAL],
+            ),
+            HookRule(
+                matcher="mcp__python__execute_file",
                 hooks=[_WRITES_CHECK, _APPROVAL],
             ),
         ],

--- a/src/osprey/services/python_executor/execution/net_guard.py
+++ b/src/osprey/services/python_executor/execution/net_guard.py
@@ -1,0 +1,262 @@
+"""Renderer for the runtime network guard emitted into executed scripts.
+
+PURPOSE: When a deployment runs with an **open navigation perimeter**
+(``auth.method: none``), nginx authenticates requests to the deployment's own
+web ports on the caller's behalf — a request arriving at one of those ports is
+credentialed as whoever owns the port, whoever made it. Executed agent code
+therefore must not originate connections to those ports: from inside the
+deployment host's network namespace such a connection would arrive at nginx
+already trusted. This module renders the guard that refuses exactly those
+connections, as source code spliced into the wrapped script ahead of user code
+(``services/python_executor/execution/wrapper.py``), sibling to ``fs_guard``.
+
+Why *emitted source* and not an importable guard: the guard runs in a spawned
+child that must not depend on osprey being importable there. Everything below
+the ``render_net_guard`` return is self-contained text — it imports only
+``socket`` and closes over nothing from the parent. The denied ports are baked
+in as literals, resolved *by the parent* from the deployment's perimeter stamp
+(``OSPREY_WEB_PERIMETER_DENY_PORTS``): a child that re-derived the set could
+equally derive an empty one.
+
+Patch surface — three entry points, and why they are enough:
+
+* ``socket.socket.connect`` and ``socket.socket.connect_ex`` — the class
+  methods every Python-level TCP connection resolves through.
+* ``socket.create_connection`` — the module-level convenience the high-level
+  clients call; patched in its own right so the refusal fires before any DNS
+  resolution rather than inside the per-address connect loop.
+
+The high-level HTTP stacks are deliberately **not** patched one by one, and
+the two funnels they split across are both rows above — neither row is
+redundant: ``urllib.request`` and ``http.client`` open their connections via
+``socket.create_connection``, while ``urllib3`` (and therefore ``requests``)
+ships its *own* ``create_connection`` that builds a socket and calls
+``sock.connect`` itself — which resolves through the ``socket.socket.connect``
+class rebind. Between the class rebind and the module-level funnel every
+Python-level client is covered; enumerating the clients themselves would go
+stale against every library added to the environment.
+
+Why the **port alone** is the criterion and the host is never inspected:
+loopback, the LAN address, and any hostname of the deployment host all reach
+the same nginx in the host network namespace, and SSH-tunnel deployments make
+the connection's apparent source indistinguishable from a local one — a host
+allowlist would be a sieve. The ports, by contrast, are osprey-allocated for
+this deployment, so refusing them toward *any* host costs only the ability to
+reach an unrelated remote service that happens to sit on an identical port
+number — accepted, and far cheaper than the hole. Non-``(host, port)`` address
+families (``AF_UNIX`` string/bytes paths, abstract sockets) carry no port and
+pass through untouched, which is what keeps ``multiprocessing`` — whose
+parent/worker plumbing runs over ``AF_UNIX`` — working under the guard in
+every mode.
+
+``connect_ex`` raises the same refusal instead of returning an errno. Its
+callers read a nonzero return as an ordinary, often transient, network
+failure — a polling loop would retry it silently and a port scanner would
+tally it as "closed" — so an errno would bury the one thing the refusal
+exists to deliver: the explanation. Raising keeps every refusal loud and
+identically worded, whichever entry point it came through.
+
+LIMIT — defense in depth, not a security boundary
+-------------------------------------------------
+Same stance as ``fs_guard``, stated rather than defended: the guard installs
+itself in the child's own namespace, restore handle
+(``_restore_net_patched_targets``) included, so code that knows it is there
+takes it down in one call — and the C ``_socket`` module underneath is left
+unpatched on purpose, as is ``importlib.reload(socket)``, either of which
+re-opens the route. ``NET_GUARDED_MODULES`` names what a static reload check
+*could* refuse, but ``socket`` is not folded into ``fs_guard.GUARDED_MODULES``:
+that set feeds ``path_policy``'s reload refusal for every execution, while the
+net guard exists only under an open perimeter — refusing ``reload(socket)`` in
+every deployment would police a guard that is usually not installed. The
+residual (a reload disarms the net guard silently where it *is* installed)
+adds nothing beyond the restore handle already in scope. What contains code
+deliberately attacking the boundary is the perimeter design itself — the
+deploy-time gate that refuses to grant shell-capable personas an open
+perimeter — not this monkeypatch.
+"""
+
+import textwrap
+from collections.abc import Iterable
+
+#: Leading text on every refusal the emitted guard raises. The wrapper's
+#: callers and the tests match refusals by this prefix, mirroring
+#: ``fs_guard``'s ``DEFAULT_DENYLIST_PREFIX`` pattern.
+NET_GUARD_REFUSAL_PREFIX = "Refused (navigation-only perimeter):"
+
+#: Modules the emitted guard rebinds names in — the analogue of
+#: ``fs_guard.GUARDED_MODULES``, exported so a static layer that chooses to
+#: refuse ``importlib.reload`` of them can consume the list. The intended
+#: consumer is the static reload check (task 3.3 / ``path_policy``'s layer),
+#: not the emitted guard itself. Deliberately NOT merged into
+#: ``fs_guard.GUARDED_MODULES`` — see the module docstring's LIMIT
+#: section for why ``reload(socket)`` stays a documented residual instead.
+NET_GUARDED_MODULES: tuple[str, ...] = ("socket",)
+
+#: Every entry point the guard rebinds, as ``(holder dotted name, attribute)``.
+#: ``socket.socket`` rows are rebound on the class (shadowing the inherited
+#: ``_socket.socket`` method); the ``socket`` row is a module-dict rebinding.
+#: The table is the single source the emitted install loop iterates, so a new
+#: entry point needs a row here and, if its holder is new, an alias in the
+#: emitted holder map — nothing else.
+_NET_PATCH_TARGETS: tuple[tuple[str, str], ...] = (
+    ("socket.socket", "connect"),
+    ("socket.socket", "connect_ex"),
+    ("socket", "create_connection"),
+)
+
+
+def render_net_guard(
+    *,
+    denied_ports: Iterable[int],
+    refusal_prefix: str | None = None,
+) -> str:
+    """Render the network guard as source code to embed in a child script.
+
+    Args:
+        denied_ports: The deployment's own web ports — every port a connection
+            from executed code must be refused toward, whatever the host.
+            Resolved by the parent from the perimeter stamp and passed as
+            literals. Must be non-empty: an empty set means no perimeter is
+            open, and the caller skips emission entirely rather than shipping
+            an inert guard (``ExecutionWrapper._get_net_guard`` does exactly
+            that).
+        refusal_prefix: Leading text on every refusal. Defaults to
+            :data:`NET_GUARD_REFUSAL_PREFIX`.
+
+    Returns:
+        Left-aligned Python source. Indent it yourself (``textwrap.indent``)
+        if it lands inside a block.
+
+    Raises:
+        ValueError: On an empty port set, a port outside 1–65535, a
+            non-integer port, or an empty ``refusal_prefix``.
+    """
+    ports: list[int] = []
+    for port in denied_ports:
+        if isinstance(port, bool) or not isinstance(port, int):
+            raise ValueError(f"denied_ports must be integers; got {port!r}")
+        if not 1 <= port <= 65535:
+            raise ValueError(f"denied_ports must be in 1..65535; got {port!r}")
+        ports.append(port)
+    if not ports:
+        raise ValueError(
+            "denied_ports must be non-empty — with nothing to deny the guard is "
+            "dead weight, and the caller skips emission instead of rendering it"
+        )
+    denied = tuple(sorted(set(ports)))
+
+    prefix = NET_GUARD_REFUSAL_PREFIX if refusal_prefix is None else refusal_prefix
+    if not prefix.strip():
+        raise ValueError("refusal_prefix must be non-empty — refusals are matched by their prefix")
+
+    ports_text = ", ".join(str(port) for port in denied)
+
+    return textwrap.dedent(
+        f'''
+        # --- OSPREY network guard (generated by render_net_guard) ------------
+        # Self-contained: imports nothing from osprey, because the child that
+        # runs this may not have osprey importable at all.
+        import operator as _osprey_net_operator
+        import socket as _osprey_net_socket
+
+        _OSPREY_NET_DENIED = frozenset({denied!r})
+        _OSPREY_NET_PORTS_TEXT = {ports_text!r}
+        _OSPREY_NET_PREFIX = {prefix!r}
+        _OSPREY_NET_TARGETS = {_NET_PATCH_TARGETS!r}
+        _OSPREY_NET_HOLDERS = {{
+            "socket": _osprey_net_socket,
+            "socket.socket": _osprey_net_socket.socket,
+        }}
+
+        # Originals, captured BEFORE the corresponding name is rebound. This is
+        # also the restore table: a name absent here was never patched.
+        _osprey_net_originals = {{}}
+
+
+        def _osprey_net_check(address):
+            """Refuse *address* when it names a denied port; return quietly otherwise.
+
+            Only ``(host, port, ...)`` sequences are judged — AF_INET's 2-tuple
+            and AF_INET6's 4-tuple both carry the port at index 1. Anything
+            else (an AF_UNIX path string or bytes, an abstract-socket name)
+            names no port and passes through. The port is coerced through
+            ``operator.index`` because the C layer accepts any ``__index__``
+            object (``numpy.int64``, a ctypes integer) wherever it accepts an
+            int — a plain ``isinstance(int)`` gate would wave a
+            ``numpy.int64`` port straight past the deny set. A value
+            ``operator.index`` cannot coerce names no port either, and the
+            real entry point rejects it on its own terms. The HOST is
+            deliberately never inspected — loopback, LAN address and hostname
+            all reach the same perimeter, so the osprey-allocated port is the
+            whole criterion.
+            """
+            if not isinstance(address, (tuple, list)) or len(address) < 2:
+                return
+            try:
+                _port = _osprey_net_operator.index(address[1])
+            except TypeError:
+                return
+            if _port in _OSPREY_NET_DENIED:
+                raise PermissionError(
+                    f"{{_OSPREY_NET_PREFIX}} connect to port {{_port}} refused. "
+                    f"This deployment runs with an open navigation perimeter: "
+                    f"requests reaching its own web ports "
+                    f"({{_OSPREY_NET_PORTS_TEXT}}) are authenticated at the "
+                    f"edge on the caller's behalf, so a connection from "
+                    f"executed code would arrive already credentialed. "
+                    f"Connections to every other port (EPICS gateways, the "
+                    f"archiver, external services) are unaffected."
+                )
+
+
+        def _osprey_net_capture(_dotted, _attr):
+            _original = getattr(_OSPREY_NET_HOLDERS[_dotted], _attr)
+            _osprey_net_originals[(_dotted, _attr)] = _original
+            return _original
+
+
+        def _osprey_net_wrap_method(_dotted, _attr):
+            _original = _osprey_net_capture(_dotted, _attr)
+
+            def _osprey_guarded_connect(self, address, *args, **kwargs):
+                _osprey_net_check(address)
+                return _original(self, address, *args, **kwargs)
+
+            return _osprey_guarded_connect
+
+
+        def _osprey_net_wrap_function(_dotted, _attr):
+            _original = _osprey_net_capture(_dotted, _attr)
+
+            def _osprey_guarded_create_connection(address, *args, **kwargs):
+                _osprey_net_check(address)
+                return _original(address, *args, **kwargs)
+
+            return _osprey_guarded_create_connection
+
+
+        def _install_net_patched_targets():
+            for _dotted, _attr in _OSPREY_NET_TARGETS:
+                _holder = _OSPREY_NET_HOLDERS[_dotted]
+                if not hasattr(_holder, _attr):
+                    # Future-proofing against a renamed stdlib entry point:
+                    # nothing to patch, nothing to restore.
+                    continue
+                if _dotted == "socket.socket":
+                    _replacement = _osprey_net_wrap_method(_dotted, _attr)
+                else:
+                    _replacement = _osprey_net_wrap_function(_dotted, _attr)
+                setattr(_holder, _attr, _replacement)
+
+
+        def _restore_net_patched_targets():
+            """Put every rebound name back. Idempotent, and safe in a finally."""
+            for (_dotted, _attr), _original in list(_osprey_net_originals.items()):
+                setattr(_OSPREY_NET_HOLDERS[_dotted], _attr, _original)
+            _osprey_net_originals.clear()
+
+
+        _install_net_patched_targets()
+        # --- end OSPREY network guard ----------------------------------------
+        '''
+    ).lstrip("\n")

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -13,6 +13,7 @@ from osprey.services.python_executor.execution.fs_guard import (
     EXECUTOR_PATCH_TARGETS,
     render_fs_guard,
 )
+from osprey.services.python_executor.execution.net_guard import render_net_guard
 from osprey.utils.logger import get_logger
 
 logger = get_logger("execution_wrapper")
@@ -213,6 +214,7 @@ class ExecutionWrapper:
         execution_mode: str = "readonly",
         protected_roots: Iterable[str | Path] = (),
         permitted_roots: Iterable[str | Path] = (),
+        perimeter_denied_ports: Iterable[int] = (),
     ):
         """
         Initialize the wrapper.
@@ -243,11 +245,26 @@ class ExecutionWrapper:
                 folder is added to this in :meth:`_get_filesystem_guard`, since
                 that is the one root the wrapper knows and the parent does not
                 until the folder exists.
+            perimeter_denied_ports: Host ports on this machine that executed code
+                may not connect to — the web ports of a deployment whose
+                perimeter authenticates on the caller's behalf, where a request
+                made from inside a terminal container would arrive already
+                credentialed as whoever owns the port. Resolved by the parent
+                (:func:`osprey.mcp_server.python_executor.executor._perimeter_denied_ports`,
+                which reads the deployment's stamp) and passed as literals for
+                the same reason ``protected_roots`` is: a child that re-derived
+                the set could equally derive an empty one. Empty — the default,
+                and what every non-open posture yields — means no ports are
+                denied and no network guard is emitted at all
+                (:meth:`_get_net_guard`); a non-empty set puts the guard in
+                front of user code in **every** execution mode, because the
+                perimeter is orthogonal to the write posture.
         """
         self.limits_validator = limits_validator
         self.execution_mode = execution_mode
         self.protected_roots = tuple(str(root) for root in protected_roots)
         self.permitted_roots = tuple(str(root) for root in permitted_roots)
+        self.perimeter_denied_ports = tuple(perimeter_denied_ports)
 
     def create_wrapper(self, user_code: str, execution_folder: Path | None = None) -> str:
         """
@@ -267,6 +284,7 @@ class ExecutionWrapper:
         limits_checking = self._get_limits_checking_monkeypatch()
         readonly_guard = self._get_readonly_guard()
         filesystem_guard = self._get_filesystem_guard(execution_folder)
+        net_guard = self._get_net_guard()
         metadata_init = self._get_metadata_init()
         save_artifact_injection = self._get_save_artifact_injection()
         output_capture_start = self._get_output_capture_start()
@@ -281,6 +299,7 @@ class ExecutionWrapper:
                 limits_checking,
                 readonly_guard,
                 filesystem_guard,
+                net_guard,
                 metadata_init,
                 save_artifact_injection,
                 output_capture_start,
@@ -791,6 +810,39 @@ if not _execution_dir.exists():
             refusal_prefix=prefix,
         ).strip()
 
+    def _get_net_guard(self) -> str:
+        """Generate the perimeter network guard; empty when no ports are denied.
+
+        Emitted in **every** execution mode, exactly like the filesystem guard
+        and deliberately unlike the readonly guard: the mode answers "may this
+        run touch the control system", while the perimeter answers "may this
+        run talk to the deployment's own web edge" — a readwrite run has human
+        approval to move a magnet, not to originate requests that nginx would
+        credential on the caller's behalf. What gates emission is solely
+        whether the parent handed this wrapper a non-empty deny-list, which
+        only an open-perimeter deployment does.
+
+        Splice position (kept deterministic by :meth:`create_wrapper`'s
+        assembly list): directly **after** the filesystem guard and before the
+        wrapper's own metadata/artifact machinery, so both guards form one
+        contiguous block installed ahead of any code that could open a
+        connection. Order between the two guards carries no dependency — they
+        patch disjoint entry points — but a fixed position keeps the emitted
+        script diffable. The readonly ``_READONLY_WRITE_TARGETS`` spawn/ctypes
+        table is untouched by this guard: multiprocessing and h5py-style
+        compute keep working in every mode, which the net-guard test suite
+        pins with a real ``Pool``.
+
+        Returns:
+            The guard source ready to splice, or ``""`` when
+            ``perimeter_denied_ports`` is empty — the renderer refuses an
+            empty set rather than emitting an inert guard, so skipping here is
+            the one honest spelling of "no perimeter is open".
+        """
+        if not self.perimeter_denied_ports:
+            return ""
+        return render_net_guard(denied_ports=self.perimeter_denied_ports).strip()
+
     def _get_metadata_init(self) -> str:
         """Initialize execution metadata tracking."""
         return textwrap.dedent(
@@ -1008,6 +1060,16 @@ if not _execution_dir.exists():
             """
             # Filesystem guard: put every patched entry point back.
             _restore_patched_targets()
+
+            # Network guard, same point for the same reason — looked up via
+            # globals() because it is only emitted when the deployment's
+            # perimeter denies ports, and this cleanup tail is shared by every
+            # wrapper. The persistence section below touches only the local
+            # filesystem, so nothing here depends on the restore; it exists so
+            # both guards come off together at a single documented point.
+            _osprey_net_restore = globals().get('_restore_net_patched_targets')
+            if _osprey_net_restore is not None:
+                _osprey_net_restore()
         """
         ).strip()
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_hook_log.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_hook_log.py
@@ -77,6 +77,7 @@ FALLBACK_WRITE_TOOLS = [
     "mcp__bluesky__queue_start",
     "mcp__controls__channel_write",
     "mcp__python__execute",
+    "mcp__python__execute_file",
 ]
 
 

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -146,6 +146,38 @@
     nginx_port: int, required
       Host port nginx publishes for the landing page + per-user redirects.
 
+    perimeter_open: bool, required
+      True only under the OPEN posture (`auth.method: none`), where nginx
+      injects every user's operator secret and so authenticates every request
+      that reaches it. Resolved by render.py from `_auth_tls_context()` —
+      this template never recombines the derived booleans itself. False
+      suppresses BOTH perimeter lines below, byte for byte, so `token`,
+      `password` and `oidc` carry no stamp at all.
+
+    perimeter_deny_ports: str, required (never empty — always contains at
+    least the nginx port)
+      The deployment's own web ports as a comma-separated, ascending list of
+      integers ("9080,9091,9092") — nginx's published port, 443 when
+      `tls.enabled` puts the real content server behind the TLS listener, and
+      every roster user's terminal port. Nothing else: companion panel families
+      are excluded because they are not what the injected secret opens, the
+      in-container panel proxy addresses them legitimately, and none of them
+      fronts a terminal, an agent session, or an approval prompt — which is
+      what this deny-list guards. Emitted as OSPREY_WEB_PERIMETER_DENY_PORTS
+      beside the OSPREY_WEB_PERIMETER=open marker, gated on `perimeter_open`.
+
+      These are LITERALS, not credentials — a port list, held by a container
+      that already knows its own port — so they travel as plain
+      `environment:` values rather than through `.env.users` (see the
+      SECRETS section below, which is about values that must not be rendered
+      into this file).
+
+      Both are read by the MCP server PROCESS in this container, which passes
+      the parsed list to the execution sandbox it spawns and drops both names
+      from that child's environment. That is the point of stamping them: the
+      sandbox is told which ports are off limits by its parent and cannot
+      re-derive, widen or empty the list for itself.
+
     landing_url: str, required when `services` is non-empty
       The fully-qualified origin browsers use to reach nginx, e.g.
       "http://als-deploy.lbl.gov:9080" (scheme + deploy host + nginx_port, no
@@ -172,10 +204,20 @@
     AUTH SIDECAR (all from render.py's `_auth_tls_context()`, the single parser
     of `modules.web_terminals.auth`/`tls` — this template re-parses nothing):
 
-    auth_method: str, required ("none" | "password" | "oidc")
-      "none" (the default posture) renders NO `auth:` service at all — the
-      whole block below is suppressed, byte for byte, so a deployment that has
-      not opted into authentication carries no login surface.
+    auth_method: str, required ("none" | "token" | "password" | "oidc";
+      defaults to "token"). Informational — the gate below reads the derived
+      boolean, never the name.
+    sidecar_active: bool, required (auth_method is "password" or "oidc")
+      False renders NO `auth:` service at all — the whole block below is
+      suppressed, byte for byte, so a deployment without a login wall ("token"
+      or "none") carries no login surface.
+    inject_secret, walled, token_exchange: bool, required
+      The other derived booleans, passed for contract symmetry with
+      nginx.conf.j2; unread here. In particular `inject_secret` is TRUE for
+      "none", which renders no sidecar service at all — the secret carrier
+      below (the templates mount, the envsubst output tmpfs, the per-user
+      `OSPREY_TERMINAL_SECRET_*` reference) is emitted unconditionally and
+      already covers that method with no gate of its own.
     auth_port: int, required
       Host port the sidecar's uvicorn binds — on `bind_host` only, exactly like
       the per-user apps. nginx (same host netns) is the only thing that reaches
@@ -486,7 +528,9 @@ services:
        base image ships no `/etc/nginx/osprey`. Without this the per-user secret
        snippets are never rendered, and nginx then dies at start on the
        unconditional `include /etc/nginx/osprey/secret-<user>.conf` every
-       authenticated location carries (nginx.conf.j2). A tmpfs, not a bind or a
+       secret-injecting location carries (nginx.conf.j2 emits it under
+       `inject_secret`, so `none` needs this directory exactly as `password`
+       and `oidc` do). A tmpfs, not a bind or a
        named volume: the content is regenerated from the mounted templates on
        every start and must never outlive the container or touch disk — the
        secret VALUES are what land here after substitution. Emitted at every
@@ -531,7 +575,7 @@ services:
    that ended `start_period: 10s`. Service key "auth" cannot collide with a
    roster user — users render as `web-<user>` — nor with nginx or any base
    docker-compose.yml service. #}
-{%- if auth_method != "none" %}
+{%- if sidecar_active %}
 
   auth:
     {#- Registry mode pins `auth.image`; local mode leaves it unset and the
@@ -700,7 +744,7 @@ services:
    role.
 
    Ungated on the method, unlike the `claims:` family above: the enclosing
-   `auth_method != "none"` around this whole service is what keeps it out of a
+   `sidecar_active` around this whole service is what keeps it out of a
    login-free deployment, and there is no method that mints a session without a
    container behind it to have been rendered. #}
 {%- for svc in services %}
@@ -790,6 +834,28 @@ services:
       - OSPREY_TERMINAL_BIND_HOST={{ bind_host }}
       - OSPREY_TERMINAL_WEB_PORT={{ svc.web }}
       - OSPREY_WEB_PORT={{ svc.web }}
+{%- if perimeter_open %}
+      {#- The navigation-only perimeter, and the ports it fronts. Under
+         `auth.method: none` nginx injects this user's operator secret on every
+         proxied location, so anything that reaches a web port from THIS host
+         is already authenticated as whoever owns it — including a request made
+         by agent-generated code running inside this very container, which
+         shares the host network namespace with every other terminal.
+
+         The MCP server process reads these two, hands the parsed port list to
+         the execution sandbox as a constructor argument, and drops both names
+         from the sandbox's own environment: the deny-list is passed DOWN, never
+         re-derived inside the sandbox — a child that derived its own could
+         equally derive an empty one.
+
+         Emitted only under the open posture. The other three methods still
+         require a credential the sandbox does not hold, so there is nothing
+         here to deny and no line is rendered. Plain `environment:` values,
+         not `.env.users` entries: a list of the ports this deployment already
+         publishes is a literal, not a secret. #}
+      - OSPREY_WEB_PERIMETER=open
+      - OSPREY_WEB_PERIMETER_DENY_PORTS={{ perimeter_deny_ports }}
+{%- endif %}
       {#- Where the telemetry store is from inside this container. The agent's
          launch derives its OTLP endpoint from `claude_code.telemetry` with the
          host chosen for the running context, and the context it would sniff

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -38,25 +38,43 @@
       Absolute paths inside the nginx container. Only read when tls_enabled
       is true; render.py already refuses to render (ValueError) if
       tls_enabled is true but either path is missing.
-    auth_method: str, required (defaults to "none")
-      When anything other than "none", emit an `auth_request` directive in
-      every proxied `/u/<user>/` location, the per-user internal target
-      location each of them subrequests, and the public `/auth/` surface the
-      sidecar serves the login flow from. When "none", nothing auth-related is
-      emitted and the plain proxy config below is the whole render.
+    auth_method: str, required ("none" | "token" | "password" | "oidc";
+      defaults to "token"). Informational here — every gate below reads the
+      derived booleans render.py computes from it, never the name.
+    sidecar_active: bool, required (auth_method is "password" or "oidc")
+      The LOGIN WALL. When true, emit an `auth_request` directive in every
+      proxied non-exempt `/u/<user>/` location, the per-user internal target
+      location each of them subrequests, the `@osprey_auth_401` handler and
+      its two maps, `absolute_redirect off`, and the public `/auth/` surface
+      the sidecar serves the login flow from. When false ("token" and
+      "none"), none of that is emitted: there is no sidecar to answer a
+      subrequest, so nothing here may pretend one could.
+    inject_secret: bool, required (auth_method is not "token")
+      The SECRET INJECTION, and a separate axis from the wall above. When
+      true, every non-exempt `/u/<user>/` location `include`s that user's
+      envsubst'd snippet, which sets `X-Osprey-Terminal-Secret` — so nginx
+      itself vouches for the request and the app needs no token exchange.
+      "none" (open, navigation-only) is exactly the combination this seam
+      exists to render: inject_secret WITHOUT sidecar_active. "token" is the
+      opposite pair — no wall and no injection — and is the only method that
+      leaves a location with the secret header CLEARED.
+    walled, token_exchange: bool, required — passed for contract symmetry
+      with the compose overlay; unread here.
       Per-service exception: a svc with `login_exempt: true` (the roster
       entry declared `login: false`) gets NO auth_request and NO internal
       verify target — it is served publicly even while auth is on. It also
-      gets neither of the two things an authenticated location gets: no
+      gets neither of the two things an injected location gets: no
       operator-secret header is injected into it, and its cookie is not cut.
       Nothing authenticated that request at the perimeter, so the app's own
       token->cookie session is the only gate left standing, and that gate
       reads a cookie the browser has to be allowed to send.
-      Both effects hang off ONE predicate — `auth_method != "none" and not
-      svc.login_exempt` — for the reason spelled out at the strip below:
-      either half alone is a broken deployment.
+      Its two halves hang off the two predicates above, each spelled with the
+      SAME `not svc.login_exempt` half: the include under `inject_secret and
+      not svc.login_exempt`, the cookie cut under `sidecar_active and not
+      svc.login_exempt`. Never gate one half of a predicate apart from the
+      other — see the strip below for what each broken pairing costs.
 
-    auth_port: int, required when auth_method != "none" (defaults to 9070)
+    auth_port: int, required when sidecar_active (defaults to 9070)
       The loopback port the auth sidecar listens on. Reached at bind_host, the
       same way every per-user app is: the sidecar shares the host network
       namespace with nginx (see docker-compose.web.yml.j2) and publishes
@@ -93,12 +111,19 @@
     * `Authorization` is cleared unconditionally. nginx never sets it on this
       path, so an arriving value is the client's; the app's own bearer tier is
       loopback traffic inside the container and never crosses this proxy.
-    * `X-Osprey-Terminal-Secret` is either INJECTED (gated locations, from that
-      user's envsubst'd snippet) or CLEARED (auth off, or `login: false`) — it
-      is never forwarded from the client.
-    * `Cookie` is either cut entirely (gated locations, which authenticate by
-      the injected header) or narrowed to that user's own `session_cookie`
-      (auth off, or `login: false`, where that cookie is the only gate left).
+    * `X-Osprey-Terminal-Secret` is either INJECTED (`inject_secret` and not
+      `login: false`, from that user's envsubst'd snippet) or CLEARED
+      ("token", or `login: false`) — it is never forwarded from the client.
+      The two are exhaustive and mutually exclusive, which is what makes the
+      name claimed exactly once in every proxying location.
+    * `Cookie` is either cut entirely (locations behind the sidecar's
+      `auth_request`, which authenticate by the injected header AND would
+      otherwise hand a container the sidecar's origin-wide session) or
+      narrowed to that user's own `session_cookie` ("token", "none", or
+      `login: false`). Under "none" the narrowed cookie travels even though
+      the secret is injected: there is no sidecar, so no origin-wide
+      `osprey_auth_session` exists to leak, and the app's own session is
+      still what carries per-user state.
       In neither case does the browser's whole jar — which names every other
       terminal it has unlocked, and the sidecar's origin-wide session — reach a
       container running agent-generated code.
@@ -172,7 +197,18 @@
   login FLOW: a browser gets past that gate by opening the user's `?token=` URL
   once (`osprey users login-url <user>`), which the app trades for its session
   cookie. See WHAT REACHES AN UPSTREAM above for what each location forwards.
-  Both features are opt-in, and each is gated independently:
+
+  `auth.method: none` is the deliberate opposite, and the one posture that is
+  genuinely open: nginx injects each non-exempt user's operator secret itself,
+  so anyone who can reach this port reaches that terminal with no token, no
+  login page and no sidecar. Nothing below softens that — the perimeter IS the
+  network the deployment sits on, which is the trade a facility makes when it
+  chooses this method. What it still refuses is a client naming ITSELF: the
+  identity headers are cleared here exactly as under "token", because no
+  sidecar answered for this request and an unchecked subject must never reach
+  a container.
+
+  The two seams are opt-in, and each is gated independently:
 
   - `tls_enabled` (default False) emits nothing. When true, the plain port
     becomes a redirect-only server and a second `listen 443 ssl` server —
@@ -180,7 +216,8 @@
     paths — becomes the sole content server. render.py refuses to render at
     all if either path is missing, so this template never has to guard against
     an incoherent pair.
-  - `auth_method` (default "none") emits nothing. When set to a real method,
+  - without `sidecar_active` ("token", the default, and "none") the login
+    wall emits nothing. When a sidecar method is set,
     every proxied `/u/<user>/` location gets an `auth_request` naming that
     user's own internal `/_osprey_auth/<user>` location, which asks the
     sidecar `GET /verify?user=<user>` over loopback. The username in that
@@ -191,6 +228,12 @@
     page at `= /`; everything else under a user prefix is gated — except a
     svc whose roster entry declared `login: false` (`svc.login_exempt`),
     which is served ungated on purpose and gets no verify target either.
+  - without `inject_secret` ("token" only) no location includes a secret
+    snippet, and every one of them CLEARS the secret header instead. When it
+    is set ("none", "password", "oidc") each non-exempt location includes its
+    own user's snippet — the one directive that names that header — so the
+    include and the clear are two arms of one exhaustive branch and no
+    location ever carries both.
 
   Fail-closed is the invariant that survives every partial state: a sidecar
   that is down, unconfigured, or answering 503 denies the subrequest, and
@@ -261,7 +304,7 @@ map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
 }
-{% if auth_method != "none" %}
+{% if sidecar_active %}
 # Is this request a browser NAVIGATION, or something a program issued?
 #
 # It decides what a denied `auth_request` looks like. A person typing a URL or
@@ -356,7 +399,7 @@ server {
     access_log /dev/stdout osprey_sanitized;
 
     root /usr/share/nginx/html;
-{%- if auth_method != "none" %}
+{%- if sidecar_active %}
 
     # Server level on purpose, so it covers EVERY redirect this server can
     # emit — the login redirect, the `/u/<user>` bookmark 301s, and whatever
@@ -392,17 +435,18 @@ server {
     # location and proxy_pass target strip /u/{{ svc.user }} before the
     # request reaches the upstream.
     location /u/{{ svc.user }}/ {
-{% if auth_method != "none" and svc.login_exempt %}
-        # Authentication is on, but this roster entry declared `login: false`:
-        # it is served to anyone who can reach this nginx, exactly as the whole
-        # deployment is when auth is off. So this location injects no operator
-        # secret — there is no authorized request here for nginx to vouch for —
-        # and it does not cut the browser's cookie outright: the app's own
+{% if inject_secret and svc.login_exempt %}
+        # This roster entry declared `login: false`, so it is opted out of
+        # whatever front door the rest of the deployment has — the login wall
+        # under "password"/"oidc", the injected secret under "none". It is
+        # served to anyone who can reach this nginx. So this location injects no
+        # operator secret — there is no request here that nginx has vouched for
+        # — and it does not cut the browser's cookie outright: the app's own
         # token->cookie session IS the gate in front of {{ svc.user }} now, and it
         # only holds if that cookie is allowed to reach the app. What it forwards
         # is that ONE cookie and nothing else; see the Cookie header below.
 {% endif -%}
-{% if auth_method != "none" and not svc.login_exempt %}
+{% if sidecar_active and not svc.login_exempt %}
         # Authentication is on (web_terminals.auth.method is "{{ auth_method }}"):
         # every request that reaches this location — page load, panel API call,
         # WebSocket handshake, SSE stream — is authorized first by the internal
@@ -449,17 +493,27 @@ server {
         # it off — the app's own API errors are its business, not the
         # perimeter's.
         error_page 401 = @osprey_auth_401;
-
+{% endif -%}
+{% if inject_secret and not svc.login_exempt %}
         # {{ svc.user }}'s operator secret — the credential that user's app
-        # authenticates every request against — injected ONLY here, bound to
-        # the gate above rather than to the deployment's shape:
+        # authenticates every request against — injected ONLY here, and only
+        # under the ONE predicate `inject_secret and not svc.login_exempt`:
         #
-        #  - The directive is emitted inside this `auth_request`-guarded branch
-        #    and nowhere else, so an ungated location does not have it at all.
-        #    A denied subrequest ends the request before the `proxy_pass`
-        #    below, so nothing that failed the gate carries the header
-        #    upstream. And because this SETS the header, a client that sends
-        #    one of its own has it overwritten rather than forwarded.
+        #  - Under "password"/"oidc" the sidecar's subrequest gate above stands
+        #    in front of this directive, so nothing that failed the gate
+        #    reaches the `proxy_pass` below and nothing unauthorized carries
+        #    the header upstream.
+        #  - Under "none" there is no gate to stand in front of it, and that is
+        #    the method's whole content: reaching this port IS the
+        #    authorization, and nginx vouches for the request so the browser
+        #    needs no `?token=` exchange. The perimeter is the network.
+        #  - Under "token" the directive is absent entirely, and the location
+        #    CLEARS the header instead (see the branch below). The two are
+        #    exhaustive, so the name is claimed by exactly one directive in
+        #    every proxying location.
+        #  - Because this SETS the header, a client that sends one of its own
+        #    has it overwritten rather than forwarded — in every method that
+        #    emits it.
         #  - The snippet is per-user: it names {{ svc.user }}'s own variable
         #    ({{ svc.terminal_secret_env }}) and no other, so no terminal is
         #    reachable with a different terminal's secret.
@@ -477,8 +531,8 @@ server {
         # the auth sidecar included.
         #
         # A missing file is a hard startup failure, which is the right way for
-        # this to break: an auth-on deployment whose secrets were never minted
-        # must not come up serving terminals that trust anything.
+        # this to break: a deployment whose secrets were never minted must not
+        # come up serving terminals that trust anything.
         include /etc/nginx/osprey/secret-{{ svc.user }}.conf;
 {% endif %}
         proxy_pass http://{{ bind_host }}:{{ svc.web }}/;
@@ -530,7 +584,7 @@ server {
         # emitted by the security perimeter itself. That is where a recurring
         # warning is most expensive: it is the one an operator learns to scroll
         # past.
-{%- if auth_method != "none" and not svc.login_exempt %}
+{%- if sidecar_active and not svc.login_exempt %}
         # Gated: the values this perimeter DID establish, from the
         # `auth_request_set` variables above. Only a gated location has an
         # authorization to speak for. Either value may be empty — the sidecar
@@ -540,10 +594,11 @@ server {
         proxy_set_header X-Osprey-Auth-Subject $osprey_auth_subject;
         proxy_set_header X-Osprey-Auth-Role $osprey_auth_role;
 
-        # The browser's cookie header stops here — gated on the SAME predicate
-        # that included the secret above, and that is the point of writing it
-        # twice: this location authenticates by the header nginx just set, so
-        # the cookie is not the credential and has no business travelling.
+        # The browser's cookie header stops here — gated on `sidecar_active`,
+        # the SIDECAR's predicate, not on the injection predicate the secret
+        # include uses. The two coincide under "password"/"oidc" and part
+        # company under "none", deliberately, because what makes the cookie
+        # unforwardable is the sidecar's session existing at all:
         #
         # One cookie jar serves this whole origin, so forwarding it would hand
         # {{ svc.user }}'s container the sidecar's `osprey_auth_session` — the
@@ -554,19 +609,45 @@ server {
         # nothing is lost: that cookie is the gate for locations which get no
         # header, and this location gets one.
         #
-        # The two halves must never be gated apart. Strip without header is a
-        # location that authenticates nothing and 401s every request; header
-        # without strip lets an unauthenticated request carry an operator's
-        # session cookie into a container.
+        # Under "none" there is no sidecar and so no `osprey_auth_session` to
+        # leak, and the app's own session still carries per-user state — so
+        # that method narrows the jar to one cookie (the branch below) rather
+        # than cutting it.
+        #
+        # Within a sidecar method the two halves must never be gated apart.
+        # Strip without header is a location that authenticates nothing and
+        # 401s every request; header without strip lets an unauthenticated
+        # request carry an operator's session cookie into a container.
         proxy_set_header Cookie "";
+{%- else %}
+{%- if inject_secret and not svc.login_exempt %}
+        # No sidecar vouched for this request; nginx itself injects this
+        # user's operator secret below. There is no authorization to speak
+        # for, so both identity names are CLEARED here rather than forwarded:
+        # forwarding would announce a subject the perimeter never checked, and
+        # leaving the names unwritten would let the client supply them itself.
 {%- else %}
         # Ungated — authentication is off, or this entry declared
         # `login: false`. There is no authorization to speak for, so both
         # identity names are CLEARED here rather than forwarded: forwarding
         # would announce a subject the perimeter never checked, and leaving the
         # names unwritten would let the client supply them itself.
+{%- endif %}
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
+{%- if inject_secret and not svc.login_exempt %}
+        # No clear for the operator-secret header here, and its absence is
+        # load-bearing rather than an omission: the `include` above already
+        # names that header in this location's table, and a second directive
+        # for one name is what makes nginx log `could not build optimal
+        # proxy_headers_hash` on every start and every reload.
+        #
+        # The client's own value is dropped all the same. nginx answers a named
+        # header from the location's table and never from the request, so the
+        # snippet's `proxy_set_header` overwrites an arriving one exactly as a
+        # clear would — this location simply claims the name by SETTING it
+        # instead of by emptying it.
+{%- else %}
         # No operator secret is injected into this location — authentication is
         # off, or this entry declared `login: false` — so the two headers that
         # carry one are handled the other way round from the gated branch above.
@@ -577,6 +658,13 @@ server {
         # credential the app trusts absolutely, which is the one thing this
         # carrier exists to make impossible.
         proxy_set_header X-Osprey-Terminal-Secret "";
+{%- endif %}
+{%- if inject_secret and not svc.login_exempt %}
+        # The jar is narrowed rather than cut, and for a different reason than
+        # the strip in the gated arm above: there is no sidecar in this
+        # posture, so no origin-wide `osprey_auth_session` to leak. The app
+        # still keeps its own per-user session, so its cookie travels below.
+{%- else %}
         # Exactly ONE cookie is forwarded: the session cookie {{ svc.user }}'s own
         # app issues. It cannot be cut — with nothing injected here, that cookie
         # IS the only gate left in front of this terminal — but the rest of the
@@ -593,6 +681,7 @@ server {
         # the perimeter and the app cannot spell it differently. An absent
         # cookie substitutes to empty, which the app reads as no credential —
         # the same answer it gives to a request that sent none.
+{%- endif %}
         proxy_set_header Cookie "{{ svc.session_cookie }}=$cookie_{{ svc.session_cookie }}";
 {%- endif %}
         proxy_buffering off;
@@ -609,7 +698,7 @@ server {
     location = /u/{{ svc.user }} {
         return 301 /u/{{ svc.user }}/;
     }
-{% if auth_method != "none" and not svc.login_exempt %}
+{% if sidecar_active and not svc.login_exempt %}
 
     # {{ svc.user }}'s own auth target — the only thing the `auth_request` above
     # can reach. There is one of these per roster user, and the `?user=` it asks
@@ -658,7 +747,7 @@ server {
     }
 {% endif -%}
 {% endfor %}
-{% if auth_method != "none" %}
+{% if sidecar_active %}
 
     # The public login surface — the ONE place under this origin that answers
     # without a session, because it is where a session comes from. Everything

--- a/tests/agent_runner/test_write_tools.py
+++ b/tests/agent_runner/test_write_tools.py
@@ -349,12 +349,11 @@ def test_read_only_blocks_extends_clone_drive(tmp_path: Path) -> None:
         )
 
 
-def test_read_only_blocks_extends_clone_extra_tools(tmp_path: Path) -> None:
-    """The hard-coded ``_EXTRA_SIDE_EFFECT_TOOLS`` (unlisted side-effect tools
-    like the python server's execute_file) must follow an extends clone with
-    the rewritten prefix: the clone launches the SAME tool module, and SDK
-    disallow matching is by exact name, so blocking mcp__python__execute_file
-    does NOT cover mcp__python2__execute_file."""
+def test_read_only_blocks_extends_clone_exec_tools(tmp_path: Path) -> None:
+    """Both python exec tools must follow an extends clone with the rewritten
+    prefix: the clone launches the SAME tool modules, and SDK disallow matching
+    is by exact name, so blocking mcp__python__execute_file does NOT cover
+    mcp__python2__execute_file."""
     (tmp_path / "config.yml").write_text(
         "claude_code:\n  servers:\n    python2:\n      extends: python\n"
     )
@@ -362,8 +361,8 @@ def test_read_only_blocks_extends_clone_extra_tools(tmp_path: Path) -> None:
     result = read_only_disallowed_tools(tmp_path)
 
     assert "mcp__python2__execute" in result  # via the shared classifier (ask)
-    assert "mcp__python2__execute_file" in result  # via the rewritten extras
-    assert "mcp__python__execute_file" in result  # template extras unchanged
+    assert "mcp__python2__execute_file" in result  # same classifier, same ask list
+    assert "mcp__python__execute_file" in result  # template unchanged
 
 
 def test_read_only_extends_override_cannot_narrow(tmp_path: Path) -> None:
@@ -510,15 +509,10 @@ def test_registry_walk_matches_shared_classifier() -> None:
 def test_extends_clone_classifies_like_template(tmp_path: Path) -> None:
     """Drift guard (extends-aware variant of the registry guard): a clone of
     each framework server must land in the read-only disallow set exactly like
-    its template with the mcp__<template>__ prefix rewritten — INCLUDING the
-    template's ``_EXTRA_SIDE_EFFECT_TOOLS`` entries (tools in no permission
-    list, e.g. python's execute_file), which the per-server classifier cannot
-    see. Compares the full production output (read_only_disallowed_tools), not
-    the classifier internals, so a blind spot in either path fails here."""
-    from osprey.agent_runner.write_tools import (
-        _EXTRA_SIDE_EFFECT_TOOLS,
-        _server_side_effect_tools,
-    )
+    its template with the mcp__<template>__ prefix rewritten. Compares the full
+    production output (read_only_disallowed_tools), not the classifier
+    internals, so a blind spot in either path fails here."""
+    from osprey.agent_runner.write_tools import _server_side_effect_tools
     from osprey.registry.mcp import FRAMEWORK_SERVERS, build_extended_server
 
     for template_name, template in FRAMEWORK_SERVERS.items():
@@ -529,9 +523,7 @@ def test_extends_clone_classifies_like_template(tmp_path: Path) -> None:
         assert clone is not None, f"extends of {template_name!r} unexpectedly rejected"
 
         old, new = f"mcp__{template_name}__", f"mcp__{clone_name}__"
-        template_surface = _server_side_effect_tools(template) + [
-            t for t in _EXTRA_SIDE_EFFECT_TOOLS if t.startswith(old)
-        ]
+        template_surface = _server_side_effect_tools(template)
         expected = {new + t[len(old) :] if t.startswith(old) else t for t in template_surface}
 
         (tmp_path / "config.yml").write_text(

--- a/tests/cli/test_claude_code_templates.py
+++ b/tests/cli/test_claude_code_templates.py
@@ -71,10 +71,18 @@ def test_mixed_read_write_tools_key_is_always_present(tmp_path):
         assert isinstance(ctx["mixed_read_write_tools"], list)
 
 
-def test_mixed_read_write_tools_names_python_execute(tmp_path):
-    """The one documented read/write-mixed tool in a default control project."""
+def test_mixed_read_write_tools_names_both_python_exec_tools(tmp_path):
+    """The documented read/write-mixed tools in a default control project.
+
+    Both python-executor tools: they run the same arbitrary Python through the
+    same kernels, so a readonly posture has to keep both reachable and let the
+    writes-check hook decide per call.
+    """
     ctx = _build_ctx(tmp_path)
-    assert ctx["mixed_read_write_tools"] == ["mcp__python__execute"]
+    assert ctx["mixed_read_write_tools"] == [
+        "mcp__python__execute",
+        "mcp__python__execute_file",
+    ]
 
 
 def test_mixed_read_write_tools_matches_the_registry_floor(tmp_path):

--- a/tests/cli/test_hook_config_render.py
+++ b/tests/cli/test_hook_config_render.py
@@ -118,7 +118,10 @@ def test_create_project_path_emits_every_key(tmp_path):
 
     assert set(config) == _EXPECTED_KEYS
     assert "mcp__python__" in config["server_prefixes"]
-    assert config["mixed_read_write_tools"] == ["mcp__python__execute"]
+    assert config["mixed_read_write_tools"] == [
+        "mcp__python__execute",
+        "mcp__python__execute_file",
+    ]
 
 
 def test_regenerate_path_emits_every_key(tmp_path):
@@ -128,7 +131,10 @@ def test_regenerate_path_emits_every_key(tmp_path):
 
     assert set(config) == _EXPECTED_KEYS
     assert "mcp__python__" in config["server_prefixes"]
-    assert config["mixed_read_write_tools"] == ["mcp__python__execute"]
+    assert config["mixed_read_write_tools"] == [
+        "mcp__python__execute",
+        "mcp__python__execute_file",
+    ]
 
 
 def test_both_render_paths_render_the_same_file(tmp_path):
@@ -171,7 +177,12 @@ def test_keys_are_unconditional_in_both_writes_states(tmp_path, writes_enabled):
     _reconfigure(project_dir, writes_enabled=writes_enabled, claude_code_servers=_MULTI_SERVER)
     config = _regenerate(manager, project_dir)
 
-    assert config["mixed_read_write_tools"] == ["mcp__python__execute", "mcp__python2__execute"]
+    assert config["mixed_read_write_tools"] == [
+        "mcp__python__execute",
+        "mcp__python__execute_file",
+        "mcp__python2__execute",
+        "mcp__python2__execute_file",
+    ]
     assert "mcp__sitectl__.*" in config["write_tools"]
     assert "mcp__sitectl__" in config["server_prefixes"]
 
@@ -230,7 +241,12 @@ def test_mixed_read_write_tools_covers_clones_and_excludes_pure_writes(tmp_path)
     config = _regenerate(manager, project_dir)
 
     mixed = config["mixed_read_write_tools"]
-    assert mixed == ["mcp__python__execute", "mcp__python2__execute"]
+    assert mixed == [
+        "mcp__python__execute",
+        "mcp__python__execute_file",
+        "mcp__python2__execute",
+        "mcp__python2__execute_file",
+    ]
     for pure_write in ("mcp__controls__channel_write", "mcp__bluesky__queue_add"):
         assert pure_write not in mixed
     assert set(mixed).issubset(set(config["write_tools"]))

--- a/tests/cli/test_profile_to_claude_contract.py
+++ b/tests/cli/test_profile_to_claude_contract.py
@@ -1166,6 +1166,149 @@ def test_mixed_posture_leaves_python_execute_unasked_and_undenied(tmp_path):
     assert validate_agent_tools_against_permissions(project) == []
 
 
+#: The two python-executor tools. They run the same arbitrary Python through the
+#: same kernels, so every posture must reach the same verdict for both.
+_EXECUTE = "mcp__python__execute"
+_EXECUTE_FILE = "mcp__python__execute_file"
+
+#: Disables the agent-declared rescue. ``pyat-specialist`` declares ``execute``
+#: (and only ``execute``) as its compute path, so with it enabled the rescue
+#: fires and with it disabled the postures are compared on the render alone.
+#: Both are exercised: the enabled render is where the two tools can come apart,
+#: because the declaration names one of them and the rescue promotes out of
+#: ``remove_ask`` — that is exactly the fall-through this pair must not have.
+_NO_PYAT = {"claude_code.agents.pyat-specialist.enabled": False}
+
+#: Where each python exec tool must land, per (posture, pyat-specialist state).
+#:
+#: * writes-off / mixed, pyat ENABLED — ``allow``. The render pulls both from
+#:   ``ask``, and the rescue puts the whole policy unit back: the agent's
+#:   declaration names ``execute`` alone (honestly — it never calls the file
+#:   form), but both share one writes-check + approval gate, so promoting only
+#:   the named one would leave ``execute_file`` in no list at all.
+#: * writes-off / mixed, pyat DISABLED — no list. Nothing rescues them, the
+#:   render steps aside, and the two runtime hooks carry the call.
+#: * all-write — ``ask``, the registry's static position, rescue or not.
+_EXPECTED_EXEC_LISTS = {
+    ("writes-off", True): {"allow"},
+    ("writes-off", False): set(),
+    ("mixed", True): {"allow"},
+    ("mixed", False): set(),
+    ("all-write", True): {"ask"},
+    ("all-write", False): {"ask"},
+}
+
+
+def _permission_lists_holding(perms: dict, tool: str) -> set[str]:
+    """Which of allow/ask/deny the rendered permissions put *tool* in."""
+    return {name for name in ("allow", "ask", "deny") if tool in perms.get(name, [])}
+
+
+@pytest.mark.parametrize("pyat_enabled", [True, False], ids=["pyat-on", "pyat-off"])
+@pytest.mark.parametrize(
+    "posture,fields",
+    [
+        (
+            "writes-off",
+            {_TYPE_KEY: _LIVE_TYPE, "control_system.writes_enabled": False, _VA_WRITES: False},
+        ),
+        (
+            "all-write",
+            {
+                _TYPE_KEY: _LIVE_TYPE,
+                "control_system.writes_enabled": True,
+                _LIVE_WRITES: True,
+                _VA_WRITES: True,
+            },
+        ),
+        (
+            "mixed",
+            {_TYPE_KEY: _LIVE_TYPE, "control_system.writes_enabled": False, _VA_WRITES: True},
+        ),
+    ],
+)
+def test_execute_file_lands_in_the_same_permission_list_as_execute(
+    tmp_path, posture, fields, pyat_enabled
+):
+    """``execute_file`` gets the same verdict as ``execute`` under every posture.
+
+    ``execute_file`` used to be in no permission list at all — not allowed, not
+    asked, not denied — which is not a policy but a fall-through: Claude Code
+    put it to an interactive prompt with no writes-check behind it, while the
+    identical ``execute`` was approval-gated. Both run arbitrary Python through
+    the same kernels and the same execution-mode gates, so the write-posture
+    ladder has to move them together, and this pins that: whichever list one
+    lands in — or none, on the postures where the render deliberately steps
+    aside and the runtime hooks carry the call — the other lands in the same one.
+
+    Run with the ``pyat-specialist`` both enabled and disabled, because the
+    enabled render is the one that can split the pair: the rescue promotes the
+    tools an enabled agent *declares* out of ``remove_ask``, and that agent
+    declares only ``execute``. Parity alone is not enough there either — both
+    tools sitting in no list would satisfy it while leaving the file form
+    prompting — so the exact expected placement is asserted from
+    ``_EXPECTED_EXEC_LISTS``.
+
+    The hook config is asserted alongside, because "in no permission list" is
+    only a decision while the writes-check hook still gates the tool; an
+    unlisted tool missing from ``write_tools`` would be ungated after all.
+    """
+    overrides = {} if pyat_enabled else _NO_PYAT
+    project = _killswitch_project(
+        tmp_path,
+        f"execute-file-{posture}-{'pyat' if pyat_enabled else 'nopyat'}",
+        {**fields, **overrides},
+    )
+
+    perms = _rendered_permissions(project)
+    assert _permission_lists_holding(perms, _EXECUTE_FILE) == _permission_lists_holding(
+        perms, _EXECUTE
+    ), f"{posture}: execute_file must share execute's permission placement, not fall through"
+
+    expected = _EXPECTED_EXEC_LISTS[(posture, pyat_enabled)]
+    for tool in (_EXECUTE, _EXECUTE_FILE):
+        assert _permission_lists_holding(perms, tool) == expected, (
+            f"{posture} (pyat_enabled={pyat_enabled}): {tool} must land in {expected or 'no list'}"
+        )
+
+    # The rescue must not have left the enabled agent declaring a tool that no
+    # permission list mentions — the build validation that would fail on it.
+    assert validate_agent_tools_against_permissions(project) == []
+
+    hook_config = json.loads(
+        (project / ".claude" / "hooks" / "hook_config.json").read_text(encoding="utf-8")
+    )
+    assert _EXECUTE_FILE in hook_config["write_tools"], (
+        f"{posture}: execute_file must stay writes-check gated in the rendered hook config"
+    )
+    assert _EXECUTE_FILE in hook_config["mixed_read_write_tools"], (
+        f"{posture}: execute_file is read/write-mixed like execute — a readonly "
+        "script must stay runnable when writes are off"
+    )
+
+
+def test_all_write_posture_asks_for_both_python_exec_tools(tmp_path):
+    """With every target armed, both exec tools are approval-gated, not prompted.
+
+    The parity test above would be satisfied by both tools being unlisted, which
+    is the very fall-through it guards against; this pins the positive half on
+    the posture where the render does take a static position.
+    """
+    project = _killswitch_project(
+        tmp_path,
+        "execute-file-armed-ask",
+        {
+            _TYPE_KEY: _LIVE_TYPE,
+            "control_system.writes_enabled": True,
+            _LIVE_WRITES: True,
+            _VA_WRITES: True,
+        },
+    )
+    ask = _rendered_permissions(project)["ask"]
+    assert _EXECUTE in ask
+    assert _EXECUTE_FILE in ask
+
+
 def test_per_connector_keys_agreeing_with_the_global_key_still_kill_switch(tmp_path):
     """Both targets disarmed, spelled out per connector: the hard deny is back.
 

--- a/tests/cli/test_users_cmd.py
+++ b/tests/cli/test_users_cmd.py
@@ -477,9 +477,25 @@ RENDERED_CONFIG_WALLED = RENDERED_CONFIG_WITH_FQDN.replace(
 )
 
 
+#: The same deployment thrown OPEN: nginx vouches for every non-exempt
+#: terminal itself, so there is no login page and no `?token=` URL either.
+RENDERED_CONFIG_OPEN = RENDERED_CONFIG_WITH_FQDN.replace(
+    "    users:\n",
+    "    auth:\n      method: none\n    users:\n",
+)
+
+
 @pytest.fixture
 def repo_with_origin(tmp_path, monkeypatch):
     root = _make_repo(tmp_path, RENDERED_CONFIG_WITH_FQDN)
+    monkeypatch.chdir(root)
+    return root
+
+
+@pytest.fixture
+def open_repo(tmp_path, monkeypatch):
+    """An `auth.method: none` deployment: open, navigation-only."""
+    root = _make_repo(tmp_path, RENDERED_CONFIG_OPEN)
     monkeypatch.chdir(root)
     return root
 
@@ -493,12 +509,12 @@ def walled_repo(tmp_path, monkeypatch):
 
 
 class TestLoginUrl:
-    """``osprey users login-url`` — the only way into an auth-off terminal.
+    """``osprey users login-url`` — the only way into a token-gated terminal.
 
-    With `auth.method: none` (the default) nginx injects no operator secret and
-    runs no login flow, so the per-user app's own gate is the only one and a
-    browser gets past it exactly once, by opening that user's `?token=` URL.
-    Nothing else in the multi-user shape hands that URL out.
+    With `auth.method: token` (the default) nginx injects no operator secret
+    and runs no login flow, so the per-user app's own gate is the only one
+    and a browser gets past it exactly once, by opening that user's `?token=`
+    URL. Nothing else in the multi-user shape hands that URL out.
     """
 
     def test_prints_the_users_own_login_url(self, cli_runner, repo_with_origin, stub_engines):
@@ -645,6 +661,27 @@ class TestLoginUrl:
         # its path rather than on the query it would have carried.)
         assert "/u/alice/" not in combined
         assert read_env(walled_repo)[ALICE_SECRET] not in combined
+
+    def test_a_user_on_an_open_deployment_is_refused_and_told_the_plain_address(
+        self, cli_runner, open_repo, stub_engines
+    ):
+        """`auth.method: none` vouches for every non-exempt terminal itself, so
+        there is neither a login page nor a `?token=` exchange to trade — the
+        refusal must name the terminal's own address, not the login page a
+        walled deployment would.
+        """
+        cli_runner.invoke(users, ["seed"])
+
+        result = cli_runner.invoke(users, ["login-url", "alice"])
+
+        assert result.exit_code != 0
+        combined = result.stdout + result.stderr
+        assert "http://dls-deploy.example.org:8080/u/alice/" in combined
+        assert "/auth/login" not in combined
+        # No live secret anywhere: refusing is the whole point. (The
+        # explanation names the `?token=` mechanism, so the URL is matched on
+        # its path rather than on the query it would have carried.)
+        assert read_env(open_repo)[ALICE_SECRET] not in combined
 
     def test_a_login_exempt_entry_still_gets_its_url_with_auth_on(
         self, cli_runner, walled_repo, stub_engines

--- a/tests/deployment/test_collect_all_preflight.py
+++ b/tests/deployment/test_collect_all_preflight.py
@@ -160,7 +160,12 @@ def _three_problem_config(root: Path) -> dict:
             "web_terminals": {
                 "enabled": True,
                 "image_source": "local",
-                "auth": {"method": "none"},
+                # `token` — today's default posture, and what this fixture has always
+                # meant: no login wall, each terminal reached through its own magic
+                # link. `none` now means OPEN, which carries a collectable problem of
+                # its own (personas that can still reach the host network), and this
+                # deployment is about the other three.
+                "auth": {"method": "token"},
                 "default_persona": "readwrite",
                 "users": [
                     {"name": "alice", "index": 0, "persona": "unrendered"},
@@ -924,3 +929,57 @@ def test_a_privileged_default_persona_is_printed_and_the_start_proceeds(
 
     assert stubbed_start == ["build_image"]
     assert "default_persona" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# The open-mode egress refusal, as the collect-all pass reports it
+# ---------------------------------------------------------------------------
+# The pass ASKS the gate's predicate rather than raising on it, so its finding is
+# built from the same per-persona answer the gate would have raised with. Asking
+# only for the offender NAMES would report every deployment against the whole
+# four-entry egress set -- and the operator whose persona lifted exactly one of
+# them would go looking for four.
+
+
+def test_the_collect_all_preflight_reports_the_open_mode_refusal(
+    tmp_path, stubbed_start, monkeypatch
+):
+    """The refusal lands in the collect-all frame, and it names the ONE entry
+    this deployment is missing rather than the whole egress set."""
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    config = _open_mode_terminal_config(tmp_path, lift="WebFetch")
+
+    with pytest.raises(UnmetPreconditionsError) as excinfo:
+        container_lifecycle._start_stack(config, [], tmp_path, detached=True)
+
+    problem = next(
+        problem
+        for problem, _remedy in excinfo.value.findings
+        if "may still reach the host network" in problem
+    )
+    headline = problem.split("\n")[0]
+    assert "'WebFetch'" in headline
+    # The three it DOES deny stay out of the headline: the report names what to
+    # restore, not what the posture requires in general.
+    assert "'Bash'" not in headline
+    assert stubbed_start == []  # nothing was built, nothing was started
+
+
+def _open_mode_terminal_config(root: Path, *, lift: str) -> dict:
+    """The rendered deployment above, opened up, with *lift* missing from one
+    persona's shipped deny list and every other persona clean."""
+    from osprey.cli.templates.claude_code import DENY_DEFAULTS
+
+    config = _open_terminal_config(root)
+    del config["modules"]["web_terminals"]["users"][1]["login"]
+    config["modules"]["web_terminals"]["auth"] = {"method": "none"}
+    for project, deny in (
+        ("readonly-app", list(DENY_DEFAULTS)),
+        ("admin-app", [entry for entry in DENY_DEFAULTS if entry != lift]),
+    ):
+        settings_dir = root / "build" / project / ".claude"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"permissions": {"deny": deny}}), encoding="utf-8"
+        )
+    return config

--- a/tests/deployment/web_terminals/test_artifacts.py
+++ b/tests/deployment/web_terminals/test_artifacts.py
@@ -8,12 +8,19 @@ import json
 import pytest
 import yaml
 
+from osprey.cli.templates.claude_code import DENY_DEFAULTS
 from osprey.deployment.web_terminals.artifacts import (
+    OPEN_MODE_EGRESS_TOOLS,
+    UNRENDERED_SETTINGS,
     ZERO_MIGRATION_OFFENDER,
     BashLaunchTokenConflictError,
+    OpenModeEgressError,
     auth_env_digest,
     bash_launch_token_offenders,
     check_bash_launch_token_conflict,
+    check_open_mode_requirements,
+    open_mode_missing_by_persona,
+    open_mode_offenders,
     write_web_terminal_artifacts,
 )
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
@@ -194,30 +201,39 @@ def test_auth_env_digest_reads_the_file_under_the_given_root(tmp_path):
 _LAUNCH_TOKEN_LINE = "BLUESKY_LAUNCH_TOKEN=${BLUESKY_LAUNCH_TOKEN:-}"
 
 
-#: The shell-relevant subset of `settings.json.j2`'s `deny_defaults` (the template also
-#: ships the playwright and context7 MCP wildcards, which no guard here reads). Every
-#: OSPREY project denies the shell unless its config removed the entry, so a persona
-#: project fixture that shipped no `.claude/settings.json` at all would be modelling a
-#: deployment that cannot exist — and would trip the Bash/launch-token conflict guard.
-_SHIPPED_DENY = ["Bash", "Edit", "WebFetch", "WebSearch"]
+#: What `settings.json.j2` actually writes into a rendered project: the template's
+#: `deny_defaults`, verbatim. Every OSPREY project denies these unless its config
+#: removed an entry, so a persona project fixture that shipped no
+#: `.claude/settings.json` at all would be modelling a deployment that cannot exist —
+#: and would trip both the Bash/launch-token conflict guard and the open-mode egress
+#: gate, each of which reads this artifact and fails closed on its absence.
+_SHIPPED_DENY = list(DENY_DEFAULTS)
 
 
 def _write_persona_project(
-    tmp_path, name: str, project_config: dict, *, denies_bash: bool = True
+    tmp_path,
+    name: str,
+    project_config: dict,
+    *,
+    denies_bash: bool = True,
+    deny: list[str] | None = None,
 ) -> str:
     """Render a persona project under *tmp_path*; return its relative project_path.
 
-    Writes both halves of what the guard reads: the `config.yml` the entitlement
-    predicates walk, and the built `.claude/settings.json` artifact the Bash check
-    reads. `denies_bash=False` renders the artifact a project whose config carried
-    `claude_code.permissions.remove_deny: ["Bash"]` would produce.
+    Writes both halves of what the guards read: the `config.yml` the entitlement
+    predicates walk, and the built `.claude/settings.json` artifact the deny checks
+    read. `denies_bash=False` renders the artifact a project whose config carried
+    `claude_code.permissions.remove_deny: ["Bash"]` would produce; `deny` sets the
+    whole list instead, for the open-mode gate, whose question is about four entries
+    rather than one.
     """
     project_dir = tmp_path / "profiles" / name
     project_dir.mkdir(parents=True)
     (project_dir / "config.yml").write_text(
         yaml.safe_dump({"project_name": name, **project_config}), encoding="utf-8"
     )
-    deny = [entry for entry in _SHIPPED_DENY if denies_bash or entry != "Bash"]
+    if deny is None:
+        deny = [entry for entry in _SHIPPED_DENY if denies_bash or entry != "Bash"]
     (project_dir / ".claude").mkdir()
     (project_dir / ".claude" / "settings.json").write_text(
         json.dumps({"permissions": {"allow": [], "deny": deny, "ask": []}}), encoding="utf-8"
@@ -839,3 +855,250 @@ def test_a_personaless_roster_armed_on_the_va_lane_alone_is_refused_by_lane(tmp_
     # The ask-only reader binds the same entry: one shared predicate, so the
     # collect-all preflight cannot clear what the raising guard refuses.
     assert bash_launch_token_offenders(config, tmp_path) == {ZERO_MIGRATION_OFFENDER}
+
+
+# ---------------------------------------------------------------------------
+# The OPEN-mode egress gate
+#
+# `auth.method: none` means nginx vouches for every terminal it proxies. An
+# agent inside one terminal reaches nginx over loopback and is indistinguishable
+# from the operator's browser, so open mode is refused unless every persona's
+# shipped settings deny the host-network egress tools the python executor's own
+# socket guard cannot cover.
+# ---------------------------------------------------------------------------
+
+#: A persona project that is entitled to no launch token at all — writes off and
+#: no bluesky server — so these tests exercise the open-mode gate alone and a
+#: failure here can never be the Bash/launch-token guard firing instead.
+_UNARMED_PROJECT: dict = {"control_system": {"writes_enabled": False}}
+
+
+def _open_roster_config(tmp_path, *, method: str = "none", deny: list[str] | None = None):
+    """A one-user roster on *method*, whose persona ships exactly *deny*."""
+    config = _config([{"name": "alice", "index": 0, "persona": "operator"}])
+    config["modules"]["web_terminals"]["auth"] = {"method": method}
+    config["modules"]["web_terminals"]["personas"] = {
+        "operator": {
+            "project": "op",
+            "project_path": _write_persona_project(
+                tmp_path, "op", _UNARMED_PROJECT, deny=deny or list(_SHIPPED_DENY)
+            ),
+        }
+    }
+    return config
+
+
+def _without(*tools: str) -> list[str]:
+    """The shipped deny list with *tools* lifted, as `remove_deny` would render it."""
+    return [entry for entry in _SHIPPED_DENY if entry not in tools]
+
+
+def test_the_open_mode_egress_tools_are_spelled_as_the_template_ships_them(tmp_path):
+    """The gate compares literal `permissions.deny` entries against the artifact
+    `settings.json.j2` writes from `deny_defaults`. A rename there that this tuple
+    did not follow would not fail loudly — it would silently stop matching, and the
+    gate would clear a persona that still holds the tool. So the subset relationship
+    is pinned rather than left to be noticed."""
+    assert set(OPEN_MODE_EGRESS_TOOLS) <= set(DENY_DEFAULTS)
+    # And it is a STRICT subset on purpose: `Edit` writes files and the context7
+    # server reaches a documentation host, neither of which is a route back to
+    # this deployment's own terminals.
+    assert set(DENY_DEFAULTS) - set(OPEN_MODE_EGRESS_TOOLS) == {
+        "Edit",
+        "mcp__plugin_context7_context7__*",
+    }
+
+
+def test_open_mode_refuses_a_persona_that_may_run_a_shell(tmp_path):
+    """The headline case. A shell reaches every port on the host, so it walks
+    straight past the executor's in-process socket guard into a neighbour's
+    terminal — which open mode hands out to anything that asks."""
+    config = _open_roster_config(tmp_path, deny=_without("Bash"))
+
+    with pytest.raises(OpenModeEgressError) as excinfo:
+        check_open_mode_requirements(config, tmp_path)
+
+    assert excinfo.value.personas == ["operator"]
+    message = str(excinfo.value)
+    assert "'operator'" in message
+    # The remedy an operator can take without touching any persona at all.
+    assert "modules.web_terminals.auth.method to 'token'" in message
+
+
+def test_open_mode_refuses_a_persona_that_lifted_only_one_web_tool(tmp_path):
+    """`Bash` is not the whole perimeter, and a gate that only asked about it would
+    clear a persona whose agent can still GET a neighbour's terminal. The refusal
+    names the one tool that is missing rather than sending the operator through all
+    four — three of which are already denied here."""
+    config = _open_roster_config(tmp_path, deny=_without("WebFetch"))
+
+    with pytest.raises(OpenModeEgressError) as excinfo:
+        check_open_mode_requirements(config, tmp_path)
+
+    assert excinfo.value.missing_by_persona == {"operator": ["WebFetch"]}
+    message = str(excinfo.value)
+    assert "may still reach the host network via 'WebFetch'." in message
+    assert "'Bash'," not in message.split("may still reach")[1].split("\n")[0]
+
+
+def test_open_mode_passes_when_every_persona_denies_the_whole_egress_set(tmp_path):
+    """The shipped default: a project rendered from `deny_defaults` denies all four,
+    so the ordinary open deployment starts. A gate that refused this would be a gate
+    nobody could satisfy without hand-editing an artifact."""
+    check_open_mode_requirements(_open_roster_config(tmp_path), tmp_path)
+
+    assert open_mode_offenders(_open_roster_config(tmp_path / "twin"), tmp_path / "twin") == set()
+
+
+@pytest.mark.parametrize("method", ["token", "password", "oidc"])
+def test_a_walled_or_token_deployment_is_not_asked_the_open_question(tmp_path, method):
+    """The gate is about what nginx vouches for, not about what a persona may run.
+    Under `token` the browser still has to present the per-user magic link, and
+    `password`/`oidc` put a login wall in front of the roster — so a persona with a
+    shell is a deliberate, documented posture there and must not be refused."""
+    config = _open_roster_config(tmp_path, method=method, deny=_without("Bash"))
+
+    check_open_mode_requirements(config, tmp_path)
+
+    assert open_mode_offenders(config, tmp_path) == set()
+
+
+def test_open_mode_fails_closed_on_a_settings_artifact_it_cannot_read(tmp_path):
+    """An unparseable artifact is not evidence of a deny. Answering "safe" here
+    would make a corrupt or truncated settings.json the easiest way through the
+    gate — and the operator would never see it happen."""
+    config = _open_roster_config(tmp_path)
+    (tmp_path / "profiles" / "op" / ".claude" / "settings.json").write_text(
+        "{ not json", encoding="utf-8"
+    )
+
+    with pytest.raises(OpenModeEgressError) as excinfo:
+        check_open_mode_requirements(config, tmp_path)
+
+    # Nothing was read, so every tool in the set is reported missing.
+    assert excinfo.value.missing_by_persona == {"operator": list(OPEN_MODE_EGRESS_TOOLS)}
+
+
+def test_open_mode_names_the_missing_render_rather_than_all_four_tools(tmp_path):
+    """A persona with no rendered project on this host fails every deny check for
+    a reason no `permissions.deny` edit can fix. Listing the four entries there
+    sends the operator to a file that is not on the disk — so that case is
+    reported as the render it actually is, with the remedy that clears it.
+
+    This is the state a registry-mode open deployment is in by default, which is
+    why `persona_render_problem` now demands the render in that mode too."""
+    config = _open_roster_config(tmp_path)
+    (tmp_path / "profiles" / "op" / ".claude" / "settings.json").unlink()
+
+    with pytest.raises(OpenModeEgressError) as excinfo:
+        check_open_mode_requirements(config, tmp_path)
+
+    assert excinfo.value.missing_by_persona == {"operator": list(UNRENDERED_SETTINGS)}
+    message = str(excinfo.value)
+    assert "'operator' has no rendered .claude/settings.json on this host" in message
+    assert "osprey build" in message
+    # The whole set is still what the deployment must eventually deny -- an
+    # unrendered persona denies nothing -- so the headline names all four.
+    assert "'Bash'" in message
+    # And the remedy no longer claims a re-pull alone clears this: what is read
+    # here is THIS host's render, in either image-source mode.
+    assert "a re-pull alone is not enough" in message
+
+
+def test_open_mode_reads_the_settings_artifact_once_per_offender(tmp_path, monkeypatch):
+    """The gate names four entries per offender off ONE read of the artifact,
+    not one roster walk per entry. Four reads of the same small JSON file per
+    persona is affordable, but it is also four chances for the walks to disagree
+    about which personas a deployment has."""
+    from osprey.deployment.web_terminals import artifacts as artifacts_module
+
+    reads: list[str] = []
+    real = artifacts_module.settings_json_deny_entries
+
+    def counted(project_dir):
+        reads.append(str(project_dir))
+        return real(project_dir)
+
+    monkeypatch.setattr(artifacts_module, "settings_json_deny_entries", counted)
+
+    assert open_mode_missing_by_persona(_open_roster_config(tmp_path), tmp_path) == {}
+    assert len(reads) == 1
+
+
+def test_open_mode_refuses_a_persona_that_denies_one_playwright_tool_by_name(tmp_path):
+    """The near miss that looks safe. The artifact is compared by EXACT entry, so
+    a persona denying `...__browser_navigate` still ships every other browser
+    tool — and any of them reaches a neighbour's terminal just as well. The
+    refusal names the wildcard, which is the entry that actually closes it."""
+    wildcard = "mcp__plugin_playwright_playwright__*"
+    config = _open_roster_config(
+        tmp_path,
+        deny=[
+            *_without(wildcard),
+            "mcp__plugin_playwright_playwright__browser_navigate",
+        ],
+    )
+
+    with pytest.raises(OpenModeEgressError) as excinfo:
+        check_open_mode_requirements(config, tmp_path)
+
+    assert excinfo.value.missing_by_persona == {"operator": [wildcard]}
+    assert f"via {wildcard!r}." in str(excinfo.value)
+
+
+def test_open_mode_binds_the_roster_entries_that_run_no_persona(tmp_path):
+    """The zero-migration path: a bare-string roster entry runs the deploy project
+    itself, so it appears in no persona set and would otherwise walk through the
+    gate untouched. Its artifact is the deploy project's own settings.json — absent
+    here, which fails closed under the sentinel name."""
+    config = _config(["alice"])
+    config["modules"]["web_terminals"]["auth"] = {"method": "none"}
+
+    with pytest.raises(OpenModeEgressError) as excinfo:
+        write_web_terminal_artifacts(config, tmp_path)
+
+    assert excinfo.value.personas == [ZERO_MIGRATION_OFFENDER]
+    assert "no persona" in str(excinfo.value)
+    # Refused BEFORE the render, so a rejected deploy leaves nothing half-written.
+    assert not (tmp_path / "build").exists()
+    # The ask-only reader binds the same entry: one shared predicate, so the
+    # collect-all preflight cannot clear what the raising gate refuses.
+    assert open_mode_offenders(config, tmp_path) == {ZERO_MIGRATION_OFFENDER}
+
+
+def test_the_render_seam_refuses_an_open_deployment_before_writing_anything(tmp_path):
+    """`force_recreate_auth_sidecar` re-renders through neither `osprey up`'s
+    preflight nor `decommission_user`, so the seam has to answer for itself — and
+    has to refuse before the first artifact lands."""
+    config = _open_roster_config(tmp_path, deny=_without("Bash"))
+
+    with pytest.raises(OpenModeEgressError):
+        write_web_terminal_artifacts(config, tmp_path)
+
+    assert not (tmp_path / "build").exists()
+
+
+def test_an_unknown_auth_method_is_not_treated_as_open(tmp_path):
+    """A method nothing supports renders no deployment at all — the render raises on
+    it and lint reports it. Reporting it here as well would give the operator a
+    second, confusing refusal about personas, and would put a raise inside the
+    ask-only reader its callers are promised will not raise."""
+    config = _open_roster_config(tmp_path, method="sso", deny=_without("Bash"))
+
+    check_open_mode_requirements(config, tmp_path)
+
+    assert open_mode_offenders(config, tmp_path) == set()
+
+
+def test_the_collect_all_preflight_reports_the_open_mode_refusal(tmp_path, monkeypatch):
+    """The gate refuses one deploy at a time; the preflight REPORT exists to say
+    everything wrong at once. It reads the same predicate without raising, so an
+    operator sees the open-mode problem in the same pass as the others."""
+    from osprey.deployment.web_terminals import provision
+
+    monkeypatch.chdir(tmp_path)
+    config = _open_roster_config(tmp_path, deny=_without("Bash"))
+
+    findings, _advisories = provision.web_terminal_preflight_report(config, repo_root=tmp_path)
+
+    assert any("may still reach the host network" in problem for problem, _ in findings)

--- a/tests/deployment/web_terminals/test_auth_method_booleans.py
+++ b/tests/deployment/web_terminals/test_auth_method_booleans.py
@@ -1,0 +1,283 @@
+"""The four auth postures, as a truth table over the booleans everything reads.
+
+``modules.web_terminals.auth.method`` has four values, and every consumer that
+used to ask ``auth_method != "none"`` now asks one of the derived booleans that
+`_auth_tls_context` computes once:
+
+======== ============== ============= ====== ============== ==============
+method   sidecar_active inject_secret walled token_exchange open_perimeter
+======== ============== ============= ====== ============== ==============
+none      no             YES           no     no             YES
+token     no             no            no     YES            no
+password  YES            YES           YES    no             no
+oidc      YES            YES           YES    no             no
+======== ============== ============= ====== ============== ==============
+
+Read down the columns and the reason for the refactor is visible: not one of
+them is the old ``auth_method != "none"``. ``inject_secret`` is true for three
+postures, ``token_exchange`` and ``open_perimeter`` for one each (a different
+one each), ``sidecar_active`` and ``walled`` for two.
+That last pair coincides by construction — render.py derives ``walled`` FROM
+``sidecar_active`` — and is spelled separately anyway because its readers ask a
+different question: the sidecar's callers ask whether a service is rendered, the
+wall's ask whether any entry has a login. ``none`` (open) injects the secret
+without a wall; ``token`` walls nothing and injects nothing, leaving each
+terminal's own magic link as the only gate. So a scheme with two values could be
+spelled as one comparison and this one cannot, which is why the table is pinned
+here rather than left implicit in the render.
+
+This module owns that table and nothing else. It does not render artifacts —
+`test_auth_off_baseline_pin.py` pins the ``token`` bytes and
+`test_nginx_auth_surface.py` pins what each posture does to nginx. What fails
+here is the semantics one layer up: a method whose booleans came out wrong, a
+default that stopped being ``token``, or a ``== "none"`` comparison that grew
+back somewhere the four-value scheme cannot reach.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osprey.deployment.web_terminals.personas import auth_is_enforced
+from osprey.deployment.web_terminals.render import (
+    SUPPORTED_AUTH_METHODS,
+    _auth_tls_context,
+)
+
+pytestmark = pytest.mark.unit
+
+#: The derived booleans, in the order the table above reads them.
+_BOOLEANS = (
+    "sidecar_active",
+    "inject_secret",
+    "walled",
+    "token_exchange",
+    "open_perimeter",
+)
+
+#: ``method -> that method's row of :data:`_BOOLEANS`.``
+_TRUTH_TABLE = {
+    "none": (False, True, False, False, True),
+    "token": (False, False, False, True, False),
+    "password": (True, True, True, False, False),
+    "oidc": (True, True, True, False, False),
+}
+
+
+def _context(web_terminals: dict[str, Any]) -> dict[str, Any]:
+    return _auth_tls_context(web_terminals)
+
+
+# ---------------------------------------------------------------------------
+# The table itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", sorted(_TRUTH_TABLE))
+def test_each_method_derives_exactly_its_row_of_the_truth_table(method: str) -> None:
+    """Every posture's four booleans at once, as one tuple comparison.
+
+    Asserted as a tuple rather than as four assertions so a failure prints the
+    whole row: when a posture is wrong it is almost never wrong in one column,
+    and the shape of the wrongness (``none`` that walls, ``token`` that injects)
+    is what names the mistake.
+    """
+    context = _context({"auth": {"method": method}})
+
+    assert tuple(context[name] for name in _BOOLEANS) == _TRUTH_TABLE[method]
+
+
+@pytest.mark.parametrize("method", sorted(_TRUTH_TABLE))
+def test_every_derived_boolean_is_a_real_bool(method: str) -> None:
+    """The booleans are consumed by Jinja ``{% if %}`` and by Python ``if``
+    alike, and both are happy with a truthy string. Every method name is a
+    non-empty string, so a "boolean" derived as the name itself — or as
+    ``auth_method if ... else ""`` — would read True in every one of those
+    conditionals. That is accidentally correct for ``password`` and ``oidc``,
+    whose row is true in three of four columns, and silently wrong for ``none``
+    and ``token``, which is exactly the pair the four-value scheme exists to
+    keep apart. Pinning the type catches it at the source rather than at the
+    seam."""
+    context = _context({"auth": {"method": method}})
+
+    for name in _BOOLEANS:
+        assert type(context[name]) is bool, f"{name} is {type(context[name])!r}, not bool"
+
+
+@pytest.mark.parametrize(
+    "web_terminals,label",
+    [
+        ({}, "no web_terminals keys at all"),
+        ({"auth": {}}, "an auth stanza with no method"),
+        ({"auth": {"method": None}}, "an explicit null method"),
+        ({"auth": {"method": ""}}, "an empty-string method"),
+        ({"auth": {"method": 7}}, "a non-string method"),
+        ({"auth": None}, "an auth key with no mapping under it"),
+    ],
+)
+def test_an_unwritten_method_is_token(web_terminals: dict[str, Any], label: str) -> None:
+    """``token`` is the default, and every way of not-writing a method reaches
+    it — including the ways a hand-edited YAML file produces by accident.
+
+    This is the safe-by-default claim: a facility that writes no ``auth`` block
+    gets the magic-link posture, never the open one. If this ever fails for one
+    of the rows, some spelling of "unset" is falling through to a different
+    posture, and the failure mode is a deployment that is open without anybody
+    having asked for it.
+    """
+    context = _context(web_terminals)
+
+    assert context["auth_method"] == "token", label
+    assert tuple(context[name] for name in _BOOLEANS) == _TRUTH_TABLE["token"], label
+
+
+def test_the_supported_methods_are_the_four_this_module_tables() -> None:
+    """The table above is only complete while these are the only four methods.
+
+    A fifth method added to `SUPPORTED_AUTH_METHODS` without a row here would
+    otherwise ship with its four booleans untested — which is exactly the
+    forked-branch failure the derived-boolean refactor exists to prevent."""
+    assert SUPPORTED_AUTH_METHODS == ("none", "token", "password", "oidc")
+    assert set(SUPPORTED_AUTH_METHODS) == set(_TRUTH_TABLE)
+
+
+def test_an_unknown_method_is_refused_by_name_with_the_supported_set() -> None:
+    """The one input `_auth_tls_context` raises on. The message must carry both
+    the rejected spelling and the full supported set: an operator who typed
+    ``basic`` needs to be told ``token`` exists, and a message that named only
+    the mistake would send them to the source to find the alternatives."""
+    with pytest.raises(ValueError) as excinfo:
+        _context({"auth": {"method": "basic"}})
+
+    message = str(excinfo.value)
+    assert "basic" in message
+    for method in SUPPORTED_AUTH_METHODS:
+        assert method in message, f"the refusal does not name {method!r}: {message}"
+
+
+# ---------------------------------------------------------------------------
+# The one boolean read from outside the render
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,enforced",
+    [
+        ("none", False),
+        ("token", False),
+        ("password", True),
+        ("oidc", True),
+    ],
+)
+def test_auth_is_enforced_reports_the_walled_boolean(method: str, enforced: bool) -> None:
+    """`auth_is_enforced` is the capability guards' name for ``walled``, and the
+    two postures without a login wall must both report False.
+
+    ``token`` is the trap: it gates each terminal behind a magic link, so it
+    feels enforced, but no entry has a login and the privileged-terminal guards
+    have to treat its terminals the way they treat ``login: false`` ones. A
+    ``token`` that reported True here would silence exactly the warning an
+    operator running a privileged unauthenticated terminal needs to see.
+    """
+    assert auth_is_enforced({"auth": {"method": method}}) is enforced
+
+
+def test_auth_is_enforced_reads_an_unparseable_stanza_as_walled() -> None:
+    """Fail-walled on the input `_auth_tls_context` raises for. The config is
+    already being rejected by lint for the unknown method; answering False here
+    would add a second, more alarming finding about a deployment that will never
+    be built."""
+    assert auth_is_enforced({"auth": {"method": "basic"}}) is True
+
+
+# ---------------------------------------------------------------------------
+# The comparison that must not grow back
+# ---------------------------------------------------------------------------
+
+_SRC = Path(__file__).resolve().parents[3] / "src" / "osprey"
+
+#: Where `_auth_tls_context` lives, and the only file allowed an exemption.
+_PARSER_MODULE = _SRC / "deployment" / "web_terminals" / "render.py"
+
+#: The templates that used to gate on the method name directly.
+_WEB_TERMINAL_TEMPLATES = _SRC / "templates" / "modules" / "web_terminals"
+
+#: ``auth_method == "none"`` in either dialect and either operand order, with or
+#: without the ``context["auth_method"]`` subscript around the name. Deliberately
+#: narrow: it matches the exact idiom the refactor removed, so a hit is a real
+#: regression rather than something that merely mentions the word.
+_NONE_COMPARISONS = (
+    re.compile(r"""auth_method["']?\]?\s*[!=]=\s*["']none["']"""),
+    re.compile(r"""["']none["']\s*[!=]=\s*[\w.]*\[?["']?auth_method"""),
+)
+
+
+def _compares_to_none(line: str) -> bool:
+    return any(pattern.search(line) for pattern in _NONE_COMPARISONS)
+
+
+def _parser_line_span() -> range:
+    """The 1-based line numbers `_auth_tls_context`'s body occupies."""
+    tree = ast.parse(_PARSER_MODULE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_auth_tls_context":
+            assert node.end_lineno is not None
+            return range(node.lineno, node.end_lineno + 1)
+    raise AssertionError(f"_auth_tls_context is no longer defined in {_PARSER_MODULE}")
+
+
+def _guarded_sources() -> list[Path]:
+    """Every shipped Python module, plus the web-terminal Jinja templates."""
+    return sorted(_SRC.rglob("*.py")) + sorted(_WEB_TERMINAL_TEMPLATES.rglob("*.j2"))
+
+
+def test_the_exemption_below_is_load_bearing() -> None:
+    """The guard's own guard: `_auth_tls_context` really does hold a
+    ``== "none"`` comparison, so the regex demonstrably matches the idiom it
+    hunts for. Without this, a typo in the pattern would make the guard pass
+    over a codebase full of the comparison it was written to forbid."""
+    lines = _PARSER_MODULE.read_text(encoding="utf-8").splitlines()
+    span = _parser_line_span()
+
+    assert any(_compares_to_none(lines[number - 1]) for number in span)
+
+
+def test_only_the_parser_compares_the_auth_method_to_none() -> None:
+    """`_auth_tls_context` is the one place the method NAME is interpreted;
+    everywhere else reads a derived boolean.
+
+    A comparison that reappears outside the parser is how the four-value scheme
+    forks a branch somebody forgot: ``!= "none"`` used to mean "walled", and
+    under the new scheme it silently means "walled OR magic-linked OR open",
+    which is true of three postures at once and correct for none of the callers.
+    The fix for a failure here is to read the boolean that names what the site
+    actually asks — ``sidecar_active``, ``inject_secret``, ``walled``,
+    ``token_exchange`` or ``open_perimeter`` — not to widen this test.
+    """
+    sources = _guarded_sources()
+    # A moved templates directory would shrink this walk to Python only, and the
+    # two files that carried the most `!= "none"` gates are Jinja.
+    assert {"nginx.conf.j2", "docker-compose.web.yml.j2"} <= {path.name for path in sources}, (
+        f"the web-terminal templates are no longer under {_WEB_TERMINAL_TEMPLATES}"
+    )
+
+    exempt = _parser_line_span()
+    offenders: list[str] = []
+
+    for path in sources:
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not _compares_to_none(line):
+                continue
+            if path == _PARSER_MODULE and number in exempt:
+                continue
+            offenders.append(f"{path.relative_to(_SRC)}:{number}: {line.strip()}")
+
+    assert not offenders, (
+        "the auth method is compared to 'none' outside `_auth_tls_context`; read a "
+        "derived boolean instead:\n" + "\n".join(offenders)
+    )

--- a/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
+++ b/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
@@ -1,23 +1,37 @@
 """The audit-and-roles feature must be INVISIBLE to a deployment that asked for
 neither authentication nor roles — except for the audit trail itself.
 
-This is the line-level pin behind that promise (PROPOSAL success criterion SC6).
-A facility whose ``modules.web_terminals`` declares ``auth.method: none`` (or no
-``auth:`` block at all) and no ``authorization:`` block must render
+This is the line-level pin behind that promise (PROPOSAL success criterion SC6),
+and it is also what makes ``auth.method: token`` the default rather than a new
+posture nobody has run. ``token`` carries what ``auth.method: none`` used to
+mean — a per-user ``?token=`` magic link, no sidecar, no injected secret — and
+it is what an absent ``auth:`` block renders. The frozen golden below is that
+posture's output, copied out of a commit that predates the four-method scheme,
+so "``token`` is today's shipped behaviour under a new name" is a claim these
+tests check byte by byte rather than a claim the PROPOSAL merely makes. That is
+the argument for defaulting to it: writing no ``auth:`` block gets a facility
+the one posture whose bytes have been pinned all along.
+
+``none`` now means *open* — navigation-only, nginx injects each user's terminal
+secret — and renders something deliberately different. Nothing in this module
+describes ``none``; its render is pinned by ``test_nginx_auth_surface.py``.
+
+So: a facility whose ``modules.web_terminals`` declares ``auth.method: token``
+(or no ``auth:`` block at all) and no ``authorization:`` block must render
 byte-for-byte what it rendered before this feature, with exactly two exceptions:
 
   1. **the audit emitters and mounts** — ``OSPREY_AUDIT_IDENTITY``,
      ``OSPREY_AUDIT_DIR`` and the per-identity ``./var/audit/<identity>`` bind,
-     which are unconditional by design: an unauthenticated deployment still
+     which are unconditional by design: a deployment with no login wall still
      records what its agents did, and a posture that only writes a trail when
      someone opted into logins would have the trail missing exactly where it is
      least supervised.
   2. **the identity-header clears** — ``proxy_set_header X-Osprey-Auth-Subject
-     ""``/``X-Osprey-Auth-Role ""`` in every proxying location. With
-     authentication off there is no sidecar to answer for a subject, so nginx
-     must claim both names anyway: a location that names neither would hand a
-     client's own ``X-Osprey-Auth-Subject: root`` straight to a terminal
-     container, which reads that header to learn who is on the other end.
+     ""``/``X-Osprey-Auth-Role ""`` in every proxying location. Under ``token``
+     there is no sidecar to answer for a subject, so nginx must claim both names
+     anyway: a location that names neither would hand a client's own
+     ``X-Osprey-Auth-Subject: root`` straight to a terminal container, which
+     reads that header to learn who is on the other end.
 
 Everything else — every port, volume, header, ``location`` block, comment and
 blank line — must be untouched, with one REPLACEMENT the feature makes rather
@@ -33,17 +47,20 @@ the three artifacts as ``render_web_terminals(EXAMPLE_CONFIG)`` produced them
 Unlike ``golden/`` proper (see ``test_golden_render.py``, which tracks today's
 output and is re-generated with every deliberate template change), this
 directory is a historical record and must NEVER be refreshed from the current
-renderer — doing so would delete the very thing being compared against and turn
-this module into a test that passes unconditionally.
+renderer — doing so would delete the very thing being compared against, turn
+this module into a test that passes unconditionally, and destroy the evidence
+that ``token`` reproduces the old ``none``.
 ``test_the_frozen_baseline_really_predates_the_feature`` exists to make that
 mistake fail loudly rather than silently.
 
 **When a hunk here fails**, the question is not "how do I widen the allowlist".
-It is: does the new line belong in an auth-off, roles-off render at all? If it
+It is: does the new line belong in a ``token``, roles-off render at all? If it
 carries authorization, a role, a claim or a login, the answer is no and the
-template is wrong. If it is a genuine third exception to SC6, add it to the
-allowlist below *and* say so in the PROPOSAL — SC6 is a promise to operators
-who never asked for any of this, and it is worth exactly as much as the list.
+template is wrong. If it is an injected terminal secret, the ``none`` work has
+leaked into ``token`` and the fix is in the template's predicate, not here. If
+it is a genuine third exception to SC6, add it to the allowlist below *and* say
+so in the PROPOSAL — SC6 is a promise to operators who never asked for any of
+this, and it is worth exactly as much as the list.
 """
 
 from __future__ import annotations
@@ -95,7 +112,7 @@ _ALLOWED_COMPOSE_LINES = Counter(
 #: The interim per-user audit bind the pre-feature render carried — mounted at
 #: the container's audit ROOT, for the executor's old refusal ledger — which the
 #: identity-addressed bind above replaces. These, and ONLY these, may vanish
-#: from the auth-off render; anything else that disappears is still a failure.
+#: from the `token` render; anything else that disappears is still a failure.
 _REPLACED_COMPOSE_LINES = frozenset(
     {
         "      # This user's refusal audit log (`var/audit/<user>/` on the host), bound",
@@ -131,9 +148,21 @@ def _baseline(name: str) -> str:
     return (_BASELINE_DIR / name).read_text().replace(_REPO_ID_SENTINEL, _rendered_repo_id())
 
 
-def _auth_off_render() -> dict[str, str]:
-    """Today's render of the SC6 shape: no ``auth:``, no ``authorization:``."""
+def _token_render() -> dict[str, str]:
+    """Today's render of the SC6 shape: no ``auth:``, no ``authorization:``.
+
+    The absent stanza is the ``token`` posture, because that is the default
+    `_auth_tls_context` supplies. The explicit spelling is
+    :func:`_explicit_token_render`, and the two are pinned equal below.
+    """
     return render_web_terminals(EXAMPLE_CONFIG)
+
+
+def _explicit_token_render() -> dict[str, str]:
+    """The same posture written out: ``auth: {method: token}``, roles off."""
+    explicit = copy.deepcopy(EXAMPLE_CONFIG)
+    explicit["modules"]["web_terminals"]["auth"] = {"method": "token"}
+    return render_web_terminals(explicit)
 
 
 def _is_comment(line: str) -> bool:
@@ -142,10 +171,17 @@ def _is_comment(line: str) -> bool:
     return not stripped or stripped.startswith("#")
 
 
-def _opcodes(name: str) -> tuple[list[str], list[str], list[tuple]]:
-    """Baseline lines, current lines, and the line-level edit script between them."""
+def _opcodes(
+    name: str, artifacts: dict[str, str] | None = None
+) -> tuple[list[str], list[str], list[tuple]]:
+    """Baseline lines, current lines, and the line-level edit script between them.
+
+    ``artifacts`` defaults to the absent-stanza render; pass the explicit-token
+    render to hold that spelling to the same frozen baseline.
+    """
+    rendered = _token_render() if artifacts is None else artifacts
     old = _baseline(name).splitlines()
-    new = _auth_off_render()[_ARTIFACTS[name]].splitlines()
+    new = rendered[_ARTIFACTS[name]].splitlines()
     return old, new, difflib.SequenceMatcher(a=old, b=new, autojunk=False).get_opcodes()
 
 
@@ -176,15 +212,40 @@ def test_the_frozen_baseline_really_predates_the_feature() -> None:
     assert "X-Osprey-Auth-Role" not in nginx
 
 
-def test_an_explicit_auth_method_none_renders_what_an_absent_auth_block_renders() -> None:
-    """SC6 names ``auth.method: none``; ``EXAMPLE_CONFIG`` omits ``auth:``
-    entirely. `_auth_tls_context` defaults the missing block to ``"none"``, so
-    the two are the same posture — pinned here rather than assumed, because if
-    they ever diverge the allowlist below would be guarding only one of them."""
-    explicit = copy.deepcopy(EXAMPLE_CONFIG)
-    explicit["modules"]["web_terminals"]["auth"] = {"method": "none"}
+def test_the_frozen_golden_holds_todays_token_bytes_under_both_spellings() -> None:
+    """Why ``token`` is the default, stated as a test rather than as an argument.
 
-    assert render_web_terminals(explicit) == _auth_off_render()
+    ``EXAMPLE_CONFIG`` omits ``auth:`` entirely, and `_auth_tls_context` defaults
+    the missing block to ``"token"`` — so the first assertion is that the written
+    and the defaulted spelling are one posture, not two. It is pinned rather than
+    assumed because everything else in this module renders the DEFAULTED
+    spelling: if the two ever forked, the whole allowlist would be guarding only
+    one of them.
+
+    The loop then holds the EXPLICIT spelling to the frozen pre-feature golden
+    through the same allowlist, which proves one direction only — that this
+    render ADDS nothing beyond the two SC6 exceptions.
+    `test_no_pre_feature_line_is_removed_or_reworded` supplies the other
+    direction (nothing is removed or reworded) for the defaulted spelling, and
+    the asserted equality above is what extends that half to this one.
+
+    Together they say the golden is unchanged. It was copied out of a commit
+    where the only posture that could produce it was ``auth.method: none`` — so
+    the bytes ``none`` shipped are the bytes ``token`` renders, and defaulting
+    the absent stanza to ``token`` hands a facility a posture that has been
+    running all along.
+
+    When this fails, read WHICH half failed. A failed equality means the
+    explicit and defaulted paths through `_auth_tls_context` have forked. A
+    failed loop means the ``token`` render grew a line — most likely because
+    ``none``'s open-mode secret injection reached a branch that is not gated on
+    ``inject_secret``, which is a bug in the template, not in this pin.
+    """
+    explicit = _explicit_token_render()
+    assert explicit == _token_render()
+
+    for name in _ARTIFACTS:
+        _assert_added_directives_are_exactly_allowed(name, explicit)
 
 
 def test_no_pre_feature_line_is_removed_or_reworded() -> None:
@@ -202,7 +263,7 @@ def test_no_pre_feature_line_is_removed_or_reworded() -> None:
             if tag in ("delete", "replace") and not set(old[i1:i2]) <= replaceable
         ]
         assert not lost, (
-            f"{name}: the auth-off render no longer contains lines the pre-feature "
+            f"{name}: the `token` render no longer contains lines the pre-feature "
             f"render had. SC6 permits additions only: {lost}"
         )
 
@@ -210,7 +271,7 @@ def test_no_pre_feature_line_is_removed_or_reworded() -> None:
 def test_landing_page_is_byte_identical_to_the_pre_feature_render() -> None:
     """The strictest form of SC6, available for the one artifact with no
     exception: an operator's landing page must not have moved by one byte."""
-    assert _auth_off_render()["nginx/landing.html"] == _baseline("landing.html")
+    assert _token_render()["nginx/landing.html"] == _baseline("landing.html")
 
 
 def test_compose_adds_exactly_the_audit_emitters_and_mounts() -> None:
@@ -234,7 +295,7 @@ def test_no_authorization_vocabulary_reaches_a_roles_off_render() -> None:
     artifact: not a role claim, not a role map, not a sidecar recheck. This
     catches a whole class of leak in one assertion, including in the comment
     text the line allowlist deliberately ignores."""
-    artifacts = _auth_off_render()
+    artifacts = _token_render()
     for key, text in artifacts.items():
         for marker in (
             "OSPREY_AUTH_ROLE_CLAIM",
@@ -252,29 +313,36 @@ def test_no_authorization_vocabulary_reaches_a_roles_off_render() -> None:
             )
 
 
-def test_the_auth_off_render_has_no_auth_sidecar_service_at_all() -> None:
+def test_the_token_render_has_no_auth_sidecar_service_at_all() -> None:
     """The structural reason the allowlist above stays short, pinned so it cannot
     quietly stop being true.
 
     Everything the sidecar carries — its password hashes, its mapped subjects,
     its OIDC settings, its role claim/map, its per-user
     ``OSPREY_AUTH_ROSTER_ROLE_<suffix>`` bindings — lives inside a service that
-    ``auth.method: none`` never renders. So work on the sidecar's environment
-    block cannot move this render, and lines from it must never be added to the
-    SC6 allowlist: the allowlist asserts equality in BOTH directions, so an entry
-    that never renders here would fail as a missing exception rather than pass as
-    a permitted one.
+    ``auth.method: token`` never renders (only ``password``/``oidc`` stand one
+    up). So work on the sidecar's environment block cannot move this render, and
+    lines from it must never be added to the SC6 allowlist: the allowlist asserts
+    equality in BOTH directions, so an entry that never renders here would fail
+    as a missing exception rather than pass as a permitted one.
 
-    If this test ever fails, an auth-off deployment has grown a login service it
-    did not ask for, and that is the finding — not the allowlist's shortness."""
-    compose = yaml.safe_load(_auth_off_render()["docker-compose.web.yml"])
+    If this test ever fails, a deployment that asked for no login wall has grown
+    a login service anyway, and that is the finding — not the allowlist's
+    shortness."""
+    compose = yaml.safe_load(_token_render()["docker-compose.web.yml"])
 
     assert set(compose["services"]) == {"nginx", "web-alice", "web-bob"}
 
 
-def _assert_added_directives_are_exactly_allowed(name: str) -> None:
+def _assert_added_directives_are_exactly_allowed(
+    name: str, artifacts: dict[str, str] | None = None
+) -> None:
     """Every inserted non-comment line is in the allowlist for ``name``, at the
     expected multiplicity, and every allowlisted line was actually inserted.
+
+    ``artifacts`` defaults to the absent-stanza render; the explicit-token
+    spelling is held to the same allowlist by
+    `test_the_frozen_golden_holds_todays_token_bytes_under_both_spellings`.
 
     Comments are excluded on purpose: pinning prose line by line would duplicate
     the golden fixture without adding a guarantee, and reworded prose is already
@@ -282,7 +350,7 @@ def _assert_added_directives_are_exactly_allowed(name: str) -> None:
     comments) plus `test_no_authorization_vocabulary_reaches_a_roles_off_render`
     (which reads the comment text for the vocabulary that must not appear).
     """
-    _old, new, opcodes = _opcodes(name)
+    _old, new, opcodes = _opcodes(name, artifacts)
     inserted = Counter(
         line
         for tag, _i1, _i2, j1, j2 in opcodes
@@ -294,7 +362,7 @@ def _assert_added_directives_are_exactly_allowed(name: str) -> None:
     unexpected = inserted - _ALLOWED[name]
     missing = _ALLOWED[name] - inserted
     assert not unexpected, (
-        f"{name}: line(s) added to the auth-off render that SC6 does not allow. "
+        f"{name}: line(s) added to the `token` render that SC6 does not allow. "
         f"Add them to the allowlist only if they genuinely belong in a render "
         f"that asked for neither logins nor roles: {sorted(unexpected.elements())}"
     )

--- a/tests/deployment/web_terminals/test_capability_guards.py
+++ b/tests/deployment/web_terminals/test_capability_guards.py
@@ -23,6 +23,7 @@ through would be useless.
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +31,7 @@ import pytest
 import yaml
 
 from osprey.cli.build_profile import resolve_build_profile
+from osprey.cli.templates.claude_code import DENY_DEFAULTS
 from osprey.deployment.web_terminals.lint import (
     lint_profile_config,
     lint_web_terminals,
@@ -337,7 +339,10 @@ class TestAuthIsEnforced:
         "web_terminals,expected",
         [
             ({}, False),
+            # `none` is open and `token` is the magic-link posture: neither
+            # stands a login wall in front of the roster.
             ({"auth": {"method": "none"}}, False),
+            ({"auth": {"method": "token"}}, False),
             ({"auth": {"method": "password"}}, True),
             ({"auth": {"method": "oidc"}}, True),
             # An unknown method is lint's to reject; this guard does not pile on.
@@ -900,6 +905,24 @@ def _rendered_repo(tmp_path: Path, *, admin_config: dict[str, Any], login: Any) 
     }
 
 
+def _ship_persona_settings(root: Path, *projects: str, lifted: tuple[str, ...] = ()) -> None:
+    """Give each named rendered project the `.claude/settings.json` a build writes.
+
+    `_rendered_repo` writes only the `config.yml` the privilege rules read, which is
+    all those rules need. The open-mode egress gate reads this second artifact and
+    fails closed on its absence, so an `auth.method: none` deployment has to ship it
+    here too. `lifted` drops entries from the shipped deny list, the way a persona
+    whose config carried `remove_deny` would render.
+    """
+    for project in projects:
+        settings_dir = root / "build" / project / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        deny = [entry for entry in DENY_DEFAULTS if entry not in lifted]
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"permissions": {"deny": deny}}), encoding="utf-8"
+        )
+
+
 def _unrender(root: Path, project: str) -> None:
     """Remove a persona project's whole rendered directory.
 
@@ -1163,7 +1186,7 @@ class TestRenderedProjectBelt:
         assert UNKNOWN_PRIVILEGE_CODE in _codes(findings, "warn")
         message = _messages(findings, UNKNOWN_PRIVILEGE_CODE)[0]
         assert "'carol'" in message
-        assert "auth.method is 'none'" in message
+        assert "auth.method is not password or oidc" in message
         assert "turn authentication on" in message
         assert "[" not in message
 
@@ -1467,15 +1490,40 @@ class TestTheUpPreflightGate:
         assert self._problems(config, tmp_path, monkeypatch) == []
         assert any("default_persona" in message for message in self._advisories(config, tmp_path))
 
-    def test_auth_none_is_said_but_does_not_block(self, tmp_path: Path, monkeypatch):
-        """`auth.method: none` is the shipped default and a legitimate loopback
-        posture; a start refused over it would refuse deployments nobody
-        exposed."""
+    def test_open_mode_is_said_but_does_not_block_a_contained_deployment(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """`auth.method: none` (open) is a legitimate loopback posture, and the
+        privilege belt still only SAYS so: what a privileged terminal behind no wall
+        costs is an advisory, not a refusal, or a start would be refused over a
+        deployment nobody exposed.
+
+        What does refuse an open start is the separate egress gate, and only when a
+        persona can actually reach the deployment's own terminals — which is not the
+        case here, where both rendered projects ship the shipped deny list."""
         config = _rendered_repo(tmp_path, admin_config=PRIVILEGED_RENDER, login=None)
         config["modules"]["web_terminals"]["auth"] = {"method": "none"}
+        _ship_persona_settings(tmp_path, "ca-admin", "ca-readonly")
 
         assert self._problems(config, tmp_path, monkeypatch) == []
         assert any("auth.method" in message for message in self._advisories(config, tmp_path))
+
+    def test_open_mode_blocks_when_a_persona_may_reach_the_host_network(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The other half of the same posture, and the promise this gate reversed:
+        open mode HAS a refusal. Nginx vouches for every terminal it proxies, so a
+        persona whose shipped settings lift the shell is one prompt away from a
+        neighbour's session — and that start is refused rather than advised."""
+        config = _rendered_repo(tmp_path, admin_config=PRIVILEGED_RENDER, login=None)
+        config["modules"]["web_terminals"]["auth"] = {"method": "none"}
+        _ship_persona_settings(tmp_path, "ca-readonly")
+        _ship_persona_settings(tmp_path, "ca-admin", lifted=("Bash",))
+
+        problems = self._problems(config, tmp_path, monkeypatch)
+
+        assert any("may still reach the host network" in problem for problem in problems)
+        assert any("'admin'" in problem for problem in problems)
 
     def test_a_warn_with_a_blocking_code_is_printed_not_refused(self, tmp_path: Path, monkeypatch):
         """`persona_privileges_unknown` is in BOTH filter sets, because the same
@@ -1486,7 +1534,12 @@ class TestTheUpPreflightGate:
         A filter that matched on code alone would refuse this start over a
         posture the design deliberately does not block on."""
         config = _rendered_repo(tmp_path, admin_config=PRIVILEGED_RENDER, login=None)
-        config["modules"]["web_terminals"]["auth"] = {"method": "none"}
+        # `token` rather than `none`: this test is about the lint filter sets, and
+        # both postures stand no wall (`auth_is_enforced` reads `walled`), so they
+        # select the same finding. Under `none` the deliberately unrendered project
+        # would additionally trip the open-mode egress gate, which fails closed on a
+        # settings artifact it cannot read — a real refusal, but a different one.
+        config["modules"]["web_terminals"]["auth"] = {"method": "token"}
         _unrender(tmp_path, "ca-admin")
 
         assert self._problems(config, tmp_path, monkeypatch) == []

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -10,15 +10,20 @@ container or volume is ever created or removed by these tests.
 
 from __future__ import annotations
 
+import json
 import subprocess
 
 import pytest
 import yaml
 from ruamel.yaml import YAML
 
+from osprey.cli.templates.claude_code import DENY_DEFAULTS
 from osprey.deployment.compose_generator import resolve_user_volume_names
 from osprey.deployment.web_terminals import lifecycle
-from osprey.deployment.web_terminals.artifacts import BashLaunchTokenConflictError
+from osprey.deployment.web_terminals.artifacts import (
+    BashLaunchTokenConflictError,
+    OpenModeEgressError,
+)
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME, PW_HASH_VAR_PREFIX
 from osprey.deployment.web_terminals.personas import resolve_personas
 from osprey.deployment.web_terminals.provision import AUTH_SERVICE_NAME
@@ -73,6 +78,15 @@ def _config(
 def _write_config(tmp_path, config):
     path = tmp_path / "config.yml"
     path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    # The deploy project's own settings artifact, which a scaffolded root always
+    # ships. A bare-string roster entry runs the deploy project itself, so this is
+    # the file the open-mode gate reads for it — and that gate fails closed on an
+    # absent one, which would refuse every `auth.method: none` verb below for a
+    # reason none of them is about.
+    (tmp_path / ".claude").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".claude" / "settings.json").write_text(
+        json.dumps({"permissions": {"deny": list(DENY_DEFAULTS)}}), encoding="utf-8"
+    )
     return path
 
 
@@ -2392,6 +2406,73 @@ def test_decommission_refuses_before_touching_the_roster_when_a_survivor_is_conf
     assert [entry["name"] for entry in _reload_users(config_path)] == ["alice", "bob"]
     # And nothing downstream ran.
     assert [c for c in fake_runtime if c[1] == "rm"] == []
+
+
+def _open_mode_roster_config(tmp_path, users, *, personas):
+    """A roster running OPEN whose persona projects are really on disk.
+
+    `personas` maps a persona name to the tools its shipped settings LIFT from the
+    template's deny defaults, so a case can pair the open posture with a persona
+    that can still reach the host network and one that cannot.
+    """
+    catalog = {}
+    for name, lifted in personas.items():
+        project_dir = tmp_path / "profiles" / name
+        (project_dir / ".claude").mkdir(parents=True)
+        (project_dir / "config.yml").write_text(
+            yaml.safe_dump({"project_name": name, "control_system": {"writes_enabled": False}}),
+            encoding="utf-8",
+        )
+        (project_dir / ".claude" / "settings.json").write_text(
+            json.dumps({"permissions": {"deny": [e for e in DENY_DEFAULTS if e not in lifted]}}),
+            encoding="utf-8",
+        )
+        catalog[name] = {"project": name, "project_path": f"profiles/{name}"}
+    config = _config(users, personas=catalog)
+    config["modules"]["web_terminals"]["auth"] = {"method": "none"}
+    return config
+
+
+_OPEN_USERS = [
+    {"name": "alice", "index": 0, "persona": "reaching"},
+    {"name": "bob", "index": 1, "persona": "contained"},
+]
+_OPEN_PERSONAS = {"reaching": ("Bash",), "contained": ()}
+
+
+def test_decommission_refuses_before_touching_the_roster_when_open_mode_is_unsafe(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """The open-mode gate is wired into decommission for the reason the Bash gate
+    is: the roster edit is what makes a failed decommission half-applied, so the
+    refusal has to land before it rather than at the re-render that follows."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(
+        tmp_path, _open_mode_roster_config(tmp_path, _OPEN_USERS, personas=_OPEN_PERSONAS)
+    )
+
+    with pytest.raises(OpenModeEgressError) as excinfo:
+        lifecycle.decommission_user(str(config_path), "bob", assume_yes=True)
+
+    assert "reaching" in str(excinfo.value)
+    assert [entry["name"] for entry in _reload_users(config_path)] == ["alice", "bob"]
+    assert [c for c in fake_runtime if c[1] == "rm"] == []
+
+
+def test_decommission_of_the_open_mode_offenders_own_user_still_succeeds(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """The same escape hatch, on the same POST-removal roster: removing the
+    offending persona's last user drops it from the referenced set, and that
+    removal is the one remediation needing no image rebuild."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(
+        tmp_path, _open_mode_roster_config(tmp_path, _OPEN_USERS, personas=_OPEN_PERSONAS)
+    )
+
+    lifecycle.decommission_user(str(config_path), "alice", assume_yes=True)
+
+    assert [entry["name"] for entry in _reload_users(config_path)] == ["bob"]
 
 
 def test_decommission_of_the_conflicted_personas_own_user_still_succeeds(

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -494,8 +494,10 @@ def test_lint_non_boolean_user_login_is_an_error() -> None:
 
 
 def test_lint_login_false_without_auth_is_an_inert_key_warning() -> None:
-    """`login: false` with `auth.method: none` changes nothing — there is no
-    login wall to be exempt from — and the config should not claim otherwise."""
+    """`login: false` under the default `auth.method: token` changes nothing —
+    that method puts neither a login wall nor an injected operator secret in
+    front of the entry — and the config should not claim otherwise. Under
+    `none` the key is meaningful and no warning is due."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0, "login": False}]
@@ -2245,7 +2247,7 @@ def test_lint_unknown_auth_method_is_an_error() -> None:
 
 
 def test_lint_empty_auth_method_string_is_an_error() -> None:
-    """An empty `method` silently falls back to 'none' at render time (auth off),
+    """An empty `method` silently falls back to 'token' at render time (no login wall),
     so lint is where an operator learns the stanza is inert."""
     # Arrange
     config = _auth_config({"method": ""})
@@ -3302,7 +3304,7 @@ def _claims_config(method: str) -> dict:
     return config
 
 
-@pytest.mark.parametrize("method", ["password", "none"])
+@pytest.mark.parametrize("method", ["password", "token", "none"])
 def test_lint_a_claims_block_without_single_sign_on_is_a_warning(method: str) -> None:
     """No ID token arrives under either method, so the map is never read: the
     roles it names are silently never granted, and the config looks live."""
@@ -3361,3 +3363,132 @@ def test_lint_does_not_raise_on_an_incoherent_authorization_stanza_with_roles() 
 
     # Assert
     assert "web_terminals.invalid_authorization" in codes
+
+
+# ---------------------------------------------------------------------------
+# web_terminals.open_mode_egress
+#
+# The authoring-time voice of the deploy gate. Without it `osprey build` and
+# `osprey scaffold web-terminals lint|render` bless a deployment that cannot
+# come up, and the operator meets the refusal a step later than the edit that
+# caused it. The rule and the gate are driven by the SAME predicate, which is
+# what these tests are ultimately pinning: a lint that cleared what the gate
+# refuses would be the worst of both surfaces.
+# ---------------------------------------------------------------------------
+
+
+def _open_mode_config(tmp_path, *, method: str = "none", deny: list[str] | None = None) -> dict:
+    """A one-persona roster on *method* whose rendered project ships exactly *deny*."""
+    import json
+
+    from osprey.cli.templates.claude_code import DENY_DEFAULTS
+
+    project_dir = tmp_path / "als-assistant"
+    (project_dir / ".claude").mkdir(parents=True)
+    (project_dir / "Dockerfile").write_text("FROM scratch\n")
+    (project_dir / "config.yml").write_text("project_name: als-assistant\n")
+    (project_dir / ".claude" / "settings.json").write_text(
+        json.dumps({"permissions": {"deny": list(DENY_DEFAULTS) if deny is None else deny}}),
+        encoding="utf-8",
+    )
+    return _persona_config(
+        web_terminals={
+            "image_source": "local",
+            "auth": {"method": method},
+            "users": [{"name": "thellert", "index": 0, "persona": "assistant"}],
+            "personas": {
+                "assistant": {"project": "als-assistant", "project_path": str(project_dir)}
+            },
+        }
+    )
+
+
+def test_lint_open_mode_persona_that_may_reach_the_host_network_is_an_error(tmp_path) -> None:
+    """The headline. Under `auth.method: none` nginx vouches for every terminal it
+    proxies, so a persona whose shipped settings lift the shell is one prompt away
+    from a neighbour's session — and an authoring run must say so rather than
+    leaving it to the start."""
+    # Arrange
+    from osprey.cli.templates.claude_code import DENY_DEFAULTS
+
+    config = _open_mode_config(tmp_path, deny=[entry for entry in DENY_DEFAULTS if entry != "Bash"])
+
+    # Act
+    findings = lint_web_terminals(config, project_root=tmp_path)
+
+    # Assert
+    errors = [f for f in _errors(findings) if f.code == "web_terminals.open_mode_egress"]
+    assert len(errors) == 1
+    assert "'assistant' does not deny 'Bash'" in errors[0].message
+    assert "auth.method to 'token'" in errors[0].message
+
+
+def test_lint_open_mode_rule_and_the_deploy_gate_cannot_disagree(tmp_path) -> None:
+    """The property that makes the rule worth having: it is the deploy gate's own
+    predicate, not a second reading of it. A rule free to re-derive "which
+    personas may reach the network" is a rule free to bless a start nobody can
+    perform."""
+    # Arrange
+    from osprey.deployment.web_terminals.artifacts import (
+        OpenModeEgressError,
+        check_open_mode_requirements,
+    )
+
+    config = _open_mode_config(tmp_path, deny=["WebFetch"])
+
+    # Act
+    findings = lint_web_terminals(config, project_root=tmp_path)
+
+    # Assert
+    assert any(f.code == "web_terminals.open_mode_egress" for f in _errors(findings))
+    with pytest.raises(OpenModeEgressError):
+        check_open_mode_requirements(config, tmp_path)
+
+
+def test_lint_open_mode_unrendered_persona_is_told_to_render(tmp_path) -> None:
+    """The fail-closed case with the remedy that clears it. A persona with no
+    rendered settings.json denies nothing this rule can see, and telling that
+    operator to restore a deny entry points at a file that is not there."""
+    # Arrange
+    config = _open_mode_config(tmp_path)
+    (tmp_path / "als-assistant" / ".claude" / "settings.json").unlink()
+
+    # Act
+    findings = lint_web_terminals(config, project_root=tmp_path)
+
+    # Assert
+    errors = [f for f in _errors(findings) if f.code == "web_terminals.open_mode_egress"]
+    assert len(errors) == 1
+    assert "'assistant' has no rendered .claude/settings.json on this host" in errors[0].message
+
+
+def test_lint_a_walled_deployment_is_not_asked_the_open_question(tmp_path) -> None:
+    """The gate is about what nginx vouches for, not about what a persona may run:
+    behind the magic-link wall a persona with a shell is a deliberate, documented
+    posture and must not be flagged."""
+    # Arrange
+    from osprey.cli.templates.claude_code import DENY_DEFAULTS
+
+    config = _open_mode_config(
+        tmp_path, method="token", deny=[entry for entry in DENY_DEFAULTS if entry != "Bash"]
+    )
+
+    # Act
+    findings = lint_web_terminals(config, project_root=tmp_path)
+
+    # Assert
+    assert not any(f.code == "web_terminals.open_mode_egress" for f in findings)
+
+
+def test_lint_open_mode_with_the_shipped_deny_list_reports_nothing(tmp_path) -> None:
+    """The negative control: the ordinary open deployment, rendered from
+    `deny_defaults`, draws no finding — or this rule would refuse a posture
+    nobody could satisfy without hand-editing an artifact."""
+    # Arrange
+    config = _open_mode_config(tmp_path)
+
+    # Act
+    findings = lint_web_terminals(config, project_root=tmp_path)
+
+    # Assert
+    assert not any(f.code == "web_terminals.open_mode_egress" for f in findings)

--- a/tests/deployment/web_terminals/test_nginx_auth_surface.py
+++ b/tests/deployment/web_terminals/test_nginx_auth_surface.py
@@ -31,8 +31,11 @@ The structural test (:func:`test_every_proxying_location_claims_both_identity_he
 is the one that has to keep biting: it finds every location with a
 ``proxy_pass`` and demands of each that it write both names ITSELF — the gated
 forward, or the clear, never nothing and never both — so a proxying location
-added later cannot quietly become a hole. The auth-off case is not an exception
-— a deployment with no login flow still must not let a client name itself.
+added later cannot quietly become a hole. The two wall-less postures are not
+exceptions — ``token`` (the default: each terminal's own ``?token=`` exchange
+is the gate) and ``none`` (open: reaching this nginx IS the authorization)
+render no sidecar whose answer could contradict a forged header, so a client
+that named itself there would simply be believed.
 
 "Never both" is not pedantry: a name entered twice in one location's table
 makes real nginx log ``could not build optimal proxy_headers_hash`` on every
@@ -52,6 +55,7 @@ import pytest
 
 from osprey.deployment.web_terminals.render import (
     NGINX_TEMPLATES_OUTPUT_DIR,
+    TERMINAL_SECRET_HEADER,
     render_web_terminals,
     terminal_secret_env_var,
 )
@@ -96,6 +100,20 @@ def _auth_config(users: list) -> dict:
         "method": "password",
         "allow_insecure_http": True,
     }
+    return config
+
+
+def _open_config(users: list) -> dict:
+    """`_config` with the open posture on (`auth.method: none`).
+
+    The one render shape where a non-exempt location carries the operator
+    secret with NO subrequest in front of it: reaching this nginx is the
+    authorization, so the perimeter vouches for the request itself. No
+    `allow_insecure_http` is needed — the cleartext refusal guards the sidecar
+    methods' session cookies, and this posture mints no session.
+    """
+    config = copy.deepcopy(_config(users))
+    config["modules"]["web_terminals"]["auth"] = {"method": "none"}
     return config
 
 
@@ -188,6 +206,16 @@ _IDENTITY = ((SUBJECT_HEADER, _SUBJECT_VAR), (ROLE_HEADER, _ROLE_VAR))
 
 def _forward(header: str, variable: str) -> str:
     return f"proxy_set_header {header} {variable};"
+
+
+def _secret_include(user: str) -> str:
+    """The per-user snippet an injecting location pulls the secret header in from.
+
+    The header is SET by that file rather than by a directive in this fragment,
+    which is why the open render's assertions look for the include and for the
+    ABSENCE of a clear beside it.
+    """
+    return f"include /etc/nginx/osprey/secret-{user}.conf;"
 
 
 def _identity_writes(body: str) -> dict[str, list[str]]:
@@ -311,11 +339,21 @@ def test_login_exempt_location_forwards_no_identity_at_all() -> None:
     assert _ROLE_VAR not in body
 
 
-def test_auth_off_render_forwards_no_identity_and_has_no_auth_request_set() -> None:
+@pytest.mark.parametrize(
+    "config", [_config(_TWO_USERS), _open_config(_TWO_USERS)], ids=["token", "open"]
+)
+def test_a_wall_less_render_forwards_no_identity_and_has_no_auth_request_set(
+    config: dict,
+) -> None:
     """With no login flow there is no subrequest to read an identity from, so
-    the whole forwarding half is absent — while the clears below are not."""
+    the whole forwarding half is absent — while the clears below are not.
+
+    True of `none` as much as of `token`: the open posture injects an operator
+    secret, which is a credential the perimeter vouches for, but it establishes
+    no identity and so has none to name.
+    """
     # Arrange / Act
-    directives = _directives(_render_nginx(_config(_TWO_USERS)))
+    directives = _directives(_render_nginx(config))
 
     # Assert
     assert "auth_request_set" not in directives
@@ -359,20 +397,42 @@ def test_every_proxying_location_claims_both_identity_headers_with_auth_on() -> 
     assert forwarding == {"/u/alice/"}
 
 
-def test_every_proxying_location_claims_both_identity_headers_with_auth_off() -> None:
-    """The same guard with the login flow off — the deliberate part. An
-    auth-off deployment has no sidecar to contradict a forged header, so a
-    terminal that read one would be taking the client's word for who it is.
-    With no subrequest anywhere in the render there is nothing to forward, so
-    every claim here has to be a clear."""
+@pytest.mark.parametrize(
+    "config,proxying_locations",
+    [
+        (_config(_TWO_USERS), {"/u/alice/", "/u/bob/"}),
+        (_config(_EXEMPT_ROSTER), {"/u/alice/", "/u/ariel/"}),
+        (_open_config(_TWO_USERS), {"/u/alice/", "/u/bob/"}),
+        (_open_config(_EXEMPT_ROSTER), {"/u/alice/", "/u/ariel/"}),
+    ],
+    ids=["token", "token-exempt", "open", "open-exempt"],
+)
+def test_every_proxying_location_claims_both_identity_headers_without_a_login_wall(
+    config: dict, proxying_locations: set[str]
+) -> None:
+    """The same guard with no login wall — the deliberate part, and the reason
+    both wall-less postures are run through it rather than just the default one.
+
+    Neither `token` nor `none` renders a sidecar, so neither has an answer that
+    could contradict a forged header: a terminal reading one would be taking
+    the client's word for who it is. With no subrequest anywhere in either
+    render there is nothing to forward, so every claim here has to be a clear —
+    including in the `none` render, whose non-exempt locations DO carry an
+    injected credential and could otherwise look authorized enough to forward
+    an identity nobody checked.
+
+    The exempt roster is run through both because `login: false` is the entry
+    that changes shape under `none` (it is the one opted out of the injection),
+    and a claim must not be what the opt-out drops.
+    """
     # Arrange / Act
-    nginx_conf = _render_nginx(_config(_TWO_USERS))
+    nginx_conf = _render_nginx(config)
 
     # Assert
     proxying = {
         header: body for header, body in _locations(nginx_conf).items() if "proxy_pass " in body
     }
-    assert set(proxying) == {"/u/alice/", "/u/bob/"}
+    assert set(proxying) == proxying_locations
     for location, body in proxying.items():
         _assert_claims_both_identity_headers(location, body)
         assert _identity_writes(body)[SUBJECT_HEADER] == ["clear"], (
@@ -442,9 +502,12 @@ def test_no_location_writes_the_same_proxy_set_header_name_twice() -> None:
     # Arrange
     configs = (
         _config(_TWO_USERS),
+        _config(_EXEMPT_ROSTER),
         _auth_config(_ONE_USER),
         _auth_config(_TWO_USERS),
         _auth_config(_EXEMPT_ROSTER),
+        _open_config(_TWO_USERS),
+        _open_config(_EXEMPT_ROSTER),
     )
     name_of = re.compile(r"^\s*proxy_set_header\s+(\S+)", re.MULTILINE)
 
@@ -470,12 +533,188 @@ def test_no_identity_header_directive_is_written_at_server_level() -> None:
     them set `Host` at minimum) would discard a server-level clear entirely,
     while the config would read as though the perimeter were covered."""
     # Arrange / Act
-    for config in (_config(_TWO_USERS), _auth_config(_EXEMPT_ROSTER)):
+    for config in (
+        _config(_TWO_USERS),
+        _auth_config(_EXEMPT_ROSTER),
+        _open_config(_EXEMPT_ROSTER),
+    ):
         outside_locations = _directives(_server_level(_render_nginx(config)))
 
         # Assert
         assert "proxy_set_header X-Osprey-Auth-" not in outside_locations
         assert "auth_request_set" not in outside_locations
+
+
+# --------------------------------------------------------------------------
+# The open posture: injection with no wall in front of it
+# --------------------------------------------------------------------------
+
+
+def test_open_render_injects_each_non_exempt_users_own_secret_with_no_gate_in_front() -> None:
+    """`none` is the one posture where a location carries the operator secret
+    with nothing standing in front of it.
+
+    Under `password`/`oidc` the `include` sits behind an `auth_request`, so a
+    request that failed the gate never reaches the `proxy_pass`. Under `none`
+    the include IS the whole mechanism — reaching this port is the
+    authorization — so the three halves that make it safe are asserted
+    together: the location injects that user's own snippet, it does so without
+    pretending a subrequest authorized it, and it pairs that injection with the
+    NARROWED cookie rather than with the sidecar methods' outright strip.
+
+    That last pairing is this posture's own, and it is asserted here because
+    nowhere else does: `test_render.py`'s shared-predicate test holds the
+    sidecar methods, where the header and the blanket `Cookie ""` strip move
+    together. They must not move together here. With no sidecar there is no
+    origin-wide `osprey_auth_session` for a strip to protect, and cutting the
+    jar would take the app's own session cookie with it — the cookie that
+    carries this user's per-terminal state. What must still be cut is the rest
+    of the jar: one jar serves this whole origin, so a bare `$http_cookie`
+    forward would hand this container every OTHER terminal this browser has
+    unlocked, inside a container that runs agent-generated code.
+    """
+    # Arrange / Act
+    nginx_conf = _render_nginx(_open_config(_TWO_USERS))
+
+    # Assert — each non-exempt location pulls in its OWN user's snippet…
+    for index, (user, other) in enumerate((("alice", "bob"), ("bob", "alice"))):
+        body = _directives(_location_body(nginx_conf, f"/u/{user}/"))
+        assert _secret_include(user) in body
+        assert _secret_include(other) not in body
+
+        # …holds no gate that could be mistaken for one…
+        assert "auth_request" not in body
+        assert "error_page 401" not in body
+
+        # …and forwards exactly this user's own app session cookie: not the
+        # strip (which would leave the app with no session at all), and not the
+        # whole jar.
+        cookie = f"osprey_terminal_session_{_BASE_PORTS['web'] + index}"
+        assert f'proxy_set_header Cookie "{cookie}=$cookie_{cookie}";' in body
+        assert 'proxy_set_header Cookie "";' not in body
+        assert "$http_cookie" not in body
+
+
+@pytest.mark.parametrize(
+    "config", [_open_config(_ONE_USER), _open_config(_EXEMPT_ROSTER)], ids=["plain", "exempt"]
+)
+def test_open_injecting_location_leaves_the_secret_name_to_the_include_alone(
+    config: dict,
+) -> None:
+    """No clear beside the include, and the absence is load-bearing.
+
+    The included snippet SETS `X-Osprey-Terminal-Secret`, which already claims
+    the name in this location's header table — nginx answers a named header
+    from that table and never from the request, so an arriving value is
+    overwritten exactly as a clear would overwrite it. A clear written as well
+    would drop no additional forgery and would enter one name twice, which is
+    what makes nginx log `could not build optimal proxy_headers_hash` on every
+    start and reload.
+
+    Invisible to the duplicate-name guard above, which reads this fragment
+    only: the second directive lives in a file `nginx -T` resolves at start.
+
+    Run on the exempt roster as well: that render is the one where the OTHER
+    arm of the split branch is live next door, and an edit that hoisted the
+    clear out of it would land it here.
+    """
+    # Arrange / Act
+    body = _directives(_location_body(_render_nginx(config), "/u/alice/"))
+
+    # Assert — claimed, by the include…
+    assert _secret_include("alice") in body
+
+    # Assert — …and by no directive in this fragment at all.
+    assert TERMINAL_SECRET_HEADER not in body
+
+
+def test_open_login_exempt_location_is_injected_nothing_and_clears_the_secret_header() -> None:
+    """`login: false` opts an entry out of the open posture's injection exactly
+    as it opts one out of a login wall — and the clear is what makes that safe.
+
+    Nothing is vouched for here, so nothing sets the header; a value arriving
+    in it therefore came from the client, and forwarding it would let anyone
+    who can reach this port present the credential the app trusts absolutely.
+    This is the one arm of the split branch that must write the clear.
+    """
+    # Arrange / Act
+    nginx_conf = _render_nginx(_open_config(_EXEMPT_ROSTER))
+    exempt = _directives(_location_body(nginx_conf, "/u/ariel/"))
+
+    # Assert
+    assert _secret_include("ariel") not in exempt
+    assert _clear(TERMINAL_SECRET_HEADER) in exempt
+
+    # Assert — and the roster's other entry is still injected, so the opt-out
+    # is the entry's own and not the render's.
+    assert _secret_include("alice") in _directives(_location_body(nginx_conf, "/u/alice/"))
+
+
+def test_the_exempt_entry_is_served_the_same_directives_under_open_as_under_token() -> None:
+    """A `login: false` entry gets the ungated treatment whatever the posture
+    around it is.
+
+    Compared as the directives alone, in the same order, rather than as text:
+    the open render explains the opt-out in prose the token render has no
+    reason to carry, so the two bodies differ by design in every way except the
+    one that matters. What has to match is what nginx executes — same clears,
+    same single forwarded cookie, no include on either side — and order is kept
+    in the comparison because a location's header table is built in the order
+    it is written.
+    """
+    # Arrange / Act
+    served = {
+        posture: [
+            line.strip()
+            for line in _directives(_location_body(_render_nginx(config), "/u/ariel/")).splitlines()
+            if line.strip()
+        ]
+        for posture, config in (
+            ("open", _open_config(_EXEMPT_ROSTER)),
+            ("token", _config(_EXEMPT_ROSTER)),
+        )
+    }
+
+    # Assert
+    assert served["open"] == served["token"]
+    # Guard against a vacuous green: an empty body would compare equal to an
+    # empty body, and this location is one of the two the render exists for.
+    assert "proxy_pass " in " ".join(served["open"])
+
+
+def test_the_open_render_holds_no_login_surface_anywhere() -> None:
+    """Open means open: no sidecar, so nothing that would talk to one.
+
+    Each of these is a separate way for the wall to half-exist. A `/auth/`
+    prefix with no sidecar behind it is a public 502; an `internal`
+    `/_osprey_auth/<user>` target is the endpoint an `auth_request` would name;
+    the named 401 handler is where a denied request would be sent. A render
+    that emitted any of them would be describing a gate this deployment does
+    not have.
+    """
+    # Arrange / Act
+    directives = _directives(_render_nginx(_open_config(_EXEMPT_ROSTER)))
+
+    # Assert
+    assert "auth_request" not in directives
+    assert "/_osprey_auth/" not in directives
+    # The bare prefix, not `location /auth/`: a proxy_pass, a rewrite or a
+    # return naming it would be just as public as a location would.
+    assert "/auth/" not in directives
+    assert "osprey_auth_401" not in directives
+    # And no variable the sidecar's half of the template feeds — the maps and
+    # the `auth_request_set` targets alike. One left behind would be forever
+    # empty, which is how an identity forward fails OPEN.
+    assert "$osprey_auth_" not in directives
+
+    # Assert — and every location the render DOES hold is one of the roster's.
+    assert set(_locations(directives)) == {
+        "/u/alice/",
+        "/u/ariel/",
+        "= /",
+        "= /u/alice",
+        "= /u/ariel",
+    }
 
 
 # --------------------------------------------------------------------------

--- a/tests/deployment/web_terminals/test_nginx_validate.py
+++ b/tests/deployment/web_terminals/test_nginx_validate.py
@@ -6,8 +6,9 @@ the strings happen to satisfy. This module closes that gap for real by actually
 invoking `nginx -t` inside `nginx:1.27-alpine` (the base image the deployed stack
 uses) against each render shape the auth/TLS seams can produce:
 
-- the default render (`auth.method` unset -> "none", `tls.enabled` unset -> False):
-  the seam is fully inert, matching the pre-auth plain-http posture.
+- the default render (`auth.method` unset -> "token", `tls.enabled` unset ->
+  False): no wall and no injection, each terminal reached through its own
+  `?token=` exchange — the pre-auth plain-http posture.
 - the fully enabled render (`tls.enabled: true` with a real self-signed cert/key
   pair generated fresh per test run, plus `auth.method: password`): two server
   blocks, the plain port's `return 301 https://…`, `listen 443 ssl` +
@@ -16,6 +17,11 @@ uses) against each render shape the auth/TLS seams can produce:
 - the cleartext-auth render (`auth.method: password` with
   `allow_insecure_http`, the shape a facility behind its own TLS terminator
   deploys): the same auth surface inside a *single* server block.
+- the open render (`auth.method: none`, with a `login: false` entry beside a
+  normal one): no sidecar surface at all, and yet the per-user `include` +
+  envsubst chain still runs — the only shape where a secret snippet is read at
+  start with no `auth_request` in front of it, and the only one whose two
+  ungated locations are shaped differently from each other.
 
 Every one of these tests asserts the constructs it means to validate are
 actually present in the rendered fragment before handing it to nginx — a
@@ -88,9 +94,9 @@ pytestmark = [
 ]
 
 
-def _config(
-    tls: dict | None = None, auth: dict | None = None, users: list[str] | None = None
-) -> dict:
+def _config(tls: dict | None = None, auth: dict | None = None, users: list | None = None) -> dict:
+    """A rendering config; *users* takes plain names or full roster entries (a
+    `login: false` one is what the open render's exempt case needs)."""
     web_terminals: dict = {
         "enabled": True,
         "nginx_port": 9080,
@@ -304,7 +310,7 @@ def _location_body(conf: str, user: str) -> str:
 
 
 def test_default_gated_off_render_passes_nginx_t() -> None:
-    """C1: the default (auth none / tls off) render is not just inert by
+    """C1: the default (auth token / tls off) render is not just inert by
     string-match — it's a config `nginx -t` actually accepts."""
     # Arrange
     artifacts = render_web_terminals(_config())
@@ -429,6 +435,93 @@ def test_cleartext_auth_render_passes_nginx_t() -> None:
 
     # Assert
     assert result.returncode == 0, result.stderr
+
+
+def test_open_render_with_an_exempt_entry_passes_nginx_t() -> None:
+    """C4: the open render (`auth.method: none`) — the only posture that reads a
+    per-user secret snippet at start with no `auth_request` in front of it.
+
+    Worth running real nginx against rather than string-matching, because what
+    is new here is a startup-time file dependency without the surface that used
+    to imply it. The `include` is a hard startup failure when the envsubst
+    output is missing, and under `none` there is no sidecar, no `/auth/` prefix
+    and no named 401 handler around it to fail first — so a template that got
+    the injection predicate and the artifact predicate even slightly out of
+    step would produce a config that renders cleanly and refuses to start.
+
+    A `login: false` entry sits beside the injected one deliberately: this is
+    the only render where two ungated locations are shaped differently from
+    each other, one carrying an include and the other the clear that replaces
+    it.
+
+    Asserted clean rather than merely accepted: a duplicate header name — which
+    is exactly what a clear written beside the include would be, and the
+    snippet is a separate file this test is the first to resolve — leaves nginx
+    exiting 0 with `could not build optimal proxy_headers_hash` on stderr, on
+    every start and every reload.
+    """
+    roster = [{"name": "alice", "index": 0}, {"name": "kiosk", "index": 1, "login": False}]
+    users = ["alice", "kiosk"]
+    secrets = _terminal_secrets(users)
+
+    # Arrange
+    artifacts = render_web_terminals(
+        _config(users=roster, auth={"method": "none"}), terminal_secrets=secrets
+    )
+    nginx_conf = artifacts["nginx/nginx.conf"]
+
+    # Arrange — guard against a vacuous green twice over: a render that had
+    # stopped injecting would pass `nginx -t` with nothing to validate, and one
+    # that had grown a login wall would not be this posture at all.
+    directives = _directives(nginx_conf)
+    assert "include /etc/nginx/osprey/secret-alice.conf;" in directives
+    assert "secret-kiosk.conf" not in nginx_conf
+    assert f'{TERMINAL_SECRET_HEADER} "";' in directives
+    assert "auth_request" not in directives
+    assert "location /auth/" not in directives
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        conf_dir = tmp_path / "conf"
+        templates_dir = tmp_path / "templates"
+        conf_dir.mkdir()
+        templates_dir.mkdir()
+        (conf_dir / "default.conf").write_text(nginx_conf)
+        # Under `none` the snippets ARE written — the artifact predicate is the
+        # injection predicate — so the same entrypoint chain the gated renders
+        # drive applies here, for the one non-exempt user.
+        _write_secret_templates(artifacts, templates_dir)
+        assert [path.name for path in sorted(templates_dir.iterdir())] == [
+            "secret-alice.conf.template"
+        ]
+        secret_env = {terminal_secret_env_var(user): value for user, value in secrets.items()}
+
+        # Act — `-T` so the resolved snippet is observable, not just accepted.
+        result = _run_nginx_t(
+            conf_dir,
+            certs_dir=None,
+            templates_dir=templates_dir,
+            secret_env=secret_env,
+            command=("nginx", "-T"),
+        )
+
+    # Assert — accepted, and accepted without complaint.
+    assert result.returncode == 0, result.stderr
+    assert "[warn]" not in result.stderr, result.stderr
+
+    # Assert — the injected user's secret is really in the resolved config, and
+    # the exempt user's is nowhere in it. Two occurrences of the header name:
+    # alice's snippet sets it, kiosk's location clears it.
+    dump = result.stdout
+    assert dump.count(TERMINAL_SECRET_HEADER) == 2
+    snippet = _config_file_sections(dump)[f"{_NGINX_ENVSUBST_OUTPUT_DIR}/secret-alice.conf"]
+    assert f'{TERMINAL_SECRET_HEADER} "{secrets["alice"]}";' in snippet
+    assert secrets["kiosk"] not in dump
+
+    # Assert — and the ungated entry claims the same name by clearing it, which
+    # is what keeps a client from supplying one.
+    kiosk_location = _location_body(_config_file_sections(dump)[_DEFAULT_CONF_PATH], "kiosk")
+    assert f'{TERMINAL_SECRET_HEADER} "";' in kiosk_location
 
 
 def test_secret_include_is_scoped_per_user_with_no_cross_leak() -> None:

--- a/tests/deployment/web_terminals/test_perimeter_stamp.py
+++ b/tests/deployment/web_terminals/test_perimeter_stamp.py
@@ -1,0 +1,312 @@
+"""The navigation-only perimeter stamp on every per-user web-terminal service.
+
+Under ``auth.method: none`` the perimeter is nginx alone: it injects each
+user's operator secret on every proxied location, so a request that reaches a
+web port from the deploy host arrives already authenticated as whoever owns
+that port — including a request made by agent-generated code inside one of
+these containers, which share the host network namespace with each other and
+with nginx.
+
+The render's half of the answer is these two lines on each per-user service:
+``OSPREY_WEB_PERIMETER=open`` (the posture) and
+``OSPREY_WEB_PERIMETER_DENY_PORTS`` (nginx's published port, the TLS listener
+when ``tls.enabled`` puts the real content server behind it, and every roster
+user's terminal port). The MCP server process inside the container reads them
+and hands the parsed list to the execution sandbox it spawns — which is what
+makes the deny-list something the sandbox is TOLD rather than something it
+derives, and why the list has to be computed here, where the whole roster is
+known.
+
+The three credentialed methods render neither line: a caller there still has to
+present something the sandbox does not hold, so there is nothing to deny.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import yaml
+
+from osprey.deployment.web_terminals.render import render_web_terminals
+
+_NGINX_PORT = 9080
+_WEB_BASE_PORT = 9091
+
+#: The marker and list names, spelled once. The executor reads these back from
+#: the container's environment; a rename on either side is a stamp nobody reads.
+_MARKER_VAR = "OSPREY_WEB_PERIMETER"
+_DENY_PORTS_VAR = "OSPREY_WEB_PERIMETER_DENY_PORTS"
+
+
+def _config(users: list[str], **auth: object) -> dict:
+    """A minimal renderable config, optionally with an ``auth:`` stanza.
+
+    ``allow_insecure_http`` is set whenever a sidecar method is asked for: the
+    render refuses a login wall over cleartext, and that gate has its own
+    coverage elsewhere.
+    """
+    web_terminals: dict = {
+        "enabled": True,
+        "nginx_port": _NGINX_PORT,
+        "web_base_port": _WEB_BASE_PORT,
+        "artifact_base_port": 9291,
+        "ariel_base_port": 9391,
+        "lattice_base_port": 9491,
+        "users": users,
+    }
+    if auth:
+        stanza = dict(auth)
+        if stanza.get("method") in ("password", "oidc"):
+            stanza.setdefault("allow_insecure_http", True)
+        web_terminals["auth"] = stanza
+    return {
+        "facility": {"name": "Demo Light Source", "prefix": "dls", "timezone": "UTC"},
+        "registry": {"url": "git.dls.example.org:5050/physics/production/dls-profiles"},
+        "deploy": {"host": "dls-deploy", "fqdn": "dls-deploy.dls.example.org"},
+        "modules": {"web_terminals": web_terminals},
+    }
+
+
+def _user_services(config: dict) -> dict[str, dict]:
+    """The rendered per-user services, keyed by service name (``nginx`` dropped)."""
+    compose = yaml.safe_load(render_web_terminals(copy.deepcopy(config))["docker-compose.web.yml"])
+    return {name: svc for name, svc in compose["services"].items() if name != "nginx"}
+
+
+def _env(service: dict) -> dict[str, str]:
+    """A compose service's ``environment:`` list as a mapping."""
+    return dict(entry.split("=", 1) for entry in service["environment"])
+
+
+# ---------------------------------------------------------------------------
+# The open posture stamps every per-user service
+# ---------------------------------------------------------------------------
+
+
+def test_open_posture_marks_every_per_user_service() -> None:
+    """Every per-user container is told the perimeter is open — not just the first.
+
+    Per service rather than deployment-wide because that is the only place a
+    container reads: each one is a separate process tree with its own
+    environment, and a marker on one of three terminals leaves the other two
+    running an unguarded sandbox.
+    """
+    # Arrange
+    users = ["alice", "bob", "carol"]
+    config = _config(users, method="none")
+
+    # Act
+    services = _user_services(config)
+
+    # Assert
+    assert sorted(services) == [f"web-{user}" for user in users]
+    for name, service in services.items():
+        assert _env(service)[_MARKER_VAR] == "open", name
+
+
+def test_open_posture_denies_nginx_and_every_roster_web_port() -> None:
+    """The list is exactly the front door plus every user's terminal port.
+
+    Every user's port, not just this container's own: the containers share the
+    host network namespace, so alice's sandbox can reach bob's terminal on
+    loopback, and nginx's injected secret makes that request bob's.
+    """
+    # Arrange
+    users = ["alice", "bob", "carol"]
+    config = _config(users, method="none")
+    expected = f"{_NGINX_PORT},{_WEB_BASE_PORT},{_WEB_BASE_PORT + 1},{_WEB_BASE_PORT + 2}"
+
+    # Act
+    services = _user_services(config)
+
+    # Assert
+    for name, service in services.items():
+        assert _env(service)[_DENY_PORTS_VAR] == expected, name
+
+
+def test_deny_list_excludes_companion_panel_ports() -> None:
+    """Companion families (artifact, ariel, lattice) are NOT denied.
+
+    They are not what the injected secret opens; the in-container panel proxy
+    addresses them legitimately, and none of them fronts a terminal, an agent
+    session, or an approval prompt — which is what this deny-list guards.
+    Denying them would break every panel tab to guard a surface nginx does not
+    front.
+    """
+    # Arrange
+    config = _config(["alice"], method="none")
+
+    # Act
+    denied = _env(_user_services(config)["web-alice"])[_DENY_PORTS_VAR]
+
+    # Assert
+    assert denied == f"{_NGINX_PORT},{_WEB_BASE_PORT}"
+    for companion_base in (9291, 9391, 9491):
+        assert str(companion_base) not in denied.split(",")
+
+
+def test_deny_list_is_sorted_and_deduplicated() -> None:
+    """Ascending, no repeats — the rendered artifact is diffed between deploys.
+
+    A list whose order followed roster order (or dict iteration) would churn
+    this file whenever a user was added in the middle, hiding real changes in
+    the noise.
+
+    The terminals are deliberately put BELOW nginx here (web_base_port 9000
+    against nginx_port 9080), and the exact string is asserted rather than
+    "is it sorted": with the default layout the front door happens to come
+    first anyway, so a build that simply prepended nginx and appended the
+    roster would pass a sortedness check while being sorted by luck.
+    """
+    # Arrange
+    config = _config(["zoe", "alice", "mike"], method="none")
+    config["modules"]["web_terminals"]["web_base_port"] = 9000
+
+    # Act
+    denied = _env(_user_services(config)["web-zoe"])[_DENY_PORTS_VAR]
+
+    # Assert
+    assert denied == f"9000,9001,9002,{_NGINX_PORT}"
+
+
+def test_tls_deployment_denies_the_tls_listener() -> None:
+    """With TLS on, 443 is in the list — it is the port that actually serves.
+
+    nginx.conf.j2 renders `listen 443 ssl` as the SOLE content server under
+    `tls.enabled` and demotes the plain `nginx_port` to a redirect. A deny-list
+    that named only `nginx_port` would name the door that redirects and leave
+    the one that injects the operator secret and serves the terminal reachable
+    from inside the sandbox. `nginx_port` stays in the list too: the redirect
+    listener still accepts the connection.
+    """
+    # Arrange
+    config = _config(["alice"], method="none")
+    config["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "cert": "/etc/nginx/certs/tls.crt",
+        "key": "/etc/nginx/certs/tls.key",
+    }
+
+    # Act
+    denied = _env(_user_services(config)["web-alice"])[_DENY_PORTS_VAR]
+
+    # Assert
+    assert denied == f"443,{_NGINX_PORT},{_WEB_BASE_PORT}"
+
+
+def test_plain_http_deployment_does_not_deny_443() -> None:
+    """Without TLS nothing listens on 443, and the list does not invent it.
+
+    Denying a port this deployment never publishes would be a guess about the
+    host rather than a fact about the render — and the whole point of deriving
+    the list here is that it names ports this render knows exist.
+    """
+    # Arrange
+    config = _config(["alice"], method="none")
+
+    # Act
+    denied = _env(_user_services(config)["web-alice"])[_DENY_PORTS_VAR]
+
+    # Assert
+    assert "443" not in denied.split(",")
+    assert denied == f"{_NGINX_PORT},{_WEB_BASE_PORT}"
+
+
+def test_single_user_deployment_still_denies_the_nginx_port() -> None:
+    """A one-user roster carries the front door in its list.
+
+    nginx is the port that injects the secret; a deny-list of terminals alone
+    would leave the one route that authenticates on the caller's behalf open.
+    """
+    # Arrange
+    config = _config(["alice"], method="none")
+
+    # Act
+    denied = _env(_user_services(config)["web-alice"])[_DENY_PORTS_VAR]
+
+    # Assert
+    assert denied.split(",")[0] == str(_NGINX_PORT)
+
+
+def test_stamp_is_deterministic_across_renders() -> None:
+    """Same config in, byte-identical stamp out."""
+    # Arrange
+    config = _config(["alice", "bob"], method="none")
+
+    # Act
+    first = render_web_terminals(copy.deepcopy(config))["docker-compose.web.yml"]
+    second = render_web_terminals(copy.deepcopy(config))["docker-compose.web.yml"]
+
+    # Assert
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Every other posture renders neither line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        pytest.param({}, id="absent-auth-block"),
+        pytest.param({"method": "token"}, id="token"),
+        pytest.param({"method": "password"}, id="password"),
+        pytest.param({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}}, id="oidc"),
+    ],
+)
+def test_credentialed_postures_render_no_perimeter_stamp(auth: dict) -> None:
+    """`token`, `password`, `oidc` and an absent block carry neither variable.
+
+    Absence, not an inert value: a marker set to something falsy would still be
+    a variable to interpret, and the postures that render it are the postures
+    that mean it.
+    """
+    # Arrange
+    config = _config(["alice", "bob"], **auth)
+
+    # Act
+    services = _user_services(config)
+
+    # Assert
+    for name, service in services.items():
+        env = _env(service)
+        assert _MARKER_VAR not in env, name
+        assert _DENY_PORTS_VAR not in env, name
+
+
+def test_no_perimeter_text_at_all_outside_the_open_posture() -> None:
+    """Not even a comment mentions the perimeter under `token`.
+
+    The gate wraps the template comment as well as the two lines, so a
+    credentialed deployment's compose file is byte-identical to what it
+    rendered before this feature — which is what the auth-off baseline pin
+    checks line by line.
+    """
+    # Arrange
+    config = _config(["alice"], method="token")
+
+    # Act
+    compose = render_web_terminals(copy.deepcopy(config))["docker-compose.web.yml"]
+
+    # Assert
+    assert "PERIMETER" not in compose
+
+
+def test_open_posture_keeps_the_stamp_out_of_the_secret_channel() -> None:
+    """The stamp is a literal in `environment:`, never a `.env.users` reference.
+
+    A port list this container's own compose file already publishes is not a
+    credential; routing it through the secret channel would imply it is one and
+    would put it in a file `osprey users env` rewrites whole.
+    """
+    # Arrange
+    config = _config(["alice"], method="none")
+
+    # Act
+    env = _env(_user_services(config)["web-alice"])
+
+    # Assert
+    assert "$" not in env[_DENY_PORTS_VAR]
+    assert "$" not in env[_MARKER_VAR]

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -20,8 +20,12 @@ from pathlib import Path
 
 import pytest
 
+from osprey.cli.templates.claude_code import DENY_DEFAULTS
 from osprey.deployment.web_terminals import provision
-from osprey.deployment.web_terminals.artifacts import BashLaunchTokenConflictError
+from osprey.deployment.web_terminals.artifacts import (
+    BashLaunchTokenConflictError,
+    OpenModeEgressError,
+)
 from osprey.deployment.web_terminals.auth_credentials import (
     AUTH_ENV_FILENAME,
     PW_HASH_VAR_PREFIX,
@@ -303,6 +307,29 @@ def _auth_config(method: str, users=("alice", "bob"), auth_image="reg/osprey-aut
     }
 
 
+def _write_deploy_project_settings(project_root: Path) -> None:
+    """Ship the deploy project's own `.claude/settings.json`, as a scaffold does.
+
+    A bare-string roster entry runs the deploy project itself, so that file is the
+    settings artifact the entry ships — and the open-mode gate fails closed on its
+    absence. Every real project root has one; a fixture root without one models a
+    deployment that cannot exist, and would make `auth.method: none` unreachable in
+    tests that are not about the gate at all.
+
+    A root this cannot be written to is left alone rather than failed on: the
+    unwritable-root cases below are about a different refusal entirely, and none of
+    them runs an open deployment.
+    """
+    import contextlib
+    import json
+
+    with contextlib.suppress(OSError):
+        (project_root / ".claude").mkdir(parents=True, exist_ok=True)
+        (project_root / ".claude" / "settings.json").write_text(
+            json.dumps({"permissions": {"deny": list(DENY_DEFAULTS)}}), encoding="utf-8"
+        )
+
+
 def _run_preflight(monkeypatch, project_root: Path, config: dict):
     """Run the preflight from `project_root` with the non-auth steps neutered.
 
@@ -310,6 +337,7 @@ def _run_preflight(monkeypatch, project_root: Path, config: dict):
     a registry-mode root with no .env.production); it is covered by
     test_env_production.py, so stub it out to keep these assertions about auth.
     """
+    _write_deploy_project_settings(project_root)
     monkeypatch.chdir(project_root)
     monkeypatch.setattr(provision, "ensure_env_production", lambda config, root: None)
     return provision.preflight_web_terminals(config)
@@ -1135,7 +1163,11 @@ def _persona_project(root: Path, name: str, *, writes: bool, denies_bash: bool) 
         ),
         encoding="utf-8",
     )
-    deny = ["Bash", "Edit"] if denies_bash else ["Edit"]
+    # The template's own `deny_defaults`, verbatim — what a rendered project really
+    # ships. These rosters run `auth.method: none`, and the open-mode gate refuses
+    # a persona that does not deny the whole host-network egress set, so a shorter
+    # list here would refuse every one of these tests for the wrong reason.
+    deny = [entry for entry in DENY_DEFAULTS if denies_bash or entry != "Bash"]
     (project_dir / ".claude" / "settings.json").write_text(
         json.dumps({"permissions": {"deny": deny}}), encoding="utf-8"
     )
@@ -1199,6 +1231,191 @@ def test_preflight_refuses_before_any_credential_is_minted(monkeypatch, tmp_path
         provision.preflight_web_terminals(_persona_roster_config(tmp_path, denies_bash=False))
 
     assert reached == []
+
+
+# ---------------------------------------------------------------------------
+# preflight_web_terminals -- the OPEN-mode egress gate
+#
+# The twin of the block above, and pinned in the same two places for the same
+# reason: the render seam's tests cover WHAT is refused, and only this placement
+# can cover WHEN. The gate sits immediately after the Bash guard and ahead of
+# `ensure_env_production`, so an open deployment whose personas can reach its own
+# terminals is refused before the image build and before a credential is minted.
+# ---------------------------------------------------------------------------
+
+
+def _egress_permitting_roster_config(root: Path, *, lift: str = "WebFetch") -> dict:
+    """The same open roster, whose persona denies the shell but ships one web tool.
+
+    `denies_bash=True` deliberately: the Bash/launch-token guard runs first and
+    would refuse this roster on its own terms, and a test that let it fire would
+    pin the placement of the wrong guard. What is left for the open-mode gate is
+    a single lifted egress entry.
+    """
+    import json
+
+    config = _persona_roster_config(root, denies_bash=True)
+    (root / "profiles" / "rw" / ".claude" / "settings.json").write_text(
+        json.dumps({"permissions": {"deny": [entry for entry in DENY_DEFAULTS if entry != lift]}}),
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_preflight_refuses_an_egress_permitting_persona_under_open_mode(monkeypatch, tmp_path):
+    """The fail-fast gate for the open posture: a persona that still holds one
+    web tool stops the deploy in seconds, naming the persona and the entry.
+
+    `ensure_env_production` is deliberately NOT stubbed, exactly as in the Bash
+    twin above. It raises on this root too, so demanding specifically an
+    `OpenModeEgressError` proves the egress refusal is what the operator is told
+    about — a gate moved below it would surface the wrong error here."""
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(OpenModeEgressError) as excinfo:
+        provision.preflight_web_terminals(_egress_permitting_roster_config(tmp_path))
+
+    message = str(excinfo.value)
+    assert "'readwrite'" in message
+    assert "'WebFetch'" in message
+
+
+def test_preflight_refuses_the_open_deployment_before_any_credential_is_minted(
+    monkeypatch, tmp_path
+):
+    """The reason this gate sits where it does rather than merely somewhere in
+    the function. Open mode's remedy is often "turn auth on", which is exactly
+    the deployment whose passwords must not already have been minted and printed
+    for a stack that never comes up."""
+    monkeypatch.chdir(tmp_path)
+    reached: list[str] = []
+    monkeypatch.setattr(
+        provision, "ensure_env_production", lambda config, root: reached.append("env_production")
+    )
+    monkeypatch.setattr(
+        provision, "_provision_auth_secrets", lambda wt, root: reached.append("auth_secrets")
+    )
+
+    with pytest.raises(OpenModeEgressError):
+        provision.preflight_web_terminals(_egress_permitting_roster_config(tmp_path))
+
+    assert reached == []
+
+
+def test_preflight_passes_a_persona_that_denies_the_whole_egress_set(monkeypatch, tmp_path):
+    """The negative control: the shipped deny list clears this gate too, so the
+    guard cannot be passing by refusing every open deployment."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(provision, "ensure_env_production", lambda config, root: None)
+
+    provision.preflight_web_terminals(_persona_roster_config(tmp_path, denies_bash=True))
+
+
+# ---------------------------------------------------------------------------
+# Open mode requires the render the gate reads -- in BOTH image-source modes
+#
+# `check_open_mode_requirements` reads each persona's rendered
+# `.claude/settings.json` and fails closed on one it cannot read. On a pull-only
+# host nothing renders those projects, so without this every registry-mode open
+# deployment met a refusal whose remedy could not clear it. The render problem is
+# reported first so the operator meets the one thing they can act on.
+# ---------------------------------------------------------------------------
+
+
+def _registry_open_repo(root: Path, *, rendered: bool) -> dict:
+    """A registry-mode, open deployment repo; its one persona rendered or not."""
+    import json
+
+    import yaml
+
+    (root / "personas").mkdir(parents=True, exist_ok=True)
+    (root / "profile.yml").write_text("name: Facility\n", encoding="utf-8")
+    (root / ".env").write_text("ANTHROPIC_API_KEY=sk-facility\n", encoding="utf-8")
+    (root / "personas" / "operator.yml").write_text("name: operator\n", encoding="utf-8")
+    if rendered:
+        # Both copies a build leaves behind: the flat host render the catalog
+        # names, and the container repo its image is built from.
+        project = root / "build" / "op"
+        context = root / "build" / ".image" / "op" / "build"
+        (project / ".claude").mkdir(parents=True)
+        context.mkdir(parents=True)
+        for directory in (project, context):
+            (directory / "config.yml").write_text(
+                yaml.safe_dump({"project_name": "op"}), encoding="utf-8"
+            )
+            (directory / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+        (project / ".claude" / "settings.json").write_text(
+            json.dumps({"permissions": {"deny": list(DENY_DEFAULTS)}}), encoding="utf-8"
+        )
+    return {
+        "facility": {"prefix": "als"},
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "image_source": "registry",
+                "auth": {"method": "none"},
+                "users": [{"name": "alice", "index": 0, "persona": "operator"}],
+                "personas": {
+                    "operator": {
+                        "project": "op",
+                        "project_path": "build/op",
+                        "build_profile": "personas/operator.yml",
+                    }
+                },
+            }
+        },
+    }
+
+
+def test_an_open_registry_deployment_is_asked_for_the_render_the_gate_reads(monkeypatch, tmp_path):
+    """The dead end this closes. Registry mode renders nothing on this host, and
+    the gate fails closed on the artifact it cannot read — so the operator was
+    told to restore deny entries in files that are not there, and no rebuild or
+    re-pull could clear it. The render requirement comes FIRST, and the refusal
+    that follows names the missing render rather than four entries."""
+    root = tmp_path.resolve()
+    monkeypatch.chdir(root)
+
+    findings, _advisories = provision.web_terminal_preflight_report(
+        _registry_open_repo(root, rendered=False), repo_root=root
+    )
+
+    problems = [problem for problem, _remedy in findings]
+    assert any(
+        "has no rendered project at build/op" in problem and "osprey build" in problem
+        for problem in problems
+    )
+    assert any(
+        "'operator' has no rendered .claude/settings.json on this host" in problem
+        for problem in problems
+    )
+
+
+def test_a_rendered_registry_deployment_still_starts_open(monkeypatch, tmp_path):
+    """The counterfactual that keeps the requirement honest: a registry-mode open
+    deployment whose personas ARE rendered here, denying the whole egress set,
+    draws no finding at all. The cost of gating on a shipped artifact is one
+    `osprey build`, not the end of open registry deployments."""
+    root = tmp_path.resolve()
+    monkeypatch.chdir(root)
+
+    findings, _advisories = provision.web_terminal_preflight_report(
+        _registry_open_repo(root, rendered=True), repo_root=root
+    )
+
+    assert findings == []
+
+
+def test_a_walled_registry_deployment_is_not_asked_for_a_render(monkeypatch, tmp_path):
+    """The scope of the requirement, pinned. Only OPEN mode reads a rendered
+    artifact to decide whether a start is safe; a token or password deployment
+    on a pull-only host has nothing here to render and must not be told to."""
+    root = tmp_path.resolve()
+    monkeypatch.chdir(root)
+    config = _registry_open_repo(root, rendered=False)
+    config["modules"]["web_terminals"]["auth"] = {"method": "token"}
+
+    assert provision.persona_render_problem(config, root) is None
 
 
 def test_preflight_passes_a_persona_that_denies_bash(monkeypatch, tmp_path):

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -1589,8 +1589,9 @@ def test_nginx_mounts_resolve_into_the_repos_build_zone(tmp_path) -> None:
     assert {"nginx/nginx.conf", "nginx/landing.html"} <= set(artifacts)
 
 
-def test_auth_default_none() -> None:
-    """No `web_terminals.auth` stanza -> auth_method defaults to 'none' (v1 has no auth)."""
+def test_auth_default_token() -> None:
+    """No `web_terminals.auth` stanza -> auth_method defaults to 'token' (the magic-link
+    posture: no login wall, no sidecar, one ?token= exchange per user)."""
     # Arrange
     web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
 
@@ -1598,10 +1599,10 @@ def test_auth_default_none() -> None:
     context = _auth_tls_context(web_terminals)
 
     # Assert
-    assert context["auth_method"] == "none"
+    assert context["auth_method"] == "token"
 
 
-def test_auth_default_none_reads_configured_method() -> None:
+def test_auth_default_token_reads_configured_method() -> None:
     """A configured `web_terminals.auth.method` is read through, not clobbered by the default."""
     # Arrange
     web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
@@ -1614,10 +1615,10 @@ def test_auth_default_none_reads_configured_method() -> None:
     assert context["auth_method"] == "password"
 
 
-def test_auth_method_non_string_falls_back_to_none() -> None:
+def test_auth_method_non_string_falls_back_to_token() -> None:
     """A malformed (non-str) `auth.method` (well-formedness is lint's job, not this
     function's) must not leak into the rendered seam as-is — it falls back to the
-    same inert "none" default as an absent/empty method."""
+    same "token" default as an absent/empty method."""
     # Arrange
     web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
     web_terminals["auth"] = {"method": {"nested": "not-a-string"}}
@@ -1626,7 +1627,7 @@ def test_auth_method_non_string_falls_back_to_none() -> None:
     context = _auth_tls_context(web_terminals)
 
     # Assert
-    assert context["auth_method"] == "none"
+    assert context["auth_method"] == "token"
 
 
 def test_tls_default_off() -> None:
@@ -1679,7 +1680,7 @@ def test_auth_context_defaults_are_inert_without_an_auth_stanza() -> None:
     context = _auth_tls_context(web_terminals)
 
     # Assert
-    assert context["auth_method"] == "none"
+    assert context["auth_method"] == "token"
     assert context["auth_allow_insecure_http"] is False
     assert context["auth_image"] is None
     assert context["auth_oidc_issuer"] is None
@@ -1885,7 +1886,7 @@ def test_render_auth_context_gate_does_not_fire_for_method_none() -> None:
     assert "auth_request" not in artifacts["nginx/nginx.conf"]
 
 
-def test_render_succeeds_with_auth_default_none_and_tls_default_off() -> None:
+def test_render_succeeds_with_auth_default_token_and_tls_default_off() -> None:
     """A config with no auth/tls stanzas at all still renders the full artifact set — 1.4 only
     establishes the config contract, it must not change Phase-1 render behavior."""
     # Arrange
@@ -1918,7 +1919,7 @@ def test_render_tolerates_non_dict_auth_and_tls_stanzas() -> None:
     context = _auth_tls_context(config["modules"]["web_terminals"])
 
     # Assert
-    assert context["auth_method"] == "none"
+    assert context["auth_method"] == "token"
     assert context["tls_enabled"] is False
     assert "docker-compose.web.yml" in artifacts
 
@@ -2012,9 +2013,9 @@ def test_nginx_seam_auth_method_set_gates_every_proxied_user_location() -> None:
     assert "return 200;" not in directives
 
 
-def test_nginx_seam_auth_none_omits_auth_request_even_with_tls_enabled() -> None:
+def test_nginx_seam_auth_token_omits_auth_request_even_with_tls_enabled() -> None:
     """The two seams are independently gated: TLS on with `auth.method` left at its
-    "none" default must still omit `auth_request` entirely."""
+    "token" default must still omit `auth_request` entirely."""
     # Arrange
     config = copy.deepcopy(_MULTI_USER_CONFIG)
     config["modules"]["web_terminals"]["tls"] = {
@@ -2030,6 +2031,35 @@ def test_nginx_seam_auth_none_omits_auth_request_even_with_tls_enabled() -> None
     # Assert
     assert "listen 443 ssl;" in nginx_conf
     assert "auth_request" not in nginx_conf
+
+
+def test_nginx_seam_open_omits_auth_request_even_with_tls_enabled() -> None:
+    """`none` is the combination worth stating separately: it is the one
+    method that renders BOTH TLS and an injected credential and still stands no
+    wall.
+
+    Encrypting the transport says nothing about who may cross it, and injecting
+    a secret is the perimeter vouching for a request rather than checking one.
+    A seam that read either as authentication would put a login wall in front
+    of a deployment whose whole posture is that the network is the perimeter.
+    """
+    # Arrange
+    config = _open_config()
+    config["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "cert": "/etc/nginx/certs/dls.crt",
+        "key": "/etc/nginx/certs/dls.key",
+    }
+
+    # Act
+    nginx_conf = render_web_terminals(config)["nginx/nginx.conf"]
+
+    # Assert
+    assert "listen 443 ssl;" in nginx_conf
+    assert "auth_request" not in nginx_conf
+
+    # Assert — non-vacuous: this render really is the injecting posture.
+    assert _secret_include("alice") in _directives(nginx_conf)
 
 
 # ---------------------------------------------------------------------------
@@ -2168,6 +2198,17 @@ def _auth_config(users: list[str] | None = None, **auth: object) -> dict:
     stanza: dict = {"method": "password", "allow_insecure_http": True}
     stanza.update(auth)
     config["modules"]["web_terminals"]["auth"] = stanza
+    return config
+
+
+def _open_config(users: list | None = None) -> dict:
+    """A rendering config in the open posture (`auth.method: none`).
+
+    No `allow_insecure_http`: the cleartext refusal guards a sidecar's session
+    cookies, and this posture mints none.
+    """
+    config = _config(users if users is not None else ["alice", "bob", "carol"])
+    config["modules"]["web_terminals"]["auth"] = {"method": "none"}
     return config
 
 
@@ -2317,13 +2358,15 @@ def test_auth_location_verify_subrequest_fails_fast() -> None:
     assert "proxy_read_timeout 3600s;" in _location_body(nginx_conf, "location /u/alice/")
 
 
-def test_auth_location_absent_when_method_is_none() -> None:
-    """`auth.method: none` renders no auth target, no `auth_request`, and no
-    reference to the sidecar's port — byte-for-byte the pre-auth output.
+def test_no_sidecar_surface_when_the_method_runs_no_sidecar() -> None:
+    """Neither method without a sidecar renders a verify target, an
+    `auth_request` or the sidecar's port — the login wall is `sidecar_active`'s
+    alone.
 
-    (The wider byte-equality guarantee is pinned by the golden fixtures in
-    test_golden_render.py; this asserts the property directly for the explicit
-    `method: none` spelling as well as the absent-stanza default.)
+    The two are no longer the same render, which is the point of `none`: the
+    absent-stanza default (`token`) injects nothing, while `none` includes each
+    non-exempt user's secret snippet. What they share is the whole sidecar
+    surface being missing, and that is what is asserted of both.
     """
     # Arrange
     default_config = copy.deepcopy(_MULTI_USER_CONFIG)
@@ -2335,10 +2378,39 @@ def test_auth_location_absent_when_method_is_none() -> None:
     explicit_conf = _render_nginx(explicit_none)
 
     # Assert
-    assert explicit_conf == default_conf
-    assert "_osprey_auth" not in default_conf
-    assert "auth_request" not in default_conf
-    assert "9070" not in default_conf
+    for conf in (default_conf, explicit_conf):
+        assert "_osprey_auth" not in conf
+        assert "auth_request" not in conf
+        assert "9070" not in conf
+
+    # Assert — and the one thing that DOES separate them. Read off the
+    # directives: the template names this very include in the prose above it.
+    assert _secret_include("alice") in _directives(explicit_conf)
+    assert "include " not in _directives(default_conf)
+
+
+def test_the_absent_auth_stanza_renders_exactly_the_explicit_token_posture() -> None:
+    """An unwritten `auth:` block is not a fourth posture — it IS `token`.
+
+    Asserted across every artifact rather than on the nginx fragment alone,
+    because the default is what every deployment that never opted into
+    authentication renders: a divergence between the absent spelling and the
+    written one would change those deployments on an upgrade, silently, in
+    whichever artifact happened to read the method rather than a derived
+    boolean.
+    """
+    # Arrange
+    absent = copy.deepcopy(_MULTI_USER_CONFIG)
+    explicit = copy.deepcopy(_MULTI_USER_CONFIG)
+    explicit["modules"]["web_terminals"]["auth"] = {"method": "token"}
+
+    # Act
+    secrets = _secrets_for(["alice", "bob", "carol"])
+
+    # Assert
+    assert render_web_terminals(absent, terminal_secrets=secrets) == render_web_terminals(
+        explicit, terminal_secrets=secrets
+    )
 
 
 def test_auth_location_zero_users_renders_no_auth_targets() -> None:
@@ -2449,9 +2521,10 @@ def test_auth_public_location_does_not_expose_the_verify_endpoint() -> None:
     assert all("/verify?user=" in line for line in verify_lines)
 
 
-def test_auth_public_location_absent_when_method_is_none() -> None:
-    """No sidecar, no public login surface — a `none` deployment renders no
-    `/auth/` location at all."""
+def test_auth_public_location_absent_when_method_is_token() -> None:
+    """No sidecar, no public login surface — a `token` deployment renders no
+    `/auth/` location at all. (`none` is held by the open-render tests in
+    test_nginx_auth_surface.py, which rule out the bare prefix as well.)"""
     # Act
     nginx_conf = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
 
@@ -2506,14 +2579,15 @@ def test_cookie_strip_spares_the_sidecar_locations() -> None:
     assert "Cookie" not in _directives(_location_body(nginx_conf, "location = /_osprey_auth/alice"))
 
 
-def test_cookie_strip_absent_when_method_is_none() -> None:
-    """Without authentication the cookie is not CUT — it is the only gate left.
+def test_cookie_strip_absent_when_method_is_token() -> None:
+    """Under `token` the cookie is not CUT — it is the only gate left.
 
     There is no sidecar session to keep out of a container here, but there is
     still a shared cookie jar: one origin serves every terminal, so the browser's
     raw `Cookie` header names every OTHER user's session this browser holds. So
-    the auth-off location forwards exactly one cookie — the one this user's own
-    app issued — and nothing else.
+    the location forwards exactly one cookie — the one this user's own app
+    issued, which under this method is the whole authorization — and nothing
+    else.
     """
     # Act
     nginx_conf = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
@@ -2691,8 +2765,8 @@ def test_negotiated_401_login_target_is_the_public_auth_prefix() -> None:
     assert "auth_request" not in _location_body(nginx_conf, "location /auth/")
 
 
-def test_negotiated_401_absent_when_method_is_none() -> None:
-    """Nothing to negotiate without authentication: no map, no `error_page`,
+def test_negotiated_401_absent_when_method_is_token() -> None:
+    """Nothing to negotiate without a wall: no map, no `error_page`,
     no handler."""
     # Act
     nginx_conf = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
@@ -2701,6 +2775,27 @@ def test_negotiated_401_absent_when_method_is_none() -> None:
     assert "$osprey_auth_wants_login_page" not in nginx_conf
     assert "error_page" not in nginx_conf
     assert "@osprey_auth_401" not in nginx_conf
+
+
+def test_negotiated_401_absent_when_the_method_is_open() -> None:
+    """Injecting a credential is not the same as being able to ask for one.
+
+    The negotiation exists to turn a denied subrequest into either a login page
+    or a bare 401, depending on what the client is. Under `none` no request is
+    ever denied at the perimeter, so a map, an `error_page` or the named
+    handler here would describe a login flow with no login behind it — and the
+    handler redirects to `/auth/login`, which this deployment does not serve.
+    """
+    # Act
+    nginx_conf = _render_nginx(_open_config())
+
+    # Assert
+    assert "$osprey_auth_wants_login_page" not in nginx_conf
+    assert "error_page" not in nginx_conf
+    assert "@osprey_auth_401" not in nginx_conf
+
+    # Assert — non-vacuous: this render is the injecting one, not an empty one.
+    assert _secret_include("alice") in _directives(nginx_conf)
 
 
 # ---------------------------------------------------------------------------
@@ -2868,12 +2963,27 @@ def _env_names(service: dict) -> list[str]:
     return [line.split("=", 1)[0] for line in service.get("environment", [])]
 
 
-def test_auth_sidecar_service_is_absent_for_method_none() -> None:
-    """The default posture renders the overlay it renders today: no sidecar service,
-    no auth environment, no reference to the credential file. Every deployment that
-    has not opted into authentication must be untouched by this feature."""
+@pytest.mark.parametrize(
+    "auth", [None, {"method": "token"}, {"method": "none"}], ids=["absent", "token", "open"]
+)
+def test_no_sidecar_service_is_rendered_for_a_method_that_stands_no_wall(
+    auth: dict | None,
+) -> None:
+    """Every wall-less posture renders the overlay it rendered before this
+    feature existed: no sidecar service, no auth environment, no reference to
+    the credential file.
+
+    `none` is the one worth stating rather than assuming. It DOES change the
+    nginx fragment — each non-exempt location injects that user's operator
+    secret — so it is the posture most likely to acquire a sidecar by
+    association. It must not: the whole content of `none` is that the network
+    is the perimeter, and a sidecar rendered beside it would be a login wall
+    nothing routes through, holding credentials nobody presents.
+    """
     # Arrange
     config = copy.deepcopy(_MULTI_USER_CONFIG)
+    if auth is not None:
+        config["modules"]["web_terminals"]["auth"] = auth
 
     # Act
     rendered = render_web_terminals(config)["docker-compose.web.yml"]
@@ -2889,13 +2999,18 @@ def test_auth_sidecar_service_is_absent_for_method_none() -> None:
     assert AUTH_ENV_FILENAME not in rendered
 
 
-def test_auth_sidecar_service_is_the_only_service_authentication_adds() -> None:
+@pytest.mark.parametrize("method", ["password", "oidc"])
+def test_auth_sidecar_service_is_the_only_service_authentication_adds(method: str) -> None:
     """Turning auth on adds exactly one service — `auth` — and changes nothing about
     the per-user set. The name is deliberately not `web-auth`: usernames render as
     `web-<user>`, so a roster user named "auth" would collide with that spelling but
-    cannot collide with this one."""
+    cannot collide with this one.
+
+    Both sidecar methods, because the service is what `sidecar_active` renders
+    and neither method may reach that decision on its own.
+    """
     # Act
-    services = set(_compose(_auth_config())["services"])
+    services = set(_compose(_auth_config(method=method))["services"])
 
     # Assert
     assert services == {"auth", "nginx", "web-alice", "web-bob", "web-carol"}
@@ -3252,8 +3367,8 @@ def test_auth_sidecar_digest_label_is_omitted_when_no_digest_is_supplied() -> No
     assert AUTH_ENV_DIGEST_LABEL not in (auth.get("labels") or {})
 
 
-def test_method_none_render_is_byte_identical_with_and_without_a_digest() -> None:
-    """With authentication off there is no sidecar and no env_file to track:
+def test_method_token_render_is_byte_identical_with_and_without_a_digest() -> None:
+    """With no sidecar there is no env_file to track:
     a passed digest must leave the render untouched (and must not leak into
     any other service's definition)."""
     # Act
@@ -4160,10 +4275,10 @@ def test_no_secret_snippet_is_written_for_a_location_nothing_gates() -> None:
     """A snippet nothing `include`s is a plaintext secret in the nginx container
     for no reader.
 
-    nginx emits the include under exactly one predicate — `auth_method != "none"
-    and not svc.login_exempt` — so with authentication off nothing includes
-    anything, and a `login: false` entry is served ungated with the header
-    CLEARED. Neither gets a file. The roster REFUSALS still cover everyone: each
+    nginx emits the include under exactly one predicate — `inject_secret and
+    not svc.login_exempt` — so under `token` nothing includes anything, and a
+    `login: false` entry is served ungated with the header CLEARED whatever the
+    method. Neither gets a file. The roster REFUSALS still cover everyone: each
     user's own container reads its own secret whatever the perimeter does.
     """
     # Arrange
@@ -4450,7 +4565,7 @@ def test_the_secret_carrier_refuses_a_roster_name_that_is_not_one_snippet_filena
         _terminal_secret_artifacts(
             services,
             {"alice": "a", "../../etc/nginx/conf.d/evil": "b"},
-            auth_method="password",
+            inject_secret=True,
         )
 
 
@@ -4483,7 +4598,7 @@ def test_the_secret_carrier_refuses_a_dotted_name_that_derives_an_illegal_variab
     # Act / Assert
     with pytest.raises(ValueError, match=r"OSPREY_TERMINAL_SECRET_ALICE\.B"):
         _terminal_secret_artifacts(
-            [_secret_service("alice.b")], {"alice.b": "a-secret"}, auth_method="password"
+            [_secret_service("alice.b")], {"alice.b": "a-secret"}, inject_secret=True
         )
 
 
@@ -4526,7 +4641,7 @@ def test_the_secret_carrier_refuses_case_colliding_names_too() -> None:
         _terminal_secret_artifacts(
             [_secret_service("Alice"), _secret_service("alice")],
             _secrets_for(["Alice", "alice"]),
-            auth_method="password",
+            inject_secret=True,
         )
 
 
@@ -4578,6 +4693,17 @@ def _mixed_login_config(exempt: str) -> dict:
     )
 
 
+def _open_mixed_config(exempt: str) -> dict:
+    """The same roster in the open posture — the shape where the two ungated
+    locations differ from each other, one injected and one cleared."""
+    return _open_config(
+        [
+            {"name": "alice", "index": 0},
+            {"name": exempt, "index": 1, "login": False},
+        ]
+    )
+
+
 def test_nginx_gated_location_includes_only_its_own_users_secret_snippet() -> None:
     """Each authenticated location pulls in that user's snippet and no other's.
 
@@ -4619,17 +4745,48 @@ def test_nginx_secret_include_sits_inside_the_auth_guarded_branch() -> None:
     assert body.index(_secret_include("alice")) < body.index("proxy_pass ")
 
 
-def test_nginx_secret_include_absent_when_auth_method_is_none() -> None:
-    """With no gate in front of the app there is no authorized request for
-    nginx to vouch for, so it injects nothing and the app's own token->cookie
+def test_nginx_secret_include_absent_when_auth_method_is_token() -> None:
+    """`token` is the one method that injects nothing: the browser reaches each
+    app through that user's own `?token=` exchange and the app's own cookie
     session is the only gate — the posture the render had before this carrier
-    existed."""
+    existed. `none` is NOT this case; it injects without a login wall."""
     # Act
     nginx_conf = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
 
     # Assert
     assert "include " not in _directives(nginx_conf)
     assert "/etc/nginx/osprey/" not in nginx_conf
+
+
+def test_nginx_open_render_injects_the_secret_without_any_login_wall() -> None:
+    """The `none` method's whole shape, smoke-tested at the render seam.
+
+    Reaching this nginx IS the authorization, so every non-exempt location
+    carries its own user's snippet with no subrequest in front of it. An entry
+    that declared `login: false` opts out of that injection exactly as it opts
+    out of a login wall under `password`, and gets no snippet written for it.
+    """
+    # Arrange
+    config = _config([{"name": "alice", "index": 0}, {"name": "kiosk", "index": 1, "login": False}])
+    config["modules"]["web_terminals"]["auth"] = {"method": "none"}
+
+    # Act
+    artifacts = render_web_terminals(config, terminal_secrets=_secrets_for(["alice", "kiosk"]))
+    nginx_conf = artifacts["nginx/nginx.conf"]
+
+    # Assert — the non-exempt user is vouched for… (read off the directives:
+    # the template names this very include in the prose above it)
+    assert _secret_include("alice") in _directives(_location_body(nginx_conf, "location /u/alice/"))
+    # …the exempt one is not, and has the header cleared instead.
+    kiosk = _directives(_location_body(nginx_conf, "location /u/kiosk/"))
+    assert _secret_include("kiosk") not in kiosk
+    assert 'proxy_set_header X-Osprey-Terminal-Secret "";' in kiosk
+
+    # Assert — and no login wall was rendered anywhere.
+    assert "auth_request" not in nginx_conf
+    assert [path for path in artifacts if path.startswith("nginx/templates/")] == [
+        "nginx/templates/secret-alice.conf.template"
+    ]
 
 
 def test_nginx_login_exempt_location_gets_no_secret_and_keeps_its_cookie() -> None:
@@ -4653,17 +4810,26 @@ def test_nginx_login_exempt_location_gets_no_secret_and_keeps_its_cookie() -> No
 
 
 def test_nginx_secret_include_and_cookie_strip_share_one_predicate() -> None:
-    """The two effects are gated on one condition and must never diverge.
+    """Within a sidecar method the two effects move together and must never
+    diverge.
 
     A location with the strip but no header authenticates nothing and 401s
     every request; a location with the header but no strip lets an
     unauthenticated request carry an operator's session cookie into a container
     that runs agent-generated code. Asserted across every render shape rather
     than on one, because the divergence is what a later edit would reintroduce.
+
+    `none` is deliberately outside these shapes: it injects the header and
+    still narrows (rather than cuts) the cookie, because with no sidecar there
+    is no origin-wide `osprey_auth_session` for the strip to protect. Its own
+    pairing — the include beside the one forwarded session cookie — is pinned
+    by
+    `test_nginx_auth_surface.py::test_open_render_injects_each_non_exempt_users_own_secret_with_no_gate_in_front`,
+    which would fail if that render ever acquired the strip.
     """
     # Arrange
     shapes = {
-        "auth-off": (copy.deepcopy(_MULTI_USER_CONFIG), ["alice", "bob", "carol"]),
+        "token": (copy.deepcopy(_MULTI_USER_CONFIG), ["alice", "bob", "carol"]),
         "auth-on": (_auth_config(["alice", "bob"]), ["alice", "bob"]),
         "mixed": (_mixed_login_config("kiosk"), ["alice", "kiosk"]),
     }
@@ -4766,12 +4932,18 @@ def test_every_terminal_location_clears_the_authorization_header() -> None:
     costs nothing and closes the one route by which a caller could present a
     credential this proxy did not vouch for. Unconditional, unlike the cookie
     and secret headers: it is never legitimate here in any auth mode.
+
+    "Any auth mode" is the claim, so the open posture is one of the shapes: it
+    is the one where nginx DOES stamp a credential of its own, and a location
+    that forwarded the client's `Authorization` beside it would let a caller
+    add a second one the proxy never vouched for.
     """
     # Arrange
     shapes = {
-        "auth-off": (copy.deepcopy(_MULTI_USER_CONFIG), ["alice", "bob", "carol"]),
+        "token": (copy.deepcopy(_MULTI_USER_CONFIG), ["alice", "bob", "carol"]),
         "auth-on": (_auth_config(["alice", "bob"]), ["alice", "bob"]),
         "mixed": (_mixed_login_config("kiosk"), ["alice", "kiosk"]),
+        "open": (_open_mixed_config("kiosk"), ["alice", "kiosk"]),
     }
 
     # Act / Assert
@@ -4790,13 +4962,13 @@ def test_ungated_locations_clear_the_operator_secret_header() -> None:
     would let anyone who can reach the port authenticate as the operator.
     """
     # Arrange / Act
-    auth_off = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
+    token = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
     mixed = _render_nginx(_mixed_login_config("kiosk"))
     cleared = 'proxy_set_header X-Osprey-Terminal-Secret "";'
 
-    # Assert — every auth-off location clears it
+    # Assert — `token` injects nowhere, so every location clears it
     for user in ("alice", "bob", "carol"):
-        assert cleared in _directives(_location_body(auth_off, f"location /u/{user}/"))
+        assert cleared in _directives(_location_body(token, f"location /u/{user}/"))
 
     # Assert — with auth on, only the exempt location does; the gated one has
     # the include that SETS it and must not clear it afterwards.

--- a/tests/e2e/web_terminals/test_terminal_auth_multiuser_e2e.py
+++ b/tests/e2e/web_terminals/test_terminal_auth_multiuser_e2e.py
@@ -1,47 +1,91 @@
-"""Acceptance proof that the DEFAULT multi-user posture — ``auth.method: none``
-— still closes the chain in front of every terminal, because the terminal app
-owns the gate.
+"""Acceptance proof for the two multi-user postures that run NO auth sidecar:
+``auth.method: token`` (the default) and ``auth.method: none`` (open).
 
-WHY THIS LANE EXISTS ALONGSIDE ``test_auth_perimeter.py``
---------------------------------------------------------
-``test_auth_perimeter.py`` proves the *authenticated* perimeter: with
+WHY THESE LANES EXIST ALONGSIDE ``test_auth_perimeter.py``
+----------------------------------------------------------
+``test_auth_perimeter.py`` proves the *walled* perimeter: with
 ``auth.method: password`` nginx runs an ``auth_request`` against the sidecar,
 injects the per-user operator secret as a header on the way through, and strips
 the browser's cookie. There the sidecar is the front door and nginx vouches for
-every request that reaches a container.
+every request that reaches a container — but only for a request that already
+cleared a login.
 
-This lane proves the case that has NO sidecar and NO header injection at all —
-the one a fresh ``osprey init`` gives you, since ``modules.web_terminals.auth``
-defaults to ``method: none``. With auth off, nginx runs no ``auth_request``,
-injects no ``X-Osprey-Terminal-Secret`` header, and passes the browser's cookie
-straight THROUGH (all three effects hang off nginx.conf.j2's
-``auth_method != "none" and not login_exempt`` predicate). So nothing in front
-of the container authenticates anything: the per-user terminal app's own
-``WebAuthMiddleware`` is the only thing standing between one user's browser and
-another user's terminal.
+The two postures proved here have no sidecar and no login wall at all, and they
+differ in exactly one thing: whether nginx vouches for the caller.
 
-That is the more dangerous half of the design, not the less: an operator who
-never turns auth on is relying entirely on the app-owned gate. ``osprey`` mints
-a per-user operator secret for every deployment regardless of auth method
-(``ensure_terminal_secrets`` runs even when ``auth.method: none``), precisely so
-that this gate has a credential to enforce. This test is the end-to-end proof
-that it does.
+  ``token``  nginx runs no ``auth_request``, injects NO operator-secret header,
+             and passes the browser's cookie straight through. Nothing in front
+             of the container authenticates anything, so the per-user terminal
+             app's own ``WebAuthMiddleware`` is the only thing standing between
+             one user's browser and another user's terminal. A browser gets in
+             by presenting that user's minted secret once, as the ``?token=``
+             magic link, which the app exchanges for a session cookie.
 
-WHAT THIS FILE ASSERTS, ON A REAL STACK
----------------------------------------
-Against a real ``osprey up`` deployment — nginx plus a per-user terminal
-container, reached over the published ``nginx_port`` with real HTTP clients:
+  ``none``   OPEN, navigation-only. nginx injects each user's operator secret on
+             every non-exempt ``/u/<user>/`` location, so anyone who can reach
+             nginx is served that user's terminal with no credential of their
+             own. Navigation IS the authentication. A roster entry that declared
+             ``login: false`` is deliberately left OUT of that injection: it is
+             proxied ungated, and the app's own gate is then the only one in
+             front of it.
 
-  T1  A mutating request to a user's terminal API carrying NO credential — no
-      cookie, and (because auth is off) no header nginx could have injected —
-      is refused with ``401`` by the app itself, even though nginx passed it
-      through untouched.
+``token`` is what an absent ``auth:`` block renders, and it carries what
+``auth.method: none`` used to mean before the four-method scheme. That the two
+spellings render the same bytes is pinned line by line in
+``tests/deployment/web_terminals/test_auth_off_baseline_pin.py``; this module
+spells the method explicitly and does not re-prove the equality.
+
+WHAT THIS FILE ASSERTS, ON REAL STACKS
+--------------------------------------
+Two real ``osprey up --dev`` deployments — nginx plus one per-user terminal
+container per roster entry, reached over each deployment's published
+``nginx_port`` with real HTTP clients.
+
+Against the ``token`` deployment (roster: ``alice``):
+
+  T1  A mutating request to ``alice``'s terminal API carrying NO credential —
+      no cookie, and (because ``token`` injects nothing) no header nginx could
+      have supplied — is refused with ``401`` by the app itself, even though
+      nginx passed it through untouched.
   T2  The per-user ``?token=`` login URL, whose token is that user's minted
       operator secret, is exchanged by a browser for a session cookie; the SAME
-      mutating request carrying that cookie (which nginx forwards, since auth is
-      off) is then accepted with ``200``. The gate the browser had to clear is
-      the app's, reached only because the deployment minted the secret the login
-      URL carries.
+      mutating request carrying that cookie is then accepted with ``200``.
+
+Against the ``open`` deployment (roster: ``alice``; ``kiosk`` with
+``login: false``):
+
+  O1  A cookie-less, token-less client both NAVIGATES to ``/u/alice/`` and
+      performs the mutating ``PATCH`` that T1 was refused — and is served
+      ``200`` for both. The credential it never presented was injected by
+      nginx; navigation alone reached a credentialed terminal.
+  O2  The exempt ``kiosk`` entry is proxied by that same nginx but carries no
+      injected secret, so the identical requests are refused ``401`` — and
+      refused by the terminal APP (a JSON refusal body), not by the perimeter.
+      One deployment, one image, two locations: the difference is the injection.
+  O3  Every per-user container carries the perimeter stamp
+      (``OSPREY_WEB_PERIMETER=open`` plus this deployment's own web ports), and
+      code executed through the shipped ``ExecutionWrapper`` INSIDE one of those
+      containers is refused a connection to the deployment's nginx port.
+
+WHAT O3 PROVES, AND WHAT IT DOES NOT
+------------------------------------
+It proves the whole chain that is specific to a deployment: the render stamped
+the right ports onto the container, the executor's own parent-side reader parses
+that stamp back inside the real image, and a wrapped child built from it refuses
+the deployment's live nginx port. It runs an unarmed control child in the same
+container first, which DOES connect — so the refusal is a refusal and not a port
+that nothing was listening on.
+
+It does NOT prove containment. The guard is emitted source in the child's own
+namespace (``services/python_executor/execution/net_guard.py`` says so itself:
+defense in depth, not a security boundary), so code that knows it is there takes
+it down, and a shell or a browser tool never goes through it at all. That hole
+is closed at deploy time instead, by the gate that refuses an open deployment
+whose personas do not deny ``Bash``/``WebFetch``/``WebSearch``/Playwright — which
+is why this lane's persona ships the rendered deny list and why an open
+``osprey up`` here would otherwise be REFUSED rather than merely unsafe. Nor does
+it drive the MCP server: that the executor calls the reader on every execution is
+pinned by unit tests, not here.
 
 THE TERMINAL BEHIND NGINX IS REAL, NOT A STUB
 ---------------------------------------------
@@ -50,18 +94,24 @@ its subject is the perimeter and a real terminal image would only add minutes to
 a test about the sidecar. Here the terminal IS the subject: the gate under test
 lives in the terminal app, so the container behind nginx must run the real
 ``osprey web`` — the actual ``WebAuthMiddleware``, the actual ``?token=`` →
-cookie exchange handler, the actual ``PATCH /api/config`` operator route. A stub
-would prove nothing about the gate.
+cookie exchange handler, the actual ``PATCH /api/config`` operator route, and
+(for O3) the actual installed framework. A stub would prove nothing.
 
 The persona image is therefore a REAL framework install (``pip install
 osprey-framework`` with a C toolchain plus the Claude Code CLI — minutes, cold),
 which is why this file carries the ``dockerbuild`` marker and runs in its own CI
 lane rather than the shared fast e2e glob. Its recipe is not hand-rolled: the
 fixture renders a throwaway ``hello-world`` deployment with the shipped ``osprey
-init``/``osprey build`` and reuses that render's own container repo — the
-production project ``Dockerfile`` that runs ``osprey web``, and a real rendered
-``config.yml`` the app can serve — as the persona's project. So the image built
-here is the one a real deployment builds, not an approximation of it.
+init``/``osprey build`` and reuses that render's own artifacts — the production
+project ``Dockerfile`` that runs ``osprey web``, a real rendered ``config.yml``
+the app can serve, and the rendered ``.claude/settings.json`` whose deny list the
+open-mode deploy gate reads.
+
+ONE PERSONA, TWO DEPLOYMENTS. The two lanes share a single persona project and
+therefore a single image tag, so the expensive build happens once and the second
+``osprey up`` re-runs it against a byte-identical context (a runtime cache hit).
+They differ only in facility prefix, compose project and port band, so both
+stacks can be up at once without colliding.
 
 ``--dev`` is REQUIRED for the same reason it is in the perimeter lane: the
 project Dockerfile pins ``osprey-framework`` to this deployment's version, which
@@ -71,9 +121,9 @@ the image then overlays, so the terminal that runs here is this branch's code.
 
 CONTAINER-OPS SAFETY: every runtime-mutating call below names an EXACT resource
 this test created — the ``<prefix>-nginx`` / ``<prefix>-web-<user>`` containers,
-this project's volumes, and the ``:local`` image tag — or is the project-scoped
-``compose down`` the deploy lifecycle itself uses. Nothing here ever runs a
-prune, an ``-a``/``--all`` sweep, or a wildcard removal.
+each lane's own volumes, and the shared ``:local`` image tag — or is the
+project-scoped ``compose down`` the deploy lifecycle itself uses. Nothing here
+ever runs a prune, an ``-a``/``--all`` sweep, or a wildcard removal.
 """
 
 from __future__ import annotations
@@ -89,6 +139,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -96,6 +147,8 @@ import pytest
 import yaml
 
 from osprey.deployment.web_terminals.auth_credentials import terminal_secret_var
+from osprey.mcp_server.sandbox_env import PERIMETER_DENY_PORTS_ENV, PERIMETER_MARKER_ENV
+from osprey.services.python_executor.execution.net_guard import NET_GUARD_REFUSAL_PREFIX
 from osprey.utils.dotenv import parse_dotenv_file
 from tests.e2e._volumes import remove_project_volumes
 
@@ -103,7 +156,9 @@ from tests.e2e._volumes import remove_project_volumes
 # tests/deployment/test_ci_workflow_wiring.py requires every file carrying it to
 # be --ignore'd in the shared e2e-tests lane AND given its own job. Without the
 # marker this file would be swept into that lane's glob over tests/e2e/ and the
-# expensive framework build would run in the wrong lane.
+# expensive framework build would run in the wrong lane. It is also why both
+# postures live in ONE module: a second file would need its own ignore entry and
+# its own job, and would pay for the framework build a second time.
 pytestmark = [pytest.mark.e2e, pytest.mark.dockerbuild]
 
 _SUPPORTED_RUNTIMES = ("docker", "podman")
@@ -113,35 +168,126 @@ if RUNTIME not in _SUPPORTED_RUNTIMES:
         f"OSPREY_E2E_RUNTIME={RUNTIME!r} is not supported; expected one of {_SUPPORTED_RUNTIMES}"
     )
 
-# The repo DIRECTORY name, which is the deployment name: the compose project and
-# the com.osprey.project label on every image this deploy builds.
-PROJECT_NAME = "osprey-e2e-authoff-multiuser"
-PREFIX = "authoff"
+#: The persona both lanes run, and the render its image is tagged for. Named
+#: independently of either lane's facility prefix precisely because it is
+#: SHARED: one render, one ``<project>:local`` image, built once and reused by
+#: the second deployment. It must also differ from either deployment's own name
+#: — lint refuses a persona project that shadows the deployment's worker tag.
 PERSONA = "operator"
-PERSONA_PROJECT = f"{PREFIX}-operator"
-#: One user is enough for the default-posture proof: the gate under test is the
-#: app's own, and a second roster user would only add a second heavy container
-#: to a proof about one terminal's front door.
-USER = "alice"
-USERS = (USER,)
-#: The preset the throwaway persona render (and the host repo) are built from —
-#: the smallest one that stands up a serving ``osprey web``.
+PERSONA_PROJECT = "authmulti-operator"
+PERSONA_IMAGE_TAG = f"{PERSONA_PROJECT}:local"
+#: The preset the throwaway persona render (and both host repos) are built from
+#: — the smallest one that stands up a serving ``osprey web``.
 PRESET = "hello-world"
+
+
+@dataclass(frozen=True)
+class Lane:
+    """One deployment under test: a posture, a roster, and a port band.
+
+    Everything that must differ between two stacks standing up at the same time
+    is here rather than in module constants, so a helper cannot silently act on
+    the wrong deployment: the facility prefix decides every container name, the
+    project name decides the compose project and its volumes, and the port band
+    decides what nginx and each terminal bind.
+
+    ``users`` holds roster entries as they are authored in the profile. The
+    ``open`` lane must use OBJECT entries: a bare-string entry runs no persona,
+    so the open-mode deploy gate reads the DEPLOY project's settings.json for it
+    (the zero-migration sentinel) instead of the persona's, and refuses a
+    deployment whose persona is in fact clean.
+    """
+
+    posture: str
+    project_name: str
+    prefix: str
+    nginx_port: int
+    base_ports: dict[str, int]
+    users: tuple[dict[str, Any] | str, ...]
+
+    @property
+    def usernames(self) -> tuple[str, ...]:
+        return tuple(user if isinstance(user, str) else str(user["name"]) for user in self.users)
+
+    @property
+    def external_origin(self) -> str:
+        """What ``deployment_external_origin`` derives for this lane.
+
+        ``deploy.fqdn`` is ``127.0.0.1`` and TLS is off in both lanes, so the
+        origin a browser reaches is the published nginx port — which is what the
+        app checks a mutating request's ``Origin`` against.
+        """
+        return f"http://127.0.0.1:{self.nginx_port}"
+
+    @property
+    def web_ports(self) -> tuple[int, ...]:
+        """Each roster user's terminal port, allocated as the render allocates it.
+
+        ``allocate_ports`` adds the entry's INDEX to the family base, so the
+        index is read off an object entry rather than taken from its position —
+        the two agree here, and would stop agreeing the moment a roster declared
+        them apart.
+        """
+        return tuple(
+            self.base_ports["web"] + (position if isinstance(user, str) else int(user["index"]))
+            for position, user in enumerate(self.users)
+        )
+
+    def container(self, user: str) -> str:
+        return f"{self.prefix}-web-{user}"
+
+    @property
+    def nginx_container(self) -> str:
+        return f"{self.prefix}-nginx"
+
 
 # Ports well clear of every other stack a developer may have up (the tutorial
 # stacks hold 5064/5080/5432; the lifecycle fixtures the 9000s/19081; the auth
-# perimeter lane the 191xx/192xx band). This lane takes a distinct band.
-NGINX_PORT = 19680
-BASE_PORTS = {
-    "web": 19671,
-    "artifact": 19771,
-    "ariel": 19871,
-    "lattice": 19971,
-    "channel_finder": 19981,
-}
+# perimeter lane the 191xx/192xx band). Each lane takes a distinct slice of the
+# 196xx/197xx-199xx band, because both stacks are up simultaneously: pytest
+# tears a module-scoped fixture down at the end of the module, not at the end of
+# the tests that used it.
+TOKEN_LANE = Lane(
+    posture="token",
+    project_name="osprey-e2e-token-multiuser",
+    prefix="authtok",
+    nginx_port=19680,
+    base_ports={
+        "web": 19671,
+        "artifact": 19771,
+        "ariel": 19871,
+        "lattice": 19971,
+        "channel_finder": 19981,
+    },
+    #: One user is enough for the token proof: the gate under test is the app's
+    #: own, and a second roster user would only add a second heavy container to
+    #: a proof about one terminal's front door.
+    users=("alice",),
+)
 
-PERSONA_IMAGE_TAG = f"{PERSONA_PROJECT}:local"
-NGINX_C = f"{PREFIX}-nginx"
+OPEN_LANE = Lane(
+    posture="none",
+    project_name="osprey-e2e-open-multiuser",
+    prefix="authopen",
+    nginx_port=19690,
+    base_ports={
+        "web": 19691,
+        "artifact": 19791,
+        "ariel": 19891,
+        "lattice": 19941,
+        "channel_finder": 19951,
+    },
+    #: TWO entries, because the open posture's claim is a CONTRAST: `alice` is
+    #: injected into, `kiosk` declared `login: false` and is not. One container
+    #: each, from the same already-built image.
+    users=(
+        # `index` is spelled out because an OBJECT entry must carry one — profile
+        # validation refuses an object roster entry with no index, since the
+        # index (not the position) is what allocates every port family.
+        {"name": "alice", "index": 0, "persona": PERSONA},
+        {"name": "kiosk", "index": 1, "persona": PERSONA, "login": False},
+    ),
+)
 
 # The persona build is a real framework install; give it room.
 DEPLOY_UP_TIMEOUT_SEC = 1800
@@ -152,12 +298,15 @@ RENDER_TIMEOUT_SEC = 600
 # `osprey web` boot inside the container (import the framework, start the app)
 # is slower than a static stub, so readiness is polled generously.
 READY_TIMEOUT_SEC = 240.0
+# The in-container guard probe imports the framework twice (the probe itself,
+# then the wrapped child it spawns) on a container that is already serving.
+GUARD_PROBE_TIMEOUT_SEC = 300
 
 #: A benign, valid mutating update for the operator-only ``PATCH /api/config``
 #: route: a single dot-notation field that ``config_update_fields`` can write to
 #: the served ``config.yml``. The point is the STATUS the gate returns, not the
 #: value written — a display label mutates nothing the deployment relies on.
-_CONFIG_PATCH_BODY = json.dumps({"updates": {"web.app_name": "authoff-e2e"}}).encode()
+_CONFIG_PATCH_BODY = json.dumps({"updates": {"web.app_name": "multiuser-e2e"}}).encode()
 
 # ZO_INGEST_SA_TOKEN is present but inert: hello-world renders an OpenObserve
 # telemetry block whose password is `${ZO_INGEST_SA_TOKEN}`, and the deploy
@@ -168,13 +317,67 @@ _CONFIG_PATCH_BODY = json.dumps({"updates": {"web.app_name": "authoff-e2e"}}).en
 # so the value is never used.
 _ENV_CONTENT = "ANTHROPIC_API_KEY=fake-llm-key-value\nZO_INGEST_SA_TOKEN=fake-telemetry-token\n"
 
+#: The O3 probe, run by the container's own interpreter inside a per-user
+#: terminal container. Two children, one difference:
+#:
+#: * ARMED — an ``ExecutionWrapper`` built from the ports the executor's OWN
+#:   parent-side reader parsed out of this container's environment. Imported by
+#:   its real name on purpose: the private helper is the seam the executor calls
+#:   on every execution, and a rename that left the stamp unread should break
+#:   this probe rather than pass it.
+#: * CONTROL — the same wrapper with no denied ports, which must CONNECT. It is
+#:   what makes the armed refusal mean something: without it, a refusal is
+#:   indistinguishable from nothing listening on that port.
+#:
+#: Answers on one ``OSPREY_PROBE`` line of JSON so the assertions read structured
+#: data rather than scraping two children's interleaved output.
+_GUARD_PROBE = """
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
 
-def _web_container(user: str) -> str:
-    return f"{PREFIX}-web-{user}"
+from osprey.mcp_server.python_executor.executor import _perimeter_denied_ports
+from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
+
+PROBE_CODE = (
+    "import socket\\n"
+    "try:\\n"
+    "    socket.create_connection(('127.0.0.1', __NGINX_PORT__), timeout=5).close()\\n"
+    "    print('PROBE-CONNECTED')\\n"
+    "except Exception as exc:\\n"
+    "    print('PROBE-REFUSED', exc)\\n"
+)
 
 
-def _runtime_cli(*args: str, timeout: int = 30) -> subprocess.CompletedProcess:
-    return subprocess.run([RUNTIME, *args], capture_output=True, text=True, timeout=timeout)
+def run(denied_ports):
+    with tempfile.TemporaryDirectory() as tmp:
+        folder = Path(tmp)
+        script = folder / "wrapped_script.py"
+        wrapper = ExecutionWrapper(perimeter_denied_ports=denied_ports)
+        script.write_text(wrapper.create_wrapper(PROBE_CODE, folder), encoding="utf-8")
+        done = subprocess.run(
+            [sys.executable, str(script)], capture_output=True, text=True, timeout=120
+        )
+    return {"rc": done.returncode, "out": done.stdout, "err": done.stderr}
+
+
+ports = _perimeter_denied_ports(os.environ)
+print(
+    "OSPREY_PROBE "
+    + json.dumps({"ports": list(ports), "armed": run(ports), "control": run(())})
+)
+"""
+
+
+def _runtime_cli(
+    *args: str, timeout: int = 30, input_text: str | None = None
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [RUNTIME, *args], capture_output=True, text=True, timeout=timeout, input=input_text
+    )
 
 
 def _fmt(label: str, result: subprocess.CompletedProcess) -> str:
@@ -227,10 +430,27 @@ def _logs(name: str) -> str:
     return f"--- {name} stdout ---\n{result.stdout}\n--- {name} stderr ---\n{result.stderr}"
 
 
+def _container_env(name: str) -> dict[str, str]:
+    """The environment a process started in *name* inherits.
+
+    Read from the running container rather than from the rendered compose file:
+    the claim under test is that the stamp reached the process, and a compose
+    line proves only that it was written down.
+    """
+    result = _runtime_cli("exec", name, "env", timeout=30)
+    assert result.returncode == 0, _fmt(f"{RUNTIME} exec {name} env", result)
+    env: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, _, value = line.partition("=")
+        if key:
+            env[key] = value
+    return env
+
+
 def _render_reference_project(tmp_path: Path, osprey_bin: Path) -> Path:
     """Render a throwaway ``hello-world`` deployment and return its ``build/`` dir.
 
-    The persona this lane deploys must run the REAL ``osprey web``, which needs a
+    The persona both lanes deploy must run the REAL ``osprey web``, which needs a
     real container repo: the production project ``Dockerfile`` (the one that
     installs the framework and launches ``osprey web``) and a rendered
     ``config.yml`` the app can actually serve. Rather than hand-roll either — a
@@ -252,7 +472,7 @@ def _render_reference_project(tmp_path: Path, osprey_bin: Path) -> Path:
     ref_repo = tmp_path / PERSONA_PROJECT
     # Telemetry OFF in the persona render too, for the same reason the host
     # override disables it: hello-world ships it enabled against an OpenObserve
-    # store this lane does not deploy, so its rendered config.yml would carry
+    # store these lanes do not deploy, so its rendered config.yml would carry
     # `openobserve.password: ${ZO_INGEST_SA_TOKEN}` — a credential only the store
     # can issue — and `osprey up` refuses to serve a terminal whose telemetry
     # names an unresolvable secret. The perimeter lane avoids this with a
@@ -300,12 +520,21 @@ def _write_persona_project(root: Path, ref_build: Path) -> Path:
     * the flat render's ``config.yml``/``Dockerfile`` are the reference render's
       own, so ``verify_persona_renders`` reads a real provider spec;
     * the image context is the reference render's WHOLE container repo
-      (``build/.image/persona-ref/`` — ``profile.yml`` at its root, the render in
-      ``build/`` below it), copied verbatim. Its ``Dockerfile`` is the production
-      project image: ``COPY . /app/<name>/``, then ``osprey web`` from that
-      directory, which walks up to the ``profile.yml`` this copy provides and
-      serves its ``build/config.yml``. That is what makes the terminal behind
+      (``build/.image/<persona project>/`` — ``profile.yml`` at its root, the
+      render in ``build/`` below it), copied verbatim. Its ``Dockerfile`` is the
+      production project image: ``COPY . /app/<name>/``, then ``osprey web`` from
+      that directory, which walks up to the ``profile.yml`` this copy provides
+      and serves its ``build/config.yml``. That is what makes the terminal behind
       nginx a real app rather than a stub.
+
+    The flat render's ``.claude/`` tree comes along for a reason the open lane
+    depends on: ``check_open_mode_requirements`` reads this directory's
+    ``.claude/settings.json`` and REFUSES ``osprey up`` unless it denies
+    ``Bash``, ``WebFetch``, ``WebSearch`` and the Playwright wildcard. Copying
+    the rendered artifact rather than writing a deny list here is what keeps the
+    lane honest: it proves the SHIPPED render satisfies the gate, so a future
+    change to ``DENY_DEFAULTS`` that broke every open deployment would fail this
+    lane instead of being papered over by a fixture's hand-made JSON.
 
     Under ``osprey up --dev`` the persona build stages the locally-built wheel
     into this same image context and passes ``OSPREY_PIP_SPEC``/``OSPREY_DEV``,
@@ -324,30 +553,33 @@ def _write_persona_project(root: Path, ref_build: Path) -> Path:
     image_context = root.parent / ".image" / root.name
     shutil.copytree(reference_context, image_context)
 
-    # The flat render's two required files, from the same reference build.
+    # The flat render's required files, from the same reference build.
     shutil.copy2(ref_build / "config.yml", root / "config.yml")
     shutil.copy2(ref_build / "Dockerfile", root / "Dockerfile")
+    shutil.copytree(ref_build / ".claude", root / ".claude")
     return root
 
 
-def _override_text() -> str:
-    """The ``-O`` overlay carrying this lane's whole web-terminal stanza.
+def _override_text(lane: Lane) -> str:
+    """The ``-O`` overlay carrying one lane's whole web-terminal stanza.
 
     Dotted leaf keys under ``config:``, the one spelling a profile's config
     block accepts — and ``modules.web_terminals`` deliberately as ONE dotted key
     with a nested value, so it sets that subtree without replacing the rendered
     ``modules:`` mapping around it.
 
-    ``auth.method: none`` is the whole point: it is the default multi-user
-    posture, and it is what makes the app-owned gate the ONLY gate — nginx runs
-    no ``auth_request``, injects no operator-secret header, and forwards the
-    browser's cookie. With auth off there is no TLS obligation either (the render
-    only requires TLS or ``allow_insecure_http`` when a real auth method would
-    otherwise send session cookies across the network), so no certificate
-    management enters this lane.
+    ``auth.method`` is spelled explicitly in both lanes, ``token`` included even
+    though an absent ``auth:`` block renders it: a reader of this file should not
+    have to know the default to know which posture is under test. The two
+    spellings' byte equality is pinned in
+    ``tests/deployment/web_terminals/test_auth_off_baseline_pin.py``.
+
+    Neither posture carries a TLS obligation — the render requires TLS or
+    ``allow_insecure_http`` only when a sidecar would send session cookies across
+    the network — so no certificate management enters either lane.
 
     ``deployed_services: []`` drops everything the preset would otherwise deploy:
-    this lane deploys the web tier and nothing else, and a backend service would
+    these lanes deploy the web tier and nothing else, and a backend service would
     only add containers and bound ports to a proof about nginx. Telemetry goes
     off with them, and for the same reason the perimeter lane disables it — the
     preset ships it aimed at a store this deploy no longer runs.
@@ -356,8 +588,8 @@ def _override_text() -> str:
         {
             "config": {
                 "container_runtime": RUNTIME,
-                "facility.name": "E2E Auth-Off Multiuser Fixture",
-                "facility.prefix": PREFIX,
+                "facility.name": f"E2E Multiuser Fixture ({lane.posture})",
+                "facility.prefix": lane.prefix,
                 "facility.timezone": "UTC",
                 "deploy.fqdn": "127.0.0.1",
                 "deployed_services": [],
@@ -366,14 +598,16 @@ def _override_text() -> str:
                     "enabled": True,
                     "image_source": "local",
                     "default_persona": PERSONA,
-                    "nginx_port": NGINX_PORT,
-                    "web_base_port": BASE_PORTS["web"],
-                    "artifact_base_port": BASE_PORTS["artifact"],
-                    "ariel_base_port": BASE_PORTS["ariel"],
-                    "lattice_base_port": BASE_PORTS["lattice"],
-                    "channel_finder_base_port": BASE_PORTS["channel_finder"],
-                    "users": list(USERS),
-                    "auth": {"method": "none"},
+                    "nginx_port": lane.nginx_port,
+                    "web_base_port": lane.base_ports["web"],
+                    "artifact_base_port": lane.base_ports["artifact"],
+                    "ariel_base_port": lane.base_ports["ariel"],
+                    "lattice_base_port": lane.base_ports["lattice"],
+                    "channel_finder_base_port": lane.base_ports["channel_finder"],
+                    "users": [
+                        dict(user) if isinstance(user, dict) else user for user in lane.users
+                    ],
+                    "auth": {"method": lane.posture},
                 },
             }
         },
@@ -382,7 +616,7 @@ def _override_text() -> str:
 
 
 def _add_persona_catalog(repo: Path, persona_path: Path) -> None:
-    """Point the profile's persona catalog at the hand-written stub project.
+    """Point the profile's persona catalog at the reused persona project.
 
     After materialization, deliberately. ``osprey init`` renders one delta per
     catalog entry and requires each entry to name a preset that EXTENDS the host
@@ -400,17 +634,15 @@ def _add_persona_catalog(repo: Path, persona_path: Path) -> None:
     profile_path.write_text(yaml.safe_dump(profile, sort_keys=False), encoding="utf-8")
 
 
-def _make_repo(tmp_path: Path, osprey_bin: Path) -> Path:
-    """``init`` + persona catalog + ``build`` — the repo this lane deploys.
+def _make_repo(lane: Lane, tmp_path: Path, osprey_bin: Path, persona_path: Path) -> Path:
+    """``init`` + persona catalog + ``build`` — the repo one lane deploys.
 
     ``--skip-deps``/``--skip-lifecycle`` keep the render off the network and
     quick: nothing here runs the deployment's own venv, only its containers.
     """
-    ref_build = _render_reference_project(tmp_path, osprey_bin)
-    persona_path = _write_persona_project(tmp_path / "persona", ref_build)
-    repo = tmp_path / PROJECT_NAME
-    override_path = tmp_path / "override.yml"
-    override_path.write_text(_override_text(), encoding="utf-8")
+    repo = tmp_path / lane.project_name
+    override_path = tmp_path / f"{lane.prefix}-override.yml"
+    override_path.write_text(_override_text(lane), encoding="utf-8")
 
     init = _run_osprey(
         osprey_bin,
@@ -418,7 +650,7 @@ def _make_repo(tmp_path: Path, osprey_bin: Path) -> Path:
         tmp_path,
         timeout=RENDER_TIMEOUT_SEC,
     )
-    assert init.returncode == 0, _fmt("osprey init (auth-off multiuser)", init)
+    assert init.returncode == 0, _fmt(f"osprey init ({lane.posture} multiuser)", init)
 
     _add_persona_catalog(repo, persona_path)
 
@@ -428,12 +660,12 @@ def _make_repo(tmp_path: Path, osprey_bin: Path) -> Path:
         tmp_path,
         timeout=RENDER_TIMEOUT_SEC,
     )
-    assert build.returncode == 0, _fmt("osprey build (auth-off multiuser)", build)
+    assert build.returncode == 0, _fmt(f"osprey build ({lane.posture} multiuser)", build)
 
     # The repo root's .env is this deployment's secret store: `osprey up` refuses
     # to start without it, the provider-secret gate reads the key, and
     # `ensure_terminal_secrets` mints each user's OSPREY_TERMINAL_SECRET_<USER>
-    # into it — the value this test reads back to build the login URL.
+    # into it — the value the token lane reads back to build the login URL.
     env_path = repo / ".env"
     env_path.write_text(_ENV_CONTENT, encoding="utf-8")
     os.chmod(env_path, 0o600)
@@ -457,19 +689,23 @@ def _read_user_secret(repo: Path, user: str) -> str:
     return secret
 
 
-def _teardown() -> None:
-    """Exact-named sweep; failures swallowed (a safety net, never an assertion).
+def _teardown(lane: Lane) -> None:
+    """Exact-named sweep for one lane; failures swallowed (never an assertion).
 
     The volume sweep is what keeps reruns honest: ``compose down`` (like
     ``osprey down``) keeps named volumes, and a rerun inheriting a previous
     attempt's per-user volumes would start from that attempt's state.
+
+    The persona image is NOT removed here: both lanes share one tag, so removing
+    it with the other stack still running would untag an image in use. That
+    removal belongs to the fixture that owns the build (:func:`persona_project`),
+    which is set up first and therefore torn down last.
     """
-    for user in USERS:
-        _runtime_cli("rm", "-f", _web_container(user))
-    _runtime_cli("rm", "-f", NGINX_C)
-    _runtime_cli("compose", "-p", PROJECT_NAME, "down", timeout=60)
-    remove_project_volumes(PROJECT_NAME, runtime=RUNTIME)
-    _runtime_cli("rmi", "-f", PERSONA_IMAGE_TAG, timeout=60)
+    for user in lane.usernames:
+        _runtime_cli("rm", "-f", lane.container(user))
+    _runtime_cli("rm", "-f", lane.nginx_container)
+    _runtime_cli("compose", "-p", lane.project_name, "down", timeout=60)
+    remove_project_volumes(lane.project_name, runtime=RUNTIME)
 
 
 def _browser() -> tuple[urllib.request.OpenerDirector, http.cookiejar.CookieJar]:
@@ -487,21 +723,22 @@ def _browser() -> tuple[urllib.request.OpenerDirector, http.cookiejar.CookieJar]
 
 
 def _request(
+    lane: Lane,
     target: str,
     *,
     method: str = "GET",
     headers: dict[str, str] | None = None,
     data: bytes | None = None,
-    port: int = NGINX_PORT,
     opener: urllib.request.OpenerDirector | None = None,
 ) -> tuple[int, dict[str, str], str]:
     """One HTTP request, returning (status, headers, body) and never raising on 4xx/5xx.
 
     Pass ``opener`` (from :func:`_browser`) to carry a session across requests;
-    omit it for the unauthenticated probes, which must carry nothing.
+    omit it for the unauthenticated probes, which must carry nothing — and which
+    is every probe in the open lane, where carrying nothing is the point.
     """
     req = urllib.request.Request(  # noqa: S310 - loopback only
-        f"http://127.0.0.1:{port}{target}", method=method, data=data
+        f"http://127.0.0.1:{lane.nginx_port}{target}", method=method, data=data
     )
     for key, value in (headers or {}).items():
         req.add_header(key, value)
@@ -518,68 +755,156 @@ def _navigation() -> dict[str, str]:
     return {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
 
 
-def _wait_for_gate(user: str, timeout: float) -> None:
-    """Poll the user's terminal through nginx until its app-owned gate answers.
+def _patch_config(
+    lane: Lane, user: str, *, opener: urllib.request.OpenerDirector | None = None
+) -> tuple[int, dict[str, str], str]:
+    """The operator-only mutating request every posture is judged on.
+
+    One call shape across both lanes, so the postures differ in their ANSWER and
+    in nothing else. ``Origin`` is always this deployment's own — it is what a
+    browser at the published nginx port would send, and the app checks it on a
+    mutating request under both the cookie credential (strictly) and the
+    nginx-injected header (leniently).
+    """
+    return _request(
+        lane,
+        f"/u/{user}/api/config",
+        method="PATCH",
+        data=_CONFIG_PATCH_BODY,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Origin": lane.external_origin,
+        },
+        opener=opener,
+    )
+
+
+def _wait_for_gate(lane: Lane, user: str, expected: int, timeout: float) -> None:
+    """Poll one user's terminal through nginx until its gate answers *expected*.
 
     Readiness here is not "nginx is up" but "the terminal app behind it is up and
-    refusing" — an unauthenticated probe that comes back ``401`` proves the real
-    ``WebAuthMiddleware`` is running and gating, which is the precondition for
-    both assertions. A ``502`` means nginx is up but the container is still
-    booting (`osprey web` is a real framework import), so it keeps polling; a
-    refused connection means nginx itself is not listening yet. On timeout the
-    message carries both containers' logs, since a persona that never came up is
-    the most likely cause and says so only there.
+    deciding" — the mutating probe coming back with the status this posture owes
+    proves the real ``WebAuthMiddleware`` is running (``401`` where nothing
+    vouches for the caller, ``200`` where nginx injected the secret), which is
+    the precondition for every assertion below. A ``502`` means nginx is up but
+    the container is still booting (`osprey web` is a real framework import), so
+    it keeps polling; a refused connection means nginx itself is not listening
+    yet. On timeout the message carries both containers' logs, since a persona
+    that never came up is the most likely cause and says so only there.
     """
     deadline = time.monotonic() + timeout
     last = "(no attempt yet)"
     while time.monotonic() < deadline:
         try:
-            status, _, body = _request(
-                f"/u/{user}/api/config",
-                method="PATCH",
-                data=_CONFIG_PATCH_BODY,
-                headers={"Content-Type": "application/json", "Accept": "application/json"},
-            )
-            if status == 401:
+            status, _, body = _patch_config(lane, user)
+            if status == expected:
                 return
             last = f"HTTP {status}: {body[:200]}"
         except (urllib.error.URLError, ConnectionError, OSError) as exc:
             last = str(exc)
         time.sleep(3.0)
     raise AssertionError(
-        f"{user}'s terminal gate not ready after {timeout:.0f}s (last: {last})\n"
-        f"{_logs(NGINX_C)}\n{_logs(_web_container(user))}"
+        f"{user}'s terminal gate did not answer {expected} within {timeout:.0f}s "
+        f"(last: {last})\n{_logs(lane.nginx_container)}\n{_logs(lane.container(user))}"
     )
 
 
+def _deploy(lane: Lane, tmp_path: Path, persona_path: Path) -> Iterator[dict[str, Any]]:
+    """Stand one lane up, hand it to its tests, and take it down again.
+
+    The body both lane fixtures share, so the two deployments cannot come to
+    differ in how they are started, waited for, or cleaned up — only in the
+    :class:`Lane` they are handed and in the readiness each posture owes.
+    """
+    osprey_bin = _find_osprey_console_script()
+    repo = _make_repo(lane, tmp_path, osprey_bin, persona_path)
+
+    _teardown(lane)  # clear anything a previous crashed run stranded under these names
+    try:
+        # Run from inside the repo: every lifecycle verb walks up to the nearest
+        # profile.yml, so standing in the deployment is what selects it.
+        up = _run_osprey(osprey_bin, ["up", "--dev"], repo, timeout=DEPLOY_UP_TIMEOUT_SEC)
+        assert up.returncode == 0, _fmt(f"osprey up --dev ({lane.posture} multiuser)", up)
+        for user in lane.usernames:
+            # Under `open` the injected location answers 200 and the exempt one
+            # still 401s; under `token` nothing is injected anywhere.
+            expected = 200 if lane.posture == "none" and _is_injected(lane, user) else 401
+            _wait_for_gate(lane, user, expected, READY_TIMEOUT_SEC)
+        yield {
+            "lane": lane,
+            "repo": repo,
+            "secrets": {user: _read_user_secret(repo, user) for user in lane.usernames},
+        }
+    finally:
+        # The shipped teardown first — it stops the web stack the way the
+        # lifecycle does — then the exact-named sweep as a safety net.
+        _run_osprey(osprey_bin, ["down"], repo)
+        _teardown(lane)
+
+
+def _is_injected(lane: Lane, user: str) -> bool:
+    """Whether nginx injects *user*'s operator secret on their location.
+
+    The roster's own ``login: false`` opt-out, read back off the authored entry:
+    an exempt entry is proxied but never vouched for, whatever the method.
+    """
+    for entry in lane.users:
+        if isinstance(entry, dict) and str(entry["name"]) == user:
+            return entry.get("login") is not False
+    return True
+
+
 @pytest.fixture(scope="module")
-def deployment(tmp_path_factory: pytest.TempPathFactory) -> Iterator[dict[str, Any]]:
-    """One ``osprey up --dev`` for the whole module — the expensive part runs once."""
+def persona_project(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """The one persona project — and therefore the one image — both lanes deploy.
+
+    Set up before either deployment and torn down after both, which is what lets
+    it own the shared ``:local`` tag: a lane removing that image at its own
+    teardown would be untagging an image the other lane's containers still run.
+    """
     if shutil.which(RUNTIME) is None:
         pytest.skip(f"{RUNTIME} not available")
     if _runtime_cli("ps", timeout=10).returncode != 0:
         pytest.skip(f"{RUNTIME} daemon not responding")
 
-    tmp_path = tmp_path_factory.mktemp("authoff-multiuser")
+    tmp_path = tmp_path_factory.mktemp("multiuser-persona")
     osprey_bin = _find_osprey_console_script()
-    repo = _make_repo(tmp_path, osprey_bin)
-
-    _teardown()  # clear anything a previous crashed run stranded under these names
+    ref_build = _render_reference_project(tmp_path, osprey_bin)
     try:
-        # Run from inside the repo: every lifecycle verb walks up to the nearest
-        # profile.yml, so standing in the deployment is what selects it.
-        up = _run_osprey(osprey_bin, ["up", "--dev"], repo, timeout=DEPLOY_UP_TIMEOUT_SEC)
-        assert up.returncode == 0, _fmt("osprey up --dev (auth-off multiuser)", up)
-        _wait_for_gate(USER, READY_TIMEOUT_SEC)
-        yield {"repo": repo, "secret": _read_user_secret(repo, USER)}
+        yield _write_persona_project(tmp_path / "persona", ref_build)
     finally:
-        # The shipped teardown first — it stops the web stack the way the
-        # lifecycle does — then the exact-named sweep as a safety net.
-        _run_osprey(osprey_bin, ["down"], repo)
-        _teardown()
+        _runtime_cli("rmi", "-f", PERSONA_IMAGE_TAG, timeout=60)
 
 
-def test_up_builds_the_real_persona_image(deployment: dict[str, Any]) -> None:
+@pytest.fixture(scope="module")
+def token_deployment(
+    tmp_path_factory: pytest.TempPathFactory, persona_project: Path
+) -> Iterator[dict[str, Any]]:
+    """One ``osprey up --dev`` under ``auth.method: token`` for the whole module."""
+    yield from _deploy(TOKEN_LANE, tmp_path_factory.mktemp("token-multiuser"), persona_project)
+
+
+@pytest.fixture(scope="module")
+def open_deployment(
+    tmp_path_factory: pytest.TempPathFactory, persona_project: Path
+) -> Iterator[dict[str, Any]]:
+    """One ``osprey up --dev`` under ``auth.method: none`` (open) for the whole module.
+
+    That this fixture reaches ``yield`` at all is itself an assertion: the open
+    deploy gate refuses ``osprey up`` unless every referenced persona's rendered
+    ``.claude/settings.json`` denies the whole egress set, so a persona render
+    that stopped denying them would fail here rather than deploy.
+    """
+    yield from _deploy(OPEN_LANE, tmp_path_factory.mktemp("open-multiuser"), persona_project)
+
+
+# --------------------------------------------------------------------------
+# token — the default posture: no sidecar, no injection, the app's own gate
+# --------------------------------------------------------------------------
+
+
+def test_up_builds_the_real_persona_image(token_deployment: dict[str, Any]) -> None:
     """The DEPLOYED persona image built, and the per-user container is running.
 
     Everything below runs against a real terminal app; this pins that the app is
@@ -587,69 +912,199 @@ def test_up_builds_the_real_persona_image(deployment: dict[str, Any]) -> None:
     exists — rather than a stub, so a green auth assertion cannot be a green stub.
     """
     assert _image_exists(PERSONA_IMAGE_TAG), f"{PERSONA_IMAGE_TAG} was not built by 'osprey up'"
-    assert _container_id(_web_container(USER)) is not None, (
-        f"{_web_container(USER)} was not created"
+    assert _container_id(TOKEN_LANE.container("alice")) is not None, (
+        f"{TOKEN_LANE.container('alice')} was not created"
     )
 
 
-def test_uncredentialed_mutation_is_refused_by_the_app(deployment: dict[str, Any]) -> None:
-    """T1: with auth off, the app itself refuses an uncredentialed mutating request.
+def test_uncredentialed_mutation_is_refused_by_the_app(token_deployment: dict[str, Any]) -> None:
+    """T1: under ``token``, the app itself refuses an uncredentialed mutating request.
 
     nginx passed this request straight through — it ran no ``auth_request`` and
-    injected no operator-secret header, because ``auth.method: none`` — so the
-    ``401`` can only be the terminal app's own ``WebAuthMiddleware``. That is the
-    whole claim of the default posture: the chain is closed by the app-owned
+    injected no operator-secret header, because ``token`` injects nothing — so
+    the ``401`` can only be the terminal app's own ``WebAuthMiddleware``. That is
+    the whole claim of the default posture: the chain is closed by the app-owned
     gate even when nothing in front of it authenticates anything.
     """
-    status, _, body = _request(
-        f"/u/{USER}/api/config",
-        method="PATCH",
-        data=_CONFIG_PATCH_BODY,
-        headers={"Content-Type": "application/json", "Accept": "application/json"},
-    )
+    status, _, body = _patch_config(TOKEN_LANE, "alice")
     assert status == 401, (
         f"uncredentialed mutation was not refused by the app (got {status})\n"
-        f"{body[:300]}\n{_logs(_web_container(USER))}"
+        f"{body[:300]}\n{_logs(TOKEN_LANE.container('alice'))}"
     )
 
 
-def test_token_login_unlocks_the_mutation(deployment: dict[str, Any]) -> None:
+def test_token_login_unlocks_the_mutation(token_deployment: dict[str, Any]) -> None:
     """T2: the per-user ``?token=`` login URL exchanges for a cookie that unlocks it.
 
     The token is ``alice``'s minted operator secret. A cookie-less browser
     following ``/u/alice/?token=<secret>`` clears the app gate on that one GET
     (the exchange path), and the handler answers ``303`` while setting the
-    session cookie. nginx forwards that cookie on the way back — auth is off, so
-    it strips nothing — and the SAME ``PATCH`` that was refused above, now
-    carrying the cookie and this deployment's own ``Origin``, is accepted with
-    ``200``. The gate the browser had to pass is the app's, and the credential
-    that opened it is the secret the deployment minted.
+    session cookie. nginx forwards that cookie on the way back — ``token`` cuts
+    nothing — and the SAME ``PATCH`` that was refused above, now carrying the
+    cookie and this deployment's own ``Origin``, is accepted with ``200``. The
+    gate the browser had to pass is the app's, and the credential that opened it
+    is the secret the deployment minted.
     """
     client, jar = _browser()
 
-    token = urllib.parse.quote(deployment["secret"], safe="")
+    token = urllib.parse.quote(token_deployment["secrets"]["alice"], safe="")
     # Follow the login URL. The exchange sets the session cookie on the 303; the
     # jar captures it even though the opener then follows the redirect on to a
     # clean URL. What matters is the cookie, not where the redirect lands.
-    _request(f"/u/{USER}/?token={token}", headers=_navigation(), opener=client)
+    _request(TOKEN_LANE, f"/u/alice/?token={token}", headers=_navigation(), opener=client)
     assert [c.name for c in jar], (
-        f"token exchange issued no session cookie\n{_logs(_web_container(USER))}"
+        f"token exchange issued no session cookie\n{_logs(TOKEN_LANE.container('alice'))}"
     )
 
-    status, _, body = _request(
-        f"/u/{USER}/api/config",
-        method="PATCH",
-        data=_CONFIG_PATCH_BODY,
-        headers={
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            # A mutating cookie-authenticated request is Origin-checked by the
-            # app; the deployment's external origin is its published nginx port.
-            "Origin": f"http://127.0.0.1:{NGINX_PORT}",
-        },
-        opener=client,
-    )
+    status, _, body = _patch_config(TOKEN_LANE, "alice", opener=client)
     assert status == 200, (
         f"cookie-authenticated mutation was not accepted (got {status})\n"
-        f"{body[:300]}\n{_logs(_web_container(USER))}"
+        f"{body[:300]}\n{_logs(TOKEN_LANE.container('alice'))}"
+    )
+
+
+# --------------------------------------------------------------------------
+# none (open) — navigation-only: nginx vouches, the roster's exempt entry does not
+# --------------------------------------------------------------------------
+
+
+def test_open_navigation_reaches_a_credentialed_terminal(open_deployment: dict[str, Any]) -> None:
+    """O1: no token, no cookie, no header of our own — and the terminal is ours.
+
+    Both halves matter. The navigation ``GET`` shows a person reaching the page
+    with nothing but a URL, which is the posture's promise. The ``PATCH`` — the
+    very request the ``token`` lane above is refused — shows the session that
+    navigation landed in is genuinely CREDENTIALED rather than merely a public
+    page: an operator-only mutating route answered ``200``. The credential was
+    never ours; nginx injected ``alice``'s operator secret on her location, which
+    is the whole of what ``auth.method: none`` means.
+    """
+    status, _, body = _request(OPEN_LANE, "/u/alice/", headers=_navigation())
+    assert status == 200, (
+        f"navigating to alice's terminal was not served (got {status})\n"
+        f"{body[:300]}\n{_logs(OPEN_LANE.container('alice'))}"
+    )
+
+    status, _, body = _patch_config(OPEN_LANE, "alice")
+    assert status == 200, (
+        f"the injected secret did not authenticate a mutating request (got {status})\n"
+        f"{body[:300]}\n{_logs(OPEN_LANE.container('alice'))}"
+    )
+
+
+def test_open_exempt_entry_is_proxied_but_not_credentialed(
+    open_deployment: dict[str, Any],
+) -> None:
+    """O2: the ``login: false`` entry is served by the same nginx and vouched for by nobody.
+
+    ``kiosk`` declared ``login: false``, so its location is proxied without the
+    secret injection its neighbour gets — the opt-out means "left out of whatever
+    front door the rest of the deployment has", and under ``none`` that front
+    door is the injection itself. What stands in front of ``kiosk`` afterwards is
+    the app's own gate, which refuses both requests ``alice`` was served.
+
+    That the refusal comes from the APP and not from the perimeter is asserted
+    rather than assumed: nginx refuses with its own HTML error page, while the
+    terminal app answers a JSON request with a JSON ``{"detail": ...}`` body. A
+    ``401`` shaped that way was produced behind the proxy, which is what makes
+    this a statement about the exempt entry rather than about nginx.
+    """
+    status, _, body = _patch_config(OPEN_LANE, "kiosk")
+    assert status == 401, (
+        f"the exempt entry's mutating route was not refused (got {status})\n"
+        f"{body[:300]}\n{_logs(OPEN_LANE.container('kiosk'))}"
+    )
+    assert json.loads(body).get("detail"), (
+        f"the 401 did not carry the terminal app's own refusal body: {body[:300]}"
+    )
+
+    status, _, body = _request(OPEN_LANE, "/u/kiosk/", headers=_navigation())
+    assert status == 401, (
+        f"navigating to the exempt terminal was credentialed after all (got {status})\n"
+        f"{body[:300]}\n{_logs(OPEN_LANE.container('kiosk'))}"
+    )
+
+
+def test_open_stamps_the_perimeter_onto_every_user_container(
+    open_deployment: dict[str, Any],
+) -> None:
+    """O3a: every per-user container knows it is open, and which ports that covers.
+
+    Read out of the RUNNING containers, because the claim is that the stamp
+    reaches the process the executor runs in. The deny-list is this deployment's
+    own front door plus every roster user's terminal — the exact set the injected
+    secret opens — and it is asserted whole rather than by membership: a stamp
+    that named only the container's own port would leave a neighbour's terminal
+    reachable, and would still pass an ``in`` check.
+
+    The exempt entry is stamped too. Its location is not injected into, but its
+    container shares the host network namespace with the ones that are, so code
+    running there reaches ``alice``'s terminal exactly as easily.
+    """
+    expected = ",".join(str(port) for port in sorted({OPEN_LANE.nginx_port, *OPEN_LANE.web_ports}))
+    for user in OPEN_LANE.usernames:
+        env = _container_env(OPEN_LANE.container(user))
+        assert env.get(PERIMETER_MARKER_ENV) == "open", (
+            f"{user}'s container carries no open-perimeter marker: "
+            f"{env.get(PERIMETER_MARKER_ENV)!r}"
+        )
+        assert env.get(PERIMETER_DENY_PORTS_ENV) == expected, (
+            f"{user}'s container was stamped {env.get(PERIMETER_DENY_PORTS_ENV)!r}, "
+            f"expected the deployment's own web ports {expected!r}"
+        )
+
+
+def test_open_refuses_executed_code_the_deployments_own_web_port(
+    open_deployment: dict[str, Any],
+) -> None:
+    """O3b: inside the real image, a wrapped child cannot open the deployment's nginx port.
+
+    The probe runs in ``alice``'s container, on the container's own interpreter
+    and against the framework the image installed. It reads the deny-list back
+    with the executor's own parent-side reader, builds the shipped
+    ``ExecutionWrapper`` from it, and runs the wrapped script as a real child —
+    the same sequence ``_execute_via_local`` performs for every execution.
+
+    The CONTROL child is what makes the armed refusal a fact rather than a
+    coincidence: built with no denied ports, in the same container, at the same
+    moment, it connects to that port successfully. So the armed child's refusal
+    is the guard refusing a reachable port, not a report about an empty socket.
+
+    What is NOT claimed: containment. See the module docstring — the guard is a
+    monkeypatch in the child's own namespace, and the deploy-time egress gate is
+    what answers for a shell or a browser tool.
+    """
+    probe = _GUARD_PROBE.replace("__NGINX_PORT__", str(OPEN_LANE.nginx_port))
+    result = _runtime_cli(
+        "exec",
+        "-i",
+        OPEN_LANE.container("alice"),
+        "python",
+        "-",
+        timeout=GUARD_PROBE_TIMEOUT_SEC,
+        input_text=probe,
+    )
+    assert result.returncode == 0, _fmt("in-container perimeter guard probe", result)
+
+    verdicts = [line for line in result.stdout.splitlines() if line.startswith("OSPREY_PROBE ")]
+    assert verdicts, f"probe emitted no verdict line:\n{result.stdout}\n{result.stderr}"
+    verdict = json.loads(verdicts[-1].removeprefix("OSPREY_PROBE "))
+
+    assert OPEN_LANE.nginx_port in verdict["ports"], (
+        f"the executor's own reader did not parse this deployment's nginx port "
+        f"out of the container's stamp: {verdict['ports']}"
+    )
+
+    control = verdict["control"]["out"] + verdict["control"]["err"]
+    assert "PROBE-CONNECTED" in control, (
+        f"the control child could not reach the nginx port at all, so the armed "
+        f"refusal below would prove nothing:\n{control[-800:]}"
+    )
+
+    armed = verdict["armed"]["out"] + verdict["armed"]["err"]
+    assert NET_GUARD_REFUSAL_PREFIX in armed, (
+        f"executed code was not refused the deployment's own web port:\n{armed[-800:]}"
+    )
+    assert "PROBE-CONNECTED" not in armed, (
+        f"the armed child connected despite the guard:\n{armed[-800:]}"
     )

--- a/tests/interfaces/web_terminal/conftest.py
+++ b/tests/interfaces/web_terminal/conftest.py
@@ -32,6 +32,14 @@ state-changing request — and those would land in the developer's or the
 runner's own ``var/audit/<identity>/`` ledger, indistinguishable from records
 of things that really happened. Sibling modules each did this by hand; doing it
 here means a new app test cannot reintroduce the leak by forgetting to.
+
+The third autouse fixture keeps the panel-register route's deploy-host check
+off the real machine, and resets that check's TTL cache between tests. It is
+the same class of leak-guard as the other two — machine state reaching into a
+test that never asked for it — and it lived, byte-identical, in four sibling
+modules before it was moved here. Its target constant is exported as
+``HOST_ADDRS_TARGET`` for the tests that patch the helper again from the
+inside to exercise the check itself.
 """
 
 from __future__ import annotations
@@ -111,3 +119,34 @@ def _isolate_audit_zone(tmp_path, monkeypatch):
     zone = tmp_path / "audit-zone" / "var" / "audit"
     monkeypatch.setattr(writer, "audit_dir", lambda: zone)
     return zone
+
+
+#: Patch target for the panel-register route's own-address probe. Exported so a
+#: test that exercises the deploy-host check can re-patch the same attribute
+#: from inside the autouse stub below — the inner patch wins.
+HOST_ADDRS_TARGET = "osprey.interfaces.web_terminal.routes.panels._host_interface_addresses"
+
+
+@pytest.fixture(autouse=True)
+def _stub_host_interface_addresses(monkeypatch):
+    """Keep the register route's deploy-host check off the real machine.
+
+    ``_host_interface_addresses`` calls ``socket.getaddrinfo`` itself, so the
+    canned ``getaddrinfo`` patches in the panel modules would otherwise feed it
+    the same ``10.0.0.5`` the test URLs resolve to and every registration would
+    be refused as a proxy back into the deployment. Tests that exercise the
+    check patch the helper themselves — the inner patch wins.
+
+    The module-level TTL cache inside the real helper is cleared as well. That
+    cache is keyed on nothing but a timestamp, so one test that reaches the
+    real probe (or stubs ``socket.getaddrinfo`` under it) would otherwise leave
+    a result standing for the next minute of the run, and the test that
+    inherits it would be reading a neighbour's machine picture rather than its
+    own. Autouse and unconditional, for the same reason as the fixtures above:
+    the tests that need it are the ones whose authors would not think to ask.
+    """
+    from osprey.interfaces.web_terminal.routes import panels
+
+    monkeypatch.setattr(panels, "_host_addrs_cache", None)
+    with patch(HOST_ADDRS_TARGET, return_value=frozenset()):
+        yield

--- a/tests/interfaces/web_terminal/test_agent_activity_ring.py
+++ b/tests/interfaces/web_terminal/test_agent_activity_ring.py
@@ -287,7 +287,6 @@ def test_recent_route_registered_on_composite_router():
 # real DNS (the pattern test_panels_source_tag.py uses).
 _LAN_ADDR = [(2, 1, 6, "", ("10.0.0.5", 0))]
 _GETADDRINFO_TARGET = "osprey.interfaces.web_terminal.routes.panels.socket.getaddrinfo"
-
 #: Panel already in the launcher rail, so focusing it adds no membership.
 _MEMBER_PANEL = "ariel"
 #: Enabled panel deliberately left OUT of the rail, so focusing it takes the

--- a/tests/interfaces/web_terminal/test_panels_source_tag.py
+++ b/tests/interfaces/web_terminal/test_panels_source_tag.py
@@ -32,8 +32,6 @@ _MODULE = "osprey.mcp_server.http"
 # SSRF check passes without real DNS (same pattern as test_web_custom_panels).
 _LAN_ADDR = [(2, 1, 6, "", ("10.0.0.5", 0))]
 _GETADDRINFO_TARGET = "osprey.interfaces.web_terminal.routes.panels.socket.getaddrinfo"
-
-
 # ---- Route-side: source passthrough into broadcast frames ---- #
 
 

--- a/tests/interfaces/web_terminal/test_web_custom_panels.py
+++ b/tests/interfaces/web_terminal/test_web_custom_panels.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,9 +15,15 @@ from osprey.interfaces.web_terminal.app import (
     _load_panel_presets,
     create_app,
 )
+from osprey.interfaces.web_terminal.routes import panels as panels_module
 from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS
 
-from .conftest import StubWorkspaceWatcher
+from .conftest import HOST_ADDRS_TARGET, StubWorkspaceWatcher
+
+#: The real probe, bound at import time — before the autouse stub replaces the
+#: module attribute — so the memoization tests can drive the implementation the
+#: stub stands in for.
+_real_host_interface_addresses = panels_module._host_interface_addresses
 
 
 @pytest.fixture
@@ -392,6 +399,42 @@ class TestPanelsAPI:
 _LAN_ADDR = [(2, 1, 6, "", ("10.0.0.5", 0))]
 _LOOPBACK_ADDR = [(2, 1, 6, "", ("127.0.0.1", 0))]
 _GETADDRINFO_TARGET = "osprey.interfaces.web_terminal.routes.panels.socket.getaddrinfo"
+#: Aliased from the shared conftest, where the autouse stub that neutralizes
+#: this probe lives. The tests below that exercise the deploy-host check patch
+#: the same target again from the inside, and that inner patch wins.
+_HOST_ADDRS_TARGET = HOST_ADDRS_TARGET
+
+
+@pytest.mark.parametrize("run", ["first", "second"])
+def test_host_interface_probe_is_memoized_and_its_cache_does_not_leak(run):
+    """The own-address probe runs once per TTL window, and once per test.
+
+    ``_host_interface_addresses`` resolves the host's own name, which has no
+    timeout of its own — on a host with a slow or unreachable resolver that is
+    an unbounded stall, and it sits on the panel-registration path. So it is
+    memoized, and a second call inside the TTL must not re-resolve.
+
+    Running the identical body twice under the parametrization is the leak
+    guard: the cache is a module global, so if the shared conftest fixture
+    stopped resetting it, the ``second`` run would find the ``first`` run's
+    entry still fresh and observe no resolution at all — the failure mode where
+    one test's machine picture silently answers another test's question.
+    """
+    # Arrange: the hostname resolves to one LAN address; the UDP-connect probes
+    # are refused, which the helper treats as an expected non-answer.
+    with (
+        patch(_GETADDRINFO_TARGET, return_value=_LAN_ADDR) as resolve,
+        patch("osprey.interfaces.web_terminal.routes.panels.socket.socket", side_effect=OSError),
+    ):
+        # Act
+        first = _real_host_interface_addresses()
+        second = _real_host_interface_addresses()
+
+    # Assert
+    assert first == second == frozenset({ipaddress.ip_address("10.0.0.5")})
+    assert resolve.call_count == 1, (
+        f"{run}: the probe must be memoized within its TTL and reset between tests"
+    )
 
 
 def _make_client_with_runtime_panels(workspace_dir, allowlist=None):
@@ -868,6 +911,80 @@ class TestPanelRegisterAPI:
 
         # Assert
         assert resp.status_code == 200
+
+    def test_register_deploy_host_own_address_returns_422(self, client_runtime_panels):
+        """A host resolving to one of THIS host's interface addresses is rejected.
+
+        The panel proxy fetches server-side from inside the deployment, so a
+        panel pointed at the deploy host's own LAN address is a route back into
+        the deployment's web terminals — and under the ``open`` auth posture
+        nginx injects a per-user terminal secret on every request, making that
+        a route into a neighbour's terminal. Loopback alone does not catch it:
+        the address is an ordinary routable LAN address.
+        """
+        # Arrange — the host resolves to 10.0.0.5, which is also ours.
+        own = frozenset({ipaddress.ip_address("10.0.0.5")})
+
+        # Act
+        with (
+            patch(_GETADDRINFO_TARGET, return_value=_LAN_ADDR),
+            patch(_HOST_ADDRS_TARGET, return_value=own),
+        ):
+            resp = client_runtime_panels.post(
+                "/api/panels/register",
+                json={"id": "selfie", "label": "SELF", "url": "http://myself.lan:3000"},
+            )
+
+        # Assert
+        assert resp.status_code == 422
+        assert "deployment host itself" in resp.json()["detail"]
+
+    def test_register_ordinary_private_lan_host_still_succeeds(self, client_runtime_panels):
+        """A genuine private-LAN dashboard on another host is still accepted.
+
+        The deploy-host check must not degrade into a blanket RFC1918 refusal:
+        real Grafana dashboards live on 10/8, and only THIS host's own
+        addresses are off limits.
+        """
+        # Arrange — we are 192.168.1.20; the panel host is 10.0.0.5.
+        own = frozenset({ipaddress.ip_address("192.168.1.20")})
+
+        # Act
+        with (
+            patch(_GETADDRINFO_TARGET, return_value=_LAN_ADDR),
+            patch(_HOST_ADDRS_TARGET, return_value=own),
+        ):
+            resp = client_runtime_panels.post(
+                "/api/panels/register",
+                json={"id": "grafana", "label": "GRAFANA", "url": "http://grafana.lan:3000"},
+            )
+
+        # Assert
+        assert resp.status_code == 200
+
+    def test_register_loopback_rejected_when_interface_probe_fails_open(
+        self, client_runtime_panels
+    ):
+        """Loopback stays refused even when the interface probe yields nothing.
+
+        The probe fails open (an offline host with no default route and an
+        unresolvable hostname returns an empty set), so the categorical
+        loopback / link-local / unspecified checks must stand on their own.
+        """
+        # Arrange — probe returns nothing at all.
+
+        # Act
+        with (
+            patch(_GETADDRINFO_TARGET, return_value=_LOOPBACK_ADDR),
+            patch(_HOST_ADDRS_TARGET, return_value=frozenset()),
+        ):
+            resp = client_runtime_panels.post(
+                "/api/panels/register",
+                json={"id": "internal", "label": "INT", "url": "http://grafana.lan:3000"},
+            )
+
+        # Assert
+        assert resp.status_code == 422
 
 
 class TestConfigDefinedPanelReservation:

--- a/tests/mcp_server/test_audit_middleware.py
+++ b/tests/mcp_server/test_audit_middleware.py
@@ -1070,7 +1070,10 @@ class TestSpellings:
 
     def test_the_mixed_floor_is_pinned_literally(self):
         """Task 1.8's drift guard imports this exact list."""
-        assert am._FALLBACK_MIXED_TOOLS == ["mcp__python__execute"]
+        assert am._FALLBACK_MIXED_TOOLS == [
+            "mcp__python__execute",
+            "mcp__python__execute_file",
+        ]
 
     def test_the_write_floor_is_the_registry_floor(self):
         """Every ``_WRITES_CHECK``-gated tool the framework ships, not the ones

--- a/tests/mcp_server/test_d2_web_secret_scrub.py
+++ b/tests/mcp_server/test_d2_web_secret_scrub.py
@@ -298,7 +298,7 @@ async def test_executor_sandbox_subprocess_sees_no_sensitive_credential(
     _assert_negative_controls(env_keys, "python_executor sandbox", controls=("PATH",))
     assert "OSPREY_WEB_PORT" not in set(env_keys), (
         "python_executor sandbox: OSPREY_WEB_PORT must be dropped from the executor "
-        "child env (see _WEB_TERMINAL_ENV_NAMES_TO_DROP in executor.py)"
+        "child env (see SANDBOX_CHILD_ENV_DROP_NAMES in mcp_server/sandbox_env.py)"
     )
     for secret in sensitive_parent_env.values():
         assert secret not in result.stdout
@@ -329,7 +329,15 @@ async def test_workspace_sandbox_subprocess_sees_no_sensitive_credential(
     assert result.success, f"sandbox execution failed: {result.error_message}\n{result.stderr}"
     env_keys = _extract_env_keys(result.stdout)
     _assert_no_sensitive_names(env_keys, sensitive_parent_env, "workspace sandbox")
-    _assert_negative_controls(env_keys, "workspace sandbox")
+    # Same override as the python_executor probe above, and for the same reason:
+    # both sandbox children now build their environment with the shared
+    # scrub_sandbox_child_env, which drops OSPREY_WEB_PORT. PATH is the negative
+    # control; the drop itself is pinned below as expected behaviour.
+    _assert_negative_controls(env_keys, "workspace sandbox", controls=("PATH",))
+    assert "OSPREY_WEB_PORT" not in set(env_keys), (
+        "workspace sandbox: OSPREY_WEB_PORT must be dropped from the visualization "
+        "child env (see SANDBOX_CHILD_ENV_DROP_NAMES in mcp_server/sandbox_env.py)"
+    )
     for secret in sensitive_parent_env.values():
         assert secret not in result.stdout
         assert secret not in result.stderr

--- a/tests/mcp_server/test_executor_env_scrub.py
+++ b/tests/mcp_server/test_executor_env_scrub.py
@@ -6,6 +6,11 @@ prevents agent-generated code running in the local-execution sandbox from
 reading write-arming secrets (e.g. ``BLUESKY_LAUNCH_TOKEN``) and calling a
 write-gated endpoint directly, bypassing the ``writes_enabled`` re-check
 inside the Bluesky queue's arming tools.
+
+It also covers the navigation-only perimeter stamp the same seam reads: the
+deny-list of the deployment's own web ports is consumed by THIS process and
+handed to the sandbox as a constructor argument, never left in the child's
+environment for executed code to read, widen or empty.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,12 +18,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
-from osprey.mcp_server.python_executor.executor import execute_code
+from osprey.mcp_server.python_executor.executor import _perimeter_denied_ports, execute_code
 from osprey.mcp_server.sandbox_env import (
     SENSITIVE_ENV_EXACT,
     SENSITIVE_ENV_SUFFIXES,
     scrub_sensitive_env,
 )
+from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
 
 
 @pytest.fixture(autouse=True)
@@ -231,3 +237,150 @@ async def test_local_subprocess_env_keeps_config_file(tmp_path, monkeypatch):
     assert mock_spawn.await_count == 1
     passed_env = mock_spawn.await_args.kwargs["env"]
     assert passed_env.get("CONFIG_FILE") == str(tmp_path / "config.yml")
+
+
+# ---------------------------------------------------------------------------
+# _execute_via_local — the navigation-only perimeter stamp
+# ---------------------------------------------------------------------------
+#
+# Under `auth.method: none` the deployment renders OSPREY_WEB_PERIMETER=open and
+# OSPREY_WEB_PERIMETER_DENY_PORTS onto every per-user container (the render half
+# is pinned by tests/deployment/web_terminals/test_perimeter_stamp.py). This
+# process reads both, hands the parsed ports to the ExecutionWrapper, and drops
+# the two names from the sandbox child's environment: the sandbox is TOLD what
+# it may not reach, and cannot re-derive, widen or empty the list.
+
+
+async def _run_with_stubbed_subprocess() -> dict[str, str]:
+    """Run one local execution against a stubbed spawn; return the child's env.
+
+    Same stub shape as the scrub tests above — the sandbox process is never
+    really started, so the assertions are about what the seam WOULD hand it.
+    """
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = MagicMock()  # not awaited on this path; avoids an unawaited-coroutine warning
+
+    with patch(
+        "osprey.mcp_server.python_executor.executor.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        return_value=mock_proc,
+    ) as mock_spawn:
+        await execute_code("print(42)", "readonly", "test")
+
+    assert mock_spawn.await_count == 1
+    return mock_spawn.await_args.kwargs["env"]
+
+
+@pytest.mark.unit
+def test_perimeter_ports_parse_when_the_marker_is_open():
+    """Marker plus a well-formed list yields the ports, ascending and de-duplicated."""
+    env = {"OSPREY_WEB_PERIMETER": "open", "OSPREY_WEB_PERIMETER_DENY_PORTS": "9092,9080,9091"}
+    assert _perimeter_denied_ports(env) == (9080, 9091, 9092)
+
+
+@pytest.mark.unit
+def test_perimeter_ports_empty_without_the_marker():
+    """A deny-list with no marker is inert.
+
+    The marker names the posture that justifies the guard. A list rendered
+    without it would mean a credentialed method, where denying these ports
+    guards nothing and only breaks traffic entitled to them.
+    """
+    env = {"OSPREY_WEB_PERIMETER_DENY_PORTS": "9080,9091"}
+    assert _perimeter_denied_ports(env) == ()
+
+
+@pytest.mark.unit
+def test_perimeter_ports_empty_when_the_marker_is_not_open():
+    """Only the exact value "open" arms it — anything else stays inert."""
+    env = {"OSPREY_WEB_PERIMETER": "token", "OSPREY_WEB_PERIMETER_DENY_PORTS": "9080"}
+    assert _perimeter_denied_ports(env) == ()
+
+
+@pytest.mark.unit
+def test_perimeter_ports_empty_when_nothing_is_stamped():
+    """A host with no deployment stamp at all gets the inert default."""
+    assert _perimeter_denied_ports({}) == ()
+
+
+@pytest.mark.unit
+def test_perimeter_ports_ignore_junk_entries():
+    """Unparseable and out-of-range entries are skipped, not fatal.
+
+    This is deployment-rendered input read at execution time; one bad token
+    must narrow the list, never raise inside the run the guard protects — and
+    never discard the entries that did parse.
+    """
+    env = {
+        "OSPREY_WEB_PERIMETER": "open",
+        "OSPREY_WEB_PERIMETER_DENY_PORTS": "9080, ,not-a-port,,0,70000,-1,9091",
+    }
+    assert _perimeter_denied_ports(env) == (9080, 9091)
+
+
+@pytest.mark.unit
+def test_perimeter_ports_empty_when_every_entry_is_junk():
+    """A list that parses to nothing is the inert value, not a partial guard."""
+    env = {"OSPREY_WEB_PERIMETER": "open", "OSPREY_WEB_PERIMETER_DENY_PORTS": "abc,,-3"}
+    assert _perimeter_denied_ports(env) == ()
+
+
+@pytest.mark.unit
+async def test_local_wrapper_receives_the_denied_ports(tmp_path, monkeypatch):
+    """The stamped ports reach the ExecutionWrapper as a constructor argument.
+
+    The wrapper is what renders the sandbox script, so this is the seam where
+    "passed down explicitly" is either true or not.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OSPREY_WEB_PERIMETER", "open")
+    monkeypatch.setenv("OSPREY_WEB_PERIMETER_DENY_PORTS", "9091,9080")
+    _write_subprocess_config(tmp_path)
+
+    with patch(
+        "osprey.services.python_executor.execution.wrapper.ExecutionWrapper",
+        wraps=ExecutionWrapper,
+    ) as mock_wrapper:
+        await _run_with_stubbed_subprocess()
+
+    assert mock_wrapper.call_args.kwargs["perimeter_denied_ports"] == (9080, 9091)
+
+
+@pytest.mark.unit
+async def test_local_wrapper_receives_no_ports_without_a_stamp(tmp_path, monkeypatch):
+    """No stamp, no guard: the wrapper is built with the inert empty tuple."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OSPREY_WEB_PERIMETER", raising=False)
+    monkeypatch.delenv("OSPREY_WEB_PERIMETER_DENY_PORTS", raising=False)
+    _write_subprocess_config(tmp_path)
+
+    with patch(
+        "osprey.services.python_executor.execution.wrapper.ExecutionWrapper",
+        wraps=ExecutionWrapper,
+    ) as mock_wrapper:
+        await _run_with_stubbed_subprocess()
+
+    assert mock_wrapper.call_args.kwargs["perimeter_denied_ports"] == ()
+
+
+@pytest.mark.unit
+async def test_local_subprocess_env_excludes_the_perimeter_stamp(tmp_path, monkeypatch):
+    """The child never sees either name.
+
+    This is the "never re-derived inside the sandbox" half of the contract: the
+    sandbox receives the deny-list as a literal from its parent, so leaving the
+    source variables in its environment would hand executed code both the list
+    it must not widen and the port map of every neighbouring terminal.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OSPREY_WEB_PERIMETER", "open")
+    monkeypatch.setenv("OSPREY_WEB_PERIMETER_DENY_PORTS", "9080,9091")
+    _write_subprocess_config(tmp_path)
+
+    passed_env = await _run_with_stubbed_subprocess()
+
+    assert "OSPREY_WEB_PERIMETER" not in passed_env
+    assert "OSPREY_WEB_PERIMETER_DENY_PORTS" not in passed_env

--- a/tests/mcp_server/test_workspace_env_scrub.py
+++ b/tests/mcp_server/test_workspace_env_scrub.py
@@ -16,8 +16,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from osprey.mcp_server.sandbox_env import (
+    PERIMETER_DENY_PORTS_ENV,
+    PERIMETER_MARKER_ENV,
     SENSITIVE_ENV_EXACT,
     SENSITIVE_ENV_SUFFIXES,
+    scrub_sandbox_child_env,
     scrub_sensitive_env,
 )
 from osprey.mcp_server.workspace.execution.sandbox_executor import execute_sandbox_code
@@ -125,13 +128,67 @@ def test_sensitive_env_constants_are_reexports_of_canonical_module():
 
 @pytest.mark.unit
 def test_scrub_shared_with_python_executor():
-    """Both sandboxes import the SAME scrub from osprey.mcp_server.sandbox_env
+    """Both sandboxes build the child env with the SAME helper.
 
-    (not independent copies), so the deny-lists cannot drift by construction.
+    ``scrub_sandbox_child_env`` from osprey.mcp_server.sandbox_env, not
+    independent copies, so the credential scrub and the sandbox-only narrowing
+    cannot drift between the two spawn paths by construction.
     """
     from osprey.mcp_server.python_executor import executor as python_executor_module
+    from osprey.mcp_server.workspace.execution import sandbox_executor
 
-    assert python_executor_module.scrub_sensitive_env is scrub_sensitive_env
+    assert python_executor_module.scrub_sandbox_child_env is scrub_sandbox_child_env
+    assert sandbox_executor.scrub_sandbox_child_env is scrub_sandbox_child_env
+
+
+@pytest.mark.unit
+def test_drop_lists_have_a_single_definition():
+    """Neither spawn path holds a drop list of its own.
+
+    Both import the shared module's names and call the shared helper, so there
+    is no second literal tuple to drift: a name added for one spawn path is
+    added for both, or neither sees it. A local ``*_TO_DROP`` reappearing in
+    either module is exactly that drift starting.
+    """
+    from osprey.mcp_server.python_executor import executor as python_executor_module
+    from osprey.mcp_server.workspace.execution import sandbox_executor
+
+    for module in (python_executor_module, sandbox_executor):
+        assert not [name for name in vars(module) if name.endswith("_TO_DROP")]
+
+
+@pytest.mark.unit
+def test_shared_helper_drops_the_web_terminal_address_book():
+    """The pure helper drops OSPREY_WEB_PORT and the whole OSPREY_TERMINAL_ family."""
+    env = {
+        "OSPREY_WEB_PORT": "8080",
+        "OSPREY_TERMINAL_LANDING_URL": "http://deploy:9080/",
+        "OSPREY_TERMINAL_SECRET_ALICE": "secret",
+        "PATH": "/usr/bin",
+    }
+    scrubbed = scrub_sandbox_child_env(env)
+    assert scrubbed == {"PATH": "/usr/bin"}
+
+
+@pytest.mark.unit
+def test_shared_helper_drops_the_perimeter_stamp():
+    """The pure helper drops both stamp names: the parent has already read them."""
+    env = {
+        PERIMETER_MARKER_ENV: "open",
+        PERIMETER_DENY_PORTS_ENV: "9080,9091",
+        "PATH": "/usr/bin",
+    }
+    scrubbed = scrub_sandbox_child_env(env)
+    assert scrubbed == {"PATH": "/usr/bin"}
+
+
+@pytest.mark.unit
+def test_shared_helper_does_not_mutate_input():
+    """os.environ is passed directly at both call sites, so this must be a copy."""
+    env = {PERIMETER_MARKER_ENV: "open", "PATH": "/usr/bin"}
+    original = dict(env)
+    scrub_sandbox_child_env(env)
+    assert env == original
 
 
 # ---------------------------------------------------------------------------
@@ -245,6 +302,83 @@ async def test_sandbox_subprocess_env_keeps_unrelated_vars(
     assert mock_spawn.await_count == 1
     passed_env = mock_spawn.await_args.kwargs["env"]
     assert passed_env.get("HOME") == "/home/testuser"
+
+
+# ---------------------------------------------------------------------------
+# execute_sandbox_code — the web-terminal address book and the perimeter stamp
+# ---------------------------------------------------------------------------
+#
+# Mirrors the perimeter-absence coverage in test_executor_env_scrub.py against
+# the OTHER spawn seam. This sandbox renders visualizations; it has no more
+# business resolving a terminal URL, or reading a deny-list it is not the one
+# enforcing, than the general-purpose sandbox does — and it is the path that
+# was silently inheriting both.
+
+
+async def _sandbox_child_env(execution_folder, workspace_root) -> dict[str, str]:
+    """Run one visualization execution against a stubbed spawn; return the child env."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = MagicMock()  # not awaited on this path; avoids an unawaited-coroutine warning
+
+    with (
+        patch(
+            "osprey.utils.workspace.resolve_workspace_root",
+            return_value=workspace_root,
+        ),
+        patch(
+            "osprey.mcp_server.workspace.execution.sandbox_executor.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=mock_proc,
+        ) as mock_spawn,
+    ):
+        await execute_sandbox_code(code="print(42)", execution_folder=execution_folder)
+
+    assert mock_spawn.await_count == 1
+    return mock_spawn.await_args.kwargs["env"]
+
+
+@pytest.mark.unit
+async def test_sandbox_subprocess_env_excludes_the_perimeter_stamp(
+    execution_folder, workspace_root, monkeypatch
+):
+    """The visualization child never sees either stamp name.
+
+    Under `auth.method: none` the deployment stamps both onto the container.
+    Leaving them in this child's environment would hand agent-authored plotting
+    code the port map of every neighbouring terminal — and the very list it is
+    not the one enforcing, which is precisely what "told, not derived" rules
+    out.
+    """
+    monkeypatch.setenv("OSPREY_WEB_PERIMETER", "open")
+    monkeypatch.setenv("OSPREY_WEB_PERIMETER_DENY_PORTS", "9080,9091")
+
+    passed_env = await _sandbox_child_env(execution_folder, workspace_root)
+
+    assert "OSPREY_WEB_PERIMETER" not in passed_env
+    assert "OSPREY_WEB_PERIMETER_DENY_PORTS" not in passed_env
+
+
+@pytest.mark.unit
+async def test_sandbox_subprocess_env_excludes_the_web_terminal_address_book(
+    execution_folder, workspace_root, monkeypatch
+):
+    """OSPREY_WEB_PORT and the OSPREY_TERMINAL_ family are dropped here too.
+
+    These predate the perimeter stamp and were reaching this sandbox all along:
+    the python executor dropped them, its sibling did not. One shared helper is
+    what makes that a single fact rather than two.
+    """
+    monkeypatch.setenv("OSPREY_WEB_PORT", "8080")
+    monkeypatch.setenv("OSPREY_TERMINAL_LANDING_URL", "http://deploy:9080/")
+    monkeypatch.setenv("OSPREY_TERMINAL_SECRET_ALICE", "super-secret-value")
+
+    passed_env = await _sandbox_child_env(execution_folder, workspace_root)
+
+    assert "OSPREY_WEB_PORT" not in passed_env
+    assert not [name for name in passed_env if name.startswith("OSPREY_TERMINAL_")]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -1285,12 +1285,19 @@ class TestMixedReadWriteTools:
             for rule in FRAMEWORK_SERVERS["python"].hooks_pre
             if _WRITES_CHECK in rule.hooks
         ]
-        assert writes_check_matchers("python") == expected == ["mcp__python__execute"]
+        assert (
+            writes_check_matchers("python")
+            == expected
+            == ["mcp__python__execute", "mcp__python__execute_file"]
+        )
 
     def test_writes_check_matchers_rewrite_the_clone_prefix(self):
         """An ``extends`` clone's tools are named for the clone, not the
         template — the same anchored splice build_extended_server applies."""
-        assert writes_check_matchers("python", "python2") == ["mcp__python2__execute"]
+        assert writes_check_matchers("python", "python2") == [
+            "mcp__python2__execute",
+            "mcp__python2__execute_file",
+        ]
 
     def test_writes_check_matchers_unknown_template_is_empty(self):
         """A custom (non-framework) server has no template to read rules from."""
@@ -1299,7 +1306,10 @@ class TestMixedReadWriteTools:
     def test_framework_floor_is_the_fully_qualified_mixed_set(self):
         """The floor the hook/middleware fall back to when a render is
         degraded: every mixed template's write-gated tools, fully qualified."""
-        assert framework_mixed_read_write_tools() == ["mcp__python__execute"]
+        assert framework_mixed_read_write_tools() == [
+            "mcp__python__execute",
+            "mcp__python__execute_file",
+        ]
         for tool in framework_mixed_read_write_tools():
             assert tool.startswith("mcp__")
 
@@ -1307,7 +1317,10 @@ class TestMixedReadWriteTools:
         """python ships enabled by default; a disabled mixed server
         contributes nothing to the render's list."""
         servers = resolve_servers({}, _base_ctx())
-        assert mixed_read_write_tools(servers) == ["mcp__python__execute"]
+        assert mixed_read_write_tools(servers) == [
+            "mcp__python__execute",
+            "mcp__python__execute_file",
+        ]
 
         off = resolve_servers({"servers": {"python": {"enabled": False}}}, _base_ctx())
         assert mixed_read_write_tools(off) == []
@@ -1341,4 +1354,9 @@ class TestMixedReadWriteTools:
         )
         tools = mixed_read_write_tools(servers)
         assert tools == list(dict.fromkeys(tools))
-        assert tools == ["mcp__python__execute", "mcp__python2__execute"]
+        assert tools == [
+            "mcp__python__execute",
+            "mcp__python__execute_file",
+            "mcp__python2__execute",
+            "mcp__python2__execute_file",
+        ]

--- a/tests/services/python_executor/execution/test_net_guard.py
+++ b/tests/services/python_executor/execution/test_net_guard.py
@@ -1,0 +1,653 @@
+"""Tests for the emitted network guard (``net_guard.render_net_guard``).
+
+The guard is *source code*, not a callable, so — same reasoning as the
+filesystem-guard suite (``tests/services/python_executor/test_fs_guard.py``) —
+every behavioural test writes the rendered guard plus a probe into a script and
+runs it in a **real subprocess** against **real listening sockets** on
+ephemeral loopback ports, then asserts on what the probe printed. That keeps
+the ``socket.socket`` patching out of the test process, where a leaked rebind
+would poison every network-touching test after it.
+
+Three layers:
+
+* subprocess behaviour — refusal on a denied port through every patched entry
+  point, pass-through on allowed ports, the high-level ``urllib`` funnel, the
+  ``multiprocessing`` regression the proposal's IA-2 pins, and the unguarded
+  baseline;
+* renderer contract — what ``render_net_guard`` promises about its output and
+  its arguments, no subprocess needed;
+* wrapper emission — ``ExecutionWrapper.create_wrapper`` splices the guard iff
+  ports are denied, in both execution modes.
+"""
+
+import ast
+import functools
+import importlib.util
+import socket
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from osprey.services.python_executor.execution.net_guard import (
+    NET_GUARD_REFUSAL_PREFIX,
+    NET_GUARDED_MODULES,
+    render_net_guard,
+)
+from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
+
+pytestmark = pytest.mark.unit
+
+
+@functools.cache
+def _h5py_importable() -> bool:
+    """Whether the child interpreter can import h5py — probed once, lazily.
+
+    A subprocess probe (not ``find_spec``) because what matters is a real
+    import in the same interpreter the guarded child runs, and lazily (not in
+    a ``skipif`` expression) so collection never pays for the spawn.
+    """
+    return (
+        subprocess.run(  # noqa: S603 - fixed argv
+            [sys.executable, "-c", "import h5py"], capture_output=True
+        ).returncode
+        == 0
+    )
+
+
+def _run(tmp_path: Path, guard: str, probe: str) -> str:
+    """Run *guard* + *probe* in a real subprocess and return its stdout.
+
+    ``cwd`` is the test's own tmp dir so a probe may use short relative paths
+    (an ``AF_UNIX`` socket path has a hard length cap that pytest's deeply
+    nested absolute ``tmp_path`` would blow through).
+    """
+    script = tmp_path / "probe_script.py"
+    script.write_text(guard + "\n" + textwrap.dedent(probe) + "\n", encoding="utf-8")
+    proc = subprocess.run(  # noqa: S603 - fixed argv, test-authored script
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=tmp_path,
+    )
+    assert proc.returncode == 0, (
+        f"probe script failed rc={proc.returncode}\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    return proc.stdout
+
+
+@pytest.fixture
+def servers():
+    """Two real listening sockets on ephemeral loopback ports.
+
+    The first plays the deployment's web port (denied), the second an
+    unrelated service on the same host (allowed) — so a refused connect is
+    provably the guard's doing and not a dead port, and an allowed connect
+    proves the guard refuses by port, not by host.
+    """
+    denied_srv = socket.create_server(("127.0.0.1", 0))
+    allowed_srv = socket.create_server(("127.0.0.1", 0))
+    try:
+        yield denied_srv.getsockname()[1], allowed_srv.getsockname()[1]
+    finally:
+        denied_srv.close()
+        allowed_srv.close()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess behaviour — the guard live in a child interpreter
+# ---------------------------------------------------------------------------
+class TestGuardedChild:
+    """What the emitted guard does once installed in a real child."""
+
+    def test_connect_to_denied_port_is_refused_and_socket_stays_unconnected(
+        self, tmp_path: Path, servers
+    ):
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import socket
+            sock = socket.socket()
+            try:
+                sock.connect(("127.0.0.1", {denied_port}))
+                print("UNEXPECTED_CONNECTED")
+            except PermissionError as exc:
+                print("DENIED:", exc)
+            try:
+                sock.getpeername()
+                print("PEER_PRESENT")
+            except OSError:
+                print("NOT_CONNECTED")
+            print("STILL_RUNNING")
+            """,
+        )
+        assert "UNEXPECTED_CONNECTED" not in out
+        assert f"DENIED: {NET_GUARD_REFUSAL_PREFIX}" in out
+        assert f"connect to port {denied_port} refused" in out
+        # The message explains the perimeter and scopes the refusal.
+        assert "open navigation perimeter" in out
+        assert "unaffected" in out
+        # The refused socket never connected, and the refusal is a catchable
+        # exception inside the child, not a kill.
+        assert "NOT_CONNECTED" in out
+        assert "PEER_PRESENT" not in out
+        assert "STILL_RUNNING" in out
+
+    def test_connect_to_allowed_port_on_same_host_succeeds(self, tmp_path: Path, servers):
+        denied_port, allowed_port = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import socket
+            sock = socket.socket()
+            sock.connect(("127.0.0.1", {allowed_port}))
+            print("CONNECTED_TO:", sock.getpeername()[1])
+            sock.close()
+            """,
+        )
+        assert f"CONNECTED_TO: {allowed_port}" in out
+
+    def test_create_connection_is_refused_on_denied_and_works_on_allowed(
+        self, tmp_path: Path, servers
+    ):
+        denied_port, allowed_port = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import socket
+            try:
+                socket.create_connection(("127.0.0.1", {denied_port}), timeout=10)
+                print("UNEXPECTED_CONNECTED")
+            except PermissionError as exc:
+                print("DENIED:", exc)
+            sock = socket.create_connection(("127.0.0.1", {allowed_port}), timeout=10)
+            print("CONNECTED_TO:", sock.getpeername()[1])
+            sock.close()
+            """,
+        )
+        assert "UNEXPECTED_CONNECTED" not in out
+        assert f"DENIED: {NET_GUARD_REFUSAL_PREFIX}" in out
+        assert f"CONNECTED_TO: {allowed_port}" in out
+
+    def test_urllib_to_denied_port_is_refused(self, tmp_path: Path, servers):
+        # The high-level HTTP stacks are not patched one by one; they funnel
+        # through http.client into socket.create_connection. This pins that
+        # the funnel actually carries the refusal up.
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import urllib.request
+            try:
+                urllib.request.urlopen("http://127.0.0.1:{denied_port}/", timeout=10)
+                print("UNEXPECTED_FETCHED")
+            except Exception as exc:
+                print("DENIED:", exc)
+            """,
+        )
+        assert "UNEXPECTED_FETCHED" not in out
+        assert NET_GUARD_REFUSAL_PREFIX in out
+
+    def test_connect_ex_raises_the_same_refusal_not_an_errno(self, tmp_path: Path, servers):
+        # connect_ex normally *returns* an errno; the guard raises instead,
+        # because callers read a nonzero return as a transient network failure
+        # (a polling loop retries it silently, a scanner tallies "closed") and
+        # the refusal's explanation would never surface.
+        denied_port, allowed_port = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import socket
+            sock = socket.socket()
+            try:
+                rc = sock.connect_ex(("127.0.0.1", {denied_port}))
+                print("UNEXPECTED_ERRNO:", rc)
+            except PermissionError as exc:
+                print("DENIED:", exc)
+            sock2 = socket.socket()
+            print("ALLOWED_ERRNO:", sock2.connect_ex(("127.0.0.1", {allowed_port})))
+            sock2.close()
+            sock.close()
+            """,
+        )
+        assert "UNEXPECTED_ERRNO" not in out
+        assert f"DENIED: {NET_GUARD_REFUSAL_PREFIX}" in out
+        assert "ALLOWED_ERRNO: 0" in out
+
+    def test_numpy_integer_port_is_refused(self, tmp_path: Path, servers):
+        # The C layer accepts any __index__ object wherever it accepts an int,
+        # so a numpy.int64 port must hit the deny set exactly as a plain int
+        # does — a bare isinstance(int) gate waved it straight past.
+        if importlib.util.find_spec("numpy") is None:
+            pytest.skip("numpy not importable in this environment")
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import numpy
+            import socket
+            sock = socket.socket()
+            try:
+                sock.connect(("127.0.0.1", numpy.int64({denied_port})))
+                print("UNEXPECTED_CONNECTED")
+            except PermissionError as exc:
+                print("DENIED:", exc)
+            sock.close()
+            """,
+        )
+        assert "UNEXPECTED_CONNECTED" not in out
+        assert f"DENIED: {NET_GUARD_REFUSAL_PREFIX}" in out
+
+    def test_requests_to_denied_port_is_refused(self, tmp_path: Path, servers):
+        # requests rides urllib3, whose OWN create_connection calls
+        # sock.connect itself — this pins that the socket.socket.connect class
+        # rebind carries the refusal up through that second funnel. urllib3
+        # re-wraps the exception, so the assertion is on the message, not the
+        # type.
+        if importlib.util.find_spec("requests") is None:
+            pytest.skip("requests not importable in this environment")
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import requests
+            try:
+                requests.get("http://127.0.0.1:{denied_port}/", timeout=10)
+                print("UNEXPECTED_FETCHED")
+            except Exception as exc:
+                print("DENIED:", exc)
+            """,
+        )
+        assert "UNEXPECTED_FETCHED" not in out
+        assert NET_GUARD_REFUSAL_PREFIX in out
+
+    def test_ssl_wrapped_socket_connect_is_refused(self, tmp_path: Path, servers):
+        # SSLSocket overrides connect but reaches the wire via
+        # super().connect(), which resolves through the class rebind — pinned
+        # so a stdlib re-plumbing that stops doing so fails loudly.
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import socket
+            import ssl
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            sock = ctx.wrap_socket(socket.socket())
+            try:
+                sock.connect(("127.0.0.1", {denied_port}))
+                print("UNEXPECTED_CONNECTED")
+            except PermissionError as exc:
+                print("DENIED:", exc)
+            sock.close()
+            """,
+        )
+        assert "UNEXPECTED_CONNECTED" not in out
+        assert f"DENIED: {NET_GUARD_REFUSAL_PREFIX}" in out
+
+    def test_asyncio_open_connection_refused_on_denied_and_works_on_allowed(
+        self, tmp_path: Path, servers
+    ):
+        denied_port, allowed_port = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import asyncio
+
+
+            async def _probe():
+                try:
+                    await asyncio.open_connection("127.0.0.1", {denied_port})
+                    print("UNEXPECTED_CONNECTED")
+                except PermissionError as exc:
+                    print("DENIED:", exc)
+                reader, writer = await asyncio.open_connection(
+                    "127.0.0.1", {allowed_port}
+                )
+                print("ASYNC_CONNECTED_TO:", writer.get_extra_info("peername")[1])
+                writer.close()
+                await writer.wait_closed()
+
+
+            asyncio.run(_probe())
+            """,
+        )
+        assert "UNEXPECTED_CONNECTED" not in out
+        assert f"DENIED: {NET_GUARD_REFUSAL_PREFIX}" in out
+        assert f"ASYNC_CONNECTED_TO: {allowed_port}" in out
+
+    def test_server_side_round_trip_is_untouched(self, tmp_path: Path, servers):
+        # bind/listen/accept are not patched: a probe under the guard can run
+        # its own server on an undenied ephemeral port and complete a full
+        # round trip through it.
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            """
+            import socket
+            server = socket.create_server(("127.0.0.1", 0))
+            port = server.getsockname()[1]
+            client = socket.create_connection(("127.0.0.1", port), timeout=10)
+            conn, _addr = server.accept()
+            client.sendall(b"ping")
+            print("SERVER_GOT:", conn.recv(4).decode())
+            conn.sendall(b"pong")
+            print("CLIENT_GOT:", client.recv(4).decode())
+            for closable in (conn, client, server):
+                closable.close()
+            """,
+        )
+        assert "SERVER_GOT: ping" in out
+        assert "CLIENT_GOT: pong" in out
+
+    @pytest.mark.skipif(not socket.has_ipv6, reason="host has no IPv6 support")
+    def test_ipv6_sockaddr_carries_the_port_at_index_1_and_is_refused(
+        self, tmp_path: Path, servers
+    ):
+        # No IPv6 server needed: the refusal fires before any network I/O.
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import socket
+            sock = socket.socket(socket.AF_INET6)
+            try:
+                sock.connect(("::1", {denied_port}, 0, 0))
+                print("UNEXPECTED_CONNECTED")
+            except PermissionError as exc:
+                print("DENIED:", exc)
+            sock.close()
+            """,
+        )
+        assert "UNEXPECTED_CONNECTED" not in out
+        assert f"DENIED: {NET_GUARD_REFUSAL_PREFIX}" in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="AF_UNIX is POSIX-only")
+    def test_af_unix_connect_passes_through_untouched(self, tmp_path: Path, servers):
+        # A path-addressed family carries no port; the guard must not judge
+        # it. Bound relative to the child's cwd to stay under the AF_UNIX
+        # path-length cap.
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            """
+            import socket
+            server = socket.socket(socket.AF_UNIX)
+            server.bind("probe.sock")
+            server.listen(1)
+            client = socket.socket(socket.AF_UNIX)
+            client.connect("probe.sock")
+            print("UNIX_CONNECTED")
+            client.close()
+            server.close()
+            """,
+        )
+        assert "UNIX_CONNECTED" in out
+
+    def test_multiprocessing_pool_works_under_the_guard(self, tmp_path: Path, servers):
+        # IA-2 regression: the perimeter guard must leave multiprocessing
+        # compute untouched in every mode — its parent/worker plumbing runs
+        # over AF_UNIX sockets and pipes, none of which name a TCP port.
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            """
+            import multiprocessing
+
+
+            def _osprey_probe_square(value):
+                return value * value
+
+
+            if __name__ == "__main__":
+                with multiprocessing.Pool(2) as pool:
+                    print("POOL_RESULT:", pool.map(_osprey_probe_square, [1, 2, 3, 4]))
+            """,
+        )
+        assert "POOL_RESULT: [1, 4, 9, 16]" in out
+
+    def test_h5py_import_works_under_the_guard(self, tmp_path: Path, servers):
+        if not _h5py_importable():
+            pytest.skip("h5py not importable in this environment")
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            """
+            import h5py
+            print("H5PY_OK:", bool(h5py.__version__))
+            """,
+        )
+        assert "H5PY_OK: True" in out
+
+    def test_without_a_guard_both_ports_connect(self, tmp_path: Path, servers):
+        # The unguarded baseline: proof the refusals above are the guard's
+        # doing and nothing else's.
+        denied_port, allowed_port = servers
+        out = _run(
+            tmp_path,
+            "",
+            f"""
+            import socket
+            for port in ({denied_port}, {allowed_port}):
+                sock = socket.socket()
+                sock.connect(("127.0.0.1", port))
+                print("CONNECTED_TO:", sock.getpeername()[1])
+                sock.close()
+            """,
+        )
+        assert f"CONNECTED_TO: {denied_port}" in out
+        assert f"CONNECTED_TO: {allowed_port}" in out
+
+    def test_restore_handle_disarms_the_guard_today(self, tmp_path: Path, servers):
+        # Characterization of the documented tamper limit, mirroring the
+        # filesystem suite's TestTamperLimit: the guard is defense in depth,
+        # and its own uninstall is in scope for the code it guards. If this
+        # ever fails because the disarm became impossible, that is a change of
+        # posture wanting its own task — not a quiet edit here.
+        denied_port, _ = servers
+        guard = render_net_guard(denied_ports=(denied_port,))
+        out = _run(
+            tmp_path,
+            guard,
+            f"""
+            import socket
+            try:
+                socket.socket().connect(("127.0.0.1", {denied_port}))
+                print("UNEXPECTED_CONNECTED")
+            except PermissionError:
+                print("REFUSED_WHILE_INSTALLED")
+            _restore_net_patched_targets()
+            sock = socket.socket()
+            sock.connect(("127.0.0.1", {denied_port}))
+            print("DISARMED_CONNECT_LANDED:", sock.getpeername()[1])
+            sock.close()
+            """,
+        )
+        assert "REFUSED_WHILE_INSTALLED" in out
+        assert "UNEXPECTED_CONNECTED" not in out
+        assert f"DISARMED_CONNECT_LANDED: {denied_port}" in out
+
+
+# ---------------------------------------------------------------------------
+# Renderer-level contract (no subprocess needed)
+# ---------------------------------------------------------------------------
+class TestRendererContract:
+    """What the renderer itself promises about its output and its arguments."""
+
+    def test_denied_ports_are_embedded_sorted_and_deduplicated(self):
+        guard = render_net_guard(denied_ports=(8082, 8080, 8082, 8081))
+        assert "_OSPREY_NET_DENIED = frozenset((8080, 8081, 8082))" in guard
+        assert "_OSPREY_NET_PORTS_TEXT = '8080, 8081, 8082'" in guard
+
+    def test_default_refusal_prefix_is_the_module_constant(self):
+        guard = render_net_guard(denied_ports=(19680,))
+        assert f"_OSPREY_NET_PREFIX = {NET_GUARD_REFUSAL_PREFIX!r}" in guard
+
+    def test_refusal_prefix_is_overridable(self):
+        guard = render_net_guard(denied_ports=(19680,), refusal_prefix="Blocked (perimeter):")
+        assert "_OSPREY_NET_PREFIX = 'Blocked (perimeter):'" in guard
+
+    def test_empty_refusal_prefix_is_rejected(self):
+        with pytest.raises(ValueError, match="refusal_prefix"):
+            render_net_guard(denied_ports=(19680,), refusal_prefix="  ")
+
+    def test_empty_port_set_is_rejected(self):
+        # The wrapper skips emission instead — see TestWrapperEmission.
+        with pytest.raises(ValueError, match="non-empty"):
+            render_net_guard(denied_ports=())
+
+    @pytest.mark.parametrize("bad", [0, -1, 65536, "8080", True, None])
+    def test_invalid_ports_are_rejected(self, bad):
+        with pytest.raises(ValueError, match="denied_ports"):
+            render_net_guard(denied_ports=(bad,))
+
+    def test_emitted_source_is_valid_python_and_left_aligned(self):
+        guard = render_net_guard(denied_ports=(19680, 19681))
+        ast.parse(guard)
+        assert not guard.startswith((" ", "\n"))
+
+    def test_guarded_modules_names_socket_for_the_static_layer(self):
+        # Exported for a static reload check to consume; deliberately NOT
+        # merged into fs_guard.GUARDED_MODULES — see the module docstring.
+        assert NET_GUARDED_MODULES == ("socket",)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper emission — the guard is spliced iff ports are denied, in every mode
+# ---------------------------------------------------------------------------
+class TestWrapperEmission:
+    """``create_wrapper`` output carries the guard exactly when it should."""
+
+    @pytest.mark.parametrize("mode", ["readonly", "readwrite"])
+    def test_guard_emitted_when_ports_denied_in_both_modes(self, mode: str):
+        wrapped = ExecutionWrapper(
+            execution_mode=mode, perimeter_denied_ports=(19680, 19681)
+        ).create_wrapper("x = 1")
+        assert "OSPREY network guard" in wrapped
+        assert "_install_net_patched_targets" in wrapped
+        assert "frozenset((19680, 19681))" in wrapped
+        # Deterministic splice: after the filesystem guard, before user code.
+        assert (
+            wrapped.index("OSPREY filesystem guard")
+            < wrapped.index("OSPREY network guard")
+            < wrapped.index("x = 1")
+        )
+        # The shared cleanup tail takes the guard back off.
+        assert "_restore_net_patched_targets" in wrapped
+
+    @pytest.mark.parametrize("mode", ["readonly", "readwrite"])
+    def test_guard_skipped_when_no_ports_denied_in_both_modes(self, mode: str):
+        wrapped = ExecutionWrapper(execution_mode=mode).create_wrapper("x = 1")
+        assert "OSPREY network guard" not in wrapped
+        assert "_install_net_patched_targets" not in wrapped
+        # The filesystem guard is unconditional either way.
+        assert "OSPREY filesystem guard" in wrapped
+
+
+# ---------------------------------------------------------------------------
+# End-to-end arming path — executor -> wrapper -> emitted guard -> real child
+# ---------------------------------------------------------------------------
+class TestEndToEndArmingPath:
+    """The full chain a deployment actually runs, not just its halves.
+
+    ``tests/mcp_server/test_executor_env_scrub.py`` pins that the perimeter
+    stamp (``OSPREY_WEB_PERIMETER`` / ``OSPREY_WEB_PERIMETER_DENY_PORTS``) is
+    parsed and handed to a REAL ``ExecutionWrapper`` as a constructor
+    argument (``test_local_wrapper_receives_the_denied_ports``, which wraps
+    rather than mocks ``ExecutionWrapper``) — but every test that follows the
+    chain past that point stubs ``asyncio.create_subprocess_exec``, so no
+    existing test proves the wrapper's OUTPUT, once actually run, refuses a
+    denied connect. This test closes that gap the same way
+    ``test_executor_token_regression.py`` closes the analogous one for the
+    env scrub: call ``_execute_via_local`` directly (mirroring the pattern in
+    ``tests/mcp_server/test_python_execute_tool.py``'s
+    ``save_artifact()`` regressions) with the perimeter env vars actually
+    set, and read the refusal back out of the real child's stdout. No mock
+    on the arming path itself — only the listening server the child connects
+    to is test infrastructure.
+    """
+
+    async def test_denied_connect_is_refused_through_the_real_chain(self, tmp_path, monkeypatch):
+        from osprey.mcp_server.python_executor.executor import _execute_via_local
+
+        denied_srv = socket.create_server(("127.0.0.1", 0))
+        try:
+            denied_port = denied_srv.getsockname()[1]
+            # A second, unopened port in the deny-list: its number appearing
+            # in the live refusal (not just the one actually dialled) is what
+            # pins refusal-message quality — the prefix constant AND the full
+            # denied-port list are both child-visible, not just the port that
+            # happened to be hit.
+            second_denied_port = 19682
+            monkeypatch.setenv("OSPREY_WEB_PERIMETER", "open")
+            monkeypatch.setenv(
+                "OSPREY_WEB_PERIMETER_DENY_PORTS", f"{denied_port},{second_denied_port}"
+            )
+
+            execution_folder = tmp_path / "exec"
+            execution_folder.mkdir()
+            (execution_folder / "figures").mkdir()
+
+            result = await _execute_via_local(
+                code=textwrap.dedent(
+                    f"""
+                    import socket
+                    try:
+                        socket.socket().connect(("127.0.0.1", {denied_port}))
+                        print("UNEXPECTED_CONNECTED")
+                    except PermissionError as exc:
+                        print("DENIED:", exc)
+                    """
+                ),
+                execution_mode="readonly",
+                config={"timeout": 30, "python_env_path": None},
+                execution_folder=execution_folder,
+                limits_validator=None,
+            )
+        finally:
+            denied_srv.close()
+
+        assert result.success, (
+            f"real end-to-end execution failed: {result.error_message}\n{result.stderr}"
+        )
+        assert "UNEXPECTED_CONNECTED" not in result.stdout
+        assert f"DENIED: {NET_GUARD_REFUSAL_PREFIX}" in result.stdout
+        # Message-quality assertion (checklist item 5): prefix constant AND
+        # the full denied-port list are both present in the child-visible
+        # refusal, not just the single port that was dialled.
+        assert str(denied_port) in result.stdout
+        assert str(second_denied_port) in result.stdout


### PR DESCRIPTION
`auth.method: none` misled in both directions: it still ran the magic-link token exchange, so it never meant "no auth" — and there was no honest posture for a trusted-network deployment that only needs navigation, where every login wall is friction with no threat behind it.

- `token` now names the magic-link flow and is the default for an absent stanza; its render stays byte-identical to the old `none` golden (the frozen pin is unchanged).
- `none` becomes genuinely open: nginx injects each user's terminal secret at the proxy hop, so cards navigate without an exchange, while `login: false` entries are still refused by the app.
- An open perimeter leaves the sandbox as the only wall, so the posture ships with its walls: a deploy gate and lint rule refuse an open deployment whose personas lift the Bash write denies, and executed code is armed with a socket-connect guard refusing the deployment's own web ports, which the render stamps into every container.
- Two adjacent hardenings: panel URLs pointing at the deploy host's own interface addresses are refused (loopback alone was checked before), and `mcp__python__execute_file` is registered beside `execute` as one policy unit instead of living outside every permission list.
- The multiuser e2e deploys both postures for real and the four-posture framing lands in the multi-user docs.

## How it hangs together

```text
profile: auth.method (none | token | password | oidc)
              │
              ▼
   _auth_tls_context — the ONE place the method string is read
              │  derives: sidecar_active · inject_secret · walled
              │           token_exchange · open_perimeter
              │
   ┌──────────┴─────────────┐
   ▼ token (default)        ▼ none (open)
magic-link exchange      nginx.conf.j2 injects each user's
(byte-identical to       terminal secret at the proxy hop
the old `none` render)      │
                            ├─► deploy gate check_open_mode_requirements
                            │   + lint web_terminals.open_mode_egress
                            │   (refuse personas lifting Bash denies)
                            │
                            └─► compose stamp OSPREY_WEB_PERIMETER(_DENY_PORTS)
                                     │
                                     ▼
                            python executor ─► ExecutionWrapper
                                     │
                                     ▼
                            executed child: socket.connect to the
                            deployment's web ports is refused
```
