### PR TITLE
fix(knowledge): report graph-prompt bake as prompts across renders

### DIFF
--- a/changelog.d/graph-bake-log-count.changed.md
+++ b/changelog.d/graph-bake-log-count.changed.md
@@ -1,0 +1,1 @@
+The deploy and `knowledge seed-graph` logs now report the graph-schema bake as distinct prompts across renders (e.g. "2 agent prompt(s) across 8 render(s)") instead of a flat file count that read as that many agents.

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -450,7 +450,7 @@ def _bake_prompt_snapshot(session: Any) -> None:
         )
         return
     if patched:
-        note(f"Schema snapshot baked into {len(patched)} agent prompt(s).")
+        note(f"Schema snapshot baked into {prompt_snapshot.describe_patched(patched)}.")
 
 
 @knowledge.command("seed-graph")

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -5068,7 +5068,7 @@ def _bake_graph_prompt_snapshot(session, project_dir: Path) -> None:
         )
         return
     if patched:
-        _report_step(f"graph schema baked into {len(patched)} agent prompt(s)")
+        _report_step(f"graph schema baked into {prompt_snapshot.describe_patched(patched)}")
 
 
 def _stage_graphdb_store(config, compose_files, env, project_dir, *, provider=None) -> None:

--- a/src/osprey/services/facility_knowledge/seeder/prompt_snapshot.py
+++ b/src/osprey/services/facility_knowledge/seeder/prompt_snapshot.py
@@ -583,6 +583,19 @@ def apply_snapshot(render_dir: Path, blocks: Mapping[str, str]) -> list[Path]:
     return patched
 
 
+def describe_patched(patched: Sequence[Path]) -> str:
+    """A bake result as humans count it: distinct prompts × renders, not files.
+
+    The raw file count multiplies the handful of agent prompts by every render
+    of the deployment (the render itself, attached personas, image build
+    contexts — :func:`snapshot_targets`), so "16 agent prompt(s)" reads as
+    sixteen distinct agents when it is two prompts in eight places.
+    """
+    prompts = len({path.name for path in patched})
+    renders = len({path.parent for path in patched})
+    return f"{prompts} agent prompt(s) across {renders} render(s)"
+
+
 def bake_snapshot(session: Any, render_dir: Path) -> list[Path]:
     """Capture the live store's schema and bake it into *render_dir*'s prompts.
 

--- a/tests/services/facility_knowledge/test_prompt_snapshot.py
+++ b/tests/services/facility_knowledge/test_prompt_snapshot.py
@@ -651,3 +651,18 @@ def test_shared_partial_carries_exactly_these_markers():
     assert template.count("osprey:graph-snapshot") == 2, (
         "the partial must carry exactly one begin and one end marker"
     )
+
+
+class TestDescribePatched:
+    """The reported count is prompts × renders, not a flat file total."""
+
+    def test_counts_distinct_prompts_and_renders(self):
+        renders = [Path("build"), Path("build/persona-a"), Path("build/.image/x/build")]
+        patched = [
+            base / ".claude" / "agents" / name for base in renders for name in mod.TARGET_FILENAMES
+        ]
+        assert mod.describe_patched(patched) == "2 agent prompt(s) across 3 render(s)"
+
+    def test_single_file(self):
+        patched = [Path("build/.claude/agents") / mod.AGENT_FILENAME]
+        assert mod.describe_patched(patched) == "1 agent prompt(s) across 1 render(s)"


### PR DESCRIPTION
The deploy log reported the graph-schema bake as a flat file count — "graph schema baked into 16 agent prompt(s)" — which reads as sixteen distinct agents. The real shape is two graph-agent prompts replicated into every render of the deployment: the render itself, one per attached persona, and each container image's build context.

Both writers (the deploy staging step and `osprey knowledge seed-graph`) now report through one shared helper: "2 agent prompt(s) across 8 render(s)".