### PR TITLE
feat: show where a session's role came from

### DIFF
--- a/changelog.d/746.added.md
+++ b/changelog.d/746.added.md
@@ -1,0 +1,4 @@
+The web terminal's session menu now shows where the signed-in user's role
+came from — the roster entry or the identity provider — next to the role
+itself. Sessions signed in before this change show only the role until the
+next login.

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -164,9 +164,10 @@ A roster entry carries ``role:`` or ``persona:``, never both. The rules:
 - The role the token grants must be the role the roster named for the card
   that was clicked; otherwise the login is refused (``role_mismatch``). Fix
   whichever of roster or provider has drifted.
-- A role is resolved at login and travels inside the session, so a change at
-  the provider or in the roster reaches the *next* login. To withdraw a role
-  now, end the session: ``osprey users decommission <name>``.
+- A role is resolved at login and travels inside the session — together with
+  its origin, the roster entry or the provider's claim — so a change at the
+  provider or in the roster reaches the *next* login. To withdraw a role now,
+  end the session: ``osprey users decommission <name>``.
 
 Every login and refusal is recorded in ``var/audit/sidecar/auth_sidecar.jsonl``
 on the deploy host. A ``claims`` stanza under ``password`` resolves nothing;

--- a/docs/source/how-to/web-terminal/multi-user/tiers.rst
+++ b/docs/source/how-to/web-terminal/multi-user/tiers.rst
@@ -268,10 +268,13 @@ carry the mapping — ``operator: {persona: readwrite}`` written once, rather th
 a persona pinned on every entry. That changes nothing about that mechanism:
 a role resolves to a persona before anything is built, so which persona a card
 runs and which container it opens are the same either way. What the role adds is that
-it survives the login: it travels with the session, reaches the terminal as an
-identity header, is shown beside the user's name in the terminal's session
-menu, and is named on the login record in the audit trail. Where a facility
-runs single sign-on, the provider's own groups can be what decides it — see
+it survives the login: it travels with the session, reaches the terminal as
+identity headers, is shown beside the user's name in the terminal's session
+menu — together with where it came from, the roster entry or the identity
+provider's claim — and is named on the login record in the audit trail. A
+session that signed in before this was added goes on showing the role on its
+own, without its origin, until the person logs in again. Where a facility runs
+single sign-on, the provider's own groups can be what decides it — see
 :ref:`Let single sign-on pick the tier <multi-user-role-from-sso>`.
 
 What makes it hold

--- a/src/osprey/interfaces/common_middleware.py
+++ b/src/osprey/interfaces/common_middleware.py
@@ -55,6 +55,7 @@ __all__ = [
     "AUDIT_ACCOUNT_KEY",
     "AUDIT_EXPECTED_ACCOUNT_KEY",
     "AUDIT_ROLE_HEADER",
+    "AUDIT_ROLE_SOURCE_HEADER",
     "AUDIT_SUBJECT_HEADER",
     "EXEMPT_PATHS",
     "EXTERNAL_ORIGIN_ENV",
@@ -324,14 +325,21 @@ REASON_MUTATION_UNANSWERED: str = "mutation_unanswered"
 #: Spelled here rather than imported from
 #: :mod:`osprey.services.auth_sidecar.identity_headers`, which owns it: an
 #: interface app has no business pulling a service package into its import
-#: closure for two string constants. ``tests/interfaces/test_http_audit_emitters.py``
-#: pins the two spellings against each other, the same trade the rest of the
+#: closure for three string constants. ``tests/interfaces/test_http_audit_emitters.py``
+#: pins the three spellings against each other, the same trade the rest of the
 #: audit work makes for a cross-package constant.
 AUDIT_SUBJECT_HEADER: str = "X-Osprey-Auth-Subject"
 
 #: Names the role that account holds. Absent means *no* role, never a default
 #: one — the deny-safe reading the sidecar documents.
 AUDIT_ROLE_HEADER: str = "X-Osprey-Auth-Role"
+
+#: Names where that role came from — ``roster`` or ``claim``, the sidecar's
+#: closed vocabulary. Decoded under the same bound as the other two, so a
+#: value the ledger would refuse cannot reach a screen instead. The ledger
+#: reads it and does not record it: what a login granted is the sidecar's
+#: own record, and this gate has never re-stated it.
+AUDIT_ROLE_SOURCE_HEADER: str = "X-Osprey-Auth-Role-Source"
 
 #: The ``detail`` key naming the *account* a request arrived authorized as, as
 #: forwarded by nginx from the sidecar's answer.
@@ -552,8 +560,7 @@ def _recordable(value: str) -> bool:
 
     Printable ASCII, no space anywhere, and at most
     :data:`MAX_FORWARDED_VALUE_CHARS` characters. The first two are the
-    sidecar's own contract
-    for both identity headers (see
+    sidecar's own contract for all three identity headers (see
     :mod:`osprey.services.auth_sidecar.identity_headers`, which refuses to mint
     or emit anything outside printable ASCII, or anything space-padded); two
     rules are added for this ledger. A value carrying an *interior* space
@@ -562,8 +569,9 @@ def _recordable(value: str) -> bool:
     the keys appended after it past the envelope's silent truncation — so the
     one input a forger fully controls would be the one that erases the mismatch
     marker from the record. Nothing real is lost by either: an OIDC ``sub`` is
-    a short URL-safe identifier and a role name is constrained to
-    ``USERNAME_CHARSET_RE`` by the render-time lint.
+    a short URL-safe identifier, a role name is constrained to
+    ``USERNAME_CHARSET_RE`` by the render-time lint, and a role source is one
+    of two framework constants.
 
     A value that fails this did not come from the sidecar, or cannot be written
     down unambiguously; either way, copying it verbatim would put a forged or
@@ -576,23 +584,23 @@ def _recordable(value: str) -> bool:
     )
 
 
-def forwarded_identity(headers: Mapping[str, str]) -> tuple[str | None, str | None]:
-    """The ``(subject, role)`` nginx forwarded on this request, if any.
+def forwarded_identity(headers: Mapping[str, str]) -> tuple[str | None, str | None, str | None]:
+    """The ``(subject, role, role_source)`` nginx forwarded on this request, if any.
 
     Each is ``None`` when the header is absent or empty — the sidecar omits a
     header it has no value for, so absence is a state of its own and must not
     be flattened into a blank string. A value that fails :func:`_recordable`
     becomes :data:`UNSAFE_FORWARDED_VALUE`: present, and named as unusable.
 
-    Public because it is the ONE decoder for these headers: the audit
-    emitters record what it returns, and the web terminal's page shows the
-    role from it. A second reader with its own bound would let a value the
-    ledger refuses reach the screen, or the reverse. ``headers`` is read by
-    lower-cased name, so a plain dict of lower-cased keys and Starlette's
-    case-insensitive ``Headers`` both work.
+    Public because it is the ONE decoder for these headers: the audit emitters
+    record the subject and the role it returns, and the web terminal's page
+    shows the role and where it came from. A second reader with its own bound
+    would let a value the ledger refuses reach the screen, or the reverse.
+    ``headers`` is read by lower-cased name, so a plain dict of lower-cased
+    keys and Starlette's case-insensitive ``Headers`` both work.
     """
     resolved: list[str | None] = []
-    for header in (AUDIT_SUBJECT_HEADER, AUDIT_ROLE_HEADER):
+    for header in (AUDIT_SUBJECT_HEADER, AUDIT_ROLE_HEADER, AUDIT_ROLE_SOURCE_HEADER):
         raw = (headers.get(header.lower()) or "").strip()
         if not raw:
             resolved.append(None)
@@ -600,7 +608,7 @@ def forwarded_identity(headers: Mapping[str, str]) -> tuple[str | None, str | No
             resolved.append(raw)
         else:
             resolved.append(UNSAFE_FORWARDED_VALUE)
-    return resolved[0], resolved[1]
+    return resolved[0], resolved[1], resolved[2]
 
 
 def _container_user() -> str:
@@ -636,7 +644,7 @@ def _audit_detail(scope: Scope, headers: dict[str, str], **extra: str) -> tuple[
     be a behaviour change smuggled in under an audit heading, and the gate has
     never treated these headers as a credential.
     """
-    subject, role = forwarded_identity(headers)
+    subject, role, _ = forwarded_identity(headers)
     parts = [f"{key}={value}" for key, value in extra.items()]
     if subject is not None:
         container_user = _container_user()

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -220,6 +220,16 @@ DEFAULT_FEEDBACK_EMAIL = "thellert@lbl.gov"
 #: otherwise. Submission headers are never pruned, only their contexts.
 DEFAULT_FEEDBACK_MAX_STORE_BYTES = 256 * 1024 * 1024
 
+#: How each value of the forwarded role-source header reads in the session
+#: menu. The keys are the auth sidecar's closed vocabulary, spelled here
+#: rather than imported for the same reason the header names are — the
+#: terminal has no business pulling a service package into its import
+#: closure — and ``tests/interfaces/web_terminal/test_terminal_user.py``
+#: pins this key set against the sidecar's constants. Any other value
+#: renders nothing at all: an unrecognised source is a source this build
+#: cannot name, and a chip that named it anyway would be guessing.
+_ROLE_SOURCE_LABELS: dict[str, str] = {"roster": "roster", "claim": "ID token"}
+
 
 def coerce_config_str(key: str, value: object, default: str) -> str:
     """Return a configured string value, falling back to *default*.
@@ -1363,15 +1373,20 @@ def create_app(
         web_rail_position = getattr(request.app.state, "web_rail_position", DEFAULT_RAIL_POSITION)
         terminal_user = getattr(request.app.state, "terminal_user", "")
         landing_url = getattr(request.app.state, "landing_url", "")
-        # The role nginx forwarded on THIS request, off the header rather than
-        # app.state: a per-login fact, and the page GET is itself a gated
-        # request that carries it. Decoded by the audit ledger's own bound; a
-        # value that fails it is shown as nothing, not as the ledger's
-        # sentinel — with no nginx in front any client can send this header,
-        # and the chip is a display, not an authorization surface.
-        _, auth_role = forwarded_identity(request.headers)
+        # The role nginx forwarded on THIS request, and where that role came
+        # from, off the headers rather than app.state: per-login facts, and the
+        # page GET is itself a gated request that carries them. Decoded by the
+        # audit ledger's own bound; a value that fails it is shown as nothing,
+        # not as the ledger's sentinel — with no nginx in front any client can
+        # send these headers, and the chip is a display, not an authorization
+        # surface. The source is shown only through :data:`_ROLE_SOURCE_LABELS`,
+        # so a value outside the sidecar's vocabulary renders nothing.
+        _, auth_role, auth_role_source = forwarded_identity(request.headers)
         if auth_role == UNSAFE_FORWARDED_VALUE:
             auth_role = None
+        if auth_role_source == UNSAFE_FORWARDED_VALUE:
+            auth_role_source = None
+        auth_role_source_label = _ROLE_SOURCE_LABELS.get(auth_role_source or "", "")
         return templates.TemplateResponse(
             request,
             "index.html",
@@ -1384,6 +1399,7 @@ def create_app(
                 "terminal_user": terminal_user,
                 "landing_url": landing_url,
                 "auth_role": auth_role or "",
+                "auth_role_source_label": auth_role_source_label,
                 "url_prefix": url_prefix,
             },
         )

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -220,6 +220,7 @@ osprey-display-menu .display-menu-logout-icon {
 
 .header-identity-who {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   gap: var(--space-2);
   min-width: 0;
@@ -277,6 +278,22 @@ osprey-display-menu .display-menu-logout-icon {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-full);
   white-space: nowrap;
+}
+
+/* Where the role came from, subordinate to the pill it qualifies: the
+   who-line's own idiom for a qualifier — muted, small, introduced by a '·' —
+   rather than a second pill competing with the first. */
+.header-identity-who-role-source {
+  flex-shrink: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.header-identity-who-role-source::before {
+  content: '·';
+  margin-right: var(--space-1);
 }
 
 .header-identity-who-sub {

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -126,6 +126,11 @@
                 the terminal to forward it: a fact stated where it is known,
                 never a default. -#}
             {% if auth_role %}<span class="header-identity-who-role" title="Role for this session">{{ auth_role }}</span>{% endif %}
+            {#- Where that tier came from — the roster or the ID token — named
+                only when the role itself is on the line and the forwarded
+                value is one this build knows. Never an empty span, so the
+                separator it carries never appears on its own. -#}
+            {% if auth_role and auth_role_source_label %}<span class="header-identity-who-role-source" title="Where this session's role came from">{{ auth_role_source_label }}</span>{% endif %}
             {% if app_name %}<span class="header-identity-who-sub">{{ app_name }}</span>{% endif %}
           </div>
           {#- Only the ACTION depends on landing_url. A user with nowhere to

--- a/src/osprey/services/auth_sidecar/identity_headers.py
+++ b/src/osprey/services/auth_sidecar/identity_headers.py
@@ -1,13 +1,15 @@
-"""The two identity headers an authorized subrequest may carry, and their charset.
+"""The three identity headers an authorized subrequest may carry, and their charset.
 
-nginx turns the sidecar's ``auth_request`` answer into two forwarded headers —
-:data:`SUBJECT_HEADER` naming the account behind the request and
-:data:`ROLE_HEADER` naming the privilege it holds — and every terminal behind
-that boundary reads its authorization from them. Both names and the one rule
-about what may travel in them live here rather than in the route, because three
-layers have to agree on it: the session model (which refuses to *store* a value
-that could not be carried), the verify route (which emits them), and the OIDC
-callback (which refuses a *login* whose identity could not be carried).
+nginx turns the sidecar's ``auth_request`` answer into three forwarded headers —
+:data:`SUBJECT_HEADER` naming the account behind the request,
+:data:`ROLE_HEADER` naming the privilege it holds and
+:data:`ROLE_SOURCE_HEADER` naming where that role came from — and every terminal
+behind that boundary reads its authorization from them. All three names and the
+one rule about what may travel in them live here rather than in the route,
+because three layers have to agree on it: the session model (which refuses to
+*store* a value that could not be carried), the verify route (which emits
+them), and the OIDC callback (which refuses a *login* whose identity could not
+be carried).
 
 **ASCII only, and that is not a deferral.** An HTTP header value is latin-1 on
 the wire, so ``jörg@example.org`` survives one hop and arrives at the terminal
@@ -33,6 +35,7 @@ from __future__ import annotations
 
 __all__ = [
     "ROLE_HEADER",
+    "ROLE_SOURCE_HEADER",
     "SUBJECT_HEADER",
     "is_header_safe",
 ]
@@ -52,6 +55,16 @@ ROLE_HEADER = "X-Osprey-Auth-Role"
 Absent means no role, which every consumer must read as "no privileges" — never
 as a default role. That is what makes the field's empty default deny-safe end to
 end: an unresolved role and a refused one look the same downstream.
+"""
+
+ROLE_SOURCE_HEADER = "X-Osprey-Auth-Role-Source"
+"""Names where the role in :data:`ROLE_HEADER` came from, when one is carried.
+
+``roster`` means the roster's ``role:`` entry resolved it; ``claim`` means the
+OIDC ID token's role claim did. Emitted only beside a role and absent whenever
+the role is absent, so provenance can never name the origin of a privilege the
+session does not hold. Consumers read it for display, never as authorization:
+the role is what grants, and where it came from changes nothing about that.
 """
 
 _LOWEST_PRINTABLE = 0x20

--- a/src/osprey/services/auth_sidecar/routes/login.py
+++ b/src/osprey/services/auth_sidecar/routes/login.py
@@ -745,8 +745,12 @@ async def login_submit(
         # The roster entry's own `role:`, resolved by the re-check above. Empty
         # is the deny-safe value: verify emits no role header for it and every
         # consumer reads that as "no privileges", which is what every password
-        # deployment written before roles existed keeps getting.
+        # deployment written before roles existed keeps getting. The source
+        # rides along from the same grant, so the session says where its role
+        # came from with the authority that decided it rather than a second
+        # reading of the method here.
         role=role,
+        role_source=grant.role_source,
     )
 
     response = RedirectResponse(target, status_code=303, headers=_NO_STORE_HEADERS)

--- a/src/osprey/services/auth_sidecar/routes/oidc.py
+++ b/src/osprey/services/auth_sidecar/routes/oidc.py
@@ -1005,8 +1005,11 @@ async def oidc_callback(request: Request) -> Response:
         # none. Empty means "no privileges" — the deny-safe value, which verify
         # turns into an omitted role header rather than a default privilege.
         # Every other outcome refused the login above, so `with_user` can only
-        # be reached with a role it can carry.
+        # be reached with a role it can carry. The source comes from the same
+        # grant, naming which of those two authorities the role is: the claim
+        # where one decided it, the roster where none was asked.
         role=role,
+        role_source=grant.role_source,
     )
 
     response = RedirectResponse(

--- a/src/osprey/services/auth_sidecar/routes/recheck.py
+++ b/src/osprey/services/auth_sidecar/routes/recheck.py
@@ -3,25 +3,33 @@
 Every route in this service that mints a session first asks the same question —
 *given how this browser proved who it is, what is that proof worth?* — and the
 answer is a table, not a judgement call. This module is that table. It is the
-only place that maps an auth method onto the ``(subject, role)`` a session may
-carry, so a row cannot be admitted by the password path and refused by the OIDC
-one, and a method nobody wrote a row for cannot fall through into a plausible
-reading of itself.
+only place that maps an auth method onto the ``(subject, role, role_source)`` a
+session may carry, so a row cannot be admitted by the password path and refused
+by the OIDC one, and a method nobody wrote a row for cannot fall through into a
+plausible reading of itself.
 
 The matrix, one row per posture:
 
-===================  =====================================  ===================
-method               subject                                role
-===================  =====================================  ===================
-``none``             — (no session is minted)               — (no login events)
-``password``         the roster username                    the roster ``role:``
-``oidc``, unbound    the asserted IdP subject               the roster ``role:``
-``oidc``, bound      the asserted IdP subject               the claim's role,
+===================  =====================================  =====================  ==========
+method               subject                                role                   source
+===================  =====================================  =====================  ==========
+``none``             — (no session is minted)               — (no login events)    — (none)
+``password``         the roster username                    the roster ``role:``   ``roster``
+``oidc``, unbound    the asserted IdP subject               the roster ``role:``   ``roster``
+``oidc``, bound      the asserted IdP subject               the claim's role,      ``claim``
                                                             cross-checked
                                                             against the roster's
-anything else        refused at mint; verify names the      — (refused)
+anything else        refused at mint; verify names the      — (refused)            — (refused)
                      locally verified identity
-===================  =====================================  ===================
+===================  =====================================  =====================  ==========
+
+**The source says which of those two authorities the role came from**, and
+nothing more. It is :data:`ROLE_SOURCE_ROSTER` when the role is the one the
+render bound and :data:`ROLE_SOURCE_CLAIM` when a validated ID token decided it,
+and it is empty exactly when the role is — a session holding no role has no
+provenance to explain. Provenance is not privilege: nothing in this service
+decides anything from it, it only lets the far end say where the role it is
+already showing came from.
 
 **The last row's two halves dispose of it differently, which is why it is the
 one row the table qualifies.** :func:`recheck_login` refuses an unsupported
@@ -103,6 +111,8 @@ __all__ = [
     "REASON_METHOD_MISMATCH",
     "REASON_ROLE_MISMATCH",
     "REASON_UNSUPPORTED_METHOD",
+    "ROLE_SOURCE_CLAIM",
+    "ROLE_SOURCE_ROSTER",
     "SUPPORTED_METHODS",
     "LoginGrant",
     "RecheckRefused",
@@ -110,6 +120,7 @@ __all__ = [
     "recheck_login",
     "roster_roles",
     "session_role",
+    "session_role_source",
     "session_subject",
 ]
 """This module's whole public surface, declared rather than inferred.
@@ -132,6 +143,17 @@ through :class:`~osprey.services.auth_sidecar.app.AuthSettings`, which already
 lowercases it once. Folding again here would mean two components disagreeing
 about what counts as a match, and the one that is stricter should be the one
 handing out sessions."""
+
+ROLE_SOURCE_ROSTER = "roster"
+"""The role came from the roster's ``role:`` entry — the one the render bound."""
+
+ROLE_SOURCE_CLAIM = "claim"
+"""The role came from the validated ID token's claim.
+
+The two spellings are a closed vocabulary, and deliberately short: they cross
+the identity-header boundary as they are written here, so they hold to the same
+charset a role does and a far end that does not recognise one shows nothing
+rather than guessing at it."""
 
 REASON_UNSUPPORTED_METHOD = audit.REASON_UNSUPPORTED_METHOD
 """Re-exported so a route reads its category from the module that decided it."""
@@ -249,10 +271,15 @@ class LoginGrant:
         role: The role it holds, or ``""`` for none. Empty is the deny-safe
             value: verify omits the role header for it and every consumer reads
             an absent header as "no privileges".
+        role_source: Where that role came from — :data:`ROLE_SOURCE_ROSTER` or
+            :data:`ROLE_SOURCE_CLAIM` — and ``""`` exactly when ``role`` is
+            empty, since there is no provenance for a role nobody holds.
+            Display only: it explains a privilege, it never confers one.
     """
 
     subject: str
     role: str
+    role_source: str = ""
 
 
 class RecheckRefused(Exception):
@@ -332,7 +359,9 @@ def recheck_login(
             raise RecheckRefused(
                 REASON_METHOD_MISMATCH, "this login was decided by the wrong method"
             )
-        return _grant(subject=user, role=roster_roles.role_for(user))
+        return _grant(
+            subject=user, role=roster_roles.role_for(user), role_source=ROLE_SOURCE_ROSTER
+        )
 
     # METHOD_OIDC.
     if not asserted_subject or claim_role is None:
@@ -343,7 +372,7 @@ def recheck_login(
         # This deployment binds no claims, so nothing asked the provider about
         # privilege. The role is the one the RENDER bound — the same roster
         # entry the persona behind this user's door was resolved from.
-        return _grant(subject=asserted_subject, role=rendered_role)
+        return _grant(subject=asserted_subject, role=rendered_role, role_source=ROLE_SOURCE_ROSTER)
 
     if rendered_role and claim_role != rendered_role:
         # The cross-check. Refusing grants nothing: it turns away a login whose
@@ -359,10 +388,10 @@ def recheck_login(
     # `persona:` pin or the default persona, whose container is not role-bound,
     # so there is nothing for the claim to disagree with. See the module
     # docstring's "one gap".
-    return _grant(subject=asserted_subject, role=claim_role)
+    return _grant(subject=asserted_subject, role=claim_role, role_source=ROLE_SOURCE_CLAIM)
 
 
-def _grant(*, subject: str, role: str) -> LoginGrant:
+def _grant(*, subject: str, role: str, role_source: str) -> LoginGrant:
     """Build the grant, refusing a role the boundary cannot carry.
 
     Checked here rather than left to
@@ -376,12 +405,20 @@ def _grant(*, subject: str, role: str) -> LoginGrant:
     verify's gate, which denies an uncarryable one on every subrequest — a
     single decision on the one hot path, rather than a second copy of it here
     that could drift.
+
+    The *source* is normalised rather than checked, because the caller passes a
+    row of the matrix and not a value from outside: every row names a source,
+    and a row whose role came back empty — a roster entry riding a ``persona:``
+    pin, which is a legitimate login and not a mistake — has nothing for one to
+    describe. Dropping it here is what keeps "a source implies a role" true of
+    every grant this module hands out, without a second refusal shape for a
+    combination no caller can reach on purpose.
     """
     if role and not is_header_safe(role):
         raise RecheckRefused(
             audit.REASON_UNSAFE_ROLE, "the role this login resolved to cannot be carried"
         )
-    return LoginGrant(subject=subject, role=role)
+    return LoginGrant(subject=subject, role=role, role_source=role_source if role else "")
 
 
 def session_subject(*, method: str, username: str, entry: UnlockedUser | None) -> str:
@@ -449,3 +486,30 @@ def session_role(*, method: str, entry: UnlockedUser | None) -> str:
     if method == METHOD_OIDC and not entry.oidc_subject:
         return ""
     return entry.role
+
+
+def session_role_source(*, method: str, entry: UnlockedUser | None) -> str:
+    """Where the role an already-minted session still holds came from.
+
+    The source half of :func:`session_role`, and *derived* from it rather than
+    read off the entry in parallel: the source is only ever an explanation of a
+    role, so it has to disappear on every path the role does. Deriving it is
+    what makes that true by construction — the method flip the role half exists
+    for zeroes both halves in lockstep, and a signed payload that somehow
+    carries a ``source`` without a ``role`` (no shape :func:`_grant` can hand
+    out) explains a privilege the session does not hold, so it reports nothing.
+
+    Args:
+        method: The deployment's auth method.
+        entry: The unlocked entry, or ``None`` on the defensive path.
+
+    Returns:
+        :data:`ROLE_SOURCE_ROSTER` or :data:`ROLE_SOURCE_CLAIM` when this
+        session still holds a role that names one, and ``""`` otherwise.
+    """
+    # The ``None`` arm restates :func:`session_role`'s own first line, which the
+    # derivation would otherwise have already answered: it is here so the entry
+    # is narrowed for the reader (and the type checker) rather than trusted.
+    if entry is None or not session_role(method=method, entry=entry):
+        return ""
+    return entry.role_source

--- a/src/osprey/services/auth_sidecar/routes/verify.py
+++ b/src/osprey/services/auth_sidecar/routes/verify.py
@@ -4,11 +4,11 @@ nginx calls this once for every request under ``/u/<user>/`` — page loads, API
 calls, websocket handshakes alike — and turns any non-2xx answer into a denial.
 It is therefore on the hot path of the whole deployment and says as little as
 possible: a bodyless 200 or a bare 401, with no redirect and no
-``WWW-Authenticate``. The only things an authorized answer may carry are the two
-identity headers of
+``WWW-Authenticate``. The only things an authorized answer may carry are the
+three identity headers of
 :mod:`~osprey.services.auth_sidecar.identity_headers` — the account behind the
-request and the role it holds, both opaque identifiers and never a credential —
-and each only when the session holds one.
+request, the role it holds and where that role came from, all opaque
+identifiers and never a credential — and each only when the session holds one.
 Where an unauthenticated browser should be *sent* is
 nginx's decision (``error_page 401``, content-negotiated), not this route's; a
 redirect issued here would be followed by the subrequest instead of the user.
@@ -40,11 +40,11 @@ from fastapi import APIRouter, Cookie, Depends, Query, Response
 
 from ..app import AuthSettings, get_revocation_store, get_session_codec, get_settings
 from ..exceptions import InvalidSessionError
-from ..identity_headers import ROLE_HEADER, SUBJECT_HEADER, is_header_safe
+from ..identity_headers import ROLE_HEADER, ROLE_SOURCE_HEADER, SUBJECT_HEADER, is_header_safe
 from ..passwords import verify_generation_tag
 from ..revocation import RevocationStore
 from ..sessions import SESSION_COOKIE_NAME, SessionCodec, UnlockedUser
-from .recheck import session_role, session_subject
+from .recheck import session_role, session_role_source, session_subject
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +225,7 @@ def _authorized(username: str, entry: UnlockedUser | None, settings: AuthSetting
     ``is_unlocked`` has already established that ``entry`` exists, so ``None`` is
     only a defensive guard.
 
-    Two headers may ride the 200. ``X-Osprey-Auth-Subject`` names the account —
+    Three headers may ride the 200. ``X-Osprey-Auth-Subject`` names the account —
     the provider subject under OIDC, the roster username otherwise — so a later
     layer can tell who is behind the request without re-reading the cookie.
     ``X-Osprey-Auth-Role`` names the role that account holds. Each is *omitted*
@@ -259,7 +259,15 @@ def _authorized(username: str, entry: UnlockedUser | None, settings: AuthSetting
     :func:`~osprey.services.auth_sidecar.routes.recheck.session_role` now grants
     it no role either.
 
-    **An uncarryable value denies.** Both values are checked against
+    **The source rides only beside the role.** ``X-Osprey-Auth-Role-Source``
+    names which authority resolved the role in the header above it — ``roster``
+    for the entry the render bound, ``claim`` for a validated ID token — and it
+    comes from the same matrix rather than off the entry, so it is absent on
+    every path the role is absent from: a session holding no role has no
+    provenance to explain. Unlike the role, it is display only: it says where a
+    privilege came from and confers none of its own.
+
+    **An uncarryable value denies.** Every value is checked against
     :func:`~osprey.services.auth_sidecar.identity_headers.is_header_safe` even
     though the session codec refuses to store one that fails — the roster
     username reaches here without passing through the codec at all, so a
@@ -274,8 +282,9 @@ def _authorized(username: str, entry: UnlockedUser | None, settings: AuthSetting
         settings: The deployment's frozen settings.
 
     Returns:
-        A 200 carrying zero, one or both identity headers — or a 401 if an
-        identity this deployment cannot carry was about to be reported.
+        A 200 carrying as many of the three identity headers as this session
+        can fill — or a 401 if an identity this deployment cannot carry was
+        about to be reported.
     """
     headers: dict[str, str] = {}
     subject = _subject_for(username, entry, settings)
@@ -289,5 +298,13 @@ def _authorized(username: str, entry: UnlockedUser | None, settings: AuthSetting
         if not is_header_safe(role):
             return _deny(username, "the session role cannot be carried in an identity header")
         headers[ROLE_HEADER] = role
+
+        source = session_role_source(method=settings.method, entry=entry)
+        if source:
+            if not is_header_safe(source):
+                return _deny(
+                    username, "the session role source cannot be carried in an identity header"
+                )
+            headers[ROLE_SOURCE_HEADER] = source
 
     return Response(status_code=200, headers=headers)

--- a/src/osprey/services/auth_sidecar/sessions.py
+++ b/src/osprey/services/auth_sidecar/sessions.py
@@ -5,7 +5,8 @@ I" but "which roster users has this browser unlocked, and until when". That set
 lives in a single :mod:`itsdangerous`-signed cookie::
 
     {"v": 1, "sid": "<session id>", "iat": <epoch>, "users": {
-        "alice": {"exp": <epoch>, "tag": "0123456789abcdef", "sub": "", "role": ""}
+        "alice": {"exp": <epoch>, "tag": "0123456789abcdef", "sub": "",
+                  "role": "", "source": ""}
     }}
 
 **Signed, not encrypted.** Anyone holding the cookie can read the payload; they
@@ -25,15 +26,19 @@ Both entries also carry the ``"role"`` the deployment resolved for that user —
 the name of an entry in ``modules.web_terminals.authorization.roles``, not a
 privilege in itself. It is authorization *input*, so its empty default is the
 deny-safe one: an entry naming no role names no privileges, and nothing
-downstream may substitute a default for it.
+downstream may substitute a default for it. The ``"source"`` beside it names
+where that role came from — the roster or an OIDC claim — and is provenance
+only: it qualifies the role for a reader without changing what the role
+grants, and an entry naming no role names no source either.
 
-The ``"sub"`` and ``"role"`` keys are read with defaults rather than being made
-mandatory, and neither was added with a :data:`PAYLOAD_VERSION` bump: a cookie
-minted before either existed still decodes, with an empty subject and no role.
+The ``"sub"``, ``"role"`` and ``"source"`` keys are read with defaults rather
+than being made mandatory, and none of them was added with a
+:data:`PAYLOAD_VERSION` bump: a cookie minted before any of them existed still
+decodes, with an empty subject, no role and no provenance for it.
 
-**A value that cannot cross the nginx boundary is never stored.** The subject
-and the role both leave as HTTP headers (see
-:mod:`~osprey.services.auth_sidecar.identity_headers`), so both are checked
+**A value that cannot cross the nginx boundary is never stored.** The subject,
+the role and its source all leave as HTTP headers (see
+:mod:`~osprey.services.auth_sidecar.identity_headers`), so all three are checked
 against :func:`~osprey.services.auth_sidecar.identity_headers.is_header_safe`
 here — on the way in, where a caller can still be told it is wrong, and again on
 the way out, so a cookie could never hand the verify route a value its response
@@ -125,6 +130,11 @@ class UnlockedUser:
             all, which every consumer reads as "no privileges". Never a
             privilege itself — it names a role the deployment declared, which is
             what turns it into one.
+        role_source: Where :attr:`role` came from — the roster's ``role:`` entry
+            or an OIDC role claim — or ``""`` for none, which is what an entry
+            holding no role carries and what any session minted before
+            provenance travelled carries. Provenance only: it says where a
+            privilege came from, never that one is held.
     """
 
     username: str
@@ -132,6 +142,7 @@ class UnlockedUser:
     generation_tag: str = ""
     oidc_subject: str = ""
     role: str = ""
+    role_source: str = ""
 
     def is_expired(self, now: float) -> bool:
         """Whether this entry has reached its expiry at ``now``."""
@@ -205,16 +216,17 @@ class SessionState:
         generation_tag: str = "",
         oidc_subject: str = "",
         role: str = "",
+        role_source: str = "",
     ) -> SessionState:
         """Return this state with ``username`` unlocked until ``expires_at``.
 
         Re-adding a user replaces that entry in place — a fresh login restates
-        the expiry, the tag, the subject and the role without disturbing the
-        order of the others. Replacement is wholesale, not a merge: a login that
-        omits the role clears the one the previous login carried, exactly as it
-        already does for the tag and the subject. That is the safe direction: a
-        role kept across a login that no longer grants it would outlive the
-        authorization that put it there.
+        the expiry, the tag, the subject, the role and where that role came from
+        without disturbing the order of the others. Replacement is wholesale, not
+        a merge: a login that omits the role clears the one the previous login
+        carried along with its source, exactly as it already does for the tag and
+        the subject. That is the safe direction: a role kept across a login that
+        no longer grants it would outlive the authorization that put it there.
 
         Args:
             username: The roster user being unlocked.
@@ -225,14 +237,16 @@ class SessionState:
                 password mode, which has no provider account behind it.
             role: The authorization role this login resolved, or ``""`` for
                 none.
+            role_source: Where that role came from, or ``""`` for none — which
+                is what a login resolving no role passes.
 
         Raises:
-            ValueError: If ``username`` is empty, or if the subject or role
-                could not be carried in an identity header. The caller is
-                refusing a login at that point, not repairing a value: a
-                substitute identity would authorize the wrong thing, and a
-                silently dropped role would authorize *something* under a
-                privilege nobody granted.
+            ValueError: If ``username`` is empty, or if the subject, the role or
+                its source could not be carried in an identity header. The
+                caller is refusing a login at that point, not repairing a
+                value: a substitute identity would authorize the wrong thing,
+                and a silently dropped role would authorize *something* under
+                a privilege nobody granted.
         """
         if not username:
             raise ValueError("username must not be empty")
@@ -240,6 +254,8 @@ class SessionState:
             raise ValueError("oidc subject cannot be carried in an identity header")
         if role and not is_header_safe(role):
             raise ValueError("role cannot be carried in an identity header")
+        if role_source and not is_header_safe(role_source):
+            raise ValueError("role source cannot be carried in an identity header")
 
         entry = UnlockedUser(
             username=username,
@@ -247,6 +263,7 @@ class SessionState:
             generation_tag=generation_tag,
             oidc_subject=oidc_subject,
             role=role,
+            role_source=role_source,
         )
         if self.entry(username) is None:
             return replace(self, users=(*self.users, entry))
@@ -353,6 +370,7 @@ class SessionCodec:
                     "tag": user.generation_tag,
                     "sub": user.oidc_subject,
                     "role": user.role,
+                    "source": user.role_source,
                 }
                 for user in state.users
             },
@@ -415,16 +433,16 @@ class SessionCodec:
     def _decode_users(raw_users: Any) -> tuple[UnlockedUser, ...]:
         """Read the unlocked-user map out of a verified payload.
 
-        ``tag``, ``sub`` and ``role`` all default to ``""`` when absent, so a
-        cookie minted before any of those keys existed decodes at the current
-        payload version instead of signing that browser out.
+        ``tag``, ``sub``, ``role`` and ``source`` all default to ``""`` when
+        absent, so a cookie minted before any of those keys existed decodes at
+        the current payload version instead of signing that browser out.
 
-        A subject or role that could not be carried in an identity header
-        invalidates the whole cookie. Only this sidecar can have signed it, and
-        :meth:`SessionState.with_user` refuses to store such a value — so a
-        cookie carrying one is not a session to salvage, and refusing it here is
-        what keeps the verify route's answer a plain 401 rather than an encoding
-        failure on the hot path.
+        A subject, role or role source that could not be carried in an identity
+        header invalidates the whole cookie. Only this sidecar can have signed
+        it, and :meth:`SessionState.with_user` refuses to store such a value —
+        so a cookie carrying one is not a session to salvage, and refusing it
+        here is what keeps the verify route's answer a plain 401 rather than an
+        encoding failure on the hot path.
 
         Raises:
             InvalidSessionError: If the map or any entry is malformed.
@@ -459,6 +477,15 @@ class SessionCodec:
                 raise InvalidSessionError(
                     f"session entry for {username!r} carries an uncarryable role"
                 )
+            role_source = entry.get("source", "")
+            if not isinstance(role_source, str):
+                raise InvalidSessionError(
+                    f"session entry for {username!r} has a non-string role source"
+                )
+            if role_source and not is_header_safe(role_source):
+                raise InvalidSessionError(
+                    f"session entry for {username!r} carries an uncarryable role source"
+                )
             users.append(
                 UnlockedUser(
                     username=username,
@@ -466,6 +493,7 @@ class SessionCodec:
                     generation_tag=tag,
                     oidc_subject=subject,
                     role=role,
+                    role_source=role_source,
                 )
             )
         return tuple(users)

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -127,8 +127,10 @@
       In neither case does the browser's whole jar — which names every other
       terminal it has unlocked, and the sidecar's origin-wide session — reach a
       container running agent-generated code.
-    * `X-Osprey-Auth-Subject` / `X-Osprey-Auth-Role` — who the request belongs
-      to and what privilege it holds — are written by EVERY proxying location:
+    * `X-Osprey-Auth-Subject` / `X-Osprey-Auth-Role` /
+      `X-Osprey-Auth-Role-Source` — who the request belongs to, what privilege
+      it holds and where that privilege came from — are written by EVERY
+      proxying location:
       a gated `/u/<user>/` SETS them from `auth_request_set` variables carrying
       what the sidecar returned, and every other proxying location CLEARS them
       — the ungated `/u/<user>/` branch, the internal `/_osprey_auth/<user>`
@@ -462,19 +464,20 @@ server {
         # request — and it reads `$upstream_http_*`, nginx's spelling of the
         # auth upstream's response header (lowercased, dashes to underscores).
         #
-        # Both variables are LOCAL to this location and fed by this user's own
+        # The variables are LOCAL to this location and fed by this user's own
         # `auth_request` above, so no user's identity can be observed here but
         # the one this location authorizes. A denied subrequest never reaches
         # the `proxy_pass` at all, so these can only ever hold a value the
         # sidecar returned for an authorization it granted.
         #
-        # Either may be empty: the sidecar omits a header it has no value for
-        # (an OIDC session with no mapped role, say). An empty value makes the
-        # `proxy_set_header` below send nothing at all, which is the deny-safe
-        # answer — a consumer reads an absent role as no privileges, never as a
-        # default one.
+        # Any of them may be empty: the sidecar omits a header it has no value
+        # for (an OIDC session with no mapped role, say). An empty value makes
+        # the `proxy_set_header` below send nothing at all, which is the
+        # deny-safe answer — a consumer reads an absent role as no privileges,
+        # never as a default one.
         auth_request_set $osprey_auth_subject $upstream_http_x_osprey_auth_subject;
         auth_request_set $osprey_auth_role $upstream_http_x_osprey_auth_role;
+        auth_request_set $osprey_auth_role_source $upstream_http_x_osprey_auth_role_source;
 
         # Who a denied subrequest should prompt for. Carried in a variable
         # because the handler below is shared by every user; the value is
@@ -554,18 +557,18 @@ server {
         # and clearing the header costs it nothing. Unconditional, unlike the
         # two below: the header is never legitimate here in any auth mode.
         proxy_set_header Authorization "";
-        # The two identity headers — who the request belongs to and what
-        # privilege it holds. Both names are written into EVERY proxying
-        # location's own header set, by whichever arm of the branch below
-        # renders: gated, from the values the sidecar just returned; ungated, as
-        # an explicit clear.
+        # The three identity headers — who the request belongs to, what
+        # privilege it holds and where that privilege came from. All three
+        # names are written into EVERY proxying location's own header set, by
+        # whichever arm of the branch below renders: gated, from the values the
+        # sidecar just returned; ungated, as an explicit clear.
         #
         # Naming them is what drops the client's own. nginx builds one
         # proxy-headers table per location and copies the client's remaining
         # headers around it, so a name in that table is answered by its
         # directive and never by the request — including when the directive
         # evaluates EMPTY, which sends nothing rather than falling back to what
-        # arrived. A location naming neither would hand a client's values
+        # arrived. A location naming none of them would hand a client's values
         # straight to a container.
         #
         # Only this perimeter may name a user to a terminal: these headers are
@@ -587,12 +590,13 @@ server {
 {%- if sidecar_active and not svc.login_exempt %}
         # Gated: the values this perimeter DID establish, from the
         # `auth_request_set` variables above. Only a gated location has an
-        # authorization to speak for. Either value may be empty — the sidecar
-        # omits a header it has no value for — and an empty one is not sent at
-        # all, which is the deny-safe answer and still not the client's: the
-        # name is claimed by this directive either way.
+        # authorization to speak for. Any of these values may be empty — the
+        # sidecar omits a header it has no value for — and an empty one is not
+        # sent at all, which is the deny-safe answer and still not the
+        # client's: the name is claimed by this directive either way.
         proxy_set_header X-Osprey-Auth-Subject $osprey_auth_subject;
         proxy_set_header X-Osprey-Auth-Role $osprey_auth_role;
+        proxy_set_header X-Osprey-Auth-Role-Source $osprey_auth_role_source;
 
         # The browser's cookie header stops here — gated on `sidecar_active`,
         # the SIDECAR's predicate, not on the injection predicate the secret
@@ -623,18 +627,20 @@ server {
 {%- if inject_secret and not svc.login_exempt %}
         # No sidecar vouched for this request; nginx itself injects this
         # user's operator secret below. There is no authorization to speak
-        # for, so both identity names are CLEARED here rather than forwarded:
-        # forwarding would announce a subject the perimeter never checked, and
-        # leaving the names unwritten would let the client supply them itself.
+        # for, so all three identity names are CLEARED here rather than
+        # forwarded: forwarding would announce a subject the perimeter never
+        # checked, and leaving the names unwritten would let the client supply
+        # them itself.
 {%- else %}
         # Ungated — authentication is off, or this entry declared
-        # `login: false`. There is no authorization to speak for, so both
+        # `login: false`. There is no authorization to speak for, so all three
         # identity names are CLEARED here rather than forwarded: forwarding
         # would announce a subject the perimeter never checked, and leaving the
         # names unwritten would let the client supply them itself.
 {%- endif %}
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
+        proxy_set_header X-Osprey-Auth-Role-Source "";
 {%- if inject_secret and not svc.login_exempt %}
         # No clear for the operator-secret header here, and its absence is
         # load-bearing rather than an omission: the `include` above already
@@ -727,10 +733,11 @@ server {
         # the session cookie and the render-time `?user=` above, and must never
         # see a value the request supplied. The clear lives in this location
         # rather than at server level because a location-level
-        # `proxy_set_header` — the four below, at minimum — replaces the whole
-        # inherited set, so a server-level clear would be discarded right here.
+        # `proxy_set_header` — the ones below — replaces the whole inherited
+        # set, so a server-level clear would be discarded right here.
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
+        proxy_set_header X-Osprey-Auth-Role-Source "";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -799,6 +806,7 @@ server {
         # nothing it serves may read one out of the request.
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
+        proxy_set_header X-Osprey-Auth-Role-Source "";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/tests/deployment/web_terminals/golden/nginx.conf
+++ b/tests/deployment/web_terminals/golden/nginx.conf
@@ -107,18 +107,18 @@ server {
         # and clearing the header costs it nothing. Unconditional, unlike the
         # two below: the header is never legitimate here in any auth mode.
         proxy_set_header Authorization "";
-        # The two identity headers — who the request belongs to and what
-        # privilege it holds. Both names are written into EVERY proxying
-        # location's own header set, by whichever arm of the branch below
-        # renders: gated, from the values the sidecar just returned; ungated, as
-        # an explicit clear.
+        # The three identity headers — who the request belongs to, what
+        # privilege it holds and where that privilege came from. All three
+        # names are written into EVERY proxying location's own header set, by
+        # whichever arm of the branch below renders: gated, from the values the
+        # sidecar just returned; ungated, as an explicit clear.
         #
         # Naming them is what drops the client's own. nginx builds one
         # proxy-headers table per location and copies the client's remaining
         # headers around it, so a name in that table is answered by its
         # directive and never by the request — including when the directive
         # evaluates EMPTY, which sends nothing rather than falling back to what
-        # arrived. A location naming neither would hand a client's values
+        # arrived. A location naming none of them would hand a client's values
         # straight to a container.
         #
         # Only this perimeter may name a user to a terminal: these headers are
@@ -138,12 +138,13 @@ server {
         # warning is most expensive: it is the one an operator learns to scroll
         # past.
         # Ungated — authentication is off, or this entry declared
-        # `login: false`. There is no authorization to speak for, so both
+        # `login: false`. There is no authorization to speak for, so all three
         # identity names are CLEARED here rather than forwarded: forwarding
         # would announce a subject the perimeter never checked, and leaving the
         # names unwritten would let the client supply them itself.
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
+        proxy_set_header X-Osprey-Auth-Role-Source "";
         # No operator secret is injected into this location — authentication is
         # off, or this entry declared `login: false` — so the two headers that
         # carry one are handled the other way round from the gated branch above.
@@ -212,18 +213,18 @@ server {
         # and clearing the header costs it nothing. Unconditional, unlike the
         # two below: the header is never legitimate here in any auth mode.
         proxy_set_header Authorization "";
-        # The two identity headers — who the request belongs to and what
-        # privilege it holds. Both names are written into EVERY proxying
-        # location's own header set, by whichever arm of the branch below
-        # renders: gated, from the values the sidecar just returned; ungated, as
-        # an explicit clear.
+        # The three identity headers — who the request belongs to, what
+        # privilege it holds and where that privilege came from. All three
+        # names are written into EVERY proxying location's own header set, by
+        # whichever arm of the branch below renders: gated, from the values the
+        # sidecar just returned; ungated, as an explicit clear.
         #
         # Naming them is what drops the client's own. nginx builds one
         # proxy-headers table per location and copies the client's remaining
         # headers around it, so a name in that table is answered by its
         # directive and never by the request — including when the directive
         # evaluates EMPTY, which sends nothing rather than falling back to what
-        # arrived. A location naming neither would hand a client's values
+        # arrived. A location naming none of them would hand a client's values
         # straight to a container.
         #
         # Only this perimeter may name a user to a terminal: these headers are
@@ -243,12 +244,13 @@ server {
         # warning is most expensive: it is the one an operator learns to scroll
         # past.
         # Ungated — authentication is off, or this entry declared
-        # `login: false`. There is no authorization to speak for, so both
+        # `login: false`. There is no authorization to speak for, so all three
         # identity names are CLEARED here rather than forwarded: forwarding
         # would announce a subject the perimeter never checked, and leaving the
         # names unwritten would let the client supply them itself.
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
+        proxy_set_header X-Osprey-Auth-Role-Source "";
         # No operator secret is injected into this location — authentication is
         # off, or this entry declared `login: false` — so the two headers that
         # carry one are handled the other way round from the gated branch above.

--- a/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
+++ b/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
@@ -122,13 +122,14 @@ _REPLACED_COMPOSE_LINES = frozenset(
     }
 )
 
-#: Task 4.7 (nginx-identity-headers), ungated arm. Two clears per `/u/<user>/`
+#: Task 4.7 (nginx-identity-headers), ungated arm. Three clears per `/u/<user>/`
 #: location, and NOTHING else: no `auth_request_set`, no forward, no `/auth/`
 #: location — those render only with authentication on.
 _ALLOWED_NGINX_LINES = Counter(
     {
         '        proxy_set_header X-Osprey-Auth-Subject "";': 2,
         '        proxy_set_header X-Osprey-Auth-Role "";': 2,
+        '        proxy_set_header X-Osprey-Auth-Role-Source "";': 2,
     }
 )
 
@@ -281,10 +282,10 @@ def test_compose_adds_exactly_the_audit_emitters_and_mounts() -> None:
     _assert_added_directives_are_exactly_allowed("docker-compose.web.yml")
 
 
-def test_nginx_adds_exactly_the_two_identity_header_clears() -> None:
-    """The nginx config's whole SC6 exception: the two clears, once each in each
-    of the two ungated `/u/<user>/` locations, from task 4.7. Nothing from the
-    gated arm may appear here — no `auth_request_set`, no forward — and the
+def test_nginx_adds_exactly_the_three_identity_header_clears() -> None:
+    """The nginx config's whole SC6 exception: the three clears, once each in
+    each of the two ungated `/u/<user>/` locations, from task 4.7. Nothing from
+    the gated arm may appear here — no `auth_request_set`, no forward — and the
     count catches a clear that reached only one of the two locations."""
     _assert_added_directives_are_exactly_allowed("nginx.conf")
 

--- a/tests/deployment/web_terminals/test_nginx_auth_surface.py
+++ b/tests/deployment/web_terminals/test_nginx_auth_surface.py
@@ -1,9 +1,11 @@
 """The identity headers the nginx perimeter forwards — and refuses to relay.
 
-The auth sidecar answers an authorized ``auth_request`` with two headers naming
-who the request belongs to (:data:`~osprey.services.auth_sidecar.identity_headers.SUBJECT_HEADER`)
-and what privilege they hold (:data:`~osprey.services.auth_sidecar.identity_headers.ROLE_HEADER`).
-nginx is what carries those two values from the subrequest's response into the
+The auth sidecar answers an authorized ``auth_request`` with three headers naming
+who the request belongs to (:data:`~osprey.services.auth_sidecar.identity_headers.SUBJECT_HEADER`),
+what privilege they hold (:data:`~osprey.services.auth_sidecar.identity_headers.ROLE_HEADER`)
+and where that privilege came from
+(:data:`~osprey.services.auth_sidecar.identity_headers.ROLE_SOURCE_HEADER`).
+nginx is what carries those values from the subrequest's response into the
 proxied request, and it is also the only thing standing between a client that
 simply *types* them and a terminal that would believe them. Both halves are
 rendered here, so both are pinned here.
@@ -15,8 +17,8 @@ silent rather than loud:
    or from the client.** nginx builds that table per location and copies the
    request's remaining headers around it, so naming a header — as a clear, or
    as a forward whose value happens to be empty — is what drops the client's
-   own. A location naming neither identity header is a hole; which of the two
-   directives claims the name is a separate question from whether it is
+   own. A location naming none of the identity headers is a hole; which of the
+   two directives claims a name is a separate question from whether it is
    claimed.
 2. **A ``proxy_set_header`` at location level replaces the entire inherited
    set.** A single server-level clear would therefore be discarded by every
@@ -27,9 +29,9 @@ silent rather than loud:
    ``/_osprey_auth/<user>`` needs its own clear too: without one, a client's
    forged subject reaches the sidecar as though the perimeter had put it there.
 
-The structural test (:func:`test_every_proxying_location_claims_both_identity_headers_with_auth_on`)
+The structural test (:func:`test_every_proxying_location_claims_every_identity_header_with_auth_on`)
 is the one that has to keep biting: it finds every location with a
-``proxy_pass`` and demands of each that it write both names ITSELF — the gated
+``proxy_pass`` and demands of each that it write every name ITSELF — the gated
 forward, or the clear, never nothing and never both — so a proxying location
 added later cannot quietly become a hole. The two wall-less postures are not
 exceptions — ``token`` (the default: each terminal's own ``?token=`` exchange
@@ -59,7 +61,11 @@ from osprey.deployment.web_terminals.render import (
     render_web_terminals,
     terminal_secret_env_var,
 )
-from osprey.services.auth_sidecar.identity_headers import ROLE_HEADER, SUBJECT_HEADER
+from osprey.services.auth_sidecar.identity_headers import (
+    ROLE_HEADER,
+    ROLE_SOURCE_HEADER,
+    SUBJECT_HEADER,
+)
 
 _BASE_PORTS = {"web": 9091, "artifact": 9291, "ariel": 9391, "lattice": 9491}
 
@@ -198,10 +204,15 @@ def _upstream_var(header: str) -> str:
 
 _SUBJECT_VAR = "$osprey_auth_subject"
 _ROLE_VAR = "$osprey_auth_role"
+_ROLE_SOURCE_VAR = "$osprey_auth_role_source"
 
-#: The two identity headers, each paired with the variable a gated location
+#: The three identity headers, each paired with the variable a gated location
 #: forwards it from.
-_IDENTITY = ((SUBJECT_HEADER, _SUBJECT_VAR), (ROLE_HEADER, _ROLE_VAR))
+_IDENTITY = (
+    (SUBJECT_HEADER, _SUBJECT_VAR),
+    (ROLE_HEADER, _ROLE_VAR),
+    (ROLE_SOURCE_HEADER, _ROLE_SOURCE_VAR),
+)
 
 
 def _forward(header: str, variable: str) -> str:
@@ -232,25 +243,27 @@ def _identity_writes(body: str) -> dict[str, list[str]]:
     }
 
 
-def _assert_claims_both_identity_headers(location: str, body: str) -> None:
-    """*location* writes both identity names itself, the same way, exactly once.
+def _assert_claims_every_identity_header(location: str, body: str) -> None:
+    """*location* writes every identity name itself, the same way, exactly once.
 
     The safety property is that the name is claimed at all — nginx answers a
     named header from the location's own table and never from the request, so
-    a clear and a forward are equally good at dropping a forged value, and
-    neither is optional. What is ruled out here is a location that writes one
-    name and not the other, one that writes neither (the client's own header
-    reaches the container), and one that writes a name twice (no extra safety,
-    a `proxy_headers_hash` warning on every reload).
+    a clear and a forward are equally good at dropping a forged value, and not
+    one of them is optional. What is ruled out here is a location that writes
+    some of the names and not the rest, one that writes none of them (the
+    client's own header reaches the container), and one that writes a name
+    twice (no extra safety, a `proxy_headers_hash` warning on every reload).
+
+    Written over whatever `_IDENTITY` holds rather than name by name, so a
+    header added to that tuple is *checked* the day it is added rather than
+    merely computed: a name nothing asserts on is no guard at all.
     """
     writes = _identity_writes(body)
-    assert writes[SUBJECT_HEADER] == writes[ROLE_HEADER], (
-        f"{location} claims the two identity headers differently: {writes}"
-    )
-    assert len(writes[SUBJECT_HEADER]) == 1, (
-        f"{location} must claim each identity header exactly once: {writes}"
-    )
-    if writes[SUBJECT_HEADER] == ["forward"]:
+    claimed = {tuple(claims) for claims in writes.values()}
+    assert len(claimed) == 1, f"{location} claims the identity headers differently: {writes}"
+    (claim,) = claimed
+    assert len(claim) == 1, f"{location} must claim each identity header exactly once: {writes}"
+    if claim == ("forward",):
         assert "auth_request /" in body, (
             f"{location} forwards an identity, but holds no auth_request that could establish one"
         )
@@ -274,8 +287,8 @@ _EXEMPT_ROSTER = [
 
 def test_rendered_header_names_are_the_sidecar_s_own_spelling() -> None:
     """The template writes the header names as literals — nginx conf has no way
-    to import a Python constant — so the two spellings are held together by this
-    assertion instead. A rename on the sidecar side that stopped here would
+    to import a Python constant — so the three spellings are held together by
+    this assertion instead. A rename on the sidecar side that stopped here would
     leave nginx forwarding a header nothing reads and clearing one nothing sets.
     """
     # Arrange / Act
@@ -284,8 +297,10 @@ def test_rendered_header_names_are_the_sidecar_s_own_spelling() -> None:
     # Assert
     assert SUBJECT_HEADER == "X-Osprey-Auth-Subject"
     assert ROLE_HEADER == "X-Osprey-Auth-Role"
+    assert ROLE_SOURCE_HEADER == "X-Osprey-Auth-Role-Source"
     assert _clear(SUBJECT_HEADER) in nginx_conf
     assert _clear(ROLE_HEADER) in nginx_conf
+    assert _clear(ROLE_SOURCE_HEADER) in nginx_conf
 
 
 # --------------------------------------------------------------------------
@@ -293,8 +308,8 @@ def test_rendered_header_names_are_the_sidecar_s_own_spelling() -> None:
 # --------------------------------------------------------------------------
 
 
-def test_gated_user_location_forwards_both_identity_headers_from_the_auth_answer() -> None:
-    """A gated `/u/<user>/` reads both values off its own `auth_request`'s
+def test_gated_user_location_forwards_every_identity_header_from_the_auth_answer() -> None:
+    """A gated `/u/<user>/` reads every value off its own `auth_request`'s
     response and sets them on the proxied request. `auth_request_set` is the
     only construct that can do this: the subrequest's response headers are
     otherwise not visible to the parent request at all."""
@@ -304,25 +319,30 @@ def test_gated_user_location_forwards_both_identity_headers_from_the_auth_answer
     # Assert — the values are lifted out of alice's own subrequest…
     assert f"auth_request_set {_SUBJECT_VAR} {_upstream_var(SUBJECT_HEADER)};" in body
     assert f"auth_request_set {_ROLE_VAR} {_upstream_var(ROLE_HEADER)};" in body
+    assert f"auth_request_set {_ROLE_SOURCE_VAR} {_upstream_var(ROLE_SOURCE_HEADER)};" in body
 
     # Assert — …and put on the request that reaches alice's container.
     assert f"proxy_set_header {SUBJECT_HEADER} {_SUBJECT_VAR};" in body
     assert f"proxy_set_header {ROLE_HEADER} {_ROLE_VAR};" in body
+    assert f"proxy_set_header {ROLE_SOURCE_HEADER} {_ROLE_SOURCE_VAR};" in body
 
 
 def test_the_forward_is_emitted_once_per_gated_user_and_nowhere_else() -> None:
-    """Two gated users, two forwards each — and nothing on the exempt entry, the
-    internal verify target, `/auth/`, or the landing page. The count is what
-    makes this bite: a forward hoisted somewhere shared would still satisfy a
-    plain substring check while handing one user's identity to another."""
+    """Two gated users, one forward per identity header each — and nothing on
+    the exempt entry, the internal verify target, `/auth/`, or the landing page.
+    The count is what makes this bite: a forward hoisted somewhere shared would
+    still satisfy a plain substring check while handing one user's identity to
+    another."""
     # Arrange / Act
     directives = _directives(_render_nginx(_auth_config(_TWO_USERS)))
 
     # Assert
     assert directives.count(f"proxy_set_header {SUBJECT_HEADER} {_SUBJECT_VAR};") == 2
     assert directives.count(f"proxy_set_header {ROLE_HEADER} {_ROLE_VAR};") == 2
+    assert directives.count(f"proxy_set_header {ROLE_SOURCE_HEADER} {_ROLE_SOURCE_VAR};") == 2
     assert directives.count(f"auth_request_set {_SUBJECT_VAR} ") == 2
     assert directives.count(f"auth_request_set {_ROLE_VAR} ") == 2
+    assert directives.count(f"auth_request_set {_ROLE_SOURCE_VAR} ") == 2
 
 
 def test_login_exempt_location_forwards_no_identity_at_all() -> None:
@@ -337,6 +357,7 @@ def test_login_exempt_location_forwards_no_identity_at_all() -> None:
     assert "auth_request_set" not in body
     assert _SUBJECT_VAR not in body
     assert _ROLE_VAR not in body
+    assert _ROLE_SOURCE_VAR not in body
 
 
 @pytest.mark.parametrize(
@@ -359,6 +380,7 @@ def test_a_wall_less_render_forwards_no_identity_and_has_no_auth_request_set(
     assert "auth_request_set" not in directives
     assert _SUBJECT_VAR not in directives
     assert _ROLE_VAR not in directives
+    assert _ROLE_SOURCE_VAR not in directives
 
 
 # --------------------------------------------------------------------------
@@ -366,9 +388,9 @@ def test_a_wall_less_render_forwards_no_identity_and_has_no_auth_request_set(
 # --------------------------------------------------------------------------
 
 
-def test_every_proxying_location_claims_both_identity_headers_with_auth_on() -> None:
+def test_every_proxying_location_claims_every_identity_header_with_auth_on() -> None:
     """The structural guard, auth on: every location that opens an upstream
-    connection writes both identity names itself — the gated one by forwarding
+    connection writes every identity name itself — the gated one by forwarding
     what the sidecar answered, the rest by clearing. Written against
     `proxy_pass` rather than against a list of known paths so a location added
     later is covered the day it is added, not the day someone remembers this
@@ -383,9 +405,10 @@ def test_every_proxying_location_claims_both_identity_headers_with_auth_on() -> 
     }
     assert set(proxying) == {"/u/alice/", "/u/ariel/", "= /_osprey_auth/alice", "/auth/"}
 
-    # Assert — and not one of them leaves either name for the client to supply.
+    # Assert — and not one of them leaves any of the names for the client to
+    # supply.
     for location, body in proxying.items():
-        _assert_claims_both_identity_headers(location, body)
+        _assert_claims_every_identity_header(location, body)
 
     # Assert — exactly one of them is entitled to forward, and it is the gated
     # user's own location. Everything else clears.
@@ -407,7 +430,7 @@ def test_every_proxying_location_claims_both_identity_headers_with_auth_on() -> 
     ],
     ids=["token", "token-exempt", "open", "open-exempt"],
 )
-def test_every_proxying_location_claims_both_identity_headers_without_a_login_wall(
+def test_every_proxying_location_claims_every_identity_header_without_a_login_wall(
     config: dict, proxying_locations: set[str]
 ) -> None:
     """The same guard with no login wall — the deliberate part, and the reason
@@ -434,13 +457,13 @@ def test_every_proxying_location_claims_both_identity_headers_without_a_login_wa
     }
     assert set(proxying) == proxying_locations
     for location, body in proxying.items():
-        _assert_claims_both_identity_headers(location, body)
+        _assert_claims_every_identity_header(location, body)
         assert _identity_writes(body)[SUBJECT_HEADER] == ["clear"], (
             f"{location} forwards an identity in a render that authorizes nobody"
         )
 
 
-def test_the_internal_verify_target_clears_both_identity_headers() -> None:
+def test_the_internal_verify_target_clears_every_identity_header() -> None:
     """Called out on its own because the reason is not the same as everywhere
     else: an auth subrequest INHERITS the parent request's headers, so without
     a clear here a client's forged subject arrives at the sidecar looking like
@@ -451,9 +474,10 @@ def test_the_internal_verify_target_clears_both_identity_headers() -> None:
     # Assert
     assert _clear(SUBJECT_HEADER) in body
     assert _clear(ROLE_HEADER) in body
+    assert _clear(ROLE_SOURCE_HEADER) in body
 
 
-def test_the_public_auth_prefix_clears_both_identity_headers() -> None:
+def test_the_public_auth_prefix_clears_every_identity_header() -> None:
     """`/auth/` is the one location deliberately outside `auth_request` — it is
     where a session comes from. That makes it reachable by anyone, so it is the
     one an unauthenticated client would forge into."""
@@ -463,6 +487,7 @@ def test_the_public_auth_prefix_clears_both_identity_headers() -> None:
     # Assert
     assert _clear(SUBJECT_HEADER) in body
     assert _clear(ROLE_HEADER) in body
+    assert _clear(ROLE_SOURCE_HEADER) in body
 
 
 def test_the_gated_location_forwards_instead_of_also_clearing() -> None:
@@ -482,14 +507,16 @@ def test_the_gated_location_forwards_instead_of_also_clearing() -> None:
     # Assert — claimed, by the forward…
     assert _forward(SUBJECT_HEADER, _SUBJECT_VAR) in body
     assert _forward(ROLE_HEADER, _ROLE_VAR) in body
+    assert _forward(ROLE_SOURCE_HEADER, _ROLE_SOURCE_VAR) in body
 
     # Assert — …and by nothing else.
     assert _clear(SUBJECT_HEADER) not in body
     assert _clear(ROLE_HEADER) not in body
+    assert _clear(ROLE_SOURCE_HEADER) not in body
 
 
 def test_no_location_writes_the_same_proxy_set_header_name_twice() -> None:
-    """Across every topology, and for EVERY header name — not just the two
+    """Across every topology, and for EVERY header name — not just the three
     identity ones.
 
     nginx hashes each location's `proxy_set_header` entries by name, and a
@@ -792,6 +819,7 @@ def test_real_nginx_reads_the_auth_on_render_without_a_single_warning() -> None:
     # emitting the forwarding half entirely would also warn about nothing.
     assert _forward(SUBJECT_HEADER, _SUBJECT_VAR) in nginx_conf
     assert _forward(ROLE_HEADER, _ROLE_VAR) in nginx_conf
+    assert _forward(ROLE_SOURCE_HEADER, _ROLE_SOURCE_VAR) in nginx_conf
     assert _clear(SUBJECT_HEADER) in nginx_conf
 
     # Only the gated users get a snippet — an exempt location includes none —

--- a/tests/e2e/test_full_chain_auth.py
+++ b/tests/e2e/test_full_chain_auth.py
@@ -1,7 +1,7 @@
 """Acceptance proof for the WHOLE identity chain on real artifacts: a password
 login at the deployed sidecar, an ``authorization:`` role that decides which
-persona a user's container runs, the two identity headers nginx forwards from
-the sidecar's answer, and the audit records those decisions leave behind in
+persona a user's container runs, the three identity headers nginx forwards
+from the sidecar's answer, and the audit records those decisions leave behind in
 each identity's OWN ledger subdirectory.
 
 This lane is the automated acceptance for SC2, SC4 and SC5. Every other test of
@@ -42,15 +42,16 @@ user       role           persona     what only this entry can prove
 ``alice``  ``operator``   REAL app    A password login reaches HER container,
                                       and an in-container protected-key refusal
                                       lands in ``var/audit/alice/``.
-``bob``    ``observer``   probe stub  Subject AND role arrive at the upstream,
-                                      exactly once each, carrying the sidecar's
-                                      values — and a client-forged header does
-                                      not.
+``bob``    ``observer``   probe stub  Subject, role AND role source arrive at
+                                      the upstream, exactly once each, carrying
+                                      the sidecar's values — and client-forged
+                                      headers do not.
 ``carol``  (none)         probe stub  A session with no role forwards the
-                                      subject and NO role header at all —
-                                      absent, never present-and-blank.
+                                      subject and NEITHER a role nor a
+                                      role-source header at all — absent, never
+                                      present-and-blank.
 ``kiosk``  (none)         probe stub  ``login: false``: the ungated branch
-                                      forwards NEITHER header.
+                                      forwards NONE of the three.
 ``dave``   (none)         probe stub  A role the boundary cannot carry refuses
                                       the login 403 instead of poisoning a
                                       header (see FAULT INJECTION below).
@@ -85,13 +86,13 @@ guard, not a claim that nginx skipped an empty clear. The unconditional
 exempt ``/u/kiosk/`` and each ``/_osprey_auth/<user>`` subrequest — where there
 is no sidecar answer to forward and the clear is the only thing standing
 between a client's header and the upstream. That is what
-``test_the_exempt_branch_forwards_neither_identity_header`` proves.
+``test_the_exempt_branch_forwards_no_identity_header`` proves.
 
 WHAT THE EXEMPT BRANCH DOES NOT PROVE HERE: it runs against the alpine stub, so
-this lane shows only that nginx forwards neither identity header on the ungated
-arm. It does not show that a ``login: false`` terminal is actually usable by an
-anonymous person on a REAL image, where the same arm also clears the operator
-secret and forwards only the app's own session cookie.
+this lane shows only that nginx forwards none of the identity headers on the
+ungated arm. It does not show that a ``login: false`` terminal is actually
+usable by an anonymous person on a REAL image, where the same arm also
+clears the operator secret and forwards only the app's own session cookie.
 ``tests/e2e/web_terminals/test_terminal_auth_multiuser_e2e.py`` drives that
 ungated arm against a real ``osprey web``, so the pair covers it.
 
@@ -169,7 +170,11 @@ import pytest
 import yaml
 
 from osprey.audit.protected import SURFACE_HTTP_CONFIG
-from osprey.services.auth_sidecar.identity_headers import ROLE_HEADER, SUBJECT_HEADER
+from osprey.services.auth_sidecar.identity_headers import (
+    ROLE_HEADER,
+    ROLE_SOURCE_HEADER,
+    SUBJECT_HEADER,
+)
 from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME
 from tests.e2e._volumes import remove_project_volumes
 
@@ -206,6 +211,13 @@ PROBE_PROJECT = f"{PREFIX}-probe"
 #: itself an assertion about role resolution.
 ROLE_OPERATOR = "operator"
 ROLE_OBSERVER = "observer"
+
+#: The provenance value a password roster produces, spelled as it crosses the
+#: wire rather than imported: this lane's subject is what the upstream actually
+#: receives, so a rename of the sidecar's constant must fail here rather than
+#: follow along. ``claim`` is the other member of the vocabulary and cannot
+#: appear in this deployment, which has no IdP.
+ROLE_SOURCE_ROSTER = "roster"
 
 REAL_USER = "alice"
 HEADER_USER = "bob"
@@ -1322,7 +1334,7 @@ def test_a_password_login_reaches_that_users_own_terminal(deployment: dict[str, 
     )
 
 
-def test_the_upstream_receives_exactly_one_subject_and_one_role_header(
+def test_the_upstream_receives_exactly_one_subject_and_one_role_and_one_role_source_header(
     deployment: dict[str, Any],
 ) -> None:
     """SC4: the sidecar's identity arrives at the container, once, unduplicated.
@@ -1342,7 +1354,10 @@ def test_the_upstream_receives_exactly_one_subject_and_one_role_header(
     The role's VALUE is the roster role ``bob``'s entry declares, which is what
     makes this an assertion about the whole binding — roster ``role:`` →
     sidecar session → verify's response headers → ``auth_request_set`` →
-    forwarded header — rather than about nginx alone.
+    forwarded header — rather than about nginx alone. The role-source header
+    rides that same binding one step further: ``roster`` is the only provenance
+    a password deployment can produce, so its arrival proves the third header
+    travels the whole chain and is not merely rendered into the config.
     """
     report = _probe_report(HEADER_USER, opener=deployment["sessions"][HEADER_USER])
     assert _forwarded(report, SUBJECT_HEADER) == [HEADER_USER], (
@@ -1351,12 +1366,16 @@ def test_the_upstream_receives_exactly_one_subject_and_one_role_header(
     assert _forwarded(report, ROLE_HEADER) == [ROLE_OBSERVER], (
         f"{ROLE_HEADER} did not arrive exactly once carrying the roster role: {report}"
     )
+    assert _forwarded(report, ROLE_SOURCE_HEADER) == [ROLE_SOURCE_ROSTER], (
+        f"{ROLE_SOURCE_HEADER} did not arrive exactly once carrying the role's"
+        f" roster provenance: {report}"
+    )
 
 
 def test_a_client_forged_identity_header_never_reaches_the_upstream(
     deployment: dict[str, Any],
 ) -> None:
-    """SC4: no proxying location accepts a client-supplied value for either header.
+    """SC4: no proxying location accepts a client-supplied value for any of them.
 
     Sent by an AUTHORIZED client, deliberately: an unauthenticated forgery is
     stopped by the perimeter and would prove nothing about the header handling.
@@ -1369,18 +1388,29 @@ def test_a_client_forged_identity_header_never_reaches_the_upstream(
     forwards and the forged values arrive verbatim, which is what makes this
     assert honest; the unconditional empty clears this lane also relies on are
     in the ungated locations and are proved by
-    ``test_the_exempt_branch_forwards_neither_identity_header``.
+    ``test_the_exempt_branch_forwards_no_identity_header``. The forged
+    role-source is the sharpest of the three: a client that could name its own
+    provenance would be able to dress a roster role up as an IdP claim, so the
+    gated forward has to win over the forgery there too.
     """
     report = _probe_report(
         HEADER_USER,
         opener=deployment["sessions"][HEADER_USER],
-        headers={**_navigation(), SUBJECT_HEADER: "root", ROLE_HEADER: "admin"},
+        headers={
+            **_navigation(),
+            SUBJECT_HEADER: "root",
+            ROLE_HEADER: "admin",
+            ROLE_SOURCE_HEADER: "claim",
+        },
     )
     assert _forwarded(report, SUBJECT_HEADER) == [HEADER_USER], (
         f"a forged {SUBJECT_HEADER} survived the gated location: {report}"
     )
     assert _forwarded(report, ROLE_HEADER) == [ROLE_OBSERVER], (
         f"a forged {ROLE_HEADER} survived the gated location: {report}"
+    )
+    assert _forwarded(report, ROLE_SOURCE_HEADER) == [ROLE_SOURCE_ROSTER], (
+        f"a forged {ROLE_SOURCE_HEADER} survived the gated location: {report}"
     )
 
 
@@ -1393,7 +1423,11 @@ def test_a_session_with_no_role_forwards_a_subject_and_no_role_header(
     empty role — and every consumer must read a missing ``X-Osprey-Auth-Role``
     as "no privileges". A present-but-empty header would be read by a consumer
     checking presence as a role that exists, which is the accidental-grant this
-    pins shut. Only a runtime observation can tell the two apart.
+    pins shut. Only a runtime observation can tell the two apart. The
+    role-source header is absent for the same reason and by the same rule: it
+    describes where a role came from, so with no role there is nothing for it
+    to describe and an empty ``roster`` would be a provenance claim about a
+    privilege nobody holds.
     """
     report = _probe_report(NO_ROLE_USER, opener=deployment["sessions"][NO_ROLE_USER])
     assert _forwarded(report, SUBJECT_HEADER) == [NO_ROLE_USER], (
@@ -1402,29 +1436,43 @@ def test_a_session_with_no_role_forwards_a_subject_and_no_role_header(
     assert _forwarded(report, ROLE_HEADER) == [], (
         f"{ROLE_HEADER} arrived for a session that holds no role: {report}"
     )
+    assert _forwarded(report, ROLE_SOURCE_HEADER) == [], (
+        f"{ROLE_SOURCE_HEADER} arrived beside no role at all: {report}"
+    )
 
 
-def test_the_exempt_branch_forwards_neither_identity_header(deployment: dict[str, Any]) -> None:
+def test_the_exempt_branch_forwards_no_identity_header(deployment: dict[str, Any]) -> None:
     """SC4: a ``login: false`` location establishes no identity, so it forwards none.
 
     ``kiosk`` sits on the ungated branch: nginx runs no ``auth_request`` for it,
     so there is no sidecar answer to forward — and the unconditional clears mean
-    the terminal receives neither header rather than an empty one. Reached with
-    no credential at all, which is what ``login: false`` means.
+    the terminal receives none of the three headers rather than empty ones.
+    Reached with no credential at all, which is what ``login: false`` means.
 
     Forged headers are sent on the same request: the ungated branch is the one
     where a client could most plausibly hope to supply its own identity, and the
-    clears are the only thing stopping it.
+    clears are the only thing stopping it. All three identity headers are
+    forged and all three have to be absent — the role-source clear included,
+    since a provenance arriving where no identity was established would be a
+    claim about a role the branch never resolved.
     """
     report = _probe_report(
         EXEMPT_USER,
-        headers={**_navigation(), SUBJECT_HEADER: "root", ROLE_HEADER: "admin"},
+        headers={
+            **_navigation(),
+            SUBJECT_HEADER: "root",
+            ROLE_HEADER: "admin",
+            ROLE_SOURCE_HEADER: "claim",
+        },
     )
     assert _forwarded(report, SUBJECT_HEADER) == [], (
         f"the exempt branch forwarded {SUBJECT_HEADER}: {report}"
     )
     assert _forwarded(report, ROLE_HEADER) == [], (
         f"the exempt branch forwarded {ROLE_HEADER}: {report}"
+    )
+    assert _forwarded(report, ROLE_SOURCE_HEADER) == [], (
+        f"the exempt branch forwarded {ROLE_SOURCE_HEADER}: {report}"
     )
 
 

--- a/tests/interfaces/test_http_audit_emitters.py
+++ b/tests/interfaces/test_http_audit_emitters.py
@@ -46,6 +46,7 @@ from osprey.interfaces.common_middleware import (
     AUDIT_ACCOUNT_KEY,
     AUDIT_EXPECTED_ACCOUNT_KEY,
     AUDIT_ROLE_HEADER,
+    AUDIT_ROLE_SOURCE_HEADER,
     AUDIT_SUBJECT_HEADER,
     AUDITED_REFUSAL_STATUSES,
     EXTERNAL_ORIGIN_ENV,
@@ -63,6 +64,7 @@ from osprey.interfaces.common_middleware import (
     WEB_AUTH_SURFACE,
     HttpAuditMiddleware,
     WebAuthMiddleware,
+    forwarded_identity,
 )
 from osprey.interfaces.web_auth import WebCredentials, reset_web_credentials
 from osprey.utils.identity import AUDIT_IDENTITY_ENV
@@ -418,6 +420,32 @@ class TestForwardedIdentity:
         assert AUDIT_ACCOUNT_KEY not in detail_parts(record)
         assert record["role"] is None
 
+    def test_the_decoder_returns_the_source_beside_the_subject_and_role(self):
+        """The third name is decoded under the same bound as the first two.
+
+        Asserted on the decoder directly, not through an emitter: the ledger
+        reads the tuple and records only its first two values, so a third name
+        that quietly stopped being decoded would leave every record in this
+        module exactly as it is today, and only the terminal's chip would go
+        blank.
+        """
+        base = {
+            AUDIT_SUBJECT_HEADER.lower(): "alice",
+            AUDIT_ROLE_HEADER.lower(): "operator",
+        }
+
+        assert forwarded_identity(base) == ("alice", "operator", None)
+        assert forwarded_identity({**base, AUDIT_ROLE_SOURCE_HEADER.lower(): "roster"}) == (
+            "alice",
+            "operator",
+            "roster",
+        )
+        assert forwarded_identity({**base, AUDIT_ROLE_SOURCE_HEADER.lower(): "ro ster"}) == (
+            "alice",
+            "operator",
+            UNSAFE_FORWARDED_VALUE,
+        )
+
     def test_a_subject_matching_this_container_is_not_flagged(self, app_stub, records, monkeypatch):
         monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
         drive(
@@ -586,13 +614,18 @@ class TestForwardedIdentity:
         """The names are spelled locally; this is what keeps them in step.
 
         Importing them would put a service package in the interfaces' import
-        closure for two string constants, so the drift check is a test — the
+        closure for three string constants, so the drift check is a test — the
         same trade the rest of the audit work makes.
         """
-        from osprey.services.auth_sidecar.identity_headers import ROLE_HEADER, SUBJECT_HEADER
+        from osprey.services.auth_sidecar.identity_headers import (
+            ROLE_HEADER,
+            ROLE_SOURCE_HEADER,
+            SUBJECT_HEADER,
+        )
 
         assert AUDIT_SUBJECT_HEADER == SUBJECT_HEADER
         assert AUDIT_ROLE_HEADER == ROLE_HEADER
+        assert AUDIT_ROLE_SOURCE_HEADER == ROLE_SOURCE_HEADER
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/interfaces/web_terminal/test_terminal_user.py
+++ b/tests/interfaces/web_terminal/test_terminal_user.py
@@ -214,18 +214,31 @@ class TestSessionFooter:
 
 
 class TestAuthRole:
-    """``X-Osprey-Auth-Role`` -> the identity menu's who-line.
+    """``X-Osprey-Auth-Role`` and ``X-Osprey-Auth-Role-Source`` -> the who-line.
 
     nginx forwards the role the auth sidecar resolved on every gated request,
-    the page GET included, so ``root()`` reads it off the request rather than
-    off ``app.state``: it is a per-login fact, not a render-time one. The
-    header is decoded by the same bound the audit ledger applies, and a value
-    that fails it renders NOTHING — in a topology with no nginx in front, any
-    client can send the header, and the chip is a display, not an
-    authorization surface.
+    and beside it where that role came from, the page GET included — so
+    ``root()`` reads both off the request rather than off ``app.state``: they
+    are per-login facts, not render-time ones. Both headers are decoded by the
+    same bound the audit ledger applies, and a value that fails it renders
+    NOTHING — in a topology with no nginx in front, any client can send these
+    headers, and the chip is a display, not an authorization surface.
+
+    The source is shown only through ``root()``'s closed vocabulary and only
+    beside a role: a qualifier with nothing to qualify would be a separator
+    hanging off the end of the line.
     """
 
     ENV = {"OSPREY_TERMINAL_USER": "alice"}
+
+    #: The source span's full opening tag, asserted whole rather than by its
+    #: class alone — ``header-identity-who-role`` is a substring of
+    #: ``header-identity-who-role-source``, so a bare class check cannot tell
+    #: the pill from its qualifier.
+    SOURCE_SPAN = (
+        'class="header-identity-who-role-source" title="Where this session\'s role came from">'
+    )
+    ROLE_PILL = 'class="header-identity-who-role" title="Role for this session">operator<'
 
     def _body(self, workspace_dir, headers, env=None):
         cfg = {"watch_dir": str(workspace_dir)}
@@ -241,6 +254,9 @@ class TestAuthRole:
 
         assert 'class="header-identity-who-name">alice<' in body
         assert 'class="header-identity-who-role" title="Role for this session">operator<' in body
+        # A role with no source beside it — the shape every pre-upgrade session
+        # decodes to — shows the pill alone, with no qualifier span at all.
+        assert 'class="header-identity-who-role-source"' not in body
 
     @pytest.mark.parametrize(
         "headers",
@@ -297,6 +313,80 @@ class TestAuthRole:
         assert 'class="header-identity"' not in body
         assert "header-identity-who-role" not in body
 
+    @pytest.mark.parametrize(
+        ("source", "label"),
+        [
+            pytest.param("roster", "roster", id="roster"),
+            pytest.param("claim", "ID token", id="claim"),
+        ],
+    )
+    def test_the_source_is_shown_after_the_role(self, workspace_dir, source, label):
+        """The sidecar's word is translated for the reader: a login bound by
+        the roster says so in the roster's own term, while ``claim`` becomes
+        "ID token", which is what an operator sees named everywhere else."""
+        body = self._body(
+            workspace_dir,
+            {"X-Osprey-Auth-Role": "operator", "X-Osprey-Auth-Role-Source": source},
+        )
+
+        assert self.ROLE_PILL in body
+        assert self.SOURCE_SPAN + label + "<" in body
+
+    def test_a_source_without_a_role_renders_nothing(self, workspace_dir):
+        """The qualifier is gated on the role, not only on itself. A payload
+        shape the sidecar never mints could carry a source alone; the who-line
+        would then show a separator qualifying nothing."""
+        body = self._body(workspace_dir, {"X-Osprey-Auth-Role-Source": "roster"})
+
+        assert 'class="header-identity-who-name">alice<' in body
+        assert 'class="header-identity-who-role-source"' not in body
+
+    def test_a_source_outside_the_vocabulary_renders_nothing(self, workspace_dir):
+        """``ldap`` clears the header bound and is still not a source this
+        build can name. The role it qualifies is unaffected: the chip drops
+        the word it does not know, not the fact it does."""
+        body = self._body(
+            workspace_dir,
+            {"X-Osprey-Auth-Role": "operator", "X-Osprey-Auth-Role-Source": "ldap"},
+        )
+
+        assert self.ROLE_PILL in body
+        assert 'class="header-identity-who-role-source"' not in body
+        assert "ldap" not in body
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("ro ster", id="interior-space"),
+            pytest.param("a" * 129, id="over-long"),
+            pytest.param("ros\x7fter", id="control-char"),
+        ],
+    )
+    def test_a_source_the_sidecar_could_not_have_sent_renders_nothing(self, workspace_dir, value):
+        """Same bound as the role, and the same answer: the ledger's
+        ``<unsafe>`` sentinel is suppressed rather than rendered, here as
+        well."""
+        body = self._body(
+            workspace_dir,
+            {"X-Osprey-Auth-Role": "operator", "X-Osprey-Auth-Role-Source": value},
+        )
+
+        assert self.ROLE_PILL in body
+        assert 'class="header-identity-who-role-source"' not in body
+        assert "&lt;unsafe&gt;" not in body
+
+    def test_a_source_without_a_user_renders_no_chip(self, workspace_dir):
+        """Single-user terminals render no identity chip at all; a stray pair
+        of identity headers must not conjure one."""
+        body = self._body(
+            workspace_dir,
+            {"X-Osprey-Auth-Role": "operator", "X-Osprey-Auth-Role-Source": "roster"},
+            env={},
+        )
+
+        assert 'class="header-identity"' not in body
+        assert 'class="header-identity-who-role-source"' not in body
+
     def test_the_context_carries_the_role(self, workspace_dir):
         cfg = {"watch_dir": str(workspace_dir)}
         with (
@@ -313,8 +403,35 @@ class TestAuthRole:
                     return original(request, name, context, *args, **kwargs)
 
                 with patch.object(app_module.templates, "TemplateResponse", side_effect=_capture):
-                    assert c.get("/", headers={"X-Osprey-Auth-Role": "operator"}).status_code == 200
+                    assert (
+                        c.get(
+                            "/",
+                            headers={
+                                "X-Osprey-Auth-Role": "operator",
+                                "X-Osprey-Auth-Role-Source": "roster",
+                            },
+                        ).status_code
+                        == 200
+                    )
                     assert captured["auth_role"] == "operator"
+                    assert captured["auth_role_source_label"] == "roster"
                     captured.clear()
                     assert c.get("/").status_code == 200
                     assert captured["auth_role"] == ""
+                    assert captured["auth_role_source_label"] == ""
+
+    def test_the_source_vocabulary_is_the_sidecar_s_own(self):
+        """The label map's keys are the sidecar's own constants.
+
+        Importing them at module scope would put a service package in the
+        terminal's import closure for two string constants, so the drift check
+        is a test — the same trade ``test_http_audit_emitters.py`` makes for
+        the header names. Without it, renaming a value in ``recheck.py`` would
+        silently blank the qualifier instead of failing anything.
+        """
+        from osprey.services.auth_sidecar.routes.recheck import (
+            ROLE_SOURCE_CLAIM,
+            ROLE_SOURCE_ROSTER,
+        )
+
+        assert set(app_module._ROLE_SOURCE_LABELS) == {ROLE_SOURCE_ROSTER, ROLE_SOURCE_CLAIM}

--- a/tests/services/auth_sidecar/test_login_recheck.py
+++ b/tests/services/auth_sidecar/test_login_recheck.py
@@ -46,7 +46,11 @@ from fastapi.testclient import TestClient
 from osprey.deployment.web_terminals.personas import env_var_suffix
 from osprey.services.auth_sidecar import audit
 from osprey.services.auth_sidecar.app import STATE_COOKIE_NAME, create_app
-from osprey.services.auth_sidecar.identity_headers import ROLE_HEADER, SUBJECT_HEADER
+from osprey.services.auth_sidecar.identity_headers import (
+    ROLE_HEADER,
+    ROLE_SOURCE_HEADER,
+    SUBJECT_HEADER,
+)
 from osprey.services.auth_sidecar.passwords import hash_password
 from osprey.services.auth_sidecar.routes import recheck
 from osprey.services.auth_sidecar.routes import verify as verify_module
@@ -58,15 +62,22 @@ from osprey.services.auth_sidecar.routes.oidc import (
 from osprey.services.auth_sidecar.routes.recheck import (
     METHOD_OIDC,
     METHOD_PASSWORD,
+    ROLE_SOURCE_CLAIM,
+    ROLE_SOURCE_ROSTER,
     LoginGrant,
     RecheckRefused,
     RosterRoles,
     recheck_login,
     session_role,
+    session_role_source,
     session_subject,
 )
 from osprey.services.auth_sidecar.routes.verify import VERIFY_PATH
-from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME, UnlockedUser
+from osprey.services.auth_sidecar.sessions import (
+    SESSION_COOKIE_NAME,
+    SessionCodec,
+    UnlockedUser,
+)
 from osprey.utils.identity import AUDIT_IDENTITY_ENV, TERMINAL_USER_ENV
 
 SESSION_SECRET = "session-secret-value"
@@ -167,6 +178,18 @@ def _issued_cookie(response: httpx.Response) -> str:
         if header.startswith(f"{SESSION_COOKIE_NAME}="):
             return header.split(";", 1)[0].split("=", 1)[1]
     raise AssertionError("the login issued no session cookie")
+
+
+def _minted_entry(cookie: str, user: str) -> UnlockedUser:
+    """The entry a login actually signed, read back out of the cookie it issued.
+
+    The role a session carries is visible from verify's headers; the source it
+    carries is only visible beside a role, so the cookie itself is where the two
+    halves can be seen to have been minted together.
+    """
+    entry = SessionCodec(SESSION_SECRET).decode(cookie).entry(user)
+    assert entry is not None, "the login minted no entry for this user"
+    return entry
 
 
 def _verify(client: TestClient, user: str, cookie: str) -> httpx.Response:
@@ -273,7 +296,8 @@ class TestTheNoneRow:
 
 
 class TestThePasswordRow:
-    """The roster username is the subject; the roster entry's role is the role."""
+    """The roster username is the subject; the roster entry's role is the role,
+    and the grant says so — nothing else was asked."""
 
     def test_the_grant_names_the_roster_user_and_their_role(self) -> None:
         grant = recheck_login(
@@ -281,13 +305,13 @@ class TestThePasswordRow:
             user="alice",
             roster_roles=RosterRoles({"alice": "operator"}),
         )
-        assert grant == LoginGrant(subject="alice", role="operator")
+        assert grant == LoginGrant(subject="alice", role="operator", role_source=ROLE_SOURCE_ROSTER)
 
     def test_a_roster_entry_with_no_role_grants_none(self) -> None:
         grant = recheck_login(
             method=METHOD_PASSWORD, user="alice", roster_roles=RosterRoles({"bob": "operator"})
         )
-        assert grant == LoginGrant(subject="alice", role="")
+        assert grant == LoginGrant(subject="alice", role="", role_source="")
 
     def test_the_login_mints_the_roster_role_into_the_session(
         self, monkeypatch: pytest.MonkeyPatch
@@ -296,10 +320,12 @@ class TestThePasswordRow:
         with TestClient(create_app(PASSWORD_ENV), base_url="https://testserver") as client:
             login = _login(client)
             assert login.status_code == 303
-            response = _verify(client, "alice", _issued_cookie(login))
+            cookie = _issued_cookie(login)
+            response = _verify(client, "alice", cookie)
         assert response.status_code == 200
         assert response.headers[SUBJECT_HEADER] == "alice"
         assert response.headers[ROLE_HEADER] == "operator"
+        assert _minted_entry(cookie, "alice").role_source == ROLE_SOURCE_ROSTER
 
     def test_the_ledger_reports_the_role_the_login_granted(
         self, zone: Path, monkeypatch: pytest.MonkeyPatch
@@ -324,7 +350,8 @@ class TestThePasswordRow:
 class TestTheOidcRowWithoutAClaimsMap:
     """No claim binding: nothing asked the provider about privilege, so the role
     is the one the RENDER bound — the roster entry this user's persona came
-    from. Audited like every other login."""
+    from, which is what the grant names as its source. Audited like every other
+    login."""
 
     def test_the_grant_carries_the_provider_subject_and_the_roster_role(self) -> None:
         grant = recheck_login(
@@ -334,7 +361,9 @@ class TestTheOidcRowWithoutAClaimsMap:
             asserted_subject=ALICE_SUBJECT,
             claim_role="",
         )
-        assert grant == LoginGrant(subject=ALICE_SUBJECT, role="observer")
+        assert grant == LoginGrant(
+            subject=ALICE_SUBJECT, role="observer", role_source=ROLE_SOURCE_ROSTER
+        )
 
     def test_a_roster_entry_with_no_role_still_grants_none(self) -> None:
         grant = recheck_login(
@@ -344,7 +373,7 @@ class TestTheOidcRowWithoutAClaimsMap:
             asserted_subject=ALICE_SUBJECT,
             claim_role="",
         )
-        assert grant == LoginGrant(subject=ALICE_SUBJECT, role="")
+        assert grant == LoginGrant(subject=ALICE_SUBJECT, role="", role_source="")
 
     def test_the_session_carries_the_roster_role(
         self, zone: Path, monkeypatch: pytest.MonkeyPatch
@@ -356,6 +385,7 @@ class TestTheOidcRowWithoutAClaimsMap:
         response = _callback(_oidc_app())
         assert response.status_code == 303
         assert [record.get("role") for record in _records(zone)] == ["observer"]
+        assert _minted_entry(_issued_cookie(response), "alice").role_source == ROLE_SOURCE_ROSTER
 
     def test_the_login_is_recorded(self, zone: Path) -> None:
         assert _callback(_oidc_app()).status_code == 303
@@ -366,7 +396,8 @@ class TestTheOidcRowWithoutAClaimsMap:
 
 class TestTheOidcRowWithAClaimsMap:
     """The role comes from the validated token — and must be the one this user's
-    terminal was rendered as."""
+    terminal was rendered as. The token is what decided it, so the token is what
+    the grant credits."""
 
     def test_the_grant_carries_the_resolved_role(self) -> None:
         grant = recheck_login(
@@ -376,7 +407,9 @@ class TestTheOidcRowWithAClaimsMap:
             asserted_subject=ALICE_SUBJECT,
             claim_role="operator",
         )
-        assert grant == LoginGrant(subject=ALICE_SUBJECT, role="operator")
+        assert grant == LoginGrant(
+            subject=ALICE_SUBJECT, role="operator", role_source=ROLE_SOURCE_CLAIM
+        )
 
     def test_a_claim_role_that_is_not_the_rendered_one_refuses(self) -> None:
         """SC4's first clause. alice's container was built from ``observer``;
@@ -403,7 +436,9 @@ class TestTheOidcRowWithAClaimsMap:
             asserted_subject=ALICE_SUBJECT,
             claim_role="operator",
         )
-        assert grant == LoginGrant(subject=ALICE_SUBJECT, role="operator")
+        assert grant == LoginGrant(
+            subject=ALICE_SUBJECT, role="operator", role_source=ROLE_SOURCE_CLAIM
+        )
 
     def test_a_mapped_group_becomes_the_session_role(
         self, zone: Path, monkeypatch: pytest.MonkeyPatch
@@ -413,8 +448,10 @@ class TestTheOidcRowWithAClaimsMap:
             userinfo={"sub": ALICE_SUBJECT, GROUP_CLAIM: [OPERATOR_GROUP]},
             binding=RoleBinding(claim=GROUP_CLAIM, claim_map=CLAIM_MAP),
         )
-        assert _callback(app).status_code == 303
+        response = _callback(app)
+        assert response.status_code == 303
         assert [record.get("role") for record in _records(zone)] == ["operator"]
+        assert _minted_entry(_issued_cookie(response), "alice").role_source == ROLE_SOURCE_CLAIM
 
     def test_an_unmapped_group_fails_closed(self, zone: Path) -> None:
         app = _oidc_app(
@@ -470,13 +507,28 @@ class TestTheClaimIsCrossCheckedAgainstTheRenderedRole:
         self, zone: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The control: the same deployment, the same user, the group that maps
-        to the role her terminal was actually built from."""
+        to the role her terminal was actually built from.
+
+        The grant is watched as well as the ledger, because the two authorities
+        agreeing is exactly the case where the answer could plausibly be filed
+        under either one. It is the token's: the roster was the cross-check
+        here, not the decision.
+        """
         _bind_roster_roles(monkeypatch, alice="observer")
+        grants: list[LoginGrant] = []
+
+        def recording(**kwargs: Any) -> LoginGrant:
+            grant = recheck_login(**kwargs)
+            grants.append(grant)
+            return grant
+
+        monkeypatch.setattr("osprey.services.auth_sidecar.routes.oidc.recheck_login", recording)
 
         result = _callback(self._app("als-observers"))
 
         assert result.status_code == 303
         assert [(r["decision"], r.get("role")) for r in _records(zone)] == [("allowed", "observer")]
+        assert [(g.role, g.role_source) for g in grants] == [("observer", ROLE_SOURCE_CLAIM)]
 
     def test_the_admitted_role_reaches_the_verify_subrequest(
         self, monkeypatch: pytest.MonkeyPatch
@@ -495,6 +547,7 @@ class TestTheClaimIsCrossCheckedAgainstTheRenderedRole:
             response = _verify(client, "alice", _issued_cookie(login))
         assert response.status_code == 200
         assert response.headers[ROLE_HEADER] == "observer"
+        assert response.headers[ROLE_SOURCE_HEADER] == ROLE_SOURCE_CLAIM
 
 
 # --- fail closed ------------------------------------------------------------
@@ -649,6 +702,8 @@ class TestTheAntiLookupInvariant:
             "REASON_METHOD_MISMATCH",
             "REASON_ROLE_MISMATCH",
             "REASON_UNSUPPORTED_METHOD",
+            "ROLE_SOURCE_CLAIM",
+            "ROLE_SOURCE_ROSTER",
             "SUPPORTED_METHODS",
             "LoginGrant",
             "RecheckRefused",
@@ -656,6 +711,7 @@ class TestTheAntiLookupInvariant:
             "recheck_login",
             "roster_roles",
             "session_role",
+            "session_role_source",
             "session_subject",
         }
     )
@@ -933,9 +989,16 @@ class TestAMethodChangeUnderAnOutstandingCookie:
     """
 
     @staticmethod
-    def _password_entry(role: str = "operator") -> UnlockedUser:
+    def _password_entry(
+        role: str = "operator", role_source: str = ROLE_SOURCE_ROSTER
+    ) -> UnlockedUser:
         return UnlockedUser(
-            username="alice", expires_at=0, generation_tag="tag", oidc_subject="", role=role
+            username="alice",
+            expires_at=0,
+            generation_tag="tag",
+            oidc_subject="",
+            role=role,
+            role_source=role_source,
         )
 
     def test_a_password_session_keeps_its_role_under_password(self) -> None:
@@ -958,6 +1021,26 @@ class TestAMethodChangeUnderAnOutstandingCookie:
     def test_a_missing_entry_holds_no_role(self) -> None:
         assert session_role(method=METHOD_OIDC, entry=None) == ""
 
+    def test_a_password_session_keeps_its_source_under_password(self) -> None:
+        """The source rides with the role it explains, on the unchanged path."""
+        entry = self._password_entry()
+        assert session_role_source(method=METHOD_PASSWORD, entry=entry) == ROLE_SOURCE_ROSTER
+
+    def test_a_password_session_read_under_oidc_holds_no_source(self) -> None:
+        """Lockstep: the flip that retires the role retires its provenance too,
+        so nothing is left naming where a lapsed privilege came from."""
+        assert session_role_source(method=METHOD_OIDC, entry=self._password_entry()) == ""
+
+    def test_a_missing_entry_holds_no_source(self) -> None:
+        assert session_role_source(method=METHOD_OIDC, entry=None) == ""
+
+    def test_a_source_without_a_role_explains_nothing(self) -> None:
+        """No grant can mint this shape — only a payload signed by something
+        other than :func:`_grant` — and the derived reader drops it rather than
+        forwarding provenance for a role the session does not hold."""
+        entry = self._password_entry(role="", role_source=ROLE_SOURCE_ROSTER)
+        assert session_role_source(method=METHOD_PASSWORD, entry=entry) == ""
+
     def test_the_flipped_deployment_forwards_no_role_header(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -970,6 +1053,7 @@ class TestAMethodChangeUnderAnOutstandingCookie:
             cookie = _issued_cookie(login)
             before = _verify(client, "alice", cookie)
         assert before.headers[ROLE_HEADER] == "operator"
+        assert before.headers[ROLE_SOURCE_HEADER] == ROLE_SOURCE_ROSTER
 
         flipped = {**OIDC_ENV, "OSPREY_AUTH_SESSION_SECRET": SESSION_SECRET}
         with TestClient(create_app(flipped), base_url="https://testserver") as client:
@@ -977,6 +1061,9 @@ class TestAMethodChangeUnderAnOutstandingCookie:
 
         assert after.status_code == 200
         assert ROLE_HEADER.lower() not in after.headers
+        # The source is derived from the role, so it lapses in the same breath —
+        # never left naming where a retired privilege came from.
+        assert ROLE_SOURCE_HEADER.lower() not in after.headers
         # The subject half was already closed; asserted beside it so the two
         # halves of one identity cannot drift back apart.
         assert SUBJECT_HEADER.lower() not in after.headers

--- a/tests/services/auth_sidecar/test_role_payload.py
+++ b/tests/services/auth_sidecar/test_role_payload.py
@@ -1,13 +1,15 @@
-"""Tests for the role field, the identity headers, and what may travel in them.
+"""Tests for the role field and its source, the identity headers, and what may
+travel in them.
 
 Three things are pinned here, and they are one property seen from three sides:
 *an identity the deployment cannot carry across the nginx boundary is not an
 identity this sidecar will authorise with.*
 
-* **The payload carries a role.** ``UnlockedUser`` gained a ``role``, additively
-  and deny-safe: absent means ``""``, a cookie minted before the field existed
-  still decodes, and no payload version was burned.
-* **Both identity headers are emitted, or neither value is invented.** A
+* **The payload carries a role, and where it came from.** ``UnlockedUser``
+  gained a ``role`` and then a ``role_source``, both additively and deny-safe:
+  absent means ``""``, a cookie minted before either field existed still
+  decodes, and no payload version was burned for either.
+* **All three identity headers are emitted, or no value is invented.** A
   password session names the roster user in ``X-Osprey-Auth-Subject`` (presence
   still means a known account); an OIDC session names the provider subject; a
   session that holds neither leaves the header absent rather than blank.
@@ -41,6 +43,7 @@ from osprey.services.auth_sidecar.app import STATE_COOKIE_NAME, AuthSettings, cr
 from osprey.services.auth_sidecar.exceptions import InvalidSessionError
 from osprey.services.auth_sidecar.identity_headers import (
     ROLE_HEADER,
+    ROLE_SOURCE_HEADER,
     SUBJECT_HEADER,
     is_header_safe,
 )
@@ -122,18 +125,26 @@ def _raw_cookie(users: dict[str, dict[str, Any]]) -> str:
     return URLSafeSerializer(SESSION_SECRET, salt=SIGNATURE_SALT).dumps(payload)
 
 
-def _password_entry(username: str = "alice", *, role: str = "", ttl: float = 600.0) -> UnlockedUser:
+def _password_entry(
+    username: str = "alice", *, role: str = "", role_source: str = "", ttl: float = 600.0
+) -> UnlockedUser:
     """A password-mode entry: a generation tag, no subject."""
     return UnlockedUser(
         username=username,
         expires_at=SessionCodec(SESSION_SECRET).now() + ttl,
         generation_tag=generation_tag(ALICE_HASH),
         role=role,
+        role_source=role_source,
     )
 
 
 def _oidc_entry(
-    username: str = "alice", *, subject: str = ALICE_SUBJECT, role: str = "", ttl: float = 600.0
+    username: str = "alice",
+    *,
+    subject: str = ALICE_SUBJECT,
+    role: str = "",
+    role_source: str = "",
+    ttl: float = 600.0,
 ) -> UnlockedUser:
     """An OIDC entry: a subject, no generation tag."""
     return UnlockedUser(
@@ -142,6 +153,7 @@ def _oidc_entry(
         generation_tag="",
         oidc_subject=subject,
         role=role,
+        role_source=role_source,
     )
 
 
@@ -219,6 +231,14 @@ def recorded(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 
 
 # --- what may travel in an identity header ----------------------------------
+
+
+def test_the_role_source_header_spelling() -> None:
+    """The nginx template writes the name as a literal and the terminal
+    re-spells it rather than importing it, so nothing but an assertion holds
+    the three copies together. A rename that stopped at the constant would
+    leave the provenance forwarded under a name nothing reads."""
+    assert ROLE_SOURCE_HEADER == "X-Osprey-Auth-Role-Source"
 
 
 class TestHeaderSafety:
@@ -308,6 +328,101 @@ class TestRoleOnThePayload:
             SessionCodec(SESSION_SECRET).decode(raw)
 
 
+class TestRoleSourceOnThePayload:
+    """``role_source`` is additive and deny-safe, on the role's own terms."""
+
+    def test_role_source_defaults_to_empty(self) -> None:
+        """Provenance for no role is no provenance — ``""``, never ``None`` and
+        never a guess at which end resolved a role the entry does not hold."""
+        entry = UnlockedUser(username="alice", expires_at=1.0)
+        assert entry.role_source == ""
+
+    def test_role_source_round_trips_through_the_cookie(self) -> None:
+        codec = SessionCodec(SESSION_SECRET)
+        state = codec.new_state().with_user(
+            "alice", expires_at=codec.now() + 600, role="operator", role_source="roster"
+        )
+        entry = codec.decode(codec.encode(state)).entry("alice")
+        assert entry is not None
+        assert entry.role == "operator"
+        assert entry.role_source == "roster"
+
+    def test_a_cookie_minted_before_the_field_existed_still_decodes(self) -> None:
+        """The upgrade case this field is shaped around: a session already open
+        keeps its role and simply shows no provenance until the next login."""
+        raw = _raw_cookie(
+            {
+                "alice": {
+                    "exp": SessionCodec(SESSION_SECRET).now() + 600,
+                    "tag": "0123456789abcdef",
+                    "role": "operator",
+                }
+            }
+        )
+        entry = SessionCodec(SESSION_SECRET).decode(raw).entry("alice")
+        assert entry is not None
+        assert entry.role == "operator"
+        assert entry.role_source == ""
+
+    def test_the_payload_version_was_not_bumped_for_the_source_either(self) -> None:
+        assert PAYLOAD_VERSION == 1
+
+    def test_a_fresh_login_replaces_the_role_source_wholesale(self) -> None:
+        """The source cannot outlive the role it qualifies: a login naming no
+        role clears both, so provenance never names the origin of a privilege
+        this session no longer holds."""
+        codec = SessionCodec(SESSION_SECRET)
+        state = (
+            codec.new_state()
+            .with_user("alice", expires_at=codec.now() + 600, role="operator", role_source="claim")
+            .with_user("alice", expires_at=codec.now() + 600)
+        )
+        entry = state.entry("alice")
+        assert entry is not None
+        assert entry.role == ""
+        assert entry.role_source == ""
+
+    def test_a_non_string_role_source_is_refused(self) -> None:
+        raw = _raw_cookie(
+            {
+                "alice": {
+                    "exp": SessionCodec(SESSION_SECRET).now() + 600,
+                    "tag": "",
+                    "role": "operator",
+                    "source": ["roster"],
+                }
+            }
+        )
+        with pytest.raises(InvalidSessionError):
+            SessionCodec(SESSION_SECRET).decode(raw)
+
+    def test_with_user_refuses_an_uncarryable_role_source(self) -> None:
+        """The mint-side half of the same guard the subject and the role get:
+        a value the boundary would mangle is refused where the caller can
+        still be told, not dropped at the end of a successful login."""
+        codec = SessionCodec(SESSION_SECRET)
+        with pytest.raises(ValueError, match="role source"):
+            codec.new_state().with_user(
+                "alice", expires_at=codec.now() + 600, role="operator", role_source="röster"
+            )
+
+    def test_decoding_refuses_an_uncarryable_role_source(self) -> None:
+        """And the read-side half. Only this sidecar could have signed such a
+        cookie, so it is refused rather than returned with the source dropped."""
+        raw = _raw_cookie(
+            {
+                "alice": {
+                    "exp": SessionCodec(SESSION_SECRET).now() + 600,
+                    "tag": "",
+                    "role": "operator",
+                    "source": NON_ASCII_SUBJECT,
+                }
+            }
+        )
+        with pytest.raises(InvalidSessionError):
+            SessionCodec(SESSION_SECRET).decode(raw)
+
+
 class TestOnlyCarryableIdentitiesAreStored:
     """The mint path refuses what the boundary cannot carry."""
 
@@ -382,13 +497,14 @@ class TestSubjectHeader:
         assert response.status_code == 200
         assert SUBJECT_HEADER.lower() not in response.headers
 
-    def test_a_denial_carries_neither_header(self) -> None:
-        cookie = _mint(_oidc_entry(role="operator"))
+    def test_a_denial_carries_no_identity_header(self) -> None:
+        cookie = _mint(_oidc_entry(role="operator", role_source="claim"))
         with TestClient(_oidc_app()) as client:
             response = _verify(client, "bob", cookie)
         assert response.status_code == 401
         assert SUBJECT_HEADER.lower() not in response.headers
         assert ROLE_HEADER.lower() not in response.headers
+        assert ROLE_SOURCE_HEADER.lower() not in response.headers
 
 
 class TestRoleHeader:
@@ -417,6 +533,74 @@ class TestRoleHeader:
         assert response.status_code == 200
         assert response.headers[SUBJECT_HEADER] == ALICE_SUBJECT
         assert response.headers[ROLE_HEADER] == "observer"
+
+
+class TestRoleSourceHeader:
+    """The source rides beside the role, and only beside it."""
+
+    def test_a_roster_role_names_its_source(self) -> None:
+        cookie = _mint(_password_entry(role="operator", role_source="roster"))
+        with TestClient(create_app(PASSWORD_ENV)) as client:
+            response = _verify(client, "alice", cookie)
+        assert response.status_code == 200
+        assert response.headers[ROLE_HEADER] == "operator"
+        assert response.headers[ROLE_SOURCE_HEADER] == "roster"
+
+    def test_a_claimed_role_names_its_source(self) -> None:
+        cookie = _mint(_oidc_entry(role="observer", role_source="claim"))
+        with TestClient(_oidc_app()) as client:
+            response = _verify(client, "alice", cookie)
+        assert response.status_code == 200
+        assert response.headers[ROLE_HEADER] == "observer"
+        assert response.headers[ROLE_SOURCE_HEADER] == "claim"
+
+    def test_an_entry_with_no_role_omits_the_source_too(self) -> None:
+        """Nothing to explain: the header names the origin of a privilege, so
+        it cannot be present where the privilege is not."""
+        cookie = _mint(_password_entry())
+        with TestClient(create_app(PASSWORD_ENV)) as client:
+            response = _verify(client, "alice", cookie)
+        assert response.status_code == 200
+        assert ROLE_HEADER.lower() not in response.headers
+        assert ROLE_SOURCE_HEADER.lower() not in response.headers
+
+    def test_a_source_signed_without_a_role_forwards_neither(self) -> None:
+        """A payload no login route can mint, signed by hand the way an older
+        cookie is: the reader derives the source from the role, so a source
+        standing alone authorises the same 200 and forwards nothing about it."""
+        raw = _raw_cookie(
+            {
+                "alice": {
+                    "exp": SessionCodec(SESSION_SECRET).now() + 600,
+                    "tag": generation_tag(ALICE_HASH),
+                    "source": "claim",
+                }
+            }
+        )
+        with TestClient(create_app(PASSWORD_ENV)) as client:
+            response = _verify(client, "alice", raw)
+        assert response.status_code == 200
+        assert ROLE_HEADER.lower() not in response.headers
+        assert ROLE_SOURCE_HEADER.lower() not in response.headers
+
+    def test_a_source_that_cannot_be_carried_is_refused(self) -> None:
+        """The source's own branch of the carriage guard, reached directly for
+        the reason the role's is: the codec refuses to decode such a value and
+        ``with_user`` refuses to mint one, and a guard no test reaches is one
+        refactor away from being deleted as dead code."""
+        settings = AuthSettings.from_env(PASSWORD_ENV)
+        entry = UnlockedUser(
+            username="alice",
+            expires_at=SessionCodec(SESSION_SECRET).now() + 600.0,
+            generation_tag=generation_tag(ALICE_HASH),
+            role="operator",
+            role_source="roster\r\nX-Osprey-Auth-Role: admin",
+        )
+        response = _authorized("alice", entry, settings)
+        assert response.status_code == 401
+        assert ROLE_SOURCE_HEADER.lower() not in response.headers
+        assert ROLE_HEADER.lower() not in response.headers
+        assert SUBJECT_HEADER.lower() not in response.headers
 
 
 class TestAnUncarryableIdentityDenies:


### PR DESCRIPTION
Since the sidecar started resolving a role at login, the terminal has shown the
role a session holds but nothing about who decided it. A roster-bound role and
one an identity provider's claim decided look identical in the session menu,
which is exactly the distinction an operator needs when a tier looks wrong.

Record the source at login (`roster` for the roster entry's `role:`, `claim`
for an OIDC ID-token claim), carry it on the session under a defaulted payload
key, and emit it as a third identity header only beside a role. nginx forwards
it on the gated arm and writes an explicit clear for the name on every ungated
location, so a client can never supply it. The terminal maps the closed
vocabulary to a muted qualifier beside the role pill; anything outside that
vocabulary, or a source arriving without a role, renders nothing.

No `PAYLOAD_VERSION` bump: a cookie signed before this change decodes with an
empty source, so live sessions stay valid and show the role alone until the
next login.

Closes #746

## How it hangs together

```text
┌──────────────┐    ┌──────────────┐    ┌──────────────┐
│  recheck.py  │───▶│  sessions.py │───▶│   verify.py  │
│ role + source│    │ "source" key │    │ third header │
└──────────────┘    └──────────────┘    └──────────────┘
  minted at login.py / oidc.py sign-in          │ auth_request answer
                                                ▼
┌──────────────┐    ┌──────────────┐    ┌──────────────┐
│ web_terminal │◀───│ middleware.py│◀───│ nginx.conf.j2│
│ "· roster" / │    │ decode       │    │ gated: fwd   │
│ "· ID token" │    │ 3-tuple      │    │ ungated: ""  │
└──────────────┘    └──────────────┘    └──────────────┘
```
