### PR TITLE
refactor(web-terminal): one owner for the agent_activity frame type and the tile-attribution pair

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ uv run osprey skills install osprey-contribute
 
 It walks you through branching, commits, push, PR, and CI iteration following
 the conventions on this page — including the protected-branch reality on
-`main` (no direct pushes; eight required CI checks; linear history). Once
+`main` (no direct pushes; required CI checks that admins cannot bypass). Once
 installed, just open Claude Code in the repo and describe what you want to
 contribute; the skill picks up wherever you are in the journey.
 

--- a/changelog.d/followups-mechanical.internal.md
+++ b/changelog.d/followups-mechanical.internal.md
@@ -1,0 +1,3 @@
+Web-terminal JS: the `agent_activity` SSE frame type is spelled in one shared
+constant, and the agent tile-attribution gesture (rail flash + tile glow) has
+one owner function instead of a hand-copied pair.

--- a/docs/source/contributing/workflow.rst
+++ b/docs/source/contributing/workflow.rst
@@ -93,12 +93,16 @@ Pull Request Process
 Branch Protection on ``main``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Direct pushes to ``main`` are rejected. All changes land via PR. The ruleset
-enforces:
+Direct pushes to ``main`` are rejected. All changes land via PR. GitHub branch
+protection on ``main`` enforces:
 
-- All required CI checks must pass (no admin bypass).
-- Linear history (use ``gh pr merge --rebase``; merge commits are rejected).
+- The required status checks must pass: ``pre-commit.ci - pr`` and
+  ``All CI Checks Passed`` (the aggregate job every CI lane feeds). Admins
+  cannot bypass them.
 - Force-pushes and branch deletion on ``main`` are denied.
+
+Linear history is not enforced: a PR may land as a merge commit or a rebase,
+and both appear in ``main``'s history.
 
 If a required check turns out to be wrong, fix it forward — there is no
 escape hatch.

--- a/src/osprey/interfaces/web_terminal/static/js/activity-format.js
+++ b/src/osprey/interfaces/web_terminal/static/js/activity-format.js
@@ -13,6 +13,14 @@
 /** @typedef {import('./panel-manager.js').AgentActivityEvent} AgentActivityFrame */
 
 /**
+ * The `type` discriminator an agent_activity SSE frame carries. Spelled once
+ * here so the session page's forwarder, panel-sse's dispatcher and the panel
+ * frames it synthesizes cannot drift apart on a rename; the AgentActivityEvent
+ * typedef in panel-manager.js derives its literal from this constant too.
+ */
+export const AGENT_ACTIVITY_FRAME = 'agent_activity';
+
+/**
  * The tool name the panel routes mirror an agent arrange under. Its subject is
  * the workspace itself rather than a single panel, so it is worded apart from
  * the PANEL_VERBS table — and the strip keys its burst coalescing on it.

--- a/src/osprey/interfaces/web_terminal/static/js/panel-agent-attention.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-agent-attention.js
@@ -19,6 +19,7 @@
 
 import { fetchJSON } from './api.js';
 import { getEntry, setEntryAttention } from './panel-rail.js';
+import { glowPanel } from './dock-iframe.js';
 import { flashElement } from '/design-system/js/highlight.js';
 
 /** @type {HTMLElement} */
@@ -38,6 +39,16 @@ export function initAgentAttention(el) { railEl = el; }
  * @param {string} panelId
  */
 export function flashAgentGlow(panelId) { const entry = getEntry(railEl, panelId); if (entry) flashElement(entry); }
+
+/**
+ * Attribute a tile the agent visibly changed on BOTH surfaces at once: the
+ * rail entry flashes (flashAgentGlow) and the tile body glows (glowPanel).
+ * The single owner of that pair — the agent switch and arrange paths. Paths
+ * that touch only the rail (a show, a hide, a register: no tile exists to
+ * attribute to) call flashAgentGlow alone, on purpose.
+ * @param {string} panelId
+ */
+export function flashAgentTile(panelId) { flashAgentGlow(panelId); glowPanel(panelId); }
 
 /** Newest badge-causing server ts seen this page lifetime, per panel.
  *  @type {Map<string, number>} */

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -41,7 +41,7 @@ import { applyConfigTabGate } from './config-tab.js';
 import { applyScaffoldWriteGate } from './scaffold/write-gate.js';
 import {
   initDockIframeAdapter, focusPanel, hidePanel, concealPanel,
-  setKnownServicePanels, setServerVisiblePanels, glowPanel,
+  setKnownServicePanels, setServerVisiblePanels,
 } from './dock-iframe.js';
 import { initPanelPlacement, dropPanelAt } from './panel-placement.js';
 import { createPanelIframe } from './panel-iframe-factory.js';
@@ -59,7 +59,7 @@ import {
   initPanelLifecycle, freshPanelState, renderRail, ensureRailMembership,
   initPanel, assumeHealthy, startHealthPolling,
 } from './panel-lifecycle.js';
-import { initAgentAttention, flashAgentGlow, clearBadge } from './panel-agent-attention.js';
+import { initAgentAttention, flashAgentTile, clearBadge } from './panel-agent-attention.js';
 import { subscribePanelEvents } from './panel-sse.js';
 
 // ---- Types ----
@@ -115,7 +115,7 @@ import { subscribePanelEvents } from './panel-sse.js';
  * @property {'agent'} [source]
  *
  * @typedef {object} AgentActivityEvent
- * @property {'agent_activity'} type
+ * @property {typeof import('./activity-format.js').AGENT_ACTIVITY_FRAME} type
  * @property {string} tool
  * @property {{ kind: 'panel' | 'channel' | 'run' | 'artifact' | 'config' | 'ui',
  *   panel?: string, detail?: string }} target
@@ -285,11 +285,11 @@ export async function initPanelManager(panelId) {
     getActive: getActiveTabId,
     clearActive: clearActivePanel,
     renderEmpty: renderEmptyState,
-    // An arranged tile is attributed on both surfaces: its rail entry flashes,
-    // and the tile body itself glows. Only the arrange path passes through
-    // here, which is the one placement verb an agent drives — the rail ⊞ and
-    // drag-and-drop are human gestures and never glow.
-    glow: (id) => { flashAgentGlow(id); glowPanel(id); },
+    // An arranged tile is attributed on both surfaces (rail entry flash + tile
+    // body glow, one gesture: flashAgentTile). Only the arrange path passes
+    // through here, which is the one placement verb an agent drives — the
+    // rail ⊞ and drag-and-drop are human gestures and never glow.
+    glow: flashAgentTile,
     openTerminal: openTerminalPanel,
   });
 

--- a/src/osprey/interfaces/web_terminal/static/js/panel-sse.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-sse.js
@@ -23,9 +23,12 @@
  */
 
 import { fetchJSON, createEventSource } from './api.js';
-import { hidePanel, glowPanel } from './dock-iframe.js';
+import { hidePanel } from './dock-iframe.js';
 import { withEchoSuppressed } from './dock-sync.js';
-import { flashAgentGlow, badgePanelActivity, restoreAgentBadges } from './panel-agent-attention.js';
+import {
+  flashAgentGlow, flashAgentTile, badgePanelActivity, restoreAgentBadges,
+} from './panel-agent-attention.js';
+import { AGENT_ACTIVITY_FRAME } from './activity-format.js';
 import { PANELS } from './panel-catalog.js';
 import { ensureRailMembership, addPanel } from './panel-lifecycle.js';
 import { applyAgentSwitch, applyArrange } from './panel-placement.js';
@@ -147,13 +150,12 @@ export function subscribePanelEvents(sseDeps) {
           // Human focus is never broadcast (the server mirrors it silently and
           // the gesturing client applies it locally), so an unattributed frame
           // can only come from an out-of-contract caller; it keeps the plain
-          // activation. The glow runs after the switch so a just-added entry
-          // can flash, and the tile glow after the placement so it measures the
-          // tile the switch actually surfaced.
+          // activation. The attribution runs after the switch so a just-added
+          // entry can flash and the tile glow measures the tile the switch
+          // actually surfaced.
           if (data.source === 'agent') {
             applyAgentSwitch(data.panel);
-            flashAgentGlow(data.panel);
-            glowPanel(data.panel);
+            flashAgentTile(data.panel);
           } else {
             c.activate(data.panel);
           }
@@ -182,7 +184,7 @@ export function subscribePanelEvents(sseDeps) {
           // the user activates when they want it.
           if (data.source === 'agent') flashAgentGlow(data.id);
 
-        } else if (data.type === 'agent_activity' && data.target) {
+        } else if (data.type === AGENT_ACTIVITY_FRAME && data.target) {
           // kind 'panel' with a live rail entry → persistent badge + glow via
           // badgePanelActivity; everything the rail cannot anchor falls through
           // to the activity-strip seam (no-op until a handler registers).
@@ -234,7 +236,7 @@ function applyPanelVisibility(panel, visible, source) {
   // agent_activity branch's rail-anchor routing, so the two halves of the
   // agent's rail vocabulary read the same way on the strip.
   if (visible && source === 'agent') flashAgentGlow(panel);
-  if (source === 'agent') c.reportActivity({ type: 'agent_activity', ts: Date.now(),
+  if (source === 'agent') c.reportActivity({ type: AGENT_ACTIVITY_FRAME, ts: Date.now(),
     tool: visible ? 'add_panel_to_rail' : 'remove_panel_from_rail',
     target: { kind: 'panel', panel } });
 
@@ -289,7 +291,7 @@ function applyPanelClose(panel, source) {
   // is an entry left to glow — the operator can see which panel just went away.
   if (source === 'agent') {
     flashAgentGlow(panel);
-    ctx().reportActivity({ type: 'agent_activity', ts: Date.now(),
+    ctx().reportActivity({ type: AGENT_ACTIVITY_FRAME, ts: Date.now(),
       tool: 'close_panel', target: { kind: 'panel', panel } });
   }
 }

--- a/src/osprey/interfaces/web_terminal/static/js/session.js
+++ b/src/osprey/interfaces/web_terminal/static/js/session.js
@@ -16,6 +16,7 @@ import '/design-system/js/components/osprey-theme-switcher.js';
 import { renderAgents, renderToolLog, renderArtifacts, renderConversation } from './session-views.js';
 import { withPrefix, createEventSource } from './api.js';
 import { bootActivityStrip } from './activity-strip.js';
+import { AGENT_ACTIVITY_FRAME } from './activity-format.js';
 
 /** @typedef {'agents'|'toollog'|'artifacts'|'conversation'} ViewName */
 /** @typedef {import('./panel-manager.js').AgentActivityEvent} AgentActivityEvent */
@@ -170,7 +171,7 @@ export function wireActivityStrip(strip, eventSourceFactory = createEventSource)
   return eventSourceFactory('/api/files/events', {
     onMessage: (data) => {
       if (!data || typeof data !== 'object') return;
-      if (data.type !== 'agent_activity' || !data.target) return;
+      if (data.type !== AGENT_ACTIVITY_FRAME || !data.target) return;
       strip.handleActivity(data);
     },
   });


### PR DESCRIPTION
Three mechanical items from the follow-ups ledger, bundled.

## 1. `'agent_activity'` frame type — one constant
The literal was spelled inline at `session.js:173` and `panel-sse.js:185/237/292`, with the `AgentActivityEvent` typedef at `panel-manager.js:118` carrying a fourth copy. It now lives once as `AGENT_ACTIVITY_FRAME` in `activity-format.js` — the agent-activity vocabulary module, already home to `ARRANGE_TOOL` and a leaf, so `panel-sse.js` keeps its "never import panel-manager" rule. The typedef derives its literal via `typeof import('./activity-format.js').AGENT_ACTIVITY_FRAME` (type-only; no new runtime edge). A rename can no longer half-land: tsc fails on any site still spelling the old string.

## 2. `flashAgentGlow` + `glowPanel` — one owner
The pair was hand-copied at the agent `panel_focus` branch (`panel-sse.js:155-156`) **and** at `panel-manager.js:292` (the `glow` placement seam) — the ledger under-counted; there were already two copies. `flashAgentTile(panelId)` in `panel-agent-attention.js` now owns the gesture. The three rail-only sites (show / hide / register) deliberately keep `flashAgentGlow` alone: `panel-manager.test.mjs` pins that those glow no tile ("no tile exists to attribute to"), so folding them would change pinned behaviour. The owner's docstring says why, which is what stops the next copy.

## 3. `workflow.rst` branch-protection claim
Verified against the forge (`gh api repos/als-apg/osprey/branches/main/protection` and `/rulesets/10546855`):
- what enforces is **classic branch protection**, not a ruleset — the ruleset named `main` has an empty `ref_name.include` (bound to no branch) and lists only deletion / non-fast-forward;
- required checks are `pre-commit.ci - pr` and `All CI Checks Passed`, `enforce_admins: true` ✔;
- `required_linear_history: false` — merge commits are **not** rejected; 10 of the last 40 commits on `main` are PR merges.

Reworded to that. `CONTRIBUTING.md:76` repeated the same claim ("eight required CI checks; linear history") and gets the same half-line fix.

**Residue for the overlord, not fixed here:** `src/osprey/templates/skills/osprey-contribute/SKILL.md:283-320` tells contributors `--rebase` is required *because* branch protection requires linear history. That is the same false premise, but rewording a bundled skill's merge guidance is a policy choice (which merge style do we want contributors to use?), not a mechanical fix.

## Verification
- `npm run typecheck` clean · `npm run lint` clean · `npm run test:js` 120 files / 2572 tests pass
- `./scripts/quick_check.sh` 33477 passed, 223 skipped, 1 xfailed
- fragment: `changelog.d/followups-mechanical.internal.md`

https://claude.ai/code/session_0129aBmKxycBpHBi9TdnbkQt
