### PR TITLE
fix: refuse at build a typo'd execution backend and a consumer of an undeployed service

### DIFF
--- a/changelog.d/465.fixed.md
+++ b/changelog.d/465.fixed.md
@@ -1,0 +1,7 @@
+`osprey build` now refuses two configs that used to fail only at first use.
+A typo in `execution.execution_method` fails at build with the accepted
+values, instead of on the first `execute` call of a deployed container. And a
+deploying profile that switches on a client of a service it does not deploy —
+the bluesky MCP server left on after the `bluesky:` block was removed — is
+refused naming the service missing from `deployed_services`, unless the
+profile names one this deployment does not run.

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -523,7 +523,12 @@ The qmd sidecar behind hybrid logbook search is guarded the same way. The
 answers it, but an attached project renders ``services: {}`` — so on its own it
 would keep the mode with nothing behind it, and every logbook query would fail
 with *no qmd sidecar is configured*. ``osprey build`` refuses that instead of
-rendering it.
+rendering it. A deploying profile is held to the same rule from the other side:
+a client left switched on for a service the profile no longer deploys — the
+bluesky MCP server after the ``bluesky:`` block was removed — is refused naming
+the service missing from ``deployed_services``, unless the profile names one
+this deployment does not run (an external store's ``uri``, an ARIEL database
+DSN).
 
 An attached project rarely has to say anything, because **the build tells it
 where the host's services are**. Every client-facing fact — the sidecar's port,

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1212,6 +1212,50 @@ def _rendered_config(render_dir: Path) -> dict[str, Any]:
         return yaml.safe_load(fh) or {}
 
 
+def _resolve_rendered_execution_method(render_dir: Path) -> list[str]:
+    """Run the execution-backend resolver on a render, writing back what runs.
+
+    ``execution.execution_method`` is read by every container's python
+    executor through :func:`osprey_connectors.config.resolve_execution_method`
+    — at its first ``execute`` call. A profile's ``config:`` overlay writes
+    whatever it says into the render and nothing else reads it back, so a
+    typo used to survive build, deploy and MCP startup. The same resolver
+    runs here instead: an unknown backend is a refusal carrying the
+    resolver's own message, and a legacy spelling (``local``, ``container``)
+    is rewritten into the render as the backend that runs — ``container``'s
+    one-time deprecation warning fires here, where the operator is, rather
+    than once per container.
+
+    Returns:
+        The refusal, as one message, or nothing.
+    """
+    from osprey_connectors.config import resolve_execution_method
+
+    config_path = render_dir / "config.yml"
+    config = _rendered_config(render_dir)
+    try:
+        method = resolve_execution_method(config, source=str(config_path))
+    except ValueError as e:
+        return [str(e)]
+
+    execution = config.get("execution")
+    written = execution.get("execution_method") if isinstance(execution, dict) else None
+    if written == method:
+        return []
+
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    with config_path.open("r", encoding="utf-8") as fh:
+        document = yaml.load(fh)
+    if not isinstance(document.get("execution"), Mapping):
+        document["execution"] = {}
+    document["execution"]["execution_method"] = method
+    with config_path.open("w", encoding="utf-8") as fh:
+        yaml.dump(document, fh)
+    return []
+
+
 def _template_host_config(
     shared: _SharedRenderInputs,
     build_profile: Any,
@@ -1531,10 +1575,14 @@ def _render_project(
     # deploys no such service) alike. AFTER the injectors: a deploying profile
     # that pins only `web.panels.events.path` has its `url` written by the
     # dispatch injector, and refusing before that would name a key the build
-    # was about to write.
-    unreachable = reach_errors(_rendered_config(render_dir))
-    if unreachable:
-        raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(unreachable))
+    # was about to write. The execution backend is read here for the same
+    # reason: it is the render, not the profile, that a container loads.
+    unrunnable = [
+        *_resolve_rendered_execution_method(render_dir),
+        *reach_errors(_rendered_config(render_dir)),
+    ]
+    if unrunnable:
+        raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(unrunnable))
 
     applied = _apply_conventions(
         repo_root,

--- a/src/osprey/deployment/reach.py
+++ b/src/osprey/deployment/reach.py
@@ -28,7 +28,10 @@ enforcement reads the same declaration:
   laid over them, which is where a host that differs is named.
 * **The build refuses.** :func:`reach_errors` reads a rendered config and
   refuses a consumer that is on with nothing to resolve — the generic backstop
-  for a render whose host, or whose app template, deploys no such service.
+  for a render whose host, or whose app template, deploys no such service —
+  and, on a deploying render, a consumer that is on for a service the
+  deployment does not run: its client would resolve the compiled-in loopback
+  default and dial a port nothing publishes.
 * **Tests check the seams.** The credential grants and shared paths declared
   here are what ``tests/deployment/test_reach_contract.py`` walks over a real
   built stack: switch on ⇒ endpoint resolves ∧ credential in the container's
@@ -222,6 +225,12 @@ class ReachContract:
         derived_by: Name of the build block that already derives this
             service's client facts for attached renders on its own path
             (the archive: :func:`osprey.cli.build_profile_archiver.va_archiver_config_overrides`).
+        names_external: Whether the render names a service of this kind that
+            the deployment does not run itself — an explicit URI, DSN or URL
+            rather than the port a deployed one would publish. The one shape
+            in which a deploying render keeps a consumer on for a service
+            absent from ``deployed_services``. ``None`` where the service has
+            no such form (the sidecar and the plan lanes are loopback-only).
         note: One line for the completeness report.
     """
 
@@ -231,6 +240,7 @@ class ReachContract:
     credentials: tuple[CredentialGrant, ...] = ()
     no_client_reach: bool = False
     derived_by: str | None = None
+    names_external: Predicate | None = None
     note: str = ""
 
 
@@ -424,6 +434,41 @@ def _panel_url_resolves(panel_id: str) -> Predicate:
 
 def _always(_config: Mapping[str, Any]) -> bool:
     return True
+
+
+# ---------------------------------------------------------------------------
+# A service named elsewhere — the external shapes a deploying render may keep
+# a consumer on for without running the service
+# ---------------------------------------------------------------------------
+
+
+def _graphdb_named(config: Mapping[str, Any]) -> bool:
+    # The template's documented external store: an explicit `uri:` with
+    # `graphdb` left out of `deployed_services`.
+    return bool(dotted_get(config, f"services.{GRAPHDB_SERVICE_NAME}.uri"))
+
+
+def _ariel_database_named(config: Mapping[str, Any]) -> bool:
+    # resolve_ariel_dsn's first two rungs: a DSN that may point at a database
+    # with no `services.postgresql` counterpart.
+    database = as_dict(dotted_get(config, "ariel.database"))
+    return bool(database.get("uri") or database.get("connection_string"))
+
+
+def _bridge_named(config: Mapping[str, Any]) -> bool:
+    # bridge_url_from_config's first rung: a bridge that is not the one this
+    # deployment publishes.
+    return bool(dotted_get(config, "bluesky.bridge_url"))
+
+
+def _va_gateway_named(config: Mapping[str, Any]) -> bool:
+    # _va_dial's rule: a gateway row that names its own address is dialed
+    # there, wherever the simulator runs.
+    gateways = as_dict(dotted_get(config, "control_system.connector.virtual_accelerator.gateways"))
+    return any(
+        isinstance(gateway, Mapping) and bool(gateway.get("address"))
+        for gateway in gateways.values()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -664,6 +709,7 @@ REACH_CONTRACTS: dict[str, ReachContract] = {
             ProjectedKey(f"services.{GRAPHDB_SERVICE_NAME}.username", gate=_graph_store_wanted),
         ),
         credentials=(CredentialGrant(GRAPHDB_PASSWORD_ENV, config_needs_graphdb_password),),
+        names_external=_graphdb_named,
         note="the graph MCP server and the graph channel finder dial bolt on loopback",
     ),
     "postgresql": ReachContract(
@@ -685,6 +731,7 @@ REACH_CONTRACTS: dict[str, ReachContract] = {
             ProjectedKey("services.postgresql.database_name", gate=_ariel_on),
         ),
         credentials=(CredentialGrant("ARIEL_DB_PASSWORD", config_needs_ariel_password),),
+        names_external=_ariel_database_named,
         note="resolve_ariel_dsn derives the DSN from the block on loopback",
     ),
     "openobserve": ReachContract(
@@ -729,6 +776,7 @@ REACH_CONTRACTS: dict[str, ReachContract] = {
             ProjectedKey("services.bluesky.target", gate=_bluesky_server_on),
         ),
         credentials=(CredentialGrant("BLUESKY_LAUNCH_TOKEN", _launch_token_needed(LANE_ONE)),),
+        names_external=_bridge_named,
         note="resolve_bridge_url dials the published port on loopback",
     ),
     # The SECOND plan lane a deploying profile opts into (`bluesky.second_lane`),
@@ -760,6 +808,9 @@ REACH_CONTRACTS: dict[str, ReachContract] = {
         # secret — is in the sidecar's OWN compose file (services/bluesky_web,
         # rendered in the services stack), keyed on the same panel declaration
         # (personas.bluesky_panel_secret_env_vars).
+        # The url IS the endpoint: a profile that pins one for a sidecar it
+        # does not deploy has named it.
+        names_external=_panel_url_resolves(BLUESKY_PANEL_ID),
         note="the panel proxy dials the sidecar at web.panels.bluesky.url with the user's own secret",
     ),
     "event_dispatcher": ReachContract(
@@ -778,6 +829,7 @@ REACH_CONTRACTS: dict[str, ReachContract] = {
             for leaf in ("url", "path", "label", "health_endpoint")
         ),
         credentials=(CredentialGrant("EVENT_DISPATCHER_TOKEN", config_needs_dispatcher_token),),
+        names_external=_panel_url_resolves(EVENTS_PANEL_ID),
         note="the panel proxy dials the dispatcher at web.panels.events.url",
     ),
     "virtual_accelerator": ReachContract(
@@ -794,6 +846,7 @@ REACH_CONTRACTS: dict[str, ReachContract] = {
             ),
         ),
         projected=(ProjectedKey("services.virtual_accelerator.port", gate=_va_connector_on),),
+        names_external=_va_gateway_named,
         note="the connector fills every gateway port from the block",
     ),
     "live_standin": ReachContract(
@@ -946,6 +999,14 @@ def reach_dials(config: Mapping[str, Any]) -> list[tuple[ReachContract, Consumer
     ]
 
 
+def _deployed_services(config: Mapping[str, Any]) -> frozenset[str]:
+    """The services *config* deploys; empty for an attached render."""
+    deployed = config.get("deployed_services")
+    if not isinstance(deployed, list):
+        return frozenset()
+    return frozenset(str(service) for service in deployed)
+
+
 def reach_errors(config: Mapping[str, Any]) -> list[str]:
     """Refuse a rendered config whose consumer is on with nothing to resolve.
 
@@ -954,23 +1015,47 @@ def reach_errors(config: Mapping[str, Any]) -> list[str]:
     for an attached render whose host projected nothing, and for a standalone
     attached profile that pinned nothing, alike.
 
+    Two states refuse. A consumer on with no endpoint to resolve, whatever
+    the render. And, on a DEPLOYING render (``deployed_services`` non-empty),
+    a consumer on for a service the deployment does not run and the render
+    does not name elsewhere (:attr:`ReachContract.names_external`): its
+    client would resolve the port a deployed one publishes — a compiled-in
+    loopback default answers whether or not anything listens — and fail at
+    first use. An attached render (``deploy_services: false``, empty list)
+    dials its HOST's published ports on the shared network namespace, which
+    is the projection's whole point, so the second rule never reads one.
+
     Returns:
         One error per unresolvable consumer whose contract refuses, naming
-        the switch and the key that fixes it.
+        the switch and the key — or the service — that fixes it.
     """
     errors: list[str] = []
+    deployed = _deployed_services(config)
     for contract, consumer in live_consumers(config):
-        if not consumer.refuse or consumer.resolves(config):
+        if not consumer.refuse:
             continue
-        keys = ", ".join(projected.key for projected in contract.projected) or (
-            f"services.{contract.service}"
-        )
-        errors.append(
-            f"{consumer.name} is switched on ({consumer.switch_key}) but this render carries "
-            f"nothing for it to dial: no {keys}. An attached render (deploy_services: false) "
-            f"is told these by the build — from its hosting deployment's render, or, built "
-            f"on its own, from what its app template deploys — so the deployment it shares "
-            f"a host with runs no such service. Name one under `config:` ({keys}), or "
-            f"switch the consumer off."
-        )
+        if not consumer.resolves(config):
+            keys = ", ".join(projected.key for projected in contract.projected) or (
+                f"services.{contract.service}"
+            )
+            errors.append(
+                f"{consumer.name} is switched on ({consumer.switch_key}) but this render "
+                f"carries nothing for it to dial: no {keys}. An attached render "
+                f"(deploy_services: false) is told these by the build — from its hosting "
+                f"deployment's render, or, built on its own, from what its app template "
+                f"deploys — so the deployment it shares a host with runs no such service. "
+                f"Name one under `config:` ({keys}), or switch the consumer off."
+            )
+        elif (
+            deployed
+            and contract.service not in deployed
+            and not (contract.names_external and contract.names_external(config))
+        ):
+            elsewhere = ", name one this deployment does not run" if contract.names_external else ""
+            errors.append(
+                f"{consumer.name} is switched on ({consumer.switch_key}) but this deployment "
+                f"does not run `{contract.service}`: it is not in deployed_services, so the "
+                f"client would dial the port a deployed `{contract.service}` publishes and "
+                f"find nothing listening. Deploy it{elsewhere}, or switch the consumer off."
+            )
     return errors

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -110,8 +110,10 @@ web_panels:
 # ── Scanning and simulated hardware ──────────────────────────────────────────
 # These three blocks give you a working plan setup with no real hardware: a
 # Bluesky bridge with a Tiled data catalog, a simulated accelerator that speaks
-# EPICS, and the web panels for both. Delete this section (and the bluesky
-# panel above) if you do not want it.
+# EPICS, and the web panels for both. To drop it, delete this section, the
+# bluesky panel above, AND the `claude_code.servers.bluesky.enabled: true`
+# line under `config:` below — the block deploys the bridge, the line switches
+# on the server that dials it, and the build refuses the line left on alone.
 bluesky:
   port: 8090
   tiled_enabled: true      # also runs the Tiled data catalog

--- a/tests/cli/test_build_execution_method.py
+++ b/tests/cli/test_build_execution_method.py
@@ -1,0 +1,89 @@
+"""The execution backend is resolved at build, on the rendered config (issue #465).
+
+``execution.execution_method`` is read by every container's python executor
+through :func:`osprey.utils.config.resolve_execution_method` — at its FIRST
+``execute`` call. A profile's ``config:`` overlay can write any value into the
+render, and nothing on the build path used to read it back, so a typo
+survived ``osprey build``, ``osprey up`` and MCP startup and surfaced as a
+failed tool call inside a deployed container. The build now runs the same
+resolver on each render: an unknown backend is refused with the resolver's
+message, and a legacy spelling (``local``, ``container``) is written into the
+render as the backend that runs, with ``container``'s deprecation warning
+raised where the operator is.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from osprey.cli.build_cmd import build
+from osprey.utils import config as config_module
+
+CI_FLAGS = ["--skip-deps", "--skip-lifecycle"]
+
+PROFILE = """\
+name: Execution Method
+app_template: hello_world
+provider: anthropic
+config:
+{override}"""
+
+
+@pytest.fixture(autouse=True)
+def _reset_container_warning():
+    """The resolver warns about ``container`` once per process; start clean."""
+    config_module._container_method_warned = False
+    yield
+    config_module._container_method_warned = False
+
+
+def _build_repo(tmp_path: Path, monkeypatch, override: str):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "profile.yml").write_text(PROFILE.format(override=override))
+    monkeypatch.chdir(repo)
+    result = CliRunner().invoke(build, CI_FLAGS)
+    return repo, result
+
+
+def _rendered_method(repo: Path) -> str:
+    config = yaml.safe_load((repo / "build" / "config.yml").read_text())
+    return config["execution"]["execution_method"]
+
+
+def test_an_unknown_backend_is_refused_at_build(tmp_path: Path, monkeypatch, caplog):
+    with caplog.at_level(logging.ERROR):
+        repo, result = _build_repo(tmp_path, monkeypatch, "  execution.execution_method: docker\n")
+
+    assert result.exit_code != 0
+    reported = result.output + caplog.text + str(result.exception or "")
+    assert "execution.execution_method: 'docker'" in reported
+    assert "Expected 'subprocess'" in reported
+    assert "Unexpected error" not in reported
+
+
+def test_container_is_warned_at_build_and_rendered_as_subprocess(
+    tmp_path: Path, monkeypatch, caplog
+):
+    with caplog.at_level(logging.WARNING, logger="CONFIG"):
+        repo, result = _build_repo(
+            tmp_path, monkeypatch, "  execution.execution_method: container\n"
+        )
+
+    assert result.exit_code == 0, result.output
+    assert _rendered_method(repo) == "subprocess"
+    deprecations = [r for r in caplog.records if "is deprecated" in r.getMessage()]
+    assert len(deprecations) == 1, [r.getMessage() for r in deprecations]
+    assert "config.yml" in deprecations[0].getMessage()
+
+
+def test_local_is_rendered_as_subprocess(tmp_path: Path, monkeypatch):
+    repo, result = _build_repo(tmp_path, monkeypatch, "  execution.execution_method: local\n")
+
+    assert result.exit_code == 0, result.output
+    assert _rendered_method(repo) == "subprocess"

--- a/tests/deployment/test_reach_contract.py
+++ b/tests/deployment/test_reach_contract.py
@@ -473,6 +473,120 @@ def test_a_render_with_no_live_consumer_is_refused_nothing():
     assert reach_errors({}) == []
 
 
+# A deploying render — `deployed_services` non-empty — is the other side of the
+# same contract. Its consumers' clients dial the port the deployment's OWN
+# service publishes on loopback, and a consumer whose resolver always answers
+# (a compiled-in default) cannot be refused for lack of an endpoint. It has to
+# be refused for the deployment not running the service that endpoint implies.
+
+
+def test_a_deploying_render_refuses_a_consumer_of_a_service_it_does_not_deploy():
+    """The `bluesky: null` hole: removing the Bluesky stack from a profile is a
+    two-key edit (the ``bluesky:`` block that injects the service, and
+    ``claude_code.servers.bluesky.enabled`` that switches its consumer on), and
+    a profile that removed only the block rendered clean — the bluesky MCP
+    server then dialed 127.0.0.1:8090 at first use and found nothing."""
+    config = {
+        "claude_code": {"servers": {"bluesky": {"enabled": True}}},
+        "deployed_services": ["postgresql"],
+    }
+
+    (error,) = reach_errors(config)
+
+    assert "bluesky MCP server" in error
+    assert "claude_code.servers.bluesky.enabled" in error
+    assert "`bluesky`" in error
+    assert "deployed_services" in error
+
+
+def test_every_always_resolving_consumer_is_refused_the_same_way():
+    """Each consumer whose client resolver always answers from a shipped
+    default is refused on a deploying render that does not run its service —
+    not only the bluesky one the hole was found in."""
+    cases = {
+        "postgresql": {"ariel": {"search_modules": {}}},
+        "openobserve": {"claude_code": {"telemetry": {"enabled": True, "backend": "openobserve"}}},
+        "virtual_accelerator": {"control_system": {"type": "virtual_accelerator"}},
+    }
+    for service, switched_on in cases.items():
+        errors = reach_errors({**switched_on, "deployed_services": ["qmd"]})
+        assert len(errors) == 1, (service, errors)
+        assert f"`{service}`" in errors[0], (service, errors)
+
+
+def test_an_attached_render_is_told_its_hosts_service_and_is_not_refused():
+    """An attached render (``deploy_services: false``) renders
+    ``deployed_services: []``: its clients dial the HOSTING deployment's
+    published port on the shared network namespace, which is exactly what the
+    projection is for. The deploying rule must not touch it — with the key
+    empty or absent alike."""
+    switched_on = {"claude_code": {"servers": {"bluesky": {"enabled": True}}}}
+
+    assert reach_errors({**switched_on, "deployed_services": []}) == []
+    assert reach_errors(switched_on) == []
+
+
+def test_a_deploying_render_that_runs_the_service_is_not_refused():
+    config = {
+        "claude_code": {"servers": {"bluesky": {"enabled": True}}},
+        "services": {"bluesky": {"port": 8090}},
+        "deployed_services": ["postgresql", "bluesky"],
+    }
+
+    assert reach_errors(config) == []
+
+
+def test_a_deploying_render_may_name_a_service_it_does_not_run():
+    """The documented external shapes: a graph store the facility runs
+    (``services.graphdb.uri`` with ``graphdb`` left OUT of
+    ``deployed_services``), an ARIEL database named by DSN, a bridge named by
+    URL. Each names the endpoint outright rather than deriving it from a
+    service this deployment would publish, so there is nothing to refuse."""
+    external = [
+        {
+            "channel_finder": {"pipeline_mode": "graph"},
+            "services": {"graphdb": {"uri": "bolt://graph.facility.org:7687"}},
+        },
+        {"ariel": {"database": {"uri": "postgresql://ariel@db.facility.org/ariel"}}},
+        {
+            "claude_code": {"servers": {"bluesky": {"enabled": True}}},
+            "bluesky": {"bridge_url": "http://bridge.facility.org:8090"},
+        },
+    ]
+    for config in external:
+        assert reach_errors({**config, "deployed_services": ["openobserve"]}) == [], config
+
+
+def test_the_deploying_rule_has_no_consumer_to_refuse_where_no_client_dials():
+    """Two kinds of contract carry no consumer at all, so no rule that walks
+    live consumers can refuse them — and that is the truth of each:
+
+    * ``derived_by`` (mongodb ← va_archiver): the archiver connector's client
+      facts are derived from the ``va_archiver:`` block on their own build
+      path, which refuses an attached profile that names no host itself.
+    * ``no_client_reach`` (the recorder, the dispatch worker, the chat
+      bridges): nothing inside a persona container dials them; each is a
+      host-side writer or a worker that dials the persona, never the reverse.
+    """
+    silent = [
+        contract
+        for contract in REACH_CONTRACTS.values()
+        if contract.derived_by or contract.no_client_reach
+    ]
+    assert {c.service for c in silent} >= {"mongodb", "archiver_recorder", "dispatch_worker"}
+    for contract in silent:
+        assert contract.consumers == (), contract.service
+
+    # A deploying render that reads an archive and dispatches events, with none
+    # of those services in its list, is refused nothing on their account.
+    config = {
+        "archiver": {"type": "mongodb_archiver"},
+        "va_archiver": {"host": "localhost"},
+        "deployed_services": ["postgresql"],
+    }
+    assert reach_errors(config) == []
+
+
 def test_bluesky_panel_secret_vars_follow_each_users_own_project(tmp_path):
     """The roster grant is per USER: a persona user by their persona's rendered
     config, a persona-less user by the deploy config they run (the same rule

--- a/tests/e2e/test_archiver_world_e2e.py
+++ b/tests/e2e/test_archiver_world_e2e.py
@@ -219,6 +219,14 @@ def _override_yaml() -> str:
     Nulling the key keeps the recorder on the VA under test, and keeps a second
     emulated container out of the build.
 
+    Trimming ``deployed_services`` does not switch off the preset's consumers
+    of what it trimmed away, and the build refuses a deploying render whose
+    consumer is on for a service it does not run — the ARIEL database and
+    hybrid search (``ariel:`` nulled, the section being both consumers'
+    switch), the OTLP exporter and the bluesky MCP server are switched off
+    here by the keys that refusal names. Nothing in this lane dials any of
+    them.
+
     That trim is not only about speed. The preset's full stack publishes
     postgres, openobserve, the bluesky bridge, Tiled and the panels on fixed
     host ports, and a developer box running any OSPREY demo stack already holds
@@ -232,6 +240,9 @@ def _override_yaml() -> str:
         "  archiver.type: mongodb_archiver\n"
         "  modules.web_terminals.enabled: false\n"
         "  deployed_services: []\n"
+        "  ariel:\n"
+        "  claude_code.telemetry.enabled: false\n"
+        "  claude_code.servers.bluesky.enabled: false\n"
         "va_archiver:\n"
         f"  port_host: {MONGO_PORT_HOST}\n"
         f"  freshness_channel: {FRESHNESS_CANARY}\n"

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -239,8 +239,10 @@ web_panels:
 # ── Scanning and simulated hardware ──────────────────────────────────────────
 # These three blocks give you a working plan setup with no real hardware: a
 # Bluesky bridge with a Tiled data catalog, a simulated accelerator that speaks
-# EPICS, and the web panels for both. Delete this section (and the bluesky
-# panel above) if you do not want it.
+# EPICS, and the web panels for both. To drop it, delete this section, the
+# bluesky panel above, AND the `claude_code.servers.bluesky.enabled: true`
+# line under `config:` below — the block deploys the bridge, the line switches
+# on the server that dials it, and the build refuses the line left on alone.
 bluesky:
   port: 8090
   tiled_enabled: true      # also runs the Tiled data catalog


### PR DESCRIPTION
Addresses #465 (finding 2: config names things that exist). Two build-time refusals for configs that used to fail only at first use inside a deployed container.

## A — `execution.execution_method` is resolved on the render

The rendered `execution:` block comes from the app template plus the profile's `config:` overlay, and nothing on the build path read it back, so `execution_method: docker` survived build, deploy and MCP startup and failed in `executor._read_config` on the first `execute` call.

The build now runs `resolve_execution_method()` on each render, beside the reach check in `_render_project` (`build_cmd.py`): an unknown backend is refused with the resolver's own message; `local`/`container` are written into the render as `subprocess`, with `container`'s one-time deprecation warning raised at build where the operator is.

The check lives on the build path rather than in `ConfigBuilder._get_execution_config()` because the build never constructs a `ConfigBuilder` — the rendered `execution:` block is template + overlay — and a `ConfigBuilder` that raised at construction would be swallowed by `load_osprey_config()` (`except Exception: return {}`), turning a hand-edited typo in a deployed `config.yml` into an empty config for every runtime reader. `tests/cli/test_build_execution_method.py` builds a real profile for each case.

## B — a deploying render refuses a consumer of a service it does not run

`reach_errors()` could never refuse the bluesky, ARIEL-database, telemetry or virtual-accelerator consumers: their client resolvers always answer from a compiled-in loopback default (`resolves=_always`). Removing the Bluesky stack from a profile is a two-key edit (`bluesky:` block vs `claude_code.servers.bluesky.enabled`), and a profile that removed only the block rendered clean and dialed `127.0.0.1:8090` at first use — the BELLA finding #2 shape.

On a render whose `deployed_services` is non-empty, a live consumer whose service is absent from that list is now refused, naming the switch key and the missing service — unless the render names one elsewhere (`ReachContract.names_external`: an explicit graph-store `uri`, an ARIEL database DSN, a bridge URL, a pinned panel URL, a VA gateway address — the shapes the templates document). Attached renders (empty list) dial their host's published ports and are untouched. `derived_by` and `no_client_reach` contracts carry no consumer, so the rule cannot reach them; the test says why for each. The control-assistant preset's removal comment (and its exemplar) now names both keys; the profile reference gets one sentence.

A trimmed `deployed_services` now has to switch the preset's inherited consumers off as well — the refusal text names each one with its key; the archiver-world e2e fixture was the first to hit it (ARIEL database + hybrid search, the OTLP exporter, and the bluesky MCP server left on after `bluesky: null`).

Reproduced first: `reach_errors({'claude_code': {'servers': {'bluesky': {'enabled': True}}}, 'deployed_services': ['postgresql']})` returned `[]` on main.

## Out of scope

`osprey validate` does not run `reach_errors()` (or this resolver) — only `osprey build` does. Unchanged here.

## Verification

- `./scripts/quick_check.sh` — 33 496 passed; one live-Neo4j-in-Docker test flaked under `-n 4` and passes alone
- `uv run pytest tests/deployment/test_reach_contract.py tests/utils/test_execution_method_resolution.py tests/cli/test_persona_presets.py tests/cli/test_bluesky_*.py tests/cli/test_build_graphdb_removal.py tests/cli/test_build_execution_method.py tests/cli/test_init_verb.py` — green
- rebased onto #765 before opening

