### PR TITLE
feat(init): seed a runnable MCP server and answer first-hour questions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ uv run osprey skills install osprey-contribute
 
 It walks you through branching, commits, push, PR, and CI iteration following
 the conventions on this page — including the protected-branch reality on
-`main` (no direct pushes; eight required CI checks; linear history). Once
+`main` (no direct pushes; required CI checks that admins cannot bypass). Once
 installed, just open Claude Code in the repo and describe what you want to
 contribute; the skill picks up wherever you are in the journey.
 

--- a/changelog.d/deployment-readme-questions.added.md
+++ b/changelog.d/deployment-readme-questions.added.md
@@ -1,0 +1,4 @@
+A new deployment repo's `README.md` ends with a `Common questions` section
+answering the three things operators reach for first: adding their own MCP
+server, adding a web panel, and mounting an extra directory into a web
+terminal. Each answer names the profile key and shows its shape.

--- a/changelog.d/followups-mechanical.internal.md
+++ b/changelog.d/followups-mechanical.internal.md
@@ -1,0 +1,3 @@
+Web-terminal JS: the `agent_activity` SSE frame type is spelled in one shared
+constant, and the agent tile-attribution gesture (rail flash + tile glow) has
+one owner function instead of a hand-copied pair.

--- a/changelog.d/hello-world-example-server.added.md
+++ b/changelog.d/hello-world-example-server.added.md
@@ -1,0 +1,6 @@
+The hello-world preset now ships a working example MCP server. `osprey init`
+seeds its package into the new repository's `mcp_servers/example_server/`
+directory, and the profile's live `mcp_servers:` entry launches it, so the
+first session already has a facility tool — `example_status` — to call.
+Copy the directory and replace the tool to start on your own server; delete
+the directory and the profile block together to drop it.

--- a/changelog.d/mcp-command-placeholder.fixed.md
+++ b/changelog.d/mcp-command-placeholder.fixed.md
@@ -1,0 +1,3 @@
+A facility MCP server's `command` now resolves `{project_root}` and
+`{current_python_env}` placeholders, matching the existing behavior of its
+`args` and `env` fields.

--- a/changelog.d/profile-key-annotations.added.md
+++ b/changelog.d/profile-key-annotations.added.md
@@ -1,0 +1,6 @@
+An emitted `profile.yml` now explains its two hardest keys in place. Above
+`web_panels:` it says which panels can simply be uncommented and shows what a
+panel of your own looks like — a list entry plus its `web.panels.<id>.url`
+address under `config:`. Above `env:` it shows the block that replaces
+`env: {}`, naming `required`, `pinned`, `defaults` and `file`. Both are
+comments, so nothing about what the profile builds changes.

--- a/docs/source/contributing/workflow.rst
+++ b/docs/source/contributing/workflow.rst
@@ -93,12 +93,16 @@ Pull Request Process
 Branch Protection on ``main``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Direct pushes to ``main`` are rejected. All changes land via PR. The ruleset
-enforces:
+Direct pushes to ``main`` are rejected. All changes land via PR. GitHub branch
+protection on ``main`` enforces:
 
-- All required CI checks must pass (no admin bypass).
-- Linear history (use ``gh pr merge --rebase``; merge commits are rejected).
+- The required status checks must pass: ``pre-commit.ci - pr`` and
+  ``All CI Checks Passed`` (the aggregate job every CI lane feeds). Admins
+  cannot bypass them.
 - Force-pushes and branch deletion on ``main`` are denied.
+
+Linear history is not enforced: a PR may land as a merge commit or a rebase,
+and both appear in ``main``'s history.
 
 If a required check turns out to be wrong, fix it forward — there is no
 escape hatch.

--- a/docs/source/getting-started/hello-world-tutorial.rst
+++ b/docs/source/getting-started/hello-world-tutorial.rst
@@ -349,6 +349,6 @@ commented blocks map everything it can become.
 - **How it works**: :doc:`conceptual-tutorial` explains the MCP server
   architecture, the connector system, and the safety mechanisms in depth.
 - **The profile format**: :doc:`../how-to/build-profiles` documents every key
-  those 13 commented blocks can hold.
+  those 12 commented blocks can hold.
 - **CLI reference**: :doc:`/reference/cli` covers all ``osprey``
   commands.

--- a/docs/source/getting-started/hello-world-tutorial.rst
+++ b/docs/source/getting-started/hello-world-tutorial.rst
@@ -352,3 +352,10 @@ commented blocks map everything it can become.
   those 12 commented blocks can hold.
 - **CLI reference**: :doc:`/reference/cli` covers all ``osprey``
   commands.
+
+The deployment repo that ``osprey init`` created also contains
+``mcp_servers/example_server/``, a small working MCP server; its
+``example_status`` tool is one the agent already has. Copying that directory
+is the quickest way to start your own. The repo's ``README.md`` has a
+"Common questions" section that explains how to add your own server, panel,
+or volume.

--- a/docs/source/how-to/agent-interfaces/add-mcp-server.rst
+++ b/docs/source/how-to/agent-interfaces/add-mcp-server.rst
@@ -28,16 +28,22 @@ Declare the server in the deployment's ``profile.yml``, under the top-level
          MY_API_KEY: "${MY_API_KEY}"
 
      my-python-server:
-       command: "python"
+       command: "{current_python_env}"
        args: ["-m", "my_package.server"]
        env:
-         OSPREY_CONFIG: "{project_root}/config.yml"
+         OSPREY_CONFIG: "{project_root}/build/config.yml"
 
 Each entry needs a ``command`` — or, for a server that is already running
 somewhere, a ``url`` instead; the two are mutually exclusive. ``args`` and
 ``env`` are optional. ``{project_root}`` is expanded to the project directory
-at build time; ``${VAR}`` is left alone for the shell or the container to
-resolve at run time.
+at build time, and ``{current_python_env}`` to the project's own Python
+interpreter — the one the framework's servers run under. ``${VAR}`` is left
+alone for the shell or the container to resolve at run time. A Python module
+launched with ``-m`` has to be importable by that interpreter: either declare
+its package under the profile's ``dependencies:`` so it is installed into the
+project venv, or ship it in the profile's ``mcp_servers/`` directory and reach
+it with ``PYTHONPATH: "{project_root}/build/_mcp_servers"`` (see
+:ref:`profile-mcp-servers`).
 
 To set permissions on a server, name its tools:
 

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -156,7 +156,7 @@ name *is* the declaration, and where each one lands is fixed.
      - ``services/``
      - a directory per compose service
    * - ``project/``
-     - the project root
+     - the build root (``build/``)
      - any file, mirrored verbatim
 
 Nested paths inside a markdown directory are preserved, so
@@ -846,7 +846,7 @@ What gets generated
 
 .. code-block:: text
 
-   my-project/
+   my-project/build/
    ├── .claude/
    │   ├── agents/           # built-ins, plus anything from the profile's agents/
    │   ├── rules/            # built-ins, plus the profile's rules/

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -110,7 +110,7 @@ profile (repeatable). RHS is parsed as YAML. Top-level shorthands: ``provider``,
 repository, discarding edits to ``profile.yml``, ``data/``, ``personas/``,
 ``triggers.yml``, ``web-terminal-context/``, and ``.env.example``. Never touches
 ``.env``, ``.git``, ``var/``, ``build/``, ``.gitignore``, ``README.md``,
-``ci-extra.yml``, the CI file, or ``scripts/verify.sh``.
+``ci-extra.yml``, the CI file, ``scripts/verify.sh``, or ``mcp_servers/``.
 
 ``--no-git`` — Skip ``git init`` and the initial commit.
 

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -209,10 +209,10 @@ configuration) and ``.claude/settings.json`` (tool permissions) — so a later
 
    mcp_servers:
      my_server:
-       command: python
+       command: "{current_python_env}"
        args: ["-m", "my_server"]
        env:
-         CONFIG: "{project_root}/config.yml"
+         CONFIG: "{project_root}/build/config.yml"
          API_KEY: "${MY_API_KEY}"
        permissions:
          allow: ["safe_tool"]
@@ -244,8 +244,11 @@ own key — so name the compose service after the ``mcp_servers:`` key or that
 URL points at no host.
 
 **Placeholders:** ``{project_root}`` resolves at build time to the absolute
-project path; ``${ENV_VAR}`` is preserved for the container or shell to resolve
-at runtime.
+project path, and ``{current_python_env}`` to the interpreter the framework's
+own MCP servers run under (the project venv under the default
+``python_env: project``; see the key table above), which is what a Python
+server shipped with the profile should launch under too. ``${ENV_VAR}`` is
+preserved for the container or shell to resolve at runtime.
 
 **Permission wiring:** for a server named ``my_server`` with
 ``allow: ["safe_tool"]``, the build adds ``mcp__my_server__safe_tool`` to the
@@ -255,8 +258,8 @@ Shipping the server's code
 --------------------------
 
 Put the package in the profile's ``mcp_servers/`` directory — one directory per
-server. The build copies it to ``_mcp_servers/`` in the project, so the launch
-command finds it:
+server. The build copies it to ``build/_mcp_servers/`` in the project, so the
+launch command finds it:
 
 .. code-block:: text
 
@@ -271,11 +274,11 @@ command finds it:
 
    mcp_servers:
      phoebus:
-       command: python
+       command: "{current_python_env}"
        args: ["-m", "phoebus"]
        env:
-         OSPREY_CONFIG: "{project_root}/config.yml"
-         PYTHONPATH: "{project_root}/_mcp_servers"
+         OSPREY_CONFIG: "{project_root}/build/config.yml"
+         PYTHONPATH: "{project_root}/build/_mcp_servers"
        permissions:
          allow: ["phoebus_launch"]
 

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -168,6 +168,41 @@ _SYNTHESIS_RATIONALE: dict[str, str] = {
     "web_panels": "Panels offered by the web terminal.",
 }
 
+# Two keys need more than a one-line rationale: their shape is not obvious from
+# the empty default the emitter writes, and guessing it wrong is a build error
+# rather than a quiet no-op. Each entry replaces that key's rationale line with
+# a block written above the key. Every line is already '#'-prefixed (like
+# _PROVENANCE_COMMENT below), so an annotated key's value is left exactly as the
+# profile resolved it.
+_ANNOTATIONS: dict[str, tuple[str, ...]] = {
+    "web_panels": (
+        "# Tabs the web workspace offers beside the terminal. To turn on a panel",
+        "# the framework already ships, uncomment one listed under this key.",
+        "# A panel of your own is a list entry plus its address under `config:`:",
+        "#",
+        "#   web_panels:",
+        "#     - elog",
+        "#",
+        "# and, under `config:`, web.panels.elog.url alongside web.panels.elog.label,",
+        "# web.panels.elog.path and — optional — web.panels.elog.health_endpoint.",
+    ),
+    "env": (
+        "# Environment variables the deployment needs. Replace `env: {}` with any",
+        "# of `required` (the variable must be set somewhere), `pinned` (this",
+        "# repo's own env chain owns it outright, and nowhere else), `defaults`",
+        "# (name to value) and `file` (a profile-relative path copied in as .env):",
+        "#",
+        "#   env:",
+        "#     required: [EPICS_CA_ADDR_LIST]",
+        "#     pinned: [ARIEL_DB_PASSWORD]",
+        "#     defaults:",
+        "#       EPICS_CA_ADDR_LIST: 127.0.0.1",
+        "#     file: env/facility.env",
+        "#",
+        "# If `env:` already has children, add yours under it.",
+    ),
+}
+
 # The stamp is always written, so it carries its explanation rather than a
 # synthesis rationale: it is a floor for readers, not a preset choice.
 _REQUIRES_VERSION_COMMENT = (
@@ -1203,8 +1238,19 @@ def emit_standalone_profile_yaml(
     for field in synthesized:
         rationale = _SYNTHESIS_RATIONALE.get(field)
         key = _FIELD_TO_YAML.get(field, field)
-        if rationale and key in doc:
+        if rationale and key in doc and field not in _ANNOTATIONS:
             _set_pre_comment(doc, key, [f"# {rationale}"], 0)
+
+    # Annotated keys carry a worked example instead of a rationale line, and get
+    # it whether or not the preset left them unset: the shape of a custom panel
+    # or an env block is what a facility has to be told, not the fact that the
+    # key is present. Appending keeps any preset's own header above the key
+    # first, and column 0 keeps the block out of the artifact menus, which are
+    # inserted into the dumped text further down.
+    for field, annotation in _ANNOTATIONS.items():
+        key = _FIELD_TO_YAML.get(field, field)
+        if key in doc:
+            _set_pre_comment(doc, key, list(annotation), 0)
     if "requires_osprey_version" in doc:
         _set_pre_comment(doc, "requires_osprey_version", [_REQUIRES_VERSION_COMMENT], 0)
     if "provenance" in doc:

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -41,6 +41,7 @@ from .build_profile_load import _PROFILE_SCHEMA_MIN_OSPREY
 from .build_profile_merge import _deep_merge, _resolve_extends, compute_preset_hash
 from .build_profile_presets import _load_preset_raw
 from .build_profile_resolve import merge_cli_overrides
+from .profile_conventions import BUILD_OUTPUT_DIR
 
 # YAML-surface spellings that differ from the canonical resolved-content field
 # name (D2: the rename is confined to the profile-YAML surface, so the
@@ -201,8 +202,18 @@ _MCP_SERVERS_APPENDIX = """
 # "http"; "sse" is the legacy event-stream wire and needs an explicit url.
 # Tool names under permissions are bare — `allow` runs them unprompted, `ask`
 # prompts the operator on every call.
+# A Python server's package lives at mcp_servers/<package>/ beside this file;
+# the build copies it to __BUILD__/_mcp_servers/<package>/ for `-m <package>`.
 #
 # mcp_servers:
+#   my_server:
+#     command: "{current_python_env}"
+#     args: [-m, my_server]
+#     env:
+#       OSPREY_CONFIG: "{project_root}/__BUILD__/config.yml"
+#       PYTHONPATH: "{project_root}/__BUILD__/_mcp_servers"
+#     permissions:
+#       allow: [my_tool]
 #   matlab:
 #     command: /opt/matlab/bin/mcp-matlab
 #     args: [--workspace, /opt/matlab/scripts]
@@ -216,7 +227,7 @@ _MCP_SERVERS_APPENDIX = """
 #     transport: http
 #     permissions:
 #       allow: [get_twiss]
-"""
+""".replace("__BUILD__", BUILD_OUTPUT_DIR)
 
 # Appended when the resolved profile has no ``artifact_server:`` block.
 _CATEGORIES_APPENDIX = """

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -45,7 +45,7 @@ from osprey.utils.logger import get_logger
 from osprey.utils.workspace import STATE_ZONE_DIRS
 
 from . import output
-from .profile_conventions import BUILD_OUTPUT_DIR, STATE_DIR
+from .profile_conventions import BUILD_OUTPUT_DIR, STATE_DIR, convention_for
 from .repo_resolver import HELD_SOURCE_ZONE_DIRNAME
 from .variant_selection import (
     VARIANT_DIRNAME,
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     # lazy-import budget test in tests/cli/test_main.py pins this).
     from osprey.deployment.reset import ForeignCheckoutError
 
+    from .build_profile_schema import McpServerDef
     from .deploy_scaffold import ScaffoldedFile
     from .profile_cmd import _MaterializedProfile
 
@@ -93,8 +94,10 @@ def _repo_gitignore() -> str:
     Every zone entry is ANCHORED with a leading slash, which is the whole
     subtlety of the file: an unanchored ``build/`` or ``.env*`` also matches a
     same-named path anywhere deeper in the tree, including files moved there
-    later, and it does it silently. The editor noise at the end is the one
-    deliberate exception, being a name pattern rather than a path.
+    later, and it does it silently. The noise at the end is the deliberate
+    exception, being a set of name patterns rather than paths: editor droppings
+    and Python bytecode are junk wherever they land, and a seeded server package
+    run in place lands them well below the root.
     """
     return f"""\
 # This repo is the deployment: the source zone is tracked, and the
@@ -138,14 +141,17 @@ def _repo_gitignore() -> str:
 # `osprey reset` — anchored for the same reason the zones above are.
 /{MERGED_COMPOSE_FILENAME}
 
-# OS / editor noise. Deliberately unanchored: these are junk at any depth.
+# OS / editor noise, and the bytecode Python leaves beside any server package
+# run in place. Deliberately unanchored: these are junk at any depth.
 .DS_Store
 *.swp
 *.swo
+__pycache__/
+*.py[co]
 """
 
 
-def _repo_env_shared(name: str) -> str:
+def _repo_env_shared(name: str, seeded: tuple[str, ...] = ()) -> str:
     """The committed half of the deployment's environment, as a commented starter.
 
     Every line is commented out, because a deployment needs no shared defaults
@@ -196,7 +202,7 @@ def _repo_env_shared(name: str) -> str:
 """
 
 
-def _repo_readme(name: str) -> str:
+def _repo_readme(name: str, seeded: tuple[str, ...] = ()) -> str:
     """The README an operator meets this layout through.
 
     Its subject is the repo, not the profile: which zone survives what, and the
@@ -218,7 +224,7 @@ the folder name is the assistant's name.
 | Generated files | `{BUILD_OUTPUT_DIR}/` | no | no, safe to delete |
 | The agent's memory and audit log | `{STATE_DIR}/agent_data/`, `{STATE_DIR}/audit/` | no | yes |
 
-In full, the first row is: {_source_zone_prose()}.
+In full, the first row is: {_source_zone_prose(seeded)}.
 
 `{BUILD_OUTPUT_DIR}/` is generated from your settings every time you run `osprey build`.
 Deleting it is always safe: no settings, no keys and no agent memory live there.
@@ -309,7 +315,7 @@ git clone <this repo> && tar xf state.tar.gz && osprey build && osprey up -d
 """
 
 
-def _ci_extra_text(name: str) -> str:
+def _ci_extra_text(name: str, seeded: tuple[str, ...] = ()) -> str:
     """The starter ``ci-extra.yml`` — an include point with nothing in it yet.
 
     Written by this command and by nothing else, ever: the pipeline beside it
@@ -355,7 +361,7 @@ _IN_PLACE_NOT_EMPTY = (
 _NOT_A_DIRECTORY = "Not a directory: {target}. `osprey init` creates a deployment repo there."
 
 # ---------------------------------------------------------------------------
-# Every file `init` writes belongs to exactly one of three categories
+# Every path `init` writes belongs to exactly one of four categories
 # ---------------------------------------------------------------------------
 #
 # The categories are what make "--force is safe" checkable rather than asserted.
@@ -377,27 +383,37 @@ _NOT_A_DIRECTORY = "Not a directory: {target}. `osprey init` creates a deploymen
 #                 scaffolding engine under its marker contract and never
 #                 forced from here (see `_emit_ci`); regenerating an unmarked
 #                 one is `osprey scaffold ci`'s job, with its own `--force`.
+#   4. SEEDED     :data:`WRITE_ONCE_DIRS` below — directories copied out of the
+#                 app bundle on a repo's FIRST-EVER materialization. Never
+#                 replaced and never resurrected: `--force`/`--reset` neither
+#                 touch them nor seed them again, so one the facility deleted
+#                 stays deleted rather than reappearing under a later re-init.
 #
 # Nothing else in the repo is written by this command at all, so everything
 # else — `.env`, `var/`, `build/`, `.git` — survives by construction rather
 # than by a promise anybody has to maintain.
 
 
-def _repo_gitignore_for(_name: str) -> str:
+def _repo_gitignore_for(name: str, seeded: tuple[str, ...] = ()) -> str:
     """:func:`_repo_gitignore`, with the uniform signature the table needs.
 
     The zone paths are the layout's, not the deployment's, so this is the one
-    write-once file whose text does not vary with the name.
+    write-once file whose text varies with neither the name nor what was seeded
+    — the bytecode patterns already cover a seeded server package wherever it
+    put its ``__pycache__``.
     """
     return _repo_gitignore()
 
 
 #: Files ``init`` authors and never rewrites, each with the builder producing
 #: its text. This mapping DRIVES the writing — ``init`` loops over it rather
-#: than naming the three files again — so a file that is written is a file that
+#: than naming the four files again — so a file that is written is a file that
 #: is listed, and the ``--force`` promise below cannot describe a set the code
-#: does not implement.
-WRITE_ONCE_FILES: Mapping[str, Callable[[str], str]] = {
+#: does not implement. Every builder takes the same pair — the deployment's
+#: name, and the directories :data:`WRITE_ONCE_DIRS` actually seeded into this
+#: repo — so that a builder may start describing a seeded directory without the
+#: loop that calls it having to learn which builders care.
+WRITE_ONCE_FILES: Mapping[str, Callable[[str, tuple[str, ...]], str]] = {
     ".gitignore": _repo_gitignore_for,
     ENV_SHARED_FILENAME: _repo_env_shared,
     "README.md": _repo_readme,
@@ -410,13 +426,31 @@ WRITE_ONCE_FILES: Mapping[str, Callable[[str], str]] = {
 #: ``CI_OUTPUT_NAMES`` and :data:`REPO_VERIFY_PATH` so the two cannot drift.
 CI_EMITTED_PATHS: tuple[str, ...] = (".gitlab-ci.yml", "/".join(REPO_VERIFY_PATH))
 
+#: The profile-root directory one Python MCP server's package lives in — the
+#: source name of the convention row that carries those packages into a build.
+#: Named here, above the first table that needs it, because the directory the
+#: seeding writes and the directory the pairing check reads are the same one:
+#: spelling it twice is how a rename leaves the check looking for a name
+#: nothing writes any more.
+MCP_SERVER_SOURCE_DIR: str = "mcp_servers"
 
-def _source_zone_prose() -> str:
+#: Directories seeded out of the app bundle the first time a repo is
+#: materialized, mapping the name each takes at the repo root to the
+#: bundle-relative path it is copied from. Once seeded they are the facility's:
+#: nothing rewrites them, and nothing puts one back that the facility removed.
+#: Like the tables above this one DRIVES its consumers — the seeding, the
+#: ``--force`` promise, the README's zone row and the tests all iterate it — so
+#: a second seeded directory joins every one of them by being listed here.
+WRITE_ONCE_DIRS: Mapping[str, str] = {MCP_SERVER_SOURCE_DIR: "mcp_servers"}
+
+
+def _source_zone_prose(seeded: tuple[str, ...] = ()) -> str:
     """The SOURCE row of the README's zone table, derived from the categories above.
 
     The source zone is exactly what a materialization owns
     (:data:`~.profile_cmd.MATERIALIZED_SOURCE_ENTRIES`), plus the repo shell
-    ``init`` authors once (:data:`WRITE_ONCE_FILES`), plus the CI pair the
+    ``init`` authors once (:data:`WRITE_ONCE_FILES`), plus whatever
+    :data:`WRITE_ONCE_DIRS` seeded into THIS repo, plus the CI pair the
     scaffolding engine emits (:data:`CI_EMITTED_PATHS`) — the same
     derive-from-the-tables rule :data:`PRESERVED_BY_FORCE` follows, for the same
     reason. Naming the zone by hand is how this table came to advertise
@@ -428,6 +462,11 @@ def _source_zone_prose() -> str:
     a trailing slash — ``.env.example`` has one, so the split holds for every
     entry in that table. Write-once and CI entries are files by construction.
 
+    ``seeded`` is what this repo actually received, not the seeding table: an
+    app template that ships no server package seeds nothing, and its README must
+    not name a directory the operator will not find. The names arrive already
+    filtered, so the row grows only where the directory does.
+
     Imported inside the body rather than at module scope: ``profile_cmd`` pulls
     the build-profile chain in with it, which ``osprey --help`` must stay off
     (TR-2), and this is only ever called while a repo is being written.
@@ -437,6 +476,7 @@ def _source_zone_prose() -> str:
     entries = [
         f"{name}/" if not Path(name).suffix else name for name in MATERIALIZED_SOURCE_ENTRIES
     ]
+    entries.extend(f"{name}/" for name in seeded)
     entries.extend(WRITE_ONCE_FILES)
     entries.extend(CI_EMITTED_PATHS)
     return ", ".join(f"`{name}`" for name in entries)
@@ -446,13 +486,16 @@ def _source_zone_prose() -> str:
 _UNTOUCHED_BY_INIT: tuple[str, ...] = (".env", ".git", f"{STATE_DIR}/", f"{BUILD_OUTPUT_DIR}/")
 
 #: Everything a re-materialization leaves intact — DERIVED from the categories
-#: above rather than declared beside them. A new write-once file appears here
-#: the moment it is added to the table that writes it, which is the property a
-#: hand-maintained list cannot offer.
+#: above rather than declared beside them. A new write-once file — or a new
+#: seeded directory — appears here the moment it is added to the table that
+#: writes it, which is the property a hand-maintained list cannot offer. The
+#: seeded directories carry a trailing slash, both because that is what they
+#: are and because the survival tests read the slash as "put a file inside it".
 PRESERVED_BY_FORCE: tuple[str, ...] = (
     *_UNTOUCHED_BY_INIT,
     *WRITE_ONCE_FILES,
     *CI_EMITTED_PATHS,
+    *(f"{name}/" for name in WRITE_ONCE_DIRS),
 )
 
 _PRESERVED_PROSE = ", ".join(PRESERVED_BY_FORCE)
@@ -1217,6 +1260,12 @@ def init(
     # mid-replacement is a whole repo again, so the refusals below judge the
     # deployment the operator has rather than the wreck of one.
     _reinstate_held_source_zone(target)
+    # Write-once is a promise about the REPO, not about one materialization, so
+    # the question has to be asked here — before `_replacing_source_zone` moves
+    # profile.yml aside. Inside the materializer a `--force` or `--reset` run
+    # always looks like a first init, and would re-seed a directory the operator
+    # deliberately deleted.
+    first_ever = not (target / "profile.yml").is_file()
     # `--reset` implies `--force`'s file half. Its promise is "start over on
     # this name", and a source zone left standing from the last deployment is
     # not a start over — an edited profile.yml or a file an older preset wrote
@@ -1245,6 +1294,7 @@ def init(
                         overrides,
                         set_pairs,
                         profile_name=_directory_derived_name(target.name),
+                        seed_dirs=WRITE_ONCE_DIRS if first_ever else None,
                     )
             except BuildProfileError as e:
                 # Reaching here means a packaging problem, not a user mistake —
@@ -1260,11 +1310,11 @@ def init(
             phase.step(f"settings and data from preset {preset}")
 
             name = materialized.profile_name
-            # Driven off the table rather than three calls written out: the set of
+            # Driven off the table rather than four calls written out: the set of
             # files this command authors and the set the --force promise names are
             # then the same object, not two lists that agree today.
             for filename, build_text in WRITE_ONCE_FILES.items():
-                _write_if_absent(target / filename, build_text(name))
+                _write_if_absent(target / filename, build_text(name, materialized.seeded))
             for relative in _STATE_DIRS:
                 (target / relative).mkdir(parents=True, exist_ok=True)
 
@@ -1280,6 +1330,17 @@ def init(
             git_note = _bootstrap_git(target, no_git=no_git)
 
         _report(target, materialized, deploy_files, git_note)
+
+        # After the report, and about the repo that was already here rather
+        # than the one just written: a `--force` run restores the block that
+        # names the server, and never the package it starts.
+        for entry, module in _missing_server_packages(materialized.resolved.mcp_servers, target):
+            output.warn(
+                f"profile.yml declares {entry} but "
+                f"{MCP_SERVER_SOURCE_DIR}/{module}/ is missing; "
+                "delete the block too, or copy the package back.",
+                "Every session otherwise waits 20 s for a server that cannot start.",
+            )
 
         # After the repo exists and before anything is built or started. The
         # repo root is what `reset_deployment` reads to resolve the project
@@ -1468,6 +1529,57 @@ def _emit_ci(target: Path, *, declared: bool) -> list[ScaffoldedFile]:
     # shape, and a caller able to choose either path could put the check
     # somewhere the emitted pipeline does not look.
     return scaffold_deploy_files(target, force=False)
+
+
+def _missing_server_packages(
+    resolved_mcp_servers: Mapping[str, McpServerDef],
+    target: Path,
+) -> list[tuple[str, str]]:
+    """The servers this profile declares whose package is not in the repo.
+
+    The entry and the package it starts are two halves of one thing, and only
+    one half is write-once: a repo whose ``mcp_servers/<module>/`` was deleted
+    still gets its ``profile.yml`` written again by ``--force``, live block and
+    all. Nothing puts the package back, and the sessions that follow each wait
+    out the client's start-up timeout on a command that cannot import anything.
+
+    Only the pairing this repo owns is judged. A server reached over the
+    network has no package here, and one started from a program already on the
+    host has one this command cannot see, so both read as fine. What is left is
+    the shape the build supports: ``-m <module>`` run against the copy of this
+    directory the build puts under the output zone, which is what makes the
+    module name in the arguments a directory name in the repo.
+
+    Args:
+        resolved_mcp_servers: The ``mcp_servers`` block of the resolved profile.
+        target: The repo root the packages sit in.
+
+    Returns:
+        One ``(entry name, module)`` pair per unpaired entry, in profile order.
+    """
+    convention = convention_for(MCP_SERVER_SOURCE_DIR)
+    if convention is None:  # pragma: no cover - the row is part of the table
+        return []
+    # What the build copies the packages into, and so what an entry's
+    # PYTHONPATH says when the package it wants is one of this repo's.
+    build_zone = f"/{BUILD_OUTPUT_DIR}/{convention.destination}"
+
+    unpaired: list[tuple[str, str]] = []
+    for name, server in resolved_mcp_servers.items():
+        if server.url:
+            continue
+        if build_zone not in server.env.get("PYTHONPATH", ""):
+            continue
+        args = list(server.args)
+        if "-m" not in args:
+            continue
+        position = args.index("-m") + 1
+        if position == len(args):
+            continue
+        module = args[position]
+        if not (target / MCP_SERVER_SOURCE_DIR / module).is_dir():
+            unpaired.append((name, module))
+    return unpaired
 
 
 def _report(

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -312,6 +312,63 @@ is a copy of those two, and a restore is:
 ```bash
 git clone <this repo> && tar xf state.tar.gz && osprey build && osprey up -d
 ```
+
+## Common questions
+
+### Adding an MCP server of your own
+
+Put the server's Python package at `mcp_servers/<name>/`. `osprey build` copies
+it to `{BUILD_OUTPUT_DIR}/_mcp_servers/<name>/`, and an entry under `mcp_servers:`
+in `profile.yml` says how to start it:
+
+```yaml
+mcp_servers:
+  my_server:
+    command: "{{current_python_env}}"
+    args: [-m, my_server]
+    env:
+      PYTHONPATH: "{{project_root}}/{BUILD_OUTPUT_DIR}/_mcp_servers"
+```
+
+The hello-world preset ships `example_server` as a worked copy to read. Which
+buckets the artifact gallery sorts into is a separate, top-level key, one entry
+per bucket:
+
+```yaml
+artifact_server:
+  categories:
+    beam_studies: {{label: Beam studies, color: "#4C6EF5"}}
+```
+
+### Adding a panel of your own
+
+A panel is two halves, and one without the other is a tab that opens nothing.
+The id goes in the `web_panels:` list, and its address goes under `config:`, as
+the comment above `web_panels:` in `profile.yml` shows:
+
+```yaml
+web_panels:
+  - elog
+
+config:
+  web.panels.elog.url: http://elog.example.org
+  web.panels.elog.label: Elog
+  web.panels.elog.path: /elog
+```
+
+### Mounting an extra directory into a web terminal
+
+Deployments that give people their own web terminals mount per persona, under
+`config:`. Each entry is a container volume string of two or three non-empty
+parts, `source:target` or `source:target:mode`:
+
+```yaml
+config:
+  modules.web_terminals.personas.operator.extra_mounts:
+    - /opt/facility/data:/data:ro
+```
+
+Every key named here is written up in full at https://als-apg.github.io/osprey/.
 """
 
 

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -887,7 +887,7 @@ def _persona_profile_texts(
     return texts
 
 
-def _cleanup(target: Path) -> str:
+def _cleanup(target: Path, seeded: tuple[str, ...] = ()) -> str:
     """Remove what a failed materialization wrote, and say what is left.
 
     Only the entries a materialization owns (:data:`MATERIALIZED_SOURCE_ENTRIES`)
@@ -895,19 +895,29 @@ def _cleanup(target: Path) -> str:
     operator's own files — a ``.git``, an ``.env``, a clone's README — and a
     failed run must never cost one of those.
 
+    Args:
+        target: The repo root the failed materialization was writing into.
+        seeded: Write-once directories THIS run created (the ``seed_dirs`` it
+            actually copied — never one it found already there). They are not
+            in :data:`MATERIALIZED_SOURCE_ENTRIES`, because a later ``--force``
+            must leave an operator's own edits inside them alone; but a run that
+            just created one and then failed owns it, so a first init that fails
+            leaves nothing behind.
+
     Returns:
         A sentence for the refusal it is appended to, naming anything that could
         not be removed so the operator knows a retry will refuse too.
     """
     import shutil
 
-    for name in MATERIALIZED_SOURCE_ENTRIES:
+    owned = (*MATERIALIZED_SOURCE_ENTRIES, *seeded)
+    for name in owned:
         entry = target / name
         if entry.is_dir():
             shutil.rmtree(entry, ignore_errors=True)
         else:
             entry.unlink(missing_ok=True)
-    remaining = [name for name in MATERIALIZED_SOURCE_ENTRIES if (target / name).exists()]
+    remaining = [name for name in owned if (target / name).exists()]
     if remaining:
         return (
             f"Partly-written files remain in {target}: {', '.join(remaining)} — "
@@ -994,6 +1004,13 @@ class _MaterializedProfile(NamedTuple):
     profile that emits none. The per-persona facts a summary needs (each tier's
     panels and its write posture) live in these, not in the host profile."""
 
+    seeded: tuple[str, ...]
+    """The write-once directories this materialization seeded — empty on every
+    re-run, because a name already present in the target is left as the operator
+    left it. Returned because only this run knows which of them it created, and
+    that is the difference between a directory the caller may still clear and
+    one that is now the operator's."""
+
 
 def _materialize_profile_directory(
     target_dir: Path,
@@ -1002,6 +1019,7 @@ def _materialize_profile_directory(
     set_pairs: tuple[str, ...] = (),
     *,
     profile_name: str | None = None,
+    seed_dirs: Mapping[str, str] | None = None,
 ) -> _MaterializedProfile:
     """Materialize an editable, standalone profile directory from ``preset_name``.
 
@@ -1029,6 +1047,14 @@ def _materialize_profile_directory(
         profile_name: Display name for the emitted profile. Defaults to one
             derived from the repo directory's own name. ``--set name=`` wins
             over both.
+        seed_dirs: Write-once directories to copy out of the bundle, mapping a
+            profile-root directory name to the bundle-relative tree it comes
+            from (e.g. ``{"mcp_servers": "mcp_servers"}``). Each is copied only
+            when the bundle ships it and the target does not already have it, so
+            the copy happens on a repo's first init and never again — which is
+            why these are NOT in :data:`MATERIALIZED_SOURCE_ENTRIES`: a later
+            ``--force`` re-materialization must not delete servers an operator
+            has since written.
 
     Returns:
         What was written, for the caller's summary (:class:`_MaterializedProfile`).
@@ -1135,6 +1161,10 @@ def _materialize_profile_directory(
     # settled by the caller, which also owns what to clear if this fails.
     target.mkdir(parents=True, exist_ok=True)
 
+    # Bound before the try so both failure arms can hand it to `_cleanup`: the
+    # seeds this run created are the only ones it is allowed to remove.
+    seeded: list[str] = []
+
     try:
         # Verbatim copy (D1/FR2): staging subdirectories and any stray `.j2`
         # come across byte-identical — a profile data tree is content, never
@@ -1212,6 +1242,27 @@ def _materialize_profile_directory(
                 "  Persona deltas: %s",
                 ", ".join(f"{_PERSONA_PROFILE_DIRNAME}/{name}.yml" for name in persona_texts),
             )
+        # Write-once seeds, outside the web-tier branch because they
+        # are not a web-tier fact: a directory the deployment OWNS from its first
+        # init — an operator's MCP servers, say — copied out of the bundle once
+        # and never replaced. An existing one is left exactly as the operator
+        # left it, and nothing is written when the bundle ships no such tree, so
+        # a bundle gaining or losing one changes only what a fresh init seeds.
+        # `__pycache__` and its byte-code are dropped so the seed from a source
+        # checkout is byte-identical to the seed from a wheel.
+        for name, src_rel in (seed_dirs or {}).items():
+            src = Path(manager.template_root) / "apps" / resolved.data_bundle / src_rel
+            if src.is_dir() and not (target / name).exists():
+                # Recorded BEFORE the copy starts, so a copy that dies half-way
+                # still leaves `_cleanup` a name to remove.
+                seeded.append(name)
+                shutil.copytree(
+                    src,
+                    target / name,
+                    ignore=shutil.ignore_patterns("__pycache__", "*.py[co]"),
+                )
+        if seeded:
+            logger.debug("  Seeded: %s", ", ".join(f"{name}/" for name in seeded))
 
         # The round-trip runs last because it validates `data:` against the tree
         # that must already be on disk. Only the host profile is resolved: a
@@ -1232,11 +1283,11 @@ def _materialize_profile_directory(
             if (overrides or set_pairs)
             else "The materialized profile does not validate"
         )
-        raise click.UsageError(f"{blame}: {e}\n{_cleanup(target)}") from e
+        raise click.UsageError(f"{blame}: {e}\n{_cleanup(target, seeded=tuple(seeded))}") from e
     except Exception:
         # Any other failure (a copy error, a full disk) must not leave a
         # half-materialized directory that looks buildable.
-        _cleanup(target)
+        _cleanup(target, seeded=tuple(seeded))
         raise
 
     logger.debug("Wrote profile directory: %s", target)
@@ -1247,4 +1298,5 @@ def _materialize_profile_directory(
         written.deploy is not None,
         written,
         persona_deltas,
+        tuple(seeded),
     )

--- a/src/osprey/interfaces/web_terminal/static/js/activity-format.js
+++ b/src/osprey/interfaces/web_terminal/static/js/activity-format.js
@@ -13,6 +13,14 @@
 /** @typedef {import('./panel-manager.js').AgentActivityEvent} AgentActivityFrame */
 
 /**
+ * The `type` discriminator an agent_activity SSE frame carries. Spelled once
+ * here so the session page's forwarder, panel-sse's dispatcher and the panel
+ * frames it synthesizes cannot drift apart on a rename; the AgentActivityEvent
+ * typedef in panel-manager.js derives its literal from this constant too.
+ */
+export const AGENT_ACTIVITY_FRAME = 'agent_activity';
+
+/**
  * The tool name the panel routes mirror an agent arrange under. Its subject is
  * the workspace itself rather than a single panel, so it is worded apart from
  * the PANEL_VERBS table — and the strip keys its burst coalescing on it.

--- a/src/osprey/interfaces/web_terminal/static/js/panel-agent-attention.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-agent-attention.js
@@ -19,6 +19,7 @@
 
 import { fetchJSON } from './api.js';
 import { getEntry, setEntryAttention } from './panel-rail.js';
+import { glowPanel } from './dock-iframe.js';
 import { flashElement } from '/design-system/js/highlight.js';
 
 /** @type {HTMLElement} */
@@ -38,6 +39,16 @@ export function initAgentAttention(el) { railEl = el; }
  * @param {string} panelId
  */
 export function flashAgentGlow(panelId) { const entry = getEntry(railEl, panelId); if (entry) flashElement(entry); }
+
+/**
+ * Attribute a tile the agent visibly changed on BOTH surfaces at once: the
+ * rail entry flashes (flashAgentGlow) and the tile body glows (glowPanel).
+ * The single owner of that pair — the agent switch and arrange paths. Paths
+ * that touch only the rail (a show, a hide, a register: no tile exists to
+ * attribute to) call flashAgentGlow alone, on purpose.
+ * @param {string} panelId
+ */
+export function flashAgentTile(panelId) { flashAgentGlow(panelId); glowPanel(panelId); }
 
 /** Newest badge-causing server ts seen this page lifetime, per panel.
  *  @type {Map<string, number>} */

--- a/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-manager.js
@@ -41,7 +41,7 @@ import { applyConfigTabGate } from './config-tab.js';
 import { applyScaffoldWriteGate } from './scaffold/write-gate.js';
 import {
   initDockIframeAdapter, focusPanel, hidePanel, concealPanel,
-  setKnownServicePanels, setServerVisiblePanels, glowPanel,
+  setKnownServicePanels, setServerVisiblePanels,
 } from './dock-iframe.js';
 import { initPanelPlacement, dropPanelAt } from './panel-placement.js';
 import { createPanelIframe } from './panel-iframe-factory.js';
@@ -59,7 +59,7 @@ import {
   initPanelLifecycle, freshPanelState, renderRail, ensureRailMembership,
   initPanel, assumeHealthy, startHealthPolling,
 } from './panel-lifecycle.js';
-import { initAgentAttention, flashAgentGlow, clearBadge } from './panel-agent-attention.js';
+import { initAgentAttention, flashAgentTile, clearBadge } from './panel-agent-attention.js';
 import { subscribePanelEvents } from './panel-sse.js';
 
 // ---- Types ----
@@ -115,7 +115,7 @@ import { subscribePanelEvents } from './panel-sse.js';
  * @property {'agent'} [source]
  *
  * @typedef {object} AgentActivityEvent
- * @property {'agent_activity'} type
+ * @property {typeof import('./activity-format.js').AGENT_ACTIVITY_FRAME} type
  * @property {string} tool
  * @property {{ kind: 'panel' | 'channel' | 'run' | 'artifact' | 'config' | 'ui',
  *   panel?: string, detail?: string }} target
@@ -285,11 +285,11 @@ export async function initPanelManager(panelId) {
     getActive: getActiveTabId,
     clearActive: clearActivePanel,
     renderEmpty: renderEmptyState,
-    // An arranged tile is attributed on both surfaces: its rail entry flashes,
-    // and the tile body itself glows. Only the arrange path passes through
-    // here, which is the one placement verb an agent drives — the rail ⊞ and
-    // drag-and-drop are human gestures and never glow.
-    glow: (id) => { flashAgentGlow(id); glowPanel(id); },
+    // An arranged tile is attributed on both surfaces (rail entry flash + tile
+    // body glow, one gesture: flashAgentTile). Only the arrange path passes
+    // through here, which is the one placement verb an agent drives — the
+    // rail ⊞ and drag-and-drop are human gestures and never glow.
+    glow: flashAgentTile,
     openTerminal: openTerminalPanel,
   });
 

--- a/src/osprey/interfaces/web_terminal/static/js/panel-sse.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-sse.js
@@ -23,9 +23,12 @@
  */
 
 import { fetchJSON, createEventSource } from './api.js';
-import { hidePanel, glowPanel } from './dock-iframe.js';
+import { hidePanel } from './dock-iframe.js';
 import { withEchoSuppressed } from './dock-sync.js';
-import { flashAgentGlow, badgePanelActivity, restoreAgentBadges } from './panel-agent-attention.js';
+import {
+  flashAgentGlow, flashAgentTile, badgePanelActivity, restoreAgentBadges,
+} from './panel-agent-attention.js';
+import { AGENT_ACTIVITY_FRAME } from './activity-format.js';
 import { PANELS } from './panel-catalog.js';
 import { ensureRailMembership, addPanel } from './panel-lifecycle.js';
 import { applyAgentSwitch, applyArrange } from './panel-placement.js';
@@ -147,13 +150,12 @@ export function subscribePanelEvents(sseDeps) {
           // Human focus is never broadcast (the server mirrors it silently and
           // the gesturing client applies it locally), so an unattributed frame
           // can only come from an out-of-contract caller; it keeps the plain
-          // activation. The glow runs after the switch so a just-added entry
-          // can flash, and the tile glow after the placement so it measures the
-          // tile the switch actually surfaced.
+          // activation. The attribution runs after the switch so a just-added
+          // entry can flash and the tile glow measures the tile the switch
+          // actually surfaced.
           if (data.source === 'agent') {
             applyAgentSwitch(data.panel);
-            flashAgentGlow(data.panel);
-            glowPanel(data.panel);
+            flashAgentTile(data.panel);
           } else {
             c.activate(data.panel);
           }
@@ -182,7 +184,7 @@ export function subscribePanelEvents(sseDeps) {
           // the user activates when they want it.
           if (data.source === 'agent') flashAgentGlow(data.id);
 
-        } else if (data.type === 'agent_activity' && data.target) {
+        } else if (data.type === AGENT_ACTIVITY_FRAME && data.target) {
           // kind 'panel' with a live rail entry → persistent badge + glow via
           // badgePanelActivity; everything the rail cannot anchor falls through
           // to the activity-strip seam (no-op until a handler registers).
@@ -234,7 +236,7 @@ function applyPanelVisibility(panel, visible, source) {
   // agent_activity branch's rail-anchor routing, so the two halves of the
   // agent's rail vocabulary read the same way on the strip.
   if (visible && source === 'agent') flashAgentGlow(panel);
-  if (source === 'agent') c.reportActivity({ type: 'agent_activity', ts: Date.now(),
+  if (source === 'agent') c.reportActivity({ type: AGENT_ACTIVITY_FRAME, ts: Date.now(),
     tool: visible ? 'add_panel_to_rail' : 'remove_panel_from_rail',
     target: { kind: 'panel', panel } });
 
@@ -289,7 +291,7 @@ function applyPanelClose(panel, source) {
   // is an entry left to glow — the operator can see which panel just went away.
   if (source === 'agent') {
     flashAgentGlow(panel);
-    ctx().reportActivity({ type: 'agent_activity', ts: Date.now(),
+    ctx().reportActivity({ type: AGENT_ACTIVITY_FRAME, ts: Date.now(),
       tool: 'close_panel', target: { kind: 'panel', panel } });
   }
 }

--- a/src/osprey/interfaces/web_terminal/static/js/session.js
+++ b/src/osprey/interfaces/web_terminal/static/js/session.js
@@ -16,6 +16,7 @@ import '/design-system/js/components/osprey-theme-switcher.js';
 import { renderAgents, renderToolLog, renderArtifacts, renderConversation } from './session-views.js';
 import { withPrefix, createEventSource } from './api.js';
 import { bootActivityStrip } from './activity-strip.js';
+import { AGENT_ACTIVITY_FRAME } from './activity-format.js';
 
 /** @typedef {'agents'|'toollog'|'artifacts'|'conversation'} ViewName */
 /** @typedef {import('./panel-manager.js').AgentActivityEvent} AgentActivityEvent */
@@ -170,7 +171,7 @@ export function wireActivityStrip(strip, eventSourceFactory = createEventSource)
   return eventSourceFactory('/api/files/events', {
     onMessage: (data) => {
       if (!data || typeof data !== 'object') return;
-      if (data.type !== 'agent_activity' || !data.target) return;
+      if (data.type !== AGENT_ACTIVITY_FRAME || !data.target) return;
       strip.handleActivity(data);
     },
   });

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -83,6 +83,35 @@ output_styles:
 
 web_panels: []   # Extra tabs in the web workspace, beside the terminal
 
+# Your own MCP servers, injected into the build's .mcp.json next to the
+# framework ones. An entry is either stdio (command/args/env) or remote (url,
+# or just port to derive http://localhost:<port>/mcp). transport defaults to
+# "http"; "sse" is the legacy event-stream wire and needs an explicit url.
+mcp_servers:
+  # A Python server's package lives at mcp_servers/<package>/ beside this file;
+  # the build copies it to build/_mcp_servers/<package>/ for `-m <package>`.
+  example_server:
+    command: "{current_python_env}"
+    args: [-m, example_server]
+    env:
+      OSPREY_CONFIG: "{project_root}/build/config.yml"
+      PYTHONPATH: "{project_root}/build/_mcp_servers"
+    # Tool names under permissions are bare — `allow` runs them unprompted, `ask`
+    # prompts the operator on every call.
+    permissions:
+      allow: [example_status]
+  # Delete this block and mcp_servers/example_server/ together: one without
+  # the other costs every session a 20 s wait for a server that cannot start.
+  # Editing either is a source change, not a build tweak: rebuild afterwards,
+  # since the directory enters the image context and the drift fingerprint.
+  #
+  #   lattice:
+  #     url: http://lattice.example.org:8400/mcp
+  #     port: 8400
+  #     transport: http
+  #     permissions:
+  #       allow: [get_twiss]
+
 # ── Everything else ──────────────────────────────────────────────────────────
 # One dotted `key.path` per line. Never write a nested block here: it would
 # replace the whole subtree and silently drop the keys beside it.

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -1307,7 +1307,7 @@ def _server_to_dict(sdef: ServerDefinition, ctx: dict) -> dict:
         command = ""
         args = []
     elif sdef.is_external:
-        command = sdef.external_command or ""
+        command = _resolve_placeholder(sdef.external_command or "", ctx)
         args = [_resolve_placeholder(a, ctx) for a in sdef.external_args]
     else:
         command = ctx.get("current_python_env", "python")

--- a/src/osprey/templates/apps/hello_world/mcp_servers/example_server/__init__.py
+++ b/src/osprey/templates/apps/hello_world/mcp_servers/example_server/__init__.py
@@ -1,0 +1,13 @@
+"""The hello-world preset's worked example of a facility MCP server.
+
+This package is seeded into a deployment repository's ``mcp_servers/`` directory
+the first time ``osprey init`` runs with the hello-world preset. From there
+``osprey build`` copies it to ``build/_mcp_servers/example_server/``, and the
+profile's ``mcp_servers:`` entry launches it as ``python -m example_server`` with
+``build/_mcp_servers`` on ``PYTHONPATH``.
+
+It depends on nothing but ``fastmcp`` — deliberately, so that it runs standalone
+and stays readable as a starting point. Copy the directory, rename it, and
+replace :func:`example_server.server.example_status` with tools that talk to your
+own facility.
+"""

--- a/src/osprey/templates/apps/hello_world/mcp_servers/example_server/__main__.py
+++ b/src/osprey/templates/apps/hello_world/mcp_servers/example_server/__main__.py
@@ -1,0 +1,8 @@
+"""Stdio entry point: ``python -m example_server``."""
+
+from __future__ import annotations
+
+from .server import mcp
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/osprey/templates/apps/hello_world/mcp_servers/example_server/server.py
+++ b/src/osprey/templates/apps/hello_world/mcp_servers/example_server/server.py
@@ -1,0 +1,48 @@
+"""FastMCP server ``example_server`` — the hello-world preset's worked example.
+
+Defines the server object and its single read-only tool, ``example_status``.
+Launched over stdio by ``python -m example_server`` (see ``__main__``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+
+from fastmcp import FastMCP
+
+mcp = FastMCP(
+    "example_server",
+    instructions=(
+        "Worked example of a facility MCP server, shipped with the hello-world "
+        "preset. example_status reports that the server is alive and which "
+        "Python interpreter is running it. It is read-only and has no other "
+        "tools; a real facility server replaces it."
+    ),
+)
+
+
+@mcp.tool()
+async def example_status() -> str:
+    """Report that the example MCP server is alive and which Python runs it.
+
+    This is the worked example that ships with the hello-world preset, so its
+    job is to prove the wiring rather than to do facility work: a successful
+    call means the profile's ``mcp_servers:`` entry launched this process and
+    the two of you are speaking MCP. It is read-only and has no side effects,
+    so call it freely whenever you want to confirm the server is reachable.
+
+    Returns:
+        A JSON object with ``server`` (the server name, always
+        ``example_server``), ``utc`` (the current time as an ISO-8601 UTC
+        timestamp), and ``python`` (the path of the interpreter running this
+        server, useful when diagnosing which environment was launched).
+    """
+    return json.dumps(
+        {
+            "server": "example_server",
+            "utc": datetime.now(UTC).isoformat(),
+            "python": sys.executable,
+        }
+    )

--- a/tests/cli/test_emit_partition.py
+++ b/tests/cli/test_emit_partition.py
@@ -213,10 +213,18 @@ def test_hello_world_extension_surface_is_pinned() -> None:
     dropped, would quietly delete a lesson. Pin the set exactly, by name, so
     both a shrink and an unexpected growth fail here and get looked at.
 
-    The count is 13, not 14: a *bare* emission templates 14, but `osprey init`
+    The count is 12, not 13: a *bare* emission templates 13, but `osprey init`
     injects `data=data` into `set_pairs` (``profile_cmd``), which makes `data`
     an active key. What ships to the reader is the materialized profile, so
-    that is what is pinned — do not "correct" this to the bare-emission 14.
+    that is what is pinned — do not "correct" this to the bare-emission 13.
+
+    `mcp_servers` left this set deliberately, and no lesson left with it: the
+    preset now carries a live `example_server` entry for the package seeded
+    into the repo, so the key emits active instead of templated. The stdio
+    teaching moved into that block's comments in the appendix's own words,
+    and a commented `lattice:` sibling still shows the remote form, so the
+    reader sees both without uncommenting anything. That copy is guarded
+    against drift by ``tests/cli/test_example_server_launch.py``.
     """
     _, templated = _active_and_commented(_emit("hello-world", set_pairs=("data=data",)))
 
@@ -225,7 +233,6 @@ def test_hello_world_extension_surface_is_pinned() -> None:
         "tier",
         "default_panel",
         "deploy",
-        "mcp_servers",
         "artifact_server",
         "dispatch",
         "bluesky",

--- a/tests/cli/test_example_server_launch.py
+++ b/tests/cli/test_example_server_launch.py
@@ -1,0 +1,195 @@
+"""Packaging checks for the hello-world preset's seeded example MCP server.
+
+Four checks live here. The git-visibility one asserts the three packaged files
+are not swallowed by any ignore rule, or the seed would silently fail to reach
+a deployment repository. The drift guard asserts that the preset's live
+``mcp_servers:`` block still teaches what the emitter's commented appendix
+teaches: hello-world is the one preset whose block is active, so its readers
+never see that appendix, and its comments are the only copy of that lesson they
+get. The launch tests -- named to contain "spawns" -- materialize and build a
+fresh hello-world repo, then actually spawn the rendered ``example_server``
+entry over stdio and confirm ``tools/list`` advertises ``example_status`` and
+that the build wires the ``mcp__example_server__.*`` guidance hook: the only
+way to know the seeded server is not just present on disk but actually
+launchable through the entry OSPREY itself renders.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.build_cmd import build
+from osprey.cli.build_profile_emit import _MCP_SERVERS_APPENDIX
+from osprey.cli.init_cmd import init
+from tests.integration._mcp_handshake import list_mcp_tools
+
+PACKAGE_DIR = Path("src/osprey/templates/apps/hello_world/mcp_servers/example_server")
+PACKAGED_FILES = ("__init__.py", "server.py", "__main__.py")
+
+# The only comment lines the hello-world block may carry that the appendix does
+# not: two facts that are true of the seeded example and of nothing else. Both
+# are pinned in both directions below -- an appendix line may not impersonate
+# one, and dropping one from the preset fails here rather than quietly costing
+# a reader the warning.
+_HELLO_WORLD_ONLY_COMMENTS: tuple[str, ...] = (
+    "# Delete this block and mcp_servers/example_server/ together: one without",
+    "# the other costs every session a 20 s wait for a server that cannot start.",
+    "# Editing either is a source change, not a build tweak: rebuild afterwards,",
+    "# since the directory enters the image context and the drift fingerprint.",
+)
+
+
+def _repo_root() -> Path:
+    """Return the git checkout root, skipping the test when there is none."""
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        pytest.skip("not a git checkout")
+    return Path(completed.stdout.strip())
+
+
+def test_packaged_seed_is_not_git_ignored() -> None:
+    """Every file of the seeded example server is visible to git."""
+    root = _repo_root()
+    for filename in PACKAGED_FILES:
+        path = root / PACKAGE_DIR / filename
+        assert path.is_file(), f"packaged seed file is missing: {path}"
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", str(path)],
+            cwd=root,
+            check=False,
+        )
+        assert result.returncode == 1, (
+            f"{path} is git-ignored (git check-ignore exit {result.returncode}); "
+            "the seeded example server would never reach a deployment repo"
+        )
+
+
+def _hello_world_preset_text() -> str:
+    """Read the packaged hello-world preset, the file the emitter copies from."""
+    presets = importlib.resources.files("osprey.profiles.presets")
+    return presets.joinpath("hello-world.yml").read_text(encoding="utf-8")
+
+
+def _mcp_servers_comment_lines() -> list[str]:
+    """Return the stripped comment lines inside the preset's mcp_servers block.
+
+    The block runs from the top-level ``mcp_servers:`` key to the next line
+    that starts in column 0 -- the next key or section divider. Comments above
+    the key introduce the section rather than living in it, so they are out of
+    scope; everything indented under it is the block.
+    """
+    lines = _hello_world_preset_text().splitlines()
+    starts = [i for i, line in enumerate(lines) if line.startswith("mcp_servers:")]
+    assert len(starts) == 1, "hello-world must carry exactly one live mcp_servers block"
+
+    comments: list[str] = []
+    for line in lines[starts[0] + 1 :]:
+        if line and not line[0].isspace():
+            break
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            comments.append(stripped)
+    return comments
+
+
+def test_block_comments_are_appendix_lines_or_pinned_extras() -> None:
+    """Nothing in the block is invented prose.
+
+    Every other preset gets the ``mcp_servers`` lesson from the emitter's
+    commented appendix. hello-world spends that slot on a working entry, so the
+    lesson has to be re-taught inside the block -- and re-teaching it in fresh
+    words is how the two drift apart, one gaining a caveat the other never
+    hears about. Requiring each line to be an appendix line verbatim makes the
+    appendix the single source, and makes an appendix edit fail here until the
+    preset is brought along.
+    """
+    appendix = {line.strip() for line in _MCP_SERVERS_APPENDIX.splitlines()}
+    allowed = appendix | set(_HELLO_WORLD_ONLY_COMMENTS)
+
+    unknown = [line for line in _mcp_servers_comment_lines() if line not in allowed]
+    assert not unknown, (
+        "hello-world's mcp_servers block carries comment lines that are neither a "
+        f"line of _MCP_SERVERS_APPENDIX nor a pinned hello-world-only fact: {unknown}"
+    )
+
+
+def test_hello_world_only_comments_are_all_present() -> None:
+    """The two hello-world-only facts stay in the block.
+
+    They are the half of the block the appendix cannot supply: the seeded
+    package and the profile entry are a pair, and editing either is a source
+    change. Losing them costs a reader a 20 s startup wait or a stale build
+    with no error to explain it, which is exactly the kind of loss a comment
+    edit makes silently.
+    """
+    present = set(_mcp_servers_comment_lines())
+
+    missing = [line for line in _HELLO_WORLD_ONLY_COMMENTS if line not in present]
+    assert not missing, (
+        f"hello-world's mcp_servers block no longer carries these pinned lines: {missing}"
+    )
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_rendered_entry_spawns_the_seeded_server(runner: CliRunner, tmp_path: Path) -> None:
+    """The rendered ``example_server`` entry is not just present -- it launches.
+
+    Every other test in this module reasons about text: files on disk, comment
+    lines in a preset. This one is the proof that the text is true -- that
+    ``osprey init`` then ``osprey build`` produce an ``.mcp.json`` entry a real
+    client can spawn over stdio, that it answers the MCP handshake, and that
+    the build wires the ``mcp__example_server__.*`` guidance hook the registry
+    attaches whenever a server declares ``permissions``. A drift in the seeded
+    package, the emitted command, or the ``PYTHONPATH`` would leave every
+    other check in this module green while every session that reaches this
+    server waits 20 s for a launch that was never going to succeed.
+    """
+    target = tmp_path / "my-facility"
+    init_result = runner.invoke(init, [str(target), "--preset", "hello-world", "--no-git"])
+    assert init_result.exit_code == 0, init_result.output
+
+    build_result = runner.invoke(build, ["--repo", str(target), "--skip-deps", "--skip-lifecycle"])
+    assert build_result.exit_code == 0, build_result.output
+
+    server_py = target / "build" / "_mcp_servers" / "example_server" / "server.py"
+    assert server_py.is_file(), f"build did not copy the seeded server to {server_py}"
+
+    mcp_json = target / "build" / ".mcp.json"
+    servers = json.loads(mcp_json.read_text(encoding="utf-8"))["mcpServers"]
+    entry = servers["example_server"]
+
+    command = Path(entry["command"])
+    assert command.is_absolute(), f"rendered command is not absolute: {entry['command']}"
+
+    pythonpath = Path(entry["env"]["PYTHONPATH"])
+    assert pythonpath.is_dir(), f"rendered PYTHONPATH does not exist: {pythonpath}"
+
+    tools = list_mcp_tools(entry["command"], list(entry["args"]), entry.get("env"), timeout=30.0)
+    assert "example_status" in tools, (
+        f"example_server did not advertise example_status; advertised: {tools}"
+    )
+
+    settings_json = target / "build" / ".claude" / "settings.json"
+    settings = json.loads(settings_json.read_text(encoding="utf-8"))
+    post_rules = settings["hooks"]["PostToolUse"]
+    matchers = [rule["matcher"] for rule in post_rules]
+    assert "mcp__example_server__.*" in matchers, (
+        "build did not wire the example_server guidance hook into PostToolUse; "
+        f"matchers present: {matchers}"
+    )

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -36,10 +36,13 @@ from click.testing import CliRunner
 from rich.console import Console
 
 from osprey.cli.init_cmd import (
+    _PRESERVED_PROSE,
     CI_EMITTED_PATHS,
     PRESERVED_BY_FORCE,
     REPO_VERIFY_PATH,
+    WRITE_ONCE_DIRS,
     WRITE_ONCE_FILES,
+    _source_zone_prose,
     init,
 )
 from osprey.cli.main import cli
@@ -535,10 +538,18 @@ def _seed_survivor(repo: Path, entry: str) -> Path:
     agent's memory surviving, not the empty directory being re-created. ``.git``
     is a directory too, and its own contents are git's, so it gets the same
     treatment rather than being special-cased into a weaker assertion.
+
+    A seeded directory (:data:`~osprey.cli.init_cmd.WRITE_ONCE_DIRS`) is a
+    profile convention directory, holding one directory per server, so its
+    sentinel goes a level deeper: a bare file directly inside it is not merely
+    an unrealistic survivor but an invalid repo, and the re-materialization
+    under test would refuse it before it ever got to preserving anything.
     """
     relative = f"{entry.rstrip('/')}/sentinel.txt" if entry.endswith("/") else entry
     if entry == ".git":
         relative = ".git/sentinel.txt"
+    if entry.rstrip("/") in WRITE_ONCE_DIRS:
+        relative = f"{entry.rstrip('/')}/sentinel/sentinel.txt"
     survivor = repo / relative
     survivor.parent.mkdir(parents=True, exist_ok=True)
     survivor.write_text(SENTINEL, encoding="utf-8")
@@ -567,7 +578,7 @@ def test_every_file_a_rendered_repo_ships_is_in_a_named_category(
         run_init(runner, str(target), "--preset", "hello-world", "-O", str(override)).exit_code == 0
     )
 
-    top_level = {*MATERIALIZED_SOURCE_ENTRIES, *WRITE_ONCE_FILES, ".env"}
+    top_level = {*MATERIALIZED_SOURCE_ENTRIES, *WRITE_ONCE_FILES, *WRITE_ONCE_DIRS, ".env"}
     uncategorised = []
     for path in sorted(target.rglob("*")):
         if not path.is_file():
@@ -637,6 +648,50 @@ def test_force_replaces_the_source_zone_and_nothing_else(
     # by the command having done nothing at all.
     assert not (exemplar_repo / "data" / "stale.json").exists()
     assert replaced_marker not in (exemplar_repo / "profile.yml").read_text(encoding="utf-8")
+
+
+def test_the_preserve_promise_an_operator_reads_names_the_seeded_directory(
+    runner: CliRunner,
+) -> None:
+    """`mcp_servers/` is only write-once if every promise about it says so.
+
+    The survival test above proves the behaviour; this proves the operator is
+    told. Both derive from :data:`~osprey.cli.init_cmd.PRESERVED_BY_FORCE`, so
+    the point being pinned is that the seeded directory really did reach it and
+    therefore reaches the two help strings and the already-a-repo refusal —
+    which is the whole reason it is splatted in rather than listed by hand.
+    """
+    assert "mcp_servers/" in _PRESERVED_PROSE
+
+    option_help = {
+        param.name: param.help for param in init.params if isinstance(param, click.Option)
+    }
+    assert "mcp_servers/" in option_help["force"]
+    assert "mcp_servers/" in option_help["reset"]
+
+    # …and survives Click's own rendering, where the prose is rewrapped to the
+    # terminal: an operator who runs `--help` is told, not just a param object.
+    rendered = runner.invoke(init, ["--help"])
+    assert rendered.exit_code == 0, rendered.output
+    assert "mcp_servers/" in rendered.output
+
+
+def test_the_zone_row_names_a_seeded_directory_only_when_one_was_seeded() -> None:
+    """The README's SOURCE row describes THIS repo, not the seeding table.
+
+    A repo that received ``mcp_servers/`` names it, between the materialized
+    entries it follows on disk and the repo shell that follows it. One that
+    received nothing — every app template that ships no server package — must
+    read exactly as it did before the category existed, or the README sends an
+    operator looking for a directory that was never written.
+    """
+    from osprey.cli.profile_cmd import MATERIALIZED_SOURCE_ENTRIES
+
+    entries = [item.strip("`") for item in _source_zone_prose(("mcp_servers",)).split(", ")]
+
+    assert entries.index("mcp_servers/") == len(MATERIALIZED_SOURCE_ENTRIES)
+    assert entries.index("mcp_servers/") < entries.index(next(iter(WRITE_ONCE_FILES)))
+    assert "mcp_servers" not in _source_zone_prose()
 
 
 def test_force_never_regenerates_a_hand_written_pipeline(runner: CliRunner, tmp_path: Path) -> None:

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -164,6 +164,34 @@ def test_authored_files_match_the_exemplar_byte_for_byte(exemplar_repo: Path, na
     )
 
 
+#: The questions the README's last section answers, one heading each.
+COMMON_QUESTION_HEADINGS = (
+    "### Adding an MCP server of your own",
+    "### Adding a panel of your own",
+    "### Mounting an extra directory into a web terminal",
+)
+
+#: Placeholder syntax the answers QUOTE rather than fill in. Every one of these
+#: is a literal brace inside the README's own f-string, and the f-string is the
+#: reason they are worth an assertion: an undoubled brace is not a typo that
+#: renders oddly, it is a ``KeyError`` on the operator's first ``init``.
+QUOTED_PLACEHOLDERS = ("{label", "{current_python_env}", "{project_root}")
+
+
+def test_the_readme_answers_the_common_questions(exemplar_repo: Path) -> None:
+    """The three things an operator goes looking for after their first build.
+
+    Asserted on the emitted file rather than on the builder's source, because
+    what is under test is what the operator reads: the section survives the
+    f-string, braces and all.
+    """
+    readme = exemplar_repo.joinpath("README.md").read_text(encoding="utf-8")
+
+    assert "## Common questions" in readme
+    assert [heading for heading in COMMON_QUESTION_HEADINGS if heading not in readme] == []
+    assert [literal for literal in QUOTED_PLACEHOLDERS if literal not in readme] == []
+
+
 def test_every_source_path_the_exemplar_names_is_emitted(exemplar_repo: Path) -> None:
     """Shape, not bytes: the exemplar's data tree pins paths, not the whole bundle."""
     missing = sorted(

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -488,9 +488,14 @@ def init_stubs(monkeypatch, seen):
     from osprey.cli import build_cmd, deploy_cmd, init_cmd, profile_cmd
     from osprey.deployment import container_lifecycle
 
+    class _Resolved:
+        mcp_servers: dict = {}
+
     class _Materialized:
         profile_name = "probe"
         deploy_declared = False
+        seeded = ()
+        resolved = _Resolved()
 
     def materialize(target, *args, **kwargs):
         Path(target).mkdir(parents=True, exist_ok=True)

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -212,7 +212,10 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # The comment-only fixes that shipped alongside it (correcting the
     # mislabelled memory-guard/writes-check comments in the other presets)
     # contributed nothing to any digest, including this one.
-    "hello-world": "sha256:b737b03979d25bec8de1aa4d382fa07ebc64971a093b59e8b0be21f1197ef395",
+    # Moved again when the preset gained a live `mcp_servers.example_server`
+    # block, so a rebuilt project launches the seeded example MCP server and
+    # its `example_status` tool appears in the session.
+    "hello-world": "sha256:fdd41e470ce46d49f206640e558eaab9e909ce034b6bcc456ff50e3edb1e0436",
 }
 
 

--- a/tests/cli/test_profile_annotations.py
+++ b/tests/cli/test_profile_annotations.py
@@ -1,0 +1,396 @@
+"""Annotated profile keys — the two keys an emitted profile has to teach.
+
+``web_panels`` and ``env`` are the keys whose shape a facility cannot guess
+from the empty default the emitter writes, so they carry a worked example
+instead of the one-line synthesis rationale every other explicit key gets.
+These tests pin what that buys: the example is valid YAML, it is entirely
+commented (so it never changes what the profile resolves to), it lands
+immediately above its key in every bundled preset, and it displaces the
+rationale line rather than sitting next to it.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from osprey.cli.build_cmd import build
+from osprey.cli.build_profile import BuildProfile, list_presets, resolve_build_profile
+from osprey.cli.build_profile_emit import (
+    _ANNOTATIONS,
+    _EXPLICIT_KEYS,
+    _FIELD_TO_YAML,
+    _SYNTHESIS_RATIONALE,
+    emit_standalone_profile_yaml,
+)
+from osprey.cli.init_cmd import init
+
+# The lines the edited-text gates below apply: the block-style snippet
+# inside each annotation, which is the part a facility copies and edits. Keyed
+# by the annotated field so the guard below can prove the set has not drifted
+# from _ANNOTATIONS, and each fragment is proved to be a real run of lines out
+# of its annotation rather than a hand-copied paraphrase.
+_ANNOTATION_FRAGMENTS: dict[str, tuple[str, ...]] = {
+    "web_panels": (
+        "#   web_panels:",
+        "#     - elog",
+    ),
+    "env": (
+        "#   env:",
+        "#     required: [EPICS_CA_ADDR_LIST]",
+        "#     pinned: [ARIEL_DB_PASSWORD]",
+        "#     defaults:",
+        "#       EPICS_CA_ADDR_LIST: 127.0.0.1",
+        "#     file: env/facility.env",
+    ),
+}
+
+
+def _emit(preset: str) -> str:
+    return emit_standalone_profile_yaml(preset, (), (), "Emitted")
+
+
+def _uncomment(line: str) -> str:
+    """Drop the leading ``#`` and the single space that follows it, if any."""
+    body = line[1:]
+    return body[1:] if body.startswith(" ") else body
+
+
+def _snippet(lines: tuple[str, ...]) -> str:
+    """The block-style YAML example inside an annotation, dedented.
+
+    The example is the annotation's indented run: prose sits at column 0 once
+    the comment marker is off, the example is indented under it.
+    """
+    body = [_uncomment(line) for line in lines]
+    indented = [index for index, line in enumerate(body) if line.startswith(" ")]
+    assert indented, "annotation carries no block-style example"
+    assert indented == list(range(indented[0], indented[-1] + 1)), (
+        "the block-style example must be one contiguous run of lines"
+    )
+    return textwrap.dedent("\n".join(body[indented[0] : indented[-1] + 1]) + "\n")
+
+
+def _yaml_key(field: str) -> str:
+    return _FIELD_TO_YAML.get(field, field)
+
+
+# ---------------------------------------------------------------------------
+# (a) the table itself
+# ---------------------------------------------------------------------------
+
+
+def test_annotated_fields_are_explicit_members() -> None:
+    """Only a key that is always written can be annotated above itself."""
+    assert set(_ANNOTATIONS) <= _EXPLICIT_KEYS
+
+
+@pytest.mark.parametrize("field", sorted(_ANNOTATIONS))
+def test_every_annotation_line_is_a_comment(field: str) -> None:
+    """No line may open a bare YAML key — an annotation must not change the doc."""
+    for line in _ANNOTATIONS[field]:
+        assert line.startswith("#"), f"{field}: {line!r} is not commented"
+
+
+@pytest.mark.parametrize("field", sorted(_ANNOTATIONS))
+def test_annotation_example_is_valid_yaml(field: str) -> None:
+    """What we tell a facility to uncomment has to parse once uncommented."""
+    loaded = yaml.safe_load(_snippet(_ANNOTATIONS[field]))
+    assert isinstance(loaded, dict) and loaded, f"{field}: example is not a mapping"
+
+
+def test_web_panels_names_the_dotted_url_key() -> None:
+    """A custom panel is only real once ``web.panels.<id>.url`` is set."""
+    text = "\n".join(_ANNOTATIONS["web_panels"])
+    for leaf in ("url", "label", "path", "health_endpoint"):
+        assert f"web.panels.elog.{leaf}" in text
+
+
+def test_env_names_every_env_config_member() -> None:
+    """All four EnvConfig members, so none of them is discovered by accident."""
+    example = yaml.safe_load(_snippet(_ANNOTATIONS["env"]))["env"]
+    assert set(example) == {"required", "pinned", "defaults", "file"}
+
+
+# ---------------------------------------------------------------------------
+# (b) the annotation reaches every emitted profile, above its key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("preset", list_presets())
+@pytest.mark.parametrize("field", sorted(_ANNOTATIONS))
+def test_annotation_sits_immediately_above_its_key(preset: str, field: str) -> None:
+    annotation = list(_ANNOTATIONS[field])
+    key = _yaml_key(field)
+    lines = _emit(preset).splitlines()
+
+    assert sum(1 for line in lines if line == annotation[0]) == 1, (
+        f"{preset}: the {field} annotation must appear exactly once"
+    )
+    key_lines = [index for index, line in enumerate(lines) if line.startswith(f"{key}:")]
+    assert len(key_lines) == 1, f"{preset}: expected one top-level `{key}:`"
+    index = key_lines[0]
+    assert lines[index - len(annotation) : index] == annotation, (
+        f"{preset}: the {field} annotation is not the block directly above `{key}:`"
+    )
+
+
+def test_annotation_lands_below_a_preset_authored_header() -> None:
+    """control-assistant heads its ``env:`` block; our block goes under it."""
+    lines = _emit("control-assistant").splitlines()
+    index = next(i for i, line in enumerate(lines) if line.startswith("env:"))
+    above = lines[: index - len(_ANNOTATIONS["env"])]
+    assert above[-1].startswith("#")
+    assert "Passwords for the webhook service above" in "\n".join(above[-6:])
+
+
+# ---------------------------------------------------------------------------
+# (c) an annotated key gets no rationale line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", sorted(_ANNOTATIONS))
+def test_annotated_key_displaces_its_rationale(field: str) -> None:
+    """hello-world synthesizes ``env``; the rationale line must not survive."""
+    text = _emit("hello-world")
+    rationale = _SYNTHESIS_RATIONALE.get(field)
+    assert rationale is not None, f"{field} has no rationale to displace"
+    assert f"# {rationale}" not in text
+
+
+# ---------------------------------------------------------------------------
+# (d) the edited-text fragments the gates below apply
+# ---------------------------------------------------------------------------
+
+
+def test_fragments_cover_exactly_the_annotated_fields() -> None:
+    assert set(_ANNOTATION_FRAGMENTS) == set(_ANNOTATIONS)
+
+
+@pytest.mark.parametrize("field", sorted(_ANNOTATION_FRAGMENTS))
+def test_fragment_is_a_contiguous_run_of_its_annotation(field: str) -> None:
+    annotation = list(_ANNOTATIONS[field])
+    fragment = list(_ANNOTATION_FRAGMENTS[field])
+    start = annotation.index(fragment[0])
+    assert annotation[start : start + len(fragment)] == fragment
+
+
+# ---------------------------------------------------------------------------
+# (e) the edited text resolves, and keeps what the key already resolved to
+# ---------------------------------------------------------------------------
+
+# The dotted half of the web_panels annotation. The list entry alone is not a
+# panel — the annotation's prose says so, and the resolver enforces it — so the
+# edit a facility actually makes is the snippet plus these three keys.
+_ELOG_URL = "http://127.0.0.1:8020"
+_ELOG_CONFIG_LINES = (
+    f"  web.panels.elog.url: {_ELOG_URL}",
+    "  web.panels.elog.label: ELOG",
+    "  web.panels.elog.path: /",
+)
+
+# What each edit is supposed to have added, expressed the same way
+# ``_resolved_entries`` expresses what the profile resolved to. The empty case
+# applies the annotation's own example verbatim, so what it adds is that
+# example's contents; the populated case adds the one new entry a facility
+# would append beside what the preset already set.
+_EMPTY_CASE_ADDITIONS: dict[str, set[tuple[str, ...]]] = {
+    "web_panels": {("panel", "elog")},
+    "env": {
+        ("required", "EPICS_CA_ADDR_LIST"),
+        ("pinned", "ARIEL_DB_PASSWORD"),
+        ("defaults", "EPICS_CA_ADDR_LIST", "127.0.0.1"),
+    },
+}
+_POPULATED_CASE_ADDITIONS: dict[str, set[tuple[str, ...]]] = {
+    "web_panels": {("panel", "elog")},
+    "env": {("required", "MY_TOKEN")},
+}
+
+
+def _sole_key_line(lines: list[str], key: str) -> int:
+    """Index of the one top-level ``<key>:`` line, proved to be the only one.
+
+    A YAML mapping with the key twice parses fine and silently keeps the last
+    one, so "it still loads" says nothing about an edit. Counting the key is
+    what makes the resolved-value comparison below mean anything.
+    """
+    matches = [
+        index
+        for index, line in enumerate(lines)
+        if line[:1] not in ("", " ", "#") and line.split("#", 1)[0].rstrip().startswith(f"{key}:")
+    ]
+    assert len(matches) == 1, f"expected exactly one top-level `{key}:`, found {len(matches)}"
+    return matches[0]
+
+
+def _resolve(profile_dir: Path, lines: list[str]) -> BuildProfile:
+    """Write *lines* as the profile of a bare directory and resolve them."""
+    path = profile_dir / "profile.yml"
+    path.write_text("\n".join(lines) + "\n")
+    return resolve_build_profile(path, None)[0]
+
+
+def _resolved_entries(field: str, profile: BuildProfile) -> set[tuple[str, ...]]:
+    """The annotated key's resolved content, as comparable entries."""
+    if field == "web_panels":
+        return {("panel", panel) for panel in profile.web_panels}
+    env = profile.env
+    return (
+        {("required", name) for name in env.required}
+        | {("pinned", name) for name in env.pinned}
+        | {("defaults", name, str(value)) for name, value in env.defaults.items()}
+    )
+
+
+def _edit_empty_key(field: str, lines: list[str], profile_dir: Path) -> list[str]:
+    """Uncomment the annotation's example straight over the empty key it documents."""
+    edited = list(lines)
+    index = _sole_key_line(edited, _yaml_key(field))
+    snippet = _snippet(_ANNOTATIONS[field]).splitlines()
+    edited = edited[:index] + snippet + edited[index + 1 :]
+
+    if field == "web_panels":
+        config = _sole_key_line(edited, "config")
+        edited = edited[: config + 1] + list(_ELOG_CONFIG_LINES) + edited[config + 1 :]
+    else:
+        # The example's `file:` is a profile-relative path, and the resolver
+        # refuses one that is not there. Making it exist keeps the whole
+        # example under test rather than trimming the line out of it.
+        (profile_dir / "env").mkdir(exist_ok=True)
+        (profile_dir / "env" / "facility.env").write_text("EPICS_CA_ADDR_LIST=127.0.0.1\n")
+    return edited
+
+
+def _edit_populated_key(field: str, lines: list[str]) -> list[str]:
+    """Follow the annotation's populated-case instruction: add under what is there."""
+    edited = list(lines)
+    if field == "web_panels":
+        index = _sole_key_line(edited, "web_panels")
+        edited = edited[: index + 1] + ["  - elog"] + edited[index + 1 :]
+        config = _sole_key_line(edited, "config")
+        return edited[: config + 1] + list(_ELOG_CONFIG_LINES) + edited[config + 1 :]
+
+    index = _sole_key_line(edited, "env")
+    required = next(
+        offset
+        for offset in range(index + 1, len(edited))
+        if edited[offset].split("#", 1)[0].rstrip() == "  required:"
+    )
+    return edited[: required + 1] + ["    - MY_TOKEN"] + edited[required + 1 :]
+
+
+@pytest.mark.parametrize("preset", ["hello-world", "control-assistant"])
+@pytest.mark.parametrize("field", sorted(_ANNOTATIONS))
+def test_edited_annotation_keeps_everything_the_key_already_resolved(
+    field: str, preset: str, tmp_path: Path
+) -> None:
+    """The example is only worth shipping if editing it in is additive.
+
+    hello-world leaves both keys empty and control-assistant populates both, so
+    the two presets are the two edits a facility actually makes: uncomment the
+    example over an empty key, or add one entry beside existing ones. Either
+    way the key must still resolve, must still be the only one of its name, and
+    must still carry everything it carried before the edit.
+    """
+    key = _yaml_key(field)
+    lines = _emit(preset).splitlines()
+    _sole_key_line(lines, key)
+
+    before = _resolved_entries(field, _resolve(tmp_path, lines))
+    assert bool(before) == (preset == "control-assistant"), (
+        f"{preset}: expected `{key}:` to be "
+        f"{'populated' if preset == 'control-assistant' else 'empty'} before the edit"
+    )
+
+    if before:
+        edited = _edit_populated_key(field, lines)
+        expected_new = _POPULATED_CASE_ADDITIONS[field]
+    else:
+        edited = _edit_empty_key(field, lines, tmp_path)
+        expected_new = _EMPTY_CASE_ADDITIONS[field]
+
+    _sole_key_line(edited, key)
+    after = _resolved_entries(field, _resolve(tmp_path, edited))
+
+    assert before <= after, f"{preset}: the edit dropped {sorted(before - after)}"
+    assert expected_new <= after, f"{preset}: the edit did not add {sorted(expected_new - after)}"
+
+
+# ---------------------------------------------------------------------------
+# (f) the fragments, applied as an override, survive init and build
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _init_with_fragment(runner: CliRunner, tmp_path: Path, fragment: dict[str, object]):
+    """Materialize control-assistant with *fragment* layered on top of it."""
+    override = tmp_path / "frag.yml"
+    override.write_text(yaml.safe_dump(fragment))
+    target = tmp_path / "facility"
+    result = runner.invoke(
+        init,
+        [str(target), "--preset", "control-assistant", "--no-git", "-O", str(override)],
+    )
+    return target, result
+
+
+def _build_from(runner: CliRunner, repo: Path):
+    return runner.invoke(build, ["--repo", str(repo), "--skip-deps", "--skip-lifecycle"])
+
+
+def test_fragment_web_panel_reaches_the_built_config(runner: CliRunner, tmp_path: Path) -> None:
+    """The panel the annotation teaches has to arrive in build/config.yml.
+
+    Resolving is not the claim the example makes — it says the facility gets a
+    tab pointed at its own address, and only the rendered config can show that.
+    """
+    repo, result = _init_with_fragment(
+        runner,
+        tmp_path,
+        {
+            "web_panels": ["elog"],
+            "config": {
+                "web.panels.elog.url": _ELOG_URL,
+                "web.panels.elog.label": "ELOG",
+                "web.panels.elog.path": "/",
+            },
+        },
+    )
+    assert result.exit_code == 0, result.output
+
+    built = _build_from(runner, repo)
+    assert built.exit_code == 0, built.output
+
+    config = yaml.safe_load((repo / "build" / "config.yml").read_text())
+    assert config["web"]["panels"]["elog"]["url"] == _ELOG_URL
+
+
+def test_fragment_web_panel_list_alone_is_refused(runner: CliRunner, tmp_path: Path) -> None:
+    """The half the annotation warns about must fail loudly, not quietly.
+
+    A list entry with no address behind it would otherwise produce a repo whose
+    web workspace advertises a tab that goes nowhere.
+    """
+    _, result = _init_with_fragment(runner, tmp_path, {"web_panels": ["elog"]})
+
+    assert result.exit_code != 0
+    assert "Unknown web_panel 'elog'" in result.output
+    assert "no 'web.panels.elog.url' config override" in result.output
+
+
+def test_fragment_env_required_reaches_the_env_example(runner: CliRunner, tmp_path: Path) -> None:
+    """A required variable is only documented once it is in .env.example."""
+    repo, result = _init_with_fragment(runner, tmp_path, {"env": {"required": ["MY_TOKEN"]}})
+    assert result.exit_code == 0, result.output
+
+    assert "MY_TOKEN" in (repo / ".env.example").read_text()
+    assert _build_from(runner, repo).exit_code == 0

--- a/tests/cli/test_profile_to_claude_contract.py
+++ b/tests/cli/test_profile_to_claude_contract.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import sys
 import textwrap
 from pathlib import Path
 
@@ -33,6 +34,7 @@ from click.testing import CliRunner
 
 from osprey.bluesky_tool_names import QUEUE_CONTROL_TOOLS
 from osprey.cli.build_cmd import build
+from osprey.cli.init_cmd import init
 from osprey.cli.templates.manager import TemplateManager
 from osprey.cli.validate_claude_artifacts import (
     validate_agent_tools_against_permissions,
@@ -206,6 +208,40 @@ def test_mcp_permissions_ask_round_trip(built_control_assistant_project):
     assert "mcp__controls__channel_write" in ask
     assert "mcp__osprey_workspace__setup_patch" in ask
     assert "mcp__ariel__entry_create" in ask
+
+
+def test_external_server_command_placeholder_resolves_to_interpreter(tmp_path):
+    """An external ``mcp_servers:`` entry's ``command`` resolves ``{current_python_env}``.
+
+    ``args`` and ``env`` already ran through ``_resolve_placeholder``;
+    ``command`` is the fix under test. Materialized into a fresh tmp repo — not
+    the module-scoped ``built_hello_world_project`` fixture — so the ``probe``
+    fragment cannot leak into sibling tests.
+    """
+    override = tmp_path / "probe.yml"
+    override.write_text(
+        'mcp_servers:\n  probe:\n    command: "{current_python_env}"\n    args: ["-m", "probe"]\n',
+        encoding="utf-8",
+    )
+    target = tmp_path / "probe-repo"
+    runner = CliRunner()
+
+    init_result = runner.invoke(
+        init,
+        [str(target), "--preset", "hello-world", "--no-git", "-O", str(override)],
+    )
+    assert init_result.exit_code == 0, init_result.output
+
+    build_result = runner.invoke(build, ["--repo", str(target), "--skip-deps", "--skip-lifecycle"])
+    assert build_result.exit_code == 0, build_result.output
+
+    mcp_config = json.loads((target / "build" / ".mcp.json").read_text())
+    probe = mcp_config["mcpServers"]["probe"]
+    assert probe["command"] == sys.executable, (
+        f"{{current_python_env}} should resolve to the running interpreter "
+        f"(--skip-deps); got {probe['command']!r}"
+    )
+    assert probe["args"] == ["-m", "probe"], "args must round-trip untouched"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_write_once_dirs.py
+++ b/tests/cli/test_write_once_dirs.py
@@ -1,0 +1,480 @@
+"""Contract tests for the WRITE-ONCE directories a materialization seeds.
+
+A seed directory is copied out of the app bundle on a repo's first init and
+never again: it becomes the operator's, so a re-materialization must find it
+already there and leave it alone. That is why seeds are deliberately absent
+from ``MATERIALIZED_SOURCE_ENTRIES`` — the entries a later ``--force`` is
+allowed to replace — and why the one case that DOES remove a seed is a run that
+created it and then failed, which owns the tree it just wrote.
+
+The bundle these tests seed from is synthetic: a template root assembled in
+``tmp_path`` that symlinks the real one everywhere except the bundle under
+test, whose ``mcp_servers/`` is planted here. That keeps the assertions about
+copy SEMANTICS (byte-code dropped, existing tree untouched, failure cleaned up)
+independent of whatever the packaged bundle happens to ship on any given day.
+The verb-level section at the end runs ``osprey init`` against the PACKAGED
+bundle instead, because what a first init seeds into an operator's repo is the
+shipped package and nothing else; those tests skip when the bundle ships no
+such tree.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+import osprey.cli.build_profile as build_profile_mod
+from osprey.cli.build_profile_schema import McpServerDef
+from osprey.cli.init_cmd import _missing_server_packages, init
+from osprey.cli.profile_cmd import _materialize_profile_directory
+from osprey.cli.profile_conventions import BUILD_OUTPUT_DIR
+from osprey.cli.templates.manager import TemplateManager
+from osprey.errors import BuildProfileError
+
+#: The preset materialized by most tests here, and the bundle it names.
+PRESET = "hello-world"
+BUNDLE = "hello_world"
+
+#: What a caller passes: profile-root directory name → bundle-relative source.
+SEED_DIRS = {"mcp_servers": "mcp_servers"}
+
+
+def _packaged_template_root() -> Path:
+    """The installed template root, read before any monkeypatching."""
+    return Path(TemplateManager().template_root)
+
+
+#: The seed the shipped bundle carries. The tests below read the real tree
+#: rather than a planted one, because what a first ``osprey init`` puts in an
+#: operator's repo IS this package — a synthetic stand-in could not catch a
+#: bundle that stopped shipping it.
+_PACKAGED_SEED = _packaged_template_root() / "apps" / BUNDLE / "mcp_servers"
+
+needs_packaged_seed = pytest.mark.skipif(
+    not _PACKAGED_SEED.is_dir(),
+    reason=f"the packaged {BUNDLE} bundle ships no mcp_servers/ tree",
+)
+
+
+@pytest.fixture
+def synthetic_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point every ``TemplateManager`` at a root whose bundle ships a known seed.
+
+    Everything but the bundle under test is symlinked, so the root costs
+    nothing to build and the rest of the materialization (the ``claude_code``
+    context baseline, the deploy templates) behaves exactly as it does against
+    the real installation.
+
+    Returns:
+        The bundle's planted ``mcp_servers/`` source tree.
+    """
+    real = _packaged_template_root()
+    root = tmp_path / "template-root"
+    (root / "apps").mkdir(parents=True)
+    for entry in real.iterdir():
+        if entry.name != "apps":
+            (root / entry.name).symlink_to(entry)
+    for entry in (real / "apps").iterdir():
+        if entry.name != BUNDLE:
+            (root / "apps" / entry.name).symlink_to(entry)
+
+    # Copied without the packaged seed: what this bundle ships as `mcp_servers/`
+    # is planted below, so these tests read the same either side of the day the
+    # real seed lands.
+    shutil.copytree(
+        real / "apps" / BUNDLE,
+        root / "apps" / BUNDLE,
+        ignore=shutil.ignore_patterns("mcp_servers", "__pycache__"),
+    )
+    seed = root / "apps" / BUNDLE / "mcp_servers"
+    (seed / "fake_server").mkdir(parents=True)
+    (seed / "fake_server" / "__init__.py").write_text('"""Planted."""\n', encoding="utf-8")
+    # Byte-code a source checkout accumulates and a wheel never ships. It must
+    # not reach the operator's repo, or the same seed would differ by where
+    # osprey was installed from.
+    (seed / "fake_server" / "__pycache__").mkdir()
+    (seed / "fake_server" / "__pycache__" / "x.pyc").write_bytes(b"\x00stale byte-code")
+
+    monkeypatch.setattr(TemplateManager, "_get_template_root", lambda self: root)
+    return seed
+
+
+def _fail_on_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make only the CLOSING resolve — the read-back of the written file — fail.
+
+    The opening resolve takes ``None`` and a preset name; the round-trip takes
+    the path of the ``profile.yml`` just written. Failing on the second is what
+    puts the failure AFTER the seed, which is the case this file is about.
+    """
+    real = build_profile_mod.resolve_build_profile
+
+    def resolve(profile_path, preset_name, *args, **kwargs):
+        if profile_path is not None:
+            raise BuildProfileError("planted round-trip failure")
+        return real(profile_path, preset_name, *args, **kwargs)
+
+    monkeypatch.setattr(build_profile_mod, "resolve_build_profile", resolve)
+
+
+def test_failed_first_run_leaves_no_seed(
+    synthetic_bundle: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run that seeds and then fails removes the tree it just created.
+
+    The seed is not in ``MATERIALIZED_SOURCE_ENTRIES``, so the only thing that
+    can remove it is the run's own record of having made it — which is exactly
+    the guarantee a first init needs: it either produces a repo or nothing.
+    """
+    target = tmp_path / "repo"
+    real_resolve = build_profile_mod.resolve_build_profile
+    _fail_on_round_trip(monkeypatch)
+
+    with pytest.raises(click.UsageError) as refusal:
+        _materialize_profile_directory(target, PRESET, seed_dirs=SEED_DIRS)
+
+    assert not (target / "mcp_servers").exists()
+    assert not (target / "profile.yml").exists()
+    assert not (target / "data").exists()
+    # `_cleanup`'s own verdict: nothing it owns survived, seed included.
+    assert "Nothing was materialized." in str(refusal.value)
+
+    # And the retry — the operator fixing whatever broke and running again —
+    # seeds, because the failed run left the name free.
+    monkeypatch.setattr(build_profile_mod, "resolve_build_profile", real_resolve)
+    materialized = _materialize_profile_directory(target, PRESET, seed_dirs=SEED_DIRS)
+
+    assert materialized.seeded == ("mcp_servers",)
+    assert (target / "mcp_servers" / "fake_server" / "__init__.py").is_file()
+
+
+def test_seed_carries_no_byte_code(synthetic_bundle: Path, tmp_path: Path) -> None:
+    """A seed from a source checkout matches a seed from a wheel."""
+    target = tmp_path / "repo"
+
+    materialized = _materialize_profile_directory(target, PRESET, seed_dirs=SEED_DIRS)
+
+    seeded = target / "mcp_servers"
+    assert materialized.seeded == ("mcp_servers",)
+    assert (seeded / "fake_server" / "__init__.py").read_text(
+        encoding="utf-8"
+    ) == '"""Planted."""\n'
+    assert list(seeded.rglob("__pycache__")) == []
+    assert list(seeded.rglob("*.pyc")) == []
+
+
+def test_bundle_without_the_tree_seeds_nothing(tmp_path: Path) -> None:
+    """A bundle that ships no such directory is not an error, and writes nothing.
+
+    The control assistant ships no ``mcp_servers/``, so asking for one is a
+    no-op rather than a refusal: the same caller passes the same seed table for
+    every preset, and only the bundles that ship the tree get it.
+    """
+    target = tmp_path / "repo"
+
+    materialized = _materialize_profile_directory(target, "control-assistant", seed_dirs=SEED_DIRS)
+
+    assert materialized.seeded == ()
+    assert not (target / "mcp_servers").exists()
+
+
+def test_existing_directory_is_left_alone(synthetic_bundle: Path, tmp_path: Path) -> None:
+    """Write-once: a name already in the target is the operator's, not the bundle's.
+
+    It is also not reported as seeded — the caller uses that list to decide what
+    a failed run may delete, and deleting a directory this run did not create is
+    the one thing the write-once rule exists to prevent.
+    """
+    target = tmp_path / "repo"
+    mine = target / "mcp_servers" / "my_server"
+    mine.mkdir(parents=True)
+    (mine / "server.py").write_text("# the operator's own server\n", encoding="utf-8")
+
+    materialized = _materialize_profile_directory(target, PRESET, seed_dirs=SEED_DIRS)
+
+    assert materialized.seeded == ()
+    assert (mine / "server.py").read_text(encoding="utf-8") == "# the operator's own server\n"
+    assert not (target / "mcp_servers" / "fake_server").exists()
+
+
+def test_no_seed_dirs_asked_for_seeds_nothing(synthetic_bundle: Path, tmp_path: Path) -> None:
+    """Today's callers pass nothing, and see no behavior change from the seam."""
+    target = tmp_path / "repo"
+
+    materialized = _materialize_profile_directory(target, PRESET)
+
+    assert materialized.seeded == ()
+    assert not (target / "mcp_servers").exists()
+
+
+@needs_packaged_seed
+def test_packaged_bundle_seeds_its_servers(tmp_path: Path) -> None:
+    """The real bundle, seeded through the real template root."""
+    target = tmp_path / "repo"
+
+    materialized = _materialize_profile_directory(target, PRESET, seed_dirs=SEED_DIRS)
+
+    assert materialized.seeded == ("mcp_servers",)
+    assert (target / "mcp_servers").is_dir()
+    assert list((target / "mcp_servers").rglob("__pycache__")) == []
+    assert list((target / "mcp_servers").rglob("*.pyc")) == []
+
+
+# ---------------------------------------------------------------------------
+# Through the verb, on the packaged bundle
+# ---------------------------------------------------------------------------
+
+#: Content an operator adds to the seeded tree, looked for after the verb runs
+#: again. Distinctive, so a directory re-seeded with the bundle's own files
+#: reads as destroyed rather than as preserved.
+SENTINEL = "written-by-the-operator\n"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _init(runner: CliRunner, target: Path, preset: str = PRESET, *extra: str):
+    """Run the verb the way an operator does, minus the git repository.
+
+    ``--no-git`` throughout: every assertion here is about which files are on
+    disk afterwards, and a repository around them would only slow the run down.
+    """
+    return runner.invoke(init, [str(target), "--preset", preset, "--no-git", *extra])
+
+
+def _zone_row(repo: Path) -> str:
+    """The README sentence that spells the source zone out in full.
+
+    Read as a line rather than searched for in the whole file, so that prose
+    elsewhere in the README mentioning a directory by name cannot stand in for
+    the zone table having claimed it.
+    """
+    readme = (repo / "README.md").read_text(encoding="utf-8")
+    return next(line for line in readme.splitlines() if line.startswith("In full, the first row"))
+
+
+def _reset_runs_without_a_container_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let ``--reset`` past the machinery that wants a live container runtime.
+
+    ``init`` refuses ``--reset`` up front unless a runtime answers, then hands
+    the previous deployment's containers and volumes to ``reset_for_reinit``.
+    Both are stubbed exactly as ``test_init_verb.py`` stubs them: what is under
+    test here is which files the re-materialization leaves standing, and that
+    must not depend on whether the developer has Docker Desktop open.
+    """
+    from osprey.deployment.reset import ResetOutcome
+
+    monkeypatch.setattr(
+        "osprey.deployment.runtime_helper.verify_runtime_is_running",
+        lambda config=None: (True, ""),
+    )
+    monkeypatch.setattr(
+        "osprey.deployment.reset.reset_for_reinit",
+        lambda repo_root, **kw: ResetOutcome.COMPLETED,
+    )
+    monkeypatch.setattr("osprey.cli.init_cmd._surviving_project_resources", lambda target: [])
+
+
+@needs_packaged_seed
+def test_first_init_seeds_the_shipped_server_package(runner: CliRunner, tmp_path: Path) -> None:
+    """A brand-new repo comes with the bundle's server package already in it.
+
+    Byte-compared against what is packaged rather than checked for existence:
+    the point of shipping a worked example is that the operator reads the code
+    the framework's own tests exercise, not an approximation of it.
+    """
+    target = tmp_path / "demo"
+
+    result = _init(runner, target)
+
+    assert result.exit_code == 0, result.output
+    seeded = target / "mcp_servers" / "example_server"
+    for name in ("__init__.py", "server.py", "__main__.py"):
+        assert (
+            seeded.joinpath(name).read_bytes()
+            == (_PACKAGED_SEED / "example_server" / name).read_bytes()
+        ), name
+    # A source checkout accumulates byte-code beside the package; a wheel never
+    # ships it. Neither may reach the operator's repo.
+    assert list((target / "mcp_servers").rglob("__pycache__")) == []
+    assert list((target / "mcp_servers").rglob("*.py[co]")) == []
+
+
+@needs_packaged_seed
+def test_the_zone_row_names_the_directory_only_where_it_was_seeded(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """The README describes the repo the operator got, not the seeding table.
+
+    A preset whose bundle ships no server package must not hand its operator a
+    README naming a directory they will not find.
+    """
+    seeding = tmp_path / "seeded"
+    bare = tmp_path / "bare"
+    assert _init(runner, seeding).exit_code == 0
+    assert _init(runner, bare, "control-assistant").exit_code == 0
+
+    assert "`mcp_servers/`" in _zone_row(seeding)
+    assert "mcp_servers" not in _zone_row(bare)
+
+
+@needs_packaged_seed
+def test_a_file_added_to_the_seed_survives_force_and_reset(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Write-once through the verb: re-materializing never costs the operator a server.
+
+    The sentinel goes one level below ``mcp_servers/`` because that directory is
+    a profile convention directory — one directory per server — so a bare file
+    directly inside it would make the repo fail validation rather than model
+    anything an operator would have written.
+    """
+    target = tmp_path / "demo"
+    assert _init(runner, target).exit_code == 0
+    mine = target / "mcp_servers" / "example_server" / "sentinel.txt"
+    mine.write_text(SENTINEL, encoding="utf-8")
+
+    forced = _init(runner, target, PRESET, "--force")
+
+    assert forced.exit_code == 0, forced.output
+    assert mine.read_text(encoding="utf-8") == SENTINEL
+
+    _reset_runs_without_a_container_runtime(monkeypatch)
+    reset = _init(runner, target, PRESET, "--reset")
+
+    assert reset.exit_code == 0, reset.output
+    assert mine.read_text(encoding="utf-8") == SENTINEL
+
+
+@needs_packaged_seed
+def test_a_deleted_seed_is_never_put_back(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Removing the directory is a decision, and re-running the verb respects it.
+
+    This is why the "has this name ever been initialized?" question is asked in
+    ``init`` and not in the materializer: inside it, the hold-aside has already
+    moved ``profile.yml`` away, so every ``--force`` run looks like a first init
+    and would put the deleted tree straight back.
+    """
+    target = tmp_path / "demo"
+    assert _init(runner, target).exit_code == 0
+    shutil.rmtree(target / "mcp_servers")
+
+    forced = _init(runner, target, PRESET, "--force")
+
+    assert forced.exit_code == 0, forced.output
+    assert not (target / "mcp_servers").exists()
+
+    _reset_runs_without_a_container_runtime(monkeypatch)
+    reset = _init(runner, target, PRESET, "--reset")
+
+    assert reset.exit_code == 0, reset.output
+    assert not (target / "mcp_servers").exists()
+
+
+# ── The pairing warning ──────────────────────────────────────────────────────
+# A server entry and the package it starts are two halves of one thing, and
+# only one half is write-once. `--force` on a repo whose `mcp_servers/` was
+# deleted writes profile.yml again, live block and all, and never puts the
+# package back: the pair is broken, and nothing said so until this warning.
+
+
+#: What the warning says once the entry name and module are filled in. Spelled
+#: out here rather than imported from the code under test, so a reworded
+#: warning has to be read by someone before it can pass.
+WARNING_TAIL = "is missing; delete the block too, or copy the package back."
+WARNING_SUMMARY = (
+    f"profile.yml declares example_server but mcp_servers/example_server/ {WARNING_TAIL}"
+)
+WARNING_DETAIL = "Every session otherwise waits 20 s for a server that cannot start."
+
+
+@needs_packaged_seed
+def test_a_paired_first_init_prints_no_warning(runner: CliRunner, tmp_path: Path) -> None:
+    """The repo the verb just created is paired, so it has nothing to say.
+
+    This is the common case by a wide margin, and a warning here would train
+    everyone to ignore the one case that matters.
+    """
+    result = _init(runner, tmp_path / "demo")
+
+    assert result.exit_code == 0, result.output
+    assert WARNING_TAIL not in result.output
+
+
+def test_a_preset_declaring_no_server_prints_no_warning(runner: CliRunner, tmp_path: Path) -> None:
+    """The control assistant declares no Python server, so there is no pair to break.
+
+    The check reads the profile rather than the directory: a preset with no
+    ``mcp_servers`` block must not be told that a package is missing just
+    because it has no ``mcp_servers/`` either.
+    """
+    result = _init(runner, tmp_path / "bare", "control-assistant")
+
+    assert result.exit_code == 0, result.output
+    assert WARNING_TAIL not in result.output
+
+
+@needs_packaged_seed
+def test_a_deleted_package_draws_a_warning_on_the_next_forced_run(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Deleting the directory alone leaves a declaration that cannot start.
+
+    Removing the package is a decision the verb respects (see
+    ``test_a_deleted_seed_is_never_put_back``), and the profile written beside
+    it still names the server. Saying so is the whole point: the operator meant
+    to drop the example and has done half of it.
+    """
+    target = tmp_path / "demo"
+    assert _init(runner, target).exit_code == 0
+    shutil.rmtree(target / "mcp_servers")
+
+    forced = _init(runner, target, PRESET, "--force")
+
+    assert forced.exit_code == 0, forced.output
+    assert WARNING_SUMMARY in forced.output
+    assert WARNING_DETAIL in forced.output
+
+
+def test_the_warning_reads_only_servers_this_repo_could_pair(tmp_path: Path) -> None:
+    """Only a package the build copies out of this repo can be missing from it.
+
+    A remote server has no package here at all, and one started from a binary
+    on the host has one this command cannot see. Both are fine as they stand,
+    and a warning about either would be wrong rather than merely noisy.
+    """
+    target = tmp_path / "repo"
+    (target / "mcp_servers" / "present_server").mkdir(parents=True)
+    build_zone = f"{{project_root}}/{BUILD_OUTPUT_DIR}/_mcp_servers"
+    servers = {
+        "gone": McpServerDef(
+            command="{current_python_env}",
+            args=["-m", "gone_server"],
+            env={"PYTHONPATH": build_zone},
+        ),
+        "present": McpServerDef(
+            command="{current_python_env}",
+            args=["-m", "present_server"],
+            env={"PYTHONPATH": build_zone},
+        ),
+        "remote": McpServerDef(url="http://lattice.example.org:8400/mcp", port=8400),
+        "binary": McpServerDef(
+            command="/usr/local/bin/facility-mcp",
+            args=["--stdio"],
+            env={"PYTHONPATH": build_zone},
+        ),
+        "elsewhere": McpServerDef(
+            command="{current_python_env}",
+            args=["-m", "vendored_server"],
+            env={"PYTHONPATH": "/opt/vendor/lib"},
+        ),
+    }
+
+    assert _missing_server_packages(servers, target) == [("gone", "gone_server")]

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -226,6 +226,15 @@ agents:
 output_styles:
   - control-operator  # Terse, actionable output style for control-room operators
 
+# Tabs the web workspace offers beside the terminal. To turn on a panel
+# the framework already ships, uncomment one listed under this key.
+# A panel of your own is a list entry plus its address under `config:`:
+#
+#   web_panels:
+#     - elog
+#
+# and, under `config:`, web.panels.elog.url alongside web.panels.elog.label,
+# web.panels.elog.path and — optional — web.panels.elog.health_endpoint.
 web_panels:
   - ariel           # ARIEL search interface (past experiments, papers)
   - channel-finder  # Interactive channel-finder web UI
@@ -488,6 +497,19 @@ dispatch:
 # the service refuses to start without them. `osprey up` generates a strong
 # random value for each one into this repo's .env, so a new deployment is
 # secure with no editing. Put your own values in .env to override.
+# Environment variables the deployment needs. Replace `env: {}` with any
+# of `required` (the variable must be set somewhere), `pinned` (this
+# repo's own env chain owns it outright, and nowhere else), `defaults`
+# (name to value) and `file` (a profile-relative path copied in as .env):
+#
+#   env:
+#     required: [EPICS_CA_ADDR_LIST]
+#     pinned: [ARIEL_DB_PASSWORD]
+#     defaults:
+#       EPICS_CA_ADDR_LIST: 127.0.0.1
+#     file: env/facility.env
+#
+# If `env:` already has children, add yours under it.
 env:
   required:
     - EVENT_DISPATCHER_TOKEN

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -536,8 +536,18 @@ panel_presets: {}
 # "http"; "sse" is the legacy event-stream wire and needs an explicit url.
 # Tool names under permissions are bare — `allow` runs them unprompted, `ask`
 # prompts the operator on every call.
+# A Python server's package lives at mcp_servers/<package>/ beside this file;
+# the build copies it to build/_mcp_servers/<package>/ for `-m <package>`.
 #
 # mcp_servers:
+#   my_server:
+#     command: "{current_python_env}"
+#     args: [-m, my_server]
+#     env:
+#       OSPREY_CONFIG: "{project_root}/build/config.yml"
+#       PYTHONPATH: "{project_root}/build/_mcp_servers"
+#     permissions:
+#       allow: [my_tool]
 #   matlab:
 #     command: /opt/matlab/bin/mcp-matlab
 #     args: [--workspace, /opt/matlab/scripts]

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -1142,10 +1142,13 @@ GITIGNORE = """\
 # `osprey reset` — anchored for the same reason the zones above are.
 /.osprey-compose.yml
 
-# OS / editor noise. Deliberately unanchored: these are junk at any depth.
+# OS / editor noise, and the bytecode Python leaves beside any server package
+# run in place. Deliberately unanchored: these are junk at any depth.
 .DS_Store
 *.swp
 *.swo
+__pycache__/
+*.py[co]
 """
 
 ENV_EXAMPLE = """\

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -1369,6 +1369,63 @@ is a copy of those two, and a restore is:
 ```bash
 git clone <this repo> && tar xf state.tar.gz && osprey build && osprey up -d
 ```
+
+## Common questions
+
+### Adding an MCP server of your own
+
+Put the server's Python package at `mcp_servers/<name>/`. `osprey build` copies
+it to `build/_mcp_servers/<name>/`, and an entry under `mcp_servers:`
+in `profile.yml` says how to start it:
+
+```yaml
+mcp_servers:
+  my_server:
+    command: "{current_python_env}"
+    args: [-m, my_server]
+    env:
+      PYTHONPATH: "{project_root}/build/_mcp_servers"
+```
+
+The hello-world preset ships `example_server` as a worked copy to read. Which
+buckets the artifact gallery sorts into is a separate, top-level key, one entry
+per bucket:
+
+```yaml
+artifact_server:
+  categories:
+    beam_studies: {label: Beam studies, color: "#4C6EF5"}
+```
+
+### Adding a panel of your own
+
+A panel is two halves, and one without the other is a tab that opens nothing.
+The id goes in the `web_panels:` list, and its address goes under `config:`, as
+the comment above `web_panels:` in `profile.yml` shows:
+
+```yaml
+web_panels:
+  - elog
+
+config:
+  web.panels.elog.url: http://elog.example.org
+  web.panels.elog.label: Elog
+  web.panels.elog.path: /elog
+```
+
+### Mounting an extra directory into a web terminal
+
+Deployments that give people their own web terminals mount per persona, under
+`config:`. Each entry is a container volume string of two or three non-empty
+parts, `source:target` or `source:target:mode`:
+
+```yaml
+config:
+  modules.web_terminals.personas.operator.extra_mounts:
+    - /opt/facility/data:/data:ro
+```
+
+Every key named here is written up in full at https://als-apg.github.io/osprey/.
 """
 
 

--- a/tests/integration/test_build_boot.py
+++ b/tests/integration/test_build_boot.py
@@ -56,6 +56,9 @@ EXPECTED_TOOLS: dict[str, set[str]] = {
         "session_log",
     },
     "ariel": {"keyword_search", "entry_get", "sql_query", "semantic_search"},
+    # Seeded by the hello-world preset, not a framework server: the worked
+    # example a first-time user gets from `osprey init --preset hello-world`.
+    "example_server": {"example_status"},
 }
 # channel-finder: enumerated dynamically since which backend is enabled
 # (hierarchical | in_context | middle_layer) depends on preset config.

--- a/tests/mcp_server/test_fastmcp_contract.py
+++ b/tests/mcp_server/test_fastmcp_contract.py
@@ -932,10 +932,13 @@ class TestEveryFrameworkServerLaunchesThroughRunMcpServer:
         by that rule rather than by name.
         """
         rostered = {_module_path(module) for module in _expanded_roster().values()}
+        # App bundles under ``osprey/templates`` ship example servers for the
+        # deployment repo to own; they are seeded into repos, never rostered.
+        bundles = SRC_ROOT.joinpath("osprey", "templates")
         on_disk = {
             path.parent
             for path in SRC_ROOT.joinpath("osprey").rglob("__main__.py")
-            if path.parent in _fastmcp_constructing_packages()
+            if path.parent in _fastmcp_constructing_packages() and not path.is_relative_to(bundles)
         }
         assert on_disk, "found no FastMCP entry points at all — the walk is broken"
         assert on_disk == rostered

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -97,6 +97,29 @@ class TestResolveServers:
         assert s["permissions_ask"] == ["write_data"]
         assert s["is_custom"] is True
 
+    def test_resolve_external_command_resolves_current_python_env(self):
+        """An external server's ``command`` resolves {current_python_env}
+        the same way ``args`` and ``env`` already do."""
+        ctx = _base_ctx()
+        cfg = {"servers": {"my-server": {"command": "{current_python_env}"}}}
+        s = _resolve_one(cfg, "my-server", ctx)
+        assert s["command"] == "/usr/bin/python3"
+
+    def test_resolve_external_command_resolves_project_root(self):
+        """An external server's ``command`` resolves {project_root}."""
+        ctx = _base_ctx()
+        cfg = {"servers": {"my-server": {"command": "{project_root}/bin/x"}}}
+        s = _resolve_one(cfg, "my-server", ctx)
+        assert s["command"] == "/tmp/test-project/bin/x"
+
+    def test_resolve_external_command_leaves_dollar_var_untouched(self):
+        """``${VAR}`` in an external server's ``command`` survives verbatim,
+        matching the existing behavior for ``args`` and ``env``."""
+        ctx = _base_ctx()
+        cfg = {"servers": {"my-server": {"command": "${TOOL_HOME}/bin/x"}}}
+        s = _resolve_one(cfg, "my-server", ctx)
+        assert s["command"] == "${TOOL_HOME}/bin/x"
+
     def test_resolve_custom_server_url_defaults_to_http_transport(self):
         """A URL server without a transport key resolves as streamable-HTTP."""
         ctx = _base_ctx()


### PR DESCRIPTION
Four gaps a new deployment hits in its first hour, each one a place where
the scaffolding told the user less than it knew.

**A facility MCP server's `command` was never placeholder-resolved.**
`args` and `env` went through resolution; `command` did not. A server
declared as `command: "{current_python_env}"` launched the literal string
and failed at spawn. The docs example compounded it by pointing
`OSPREY_CONFIG` and `PYTHONPATH` at the repo root instead of `build/`.
Both are corrected; a contract test pins the resolved command through
`osprey init` and `osprey build`.

**Empty `web_panels:` and `env:` keys gave no hint what goes under them.**
Every emitted `profile.yml` now carries a comment above each with a
snippet that can be pasted over the empty key, plus one line for the
populated case. Tests apply each snippet to an empty and a populated
preset and prove nothing already resolved is lost.

**hello-world had no MCP server a user could run.** The only reference
was a commented-out block. The preset now declares a live
`mcp_servers.example_server` entry, and `osprey init` seeds the matching
`mcp_servers/example_server/` package on a repo's first-ever init. That
needed a new write-once directory category (`WRITE_ONCE_DIRS`): seeded
once from the app bundle, never replaced or resurrected by `--force` or
`--reset`, because the user is expected to edit it. A unit test completes
the stdio handshake against the rendered `.mcp.json`; build-boot-smoke
does the same with real dependencies. The hello-world extension-surface
pin moves from 13 to 12 commented blocks because the `mcp_servers` lesson
now lives in a live block.

**The seeded README did not answer the three questions every new
deployment asks.** It now covers adding an MCP server, a panel, and an
extra web-terminal mount, in wording that holds for every preset and
links only the docs root.

Reach limits, stated so nobody expects otherwise:
- `README.md` and `.gitignore` are write-once, so existing repos receive
  neither the questions section nor the new `__pycache__` ignore entries.
- An older hello-world repo re-materialized with `--force` gets the live
  `mcp_servers:` block but no `mcp_servers/example_server/` (write-once
  directories are never re-seeded). `osprey init` warns about the missing
  package and says what to do.

## How it hangs together

```text
┌──────────────────────────────┐
│ hello-world.yml preset       │
│ mcp_servers.example_server   │
│   command: {current_python…} │
└──────────────┬───────────────┘
        ┌──────┴─────────────────────────┐
        ▼                                ▼
┌──────────────────────┐     ┌────────────────────────────┐
│ osprey init          │     │ osprey build               │
│ first-ever init:     │     │ registry/mcp.py resolves   │
│  WRITE_ONCE_DIRS →   │     │ placeholders in command    │
│  mcp_servers/        │     │ (was: args + env only)     │
│   example_server/    │     └──────────────┬─────────────┘
│  README.md (3 FAQs)  │                    ▼
└──────────┬───────────┘     ┌────────────────────────────┐
           │                 │ build/.mcp.json            │
           │ seeds           │  example_server → python   │
           │                 │  -m mcp_servers.example_…  │
           │                 │ build/.claude/settings.json│
           │                 │  PostToolUse               │
           │                 │  mcp__example_server__.*   │
           │                 └──────────────┬─────────────┘
           ▼                                │ spawns (stdio)
┌──────────────────────────┐                │
│ mcp_servers/             │◄───────────────┘
│  example_server (FastMCP)│
└──────────────────────────┘

┌──────────────────────────────┐
│ osprey profile emit          │
│ profile.yml: snippet comment │
│ above web_panels: and env:   │
└──────────────────────────────┘
```
