### PR TITLE
Deployment-layer bundle: dead kernel templates (#769), shared-path reach resolver (#770), rootless gid-0 join (#774)

### DIFF
--- a/changelog.d/769.removed.md
+++ b/changelog.d/769.removed.md
@@ -1,0 +1,3 @@
+The `render_kernel_templates` service-entry key and the Jupyter kernel
+template rendering behind it. They belonged to a container execution backend
+that never shipped; no service template carried a `kernel.json.j2`.

--- a/changelog.d/770.fixed.md
+++ b/changelog.d/770.fixed.md
@@ -1,0 +1,5 @@
+`osprey build` refuses a render entitled to a shared host directory that is
+not there — a `facility_knowledge.bundle_path` naming no directory on the
+host, or an ARIEL `qmd_export.mirror_path` the deploy could not create —
+naming the key, instead of binding a source the container runtime would
+create root-owned or an empty bundle.

--- a/changelog.d/774.fixed.md
+++ b/changelog.d/774.fixed.md
@@ -1,0 +1,5 @@
+Web-terminal containers under rootless podman (or rootless docker) can write
+their audit directory and the facility-knowledge bundle again. The entrypoint
+now joins a gid-0 mount when the kernel's uid map shows container root is the
+invoking host user, instead of refusing it as the host's root group; the
+system-group floor and the rootful case are unchanged.

--- a/docs/source/how-to/deploy-project/index.rst
+++ b/docs/source/how-to/deploy-project/index.rst
@@ -62,7 +62,7 @@ Each service entry must point ``path:`` at a directory containing a
 ``docker-compose.yml.j2`` template. Everything else under the service key is
 project-specific configuration exposed to the template as
 ``{{services.<name>.<key>}}``. Beyond ``path``, a service entry may also
-declare ``copy_src``, ``additional_dirs``, and ``render_kernel_templates``
+declare ``copy_src`` and ``additional_dirs``
 (a multi-container service is expressed by the ``docker-compose.yml.j2``
 template defining more than one compose service). For how facility services
 are declared inside a build profile, see :ref:`profile-services`.

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1579,7 +1579,7 @@ def _render_project(
     # reason: it is the render, not the profile, that a container loads.
     unrunnable = [
         *_resolve_rendered_execution_method(render_dir),
-        *reach_errors(_rendered_config(render_dir)),
+        *reach_errors(_rendered_config(render_dir), repo_root=repo_root),
     ]
     if unrunnable:
         raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(unrunnable))

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -4,7 +4,7 @@ Handles Jinja2 template rendering, service discovery, build directory
 management, and Docker Compose file creation for container deployments.
 
 Working-directory precondition: the render helpers here (:func:`setup_build_dir`,
-:func:`render_kernel_templates`, :func:`_incremental_setup_build_dir`) resolve
+:func:`_incremental_setup_build_dir`) resolve
 ``build_dir`` and each service's declared ``path`` RELATIVELY, against the
 process working directory, and are called from the build with that directory at
 the repo root. They are not safe to call from anywhere else. The one function
@@ -1388,8 +1388,8 @@ def render_template(template_path, config, out_dir):
 
     This function processes Jinja2 templates using the configuration
     as context, generating concrete configuration files for container deployment.
-    The system supports multiple template types including Docker Compose files
-    and Jupyter kernel configurations, with intelligent output filename detection.
+    The output filename is derived from the template's: ``docker-compose.yml.j2``
+    renders to the compose file name, anything else drops its ``.j2`` suffix.
 
     Template rendering uses the complete configuration dictionary as Jinja2 context,
     enabling templates to access any configuration value including environment
@@ -1418,24 +1418,8 @@ def render_template(template_path, config, out_dir):
             ... )
             >>> print(output_path)  # 'build/services/mongo/docker-compose.yml'
 
-        Jupyter kernel template rendering::
-
-            >>> config = {'project_root': '/home/user/project'}
-            >>> output_path = render_template(
-            ...     'services/jupyter/python3-epics/kernel.json.j2',
-            ...     config,
-            ...     'build/services/jupyter/python3-epics'
-            ... )
-            >>> print(output_path)  # 'build/services/jupyter/python3-epics/kernel.json'
-
-    .. note::
-       The function automatically determines output filenames based on template
-       naming conventions: .j2 extension is removed, and specific patterns
-       like docker-compose.yml.j2 and kernel.json.j2 are recognized.
-
     .. seealso::
        :func:`setup_build_dir` : Uses this function for service template processing
-       :func:`render_kernel_templates` : Batch processing of kernel templates
     """
     env = Environment(loader=FileSystemLoader("."))
     template = env.get_template(template_path)
@@ -1447,8 +1431,6 @@ def render_template(template_path, config, out_dir):
     # Determine output filename based on template type
     if template_path.endswith("docker-compose.yml.j2"):
         output_filename = COMPOSE_FILE_NAME
-    elif template_path.endswith("kernel.json.j2"):
-        output_filename = "kernel.json"
     else:
         # Generic fallback: remove .j2 extension
         output_filename = os.path.basename(template_path)[:-3]
@@ -1502,74 +1484,6 @@ def _stage_dev_wheel_for_context(out_dir, dev_mode):
     _copy_local_framework_for_override(out_dir)
     logger.debug("Development mode: Osprey override prepared")
     return True
-
-
-def render_kernel_templates(source_dir, config, out_dir):
-    """Process all Jupyter kernel templates in a service directory.
-
-    This function provides batch processing for Jupyter kernel configuration
-    templates, automatically discovering all kernel.json.j2 files within a
-    service directory and rendering them with the current configuration context.
-    This is particularly useful for Jupyter services that provide multiple
-    kernel environments with different configurations.
-
-    The function recursively searches the source directory for kernel template
-    files and processes each one, maintaining the relative directory structure
-    in the output. This ensures that kernel configurations are placed in the
-    correct locations for Jupyter to discover them.
-
-    :param source_dir: Source directory to search for kernel templates
-    :type source_dir: str
-    :param config: Configuration dictionary for template rendering
-    :type config: dict
-    :param out_dir: Base output directory for rendered kernel files
-    :type out_dir: str
-
-    Examples:
-        Kernel template processing for Jupyter service::
-
-            >>> # Source structure:
-            >>> # services/jupyter/
-            >>> #   ├── python3-epics-readonly/kernel.json.j2
-            >>> #   └── python3-epics-write/kernel.json.j2
-            >>>
-            >>> render_kernel_templates(
-            ...     'services/jupyter',
-            ...     {'project_root': '/home/user/project'},
-            ...     'build/services/jupyter'
-            ... )
-            >>> # Output structure:
-            >>> # build/services/jupyter/
-            >>> #   ├── python3-epics-readonly/kernel.json
-            >>> #   └── python3-epics-write/kernel.json
-
-    .. note::
-       This function is typically called automatically by setup_build_dir when
-       a service configuration includes 'render_kernel_templates: true'.
-
-    .. seealso::
-       :func:`render_template` : Core template rendering used by this function
-       :func:`setup_build_dir` : Calls this function for kernel template processing
-    """
-    kernel_templates = []
-
-    # Look for kernel.json.j2 files in subdirectories
-    for root, _dirs, files in os.walk(source_dir):
-        for file in files:
-            if file == "kernel.json.j2":
-                template_path = os.path.relpath(os.path.join(root, file), os.getcwd())
-                kernel_templates.append(template_path)
-
-    # Render each kernel template
-    for template_path in kernel_templates:
-        # Calculate relative output directory
-        rel_template_dir = os.path.dirname(os.path.relpath(template_path, source_dir))
-        kernel_out_dir = (
-            os.path.join(out_dir, rel_template_dir) if rel_template_dir != "." else out_dir
-        )
-
-        render_template(template_path, config, kernel_out_dir)
-        logger.debug(f"Rendered kernel template: {template_path} -> {kernel_out_dir}/kernel.json")
 
 
 #: Bits a shared corpus directory must carry: ``rwxrws---``, ORed onto whatever
@@ -2006,10 +1920,7 @@ def render_service_templates(source_dir, config, out_dir):
     ``docker-compose.yml.j2`` is rendered with the same context, dropping the
     extension (``index.yml.j2`` -> ``index.yml``).
 
-    Only the service's own directory is scanned, not its subdirectories:
-    ``kernel.json.j2`` files live one level down and belong to
-    :func:`render_kernel_templates`, which is opt-in per service and would
-    otherwise render them twice.
+    Only the service's own directory is scanned, not its subdirectories.
 
     :param source_dir: The service's template directory
     :type source_dir: str
@@ -2022,7 +1933,7 @@ def render_service_templates(source_dir, config, out_dir):
     """
     rendered = []
     for name in sorted(os.listdir(source_dir)):
-        if not name.endswith(".j2") or name in (TEMPLATE_FILENAME, "kernel.json.j2"):
+        if not name.endswith(".j2") or name == TEMPLATE_FILENAME:
             continue
         template_path = os.path.relpath(os.path.join(source_dir, name), os.getcwd())
         rendered.append(render_template(template_path, config, out_dir))
@@ -2583,7 +2494,6 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
     4. Copy source code if requested (copy_src: true)
     5. Copy additional directories as specified
     6. Create flattened configuration file for container use
-    7. Process kernel templates if specified
 
     Source code copying includes intelligent handling of requirements files,
     automatically copying global requirements.txt to the container source
@@ -2606,7 +2516,6 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
             >>> container_cfg = {
             ...     'copy_src': True,
             ...     'additional_dirs': ['docs', 'scripts'],
-            ...     'render_kernel_templates': False
             ... }
             >>> compose_path = setup_build_dir(
             ...     'services/osprey/jupyter/docker-compose.yml.j2',
@@ -2623,7 +2532,6 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
             ...         'docs',  # Simple directory copy
             ...         {'src': 'external_data', 'dst': 'data'}  # Custom mapping
             ...     ],
-            ...     'render_kernel_templates': True
             ... }
             >>> compose_path = setup_build_dir(template_path, config, container_cfg)
 
@@ -2638,7 +2546,6 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
 
     .. seealso::
        :func:`render_template` : Template rendering used by this function
-       :func:`render_kernel_templates` : Kernel template processing
        :class:`configs.config.ConfigBuilder` : Configuration flattening
     """
     # Create the build directory for this service
@@ -2699,7 +2606,7 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
         for file in [] if renders_in_place else os.listdir(source_dir):
             src_path = os.path.join(source_dir, file)
             dst_path = os.path.join(out_dir, file)
-            # Skip template files (both docker-compose and kernel templates)
+            # Skip template files: they are inputs, rendered separately
             if file != TEMPLATE_FILENAME and not file.endswith(".j2"):
                 if os.path.isdir(src_path):
                     shutil.copytree(src_path, dst_path)
@@ -2843,11 +2750,6 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
                 config_yml_dst = os.path.join(out_dir, "config.yml")
                 shutil.copy2(config_yml_src, config_yml_dst)
                 logger.debug(f"Copied original config.yml to {config_yml_dst}")
-
-        # Render kernel templates if specified in service configuration
-        if container_cfg.get("render_kernel_templates", False):
-            logger.debug(f"Processing kernel templates for {source_dir}")
-            render_kernel_templates(source_dir, config, out_dir)
 
     return compose_filepath
 

--- a/src/osprey/deployment/reach.py
+++ b/src/osprey/deployment/reach.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -111,6 +112,9 @@ Predicate = Callable[[Mapping[str, Any]], bool]
 #: ``(host, port)`` — what a consumer's client actually connects to.
 Dial = tuple[str, int]
 Dialer = Callable[[Mapping[str, Any]], "Dial | None"]
+#: The host directory a shared path binds, anchored on the deployment repo
+#: root (``None`` resolves it from the config), or ``None`` when unconfigured.
+HostDir = Callable[[Mapping[str, Any], "str | Path | None"], "Path | None"]
 
 
 def dotted_get(config: Mapping[str, Any] | None, dotted_key: str) -> Any:
@@ -252,11 +256,63 @@ class SharedPath:
         config_key: The dotted key naming the directory.
         gate: Which renders are entitled — the predicate the render mounts by.
         describe: What lives there, for messages.
+        host_dir: The bind source on the host, read through the one reader the
+            deploy provisions from and the renderers emit the mount from — so
+            the directory this refuses over is the directory that would have
+            been bound.
+        provisioned: Whether the deploy creates the directory before the first
+            bind (:func:`~osprey.deployment.compose_generator.ensure_shared_corpus_dir`).
+            ``True`` for a writer's output, where "not there yet" is the
+            ordinary first-deploy state and only a directory the deploy could
+            not create refuses; ``False`` for authored content, which nothing
+            fills for the operator, so it has to be there at build time.
     """
 
     config_key: str
     gate: Predicate
     describe: str
+    host_dir: HostDir
+    provisioned: bool = False
+
+    def resolves(self, config: Mapping[str, Any], repo_root: str | Path | None = None) -> bool:
+        """Whether this render's bind source is — or can be — on the host."""
+        return self.unresolved(config, repo_root) is None
+
+    def unresolved(
+        self, config: Mapping[str, Any], repo_root: str | Path | None = None
+    ) -> str | None:
+        """Why the bind source is not on the host, or ``None`` when it is.
+
+        The counterpart of :attr:`Consumer.resolves` for a directory: a
+        consumer with nothing to dial fails at first use, and a container
+        handed a bind whose source is missing has the runtime create it —
+        root-owned under a rootful daemon, so nothing that runs as ``osprey``
+        can write it — or, for authored content, binds an empty directory the
+        deploy provisioned on the spot, so every reader inside finds nothing.
+        """
+        path = self.host_dir(config, repo_root)
+        if path is None:
+            return f"{self.config_key} names no directory"
+        if path.is_dir():
+            return None
+        if path.exists():
+            return f"{path} is not a directory"
+        if not self.provisioned:
+            return f"this host has no directory at {path}"
+        blocker = _nearest_existing(path)
+        if blocker is not None and blocker.is_dir() and os.access(blocker, os.W_OK):
+            return None
+        return f"the deploy cannot create {path}: " + (
+            f"{blocker} is not a directory this user can write" if blocker else "no such root"
+        )
+
+
+def _nearest_existing(path: Path) -> Path | None:
+    """The first ancestor of *path* that exists, or ``None``."""
+    for ancestor in path.parents:
+        if ancestor.exists():
+            return ancestor
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -909,6 +965,21 @@ REACH_CONTRACTS: dict[str, ReachContract] = {
     ),
 }
 
+
+def _bundle_host_dir(config: Mapping[str, Any], repo_root: str | Path | None) -> Path | None:
+    # Imported here, as :mod:`osprey.deployment.web_terminals.personas` does:
+    # compose_generator imports the web-terminal package at module level.
+    from osprey.deployment.compose_generator import resolve_facility_bundle_dir
+
+    return resolve_facility_bundle_dir(config, repo_root)
+
+
+def _mirror_host_dir(config: Mapping[str, Any], repo_root: str | Path | None) -> Path | None:
+    from osprey.deployment.compose_generator import resolve_ariel_mirror_dir
+
+    return resolve_ariel_mirror_dir(config, repo_root)
+
+
 #: Host directories bound into entitled persona containers, each at the path
 #: the container's own resolver derives for the key (see
 #: :mod:`osprey.deployment.web_terminals.render`).
@@ -917,11 +988,14 @@ SHARED_PATHS: tuple[SharedPath, ...] = (
         "facility_knowledge.bundle_path",
         config_needs_facility_bundle,
         "the facility-knowledge bundle (OKF panel, facility_knowledge MCP server)",
+        _bundle_host_dir,
     ),
     SharedPath(
         "ariel.enhancement_modules.qmd_export.mirror_path",
         config_needs_ariel_mirror,
         "the ARIEL qmd mirror (qmd_export writes it; the sidecar indexes it)",
+        _mirror_host_dir,
+        provisioned=True,
     ),
 )
 
@@ -1007,7 +1081,7 @@ def _deployed_services(config: Mapping[str, Any]) -> frozenset[str]:
     return frozenset(str(service) for service in deployed)
 
 
-def reach_errors(config: Mapping[str, Any]) -> list[str]:
+def reach_errors(config: Mapping[str, Any], *, repo_root: str | Path | None = None) -> list[str]:
     """Refuse a rendered config whose consumer is on with nothing to resolve.
 
     Read on the RENDERED config — the ground truth every client loads — so it
@@ -1025,9 +1099,17 @@ def reach_errors(config: Mapping[str, Any]) -> list[str]:
     dials its HOST's published ports on the shared network namespace, which
     is the projection's whole point, so the second rule never reads one.
 
+    A third refuses a shared path: a render entitled to a host directory
+    (:data:`SHARED_PATHS`) whose bind source is not on the host and will not
+    be by the time it is bound (:meth:`SharedPath.unresolved`). Read against
+    *repo_root* when the build passes it — the tree the render anchors on,
+    which a ``--runtime-root`` render's own ``project_root`` does not name —
+    and otherwise resolved from the config the way every bind source is.
+
     Returns:
         One error per unresolvable consumer whose contract refuses, naming
-        the switch and the key — or the service — that fixes it.
+        the switch and the key — or the service — that fixes it; one per
+        entitled shared path that is not there, naming the key.
     """
     errors: list[str] = []
     deployed = _deployed_services(config)
@@ -1057,5 +1139,17 @@ def reach_errors(config: Mapping[str, Any]) -> list[str]:
                 f"does not run `{contract.service}`: it is not in deployed_services, so the "
                 f"client would dial the port a deployed `{contract.service}` publishes and "
                 f"find nothing listening. Deploy it{elsewhere}, or switch the consumer off."
+            )
+    for shared in SHARED_PATHS:
+        if not shared.gate(config):
+            continue
+        why = shared.unresolved(config, repo_root)
+        if why is not None:
+            errors.append(
+                f"This render is entitled to {shared.describe} ({shared.config_key}), "
+                f"but {why}. Bound anyway, the container runtime would create the "
+                f"source itself — root-owned under a rootful daemon, so nothing running "
+                f"as `osprey` could write it — or the container would read an empty "
+                f"directory. Put it there, or point {shared.config_key} at where it is."
             )
     return errors

--- a/src/osprey/templates/project/entrypoint.sh
+++ b/src/osprey/templates/project/entrypoint.sh
@@ -186,6 +186,35 @@ PY
 #: share a group, and joining it twice is noise at best.
 JOINED_GIDS=''
 
+#: Where the kernel reports how this container's uids map onto its parent
+#: namespace. One line, `0 0 4294967295`, is the identity: container root is
+#: the host's root. Anything else is a user namespace of the container's own.
+UID_MAP=/proc/self/uid_map
+
+# Whether this container's root is an unprivileged host user rather than the
+# host's root — the rootless shape (rootless podman, rootless docker), where
+# the invoking user maps to uid/gid 0 inside and everything that user owns on
+# the host presents as root-owned in here.
+#
+# Read off the uid map rather than guessed from the runtime, because the map
+# is the one thing the kernel states about it: a rootful daemon with an
+# ownership remap (Docker Desktop's file sharing) runs its containers under
+# the identity map and is NOT this case. A container with no readable map —
+# a non-Linux test host, a kernel without user namespaces — is not this case
+# either: the answer that grants nothing is the safe default.
+container_root_is_host_user() {
+    [ -r "$UID_MAP" ] || return 1
+    _mapped=0
+    while read -r _inside _outside _count; do
+        [ -n "$_inside" ] || continue
+        _mapped=1
+        if [ "$_inside" = 0 ] && [ "$_outside" = 0 ] && [ "$_count" = 4294967295 ]; then
+            return 1
+        fi
+    done < "$UID_MAP"
+    [ "$_mapped" = 1 ]
+}
+
 join_mounted_group() {
     _var=$1
     _dir=$2
@@ -226,7 +255,20 @@ join_mounted_group() {
     # and those pass this branch. They are caught one level down instead:
     # `groupadd` refuses a gid over GID_MAX and the join warns, which is why
     # that warning names the case too.
-    if [ "$_gid" -lt 100 ]; then
+    #
+    # The one gid the floor lets through, and only in one shape: gid 0 in a
+    # ROOTLESS container. There the invoking host user IS container root, so
+    # a directory that user owns and deliberately provisioned (setgid 2770,
+    # the host user's own group) presents as gid 0 in here — exactly what the
+    # floor was written to reject, for a reason that does not hold: joining
+    # gid 0 hands `osprey` the host user's own group, which is what the setgid
+    # design meant all along, and no host privilege grows because the
+    # container never had any. The system range (1-99) stays refused — no
+    # mount the render names is owned by `disk` or `shadow` on any host.
+    if [ "$_gid" -eq 0 ] && container_root_is_host_user; then
+        log "$_var=$_dir is owned by gid 0 in a rootless container, where container"
+        log "         root is the host user that provisioned it; joining that group."
+    elif [ "$_gid" -lt 100 ]; then
         log "WARNING: $_var=$_dir is owned by gid $_gid — the root group or a system"
         log "         group. REFUSING to add osprey to it. A bind mount that looks"
         log "         root-owned inside the container usually means the host's"

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -1881,6 +1881,9 @@ def _tier_repo(tmp_path: Path, paradigm: str, tier: int | None = None) -> Path:
     if tier is not None:
         profile_data["tier"] = tier
     (repo / "profile.yml").write_text(yaml.dump(profile_data, default_flow_style=False))
+    # The bundle's source zone `osprey init` lays down beside the profile; the
+    # Reach Contract refuses a render whose bind source is not there.
+    (repo / "data" / "facility_knowledge").mkdir(parents=True)
     return repo
 
 

--- a/tests/cli/test_build_graphdb_removal.py
+++ b/tests/cli/test_build_graphdb_removal.py
@@ -53,6 +53,9 @@ def _build_repo(tmp_path: Path, monkeypatch, override: str):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "profile.yml").write_text(PROFILE.format(override=override))
+    # The bundle's source zone `osprey init` lays down beside the profile; the
+    # Reach Contract refuses a render whose bind source is not there.
+    (repo / "data" / "facility_knowledge").mkdir(parents=True)
     monkeypatch.chdir(repo)
     result = CliRunner().invoke(build, CI_FLAGS)
     return repo, result

--- a/tests/cli/test_build_preset.py
+++ b/tests/cli/test_build_preset.py
@@ -907,6 +907,11 @@ class TestDeployServicesKnob:
         profile = tmp_path / "smoke" / "profile.yml"
         profile.parent.mkdir()
         profile.write_text(self._PROFILE + extra)
+        # The bundle's source zone, which `osprey init` lays down beside the
+        # profile and the deploy binds into every entitled container. A bare
+        # profile without it is refused by the Reach Contract (the bind source
+        # would be an empty directory), and this class is about the knob.
+        (profile.parent / "data" / "facility_knowledge").mkdir(parents=True)
         result = _render_from(runner, str(profile))
         assert result.exit_code == 0, result.output
         return _project(tmp_path, "smoke")

--- a/tests/cli/test_graph_agent_surface.py
+++ b/tests/cli/test_graph_agent_surface.py
@@ -282,6 +282,9 @@ def _write_profile(repo: Path, config: dict | None = None) -> Path:
         ),
         encoding="utf-8",
     )
+    # The bundle's source zone `osprey init` lays down beside the profile; the
+    # Reach Contract refuses a render whose bind source is not there.
+    (repo / "data" / "facility_knowledge").mkdir(parents=True)
     return repo
 
 

--- a/tests/cli/test_lifecycle_promotions.py
+++ b/tests/cli/test_lifecycle_promotions.py
@@ -1106,18 +1106,6 @@ class TestDemotedRowsOnTheMiscDeployPath:
         assert framework_rule.read_text(encoding="utf-8") == "# facility\n"
         assert _levels_for(caplog, "profile overrides framework rule") == {logging.DEBUG}
 
-    def test_the_kernel_template_render_is_a_debug_line(self, monkeypatch, tmp_path, caplog):
-        """Rows 40 and 41: a per-file path inside a loop, and its announcement."""
-        source_dir, out_dir = _a_kernel_template(tmp_path)
-        # The render itself is jinja's business; only what it narrates is under
-        # test, and a real render needs the loader root the pipeline sets up.
-        monkeypatch.setattr(compose_generator, "render_template", lambda *a, **k: None)
-
-        with caplog.at_level(logging.DEBUG):
-            compose_generator.render_kernel_templates(str(source_dir), {}, str(out_dir))
-
-        assert _levels_for(caplog, "Rendered kernel template") == {logging.DEBUG}
-
     def test_the_legacy_clean_narration_is_debug_lines(self, monkeypatch, tmp_path, caplog):
         """Rows 10, 38 and 39: raw argv, and a bare completion with no phase."""
         _stub_the_legacy_clean(monkeypatch, tmp_path)
@@ -1313,16 +1301,6 @@ def _rendered_project(tmp_path: Path, name: str) -> Path:
     return TemplateManager().create_project(
         project_name=name, output_dir=tmp_path, data_bundle="hello_world"
     )
-
-
-def _a_kernel_template(tmp_path: Path) -> tuple[Path, Path]:
-    """A source tree holding one kernel template, and somewhere to render it."""
-    source_dir = tmp_path / "service"
-    (source_dir / "kernels").mkdir(parents=True)
-    (source_dir / "kernels" / "kernel.json.j2").write_text("{}", encoding="utf-8")
-    out_dir = tmp_path / "out"
-    out_dir.mkdir()
-    return source_dir, out_dir
 
 
 def _stub_the_legacy_clean(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/cli/test_set_verb.py
+++ b/tests/cli/test_set_verb.py
@@ -434,6 +434,9 @@ def _honesty_repo(tmp_path: Path, name: str = "honesty") -> Path:
         "tier: 1\n",
         encoding="utf-8",
     )
+    # The bundle's source zone `osprey init` lays down beside the profile; the
+    # Reach Contract refuses a render whose bind source is not there.
+    (repo / "data" / "facility_knowledge").mkdir(parents=True)
     return repo
 
 

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -1674,7 +1674,7 @@ def test_setup_build_dir_stages_a_config_naming_no_interpreter(
 
     template_path = str(Path("services") / "worker" / "docker-compose.yml.j2")
     config = {"project_name": "staged-no-interp", "build_dir": "./build"}
-    container_cfg = {"copy_src": False, "render_kernel_templates": False}
+    container_cfg = {"copy_src": False}
 
     setup_build_dir(template_path, config, container_cfg)
 
@@ -1728,7 +1728,7 @@ def test_setup_build_dir_stages_the_execution_block_verbatim(
 
     template_path = str(Path("services") / "worker" / "docker-compose.yml.j2")
     config = {"project_name": "pep-fixture-2", "build_dir": "./build"}
-    container_cfg = {"copy_src": False, "render_kernel_templates": False}
+    container_cfg = {"copy_src": False}
 
     setup_build_dir(template_path, config, container_cfg)
 

--- a/tests/deployment/test_entrypoint_script.py
+++ b/tests/deployment/test_entrypoint_script.py
@@ -75,6 +75,18 @@ REAL_FIND = shutil.which("find") or ""
 #: because mount paths in these tests deliberately contain spaces.
 GID_MAP_SEP = "\t"
 
+#: Where the script reads the container's user-namespace mapping. The sandbox
+#: points the script's copy at a fabricated file, because no test host is a
+#: rootless container and macOS has no ``/proc`` at all.
+UID_MAP_PATH = "/proc/self/uid_map"
+
+#: The kernel's spelling of "no user namespace": container root is host root.
+IDENTITY_UID_MAP = "         0          0 4294967295\n"
+
+#: rootless podman with the default subuid layout: the invoking host user
+#: (here uid 1000) is container root; everything else maps into a subuid range.
+ROOTLESS_UID_MAP = "         0       1000          1\n         1     100000      65536\n"
+
 
 @pytest.fixture(scope="module")
 def text() -> str:
@@ -153,6 +165,13 @@ class TestScriptShape:
         assert RENDER_NAMED_VARS <= read, f"a render-named mount is never joined: {read}"
         others = read - RENDER_NAMED_VARS
         assert not others, f"the join reads variables the render does not name: {others}"
+
+    def test_the_uid_map_is_the_kernels(self, text: str):
+        """Read from the one path the kernel states it at — not from the env,
+        which is the render's to name and this script's to trust for mounts
+        only, and not guessed from the runtime."""
+        assert f"UID_MAP={UID_MAP_PATH}\n" in text
+        assert not re.search(r"OSPREY_[A-Z_]*UID_MAP", text), "the map path is taken from the env"
 
     def test_the_gid_is_stat_ed_off_the_mount(self, text: str):
         """Not passed in. A gid rendered into the compose file is the host's
@@ -271,7 +290,20 @@ class Sandbox:
         stat_rc: int | None = None,
         stat_out: str | None = None,
         probe_rc: int = 0,
+        uid_map: str | None = None,
     ) -> Run:
+        # The map is read off a path the script hardcodes, so the sandbox's
+        # copy of the script is re-pointed at a file holding the fabricated
+        # map — the same move as the stubbed `stat`, for the same reason: the
+        # real one answers for the test host, never for the case under test.
+        # `None` leaves the real path in, which no test host can read.
+        script_text = TEMPLATE.read_text()
+        if uid_map is not None:
+            uid_map_file = self.tmp / "uid_map"
+            uid_map_file.write_text(uid_map)
+            assert UID_MAP_PATH in script_text
+            script_text = script_text.replace(UID_MAP_PATH, str(uid_map_file))
+        self.script.write_text(script_text)
         bindir = self._stubs(
             uid=uid,
             groupadd_rc=groupadd_rc,
@@ -787,6 +819,110 @@ class TestTheGidFloor:
         run = sandbox.run(audit_dir=audit, bundle_dir=bundle)
 
         assert _usermods(run) == ["usermod osprey-mount-4000 osprey"]
+
+
+class TestTheFloorInARootlessContainer:
+    """gid 0 is joinable exactly when container root is the host user.
+
+    Under rootless podman the invoking host user maps to uid/gid 0 inside, so
+    the audit subdir and the bundle that user provisioned (setgid, the user's
+    own group) present as gid 0 — the floor's signature for a remap, for a
+    reason that does not hold there. The script tells the two apart by the
+    kernel's uid map, which is fabricated here: no test host is a rootless
+    container, and the logic under test is the guard, not the kernel.
+    """
+
+    def test_gid_0_is_joined_when_the_uid_map_is_not_the_identity(self, sandbox: Sandbox):
+        audit = sandbox.audit_mount(gid=0)
+
+        run = sandbox.run(audit_dir=audit, uid_map=ROOTLESS_UID_MAP)
+
+        assert run.returncode == 0, run.stderr
+        assert _groupadds(run) == [], "gid 0 is `root` in every image's /etc/group"
+        assert _usermods(run) == ["usermod root osprey"]
+        assert _warnings(run) == [], run.stderr
+
+    def test_the_join_is_verified_like_any_other(self, sandbox: Sandbox):
+        """Membership in gid 0 is the mechanism; the probe still asks whether
+        the write the audit trail depends on actually works."""
+        audit = sandbox.audit_mount(gid=0)
+
+        run = sandbox.run(audit_dir=audit, uid_map=ROOTLESS_UID_MAP)
+
+        assert _probes(run) == [f"probe osprey -w {audit}"]
+        assert "joined osprey to group root (gid 0)" in run.stderr
+
+    def test_the_log_says_why_the_floor_was_lifted(self, sandbox: Sandbox):
+        audit = sandbox.audit_mount(gid=0)
+
+        run = sandbox.run(audit_dir=audit, uid_map=ROOTLESS_UID_MAP)
+
+        lifted = [line for line in run.stderr.splitlines() if "rootless container" in line]
+        assert len(lifted) == 1, run.stderr
+        assert AUDIT_VAR in lifted[0]
+        assert str(audit) in lifted[0]
+
+    def test_gid_0_stays_refused_under_the_identity_map(self, sandbox: Sandbox):
+        """A rootful daemon — Docker Desktop's remap included — runs under the
+        identity map, and there gid 0 still means the host's root group."""
+        audit = sandbox.audit_mount(gid=0)
+
+        run = sandbox.run(audit_dir=audit, uid_map=IDENTITY_UID_MAP)
+
+        assert run.group_ops == [], "osprey was added to gid 0 under the identity map"
+        assert len(_warnings(run)) == 1, run.stderr
+        assert "gid 0" in _warnings(run)[0]
+
+    def test_gid_0_stays_refused_with_no_readable_map(self, sandbox: Sandbox):
+        """No map, no evidence: the default is the answer that grants nothing.
+        (This is also what every test above this class runs under.)"""
+        audit = sandbox.audit_mount(gid=0)
+
+        run = sandbox.run(audit_dir=audit, uid_map=None)
+
+        assert run.group_ops == []
+        assert len(_warnings(run)) == 1, run.stderr
+
+    def test_an_empty_map_is_not_evidence_either(self, sandbox: Sandbox):
+        audit = sandbox.audit_mount(gid=0)
+
+        run = sandbox.run(audit_dir=audit, uid_map="")
+
+        assert run.group_ops == []
+
+    @pytest.mark.parametrize("gid", [1, 20, 99])
+    def test_the_system_range_stays_refused_in_a_rootless_container(
+        self, sandbox: Sandbox, gid: int
+    ):
+        """Only gid 0 is the host user in a rootless container; a mount that
+        presents `daemon` or `dialout` is still not a group the render meant."""
+        audit = sandbox.audit_mount(gid=gid)
+
+        run = sandbox.run(audit_dir=audit, uid_map=ROOTLESS_UID_MAP)
+
+        assert run.group_ops == [], f"osprey was added to gid {gid}"
+        assert len(_warnings(run)) == 1, run.stderr
+
+    def test_a_host_group_joins_the_same_way_in_a_rootless_container(self, sandbox: Sandbox):
+        """The map changes nothing above the floor."""
+        audit = sandbox.audit_mount(gid=3000)
+
+        run = sandbox.run(audit_dir=audit, uid_map=ROOTLESS_UID_MAP)
+
+        assert _usermods(run) == ["usermod osprey-mount-3000 osprey"]
+
+    def test_gid_0_and_a_host_gid_are_each_joined_once(self, sandbox: Sandbox):
+        """The audit subdir at gid 0 and a bundle at a host gid — the mixed
+        shape a rootless host with one shared bundle group produces."""
+        audit = sandbox.audit_mount(gid=0)
+        bundle = sandbox.bundle_mount(gid=0)
+        mirror = sandbox.mirror_mount(gid=3000)
+
+        run = sandbox.run(
+            audit_dir=audit, bundle_dir=bundle, mirror_dir=mirror, uid_map=ROOTLESS_UID_MAP
+        )
+
+        assert _usermods(run) == ["usermod root osprey", "usermod osprey-mount-3000 osprey"]
 
 
 class TestTheJoinFailsOpen:

--- a/tests/deployment/test_qmd_compose_fragment.py
+++ b/tests/deployment/test_qmd_compose_fragment.py
@@ -527,7 +527,7 @@ def test_render_service_templates_renders_siblings_and_skips_the_compose_templat
     (source / "docker-compose.yml.j2").write_text("compose")
     (source / "index.yml.j2").write_text("hello {{ name }}")
     (source / "Dockerfile").write_text("FROM scratch")
-    (source / "sub" / "kernel.json.j2").write_text("{}")
+    (source / "sub" / "nested.yml.j2").write_text("{}")
     out = tmp_path / "out"
     monkeypatch.chdir(tmp_path)
 

--- a/tests/deployment/test_reach_contract.py
+++ b/tests/deployment/test_reach_contract.py
@@ -326,6 +326,23 @@ def test_every_live_consumer_in_every_persona_resolves(built_stack, entries):
     assert checked, "no persona switched any consumer on — the fixture lost its preconditions"
 
 
+def test_every_entitled_shared_path_in_every_persona_resolves(built_stack, entries):
+    """The preset ships its bundle and the build anchors every render on the
+    repo, so what each persona is entitled to is on the host it was built on."""
+    checked = 0
+    for entry in entries:
+        config = _persona_config(built_stack, entry)
+        for shared in SHARED_PATHS:
+            if not shared.gate(config):
+                continue
+            checked += 1
+            assert shared.unresolved(config, built_stack) is None, (
+                f"persona {entry['persona']!r} is entitled to {shared.describe} "
+                f"({shared.config_key}) but {shared.unresolved(config, built_stack)}"
+            )
+    assert checked
+
+
 def test_every_projected_fact_matches_the_hosts(built_stack, host_config, entries):
     """What a persona was told is what the host render says — value for value."""
     checked = 0
@@ -454,11 +471,12 @@ def test_a_consumer_switched_on_with_nothing_to_dial_is_refused():
     assert "services.qmd.port" in error
 
 
-def test_a_degrading_consumer_is_not_refused():
+def test_a_degrading_consumer_is_not_refused(tmp_path):
     """The OKF panel's ranked search falls back to substring matching without
     a sidecar, by design — its contract says ``refuse=False``, so the same
     unresolved state that refuses hybrid search builds cleanly here (the
     ``reach`` health category still reports it)."""
+    (tmp_path / "data" / "facility_knowledge").mkdir(parents=True)
     config = {
         "web": {"panels": {"okf": {"enabled": True}}},
         "facility_knowledge": {"bundle_path": "data/facility_knowledge"},
@@ -466,11 +484,113 @@ def test_a_degrading_consumer_is_not_refused():
 
     live = [consumer.name for _, consumer in live_consumers(config)]
     assert "OKF panel ranked search" in live
-    assert reach_errors(config) == []
+    assert reach_errors(config, repo_root=tmp_path) == []
 
 
 def test_a_render_with_no_live_consumer_is_refused_nothing():
     assert reach_errors({}) == []
+
+
+# A shared path is the directory-shaped half of the same contract: a render
+# entitled to a host directory whose bind source is not there would have the
+# container runtime create it (root-owned under a rootful daemon) or read an
+# empty one the deploy provisioned on the spot. Anchored on the repo root the
+# build passes, exactly as the bind source is.
+
+
+def _entitled_to_bundle(bundle_path: str) -> dict:
+    return {"facility_knowledge": {"bundle_path": bundle_path}}
+
+
+def _entitled_to_mirror(mirror_path: str) -> dict:
+    return {
+        "ariel": {
+            "enhancement_modules": {
+                "qmd_export": {"enabled": True, "settings": {"mirror_path": mirror_path}}
+            }
+        }
+    }
+
+
+def test_every_shared_path_says_where_it_binds():
+    """The registry is complete only while every entry can be resolved to a
+    host directory and says whether the deploy provisions it."""
+    for shared in SHARED_PATHS:
+        assert callable(shared.host_dir), shared.config_key
+        assert isinstance(shared.provisioned, bool), shared.config_key
+        assert shared.describe, shared.config_key
+
+
+def test_a_bundle_that_is_not_on_the_host_is_refused(tmp_path):
+    """Authored content: nothing in the deploy fills it, so a key naming a
+    directory that is not there is a typo or a bundle that was never put in
+    place — refused at build time, naming the key, rather than bound empty."""
+    (error,) = reach_errors(_entitled_to_bundle("data/facility_knowledge"), repo_root=tmp_path)
+
+    assert "facility_knowledge.bundle_path" in error
+    assert str(tmp_path / "data" / "facility_knowledge") in error
+
+
+def test_a_bundle_on_the_host_is_not_refused(tmp_path):
+    (tmp_path / "data" / "facility_knowledge").mkdir(parents=True)
+
+    assert reach_errors(_entitled_to_bundle("data/facility_knowledge"), repo_root=tmp_path) == []
+
+
+def test_a_bundle_path_naming_a_file_is_refused(tmp_path):
+    (tmp_path / "bundle.tar").write_text("")
+
+    (error,) = reach_errors(_entitled_to_bundle("bundle.tar"), repo_root=tmp_path)
+
+    assert "not a directory" in error
+    assert "facility_knowledge.bundle_path" in error
+
+
+def test_an_absolute_bundle_path_is_read_as_given(tmp_path):
+    """Operator-owned, outside the repo, not re-anchored — the same rule the
+    renderers apply to the mount source."""
+    elsewhere = tmp_path / "srv" / "okf"
+    elsewhere.mkdir(parents=True)
+
+    assert reach_errors(_entitled_to_bundle(str(elsewhere)), repo_root=tmp_path / "repo") == []
+    (error,) = reach_errors(
+        _entitled_to_bundle(str(tmp_path / "srv" / "okf-typo")), repo_root=tmp_path
+    )
+    assert str(tmp_path / "srv" / "okf-typo") in error
+
+
+def test_a_render_naming_no_bundle_is_entitled_to_none(tmp_path):
+    """No key, no entitlement, nothing to refuse — a dispatch worker mounts no
+    bundle and must not be refused over a directory it never binds."""
+    assert reach_errors({"facility_knowledge": {}}, repo_root=tmp_path) == []
+
+
+def test_a_mirror_the_deploy_will_provision_is_not_refused(tmp_path):
+    """A writer's output: the deploy creates it before the first bind
+    (``ensure_shared_corpus_dir``), so a mirror that is not there yet is the
+    ordinary first-deploy state."""
+    assert reach_errors(_entitled_to_mirror("var/ariel_mirror"), repo_root=tmp_path) == []
+
+
+def test_a_mirror_the_deploy_cannot_create_is_refused(tmp_path):
+    """The one mirror state that ends root-owned: a path the deploy's mkdir
+    would fail on, because what stands where its parent should be is not a
+    writable directory."""
+    (tmp_path / "blocker").write_text("")
+
+    (error,) = reach_errors(_entitled_to_mirror("blocker/ariel_mirror"), repo_root=tmp_path)
+
+    assert "ariel.enhancement_modules.qmd_export.mirror_path" in error
+    assert "cannot create" in error
+    assert str(tmp_path / "blocker") in error
+
+
+def test_a_disabled_export_is_entitled_to_no_mirror(tmp_path):
+    config = _entitled_to_mirror("blocker/ariel_mirror")
+    config["ariel"]["enhancement_modules"]["qmd_export"]["enabled"] = False
+    (tmp_path / "blocker").write_text("")
+
+    assert reach_errors(config, repo_root=tmp_path) == []
 
 
 # A deploying render — `deployed_services` non-empty — is the other side of the


### PR DESCRIPTION
Three deployment-layer fixes, one commit each.

## #769 — drop the Jupyter-era kernel template rendering

`render_kernel_templates`, the `kernel.json.j2` branch inside `render_template`, the `render_kernel_templates:` service-entry opt-in in `setup_build_dir`, and the docs mention are gone. Nothing under `templates/services/` carries a kernel template (the only two "kernel" hits in `templates/` are Linux-kernel comments), and the sole remaining caller was a log-level narration test of the helper itself. `render_template` stays — it is the live compose/service renderer; the issue's `process_kernel_template`/`process_service_kernels` names were the pre-rename spellings.

## #770 — `SharedPath` gets a host-directory resolver

`SharedPath` now carries the host-directory reader the deploy provisions from and the renderers emit the mount from (`resolve_facility_bundle_dir` / `resolve_ariel_mirror_dir`), plus a `provisioned` flag. `reach_errors()` walks every entitled shared path and refuses, naming the config key; the build passes its repo root, the same anchoring `resolve_limits_mount` takes as a parameter.

One premise correction against main: the deploy **already provisions both directories** before the first bind (`_ensure_agent_data_structure` on the build path, `provision.py` on the web-terminal path, both via `ensure_shared_corpus_dir`, non-fatal by design). So a blanket "must exist at build time" would refuse every fresh ARIEL deployment — the mirror is written by the deployment's own exporter and never exists before the first deploy. The resolver therefore asks per path:

- **bundle** (`provisioned=False`, authored content): must be a directory on the host. A missing one would be provisioned *empty* and bound over the container's copy — every reader finds nothing. This is what `osprey init` lays down at `<repo>/data/facility_knowledge`; the sidecar binds `./data/facility_knowledge` repo-relative.
- **mirror** (`provisioned=True`, a writer's output): exists, or its nearest existing ancestor is a directory this user can write — the one state that would otherwise end with the runtime creating the source root-owned.

Five test fixtures built the control_assistant bundle from a bare `profile.yml` with no `data/` source zone; they now create it, because the render they built would have deployed an empty bundle.

## #774 — join a gid-0 mount when container root is the host user

`join_mounted_group` reads `/proc/self/uid_map`: gid 0 is joinable only when the map is **not** the identity (`0 0 4294967295`) — the rootless shape, where the invoking host user *is* container root and the setgid directory it provisioned presents as gid 0. A rootful daemon (Docker Desktop's remap included) runs under the identity map and still refuses; the system range 1–99 stays refused everywhere; no readable map grants nothing. The `userns_mode` render knob from the issue was deliberately not attempted.

**Live verification stays with the reporter's RHEL host.** There is no rootless podman on the development machine; the sandbox tests re-point the script's `UID_MAP` constant at a fabricated map (identity / rootless / empty / absent) and pin the guard logic, the verified-write probe, the lifted-floor log line, and that the system range and rootful case are unchanged.

## Verification

- `./scripts/quick_check.sh`: 33,602 passed, 223 skipped.
- Slow lane (`tests/cli tests/deployment tests/templates tests/health -m slow`): 130 passed, incl. the built-stack Reach Contract seams.
- `scripts/changelog_fragments.py check`: three fragments valid.

Fixes #769, fixes #770, fixes #774.

https://claude.ai/code/session_01CNXKA57aTKj7ng2PbjfYro
