### PR TITLE
feat(bluesky): page device listings and bound the refusal body

### DIFF
--- a/changelog.d/766.changed.md
+++ b/changelog.d/766.changed.md
@@ -1,0 +1,7 @@
+`GET /devices` now returns one page of devices with the total count, and
+accepts `prefix`, `limit` and `offset` to narrow and page through them; the
+agent's device listing takes the same three. A build profile can set
+`bluesky.device_page_size` to change the page size (default 500). A refusal
+that names an unknown device still spells out the addressable devices when
+they fit in one page; a larger namespace now carries a count and a link to
+the paged listing instead.

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -918,7 +918,7 @@ bluesky
 
 The ``bluesky:`` section configures the Bluesky stack a deployment brings up —
 the bridge, the queue server, the BLUESKY panel and, optionally, the Tiled data
-store. It accepts exactly seven keys; a misspelled or unknown key **fails the
+store. It accepts exactly eight keys; a misspelled or unknown key **fails the
 build** and prints the valid set:
 
 .. list-table::
@@ -945,6 +945,11 @@ build** and prints the valid set:
      - The file listing the devices plans may drive or record
        (default ``data/bluesky_devices.yml``) — see
        :doc:`/how-to/bluesky/write-plans`.
+   * - ``device_page_size``
+     - How many devices the bridge lists at once (default 500). A larger set
+       is served a page at a time and can be narrowed by an exact name
+       prefix. The same number decides when a refusal for an unknown device
+       stops listing every device it does know and gives a count instead.
 
 Whether a deployment can execute plans at all is not set here: it follows from
 the control system the deployment runs. See :doc:`/how-to/bluesky/queue` for

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -889,15 +889,37 @@ def _facility_plan_keys(bluesky: BlueskyConfig) -> dict[str, Any]:
     ``os.pathsep`` join is done Python-side because the Jinja render context has
     no ``os`` module.
 
+    ``device_page_size`` is a THIRD contract: omit-when-EQUALS-DEFAULT. It is
+    neither always-written like ``devices_file`` nor omit-when-unset like its
+    two neighbours, because the key is never unset — it is an ``int`` with a
+    dataclass default, so "unset" and "authored at the default" arrive here as
+    the same value and cannot be told apart. Writing it unconditionally would
+    put a line into every existing project's config.yml and an env var into
+    every rendered bridge, changing renders that are otherwise unchanged; so
+    the line is written only when the profile asks for something OTHER than the
+    default. A profile that authors the default explicitly therefore renders no
+    line at all — and that is exactly right, because the bridge falls back to
+    the same default when the env var is absent, so the two spellings deploy
+    identical behaviour. The comparison is against
+    ``BlueskyConfig.device_page_size``, the dataclass default itself, so the
+    build and the bridge cannot drift apart over a literal.
+
     Shared by both lanes, because plans and devices are properties of the
     facility rather than of a target — a per-lane restatement is how the two
     lanes would end up loading different plans from one profile.
     """
+    # Runtime import: the class is otherwise only a TYPE_CHECKING name here, and
+    # the omit-when-default comparison needs the dataclass default itself rather
+    # than a literal repeated on this side of the build.
+    from osprey.cli.build_profile_schema import BlueskyConfig
+
     keys: dict[str, Any] = {"devices_file": bluesky.devices_file}
     if bluesky.plan_dir:
         keys["plan_dir"] = bluesky.plan_dir
     if bluesky.excluded_plans:
         keys["excluded_plans"] = os.pathsep.join(bluesky.excluded_plans)
+    if bluesky.device_page_size != BlueskyConfig.device_page_size:
+        keys["device_page_size"] = bluesky.device_page_size
     return keys
 
 

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -742,6 +742,15 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             raise BuildProfileError(
                 f"bluesky.devices_file must be a non-empty path string (got {devices_file!r})"
             )
+        device_page_size = bluesky_raw.get("device_page_size", BlueskyConfig.device_page_size)
+        if (
+            not isinstance(device_page_size, int)
+            or isinstance(device_page_size, bool)
+            or device_page_size < 1
+        ):
+            raise BuildProfileError(
+                f"bluesky.device_page_size must be an integer >= 1 (got {device_page_size!r})"
+            )
         bluesky = BlueskyConfig(
             port=bluesky_raw.get("port", 8090),
             tiled_enabled=bluesky_raw.get("tiled_enabled", False),
@@ -750,6 +759,7 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             plan_dir=bluesky_raw.get("plan_dir"),
             excluded_plans=excluded_plans,
             devices_file=devices_file,
+            device_page_size=device_page_size,
         )
 
     va_raw = raw.get("virtual_accelerator")

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -429,6 +429,26 @@ class BlueskyConfig:
     devices, so the only question is which file names them, and an unwritten
     key would leave the staging step re-deriving this default for itself.
     """
+    device_page_size: int = 500
+    """How many devices one page of the bridge's device listing carries.
+
+    ONE number bounds both halves of the same contract: the page size the
+    bridge's ``GET /devices`` returns, and the inline threshold in the body of
+    its ``400`` refusal for an unknown device — below that count the refusal
+    spells the addressable devices out, above it the caller is pointed at the
+    paged listing instead. Keeping them the same number means a facility never
+    tunes one against the other.
+
+    Authored per facility, because "how many devices is too many to read in one
+    breath" is a property of the facility's device file, not of OSPREY. The
+    default is deliberately generous: a deployment whose device file is smaller
+    than this never sees a second page and never sees a truncated refusal.
+
+    At the default value this key renders NOTHING into ``config.yml`` or the
+    compose file — the rendered deployment carries the key only when a profile
+    authors a value that differs, and the bridge falls back to the same default
+    when the env var is absent.
+    """
 
     def second_lane_port(self) -> int:
         """Host port lane 2's bridge publishes, derived from lane 1's.

--- a/src/osprey/mcp_server/bluesky/tools/queue.py
+++ b/src/osprey/mcp_server/bluesky/tools/queue.py
@@ -222,10 +222,12 @@ _REFUSAL_HINTS: dict[str, list[str]] = {
     # that was never the problem; it points at the device list instead.
     "unknown_device": [
         "A device name in the staged plan is not one this worker built. Call "
-        "list_devices for the names it actually has, then set_draft the corrected "
-        "name (which mints a new revision) and add that revision.",
-        "The error's details carry available_devices — the complete set — so pick "
-        "from it rather than guessing a spelling or a nearby name.",
+        "list_devices with a prefix for the names it actually has, then set_draft the "
+        "corrected name (which mints a new revision) and add that revision.",
+        "The error's details carry available_devices when the worker's namespace fits "
+        "one page; a larger namespace reports available_count and available_devices_url "
+        "instead. Either way, list_devices is what reads the names — pick one from "
+        "there rather than guessing a spelling or a nearby name.",
     ],
     "session_plan_unvalidated": [
         "Session plans need a current passing validation; run validate_plan on the plan "
@@ -1149,9 +1151,12 @@ async def queue_add(draft_revision: int, lane: str | None = None) -> str:
           Edit the draft to mint a new revision.
         - unknown_device: a device name in the staged plan is not one this
           worker built, caught before the item was queued rather than as a
-          failed run. ``details.available_devices`` is the complete set of
-          names it does have (list_devices reads the same set) — correct the
-          name with set_draft, which mints a new revision, then add that one.
+          failed run. ``details.available_devices`` lists the names it does
+          have when the worker's namespace fits one page; a larger namespace
+          reports ``details.available_count`` and
+          ``details.available_devices_url`` instead. Read the names with
+          list_devices (pass a prefix), then correct the name with set_draft,
+          which mints a new revision, and add that one.
         - session_plan_unvalidated / session_plan_not_in_namespace: the plan is
           a session plan with no current passing validation, or its validated
           bytes are not in the worker's namespace. Run validate_plan again.

--- a/src/osprey/mcp_server/bluesky/tools/read_tools.py
+++ b/src/osprey/mcp_server/bluesky/tools/read_tools.py
@@ -34,7 +34,7 @@ the "Figure projection" section at the bottom of this file.
 
 import json
 from collections.abc import Sequence
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 import anyio
 from pydantic import ValidationError
@@ -148,8 +148,8 @@ async def list_plans() -> str:
 # Tool 4: list devices
 # ---------------------------------------------------------------------------
 @mcp.tool()
-async def list_devices() -> str:
-    """List the device names this deployment's plans accept.
+async def list_devices(prefix: str = "", limit: int | None = None, offset: int = 0) -> str:
+    """List the device names this deployment's plans accept, one page at a time.
 
     Plan parameters carry devices as strings, and this is the set those strings
     must come from — a name that is not here is not a device the worker has,
@@ -159,18 +159,76 @@ async def list_devices() -> str:
     whose declared role matches how it is meant to be used. Read this before
     staging any device name into the draft; never invent or guess one.
 
+    One page comes back per call, alongside ``total`` — how many names matched
+    before the page was cut — so "that is all of them" is always
+    distinguishable from "there is more". A facility-scale namespace is far
+    larger than one page: when a specific device is wanted, ``prefix`` is the
+    way to reach it, not paging to the end.
+
+    Args:
+        prefix: Return only names starting with this, matched literally and
+            CASE-SENSITIVELY, exactly as the worker spells them. Empty (the
+            default) returns every name.
+        limit: Maximum entries in this page. ``None`` (the default) asks for
+            the bridge's full page size. Values outside 1..page-size are
+            clamped by the bridge, never rejected.
+        offset: Index into the matching names to start this page at, counted
+            from 0. Clamped up to at least 0, likewise never rejected.
+
     Returns:
-        JSON ``{"status": "success", "devices": [...]}``, each entry
-        ``{"name"}`` plus whichever of ``is_movable``/``is_readable``/
-        ``is_flyable`` the worker reported — ``is_movable`` marks a device that
-        can be driven as a setpoint, ``is_readable`` one that can be read as a
-        readback. A missing flag means the worker did not say, not "no".
-        An empty list means this deployment's worker built no devices at all.
+        JSON ``{"status": "success", "devices": [...], "total", "offset",
+        "limit"}``. Each entry is ``{"name"}`` plus whichever of
+        ``is_movable``/``is_readable``/``is_flyable`` the worker reported —
+        ``is_movable`` marks a device that can be driven as a setpoint,
+        ``is_readable`` one that can be read as a readback. A missing flag
+        means the worker did not say, not "no".
+
+        ``total`` counts the matches before the page cut; ``offset`` and
+        ``limit`` are the EFFECTIVE values the bridge used after clamping, not
+        necessarily the ones asked for. A ``"note"`` appears whenever this page
+        holds fewer than ``total`` entries, saying how many are missing and how
+        to reach them — relay that rather than describing the page as the whole
+        set. ``devices: []`` with ``total: 0`` means nothing matched: for an
+        empty ``prefix`` the worker built no devices at all, and otherwise no
+        name starts with it (check the spelling and the case).
     """
-    status, body = await anyio.to_thread.run_sync(_http_get_json, "/devices")
+    params: dict[str, str | int] = {}
+    if prefix:
+        params["prefix"] = prefix
+    if limit is not None:
+        params["limit"] = limit
+    if offset:
+        params["offset"] = offset
+    path = "/devices" + (f"?{urlencode(params)}" if params else "")
+    status, body = await anyio.to_thread.run_sync(_http_get_json, path)
     if status != 200:
         return make_error("bluesky_bridge_error", bridge_error_message(body, status))
-    return json.dumps({"status": "success", "devices": body})
+    # The route clamps; this tool reports what came back rather than what was
+    # asked for, so `offset`/`limit` below are the bridge's effective values.
+    devices = body["devices"]
+    total = body["total"]
+    effective_offset = body["offset"]
+    result = {
+        "status": "success",
+        "devices": devices,
+        "total": total,
+        "offset": effective_offset,
+        "limit": body["limit"],
+    }
+    if len(devices) < total:
+        if effective_offset >= total:
+            result["note"] = (
+                f"This page is empty because offset {effective_offset} is past the end of "
+                f"the namespace, which holds {total} matching devices — read again from a "
+                "lower offset."
+            )
+        else:
+            result["note"] = (
+                f"{total - effective_offset - len(devices)} of the {total} matching devices "
+                "are not on this page — narrow the search with prefix, or read the next page "
+                "with offset."
+            )
+    return json.dumps(result)
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -194,6 +194,8 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
       `BLUESKY_DEVICES_FILE`: the posture it guards against is a property of
       the project config, not of whether this deployment wires up any devices
       at all, and a gated guard leaves whole classes of deployment unchecked.
+      Alongside it, `queue.device_page_size()` is parsed once so a malformed
+      `BLUESKY_DEVICE_PAGE_SIZE` fails the boot instead of the first request.
     - The document plane: the 0MQ proxy the queueserver's Publisher connects
       to, and the dispatcher that turns that stream into live rows.
       Unconfigured is a no-op; see `document_plane.start_from_env`.
@@ -212,6 +214,11 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # limits checking on + an unreadable limits database), before anything
     # else is brought up.
     _assert_limits_readable_if_writable()
+
+    # A malformed device page size is a boot-time refusal too: the number is
+    # read per request downstream, so parsing it once here turns a bad env var
+    # into a failed start rather than a surprise 500 on the first caller.
+    queue.device_page_size()
 
     # The document plane's 0MQ proxy — the binding element the queueserver's
     # Publisher connects to, and the RemoteDispatcher that turns that stream
@@ -508,7 +515,11 @@ def _device_entry(name: str, description: Any) -> dict[str, Any]:
 
 
 @app.get("/devices")
-async def list_devices() -> list[dict]:
+async def list_devices(
+    prefix: str = "",
+    limit: int | None = None,
+    offset: int = 0,
+) -> dict[str, Any]:
     """Devices the queueserver worker built, by the name plans resolve them under.
 
     The companion of `GET /plans`: a plan's device parameters carry device
@@ -517,19 +528,56 @@ async def list_devices() -> list[dict]:
     fails on the run's first iteration — after an enqueue and a start — so this
     route is what turns picking a device into a lookup rather than a guess.
 
+    The response is `{"devices", "total", "offset", "limit"}`. `devices` is one
+    page, sorted by name; `total` is how many names matched *before* the page
+    was cut, so a caller can tell "that is all of them" from "there is more".
     Each entry is `{"name", ...}` plus whatever of `is_movable`/`is_readable`/
     `is_flyable` the manager reported for it, which is how a caller tells a
     drivable setpoint from a read-only readback.
+
+    `prefix` filters by literal, case-sensitive `str.startswith` — device names
+    come out of the worker's namespace verbatim, so folding case here would
+    invent matches the worker cannot resolve. A prefix nothing starts with is a
+    200 with `devices: []` and `total: 0`: an empty set is an answer, not a
+    failure to answer.
+
+    `limit` and `offset` are CLAMPED, never rejected — the same posture as
+    `runs.list_records` (`runs.py:236-241`), so a nonsensical query returns a
+    sane page instead of a 422 an agent has to learn to avoid. `limit` is
+    clamped into `1..queue.device_page_size()` (unset means the full page
+    size), `offset` up to at least 0, and both are echoed back as the
+    EFFECTIVE values used, so the caller reads the bound it actually got rather
+    than the one it asked for.
+
+    `total` is recomputed per request against the manager's current answer. A
+    `total` that changes between two pages of one walk means the worker rebuilt
+    its namespace mid-walk — the pages either side of that are from different
+    device sets, and the walk is worth restarting rather than stitching.
     """
     try:
         reply = await get_queue_backend().devices_allowed()
     except QueueBackendError as exc:
         # Same mapping as every other manager-backed read (see `list_runs`).
         raise queue._http_error(exc) from exc
+    cap = queue.device_page_size()
+    bound = max(1, min(limit if limit is not None else cap, cap))
+    start = max(0, offset)
     allowed = reply.get("devices_allowed")
     if not isinstance(allowed, dict):
-        return []
-    return [_device_entry(name, description) for name, description in sorted(allowed.items())]
+        # A manager that answered without the map has no devices to report;
+        # normalizing keeps the envelope built in exactly one place below.
+        allowed = {}
+    matches = [
+        _device_entry(name, description)
+        for name, description in sorted(allowed.items())
+        if name.startswith(prefix)
+    ]
+    return {
+        "devices": matches[start : start + bound],
+        "total": len(matches),
+        "offset": start,
+        "limit": bound,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/services/bluesky_bridge/queue.py
+++ b/src/osprey/services/bluesky_bridge/queue.py
@@ -69,6 +69,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import uuid
 from typing import Any, NoReturn
 
@@ -452,19 +453,75 @@ def _referenced_channel_names(spec: PlanSpec[Any], plan_args: Any) -> tuple[set[
 
 # How many device names the refusal SENTENCE lists before summarizing the
 # rest. A real facility worker builds hundreds, and the sentence is prose an
-# agent and an operator read — the complete set is always on the wire
-# structurally in ``available_devices``, so nothing is lost by capping the
-# readable copy.
+# agent and an operator read. It is a ceiling, not the only one: the sentence
+# never names more devices than a single device page holds either, so the
+# effective cap is this limit or `device_page_size()`, whichever is smaller.
+# Capping the readable copy loses nothing — the names it drops are either in
+# the body's own ``available_devices`` (a namespace that fits in one page) or
+# one ``GET /devices`` away (one that does not).
 _SENTENCE_DEVICE_LIMIT = 20
 
+#: Env var carrying the one number that bounds this bridge's device surfaces.
+#: Authored per facility in the build profile, rendered into the compose file;
+#: the container cannot read `config.yml`, so the env var is the whole channel.
+DEVICE_PAGE_SIZE_ENV = "BLUESKY_DEVICE_PAGE_SIZE"
 
-def _available_devices_phrase(available: set[str]) -> str:
-    """The refusal sentence's device list, capped at `_SENTENCE_DEVICE_LIMIT`."""
+#: Used when the variable is unset — large enough that a facility whose worker
+#: builds a normal namespace never notices a bound at all.
+DEFAULT_DEVICE_PAGE_SIZE = 500
+
+
+def device_page_size() -> int:
+    """How many device names this bridge publishes at once.
+
+    ONE number bounds both device surfaces: the page `GET /devices` returns,
+    and the inline threshold in the 400 `unknown_device` refusal body. A
+    facility that raises it raises both together, so the two can never
+    disagree about how much of a namespace is reasonable to hand over.
+
+    Read from `os.environ` on every call — never cached at import — so a test
+    (and a re-exec'd process) sees the value its environment declares.
+
+    Raises:
+        ValueError: if the variable is set to something that is not an
+            integer, or to an integer below 1. A bound of zero publishes
+            nothing, which is a misconfiguration, not a policy.
+    """
+    raw = os.environ.get(DEVICE_PAGE_SIZE_ENV)
+    if raw is None:
+        return DEFAULT_DEVICE_PAGE_SIZE
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"{DEVICE_PAGE_SIZE_ENV}={raw!r} is not an integer; "
+            f"set it to a whole number >= 1 (default {DEFAULT_DEVICE_PAGE_SIZE})"
+        ) from None
+    if value < 1:
+        raise ValueError(
+            f"{DEVICE_PAGE_SIZE_ENV}={raw!r} must be >= 1; "
+            f"a bound below 1 would publish no devices at all"
+        )
+    return value
+
+
+def _available_devices_phrase(available: set[str], page_size: int) -> str:
+    """The refusal sentence's device list, capped for readability.
+
+    The cap is `_SENTENCE_DEVICE_LIMIT` or *page_size*, whichever is smaller —
+    the sentence is prose, and it never names more devices than one page of
+    `GET /devices` would hand over. When it summarizes, it says where the rest
+    of the names actually are: in this same body's ``available_devices`` when
+    the namespace fits in one page, and behind ``GET /devices`` when it does
+    not, which is exactly when the body omits the inline list.
+    """
     names = sorted(available)
-    if len(names) <= _SENTENCE_DEVICE_LIMIT:
+    cap = min(_SENTENCE_DEVICE_LIMIT, page_size)
+    if len(names) <= cap:
         return f"{names}"
-    shown = names[:_SENTENCE_DEVICE_LIMIT]
-    return f"{shown} (+{len(names) - len(shown)} more; full list in available_devices)"
+    shown = names[:cap]
+    where = "in available_devices" if len(names) <= page_size else "via GET /devices"
+    return f"{shown} (+{len(names) - len(shown)} more; full list {where})"
 
 
 def _refuse_unknown_devices(
@@ -487,10 +544,17 @@ def _refuse_unknown_devices(
     Three deliberate differences from the run-time version, all additive:
     ``devices`` carries EVERY unknown name across both roles (the run-time raise
     can only ever report the first one it tripped over), the in-sentence device
-    list is capped — `available_devices` carries it whole — and the one name the
-    sentence quotes is drawn from the movable names when there are any, because
-    that is the reading under which a start would have driven hardware toward a
-    channel the worker never built.
+    list is capped, and the one name the sentence quotes is drawn from the
+    movable names when there are any, because that is the reading under which a
+    start would have driven hardware toward a channel the worker never built.
+
+    How much of the namespace rides in the body is decided by one threshold,
+    `device_page_size()`, read per request. At or below it the body carries
+    ``available_devices``, every built name sorted — the common case, and the
+    one a caller picks a correction straight out of. Above it the body carries
+    ``available_count`` and ``available_devices_url`` instead, and the caller
+    pages the names from `GET /devices`. The same number bounds that page, so
+    a refusal never promises more names in one response than the route serves.
 
     400, not 409: the request itself names something that does not exist, and
     the fix is in the caller's hands — pick a name `GET /devices` lists.
@@ -498,19 +562,22 @@ def _refuse_unknown_devices(
     unknown = unknown_movable | unknown_readable
     first = sorted(unknown_movable or unknown_readable)[0]
     label = "session plan" if session_tier else "plan"
-    raise HTTPException(
-        status_code=400,
-        detail={
-            "code": "unknown_device",
-            "detail": (
-                f"{label} {plan_name!r} referenced device {first!r}, which this worker "
-                f"did not build; available devices: {_available_devices_phrase(available)}"
-            ),
-            "plan": plan_name,
-            "devices": sorted(unknown),
-            "available_devices": sorted(available),
-        },
-    )
+    cap = device_page_size()
+    detail: dict[str, Any] = {
+        "code": "unknown_device",
+        "detail": (
+            f"{label} {plan_name!r} referenced device {first!r}, which this worker "
+            f"did not build; available devices: {_available_devices_phrase(available, cap)}"
+        ),
+        "plan": plan_name,
+        "devices": sorted(unknown),
+    }
+    if len(available) <= cap:
+        detail["available_devices"] = sorted(available)
+    else:
+        detail["available_count"] = len(available)
+        detail["available_devices_url"] = "/devices"
+    raise HTTPException(status_code=400, detail=detail)
 
 
 async def _check_devices_exist(backend: QueueBackend, plan_name: str, plan_args: Any) -> None:

--- a/src/osprey/templates/claude_code/claude/skills/operating-bluesky-plans/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/operating-bluesky-plans/SKILL.md
@@ -130,9 +130,16 @@ something should not land on a plan that drives channels.
 **`list_devices()`** lists the device names this worker actually
 built, which is where every device name in `plan_args` must come from — read it
 rather than guessing a name, and put a name in the parameter whose declared
-role matches how the operator wants it used. Then stage the **entire** plan
-configuration in a **single** `set_draft` call and note the `revision` it
-returns:
+role matches how the operator wants it used. One call hands back one page of
+names plus a count of every name that matched, so "that is all of them" is
+never mistaken for "there is more"; a page holding only part of the match says
+so, and says how many it left behind. To reach a particular family of devices,
+pass a `prefix` and read that family back directly — the match is literal and
+case-sensitive — rather than paging to the end of the namespace. An unfiltered
+call is the way in when the naming is unknown: its page shows how this
+deployment spells names, and its count shows how much is behind them. Then
+stage the **entire** plan configuration in a **single** `set_draft` call and
+note the `revision` it returns:
 
 ```
 set_draft(plan_name="grid_scan", plan_args_patch={<every parameter, complete>})
@@ -148,13 +155,15 @@ it.
 
 A plan that drives several devices together deserves one more look before the
 draft goes in front of the human. `orbit_bump_sweep` is the shipped case: it
-moves three or four correctors at once on a stored beam, so read every
-corrector *and* every BPM name back from `list_devices()` rather than trusting
-a name you carried in, and be ready for the run to end early without moving
-anything — it measures the orbit noise first and refuses a `tolerance`
-narrower than twice what it measured, before its first write. Report that as
-the plan declining a band it could not verify, and say the answer is a wider
-tolerance or a quieter machine; it is not a failure to retry as-is.
+moves three or four correctors at once on a stored beam, so read each device
+family back with its own `list_devices(prefix=...)` call — the correctors
+under one prefix, the BPMs under another — rather than trusting a name you
+carried in or expecting one unpaged list to hold them all. Be ready, too, for
+the run to end early without moving anything: it measures the orbit noise
+first and refuses a `tolerance` narrower than twice what it measured, before
+its first write. Report that as the plan declining a band it could not verify,
+and say the answer is a wider tolerance or a quieter machine; it is not a
+failure to retry as-is.
 
 ---
 

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -268,6 +268,14 @@ services:
       # set omits the key entirely, so this env var never renders.
       BLUESKY_EXCLUDED_PLANS: "{{ svc.excluded_plans }}"
 {% endif %}
+{%- if svc.device_page_size %}
+      # Device-listing page size: the bridge's `device_page_size()` reads
+      # BLUESKY_DEVICE_PAGE_SIZE as ONE number bounding both the `GET /devices`
+      # page and the unknown-device refusal's inline threshold. Written by
+      # _inject_bluesky (build_injectors.py) only when the profile departs from
+      # the default, so a default-valued deploy never renders this key at all.
+      BLUESKY_DEVICE_PAGE_SIZE: "{{ svc.device_page_size }}"
+{% endif %}
 {% if svc.ca_name_servers %}
       # This lane serves the LIVE target, so its Channel Access addressing is
       # the facility's own gateway, supplied by the operator rather than known

--- a/tests/cli/test_bluesky_compose_render.py
+++ b/tests/cli/test_bluesky_compose_render.py
@@ -83,6 +83,7 @@ def _render(
     deployed_services: list[str] | None = None,
     plan_dir: str | None = None,
     excluded_plans: str | None = None,
+    device_page_size: int | None = None,
     devices_present: bool = False,
     limits_mount: dict[str, str] | None = None,
 ) -> dict[str, Any]:
@@ -119,6 +120,8 @@ def _render(
         bluesky["plan_dir"] = plan_dir
     if excluded_plans is not None:
         bluesky["excluded_plans"] = excluded_plans
+    if device_page_size is not None:
+        bluesky["device_page_size"] = device_page_size
 
     # ``lane_keys`` is seeded with 'bluesky' unconditionally (the template's
     # lane axis), so every render defines lane 1's containers whatever
@@ -704,6 +707,42 @@ def test_no_plan_dir_omits_the_mount_and_env(rendered: dict[str, Any]) -> None:
     queueserver = rendered["services"]["queueserver"]
     assert "BLUESKY_PLAN_DIRS" not in queueserver["environment"]
     assert not any(str(v).endswith(":/app/project/plans:ro") for v in queueserver["volumes"])
+
+
+def test_device_page_size_reaches_the_bridge_when_authored() -> None:
+    """An authored page size renders BLUESKY_DEVICE_PAGE_SIZE on the bridge.
+
+    The bridge's ``device_page_size()`` reads exactly this name, and the value
+    is a STRING in the container environment even though it is an int in the
+    profile — compose environments carry no other type, so the quoting in the
+    template is part of the contract rather than cosmetic.
+    """
+    bridge = _render(device_page_size=200)["services"]["bluesky-bridge"]
+    assert bridge["environment"]["BLUESKY_DEVICE_PAGE_SIZE"] == "200"
+
+
+def test_default_device_page_size_renders_no_env_anywhere(rendered: dict[str, Any]) -> None:
+    """The omit-when-default contract, asserted through the rendered artifact.
+
+    ``_facility_plan_keys`` writes the key only when the profile departs from
+    ``BlueskyConfig.device_page_size``, so a stock render carries no such
+    service key and the template's guard must therefore emit nothing at all —
+    not an empty value, and not a line in some other container.
+    """
+    assert "BLUESKY_DEVICE_PAGE_SIZE" not in yaml.safe_dump(rendered)
+
+
+def test_only_the_bridge_is_given_the_device_page_size() -> None:
+    """The worker never pages a device listing, so the key stops at the bridge.
+
+    One number bounds the ``GET /devices`` page and the unknown-device
+    refusal's inline threshold — both of which live in the HTTP facade. Handing
+    it to the RE Manager would advertise a knob the worker process does not
+    read, which reads to an operator as a setting that has an effect.
+    """
+    rendered = _render(device_page_size=200)
+    queueserver = rendered["services"]["queueserver"]
+    assert "BLUESKY_DEVICE_PAGE_SIZE" not in (queueserver["environment"] or {})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_bluesky_profile_keys.py
+++ b/tests/cli/test_bluesky_profile_keys.py
@@ -76,6 +76,7 @@ def test_every_valid_key_is_accepted_and_read() -> None:
             "plan_dir": "/facility/plans",
             "excluded_plans": ["orm"],
             "devices_file": "data/facility_devices.yml",
+            "device_page_size": 250,
         },
     }
 
@@ -89,6 +90,7 @@ def test_every_valid_key_is_accepted_and_read() -> None:
         plan_dir="/facility/plans",
         excluded_plans=["orm"],
         devices_file="data/facility_devices.yml",
+        device_page_size=250,
     )
 
 
@@ -97,6 +99,33 @@ def test_empty_block_still_takes_the_defaults() -> None:
     profile = _parse_profile({"name": "x", "bluesky": {}})
 
     assert profile.bluesky == BlueskyConfig()
+
+
+# ── values are validated, not just key names ─────────────────────────────────
+
+
+@pytest.mark.parametrize("value", [0, -5, True, "abc"])
+def test_device_page_size_rejects_a_value_that_is_not_a_positive_int(value: Any) -> None:
+    """The key is auto-accepted (it is a dataclass field), so the VALUE check is
+    the only thing standing between a nonsense page size and a shipped build.
+
+    ``True`` is in the set on purpose: it is an ``int`` to ``isinstance``, and a
+    boolean page size is an authoring mistake, not a size of one.
+    """
+    with pytest.raises(BuildProfileError) as excinfo:
+        _parse_profile({"name": "x", "bluesky": {"device_page_size": value}})
+
+    message = str(excinfo.value)
+    assert "bluesky.device_page_size" in message
+    assert repr(value) in message
+
+
+def test_device_page_size_accepts_one() -> None:
+    """The floor is inclusive — a one-device page is small, not invalid."""
+    profile = _parse_profile({"name": "x", "bluesky": {"device_page_size": 1}})
+
+    assert profile.bluesky is not None
+    assert profile.bluesky.device_page_size == 1
 
 
 # ── unknown keys are rejected ────────────────────────────────────────────────

--- a/tests/cli/test_bluesky_service_registration.py
+++ b/tests/cli/test_bluesky_service_registration.py
@@ -277,6 +277,92 @@ def test_inject_bluesky_devices_file_default_written_when_unset(tmp_path: Path) 
     assert config["services"]["bluesky"]["devices_file"] == "data/bluesky_devices.yml"
 
 
+# ---------------------------------------------------------------------------
+# Device-listing page size: the omit-when-EQUALS-DEFAULT facility plan key.
+#
+# The third contract in `_facility_plan_keys`, and the only one whose key is
+# never "unset": `device_page_size` is an int with a dataclass default, so a
+# profile that says nothing and a profile that authors 500 arrive identical.
+# Both must render NO line, so that every project built before the key existed
+# keeps its exact config.yml (and its exact compose render).
+# ---------------------------------------------------------------------------
+
+
+def test_inject_bluesky_device_page_size_written_to_config(tmp_path: Path) -> None:
+    """A non-default device_page_size is emitted into services.bluesky config."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(device_page_size=200), project_path)
+
+    config = _read_config(project_path)
+    assert config["services"]["bluesky"]["device_page_size"] == 200
+
+
+def test_inject_bluesky_default_device_page_size_omits_key(tmp_path: Path) -> None:
+    """An unstated device_page_size -> no key at all (omit-when-default).
+
+    The regression pin: the bridge falls back to the same default when the env
+    var is absent, so an unauthored page size must leave the rendered block
+    exactly as it was before this key existed.
+    """
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+
+    config = _read_config(project_path)
+    assert "device_page_size" not in config["services"]["bluesky"]
+
+
+def test_inject_bluesky_device_page_size_authored_at_default_omits_key(
+    tmp_path: Path,
+) -> None:
+    """Authoring the default EXPLICITLY renders no line either.
+
+    Where this key parts company with `devices_file`: spelling the default out
+    is not a request for a line in config.yml, because the value it would carry
+    is the one the bridge already falls back to. Same deployed behaviour, same
+    rendered artifact — asserted against the dataclass default rather than a
+    literal, so the test cannot drift from the schema.
+    """
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(device_page_size=BlueskyConfig.device_page_size), project_path)
+
+    config = _read_config(project_path)
+    assert "device_page_size" not in config["services"]["bluesky"]
+
+
+def test_inject_bluesky_device_page_size_written_to_both_lanes(tmp_path: Path) -> None:
+    """On a two-lane deploy BOTH lane blocks carry the authored page size.
+
+    The page size describes the facility's device file, not a control-system
+    target, so it belongs to the shared facility plan keys: two lanes reading
+    one devices file must page it the same way.
+    """
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+    # `second_lane` needs a switchable baseline; a VA baseline pairs lane 1 (va)
+    # with a `live` second lane and needs no VA block passed in.
+    yaml = YAML()
+    config = _read_config(project_path)
+    config["control_system"] = {"type": "virtual_accelerator"}
+    with open(project_path / "config.yml", "w") as fh:
+        yaml.dump(config, fh)
+
+    _inject_bluesky(BlueskyConfig(second_lane=True, device_page_size=250), project_path)
+
+    config = _read_config(project_path)
+    assert config["services"]["bluesky"]["device_page_size"] == 250
+    assert config["services"]["bluesky_live"]["device_page_size"] == 250
+
+
 def test_inject_bluesky_devices_file_survives_the_omit_when_unset_neighbours(
     tmp_path: Path,
 ) -> None:
@@ -475,3 +561,74 @@ def test_profile_bluesky_devices_file_empty_raises() -> None:
     """An empty string is a path to nothing, not an opt-out of the default."""
     with pytest.raises(BuildProfileError):
         _parse_profile({"name": "bad", "bluesky": {"devices_file": ""}})
+
+
+# ---------------------------------------------------------------------------
+# Device-listing page size through the rendered compose file.
+#
+# The other half of the omit-when-EQUALS-DEFAULT contract asserted above: what
+# `_facility_plan_keys` writes into config.yml has to survive the template's
+# `{% if svc.device_page_size %}` guard and arrive at the bridge under the name
+# `device_page_size()` reads. Rendered end to end, because a key written to
+# config.yml that no container ever sees is indistinguishable from a key that
+# was never written.
+# ---------------------------------------------------------------------------
+
+
+def test_device_page_size_env_round_trips_through_compose(tmp_path: Path) -> None:
+    """An authored page size reaches the bridge as BLUESKY_DEVICE_PAGE_SIZE.
+
+    Quoted, because a compose environment carries strings: the bridge parses
+    the number back out, and pinning the rendered spelling keeps the template
+    from drifting into an unquoted int the YAML loader would type differently.
+    """
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(device_page_size=200), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    bridge = rendered["services"]["bluesky-bridge"]
+    assert bridge["environment"]["BLUESKY_DEVICE_PAGE_SIZE"] == "200"
+
+
+def test_default_device_page_size_omits_the_env(tmp_path: Path) -> None:
+    """Regression: an unauthored page size renders the key nowhere at all.
+
+    This is what keeps every project built before the key existed rendering
+    byte-for-byte what it rendered then — the guard has to emit zero bytes, not
+    an empty assignment, so the assertion is against the whole rendered file
+    rather than one container's environment.
+    """
+    import yaml as pyyaml
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    assert "BLUESKY_DEVICE_PAGE_SIZE" not in pyyaml.safe_dump(rendered)
+
+
+def test_device_page_size_stops_at_the_bridge(tmp_path: Path) -> None:
+    """The queueserver block carries no page size even when one is authored.
+
+    The RE Manager's worker builds devices; it never serves a listing, so the
+    bound on `GET /devices` and on the unknown-device refusal's inline
+    threshold belongs to the HTTP facade alone.
+    """
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(device_page_size=200), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    queueserver = rendered["services"]["queueserver"]
+    assert "BLUESKY_DEVICE_PAGE_SIZE" not in (queueserver["environment"] or {})

--- a/tests/e2e/_queue_drive.py
+++ b/tests/e2e/_queue_drive.py
@@ -126,11 +126,11 @@ def wait_for_worker_environment(
     environment on a poll, downloads the worker's plan and device lists, and
     only then recomputes what is allowed. An enqueue landing in that window
     is refused with exactly the 409 this gate exists to prevent. So a second
-    phase polls ``GET /devices`` until it is non-empty: the manager assigns
-    its allowed-plans and allowed-devices lists in one synchronous body
-    (plans first), so a non-empty device list proves ``plans_allowed`` has
-    already landed. Every substrate ships at least one device, so "non-empty"
-    is the right bar.
+    phase polls ``GET /devices`` until the ``devices`` array of its paginated
+    envelope is non-empty: the manager assigns its allowed-plans and
+    allowed-devices lists in one synchronous body (plans first), so a
+    non-empty device page proves ``plans_allowed`` has already landed. Every
+    substrate ships at least one device, so "non-empty" is the right bar.
 
     Returns the manager status document that satisfied the wait. Raises
     ``AssertionError`` naming the last thing seen -- a failure here says the
@@ -160,14 +160,15 @@ def wait_for_worker_environment(
     last = "(no answer yet)"
     while time.monotonic() < deadline:
         http_status, body = request(base_url, "/devices", "GET")
-        if http_status == 200 and isinstance(body, list) and body:
+        if http_status == 200 and isinstance(body, dict) and body.get("devices"):
             return status_doc
         last = body
         time.sleep(poll)
     raise AssertionError(
         f"the RE worker environment opened but the manager never published its "
         f"device list within {timeout:.0f}s -- plans_allowed is filled on the same "
-        f"path, so an enqueue now would be refused 409 (last GET /devices: {last!r})"
+        f"path, so an enqueue now would be refused 409 "
+        f"(last GET /devices envelope: {last!r})"
     )
 
 

--- a/tests/interfaces/bluesky_web/conftest.py
+++ b/tests/interfaces/bluesky_web/conftest.py
@@ -16,7 +16,7 @@ Two things make this fixture more than ``run_app_server(app)``:
   ``test_channels_route.py``'s ``project_dir`` reproduces it. Launching with
   ``catalog=None`` writes no catalog, which is the "this deployment has no
   catalog" 404 path.
-- **A stubbed bridge.** The panel boots by fetching ``/plans``, ``/devices``,
+- **A stubbed bridge.** The panel boots by fetching ``/plans``,
   ``/bridge/health``, ``/draft``, ``/queue``, ``/runs`` and the two SSE relays
   through the sidecar's proxy routers, all of which read
   ``request.app.state.client``/``bridge_url`` at request time. After the
@@ -152,7 +152,9 @@ def _stub_bridge(request: httpx.Request) -> httpx.Response:
                 "capability": {"can_execute": True, "reason": None, "detail": None},
             },
         )
-    if path in ("/devices", "/runs"):
+    if path == "/devices":
+        return httpx.Response(200, json={"devices": [], "total": 0, "offset": 0, "limit": 500})
+    if path == "/runs":
         return httpx.Response(200, json=[])
     if path == "/draft":
         return httpx.Response(200, json={"draft": None, "revision": 0})

--- a/tests/interfaces/bluesky_web/test_read_proxy.py
+++ b/tests/interfaces/bluesky_web/test_read_proxy.py
@@ -60,19 +60,27 @@ def test_list_plans_round_trips_body_and_status() -> None:
 
 def test_list_devices_round_trips_body_and_status() -> None:
     """The operator half of device discovery: a panel reads the worker's device
-    names through the same relay the agent's tool reads them through."""
+    names through the same relay the agent's tool reads them through. The
+    bridge answers a paginated envelope, and the proxy hands it back whole --
+    counts and window included, not just the page of entries."""
+    envelope = {
+        "devices": [{"name": "COR1", "is_movable": True}],
+        "total": 1,
+        "offset": 0,
+        "limit": 500,
+    }
     seen: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.append(request)
-        return _json_response(200, [{"name": "COR1", "is_movable": True}])
+        return _json_response(200, envelope)
 
     app = _build_app(handler)
     with TestClient(app) as client:
         response = client.get("/devices")
 
     assert response.status_code == 200
-    assert response.json() == [{"name": "COR1", "is_movable": True}]
+    assert response.json() == envelope
     assert str(seen[0].url) == f"{_BRIDGE_URL}/devices"
 
 
@@ -302,6 +310,25 @@ def test_plan_source_404_passes_through_verbatim() -> None:
 # ---------------------------------------------------------------------------
 # Query-param forwarding
 # ---------------------------------------------------------------------------
+
+
+def test_list_devices_forwards_prefix_limit_offset_params() -> None:
+    """All three pagination knobs reach the bridge: a panel that pages through
+    a large device list is only as good as the params the relay carries."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return _json_response(200, {"devices": [], "total": 0, "offset": 1, "limit": 2})
+
+    app = _build_app(handler)
+    with TestClient(app) as client:
+        response = client.get("/devices", params={"prefix": "COR", "limit": "2", "offset": "1"})
+
+    assert response.status_code == 200
+    assert seen[0].url.params["prefix"] == "COR"
+    assert seen[0].url.params["limit"] == "2"
+    assert seen[0].url.params["offset"] == "1"
 
 
 def test_list_runs_forwards_limit_param() -> None:

--- a/tests/mcp_server/bluesky/test_queue_tools.py
+++ b/tests/mcp_server/bluesky/test_queue_tools.py
@@ -491,6 +491,31 @@ async def test_queue_add_unknown_device_points_at_the_device_list(tmp_path, monk
     assert not any("get_draft" in s for s in envelope["suggestions"])
 
 
+async def test_queue_add_unknown_device_relays_a_capped_device_list(tmp_path, monkeypatch):
+    """A worker whose namespace exceeds one page sends a count and a URL instead
+    of the names. Both must survive into details untouched — the agent pages the
+    names with list_devices, so the hint points there either way."""
+    _armed(tmp_path, monkeypatch)
+    body = _refusal(
+        "unknown_device",
+        "plan 'grid_scan' referenced device 'COR9', which this worker did not build; "
+        "available devices: ['BPM1', 'BPM2', 'COR1'] (+2 more; full list via GET /devices)",
+        plan="grid_scan",
+        devices=["COR9"],
+        available_count=5,
+        available_devices_url="/devices",
+    )
+    with patch(f"{_MOD}._http_post_json", return_value=(400, body)):
+        with assert_raises_error(error_type="unknown_device") as ctx:
+            await _add_fn()(draft_revision=7)
+
+    details = ctx["envelope"]["details"]
+    assert details["available_count"] == 5
+    assert details["available_devices_url"] == "/devices"
+    assert "available_devices" not in details
+    assert any("list_devices" in s for s in ctx["envelope"]["suggestions"])
+
+
 @pytest.mark.parametrize("code", ["session_plan_unvalidated", "session_plan_not_in_namespace"])
 async def test_queue_add_session_plan_refusal_names_the_offending_plan(tmp_path, monkeypatch, code):
     _armed(tmp_path, monkeypatch)

--- a/tests/mcp_server/test_bluesky_client_tools.py
+++ b/tests/mcp_server/test_bluesky_client_tools.py
@@ -210,7 +210,7 @@ async def test_list_devices_request_response_mapping(monkeypatch):
 
     def fake_get(path, **kwargs):
         captured["path"] = path
-        return 200, devices
+        return 200, {"devices": devices, "total": 2, "offset": 0, "limit": 500}
 
     monkeypatch.setattr(f"{_MOD}._http_get_json", fake_get)
 
@@ -219,9 +219,11 @@ async def test_list_devices_request_response_mapping(monkeypatch):
     assert captured["path"] == "/devices"
     data = extract_response_dict(result)
     assert data["status"] == "success"
-    # Relayed whole: a flag the bridge starts reporting reaches the agent
+    # The envelope is unpacked by named key, but the ENTRIES inside it are
+    # relayed verbatim: a flag the bridge starts reporting reaches the agent
     # without a code change here.
     assert data["devices"] == devices
+    assert (data["total"], data["offset"], data["limit"]) == (2, 0, 500)
 
 
 async def test_list_devices_unreachable(monkeypatch):

--- a/tests/mcp_server/test_read_run_tools.py
+++ b/tests/mcp_server/test_read_run_tools.py
@@ -99,26 +99,44 @@ async def test_list_plans_bridge_error():
 
 
 # ── list_devices ────────────────────────────────────────────────────────────
+def _devices_body(devices, total=None, offset=0, limit=500):
+    """One `GET /devices` envelope, defaulting `total` to a complete single page."""
+    return {
+        "devices": devices,
+        "total": len(devices) if total is None else total,
+        "offset": offset,
+        "limit": limit,
+    }
+
+
 async def test_list_devices_success():
     devices = [
         {"name": "BPM1", "is_movable": False, "is_readable": True},
         {"name": "COR1", "is_movable": True, "is_readable": True},
     ]
-    with patch(f"{_MOD}._http_get_json", return_value=(200, devices)) as m:
+    body = _devices_body(devices)
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)) as m:
         result = await _fn("list_devices")()
     assert m.call_args.args[0] == "/devices"
     data = extract_response_dict(result)
     assert data["status"] == "success"
     assert data["devices"] == devices
+    assert (data["total"], data["offset"], data["limit"]) == (2, 0, 500)
+    # A complete page is not qualified: a note here would read as "there is
+    # more" about a set the agent already has whole.
+    assert "note" not in data
 
 
 async def test_list_devices_empty():
     """A worker that built no devices is an empty list, not an error — the
     agent's next move (say so, rather than guess a name) is the same either
     way, and only an explicit empty answer supports saying it."""
-    with patch(f"{_MOD}._http_get_json", return_value=(200, [])):
+    with patch(f"{_MOD}._http_get_json", return_value=(200, _devices_body([]))):
         result = await _fn("list_devices")()
-    assert extract_response_dict(result)["devices"] == []
+    data = extract_response_dict(result)
+    assert data["devices"] == []
+    assert data["total"] == 0
+    assert "note" not in data
 
 
 async def test_list_devices_bridge_error():
@@ -126,6 +144,58 @@ async def test_list_devices_bridge_error():
         with assert_raises_error(error_type="bluesky_bridge_error") as ctx:
             await _fn("list_devices")()
     assert "no manager" in ctx["envelope"]["error_message"]
+
+
+async def test_list_devices_partial_page_reports_total_and_note():
+    """A page shorter than `total` is the case the agent must not mistake for
+    the whole namespace, so the count it is missing — and how to reach it — is
+    spelled out in the answer rather than left to be derived."""
+    devices = [{"name": "BPM1"}, {"name": "BPM2"}, {"name": "BPM3"}]
+    body = _devices_body(devices, total=4, limit=3)
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("list_devices")(limit=3)
+    data = extract_response_dict(result)
+    assert data["devices"] == devices
+    assert data["total"] == 4
+    assert data["limit"] == 3
+    assert "1 of the 4" in data["note"]
+    assert "prefix" in data["note"] and "offset" in data["note"]
+
+
+async def test_list_devices_offset_past_the_end_says_so():
+    """An offset beyond the namespace is an empty page with a non-zero total —
+    read as "nothing matched" it would send the agent looking for a spelling
+    mistake that is not there, so the note names the offset as the cause."""
+    body = _devices_body([], total=4, offset=10)
+    with patch(f"{_MOD}._http_get_json", return_value=(200, body)):
+        result = await _fn("list_devices")(offset=10)
+    data = extract_response_dict(result)
+    assert data["devices"] == []
+    assert data["total"] == 4
+    assert data["offset"] == 10
+    assert "past the end" in data["note"]
+
+
+async def test_list_devices_sends_no_query_when_called_with_no_args():
+    """The default call is the byte-for-byte path the tool has always sent: a
+    bare `/devices` asks the bridge for its own default page."""
+    with patch(f"{_MOD}._http_get_json", return_value=(200, _devices_body([]))) as m:
+        await _fn("list_devices")()
+    assert m.call_args.args[0] == "/devices"
+
+
+async def test_list_devices_sends_only_the_arguments_given():
+    with patch(f"{_MOD}._http_get_json", return_value=(200, _devices_body([]))) as m:
+        await _fn("list_devices")(prefix="COR", limit=2, offset=1)
+    assert m.call_args.args[0] == "/devices?prefix=COR&limit=2&offset=1"
+
+
+async def test_list_devices_prefix_only_omits_the_other_params():
+    """Only non-default arguments are sent, so the bridge's own defaults for
+    the rest stay in force rather than being restated by the tool."""
+    with patch(f"{_MOD}._http_get_json", return_value=(200, _devices_body([]))) as m:
+        await _fn("list_devices")(prefix="COR")
+    assert m.call_args.args[0] == "/devices?prefix=COR"
 
 
 # ── list_runs ────────────────────────────────────────────────────────────────

--- a/tests/services/bluesky_bridge/test_devices_route.py
+++ b/tests/services/bluesky_bridge/test_devices_route.py
@@ -1,11 +1,17 @@
-"""Wire contract for `GET /devices`, the worker's device-name surface.
+"""Wire contract for `GET /devices`, the worker's bounded device-name surface.
 
 A plan's device parameters are strings resolved against the queueserver
 worker's namespace, so the set of names that resolve is a thing callers have to
 be able to READ — otherwise a wrong name is only discoverable by enqueuing,
 starting, and watching the run fail on its first iteration. These tests pin
-what that route publishes: the names the manager reports, the protocol flags
-that tell a drivable setpoint from a read-only detector, and nothing else.
+what that route publishes: a page of the names the manager reports, the
+`total` that says whether the page is all of them, the protocol flags that tell
+a drivable setpoint from a read-only detector, and nothing else.
+
+They also pin that `prefix`/`limit`/`offset` are clamped rather than rejected.
+A caller reaching this route is usually an agent narrowing a namespace it does
+not know the size of; a 422 teaches it to fear the parameters, while a clamped
+page answers the question it was actually asking.
 
 Driven through a real `QueueBackend` over a scripted manager (same stand-in
 shape as `test_run_routes.py`'s), so what is pinned is the whole path — backend
@@ -21,6 +27,7 @@ from bluesky_queueserver_api.comm_base import RequestTimeoutError
 from fastapi.testclient import TestClient
 
 from osprey.services.bluesky_bridge import app as app_module
+from osprey.services.bluesky_bridge import queue
 from osprey.services.bluesky_bridge.app import app
 from osprey.services.bluesky_bridge.queue_backend import QueueBackend
 
@@ -66,7 +73,19 @@ def _allowed(**devices: Any) -> dict[str, Any]:
     return {"success": True, "devices_allowed": devices}
 
 
+def _names(payload: dict[str, Any]) -> list[str]:
+    return [entry["name"] for entry in payload["devices"]]
+
+
+# ---------------------------------------------------------------------------
+# The envelope
+# ---------------------------------------------------------------------------
+
+
 def test_lists_every_device_the_worker_built_by_name(bridge) -> None:
+    """FR-1: an unparameterised read of a namespace smaller than the page size
+    is the whole namespace, and says so — `total` equal to the entries
+    returned is how a caller knows it does not have to walk."""
     client, manager = bridge(
         _allowed(
             COR1={"is_movable": True, "is_readable": True, "is_flyable": False},
@@ -78,12 +97,151 @@ def test_lists_every_device_the_worker_built_by_name(bridge) -> None:
 
     assert resp.status_code == 200
     # Sorted by name: the answer is a lookup table, and a stable order is what
-    # lets a caller (and a diff) find a name in it.
-    assert resp.json() == [
-        {"name": "BPM1", "is_movable": False, "is_readable": True, "is_flyable": False},
-        {"name": "COR1", "is_movable": True, "is_readable": True, "is_flyable": False},
-    ]
+    # lets a caller (and a diff) find a name in it — and what makes `offset`
+    # mean the same thing across two requests.
+    assert resp.json() == {
+        "devices": [
+            {"name": "BPM1", "is_movable": False, "is_readable": True, "is_flyable": False},
+            {"name": "COR1", "is_movable": True, "is_readable": True, "is_flyable": False},
+        ],
+        "total": 2,
+        "offset": 0,
+        "limit": queue.DEFAULT_DEVICE_PAGE_SIZE,
+    }
     assert manager.calls == ["devices_allowed"]
+
+
+def test_a_page_reports_the_total_it_was_cut_from(bridge) -> None:
+    """FR-2: `limit`/`offset` cut a window out of the sorted names, and `total`
+    keeps describing the whole match set — the page is what changes, not the
+    count the caller pages against."""
+    client, _ = bridge(_allowed(**{name: {} for name in ("D1", "D2", "D3", "D4", "D5")}))
+
+    payload = client.get("/devices", params={"limit": 2, "offset": 2}).json()
+
+    assert _names(payload) == ["D3", "D4"]
+    assert payload["total"] == 5
+    assert payload["offset"] == 2
+    assert payload["limit"] == 2
+
+
+def test_an_offset_past_the_end_is_an_empty_page_not_an_error(bridge) -> None:
+    """Walking off the end is how a caller learns the walk is done; a refusal
+    there would make the last page indistinguishable from a broken request."""
+    client, _ = bridge(_allowed(D1={}, D2={}))
+
+    resp = client.get("/devices", params={"offset": 9})
+
+    assert resp.status_code == 200
+    assert resp.json()["devices"] == []
+    assert resp.json()["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# prefix
+# ---------------------------------------------------------------------------
+
+
+def test_prefix_narrows_to_the_names_that_start_with_it(bridge) -> None:
+    """FR-3: `total` follows the filter — it counts what matched, not what the
+    worker holds, so a caller pages against the set it asked for."""
+    client, _ = bridge(_allowed(COR1={}, COR2={}, BPM1={}))
+
+    payload = client.get("/devices", params={"prefix": "COR"}).json()
+
+    assert _names(payload) == ["COR1", "COR2"]
+    assert payload["total"] == 2
+
+
+def test_prefix_is_case_sensitive_and_a_miss_is_an_empty_page(bridge) -> None:
+    """FR-3: device names come out of the worker's namespace verbatim, so
+    folding case would offer matches that resolve to nothing when a plan names
+    them. A prefix nothing starts with is a 200 with no devices — an empty set
+    is an answer, and a 404 would read as "the route is missing"."""
+    client, _ = bridge(_allowed(COR1={}, COR2={}))
+
+    resp = client.get("/devices", params={"prefix": "cor"})
+
+    assert resp.status_code == 200
+    assert resp.json()["devices"] == []
+    assert resp.json()["total"] == 0
+
+
+def test_prefix_keeps_the_flag_keys_on_every_entry_it_returns(bridge) -> None:
+    """Filtering and paging change which entries come back, never their shape."""
+    client, _ = bridge(_allowed(COR1={"is_movable": True, "is_readable": True}, BPM1={}))
+
+    payload = client.get("/devices", params={"prefix": "COR"}).json()
+
+    assert payload["devices"] == [{"name": "COR1", "is_movable": True, "is_readable": True}]
+
+
+# ---------------------------------------------------------------------------
+# Clamping — never a 422
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_pulls_a_limit_below_one_up_to_a_single_entry(bridge) -> None:
+    """FR-4: `limit=0` asks for a page that answers nothing. Clamping to one
+    entry keeps the same posture as `runs.list_records`, and the echoed `limit`
+    tells the caller which bound it actually got."""
+    client, _ = bridge(_allowed(D1={}, D2={}, D3={}))
+
+    resp = client.get("/devices", params={"limit": 0})
+
+    assert resp.status_code == 200
+    assert _names(resp.json()) == ["D1"]
+    assert resp.json()["limit"] == 1
+
+
+def test_clamp_holds_a_limit_above_the_cap_down_to_the_cap(bridge, monkeypatch) -> None:
+    """FR-4: the page size is the bound this route will not exceed, so asking
+    past it cannot turn the route into the way to pull a whole namespace."""
+    monkeypatch.setenv(queue.DEVICE_PAGE_SIZE_ENV, "3")
+    client, _ = bridge(_allowed(**{f"DEV{index}": {} for index in range(6)}))
+
+    payload = client.get("/devices", params={"limit": 8}).json()
+
+    assert _names(payload) == ["DEV0", "DEV1", "DEV2"]
+    assert payload["limit"] == 3
+    assert payload["total"] == 6
+
+
+def test_clamp_lifts_a_negative_offset_to_the_start(bridge) -> None:
+    """FR-4: a negative offset would slice from the END in Python. Clamping to
+    0 answers from the start, which is what "before the beginning" means."""
+    client, _ = bridge(_allowed(D1={}, D2={}, D3={}))
+
+    resp = client.get("/devices", params={"offset": -3})
+
+    assert resp.status_code == 200
+    assert _names(resp.json()) == ["D1", "D2", "D3"]
+    assert resp.json()["offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The cap comes from the environment, per request
+# ---------------------------------------------------------------------------
+
+
+def test_cap_from_the_environment_bounds_an_unparameterised_read(bridge, monkeypatch) -> None:
+    """FR-5: with no `limit`, the page size IS the limit — a facility that
+    lowers it lowers what this route hands out, and `total` still reports the
+    namespace behind the page so the caller knows to walk."""
+    monkeypatch.setenv(queue.DEVICE_PAGE_SIZE_ENV, "3")
+    client, _ = bridge(_allowed(**{f"DEV{index}": {} for index in range(4)}))
+
+    payload = client.get("/devices").json()
+
+    assert _names(payload) == ["DEV0", "DEV1", "DEV2"]
+    assert payload["total"] == 4
+    assert payload["offset"] == 0
+    assert payload["limit"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Entry shape
+# ---------------------------------------------------------------------------
 
 
 def test_worker_internal_description_detail_stays_off_the_wire(bridge) -> None:
@@ -103,7 +261,7 @@ def test_worker_internal_description_detail_stays_off_the_wire(bridge) -> None:
         )
     )
 
-    assert client.get("/devices").json() == [
+    assert client.get("/devices").json()["devices"] == [
         {"name": "COR1", "is_movable": True, "is_readable": True, "is_flyable": False}
     ]
 
@@ -113,7 +271,7 @@ def test_a_flag_the_manager_did_not_report_stays_absent(bridge) -> None:
     would read as a device that cannot be driven, a different claim entirely."""
     client, _ = bridge(_allowed(COR1={"is_movable": True}))
 
-    assert client.get("/devices").json() == [{"name": "COR1", "is_movable": True}]
+    assert client.get("/devices").json()["devices"] == [{"name": "COR1", "is_movable": True}]
 
 
 def test_a_device_the_manager_described_with_a_non_mapping_still_lists(bridge) -> None:
@@ -123,24 +281,38 @@ def test_a_device_the_manager_described_with_a_non_mapping_still_lists(bridge) -
     this route must not give."""
     client, _ = bridge({"success": True, "devices_allowed": {"COR1": None, "BPM1": "readable"}})
 
-    assert client.get("/devices").json() == [{"name": "BPM1"}, {"name": "COR1"}]
+    assert client.get("/devices").json()["devices"] == [{"name": "BPM1"}, {"name": "COR1"}]
 
 
-def test_a_worker_with_no_devices_answers_with_an_empty_list(bridge) -> None:
+# ---------------------------------------------------------------------------
+# Nothing to report, and nobody to report it
+# ---------------------------------------------------------------------------
+
+
+def test_a_worker_with_no_devices_answers_with_an_empty_page(bridge) -> None:
     client, _ = bridge(_allowed())
 
     resp = client.get("/devices")
 
     assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.json() == {
+        "devices": [],
+        "total": 0,
+        "offset": 0,
+        "limit": queue.DEFAULT_DEVICE_PAGE_SIZE,
+    }
 
 
 def test_a_reply_carrying_no_device_map_is_empty_not_an_error(bridge) -> None:
     """A manager that answered without the key has no devices to report; that
-    is an empty set, not a failure to report one."""
+    is an empty set, not a failure to report one — and it still comes back in
+    the envelope, so a caller never has to branch on the response's shape."""
     client, _ = bridge({"success": True})
 
-    assert client.get("/devices").json() == []
+    payload = client.get("/devices").json()
+
+    assert payload["devices"] == []
+    assert payload["total"] == 0
 
 
 def test_an_unreachable_manager_is_a_503_carrying_the_code(bridge) -> None:

--- a/tests/services/bluesky_bridge/test_queue_routes.py
+++ b/tests/services/bluesky_bridge/test_queue_routes.py
@@ -839,6 +839,74 @@ def test_the_refusal_sentence_caps_a_long_device_list(client: TestClient, connec
     assert "BPM49" in detail["available_devices"]
 
 
+def test_unknown_device_refusal_reports_available_count_above_cap(
+    client: TestClient, connector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A namespace larger than one device page does not ride in the refusal
+    body. The caller gets the size and the route that pages the names, which
+    is the same bound `GET /devices` serves — a refusal never hands over more
+    in one response than the route would."""
+    monkeypatch.setenv("BLUESKY_DEVICE_PAGE_SIZE", "3")
+    connector("virtual_accelerator")
+    built = [f"BPM{n}" for n in range(5)]
+    manager = FakeManager(status=status_doc(), devices_allowed=_devices(*built))
+    _install(manager)
+    revision = _make_draft(client)
+
+    resp = client.post("/queue/items", json={"draft_revision": revision})
+
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["code"] == "unknown_device"
+    assert detail["devices"] == ["COR1"]
+    assert detail["available_count"] == 5
+    assert detail["available_devices_url"] == "/devices"
+    assert "available_devices" not in detail
+    # The sentence points at the surface that actually carries the names.
+    assert detail["detail"].endswith("more; full list via GET /devices)")
+
+
+def test_the_refusal_inlines_the_device_list_at_exactly_the_page_size(
+    client: TestClient, connector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The boundary is inclusive: a namespace that exactly fills one page is
+    still small enough to hand over whole, so the body reads as it always has
+    and no caller has to make a second request to correct one name."""
+    monkeypatch.setenv("BLUESKY_DEVICE_PAGE_SIZE", "5")
+    connector("virtual_accelerator")
+    built = [f"BPM{n}" for n in range(5)]
+    manager = FakeManager(status=status_doc(), devices_allowed=_devices(*built))
+    _install(manager)
+    revision = _make_draft(client)
+
+    detail = client.post("/queue/items", json={"draft_revision": revision}).json()["detail"]
+
+    assert detail["available_devices"] == sorted(built)
+    assert "available_count" not in detail
+    assert "available_devices_url" not in detail
+    assert "GET /devices" not in detail["detail"]
+
+
+def test_the_sentence_points_at_the_inline_list_at_exactly_the_page_size(
+    client: TestClient, connector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """At the boundary the sentence can still summarize — it is capped for
+    readability well before the page size matters — and when it does, it must
+    point at the inline list rather than at the route."""
+    monkeypatch.setenv("BLUESKY_DEVICE_PAGE_SIZE", "25")
+    connector("virtual_accelerator")
+    built = [f"BPM{n}" for n in range(25)]
+    manager = FakeManager(status=status_doc(), devices_allowed=_devices(*built))
+    _install(manager)
+    revision = _make_draft(client)
+
+    detail = client.post("/queue/items", json={"draft_revision": revision}).json()["detail"]
+
+    assert "(+5 more; full list in available_devices)" in detail["detail"]
+    assert len(detail["available_devices"]) == 25
+    assert "available_count" not in detail
+
+
 def test_a_declared_field_absent_from_the_params_is_not_checked(
     client: TestClient, connector, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/services/bluesky_bridge/test_startup_assertion.py
+++ b/tests/services/bluesky_bridge/test_startup_assertion.py
@@ -34,6 +34,9 @@ Exercised here:
   the same config starts; a read-only run needs no database at all.
 - The refusal message names the resolved per-type posture key and the lane it
   refused for, but never leaks the database file's contents.
+- The other boot-time refusal in the same hook: a `BLUESKY_DEVICE_PAGE_SIZE`
+  that is not a whole number >= 1 fails the start rather than the first
+  request.
 """
 
 from __future__ import annotations
@@ -46,6 +49,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
+from osprey.services.bluesky_bridge import queue
 from osprey.services.bluesky_bridge.app import app, set_queue_backend
 
 _DEVICES_FILE_ENV = "BLUESKY_DEVICES_FILE"
@@ -53,6 +57,7 @@ _TILED_URI_ENV = "BLUESKY_TILED_URI"
 _TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
 _LANE_ENV = "OSPREY_BLUESKY_LANE"
 _EXECUTION_MODE_ENV = "OSPREY_EXECUTION_MODE"
+_DEVICE_PAGE_SIZE_ENV = "BLUESKY_DEVICE_PAGE_SIZE"
 
 
 class _InertBackend:
@@ -82,6 +87,7 @@ def _isolated_state(monkeypatch: pytest.MonkeyPatch):
         _TILED_API_KEY_ENV,
         _LANE_ENV,
         _EXECUTION_MODE_ENV,
+        _DEVICE_PAGE_SIZE_ENV,
     ):
         monkeypatch.delenv(var, raising=False)
     set_queue_backend(_InertBackend())
@@ -417,3 +423,46 @@ def test_readonly_run_never_requires_the_limits_db(
     # Assert
     assert resp.status_code == 200
     assert probe_calls == []
+
+
+# =========================================================================
+# The device page size is parsed at boot, not at the first request
+# =========================================================================
+
+
+@pytest.mark.parametrize("bad_value", ["abc", "0", "-1"])
+def test_malformed_device_page_size_refuses_startup(
+    monkeypatch: pytest.MonkeyPatch, bad_value: str
+) -> None:
+    """A page size that is not a whole number >= 1 fails the boot.
+
+    Read-only posture, so the limits guard passes and the only thing left that
+    can refuse the lifespan is the page-size parse.
+    """
+    # Arrange
+    _patch_config(monkeypatch, writes_enabled=False)
+    monkeypatch.setenv(_DEVICE_PAGE_SIZE_ENV, bad_value)
+
+    # Act
+    with pytest.raises(ValueError) as excinfo:
+        with TestClient(app):
+            pass
+
+    # Assert
+    message = str(excinfo.value)
+    assert _DEVICE_PAGE_SIZE_ENV in message
+    assert bad_value in message
+
+
+def test_device_page_size_defaults_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset is the overwhelmingly common case, and it is not an error."""
+    monkeypatch.delenv(_DEVICE_PAGE_SIZE_ENV, raising=False)
+
+    assert queue.device_page_size() == 500
+
+
+def test_device_page_size_reads_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The value is read from `os.environ` on each call, never cached."""
+    monkeypatch.setenv(_DEVICE_PAGE_SIZE_ENV, "200")
+
+    assert queue.device_page_size() == 200


### PR DESCRIPTION
Every `GET /devices` call — and every unknown-device refusal — carried the bridge worker's full device namespace. Against a facility device file of thousands of names that payload dominated the call, and the agent's `list_devices` tool rendered the entire namespace into its own context in one reply, while the unknown-device guidance promised "the complete set" — wrong the moment the body is capped.

One number now bounds every device surface: `BLUESKY_DEVICE_PAGE_SIZE` (default 500), parsed at bridge boot so a bad value fails the start instead of the first request. `GET /devices` returns one page as `{devices, total, offset, limit}` with a case-sensitive `prefix` filter; `limit` and `offset` are clamped the way `runs.list_records` clamps, never rejected. The refusal inlines `available_devices` only while the namespace fits one page; above that it reports `available_count` and points at the listing. The MCP `list_devices` tool forwards `prefix`/`limit`/`offset` (a no-argument call still sends `/devices` unchanged) and notes when a page is short of the total, and the operating-bluesky-plans skill steers toward one prefix call per device family. The build gains the eighth `bluesky.*` profile key, `bluesky.device_page_size` (integer ≥ 1), which fails the build on a bad value and renders nothing at the default, keeping existing renders byte-identical.

Two shape choices a reviewer might push on: the refusal sentence names at most `min(20, page_size)` devices so it never exceeds one page, and the compose template uses a leading-strip `{%- if %}` so default renders stay byte-identical to the goldens.

Closes #766

## How it hangs together

```text
 BUILD
 ┌───────────────────────────────┐   ┌─────────────────────────────────┐
 │ profile key                   │   │ bridge compose environment      │
 │ bluesky.device_page_size      │──►│ BLUESKY_DEVICE_PAGE_SIZE        │
 │ int ≥ 1 · default 500         │   │ (omitted when equal to default) │
 │ bad value fails the build     │   └───────────────┬─────────────────┘
 └───────────────────────────────┘                   │ parsed at boot;
                                                     │ bad value fails
 RUNTIME                                             │ startup, not the
                                                     │ first request
 ┌──────────────┐   ┌─────────────────────┐   ┌─────▼──────────────────┐
 │ agent        │   │ MCP list_devices    │   │ bluesky bridge         │
 │ context now  │──►│ forwards prefix/    │──►│ GET /devices           │
 │ bounded by   │   │ limit/offset;       │   │ ?prefix&limit&offset   │
 │ one page     │◄──│ no-arg call sends   │   │ {devices, total,       │
 └──────────────┘   │ /devices unchanged; │◄──│  offset, limit}        │
                    │ appends note when   │   │ limit/offset clamped   │
                    │ page < total        │   │ refusal inlines names  │
                    └─────────────────────┘   │ only while ≤ 1 page,   │
                                              │ else available_count   │
                                              └────────────────────────┘
```
