### PR TITLE
fix(build): render the bluesky_web roster grant on a clean build

### DIFF
--- a/changelog.d/bluesky-roster-grant.fixed.md
+++ b/changelog.d/bluesky-roster-grant.fixed.md
@@ -1,0 +1,5 @@
+The Bluesky panel no longer answers `401 — invalid credential` to every user
+of a multi-user deployment. `osprey build` now renders the persona projects
+before the services compose files and reads their entitlements from the tree
+it is building, so the `bluesky_web` sidecar lists each entitled user's
+secret instead of the previous build's (or none).

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1007,7 +1007,11 @@ def _render_compose_files(
 
     Compose files are rendered in the same pass as everything else, because they
     are derived from the same ``config.yml``: emitting them a verb later would
-    leave ``build/`` an incomplete description of the deployment.
+    leave ``build/`` an incomplete description of the deployment. After the
+    persona renders, because they read them: the bluesky_web sidecar's compose
+    lists the secret of every user whose persona's rendered ``config.yml``
+    shows the BLUESKY tab, and what this pass writes is what ``osprey up``
+    starts.
 
     The generator resolves its inputs relative to the working directory, which
     is what makes it stageable at all: run from the staged render, every service
@@ -1063,11 +1067,16 @@ def _render_compose_files(
         # from ``build/`` once the swap lands. Derived from the config path it
         # would come out empty, and every path spelled against it would resolve
         # one directory too high at deploy time.
+        # ``persona_root`` for the same reason again: the persona renders this
+        # build has already written sit in the staged tree, and the catalog's
+        # ``project_path`` (``build/<repo>-<persona>``) names where they will
+        # be once the swap lands — the previous build's personas until then.
         config, compose_files = prepare_compose_files(
             str(zones.stage / "config.yml"),
             dev_mode=dev_mode,
             output_root=".",
             deployed_config_dir=BUILD_DIR_NAME,
+            persona_root=str(zones.stage),
         )
         # Read back inside the chdir: every path involved — the rendered files,
         # the service directories the config names — is spelled relative to the
@@ -2577,12 +2586,16 @@ def _build_repo(
             if injected:
                 phase.step(f"services injected: {', '.join(injected)}")
 
-            config = _render_compose_files(zones, runtime_root, dev_mode=dev)
-            phase.step("compose files")
-
+            # Personas BEFORE the compose files: the services render reads the
+            # personas' rendered config.yml files for its per-persona grants
+            # (the bluesky_web sidecar's roster secrets), and the start verbs
+            # are as-built — a grant this pass misses reaches no container.
             persona_renders = _render_persona_projects(shared, zones)
             if persona_renders:
                 phase.step(f"{len(persona_renders)} persona render(s)")
+
+            config = _render_compose_files(zones, runtime_root, dev_mode=dev)
+            phase.step("compose files")
 
             # The copies the images are built from — the deployment's and one per
             # persona — each rendered against the path its container sees itself at

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -2100,7 +2100,7 @@ def _stage_channel_snapshot(config, source_dir, out_dir):
 _ROSTER_SECRET_SERVICE = "bluesky_web"
 
 
-def _bluesky_panel_secret_env_vars(config, source_dir):
+def _bluesky_panel_secret_env_vars(config, source_dir, persona_root=None):
     """The per-user secret variables the bluesky_web sidecar's compose lists.
 
     Empty for every other service render, and for a deployment with no
@@ -2111,10 +2111,19 @@ def _bluesky_panel_secret_env_vars(config, source_dir):
     so a ``bluesky-web:`` fragment there would never merge into this service
     and would instead fail that stack as an image-less service.
 
+    Entitlement is read off the personas' rendered ``config.yml`` files.
+    ``osprey build`` — the one verb that renders this file; the start verbs are
+    as-built — has those renders in its staging tree, not yet at
+    ``<repo>/build``, and names that tree as ``persona_root`` so the walk reads
+    the personas this build made rather than the previous build's.
+
     :param config: Full project configuration dictionary
     :type config: dict
     :param source_dir: Service source directory being rendered
     :type source_dir: str
+    :param persona_root: Where a build in flight has rendered its personas;
+        ``None`` reads the published build zone
+    :type persona_root: str or None
     :return: ``OSPREY_TERMINAL_SECRET_<SUFFIX>`` names, roster order
     :rtype: list[str]
     """
@@ -2122,7 +2131,7 @@ def _bluesky_panel_secret_env_vars(config, source_dir):
         return []
     from osprey.deployment.web_terminals.personas import bluesky_panel_secret_env_vars
 
-    return bluesky_panel_secret_env_vars(config, resolve_repo_root(config))
+    return bluesky_panel_secret_env_vars(config, resolve_repo_root(config), persona_root)
 
 
 #: Basename of the one service directory the Bluesky plan-device file is staged
@@ -2489,7 +2498,7 @@ def _stage_bluesky_devices(config, source_dir, out_dir):
     return False
 
 
-def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
+def setup_build_dir(template_path, config, container_cfg, dev_mode=False, persona_root=None):
     """Create complete build environment for service deployment.
 
     This function orchestrates the complete build directory setup process for
@@ -2517,6 +2526,9 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
     :type container_cfg: dict
     :param dev_mode: Development mode - copy local framework to containers
     :type dev_mode: bool
+    :param persona_root: Where a build in flight has rendered its persona
+        projects, for the roster grant (:func:`_bluesky_panel_secret_env_vars`)
+    :type persona_root: str or None
     :return: Path to the rendered Docker Compose file
     :rtype: str
 
@@ -2596,7 +2608,7 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
                     logger.warning(f"Could not remove {out_dir}, using incremental update approach")
                     # Use incremental update instead of full rebuild
                     return _incremental_setup_build_dir(
-                        template_path, config, container_cfg, out_dir, dev_mode
+                        template_path, config, container_cfg, out_dir, dev_mode, persona_root
                     )
             else:
                 raise
@@ -2640,7 +2652,9 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
         "dev_mode": dev_mode and wheel_staged,
         "channel_snapshot": _stage_channel_snapshot(config, source_dir, out_dir),
         # The bluesky_web sidecar's roster grant (see the helper); [] elsewhere.
-        "bluesky_panel_secret_env_vars": _bluesky_panel_secret_env_vars(config, source_dir),
+        "bluesky_panel_secret_env_vars": _bluesky_panel_secret_env_vars(
+            config, source_dir, persona_root
+        ),
         "bluesky_devices": _stage_bluesky_devices(config, source_dir, out_dir),
     }
     compose_filepath = render_template(template_path, render_config, out_dir)
@@ -2764,7 +2778,9 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False):
     return compose_filepath
 
 
-def _incremental_setup_build_dir(template_path, config, service_config, out_dir, dev_mode=False):
+def _incremental_setup_build_dir(
+    template_path, config, service_config, out_dir, dev_mode=False, persona_root=None
+):
     """Setup build directory using incremental updates when full cleanup fails.
 
     This fallback function handles cases where the build directory cannot be
@@ -2776,6 +2792,9 @@ def _incremental_setup_build_dir(template_path, config, service_config, out_dir,
         config (dict): Configuration dictionary
         service_config (dict): Service-specific configuration
         out_dir (str): Output directory path that couldn't be cleaned
+        dev_mode (bool): Development mode, as in :func:`setup_build_dir`
+        persona_root (str | None): Where a build in flight has rendered its
+            persona projects, as in :func:`setup_build_dir`
 
     Returns:
         str: Path to the rendered docker-compose.yml file
@@ -2824,7 +2843,9 @@ def _incremental_setup_build_dir(template_path, config, service_config, out_dir,
         "dev_mode": dev_mode and wheel_staged,
         "channel_snapshot": _stage_channel_snapshot(config, source_dir, out_dir),
         # The bluesky_web sidecar's roster grant (see the helper); [] elsewhere.
-        "bluesky_panel_secret_env_vars": _bluesky_panel_secret_env_vars(config, source_dir),
+        "bluesky_panel_secret_env_vars": _bluesky_panel_secret_env_vars(
+            config, source_dir, persona_root
+        ),
         "bluesky_devices": _stage_bluesky_devices(config, source_dir, out_dir),
     }
     compose_filepath = render_template(template_path, render_config, out_dir)
@@ -2996,7 +3017,12 @@ def clean_deployment(compose_files, config=None, repo_root=None):
 
 
 def prepare_compose_files(
-    config_path, dev_mode=False, expose_network=False, output_root=None, deployed_config_dir=None
+    config_path,
+    dev_mode=False,
+    expose_network=False,
+    output_root=None,
+    deployed_config_dir=None,
+    persona_root=None,
 ):
     """Prepare compose files from configuration.
 
@@ -3044,6 +3070,21 @@ def prepare_compose_files(
         ``None`` — the deploy-time case — derives it from where the config
         being loaded actually sits, which is then also where it will be read.
     :type deployed_config_dir: str or None
+    :param persona_root: The directory holding the persona renders a per-persona
+        grant is decided from — today the bluesky_web sidecar's roster grant,
+        which lists the secret of every user whose persona's rendered
+        ``config.yml`` shows the BLUESKY tab.
+
+        ``osprey build`` passes its staging tree, for the same reason it passes
+        the two parameters above: the personas it has just rendered sit there,
+        and become ``<repo>/build/<repo>-<persona>`` only when the swap lands.
+        Read where the catalog's ``project_path`` points — the published build
+        zone — the grant would name what the PREVIOUS build's personas declared,
+        or nothing on a clean build, and the start verbs re-render nothing that
+        could correct it.
+
+        ``None`` reads the published build zone.
+    :type persona_root: str or None
     :return: Tuple of (config dict, list of compose file paths)
     :rtype: tuple[dict, list[str]]
     :raises RuntimeError: If configuration loading fails
@@ -3165,7 +3206,9 @@ def prepare_compose_files(
                     f"Template file {template_path} not found for service '{service_name}'"
                 )
 
-            out = setup_build_dir(template_path, config, service_config, dev_mode)
+            out = setup_build_dir(
+                template_path, config, service_config, dev_mode, persona_root=persona_root
+            )
             compose_files.append(out)
         else:
             raise RuntimeError(f"Service '{service_name}' not found in configuration")

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -39,6 +39,7 @@ from osprey.bluesky_bridge_connection import (
 )
 from osprey.deployment.graphdb_service import resolve_graphdb_service_config
 from osprey.registry.mcp import FRAMEWORK_SERVERS
+from osprey.utils.workspace import BUILD_DIR_NAME
 from osprey_connectors.types import (
     baseline_target,
     target_writes_enabled,
@@ -641,7 +642,9 @@ def _referenced_personas(config: Any) -> tuple[dict[str, Any], set[str]]:
     return catalog, referenced
 
 
-def _personas_whose_config(config: Any, project_root: Any, predicate) -> set[str]:
+def _personas_whose_config(
+    config: Any, project_root: Any, predicate, persona_root: Any = None
+) -> set[str]:
     """Referenced personas whose rendered ``config.yml`` satisfies ``predicate``.
 
     The one walk behind every per-persona credential grant, so two credentials
@@ -653,20 +656,49 @@ def _personas_whose_config(config: Any, project_root: Any, predicate) -> set[str
     :func:`osprey.deployment.web_terminals.env_production._claude_code_auth_secret_vars`:
     a persona whose ``project_path`` is unset, unrendered, or unreadable
     contributes nothing, because a credential is never granted on a guess.
+    ``persona_root`` is :func:`_persona_configs`'s.
     """
     return {
         persona_name
-        for persona_name, persona_config in _persona_configs(config, project_root)
+        for persona_name, persona_config in _persona_configs(config, project_root, persona_root)
         if predicate(persona_config)
     }
 
 
-def _persona_configs(config: Any, project_root: Any) -> Iterable[tuple[str, Any]]:
+def _persona_render_dir(project_root: Any, project_path: str, persona_root: Any) -> Path:
+    """Where a catalog entry's rendered project is read from.
+
+    ``project_path`` is spelled against the repo root and, for every persona
+    ``osprey init`` catalogs, names the build zone (``build/<repo>-<persona>``).
+    A render in flight has not published that zone yet: ``osprey build`` writes
+    every persona into a staging tree that becomes ``build/`` only at the final
+    swap, so a grant computed during the build must read the personas from
+    THAT tree, or it reads the previous build's — or nothing. ``persona_root``
+    is that tree; a ``project_path`` under the build zone is re-rooted beneath
+    it, one outside the zone (an absolute pin, say) is read where it points.
+    """
+    rendered = Path(project_root, project_path)
+    if persona_root is None:
+        return rendered
+    try:
+        within_build_zone = rendered.relative_to(Path(project_root, BUILD_DIR_NAME))
+    except ValueError:
+        return rendered
+    return Path(persona_root, within_build_zone)
+
+
+def _persona_configs(
+    config: Any, project_root: Any, persona_root: Any = None
+) -> Iterable[tuple[str, Any]]:
     """Yield ``(persona_name, parsed config.yml)`` for every readable referenced persona.
 
     The one disk walk behind :func:`_personas_whose_config` and
     :func:`personas_needing_archiver_password`; see the former for why a
     persona that cannot be read is skipped rather than guessed at.
+
+    :param persona_root: The directory standing in for ``<project_root>/build``
+        — the staging tree a build in flight renders its personas into. ``None``
+        reads the published build zone (see :func:`_persona_render_dir`).
     """
     import yaml
 
@@ -677,7 +709,7 @@ def _persona_configs(config: Any, project_root: Any) -> Iterable[tuple[str, Any]
         project_path = entry.get("project_path")
         if not isinstance(project_path, str) or not project_path:
             continue
-        config_yml = Path(project_root, project_path) / "config.yml"
+        config_yml = _persona_render_dir(project_root, project_path, persona_root) / "config.yml"
         if not config_yml.is_file():
             continue
         try:
@@ -730,20 +762,26 @@ def config_declares_bluesky_panel(config: Any) -> bool:
     return config_declares_panel(config, BLUESKY_PANEL_ID)
 
 
-def personas_declaring_bluesky_panel(config: Any, project_root: Any) -> set[str]:
+def personas_declaring_bluesky_panel(
+    config: Any, project_root: Any, persona_root: Any = None
+) -> set[str]:
     """Names of catalog personas whose rendered project declares the BLUESKY tab.
 
     :param config: The parsed deploy config.
     :param project_root: Deploy project root; relative ``project_path`` values
         resolve against it.
+    :param persona_root: Where a build in flight has rendered its personas;
+        see :func:`_persona_configs`.
     :return: The subset of referenced persona names whose users' operator
         secrets the bluesky-web sidecar is handed (see
         :func:`config_declares_bluesky_panel`).
     """
-    return _personas_whose_config(config, project_root, config_declares_bluesky_panel)
+    return _personas_whose_config(config, project_root, config_declares_bluesky_panel, persona_root)
 
 
-def bluesky_panel_secret_env_vars(config: Any, project_root: Any) -> list[str]:
+def bluesky_panel_secret_env_vars(
+    config: Any, project_root: Any, persona_root: Any = None
+) -> list[str]:
     """The per-user secret variables the bluesky-web sidecar is handed.
 
     One name per roster user whose terminal shows the BLUESKY tab — and so
@@ -761,15 +799,18 @@ def bluesky_panel_secret_env_vars(config: Any, project_root: Any) -> list[str]:
     order, so the rendered compose is stable across runs.
 
     Read off the personas' rendered ``config.yml`` files, like every other
-    per-persona grant — so the render that carries it is the deploy's:
-    ``osprey up`` re-renders every services compose file from the repo root
-    with the persona projects in place, while ``osprey build`` renders the
-    services compose before its persona renders and so lists nothing (or what
-    the previous build's personas declared).
+    per-persona grant. The render that carries it is ``osprey build``'s — the
+    start verbs are as-built and re-render nothing — so the build renders its
+    personas before the services compose and passes ``persona_root``, the
+    staging tree those renders sit in until the swap publishes it as
+    ``build/``. Without it the walk reads the published zone: the previous
+    build's personas, or none.
 
     :param config: The parsed deploy config.
     :param project_root: Deploy project root; relative ``project_path`` values
         resolve against it.
+    :param persona_root: Where a build in flight has rendered its personas;
+        see :func:`_persona_configs`.
     :return: Variable names (``OSPREY_TERMINAL_SECRET_<SUFFIX>``), one per
         entitled user; empty when no user shows the tab.
     """
@@ -789,7 +830,7 @@ def bluesky_panel_secret_env_vars(config: Any, project_root: Any) -> list[str]:
     default_persona = web_terminals.get("default_persona")
     if not isinstance(default_persona, str) or not default_persona:
         default_persona = None
-    entitled_personas = personas_declaring_bluesky_panel(config, project_root)
+    entitled_personas = personas_declaring_bluesky_panel(config, project_root, persona_root)
     deploy_declares = config_declares_bluesky_panel(config)
 
     names: list[str] = []

--- a/src/osprey/templates/services/bluesky_web/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky_web/docker-compose.yml.j2
@@ -133,10 +133,12 @@ services:
       # each of those variables here lets this sidecar's web gate accept any
       # of them beside the deployment-wide secret above, so no user's
       # container is ever handed that secret, and a user purged from the
-      # roster is refused here the moment `osprey up` re-renders. Only the
-      # entitled users are listed (compose_generator resolves them from the
-      # personas' rendered configs); the others cannot reach this sidecar and
-      # get no key to it. The flag is what makes web_auth ACCEPT the roster
+      # roster is refused here from the next `osprey build` on (the start
+      # verbs are as-built and re-render nothing). Only the entitled users
+      # are listed (compose_generator resolves them from the personas'
+      # rendered configs, which the build renders first); the others cannot
+      # reach this sidecar and get no key to it. The flag is what makes
+      # web_auth ACCEPT the roster
       # variables it finds: every process that loads the deploy .env sees
       # them all, and only this sidecar may treat them as its operators.
       OSPREY_TERMINAL_ACCEPT_ROSTER_SECRETS: "1"

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -385,8 +385,10 @@ class TestBuildPhases:
             # Named once, from the deployment's render — the other five passes
             # inject the same set and say nothing about it.
             "· services injected: event dispatch",
-            "· compose files",
+            # Personas before the compose files: the services render reads the
+            # personas' rendered configs for its per-persona grants.
             "· 1 persona render(s)",
+            "· compose files",
             "· 1 image build context(s)",
         ]
 

--- a/tests/deployment/test_reach_contract.py
+++ b/tests/deployment/test_reach_contract.py
@@ -404,7 +404,7 @@ def test_every_entitled_shared_path_is_mounted(built_stack, web_compose, entries
 
 
 def test_the_bluesky_web_sidecar_accepts_every_entitled_users_secret(
-    built_stack, host_config, web_compose, entries, monkeypatch
+    built_stack, host_config, web_compose, entries
 ):
     """A persona proxies its BLUESKY tab into the sidecar with the secret ITS
     container holds — its own, under the fixed ``OSPREY_TERMINAL_SECRET``.
@@ -412,21 +412,21 @@ def test_the_bluesky_web_sidecar_accepts_every_entitled_users_secret(
     separate single-file compose project that could never merge into it)
     lists every entitled user's variable beside the accept flag the web gate
     requires; a user whose persona shows no BLUESKY tab gets no key to it.
+
+    Read off the file ``osprey build`` wrote, because that is the file
+    ``osprey up`` starts: the start is as-built and re-renders nothing, so a
+    grant the build's render did not carry reaches no container. (This test
+    once re-rendered the services compose from ``build/`` with the persona
+    projects in place and asserted on THAT — a render no verb performs, which
+    is how a sidecar that refused every user's secret shipped green.)
     """
-    from osprey.deployment.compose_generator import prepare_compose_files
     from osprey.deployment.web_terminals.personas import config_declares_bluesky_panel
     from osprey.deployment.web_terminals.render import terminal_secret_env_var
     from osprey.interfaces.web_auth import ROSTER_ACCEPT_ENV
 
     assert "bluesky_web" in host_config["deployed_services"]
-    # The deploy-faithful render: `osprey up` re-renders every services compose
-    # file from the repo root with the persona projects in place. The build's
-    # own render precedes the persona renders, so it is the deploy's that
-    # carries the roster grant (see compose_generator._bluesky_panel_secret_env_vars).
-    monkeypatch.chdir(built_stack / "build")
-    _, compose_files = prepare_compose_files(str(built_stack / "build" / "config.yml"))
-    (sidecar_path,) = [f for f in compose_files if f.endswith("/bluesky_web/docker-compose.yml")]
-    sidecar_compose = yaml.safe_load(Path(sidecar_path).read_text(encoding="utf-8"))
+    sidecar_path = built_stack / "build" / "services" / "bluesky_web" / "docker-compose.yml"
+    sidecar_compose = yaml.safe_load(sidecar_path.read_text(encoding="utf-8"))
     environment = sidecar_compose["services"]["bluesky-web"]["environment"]
     assert isinstance(environment, dict)
     assert environment.get(ROSTER_ACCEPT_ENV) == "1"

--- a/tests/deployment/web_terminals/test_bluesky_sidecar_roster_proof.py
+++ b/tests/deployment/web_terminals/test_bluesky_sidecar_roster_proof.py
@@ -1,0 +1,511 @@
+"""The bluesky-web sidecar's roster grant, proven at its HTTP gate.
+
+In a multi-user deployment each per-user web terminal proxies its BLUESKY tab
+into the shared ``bluesky_web`` sidecar with the operator secret ITS container
+holds — ``OSPREY_TERMINAL_SECRET_<USER>`` from the deploy ``.env``, presented
+under the fixed ``OSPREY_TERMINAL_SECRET`` name. The sidecar's compose file
+must therefore list ``OSPREY_TERMINAL_ACCEPT_ROSTER_SECRETS: "1"`` plus one
+``OSPREY_TERMINAL_SECRET_<USER>: ${...:-}`` per entitled user, and its web gate
+(``osprey.interfaces.web_auth`` harvesting the roster, ``WebAuthMiddleware``
+checking ``X-Osprey-Terminal-Secret``) must accept exactly those. ``osprey
+build`` once rendered the sidecar's compose BEFORE the personas whose rendered
+``config.yml`` decide entitlement — and read them from a build zone the build
+in flight had not published yet — so the grant came out empty and every user's
+panel answered ``401 invalid credential``. The one test on that seam asserted
+on a re-render no verb performs, and shipped it green.
+
+This module is the proof that would have caught it on its own: a REAL
+``osprey init --preset control-assistant`` + ``osprey build`` render, the
+deploy ``.env`` written by the SAME writers ``osprey up`` calls, the sidecar
+started by ``docker compose`` from the compose files the build wrote (the
+as-built list, resolved the way the start verbs resolve it), and four requests
+at the gate that pin the whole chain: alice's own roster secret admits her,
+bob's is refused because his persona shows no BLUESKY tab, no credential is
+refused, the deployment-wide secret admits.
+
+Kept OUT of ``tests/e2e/`` deliberately: files there carrying ``dockerbuild``
+need their own CI job plus an ``--ignore`` in the shared e2e lane (see
+``test_ci_workflow_wiring.py``). The precedent for real-docker tests in the
+unit lane is ``test_auth_serving.py`` and ``test_env_digest_recreate_proof.py``
+in this same directory — module-level skip when docker is unavailable,
+exact-named teardown.
+
+WHAT THE SIDECAR IMAGE HERE IS, AND IS NOT
+------------------------------------------
+The rendered compose builds the sidecar from
+``templates/services/bluesky_web/Dockerfile``, which installs the whole
+``osprey-framework`` distribution from PyPI (a multi-minute, multi-GB build)
+and, under ``osprey build --dev``, overlays a wheel of this checkout. Neither is
+affordable here, and the Dockerfile is not what this module tests: the gate
+lives in this checkout's ``src/``. So the sidecar runs from a small harness
+image — ``python:3.11-slim`` plus the part of the distribution's declared
+dependency set the sidecar's import closure needs (taken from the installed
+distribution's own metadata, exactly as ``test_auth_serving.py`` does, so the
+harness can only contain what a deployment's ``pip install osprey-framework``
+would also install) — with this repository's ``src/`` bind-mounted. Everything
+else about the container is the rendered compose's own: the uvicorn argv, the
+environment (the roster grant included), the config and audit mounts, the
+network. A compose OVERRIDE file swaps in the harness image and the source
+mounts, gives the container a per-run name, and replaces the rendered fixed
+host port with an ephemeral loopback binding, because the deployment's port
+layout (``10071`` by default) may be in use by a real deployment on the host
+running this test.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import textwrap
+import time
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from importlib.metadata import requires as distribution_requires
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+from packaging.requirements import Requirement
+
+from osprey.deployment.compose_generator import compose_base_cmd
+from osprey.deployment.container_lifecycle import (
+    _SERVICE_TOKEN_VARS,
+    _ensure_bluesky_control_plane_keys,
+    _ensure_service_tokens,
+    as_built_compose_files,
+)
+from osprey.deployment.web_terminals.auth_credentials import terminal_secret_var
+from osprey.deployment.web_terminals.personas import (
+    config_declares_bluesky_panel,
+    resolve_personas,
+)
+from osprey.deployment.web_terminals.provision import _provision_terminal_secrets
+from osprey.interfaces.common_middleware import OPERATOR_SECRET_HEADER
+from osprey.interfaces.web_auth import OPERATOR_SECRET_ENV, ROSTER_SECRET_ENV_PREFIX
+from osprey.utils.dotenv import ENV_LOCAL_FILENAME, parse_dotenv_file
+from tests.cli.test_persona_presets import _build_persona_stack
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=10).returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+pytestmark = [
+    pytest.mark.dockerbuild,
+    pytest.mark.skipif(not _docker_available(), reason="docker not available"),
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SRC_DIR = _REPO_ROOT / "src"
+# The osprey.* tree reached via /src is shim-backed: config/logger/connectors
+# live in the osprey-connectors workspace member, so its source joins the
+# mount and the PYTHONPATH — the distribution is not yet installable from
+# PyPI inside the harness image.
+_CONNECTORS_SRC_DIR = _REPO_ROOT / "packages" / "osprey-connectors" / "src"
+
+#: The compose service key the rendered sidecar file declares.
+_SERVICE = "bluesky-web"
+
+#: The panel URL a per-user terminal proxies its BLUESKY tab to.
+_PANEL_PATH = "/bluesky/?embedded=true"
+
+#: The two roster users the assertions name. ``alice`` is the ``readwrite``
+#: persona (declares the BLUESKY tab); ``bob`` is ``readonly`` (does not).
+#: The fixture re-checks both entitlements off the persona renders, so a
+#: preset change fails there with the reason rather than as a bare 401.
+_ENTITLED_USER = "alice"
+_UNENTITLED_USER = "bob"
+
+_PACKAGES = (
+    "fastapi",
+    "uvicorn",
+    "authlib",
+    "itsdangerous",
+    "python-multipart",
+    "httpx",
+    "jinja2",
+    "ruamel.yaml",
+    "pyyaml",
+    "click",
+    "rich",
+)
+"""The sidecar's import closure, by distribution name.
+
+``import osprey.interfaces.bluesky_web.app`` in a bare ``python:3.11-slim``
+needs the web stack (the first six) and the config/registry packages
+``osprey.interfaces._app_setup`` drags in behind the auth middleware. The
+*versions* are never named here — see :func:`_declared_specs`.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Harness image
+# ---------------------------------------------------------------------------
+
+
+def _canonical(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _declared_specs() -> tuple[str, ...]:
+    """The requirement specifiers ``osprey-framework`` declares for :data:`_PACKAGES`.
+
+    Read from the *installed distribution's* metadata rather than written out
+    here, so the harness image can only contain what a deployment's
+    ``pip install osprey-framework`` would also install.
+
+    Raises:
+        AssertionError: If the distribution does not declare one of them. That
+            is a real defect rather than a harness problem — the sidecar imports
+            the package, so the deployed image would be missing it too.
+    """
+    declared: dict[str, str] = {}
+    for raw in distribution_requires("osprey-framework") or ():
+        requirement = Requirement(raw)
+        # Extras (``; extra == "dev"``) are not in a default install, so they
+        # are not in the deployed image either.
+        if requirement.marker is not None and not requirement.marker.evaluate({"extra": ""}):
+            continue
+        declared[_canonical(requirement.name)] = str(requirement)
+
+    missing = [name for name in _PACKAGES if _canonical(name) not in declared]
+    assert not missing, (
+        f"osprey-framework does not declare {missing}, which the bluesky-web sidecar "
+        "imports. The deployed sidecar image installs the distribution's declared "
+        "dependencies and would be missing them too."
+    )
+    return tuple(declared[_canonical(name)] for name in _PACKAGES)
+
+
+def _harness_dockerfile() -> str:
+    specs = " ".join(f'"{spec}"' for spec in _declared_specs())
+    return textwrap.dedent(
+        f"""\
+        FROM python:3.11-slim
+        RUN pip install --no-cache-dir {specs}
+        ENV PYTHONPATH=/src:/connectors-src PYTHONDONTWRITEBYTECODE=1
+        """
+    )
+
+
+def _build_harness_image(tmp_path: Path) -> tuple[str, bool]:
+    """Build (or reuse) the image the sidecar runs from.
+
+    The tag carries a digest of the Dockerfile, so a dependency-declaration
+    change produces a new tag instead of silently reusing a stale layer. The
+    second value says whether THIS call built it: the teardown removes the
+    image only then, leaving a tag another session (or the auth-serving
+    harness, whose Dockerfile may be byte-identical) already had on the host.
+    """
+    dockerfile = _harness_dockerfile()
+    tag = f"osprey-bluesky-roster-harness:{hashlib.sha256(dockerfile.encode()).hexdigest()[:12]}"
+
+    if subprocess.run(["docker", "image", "inspect", tag], capture_output=True).returncode == 0:
+        return tag, False
+
+    context = tmp_path / "harness"
+    context.mkdir()
+    (context / "Dockerfile").write_text(dockerfile)
+    result = subprocess.run(
+        ["docker", "build", "-t", tag, str(context)],
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    assert result.returncode == 0, f"harness image build failed:\n{result.stdout}\n{result.stderr}"
+    return tag, True
+
+
+# ---------------------------------------------------------------------------
+# The composed sidecar
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Sidecar:
+    """Everything a test needs to talk to the running sidecar."""
+
+    base_url: str
+    #: The deploy ``.env`` as compose interpolated it, secret values included.
+    env: dict[str, str]
+
+    def get(self, secret: str | None) -> httpx.Response:
+        """One ``GET`` of the panel, carrying ``secret`` the way a terminal does.
+
+        The per-user terminal's proxy presents the secret as the operator
+        header; no cookie, no ``Origin``. A test that assembled a cookie or a
+        bearer token would be exercising a different rung of the gate's
+        credential ladder.
+        """
+        headers = {OPERATOR_SECRET_HEADER: secret} if secret is not None else {}
+        return httpx.get(self.base_url + _PANEL_PATH, headers=headers, timeout=15)
+
+
+def _scrubbed_env() -> dict[str, str]:
+    """The process environment with every value that could pre-empt the render.
+
+    Two consumers see it. The mint treats a process-env value as the operator's
+    ("process env wins over .env", so a shell that exports
+    ``OSPREY_TERMINAL_SECRET`` suppresses the mint), and compose interpolates
+    from the process environment ahead of ``--env-file`` for the same names.
+    Either way the container would run on a value this test never wrote to
+    the file, and the interpolation contract under test would go unexercised.
+    """
+    minted = {var for names in _SERVICE_TOKEN_VARS.values() for var in names}
+    steering = {"OSPREY_BLUESKY_WEB_IMAGE", "COMPOSE_PROJECT_NAME", "COMPOSE_FILE"}
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if name not in minted
+        and name not in steering
+        and not name.startswith(ROSTER_SECRET_ENV_PREFIX)
+        and name != OPERATOR_SECRET_ENV
+    }
+
+
+def _write_deploy_env(repo: Path, host_config: dict) -> dict[str, str]:
+    """Mint the deploy ``.env`` exactly as ``osprey up``'s preflight does.
+
+    Three writers, all the production ones. ``_provision_terminal_secrets`` is
+    the roster mint (one ``OSPREY_TERMINAL_SECRET_<USER>`` per user — the WHOLE
+    roster, entitled or not, which is what makes bob's refusal below a refusal
+    of a real secret rather than of a blank). ``_ensure_service_tokens`` is
+    the per-service token mint that establishes the sidecar's own
+    ``OSPREY_TERMINAL_SECRET`` and the launch token its compose interpolates
+    without a default. ``_ensure_bluesky_control_plane_keys`` mints the RE
+    manager's CURVE keypair, which is not the sidecar's at all but is
+    ``:?``-required by the bridge's compose file — and compose refuses the
+    whole project on a required variable, started service or not. Nothing is
+    hand-written into the file, so what compose reads back through
+    ``${OSPREY_TERMINAL_SECRET_ALICE:-}`` is a line the real mint wrote, in
+    the real mint's spelling.
+    """
+    env_path = repo / ENV_LOCAL_FILENAME
+    with pytest.MonkeyPatch.context() as patch:
+        for name in set(os.environ) - set(_scrubbed_env()):
+            patch.delenv(name)
+        _provision_terminal_secrets(host_config["modules"]["web_terminals"], str(repo))
+        _ensure_service_tokens(host_config, expose_network=False, env_path=env_path)
+        _ensure_bluesky_control_plane_keys(host_config, env_path)
+    return parse_dotenv_file(env_path)
+
+
+def _rendered_container_port(repo: Path) -> int:
+    """The port the rendered sidecar publishes, read off the build's own file.
+
+    Read rather than recomputed from the port layout, so the override below
+    binds the port uvicorn is actually told to listen on even if allocation
+    changes. ``ports:`` entries are ``<bind>:<host>:<container>``.
+    """
+    rendered = yaml.safe_load(
+        (repo / "build" / "services" / "bluesky_web" / "docker-compose.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    published = rendered["services"][_SERVICE]["ports"]
+    assert len(published) == 1, published
+    return int(str(published[0]).rsplit(":", 1)[1])
+
+
+def _write_override(path: Path, *, image: str, container_name: str, container_port: int) -> None:
+    """The one compose file this test adds to the as-built list.
+
+    ``!override`` replaces the rendered ``ports:`` list rather than merging
+    into it — compose unions sequence keys by default, which would keep the
+    fixed host port published beside the ephemeral one and collide with a
+    deployment already on it. ``pull_policy: never`` plus ``--no-build`` on
+    the ``up`` means a missing harness tag fails loudly instead of triggering
+    the rendered ``build:`` — the multi-GB real image — as a fallback.
+    """
+    document = {
+        "services": {
+            _SERVICE: {
+                "image": image,
+                "pull_policy": "never",
+                "container_name": container_name,
+                "volumes": [
+                    f"{_SRC_DIR}:/src:ro",
+                    f"{_CONNECTORS_SRC_DIR}:/connectors-src:ro",
+                ],
+            }
+        }
+    }
+    text = yaml.safe_dump(document, sort_keys=False)
+    # PyYAML has no way to emit a custom tag on a plain sequence, and the tag
+    # is the whole point of the entry, so it is spliced in as text.
+    text += f'    ports: !override\n      - "127.0.0.1::{container_port}"\n'
+    path.write_text(text, encoding="utf-8")
+
+
+def _entitlements(repo: Path, host_config: dict) -> dict[str, bool]:
+    """Which roster users' persona renders declare the BLUESKY tab.
+
+    The same question the build's grant answers, asked of the same files, so
+    the assertions below rest on what the preset actually renders rather than
+    on this module's memory of it.
+    """
+    entries = resolve_personas(
+        host_config["modules"]["web_terminals"],
+        host_config.get("registry") or {},
+        (host_config.get("facility") or {}).get("prefix") or "",
+        strict=True,
+    )
+    return {
+        entry["name"]: config_declares_bluesky_panel(
+            yaml.safe_load(
+                (repo / "build" / entry["project"] / "config.yml").read_text(encoding="utf-8")
+            )
+        )
+        for entry in entries
+    }
+
+
+def _docker_logs(name: str) -> str:
+    result = subprocess.run(
+        ["docker", "logs", "--tail", "40", name], capture_output=True, text=True, timeout=60
+    )
+    return f"--- {name} ---\n{result.stdout}{result.stderr}"
+
+
+def _wait_for_health(base_url: str, *, container_name: str, timeout: float = 90.0) -> None:
+    """Poll the sidecar's unauthenticated ``/health`` until it answers ``200``.
+
+    Bounded rather than a fixed sleep: uvicorn takes a few seconds to import
+    the app from the bind-mounted source, less on a warm host, and a fixed
+    delay is either wasted or too short.
+    """
+    deadline = time.monotonic() + timeout
+    last = "no attempt made"
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(f"{base_url}/health", timeout=5)
+        except httpx.HTTPError as exc:  # not up yet
+            last = repr(exc)
+        else:
+            if response.status_code == 200:
+                return
+            last = f"HTTP {response.status_code}"
+        time.sleep(0.5)
+    raise AssertionError(
+        f"the bluesky-web sidecar never became ready ({last})\n{_docker_logs(container_name)}"
+    )
+
+
+@pytest.fixture(scope="module")
+def sidecar(tmp_path_factory) -> Iterator[Sidecar]:
+    """The sidecar of a real control-assistant build, up on an ephemeral port."""
+    tmp_path = tmp_path_factory.mktemp("bluesky-roster")
+    repo = _build_persona_stack(tmp_path / "my-facility")
+    host_config = yaml.safe_load((repo / "build" / "config.yml").read_text(encoding="utf-8"))
+    assert "bluesky_web" in host_config["deployed_services"]
+
+    entitlements = _entitlements(repo, host_config)
+    assert entitlements.get(_ENTITLED_USER) is True, entitlements
+    assert entitlements.get(_UNENTITLED_USER) is False, entitlements
+
+    env = _write_deploy_env(repo, host_config)
+    for var in (OPERATOR_SECRET_ENV, terminal_secret_var(_ENTITLED_USER)):
+        assert env.get(var, "").strip(), f"{var} was not minted into {ENV_LOCAL_FILENAME}"
+    assert env.get(terminal_secret_var(_UNENTITLED_USER), "").strip(), (
+        f"{_UNENTITLED_USER}'s secret was not minted: his refusal below must be of a real value"
+    )
+
+    image, built_here = _build_harness_image(tmp_path)
+
+    # One compose project per run: the container name is a host-global docker
+    # identifier and the network is namespaced by the project, so a unique
+    # name is what keeps two concurrent runs — and the host's own deployments —
+    # out of each other's way.
+    project = f"ospreywf-bluesky-roster-{uuid.uuid4().hex[:8]}"
+    container_name = f"{project}-{_SERVICE}"
+    override = tmp_path / "bluesky-web.override.yml"
+    _write_override(
+        override,
+        image=image,
+        container_name=container_name,
+        container_port=_rendered_container_port(repo),
+    )
+
+    # The as-built list — what `osprey up` starts — plus the override, pinned
+    # to the repo root the way every lifecycle verb pins its invocation, so
+    # the rendered relative mounts (`./build/services/bluesky_web/config.yml`,
+    # `./var/audit/bluesky-web`) resolve where the build put them. Every file
+    # is passed, not just the sidecar's: its rendered `depends_on` names the
+    # bridge service, which only the bridge's own file defines; `--no-deps`
+    # then starts the sidecar alone.
+    compose_files = as_built_compose_files(host_config, repo)
+    base = compose_base_cmd(["docker", "compose"], [*compose_files, str(override)], repo)
+    base += ["-p", project]
+    subprocess_env = _scrubbed_env()
+
+    def _compose(*args: str, timeout: float = 180.0) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [*base, *args], capture_output=True, text=True, timeout=timeout, env=subprocess_env
+        )
+
+    try:
+        started = _compose("up", "-d", "--no-deps", "--no-build", _SERVICE)
+        assert started.returncode == 0, f"{started.stdout}\n{started.stderr}"
+
+        bound = _compose("port", _SERVICE, str(_rendered_container_port(repo)))
+        assert bound.returncode == 0, f"{bound.stdout}\n{bound.stderr}"
+        host, _, port = bound.stdout.strip().rpartition(":")
+        assert host and port.isdigit(), bound.stdout
+        base_url = f"http://{host}:{port}"
+
+        _wait_for_health(base_url, container_name=container_name)
+        yield Sidecar(base_url=base_url, env=env)
+    finally:
+        _compose("down", "-v", "--remove-orphans", "--timeout", "5")
+        if built_here:
+            subprocess.run(["docker", "image", "rm", "-f", image], capture_output=True, timeout=120)
+
+
+# ---------------------------------------------------------------------------
+# The four requests
+# ---------------------------------------------------------------------------
+
+
+def test_an_entitled_users_own_roster_secret_opens_the_panel(sidecar: Sidecar):
+    """Alice's terminal proxies the BLUESKY tab with the secret its container
+    holds — hers. The build listed her variable, compose interpolated it from
+    the deploy ``.env``, and the gate accepted it beside the deployment-wide
+    secret: the panel renders. This is the request that answered ``401`` before
+    the build rendered the grant."""
+    response = sidecar.get(sidecar.env[terminal_secret_var(_ENTITLED_USER)])
+    assert response.status_code == 200, response.text
+    assert response.headers.get("content-type", "").startswith("text/html"), response.headers
+
+
+def test_an_unentitled_users_secret_is_refused(sidecar: Sidecar):
+    """Bob's persona shows no BLUESKY tab, so the build hands the sidecar no
+    key of his. His secret is a real value the roster mint wrote (every user
+    gets one for their own terminal's front door) and it is refused here as
+    a wrong credential, not as a missing one — the sidecar never learned it."""
+    response = sidecar.get(sidecar.env[terminal_secret_var(_UNENTITLED_USER)])
+    assert response.status_code == 401, response.text
+    assert response.json()["detail"] == "invalid credential"
+
+
+def test_no_credential_is_refused(sidecar: Sidecar):
+    """The gate is closed by default: the panel is not an open route."""
+    response = sidecar.get(None)
+    assert response.status_code == 401, response.text
+
+
+def test_the_deployment_wide_secret_opens_the_panel(sidecar: Sidecar):
+    """The sidecar's own operator secret — the one ``osprey up`` mints under
+    ``OSPREY_TERMINAL_SECRET`` — still admits. The roster grant widens the
+    gate; it does not replace the credential a single-user operator holds."""
+    response = sidecar.get(sidecar.env[OPERATOR_SECRET_ENV])
+    assert response.status_code == 200, response.text


### PR DESCRIPTION
Every user of a multi-user deployment got `401 invalid credential` from the Bluesky panel. Each terminal proxies the panel to the shared `bluesky_web` sidecar with its own operator secret, and the sidecar's compose is meant to list every entitled user's secret behind `OSPREY_TERMINAL_ACCEPT_ROSTER_SECRETS`. The compose `osprey build` wrote carried neither.

`osprey build` rendered the services compose before the persona projects, and decided entitlement by reading each persona's rendered `config.yml` from `<repo>/build` — the previous build's tree, not the staging tree this build writes. A clean build found nothing and rendered an empty grant; a rebuild listed whatever the last build's personas declared. The grant was written on the premise that `osprey up` re-renders the services compose with the personas in place, but the start verbs are as-built and re-render nothing, so no verb ever corrected it. The one test on the seam re-rendered from `build/` itself — a render no verb performs — and stayed green.

The build now renders the personas first and passes its staging tree as `persona_root`, so the entitlement walk reads the personas this build made. The existing regression test asserts on the file the build actually writes. A new docker-backed test starts the sidecar from the as-built compose files of a real `control-assistant` build, with a deploy `.env` written by the same mints `osprey up` calls, and hits its gate with each roster user's own secret: the entitled user is admitted, the unentitled one refused, no credential refused, the deployment-wide secret still admitted. The sidecar runs from a slim harness image carrying the distribution's declared dependencies with `src/` bind-mounted, so the test costs seconds rather than the full image build; it rides the unit lane like `test_auth_serving.py`.

Reviewers may want to weigh: threading `persona_root` through `prepare_compose_files → setup_build_dir → _bluesky_panel_secret_env_vars` is one more path-root parameter beside `output_root` and `deployed_config_dir`, for the same reason those exist. The alternative — computing the grant from the deploy config alone, without reading persona renders — would decouple it from ordering entirely, but every other per-persona grant reads the renders, and the grant should not be decided on a guess.

## How it hangs together

```text
osprey build (staging tree build/.tmp/…)
  │
  ├─ 1. persona renders ──► <stage>/<repo>-alice/config.yml  (BLUESKY tab: yes)
  │                         <stage>/<repo>-bob/config.yml    (BLUESKY tab: no)
  │                                        │
  ├─ 2. services compose ── persona_root ──┘  reads THIS build's personas
  │       └─► build/services/bluesky_web/docker-compose.yml
  │             OSPREY_TERMINAL_ACCEPT_ROSTER_SECRETS: "1"
  │             OSPREY_TERMINAL_SECRET_ALICE: ${…:-}
  │
  └─ swap ──► build/

osprey up (as-built, re-renders nothing) ──► docker compose up bluesky-web
                                                   │
alice's terminal ── X-Osprey-Terminal-Secret ─────►│ web gate: 200
bob's terminal   ── X-Osprey-Terminal-Secret ─────►│ web gate: 401 (no key of his)
```
