### PR TITLE
Fix four multi-user web-terminal defects: lowercase env names, lattice SSE prefix, panel path placeholders, recursive claude-config hand-back

### DIFF
--- a/changelog.d/783.fixed.md
+++ b/changelog.d/783.fixed.md
@@ -1,0 +1,10 @@
+Environment-variable names in a build profile — `services.<name>.env`,
+`env.required`, `env.pinned` — may now be lowercase. The proxy family
+(`http_proxy`, `https_proxy`, `no_proxy`) is conventionally lowercase, and
+`urllib`'s `getproxies()` (hence httpx and requests) reads whichever spelling
+comes last in a container's environment: on a rootless podman host that
+injects the login shell's lowercase `no_proxy` after the compose
+`environment:` block, an uppercase-only passthrough was silently overruled and
+every `bluesky_web` → bridge read left the compose network for the corporate
+proxy, which refused it — the BLUESKY panel's "could not load plans (HTTP
+403)". A deployment can now spell both cases.

--- a/changelog.d/784.fixed.md
+++ b/changelog.d/784.fixed.md
@@ -1,0 +1,10 @@
+Two panels lost the per-user `/u/<user>/panel/<id>` prefix behind the
+multi-user front door. The lattice dashboard subscribed its SSE stream at the
+origin root (a template-literal URL the panel proxy's root-absolute rewrite
+cannot see), so a loaded lattice never appeared until Refresh; the stream is
+a quoted literal now, and a source-contract test holds every `/api` path in
+the dashboard's JS to that shape. And a config-declared panel's `path` may
+carry `{url_prefix}` (`/u/<user>`, empty in the single-origin shape) or
+`{url_prefix_dir}` (`u/<user>/`, likewise empty) for a backend that assembles
+a URL from a query parameter at runtime — noVNC's `?path=`, which resolves
+against the origin root and could not be pointed at the user's mount before.

--- a/changelog.d/785.fixed.md
+++ b/changelog.d/785.fixed.md
@@ -1,0 +1,6 @@
+`osprey up` hands each web terminal's `/data/claude-config` volume to the
+runtime user recursively. A volume that outlived an image whose entrypoint
+still ran as root kept root-owned `projects/`, `session-env/` and `sessions/`
+under an osprey-owned top directory, so every SessionStart hook failed with
+`EACCES`, no transcript was written, and each page load spawned a fresh
+Claude session instead of resuming one.

--- a/src/osprey/cli/build_profile_archiver.py
+++ b/src/osprey/cli/build_profile_archiver.py
@@ -412,7 +412,7 @@ def va_archiver_errors(
     if not _ENV_VAR_RE.match(cfg.password_env):
         errors.append(
             f"va_archiver.password_env must be an environment variable NAME "
-            f"(uppercase letters, digits, underscores), got {cfg.password_env!r}. The "
+            f"(letters, digits, underscores), got {cfg.password_env!r}. The "
             f"password itself belongs in the deployment's .env, never in the profile."
         )
 

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -20,7 +20,16 @@ from typing import Any, Literal
 
 from osprey.port_layout import DEFAULT_PORT_BASE, SLOTS_BY_NAME, default_port, layout_ports
 
-_ENV_VAR_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+#: The shape of an environment-variable NAME wherever a profile names one
+#: (``services.<name>.env``, ``env.required``, ``env.pinned``, ...). Both cases
+#: are admitted: the proxy family (``http_proxy`` / ``https_proxy`` /
+#: ``no_proxy``) is conventionally lowercase, and a deployment behind a proxy
+#: must be able to pass or pin those spellings too — ``urllib``'s
+#: ``getproxies()`` (hence httpx and requests) reads whichever spelling comes
+#: LAST in the environment, so an uppercase-only passthrough is silently
+#: overruled by a lowercase twin the container runtime injects from the host
+#: after the compose ``environment:`` block (#783).
+_ENV_VAR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 NetworkMode = Literal["bridge", "host"]
 """How a deployed service attaches to the network."""
@@ -98,7 +107,7 @@ def env_names_errors(value: Any, key: str) -> list[str]:
             continue
         message = (
             f"{key}[{index}] must be an environment variable name matching "
-            f"[A-Z_][A-Z0-9_]* (got {name!r})"
+            f"[A-Za-z_][A-Za-z0-9_]* (got {name!r})"
         )
         if isinstance(name, bool):
             # A bare `- on` entry is read on the YAML 1.1 resolver as a bool,

--- a/src/osprey/deployment/web_terminals/seeding.py
+++ b/src/osprey/deployment/web_terminals/seeding.py
@@ -68,10 +68,18 @@ _CLAUDE_MD_TARGET = "/data/claude-config/CLAUDE.md"
 # owner :func:`_container_seed_owner` queried from the container — images name
 # their runtime user differently (osprey, dispatch, ...), so ownership is
 # always passed in, never hardcoded.
+#
+# The hand-back is RECURSIVE. The volume is the harness's home — `projects/`
+# transcripts, `session-env/` hook env files, `sessions/`, caches — and all of
+# it must be writable by the runtime user. A volume that outlived an image
+# whose entrypoint still ran as root keeps root-owned subtrees a top-level
+# chown never reaches: every SessionStart hook then fails with EACCES, no
+# transcript is written, and each page load spawns a fresh session (#785).
+# Idempotent on an already-owned volume.
 _CLAUDE_MD_SH = (
     "set -e\n"
     'owner="$1"\n'
-    'chown "$owner" /data/claude-config\n'
+    'chown -R "$owner" /data/claude-config\n'
     f"cat > {_CLAUDE_MD_TARGET}\n"
     f'chown "$owner" {_CLAUDE_MD_TARGET}\n'
 )

--- a/src/osprey/interfaces/lattice_dashboard/static/js/net.js
+++ b/src/osprey/interfaces/lattice_dashboard/static/js/net.js
@@ -191,7 +191,7 @@ export function createNetClient(callbacks) {
     // root-absolute '/api/...' only when a quote precedes it, and
     // `${API_BASE}/api/events` put a `}` there instead — so under
     // /u/<user>/panel/lattice/ the stream subscribed at the origin root and
-    // 404ed forever (#784). Every fetch() in this file already passes a
+    // 404ed forever (issue 784). Every fetch() in this file already passes a
     // quoted literal; this was the one URL assembled differently.
     eventSource = new EventSource(API_BASE + '/api/events');
 

--- a/src/osprey/interfaces/lattice_dashboard/static/js/net.js
+++ b/src/osprey/interfaces/lattice_dashboard/static/js/net.js
@@ -187,7 +187,13 @@ export function createNetClient(callbacks) {
       eventSource.close();
     }
 
-    eventSource = new EventSource(`${API_BASE}/api/events`);
+    // A quoted literal on purpose: the web terminal's panel proxy rewrites a
+    // root-absolute '/api/...' only when a quote precedes it, and
+    // `${API_BASE}/api/events` put a `}` there instead — so under
+    // /u/<user>/panel/lattice/ the stream subscribed at the origin root and
+    // 404ed forever (#784). Every fetch() in this file already passes a
+    // quoted literal; this was the one URL assembled differently.
+    eventSource = new EventSource(API_BASE + '/api/events');
 
     eventSource.onmessage = (event) => {
       try {

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -433,6 +433,41 @@ def resolve_rail_position(configured: str | None, theme_family: str | None = Non
     return family_rail_default(theme_family)
 
 
+#: Placeholders a config-declared panel's ``path`` may carry, resolved once per
+#: container from :func:`compute_url_prefix` (``/u/<user>`` behind the
+#: multi-user front door, ``""`` in the single-origin shape):
+#:
+#: * ``{url_prefix}`` — the mount as the proxy spells it, ``/u/<user>`` or
+#:   empty. For a value that is itself a root-absolute path.
+#: * ``{url_prefix_dir}`` — the same mount spelled as a directory with no
+#:   leading and a trailing slash, ``u/<user>/`` or empty. For a value the
+#:   backend roots at the origin itself and to which it prepends its own ``/``
+#:   — noVNC's ``?path=`` is the canonical case: ``vnc.html?path=
+#:   {url_prefix_dir}panel/<id>/websockify`` reaches
+#:   ``/u/<user>/panel/<id>/websockify`` behind the front door and
+#:   ``/panel/<id>/websockify`` without it, never a doubled slash.
+#:
+#: The proxy's content rewrite (:mod:`routes.proxy`) covers root-absolute
+#: string literals in what a backend *serves*; a URL the browser assembles at
+#: runtime from a query parameter is invisible to it, and the correct value is
+#: per user, so the profile cannot spell it (#784). Nothing else in ``path`` is
+#: touched.
+_URL_PREFIX_PLACEHOLDERS = ("{url_prefix}", "{url_prefix_dir}")
+
+
+def _substitute_url_prefix(path: str) -> str:
+    """Resolve :data:`_URL_PREFIX_PLACEHOLDERS` in a custom panel's ``path``.
+
+    A path without a placeholder is returned byte-identical, so every existing
+    profile renders exactly as before.
+    """
+    if not isinstance(path, str) or not any(p in path for p in _URL_PREFIX_PLACEHOLDERS):
+        return path
+    prefix = compute_url_prefix()
+    prefix_dir = f"{prefix.lstrip('/')}/" if prefix else ""
+    return path.replace("{url_prefix}", prefix).replace("{url_prefix_dir}", prefix_dir)
+
+
 def _load_panel_config() -> tuple[set[str], list[dict], str | None]:
     """Read web.panels and web.default_panel from config.yml.
 
@@ -481,7 +516,7 @@ def _load_panel_config() -> tuple[set[str], list[dict], str | None]:
                     "label": spec.get("label", panel_id.upper()),
                     "url": spec.get("url", ""),
                     "healthEndpoint": spec.get("health_endpoint"),
-                    "path": spec.get("path", "/"),
+                    "path": _substitute_url_prefix(spec.get("path", "/")),
                     # Trust marker: this panel was declared in config (a trusted
                     # input), not registered at runtime via POST /api/panels/register.
                     # Only the config loader stamps it, so credential injection

--- a/tests/cli/test_build_cmd.py
+++ b/tests/cli/test_build_cmd.py
@@ -339,7 +339,7 @@ class TestValidation:
     def test_invalid_env_var_name(self, tmp_path: Path):
         profile = BuildProfile(
             name="Test",
-            env=EnvConfig(required=["lowercase_bad"]),
+            env=EnvConfig(required=["bad-name"]),
         )
         with pytest.raises(BuildProfileError, match="Invalid env var name"):
             profile.validate(tmp_path)

--- a/tests/cli/test_env_axis_schema.py
+++ b/tests/cli/test_env_axis_schema.py
@@ -88,18 +88,30 @@ def test_checker_names_the_yaml_resolver_for_a_boolean_list() -> None:
     assert "parses as a boolean" in message
 
 
-@pytest.mark.parametrize("name", ["lowercase", "2LEADING", "WITH-DASH", "WITH SPACE", ""])
+@pytest.mark.parametrize("name", ["2LEADING", "WITH-DASH", "WITH SPACE", "", "no-proxy"])
 def test_checker_rejects_names_outside_the_pattern(name: str) -> None:
     """The same pattern ``env.required`` and ``env.pinned`` are held to."""
     assert env_names_errors([name], "services.x.env") == [
         f"services.x.env[0] must be an environment variable name matching "
-        f"[A-Z_][A-Z0-9_]* (got {name!r})"
+        f"[A-Za-z_][A-Za-z0-9_]* (got {name!r})"
     ]
+
+
+@pytest.mark.parametrize("name", ["no_proxy", "http_proxy", "https_proxy", "mixedCase_1"])
+def test_checker_admits_lowercase_names(name: str) -> None:
+    """The proxy family is conventionally lowercase and must be passable and pinnable (#783).
+
+    ``urllib``'s ``getproxies()`` takes whichever spelling comes LAST in the
+    environment, and a container runtime that injects the host's lowercase
+    ``no_proxy`` after the compose ``environment:`` block silently overrules an
+    uppercase-only passthrough — so a deployment has to be able to spell both.
+    """
+    assert env_names_errors([name], "services.x.env") == []
 
 
 def test_checker_reports_every_bad_entry_with_its_index() -> None:
     """Per-item messages, so a whole list is fixed in one pass."""
-    messages = env_names_errors(["GOOD", "bad", "ALSO_GOOD", 7], "services.x.env")
+    messages = env_names_errors(["GOOD", "b-ad", "ALSO_GOOD", 7], "services.x.env")
     assert len(messages) == 2
     assert messages[0].startswith("services.x.env[1] must be an environment variable name")
     assert messages[1].startswith("services.x.env[3] must be an environment variable name")
@@ -150,13 +162,15 @@ def test_service_block_accepts_a_name_list(tmp_path: Path) -> None:
 
 
 def test_service_block_rejects_an_invalid_name(tmp_path: Path) -> None:
-    """A lowercase name fails naming the key, the index, and the pattern."""
+    """A dashed name fails naming the key, the index, and the pattern."""
     profile = _profile(
-        services={"gchat_bridge": {"template": "osprey.gchat_bridge", "config": {"env": ["epics"]}}}
+        services={
+            "gchat_bridge": {"template": "osprey.gchat_bridge", "config": {"env": ["ep-ics"]}}
+        }
     )
     assert _env_errors(profile, tmp_path) == [
         "services.gchat_bridge.env[0] must be an environment variable name matching "
-        "[A-Z_][A-Z0-9_]* (got 'epics')"
+        "[A-Za-z_][A-Za-z0-9_]* (got 'ep-ics')"
     ]
 
 
@@ -173,10 +187,10 @@ def test_service_block_rejects_a_non_list(tmp_path: Path) -> None:
 
 def test_config_override_surface_rejects_an_invalid_name(tmp_path: Path) -> None:
     """The dotted `config:` spelling is checked the same way as the block."""
-    profile = _profile(config={"services.gchat_bridge.env": ["epics"]})
+    profile = _profile(config={"services.gchat_bridge.env": ["ep-ics"]})
     assert _env_errors(profile, tmp_path) == [
         "services.gchat_bridge.env[0] must be an environment variable name matching "
-        "[A-Z_][A-Z0-9_]* (got 'epics')"
+        "[A-Za-z_][A-Za-z0-9_]* (got 'ep-ics')"
     ]
 
 
@@ -337,7 +351,7 @@ def test_env_failures_accumulate_with_the_network_axis_and_unrelated_ones(
         services={
             "gchat_bridge": ServiceDef(
                 template="osprey.gchat_bridge",
-                config={"network": "hostnet", "env": ["epics"]},
+                config={"network": "hostnet", "env": ["ep-ics"]},
             )
         },
     )
@@ -347,7 +361,7 @@ def test_env_failures_accumulate_with_the_network_axis_and_unrelated_ones(
     assert "services.gchat_bridge.network must be one of bridge, host (got 'hostnet')" in messages
     assert (
         "services.gchat_bridge.env[0] must be an environment variable name matching "
-        "[A-Z_][A-Z0-9_]* (got 'epics')" in messages
+        "[A-Za-z_][A-Za-z0-9_]* (got 'ep-ics')" in messages
     )
 
 

--- a/tests/cli/test_profile_va_archiver_block.py
+++ b/tests/cli/test_profile_va_archiver_block.py
@@ -229,7 +229,7 @@ def test_an_empty_name_is_refused() -> None:
 
 
 def test_password_env_must_name_a_variable_not_hold_one() -> None:
-    errors = _errors(password_env="hunter2")
+    errors = _errors(password_env="hunter 2")
 
     assert any("must be an environment variable NAME" in error for error in errors)
     assert any("never in the profile" in error for error in errors)

--- a/tests/deployment/web_terminals/test_seeding.py
+++ b/tests/deployment/web_terminals/test_seeding.py
@@ -208,6 +208,33 @@ def test_claude_md_exec_content_and_target(tmp_path, monkeypatch, fake_runtime):
     assert inputs[idx] == b"BASE\nEXTRA\n"
 
 
+def test_claude_md_seed_hands_the_whole_volume_to_the_runtime_user(
+    tmp_path, monkeypatch, fake_runtime
+):
+    """The volume chown is recursive and precedes the write (#785).
+
+    A claude-config volume that outlived a root-running image keeps root-owned
+    ``projects/`` / ``session-env/`` / ``sessions/`` under an osprey-owned top
+    directory; a non-recursive chown leaves every SessionStart hook failing
+    with EACCES and no transcript persisting. The seed must hand back the whole
+    tree, owned by the uid:gid it queried, before it writes CLAUDE.md.
+    """
+    calls, inputs, ready = fake_runtime
+    monkeypatch.chdir(tmp_path)
+    _write_base_md(tmp_path, "BASE\n")
+    container = f"{_FACILITY_PREFIX}-web-alice"
+    ready.add(container)
+
+    seeding.seed_user_containers(_config(["alice"]))
+
+    (argv,) = _claude_md_calls(calls)
+    script = argv[8]
+    assert 'chown -R "$owner" /data/claude-config\n' in script
+    assert script.index('chown -R "$owner" /data/claude-config') < script.index("cat > ")
+    # $0, then $1 = the queried owner the recursive chown applies.
+    assert argv[9:11] == ["sh", "1000:1000"]
+
+
 def test_legacy_flat_extra_md_fallback(tmp_path, monkeypatch, fake_runtime):
     calls, inputs, ready = fake_runtime
     monkeypatch.chdir(tmp_path)

--- a/tests/interfaces/lattice_dashboard/test_prefix_safe_urls.py
+++ b/tests/interfaces/lattice_dashboard/test_prefix_safe_urls.py
@@ -1,0 +1,48 @@
+"""Every root-absolute API path the lattice dashboard's JS names must be a quoted literal.
+
+The web terminal serves the dashboard through its panel proxy at
+``/u/<user>/panel/lattice/``, and the proxy rewrites ``/api/...`` only when a
+quote or backtick immediately precedes it (``routes/proxy.py::_rewrite_content``).
+A path assembled with a template literal (``\\`${API_BASE}/api/events\\```) puts
+a ``}`` there instead, escapes the rewrite, and resolves at the origin root —
+which is how the SSE stream 404ed forever behind the front door (#784).
+This pins the contract at the source so the next such URL fails here, not in
+a deployment.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_STATIC_JS = Path(__file__).resolve().parents[3] / (
+    "src/osprey/interfaces/lattice_dashboard/static/js"
+)
+
+#: A ``/api`` path segment whose preceding character is neither a quote nor a
+#: backtick — the one shape the proxy cannot rewrite. Comment lines are
+#: skipped by the scan below, not by this pattern.
+_UNQUOTED_API = re.compile(r"""(?<!["'`])/api(?=[/"'`])""")
+
+
+def _code_lines(text: str):
+    for number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith(("//", "*", "/*")):
+            continue
+        yield number, line
+
+
+@pytest.mark.parametrize("js_file", sorted(_STATIC_JS.glob("*.js")), ids=lambda p: p.name)
+def test_api_paths_are_quoted_literals(js_file: Path) -> None:
+    offenders = [
+        f"{js_file.name}:{number}: {line.strip()}"
+        for number, line in _code_lines(js_file.read_text(encoding="utf-8"))
+        if _UNQUOTED_API.search(line)
+    ]
+    assert not offenders, (
+        "root-absolute /api path not spelled as a quoted literal — the panel proxy "
+        "cannot rewrite it under /u/<user>/panel/lattice/:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/interfaces/web_terminal/test_custom_panel_path_prefix.py
+++ b/tests/interfaces/web_terminal/test_custom_panel_path_prefix.py
@@ -1,0 +1,60 @@
+"""A config-declared panel's ``path`` may name the per-user URL prefix (#784).
+
+Behind the multi-user front door every terminal is mounted at ``/u/<user>/``
+and its panels at ``/u/<user>/panel/<id>/``. The proxy rewrites root-absolute
+literals in what a backend serves, but a URL the browser assembles at runtime
+from a query parameter never passes through it — noVNC's ``vnc.html?path=``
+is resolved against the origin root, so a static ``path=panel/x/websockify``
+opens ``ws://host/panel/x/websockify`` and 404s. The correct value is per user,
+so the profile spells a placeholder and ``_load_panel_config`` resolves it from
+``compute_url_prefix()`` once per container.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from osprey.interfaces.common_middleware import TERMINAL_USER_ENV
+from osprey.interfaces.web_terminal.app import _load_panel_config, _substitute_url_prefix
+
+_NOVNC = "/vnc.html?path={url_prefix_dir}panel/phoebus/websockify&autoconnect=1"
+
+
+def _config(path: str) -> dict:
+    return {"web": {"panels": {"phoebus": {"url": "http://127.0.0.1:19922", "path": path}}}}
+
+
+def _custom_path(path: str) -> str:
+    with patch("osprey.utils.workspace.load_osprey_config", return_value=_config(path)):
+        _enabled, custom, _default = _load_panel_config()
+    (panel,) = custom
+    return panel["path"]
+
+
+def test_placeholders_resolve_behind_the_front_door(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
+    assert _custom_path(_NOVNC) == ("/vnc.html?path=u/alice/panel/phoebus/websockify&autoconnect=1")
+    assert _custom_path("{url_prefix}/dashboard") == "/u/alice/dashboard"
+
+
+def test_placeholders_resolve_to_nothing_in_the_single_origin_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No prefix ⇒ the noVNC path has no leading slash and the root path stays root."""
+    monkeypatch.delenv(TERMINAL_USER_ENV, raising=False)
+    assert _custom_path(_NOVNC) == "/vnc.html?path=panel/phoebus/websockify&autoconnect=1"
+    assert _custom_path("{url_prefix}/dashboard") == "/dashboard"
+
+
+def test_a_path_without_a_placeholder_is_byte_identical(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
+    assert _custom_path("/panel/") == "/panel/"
+    assert _custom_path("/dashboard?x={not_a_prefix}") == "/dashboard?x={not_a_prefix}"
+
+
+def test_substitution_tolerates_a_non_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A malformed spec reaches the browser as it always did, not as an exception."""
+    monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
+    assert _substitute_url_prefix(None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #783, closes #784, closes #785 — four small fixes from one panel walk of the ALS multi-user deployment (nginx front door at `/u/<user>/`, rootless podman host behind squid), bundled to save CI cycles. Each is independent; the commit message carries the per-fix story.

| Fix | Where | Test |
|---|---|---|
| Env-name schema admits lowercase — `no_proxy`/`http_proxy`/`https_proxy` become passable via `services.<name>.env` and pinnable via `env.pinned` | `cli/build_profile_schema.py` `_ENV_VAR_RE` | `tests/cli/test_env_axis_schema.py` (new accept case; the "invalid" fixtures move to a dashed name) |
| Lattice dashboard SSE subscribes at `/api/events` through the panel proxy instead of the origin root | `interfaces/lattice_dashboard/static/js/net.js` | `tests/interfaces/lattice_dashboard/test_prefix_safe_urls.py` — every `/api` in the dashboard's JS must be a quoted literal (the shape `_rewrite_content` can see) |
| `{url_prefix}` / `{url_prefix_dir}` placeholders in a config-declared panel's `path` | `interfaces/web_terminal/app.py` `_substitute_url_prefix` | `tests/interfaces/web_terminal/test_custom_panel_path_prefix.py` |
| Seed hands `/data/claude-config` back to the runtime user recursively | `deployment/web_terminals/seeding.py` `_CLAUDE_MD_SH` | `tests/deployment/web_terminals/test_seeding.py` |

Why `{url_prefix_dir}` as well: noVNC prepends its own `/` to `?path=`, so a value with a leading slash would open `ws://host//u/<user>/…` — nginx merges that, the single-origin FastAPI router does not. `path={url_prefix_dir}panel/phoebus/websockify` yields `u/alice/panel/phoebus/websockify` behind the front door and `panel/phoebus/websockify` without it.

Measured, for the record (the #783 half): with compose passing `NO_PROXY=good-list` and podman injecting the host's lowercase twin, the container sees `['HTTP_PROXY', 'NO_PROXY', 'http_proxy', 'no_proxy']` and `urllib.request.proxy_bypass('bluesky-bridge')` is `False`.

Deployment side: ALS adopts all four at the next repin (`services.bluesky_web.env` with the six proxy names; `web.panels.phoebus.path` with `{url_prefix_dir}`; the `.env.shared` marker deleted).
