### PR TITLE
feat: per-type limits-checking posture

### DIFF
--- a/changelog.d/779.changed.md
+++ b/changelog.d/779.changed.md
@@ -1,0 +1,17 @@
+Limits checking can now be stated per connector type:
+`control_system.connector.<type>.limits_checking` gives `enabled` and
+`allow_unlisted_channels` for that connector alone, so one deployment can hold
+a strict posture for the live machine and a permissive one for a virtual
+accelerator. A block must state both settings; one alone is refused by
+`osprey build` and `osprey validate`. The limits database path stays
+deployment-wide.
+
+When the write-approval hook cannot read the session's control target, it now
+validates against the most restrictive posture of any reachable target instead
+of the deployment-wide block. `channel_limits` reports
+`allow_unlisted_channels` as `null` when nothing sets it, and unlisted
+channels are refused in that case. Limits output also carries
+`allow_unlisted_key`, naming the configuration key that answered. The
+`control-assistant` preset now ships a permissive `virtual_accelerator`
+block, so a deployment built from it reports a preset-staleness advisory
+until `osprey build` is re-run.

--- a/docs/source/how-to/control-systems/switch-control-target.rst
+++ b/docs/source/how-to/control-systems/switch-control-target.rst
@@ -147,12 +147,16 @@ would make the live target look ready while naming a channel nothing answers.
 Set it to a channel your facility actually serves.
 
 **A strict limits posture** (``limits_posture``).
-``control_system.limits_checking.enabled`` must be ``true`` and
-``control_system.limits_checking.allow_unlisted_channels`` must be ``false`` —
-every writable channel is on the list, and a channel that is not on the list is
-refused rather than allowed through. This one guards ``standin`` too: both are
-machines you meet hardware behaviour on, and a rehearsal on a permissive posture
-rehearses the wrong facility.
+Limits checking must be ``enabled: true`` with ``allow_unlisted_channels:
+false`` — every writable channel is on the list, and a channel that is not on
+the list is refused rather than allowed through. The posture is the target's
+own: ``control_system.connector.<type>.limits_checking`` when that target's
+connector type states a block, and the deployment-wide
+``control_system.limits_checking`` when it does not. The refusal names whichever
+of the two answered, so you edit the line that decides rather than one it
+overrides. This gate guards ``standin`` too: both are machines you meet hardware
+behaviour on, and a rehearsal on a permissive posture rehearses the wrong
+facility.
 
 **An operator acknowledgment** (``operator_ack_missing``).
 ``control_system.target_switch.live_gateway_acknowledged`` must be set, to the
@@ -291,6 +295,15 @@ has actually measured it — whether its gateway answered.
        the real machine, and the channel a switch would prove it with. Two rows
        of the same deployment can disagree about the first one: write posture is
        per target, so a simulator may be armed beside a live machine that is not.
+   * - ``limits_strict``
+     - Whether **this target** runs the strict limits posture — limits checking
+       on and unlisted channels refused — which is what the ``limits_posture``
+       gate above requires. Rows can disagree here too, but only from the
+       deployment's config: a deployment can relax unlisted channels for its
+       simulator alone. Unlike ``writes_permitted``, no session narrowing
+       moves it. A target whose config states neither setting reads
+       ``false``, because a deployment that has stated nothing has refused
+       nothing.
 
 Two things the roster is careful about are worth knowing, because they are the
 difference between a report you can act on and one that flatters you:
@@ -485,18 +498,25 @@ pointed at its own control system can stand a rehearsal up next to it without
 losing sight of its machine.
 
 **Set the posture yourself.** The strict limits pair is the profile's to state,
-in its ``config:`` block:
+in its ``config:`` block. The stand-in gets no block of its own — it is
+hardware-shaped, so it keeps the deployment-wide pair the live machine runs
+under, and only the simulator is relaxed:
 
 .. code-block:: yaml
 
    config:
      control_system.limits_checking.enabled: true
      control_system.limits_checking.allow_unlisted_channels: false
+     control_system.connector.virtual_accelerator.limits_checking.enabled: true
+     control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels: true
 
-That is what a switch to either real-machine target requires. Without it
-``control_target_set standin`` refuses with ``limits_posture``, which is the
+That first pair is what a switch to either real-machine target requires. Without
+it ``control_target_set standin`` refuses with ``limits_posture``, which is the
 right refusal: a rehearsal on a permissive posture rehearses a facility you do
-not have.
+not have. Writing the relaxation under ``virtual_accelerator`` instead of
+deployment-wide is what keeps the rehearsal honest — a per-type block replaces
+the pair above for that type alone, and must state both settings or ``osprey
+build`` and ``osprey validate`` refuse it.
 
 **Three rows on the roster.** Ask where the session could go and you get one row
 per configured machine::

--- a/docs/source/how-to/control-systems/use-virtual-accelerator.rst
+++ b/docs/source/how-to/control-systems/use-virtual-accelerator.rst
@@ -317,19 +317,39 @@ exactly that pair of keys.
 
 .. note::
 
-   The limits posture is a separate decision, and it is the profile's to make.
-   Shipped permissive (``limits_checking.allow_unlisted_channels: true``), the
-   limits checker does not block a channel *absent* from
-   ``channel_limits.json``: range enforcement covers the listed channels, and
-   it is not a closed allowlist.
+   The limits posture is a separate decision, and it is per connector type in
+   the same way. ``control_system.limits_checking`` is the pair a type inherits
+   when it says nothing about itself; a ``limits_checking`` block under a type's
+   ``connector:`` entry answers for that type instead.
 
-   A deployment that rehearses on a stand-in wants the strict posture instead —
-   limits checking on, unlisted channels refused — because that is what a switch
-   to either real-machine target requires, and rehearsing it is what the
-   stand-in is for. Write the pair in the build profile's ``config:`` block; the
-   ``control-assistant`` preset does. It applies to the whole deployment, so an
-   unlisted channel is refused on the simulator too. See `Rehearsing against a
-   live target`_.
+   .. code-block:: yaml
+
+      control_system:
+        limits_checking:
+          enabled: true                       # the posture the live machine runs
+          allow_unlisted_channels: false      # under, and every type inherits
+        connector:
+          virtual_accelerator:
+            limits_checking:
+              enabled: true                   # ... and the simulator alone lets
+              allow_unlisted_channels: true   # an unlisted channel through
+
+   That is the shape ``config.yml`` ends up in; write it in the build profile's
+   ``config:`` block as flat dotted keys, as the ``control-assistant`` preset
+   does. A per-type block replaces the inherited pair as a *whole*: nothing is
+   borrowed from the deployment-wide block, so both settings have to be written
+   out. A block stating one of them alone is refused by ``osprey build`` and
+   ``osprey validate``, naming the one that is missing. The limits database
+   itself stays deployment-wide — ``limits_checking.database_path`` is one file
+   for every target, and a per-type block does not take a path.
+
+   With the pair above, a write to the simulator is still checked against the
+   ranges ``channel_limits.json`` gives for the channels it lists; what changes
+   is that a channel the file does *not* list is allowed through on the
+   simulator and refused on the live machine and the stand-in. That strict
+   posture is what a switch to either real-machine target requires, and
+   rehearsing it is what the stand-in is for. See `Rehearsing against a live
+   target`_.
 
 The archive
 ===========

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -175,7 +175,15 @@ sections in their own ``config.yml.j2``.
      # for the key to mean anything (see the "Use the Virtual Accelerator"
      # how-to).
      control_system.connector.virtual_accelerator.writes_enabled: true
+     # Limits checking works the same way. This pair is the deployment's, and
+     # every type inherits it ...
      control_system.limits_checking.enabled: true
+     control_system.limits_checking.allow_unlisted_channels: false
+     # ... while a per-type block replaces it whole for one type. Both settings
+     # have to be stated: one alone is refused by `osprey build` and
+     # `osprey validate`.
+     control_system.connector.virtual_accelerator.limits_checking.enabled: true
+     control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels: true
 
      # Archiver
      archiver.type: epics_archiver
@@ -191,6 +199,46 @@ sections in their own ``config.yml.j2``.
 
      # Approval policy
      approval.default_policy: always
+
+.. note::
+
+   **Connector types whose name contains a dot** are the one place the flat form
+   does not work. A custom connector is named by its module path, and the build
+   splits only the *first* key of each ``config:`` entry on dots — so
+   ``control_system.connector.mypkg.TangoConnector.limits_checking.enabled``
+   renders the type's module path as two nested keys, ``mypkg`` and
+   ``TangoConnector``, instead of the one key the connector is actually called.
+   ``osprey build`` and ``osprey validate`` refuse that entry by name rather
+   than letting it render somewhere nothing reads. Write such a type as its own
+   map key under a dotted prefix, which is the one spelling that puts the block
+   where the connector looks for it:
+
+   .. code-block:: yaml
+
+      config:
+        control_system.connector:
+          mypkg.TangoConnector:
+            limits_checking:
+              enabled: true
+              allow_unlisted_channels: false
+
+   **That entry replaces the whole rendered connector section.** ``connector``
+   is the last key of the dotted prefix, and a leaf is assigned verbatim — so
+   the mapping has to carry every connector block the deployment needs, not only
+   the custom type's. Copy the ``mock``, ``virtual_accelerator`` and ``epics``
+   blocks, with their gateways, ports and probe channels, from
+   ``templates/project/config.yml.j2`` or from a prior render's ``config.yml``.
+   Nothing outside ``connector`` is disturbed, and nothing refuses a mapping
+   that leaves a block out: the deployment simply comes up without the addresses
+   that block held.
+
+   What is never right is a bare ``control_system:`` mapping beside flat
+   ``control_system.*`` keys — the bare top-level key is the only spelling that
+   does not merge, since deeper dotted prefixes are walked into rather than
+   assigned over. It replaces the whole rendered section, so which of the two
+   reaches ``config.yml`` depends on key order. ``osprey build`` and ``osprey
+   validate`` refuse that pair by name too. Built-in types have no dots and take
+   the flat form.
 
 
 .. _profile-mcp-servers:
@@ -645,6 +693,13 @@ normally writes the pair itself:
    config:
      control_system.limits_checking.enabled: true
      control_system.limits_checking.allow_unlisted_channels: false
+
+That pair is the deployment's, and the stand-in inherits it: the build writes no
+``limits_checking`` block under ``control_system.connector.live_standin``, and a
+profile should not either, since a permissive block there would make
+``control_target_set standin`` refuse the very rehearsal the stand-in exists
+for. A simulator beside it is where a per-type block belongs — see
+:ref:`limits-checking-config`.
 
 ``control_system.target_switch.live_gateway_acknowledged`` stays the live
 machine's alone — the stand-in's equivalent is the ``live_standin`` line itself.

--- a/docs/source/reference/contracts/connectors.rst
+++ b/docs/source/reference/contracts/connectors.rst
@@ -175,8 +175,8 @@ connector type:
 
 A connector type that carries no ``writes_enabled`` of its own inherits
 ``control_system.writes_enabled``; one that carries it uses its own value and
-never falls back. Both default to blocked when omitted, and **only a literal
-``true`` arms writes** — the quoted string ``'true'`` and the number ``1`` do
+never falls back. Both default to blocked when omitted, and **only a literal**
+``true`` **arms writes** — the quoted string ``'true'`` and the number ``1`` do
 not. A custom connector's block is keyed by the same dotted module path that
 selects it, so ``mypackage.TangoConnector`` names one block and is never split
 on its dots.
@@ -218,10 +218,45 @@ Limits Checking
        enabled: true                     # Enable limits validation
        database_path: ./limits_db.json   # Path to the channel limits JSON
        allow_unlisted_channels: false    # Block writes to channels not in the database
+     connector:
+       virtual_accelerator:
+         limits_checking:                # This connector type's own posture,
+           enabled: true                 # replacing the pair above for it alone
+           allow_unlisted_channels: true
 
 When enabled, every ``write_channel()`` call is validated against the limits
 database before the write reaches hardware. The database format is the
 per-channel configuration above.
+
+The posture is per connector type. ``control_system.limits_checking`` is what a
+type inherits when it says nothing about itself, and
+``control_system.connector.<type>.limits_checking`` answers for that type
+instead — so one deployment can refuse unlisted channels on its live machine
+while letting them through on a simulator. Three rules govern the per-type
+block:
+
+- **It replaces, it does not merge.** A per-type block must state both
+  ``enabled`` and ``allow_unlisted_channels``; neither is inherited. A block
+  stating one alone is refused by ``osprey build`` and ``osprey validate``,
+  naming the missing setting — and a half-written block that reaches a running
+  deployment anyway, by a hand-edited ``config.yml`` or an older render, blocks
+  every write until it is completed.
+- **The database stays deployment-wide.** ``database_path`` is not a per-type
+  setting: the deployment mounts one limits file, and every target is checked
+  against it.
+- **Only explicit values decide.** ``allow_unlisted_channels`` is true, false,
+  or unstated. With limits checking enabled, an ``allow_unlisted_channels``
+  that no key states refuses unlisted channels — permission needs an explicit
+  ``true``. A deployment that states no limits posture at all runs no limits
+  checking, and nothing on that path refuses an unlisted channel.
+
+A refusal about an unlisted channel — and the target switch's
+``limits_posture`` refusal — names the key that answered, the per-type one where
+a block spoke and the deployment-wide one where none did, so an operator edits
+the line that decides rather than one it overrides. The ``channel_limits`` tool
+reports the same pair for the target the session is on, including ``null`` where
+nothing states an answer, alongside ``allow_unlisted_key`` naming the key it
+read.
 
 .. seealso::
 
@@ -302,11 +337,11 @@ The shared helpers in ``osprey.connectors.archiver._timerange`` (``to_utc``,
 ``aggregate_series``, ``reject_non_numeric``) implement all of the above --
 every in-tree connector builds on them rather than reimplementing binning.
 
-**The ``value`` dtype rule.** Enum/status channels carry string values, and
-``get_data`` never coerces them: a channel's own dtype flows through, and only
-mixing non-numeric with numeric channels in one query promotes the shared
-``value`` column. Forcing ``value`` to ``float64`` "for consistency" silently
-corrupts every enum/status channel. (This is deliberately not the live-read
+**The dtype rule for** ``value``\ **.** Enum/status channels carry string
+values, and ``get_data`` never coerces them: a channel's own dtype flows
+through, and only mixing non-numeric with numeric channels in one query promotes
+the shared ``value`` column. Forcing ``value`` to ``float64`` "for consistency"
+silently corrupts every enum/status channel. (This is deliberately not the live-read
 contract, where an enum reads as its index with the label in ``enum_label`` --
 an archiver reports what its backend recorded, and these backends recorded the
 string.)

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
@@ -663,9 +663,11 @@ class ControlSystemConnector(ABC):
 
     _limits_validator: Any = None  # Initialized by subclasses in connect()
     # The connector type this instance was built as. Stamped by
-    # ConnectorFactory.create_control_system_connector() between construction and
-    # connect(), so connect() can already read the posture. Stays None on an
-    # instance nobody built through the factory: no type, so no per-type block.
+    # ConnectorFactory.build_control_system_connector() between construction and
+    # connect(), so connect() can already read the posture
+    # (create_control_system_connector() is that build plus connect()). Stays
+    # None on an instance nobody built through the factory: no type, so no
+    # per-type block.
     _connector_type: str | None = None
     # The session target this instance was built for. Stamped by the same
     # factory seam as _connector_type, from the target the *caller* named — the

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/doocs_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/doocs_connector.py
@@ -59,7 +59,7 @@ class DOOCSConnector(ControlSystemConnector):
             raise ImportError("doocs4py is required for the DOOCS connector.") from None
 
         # Initialize limits validator for automatic validation and confirm policy
-        self._limits_validator = LimitsValidator.from_config()
+        self._limits_validator = LimitsValidator.from_config(connector_type=self._connector_type)
         if self._limits_validator:
             logger.debug("DOOCS connector: limits validator initialized")
 

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -472,7 +472,7 @@ class EPICSConnector(ControlSystemConnector):
         # Initialize limits validator for automatic validation and confirm policy
         from osprey_connectors.control_system.limits_validator import LimitsValidator
 
-        self._limits_validator = LimitsValidator.from_config()
+        self._limits_validator = LimitsValidator.from_config(connector_type=self._connector_type)
         if self._limits_validator:
             logger.debug("EPICS connector: limits validator initialized")
 

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
@@ -7,6 +7,12 @@ from pathlib import Path
 from typing import Any
 
 from osprey_connectors.logger import get_logger
+from osprey_connectors.types import (
+    LimitsPosture,
+    most_restrictive_limits_posture,
+    target_limits_posture,
+    type_limits_posture,
+)
 
 logger = get_logger("limits_validator")
 
@@ -41,7 +47,7 @@ class LimitsValidator:
         self,
         limits_database: dict[str, ChannelLimitsConfig],
         policy_config: dict,
-        raw_db: dict = None,
+        raw_db: dict | None = None,
         failsafe_reason: str | None = None,
     ):
         self.limits = limits_database
@@ -93,69 +99,233 @@ class LimitsValidator:
         return db_path
 
     @classmethod
-    def from_config(cls):
-        """Load validator from Osprey configuration.
+    def _load_configured_database(
+        cls,
+    ) -> tuple[tuple[dict[str, ChannelLimitsConfig], dict] | None, str | None]:
+        """Resolve and load the deployment-wide limits database.
 
-        Returns None if configuration is not available or limits checking is disabled.
-        This allows connectors to work in test environments without config files.
+        The database path is deployment-wide even where the posture is not: a
+        deployment mounts one limits file (``compose_generator.py`` binds a
+        single path), so a per-type block changes policy and never the data.
+        This is the half of validator construction that is the same for every
+        posture, kept in one place so that the deployment-wide and per-type
+        entry points cannot drift in how they resolve a relative path or in
+        which load failures they treat as fatal.
+
+        Failure is reported rather than raised because both entry points answer
+        it the same way — with a fail-safe validator that blocks every write.
+        Returning ``None`` instead would leave writes unchecked, and raising
+        would crash a connector on a deployment that never writes at all.
+
+        Returns:
+            A ``(loaded, failsafe_reason)`` pair with exactly one half set:
+            either the ``(limits_database, raw_database)`` tuple, or a reason
+            string naming what could not be read, ready to hand to
+            ``failsafe_reason``.
+        """
+        from osprey_connectors.config import default_config_path, get_config_value
+
+        db_path = get_config_value("control_system.limits_checking.database_path", None)
+        # Validate db_path is actually a string path (not None, False, or other types)
+        if not db_path or not isinstance(db_path, str):
+            logger.warning(
+                "Limits checking enabled but no database path configured - blocking all writes"
+            )
+            return None, (
+                "limits checking is enabled but "
+                "control_system.limits_checking.database_path is not configured"
+            )
+
+        project_root = get_config_value("project_root", None)
+        resolved_path = cls.resolve_database_path(
+            db_path, project_root, config_path=default_config_path()
+        )
+        if resolved_path != db_path:
+            logger.debug(f"Resolved limits database path: {resolved_path}")
+        db_path = resolved_path
+
+        try:
+            limits_db, raw_db = cls._load_limits_database(db_path)
+        except ValueError as e:
+            # Same failsafe as the missing-database-path case above: a
+            # missing/unparseable database must never crash the connector
+            # (a read-only deployment needs no limits) nor silently disable
+            # checking (returning None would leave writes unchecked) — an
+            # empty DB blocks every write with a clear refusal instead.
+            logger.warning(
+                f"Limits checking enabled but the database at {db_path} could not "
+                f"be read or parsed - blocking all writes. {e}"
+            )
+            return None, (f"the limits database at {db_path} could not be read or parsed: {e}")
+
+        logger.debug(f"Loaded limits database with {len(limits_db)} channels")
+        return (limits_db, raw_db), None
+
+    @classmethod
+    def from_config(
+        cls,
+        *,
+        connector_type: str | None = None,
+        target: str | None = None,
+    ) -> "LimitsValidator | None":
+        """Load a validator for the limits posture the caller acts under.
+
+        Three call shapes, one per identity a caller can hold:
+
+        - **Neither argument** asks the deployment-wide question,
+          ``control_system.limits_checking``, and never resolves a target. It is
+          what a caller holding no machine of its own asks — the connector
+          registry's log line, the executor's config helper — and it is the
+          shape every caller had before per-type blocks existed, so a deployment
+          that wrote none behaves as it did — except that a deployment-wide
+          leaf written as something other than a literal boolean now blocks
+          every write instead of being read as truthy.
+        - **connector_type** is what a connector, factory or IPC child asks:
+          they know which connector type they are and never which target
+          selected it.
+        - **target** is what a tool, hook, roster or the executor asks: they
+          follow the session's control target, which is resolved to its
+          connector type here so both shapes read one posture.
+
+        A present ``control_system.connector.<type>.limits_checking`` block
+        overrides the deployment-wide pair whole; absent, the deployment-wide
+        block answers. The key that answered travels into ``policy`` so a later
+        refusal names the config line an operator can edit.
+
+        Args:
+            connector_type: The connector type to resolve the posture for, as
+                the config's ``control_system.connector`` table keys it.
+            target: The session control target to resolve the posture for, one
+                of :data:`osprey_connectors.types.CONTROL_TARGETS`. A target
+                that does not resolve to a type gets the deployment-wide block,
+                as the write posture does.
+
+        Returns:
+            An enforcing validator; a fail-safe validator that blocks every
+            write when the resolved block is incomplete or the limits database
+            is unavailable; or ``None`` when limits checking is off for this
+            posture or the config could not be read at all.
+
+        Raises:
+            TypeError: If both *connector_type* and *target* are given. A target
+                already names a type, so stating both states the posture twice
+                and leaves it undefined which one the caller meant. Raised
+                before any config is read, so it surfaces as the caller bug it
+                is rather than as a missing-config ``None``.
+        """
+        if connector_type is not None and target is not None:
+            raise TypeError(
+                "LimitsValidator.from_config() takes connector_type or target, not both: "
+                "a target resolves to a connector type, so passing both states the "
+                "posture twice"
+            )
+        try:
+            from osprey_connectors.config import get_config_value
+
+            section = get_config_value("control_system", {})
+        except (FileNotFoundError, KeyError, RuntimeError) as e:
+            # Config not available (test environment, etc.) - limits checking disabled
+            logger.debug(f"Limits validator not initialized (config unavailable): {e}")
+            return None
+
+        if target is not None:
+            posture = target_limits_posture(section, target)
+        else:
+            posture = type_limits_posture(section, connector_type)
+        return cls._from_posture(posture)
+
+    @classmethod
+    def from_config_most_restrictive(cls) -> "LimitsValidator | None":
+        """Load a validator for the posture that holds across every reachable target.
+
+        What a caller with no target of its own has to assume. The stdlib limits
+        hook is the one that needs it: when the session's control target cannot
+        be read — none written yet, an unreadable state directory, a target that
+        resolves to nothing — it still has to decide about a write, and the
+        machine it is deciding about is any of the ones a session here can
+        select.
+
+        The fold is :func:`osprey_connectors.types.most_restrictive_limits_posture`'s:
+        limits checking is on when any reachable target has it on, and unlisted
+        channels are allowed only where every reachable target allows them. The
+        result names the deployment-wide keys, because no per-type line decides
+        a union and naming one would send an operator to edit a single machine
+        rather than the answer.
+
+        Returns:
+            An enforcing validator, a fail-safe one, or ``None`` — the same
+            envelope :meth:`from_config` returns, for the same reasons.
         """
         try:
-            from osprey_connectors.config import default_config_path, get_config_value
+            from osprey_connectors.config import get_config_value
 
-            enabled = get_config_value("control_system.limits_checking.enabled", False)
-            if not enabled:
+            section = get_config_value("control_system", {})
+        except (FileNotFoundError, KeyError, RuntimeError) as e:
+            # Config not available (test environment, etc.) - limits checking disabled
+            logger.debug(f"Limits validator not initialized (config unavailable): {e}")
+            return None
+
+        return cls._from_posture(most_restrictive_limits_posture(section))
+
+    @classmethod
+    def _from_posture(cls, posture: LimitsPosture) -> "LimitsValidator | None":
+        """Build a validator for an already-resolved limits posture.
+
+        The caller resolves the posture for the thing it is acting on — a
+        connector for its own type, a tool or hook for the session's target —
+        and this turns that answer into an enforcing validator. The posture's
+        answering key travels into ``policy`` so that a later refusal names the
+        config line an operator can edit: on a deployment that relaxed unlisted
+        channels for its simulator alone, quoting the deployment-wide key would
+        send them to flip a line the per-type block overrides.
+
+        An incomplete block is checked before ``enabled``, and on purpose. Such
+        a block answered neither leaf, so ``enabled`` is ``None`` and the
+        disabled branch would wave every write through on exactly the config
+        nobody has finished writing. Blocking instead is the same choice the
+        missing-database-path branch makes.
+
+        A block is incomplete two ways, and the second is why this branch comes
+        first. A per-type block may omit a leaf. Either block may write one as
+        something no reader can turn into a boolean — a quoted ``'true'``, a
+        ``1``, an unexpanded ``'${LIMITS_ON}'``, which is the shape environment
+        expansion leaves behind when nothing set the variable. That second one
+        is a deployment trying to switch limits checking *on*; reading it as an
+        unset ``enabled`` would take the disabled branch and check nothing.
+
+        Args:
+            posture: The resolved posture, from the ``types`` resolver family.
+
+        Returns:
+            An enforcing validator; a fail-safe validator that blocks every
+            write when the block is incomplete or the database is unavailable;
+            or ``None`` when limits checking is off for this posture or the
+            config could not be read at all.
+        """
+        try:
+            if posture.incomplete:
+                reason = (
+                    f"{posture.block_key} does not state "
+                    f"{', '.join(posture.incomplete)} as true/false"
+                )
+                logger.warning(f"Incomplete limits block - blocking all writes: {reason}")
+                return cls({}, {}, {}, failsafe_reason=reason)
+
+            if posture.enabled is not True:
                 return None
 
-            db_path = get_config_value("control_system.limits_checking.database_path", None)
-            # Validate db_path is actually a string path (not None, False, or other types)
-            if not db_path or not isinstance(db_path, str):
-                logger.warning(
-                    "Limits checking enabled but no database path configured - blocking all writes"
-                )
-                return cls(
-                    {},
-                    {},
-                    {},
-                    failsafe_reason=(
-                        "limits checking is enabled but "
-                        "control_system.limits_checking.database_path is not configured"
-                    ),
-                )  # Empty DB = blocks all (failsafe)
+            loaded, failsafe_reason = cls._load_configured_database()
+            if loaded is None:
+                # Empty DB = blocks all (failsafe)
+                return cls({}, {}, {}, failsafe_reason=failsafe_reason)
+            limits_db, raw_db = loaded
 
-            project_root = get_config_value("project_root", None)
-            resolved_path = cls.resolve_database_path(
-                db_path, project_root, config_path=default_config_path()
-            )
-            if resolved_path != db_path:
-                logger.debug(f"Resolved limits database path: {resolved_path}")
-            db_path = resolved_path
-
-            try:
-                limits_db, raw_db = cls._load_limits_database(db_path)
-            except ValueError as e:
-                # Same failsafe as the missing-database-path case above: a
-                # missing/unparseable database must never crash the connector
-                # (a read-only deployment needs no limits) nor silently disable
-                # checking (returning None would leave writes unchecked) — an
-                # empty DB blocks every write with a clear refusal instead.
-                logger.warning(
-                    f"Limits checking enabled but the database at {db_path} could not "
-                    f"be read or parsed - blocking all writes. {e}"
-                )
-                return cls(
-                    {},
-                    {},
-                    {},
-                    failsafe_reason=(
-                        f"the limits database at {db_path} could not be read or parsed: {e}"
-                    ),
-                )  # Empty DB = blocks all (failsafe)
-            logger.debug(f"Loaded limits database with {len(limits_db)} channels")
-
+            # Both entries are JSON-serialisable: the python executor embeds
+            # this dict verbatim into the sandbox (wrapper.py), so the
+            # tri-state rides as null rather than as anything richer.
             policy = {
-                "allow_unlisted_channels": get_config_value(
-                    "control_system.limits_checking.allow_unlisted_channels", False
-                ),
+                "allow_unlisted_channels": posture.allow_unlisted,
+                "allow_unlisted_key": posture.key("allow_unlisted_channels"),
             }
 
             return cls(limits_db, policy, raw_db)
@@ -427,17 +597,31 @@ class LimitsValidator:
                         f"about channel '{channel_address}'."
                     ),
                 )
-            # Unlisted channel - check policy
-            if self.policy.get("allow_unlisted_channels", False):
+            # Unlisted channel - check policy. Only an explicit `True` is
+            # permission: the policy carries the posture's tri-state verbatim
+            # so that `channel_limits` can report an unstated answer as `null`,
+            # and unstated is nobody's permission to write an unlisted channel.
+            if self.policy.get("allow_unlisted_channels") is True:
                 return  # Allow unlisted channel
             else:
-                # FAILSAFE: Block unlisted channels
+                # FAILSAFE: Block unlisted channels. Name the key that actually
+                # answered — a deployment may set this per connector type, and
+                # quoting the deployment-wide key there would send an operator
+                # to flip a line the per-type block overrides. A validator built
+                # from a bare policy dict carries no key; the deployment-wide
+                # one is the honest answer for it.
+                answering_key = self.policy.get(
+                    "allow_unlisted_key", "control_system.limits_checking.allow_unlisted_channels"
+                )
                 logger.warning(f"Blocked write to unlisted channel: {channel_address}={value}")
                 raise ChannelLimitsViolationError(
                     channel_address=channel_address,
                     value=value,
                     violation_type="UNLISTED_CHANNEL",
-                    violation_reason=f"Channel '{channel_address}' not in limits database",
+                    violation_reason=(
+                        f"Channel '{channel_address}' not in limits database "
+                        f"('{answering_key}' does not allow unlisted channels)"
+                    ),
                 )
 
         # Check 2: Channel is writable?

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/mock_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/mock_connector.py
@@ -82,7 +82,7 @@ class MockConnector(ControlSystemConnector):
         # Initialize limits validator for automatic validation and confirm policy
         from osprey_connectors.control_system.limits_validator import LimitsValidator
 
-        self._limits_validator = LimitsValidator.from_config()
+        self._limits_validator = LimitsValidator.from_config(connector_type=self._connector_type)
         if self._limits_validator:
             logger.debug("Mock connector: limits validator initialized")
 

--- a/packages/osprey-connectors/src/osprey_connectors/factory.py
+++ b/packages/osprey-connectors/src/osprey_connectors/factory.py
@@ -74,11 +74,11 @@ class ConnectorFactory:
         logger.debug(f"Registered archiver connector: {name}")
 
     @classmethod
-    async def create_control_system_connector(
-        cls, config: dict[str, Any] = None, *, control_target: str | None = None
-    ) -> ControlSystemConnector:
+    def build_control_system_connector(
+        cls, config: dict[str, Any] | None = None, *, control_target: str | None = None
+    ) -> tuple[ControlSystemConnector, dict[str, Any]]:
         """
-        Create and configure a control system connector.
+        Build a control system connector and its type config, without connecting.
 
         Args:
             config: Control system configuration dict with keys:
@@ -96,23 +96,17 @@ class ConnectorFactory:
                 behaviour every caller had before the stamp existed.
 
         Returns:
-            Initialized and connected ControlSystemConnector
+            ``(connector, type_config)`` — the stamped but *unconnected*
+            connector, and the type-specific config block ``connect()`` takes.
+            Both halves are needed to finish the build, and the second is not
+            derivable from the first, so they travel together.
 
         Raises:
             ValueError: If connector type is unknown or config is invalid
-            ConnectionError: If connection fails
 
         Example:
-            >>> config = {
-            >>>     'type': 'epics',
-            >>>     'connector': {
-            >>>         'epics': {
-            >>>             'timeout': 5.0,
-            >>>             'gateways': {'read_only': {...}}
-            >>>         }
-            >>>     }
-            >>> }
-            >>> connector = await ConnectorFactory.create_control_system_connector(config)
+            >>> connector, type_config = ConnectorFactory.build_control_system_connector(config)
+            >>> await connector.connect(type_config)
         """
         # Load config if not provided
         if config is None:
@@ -161,8 +155,9 @@ class ConnectorFactory:
 
         # Create connector instance
         connector = connector_class()
-        # The one seam between construction and connect(): the write posture is
-        # per connector type, and connect() itself may already consult it.
+        # The one seam between construction and connect(): the write posture and
+        # the limits posture are both per connector type, and connect() itself
+        # already consults the stamp to load them.
         connector._connector_type = connector_type
         # Beside it, and for the same reason: the session half of the posture is
         # per target, so the target has to be on the instance before connect()
@@ -175,10 +170,52 @@ class ConnectorFactory:
         connector_configs = config.get("connector", {})
         type_config = connector_configs.get(connector_type, {})
 
-        # Connect with configuration
-        await connector.connect(type_config)
+        logger.debug(f"Built control system connector: {connector_type}")
+        return connector, type_config
 
-        logger.debug(f"Created control system connector: {connector_type}")
+    @classmethod
+    async def create_control_system_connector(
+        cls, config: dict[str, Any] | None = None, *, control_target: str | None = None
+    ) -> ControlSystemConnector:
+        """
+        Create, configure and connect a control system connector.
+
+        The whole build in one call, and what almost every caller wants.
+        :meth:`build_control_system_connector` is the same build stopped one
+        step short, for the one caller that has to reach the instance between
+        the type stamp and ``connect()``.
+
+        Args:
+            config: Control system configuration dict, as
+                :meth:`build_control_system_connector` documents it.
+            control_target: The session target this connector is being built
+                for, stamped on the instance as
+                :meth:`build_control_system_connector` documents it.
+
+        Returns:
+            Initialized and connected ControlSystemConnector
+
+        Raises:
+            ValueError: If connector type is unknown or config is invalid
+            ConnectionError: If connection fails
+
+        Example:
+            >>> config = {
+            >>>     'type': 'epics',
+            >>>     'connector': {
+            >>>         'epics': {
+            >>>             'timeout': 5.0,
+            >>>             'gateways': {'read_only': {...}}
+            >>>         }
+            >>>     }
+            >>> }
+            >>> connector = await ConnectorFactory.create_control_system_connector(config)
+        """
+        connector, type_config = cls.build_control_system_connector(
+            config, control_target=control_target
+        )
+        await connector.connect(type_config)
+        logger.debug(f"Created control system connector: {connector._connector_type}")
         return connector
 
     @classmethod
@@ -414,7 +451,7 @@ def register_builtin_connectors() -> None:
         (types.DOOCS, DOOCSConnector),
         # The live stand-in is a soft IOC, so the EPICS connector is what reaches
         # it — but it registers under its own name rather than sharing 'epics'.
-        # The registry key is what create_control_system_connector() stamps onto
+        # The registry key is what build_control_system_connector() stamps onto
         # the instance as _connector_type, and that stamp is what selects the
         # connector block ('control_system.connector.live_standin') and the write
         # posture read from it. Registering the stand-in as 'epics' would give it

--- a/packages/osprey-connectors/src/osprey_connectors/types.py
+++ b/packages/osprey-connectors/src/osprey_connectors/types.py
@@ -33,8 +33,22 @@ simulator alone; and the lint that reads the config, the persona that tells an
 operator what they hold, and the connector that would perform the write all have
 to agree about which types are armed. Two readings of one posture is one of them
 being wrong about a machine somebody can move.
+
+:class:`LimitsPosture` is the same story for limits checking, which is likewise
+per connector type: a deployment may relax unlisted channels on its simulator
+while its live machine refuses them. It carries the resolved posture together
+with the config key that answered it, so a refusal names the line an operator
+would have to edit rather than one some per-type block overrides.
+
+Where the write family reads an unusable value as "not armed" and is done, the
+limits family cannot: "no limits checking configured" is itself a permissive
+answer, so a leaf written as something no reader can turn into a boolean is
+reported as a block that failed to state it rather than as a block that stated
+nothing. Such a posture answers neither leaf, and a caller that must act blocks
+every write instead of waving them through unchecked.
 """
 
+from dataclasses import dataclass
 from typing import Any
 
 # -- Control system connector types (have implementations) --
@@ -525,6 +539,410 @@ def any_target_writes_enabled(section: Any) -> bool:
     return any(session_posture(section).values())
 
 
+# -- Limits posture --
+# Limits checking is per connector type for the same reason write posture is: a
+# deployment with a live machine beside a virtual accelerator has one posture
+# per machine, not one per deployment. The block overrides *whole* — a per-type
+# block states both leaves and then answers alone — so the value below carries
+# the two leaves together with the key that answered them.
+
+#: The limits block's own name, both deployment-wide
+#: (``control_system.limits_checking``) and inside one connector block
+#: (``control_system.connector.<type>.limits_checking``). One name because it is
+#: one block at two scopes, the per-type one overriding the other whole.
+LIMITS_CHECKING_LEAF = "limits_checking"
+
+#: The leaves a limits block has to state to answer at all. ``database_path`` is
+#: deliberately not among them: the deployment mounts one limits database, so a
+#: per-type block that omits the path is complete rather than incomplete.
+LIMITS_LEAVES = ("enabled", "allow_unlisted_channels")
+
+
+@dataclass(frozen=True)
+class LimitsPosture:
+    """A resolved limits posture, together with the config key that answered it.
+
+    The value and its key travel as one because a refusal has to send an
+    operator to the line they can actually edit. A deployment that relaxed
+    ``allow_unlisted_channels`` for its simulator alone has two keys in play,
+    and a refusal naming the deployment-wide one would have the operator flip a
+    line the per-type block overrides — a change that does nothing, on a
+    posture they did not mean to touch. Resolving the value without carrying
+    its key back is what makes that mistake available, so this type does not
+    offer the value on its own.
+
+    Both leaves are tri-state. ``None`` is "no block said", which is not the
+    same as a block saying ``false``: silence is what a deployment that never
+    configured limits checking has, and every write path treats it as no
+    permission rather than as a decision. Only :data:`LIMITS_LEAVES` are
+    carried; the limits database path stays deployment-wide.
+
+    Attributes:
+        enabled: Whether limits checking is on, or ``None`` when unstated.
+        allow_unlisted: Whether channels absent from the limits database may be
+            written, or ``None`` when unstated. Write paths allow only on
+            ``True``.
+        connector_type: The connector type whose block answered, or ``None``
+            when the deployment-wide block did. It selects the key spelling and
+            nothing else.
+        incomplete: The :data:`LIMITS_LEAVES` the answering block failed to
+            state, in :data:`LIMITS_LEAVES` order — a leaf a per-type block
+            omitted, or a leaf either block wrote as something other than a
+            literal boolean. Empty for a well-formed block. A non-empty value
+            means the posture answered nothing — both leaves are ``None`` —
+            and a reader that must act builds a failsafe rather than guessing
+            which half of the block was meant. The one posture not read from a
+            single block, :func:`most_restrictive_limits_posture`'s fold, may
+            carry definite leaves beside a non-empty tuple; readers check this
+            field first for exactly that reason.
+    """
+
+    enabled: bool | None
+    allow_unlisted: bool | None
+    connector_type: str | None
+    incomplete: tuple[str, ...] = ()
+
+    def key(self, leaf: str) -> str:
+        """The config key this posture's *leaf* was read from.
+
+        ``control_system.connector.<type>.limits_checking.<leaf>`` when a
+        connector block answered, and ``control_system.limits_checking.<leaf>``
+        when the deployment-wide block did. A custom connector's dotted module
+        path (``'mypackage.TangoConnector'``) is one key and is interpolated
+        whole, never split on its dots.
+
+        A posture holding no type at all — the deployment-wide answer, and the
+        fallback a target that resolves to no type gets — spells the
+        deployment-wide key, which is where such a posture was read from
+        anyway. Same reading :func:`writes_enabled_key` gives the same case.
+
+        Args:
+            leaf: One of :data:`LIMITS_LEAVES`.
+
+        Returns:
+            The dotted key, as a caller spells it for ``get_config_value`` and
+            as a refusal names it to an operator.
+        """
+        if not self.connector_type:
+            return f"control_system.{LIMITS_CHECKING_LEAF}.{leaf}"
+        return f"control_system.connector.{self.connector_type}.{LIMITS_CHECKING_LEAF}.{leaf}"
+
+    @property
+    def block_key(self) -> str:
+        """The dotted key of the whole ``limits_checking`` block, without a leaf.
+
+        What a refusal names when the block itself is the problem — it is not a
+        mapping, or it failed to state leaves an operator now has to go and
+        write. Spelled off :meth:`key` rather than rebuilt, so a refusal about a
+        block and a refusal about one of its leaves cannot disagree about where
+        the block is.
+        """
+        return self.key(LIMITS_LEAVES[0]).rsplit(".", 1)[0]
+
+    @property
+    def strict(self) -> bool:
+        """Whether this posture refuses everything the limits database does not list.
+
+        Limits checking on *and* unlisted channels explicitly refused — the only
+        definition of "strict" in the codebase, so the switch gate, the target
+        roster and the docs cannot drift into three readings of one word.
+
+        Explicit on both leaves: ``None`` is a deployment that never stated a
+        posture, and a deployment that stated nothing has refused nothing.
+        Counting silence as strict would advertise a guarantee no config line
+        backs, on exactly the deployments least likely to have checked.
+        """
+        return self.enabled is True and self.allow_unlisted is False
+
+
+def type_limits_posture(section: Any, connector_type: str | None) -> LimitsPosture:
+    """The limits posture one connector *type* runs under.
+
+    ``control_system.connector.<type>.limits_checking`` when that block is
+    there, and ``control_system.limits_checking`` when it is not, where
+    *connector_type* is one key. A custom connector's dotted module path
+    (``'mypackage.TangoConnector'``) names a single block, never a path through
+    several, so the type is looked up whole and never split on its dots.
+
+    The per-type block overrides **whole**, and that is the rule the rest of the
+    family is built on:
+
+    - **Absent** — no connector table, no block for this type, a connector
+      block that is not a mapping, or one carrying no ``limits_checking`` key
+      at all — inherits the deployment-wide block, both leaves tri-state. That
+      is the compatibility story: a deployment that says nothing per type keeps
+      the posture it had when the deployment-wide block was the only posture
+      there was.
+    - **Present but not a mapping** — ``limits_checking: 'true'``, a list, a
+      bare ``limits_checking:`` — is a block written and unreadable, not an
+      absent one, so it answers nothing with both leaves incomplete. Inheriting
+      there would hand the deployment-wide posture to a type whose own block
+      says something nobody can read, which is the one case where inheritance
+      would be a guess rather than compatibility.
+    - **Present and complete** answers alone. Not one leaf is borrowed from the
+      deployment-wide block, because a facility that wrote a block under its
+      live machine has described *that* machine, and a global relaxation meant
+      for a simulator must not complete it into permission on hardware.
+    - **Present and failing to state a leaf** answers *nothing*: both leaves
+      ``None``, and :attr:`LimitsPosture.incomplete` names what it failed to
+      state. Half a block is a config the build and ``osprey validate`` refuse
+      outright; a hand-edited or older render can still carry one, and then a
+      reader that must act builds a failsafe — blocking every write — rather
+      than guessing which half was meant.
+
+    A block fails to state a leaf in two ways, and only the first is particular
+    to per-type blocks. A per-type block may **omit** one, which the
+    deployment-wide block may do freely because it inherits nothing. Either
+    block may **write one unreadably** — the ``None`` YAML gives a bare
+    ``enabled:``, the quoted ``'true'``, a ``1``, an unexpanded
+    ``'${LIMITS_ON}'`` — and that is a failure in both scopes. It has to be:
+    an unreadable leaf read as merely unset would leave ``enabled`` meaning
+    "this deployment configured no limits checking", so a deployment that wrote
+    ``enabled: 'true'`` to switch checking *on* would have its writes go
+    unchecked. Reported as unstated, it costs a config edit; read as unset, it
+    would cost the guarantee the line was written to provide. Both readings are
+    the build refusal's too (:func:`incomplete_limits_blocks`), so a config the
+    build accepts and one the runtime enforces cannot come apart.
+
+    Keyed by type rather than by session target for the reason
+    :func:`type_writes_enabled` is: a connector, the factory that builds it, an
+    IPC child all know which connector type they are and never which target
+    selected it. :func:`target_limits_posture` is this same answer for the
+    holders that carry a target instead.
+
+    Args:
+        section: The ``control_system:`` config section, in the same shape
+            :func:`resolve_control_system_type` takes.
+        connector_type: A connector type name, as
+            :func:`resolve_control_system_type` and :func:`resolve_target`
+            return it — which is also its connector sub-block key. ``None``
+            (or an empty name) asks the deployment-wide question, which is what
+            a caller holding no type at all has always asked.
+
+    Returns:
+        The resolved :class:`LimitsPosture`, carrying the type whose block
+        answered — or ``None`` for the deployment-wide block, which is the key
+        such a posture was read from anyway. Never raises: a section or a
+        connector table that is not a mapping is a deployment that has said
+        nothing, and a deployment that has said nothing states no posture — a
+        ``limits_checking`` value that is present but not a mapping is instead
+        an unreadable block, incomplete on both leaves.
+    """
+    if connector_type:
+        connector = section.get("connector") if isinstance(section, dict) else None
+        block = connector.get(connector_type) if isinstance(connector, dict) else None
+        if isinstance(block, dict) and LIMITS_CHECKING_LEAF in block:
+            limits = block[LIMITS_CHECKING_LEAF]
+            if not isinstance(limits, dict):
+                return LimitsPosture(None, None, connector_type, LIMITS_LEAVES)
+            return _block_limits_posture(limits, connector_type, whole=True)
+    return _global_limits_posture(section)
+
+
+def target_limits_posture(section: Any, target: Any) -> LimitsPosture:
+    """The limits posture one session *target* runs under.
+
+    :func:`type_limits_posture` for the type that target resolves to, so a
+    holder following the session target and the connector that knows only its
+    own type read one posture and not two. The roster row, the stdlib hook, the
+    executor and the tool layer all arrive here; the connector, the factory and
+    the IPC child arrive at :func:`type_limits_posture` — and a deployment that
+    described one machine must not answer them differently.
+
+    A target that does not resolve answers the deployment-wide block instead.
+    Two shapes reach that branch and both mean the same thing: there is no
+    per-type block to consult because there is no type. An unknown target names
+    nothing. ``live`` on a mock or hello_world-style deployment names a machine
+    the config never described, which :func:`resolve_target` refuses to guess.
+    Such a deployment has only ever had the one deployment-wide block, and
+    keeping it is parity rather than a fallback — the same reading
+    :func:`target_writes_enabled` takes, so the two postures a refusal may quote
+    cannot disagree about which deployments have a second machine. Refusing here
+    would instead take the posture away from every deployment that never had a
+    second target.
+
+    Args:
+        section: The ``control_system:`` config section, in the same shape
+            :func:`resolve_control_system_type` takes.
+        target: The session target, one of :data:`CONTROL_TARGETS`.
+
+    Returns:
+        The resolved :class:`LimitsPosture` for that target, carrying the type
+        whose block answered — or ``None`` for the deployment-wide block, which
+        is both what an unresolvable target gets and what a resolvable one gets
+        when its type wrote no block. Never raises.
+    """
+    try:
+        connector_type = resolve_target(section, target)
+    except ValueError:
+        return _global_limits_posture(section)
+    return type_limits_posture(section, connector_type)
+
+
+def most_restrictive_limits_posture(section: Any) -> LimitsPosture:
+    """The limits posture that holds across every target a session here can select.
+
+    What a caller with no target of its own has to assume. The stdlib hook is
+    the one that needs it: when the session's control target cannot be read —
+    no state written yet, an unreadable state directory, a target that resolves
+    to nothing — it still has to decide about a write, and the machine it is
+    deciding about is any of the reachable ones.
+
+    The reachable set is exactly :func:`session_posture`'s: every
+    :func:`configured_targets` when the deployment renders the switch
+    (:func:`switch_capable`), and otherwise the single connector
+    ``control_system.type`` builds, read by *type* through
+    :func:`type_limits_posture`. Reading the baseline by type rather than by
+    target is what keeps a mock deployment that happens to carry an ``epics``
+    block from folding that block's relaxation into an answer no session here
+    could ever reach; and walking the configured targets rather than
+    :data:`CONTROL_TARGETS` keeps :func:`target_limits_posture`'s
+    unresolvable-target fallback from voting for a machine nobody stood up.
+
+    The two leaves fold in opposite directions, each toward the answer that
+    costs a config edit rather than a machine:
+
+    - ``enabled`` is ``True`` when *any* reachable posture has it ``True``.
+      Limits checking being on somewhere is a constraint that may apply to the
+      write in hand.
+    - ``allow_unlisted`` is ``True`` only when *every* reachable posture has it
+      ``True``. Permission to write a channel the limits database does not list
+      holds only where every machine grants it, so one strict target — or one
+      that states nothing, ``None`` and an incomplete block alike counting as
+      not-``True`` — makes the answer strict.
+
+    Incompleteness travels with them, as the union of every reachable
+    posture's :attr:`LimitsPosture.incomplete` in :data:`LIMITS_LEAVES` order.
+    One reachable machine whose block cannot be read makes the fold incomplete,
+    and a reader that must act therefore builds the blocking failsafe. Dropping
+    it would be the worst failure available here: both leaf folds send an
+    incomplete posture's ``None`` to ``False``, which reads as "checking off,
+    nothing permitted" — and a validator built from *that* is no validator at
+    all, so the caller with the least information about which machine it is
+    touching would be the one waved through. This is the fail-closed direction
+    :func:`LimitsValidator.from_config_most_restrictive`'s callers are promised.
+
+    The result is derived rather than read, which is why both leaves come back
+    definite where a single block's would be tri-state, and why the posture
+    carries no connector type: no per-type line answers for a union, and naming
+    one would send an operator to edit a machine rather than the answer. The
+    deployment-wide keys :meth:`LimitsPosture.key` then spells are the honest
+    ones — they are the lines that decide every target that wrote no block.
+
+    Args:
+        section: The ``control_system:`` config section, in the same shape
+            :func:`resolve_control_system_type` takes.
+
+    Returns:
+        The folded :class:`LimitsPosture`, always carrying ``None`` for its
+        connector type, and incomplete when any reachable posture is. Never
+        raises and never folds an empty set:
+        :func:`configured_targets` always holds the baseline, and a deployment
+        that says nothing still has one target.
+    """
+    if switch_capable(section):
+        postures = [
+            target_limits_posture(section, target) for target in configured_targets(section)
+        ]
+    else:
+        postures = [type_limits_posture(section, resolve_control_system_type(section))]
+    return LimitsPosture(
+        enabled=any(posture.enabled is True for posture in postures),
+        allow_unlisted=all(posture.allow_unlisted is True for posture in postures),
+        connector_type=None,
+        incomplete=tuple(
+            leaf
+            for leaf in LIMITS_LEAVES
+            if any(leaf in posture.incomplete for posture in postures)
+        ),
+    )
+
+
+def incomplete_limits_blocks(section: Any) -> list[str]:
+    """Every half-written per-type limits block in a rendered section, named.
+
+    A per-type ``limits_checking`` block overrides whole, so a block that states
+    one leaf states no posture at all: :func:`type_limits_posture` answers
+    ``None`` twice for it and a write path that must act builds a failsafe. The
+    build and ``osprey validate`` refuse such a config outright rather than ship
+    a deployment whose limits posture silently stopped working, and this is what
+    they read to do it — the rendered config itself, so a spelling the profile
+    layer could not classify is still caught before it reaches a machine.
+
+    A lint and not a posture: it answers about a section rather than about a
+    target, and each line it emits names the key an operator has to fix. It
+    reports exactly what :func:`type_limits_posture` reads as a block that
+    failed to state a leaf — the two share :func:`_unstated_limits_leaves`, so
+    a config the build accepts and one the runtime enforces cannot come apart —
+    which is the two failures a block can have:
+
+    - A **per-type** block that omits a leaf. The deployment-wide block is not
+      reported for an omission: it inherits nothing, so a leaf it never carried
+      is the tri-state's ``None`` and the shape every deployment predating
+      per-type blocks has.
+    - **Either** block writing a leaf as something no reader can turn into a
+      boolean — a quoted ``'true'``, a ``1``, a bare ``enabled:``, an
+      unexpanded ``'${LIMITS_ON}'``. Environment expansion yields strings, so
+      this is what a deployment gets when it wires a limits leaf to a variable
+      nothing set. It blocks every write at runtime, which is the safe
+      direction but a poor way to find out; refusing the build is where that
+      config is cheap to fix.
+    - **Either** ``limits_checking`` being present but not a mapping at all,
+      which gets one line naming the block and quoting what was found there
+      instead of a line per leaf: there are no leaves to name.
+
+    Args:
+        section: The ``control_system:`` config section, in the same shape
+            :func:`resolve_control_system_type` takes — the *rendered* one, as
+            the build produced it, since that is the config a deployment runs.
+
+    Returns:
+        One line per unstated leaf: the deployment-wide block first, then the
+        connector blocks in the order the section carries them, leaves in
+        :data:`LIMITS_LEAVES` order, so one refusal lists everything an operator
+        has to fix. Empty for a section whose blocks are complete, absent, or
+        not blocks at all. Never raises: a lint that crashed on a malformed
+        config would fail a build without saying what is wrong with it.
+    """
+    if not isinstance(section, dict):
+        return []
+    connector = section.get("connector")
+    blocks: list[tuple[Any, Any, bool]] = []
+    if LIMITS_CHECKING_LEAF in section:
+        blocks.append((None, section[LIMITS_CHECKING_LEAF], False))
+    if isinstance(connector, dict):
+        blocks.extend(
+            (connector_type, block[LIMITS_CHECKING_LEAF], True)
+            for connector_type, block in connector.items()
+            if isinstance(block, dict) and LIMITS_CHECKING_LEAF in block
+        )
+    errors: list[str] = []
+    for connector_type, block, whole in blocks:
+        # The posture this block would answer with, built for its keys alone —
+        # so the line naming the block and the lines naming its leaves are
+        # spelled by one thing.
+        posture = LimitsPosture(None, None, connector_type)
+        if not isinstance(block, dict):
+            errors.append(
+                f"{posture.block_key} is {block!r}, not a block; a limits "
+                f"block is a mapping stating {LIMITS_LEAVES[0]} and {LIMITS_LEAVES[1]}"
+            )
+            continue
+        for leaf, written in _unstated_limits_leaves(block, whole=whole):
+            if written:
+                errors.append(
+                    f"{posture.key(leaf)} is {block[leaf]!r}, not a literal true or false; "
+                    "a limits leaf that cannot be read states no posture and blocks "
+                    "every write as a failsafe"
+                )
+            else:
+                errors.append(
+                    f"{posture.key(leaf)} is missing; a per-type limits block must state "
+                    f"both {LIMITS_LEAVES[0]} and {LIMITS_LEAVES[1]}"
+                )
+    return errors
+
+
 def _global_writes_enabled(section: Any) -> bool:
     """The deployment-wide posture, ``control_system.writes_enabled``.
 
@@ -532,6 +950,116 @@ def _global_writes_enabled(section: Any) -> bool:
     gets, so a quoted ``'true'`` or a ``1`` arms nothing at either level.
     """
     return isinstance(section, dict) and section.get(TYPE_WRITES_ENABLED_LEAF) is True
+
+
+def _global_limits_posture(section: Any) -> LimitsPosture:
+    """The deployment-wide posture, ``control_system.limits_checking``.
+
+    A leaf this block does not carry is the tri-state and not a malformed
+    block: silence here is the shape every deployment predating per-type blocks
+    has, and only a per-type block, which overrides whole, has to state both
+    leaves to answer at all. A leaf it *does* carry but spells as something
+    other than a literal boolean is unreadable in either block alike — see
+    :func:`_unstated_limits_leaves` — and so is the whole block when
+    ``limits_checking`` is present but is not a mapping, which is incomplete on
+    both leaves rather than the silence of a deployment that wrote none.
+    """
+    if not isinstance(section, dict) or LIMITS_CHECKING_LEAF not in section:
+        return _block_limits_posture({}, None, whole=False)
+    block = section[LIMITS_CHECKING_LEAF]
+    if not isinstance(block, dict):
+        return LimitsPosture(None, None, None, LIMITS_LEAVES)
+    return _block_limits_posture(block, None, whole=False)
+
+
+def _unstated_limits_leaves(block: dict[str, Any], *, whole: bool) -> list[tuple[str, bool]]:
+    """The leaves a limits block fails to state, and whether each was written.
+
+    One classifier for both scopes and both readers — the posture resolvers and
+    the build's render check — because "which leaves did this block fail to
+    state" decided twice is a config the build accepts and the runtime refuses,
+    or worse the other way round.
+
+    Two ways a block fails to state a leaf, and they are told apart by the
+    boolean each entry carries:
+
+    - **Absent** (``False``), which is a failure only under *whole*: a per-type
+      block overrides the deployment-wide pair entire, so it has to state both
+      leaves to answer at all. The deployment-wide block is read with
+      ``whole=False``, where an absent leaf is simply the tri-state's ``None``.
+    - **Written but unreadable** (``True``) — a quoted ``'true'``, a ``1``, a
+      bare ``enabled:``, an unexpanded ``'${LIMITS_ON}'`` that no environment
+      resolved — which is a failure in *either* scope. This is the leaf that
+      cannot be allowed to read as a plain unset: unset ``enabled`` means "no
+      limits checking configured", so a deployment that wrote
+      ``enabled: 'true'`` meaning to switch checking *on* would have every
+      write waved through unchecked. Reporting it unstated instead makes the
+      posture incomplete, and an incomplete posture blocks. The config edit is
+      one line; the alternative is unchecked writes on a machine somebody
+      believed was guarded.
+
+    Args:
+        block: A ``limits_checking`` mapping, deployment-wide or per type.
+        whole: Whether an absent leaf is a failure, which it is exactly when
+            the block overrides another one entire.
+
+    Returns:
+        ``(leaf, was_written)`` in :data:`LIMITS_LEAVES` order, empty for a
+        block that states everything it has to.
+    """
+    unstated: list[tuple[str, bool]] = []
+    for leaf in LIMITS_LEAVES:
+        if leaf not in block:
+            if whole:
+                unstated.append((leaf, False))
+        elif _limits_leaf(block[leaf]) is None:
+            unstated.append((leaf, True))
+    return unstated
+
+
+def _block_limits_posture(
+    block: dict[str, Any], connector_type: str | None, *, whole: bool
+) -> LimitsPosture:
+    """One ``limits_checking`` mapping read into a posture.
+
+    A block that fails to state any leaf answers *nothing* — both leaves
+    ``None``, with :attr:`LimitsPosture.incomplete` naming what it failed to
+    state. Half an answer is not available: neither leaf of a block written
+    with the other one unreadable can be trusted to mean what a reader would do
+    with it, and a caller that must act builds a failsafe from ``incomplete``
+    rather than guessing.
+    """
+    unstated = _unstated_limits_leaves(block, whole=whole)
+    if unstated:
+        return LimitsPosture(None, None, connector_type, tuple(leaf for leaf, _ in unstated))
+    enabled_leaf, allow_unlisted_leaf = LIMITS_LEAVES
+    return LimitsPosture(
+        enabled=_limits_leaf(block.get(enabled_leaf)),
+        allow_unlisted=_limits_leaf(block.get(allow_unlisted_leaf)),
+        connector_type=connector_type,
+    )
+
+
+def _limits_leaf(value: Any) -> bool | None:
+    """One limits leaf as a literal boolean, or ``None`` for anything else.
+
+    The literal booleans and nothing else are readable. A quoted ``'true'``, a
+    ``1``, a bare ``enabled:`` — the same values :func:`type_writes_enabled`
+    refuses to read as an arming — are not.
+
+    Unlike write posture, ``None`` here is not itself the safe answer, which is
+    why no caller reads this directly: an unset ``enabled`` means "this
+    deployment configured no limits checking", so a leaf written unreadably and
+    reported as merely unset would turn an attempt to switch checking *on* into
+    writes that are never checked at all. :func:`_unstated_limits_leaves` is
+    what the resolvers use, and it separates a leaf nobody wrote from a leaf
+    nobody can read.
+    """
+    if value is True:
+        return True
+    if value is False:
+        return False
+    return None
 
 
 def _live_type(section: Any) -> str:

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -541,11 +541,39 @@ keys:
       Escaped, so the vacuity cap does not apply.
   control_system.limits_checking: {evidence: 'limits_checking'}
   control_system.limits_checking.enabled:
-    evidence: 'get_config_value\("control_system\.limits_checking\.enabled", False\)'
+    evidence: '_limits_leaf\(block\.get\(enabled_leaf\)\)'
+    note: >-
+      Deployment-wide limits posture, and no longer read by a dotted
+      `get_config_value` call: every reader now goes through the per-type
+      resolver family in `osprey_connectors.types`, whose inherit branch falls
+      back to this deployment-wide block when the acting connector type wrote
+      no block of its own. Both scopes read their leaves through the one
+      shared helper `_block_limits_posture`, so this anchor is shared with the
+      per-type entries below; the per-type branch stays covered by the parent
+      entries' `limits = block[LIMITS_CHECKING_LEAF]` anchor. A leaf
+      absent here is unset; one PRESENT but not literally `true`/`false` makes
+      the block incomplete in either scope, so the posture answers neither
+      leaf, `_from_posture` returns the blocking failsafe and `osprey build`
+      refuses it via `incomplete_limits_blocks`.
   control_system.limits_checking.database_path:
     evidence: 'get_config_value\("control_system\.limits_checking\.database_path", None\)'
+    note: >-
+      Deliberately NOT per connector type: a deployment mounts one limits
+      database (`compose_generator.py`), so the path stays deployment-wide and
+      a per-type block that omits it is complete rather than half-written. The
+      one reader is `LimitsValidator._load_configured_database`, which is where
+      this call now lives; the dotted spelling is the anchor because it is the
+      only place the key is named.
   control_system.limits_checking.allow_unlisted_channels:
-    evidence: 'allow_unlisted_channels'
+    evidence: '_limits_leaf\(block\.get\(allow_unlisted_leaf\)\)'
+    note: >-
+      Anchored on the leaf read in `_block_limits_posture` rather than on the
+      bare word: `allow_unlisted_channels` now travels as a policy field and as
+      an answering key through the validator, the tool layer and the roster, so
+      a bare match no longer proves a config reader exists. That one reader
+      serves the per-type entries below too. Same absent/unreadable reading as
+      `enabled` above, and only literal `true` lets a write reach a channel the
+      limits database does not list.
   control_system.write_tools:
     rendered: false
     evidence: 'control_system\.get\("write_tools", \[\]\)'
@@ -685,6 +713,109 @@ keys:
       decision that cannot ship pre-made, so no shipped preset ever sets this
       one true; `control-assistant-readonly` writes it false into an applied
       project's config.yml, which is the one way a build produces it.
+  control_system.connector.virtual_accelerator.limits_checking:
+    rendered: false
+    evidence: 'limits = block\[LIMITS_CHECKING_LEAF\]'
+    note: >-
+      Per-connector-type override of the deployment-wide
+      `control_system.limits_checking` block above, and the reason that block
+      grew a per-type shape at all: a deployment running a live machine beside
+      a virtual accelerator holds one limits posture per machine, not one per
+      deployment. It overrides WHOLE -- a block that is present states both
+      leaves below and then answers alone, inheriting nothing -- so a global
+      relaxation meant for a simulator can never complete a half-written block
+      into permission on hardware. Only the two leaves below: `database_path`
+      stays deployment-wide because a deployment mounts one limits database.
+      Written commented in the templates that carry a virtual_accelerator
+      block, so no template render carries it and `rendered` stays false; the
+      shipped `control-assistant` preset DOES write both leaves into a
+      project's real config.yml, so an audit of a built deployment finds them.
+      The reader is `type_limits_posture` in `osprey_connectors.types`, and the
+      evidence is the line in it that takes this block out of the resolved
+      connector block -- disjoint from the deployment-wide read in
+      `_global_limits_posture` (`section[...]`), so each entry dies with exactly
+      its own reader. The epics and live_standin entries below cite the same
+      site on purpose: one type-keyed resolver serves every connector type, a
+      custom connector's dotted module path included. No `mock` or `doocs`
+      entry, because no template or preset writes either block.
+  control_system.connector.virtual_accelerator.limits_checking.enabled:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(enabled_leaf\)\)'
+    note: >-
+      Whether limits checking runs for this connector type. Literal `true` or
+      `false` states a posture. A leaf PRESENT but spelled otherwise (a quoted
+      `'true'`, a `1`, the `None` a bare `enabled:` gives, an unexpanded
+      `${VAR}`) is unreadable, and a per-type block missing this leaf is
+      half-written: either way the block is incomplete, the posture answers
+      neither leaf, `_from_posture` returns the blocking failsafe and `osprey
+      build` refuses it by name via `incomplete_limits_blocks`. Reading an
+      unreadable leaf as merely unset would instead mean "no limits checking
+      configured" and wave every write through. The evidence is the shared leaf
+      read in `_block_limits_posture`, which answers for the deployment-wide
+      entry above too; the per-type branch is pinned by the parent entry's
+      block lookup.
+  control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(allow_unlisted_leaf\)\)'
+    note: >-
+      Whether channels the limits database does not list may be written for
+      this connector type. Same reading and the same shared reader as
+      `enabled` above, and write paths allow only on literal `true`.
+      This is the leaf the per-type block was added for: a facility running a
+      live machine beside a simulator could not hold `false` for the machine
+      and `true` for the simulator, and carried the relaxation deployment-wide
+      as a marked deviation instead.
+  control_system.connector.epics.limits_checking:
+    rendered: false
+    evidence: 'limits = block\[LIMITS_CHECKING_LEAF\]'
+    note: >-
+      Same block, same whole-block override semantics and the same single
+      type-keyed reader for the epics block, likewise written commented in the
+      templates that carry an epics block so no template render carries it.
+      Relaxing limits against a live machine is a facility decision that cannot
+      ship pre-made, so no shipped preset writes this one.
+  control_system.connector.epics.limits_checking.enabled:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(enabled_leaf\)\)'
+    note: >-
+      Same leaf, same absent/unreadable reading and the same shared reader
+      for the epics block.
+  control_system.connector.epics.limits_checking.allow_unlisted_channels:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(allow_unlisted_leaf\)\)'
+    note: >-
+      Same leaf, same absent/unreadable reading and the same shared reader
+      for the epics block. Setting it `true` is what makes a live target stop
+      counting
+      as strict, which the target-switch gate refuses by naming this key.
+  control_system.connector.live_standin.limits_checking:
+    rendered: false
+    evidence: 'limits = block\[LIMITS_CHECKING_LEAF\]'
+    note: >-
+      The live stand-in's own limits block. Never authored and never rendered
+      by a template: the build derives the stand-in's connector block from
+      `virtual_accelerator.live_standin` (see the parent entry above), and the
+      resolver reads a `limits_checking` block inside it exactly as it reads
+      one inside any other `control_system.connector.<type>` block. The
+      stand-in is a connector type of its own, so it does NOT inherit the
+      virtual_accelerator block a deployment wrote -- a rehearsal target that
+      silently took the simulator's relaxation would be the one deployment
+      where the posture an operator reads is not the posture that runs.
+  control_system.connector.live_standin.limits_checking.enabled:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(enabled_leaf\)\)'
+    note: >-
+      One of the two leaves of the derived block a profile is free to write.
+      Same absent/unreadable reading and the same shared reader as the other
+      types.
+  control_system.connector.live_standin.limits_checking.allow_unlisted_channels:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(allow_unlisted_leaf\)\)'
+    note: >-
+      The other leaf of the derived block. Same absent/unreadable reading and
+      the same shared reader; the shipped `control-assistant` preset writes no
+      live_standin block, so a stand-in target there answers the
+      deployment-wide posture and stays strict where the deployment is.
 
   # ── Control-system target switch ────────────────────────────────────
   control_system.target_switch:

--- a/scripts/config_key_parity.md
+++ b/scripts/config_key_parity.md
@@ -105,6 +105,19 @@ absent inherits the global key, literally `true` arms writes for that connector
 type, and any other value leaves them unarmed. Arming writes is a per-facility
 decision, so no template may ship it live in any of the five.
 
+`control_system.connector.<type>.limits_checking` is the same story for the
+limits posture, and is likewise **not** parity-required. It overrides the
+deployment-wide `control_system.limits_checking` block whole -- a per-type
+block states both `enabled` and `allow_unlisted_channels` and then answers
+alone -- and is written commented in the templates that carry the matching
+connector block, so it is never rendered and never enters the union a parity
+guard would compare. Only `virtual_accelerator`, `epics` and `live_standin`
+carry entries; `mock` and `doocs` write no block. `database_path` has no
+per-type spelling: a deployment mounts one limits database, so that leaf stays
+deployment-wide, and a per-type block omitting it is complete rather than
+half-written. How relaxed a machine's limits checking may be is a per-facility
+decision, so no template may ship either leaf live in any of the five.
+
 ### `api.providers` membership
 
 Not a fixed set. `project`, `control_assistant` and `hello_world` ship the full

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1267,6 +1267,38 @@ def _resolve_rendered_execution_method(render_dir: Path) -> list[str]:
     return []
 
 
+def _incomplete_limits_errors(render_dir: Path) -> list[str]:
+    """Every ``limits_checking`` block in a render that fails to state a leaf, named.
+
+    Both scopes are read: the deployment-wide block and every per-type block.
+    A per-type block overrides the deployment-wide pair whole, so a block that
+    states one leaf answers no posture at all; a leaf that is present but not
+    a literal ``true``/``false`` (``"true"``, ``1``, an unexpanded ``${VAR}``)
+    answers nothing either, in either scope; and a ``limits_checking`` value
+    that is not a mapping at all answers neither leaf. Each of those makes
+    every write path fall back to refusing unlisted channels — a deployment
+    whose limits posture quietly stopped doing what its author wrote.
+    ``osprey validate`` catches the ones a ``config:`` block spelled; this
+    reads the config a deployment actually runs, so a block an injector or an
+    app template assembled is caught too.
+
+    Args:
+        render_dir: The rendered project directory, read after the injectors.
+
+    Returns:
+        One line per missing or unreadable leaf, naming the key an operator
+        has to add or rewrite as a literal boolean; one line naming the block
+        and its value when ``limits_checking`` is not a mapping; nothing for a
+        render whose blocks are complete or absent.
+    """
+    from osprey_connectors.types import incomplete_limits_blocks
+
+    errors: list[str] = incomplete_limits_blocks(
+        _rendered_config(render_dir).get("control_system") or {}
+    )
+    return errors
+
+
 def _template_host_config(
     shared: _SharedRenderInputs,
     build_profile: Any,
@@ -1582,6 +1614,7 @@ def _render_project(
     unrunnable = [
         *_resolve_rendered_execution_method(render_dir),
         *reach_errors(_rendered_config(render_dir), repo_root=repo_root),
+        *_incomplete_limits_errors(render_dir),
     ]
     if unrunnable:
         raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(unrunnable))
@@ -2407,7 +2440,11 @@ def _build_repo(
     from osprey.deployment.subprocess_capture import diagnose_captured_failure
 
     from .build_profile import resolve_build_document
-    from .build_profile_deploy import deploy_aware_config_errors, deploy_aware_config_warnings
+    from .build_profile_deploy import (
+        deploy_aware_config_errors,
+        deploy_aware_config_warnings,
+        limits_block_errors,
+    )
     from .build_profile_va_faults import live_standin_lattice_errors
     from .phase_reporter import current_reporter
     from .variant_selection import VARIANT_DIRNAME, resolve_variant_selection
@@ -2464,6 +2501,11 @@ def _build_repo(
         web_errors = deploy_aware_config_errors(
             build_profile.deploy, build_profile.config, profile_root=repo_root
         )
+        # A sibling call, exactly as `osprey validate` makes it — see the note
+        # beside the same line in `validate_cmd.py`. Raising here, profile-side,
+        # is what keeps the render-side `_incomplete_limits_errors` from
+        # reporting the same half-written block a second time.
+        web_errors = [*web_errors, *limits_block_errors(build_profile.config)]
         if web_errors:
             raise click.UsageError("Profile validation failed:\n  - " + "\n  - ".join(web_errors))
         web_warnings = deploy_aware_config_warnings(

--- a/src/osprey/cli/build_profile_deploy.py
+++ b/src/osprey/cli/build_profile_deploy.py
@@ -21,11 +21,17 @@ consume it want exactly one import.
 from __future__ import annotations
 
 import difflib
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from osprey.errors import BuildProfileError
+from osprey_connectors.types import (
+    LIMITS_CHECKING_LEAF,
+    LIMITS_LEAVES,
+    SET_CONTROL_SYSTEM_TYPES,
+)
 
 from .build_profile_schema import _ENV_VAR_RE
 
@@ -57,6 +63,16 @@ _PROFILE_OWNED_KEYS: dict[str, str] = {
 #: Environment declarations have one channel for the whole profile, so the
 #: deploy block names variables but never declares them.
 _ENV_CHANNEL_KEYS: tuple[str, ...] = ("env", "environment")
+
+#: The rendered config section a per-type limits posture lives in, and the
+#: dotted spelling of the same path for a spelling-agnostic lookup. The block's
+#: own key and the leaves that make it complete come from
+#: :mod:`osprey_connectors.types`, which is where the resolvers read them: a
+#: build that refused a different pair than the runtime answers with would be
+#: refusing profiles the deployment can honour, or passing ones it cannot.
+_CONTROL_SYSTEM_KEY = "control_system"
+_CONNECTOR_SEGMENTS: tuple[str, ...] = (_CONTROL_SYSTEM_KEY, "connector")
+_CONNECTOR_PREFIX = ".".join(_CONNECTOR_SEGMENTS)
 
 #: The rendered-config subtree the multi-user web stack reads at deploy time.
 #: ``deploy.image_source`` is propagated into it at build time, which is what
@@ -317,6 +333,214 @@ def deploy_aware_config_warnings(
     return profile_config_warnings(
         {**config, **deploy_config_overrides(deploy, config)}, profile_root=profile_root
     )
+
+
+def limits_block_errors(config: Mapping[str, Any]) -> list[str]:
+    """Refuse a profile whose per-type ``limits_checking`` block will not render.
+
+    ``control_system.connector.<type>.limits_checking`` overrides the
+    deployment-wide ``enabled`` / ``allow_unlisted_channels`` pair as a WHOLE
+    block — there is no leaf inheritance — so a block stating one leaf has no
+    posture to answer with, and every reader falls back to the failsafe
+    validator. That is a deployment quietly stricter (or, for the operator who
+    meant to relax a simulator, quietly unchanged) than the profile says.
+
+    The other half of the check is about the render rather than the block. A
+    ``config:`` entry reaches ``config.yml`` through
+    :func:`osprey.utils.config_writer.config_update_fields`, which splits only
+    the TOP-LEVEL key of each entry on dots and assigns the value verbatim at
+    the leaf it lands on. Every dot below that key therefore stays inside a
+    literal key name. So the flat leaf a preset writes
+    (``control_system.connector.virtual_accelerator.limits_checking.enabled``)
+    renders where it reads, while the same block written for a dotted custom
+    type flattened into one key renders four levels too deep, and
+    ``control_system.connector.<type>: {"limits_checking.enabled": true}``
+    renders a key literally named ``limits_checking.enabled``. Both look right
+    in the profile and are invisible afterwards; a custom type spelled as its
+    own map key under a ``control_system.connector`` prefix is the spelling
+    that works.
+
+    Mixed spellings are otherwise legal and are not judged here: a profile is
+    free to write a leaf flat, as a dotted prefix over a mapping, or fully
+    nested (:func:`osprey.cli.build_profile_reach._spelled_values` reads all of
+    them), and two dotted keys at different depths below ``control_system``
+    merge at render. The one exception is a bare top-level ``control_system:``
+    mapping beside flat ``control_system.*`` keys, which does not merge and
+    leaves no way to attribute a limits leaf to one spelling or the other —
+    :func:`_mixed_depth_control_system_errors` has the mechanism.
+
+    Registry-free by construction: a per-type block is checked for every
+    built-in connector type and for every type the profile itself names,
+    whether or not the deployment selects it. A stray block is still a stated
+    posture, and a deployment pointed at that type later would inherit it.
+
+    Args:
+        config: The profile's ``config:`` block, as merged — presets, ``-O``
+            overlays, ``--set`` pairs and ``extends`` parents folded together.
+            A non-mapping has nothing to refuse.
+
+    Returns:
+        One message per problem, empty when the profile's limits blocks are
+        sound. Each message names the ``config:`` line(s) to fix:
+
+        * a per-type ``limits_checking`` path that does not render as
+          ``control_system.connector.<type>.limits_checking.<leaf>`` — the
+          message names the entry as the profile wrote it, and the path it
+          actually renders to;
+        * a ``config:`` block addressing ``control_system`` at two depths — the
+          message names the shallower key and every deeper key inside it;
+        * a per-type block stating one of its two leaves — the message names
+          the connector type, the leaf the profile did state, and the missing
+          leaf.
+    """
+    if not isinstance(config, dict):
+        return []
+
+    # Imported in-function: this module sits on `BuildProfile`'s import chain,
+    # and the reach registry behind `_spelled_values` pulls the whole
+    # service-resolution package in with it.
+    from .build_profile_reach import _spelled_values
+
+    errors: list[str] = []
+    named_types: set[str] = set()
+
+    for written, rendered, _value in _rendered_leaf_paths(config):
+        if tuple(rendered[: len(_CONNECTOR_SEGMENTS)]) != _CONNECTOR_SEGMENTS:
+            continue
+        below = rendered[len(_CONNECTOR_SEGMENTS) :]
+        if not any(LIMITS_CHECKING_LEAF in segment.split(".") for segment in below):
+            continue
+        # The one shape that renders where it reads: <type>, the block, a leaf.
+        if len(below) == 3 and below[1] == LIMITS_CHECKING_LEAF:
+            named_types.add(below[0])
+            continue
+        errors.append(
+            f"The profile's config: block writes `{written}`, which renders as "
+            f"`{'.'.join(rendered)}` — not a per-type limits block. A per-type posture is "
+            f"exactly `control_system.connector.<type>.limits_checking.<leaf>`, and the build "
+            f"splits only the top-level key of each config: entry on dots, so every dot below "
+            f"it becomes part of a literal key name. Write a built-in type's leaves flat, and "
+            f"a dotted custom type as its own map key:\n"
+            f"  config:\n"
+            f"    control_system.connector:\n"
+            f"      mypkg.TangoConnector:\n"
+            f"        limits_checking:\n"
+            f"          enabled: true\n"
+            f"          allow_unlisted_channels: false"
+        )
+
+    errors.extend(_mixed_depth_control_system_errors(config))
+
+    candidates = set(SET_CONTROL_SYSTEM_TYPES) | named_types
+    for _spelling, value in _spelled_values(config, _CONNECTOR_PREFIX):
+        if isinstance(value, dict):
+            candidates.update(key for key in value if isinstance(key, str))
+
+    for connector_type in sorted(candidates):
+        spelled = {
+            leaf: _spelled_values(
+                config, f"{_CONNECTOR_PREFIX}.{connector_type}.{LIMITS_CHECKING_LEAF}.{leaf}"
+            )
+            for leaf in LIMITS_LEAVES
+        }
+        stated = [leaf for leaf in LIMITS_LEAVES if spelled[leaf]]
+        if not stated or len(stated) == len(LIMITS_LEAVES):
+            continue
+        missing = [leaf for leaf in LIMITS_LEAVES if not spelled[leaf]]
+        stated_spelling, _stated_value = spelled[stated[0]][0]
+        errors.append(
+            f"The per-type limits block for connector type {connector_type!r} is incomplete: "
+            f"the profile's config: block writes `{stated_spelling}` but never "
+            f"{', '.join(repr(leaf) for leaf in missing)}. A per-type block overrides the "
+            f"deployment-wide `control_system.limits_checking` pair as a whole — no leaf is "
+            f"inherited — so a block missing one has no posture to answer with, and every "
+            f"reader falls back to refusing unlisted channels. State both "
+            f"{', '.join(repr(leaf) for leaf in LIMITS_LEAVES)}, or remove the block "
+            f"and let the deployment-wide pair answer for this type."
+        )
+
+    return errors
+
+
+def _rendered_leaf_paths(config: Mapping[str, Any]) -> list[tuple[str, list[str], Any]]:
+    """Every leaf a ``config:`` block writes, with where the render will put it.
+
+    Args:
+        config: The profile's ``config:`` block.
+
+    Returns:
+        One entry per non-mapping value reachable in the block:
+        ``(spelling, rendered path, value)``. The spelling is the chain of map
+        keys as written, joined ``key: key`` the way
+        :func:`osprey.cli.build_profile_reach._spelled_values` names a line.
+        The rendered path is the top-level key split on dots followed by every
+        deeper map key *unsplit* — which is what
+        :func:`osprey.utils.config_writer.config_update_fields` produces.
+    """
+    found: list[tuple[str, list[str], Any]] = []
+    for key, value in config.items():
+        if isinstance(key, str):
+            _collect_leaves([key], key.split("."), value, found)
+    return found
+
+
+def _collect_leaves(
+    written: list[str],
+    rendered: list[str],
+    value: Any,
+    found: list[tuple[str, list[str], Any]],
+) -> None:
+    """Descend *value*, appending one entry per leaf to *found*."""
+    if isinstance(value, dict):
+        for key, sub_value in value.items():
+            if isinstance(key, str):
+                _collect_leaves([*written, key], [*rendered, key], sub_value, found)
+        return
+    found.append((": ".join(written), rendered, value))
+
+
+def _mixed_depth_control_system_errors(config: Mapping[str, Any]) -> list[str]:
+    """Refuse a bare top-level ``control_system:`` key beside flat ``control_system.*`` ones.
+
+    Exactly that pair, and no deeper one. A deeper pair —
+    ``control_system.connector:`` holding one type's block beside
+    ``control_system.connector.epics.writes_enabled`` — renders correctly
+    today: :func:`~osprey.utils.config_writer._set_dotted_anchored` runs with
+    ``create_only=True``, so it walks INTO whatever an existing intermediate
+    key holds rather than replacing it, and the two entries merge. Refusing
+    those would refuse profiles the build already honours.
+
+    The bare key is the one that does not merge. It is a top-level ``config:``
+    entry with no dots to walk, so the render assigns its value verbatim at
+    ``control_system`` and replaces the whole rendered section — the flat
+    entries beside it land in a subtree that is then thrown away, or throw the
+    bare one away, depending on key order. The reach helpers read both
+    spellings and so cannot say which of the two a limits leaf belongs to,
+    which is exactly the attribution :func:`limits_block_errors` needs before
+    it can call a per-type block complete. ``claude_code`` is guarded against
+    the same shape by
+    :func:`osprey.cli.build_profile_load._reject_mixed_claude_code_spellings`.
+
+    The bare key's value is not inspected: a nested mapping is what a profile
+    writing this actually has, and a scalar there is no better.
+    """
+    if _CONTROL_SYSTEM_KEY not in config:
+        return []
+    flat = sorted(
+        key for key in config if isinstance(key, str) and key.startswith(f"{_CONTROL_SYSTEM_KEY}.")
+    )
+    if not flat:
+        return []
+    return [
+        f"The profile's config: block addresses {_CONTROL_SYSTEM_KEY!r} at two depths: the "
+        f"bare key {_CONTROL_SYSTEM_KEY!r} itself, and the flat key(s) "
+        f"{', '.join(repr(key) for key in flat)} beside it. Both survive the merge as "
+        f"separate keys, and the bare key's value is written verbatim over the whole "
+        f"rendered control_system section, so which of the two reaches config.yml depends "
+        f"on key order — a limits posture, a write posture or a gateway among them. Keep "
+        f"one spelling: fold the bare mapping's leaves into flat keys, or write every "
+        f"control_system fact inside the nested mapping."
+    ]
 
 
 def _reject_duplicate_image_source(config: Any, image_source: str, problems: list[str]) -> None:

--- a/src/osprey/cli/validate_cmd.py
+++ b/src/osprey/cli/validate_cmd.py
@@ -79,7 +79,11 @@ def check_profile_file(profile_file: Path) -> None:
         click.UsageError: With every accumulated problem, so the caller exits 2.
     """
     from .build_profile import resolve_build_profile
-    from .build_profile_deploy import deploy_aware_config_errors, deploy_aware_config_warnings
+    from .build_profile_deploy import (
+        deploy_aware_config_errors,
+        deploy_aware_config_warnings,
+        limits_block_errors,
+    )
     from .variant_selection import VARIANT_DIRNAME, VariantSelection, resolve_variant_selection
 
     variant = VariantSelection(name=None, path=None)
@@ -113,6 +117,14 @@ def check_profile_file(profile_file: Path) -> None:
     web_errors = deploy_aware_config_errors(
         build_profile.deploy, build_profile.config, profile_root=profile_root
     )
+    # A sibling call, not a line inside `deploy_aware_config_errors`: that
+    # function judges the multi-user web stack against the deploy block, and
+    # `osprey build` runs it over the RENDERED config as well. A per-type
+    # `limits_checking` block is neither web-stack business nor a render fact —
+    # it is a claim the `config:` block makes about a posture, checked once,
+    # here and in the build's own profile-side pass. Folded into the web lint it
+    # would be asked twice during a build and refuse the same profile twice.
+    web_errors = [*web_errors, *limits_block_errors(build_profile.config)]
     if web_errors:
         # "Profile validation failed", not "Build profile ...": the success line
         # below says "Profile is valid", and `BuildProfile.validate` already owns

--- a/src/osprey/mcp_server/control_system/target_eligibility.py
+++ b/src/osprey/mcp_server/control_system/target_eligibility.py
@@ -121,8 +121,10 @@ from osprey_connectors.types import (
     TARGET_LIVE,
     TARGET_STANDIN,
     VIRTUAL_ACCELERATOR,
+    LimitsPosture,
     resolve_target,
     target_writes_enabled,
+    type_limits_posture,
 )
 
 # -- Config keys, spelled once ---------------------------------------------
@@ -132,8 +134,6 @@ from osprey_connectors.types import (
 ACK_KEY = "control_system.target_switch.live_gateway_acknowledged"
 #: The same key's leaf, derived from it so the two cannot drift apart.
 ACK_LEAF = ACK_KEY.rsplit(".", 1)[1]
-LIMITS_ENABLED_KEY = "control_system.limits_checking.enabled"
-ALLOW_UNLISTED_KEY = "control_system.limits_checking.allow_unlisted_channels"
 #: The build-profile key that stands the stand-in up. Named in a refusal so the
 #: operator is told the one line to delete, not merely which fact is true.
 STANDIN_PROFILE_KEY = "virtual_accelerator.live_standin"
@@ -544,12 +544,18 @@ def _is_set(value: Any) -> bool:
     return bool(value)
 
 
-def _strict_limits(config: Any) -> bool:
-    """The FR-8 limits posture: checking on, and unlisted channels refused."""
-    limits = _sub(_section(config, "control_system"), "limits_checking")
-    return bool(limits.get("enabled", False)) and not bool(
-        limits.get("allow_unlisted_channels", True)
-    )
+def _limits_posture(config: Any, connector_type: str) -> LimitsPosture:
+    """The limits posture *connector_type* runs under, with its answering key.
+
+    Per connector type rather than per deployment, for the reason the write
+    posture is: a deployment with a live machine beside a virtual accelerator
+    holds one posture per machine, and a relaxation written for the simulator
+    must not decide what the live gate sees. The resolved value travels with the
+    key that answered so a refusal sends the operator to the line they can
+    actually edit — the per-type one when a per-type block spoke, the
+    deployment-wide one when none did.
+    """
+    return type_limits_posture(_section(config, "control_system"), connector_type)
 
 
 def _selected_role_missing(
@@ -783,12 +789,18 @@ def evaluate_eligibility(
         # hardware behaviour on. The stand-in really is dialled, really refuses
         # out-of-limit writes and really carries `real_machine` — a rehearsal on
         # a permissive posture would rehearse the wrong facility.
-        if not _strict_limits(config):
+        posture = _limits_posture(config, connector_type)
+        if not posture.strict:
+            # Both keys off the posture, so a per-type block that answered is
+            # the line the operator is sent to and the deployment-wide one it
+            # overrides is not mentioned at all.
+            enabled_key = posture.key("enabled")
+            allow_unlisted_key = posture.key("allow_unlisted_channels")
             return Eligibility(
                 False,
                 REASON_LIMITS_POSTURE,
                 f"Switching to target {target!r} requires the strict limits posture: "
-                f"'{LIMITS_ENABLED_KEY}' true and '{ALLOW_UNLISTED_KEY}' false.",
+                f"'{enabled_key}' true and '{allow_unlisted_key}' false.",
             )
 
     if target == TARGET_LIVE and switching_away:

--- a/src/osprey/mcp_server/control_system/tools/channel_limits.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_limits.py
@@ -7,12 +7,63 @@ import json
 import logging
 import re
 
+from osprey.mcp_server.control_system import target_state
 from osprey.mcp_server.control_system.server import mcp
 from osprey.mcp_server.errors import make_error
 
 logger = logging.getLogger("osprey.mcp_server.tools.channel_limits")
 
 VALID_FILTERS = frozenset({"writable", "read_only", "has_step_limit", "has_range"})
+
+#: The key a posture that names no connector type was read from. A validator
+#: built from a bare policy dict carries no key of its own; this is the honest
+#: answer for it, and it is the same fallback ``LimitsValidator.validate``
+#: quotes when it refuses such a write.
+DEPLOYMENT_WIDE_UNLISTED_KEY = "control_system.limits_checking.allow_unlisted_channels"
+
+
+def _session_target() -> str | None:
+    """The control target this server is on, or ``None`` if there is no record.
+
+    ``None`` is the single answer for every "there is no usable target" case —
+    no state file, an unreadable state directory, a record whose target is not
+    a non-empty string. Every one of them means the same thing to the caller:
+    ask :meth:`LimitsValidator.from_config` without a target and get the
+    deployment-wide block, which is the posture a target that resolves to
+    nothing gets anyway.
+
+    Reading is wrapped because :func:`target_state.state_dir` resolves a shared
+    data root and can raise, and a read-only metadata lookup must not fail on
+    the way to reporting what the deployment allows.
+    """
+    try:
+        record = target_state.read()
+    except Exception:  # noqa: BLE001 - a target that cannot be read is simply absent
+        logger.debug("Could not read the control-system target state", exc_info=True)
+        return None
+    if not isinstance(record, dict):
+        return None
+    target = record.get("target")
+    if not isinstance(target, str) or not target.strip():
+        return None
+    return target.strip()
+
+
+def _unlisted_policy(validator) -> tuple[bool | None, str]:
+    """The unlisted-channel posture as reported, plus the key that answered.
+
+    The value is the validator's own tri-state, verbatim and with no default:
+    ``True`` allows an unlisted channel, ``False`` refuses it, and ``None``
+    means no key states an answer — which also refuses. Defaulting an unstated
+    answer to ``True`` here would tell an operator their deployment permits
+    writes that every write path in fact blocks.
+
+    Returns:
+        An ``(allow_unlisted, answering_key)`` pair.
+    """
+    allow_unlisted = validator.policy.get("allow_unlisted_channels")
+    answering_key = validator.policy.get("allow_unlisted_key") or DEPLOYMENT_WIDE_UNLISTED_KEY
+    return allow_unlisted, answering_key
 
 
 def _build_summary(validator) -> dict:
@@ -28,6 +79,8 @@ def _build_summary(validator) -> dict:
     # How many channels resolve to confirmed writes
     confirmed = sum(1 for addr in validator.limits if validator.resolve_confirm(addr))
 
+    allow_unlisted, answering_key = _unlisted_policy(validator)
+
     return {
         "status": "success",
         "description": f"Limits database: {total} channels configured",
@@ -41,7 +94,14 @@ def _build_summary(validator) -> dict:
             "version": validator._raw_db.get("_version"),
         },
         "access_details": {
-            "policy": validator.policy,
+            # The posture's own fields are restated so that the two the caller
+            # reasons about are always present and always the tri-state, even
+            # for a validator whose policy dict was hand-built.
+            "policy": {
+                **validator.policy,
+                "allow_unlisted_channels": allow_unlisted,
+                "allow_unlisted_key": answering_key,
+            },
             "defaults": validator._raw_db.get("defaults"),
         },
     }
@@ -139,7 +199,11 @@ async def channel_limits(
                    has_step_limit, has_range.
 
     Returns:
-        JSON with channel limits configuration or database summary.
+        JSON with channel limits configuration or database summary. The
+        reported ``allow_unlisted_channels`` is the posture of the control
+        target this session is on and may be ``null`` — no config key states
+        an answer, and unlisted channels are refused; ``allow_unlisted_key``
+        names the key that answered.
     """
     # Validate parameter combinations
     if channels is not None and (pattern is not None or name_contains is not None):
@@ -185,7 +249,11 @@ async def channel_limits(
 
     validator = None
     if LimitsValidator is not None:
-        validator = LimitsValidator.from_config()
+        # The posture reported is the one this session writes under: a
+        # deployment may relax unlisted channels for its virtual accelerator
+        # alone, and reporting the deployment-wide answer on a VA session would
+        # describe a machine the caller is not on.
+        validator = LimitsValidator.from_config(target=_session_target())
 
     if validator is None:
         return json.dumps(
@@ -206,23 +274,26 @@ async def channel_limits(
 
     if channels is not None:
         # Lookup mode
+        allow_unlisted, answering_key = _unlisted_policy(validator)
         results = {}
         for addr in channels:
             if addr in validator.limits:
                 results[addr] = _build_channel_entry(validator, addr)
             else:
-                # Channel not in database — show what the policy would do
-                allow_unlisted = validator.policy.get("allow_unlisted_channels", True)
-                if allow_unlisted:
-                    results[addr] = {
-                        "in_database": False,
-                        "policy_action": "allowed (no limits enforced)",
-                    }
-                else:
-                    results[addr] = {
-                        "in_database": False,
-                        "policy_action": "BLOCKED (unlisted channels not allowed)",
-                    }
+                # Channel not in database — show what the policy would do.
+                # Only an explicit True is permission, exactly as the validator
+                # decides it: an unstated answer refuses, and says which key is
+                # unstated rather than reporting a write that would be blocked.
+                results[addr] = {
+                    "in_database": False,
+                    "allow_unlisted_channels": allow_unlisted,
+                    "allow_unlisted_key": answering_key,
+                    "policy_action": (
+                        "allowed (no limits enforced)"
+                        if allow_unlisted is True
+                        else f"BLOCKED ('{answering_key}' does not allow unlisted channels)"
+                    ),
+                }
 
         return json.dumps(
             {

--- a/src/osprey/mcp_server/control_system/tools/channel_write.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_write.py
@@ -505,7 +505,14 @@ async def channel_write(
 
     validator = None
     if LimitsValidator is not None:
-        validator = LimitsValidator.from_config()
+        # The posture the session's target runs under, not the deployment's. A
+        # deployment may relax unlisted channels for its simulator alone, and
+        # the binding captured at entry is already the answer to "which machine
+        # is this write for" — reading the state file a second time here could
+        # only disagree with the binding every other check in this tool uses.
+        # No binding means no published target, which resolves the
+        # deployment-wide block, exactly as this call did before.
+        validator = LimitsValidator.from_config(target=entry_binding[0] if entry_binding else None)
 
     violations: list[dict] = []
     for op in operations:

--- a/src/osprey/mcp_server/control_system/tools/control_target.py
+++ b/src/osprey/mcp_server/control_system/tools/control_target.py
@@ -127,7 +127,7 @@ from osprey.mcp_server.http import (
     notify_target_switch_async,
 )
 from osprey_connectors.control_system.base import is_readonly_run
-from osprey_connectors.types import configured_targets
+from osprey_connectors.types import configured_targets, target_limits_posture
 
 logger = logging.getLogger("osprey.mcp_server.tools.control_target")
 
@@ -353,6 +353,16 @@ def target_rows(
             # simulator can be armed beside a live machine that is not. The
             # gateway those writes would leave by is `selected_role`.
             "writes_permitted": writes_permitted,
+            # This target's own limits posture, per connector type for the same
+            # reason the write posture is: a deployment may relax unlisted
+            # channels on its simulator while its live machine refuses them.
+            # Strict means limits checking on and unlisted channels explicitly
+            # refused; a target whose config states neither is not strict,
+            # because a deployment that stated nothing has refused nothing.
+            # Unlike `writes_permitted`, this is a deployment fact, not a
+            # session one: the store narrows what a session may write, never
+            # which channels a target's limits database governs.
+            "limits_strict": target_limits_posture(section, target).strict,
         }
         probe_channel = display.get("probe_channel") or ""
         if probe_channel:
@@ -407,8 +417,11 @@ async def control_target() -> str:
     reachability observation where it has one (``endpoint_tcp``, ``probed_at``,
     and ``stale`` once an observation is too old to stand); whether writes are
     permitted on that target, which is a per-target answer and not one flag for
-    the deployment; whether the target is the real machine; and the channel a
-    switch would read to prove the target is reachable.
+    the deployment; whether that target's limits posture is strict
+    (``limits_strict`` — limits checking on and channels the limits database
+    does not list refused), which is per-target for the same reason; whether
+    the target is the real machine; and the channel a switch would read to
+    prove the target is reachable.
 
     A target nobody has activated yet is described from configuration alone —
     that is what makes this answer correct before any switch has happened.

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -347,13 +347,50 @@ def _create_execution_folder() -> Path:
     return folder
 
 
-def _load_limits_validator():
-    """Load LimitsValidator from config.  Returns None if disabled or unavailable."""
+def _load_limits_validator(target: str | None):
+    """Load the LimitsValidator for the target this run is stamped against.
+
+    The limits posture is per control target, so the policy embedded in the
+    sandbox has to be the posture of the machine the sandbox will reach —
+    resolved from the same target the stamp carries, not from a second look at
+    the config.
+
+    Args:
+        target: The session's control target, as
+            :func:`_apply_target_stamp` resolved it. A target that names no
+            machine on this deployment gets the deployment-wide block, which is
+            what the baseline is.
+
+    Returns:
+        An enforcing validator, a fail-safe one that blocks every write, or
+        ``None`` when limits checking is off for this posture or the
+        configuration could not be read at all.
+
+        A configuration broken beyond that documented-unavailable set — a
+        ``ValueError``, ``yaml.YAMLError`` or ``IsADirectoryError`` out of the
+        config loader — is deliberately left to propagate and fail the
+        execution (``execute_code`` turns it into a ``FAILURE_KIND_SETUP``
+        result) rather than running agent code unchecked against a deployment
+        that asked for checking. That is the opposite of
+        :func:`_target_is_resolvable`, which swallows everything on purpose:
+        an unstampable target costs the run only its target, while an
+        unreadable limits posture would cost it the guard.
+
+    Raises:
+        TypeError: Propagated from ``from_config`` — a call that states the
+            posture twice is a bug in this module, and answering it with a
+            ``None`` validator would run the sandbox unchecked on a deployment
+            that asked for checking.
+    """
     try:
         from osprey.connectors.control_system.limits_validator import LimitsValidator
 
-        return LimitsValidator.from_config()
-    except Exception:
+        return LimitsValidator.from_config(target=target)
+    except (ImportError, FileNotFoundError, KeyError, RuntimeError):
+        # Exactly the errors `from_config` documents as "configuration is not
+        # available", plus the import itself failing. A blanket `except` here
+        # would also swallow the TypeError it raises for a caller that states
+        # the posture twice, turning that bug into a silently unvalidated run.
         logger.debug("Limits validator not available", exc_info=True)
         return None
 
@@ -629,8 +666,10 @@ def _perimeter_denied_ports(env: Mapping[str, str]) -> tuple[int, ...]:
     list.
 
     Args:
-        env: The parent process's environment (``os.environ``), read BEFORE the
-            sandbox scrub — the child never receives either name.
+        env: The parent process's UNSCRUBBED environment (``os.environ``) — not
+            the scrubbed sandbox environment, which drops both names, so
+            reading from there would always yield an empty deny-list. The child
+            never receives either name.
 
     Returns:
         The denied ports, de-duplicated and ascending. Empty when the marker is
@@ -669,7 +708,6 @@ async def _execute_via_local(
     execution_mode: str,
     config: dict,
     execution_folder: Path,
-    limits_validator,
 ) -> ExecutionResult:
     """Execute code in a host subprocess with the ExecutionWrapper."""
     from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
@@ -682,6 +720,28 @@ async def _execute_via_local(
     # never re-derives the layout for itself.
     project_root = _resolve_project_root()
     osprey_config = load_osprey_config()
+
+    # Credential scrub plus the sandbox-only narrowing, in one shared helper, so
+    # this path and the visualization sandbox cannot drop different sets.
+    sandbox_env = scrub_sandbox_child_env(os.environ)
+    # The declared mode becomes a runtime property of the subprocess: the
+    # connector base class refuses writes and the EPICS connector stays on
+    # the read_only gateway when this says readonly, so a readonly run cannot
+    # write however the call is spelled — the pre-execution regex only ever
+    # saw the standard spellings.
+    sandbox_env["OSPREY_EXECUTION_MODE"] = execution_mode
+    # Which machine those writes and reads reach is the second runtime property
+    # of the subprocess, and it is stamped for the same reason as the mode: the
+    # sandbox is a fresh process that builds its own connector, so the target
+    # has to travel with it rather than being re-derived there.
+    #
+    # Resolved before the wrapper is built because the limits posture is per
+    # target: one read of the session's target record answers both what the
+    # sandbox is stamped with and which posture is compiled into it. Reading it
+    # twice would let a switch landing in between hand the sandbox one
+    # machine's policy and another machine's stamp.
+    control_target = _apply_target_stamp(sandbox_env)
+    limits_validator = _load_limits_validator(target=control_target)
 
     wrapper = ExecutionWrapper(
         limits_validator=limits_validator,
@@ -712,21 +772,6 @@ async def _execute_via_local(
     start_time = time.time()
 
     python_bin = str(resolve_agent_interpreter(project_root))
-
-    # Credential scrub plus the sandbox-only narrowing, in one shared helper, so
-    # this path and the visualization sandbox cannot drop different sets.
-    sandbox_env = scrub_sandbox_child_env(os.environ)
-    # The declared mode becomes a runtime property of the subprocess: the
-    # connector base class refuses writes and the EPICS connector stays on
-    # the read_only gateway when this says readonly, so a readonly run cannot
-    # write however the call is spelled — the pre-execution regex only ever
-    # saw the standard spellings.
-    sandbox_env["OSPREY_EXECUTION_MODE"] = execution_mode
-    # Which machine those writes and reads reach is the second runtime property
-    # of the subprocess, and it is stamped for the same reason as the mode: the
-    # sandbox is a fresh process that builds its own connector, so the target
-    # has to travel with it rather than being re-derived there.
-    control_target = _apply_target_stamp(sandbox_env)
 
     # A switch of the session target retires the connector host this run was
     # stamped against, so the switch tool has to be able to see that a run is
@@ -826,8 +871,11 @@ async def execute_code(
     """Execute Python code in a host subprocess.
 
     Reads ``config.yml`` for the execution timeout, creates an isolated
-    execution folder, loads the limits validator, and runs the wrapped code in
-    a subprocess. The subprocess backend is the only backend OSPREY ships.
+    execution folder, and runs the wrapped code in a subprocess. The limits
+    validator is loaded further in, where the session's control target is
+    resolved, so that one read answers both which machine the sandbox reaches
+    and which posture it enforces. The subprocess backend is the only backend
+    OSPREY ships.
 
     Args:
         code: Python source code to execute.
@@ -841,11 +889,8 @@ async def execute_code(
     try:
         config = _read_config()
         execution_folder = _create_execution_folder()
-        limits_validator = _load_limits_validator()
 
-        return await _execute_via_local(
-            code, execution_mode, config, execution_folder, limits_validator
-        )
+        return await _execute_via_local(code, execution_mode, config, execution_folder)
     except Exception as exc:
         logger.error(
             "Execution setup failed (%s: %s)",

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -203,6 +203,19 @@ config:
   # switch onto them, so a rehearsal runs the posture the real machine gets.
   control_system.limits_checking.enabled: true
   control_system.limits_checking.allow_unlisted_channels: false
+  # The sandbox simulator is the exception, and it states the exception as a
+  # whole block: a per-type posture REPLACES the pair above for that connector
+  # type rather than merging with it, so both leaves are written out here.
+  # Writes to the simulator are still checked against the same file; what
+  # changes is that a channel the file does not list is allowed through
+  # instead of refused, because on a scratch machine an unlisted channel is a
+  # gap in the file rather than a hazard. `live_standin` deliberately gets NO
+  # block of its own: it is hardware-shaped, so it keeps the strict pair the
+  # real machine gets, and a permissive block here would make
+  # `control_target_set standin` refuse the very switch this preset exists to
+  # rehearse.
+  control_system.connector.virtual_accelerator.limits_checking.enabled: true
+  control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels: true
   # Use the archive declared by `va_archiver:` above. Declaring the block does
   # not turn it on; without this line you would deploy a store and not read it.
   archiver.type: mongodb_archiver

--- a/src/osprey/services/bluesky_bridge/qserver_startup.py
+++ b/src/osprey/services/bluesky_bridge/qserver_startup.py
@@ -208,22 +208,30 @@ async def create_connector() -> Any:
     if lane_degraded:
         logger.warning("qserver_startup: %s", lane_degraded)
     register_builtin_connectors()  # idempotent; must run before create
-    connector = await ConnectorFactory.create_control_system_connector(
+    # Built in two steps rather than through `create_control_system_connector`
+    # so the TYPE stamp can be cleared BEFORE `connect()`: a connector loads its
+    # limits validator inside connect(), keyed on the stamp, so a clear that
+    # came afterwards would leave the validator built against the wrong block.
+    connector, type_config = ConnectorFactory.build_control_system_connector(
+        build_connector_config(control_system_type),
         # This lane's OWN target, not the deployment baseline: a two-lane
         # deployment is exactly where the two differ, and the machine this
         # worker drives is the one its lane declares.
-        build_connector_config(control_system_type),
         control_target=resolve_lane_identity()[1],
     )
     if lane_degraded:
         # The factory stamps the type it built, and the reference monitor keys
-        # this deployment's per-type write posture on that stamp. A degraded
-        # lane was built as the baseline type while addressing a machine this
-        # config never tied to that type, so the type's block does not describe
-        # it: clearing the stamp is what makes the monitor read
-        # `control_system.writes_enabled` — the only posture the config has
-        # ever stated about this lane — which is also what
-        # `worker_writes_enabled` reports.
+        # this deployment's per-type write and limits postures on that stamp. A
+        # degraded lane was built as the baseline type while addressing a
+        # machine this config never tied to that type, so the type's block does
+        # not describe it: clearing the stamp is what makes the monitor read
+        # `control_system.writes_enabled` and the deployment-wide
+        # `limits_checking` block — the only postures the config has ever
+        # stated about this lane — which is also what `worker_writes_enabled`
+        # reports. EPICS gateway selection inside connect() is the stamp's third
+        # reader, so clearing it first moves that to the deployment-wide posture
+        # too; a no-op for this worker, whose type_config is gateway-less by
+        # construction, but it keeps all three readers on one answer.
         #
         # The TARGET stamp is left alone. Degradation is a statement about the
         # config's type table, not about the lane: rung 3 is reached precisely
@@ -232,6 +240,7 @@ async def create_connector() -> Any:
         # this worker address", and it indexes the session store rather than any
         # config block.
         connector._connector_type = None
+    await connector.connect(type_config)
     logger.info(
         "qserver_startup: connected the worker's OSPREY connector (type=%s, %s, writes %s)",
         control_system_type,

--- a/src/osprey/services/bluesky_bridge/validation.py
+++ b/src/osprey/services/bluesky_bridge/validation.py
@@ -11,9 +11,9 @@ Two independent gates, each defense-in-depth against a different failure:
 
 - :func:`_assert_limits_readable_if_writable` — a STARTUP guard. Refuses to
   bring the bridge up in the one unsafe posture: writes enabled for the
-  target THIS LANE serves + limits checking enabled + the limits database
-  unreadable. Fail-OPEN by design (see its docstring): every other
-  combination starts normally.
+  target THIS LANE serves + limits checking enabled for that same target +
+  the limits database unreadable. Fail-OPEN by design (see its docstring):
+  every other combination starts normally.
 - :func:`_validate_launchable_request` — a per-ENQUEUE gate. Refuses to enqueue
   a session/unreviewed plan whose CURRENT on-disk content has no passing
   validation record, re-reading and re-hashing the file at enqueue time rather
@@ -82,14 +82,22 @@ def _assert_limits_readable_if_writable() -> None:
     re-checked here. That is deliberate and costs nothing, because the gate
     that stands between a plan and hardware is the per-write one, not this.
 
+    Limits checking is resolved the same way, and for the same reason: a
+    deployment may leave its virtual accelerator unchecked while its live
+    machine enforces limits, so the condition is
+    ``control_system.connector.<type>.limits_checking.enabled`` for this
+    lane's type, inheriting the deployment-wide block where no per-type block
+    says anything. Only ``database_path`` stays deployment-wide — the
+    deployment mounts one limits database, and a per-type block that omits the
+    path is complete rather than incomplete.
+
     Fail-OPEN by design: this is the ONLY combination that refuses
-    startup — this lane's write posture AND
-    ``control_system.limits_checking.enabled`` both true, AND the limits
-    database is missing, unreadable, or unparseable. Every other combination
-    starts normally: writes disabled (read-only posture) never even probes
-    the database; writes enabled with limits checking disabled needs no
-    database at all; writes enabled with a readable database is the healthy
-    case. A writable deploy with no working limits enforcement is the one
+    startup — this lane's write posture AND this lane's limits posture both
+    true, AND the limits database is missing, unreadable, or unparseable.
+    Every other combination starts normally: writes disabled (read-only
+    posture) never even probes the database; writes enabled with limits
+    checking disabled needs no database at all; writes enabled with a readable
+    database is the healthy case. A writable deploy with no working limits enforcement is the one
     unsafe posture this guard exists to catch before any connector/CA work
     begins.
 
@@ -112,14 +120,18 @@ def _assert_limits_readable_if_writable() -> None:
 
     Raises:
         RuntimeError: naming the lane, its target, and which condition failed
-            (the resolved posture key, and whether the database path was
-            configured/found/parseable) — never the database's file contents
-            or any other secret value.
+            (both resolved posture keys, so an operator is sent to the lines
+            that actually answered rather than to a deployment-wide one some
+            per-type block overrides, whether the posture could be read at
+            all — a leaf missing from a per-type block or written as anything
+            but a literal boolean in either scope names every such leaf — and
+            whether the database path was configured/found/parseable) — never
+            the database's file contents or any other secret value.
     """
     from osprey.audit.posture import posture_session
     from osprey.utils.config import get_config_value
     from osprey_connectors import session_store
-    from osprey_connectors.types import target_writes_enabled_key
+    from osprey_connectors.types import target_limits_posture, target_writes_enabled_key
 
     from .queue_backend import resolve_lane_identity
 
@@ -127,7 +139,6 @@ def _assert_limits_readable_if_writable() -> None:
 
     try:
         section = get_config_value("control_system", {})
-        limits_enabled = get_config_value("control_system.limits_checking.enabled", False)
         db_path = get_config_value("control_system.limits_checking.database_path", None)
         project_root = get_config_value("project_root", None)
     except (FileNotFoundError, KeyError, RuntimeError):
@@ -135,17 +146,28 @@ def _assert_limits_readable_if_writable() -> None:
 
     if not session_store.effective_writes(section, posture_session(), lane_target):
         return
-    if not limits_enabled:
+    posture = target_limits_posture(section, lane_target)
+    writes_key = target_writes_enabled_key(section, lane_target)
+    if posture.incomplete:
+        # The connector and the hook both build the blocking failsafe from
+        # this same posture, so no write would get through anyway; the gate
+        # exists to turn that into a startup refusal that names the lines.
+        unreadable = ", ".join(posture.key(leaf) for leaf in posture.incomplete)
+        raise RuntimeError(
+            f"refusing to start writable: lane {lane} serves target {lane_target}, "
+            f"where {writes_key} is set, but its limits posture cannot be read: "
+            f"{unreadable} must each be a literal true or false"
+        )
+    if posture.enabled is not True:
         return
 
-    writes_key = target_writes_enabled_key(section, lane_target)
+    limits_key = posture.key("enabled")
 
     if not db_path or not isinstance(db_path, str):
         raise RuntimeError(
             f"refusing to start writable: lane {lane} serves target {lane_target}, "
-            f"where {writes_key} and control_system.limits_checking.enabled are "
-            "both set, but control_system.limits_checking.database_path is not "
-            "configured"
+            f"where {writes_key} and {limits_key} are both set, but "
+            "control_system.limits_checking.database_path is not configured"
         )
 
     from osprey.connectors.control_system.limits_validator import LimitsValidator
@@ -162,8 +184,7 @@ def _assert_limits_readable_if_writable() -> None:
     except Exception as exc:
         raise RuntimeError(
             f"refusing to start writable: lane {lane} serves target {lane_target}, "
-            f"where {writes_key} and control_system.limits_checking.enabled are "
-            "both set, but the configured "
+            f"where {writes_key} and {limits_key} are both set, but the configured "
             "control_system.limits_checking.database_path could not be read or "
             "parsed"
         ) from exc

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -535,6 +535,12 @@ control_system:
       # live machine read-only. The shipped `control-assistant-va-readwrite`
       # persona is exactly this pair of keys.
       # writes_enabled: true
+      # Limits-checking posture for this connector type alone. A block here
+      # overrides the deployment-wide `limits_checking` block above as a whole
+      # (both leaves required) - database_path stays deployment-wide.
+      # limits_checking:
+      #   enabled: true
+      #   allow_unlisted_channels: true
       # Channel the target switch reads to prove this target is reachable
       # before making it active. A target with no probe_channel is never
       # switched to. This one is served by the simulation machine model above.
@@ -575,6 +581,12 @@ control_system:
       # carries its own posture never falls back to the deployment-wide key, so
       # `false` holds even if a profile or an overlay turns that key on.
       # writes_enabled: false
+      # Limits-checking posture for the live machine. A block here overrides
+      # the deployment-wide `limits_checking` block above as a whole (both
+      # leaves required) - database_path stays deployment-wide.
+      # limits_checking:
+      #   enabled: true
+      #   allow_unlisted_channels: false
       # Channel the target switch reads to prove the live machine is reachable
       # before making it active. Facility-specific, so nothing is shipped set:
       # while it is unset this target is never switched to (the deployment

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_limits.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_limits.py
@@ -20,11 +20,25 @@ stdin ──► Parse JSON
              YES
               │
               ▼
-         Import LimitsValidator
+         Import LimitsValidator ──FAILS──► EXIT (allow)
               │
               ▼
-         validator = from_config()
-              │
+         Per-target API?  ──NO──► from_config()  ──┐
+              │                   (older framework)│
+             YES                                   │
+              │                                    │
+              ▼                                    │
+         Session target                            │
+         named?                                    │
+              │                                    │
+        ┌─────┴─────┐                              │
+       YES          NO                             │
+        │            │                             │
+        ▼            ▼                             │
+   from_config    from_config_                     │
+   (target=…)     most_restrictive()               │
+        │            │                             │
+        └─────┬──────┴─────────────────────────────┘
               ▼
          validator exists? ──NO──► EXIT (allow)
               │
@@ -50,16 +64,115 @@ stdin ──► Parse JSON
 
 Validates every channel write against min/max/step/writable constraints
 from the limits database. Supports both single-write and batch-write forms.
-If `LimitsValidator` is not importable or not configured, allows the write
-through (fail-open for environments without limits).
+
+The posture that database is applied under is a property of the machine a write
+would reach, not of the deployment as a whole:
+`control_system.connector.<type>.limits_checking` overrides the deployment-wide
+`control_system.limits_checking` block whole, so a facility can refuse unlisted
+channels on its ring and allow them on its virtual accelerator. Three branches
+decide which posture this hook validates under, and a fourth case leaves it with
+no posture to apply:
+
+1. **The session names a target** — `from_config(target=…)`, the posture of
+   the machine this write would actually reach. Every refusal names the key
+   that answered, which on a per-target deployment is the connector block
+   rather than the deployment-wide one. A target the config resolves to no
+   connector type — `live` on a deployment that never named its real machine —
+   is still an identified target, and the resolver answers it with the
+   deployment-wide block, exactly as the write posture does.
+2. **It names none** — no state file yet, an unreadable or ambiguous state
+   directory, or a render without the sibling reader —
+   `from_config_most_restrictive()`: limits checking on where any reachable
+   target has it on, unlisted channels allowed only where every reachable
+   target allows them. Naming a target here would be a guess, and a guess
+   between a simulator and a ring is a guess in favour of hardware.
+3. **The framework is older than this render** — hooks are rendered by
+   `osprey build` on the host, while a service keeps the `osprey` its image was
+   built with until the next `osprey up --build`, so a validator with no
+   `target` argument and no `from_config_most_restrictive` is reachable. It is
+   probed for, never caught, and answered with the deployment-wide block: what
+   that framework did when the deployment-wide block was the whole story.
+4. **There is no validator to consult** — `LimitsValidator` is not importable
+   (`osprey` off the interpreter's path), or the resolved posture switches
+   limits checking off — and the write is allowed through for the MCP tool to
+   decide. This is the hook's only fail-open direction. A *failsafe* validator
+   is not one of them: an incomplete per-type block or an unreadable database
+   still builds a validator, and it blocks every write.
+
+The target itself comes from `osprey_target_state`, the same stdlib reader the
+writes kill switch and the approval prompt use, so one session cannot be
+described as pointing at two machines.
 """
 
+import inspect
 import json
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from osprey_hook_log import AUDIT_DECISION_REFUSED, emit_audit, get_hook_input, log_hook
+
+# The shared, stdlib-only reader for the control-system target state, imported
+# while this file's own directory is still the first `sys.path` entry the line
+# above put there, because it is a sibling script rather than an installed
+# module.
+#
+# Guarded the way `osprey_writes_check` guards it: a project rendered before the
+# reader existed has no such sibling, and a hook that cannot learn its target
+# validates under the posture every reachable target agrees on.
+try:
+    import osprey_target_state as _target_state
+except Exception:  # pragma: no cover - older render without the reader
+    _target_state = None
+
+
+def _session_target(hook_input):
+    """The control target this session is pointed at, or ``None``.
+
+    ``None`` means unidentifiable rather than absent, and every route to it —
+    a render without the sibling reader, the reader's own baseline fallback (no
+    state file, an unreadable or ambiguous state directory), or an exception on
+    the way — is the same answer, because the caller does the same thing with
+    all of them: validate under the most restrictive posture. The reader is
+    documented never to raise, so the guard here is belt-and-braces; what it
+    guarantees is that no failure of target IDENTITY can turn into a write that
+    was never checked.
+    """
+    if _target_state is None:
+        return None
+    try:
+        result = _target_state.read_session_target(hook_input)
+        if _target_state.is_baseline(result):
+            return None
+        return result.get("target")
+    except Exception:
+        return None
+
+
+def _supports_per_target_postures(validator_cls):
+    """Whether the installed framework can resolve a limits posture per target.
+
+    A version probe, not a feature flag. Hooks are rendered into the repo by
+    ``osprey build``, which runs on the host, while the services that carry
+    ``osprey`` keep the image they were built with until the next
+    ``osprey up --build``. So this render can meet an older validator, one whose
+    ``from_config`` takes no ``target`` and which has no
+    ``from_config_most_restrictive`` at all. Calling either there raises
+    straight past this hook, and an exception here exits non-zero with no
+    decision — which the agent runtime reads as no opinion, so the write would
+    reach the machine with no limits applied at all.
+
+    Probed rather than caught, deliberately: a blanket ``except (AttributeError,
+    TypeError)`` around the call would also swallow those raised *inside* a
+    current resolver or database load, and silently answer a real fault with the
+    deployment-wide posture.
+    """
+    if getattr(validator_cls, "from_config_most_restrictive", None) is None:
+        return False
+    try:
+        return "target" in inspect.signature(validator_cls.from_config).parameters
+    except (TypeError, ValueError):  # pragma: no cover - unintrospectable callable
+        return False
 
 
 def main():
@@ -84,9 +197,24 @@ def main():
         # osprey not installed — allow and let the MCP tool handle it
         sys.exit(0)
 
-    validator = LimitsValidator.from_config()
+    if not _supports_per_target_postures(LimitsValidator):
+        # Framework older than this render (see `_supports_per_target_postures`):
+        # ask the deployment-wide question, which is exactly what that framework
+        # did when it was the whole story. Falling back to allowing the write
+        # instead would take limits off a machine that still enforces them.
+        validator = LimitsValidator.from_config()
+    else:
+        target = _session_target(hook_input)
+        if target is None:
+            # The posture every target a session here could reach agrees on. A
+            # baseline fallback still NAMES the deployment's baseline target,
+            # and validating under it would apply one machine's posture to a
+            # session that may have switched away from it.
+            validator = LimitsValidator.from_config_most_restrictive()
+        else:
+            validator = LimitsValidator.from_config(target=target)
     if validator is None:
-        # Limits validation disabled in config
+        # Limits checking is off for this posture
         sys.exit(0)
 
     # Collect operations to validate. Support both single and batch writes.

--- a/src/osprey/templates/claude_code/claude/skills/setup-mode/SKILL.md.j2
+++ b/src/osprey/templates/claude_code/claude/skills/setup-mode/SKILL.md.j2
@@ -129,6 +129,7 @@ Expected subdirectories in `{{ agent_data_root }}/`:
 | `control_system.connector.<type>.writes_enabled` | Cold | Write posture for one connector type, which answers instead of the key above for that type — same rebuild and restart, and `permissions.deny` changes shape when the two targets stop agreeing |
 | `control_system.limits_checking.enabled` | Hot | Hooks re-read on each call |
 | `control_system.limits_checking.allow_unlisted_channels` | Hot | Hooks re-read on each call |
+| `control_system.connector.<type>.limits_checking.*` | Hot | Per-connector-type limits-checking posture, which answers instead of the keys above for that type — hooks re-read on each call |
 | `approval.mode` | Hot | Hooks re-read on each call |
 | `control_system.type` | Cold | Requires MCP server restart. To change target for this session, use `control_target_set` (run-time switch, asks for approval) — do not rebuild to switch target |
 | `control_system.target_switch.drain_timeout_s` | Cold | Read when a switch drains in-flight work, from the config the server cached at launch — requires MCP server restart |

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -251,6 +251,12 @@ control_system:
       # the simulator while the deployment-wide `writes_enabled` above keeps the
       # real machine read-only. Left out, this type inherits that key.
       # writes_enabled: true
+      # Limits-checking posture for this connector type alone. A block here
+      # overrides the deployment-wide `limits_checking` block above as a whole
+      # (both leaves required) - database_path stays deployment-wide.
+      # limits_checking:
+      #   enabled: true
+      #   allow_unlisted_channels: true
       # Channel the target switch reads to prove this target is reachable
       # before making it active. A target with no probe_channel is never
       # switched to. Replace with a channel your VA's machine model serves.
@@ -286,6 +292,12 @@ control_system:
       # never falls back to the deployment-wide key, so `false` here holds even
       # if a profile or an overlay turns that key on.
       # writes_enabled: false
+      # Limits-checking posture for the live machine. A block here overrides
+      # the deployment-wide `limits_checking` block above as a whole (both
+      # leaves required) - database_path stays deployment-wide.
+      # limits_checking:
+      #   enabled: true
+      #   allow_unlisted_channels: false
       # Channel the target switch reads to prove the live machine is reachable
       # before making it active. Facility-specific, so nothing is shipped set:
       # while it is unset this target is never switched to (the deployment

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -542,8 +542,9 @@ services:
     environment:
       # Same CONFIG_FILE convention as the bridge: the per-put reference
       # monitor now runs in THIS container (the RunEngine lives here), so it
-      # reads control_system.type / writes_enabled / limits_checking from the
-      # mounted config.yml, not from the image's WORKDIR.
+      # reads control_system.type / writes_enabled / limits_checking /
+      # connector.<type>.limits_checking from the mounted config.yml, not
+      # from the image's WORKDIR.
       CONFIG_FILE: /app/project/config.yml
       TZ: {{ system.timezone }}
 {%- if svc.target %}

--- a/tests/cli/test_build_profile_validate.py
+++ b/tests/cli/test_build_profile_validate.py
@@ -19,8 +19,10 @@ the per-field branches those files leave untouched.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
+from click.testing import CliRunner, Result
 
 from osprey.cli.build_profile import (
     BlueskyConfig,
@@ -843,3 +845,174 @@ def test_an_app_template_without_ariel_needs_no_sidecar(tmp_path: Path) -> None:
     BuildProfile(name="x", data_bundle="channel_finder_standalone", deploy_services=False).validate(
         tmp_path
     )
+
+
+# ---------------------------------------------------------------------------
+# The build's render-side limits-block refusal
+# ---------------------------------------------------------------------------
+#
+# The profile-side lint reads what a `config:` block spelled; this one reads
+# the config a deployment actually runs, so a half-written per-type block that
+# no profile spelling explains — one an injector assembled, one an app template
+# shipped — is still refused before it reaches a machine.
+
+
+def _write_render(tmp_path: Path, control_system: object) -> Path:
+    """A render directory holding nothing but the ``control_system:`` section.
+
+    The build reads its own ``config.yml`` back after the injectors have run,
+    which is the only file this check touches.
+    """
+    import yaml
+
+    render_dir = tmp_path / "render"
+    render_dir.mkdir()
+    (render_dir / "config.yml").write_text(
+        yaml.safe_dump({"project_name": "demo", "control_system": control_system}),
+        encoding="utf-8",
+    )
+    return render_dir
+
+
+def _render_limits_errors(render_dir: Path) -> list[str]:
+    """The build's own render-side limits check, as ``_render_project`` runs it."""
+    from osprey.cli.build_cmd import _incomplete_limits_errors
+
+    return _incomplete_limits_errors(render_dir)
+
+
+def test_render_with_a_half_written_limits_block_is_unrunnable(tmp_path: Path) -> None:
+    """A per-type block stating only ``enabled`` answers no posture at all.
+
+    It overrides the deployment-wide pair whole, so the deployment silently
+    falls back to refusing unlisted channels — the refusal names the leaf an
+    operator has to add rather than letting a build ship that surprise.
+    """
+    render_dir = _write_render(
+        tmp_path, {"connector": {"virtual_accelerator": {"limits_checking": {"enabled": True}}}}
+    )
+
+    (error,) = _render_limits_errors(render_dir)
+
+    assert (
+        "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+        in error
+    )
+
+
+def test_render_with_a_complete_limits_block_is_runnable(tmp_path: Path) -> None:
+    """Both leaves stated is the supported way to relax a simulator alone."""
+    render_dir = _write_render(
+        tmp_path,
+        {
+            "connector": {
+                "virtual_accelerator": {
+                    "limits_checking": {"enabled": True, "allow_unlisted_channels": True}
+                }
+            }
+        },
+    )
+
+    assert _render_limits_errors(render_dir) == []
+
+
+def test_render_without_a_per_type_limits_block_is_runnable(tmp_path: Path) -> None:
+    """Silence is every deployment predating per-type blocks; only a half-written one is refused."""
+    render_dir = _write_render(
+        tmp_path,
+        {
+            "type": "virtual_accelerator",
+            "connector": {"virtual_accelerator": {"prefix": "SR:"}},
+            "limits_checking": {"enabled": True},
+        },
+    )
+
+    assert _render_limits_errors(render_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# The build's profile-side limits-block refusal
+# ---------------------------------------------------------------------------
+#
+# `osprey validate` is the verb an operator runs by hand; `osprey build` is the
+# one that has to refuse, because a deployment reaches a machine through the
+# build and not through the verb somebody remembered to run. Both ask
+# `limits_block_errors` about the same `config:` block, so a profile refused by
+# one is refused by the other with the same words.
+#
+# Profile-side, not render-side: raising here means a build stops before the
+# render, so the one-leaf case is reported once — by the check that can name
+# the profile key an author has to fix — instead of twice.
+
+
+def _build_with_config(tmp_path: Path, config: dict[str, Any], name: str) -> Result:
+    """Run ``osprey build`` against a repo whose profile states *config*.
+
+    The profile names no provider, so a build that gets past the profile-side
+    lint stops at the next refusal instead of rendering — which is what makes
+    the passing case below cheap and what its assertion reads.
+    """
+    import yaml
+
+    from osprey.cli.build_cmd import build
+
+    repo = tmp_path / name
+    repo.mkdir()
+    (repo / "profile.yml").write_text(
+        yaml.safe_dump(
+            {"name": "Demo Facility", "data_bundle": "hello_world", "config": config},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return CliRunner().invoke(build, ["--repo", str(repo), "--skip-deps", "--skip-lifecycle"])
+
+
+def test_build_refuses_a_profile_writing_only_one_limits_leaf(tmp_path: Path) -> None:
+    """One leaf states a posture nothing answers: the per-type block overrides
+    the deployment-wide pair whole, so the missing leaf falls back to refusing
+    unlisted channels rather than to what the profile meant."""
+    result = _build_with_config(
+        tmp_path,
+        {"control_system.connector.virtual_accelerator.limits_checking.enabled": True},
+        "half-a-block",
+    )
+
+    assert result.exit_code != 0, result.output
+    assert "Profile validation failed" in result.output
+    assert "allow_unlisted_channels" in result.output
+    assert "virtual_accelerator" in result.output
+
+
+def test_build_refuses_a_flat_dotted_custom_type(tmp_path: Path) -> None:
+    """Flattened, the dots in ``mypkg.TangoConnector`` are indistinguishable
+    from path separators, so the emitter renders a key no connector reads. The
+    build names the offending key instead of rendering the dead spelling."""
+    key = "control_system.connector.mypkg.TangoConnector.limits_checking.enabled"
+
+    result = _build_with_config(tmp_path, {key: True}, "dotted-type")
+
+    assert result.exit_code != 0, result.output
+    assert "Profile validation failed" in result.output
+    assert key in result.output
+
+
+def test_build_passes_a_complete_per_type_limits_block(tmp_path: Path) -> None:
+    """The supported spelling reaches the checks past the lint untouched.
+
+    Pinned beside the two refusals because a lint that refuses every profile
+    passes both of those on its own. The provider refusal is the marker: it is
+    the next thing the build asks after the profile-side lint.
+    """
+    result = _build_with_config(
+        tmp_path,
+        {
+            "control_system.connector.virtual_accelerator.limits_checking.enabled": True,
+            "control_system.connector.virtual_accelerator.limits_checking."
+            "allow_unlisted_channels": True,
+        },
+        "whole-block",
+    )
+
+    assert "Profile validation failed" not in result.output
+    assert "names no provider" in result.output

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -662,12 +662,19 @@ class TestControlAssistantPersonas:
         # for its type instead and never fall back, so the tier that must
         # refuse everywhere pins each block off by name. What the two mean by
         # the axis is compared through the resolver, per target, in
-        # TestWritePostureMatrix.
+        # TestWritePostureMatrix. Only the WRITE leaf is tier-specific: the
+        # base's per-type limits block rides along on every tier by design,
+        # so the predicate names the leaf rather than the connector namespace.
         assert ro_cfg.pop(WRITES_KEY) is False
         assert ro_cfg.pop(EPICS_WRITES_KEY) is False
         assert ro_cfg.pop(VA_WRITES_KEY) is False
         assert rw_cfg.pop(WRITES_KEY) is True
-        assert not [key for key in rw_cfg if str(key).startswith("control_system.connector.")]
+        assert not [
+            key
+            for key in rw_cfg
+            if str(key).startswith("control_system.connector.")
+            and str(key).endswith(".writes_enabled")
+        ]
         # Axis 2 — surface: chat-first for the viewer, full dock for the operator.
         assert ro_cfg.pop(UI_MODE_KEY) == "simple"
         assert rw_cfg.pop(UI_MODE_KEY) == "expert"
@@ -1118,14 +1125,18 @@ class TestWritePostureMatrix:
         assert [key for key in profile.config if str(key).startswith("services.")] == []
 
     def test_the_flat_tiers_are_armed_on_every_target(self, tmp_path: Path) -> None:
-        """readwrite and admin write no per-type key at all, so both machines
-        read their flat ``true``. Asserted through the resolver so that the
-        claim survives the key stopping being the whole answer."""
+        """readwrite and admin write no per-type WRITE key at all, so both
+        machines read their flat ``true`` (the base's per-type limits block is
+        a separate concern and rides along). Asserted through the resolver so
+        that the claim survives the key stopping being the whole answer."""
         for preset in ("control-assistant-readwrite", "control-assistant-admin"):
             profile = resolve_preset(preset)
             assert profile.config.get(WRITES_KEY) is True
             assert [
-                key for key in profile.config if str(key).startswith("control_system.connector.")
+                key
+                for key in profile.config
+                if str(key).startswith("control_system.connector.")
+                and str(key).endswith(".writes_enabled")
             ] == []
 
             section = _rendered_control_system(tmp_path, preset)

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -165,14 +165,30 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # branch's recorded value but the one the merged preset actually hashes to:
     # a `live_standin` baseline with the strict limits pair, placed on the port
     # block. Deploy-visible for both reasons at once.
-    "control-assistant": "sha256:ea77ab02508d4b12f1c0dd1002770fde1070f0cdf0d182785535fcc4f175d8c6",
+    #
+    # Moved once more, and all six control-assistant entries together again,
+    # when the base preset gave the sandbox simulator a limits posture of its
+    # own: `control_system.connector.virtual_accelerator.limits_checking.
+    # enabled: true` and `...allow_unlisted_channels: true`. A per-type block
+    # replaces the deployment-wide pair for that connector type as a whole, so
+    # both leaves are stated. The strict pair itself is unchanged and still
+    # governs the two hardware-shaped targets, and `live_standin` deliberately
+    # gained no block of its own — a permissive one there would make
+    # `control_target_set standin` refuse the switch this preset exists to
+    # rehearse. Deploy-visible on the simulator: a write to a channel
+    # `data/channel_limits.json` does not list is now allowed on the `va`
+    # target where it was refused, so the staleness advisory firing on
+    # already-deployed control-assistant projects is the correct signal.
+    "control-assistant": "sha256:c8d4f280789d363bc418002b27e229c7fc80cedf6bac469cae42ace2318d2098",
     # Moved with the base above: `live_standin` baseline + strict limits pair.
+    # Moved again with the base: permissive `virtual_accelerator` limits block.
     "control-assistant-admin": (
-        "sha256:873fdd1f43c65c15d2021a7f4869704fb943a1be2a022c0e78cdc34b48449c2b"
+        "sha256:3f111428abad719585dfa50fc86f5f93fc1dd776ff648f1d99e16cdb8a10b84e"
     ),
     # Moved with the base above: `live_standin` baseline + strict limits pair.
+    # Moved again with the base: permissive `virtual_accelerator` limits block.
     "control-assistant-ariel": (
-        "sha256:0f91798146907adef25fd6cce8429488eb58af3d9f5eb6bc93cddb55c2aaaee7"
+        "sha256:25df29b2f388287941c9ce4a1a05531f2fffca06ea8e4229f66b40c9c820a85d"
     ),
     # The two operator tiers below moved together, and alone, when each gained
     # the single dotted key `services.graphdb.port_host: 7687` in its `config:`
@@ -230,12 +246,14 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # same commit contributed nothing, which is the digest being comment-blind
     # exactly as the note at the top of this table says.
     # Moved with the base above: `live_standin` baseline + strict limits pair.
+    # Moved again with the base: permissive `virtual_accelerator` limits block.
     "control-assistant-readonly": (
-        "sha256:f0c1eec4c586057778871c2b071b9ada0f8520c919b4e79567dfb0d8e5abf082"
+        "sha256:d6680f9c8c1e37d249cd3852f293ea9b81ae2ddaa56d5779c76fb350358221ef"
     ),
     # Moved with the base above: `live_standin` baseline + strict limits pair.
+    # Moved again with the base: permissive `virtual_accelerator` limits block.
     "control-assistant-readwrite": (
-        "sha256:89f05aa008a36ca39dbba53af6f07490d2e64e961f999b3933fc5b44e7491f65"
+        "sha256:7c2c8c4ed559f160a225ad7c42078585592b7fece43927454526ac8c9782ef97"
     ),
     # New with per-target write posture, not a moved entry: the rung between
     # the two flat tiers, armed on the virtual accelerator alone. It pins the
@@ -244,8 +262,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # it, so which machine the session is pointed at decides whether its writes
     # land.
     # Moved with the base above: `live_standin` baseline + strict limits pair.
+    # Moved again with the base: permissive `virtual_accelerator` limits block.
     "control-assistant-va-readwrite": (
-        "sha256:f95e419a917e20c9272bcb1431e33c8330988c7a9349d8ae261af8b8924b9cb7"
+        "sha256:30aac62fd5b81dfaaaf3ac75c3358278aadd33e35de1cad74d3ecd37262d2704"
     ),
     # Moved when the onboarding rewrite dropped the `facility` rule. The
     # wholesale comment rewrite that shipped alongside it contributed nothing:

--- a/tests/cli/test_profile_validate_limits_block.py
+++ b/tests/cli/test_profile_validate_limits_block.py
@@ -1,0 +1,179 @@
+"""The per-type limits block, as the build and ``osprey profile validate`` read it.
+
+``control_system.connector.<type>.limits_checking`` overrides the
+deployment-wide pair as a whole block, so a profile that writes one leaf, or
+writes the block somewhere the render will not put it, has stated a posture
+nothing will ever answer with. Both are refused by name rather than ignored.
+
+The refusals are about the RENDER, not about spelling taste: a ``config:``
+entry's top-level key is the only part the emitter splits on dots
+(:func:`osprey.utils.config_writer.config_update_fields`), so every dot below
+it lands in a literal key name. That is what separates the two custom-type
+spellings tested here — one map key holding the dotted type renders correctly,
+the same type flattened into the top-level key does not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from osprey.cli.build_profile_deploy import limits_block_errors
+
+CUSTOM_TYPE = "mypkg.TangoConnector"
+
+
+def _complete(*, enabled: bool = True, allow_unlisted: bool = False) -> dict[str, Any]:
+    """The two leaves of one per-type block, as a mapping."""
+    return {"enabled": enabled, "allow_unlisted_channels": allow_unlisted}
+
+
+def test_a_complete_flat_built_in_block_passes() -> None:
+    config = {
+        "control_system.connector.virtual_accelerator.limits_checking.enabled": True,
+        "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels": (
+            True
+        ),
+    }
+    assert limits_block_errors(config) == []
+
+
+def test_a_flat_built_in_block_missing_a_leaf_names_the_leaf() -> None:
+    config = {"control_system.connector.virtual_accelerator.limits_checking.enabled": True}
+    errors = limits_block_errors(config)
+    assert len(errors) == 1
+    assert "allow_unlisted_channels" in errors[0]
+    assert "virtual_accelerator" in errors[0]
+
+
+def test_a_flat_built_in_block_missing_enabled_names_enabled() -> None:
+    config = {
+        "control_system.connector.epics.limits_checking.allow_unlisted_channels": False,
+    }
+    errors = limits_block_errors(config)
+    assert len(errors) == 1
+    assert "'enabled'" in errors[0]
+    assert "epics" in errors[0]
+
+
+def test_a_flat_dotted_custom_type_is_refused_even_when_both_leaves_are_stated() -> None:
+    """The dots in the type are indistinguishable from path separators once flattened."""
+    config = {
+        f"control_system.connector.{CUSTOM_TYPE}.limits_checking.enabled": True,
+        f"control_system.connector.{CUSTOM_TYPE}.limits_checking.allow_unlisted_channels": True,
+    }
+    errors = limits_block_errors(config)
+    assert len(errors) == 2
+    joined = "\n".join(errors)
+    assert f"control_system.connector.{CUSTOM_TYPE}.limits_checking.enabled" in joined
+    assert (
+        f"control_system.connector.{CUSTOM_TYPE}.limits_checking.allow_unlisted_channels" in joined
+    )
+
+
+def test_a_dotted_leaf_map_key_is_refused() -> None:
+    """``virtual_accelerator: {"limits_checking.enabled": …}`` renders one literal key."""
+    config = {
+        "control_system.connector.virtual_accelerator": {"limits_checking.enabled": True},
+    }
+    errors = limits_block_errors(config)
+    assert errors
+    assert any("limits_checking.enabled" in error for error in errors)
+
+
+def test_a_complete_dotted_prefix_custom_type_passes() -> None:
+    """A dotted type spelled as its own map key is the spelling that renders."""
+    config = {"control_system.connector": {CUSTOM_TYPE: {"limits_checking": _complete()}}}
+    assert limits_block_errors(config) == []
+
+
+def test_a_dotted_prefix_custom_type_missing_a_leaf_names_the_leaf() -> None:
+    config = {
+        "control_system.connector": {CUSTOM_TYPE: {"limits_checking": {"enabled": True}}},
+    }
+    errors = limits_block_errors(config)
+    assert len(errors) == 1
+    assert "allow_unlisted_channels" in errors[0]
+    assert CUSTOM_TYPE in errors[0]
+
+
+def test_a_fully_nested_block_passes() -> None:
+    config = {
+        "control_system": {
+            "connector": {"virtual_accelerator": {"limits_checking": _complete()}},
+        }
+    }
+    assert limits_block_errors(config) == []
+
+
+def test_control_system_addressed_at_two_depths_names_both_lines() -> None:
+    config = {
+        "control_system": {
+            "connector": {"virtual_accelerator": {"limits_checking": _complete()}},
+        },
+        "control_system.limits_checking.enabled": True,
+    }
+    errors = limits_block_errors(config)
+    assert len(errors) == 1
+    assert "'control_system'" in errors[0]
+    assert "'control_system.limits_checking.enabled'" in errors[0]
+
+
+def test_a_deeper_pair_below_control_system_passes() -> None:
+    """Two dotted keys at different depths merge at render, so they are not refused.
+
+    ``config_update_fields`` writes each entry through ``_set_dotted_anchored``
+    with ``create_only=True``, which walks into whatever an existing
+    intermediate key holds. Only the bare top-level key, having no dots to
+    walk, replaces a subtree.
+    """
+    config = {
+        "control_system.connector": {"virtual_accelerator": {"limits_checking": _complete()}},
+        "control_system.connector.epics.limits_checking.enabled": True,
+        "control_system.connector.epics.limits_checking.allow_unlisted_channels": False,
+    }
+    assert limits_block_errors(config) == []
+
+
+def test_a_config_with_no_limits_keys_passes() -> None:
+    config = {
+        "control_system.type": "live_standin",
+        "control_system.writes_enabled": False,
+        "control_system.connector.virtual_accelerator.writes_enabled": True,
+    }
+    assert limits_block_errors(config) == []
+
+
+def test_gateway_keys_are_untouched() -> None:
+    config = {
+        "control_system.connector.epics.gateways.read.address": "gw-read.example.org",
+        "control_system.connector.epics.gateways.write.address": "gw-write.example.org",
+        "control_system.connector.epics.limits_checking.enabled": True,
+        "control_system.connector.epics.limits_checking.allow_unlisted_channels": False,
+    }
+    assert limits_block_errors(config) == []
+
+
+def test_the_deployment_wide_block_is_untouched() -> None:
+    """Only ``control_system.connector.*`` paths are per-type; the pair above is not."""
+    config = {
+        "control_system.limits_checking.enabled": True,
+        "control_system.limits_checking.database_path": "limits.yml",
+    }
+    assert limits_block_errors(config) == []
+
+
+def test_a_non_mapping_config_has_nothing_to_refuse() -> None:
+    assert limits_block_errors({}) == []
+    assert limits_block_errors(None) == []  # type: ignore[arg-type]
+
+
+def test_a_stray_block_for_a_type_the_deployment_does_not_run_is_still_checked() -> None:
+    """The refusal is about the block's shape, not about whether the type is selected."""
+    config = {
+        "control_system.type": "mock",
+        "control_system.connector.live_standin.limits_checking.enabled": True,
+    }
+    errors = limits_block_errors(config)
+    assert len(errors) == 1
+    assert "live_standin" in errors[0]
+    assert "allow_unlisted_channels" in errors[0]

--- a/tests/cli/test_validate_config_verbs.py
+++ b/tests/cli/test_validate_config_verbs.py
@@ -246,6 +246,62 @@ def test_validate_still_runs_the_deploy_config_lint(
     assert "registry.url is not set" in result.output
 
 
+def test_validate_refuses_a_per_type_limits_block_missing_a_leaf(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-type ``limits_checking`` block overrides the deployment-wide pair
+    as a whole, so a block stating one leaf has no posture to answer with and
+    every reader falls back to refusing unlisted channels. The verb an operator
+    runs after a profile edit has to say so — by name — rather than report a
+    deployment valid that will quietly ignore what the profile stated."""
+    root = tmp_path / "half-a-block"
+    _write_profile(
+        root,
+        {
+            "name": "Demo Facility",
+            "data_bundle": "hello_world",
+            "config": {
+                "control_system.connector.virtual_accelerator.limits_checking.enabled": True
+            },
+        },
+    )
+    monkeypatch.chdir(root)
+
+    result = runner.invoke(validate, [])
+
+    assert result.exit_code == 2, result.output
+    assert "allow_unlisted_channels" in result.output
+    assert "virtual_accelerator" in result.output
+
+
+def test_validate_passes_a_complete_per_type_limits_block(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of the same check: a block stating both leaves is the
+    supported way to relax a simulator without relaxing the machine, so it must
+    reach the verdict untouched. Pinned beside the refusal because a lint that
+    refuses everything passes the test above on its own."""
+    root = tmp_path / "whole-block"
+    _write_profile(
+        root,
+        {
+            "name": "Demo Facility",
+            "data_bundle": "hello_world",
+            "config": {
+                "control_system.connector.virtual_accelerator.limits_checking.enabled": True,
+                "control_system.connector.virtual_accelerator.limits_checking."
+                "allow_unlisted_channels": True,
+            },
+        },
+    )
+    monkeypatch.chdir(root)
+
+    result = runner.invoke(validate, [])
+
+    assert result.exit_code == 0, result.output
+    assert "Profile is valid" in result.output
+
+
 def test_validate_points_at_build_not_at_a_project_name(
     runner: CliRunner, repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/connectors/ipc/test_host_child.py
+++ b/tests/connectors/ipc/test_host_child.py
@@ -24,6 +24,7 @@ actually used) belong to a connector that configures an EPICS environment,
 which the mock deliberately does not.
 """
 
+import asyncio
 import json
 import os
 import queue
@@ -678,6 +679,54 @@ def _va_config(gateways):
     }
 
 
+# --------------------------------------------- limits posture (child build)
+#
+# Limits posture is per connector type, and the child never learns which type
+# it is by asking: the factory stamps ``_connector_type`` between construction
+# and ``connect()``, and the connector builds its validator from that stamp. So
+# there is nothing in this package for a per-type block to reach — the child
+# inherits the posture by pointing at the project config and resolving its
+# target, exactly as the parent would have.
+#
+# These two run the child's own ``_build_connector`` in this process rather
+# than over a pipe, because what is being pinned is an attribute of the
+# connector living inside the child and the wire serves connector *methods*
+# (:data:`host.PROXY_METHODS`) — the policy a validator was built with never
+# crosses it. Everything up to that attribute is the real path: the on-disk
+# config the child is pointed at, ``resolve_target``, the factory, ``connect()``.
+
+
+DEPLOYMENT_WIDE_ALLOW_KEY = "control_system.limits_checking.allow_unlisted_channels"
+VA_ALLOW_KEY = (
+    "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+)
+
+
+def _limits_control_system(database_path: Path) -> dict:
+    """A deployment that refuses unlisted channels everywhere but its simulator.
+
+    The deployment-wide block is strict and the virtual accelerator's own block
+    relaxes it, so the two targets disagree and only a reader that resolved its
+    own type can say which answer it got. The deployment's own type is the mock
+    by dotted path, so ``live`` resolves to it and needs no EPICS; ``va``
+    resolves to ``virtual_accelerator`` whatever the deployment was built for.
+    """
+    return {
+        "type": MOCK_TYPE,
+        "limits_checking": {
+            "enabled": True,
+            "allow_unlisted_channels": False,
+            "database_path": str(database_path),
+        },
+        "connector": {
+            MOCK_TYPE: {"response_delay_ms": 10, "noise_level": 0.0},
+            "virtual_accelerator": {
+                "limits_checking": {"enabled": True, "allow_unlisted_channels": True}
+            },
+        },
+    }
+
+
 @pytest.fixture
 def va_deployment(tmp_path, monkeypatch):
     """Put an armed virtual accelerator on disk and in reach of this process."""
@@ -827,3 +876,58 @@ async def test_a_narrowed_target_reports_the_posture_its_writes_are_refused_on(
     derivation, verification = _verify(config, report, connector._writes_enabled)
     assert derivation.selected_role == "read_only"
     assert verification.ok, verification.detail
+
+
+@pytest.fixture
+def limits_deployment(tmp_path):
+    """The mixed-posture deployment on disk, beside a real limits database.
+
+    The database path is deployment-wide — one file per deployment — and has to
+    resolve to something loadable, or every posture collapses to the same
+    fail-safe validator and the test would pass without reading a block.
+    """
+    database = tmp_path / "limits.json"
+    database.write_text(json.dumps({"SR:CORR:1:SP": {"min_value": -1.0, "max_value": 1.0}}))
+    section = _limits_control_system(database)
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(yaml.safe_dump({"control_system": section}))
+    return section, str(config_file)
+
+
+def _child_limits_policy(section: dict, config_file: str, target: str) -> dict:
+    """The policy the child's connector ends up validating writes against."""
+
+    async def build():
+        connector, _report = await host._build_connector(
+            {"control_system": section, "target": target, "config_file": config_file}
+        )
+        try:
+            return dict(connector._limits_validator.policy)
+        finally:
+            await connector.disconnect()
+
+    return asyncio.run(build())
+
+
+def test_child_limits_posture_comes_from_the_block_for_the_target_it_serves(limits_deployment):
+    section, config_file = limits_deployment
+
+    policy = _child_limits_policy(section, config_file, "va")
+
+    # The simulator's own block answered, and the refusal an operator would
+    # eventually read names that line rather than the deployment-wide one it
+    # overrides.
+    assert policy["allow_unlisted_channels"] is True
+    assert policy["allow_unlisted_key"] == VA_ALLOW_KEY
+
+
+def test_child_limits_posture_falls_back_to_the_deployment_wide_block(limits_deployment):
+    section, config_file = limits_deployment
+
+    policy = _child_limits_policy(section, config_file, "live")
+
+    # This deployment wrote no block for the type ``live`` resolves to, so the
+    # deployment-wide refusal is the whole posture — and the simulator's
+    # relaxation, two keys away in the same file, does not reach it.
+    assert policy["allow_unlisted_channels"] is False
+    assert policy["allow_unlisted_key"] == DEPLOYMENT_WIDE_ALLOW_KEY

--- a/tests/connectors/test_auto_verification.py
+++ b/tests/connectors/test_auto_verification.py
@@ -29,7 +29,14 @@ def _write_limits_db(tmp_path, limits_db):
 
 
 def _limits_config(limits_file, **extra):
-    """Config map that enables limits checking against ``limits_file``."""
+    """Config map that enables limits checking against ``limits_file``.
+
+    The connector resolves its posture from the nested ``control_system``
+    section while the database path is still read by its dotted key, so the map
+    answers both spellings of one deployment. The section is derived from the
+    dotted entries — including any an ``extra`` overrode — rather than written
+    twice, so the two spellings cannot drift apart.
+    """
     config_map = {
         "control_system.limits_checking.enabled": True,
         "control_system.limits_checking.database_path": str(limits_file),
@@ -38,6 +45,14 @@ def _limits_config(limits_file, **extra):
         "control_system.writes_enabled": True,
     }
     config_map.update(extra)
+    config_map["control_system"] = {
+        "writes_enabled": config_map["control_system.writes_enabled"],
+        "limits_checking": {
+            key.split(".")[-1]: value
+            for key, value in config_map.items()
+            if key.startswith("control_system.limits_checking.")
+        },
+    }
 
     def get_config_value(key, default=None):
         return config_map.get(key, default)

--- a/tests/connectors/test_connector_limits_posture.py
+++ b/tests/connectors/test_connector_limits_posture.py
@@ -1,0 +1,289 @@
+"""Each connector builds its limits validator for its own connector type.
+
+A deployment may relax ``allow_unlisted_channels`` for its simulator while its
+live machine refuses unlisted channels. The block that decides is
+``control_system.connector.<type>.limits_checking``, so the connector has to ask
+about the type it *is* rather than about the deployment as a whole — otherwise
+the simulator's relaxation would leak onto the live machine, or the live
+machine's refusal onto the simulator.
+
+The type a connector is comes from the factory, which stamps ``_connector_type``
+between construction and ``connect()``. A connector built outside the factory
+carries no stamp, and an unstamped connector reads the deployment-wide block —
+the same parity rule the per-type write posture follows
+(``tests/connectors/test_writes_enabled.py``), so a deployment that wrote no
+per-type block behaves exactly as it did before they existed.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osprey.connectors.types import DOOCS, EPICS, LIVE_STANDIN, VIRTUAL_ACCELERATOR
+from osprey.errors import ChannelLimitsViolationError
+
+DEPLOYMENT_WIDE_ALLOW_KEY = "control_system.limits_checking.allow_unlisted_channels"
+
+
+def _type_allow_key(connector_type: str) -> str:
+    """The per-type spelling of the unlisted-channel key for *connector_type*."""
+    return f"control_system.connector.{connector_type}.limits_checking.allow_unlisted_channels"
+
+
+def _limits_db(tmp_path: Path) -> Path:
+    """A one-channel limits database, so a validator loads rather than failsafes."""
+    db_file = tmp_path / "limits.json"
+    db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+    return db_file
+
+
+def _permissive_simulators_section() -> dict[str, Any]:
+    """Deployment-wide strict; the simulator, stand-in and DOOCS blocks relaxed.
+
+    The configuration the feature exists for. ``epics`` deliberately carries no
+    ``limits_checking`` block: the live machine inherits the deployment-wide
+    refusal, and every other type states its own relaxation.
+    """
+    return {
+        "type": EPICS,
+        "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
+        "connector": {
+            EPICS: {"gateway_address": "live.example"},
+            VIRTUAL_ACCELERATOR: {
+                "limits_checking": {"enabled": True, "allow_unlisted_channels": True}
+            },
+            LIVE_STANDIN: {"limits_checking": {"enabled": True, "allow_unlisted_channels": True}},
+            DOOCS: {"limits_checking": {"enabled": True, "allow_unlisted_channels": True}},
+        },
+    }
+
+
+def _patch_config(monkeypatch, section: dict[str, Any], db_path: Path) -> None:
+    """Serve one ``control_system:`` section plus the limits database path.
+
+    The posture is read from the whole section (the resolvers walk it) while the
+    database path stays deployment-wide and dotted — one file per deployment, so
+    a per-type block changes policy and never the data.
+    """
+
+    def fake_get_config_value(key: str, default: Any = None) -> Any:
+        if key == "control_system":
+            return section
+        if key == "control_system.limits_checking.database_path":
+            return str(db_path)
+        if key == "control_system.writes_enabled":
+            return section.get("writes_enabled", default)
+        return default
+
+    monkeypatch.setattr("osprey.utils.config.get_config_value", fake_get_config_value)
+    monkeypatch.setattr("osprey.utils.config.default_config_path", lambda: None)
+
+
+def _posture(connector) -> tuple[Any, Any]:
+    """The unlisted-channel policy the connector's validator was built with."""
+    policy = connector._limits_validator.policy
+    return policy["allow_unlisted_channels"], policy["allow_unlisted_key"]
+
+
+# ---------------------------------------------------------------------------
+# Mock connector
+# ---------------------------------------------------------------------------
+
+
+async def _connected_mock(monkeypatch, section, db_path, connector_type):
+    from osprey.connectors.control_system.mock_connector import MockConnector
+
+    _patch_config(monkeypatch, section, db_path)
+    connector = MockConnector()
+    connector._connector_type = connector_type
+    await connector.connect({"response_delay_ms": 0})
+    return connector
+
+
+class TestMockConnectorPosture:
+    """``MockConnector.connect()`` asks about the type the factory stamped."""
+
+    @pytest.mark.asyncio
+    async def test_stamped_type_reads_its_own_block(self, monkeypatch, tmp_path):
+        connector = await _connected_mock(
+            monkeypatch,
+            _permissive_simulators_section(),
+            _limits_db(tmp_path),
+            VIRTUAL_ACCELERATOR,
+        )
+
+        assert _posture(connector) == (True, _type_allow_key(VIRTUAL_ACCELERATOR))
+
+    @pytest.mark.asyncio
+    async def test_unstamped_connector_reads_the_deployment_wide_block(self, monkeypatch, tmp_path):
+        """Parity: a connector built outside the factory behaves as it always has."""
+        connector = await _connected_mock(
+            monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path), None
+        )
+
+        assert _posture(connector) == (False, DEPLOYMENT_WIDE_ALLOW_KEY)
+
+    @pytest.mark.asyncio
+    async def test_type_without_a_block_inherits_deployment_wide(self, monkeypatch, tmp_path):
+        """``epics`` states no limits block, so the deployment-wide one answers."""
+        connector = await _connected_mock(
+            monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path), EPICS
+        )
+
+        assert _posture(connector) == (False, DEPLOYMENT_WIDE_ALLOW_KEY)
+
+    @pytest.mark.asyncio
+    async def test_refusal_names_the_key_that_answered(self, monkeypatch, tmp_path):
+        """The live machine's refusal quotes its own key, not the simulator's.
+
+        The end the posture exists for: an operator reading the refusal is sent
+        to the line they can actually edit.
+        """
+        connector = await _connected_mock(
+            monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path), EPICS
+        )
+
+        with pytest.raises(ChannelLimitsViolationError) as excinfo:
+            connector._limits_validator.validate("NOT:IN:DB", 1.0)
+
+        assert DEPLOYMENT_WIDE_ALLOW_KEY in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_simulator_allows_the_unlisted_channel_the_live_machine_refuses(
+        self, monkeypatch, tmp_path
+    ):
+        """One deployment, two answers for the same channel — the point of the feature."""
+        connector = await _connected_mock(
+            monkeypatch,
+            _permissive_simulators_section(),
+            _limits_db(tmp_path),
+            VIRTUAL_ACCELERATOR,
+        )
+
+        connector._limits_validator.validate("NOT:IN:DB", 1.0)  # allowed, no raise
+
+
+# ---------------------------------------------------------------------------
+# EPICS connector (and the VA connector that inherits its connect())
+# ---------------------------------------------------------------------------
+
+_EPICS_VARS = [
+    "EPICS_CA_ADDR_LIST",
+    "EPICS_CA_SERVER_PORT",
+    "EPICS_CA_NAME_SERVERS",
+    "EPICS_CA_AUTO_ADDR_LIST",
+]
+
+
+@pytest.fixture
+def clean_epics_env(monkeypatch):
+    """Snapshot EPICS_* env vars so connect()'s direct os.environ writes are restored."""
+    for var in _EPICS_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+    for var in _EPICS_VARS:
+        os.environ.pop(var, None)
+
+
+def _gateways() -> dict[str, Any]:
+    return {"read_only": {"address": "ro.example.com", "port": 5064}}
+
+
+class TestEPICSConnectorPosture:
+    """The EPICS connector, and everything that inherits its ``connect()``."""
+
+    @pytest.mark.asyncio
+    async def test_stand_in_reads_its_own_block(self, monkeypatch, tmp_path, clean_epics_env):
+        """``live_standin`` is a type of its own, served by this same connector."""
+        from osprey.connectors.control_system.epics_connector import EPICSConnector
+
+        _patch_config(monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path))
+        connector = EPICSConnector()
+        connector._connector_type = LIVE_STANDIN
+        await connector.connect({"gateways": _gateways()})
+
+        assert _posture(connector) == (True, _type_allow_key(LIVE_STANDIN))
+
+    @pytest.mark.asyncio
+    async def test_live_type_inherits_deployment_wide(self, monkeypatch, tmp_path, clean_epics_env):
+        from osprey.connectors.control_system.epics_connector import EPICSConnector
+
+        _patch_config(monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path))
+        connector = EPICSConnector()
+        connector._connector_type = EPICS
+        await connector.connect({"gateways": _gateways()})
+
+        assert _posture(connector) == (False, DEPLOYMENT_WIDE_ALLOW_KEY)
+
+    @pytest.mark.asyncio
+    async def test_unstamped_connector_reads_the_deployment_wide_block(
+        self, monkeypatch, tmp_path, clean_epics_env
+    ):
+        from osprey.connectors.control_system.epics_connector import EPICSConnector
+
+        _patch_config(monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path))
+        connector = EPICSConnector()
+        await connector.connect({"gateways": _gateways()})
+
+        assert _posture(connector) == (False, DEPLOYMENT_WIDE_ALLOW_KEY)
+
+    @pytest.mark.asyncio
+    async def test_va_connector_inherits_the_wiring_through_super_connect(
+        self, monkeypatch, tmp_path, clean_epics_env
+    ):
+        """``VirtualAcceleratorConnector`` builds no validator of its own."""
+        from osprey.connectors.control_system.va_connector import VirtualAcceleratorConnector
+
+        _patch_config(monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path))
+        connector = VirtualAcceleratorConnector()
+        connector._connector_type = VIRTUAL_ACCELERATOR
+        await connector.connect({"gateways": _gateways()})
+
+        assert _posture(connector) == (True, _type_allow_key(VIRTUAL_ACCELERATOR))
+
+
+# ---------------------------------------------------------------------------
+# DOOCS connector
+# ---------------------------------------------------------------------------
+
+
+def _mock_doocs4py() -> MagicMock:
+    """A doocs4py stand-in, so ``connect()`` needs no DOOCS installation."""
+    module = MagicMock()
+    module.__version__ = "2.0.0"
+    module.names.return_value = [("FACILITY", "XFEL")]
+    return module
+
+
+async def _connected_doocs(monkeypatch, section, db_path, connector_type):
+    _patch_config(monkeypatch, section, db_path)
+    with patch.dict(sys.modules, {"doocs4py": _mock_doocs4py()}):
+        from osprey.connectors.control_system.doocs_connector import DOOCSConnector
+
+        connector = DOOCSConnector()
+        connector._connector_type = connector_type
+        await connector.connect({})
+    return connector
+
+
+class TestDOOCSConnectorPosture:
+    @pytest.mark.asyncio
+    async def test_stamped_type_reads_its_own_block(self, monkeypatch, tmp_path):
+        connector = await _connected_doocs(
+            monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path), DOOCS
+        )
+
+        assert _posture(connector) == (True, _type_allow_key(DOOCS))
+
+    @pytest.mark.asyncio
+    async def test_unstamped_connector_reads_the_deployment_wide_block(self, monkeypatch, tmp_path):
+        connector = await _connected_doocs(
+            monkeypatch, _permissive_simulators_section(), _limits_db(tmp_path), None
+        )
+
+        assert _posture(connector) == (False, DEPLOYMENT_WIDE_ALLOW_KEY)

--- a/tests/connectors/test_epics_connector.py
+++ b/tests/connectors/test_epics_connector.py
@@ -169,7 +169,7 @@ class TestConnect:
         sentinel = MagicMock(name="limits_validator")
         monkeypatch.setattr(
             "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
-            classmethod(lambda cls: sentinel),
+            classmethod(lambda cls, *, connector_type=None, target=None: sentinel),
         )
 
         connector = EPICSConnector()

--- a/tests/connectors/test_factory_control_target.py
+++ b/tests/connectors/test_factory_control_target.py
@@ -1,7 +1,8 @@
 """Every connector carries the session target it was built for.
 
-``ConnectorFactory.create_control_system_connector`` stamps two things on the
-instance it returns: the connector *type*, which selects the deployment's
+``ConnectorFactory.build_control_system_connector`` — and
+``create_control_system_connector``, which is that build plus ``connect()`` —
+stamps two things on the instance it returns: the connector *type*, which selects the deployment's
 connector block and the per-type write posture, and the control *target*, which
 indexes the per-(session, target) posture store. They answer different questions
 and neither is derivable from the other — a two-lane deployment's VA lane and
@@ -44,25 +45,42 @@ class _RecordingFactory:
 
     Stamps the instance the way the real factory does, so a site that clears or
     rewrites a stamp afterwards (the degraded bridge lane) is observed doing it.
+    Both entry points are recorded: the one-call ``create`` and the two-step
+    ``build`` a site uses when it has to reach the instance before ``connect()``.
     """
 
     def __init__(self) -> None:
         self.calls: list[tuple[Any, str | None]] = []
 
-    async def __call__(self, config: Any = None, *, control_target: str | None = None) -> Any:
-        self.calls.append((config, control_target))
-        connector = SimpleNamespace(
+    def _stamped(self, config: Any, control_target: str | None) -> Any:
+        return SimpleNamespace(
             _connector_type=(config or {}).get("type"),
             _control_target=control_target,
+            connect=_noop_connect,
             disconnect=_noop_disconnect,
         )
-        return connector
+
+    async def __call__(self, config: Any = None, *, control_target: str | None = None) -> Any:
+        self.calls.append((config, control_target))
+        return self._stamped(config, control_target)
+
+    def build(
+        self, config: Any = None, *, control_target: str | None = None
+    ) -> tuple[Any, dict[str, Any]]:
+        self.calls.append((config, control_target))
+        connector = self._stamped(config, control_target)
+        type_config = (config or {}).get("connector", {}).get((config or {}).get("type"), {})
+        return connector, type_config
 
     @property
     def target(self) -> str | None:
         """The target named by the one call this factory was asked to make."""
         assert len(self.calls) == 1, f"expected exactly one construction, got {self.calls}"
         return self.calls[0][1]
+
+
+async def _noop_connect(type_config: Any = None) -> None:
+    return None
 
 
 async def _noop_disconnect() -> None:
@@ -75,6 +93,9 @@ def recording_factory(monkeypatch: pytest.MonkeyPatch) -> _RecordingFactory:
     spy = _RecordingFactory()
     monkeypatch.setattr(
         factory_module.ConnectorFactory, "create_control_system_connector", spy, raising=True
+    )
+    monkeypatch.setattr(
+        factory_module.ConnectorFactory, "build_control_system_connector", spy.build, raising=True
     )
     monkeypatch.setattr(factory_module, "register_builtin_connectors", lambda: None)
     return spy

--- a/tests/connectors/test_limits_loader_fail_closed.py
+++ b/tests/connectors/test_limits_loader_fail_closed.py
@@ -17,8 +17,19 @@ from osprey.errors import ChannelLimitsViolationError
 
 
 def _patch_config(monkeypatch, db_file, allow_unlisted: bool = False):
-    """Point from_config at a limits file on disk."""
+    """Point from_config at a limits file on disk.
+
+    ``from_config`` reads the nested ``control_system`` section to resolve the
+    posture and the dotted key for the database path, so the shim answers both
+    spellings of the one deployment these tests describe.
+    """
     values = {
+        "control_system": {
+            "limits_checking": {
+                "enabled": True,
+                "allow_unlisted_channels": allow_unlisted,
+            },
+        },
         "control_system.limits_checking.enabled": True,
         "control_system.limits_checking.database_path": str(db_file),
         "control_system.limits_checking.allow_unlisted_channels": allow_unlisted,

--- a/tests/connectors/test_limits_posture.py
+++ b/tests/connectors/test_limits_posture.py
@@ -1,0 +1,1273 @@
+"""Limits posture, per connector type — the value, its key, and "strict".
+
+``control_system.limits_checking`` used to be one block for the whole
+deployment, so a deployment running a live machine beside a virtual accelerator
+could not hold ``allow_unlisted_channels: false`` for the one and ``true`` for
+the other. The posture is now per connector type, and the piece pinned here is
+the value that carries it: :class:`~osprey_connectors.types.LimitsPosture`
+holds the two leaves *together with the key that answered them*, so a refusal
+sends an operator to the line they actually have to edit rather than to a
+deployment-wide key some per-type block overrides.
+
+``strict`` is defined here and nowhere else in the codebase: limits checking on
+*and* unlisted channels refused. The tri-state matters — ``None`` is "the
+deployment never said", which is not the same as "the deployment said no", and
+only an explicit ``False`` makes a target strict.
+
+The resolvers that *build* a posture from a config section are pinned in the
+sibling test classes in this module.
+"""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+from typing import Any
+
+import pytest
+
+from osprey_connectors import types as connector_types
+from osprey_connectors.types import (
+    CONTROL_TARGETS,
+    EPICS,
+    LIMITS_CHECKING_LEAF,
+    LIMITS_LEAVES,
+    LIVE_STANDIN,
+    MOCK,
+    TARGET_LIVE,
+    TARGET_STANDIN,
+    TARGET_VA,
+    VIRTUAL_ACCELERATOR,
+    LimitsPosture,
+    incomplete_limits_blocks,
+    most_restrictive_limits_posture,
+    target_limits_posture,
+    type_limits_posture,
+)
+
+CUSTOM_TYPE = "mypackage.TangoConnector"
+
+#: Leaf values a limits block may carry that no reader can turn into a boolean.
+#: ``"${X}"`` is the one that matters most: environment expansion always yields
+#: strings, so an unset variable reaches the resolvers looking exactly like this.
+UNREADABLE_LEAVES = ["true", "false", 1, 0, None, [], {}, "${X}"]
+
+ENABLED_LEAF, ALLOW_UNLISTED_LEAF = LIMITS_LEAVES
+
+
+def _section(limits_checking: Any = ..., connector: Any = ...) -> dict[str, Any]:
+    """A ``control_system:`` section as the rendered config.yml carries it.
+
+    Each key is present only when given, so a test can state the difference
+    between a deployment that wrote a block and one that never had one.
+    """
+    section: dict[str, Any] = {}
+    if limits_checking is not ...:
+        section[LIMITS_CHECKING_LEAF] = limits_checking
+    if connector is not ...:
+        section["connector"] = connector
+    return section
+
+
+def _block(enabled: Any = ..., allow_unlisted: Any = ...) -> dict[str, Any]:
+    """A ``limits_checking:`` block, each leaf present only when given.
+
+    Leaf *presence* is what decides whether a per-type block is complete, so
+    omitting a leaf here is how a test writes an incomplete block.
+    """
+    block: dict[str, Any] = {}
+    if enabled is not ...:
+        block[ENABLED_LEAF] = enabled
+    if allow_unlisted is not ...:
+        block[ALLOW_UNLISTED_LEAF] = allow_unlisted
+    return block
+
+
+class TestLimitsPosture:
+    """The posture value: its key spelling, ``strict``, and its immutability."""
+
+    def test_leaf_constants_name_the_block_and_its_two_leaves(self) -> None:
+        """The block name and the leaves a block must state are spelled once."""
+        assert LIMITS_CHECKING_LEAF == "limits_checking"
+        assert LIMITS_LEAVES == ("enabled", "allow_unlisted_channels")
+        assert isinstance(LIMITS_LEAVES, tuple)
+
+    def test_leaves_exclude_database_path(self) -> None:
+        """``database_path`` stays deployment-wide, so it is not a block leaf.
+
+        Compose mounts one limits database for the deployment; a per-type block
+        that omits the path is complete, not incomplete.
+        """
+        assert "database_path" not in LIMITS_LEAVES
+
+    @pytest.mark.parametrize("leaf", LIMITS_LEAVES)
+    def test_key_names_the_per_type_block_when_a_type_answered(self, leaf: str) -> None:
+        """A posture read from a connector block names that block's key."""
+        posture = LimitsPosture(
+            enabled=True, allow_unlisted=True, connector_type="virtual_accelerator"
+        )
+        assert posture.key(leaf) == (
+            f"control_system.connector.virtual_accelerator.limits_checking.{leaf}"
+        )
+
+    @pytest.mark.parametrize("leaf", LIMITS_LEAVES)
+    def test_key_names_the_deployment_wide_block_without_a_type(self, leaf: str) -> None:
+        """No type answered means the deployment-wide block answered."""
+        posture = LimitsPosture(enabled=True, allow_unlisted=False, connector_type=None)
+        assert posture.key(leaf) == f"control_system.limits_checking.{leaf}"
+
+    def test_key_keeps_a_dotted_custom_type_whole(self) -> None:
+        """A custom connector's dotted module path is one key, never a path."""
+        posture = LimitsPosture(enabled=True, allow_unlisted=False, connector_type=CUSTOM_TYPE)
+        assert posture.key("enabled") == (
+            "control_system.connector.mypackage.TangoConnector.limits_checking.enabled"
+        )
+
+    def test_key_treats_an_empty_type_as_no_type(self) -> None:
+        """An empty type names nothing, so the deployment-wide key answers.
+
+        Same reading :func:`~osprey_connectors.types.writes_enabled_key` gives a
+        caller holding no type: a key with an empty segment in it would send an
+        operator to a line that cannot exist.
+        """
+        posture = LimitsPosture(enabled=None, allow_unlisted=None, connector_type="")
+        assert posture.key("enabled") == "control_system.limits_checking.enabled"
+
+    @pytest.mark.parametrize(
+        ("enabled", "allow_unlisted", "expected"),
+        [
+            (True, False, True),
+            (True, True, False),
+            (True, None, False),
+            (False, False, False),
+            (False, True, False),
+            (False, None, False),
+            (None, False, False),
+            (None, True, False),
+            (None, None, False),
+        ],
+    )
+    def test_strict_truth_table(
+        self, enabled: bool | None, allow_unlisted: bool | None, expected: bool
+    ) -> None:
+        """Strict is checking on *and* unlisted channels explicitly refused.
+
+        ``None`` counts as not-strict on both leaves: a deployment that never
+        stated a posture has not refused anything, and reading silence as a
+        refusal would call a target strict on a guarantee nobody wrote down.
+        """
+        posture = LimitsPosture(enabled=enabled, allow_unlisted=allow_unlisted, connector_type=None)
+        assert posture.strict is expected
+
+    def test_strict_is_unaffected_by_the_answering_type(self) -> None:
+        """Which block answered changes the key, never the posture."""
+        deployment_wide = LimitsPosture(enabled=True, allow_unlisted=False, connector_type=None)
+        per_type = LimitsPosture(enabled=True, allow_unlisted=False, connector_type="epics")
+        assert deployment_wide.strict is per_type.strict is True
+
+    def test_an_incomplete_block_is_never_strict(self) -> None:
+        """A block missing a leaf answers ``None``, which is not strict."""
+        posture = LimitsPosture(
+            enabled=None,
+            allow_unlisted=None,
+            connector_type="virtual_accelerator",
+            incomplete=("allow_unlisted_channels",),
+        )
+        assert posture.strict is False
+
+    def test_incomplete_defaults_to_empty(self) -> None:
+        """A posture built without the field describes a well-formed block."""
+        posture = LimitsPosture(enabled=True, allow_unlisted=True, connector_type=None)
+        assert posture.incomplete == ()
+
+    def test_incomplete_names_the_missing_leaves(self) -> None:
+        """The field carries leaf names, so a refusal can quote them."""
+        posture = LimitsPosture(
+            enabled=None,
+            allow_unlisted=None,
+            connector_type="epics",
+            incomplete=("enabled", "allow_unlisted_channels"),
+        )
+        assert posture.incomplete == ("enabled", "allow_unlisted_channels")
+
+    def test_posture_is_frozen(self) -> None:
+        """The posture a refusal quotes cannot be edited after it was resolved."""
+        posture = LimitsPosture(enabled=True, allow_unlisted=False, connector_type=None)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            posture.enabled = False  # type: ignore[misc]
+
+    def test_postures_compare_by_value(self) -> None:
+        """Two resolutions of the same config are the same posture."""
+        assert LimitsPosture(True, False, "epics") == LimitsPosture(True, False, "epics")
+        assert LimitsPosture(True, False, "epics") != LimitsPosture(True, False, None)
+
+    def test_public_symbols_are_importable_from_types(self) -> None:
+        """The posture and its constants are part of the module's public surface.
+
+        :mod:`osprey_connectors.types` publishes no ``__all__`` today — every
+        public name in it is reachable by import, and the writes family beside
+        this one is consumed that way. The assertion is written so that adding
+        one later has to include these names rather than silently drop them.
+        """
+        exported = getattr(connector_types, "__all__", None)
+        for name in ("LimitsPosture", "LIMITS_CHECKING_LEAF", "LIMITS_LEAVES"):
+            assert hasattr(connector_types, name)
+            if exported is not None:
+                assert name in exported
+
+
+class TestTypeLimitsPosture:
+    """Resolving one connector *type*'s posture out of a config section.
+
+    The whole-block rule lives here: a per-type ``limits_checking`` block that
+    is present states both leaves and then answers alone, with no leaf borrowed
+    from the deployment-wide block; a block that is absent — or is not a
+    mapping, at any level — leaves the deployment-wide block answering, which
+    is the compatibility story for every deployment that never wrote one.
+    """
+
+    # ------------------------------------------------------------------
+    # No per-type block: the deployment-wide block answers
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("deployment_wide", "expected"),
+        [
+            (_block(True, True), (True, True)),
+            (_block(True, False), (True, False)),
+            (_block(False, True), (False, True)),
+            (_block(False, False), (False, False)),
+            (_block(enabled=True), (True, None)),
+            (_block(enabled=False), (False, None)),
+            (_block(allow_unlisted=True), (None, True)),
+            (_block(allow_unlisted=False), (None, False)),
+            (_block(), (None, None)),
+        ],
+    )
+    def test_a_type_with_no_block_of_its_own_reads_the_deployment_wide_block(
+        self, deployment_wide: dict[str, Any], expected: tuple[bool | None, bool | None]
+    ) -> None:
+        """Both leaves are tri-state there: unset stays ``None``, never guessed.
+
+        A deployment that says nothing per type keeps exactly the posture it had
+        when the deployment-wide block was the only one there was.
+        """
+        section = _section(deployment_wide, connector={EPICS: {"timeout": 5.0}})
+        posture = type_limits_posture(section, EPICS)
+        assert (posture.enabled, posture.allow_unlisted) == expected
+        assert posture.connector_type is None
+        assert posture.incomplete == ()
+
+    def test_the_deployment_wide_answer_names_the_deployment_wide_key(self) -> None:
+        """Carrying no type is what makes the refusal name the editable line."""
+        posture = type_limits_posture(_section(_block(True, False)), EPICS)
+        assert posture.key(ENABLED_LEAF) == "control_system.limits_checking.enabled"
+        assert posture.key(ALLOW_UNLISTED_LEAF) == (
+            "control_system.limits_checking.allow_unlisted_channels"
+        )
+
+    def test_a_leaf_the_deployment_wide_block_never_carried_is_not_incomplete(self) -> None:
+        """Only a *per-type* block has to state both leaves to answer.
+
+        Deployment-wide silence on one leaf is the tri-state, not a malformed
+        block: it is the shape every deployment predating per-type blocks has,
+        and reading it as incomplete would block every write on the fleet.
+        """
+        posture = type_limits_posture(_section(_block(enabled=True)), EPICS)
+        assert posture == LimitsPosture(True, None, None)
+        assert posture.incomplete == ()
+
+    def test_a_type_the_deployment_never_configured_reads_the_deployment_wide_block(
+        self,
+    ) -> None:
+        """A stray block for some other type does not answer for this one."""
+        section = _section(
+            _block(True, False),
+            connector={EPICS: {LIMITS_CHECKING_LEAF: _block(True, True)}},
+        )
+        assert type_limits_posture(section, MOCK) == LimitsPosture(True, False, None)
+
+    # ------------------------------------------------------------------
+    # Garbage counts as absent, and nothing raises
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "connector",
+        [
+            ...,
+            {},
+            {VIRTUAL_ACCELERATOR: {LIMITS_CHECKING_LEAF: _block(False, True)}},
+            {EPICS: {}},
+            {EPICS: {"timeout": 5.0}},
+            {EPICS: "epics"},
+            {EPICS: None},
+            "epics",
+            ["epics"],
+            None,
+        ],
+    )
+    def test_anything_that_is_not_a_per_type_block_counts_as_absent(self, connector: Any) -> None:
+        """A block has to be a mapping at every level to answer for its type.
+
+        A string, a list or a bare ``limits_checking:`` states no posture, and
+        reading one as a block would either raise on a write path or invent a
+        posture out of a typo. Falling through to the deployment-wide block
+        leaves the deployment the posture it actually wrote down.
+        """
+        section = _section(_block(True, False), connector=connector)
+        assert type_limits_posture(section, EPICS) == LimitsPosture(True, False, None)
+
+    @pytest.mark.parametrize("limits_checking", [None, "true", ["enabled"], 5])
+    def test_a_per_type_block_that_is_not_a_mapping_is_unreadable(
+        self, limits_checking: Any
+    ) -> None:
+        """It does not inherit: this type said something nobody can read.
+
+        Falling through to the deployment-wide block here would hand a machine
+        the posture some other line wrote, on exactly the type whose own block
+        is unreadable — the one case where inheritance is a guess rather than
+        compatibility. Both leaves incomplete instead, so a reader blocks.
+        """
+        section = _section(
+            _block(True, True),
+            connector={EPICS: {LIMITS_CHECKING_LEAF: limits_checking}},
+        )
+        assert type_limits_posture(section, EPICS) == LimitsPosture(
+            None, None, EPICS, LIMITS_LEAVES
+        )
+
+    @pytest.mark.parametrize("section", [None, "control_system", ["control_system"], 5, True])
+    def test_a_section_that_is_not_a_mapping_states_nothing(self, section: Any) -> None:
+        """Never raises: a section nobody can read is a deployment that said nothing."""
+        assert type_limits_posture(section, EPICS) == LimitsPosture(None, None, None)
+
+    def test_a_deployment_that_wrote_no_block_at_all_states_nothing(self) -> None:
+        """Silence one level up, which is what a fresh deployment has."""
+        assert type_limits_posture(_section(), EPICS) == LimitsPosture(None, None, None)
+
+    @pytest.mark.parametrize("limits_checking", [None, "true", ["enabled"], 5])
+    def test_a_deployment_wide_block_that_is_not_a_mapping_is_unreadable(
+        self, limits_checking: Any
+    ) -> None:
+        """A block written and unreadable is not the same as no block.
+
+        ``limits_checking: 'true'`` and a bare ``limits_checking:`` are a
+        deployment that tried to say something; reading them as silence would
+        leave checking off on a config whose author believed it was on. Both
+        leaves incomplete, so a reader that must act blocks.
+        """
+        posture = type_limits_posture(_section(limits_checking), EPICS)
+        assert posture == LimitsPosture(None, None, None, LIMITS_LEAVES)
+
+    # ------------------------------------------------------------------
+    # A complete per-type block answers alone
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("connector_type", [EPICS, VIRTUAL_ACCELERATOR, CUSTOM_TYPE])
+    @pytest.mark.parametrize("enabled", [True, False])
+    @pytest.mark.parametrize("allow_unlisted", [True, False])
+    def test_a_complete_block_answers_alone_and_names_its_own_key(
+        self, connector_type: str, enabled: bool, allow_unlisted: bool
+    ) -> None:
+        """The override is whole: the deployment-wide block is not consulted.
+
+        The deployment-wide block below states the opposite of both leaves, so
+        a resolver that inherited either half would be caught here — for a
+        built-in type and for a custom connector's dotted module path alike.
+        """
+        section = _section(
+            _block(not enabled, not allow_unlisted),
+            connector={connector_type: {LIMITS_CHECKING_LEAF: _block(enabled, allow_unlisted)}},
+        )
+        posture = type_limits_posture(section, connector_type)
+        assert posture == LimitsPosture(enabled, allow_unlisted, connector_type)
+        assert posture.key(ENABLED_LEAF) == (
+            f"control_system.connector.{connector_type}.limits_checking.enabled"
+        )
+
+    def test_a_complete_block_answers_where_no_deployment_wide_block_exists(self) -> None:
+        """A per-type block is a posture on its own, not a modifier of one."""
+        section = _section(connector={EPICS: {LIMITS_CHECKING_LEAF: _block(True, False)}})
+        assert type_limits_posture(section, EPICS) == LimitsPosture(True, False, EPICS)
+
+    def test_a_per_type_block_can_be_strict_where_the_deployment_is_not(self) -> None:
+        """The whole point of the feature, read through :attr:`LimitsPosture.strict`."""
+        section = _section(
+            _block(True, True),
+            connector={EPICS: {LIMITS_CHECKING_LEAF: _block(True, False)}},
+        )
+        assert type_limits_posture(section, EPICS).strict is True
+        assert type_limits_posture(section, VIRTUAL_ACCELERATOR).strict is False
+
+    def test_a_dotted_custom_type_is_one_key_and_not_a_path(self) -> None:
+        """``mypackage.TangoConnector`` names one block, never two nested ones.
+
+        A connector table that happens to nest the dots is not this type's
+        block, so the deployment-wide posture answers rather than a mapping
+        that only looks like a match after splitting a key nobody split.
+        """
+        section = _section(
+            _block(True, False),
+            connector={
+                "mypackage": {"TangoConnector": {LIMITS_CHECKING_LEAF: _block(False, True)}}
+            },
+        )
+        assert type_limits_posture(section, CUSTOM_TYPE) == LimitsPosture(True, False, None)
+
+    # ------------------------------------------------------------------
+    # Leaf values: only the literal booleans state a posture
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("value", UNREADABLE_LEAVES)
+    def test_a_per_type_leaf_that_cannot_be_read_is_an_incomplete_block(self, value: Any) -> None:
+        """A leaf nobody can read is a block that failed to state it.
+
+        Not merely an unstated posture. ``enabled`` unset means "this
+        deployment configured no limits checking", so a block that wrote
+        ``enabled: 'true'`` — meaning to switch checking on — would have every
+        write waved through if the value were read as plain silence. Naming it
+        incomplete is what makes a reader block instead.
+        """
+        section = _section(
+            _block(True, True),
+            connector={EPICS: {LIMITS_CHECKING_LEAF: _block(value, value)}},
+        )
+        posture = type_limits_posture(section, EPICS)
+        assert posture == LimitsPosture(None, None, EPICS, LIMITS_LEAVES)
+        assert posture.strict is False
+
+    @pytest.mark.parametrize("value", UNREADABLE_LEAVES)
+    def test_a_deployment_wide_leaf_that_cannot_be_read_is_an_incomplete_block(
+        self, value: Any
+    ) -> None:
+        """Same reading at the deployment-wide level, so the two cannot drift.
+
+        Omitting a leaf is legal here and writing one unreadably is not: the
+        deployment-wide block inherits nothing, but a line it did write and
+        nobody can read is the same hazard in either scope.
+        """
+        assert type_limits_posture(_section(_block(value, value)), EPICS) == LimitsPosture(
+            None, None, None, LIMITS_LEAVES
+        )
+
+    @pytest.mark.parametrize("value", UNREADABLE_LEAVES)
+    @pytest.mark.parametrize("leaf", LIMITS_LEAVES)
+    def test_one_unreadable_leaf_makes_the_whole_block_answer_nothing(
+        self, leaf: str, value: Any
+    ) -> None:
+        """The readable half is dropped too, in either scope.
+
+        A block written half in one spelling and half in another is a config
+        nobody has finished; keeping the readable leaf would hand a caller a
+        posture assembled out of one line the operator wrote and one they
+        cannot have meant.
+        """
+        block = {**_block(True, False), leaf: value}
+        deployment_wide = type_limits_posture(_section(block), EPICS)
+        assert deployment_wide == LimitsPosture(None, None, None, (leaf,))
+        per_type = type_limits_posture(
+            _section(_block(True, True), connector={EPICS: {LIMITS_CHECKING_LEAF: block}}), EPICS
+        )
+        assert per_type == LimitsPosture(None, None, EPICS, (leaf,))
+
+    def test_an_unexpanded_environment_variable_is_unreadable(self) -> None:
+        """Environment expansion yields strings, so this is the shape it reaches us in.
+
+        A deployment that wired ``enabled`` to a variable nothing set must not
+        end up with limits checking silently off.
+        """
+        section = _section(_block("${OSPREY_LIMITS_ENABLED}", "${OSPREY_ALLOW_UNLISTED}"))
+        posture = type_limits_posture(section, EPICS)
+        assert posture.incomplete == LIMITS_LEAVES
+        assert posture.enabled is None
+
+    # ------------------------------------------------------------------
+    # An incomplete per-type block answers nothing, and says what is missing
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("connector_type", [EPICS, CUSTOM_TYPE])
+    @pytest.mark.parametrize(
+        ("block", "missing"),
+        [
+            (_block(enabled=True), ("allow_unlisted_channels",)),
+            (_block(enabled=False), ("allow_unlisted_channels",)),
+            (_block(allow_unlisted=True), ("enabled",)),
+            (_block(allow_unlisted=False), ("enabled",)),
+            (_block(), ("enabled", "allow_unlisted_channels")),
+        ],
+    )
+    def test_a_block_missing_a_leaf_answers_nothing_and_names_what_is_missing(
+        self, connector_type: str, block: dict[str, Any], missing: tuple[str, ...]
+    ) -> None:
+        """No half-answer and no inheritance: the block is present, so it answers.
+
+        The deployment-wide block below is permissive on both leaves. Borrowing
+        either half would hand a deployment a posture it never wrote, on a
+        block it half-wrote — so the posture states ``None`` twice and carries
+        the missing leaf names for the refusal to quote.
+        """
+        section = _section(
+            _block(True, True),
+            connector={connector_type: {LIMITS_CHECKING_LEAF: block}},
+        )
+        posture = type_limits_posture(section, connector_type)
+        assert posture == LimitsPosture(None, None, connector_type, missing)
+        assert posture.strict is False
+
+    def test_missing_leaves_are_listed_in_leaf_order(self) -> None:
+        """So a refusal reads the same way whichever leaf was dropped."""
+        section = _section(connector={EPICS: {LIMITS_CHECKING_LEAF: {"database_path": "/x.db"}}})
+        assert type_limits_posture(section, EPICS).incomplete == LIMITS_LEAVES
+
+    def test_an_incomplete_block_still_names_its_own_key(self) -> None:
+        """The operator has to be sent to the block they half-wrote."""
+        section = _section(
+            _block(True, False),
+            connector={EPICS: {LIMITS_CHECKING_LEAF: _block(enabled=True)}},
+        )
+        posture = type_limits_posture(section, EPICS)
+        assert posture.key(ALLOW_UNLISTED_LEAF) == (
+            "control_system.connector.epics.limits_checking.allow_unlisted_channels"
+        )
+
+    def test_database_path_alongside_both_leaves_is_a_complete_block(self) -> None:
+        """The path is deployment-wide, so carrying one per type breaks nothing."""
+        block = {**_block(True, False), "database_path": "/limits.db"}
+        section = _section(connector={EPICS: {LIMITS_CHECKING_LEAF: block}})
+        assert type_limits_posture(section, EPICS) == LimitsPosture(True, False, EPICS)
+
+    # ------------------------------------------------------------------
+    # A caller holding no type at all
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("connector_type", [None, ""])
+    def test_a_caller_with_no_type_reads_the_deployment_wide_block(
+        self, connector_type: str | None
+    ) -> None:
+        """No type is not "some type": it is the deployment-wide question.
+
+        The validator built without a type and the fallback a target that
+        resolves to none gets both arrive here, and both must read the block
+        they have always read rather than a per-type block for a machine the
+        caller never named.
+        """
+        section = _section(
+            _block(True, False),
+            connector={EPICS: {LIMITS_CHECKING_LEAF: _block(False, True)}},
+        )
+        posture = type_limits_posture(section, connector_type)
+        assert posture == LimitsPosture(True, False, None)
+        assert posture.key(ENABLED_LEAF) == "control_system.limits_checking.enabled"
+
+    # ------------------------------------------------------------------
+    # Reading a posture changes nothing
+    # ------------------------------------------------------------------
+
+    def test_resolving_does_not_mutate_the_section(self) -> None:
+        """Resolvers read a shared, once-loaded config; none of them may write to it."""
+        section = _section(
+            _block(True, False),
+            connector={EPICS: {LIMITS_CHECKING_LEAF: _block(enabled=True)}},
+        )
+        before = copy.deepcopy(section)
+        for connector_type in (EPICS, MOCK, CUSTOM_TYPE, None):
+            type_limits_posture(section, connector_type)
+        assert section == before
+
+
+def _va_baseline_deployment() -> dict[str, Any]:
+    """A virtual-accelerator deployment that also names its facility's machine.
+
+    Deployment-wide strict, with the virtual accelerator relaxed in a block of
+    its own — the configuration the feature exists for. ``live`` is derived from
+    the single non-simulated connector block, so all three targets resolve.
+    """
+    return {
+        "type": VIRTUAL_ACCELERATOR,
+        LIMITS_CHECKING_LEAF: _block(True, False),
+        "connector": {
+            EPICS: {"gateway_address": "live.example"},
+            VIRTUAL_ACCELERATOR: {
+                "gateway_address": "va.example",
+                LIMITS_CHECKING_LEAF: _block(True, True),
+            },
+        },
+    }
+
+
+def _standin_deployment() -> dict[str, Any]:
+    """An EPICS deployment running the live stand-in beside its own machine.
+
+    ``live_standin`` is a connector type of its own, so its block is where the
+    stand-in's posture is written and it never answers for ``live``.
+    """
+    return {
+        "type": EPICS,
+        LIMITS_CHECKING_LEAF: _block(True, False),
+        "connector": {
+            EPICS: {"gateway_address": "live.example"},
+            VIRTUAL_ACCELERATOR: {"gateway_address": "va.example"},
+            LIVE_STANDIN: {
+                "gateway_address": "standin.example",
+                LIMITS_CHECKING_LEAF: _block(True, True),
+            },
+        },
+    }
+
+
+def _mock_deployment() -> dict[str, Any]:
+    """A mock deployment: no real machine, so ``live`` does not resolve at all."""
+    return {
+        "type": MOCK,
+        LIMITS_CHECKING_LEAF: _block(True, False),
+        "connector": {MOCK: {"channel_count": 12}},
+    }
+
+
+class TestTargetLimitsPosture:
+    """Resolving one session *target*'s posture out of a config section.
+
+    The target half of the family: a roster row, a hook, the executor and the
+    tool layer carry a target rather than a connector type, and they must read
+    the same posture the connector itself runs under. So the target is resolved
+    to its type first and :func:`type_limits_posture` answers from there — one
+    posture per machine, never one per holder.
+
+    A target that does not resolve answers the deployment-wide block, which is
+    the reading :func:`~osprey_connectors.types.target_writes_enabled` already
+    takes: there is no per-type block to consult because there is no type, and
+    a deployment that never had a second target keeps the posture it wrote.
+    """
+
+    # ------------------------------------------------------------------
+    # A VA-baseline deployment with the simulator relaxed
+    # ------------------------------------------------------------------
+
+    def test_va_reads_the_virtual_accelerator_block(self) -> None:
+        """The relaxation is written under the simulator, so the simulator has it."""
+        posture = target_limits_posture(_va_baseline_deployment(), TARGET_VA)
+        assert posture == LimitsPosture(True, True, VIRTUAL_ACCELERATOR)
+        assert posture.key(ALLOW_UNLISTED_LEAF) == (
+            "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+        )
+        assert posture.strict is False
+
+    def test_live_keeps_the_deployment_wide_posture(self) -> None:
+        """``live`` resolves to ``epics`` here, which wrote no block of its own.
+
+        The simulator's relaxation must not reach the facility's machine, and
+        the refusal an operator sees on ``live`` has to name the deployment-wide
+        line, because that is the line that answered.
+        """
+        posture = target_limits_posture(_va_baseline_deployment(), TARGET_LIVE)
+        assert posture == LimitsPosture(True, False, None)
+        assert posture.key(ALLOW_UNLISTED_LEAF) == (
+            "control_system.limits_checking.allow_unlisted_channels"
+        )
+        assert posture.strict is True
+
+    def test_standin_with_no_block_of_its_own_keeps_the_deployment_wide_posture(self) -> None:
+        """A stand-in nobody wrote a block for is not relaxed by the simulator's."""
+        posture = target_limits_posture(_va_baseline_deployment(), TARGET_STANDIN)
+        assert posture == LimitsPosture(True, False, None)
+        assert posture.key(ENABLED_LEAF) == "control_system.limits_checking.enabled"
+
+    # ------------------------------------------------------------------
+    # A deployment running the live stand-in
+    # ------------------------------------------------------------------
+
+    def test_standin_reads_its_own_connector_block(self) -> None:
+        """``live_standin`` is a type of its own, so it has a posture of its own."""
+        posture = target_limits_posture(_standin_deployment(), TARGET_STANDIN)
+        assert posture == LimitsPosture(True, True, LIVE_STANDIN)
+        assert posture.key(ENABLED_LEAF) == (
+            "control_system.connector.live_standin.limits_checking.enabled"
+        )
+
+    @pytest.mark.parametrize("target", [TARGET_LIVE, TARGET_VA])
+    def test_the_standin_block_answers_for_no_other_target(self, target: str) -> None:
+        """Standing up the stand-in relaxes the stand-in and nothing else."""
+        posture = target_limits_posture(_standin_deployment(), target)
+        assert posture == LimitsPosture(True, False, None)
+        assert posture.strict is True
+
+    def test_an_unknown_target_answers_the_deployment_wide_block(self) -> None:
+        """No type means no per-type block, so the deployment-wide one answers."""
+        posture = target_limits_posture(_standin_deployment(), "labatory")
+        assert posture == LimitsPosture(True, False, None)
+        assert posture.key(ENABLED_LEAF) == "control_system.limits_checking.enabled"
+
+    @pytest.mark.parametrize("target", [None, "", "LIVE", 5, ["live"]])
+    def test_a_target_that_is_not_a_target_never_raises(self, target: Any) -> None:
+        """A holder reading a posture must not be the thing that crashes on a typo."""
+        assert target_limits_posture(_standin_deployment(), target) == LimitsPosture(
+            True, False, None
+        )
+
+    # ------------------------------------------------------------------
+    # A mock deployment, where ``live`` names no machine at all
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("target", [TARGET_LIVE, TARGET_VA, TARGET_STANDIN])
+    def test_a_mock_deployment_answers_the_deployment_wide_block_everywhere(
+        self, target: str
+    ) -> None:
+        """``live`` does not resolve here and the other two wrote no block.
+
+        Parity with :func:`~osprey_connectors.types.target_writes_enabled`:
+        refusing here would take the posture away from every deployment that
+        never had a second target, rather than protecting anything.
+        """
+        posture = target_limits_posture(_mock_deployment(), target)
+        assert posture == LimitsPosture(True, False, None)
+        assert posture.key(ENABLED_LEAF) == "control_system.limits_checking.enabled"
+
+    def test_a_mock_deployment_with_no_block_at_all_states_nothing(self) -> None:
+        """Silence resolves to silence, on a target that resolves and one that does not."""
+        section = _section(connector={MOCK: {"channel_count": 12}})
+        assert target_limits_posture(section, TARGET_LIVE) == LimitsPosture(None, None, None)
+        assert target_limits_posture(section, TARGET_VA) == LimitsPosture(None, None, None)
+
+    def test_a_mock_deployment_reads_a_stray_block_only_where_the_target_resolves(self) -> None:
+        """A single stray ``epics`` block is what ``live`` derives from here.
+
+        Deliberately the same derivation
+        :func:`~osprey_connectors.types.resolve_target` performs for write
+        posture, so a holder that carries a target reads one machine's posture
+        and not two. The reachable-set resolver is where such a deployment's
+        stray block is ruled out, because there no session can select it.
+        """
+        section = {
+            "type": MOCK,
+            LIMITS_CHECKING_LEAF: _block(True, False),
+            "connector": {
+                MOCK: {"channel_count": 12},
+                EPICS: {LIMITS_CHECKING_LEAF: _block(True, True)},
+            },
+        }
+        assert target_limits_posture(section, TARGET_LIVE) == LimitsPosture(True, True, EPICS)
+        assert target_limits_posture(section, TARGET_VA) == LimitsPosture(True, False, None)
+
+    # ------------------------------------------------------------------
+    # Incomplete blocks and malformed sections
+    # ------------------------------------------------------------------
+
+    def test_a_target_whose_block_is_incomplete_answers_nothing(self) -> None:
+        """The whole-block rule reaches the target half unchanged."""
+        section = _va_baseline_deployment()
+        section["connector"][VIRTUAL_ACCELERATOR][LIMITS_CHECKING_LEAF] = _block(enabled=True)
+        posture = target_limits_posture(section, TARGET_VA)
+        assert posture == LimitsPosture(None, None, VIRTUAL_ACCELERATOR, (ALLOW_UNLISTED_LEAF,))
+        assert posture.strict is False
+
+    @pytest.mark.parametrize("section", [None, "control_system", ["control_system"], {}])
+    def test_a_section_that_states_nothing_answers_nothing(self, section: Any) -> None:
+        """Never raises, whichever target is asked about."""
+        for target in CONTROL_TARGETS:
+            assert target_limits_posture(section, target) == LimitsPosture(None, None, None)
+
+    def test_resolving_a_target_does_not_mutate_the_section(self) -> None:
+        """Resolvers read a shared, once-loaded config; none of them may write to it."""
+        section = _standin_deployment()
+        before = copy.deepcopy(section)
+        for target in [*CONTROL_TARGETS, "labatory", None]:
+            target_limits_posture(section, target)
+        assert section == before
+
+
+class TestMostRestrictive:
+    """The posture that holds across every target a session here can select.
+
+    What a caller with no target of its own has to assume: the stdlib hook when
+    the session's target cannot be read, and any reader that must answer before
+    a target is chosen. The reachable set is exactly the one
+    :func:`~osprey_connectors.types.session_posture` walks — the configured
+    targets when the deployment renders the switch, and otherwise the single
+    connector ``control_system.type`` builds, read by *type*. A speculative loop
+    over every target in the vocabulary would let the unresolvable-target
+    fallback answer for machines no session here reaches.
+
+    The answer is derived rather than read, so both leaves are definite: a
+    ``None`` among the inputs counts as not-``True`` on both, and the key stays
+    the deployment-wide one because no single per-type line answers for a union.
+    """
+
+    # ------------------------------------------------------------------
+    # The feature's own configuration
+    # ------------------------------------------------------------------
+
+    def test_one_strict_target_makes_the_answer_strict(self) -> None:
+        """A relaxed simulator does not relax what a targetless caller may assume.
+
+        ``live`` is strict here and ``va`` is not, so the union refuses unlisted
+        channels: the caller that does not know which machine it is about to
+        touch must not be handed the permissive half.
+        """
+        posture = most_restrictive_limits_posture(_va_baseline_deployment())
+        assert posture == LimitsPosture(True, False, None)
+        assert posture.strict is True
+
+    def test_all_permissive_targets_answer_permissive(self) -> None:
+        """The union is not a fail-closed constant: it reports what was written."""
+        section = _va_baseline_deployment()
+        section[LIMITS_CHECKING_LEAF] = _block(True, True)
+        posture = most_restrictive_limits_posture(section)
+        assert posture == LimitsPosture(True, True, None)
+        assert posture.strict is False
+
+    def test_the_answer_names_the_deployment_wide_keys(self) -> None:
+        """No per-type line answers for a union, so none is named.
+
+        Sending an operator to one target's block for a posture that came from
+        every target would have them edit a line that changes one machine and
+        not the answer.
+        """
+        posture = most_restrictive_limits_posture(_va_baseline_deployment())
+        assert posture.connector_type is None
+        assert posture.key(ENABLED_LEAF) == "control_system.limits_checking.enabled"
+        assert posture.key(ALLOW_UNLISTED_LEAF) == (
+            "control_system.limits_checking.allow_unlisted_channels"
+        )
+
+    def test_a_configured_standin_is_part_of_the_reachable_set(self) -> None:
+        """Every configured target counts, not just the two the switch is named for."""
+        section = _standin_deployment()
+        section[LIMITS_CHECKING_LEAF] = _block(True, True)
+        assert most_restrictive_limits_posture(section) == LimitsPosture(True, True, None)
+        section["connector"][LIVE_STANDIN][LIMITS_CHECKING_LEAF] = _block(True, False)
+        assert most_restrictive_limits_posture(section) == LimitsPosture(True, False, None)
+
+    # ------------------------------------------------------------------
+    # A deployment with no per-type block at all
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("deployment_wide", [_block(True, False), _block(True, True)])
+    def test_no_per_type_block_answers_the_deployment_wide_posture(
+        self, deployment_wide: dict[str, Any]
+    ) -> None:
+        """The compatibility story: every target reads one block, so the union is it."""
+        section = _va_baseline_deployment()
+        section[LIMITS_CHECKING_LEAF] = deployment_wide
+        del section["connector"][VIRTUAL_ACCELERATOR][LIMITS_CHECKING_LEAF]
+        expected = type_limits_posture(section, EPICS)
+        assert most_restrictive_limits_posture(section) == expected
+
+    # ------------------------------------------------------------------
+    # ``enabled`` is a union, ``allow_unlisted`` an intersection
+    # ------------------------------------------------------------------
+
+    def test_enabled_is_true_when_any_target_checks_limits(self) -> None:
+        """Checking is on for the caller as soon as one reachable machine checks.
+
+        The two leaves fold in opposite directions on purpose: limits checking
+        being on somewhere is a constraint that may apply, while permission to
+        write unlisted channels only holds where every machine grants it.
+        """
+        section = _va_baseline_deployment()
+        section[LIMITS_CHECKING_LEAF] = _block(False, True)
+        section["connector"][VIRTUAL_ACCELERATOR][LIMITS_CHECKING_LEAF] = _block(True, True)
+        assert most_restrictive_limits_posture(section) == LimitsPosture(True, True, None)
+
+    def test_enabled_is_false_when_no_target_checks_limits(self) -> None:
+        """A deployment nobody checks limits on is reported as such."""
+        section = _va_baseline_deployment()
+        section[LIMITS_CHECKING_LEAF] = _block(False, True)
+        section["connector"][VIRTUAL_ACCELERATOR][LIMITS_CHECKING_LEAF] = _block(False, True)
+        assert most_restrictive_limits_posture(section) == LimitsPosture(False, True, None)
+
+    @pytest.mark.parametrize(
+        "va_block", [_block(True, ...), _block(True, None), _block(True, "yes")]
+    )
+    def test_a_target_that_states_nothing_counts_as_not_permitted(
+        self, va_block: dict[str, Any]
+    ) -> None:
+        """``None`` is not ``True``, whether it came from silence or from garbage.
+
+        An incomplete block, a leaf YAML read as ``None`` and a quoted string
+        all leave one reachable target with no stated permission, and a union
+        that granted permission anyway would be inventing it.
+        """
+        section = _va_baseline_deployment()
+        section[LIMITS_CHECKING_LEAF] = _block(True, True)
+        section["connector"][VIRTUAL_ACCELERATOR][LIMITS_CHECKING_LEAF] = va_block
+        posture = most_restrictive_limits_posture(section)
+        assert posture == LimitsPosture(True, False, None, (ALLOW_UNLISTED_LEAF,))
+        assert posture.strict is True
+
+    def test_a_deployment_that_stated_nothing_permits_nothing(self) -> None:
+        """Both leaves fold to a definite ``False``: silence grants no permission."""
+        assert most_restrictive_limits_posture(_section()) == LimitsPosture(False, False, None)
+
+    @pytest.mark.parametrize("value", UNREADABLE_LEAVES)
+    def test_a_deployment_whose_only_posture_is_unreadable_permits_nothing(
+        self, value: Any
+    ) -> None:
+        """An incomplete posture counts as not-``True`` on both leaves.
+
+        The union must not report checking as *on* because a line meant to
+        switch it on could not be read — the caller would be told a guarantee
+        holds that the runtime is about to refuse every write over.
+        """
+        section = {
+            "type": VIRTUAL_ACCELERATOR,
+            LIMITS_CHECKING_LEAF: _block(value, value),
+            "connector": {VIRTUAL_ACCELERATOR: {"gateway_address": "va.example"}},
+        }
+        assert most_restrictive_limits_posture(section) == LimitsPosture(
+            False, False, None, LIMITS_LEAVES
+        )
+
+    def test_one_unreadable_target_makes_the_union_strict(self) -> None:
+        """A reachable machine nobody can read a posture for grants no permission."""
+        section = _va_baseline_deployment()
+        section[LIMITS_CHECKING_LEAF] = _block(True, True)
+        section["connector"][VIRTUAL_ACCELERATOR][LIMITS_CHECKING_LEAF] = _block(True, "${X}")
+        posture = most_restrictive_limits_posture(section)
+        assert posture == LimitsPosture(True, False, None, (ALLOW_UNLISTED_LEAF,))
+        assert posture.strict is True
+
+    # ------------------------------------------------------------------
+    # Deployments that do not render the switch
+    # ------------------------------------------------------------------
+
+    def test_a_mock_deployment_ignores_a_stray_live_block(self) -> None:
+        """No switch here, so the built connector's own posture is the whole answer.
+
+        ``live`` derives to ``epics`` on this section, but no session on a mock
+        deployment ever reaches it — reading its relaxation would publish a
+        posture the runtime does not share. The baseline is read by *type*, so
+        the stray block is not consulted at all.
+        """
+        section = {
+            "type": MOCK,
+            LIMITS_CHECKING_LEAF: _block(True, False),
+            "connector": {
+                MOCK: {"channel_count": 12},
+                EPICS: {LIMITS_CHECKING_LEAF: _block(True, True)},
+            },
+        }
+        posture = most_restrictive_limits_posture(section)
+        assert posture == LimitsPosture(True, False, None)
+        assert posture.strict is True
+
+    def test_a_mock_deployment_reads_its_own_per_type_block(self) -> None:
+        """The baseline type's block still answers where the deployment wrote one."""
+        section = {
+            "type": MOCK,
+            LIMITS_CHECKING_LEAF: _block(True, False),
+            "connector": {MOCK: {LIMITS_CHECKING_LEAF: _block(True, True)}},
+        }
+        assert most_restrictive_limits_posture(section) == LimitsPosture(True, True, None)
+
+    def test_a_va_only_deployment_reads_its_own_block(self) -> None:
+        """One configured target and no switch: that target's posture is the answer."""
+        section = {
+            "type": VIRTUAL_ACCELERATOR,
+            LIMITS_CHECKING_LEAF: _block(True, False),
+            "connector": {VIRTUAL_ACCELERATOR: {LIMITS_CHECKING_LEAF: _block(True, True)}},
+        }
+        assert most_restrictive_limits_posture(section) == LimitsPosture(True, True, None)
+
+    # ------------------------------------------------------------------
+    # Malformed sections
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("section", [None, "control_system", ["control_system"], {}, 5])
+    def test_a_section_that_states_nothing_never_raises(self, section: Any) -> None:
+        """A caller with no target is often the one with no good config either."""
+        assert most_restrictive_limits_posture(section) == LimitsPosture(False, False, None)
+
+    # ------------------------------------------------------------------
+    # Incompleteness travels through the fold
+    # ------------------------------------------------------------------
+
+    def test_an_incomplete_reachable_posture_makes_the_fold_incomplete(self) -> None:
+        """Dropping this is the worst failure available in this function.
+
+        Both leaf folds send an incomplete posture's ``None`` to ``False``,
+        which reads as "checking off, and nothing permitted" — and a validator
+        built from a posture whose ``enabled`` is not ``True`` is no validator
+        at all. So a fold that forgot the incompleteness would hand *no*
+        enforcement to the one caller that does not know which machine it is
+        about to touch, on a deployment whose only limits line cannot be read.
+        """
+        section = {"type": EPICS, LIMITS_CHECKING_LEAF: _block("true", False)}
+        assert type_limits_posture(section, EPICS).incomplete == (ENABLED_LEAF,)
+        assert most_restrictive_limits_posture(section).incomplete == (ENABLED_LEAF,)
+
+    def test_the_fold_unions_incomplete_leaves_in_leaf_order(self) -> None:
+        """Different reachable machines may fail to state different leaves."""
+        section = _va_baseline_deployment()
+        section[LIMITS_CHECKING_LEAF] = _block("true", True)
+        section["connector"][VIRTUAL_ACCELERATOR][LIMITS_CHECKING_LEAF] = _block(enabled=True)
+        assert most_restrictive_limits_posture(section).incomplete == LIMITS_LEAVES
+
+    def test_a_deployment_whose_blocks_are_all_well_formed_folds_complete(self) -> None:
+        """The fold does not invent incompleteness either."""
+        assert most_restrictive_limits_posture(_va_baseline_deployment()).incomplete == ()
+
+    def test_resolving_the_union_does_not_mutate_the_section(self) -> None:
+        """Resolvers read a shared, once-loaded config; none of them may write to it."""
+        section = _standin_deployment()
+        before = copy.deepcopy(section)
+        most_restrictive_limits_posture(section)
+        assert section == before
+
+
+def _missing(connector_type: str, leaf: str) -> str:
+    """The line the build refusal is expected to carry for one missing leaf."""
+    return (
+        f"control_system.connector.{connector_type}.limits_checking.{leaf} is missing; "
+        "a per-type limits block must state both enabled and allow_unlisted_channels"
+    )
+
+
+def _not_a_block(connector_type: str | None, value: Any) -> str:
+    """The line the build refusal is expected to carry for a non-mapping block."""
+    key = LimitsPosture(None, None, connector_type).key(ENABLED_LEAF).rsplit(".", 1)[0]
+    return (
+        f"{key} is {value!r}, not a block; a limits block is a mapping stating "
+        "enabled and allow_unlisted_channels"
+    )
+
+
+def _unreadable(connector_type: str | None, leaf: str, value: Any) -> str:
+    """The line the build refusal is expected to carry for one unreadable leaf.
+
+    Spelled from :meth:`~osprey_connectors.types.LimitsPosture.key` so the test
+    pins the sentence rather than restating how a key is built.
+    """
+    key = LimitsPosture(None, None, connector_type).key(leaf)
+    return (
+        f"{key} is {value!r}, not a literal true or false; a limits leaf that "
+        "cannot be read states no posture and blocks every write as a failsafe"
+    )
+
+
+class TestIncompleteBlocks:
+    """The half-written per-type blocks a render carries, named for a refusal.
+
+    The build and ``osprey validate`` refuse a profile that writes one leaf of a
+    ``limits_checking`` block, because half a block is a posture nobody stated:
+    :func:`~osprey_connectors.types.type_limits_posture` answers ``None`` twice
+    for it and a write path falls back to a failsafe. This resolver is the
+    render-side half of that refusal — it reads the config the build actually
+    produced, so a spelling the profile layer could not classify still gets
+    caught before it ships.
+
+    It is a lint and not a posture: it answers about a *section*, never raises,
+    and says nothing at all about a deployment whose blocks are well-formed.
+    """
+
+    # ------------------------------------------------------------------
+    # Nothing to report
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "section",
+        [
+            _va_baseline_deployment(),
+            _standin_deployment(),
+            _mock_deployment(),
+            _section(_block(True, False)),
+            _section(_block(True, False), connector={EPICS: {"gateway_address": "x"}}),
+            _section(connector={EPICS: {LIMITS_CHECKING_LEAF: _block(True, False)}}),
+        ],
+    )
+    def test_well_formed_and_absent_blocks_report_nothing(self, section: Any) -> None:
+        """A complete block and no block at all are both legal configs."""
+        assert incomplete_limits_blocks(section) == []
+
+    def test_a_block_carrying_both_leaves_and_a_path_is_complete(self) -> None:
+        """``database_path`` is deployment-wide, so carrying one per type is legal."""
+        block = {**_block(True, False), "database_path": "/limits.db"}
+        section = _section(connector={EPICS: {LIMITS_CHECKING_LEAF: block}})
+        assert incomplete_limits_blocks(section) == []
+
+    @pytest.mark.parametrize("value", UNREADABLE_LEAVES)
+    def test_an_unreadable_per_type_leaf_is_reported(self, value: Any) -> None:
+        """The same reading the resolver takes, so the two cannot disagree.
+
+        Such a block blocks every write at runtime, which is the safe direction
+        but a poor way to find out. Refusing the build is where the config is
+        still cheap to fix.
+        """
+        section = _section(connector={EPICS: {LIMITS_CHECKING_LEAF: _block(value, value)}})
+        assert incomplete_limits_blocks(section) == [
+            _unreadable(EPICS, ENABLED_LEAF, value),
+            _unreadable(EPICS, ALLOW_UNLISTED_LEAF, value),
+        ]
+
+    @pytest.mark.parametrize("value", UNREADABLE_LEAVES)
+    def test_an_unreadable_deployment_wide_leaf_is_reported(self, value: Any) -> None:
+        """The hazard is the leaf, not the block it sits in.
+
+        A deployment-wide ``enabled`` nobody can read is exactly the shape an
+        unexpanded ``${VAR}`` arrives in, and the deployment-wide block is where
+        most deployments write their only limits posture.
+        """
+        assert incomplete_limits_blocks(_section(_block(enabled=value))) == [
+            _unreadable(None, ENABLED_LEAF, value)
+        ]
+
+    def test_an_unreadable_leaf_line_says_what_it_found_and_what_it_costs(self) -> None:
+        """The refusal quotes the value, so an operator sees why it did not read."""
+        section = _section(_block(enabled="${OSPREY_LIMITS_ENABLED}"))
+        assert incomplete_limits_blocks(section) == [
+            "control_system.limits_checking.enabled is '${OSPREY_LIMITS_ENABLED}', "
+            "not a literal true or false; a limits leaf that cannot be read states "
+            "no posture and blocks every write as a failsafe"
+        ]
+
+    @pytest.mark.parametrize("value", [None, "true", ["enabled"], 5])
+    def test_a_per_type_block_that_is_not_a_mapping_is_reported_once(self, value: Any) -> None:
+        """One line naming the block, because there are no leaves to name."""
+        section = _section(connector={EPICS: {LIMITS_CHECKING_LEAF: value}})
+        assert incomplete_limits_blocks(section) == [_not_a_block(EPICS, value)]
+
+    @pytest.mark.parametrize("value", [None, "true", ["enabled"], 5])
+    def test_a_deployment_wide_block_that_is_not_a_mapping_is_reported_once(
+        self, value: Any
+    ) -> None:
+        """The block is written and unreadable in either scope alike."""
+        assert incomplete_limits_blocks(_section(value)) == [_not_a_block(None, value)]
+
+    def test_a_bare_limits_checking_line_is_reported_rather_than_ignored(self) -> None:
+        """The shape a half-typed block actually has in YAML."""
+        assert incomplete_limits_blocks(_section(None)) == [
+            "control_system.limits_checking is None, not a block; a limits block "
+            "is a mapping stating enabled and allow_unlisted_channels"
+        ]
+
+    def test_a_leaf_the_deployment_wide_block_never_carried_is_not_reported(self) -> None:
+        """Only a per-type block has to state both leaves to answer at all.
+
+        Deployment-wide silence on a leaf is the shape every deployment
+        predating per-type blocks has; refusing it would refuse the fleet.
+        """
+        assert incomplete_limits_blocks(_section(_block(enabled=True))) == []
+        assert incomplete_limits_blocks(_section(_block())) == []
+
+    def test_the_deployment_wide_block_is_reported_before_the_connector_blocks(self) -> None:
+        """One refusal, read top-down the way the config is written."""
+        section = _section(
+            _block(enabled="true"),
+            connector={EPICS: {LIMITS_CHECKING_LEAF: _block(enabled=True)}},
+        )
+        assert incomplete_limits_blocks(section) == [
+            _unreadable(None, ENABLED_LEAF, "true"),
+            _missing(EPICS, ALLOW_UNLISTED_LEAF),
+        ]
+
+    # ------------------------------------------------------------------
+    # One line per missing leaf
+    # ------------------------------------------------------------------
+
+    def test_a_block_missing_allow_unlisted_names_that_key(self) -> None:
+        """The refusal quotes the key an operator has to add, verbatim."""
+        section = _section(
+            connector={VIRTUAL_ACCELERATOR: {LIMITS_CHECKING_LEAF: _block(enabled=True)}}
+        )
+        assert incomplete_limits_blocks(section) == [
+            "control_system.connector.virtual_accelerator.limits_checking."
+            "allow_unlisted_channels is missing; a per-type limits block must state "
+            "both enabled and allow_unlisted_channels"
+        ]
+
+    def test_a_block_missing_enabled_names_that_key(self) -> None:
+        """Either leaf alone is half a block, so either one is refused."""
+        section = _section(connector={EPICS: {LIMITS_CHECKING_LEAF: _block(allow_unlisted=False)}})
+        assert incomplete_limits_blocks(section) == [_missing(EPICS, ENABLED_LEAF)]
+
+    def test_a_block_missing_both_leaves_names_both_in_leaf_order(self) -> None:
+        """One line per leaf, so an operator can add them without re-running the build."""
+        section = _section(
+            connector={EPICS: {LIMITS_CHECKING_LEAF: {"database_path": "/limits.db"}}}
+        )
+        assert incomplete_limits_blocks(section) == [
+            _missing(EPICS, ENABLED_LEAF),
+            _missing(EPICS, ALLOW_UNLISTED_LEAF),
+        ]
+
+    def test_an_empty_block_is_incomplete_rather_than_absent(self) -> None:
+        """A written ``limits_checking:`` with nothing under it is a half-written block."""
+        section = _section(_block(True, False), connector={EPICS: {LIMITS_CHECKING_LEAF: _block()}})
+        assert incomplete_limits_blocks(section) == [
+            _missing(EPICS, ENABLED_LEAF),
+            _missing(EPICS, ALLOW_UNLISTED_LEAF),
+        ]
+
+    def test_every_connector_type_is_walked(self) -> None:
+        """One build refusal lists every half-written block the render carries."""
+        section = _section(
+            connector={
+                EPICS: {LIMITS_CHECKING_LEAF: _block(True, False)},
+                VIRTUAL_ACCELERATOR: {LIMITS_CHECKING_LEAF: _block(enabled=True)},
+                LIVE_STANDIN: {LIMITS_CHECKING_LEAF: _block(allow_unlisted=True)},
+            }
+        )
+        assert incomplete_limits_blocks(section) == [
+            _missing(VIRTUAL_ACCELERATOR, ALLOW_UNLISTED_LEAF),
+            _missing(LIVE_STANDIN, ENABLED_LEAF),
+        ]
+
+    def test_a_dotted_custom_type_is_named_whole(self) -> None:
+        """The connector table's key is the type, dots and all, never a path."""
+        section = _section(connector={CUSTOM_TYPE: {LIMITS_CHECKING_LEAF: _block(enabled=True)}})
+        assert incomplete_limits_blocks(section) == [
+            "control_system.connector.mypackage.TangoConnector.limits_checking."
+            "allow_unlisted_channels is missing; a per-type limits block must state "
+            "both enabled and allow_unlisted_channels"
+        ]
+
+    def test_the_reported_key_is_the_one_the_resolver_reads(self) -> None:
+        """Refusal and runtime name one line, because both spell it from the posture."""
+        section = _section(connector={EPICS: {LIMITS_CHECKING_LEAF: _block(enabled=True)}})
+        posture = type_limits_posture(section, EPICS)
+        assert posture.incomplete == (ALLOW_UNLISTED_LEAF,)
+        assert incomplete_limits_blocks(section)[0].startswith(
+            posture.key(ALLOW_UNLISTED_LEAF) + " is missing;"
+        )
+
+    # ------------------------------------------------------------------
+    # Malformed sections: a lint never raises
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "connector",
+        [
+            {EPICS: "epics"},
+            {EPICS: None},
+            {EPICS: ["limits_checking"]},
+            "epics",
+            ["epics"],
+            None,
+            {},
+        ],
+    )
+    def test_anything_that_is_not_a_block_is_not_an_incomplete_block(self, connector: Any) -> None:
+        """A block has to be a mapping to be half-written.
+
+        Reporting a string as a missing leaf would send an operator to add a
+        leaf under a line that is not a block at all; the deployment simply has
+        no per-type posture there, which the resolver already reads as absent.
+        """
+        assert incomplete_limits_blocks(_section(_block(True, False), connector=connector)) == []
+
+    @pytest.mark.parametrize("section", [None, "control_system", ["control_system"], 5, {}])
+    def test_a_section_that_is_not_a_section_reports_nothing(self, section: Any) -> None:
+        """Pure over the rendered section, and never the thing that fails a build."""
+        assert incomplete_limits_blocks(section) == []
+
+    def test_linting_does_not_mutate_the_section(self) -> None:
+        """Resolvers read a shared, once-loaded config; none of them may write to it."""
+        section = _section(
+            _block(True, False),
+            connector={
+                EPICS: {LIMITS_CHECKING_LEAF: _block(enabled=True)},
+                VIRTUAL_ACCELERATOR: {"gateway_address": "va.example"},
+            },
+        )
+        before = copy.deepcopy(section)
+        incomplete_limits_blocks(section)
+        assert section == before

--- a/tests/connectors/test_limits_validator.py
+++ b/tests/connectors/test_limits_validator.py
@@ -22,6 +22,7 @@ from osprey.connectors.control_system.limits_validator import (
     LimitsValidator,
 )
 from osprey.errors import ChannelLimitsViolationError
+from osprey_connectors.types import EPICS, VIRTUAL_ACCELERATOR, LimitsPosture
 
 
 def _make_validator(tmp_path, db: dict, policy: dict | None = None) -> LimitsValidator:
@@ -188,6 +189,43 @@ class TestResolveDatabasePath:
 # ---------------------------------------------------------------------------
 
 
+def _nested_control_system(values: dict) -> dict:
+    """The nested ``control_system:`` mapping the dotted keys in *values* spell.
+
+    The real config singleton answers both spellings of one line: a dotted
+    ``get_config_value("control_system.limits_checking.enabled")`` and the
+    nested section ``get_config_value("control_system")`` read the same YAML.
+    ``from_config`` now asks for the section — the posture resolvers walk it —
+    while the database path is still read dotted, so a shim that only answered
+    the dotted keys would hand the resolvers an empty deployment. Deriving the
+    section from the same map keeps the two spellings describing one config
+    instead of two, which is what the tests below are written against.
+
+    Nesting on every dot is only correct because these keys name built-in
+    leaves. A ``control_system.connector.*`` key would be nested on the dots of
+    the connector type too — ``mypackage.TangoConnector`` becoming two levels —
+    which is exactly the mistake the resolvers refuse to make, so a test that
+    needs a per-type block passes ``control_system`` itself rather than adding
+    one here.
+    """
+    section: dict = {}
+    for key, value in values.items():
+        if not key.startswith("control_system."):
+            continue
+        if key.startswith("control_system.connector."):
+            pytest.fail(
+                f"{key!r} cannot be spelled dotted in this shim: a connector type may "
+                "itself contain dots, and nesting on every dot would build a section no "
+                "config ever has. Pass an explicit 'control_system' entry instead."
+            )
+        node = section
+        parts = key.split(".")[1:]
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        node[parts[-1]] = value
+    return section
+
+
 def _patch_config(
     monkeypatch,
     values: dict,
@@ -196,15 +234,27 @@ def _patch_config(
 ):
     """Patch get_config_value with a key->value map (default fallback otherwise).
 
+    Dotted ``control_system.*`` entries also answer the nested
+    ``control_system`` section, so one map describes one deployment. A test that
+    needs a section the dotted spelling cannot reach — a per-type connector
+    block, or a section that is present but empty — passes ``control_system``
+    itself as an entry, and that value is returned verbatim.
+
     ``config_path`` stands in for ``default_config_path()`` — the path of the
     config the singleton actually loaded. ``None`` (the default) models a
     process whose config came from somewhere the singleton can't name, which
     keeps the env-var/project_root fallback branches testable in isolation.
     """
+    if "control_system" in values:
+        section = values["control_system"]
+    else:
+        section = _nested_control_system(values) or None
 
     def fake_get_config_value(key, default=None):
         if raise_exc is not None:
             raise raise_exc
+        if key == "control_system" and section is not None:
+            return section
         return values.get(key, default)
 
     monkeypatch.setattr("osprey.utils.config.get_config_value", fake_get_config_value)
@@ -214,6 +264,51 @@ def _patch_config(
 class TestFromConfig:
     def test_returns_none_when_disabled(self, monkeypatch):
         _patch_config(monkeypatch, {"control_system.limits_checking.enabled": False})
+
+        assert LimitsValidator.from_config() is None
+
+    @pytest.mark.parametrize("value", ["true", 1, "${OSPREY_LIMITS_ENABLED}"])
+    def test_unreadable_enabled_blocks_rather_than_switching_checking_off(
+        self, monkeypatch, tmp_path, value
+    ):
+        """A deployment-wide ``enabled`` nobody can read blocks every write.
+
+        The dangerous reading is the quiet one. ``enabled`` unset means "this
+        deployment configured no limits checking", so a leaf written as
+        ``'true'``, as ``1``, or as an environment variable nothing expanded —
+        expansion always yields strings — would otherwise return no validator
+        at all, and every write would go unchecked on a deployment whose config
+        says, in the only spelling its author knew, that checking is on.
+        """
+        db_file = tmp_path / "limits.json"
+        db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system.limits_checking.enabled": value,
+                "control_system.limits_checking.database_path": str(db_file),
+            },
+        )
+
+        validator = LimitsValidator.from_config()
+
+        assert isinstance(validator, LimitsValidator)
+        assert validator.limits == {}
+        assert validator.failsafe_reason == (
+            "control_system.limits_checking does not state enabled as true/false"
+        )
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("FOO", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+
+    def test_a_leaf_the_deployment_wide_block_never_carried_still_disables(self, monkeypatch):
+        """Absent is not unreadable: a deployment that said nothing gets no validator.
+
+        The compatibility half of the same rule — every deployment that never
+        wrote a limits block must keep behaving as it did, or the fail-closed
+        reading above would block the fleet instead of the typo.
+        """
+        _patch_config(monkeypatch, {"control_system.limits_checking.database_path": "/x.json"})
 
         assert LimitsValidator.from_config() is None
 
@@ -369,6 +464,557 @@ class TestFromConfig:
 
         assert "SR:C1:HCM:SP" in validator.limits
         validator.validate("SR:C1:HCM:SP", 0.5)  # listed and in range: allowed
+
+
+DEPLOYMENT_WIDE_ALLOW_KEY = "control_system.limits_checking.allow_unlisted_channels"
+VA_ALLOW_KEY = (
+    "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+)
+
+
+def _limits_db(tmp_path) -> Path:
+    """A one-channel limits database, so a validator loads rather than failsafes."""
+    db_file = tmp_path / "limits.json"
+    db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+    return db_file
+
+
+def _va_permissive_section() -> dict:
+    """Deployment-wide strict, virtual accelerator relaxed in a block of its own.
+
+    The configuration the feature exists for: ``live`` (EPICS here) keeps the
+    deployment-wide refusal of unlisted channels while the simulator relaxes it,
+    and both connector blocks are present so all three call shapes resolve.
+    """
+    return {
+        "type": VIRTUAL_ACCELERATOR,
+        "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
+        "connector": {
+            EPICS: {"gateway_address": "live.example"},
+            VIRTUAL_ACCELERATOR: {
+                "gateway_address": "va.example",
+                "limits_checking": {"enabled": True, "allow_unlisted_channels": True},
+            },
+        },
+    }
+
+
+class TestFromConfigCallShapes:
+    """The three shapes ``from_config`` answers, and the one it refuses.
+
+    No argument is the deployment-wide question every caller asked before per-type
+    blocks existed; ``connector_type=`` is what a connector holding its own type
+    asks; ``target=`` is what a tool, hook or roster following the session's target
+    asks. Passing both states the posture twice, and is a caller bug rather than a
+    posture.
+    """
+
+    def test_no_arg_returns_none_when_the_section_is_absent(self, monkeypatch):
+        """No ``control_system:`` at all is a deployment that stated no posture."""
+        _patch_config(monkeypatch, {"project_root": None})
+
+        assert LimitsValidator.from_config() is None
+
+    def test_no_arg_returns_none_when_the_section_is_empty(self, monkeypatch):
+        """An empty section states no ``enabled``, which is not a ``true``."""
+        _patch_config(monkeypatch, {"control_system": {}})
+
+        assert LimitsValidator.from_config() is None
+
+    def test_no_arg_reads_the_deployment_wide_block(self, monkeypatch, tmp_path):
+        """A deployment with only the deployment-wide block behaves as it always has."""
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": {
+                    "limits_checking": {"enabled": True, "allow_unlisted_channels": True}
+                },
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config()
+
+        assert validator.policy["allow_unlisted_channels"] is True
+        assert validator.policy["allow_unlisted_key"] == DEPLOYMENT_WIDE_ALLOW_KEY
+
+    def test_no_arg_does_not_pick_up_a_per_type_block(self, monkeypatch, tmp_path):
+        """The targetless question is deployment-wide and resolves no target.
+
+        ``registry/manager.py`` and the executor's config helper call
+        ``from_config()`` holding neither a type nor a target; folding the
+        simulator's relaxation into their answer would report a posture no
+        machine of theirs runs under.
+        """
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": _va_permissive_section(),
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config()
+
+        assert validator.policy["allow_unlisted_channels"] is False
+        assert validator.policy["allow_unlisted_key"] == DEPLOYMENT_WIDE_ALLOW_KEY
+
+    def test_connector_type_reads_that_type_s_block(self, monkeypatch, tmp_path):
+        """A connector asks about its own type and gets its own block's answer."""
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": _va_permissive_section(),
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config(connector_type=VIRTUAL_ACCELERATOR)
+
+        assert validator.policy["allow_unlisted_channels"] is True
+        assert validator.policy["allow_unlisted_key"] == VA_ALLOW_KEY
+
+    def test_connector_type_without_a_block_inherits_deployment_wide(self, monkeypatch, tmp_path):
+        """The live machine wrote no block, so the deployment-wide one answers for it."""
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": _va_permissive_section(),
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config(connector_type=EPICS)
+
+        assert validator.policy["allow_unlisted_channels"] is False
+        assert validator.policy["allow_unlisted_key"] == DEPLOYMENT_WIDE_ALLOW_KEY
+
+    def test_target_reads_the_block_of_the_type_it_resolves_to(self, monkeypatch, tmp_path):
+        """``va`` resolves to ``virtual_accelerator``, so the two shapes agree."""
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": _va_permissive_section(),
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config(target="va")
+
+        assert validator.policy["allow_unlisted_channels"] is True
+        assert validator.policy["allow_unlisted_key"] == VA_ALLOW_KEY
+
+    def test_target_live_keeps_the_deployment_wide_refusal(self, monkeypatch, tmp_path):
+        """The relaxation written for the simulator must not reach the machine."""
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": _va_permissive_section(),
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config(target="live")
+
+        assert validator.policy["allow_unlisted_channels"] is False
+        assert validator.policy["allow_unlisted_key"] == DEPLOYMENT_WIDE_ALLOW_KEY
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:LISTED", 1.0)
+        assert exc.value.violation_type == "UNLISTED_CHANNEL"
+
+    def test_both_arguments_is_a_type_error(self, monkeypatch):
+        """A target already names a type; stating both leaves the caller's intent unclear."""
+        _patch_config(monkeypatch, {"control_system": _va_permissive_section()})
+
+        with pytest.raises(TypeError):
+            LimitsValidator.from_config(connector_type=VIRTUAL_ACCELERATOR, target="va")
+
+    def test_both_arguments_raise_even_when_the_config_is_unreadable(self, monkeypatch):
+        """The caller bug is not swallowed by the config-unavailable envelope.
+
+        The executor wraps its load in a blanket ``except``; a ``TypeError`` that
+        the missing-config branch turned into ``None`` would leave that call site
+        silently unchecked instead of failing loudly in its own tests.
+        """
+        _patch_config(monkeypatch, {}, raise_exc=RuntimeError("no config"))
+
+        with pytest.raises(TypeError):
+            LimitsValidator.from_config(connector_type=EPICS, target="live")
+
+    def test_incomplete_per_type_block_yields_the_blocking_failsafe(self, monkeypatch, tmp_path):
+        """A half-written block answers nothing, so the write path blocks.
+
+        The build refuses such a config, but a hand-edited or older render can
+        still carry one and it still has to reach a machine safely.
+        """
+        section = _va_permissive_section()
+        section["connector"][VIRTUAL_ACCELERATOR]["limits_checking"] = {"enabled": True}
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": section,
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config(target="va")
+
+        assert "allow_unlisted_channels" in validator.failsafe_reason
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("FOO", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+
+
+class TestFromConfigMostRestrictive:
+    """The posture a caller with no target of its own has to assume.
+
+    The stdlib hook's fallback: with the session's control target unreadable, the
+    machine the write is about could be any of the reachable ones, so the answer
+    holds across all of them and names the deployment-wide keys — no per-type
+    line decides a union.
+    """
+
+    def test_one_strict_target_makes_the_answer_strict(self, monkeypatch, tmp_path):
+        """The relaxed simulator does not relax what a targetless caller may assume."""
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": _va_permissive_section(),
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config_most_restrictive()
+
+        assert validator.policy == {
+            "allow_unlisted_channels": False,
+            "allow_unlisted_key": DEPLOYMENT_WIDE_ALLOW_KEY,
+        }
+
+    def test_all_permissive_targets_answer_permissive(self, monkeypatch, tmp_path):
+        """Not a fail-closed constant: it reports what every reachable target wrote."""
+        section = _va_permissive_section()
+        section["limits_checking"] = {"enabled": True, "allow_unlisted_channels": True}
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": section,
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config_most_restrictive()
+
+        assert validator.policy["allow_unlisted_channels"] is True
+        assert validator.policy["allow_unlisted_key"] == DEPLOYMENT_WIDE_ALLOW_KEY
+
+    @pytest.mark.parametrize("value", ["true", 1, "${OSPREY_LIMITS_ENABLED}"])
+    def test_an_unreadable_reachable_leaf_yields_the_failsafe_and_not_none(
+        self, monkeypatch, tmp_path, value
+    ):
+        """One reachable machine with an unreadable block blocks the whole fold.
+
+        This is the branch that must not fail open. Both leaf folds send an
+        incomplete posture's `None` to `False`, so a fold that dropped the
+        incompleteness would answer "checking off" -- and no validator at all is
+        built for that, leaving the caller with the least information about
+        which machine it is touching the one waved through.
+        """
+        section = _va_permissive_section()
+        section["limits_checking"] = {"enabled": value, "allow_unlisted_channels": False}
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": section,
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        validator = LimitsValidator.from_config_most_restrictive()
+
+        assert isinstance(validator, LimitsValidator)
+        assert validator.limits == {}
+        assert validator.failsafe_reason == (
+            "control_system.limits_checking does not state enabled as true/false"
+        )
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("ANY:CHANNEL", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+
+    def test_limits_disabled_everywhere_is_no_validator(self, monkeypatch, tmp_path):
+        """No reachable target checks limits, so there is nothing to enforce."""
+        section = _va_permissive_section()
+        section["limits_checking"] = {"enabled": False, "allow_unlisted_channels": False}
+        section["connector"][VIRTUAL_ACCELERATOR]["limits_checking"] = {
+            "enabled": False,
+            "allow_unlisted_channels": True,
+        }
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system": section,
+                "control_system.limits_checking.database_path": str(_limits_db(tmp_path)),
+            },
+        )
+
+        assert LimitsValidator.from_config_most_restrictive() is None
+
+    def test_returns_none_when_config_unavailable(self, monkeypatch):
+        """Same envelope as ``from_config``: no config, no checking."""
+        _patch_config(monkeypatch, {}, raise_exc=RuntimeError("no config"))
+
+        assert LimitsValidator.from_config_most_restrictive() is None
+
+
+# ---------------------------------------------------------------------------
+# _from_posture
+# ---------------------------------------------------------------------------
+
+
+class TestFromPosture:
+    """Building a validator from an already-resolved :class:`LimitsPosture`.
+
+    ``from_config`` reads the deployment-wide block and nothing else.
+    ``_from_posture`` takes the posture a caller resolved for the target or
+    connector type it is acting on, so a deployment that relaxed unlisted
+    channels for its simulator alone gets the simulator's answer on the
+    simulator's write path — and carries the key that answered it, so a refusal
+    names the line an operator can actually edit.
+
+    The database path stays deployment-wide: one file is mounted per
+    deployment, so every posture loads the same database and differs only in
+    policy.
+    """
+
+    def test_returns_none_when_posture_says_disabled(self, monkeypatch):
+        """``enabled: false`` is limits checking off — no validator at all."""
+        _patch_config(monkeypatch, {})
+        posture = LimitsPosture(enabled=False, allow_unlisted=True, connector_type=EPICS)
+
+        assert LimitsValidator._from_posture(posture) is None
+
+    def test_returns_none_when_posture_is_unstated(self, monkeypatch):
+        """An unstated ``enabled`` is not a ``true`` — same answer as ``false``."""
+        _patch_config(monkeypatch, {})
+        posture = LimitsPosture(enabled=None, allow_unlisted=None, connector_type=None)
+
+        assert LimitsValidator._from_posture(posture) is None
+
+    def test_deployment_wide_posture_names_the_deployment_wide_key(self, monkeypatch, tmp_path):
+        """No connector type in the posture -> the deployment-wide key answers."""
+        db_file = tmp_path / "limits.json"
+        db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": str(db_file)},
+        )
+        posture = LimitsPosture(enabled=True, allow_unlisted=False, connector_type=None)
+
+        validator = LimitsValidator._from_posture(posture)
+
+        assert validator.policy == {
+            "allow_unlisted_channels": False,
+            "allow_unlisted_key": "control_system.limits_checking.allow_unlisted_channels",
+        }
+        assert "FOO" in validator.limits
+
+    def test_per_type_posture_names_the_per_type_key(self, monkeypatch, tmp_path):
+        """A per-type block answered, so the per-type key is what a refusal quotes.
+
+        Naming the deployment-wide key here would send an operator to flip a
+        line this block overrides — a change that does nothing.
+        """
+        db_file = tmp_path / "limits.json"
+        db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": str(db_file)},
+        )
+        posture = LimitsPosture(
+            enabled=True, allow_unlisted=True, connector_type=VIRTUAL_ACCELERATOR
+        )
+
+        validator = LimitsValidator._from_posture(posture)
+
+        assert validator.policy["allow_unlisted_channels"] is True
+        assert validator.policy["allow_unlisted_key"] == (
+            "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+        )
+        validator.validate("NOT:LISTED", 1.0)  # permissive posture allows unlisted
+
+    def test_strict_posture_still_refuses_unlisted_channels(self, monkeypatch, tmp_path):
+        """The permissive answer belongs to one type; another type stays strict."""
+        db_file = tmp_path / "limits.json"
+        db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": str(db_file)},
+        )
+        posture = LimitsPosture(enabled=True, allow_unlisted=False, connector_type=EPICS)
+
+        validator = LimitsValidator._from_posture(posture)
+
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:LISTED", 1.0)
+        assert exc.value.violation_type == "UNLISTED_CHANNEL"
+
+    def test_unstated_allow_unlisted_refuses_unlisted_channels(self, monkeypatch, tmp_path):
+        """Tri-state: ``None`` is nobody's permission, so unlisted stays refused.
+
+        The value is carried into the policy verbatim (``channel_limits``
+        reports it as ``null``) rather than collapsed to ``False``, but the
+        write path allows only on an explicit ``True``.
+        """
+        db_file = tmp_path / "limits.json"
+        db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": str(db_file)},
+        )
+        posture = LimitsPosture(enabled=True, allow_unlisted=None, connector_type=None)
+
+        validator = LimitsValidator._from_posture(posture)
+
+        assert validator.policy["allow_unlisted_channels"] is None
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:LISTED", 1.0)
+        assert exc.value.violation_type == "UNLISTED_CHANNEL"
+
+    def test_incomplete_block_yields_failsafe_naming_block_and_leaf(self, monkeypatch, tmp_path):
+        """A half-written per-type block blocks every write and says which line is missing.
+
+        The build refuses such a block, but a hand-edited deployed config, an
+        older render or a fixture can still carry one. The posture then answered
+        nothing, so guessing which half was meant is not available: block
+        everything and name the block plus the missing leaf.
+        """
+        db_file = tmp_path / "limits.json"
+        db_file.write_text(json.dumps({"FOO": {"min_value": 0.0, "max_value": 10.0}}))
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": str(db_file)},
+        )
+        posture = LimitsPosture(
+            enabled=None,
+            allow_unlisted=None,
+            connector_type=VIRTUAL_ACCELERATOR,
+            incomplete=("allow_unlisted_channels",),
+        )
+
+        validator = LimitsValidator._from_posture(posture)
+
+        assert isinstance(validator, LimitsValidator)
+        assert validator.limits == {}
+        assert validator.failsafe_reason == (
+            "control_system.connector.virtual_accelerator.limits_checking "
+            "does not state allow_unlisted_channels as true/false"
+        )
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("FOO", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+
+    def test_incomplete_block_names_every_missing_leaf(self, monkeypatch):
+        """Both leaves missing under a present block: both are named."""
+        _patch_config(monkeypatch, {})
+        posture = LimitsPosture(
+            enabled=None,
+            allow_unlisted=None,
+            connector_type="mypackage.TangoConnector",
+            incomplete=("enabled", "allow_unlisted_channels"),
+        )
+
+        validator = LimitsValidator._from_posture(posture)
+
+        assert validator.failsafe_reason == (
+            "control_system.connector.mypackage.TangoConnector.limits_checking "
+            "does not state enabled, allow_unlisted_channels as true/false"
+        )
+
+    def test_missing_database_path_yields_blocking_failsafe(self, monkeypatch):
+        """Enabled with nowhere to read limits from -> block, don't wave writes through."""
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": None},
+        )
+        posture = LimitsPosture(enabled=True, allow_unlisted=True, connector_type=EPICS)
+
+        validator = LimitsValidator._from_posture(posture)
+
+        assert isinstance(validator, LimitsValidator)
+        assert "database_path" in validator.failsafe_reason
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("ANY:CHANNEL", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+
+    def test_unreadable_database_yields_blocking_failsafe(self, monkeypatch, tmp_path):
+        """An unparseable database blocks even a permissive posture."""
+        db_file = tmp_path / "limits.json"
+        db_file.write_text("{not valid json")
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": str(db_file)},
+        )
+        posture = LimitsPosture(
+            enabled=True, allow_unlisted=True, connector_type=VIRTUAL_ACCELERATOR
+        )
+
+        validator = LimitsValidator._from_posture(posture)
+
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("ANY:CHANNEL", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+
+    def test_database_path_is_read_deployment_wide(self, monkeypatch, tmp_path):
+        """A per-type posture reads the one deployment-wide database path.
+
+        There is no per-type ``database_path``: the deployment mounts a single
+        limits file, so the per-type block changes policy only.
+        """
+        (tmp_path / "limits.json").write_text(json.dumps({"BAR": {"max_value": 5.0}}))
+        monkeypatch.delenv("CONFIG_FILE", raising=False)
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system.limits_checking.database_path": "limits.json",
+                "project_root": str(tmp_path),
+            },
+        )
+        posture = LimitsPosture(
+            enabled=True, allow_unlisted=False, connector_type=VIRTUAL_ACCELERATOR
+        )
+
+        validator = LimitsValidator._from_posture(posture)
+
+        assert "BAR" in validator.limits
+
+    def test_policy_is_json_serialisable(self, monkeypatch, tmp_path):
+        """The executor embeds ``policy`` into the sandbox as JSON verbatim.
+
+        A posture value that does not survive ``json.dumps`` would break the
+        sandbox's rebuilt validator, so the tri-state must ride as ``null``
+        rather than as anything richer.
+        """
+        db_file = tmp_path / "limits.json"
+        db_file.write_text(json.dumps({"FOO": {"max_value": 10.0}}))
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": str(db_file)},
+        )
+        posture = LimitsPosture(
+            enabled=True, allow_unlisted=None, connector_type=VIRTUAL_ACCELERATOR
+        )
+
+        validator = LimitsValidator._from_posture(posture)
+
+        assert json.loads(json.dumps(validator.policy)) == validator.policy
+        assert json.loads(json.dumps(validator.policy))["allow_unlisted_channels"] is None
+
+    def test_returns_none_when_config_unavailable(self, monkeypatch):
+        """The config-unavailable envelope is unchanged: no config, no checking."""
+        _patch_config(monkeypatch, {}, raise_exc=RuntimeError("no config"))
+        posture = LimitsPosture(enabled=True, allow_unlisted=False, connector_type=EPICS)
+
+        assert LimitsValidator._from_posture(posture) is None
 
 
 # ---------------------------------------------------------------------------
@@ -689,3 +1335,105 @@ class TestValidate:
             validator.validate("FOO", -5.0)
 
         assert exc.value.violation_type == "MIN_EXCEEDED"
+
+
+# ---------------------------------------------------------------------------
+# validate() — the unlisted refusal names the key that answered
+# ---------------------------------------------------------------------------
+
+
+class TestUnlistedRefusalNamesKey:
+    """An unlisted-channel refusal quotes the config line an operator can edit.
+
+    A deployment may answer `allow_unlisted_channels` per connector type, so
+    the deployment-wide key is not always the one in force: quoting it on a
+    deployment whose per-type block overrides it would send an operator to
+    flip a line that changes nothing. The validator carries the answering key
+    in its policy (`_from_posture`) and the refusal repeats it.
+    """
+
+    DEPLOYMENT_WIDE_KEY = "control_system.limits_checking.allow_unlisted_channels"
+    PER_TYPE_KEY = (
+        "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+    )
+
+    def test_refusal_names_the_per_type_key_the_policy_carries(self, tmp_path):
+        """A per-type block answered, so its key is the one worth quoting."""
+        validator = _make_validator(
+            tmp_path,
+            {"FOO": {"max_value": 10.0}},
+            policy={
+                "allow_unlisted_channels": False,
+                "allow_unlisted_key": self.PER_TYPE_KEY,
+            },
+        )
+
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:IN:DB", 5.0)
+
+        assert exc.value.violation_type == "UNLISTED_CHANNEL"
+        assert self.PER_TYPE_KEY in exc.value.violation_reason
+        assert "not in limits database" in exc.value.violation_reason
+
+    def test_refusal_falls_back_to_the_deployment_wide_key(self, tmp_path):
+        """A hand-built validator carries no key — the deployment-wide one answers.
+
+        Validators built outside `_from_posture` (tests, and any caller that
+        passes a bare policy dict) keep working and still name a real key.
+        """
+        validator = _make_validator(
+            tmp_path,
+            {"FOO": {"max_value": 10.0}},
+            policy={"allow_unlisted_channels": False},
+        )
+
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:IN:DB", 5.0)
+
+        assert exc.value.violation_type == "UNLISTED_CHANNEL"
+        assert self.DEPLOYMENT_WIDE_KEY in exc.value.violation_reason
+
+    def test_empty_policy_still_refuses_and_names_the_deployment_wide_key(self, tmp_path):
+        """No policy at all is nobody's permission, not a permissive default."""
+        validator = _make_validator(tmp_path, {"FOO": {"max_value": 10.0}}, policy={})
+
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:IN:DB", 5.0)
+
+        assert exc.value.violation_type == "UNLISTED_CHANNEL"
+        assert self.DEPLOYMENT_WIDE_KEY in exc.value.violation_reason
+
+    def test_unstated_policy_value_refuses(self, tmp_path):
+        """Tri-state: a stored `None` is unset, and unset refuses.
+
+        The posture carries the unstated answer verbatim so `channel_limits`
+        can report it as `null`; the write path allows only an explicit `True`.
+        """
+        validator = _make_validator(
+            tmp_path,
+            {"FOO": {"max_value": 10.0}},
+            policy={
+                "allow_unlisted_channels": None,
+                "allow_unlisted_key": self.PER_TYPE_KEY,
+            },
+        )
+
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:IN:DB", 5.0)
+
+        assert exc.value.violation_type == "UNLISTED_CHANNEL"
+        assert self.PER_TYPE_KEY in exc.value.violation_reason
+
+    @pytest.mark.parametrize("truthy", ["true", 1, "yes"])
+    def test_only_a_real_true_allows_unlisted_channels(self, tmp_path, truthy):
+        """A truthy non-bool is a config mistake, not permission to write."""
+        validator = _make_validator(
+            tmp_path,
+            {"FOO": {"max_value": 10.0}},
+            policy={"allow_unlisted_channels": truthy},
+        )
+
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("NOT:IN:DB", 5.0)
+
+        assert exc.value.violation_type == "UNLISTED_CHANNEL"

--- a/tests/deployment/goldens/bluesky_single_lane/full.yml
+++ b/tests/deployment/goldens/bluesky_single_lane/full.yml
@@ -367,8 +367,9 @@ services:
     environment:
       # Same CONFIG_FILE convention as the bridge: the per-put reference
       # monitor now runs in THIS container (the RunEngine lives here), so it
-      # reads control_system.type / writes_enabled / limits_checking from the
-      # mounted config.yml, not from the image's WORKDIR.
+      # reads control_system.type / writes_enabled / limits_checking /
+      # connector.<type>.limits_checking from the mounted config.yml, not
+      # from the image's WORKDIR.
       CONFIG_FILE: /app/project/config.yml
       TZ: UTC
       # ── queue control plane (server side) ────────────────────────────────

--- a/tests/deployment/goldens/bluesky_single_lane/minimal.yml
+++ b/tests/deployment/goldens/bluesky_single_lane/minimal.yml
@@ -284,8 +284,9 @@ services:
     environment:
       # Same CONFIG_FILE convention as the bridge: the per-put reference
       # monitor now runs in THIS container (the RunEngine lives here), so it
-      # reads control_system.type / writes_enabled / limits_checking from the
-      # mounted config.yml, not from the image's WORKDIR.
+      # reads control_system.type / writes_enabled / limits_checking /
+      # connector.<type>.limits_checking from the mounted config.yml, not
+      # from the image's WORKDIR.
       CONFIG_FILE: /app/project/config.yml
       TZ: UTC
       # ── queue control plane (server side) ────────────────────────────────

--- a/tests/e2e/claude_code/conftest.py
+++ b/tests/e2e/claude_code/conftest.py
@@ -47,6 +47,13 @@ def _point_at_safety_limits_db(repo: Path) -> None:
     exists to prove an unlisted channel goes through under it. The pin selects
     the posture the scenarios describe rather than inheriting whichever one the
     preset ships.
+
+    The pin stays DEPLOYMENT-WIDE on purpose, not spelled per connector type:
+    this lane baselines on the live stand-in and its scenarios reach whichever
+    target the deployment happens to hold, so pinning
+    ``control_system.limits_checking`` covers all of them without enumerating
+    types. The per-type ``connector.<type>.limits_checking`` override is
+    exercised by the VA-substrate lane instead.
     """
     config_path = render_dir(repo) / "config.yml"
     config = yaml.safe_load(config_path.read_text())

--- a/tests/e2e/test_target_switch_agentic.py
+++ b/tests/e2e/test_target_switch_agentic.py
@@ -158,10 +158,13 @@ VA_PROBE_CHANNEL = BENCH_PROBE_CHANNEL
 
 #: The one setpoint this module writes. Listed in the render's shipped
 #: ``data/channel_limits.json`` with a ±12 A band — which matters, because the
-#: overlay sets ``allow_unlisted_channels: false``: the limits hook sits AHEAD
-#: of the approval hook in the PreToolUse chain, so a write to an unlisted
-#: channel is denied before approval ever runs, and this module would then
-#: observe no hook event at all.
+#: overlay's deployment-wide ``allow_unlisted_channels: false`` answers the
+#: ``live`` target (no per-type block of its own), while the ``va`` baseline
+#: runs the preset's permissive ``virtual_accelerator`` block: the limits hook
+#: sits AHEAD of the approval hook in the PreToolUse chain, so on ``live`` a
+#: write to an unlisted channel is denied before approval ever runs, and this
+#: module would then observe no hook event at all. Every channel this lane
+#: writes is listed either way.
 CORRECTOR_SP = "SR:MAG:HCM:01:CURRENT:SP"
 SMOKE_WRITE_VALUE = 0.5
 
@@ -402,11 +405,18 @@ def _overlay_text(*, bench_port: int, va_port: int) -> str:
     ``target_switch.live_gateway_acknowledged``
         The operator acknowledgment naming this run's bench endpoint.
     ``limits_checking.allow_unlisted_channels``
-        The ONLY limits key set. The render already ships its own 2908-channel
-        ``data/channel_limits.json`` as ``database_path``; the template
-        hardcodes ``allow_unlisted_channels: true``, and the strict-limits gate
-        requires it falsy — so omitting this one line leaves the live target
-        blocked on a limits-posture reason and no switch is ever reachable.
+        The only DEPLOYMENT-WIDE limits key this overlay sets. The preset
+        already ships it ``false``, and the render keeps its own 2908-channel
+        ``data/channel_limits.json`` as ``database_path``; the line is restated
+        here so the lane pins the posture it needs rather than silently
+        inheriting whatever the preset's posture later becomes. The
+        strict-limits gate requires it falsy — true or absent leaves the live
+        target blocked on a limits-posture reason and no switch is ever
+        reachable. The overlay writes no per-type
+        ``connector.<type>.limits_checking`` block of its own: the preset's
+        permissive ``virtual_accelerator`` block rides along and answers for the
+        simulator, while ``live`` — an ``epics`` target with no block of its own
+        — is answered by this deployment-wide key.
 
     And the trims, which remove backends AND every surface that names them:
 
@@ -492,7 +502,10 @@ def _overlay_text(*, bench_port: int, va_port: int) -> str:
         ".use_name_server: true",
         "  # The operator acknowledgment, naming this run's live endpoint.",
         f"  control_system.target_switch.live_gateway_acknowledged: localhost:{bench_port}",
-        "  # The only limits key: the render's own 2908-channel database stays.",
+        "  # The only DEPLOYMENT-WIDE limits key. The preset already ships it",
+        "  # false; restated so the lane pins the posture rather than inheriting",
+        "  # it. No per-type epics block, so this is what answers for live. The",
+        "  # render's own 2908-channel database stays.",
         "  control_system.limits_checking.allow_unlisted_channels: false",
         "  claude_code.servers.bluesky.enabled: false",
         "  modules.web_terminals.enabled: false",
@@ -963,7 +976,9 @@ def test_the_roster_makes_va_the_baseline_and_live_reachable(
         f"the live target is not switchable: reason={rows['live']['reason']!r} "
         f"detail={rows['live']['detail']!r}. The overlay's acknowledgment "
         f"({switch_deployment.live_endpoint}) or its "
-        "limits_checking.allow_unlisted_channels: false line is no longer reaching the render."
+        "limits_checking.allow_unlisted_channels: false line — the only DEPLOYMENT-WIDE "
+        "limits key this lane sets, and with no per-type epics block the one that answers "
+        "for live — is no longer reaching the render."
     )
     assert rows["live"].get("probe_channel") == BENCH_PROBE_CHANNEL, (
         "the live target has no destination probe channel, so every switch toward it would "

--- a/tests/e2e/test_va_substrate_equivalence.py
+++ b/tests/e2e/test_va_substrate_equivalence.py
@@ -598,6 +598,11 @@ def _host_ca_op_spec(
     that is set and against ``project_root`` otherwise, and this subprocess sets
     neither anchor to the render.
 
+    The permissive half of the posture is spelled PER CONNECTOR TYPE, on
+    ``virtual_accelerator`` -- the type this proof drives -- so the
+    deployment-wide block keeps the strict posture a live machine deserves and
+    this lane exercises the per-type override rather than relaxing everything.
+
     ``CONNECTOR_CONFIG`` is passed verbatim so the subprocess builds a REAL
     production ``VirtualAcceleratorConnector`` via ``ConnectorFactory`` under
     test-supplied config. Config keys these proofs don't exercise fall to code
@@ -612,7 +617,15 @@ def _host_ca_op_spec(
         "control_system.limits_checking.database_path": str(
             repo / "build" / "data" / "channel_limits.json"
         ),
-        "control_system.limits_checking.allow_unlisted_channels": True,
+        # BOTH per-type leaves, deliberately: a per-type ``limits_checking``
+        # block overrides the deployment-wide pair as a WHOLE, so one leaf on
+        # its own is an incomplete block -- which resolves to the failsafe
+        # validator, refuses every write, and turns this lane red. Spelled flat
+        # and dotted like the rest of this map; the subprocess shim assembles
+        # the nested ``control_system`` section the resolver reads.
+        "control_system.connector.virtual_accelerator.limits_checking.enabled": True,
+        "control_system.connector.virtual_accelerator.limits_checking"
+        ".allow_unlisted_channels": True,
         "project_root": str(repo),
     }
     return {

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -341,6 +341,19 @@ config:
   # switch onto them, so a rehearsal runs the posture the real machine gets.
   control_system.limits_checking.enabled: true
   control_system.limits_checking.allow_unlisted_channels: false
+  # The sandbox simulator is the exception, and it states the exception as a
+  # whole block: a per-type posture REPLACES the pair above for that connector
+  # type rather than merging with it, so both leaves are written out here.
+  # Writes to the simulator are still checked against the same file; what
+  # changes is that a channel the file does not list is allowed through
+  # instead of refused, because on a scratch machine an unlisted channel is a
+  # gap in the file rather than a hazard. `live_standin` deliberately gets NO
+  # block of its own: it is hardware-shaped, so it keeps the strict pair the
+  # real machine gets, and a permissive block here would make
+  # `control_target_set standin` refuse the very switch this preset exists to
+  # rehearse.
+  control_system.connector.virtual_accelerator.limits_checking.enabled: true
+  control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels: true
   # Use the archive declared by `va_archiver:` above. Declaring the block does
   # not turn it on; without this line you would deploy a store and not read it.
   archiver.type: mongodb_archiver

--- a/tests/hooks/test_limits_hook.py
+++ b/tests/hooks/test_limits_hook.py
@@ -9,37 +9,40 @@ specified by control_system.limits_checking.database_path. Tests must create
 a proper database file for validation to work.
 """
 
+import importlib
+import io
 import json
+import os
+import sys
+import types
 
 import pytest
+import yaml
+
+from osprey_connectors.types import most_restrictive_limits_posture, target_limits_posture
 
 
 def _make_limits_config(tmp_path, channels_db, enabled=True, allow_unlisted=False):
-    """Create config.yml + channel_limits.json for limits testing."""
-    # Write channel limits database
-    db_path = tmp_path / "channel_limits.json"
-    db_path.write_text(json.dumps(channels_db))
+    """Create config.yml + channel_limits.json for a deployment-wide posture.
 
-    # Write config
-    import yaml
-
-    config_path = tmp_path / "config.yml"
-    config_path.write_text(
-        yaml.dump(
-            {
-                "control_system": {
-                    "type": "mock",
-                    "writes_enabled": True,
-                    "limits_checking": {
-                        "enabled": enabled,
-                        "database_path": str(db_path),
-                        "allow_unlisted_channels": allow_unlisted,
-                    },
-                },
-            }
-        )
+    The single-block shape, which is what every deployment had before per-type
+    blocks existed: one mock connector, writes armed, and the two limits leaves
+    stated deployment-wide. `_limits_config` writes it, so the sections these
+    tests run against and the ones the per-type tests below run against are
+    written by one thing.
+    """
+    return _limits_config(
+        tmp_path,
+        {
+            "type": "mock",
+            "writes_enabled": True,
+            "limits_checking": {
+                "enabled": enabled,
+                "allow_unlisted_channels": allow_unlisted,
+            },
+        },
+        channels_db,
     )
-    return config_path
 
 
 @pytest.mark.unit
@@ -331,4 +334,622 @@ def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
 
     assert returncode == 0
     assert stdout.strip() == ""
+    assert "Traceback" not in stderr
+
+
+# -- Per-target limits posture --
+#
+# The limits posture is a property of the machine a write would reach, not of
+# the deployment as a whole: `control_system.connector.<type>.limits_checking`
+# overrides the deployment-wide `control_system.limits_checking` block whole, so
+# a facility can refuse unlisted channels on its ring and allow them on its
+# virtual accelerator. The hook therefore resolves the session's target before
+# it builds a validator, and the tests below state that in the same shape
+# `test_writes_check_hook.py` states the write posture: the expected decision is
+# computed from the framework resolver rather than written out per config.
+
+
+#: The one channel the limits database lists, and one it does not. The unlisted
+#: write is what the `allow_unlisted_channels` leaf decides, which is the leaf a
+#: per-type block exists to differ on.
+KNOWN_DB = {"KNOWN:PV": {"min_value": 0.0, "max_value": 100.0, "writable": True}}
+UNLISTED_CHANNEL = "UNKNOWN:PV"
+
+
+def _limits_config(tmp_path, section, channels_db=None):
+    """Write `config.yml` carrying *section*, plus the limits database.
+
+    `database_path` stays deployment-wide — a deployment mounts one limits file
+    — so it is injected into the section's own `limits_checking` block whatever
+    per-type blocks the shape carries. It states no posture, so the section a
+    test hands in and the section written here resolve identically.
+    """
+    db_path = tmp_path / "channel_limits.json"
+    db_path.write_text(json.dumps(KNOWN_DB if channels_db is None else channels_db))
+
+    rendered = json.loads(json.dumps(section))  # deep copy; every value is JSON
+    rendered.setdefault("limits_checking", {})["database_path"] = str(db_path)
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(yaml.dump({"control_system": rendered}))
+    return config_path
+
+
+def _state_dir(repo_root):
+    """The state directory the reader derives from a repo root."""
+    directory = repo_root / "var" / "agent_data" / "control_target"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _write_session_state(repo_root, target):
+    """Write a state file this pytest process genuinely owns.
+
+    `owner_ppid` is this process, which IS on the ancestor chain of the hook
+    subprocess `hook_runner` spawns, and `server_pid` is this process, which is
+    alive by definition — so the reader's real parentage and liveness rules
+    select this record without any seam being replaced.
+    """
+    record = {
+        "target": target,
+        "generation": 3,
+        "server_pid": os.getpid(),
+        "owner_ppid": os.getpid(),
+        "targets": {
+            "live": {
+                "label": "Storage ring",
+                "endpoint": "pva://live-gw.example.org:5075",
+                "real_machine": True,
+            },
+            "va": {
+                "label": "Virtual accelerator",
+                "endpoint": "pva://127.0.0.1:5074",
+                "real_machine": False,
+            },
+            "standin": {
+                "label": "Live stand-in",
+                "endpoint": "pva://127.0.0.1:5076",
+                "real_machine": False,
+            },
+        },
+        "children": [],
+    }
+    path = _state_dir(repo_root) / f"target_state_{os.getpid()}.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+
+def _unlisted_write(tmp_path, hook_runner, config):
+    """Run the hook against a write to a channel the database does not list."""
+    return hook_runner(
+        "osprey_limits.py",
+        "mcp__controls__channel_write",
+        {"operations": [{"channel": UNLISTED_CHANNEL, "value": 50.0}]},
+        config_path=config,
+        cwd=tmp_path,
+    )
+
+
+#: A deployment strict on its ring and permissive on its simulator — the shape
+#: the per-type block exists for, reused by several tests below. Both connector
+#: blocks are non-empty, so the deployment renders the target switch and the
+#: reachable set a targetless call folds over is both targets.
+VA_PERMISSIVE = {
+    "type": "epics",
+    "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
+    "connector": {
+        "epics": {"port_host": "live-gw.example.org"},
+        "virtual_accelerator": {
+            "port_host": "127.0.0.1",
+            "limits_checking": {"enabled": True, "allow_unlisted_channels": True},
+        },
+    },
+}
+
+#: A mock deployment carrying one connector block it never builds. `live`
+#: resolves to that block, so a call that NAMES `live` reads it — while a call
+#: with no target folds over the single connector `control_system.type` builds,
+#: which is the mock, and so answers the deployment-wide posture instead.
+STRAY_LIVE_BLOCK = {
+    "type": "mock",
+    "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
+    "connector": {"epics": {"limits_checking": {"enabled": True, "allow_unlisted_channels": True}}},
+}
+
+#: A per-type block that states one leaf. It overrides whole, so it answers
+#: nothing: the validator is the failsafe one and every write is refused.
+HALF_WRITTEN_VA_BLOCK = {
+    "type": "epics",
+    "limits_checking": {"enabled": True, "allow_unlisted_channels": True},
+    "connector": {
+        "epics": {"port_host": "live-gw.example.org"},
+        "virtual_accelerator": {"limits_checking": {"enabled": True}},
+    },
+}
+
+#: A deployment permissive deployment-wide and strict on its ring — the mirror
+#: of `VA_PERMISSIVE`, and the shape whose refusal must name a per-type key.
+LIVE_STRICT_BLOCK = {
+    "type": "epics",
+    "limits_checking": {"enabled": True, "allow_unlisted_channels": True},
+    "connector": {
+        "epics": {"limits_checking": {"enabled": True, "allow_unlisted_channels": False}},
+    },
+}
+
+#: A deployment whose only limits line cannot be read: `enabled` is a string,
+#: which is what environment expansion leaves behind when nothing set the
+#: variable. It states no posture, so the block is incomplete and every write is
+#: refused — the alternative, reading it as an unset `enabled`, would mean "no
+#: limits checking configured" and wave the write through.
+UNREADABLE_DEPLOYMENT_WIDE = {
+    "type": "epics",
+    "limits_checking": {"enabled": "${OSPREY_LIMITS_ENABLED}", "allow_unlisted_channels": False},
+    "connector": {"epics": {"port_host": "live-gw.example.org"}},
+}
+
+#: `(section, session_target)` for every config shape the hook must answer.
+#: `None` as the target means no state file is written at all, so the session
+#: target is unidentifiable and the posture every reachable target agrees on is
+#: the answer.
+POSTURE_SHAPES = [
+    (VA_PERMISSIVE, "va"),
+    (VA_PERMISSIVE, "live"),
+    (VA_PERMISSIVE, "standin"),
+    (VA_PERMISSIVE, None),
+    (STRAY_LIVE_BLOCK, "live"),
+    (STRAY_LIVE_BLOCK, None),
+    (HALF_WRITTEN_VA_BLOCK, "va"),
+    (HALF_WRITTEN_VA_BLOCK, "live"),
+    (HALF_WRITTEN_VA_BLOCK, None),
+    (UNREADABLE_DEPLOYMENT_WIDE, "live"),
+    (UNREADABLE_DEPLOYMENT_WIDE, None),
+    (LIVE_STRICT_BLOCK, "live"),
+    (LIVE_STRICT_BLOCK, "va"),
+    (
+        {"type": "mock", "limits_checking": {"enabled": True, "allow_unlisted_channels": True}},
+        "live",
+    ),
+    (
+        {"type": "mock", "limits_checking": {"enabled": False, "allow_unlisted_channels": False}},
+        "live",
+    ),
+    ({"type": "mock"}, None),
+]
+
+POSTURE_SHAPE_IDS = [
+    "permissive-va-on-va",
+    "permissive-va-on-live",
+    "permissive-va-on-standin",
+    "permissive-va-no-state-file",
+    "stray-live-block-on-live",
+    "stray-live-block-no-state-file",
+    "half-written-block-on-its-own-target",
+    "half-written-block-one-target-over",
+    "half-written-block-no-state-file",
+    "unreadable-deployment-wide-on-live",
+    "unreadable-deployment-wide-no-state-file",
+    "strict-live-block-on-live",
+    "strict-live-block-on-va",
+    "mock-unresolvable-live-permissive",
+    "limits-disabled",
+    "no-posture-stated",
+]
+
+
+def _expected_allowed(posture):
+    """Whether an unlisted write passes under *posture*, per the validator's rules.
+
+    Three outcomes, in the order `LimitsValidator._from_posture` takes them: an
+    incomplete block builds the failsafe validator and refuses everything;
+    limits checking that is not explicitly on builds no validator at all and the
+    write goes through; and otherwise an unlisted channel needs an explicit
+    `True`, since a tri-state `None` is nobody's permission.
+    """
+    if posture.incomplete:
+        return False
+    if posture.enabled is not True:
+        return True
+    return posture.allow_unlisted is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("section", "target"), POSTURE_SHAPES, ids=POSTURE_SHAPE_IDS)
+def test_hook_decision_matches_the_framework_resolver(tmp_path, hook_runner, section, target):
+    """The hook and the package resolvers answer one deployment identically.
+
+    The hook cannot resolve a posture itself — the rules live in
+    `osprey_connectors.types` and the validator applies them — so what this pins
+    is that the hook asks the right QUESTION for the identity it holds: the
+    session's target when the state file names one, and the fold across every
+    reachable target when it does not. Both expectations are computed from the
+    resolvers rather than written out per shape, so a hook that asked the
+    deployment-wide question instead fails on every row where a per-type block
+    differs from it.
+    """
+    # Arrange
+    config = _limits_config(tmp_path, section)
+    if target is not None:
+        _write_session_state(tmp_path, target)
+
+    if target is None:
+        posture = most_restrictive_limits_posture(section)
+    else:
+        posture = target_limits_posture(section, target)
+
+    # Act
+    result = _unlisted_write(tmp_path, hook_runner, config)
+
+    # Assert
+    allowed = result is None
+    assert allowed is _expected_allowed(posture)
+
+
+@pytest.mark.unit
+def test_no_state_file_refuses_when_the_only_limits_line_cannot_be_read(tmp_path, hook_runner):
+    """The baseline branch every unswitched session takes must not fail open.
+
+    With no state file the hook folds across every reachable target. Both leaf
+    folds send an unreadable posture's `None` to `False`, which on its own reads
+    as "checking off, nothing permitted" -- and a validator is only built when
+    `enabled` is `True`, so a fold that dropped the incompleteness would build
+    no validator and allow the write. Stated absolutely here rather than against
+    the resolver, because the parity test above derives both sides from the very
+    fold this pins.
+    """
+    # Arrange
+    config = _limits_config(tmp_path, UNREADABLE_DEPLOYMENT_WIDE)
+
+    # Act
+    result = _unlisted_write(tmp_path, hook_runner, config)
+
+    # Assert
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.unit
+def test_live_refusal_names_the_deployment_wide_key(tmp_path, hook_runner):
+    """On `live`, a deployment that relaxed only its simulator still refuses.
+
+    And the refusal names the key that would actually lift it: the ring's own
+    connector block wrote no `limits_checking`, so the deployment-wide line is
+    the one an operator would have to edit.
+    """
+    # Arrange
+    config = _limits_config(tmp_path, VA_PERMISSIVE)
+    _write_session_state(tmp_path, "live")
+
+    # Act
+    result = _unlisted_write(tmp_path, hook_runner, config)
+
+    # Assert
+    assert result is not None
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "deny"
+    assert (
+        "control_system.limits_checking.allow_unlisted_channels"
+        in (output["permissionDecisionReason"])
+    )
+
+
+@pytest.mark.unit
+def test_va_passes_where_the_same_deployment_refuses_on_live(tmp_path, hook_runner):
+    """The same config, one target over: the simulator takes the unlisted write.
+
+    The mirror of the test above, and the whole point of the per-type block — a
+    facility whose ring refuses unlisted channels can still let an agent write
+    freely against its virtual accelerator.
+    """
+    # Arrange
+    config = _limits_config(tmp_path, VA_PERMISSIVE)
+    _write_session_state(tmp_path, "va")
+
+    # Act
+    result = _unlisted_write(tmp_path, hook_runner, config)
+
+    # Assert
+    assert result is None
+
+
+@pytest.mark.unit
+def test_per_type_refusal_names_the_connector_block(tmp_path, hook_runner):
+    """A refusal read from a connector block names that block, not the global key.
+
+    A deployment permissive deployment-wide and strict on its ring is exactly
+    the case where naming `control_system.limits_checking.allow_unlisted_channels`
+    would send the operator to flip a key that is already `true` and changes
+    nothing.
+    """
+    # Arrange
+    config = _limits_config(tmp_path, LIVE_STRICT_BLOCK)
+    _write_session_state(tmp_path, "live")
+
+    # Act
+    result = _unlisted_write(tmp_path, hook_runner, config)
+
+    # Assert
+    assert result is not None
+    reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "control_system.connector.epics.limits_checking.allow_unlisted_channels" in reason
+
+
+@pytest.mark.unit
+def test_removed_state_directory_takes_the_most_restrictive_posture(tmp_path, hook_runner):
+    """A session whose target cannot be read is refused what any target refuses.
+
+    The state directory existed and is gone — a swept `var/`, a server that
+    never started, a deployment whose agent-data root was moved — so the hook
+    cannot say which machine this write would reach. The simulator would take
+    it and the ring would not, and a guess between them could be a guess in
+    favour of hardware, so the write is refused and the refusal names the
+    deployment-wide key: no per-type line decides a union.
+    """
+    # Arrange
+    config = _limits_config(tmp_path, VA_PERMISSIVE)
+    _write_session_state(tmp_path, "va")
+    state_dir = _state_dir(tmp_path)
+    for path in state_dir.iterdir():
+        path.unlink()
+    state_dir.rmdir()
+
+    # Act
+    result = _unlisted_write(tmp_path, hook_runner, config)
+
+    # Assert
+    assert result is not None
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "deny"
+    assert (
+        "control_system.limits_checking.allow_unlisted_channels"
+        in (output["permissionDecisionReason"])
+    )
+
+
+@pytest.mark.unit
+def test_stray_connector_block_does_not_answer_for_a_targetless_call(tmp_path, hook_runner):
+    """A mock deployment answers the deployment-wide posture, stray block and all.
+
+    `live` on a mock deployment resolves to the single connector block that
+    could be a real machine, so a call NAMING `live` reads it. A call with no
+    target must not: the reachable set on a deployment that renders no switch is
+    the one connector `control_system.type` builds, which here is the mock. A
+    fold over the stray block would hand an agent the relaxation written for a
+    machine no session on this deployment can select.
+    """
+    # Arrange — no state file at all
+    config = _limits_config(tmp_path, STRAY_LIVE_BLOCK)
+
+    # Act
+    result = _unlisted_write(tmp_path, hook_runner, config)
+
+    # Assert
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.unit
+def test_osprey_unimportable_allows_the_write(tmp_path, hook_module, monkeypatch, capsys):
+    """With `osprey` off the interpreter's path the hook exits 0 and decides nothing.
+
+    The hook's one fail-open direction, and the reason it is right: a hook
+    running under a bare system `python3` has no validator to consult and no
+    posture to read, so refusing would block every write on a deployment whose
+    limits are enforced by the MCP tool anyway. Driven in-process because the
+    import can only be made to fail from inside the interpreter — a hook
+    subprocess started by this suite has the venv, and therefore `osprey`, on
+    its path by construction.
+    """
+    # Arrange
+    hook = hook_module("osprey_limits")
+    monkeypatch.setitem(sys.modules, "osprey.connectors.control_system.limits_validator", None)
+    # A `None` entry in `sys.modules` is what makes the hook's own import raise.
+    # Asserted here so that a test which stopped exercising the branch cannot
+    # pass by exiting 0 for some other reason.
+    with pytest.raises(ImportError):
+        importlib.import_module("osprey.connectors.control_system.limits_validator")
+    payload = {
+        "tool_name": "mcp__controls__channel_write",
+        "tool_input": {"operations": [{"channel": UNLISTED_CHANNEL, "value": 50.0}]},
+        "cwd": str(tmp_path),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    # Act
+    with pytest.raises(SystemExit) as exit_info:
+        hook.main()
+
+    # Assert
+    assert exit_info.value.code == 0
+    assert capsys.readouterr().out.strip() == ""
+
+
+# -- Branches only reachable from inside the interpreter --
+#
+# Three of the hook's decisions cannot be driven through `hook_runner`: a render
+# without the sibling target-state reader, that reader raising, and a framework
+# older than the render it is answering. All three are exercised in-process,
+# against a stand-in validator rather than the real one, because config loading
+# is a process-wide singleton keyed on `CONFIG_FILE` at first use — a test that
+# pointed it at its own file would either read a config an earlier test cached
+# or pin its own for every test after it. The stand-in answers exactly the
+# VA-permissive / live-strict deployment the subprocess tests above describe,
+# and records which entry point the hook asked, which is the branch under test.
+
+#: The key a deployment-wide answer names, and the one a per-type answer does.
+DEPLOYMENT_WIDE_KEY = "control_system.limits_checking.allow_unlisted_channels"
+VA_BLOCK_KEY = (
+    "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+)
+
+#: `(allow_unlisted, answering key)` for the VA-permissive / live-strict
+#: deployment, per entry point the hook can ask. The simulator takes unlisted
+#: writes; the ring, the fold across both, and the deployment-wide question an
+#: older framework asks all refuse.
+STAND_IN_POSTURES = {
+    ("target", "va"): (True, VA_BLOCK_KEY),
+    ("target", "live"): (False, DEPLOYMENT_WIDE_KEY),
+    ("most_restrictive", None): (False, DEPLOYMENT_WIDE_KEY),
+    ("deployment_wide", None): (False, DEPLOYMENT_WIDE_KEY),
+}
+
+
+def _stand_in_validator_class(calls, per_target_api=True):
+    """A `LimitsValidator` stand-in that records which entry point was asked.
+
+    With *per_target_api* false it exposes only the old no-arg `from_config` and
+    no `from_config_most_restrictive` — the shape a service still running an
+    older `osprey` image presents to a freshly rendered hook.
+    """
+
+    class _StandIn:
+        def __init__(self, allow_unlisted, key):
+            self._allow_unlisted = allow_unlisted
+            self._key = key
+
+        def validate(self, channel, value):
+            if channel in KNOWN_DB or self._allow_unlisted:
+                return
+            raise ValueError(
+                f"Channel '{channel}' not in limits database "
+                f"('{self._key}' does not allow unlisted channels)"
+            )
+
+    def _built(entry, target):
+        calls.append((entry, target))
+        return _StandIn(*STAND_IN_POSTURES[(entry, target)])
+
+    if per_target_api:
+
+        def from_config(cls, *, connector_type=None, target=None):
+            return _built("target", target)
+
+        def from_config_most_restrictive(cls):
+            return _built("most_restrictive", None)
+
+        _StandIn.from_config = classmethod(from_config)
+        _StandIn.from_config_most_restrictive = classmethod(from_config_most_restrictive)
+    else:
+
+        def old_from_config(cls):
+            return _built("deployment_wide", None)
+
+        _StandIn.from_config = classmethod(old_from_config)
+
+    return _StandIn
+
+
+def _run_in_process(hook, monkeypatch, capsys, tmp_path, validator_cls):
+    """Drive `main()` in this interpreter against *validator_cls*.
+
+    Returns `(exit_code, decision, stderr)`, where the decision is the hook's
+    parsed JSON output or `None` when it wrote none (allowed through).
+    """
+    monkeypatch.setitem(
+        sys.modules,
+        "osprey.connectors.control_system.limits_validator",
+        types.SimpleNamespace(LimitsValidator=validator_cls),
+    )
+    payload = {
+        "tool_name": "mcp__controls__channel_write",
+        "tool_input": {"operations": [{"channel": UNLISTED_CHANNEL, "value": 50.0}]},
+        "cwd": str(tmp_path),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    with pytest.raises(SystemExit) as exit_info:
+        hook.main()
+
+    captured = capsys.readouterr()
+    stdout = captured.out.strip()
+    return exit_info.value.code, (json.loads(stdout) if stdout else None), captured.err
+
+
+@pytest.mark.unit
+def test_a_render_without_the_state_reader_takes_the_most_restrictive_posture(
+    tmp_path, hook_module, monkeypatch, capsys
+):
+    """No sibling reader is a session with no identity, not a session to wave through.
+
+    A project rendered before `osprey_target_state` existed has no such sibling,
+    so the guarded import leaves `_target_state` as `None`. The hook still has a
+    validator and still has to decide, and the posture it decides under is the
+    one every reachable target agrees on — refusing what the ring refuses rather
+    than exiting 0 and letting an unlisted write reach it unchecked.
+    """
+    # Arrange
+    hook = hook_module("osprey_limits")
+    monkeypatch.setattr(hook, "_target_state", None)
+    calls = []
+
+    # Act
+    code, decision, _stderr = _run_in_process(
+        hook, monkeypatch, capsys, tmp_path, _stand_in_validator_class(calls)
+    )
+
+    # Assert
+    assert code == 0
+    assert calls == [("most_restrictive", None)]
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert DEPLOYMENT_WIDE_KEY in decision["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+@pytest.mark.unit
+def test_a_raising_state_reader_takes_the_most_restrictive_posture(
+    tmp_path, hook_module, monkeypatch, capsys
+):
+    """The reader is documented never to raise; if it did, the write is still checked.
+
+    Same branch as the missing reader, reached the other way. What it pins is
+    that no failure of target IDENTITY can turn into a write nobody validated —
+    an exception escaping `_session_target` would exit the hook non-zero with no
+    decision, which the agent runtime reads as no opinion.
+    """
+    # Arrange
+    hook = hook_module("osprey_limits")
+
+    def _boom(hook_input=None):
+        raise RuntimeError("state directory vanished mid-read")
+
+    monkeypatch.setattr(hook._target_state, "read_session_target", _boom)
+    calls = []
+
+    # Act
+    code, decision, stderr = _run_in_process(
+        hook, monkeypatch, capsys, tmp_path, _stand_in_validator_class(calls)
+    )
+
+    # Assert
+    assert code == 0
+    assert calls == [("most_restrictive", None)]
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "Traceback" not in stderr
+
+
+@pytest.mark.unit
+def test_an_older_framework_falls_back_to_the_deployment_wide_block(
+    tmp_path, hook_module, monkeypatch, capsys
+):
+    """A hook newer than the `osprey` it meets asks the question that framework can answer.
+
+    `osprey build` renders hooks into the repo on the host, while a service
+    keeps the image it was built with until the next `osprey up --build`. On
+    such a deployment `from_config_most_restrictive` does not exist and
+    `from_config` takes no `target`, and calling either would exit the hook
+    non-zero with no decision — an unlisted write reaching the machine with no
+    limits applied at all. The fallback is the deployment-wide block, which is
+    exactly what that framework enforced when it was the whole story.
+    """
+    # Arrange
+    hook = hook_module("osprey_limits")
+    calls = []
+    older = _stand_in_validator_class(calls, per_target_api=False)
+
+    # Act
+    code, decision, stderr = _run_in_process(hook, monkeypatch, capsys, tmp_path, older)
+
+    # Assert
+    assert code == 0
+    assert calls == [("deployment_wide", None)]
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert DEPLOYMENT_WIDE_KEY in decision["hookSpecificOutput"]["permissionDecisionReason"]
     assert "Traceback" not in stderr

--- a/tests/mcp_server/bluesky/test_queue_posture.py
+++ b/tests/mcp_server/bluesky/test_queue_posture.py
@@ -372,7 +372,22 @@ def _patch_bridge_config(monkeypatch, *, section, lane_targets, limits_enabled, 
     The guard does its lookups through a function-body import of
     ``osprey.utils.config``, so patching the module attribute is what takes
     effect — the same convention ``test_startup_assertion.py`` uses.
+
+    Limits checking is per connector type and the guard resolves it out of the
+    ``control_system`` SECTION, so ``limits_enabled`` is folded into the
+    section's deployment-wide ``limits_checking`` block (on a copy, so the
+    module-level section never carries one test's posture into the next)
+    rather than answered behind a dotted key the guard no longer asks for.
+    Only ``database_path`` stays a dotted lookup: it is deployment-wide.
     """
+    section = {
+        **section,
+        "limits_checking": {
+            **section.get("limits_checking", {}),
+            "enabled": limits_enabled,
+            "allow_unlisted_channels": False,
+        },
+    }
 
     def fake_get_config_value(key: str, default=None):
         if key == "control_system":

--- a/tests/mcp_server/python_executor/test_executor_adapter.py
+++ b/tests/mcp_server/python_executor/test_executor_adapter.py
@@ -250,7 +250,7 @@ def test_limits_validator_loaded_and_passed(tmp_path, monkeypatch):
 
     get_config_builder(config_path=str(tmp_path / "config.yml"), set_as_default=True)
 
-    validator = _load_limits_validator()
+    validator = _load_limits_validator(target=None)
     assert validator is not None
     assert "TEST:PV" in validator.limits
 
@@ -260,7 +260,7 @@ def test_limits_validator_disabled_gracefully(tmp_path, monkeypatch):
     """When limits_checking.enabled=false, returns None."""
     monkeypatch.chdir(tmp_path)
     _write_config(tmp_path)
-    validator = _load_limits_validator()
+    validator = _load_limits_validator(target=None)
     assert validator is None
 
 
@@ -295,7 +295,7 @@ def test_wrapper_includes_monkeypatch_when_validator_present(tmp_path, monkeypat
 
     get_config_builder(config_path=str(tmp_path / "config.yml"), set_as_default=True)
 
-    validator = _load_limits_validator()
+    validator = _load_limits_validator(target=None)
     from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
 
     wrapper = ExecutionWrapper(limits_validator=validator)

--- a/tests/mcp_server/python_executor/test_executor_limits_target.py
+++ b/tests/mcp_server/python_executor/test_executor_limits_target.py
@@ -1,0 +1,173 @@
+"""One target read feeds both the sandbox stamp and the embedded limits policy.
+
+The executor used to answer the same question twice. ``execute_code`` built the
+limits validator up front, before anything about the session's control target
+was known, and ``_execute_via_local`` resolved the stamp that routes the sandbox
+later, from its own read of the controls server's target record. That was
+harmless while the limits posture was deployment-wide and the same for every
+machine. Once it is per target it is not: a switch landing between the two reads
+would embed one machine's policy into a sandbox stamped for another, and the run
+would enforce the simulator's relaxed posture against the live machine or the
+reverse.
+
+So the record is read once, and the target it answers feeds both. These tests
+make a second read *visible*: the patched record answers ``va`` the first time
+and ``live`` every time after, so a run that reads twice disagrees with itself
+instead of quietly passing.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+from osprey.mcp_server.python_executor import executor as host_executor
+from osprey_connectors.control_system.limits_validator import LimitsValidator
+
+pytestmark = pytest.mark.unit
+
+
+def _record(target: str) -> dict:
+    """A target-state record for this session, naming *target*."""
+    return {
+        "target": target,
+        "generation": 3,
+        "server_pid": os.getpid(),
+        "owner_ppid": os.getppid(),
+    }
+
+
+def _validator_for(target: str | None) -> LimitsValidator:
+    """A validator whose policy says out loud which target it was built for."""
+    return LimitsValidator(
+        {},
+        {"allow_unlisted_channels": True, "allow_unlisted_key": f"resolved-for:{target}"},
+    )
+
+
+class _LocalRun:
+    """What one faked ``_execute_via_local`` run left behind."""
+
+    def __init__(self, env: dict[str, str], script: str, reads: int, targets: list[str | None]):
+        self.env = env
+        self.script = script
+        self.reads = reads
+        self.targets = targets
+
+
+def _run_local(tmp_path, monkeypatch) -> _LocalRun:
+    """Drive one local execution with the subprocess and the config faked out.
+
+    The record reader is the seam under test, so it is the one thing that
+    answers differently on a second call.
+    """
+    captured: dict[str, dict[str, str]] = {}
+    reads = {"n": 0}
+    targets: list[str | None] = []
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    async def fake_exec(*args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _FakeProc()
+
+    def fake_record() -> dict:
+        reads["n"] += 1
+        return _record("va" if reads["n"] == 1 else "live")
+
+    def fake_from_config(*, connector_type=None, target=None):
+        targets.append(target)
+        return _validator_for(target)
+
+    monkeypatch.setattr(host_executor, "_session_target_record", fake_record)
+    # Resolvability is a config question, answered elsewhere and pinned in
+    # tests/runtime/test_executor_target_stamp.py; here it only has to not
+    # send the run to the baseline.
+    monkeypatch.setattr(host_executor, "_target_is_resolvable", lambda target: True)
+    monkeypatch.setattr(LimitsValidator, "from_config", fake_from_config)
+    monkeypatch.setattr(host_executor, "_resolve_project_root", lambda: tmp_path)
+    monkeypatch.setattr(host_executor, "resolve_agent_interpreter", lambda root=None: "/bin/true")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    folder = tmp_path / "execution"
+    (folder / "figures").mkdir(parents=True)
+
+    asyncio.run(
+        host_executor._execute_via_local("print('hi')", "readwrite", {"timeout": 5}, folder)
+    )
+    return _LocalRun(
+        captured["env"],
+        (folder / "wrapped_script.py").read_text(encoding="utf-8"),
+        reads["n"],
+        targets,
+    )
+
+
+class TestOneRecordReadPerRun:
+    """The stamp and the embedded policy come from the same answer."""
+
+    def test_policy_and_stamp_name_the_same_target(self, tmp_path, monkeypatch):
+        run = _run_local(tmp_path, monkeypatch)
+
+        assert run.env[host_executor.ENV_CONTROL_TARGET] == "va"
+        assert "resolved-for:va" in run.script
+        # The record's second answer must not be anywhere in the run: if it is,
+        # the two halves were resolved from two different reads.
+        assert "resolved-for:live" not in run.script
+
+    def test_the_record_is_read_once(self, tmp_path, monkeypatch):
+        run = _run_local(tmp_path, monkeypatch)
+
+        assert run.reads == 1
+
+    def test_the_validator_is_built_for_the_stamped_target(self, tmp_path, monkeypatch):
+        run = _run_local(tmp_path, monkeypatch)
+
+        assert run.targets == ["va"]
+
+
+class TestLoadLimitsValidator:
+    """The helper threads a target through and stays honest about caller bugs."""
+
+    def test_target_is_passed_through(self, monkeypatch):
+        seen: list[dict] = []
+
+        def fake_from_config(*, connector_type=None, target=None):
+            seen.append({"connector_type": connector_type, "target": target})
+            return None
+
+        monkeypatch.setattr(LimitsValidator, "from_config", fake_from_config)
+
+        assert host_executor._load_limits_validator(target="live") is None
+        assert seen == [{"connector_type": None, "target": "live"}]
+
+    def test_type_error_is_not_swallowed(self, monkeypatch):
+        """A caller bug must surface as one, not as "limits checking is off".
+
+        ``from_config`` raises ``TypeError`` before reading any config when it is
+        handed both a connector type and a target. Swallowing that here would
+        turn a mis-wired call site into a silently unvalidated sandbox.
+        """
+
+        def boom(*, connector_type=None, target=None):
+            raise TypeError("takes connector_type or target, not both")
+
+        monkeypatch.setattr(LimitsValidator, "from_config", boom)
+
+        with pytest.raises(TypeError):
+            host_executor._load_limits_validator(target="va")
+
+    @pytest.mark.parametrize("exc", [FileNotFoundError, KeyError, RuntimeError, ImportError])
+    def test_config_unavailable_is_none(self, monkeypatch, exc):
+        """The errors ``from_config`` documents as "config unavailable" disable checking."""
+
+        def boom(*, connector_type=None, target=None):
+            raise exc("nope")
+
+        monkeypatch.setattr(LimitsValidator, "from_config", boom)
+
+        assert host_executor._load_limits_validator(target=None) is None

--- a/tests/mcp_server/python_executor/test_sandbox_single_posture.py
+++ b/tests/mcp_server/python_executor/test_sandbox_single_posture.py
@@ -1,0 +1,283 @@
+"""One sandbox run carries exactly one limits posture, on both write paths.
+
+A run resolves the posture twice, from different halves of the resolver family.
+The HOST resolves it for the session target and embeds it in the generated
+script (``LimitsValidator.from_config(target=...)``, serialized into the
+wrapper's monkeypatch). A connector built through the runtime's own connector
+path resolves its own inside ``connect()``, from the type the stamp resolved to
+(``LimitsValidator.from_config(connector_type=...)``). Neither consults the
+other.
+
+The two write paths do not map one-to-one onto those halves.
+``osprey.runtime.write_channel`` runs the embedded validator and *then*
+``write_channel_checked`` on the connector, which runs the connector's own — so
+its verdict is the CONJUNCTION of both halves, and a refusal there does not by
+itself say which half refused. A direct ``write_channel_checked`` on the
+connector exercises the connector's half alone. The ``injected_policy``
+assertions are what pin the host's half on its own: they read the policy the
+wrapper actually embedded, whatever the writes went on to do with it.
+
+So a per-type block the target adapter and the type adapter read differently
+shows up here and nowhere else, in one of two signatures. Host strict over a
+permissive connector: ``write_channel`` refused while the direct connector write
+is allowed. Host permissive over a strict connector: both refused, since the
+conjunction still fails — caught by ``injected_policy`` naming the wrong key
+rather than by the write outcomes. Either way the two halves disagree, in a
+single run, against a single machine. The deployment under test is the one that
+makes their answers differ at all — deployment-wide strict, with
+``connector.virtual_accelerator`` relaxed — so an implementation that resolved
+either half deployment-wide, or either half per-type, fails one of the two
+scenarios rather than passing both.
+
+Both scenarios write the SAME unlisted channel, so the only thing that moves
+between them is the session's target record.
+
+What is real here and what is not
+---------------------------------
+Real: the on-disk ``config.yml``, the limits database, the controls server's
+target-state record, ``_execute_via_local`` (which stamps the environment,
+resolves the posture and builds the wrapper), the generated script, the
+subprocess that runs it, and every ``from_config`` call either half makes.
+
+Substituted: the connector CLASS behind the two types, registered inside the
+sandbox script as :class:`MockConnector` so the run needs no soft IOC and no
+facility. The substitution is downstream of everything under test — the factory
+still stamps ``_connector_type`` from the type the target resolved to, and
+``connect()`` still reads its posture from that stamp — so it changes which wire
+a write would reach and nothing about which posture answers.
+"""
+
+import asyncio
+import json
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from osprey.mcp_server.control_system import target_state
+from osprey.mcp_server.python_executor import executor as host_executor
+
+pytestmark = pytest.mark.unit
+
+#: Absent from the limits database on purpose: the posture is the only thing
+#: that can decide this write. Free of ``:SP``/``:SET``, which the mock mirrors
+#: onto a readback channel.
+UNLISTED_CHANNEL = "SANDBOX:POSTURE:PROBE"
+
+#: The deployment-wide key, which is what a strict refusal must name.
+DEPLOYMENT_WIDE_KEY = "control_system.limits_checking.allow_unlisted_channels"
+
+#: The per-type key, which is what the relaxed VA posture answers with.
+VA_KEY = "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+
+#: Marks the one line of sandbox stdout the assertions read.
+VERDICT_PREFIX = "SINGLE_POSTURE_VERDICT "
+
+# The script the sandbox runs. Both write paths are attempted whatever the first
+# one does, so a scenario always reports two outcomes and a disagreement shows as
+# a disagreement rather than as a truncated run.
+PROBE_SCRIPT = textwrap.dedent(
+    f"""
+    import json
+
+    from osprey_connectors.control_system.mock_connector import MockConnector
+    from osprey_connectors.factory import ConnectorFactory
+
+    # See the module docstring: the class is substituted, the type keys are not.
+    ConnectorFactory.register_control_system("epics", MockConnector)
+    ConnectorFactory.register_control_system("virtual_accelerator", MockConnector)
+
+    import osprey.runtime as _rt
+
+    _verdict = {{}}
+
+    # The policy the HOST resolved and embedded, reported so a failure says which
+    # posture the sandbox was actually carrying.
+    _injected = getattr(_rt, "_limits_validator", None)
+    _verdict["injected_policy"] = None if _injected is None else _injected.policy
+
+    try:
+        _rt.write_channel({UNLISTED_CHANNEL!r}, 1.0)
+        _verdict["write_channel"] = {{"allowed": True, "error": ""}}
+    except Exception as exc:
+        _verdict["write_channel"] = {{"allowed": False, "error": str(exc)}}
+
+
+    async def _via_connector():
+        connector = await _rt._get_connector()
+        # Recorded before the write, so a refused run still reports which type
+        # the stamp resolved to.
+        _verdict["connector_type"] = connector._connector_type
+        await connector.write_channel_checked({UNLISTED_CHANNEL!r}, 2.0)
+
+
+    _verdict["connector_type"] = None
+    try:
+        _rt._run_async(_via_connector())
+        _verdict["connector"] = {{"allowed": True, "error": ""}}
+    except Exception as exc:
+        _verdict["connector"] = {{"allowed": False, "error": str(exc)}}
+
+    print({VERDICT_PREFIX!r} + json.dumps(_verdict))
+    """
+).strip()
+
+
+def _write_deployment(root: Path) -> Path:
+    """Write a VA-permissive / live-strict deployment under *root*.
+
+    ``control_system.type`` is ``epics``, so ``resolve_target`` answers ``live``
+    with the baseline type — a type with no ``limits_checking`` block of its own,
+    which is what makes it inherit the strict deployment-wide pair. ``va`` always
+    resolves to ``virtual_accelerator``, whose block relaxes both leaves.
+
+    Returns:
+        The config file's path.
+    """
+    limits_path = root / "limits.json"
+    limits_path.write_text(
+        json.dumps({"SANDBOX:LISTED:CHANNEL": {"min_value": 0.0, "max_value": 10.0}}),
+        encoding="utf-8",
+    )
+
+    config = {
+        "project_root": str(root),
+        "agent_data": {"base_dir": "var/agent_data"},
+        "control_system": {
+            "type": "epics",
+            # Otherwise the connector's writes_enabled gate refuses first and
+            # neither path ever reaches a limits decision.
+            "writes_enabled": True,
+            "limits_checking": {
+                "enabled": True,
+                "allow_unlisted_channels": False,
+                "database_path": "limits.json",
+            },
+            "connector": {
+                "virtual_accelerator": {
+                    "limits_checking": {
+                        "enabled": True,
+                        "allow_unlisted_channels": True,
+                    }
+                }
+            },
+        },
+    }
+    config_path = root / "config.yml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return config_path
+
+
+@pytest.fixture
+def deployment(tmp_path, monkeypatch):
+    """An on-disk deployment this process and its sandbox children both read.
+
+    ``OSPREY_CONFIG`` is what ``load_osprey_config`` resolves (the project root
+    and the agent-data root come from it) and ``CONFIG_FILE`` is what the
+    connectors' ``get_config_value`` singleton reads. Both are set to the same
+    file so the host's posture resolution and the sandbox's cannot be answered by
+    two different configs, and both are inherited by the child.
+    """
+    from osprey_connectors.workspace import reset_config_cache
+
+    root = tmp_path / "deployment"
+    root.mkdir()
+    config_path = _write_deployment(root)
+
+    monkeypatch.setenv("OSPREY_CONFIG", str(config_path))
+    monkeypatch.setenv("CONFIG_FILE", str(config_path))
+    reset_config_cache()
+
+    (root / "var" / "agent_data" / target_state.STATE_DIR_NAME).mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _publish_target(target: str) -> None:
+    """Write the controls-server record that puts this session on *target*.
+
+    ``server_pid`` is this process, which is alive and whose file the sandbox
+    reads back for its generation pin; ``owner_ppid`` is this process's parent,
+    which is the equality ``_session_target_record`` matches on.
+    """
+    record = {
+        "target": target,
+        "generation": 0,
+        "server_pid": os.getpid(),
+        "owner_ppid": os.getppid(),
+        "targets": {
+            name: {"label": "", "endpoint": "", "real_machine": False}
+            for name in target_state.TARGET_NAMES
+        },
+        "children": [],
+    }
+    target_state.state_file_path().write_text(json.dumps(record), encoding="utf-8")
+
+
+def _run_sandbox(root: Path, target: str) -> dict:
+    """Run the probe script in a real sandbox on *target*; return its verdict.
+
+    Drives ``_execute_via_local`` — the real path, including the environment
+    stamp, the posture resolution, the generated wrapper and the subprocess.
+    """
+    _publish_target(target)
+
+    folder = root / "var" / "agent_data" / "python_executions" / target
+    (folder / "figures").mkdir(parents=True)
+
+    result = asyncio.run(
+        host_executor._execute_via_local(PROBE_SCRIPT, "readwrite", {"timeout": 300}, folder)
+    )
+
+    assert result.control_target == target, (
+        f"the run was stamped for {result.control_target!r}, not {target!r}; "
+        f"stderr:\n{result.stderr}"
+    )
+
+    for line in result.stdout.splitlines():
+        if line.startswith(VERDICT_PREFIX):
+            return json.loads(line[len(VERDICT_PREFIX) :])
+    raise AssertionError(
+        f"the sandbox printed no verdict.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_permissive_target_allows_both_write_paths(deployment):
+    """On ``va``, the per-type block answers both halves of one run.
+
+    One scenario, one subprocess, every assertion about it — a run of the real
+    sandbox is expensive enough that splitting these across test functions would
+    buy granularity by paying for the same run several times.
+    """
+    verdict = _run_sandbox(deployment, "va")
+
+    assert verdict["write_channel"] == {"allowed": True, "error": ""}
+    assert verdict["connector"] == {"allowed": True, "error": ""}
+    # The half of the agreement the embedded policy cannot account for: the
+    # connector resolved its own posture from this type, independently.
+    assert verdict["connector_type"] == "virtual_accelerator"
+    assert verdict["injected_policy"] == {
+        "allow_unlisted_channels": True,
+        "allow_unlisted_key": VA_KEY,
+    }
+
+
+def test_strict_target_refuses_both_write_paths(deployment):
+    """On ``live``, the deployment-wide block answers both halves of one run."""
+    verdict = _run_sandbox(deployment, "live")
+
+    assert verdict["write_channel"]["allowed"] is False
+    assert DEPLOYMENT_WIDE_KEY in verdict["write_channel"]["error"]
+    assert verdict["connector"]["allowed"] is False
+    assert DEPLOYMENT_WIDE_KEY in verdict["connector"]["error"]
+    # The relaxation belongs to the virtual accelerator. A refusal quoting it on
+    # the live machine would send an operator to edit the simulator's line.
+    assert VA_KEY not in verdict["write_channel"]["error"]
+    assert VA_KEY not in verdict["connector"]["error"]
+
+    assert verdict["connector_type"] == "epics"
+    assert verdict["injected_policy"] == {
+        "allow_unlisted_channels": False,
+        "allow_unlisted_key": DEPLOYMENT_WIDE_KEY,
+    }

--- a/tests/mcp_server/test_channel_limits_tool.py
+++ b/tests/mcp_server/test_channel_limits_tool.py
@@ -1,7 +1,9 @@
 """Tests for the channel_limits MCP tool.
 
 Covers: summary mode, exact lookup (found/not-found/mixed), regex search,
-property filters, combined search+filter, parameter validation, and limits-disabled.
+property filters, combined search+filter, parameter validation, limits-disabled,
+and the reported limits posture (tri-state allow_unlisted_channels plus the
+config key that answered, resolved for the session's control target).
 """
 
 from dataclasses import dataclass
@@ -66,8 +68,22 @@ def _resolve_confirm(channel_address: str) -> bool:
     return bool(TEST_LIMITS_DB["defaults"].get("confirm", True))
 
 
-def _make_validator(allow_unlisted: bool = True) -> MagicMock:
-    """Build a mock LimitsValidator from TEST_LIMITS_DB."""
+DEPLOYMENT_WIDE_KEY = "control_system.limits_checking.allow_unlisted_channels"
+VA_KEY = "control_system.connector.virtual_accelerator.limits_checking.allow_unlisted_channels"
+
+
+def _make_validator(
+    allow_unlisted: bool | None = True,
+    allow_unlisted_key: str = DEPLOYMENT_WIDE_KEY,
+) -> MagicMock:
+    """Build a mock LimitsValidator from TEST_LIMITS_DB.
+
+    Args:
+        allow_unlisted: The tri-state posture answer — ``None`` is an unset
+            deployment-wide key, which refuses unlisted channels.
+        allow_unlisted_key: The config key that answered, as
+            ``LimitsValidator._from_posture`` puts it into ``policy``.
+    """
     validator = MagicMock()
     validator._raw_db = TEST_LIMITS_DB
     validator.resolve_confirm.side_effect = _resolve_confirm
@@ -86,9 +102,24 @@ def _make_validator(allow_unlisted: bool = True) -> MagicMock:
     validator.limits = limits
     validator.policy = {
         "allow_unlisted_channels": allow_unlisted,
+        "allow_unlisted_key": allow_unlisted_key,
         "on_violation": "error",
     }
     return validator
+
+
+def _patch_target(target: str | None = None, raises: bool = False):
+    """Patch the session control target the tool reads before building a validator."""
+    if raises:
+        return patch(
+            "osprey.mcp_server.control_system.tools.channel_limits.target_state.read",
+            side_effect=OSError("no shared data root"),
+        )
+    record = None if target is None else {"target": target, "generation": 3}
+    return patch(
+        "osprey.mcp_server.control_system.tools.channel_limits.target_state.read",
+        return_value=record,
+    )
 
 
 def _get_channel_limits():
@@ -120,6 +151,7 @@ async def test_summary_mode():
     assert data["summary"]["has_step_limit"] == 1
     assert data["summary"]["version"] == "1.0"
     assert data["access_details"]["policy"]["allow_unlisted_channels"] is True
+    assert data["access_details"]["policy"]["allow_unlisted_key"] == DEPLOYMENT_WIDE_KEY
     assert data["access_details"]["defaults"]["writable"] is True
 
 
@@ -212,6 +244,122 @@ async def test_lookup_not_found_allowed():
     ch = data["access_details"]["channels"]["UNKNOWN:PV"]
     assert ch["in_database"] is False
     assert "allowed" in ch["policy_action"]
+
+
+@pytest.mark.unit
+async def test_summary_unset_reports_null_and_deployment_wide_key():
+    """Deployment-wide key unset → the summary reports null, not a permissive default."""
+    with (
+        _patch_target(),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=_make_validator(allow_unlisted=None),
+        ),
+    ):
+        fn = _get_channel_limits()
+        result = await fn()
+
+    data = extract_response_dict(result)
+    policy = data["access_details"]["policy"]
+    assert policy["allow_unlisted_channels"] is None
+    assert policy["allow_unlisted_key"] == DEPLOYMENT_WIDE_KEY
+
+
+@pytest.mark.unit
+async def test_lookup_unset_is_refused_naming_the_deployment_wide_key():
+    """Unset is nobody's permission: the unlisted channel is refused, key named."""
+    with (
+        _patch_target(),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=_make_validator(allow_unlisted=None),
+        ),
+    ):
+        fn = _get_channel_limits()
+        result = await fn(channels=["UNKNOWN:PV"])
+
+    data = extract_response_dict(result)
+    ch = data["access_details"]["channels"]["UNKNOWN:PV"]
+    assert ch["in_database"] is False
+    assert ch["allow_unlisted_channels"] is None
+    assert ch["allow_unlisted_key"] == DEPLOYMENT_WIDE_KEY
+    assert ch["policy_action"].startswith("BLOCKED")
+    assert DEPLOYMENT_WIDE_KEY in ch["policy_action"]
+
+
+@pytest.mark.unit
+async def test_posture_is_resolved_for_the_session_target():
+    """The tool asks for the posture of the target this server is on."""
+    with (
+        _patch_target("va"),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=_make_validator(allow_unlisted=True, allow_unlisted_key=VA_KEY),
+        ) as from_config,
+    ):
+        fn = _get_channel_limits()
+        result = await fn(channels=["UNKNOWN:PV"])
+
+    from_config.assert_called_once_with(target="va")
+    data = extract_response_dict(result)
+    ch = data["access_details"]["channels"]["UNKNOWN:PV"]
+    assert ch["allow_unlisted_channels"] is True
+    assert ch["allow_unlisted_key"] == VA_KEY
+    assert ch["policy_action"] == "allowed (no limits enforced)"
+
+
+@pytest.mark.unit
+async def test_summary_reports_the_per_target_key():
+    """A per-type block answers: the summary names that key, not the deployment-wide one."""
+    with (
+        _patch_target("va"),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=_make_validator(allow_unlisted=True, allow_unlisted_key=VA_KEY),
+        ),
+    ):
+        fn = _get_channel_limits()
+        result = await fn()
+
+    data = extract_response_dict(result)
+    assert data["access_details"]["policy"]["allow_unlisted_key"] == VA_KEY
+
+
+@pytest.mark.unit
+async def test_unreadable_target_state_falls_back_to_the_deployment_wide_block():
+    """An unreadable state directory is not fatal: no target → deployment-wide posture."""
+    with (
+        _patch_target(raises=True),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=_make_validator(),
+        ) as from_config,
+    ):
+        fn = _get_channel_limits()
+        result = await fn()
+
+    from_config.assert_called_once_with(target=None)
+    assert extract_response_dict(result)["status"] == "success"
+
+
+@pytest.mark.unit
+async def test_hand_built_policy_without_a_key_names_the_deployment_wide_one():
+    """A validator built from a bare policy dict carries no key; report the honest default."""
+    validator = _make_validator(allow_unlisted=False)
+    del validator.policy["allow_unlisted_key"]
+    with (
+        _patch_target("live"),
+        patch(
+            "osprey.connectors.control_system.limits_validator.LimitsValidator.from_config",
+            return_value=validator,
+        ),
+    ):
+        fn = _get_channel_limits()
+        result = await fn(channels=["UNKNOWN:PV"])
+
+    ch = extract_response_dict(result)["access_details"]["channels"]["UNKNOWN:PV"]
+    assert ch["allow_unlisted_channels"] is False
+    assert ch["allow_unlisted_key"] == DEPLOYMENT_WIDE_KEY
 
 
 @pytest.mark.unit

--- a/tests/mcp_server/test_channel_write_tool.py
+++ b/tests/mcp_server/test_channel_write_tool.py
@@ -20,12 +20,14 @@ Note: writes_enabled check is handled by the PreToolUse hook, not the tool itsel
 The tool does its own limits validation via LimitsValidator.
 """
 
+import json
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from osprey.connectors.control_system.base import ChannelWriteResult, WriteOutcome
+from osprey.mcp_server.control_system import target_state
 from osprey.mcp_server.control_system.server_context import initialize_server_context
 from tests.mcp_server.conftest import (
     assert_raises_error,
@@ -1102,3 +1104,124 @@ async def test_emitted_key_is_the_constant_the_rules_name(tmp_path, monkeypatch)
 
     data, _ = await _run_single(_make_write_result(channel="TEST:PV", value=42.0))
     assert OUTCOME_KEY in data["summary"]["results"][0]
+
+
+# ---------------------------------------------------------------------------
+# the limits posture is the one the session's target runs under
+# ---------------------------------------------------------------------------
+
+#: A deployment that relaxed unlisted channels for its simulator alone: the
+#: deployment-wide block refuses them, and only the ``virtual_accelerator``
+#: block allows them. ``live`` resolves to ``epics``, which wrote no block, so
+#: the two targets genuinely read two different postures out of one config.
+_SPLIT_POSTURE_CONFIG = """\
+control_system:
+  type: epics
+  limits_checking:
+    enabled: true
+    allow_unlisted_channels: false
+    database_path: {db_path}
+  connector:
+    virtual_accelerator:
+      limits_checking:
+        enabled: true
+        allow_unlisted_channels: true
+"""
+
+#: Display metadata as the server's single writer records it — irrelevant to
+#: the posture, written anyway so the fixture record is the shape a reader meets.
+_SPLIT_POSTURE_TARGETS_META = {
+    "live": {"label": "LIVE MACHINE", "endpoint": "gateway.example.com:5064", "real_machine": True},
+    "va": {
+        "label": "virtual accelerator (simulation)",
+        "endpoint": "localhost:5074",
+        "real_machine": False,
+    },
+}
+
+
+def _prepare_split_posture(tmp_path, monkeypatch, target):
+    """A split-posture deployment serving *target*, with a real state file.
+
+    Nothing here is a stand-in for the thing under test: the config is loaded
+    off disk, the limits database is a real file, and the target arrives the way
+    the tool actually learns it — from the state file the controls server
+    publishes, read through ``target_state``. The one rebinding is the state
+    root, so these files land in a directory this test owns.
+    """
+    db_path = tmp_path / "limits.json"
+    db_path.write_text(
+        json.dumps({"LISTED:PV": {"min_value": 0.0, "max_value": 100.0, "writable": True}})
+    )
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text(_SPLIT_POSTURE_CONFIG.format(db_path=db_path))
+    root = tmp_path / "var" / "agent_data"
+    monkeypatch.setattr(target_state, "resolve_shared_data_root", lambda: root)
+    target_state.write_on_start(target, _SPLIT_POSTURE_TARGETS_META, generation=0)
+    initialize_server_context()
+
+
+@contextmanager
+def _real_validator(connector):
+    """Serve *connector* while the tool builds its own validator from config.
+
+    The opposite of :func:`_patched`: here the validator is exactly the one the
+    tool constructs, because which posture it constructs it from is the whole
+    question.
+    """
+    with patch(
+        "osprey.connectors.factory.ConnectorFactory.create_control_system_connector",
+        new_callable=AsyncMock,
+        return_value=connector,
+    ):
+        yield
+
+
+@pytest.mark.unit
+async def test_unlisted_write_passes_on_a_target_whose_block_allows_it(tmp_path, monkeypatch):
+    """Serving ``va``, the tool reads the simulator's own permissive block.
+
+    The deployment-wide key still refuses unlisted channels; reading it here
+    would refuse a write the operator relaxed for the simulator on purpose.
+    """
+    _prepare_split_posture(tmp_path, monkeypatch, "va")
+
+    connector = AsyncMock()
+    connector.write_channel.return_value = _make_write_result(channel="UNLISTED:PV", value=1.0)
+
+    with _real_validator(connector):
+        fn = _get_channel_write()
+        raw = await fn(operations=[{"channel": "UNLISTED:PV", "value": 1.0}])
+
+    data = extract_response_dict(raw)
+    assert data["status"] == "success"
+    assert _outcomes(data) == {"UNLISTED:PV": "confirmed"}
+    assert connector.write_channel.await_count == 1
+
+
+@pytest.mark.unit
+async def test_unlisted_write_is_refused_on_a_target_the_deployment_block_governs(
+    tmp_path, monkeypatch
+):
+    """Serving ``live``, the same write is refused and the refusal names the key.
+
+    ``live`` resolves to ``epics``, which wrote no block, so the deployment-wide
+    key is the one that answered — and it is the line an operator would have to
+    edit, so it is the line the refusal quotes. The connector is never reached.
+    """
+    _prepare_split_posture(tmp_path, monkeypatch, "live")
+
+    connector = AsyncMock()
+    connector.write_channel.return_value = _make_write_result(channel="UNLISTED:PV", value=1.0)
+
+    with _real_validator(connector):
+        fn = _get_channel_write()
+        with assert_raises_error(error_type="limits_violation") as _exc_ctx:
+            await fn(operations=[{"channel": "UNLISTED:PV", "value": 1.0}])
+
+    data = _exc_ctx["envelope"]
+    assert data["details"][0]["violation_type"] == "UNLISTED_CHANNEL"
+    assert (
+        "control_system.limits_checking.allow_unlisted_channels" in data["details"][0]["reason"]
+    ), data["details"][0]["reason"]
+    assert connector.write_channel.await_count == 0

--- a/tests/mcp_server/test_control_target_roster.py
+++ b/tests/mcp_server/test_control_target_roster.py
@@ -917,3 +917,90 @@ class TestLiveStandinLabel:
         assert metadata["live"]["real_machine"] is True
         assert metadata["standin"]["real_machine"] is True
         assert metadata["va"]["real_machine"] is False
+
+
+# ------------------------------------------------------ the limits posture
+
+
+class TestLimitsPostureRows:
+    """``limits_strict``: per target, for the same reason ``writes_permitted`` is.
+
+    Limits checking is per connector type, so a deployment can relax unlisted
+    channels on its simulator while its live machine refuses them. A single
+    flag for the deployment would tell an operator standing on hardware what is
+    true of the sandbox next to it.
+    """
+
+    async def test_each_row_carries_its_own_targets_limits_posture(
+        self, make_manager, monkeypatch, no_prober
+    ):
+        """A permissive simulator beside two strict machines: three answers, not one.
+
+        The deployment-wide block is strict and only the simulator's own block
+        relaxes it, so ``live`` and ``standin`` — neither of which wrote a block
+        — inherit the strict deployment-wide posture and the simulator answers
+        from its own.
+        """
+        raw = standin_config(
+            baseline_type="live_standin",
+            va_gateways=True,
+            strict_limits=True,
+            acknowledged=True,
+        )
+        raw["control_system"]["connector"]["virtual_accelerator"]["limits_checking"] = {
+            "enabled": True,
+            "allow_unlisted_channels": True,
+        }
+        manager = make_manager(raw=raw)
+        install_context(manager, monkeypatch)
+
+        rows = extract_response_dict(await ROSTER())["access_details"]["targets"]
+
+        assert rows["live"]["limits_strict"] is True
+        assert rows["standin"]["limits_strict"] is True
+        assert rows["va"]["limits_strict"] is False
+
+    async def test_a_deployment_that_states_no_posture_is_not_strict(
+        self, make_manager, monkeypatch, no_prober
+    ):
+        """Silence is not a guarantee: no block anywhere means no row is strict.
+
+        A deployment that never configured limits checking has refused nothing,
+        and a row saying otherwise would advertise a promise no config line
+        backs.
+        """
+        manager = make_manager(raw=config_with_gateways())
+        install_context(manager, monkeypatch)
+
+        rows = extract_response_dict(await ROSTER())["access_details"]["targets"]
+
+        assert [row["limits_strict"] for row in rows.values()] == [False, False]
+
+    def test_an_underivable_row_carries_the_deployment_wide_posture(self):
+        """``live`` on a mock deployment resolves to no type, so no block can answer.
+
+        The row is still there — the baseline always gets one — and the posture
+        it carries is the deployment-wide block, which is the only one such a
+        deployment has ever had. The simulator's own permissive block sits
+        beside it and does not answer for it.
+        """
+        raw = {
+            "control_system": {
+                "type": "mock",
+                "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
+                "connector": {
+                    "mock": {"probe_channel": LIVE_PROBE},
+                    "virtual_accelerator": {
+                        "probe_channel": VA_PROBE,
+                        "limits_checking": {"enabled": True, "allow_unlisted_channels": True},
+                    },
+                },
+            },
+            "archiver": {"type": REAL_ARCHIVER},
+        }
+
+        rows = control_target.target_rows(raw, session_target="live", baseline="live")
+
+        assert rows["live"]["endpoints"] == {}
+        assert rows["live"]["limits_strict"] is True
+        assert rows["va"]["limits_strict"] is False

--- a/tests/mcp_server/test_python_execute_tool.py
+++ b/tests/mcp_server/test_python_execute_tool.py
@@ -846,7 +846,6 @@ async def test_save_artifact_no_name_error_in_subprocess(tmp_path):
         execution_mode="readonly",
         config=config,
         execution_folder=execution_folder,
-        limits_validator=None,
     )
 
     # The core assertion: execution must succeed, not crash with NameError
@@ -878,7 +877,6 @@ async def test_save_artifact_creates_manifest_in_subprocess(tmp_path):
         execution_mode="readonly",
         config=config,
         execution_folder=execution_folder,
-        limits_validator=None,
     )
 
     assert result.success, f"Execution failed: {result.stderr}"
@@ -921,7 +919,6 @@ async def test_save_artifact_collected_into_execution_result(tmp_path):
         execution_mode="readonly",
         config=config,
         execution_folder=execution_folder,
-        limits_validator=None,
     )
 
     assert result.success, f"Execution failed: {result.stderr}"
@@ -959,7 +956,6 @@ save_artifact("<h1>Third</h1></h1>", title="Third Artifact", description="html")
         execution_mode="readonly",
         config=config,
         execution_folder=execution_folder,
-        limits_validator=None,
     )
 
     assert result.success, f"Execution failed: {result.stderr}"
@@ -1006,7 +1002,6 @@ save_artifact([1, 2, 3], title="List Data")
         execution_mode="readonly",
         config=config,
         execution_folder=execution_folder,
-        limits_validator=None,
     )
 
     assert result.success, f"Execution failed: {result.stderr}"
@@ -1079,7 +1074,6 @@ print(f"Loaded: {data['channels']}")
             execution_mode="readonly",
             config=config,
             execution_folder=execution_folder,
-            limits_validator=None,
         )
 
     assert result.success, (
@@ -1116,7 +1110,6 @@ async def test_subprocess_outputs_still_written_to_execution_folder(tmp_path):
             execution_mode="readonly",
             config=config,
             execution_folder=execution_folder,
-            limits_validator=None,
         )
 
     assert result.success, f"Execution failed: {result.stderr}"

--- a/tests/mcp_server/test_target_eligibility.py
+++ b/tests/mcp_server/test_target_eligibility.py
@@ -45,6 +45,12 @@ STANDIN_TYPE = "live_standin"
 #: would let a block that simply never set a port pass the deployed check.
 STANDIN_PORT = 5094
 
+#: The deployment-wide limits keys, spelled out rather than imported from the
+#: module under test: the gate builds them off the resolved posture, so a
+#: refusal quoting them is the assertion, not a constant the two share.
+DEPLOYMENT_WIDE_ENABLED_KEY = "control_system.limits_checking.enabled"
+DEPLOYMENT_WIDE_ALLOW_UNLISTED_KEY = "control_system.limits_checking.allow_unlisted_channels"
+
 
 # ---------------------------------------------------------------------------
 # Config builders
@@ -338,8 +344,8 @@ def test_live_without_strict_limits_is_ineligible() -> None:
 
     assert verdict.eligible is False
     assert verdict.reason == te.REASON_LIMITS_POSTURE
-    assert te.LIMITS_ENABLED_KEY in verdict.detail
-    assert te.ALLOW_UNLISTED_KEY in verdict.detail
+    assert DEPLOYMENT_WIDE_ENABLED_KEY in verdict.detail
+    assert DEPLOYMENT_WIDE_ALLOW_UNLISTED_KEY in verdict.detail
 
 
 def test_live_failing_both_posture_checks_reports_the_limits_one_first() -> None:
@@ -367,6 +373,111 @@ def test_a_blank_acknowledgment_counts_as_unset(blank: Any) -> None:
     config = _config(ack=False, target_switch={te.ACK_LEAF: blank})
 
     assert _eligibility(config, LIVE).reason == te.REASON_OPERATOR_ACK_MISSING
+
+
+# ---------------------------------------------------------------------------
+# The limits posture is read per connector type
+# ---------------------------------------------------------------------------
+#
+# A deployment with a live machine beside a virtual accelerator holds one limits
+# posture per machine, so the gate must read the posture of the type the target
+# actually resolves to and quote the key that answered — the per-type line when a
+# per-type block spoke, the deployment-wide one otherwise. Quoting the wrong key
+# would send an operator to edit a line the per-type block overrides.
+
+
+def _limits_block(**leaves: Any) -> dict[str, Any]:
+    """A ``limits_checking`` block to hang under one connector block."""
+    return {"limits_checking": dict(leaves)}
+
+
+PER_TYPE_ENABLED_KEY = f"control_system.connector.{EPICS_TYPE}.limits_checking.enabled"
+PER_TYPE_ALLOW_UNLISTED_KEY = (
+    f"control_system.connector.{EPICS_TYPE}.limits_checking.allow_unlisted_channels"
+)
+
+
+def test_a_strict_per_type_block_makes_live_eligible_on_a_permissive_deployment() -> None:
+    """The live machine's own block answers, and the deployment-wide relaxation a
+    simulator was given does not reach it."""
+    config = _config(
+        limits="permissive",
+        ack=True,
+        connector={
+            EPICS_TYPE: _epics_block(**_limits_block(enabled=True, allow_unlisted_channels=False)),
+            VA_TYPE: _va_block(),
+        },
+    )
+
+    verdict = _eligibility(config, LIVE)
+
+    assert verdict.eligible is True
+    assert verdict.reason is None
+
+
+def test_a_permissive_per_type_block_refuses_live_and_names_the_per_type_key() -> None:
+    """The per-type block overrides whole, so a strict deployment-wide block does
+    not rescue it — and the refusal names the line that actually answered."""
+    config = _config(
+        limits="strict",
+        ack=True,
+        connector={
+            EPICS_TYPE: _epics_block(**_limits_block(enabled=False, allow_unlisted_channels=True)),
+            VA_TYPE: _va_block(),
+        },
+    )
+
+    verdict = _eligibility(config, LIVE)
+
+    assert verdict.eligible is False
+    assert verdict.reason == te.REASON_LIMITS_POSTURE
+    assert PER_TYPE_ENABLED_KEY in verdict.detail
+    assert PER_TYPE_ALLOW_UNLISTED_KEY in verdict.detail
+    assert DEPLOYMENT_WIDE_ENABLED_KEY not in verdict.detail
+
+
+def test_an_incomplete_per_type_block_is_not_strict() -> None:
+    """Half a block answers nothing — not the half it states, and not the
+    deployment-wide block it overrides. The refusal names the block an operator
+    has to finish."""
+    config = _config(
+        limits="strict",
+        ack=True,
+        connector={
+            EPICS_TYPE: _epics_block(**_limits_block(enabled=True)),
+            VA_TYPE: _va_block(),
+        },
+    )
+
+    verdict = _eligibility(config, LIVE)
+
+    assert verdict.eligible is False
+    assert verdict.reason == te.REASON_LIMITS_POSTURE
+    assert PER_TYPE_ENABLED_KEY in verdict.detail
+    assert PER_TYPE_ALLOW_UNLISTED_KEY in verdict.detail
+
+
+def test_the_standin_reads_its_own_types_block_not_the_live_machines() -> None:
+    """The stand-in is a connector type of its own, so the gate follows the type
+    the target resolves to rather than the deployment's live one."""
+    config = _standin_config(
+        limits="permissive",
+        ack=True,
+        connector={
+            EPICS_TYPE: _epics_block(),
+            VA_TYPE: _va_block(),
+            STANDIN_TYPE: _standin_block(
+                **_limits_block(enabled=True, allow_unlisted_channels=False)
+            ),
+        },
+    )
+
+    assert _eligibility(config, STANDIN).eligible is True
+
+    live = _eligibility(config, LIVE)
+    assert live.eligible is False
+    assert live.reason == te.REASON_LIMITS_POSTURE
+    assert DEPLOYMENT_WIDE_ENABLED_KEY in live.detail
 
 
 def test_returning_to_live_needs_neither_posture_nor_acknowledgment() -> None:
@@ -475,8 +586,8 @@ def test_switching_to_the_standin_requires_the_strict_limits_posture() -> None:
 
     assert verdict.eligible is False
     assert verdict.reason == te.REASON_LIMITS_POSTURE
-    assert te.LIMITS_ENABLED_KEY in verdict.detail
-    assert te.ALLOW_UNLISTED_KEY in verdict.detail
+    assert DEPLOYMENT_WIDE_ENABLED_KEY in verdict.detail
+    assert DEPLOYMENT_WIDE_ALLOW_UNLISTED_KEY in verdict.detail
 
 
 def test_switching_to_the_standin_needs_no_operator_acknowledgment() -> None:

--- a/tests/runtime/test_executor_target_stamp.py
+++ b/tests/runtime/test_executor_target_stamp.py
@@ -394,7 +394,6 @@ class TestExecuteViaLocalStamping:
                 "readonly",
                 {"timeout": 5},
                 folder,
-                None,
             )
         )
         return captured["env"], result

--- a/tests/services/bluesky_bridge/test_launch_validation_gate.py
+++ b/tests/services/bluesky_bridge/test_launch_validation_gate.py
@@ -196,3 +196,169 @@ def test_gate_ignores_a_plan_name_with_no_session_file_and_no_registration() -> 
 
 def test_gate_ignores_a_request_with_no_plan_name() -> None:
     assert _validate_launchable_request({}) is None
+
+
+# =========================================================================
+# The startup guard's limits posture is THIS LANE's, not the deployment's
+# =========================================================================
+#
+# `_assert_limits_readable_if_writable` already resolves its WRITE posture per
+# connector type (`test_startup_assertion.py` pins that). Limits checking is
+# per type for the same reason: a deployment may leave its virtual accelerator
+# unchecked while its live machine enforces limits, and a lane that reads the
+# deployment-wide key instead would refuse — or, the direction that matters,
+# start — on a posture belonging to some other lane's machine.
+
+
+#: A live-baseline deployment whose virtual accelerator alone arms writes AND
+#: turns limits checking on, while the deployment-wide limits block says off.
+#: A bridge lane serving `va` must therefore demand a readable limits database
+#: that `control_system.limits_checking.enabled` alone would have excused.
+_VA_LIMITS_SECTION: dict = {
+    "type": "epics",
+    "writes_enabled": False,
+    "limits_checking": {"enabled": False, "allow_unlisted_channels": True},
+    "connector": {
+        "epics": {"gateway_address": "epics-gateway.example"},
+        "virtual_accelerator": {
+            "writes_enabled": True,
+            "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
+        },
+    },
+}
+
+#: The mirror image: the deployment-wide block turns limits checking on, and
+#: the armed lane's own block turns it off. Reading the deployment-wide key
+#: would demand a database this lane's config says it does not need.
+_VA_UNCHECKED_SECTION: dict = {
+    "type": "epics",
+    "writes_enabled": False,
+    "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
+    "connector": {
+        "epics": {"gateway_address": "epics-gateway.example"},
+        "virtual_accelerator": {
+            "writes_enabled": True,
+            "limits_checking": {"enabled": False, "allow_unlisted_channels": True},
+        },
+    },
+}
+
+_VA_LANE = "bluesky_va"
+_LANE_TARGETS = {_VA_LANE: "va", "bluesky_live": "live"}
+_VA_LIMITS_KEY = "control_system.connector.virtual_accelerator.limits_checking.enabled"
+
+
+@pytest.fixture
+def _no_execution_mode(monkeypatch: pytest.MonkeyPatch):
+    """A read-only run short-circuits the guard before any posture is read."""
+    monkeypatch.delenv("OSPREY_EXECUTION_MODE", raising=False)
+
+
+def _patch_lane_config(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    section: dict,
+    db_path: str | None = None,
+) -> None:
+    """Patch the config keys the startup guard reads, nested as it reads them.
+
+    The limits posture now comes out of the ``control_system`` SECTION — the
+    same mapping the write posture is resolved from — so the per-type block
+    lives inside `section` rather than behind a dotted key. Only
+    ``database_path`` stays deployment-wide, since the deployment mounts one
+    limits database.
+
+    The guard imports `get_config_value` inside its own body, so patching the
+    `osprey.utils.config` attribute takes effect on the next call.
+    """
+
+    def fake_get_config_value(key: str, default=None):
+        if key == "control_system":
+            return section
+        if key == "control_system.type":
+            return section.get("type", default)
+        if key == "control_system.limits_checking.database_path":
+            return db_path if db_path is not None else default
+        if key == "project_root":
+            return default
+        if key.startswith("services.") and key.endswith(".target"):
+            return _LANE_TARGETS.get(key.split(".")[1], default)
+        return default
+
+    monkeypatch.setattr("osprey.utils.config.get_config_value", fake_get_config_value)
+
+
+def _spy_on_limits_probe(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every `LimitsValidator._load_limits_database` call, still doing it."""
+    from osprey.connectors.control_system.limits_validator import LimitsValidator
+
+    probe_calls: list[str] = []
+    original_load = LimitsValidator._load_limits_database
+
+    def spy(db_path: str):
+        probe_calls.append(db_path)
+        return original_load(db_path)
+
+    monkeypatch.setattr(LimitsValidator, "_load_limits_database", staticmethod(spy))
+    return probe_calls
+
+
+def test_guard_reads_limits_enabled_from_the_lane_targets_own_block(
+    monkeypatch: pytest.MonkeyPatch, _no_execution_mode: None
+) -> None:
+    """Per-type `enabled: true` arms the guard though the deployment-wide key is false."""
+    # Arrange
+    from osprey.services.bluesky_bridge.validation import _assert_limits_readable_if_writable
+
+    monkeypatch.setenv("OSPREY_BLUESKY_LANE", _VA_LANE)
+    _patch_lane_config(monkeypatch, section=_VA_LIMITS_SECTION, db_path=None)
+
+    # Act
+    with pytest.raises(RuntimeError) as excinfo:
+        _assert_limits_readable_if_writable()
+
+    # Assert
+    message = str(excinfo.value)
+    assert _VA_LIMITS_KEY in message
+    assert "control_system.connector.virtual_accelerator.writes_enabled" in message
+    assert f"lane {_VA_LANE} serves target va" in message
+
+
+def test_unreadable_database_refusal_names_the_per_type_limits_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _no_execution_mode: None
+) -> None:
+    """The second refusal names the answering key too, not the deployment-wide one."""
+    # Arrange
+    from osprey.services.bluesky_bridge.validation import _assert_limits_readable_if_writable
+
+    monkeypatch.setenv("OSPREY_BLUESKY_LANE", _VA_LANE)
+    missing = tmp_path / "does_not_exist.json"
+    _patch_lane_config(monkeypatch, section=_VA_LIMITS_SECTION, db_path=str(missing))
+
+    # Act
+    with pytest.raises(RuntimeError) as excinfo:
+        _assert_limits_readable_if_writable()
+
+    # Assert
+    message = str(excinfo.value)
+    assert _VA_LIMITS_KEY in message
+    assert "could not be read or parsed" in message
+
+
+def test_guard_ignores_the_deployment_wide_key_when_the_lanes_block_disables_limits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _no_execution_mode: None
+) -> None:
+    """An armed lane whose own block turns limits checking off needs no database."""
+    # Arrange
+    from osprey.services.bluesky_bridge.validation import _assert_limits_readable_if_writable
+
+    monkeypatch.setenv("OSPREY_BLUESKY_LANE", _VA_LANE)
+    missing = tmp_path / "does_not_exist.json"
+    _patch_lane_config(monkeypatch, section=_VA_UNCHECKED_SECTION, db_path=str(missing))
+    probe_calls = _spy_on_limits_probe(monkeypatch)
+
+    # Act
+    assert _assert_limits_readable_if_writable() is None
+
+    # Assert
+    assert probe_calls == []

--- a/tests/services/bluesky_bridge/test_qserver_startup.py
+++ b/tests/services/bluesky_bridge/test_qserver_startup.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import os
 import time
 from collections.abc import Iterator
@@ -421,6 +422,114 @@ def test_other_types_are_forwarded_through_untouched() -> None:
         "type": "mock",
         "connector": {"mock": {}},
     }
+
+
+# ---------------------------------------------------------------------------
+# Degraded-lane posture
+# ---------------------------------------------------------------------------
+
+_DEPLOYMENT_WIDE_UNLISTED_KEY = "control_system.limits_checking.allow_unlisted_channels"
+"""The deployment-wide limits key a degraded lane must be answered by."""
+
+_PER_TYPE_UNLISTED_KEY = "control_system.connector.mock.limits_checking.allow_unlisted_channels"
+"""The per-type key a lane that resolved its own target is answered by."""
+
+
+def _posture_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Config whose ``mock`` block relaxes what the deployment-wide keys refuse.
+
+    The two postures disagree on purpose: the connector block arms writes and
+    allows unlisted channels, the deployment-wide keys do neither. Which pair a
+    built connector ends up reading is then observable on the connector itself,
+    which is what the degraded lane turns on.
+    """
+    database = tmp_path / "limits.json"
+    database.write_text(
+        json.dumps({"SR:MAG:HCM:01:CUR:SP": {"min_value": -1.0, "max_value": 1.0}}),
+        encoding="utf-8",
+    )
+    section: dict[str, Any] = {
+        "type": "mock",
+        "writes_enabled": False,
+        "limits_checking": {
+            "enabled": True,
+            "allow_unlisted_channels": False,
+            "database_path": str(database),
+        },
+        "connector": {
+            "mock": {
+                "writes_enabled": True,
+                "limits_checking": {"enabled": True, "allow_unlisted_channels": True},
+            }
+        },
+    }
+    values: dict[str, Any] = {
+        "control_system": section,
+        "control_system.writes_enabled": False,
+        "control_system.limits_checking.database_path": str(database),
+    }
+
+    monkeypatch.setattr(
+        "osprey.utils.config.get_config_value",
+        lambda key, default=None: values.get(key, default),
+    )
+    monkeypatch.setattr("osprey.utils.config.default_config_path", lambda: None)
+    # The write posture is refused outright in a readonly run, which would make
+    # both lanes agree for a reason that has nothing to do with the stamp.
+    monkeypatch.delenv("OSPREY_EXECUTION_MODE", raising=False)
+
+
+def _pin_lane(monkeypatch: pytest.MonkeyPatch, lane_degraded: str | None) -> None:
+    """Pin the lane resolver to a ``mock`` worker, degraded or not."""
+    from osprey.services.bluesky_bridge import queue_backend
+
+    monkeypatch.setattr(
+        queue_backend, "resolve_lane_connector_type", lambda: ("mock", lane_degraded)
+    )
+
+
+def test_a_degraded_lane_is_built_unstamped_before_its_validator_is_loaded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The stamp has to be gone BEFORE ``connect()``, not after it.
+
+    A connector loads its limits validator inside ``connect()``, keyed on the
+    stamp the factory left. Clearing the stamp afterwards therefore fixes the
+    write posture (read live off the attribute) while leaving the validator
+    already built against the baseline type's block — a lane addressing a
+    machine that block never described, running with that machine's limits
+    policy. Both halves have to land on the deployment-wide pair.
+    """
+    _posture_config(monkeypatch, tmp_path)
+    _pin_lane(
+        monkeypatch, "Lane 'live' declares the 'live' target, which this deployment cannot resolve"
+    )
+
+    connector = asyncio.run(qserver_startup.create_connector())
+
+    assert connector._connector_type is None
+    assert connector._limits_validator.policy["allow_unlisted_key"] == (
+        _DEPLOYMENT_WIDE_UNLISTED_KEY
+    )
+    assert connector._limits_validator.policy["allow_unlisted_channels"] is False
+    assert connector._writes_enabled is False
+    assert qserver_startup.worker_writes_enabled() is False
+
+
+def test_a_resolved_lane_keeps_its_own_types_posture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The non-degraded lane is the control: it reads the block for its type."""
+    _posture_config(monkeypatch, tmp_path)
+    _pin_lane(monkeypatch, None)
+
+    connector = asyncio.run(qserver_startup.create_connector())
+
+    assert connector._connector_type == "mock"
+    assert connector._limits_validator.policy["allow_unlisted_key"] == _PER_TYPE_UNLISTED_KEY
+    assert connector._limits_validator.policy["allow_unlisted_channels"] is True
+    assert connector._writes_enabled is True
+    assert qserver_startup.worker_writes_enabled() is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/bluesky_bridge/test_startup_assertion.py
+++ b/tests/services/bluesky_bridge/test_startup_assertion.py
@@ -114,6 +114,13 @@ def _patch_config(
     (and `lane_targets`) for a config that arms one connector type and not
     another.
 
+    Limits checking is per connector type too, and the guard reads it out of
+    the same SECTION, so `limits_enabled` is folded into the section's
+    `limits_checking` block rather than answered behind a dotted key. The copy
+    is what keeps a module-level section constant (`_MIXED_SECTION`) from
+    carrying one test's posture into the next. Only `database_path` stays
+    deployment-wide, since the deployment mounts one limits database.
+
     `_assert_limits_readable_if_writable` does its own
     `from osprey.utils.config import get_config_value` inside the function
     body (never at module import time), so patching the underlying
@@ -122,8 +129,13 @@ def _patch_config(
     takes effect on the next call.
     """
     control_system: dict[str, Any] = (
-        {"writes_enabled": writes_enabled} if section is None else section
+        {"writes_enabled": writes_enabled} if section is None else dict(section)
     )
+    if limits_enabled is not None:
+        control_system["limits_checking"] = {
+            **control_system.get("limits_checking", {}),
+            "enabled": limits_enabled,
+        }
     targets = lane_targets or {}
 
     def fake_get_config_value(key: str, default=None):
@@ -131,8 +143,6 @@ def _patch_config(
             return control_system
         if key == "control_system.type":
             return control_system.get("type", default)
-        if key == "control_system.limits_checking.enabled":
-            return limits_enabled if limits_enabled is not None else default
         if key == "control_system.limits_checking.database_path":
             return db_path if db_path is not None else default
         if key == "project_root":
@@ -276,6 +286,37 @@ def test_writable_with_relative_db_path_resolves_via_config_file_dir(
     with TestClient(app) as client:
         resp = client.get("/health")
         assert resp.status_code == 200
+
+
+def test_writable_with_an_unreadable_limits_leaf_refuses_startup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A leaf that is present but not a literal boolean is a startup refusal.
+
+    The connector and the hook would refuse every write from the same posture;
+    the gate turns that into a refusal at startup naming the line to fix,
+    rather than a lane that starts writable and then denies everything.
+    """
+    # Arrange
+    _patch_config(
+        monkeypatch,
+        section={"type": "epics", "writes_enabled": True, "limits_checking": {"enabled": "true"}},
+        db_path=str(_valid_limits_db(tmp_path)),
+    )
+    probe_calls = _spy_on_limits_probe(monkeypatch)
+
+    # Act
+    with pytest.raises(RuntimeError) as excinfo:
+        with TestClient(app):
+            pass
+
+    # Assert
+    message = str(excinfo.value)
+    assert "control_system.limits_checking.enabled" in message
+    # An ABSENT deployment-wide leaf is unset, not unreadable, so it is not named.
+    assert "control_system.limits_checking.allow_unlisted_channels" not in message
+    assert "literal true or false" in message
+    assert probe_calls == []
 
 
 def test_writable_with_limits_checking_disabled_starts_without_db(

--- a/tests/services/python_executor/execution/test_limits_validator.py
+++ b/tests/services/python_executor/execution/test_limits_validator.py
@@ -338,7 +338,12 @@ class TestLimitsValidator:
 
     @patch("osprey.utils.config.get_config_value")
     def test_from_config_disabled(self, mock_get_config):
-        """Test that from_config returns None when disabled."""
+        """Test that from_config returns None when disabled.
+
+        Every key answers ``False``, the ``control_system`` section included: a
+        section that is not a mapping is a deployment that stated no posture, so
+        the answer is still no validator rather than a crash on the shape.
+        """
         mock_get_config.return_value = False
 
         validator = LimitsValidator.from_config()
@@ -350,7 +355,9 @@ class TestLimitsValidator:
         """Test that from_config returns empty validator when no database path."""
 
         def config_side_effect(key, default):
-            if key == "control_system.limits_checking.enabled":
+            if key == "control_system":
+                return {"limits_checking": {"enabled": True, "database_path": None}}
+            elif key == "control_system.limits_checking.enabled":
                 return True
             elif key == "control_system.limits_checking.database_path":
                 return None
@@ -373,7 +380,15 @@ class TestLimitsValidator:
         db_file.write_text(json.dumps(db_content))
 
         def config_side_effect(key, default):
-            if key == "control_system.limits_checking.enabled":
+            if key == "control_system":
+                return {
+                    "limits_checking": {
+                        "enabled": True,
+                        "database_path": str(db_file),
+                        "allow_unlisted_channels": False,
+                    }
+                }
+            elif key == "control_system.limits_checking.enabled":
                 return True
             elif key == "control_system.limits_checking.database_path":
                 return str(db_file)
@@ -402,7 +417,15 @@ class TestLimitsValidator:
         db_file.write_text('{"PV1": {"min_value": 0.0},}')  # Trailing comma
 
         def config_side_effect(key, default):
-            if key == "control_system.limits_checking.enabled":
+            if key == "control_system":
+                return {
+                    "limits_checking": {
+                        "enabled": True,
+                        "database_path": str(db_file),
+                        "allow_unlisted_channels": False,
+                    }
+                }
+            elif key == "control_system.limits_checking.enabled":
                 return True
             elif key == "control_system.limits_checking.database_path":
                 return str(db_file)
@@ -423,7 +446,14 @@ class TestLimitsValidator:
         (same contract as the invalid-JSON case above)."""
 
         def config_side_effect(key, default):
-            if key == "control_system.limits_checking.enabled":
+            if key == "control_system":
+                return {
+                    "limits_checking": {
+                        "enabled": True,
+                        "database_path": "/nonexistent/path/to/limits.json",
+                    }
+                }
+            elif key == "control_system.limits_checking.enabled":
                 return True
             elif key == "control_system.limits_checking.database_path":
                 return "/nonexistent/path/to/limits.json"
@@ -466,7 +496,15 @@ class TestLimitsValidator:
         bogus_project_root = tmp_path / "host_build_path_does_not_exist"
 
         def config_side_effect(key, default):
-            if key == "control_system.limits_checking.enabled":
+            if key == "control_system":
+                return {
+                    "limits_checking": {
+                        "enabled": True,
+                        "database_path": "data/channel_limits.json",
+                        "allow_unlisted_channels": False,
+                    }
+                }
+            elif key == "control_system.limits_checking.enabled":
                 return True
             elif key == "control_system.limits_checking.database_path":
                 return "data/channel_limits.json"
@@ -498,7 +536,15 @@ class TestLimitsValidator:
         db_file.write_text(json.dumps({"TEST:PV": {"min_value": 0.0, "max_value": 100.0}}))
 
         def config_side_effect(key, default):
-            if key == "control_system.limits_checking.enabled":
+            if key == "control_system":
+                return {
+                    "limits_checking": {
+                        "enabled": True,
+                        "database_path": "data/channel_limits.json",
+                        "allow_unlisted_channels": False,
+                    }
+                }
+            elif key == "control_system.limits_checking.enabled":
                 return True
             elif key == "control_system.limits_checking.database_path":
                 return "data/channel_limits.json"

--- a/tests/services/python_executor/execution/test_net_guard.py
+++ b/tests/services/python_executor/execution/test_net_guard.py
@@ -643,7 +643,6 @@ class TestEndToEndArmingPath:
                 execution_mode="readonly",
                 config={"timeout": 30, "python_env_path": None},
                 execution_folder=execution_folder,
-                limits_validator=None,
             )
         finally:
             denied_srv.close()

--- a/tests/templates/render_axis_shapes/images-on-a-registry/bluesky.yml
+++ b/tests/templates/render_axis_shapes/images-on-a-registry/bluesky.yml
@@ -306,8 +306,9 @@ services:
     environment:
       # Same CONFIG_FILE convention as the bridge: the per-put reference
       # monitor now runs in THIS container (the RunEngine lives here), so it
-      # reads control_system.type / writes_enabled / limits_checking from the
-      # mounted config.yml, not from the image's WORKDIR.
+      # reads control_system.type / writes_enabled / limits_checking /
+      # connector.<type>.limits_checking from the mounted config.yml, not
+      # from the image's WORKDIR.
       CONFIG_FILE: /app/project/config.yml
       TZ: UTC
       # ── queue control plane (server side) ────────────────────────────────

--- a/tests/templates/render_axis_shapes/service-env-multi-container/bluesky.yml
+++ b/tests/templates/render_axis_shapes/service-env-multi-container/bluesky.yml
@@ -296,8 +296,9 @@ services:
     environment:
       # Same CONFIG_FILE convention as the bridge: the per-put reference
       # monitor now runs in THIS container (the RunEngine lives here), so it
-      # reads control_system.type / writes_enabled / limits_checking from the
-      # mounted config.yml, not from the image's WORKDIR.
+      # reads control_system.type / writes_enabled / limits_checking /
+      # connector.<type>.limits_checking from the mounted config.yml, not
+      # from the image's WORKDIR.
       CONFIG_FILE: /app/project/config.yml
       TZ: UTC
       # ── queue control plane (server side) ────────────────────────────────

--- a/tests/templates/render_defaults/bluesky.yml
+++ b/tests/templates/render_defaults/bluesky.yml
@@ -284,8 +284,9 @@ services:
     environment:
       # Same CONFIG_FILE convention as the bridge: the per-put reference
       # monitor now runs in THIS container (the RunEngine lives here), so it
-      # reads control_system.type / writes_enabled / limits_checking from the
-      # mounted config.yml, not from the image's WORKDIR.
+      # reads control_system.type / writes_enabled / limits_checking /
+      # connector.<type>.limits_checking from the mounted config.yml, not
+      # from the image's WORKDIR.
       CONFIG_FILE: /app/project/config.yml
       TZ: UTC
       # ── queue control plane (server side) ────────────────────────────────


### PR DESCRIPTION
`control_system.limits_checking` was one block for the whole deployment, while
write arming has been per connector type since #713. `VirtualAcceleratorConnector`
subclasses `EPICSConnector` and inherited the validator built in its `connect()`,
so one `allow_unlisted_channels` governed writes to the virtual accelerator and
to the live machine alike. A site running both could not keep the live machine
strict while letting a facility plan write VA channels that have no limits rows
yet; ALS carried the relaxation deployment-wide as a marked deviation.

`control_system.connector.<type>.limits_checking` now states `enabled` and
`allow_unlisted_channels` for one connector type, overriding the deployment-wide
pair as a whole block, and every reader — connectors, the factory, the IPC child,
the sandbox executor, the MCP tools, the write hook, the qserver startup gate,
the control-target roster and switch gate — resolves the posture of the target it
acts on and names the key that answered. `database_path` stays deployment-wide,
since compose mounts one file.

A block that states one setting answers nothing, so `osprey build` and
`osprey validate` refuse it rather than let a deployment run a posture its author
did not write. A setting present but not a literal boolean is treated the same
way, and every reader that must act builds a blocking validator.

Closes #779
