### PR TITLE
test: port isolation + credential honesty

### DIFF
--- a/changelog.d/e2e-port-isolation.changed.md
+++ b/changelog.d/e2e-port-isolation.changed.md
@@ -1,0 +1,4 @@
+E2E fixtures that start real services no longer squat a live deployment's
+ports: the virtual-accelerator harnesses bind ephemeral host ports instead of
+5064, and deploy-shaped e2e tests pin their own thousand-port block instead of
+the default 10000.

--- a/changelog.d/port-base-shorthand.added.md
+++ b/changelog.d/port-base-shorthand.added.md
@@ -1,0 +1,5 @@
+`port_base` is now a top-level profile shorthand: `osprey init --set
+port_base=42000` (or `port_base: 42000` in profile.yml) folds into
+`config: deployment.port_base` and moves the whole deployment — gateway,
+panels, services, stores — onto that thousand-port block. Handy for running a
+second stack beside one on the default 10000 block.

--- a/changelog.d/reset-env-auth.changed.md
+++ b/changelog.d/reset-env-auth.changed.md
@@ -1,0 +1,4 @@
+`osprey reset` (and `osprey init --reset`) now removes `.env.auth`, so a reset
+deployment cannot carry the previous generation's login passwords into a
+freshly seeded `.env`. The removal is disclosed in the reset plan; the next
+deploy re-mints every hash from `.env`.

--- a/changelog.d/stale-login-banner.fixed.md
+++ b/changelog.d/stale-login-banner.fixed.md
@@ -1,0 +1,3 @@
+The closing card no longer prints a profile-seeded login the deployed password
+hash contradicts. Such a login is withheld and the card names the rotate verb
+(`osprey users passwd <user>`) instead.

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -104,7 +104,9 @@ already encloses the target or ``--no-git`` is given.
 
 ``--set KEY.PATH=VALUE`` — Inline scalar/list override baked into the emitted
 profile (repeatable). RHS is parsed as YAML. Top-level shorthands: ``provider``,
-``model``, ``channel_finder_mode``, ``connector``.
+``model``, ``channel_finder_mode``, ``connector``, ``port_base`` (move the whole
+deployment onto another thousand-port block, e.g. ``--set port_base=42000`` —
+handy for a second stack beside one already on the default 10000 block).
 
 ``--force`` — Re-materialize the source zone of an existing deployment
 repository, discarding edits to ``profile.yml``, ``data/``, ``personas/``,

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -19,7 +19,12 @@ from pathlib import Path
 from typing import Any
 
 from osprey.errors import BuildProfileError
-from osprey.port_layout import DEFAULT_PORT_BASE, default_port, resolve_port_base
+from osprey.port_layout import (
+    DEFAULT_PORT_BASE,
+    PORT_BASE_CONFIG_KEY,
+    default_port,
+    resolve_port_base,
+)
 from osprey_connectors.types import SET_CONTROL_SYSTEM_TYPES
 
 from .build_profile_archiver import parse_va_archiver_block
@@ -153,6 +158,9 @@ _KNOWN_PROFILE_KEYS = frozenset(
         # because a materialized or hand-written profile may spell it, and
         # because this frozenset doubles as the "valid keys are:" list.
         "connector",
+        # Shorthand for config's `deployment.port_base`, consumed by
+        # _apply_port_base_shorthand — same contract as `connector` above.
+        "port_base",
         "provider",
         "model",
         "channel_finder_mode",
@@ -635,6 +643,12 @@ def _reject_mixed_claude_code_spellings(config: Any) -> None:
 CONNECTOR_PROFILE_KEY = "connector"
 CONNECTOR_CONFIG_KEY = "control_system.type"
 
+#: Top-level shorthand for ``config: {deployment.port_base: N}`` — the
+#: convenient spelling that moves a whole deployment off the default port
+#: block (``osprey init --set port_base=42000``), so a dev or CI stack never
+#: collides with a real deployment running on the defaults.
+PORT_BASE_PROFILE_KEY = "port_base"
+
 
 def _apply_connector_shorthand(raw: dict[str, Any]) -> dict[str, Any]:
     """Fold a top-level ``connector:`` shorthand into the ``config:`` block.
@@ -705,6 +719,54 @@ def _apply_connector_shorthand(raw: dict[str, Any]) -> dict[str, Any]:
     return raw
 
 
+def _apply_port_base_shorthand(raw: dict[str, Any]) -> dict[str, Any]:
+    """Fold a top-level ``port_base:`` shorthand into the ``config:`` block.
+
+    Applied beside :func:`_apply_connector_shorthand` on both entry paths
+    (CLI-layer merge and parse), for the same reason: no path a profile can
+    arrive by may carry the shorthand and have it silently ignored. Idempotent:
+    a mapping without the key is returned unchanged.
+
+    The value is range-checked through
+    :func:`~osprey.port_layout.resolve_port_base` — the resolver every runtime
+    consumer uses — so a base whose thousand-port block cannot exist fails the
+    parse with the layout's own refusal rather than surfacing at deploy.
+
+    Args:
+        raw: Raw profile mapping, mutated in place like the connector
+            shorthand it sits beside.
+
+    Returns:
+        The same mapping, with the shorthand consumed.
+
+    Raises:
+        BuildProfileError: If the value is not an in-range integer, or
+            ``config:`` is not a mapping to fold it into.
+    """
+    if PORT_BASE_PROFILE_KEY not in raw:
+        return raw
+
+    value = raw.pop(PORT_BASE_PROFILE_KEY)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise BuildProfileError(
+            f"Profile key 'port_base' must be an integer port base (got {value!r}) "
+            "— e.g. port_base: 42000."
+        )
+    try:
+        resolve_port_base({"deployment": {"port_base": value}})
+    except ValueError as exc:
+        raise BuildProfileError(f"Profile key 'port_base': {exc}") from exc
+
+    config = raw.setdefault("config", {})
+    if not isinstance(config, dict):
+        raise BuildProfileError(
+            f"Profile 'config' must be a mapping to carry the 'port_base' shorthand "
+            f"(got {type(config).__name__})"
+        )
+    config[PORT_BASE_CONFIG_KEY] = value
+    return raw
+
+
 def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
     """Parse raw YAML dict into a BuildProfile.
 
@@ -716,6 +778,7 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
     _normalize_profile_aliases(raw, "profile")
     _reject_unknown_keys(raw)
     _apply_connector_shorthand(raw)
+    _apply_port_base_shorthand(raw)
     mcp_servers: dict[str, McpServerDef] = {}
     for name, sdef in raw.get("mcp_servers", {}).items():
         if not isinstance(sdef, dict):

--- a/src/osprey/cli/build_profile_resolve.py
+++ b/src/osprey/cli/build_profile_resolve.py
@@ -35,8 +35,10 @@ from .build_profile_document import _normalize_profile_aliases, _read_profile_do
 from .build_profile_load import (
     CONNECTOR_CONFIG_KEY,
     CONNECTOR_PROFILE_KEY,
+    PORT_BASE_PROFILE_KEY,
     LoadedProfile,
     _apply_connector_shorthand,
+    _apply_port_base_shorthand,
     _parse_profile,
 )
 from .build_profile_merge import _deep_merge, _resolve_extends, resolve_profile_document
@@ -107,7 +109,11 @@ MODEL_SELECTION_OVERRIDE_KEYS = ("provider", "model", "channel_finder_mode")
 # in the same sense: which control system a project talks to is a property of
 # the deployment, not of one persona, so it belongs in profile.yml where every
 # persona delta inherits it rather than in any one persona's own file.
-SHORTHAND_OVERRIDE_KEYS = (*MODEL_SELECTION_OVERRIDE_KEYS, CONNECTOR_PROFILE_KEY)
+SHORTHAND_OVERRIDE_KEYS = (
+    *MODEL_SELECTION_OVERRIDE_KEYS,
+    CONNECTOR_PROFILE_KEY,
+    PORT_BASE_PROFILE_KEY,
+)
 
 
 def explicit_model_override_keys(set_pairs: tuple[str, ...]) -> list[str]:
@@ -338,7 +344,7 @@ def merge_cli_overrides(
     _reject_connector_type_conflict(cli_layers)
     if set_config_paths is not None:
         set_config_paths.extend(_set_config_paths(set_pairs))
-    return _apply_connector_shorthand(raw)
+    return _apply_port_base_shorthand(_apply_connector_shorthand(raw))
 
 
 def resolve_build_profile(

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1174,7 +1174,7 @@ def _point_at_set(ctx: click.Context, param: click.Parameter, value: str | None)
 #: prevent. The copy is held to the original by
 #: ``test_the_refused_flags_are_the_documented_shorthands``, so a shorthand
 #: added there and not here fails a test rather than going quietly uncaught.
-_SHORTHAND_FLAG_KEYS = ("provider", "model", "channel_finder_mode", "connector")
+_SHORTHAND_FLAG_KEYS = ("provider", "model", "channel_finder_mode", "connector", "port_base")
 
 
 def _reject_shorthand_flags(command: Callable) -> Callable:
@@ -1216,7 +1216,8 @@ def _reject_shorthand_flags(command: Callable) -> Callable:
     "RHS parsed as YAML. Top-level shorthands: provider, model, "
     "channel_finder_mode, connector (the control system to talk to — mock, "
     "epics, virtual_accelerator, doocs; a deployment being pointed at its "
-    "stand-in may also set live_standin).",
+    "stand-in may also set live_standin), port_base (move the whole "
+    "deployment off the default 10000 port block, e.g. --set port_base=42000).",
 )
 @click.option(
     "--list-presets",

--- a/src/osprey/cli/summary_card.py
+++ b/src/osprey/cli/summary_card.py
@@ -230,6 +230,16 @@ def print_call_to_action(repo_root: Path | str, state: str) -> None:
         pairs = " · ".join(f"{user} / {password}" for user, password in facts.logins)
         output.section("", [("sign in as", pairs)])
         output.note("these logins come from profile.yml; change them in .env")
+    if facts.stale_logins:
+        # A default the deployed hash contradicts is withheld above; saying
+        # nothing would leave the operator typing the profile's password at a
+        # wall that refuses it, with no clue which side is wrong.
+        users = ", ".join(facts.stale_logins)
+        verbs = " · ".join(f"osprey users passwd {user}" for user in facts.stale_logins)
+        output.note(
+            f"the seeded password in .env for {users} does not match the deployed "
+            f"login -- an earlier deploy set a different one. Reset with: {verbs}"
+        )
     if facts.token_login_users:
         output.section(
             "",

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from osprey.cli import output
 from osprey.deployment.compose_generator import resolve_project_name
@@ -52,6 +53,9 @@ from osprey.port_layout import (
     resolve_port_base,
 )
 from osprey.utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from osprey.deployment.web_terminals.auth_credentials import SeededLoginsReport
 
 logger = get_logger("deployment.summary")
 
@@ -641,6 +645,12 @@ class ClosingFacts:
     logins: tuple[tuple[str, str], ...]
     token_login_users: tuple[str, ...] = ()
     landing_url_is_external_origin: bool = True
+    #: Roster users whose ``.env`` still carries the profile-declared password
+    #: while the deployed ``.env.auth`` hash was minted from something else.
+    #: Their login line would be a lie, so the card prints the rotate verb for
+    #: them instead. See
+    #: :func:`~osprey.deployment.web_terminals.auth_credentials.seeded_logins_report`.
+    stale_logins: tuple[str, ...] = ()
 
 
 def as_built_closing_facts(repo_root: Path | str) -> ClosingFacts:
@@ -660,11 +670,13 @@ def as_built_closing_facts(repo_root: Path | str) -> ClosingFacts:
         config = _as_built_config(root)
         if config is None:
             return ClosingFacts(landing_url=None, logins=())
+        seeded = _seeded_logins(root, config)
         return ClosingFacts(
             landing_url=landing_page_url(config),
-            logins=tuple(_seeded_logins(root, config)),
+            logins=seeded.printable,
             token_login_users=tuple(token_login_users(config)),
             landing_url_is_external_origin=_external_origin_is_derivable(config),
+            stale_logins=seeded.stale,
         )
     except Exception as exc:
         logger.debug(f"Closing facts skipped: {exc}")
@@ -688,7 +700,7 @@ def _external_origin_is_derivable(config: dict) -> bool:
         return False
 
 
-def _seeded_logins(root: Path, config: dict) -> list[tuple[str, str]]:
+def _seeded_logins(root: Path, config: dict) -> SeededLoginsReport:
     """The profile-seeded logins of this deployment's roster, in roster order.
 
     Gated on there being a login to have: with ``auth.method`` at anything but
@@ -699,21 +711,24 @@ def _seeded_logins(root: Path, config: dict) -> list[tuple[str, str]]:
     ``login: false`` sit outside the wall and are skipped for the same reason --
     the same predicate credential provisioning itself uses.
     """
-    from osprey.deployment.web_terminals.auth_credentials import seeded_logins
+    from osprey.deployment.web_terminals.auth_credentials import (
+        SeededLoginsReport,
+        seeded_logins_report,
+    )
     from osprey.deployment.web_terminals.personas import entry_requires_login, normalize_users
     from osprey.deployment.web_terminals.render import _auth_tls_context
 
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
     if not web_terminals.get("enabled"):
-        return []
+        return SeededLoginsReport()
     if _auth_tls_context(web_terminals).get("auth_method") != "password":
-        return []
+        return SeededLoginsReport()
     names = [
         entry["name"]
         for entry in normalize_users(web_terminals.get("users"))
         if entry_requires_login(entry)
     ]
-    return seeded_logins(root, names)
+    return seeded_logins_report(root, names)
 
 
 def token_login_users(config: dict) -> list[str]:

--- a/src/osprey/deployment/reset.py
+++ b/src/osprey/deployment/reset.py
@@ -136,30 +136,32 @@ COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
 #: is verified against before removal — exactly as ``nuke`` verifies it.
 OSPREY_PROJECT_LABEL = "com.osprey.project"
 
-#: The web tier's credential files, as ``(filename, what it holds, how it is
-#: refreshed)``. Each is written once — a deploy creates it when it is absent
-#: and never rewrites an existing one — and reset removes none of them, which is
-#: why they are disclosed (:meth:`ResetPlan._kept_lines`) rather than left for an
-#: operator to discover after wiping the deployment they belong to.
+#: The web tier's credential files reset KEEPS, as ``(filename, what it holds,
+#: how it is refreshed)``. Each is written once — a deploy creates it when it is
+#: absent and never rewrites an existing one — and reset removes neither, which
+#: is why they are disclosed (:meth:`ResetPlan._kept_lines`) rather than left
+#: for an operator to discover after wiping the deployment they belong to.
+#:
+#: ``.env.auth`` is deliberately NOT here: reset removes it (it is on the
+#: plan's path list, with its own removal note). A password hash survives
+#: routine redeploys untouched so sessions outlive a deploy, but a reset ends
+#: every session and re-seeds ``.env`` from the profile — a hash carried across
+#: that boundary is the previous deployment's password contradicting the
+#: freshly seeded one, which is how a closing card comes to print a login the
+#: sidecar refuses.
 #:
 #: The refresh clauses are per-file because these do NOT behave alike: the same
 #: removal that gets the first re-derived (and stops a registry-mode deploy
-#: outright) costs every user their password in the second, while the third is
-#: a superseded copy nothing refreshes at all and the operator is free to drop.
-#: Every spelling comes from the module that writes it, so no disclosure here
-#: can name a file this system stopped producing.
+#: outright) leaves the second a superseded copy nothing refreshes at all and
+#: the operator is free to drop. Every spelling comes from the module that
+#: writes it, so no disclosure here can name a file this system stopped
+#: producing.
 WEB_CREDENTIAL_FILES: tuple[tuple[str, str, str], ...] = (
     (
         USERS_ENV_FILENAME,
         "the runtime secrets every web-terminal container reads",
         "Remove it and a local-mode deploy re-derives one from .env; a registry-mode "
         "deploy expects it to be there already.",
-    ),
-    (
-        AUTH_ENV_FILENAME,
-        "the web terminals' password hashes and cookie-signing secrets",
-        "Remove it and the next deploy mints a NEW password for every user; "
-        "`osprey users decommission` is what drops one departed user's entries.",
     ),
     (
         SUPERSEDED_USERS_ENV_FILENAME,
@@ -880,6 +882,12 @@ class ResetPlan:
             )
         if path == self.repo_root / MERGED_COMPOSE_FILENAME:
             return "  the merged compose document — rewritten by the next `osprey up`"
+        if path == self.repo_root / AUTH_ENV_FILENAME:
+            return (
+                "  the web logins' password hashes and cookie-signing secrets — the next "
+                "deploy re-mints them from .env, so passwords an operator set only with "
+                "`osprey users passwd` are lost"
+            )
         if path == self.audit_dir:
             return "  the safety audit log — not recoverable"
         return ""
@@ -1321,7 +1329,18 @@ def plan_reset(repo_root: Path, *, probe: RuntimeProbe, purge_audit: bool = Fals
 
     agent_data, contained = resolve_agent_data_target(repo_root, config)
 
-    paths = [repo_root / BUILD_DIRNAME, repo_root / MERGED_COMPOSE_FILENAME]
+    # `.env.auth` goes with the generation being discarded: a hash normally
+    # survives redeploys untouched (`ensure_auth_credentials` rule 1, so routine
+    # deploys never log anyone out), which after a reset would carry the
+    # PREVIOUS deployment's passwords into a repo whose `.env` was just
+    # re-seeded with the profile defaults — the closing card then names a login
+    # the sidecar refuses. Reset is the verb that ends sessions anyway; the next
+    # deploy re-mints every hash from `.env`.
+    paths = [
+        repo_root / BUILD_DIRNAME,
+        repo_root / MERGED_COMPOSE_FILENAME,
+        repo_root / AUTH_ENV_FILENAME,
+    ]
     if contained:
         paths.insert(0, agent_data)
     if purge_audit:
@@ -1563,7 +1582,15 @@ def execute_reset(plan: ResetPlan, *, probe: RuntimeProbe) -> None:
     for resource in plan.images:
         probe.remove_image(resource.name)
 
-    derived = {plan.repo_root / BUILD_DIRNAME, plan.repo_root / MERGED_COMPOSE_FILENAME}
+    # Left absent, never recreated: `build/` because its absence is what
+    # `osprey up` reads as "no build found", and the two FILES because the next
+    # deploy that needs them writes each whole (an empty directory in a file's
+    # place would fail that write).
+    derived = {
+        plan.repo_root / BUILD_DIRNAME,
+        plan.repo_root / MERGED_COMPOSE_FILENAME,
+        plan.repo_root / AUTH_ENV_FILENAME,
+    }
     for path in plan.paths:
         _wipe_directory(path, recreate=path not in derived)
 

--- a/src/osprey/deployment/web_terminals/auth_credentials.py
+++ b/src/osprey/deployment/web_terminals/auth_credentials.py
@@ -69,7 +69,7 @@ from osprey.deployment.web_terminals.personas import (
     env_var_suffix_collisions,
 )
 from osprey.interfaces.web_auth import ROSTER_SECRET_ENV_PREFIX
-from osprey.services.auth_sidecar.passwords import hash_password
+from osprey.services.auth_sidecar.passwords import hash_password, verify_password
 from osprey.utils.dotenv import (
     DEPLOY_MINTED_BANNER,
     ENV_AUTH_BANNER,
@@ -497,18 +497,64 @@ def seeded_logins(project_root: str | Path, usernames: Iterable[str]) -> list[tu
     :return: ``(username, password)`` pairs, in ``usernames`` order, holding
         only the users whose password is still the profile's declared default.
     """
+    return list(seeded_logins_report(project_root, usernames).printable)
+
+
+@dataclass(frozen=True)
+class SeededLoginsReport:
+    """What :func:`seeded_logins_report` found for a roster.
+
+    :param printable: ``(username, password)`` pairs safe to print — profile
+        defaults that nothing deployed contradicts.
+    :param stale: Usernames whose ``.env`` value still IS the profile default
+        but whose stored ``.env.auth`` hash was minted from something else, so
+        printing the default would name a password the login wall refuses.
+        These exist: a hash survives redeploys untouched by design
+        (:func:`ensure_auth_credentials` rule 1), so one minted before the
+        profile gained its default — or minted at random when ``.env`` lacked
+        the plaintext — contradicts the default forever after.
+    """
+
+    printable: tuple[tuple[str, str], ...] = ()
+    stale: tuple[str, ...] = ()
+
+
+def seeded_logins_report(project_root: str | Path, usernames: Iterable[str]) -> SeededLoginsReport:
+    """:func:`seeded_logins`, plus the defaults the deployed hash contradicts.
+
+    Verification is three-state per candidate, and only a contradiction
+    demotes:
+
+    * No stored hash — printable. Nothing deployed disagrees, and the next
+      deploy's :func:`ensure_auth_credentials` will hash exactly this value.
+    * The stored hash verifies against the default — printable.
+    * The stored hash exists and does NOT verify — ``stale``. The card must
+      not print a password the sidecar will refuse.
+
+    Advisory like :func:`seeded_logins` itself: an unreadable ``.env.auth``
+    verifies nothing and demotes nothing, so a closing card can never be the
+    thing that fails a deploy that already started.
+    """
     root = Path(project_root)
     try:
         declared = _profile_env_defaults(root)
         if not declared:
-            return []
-        env_path = root / ".env"
+            return SeededLoginsReport()
+        env_path = root / ENV_LOCAL_FILENAME
         project_env = parse_dotenv_file(env_path) if env_path.is_file() else {}
     except Exception as exc:  # pragma: no cover - advisory read
         logger.debug(f"Seeded logins skipped: {exc}")
-        return []
+        return SeededLoginsReport()
 
-    logins: list[tuple[str, str]] = []
+    try:
+        env_auth_path = root / AUTH_ENV_FILENAME
+        stored = parse_dotenv_file(env_auth_path) if env_auth_path.is_file() else {}
+    except Exception as exc:  # advisory read — verify nothing, demote nothing
+        logger.debug(f"Seeded-login verification skipped: {exc}")
+        stored = {}
+
+    printable: list[tuple[str, str]] = []
+    stale: list[str] = []
     for name in usernames:
         variable = f"{PW_PLAINTEXT_VAR_PREFIX}{env_var_suffix(name)}"
         # Trimmed on both sides, because that is what `ensure_auth_credentials`
@@ -516,9 +562,14 @@ def seeded_logins(project_root: str | Path, usernames: Iterable[str]) -> list[tu
         # an editor padded, even though the padded value produced exactly the
         # profile default's hash.
         current = project_env.get(variable, "").strip()
-        if current and current == str(declared.get(variable, "")).strip():
-            logins.append((name, current))
-    return logins
+        if not current or current != str(declared.get(variable, "")).strip():
+            continue
+        stored_hash = stored.get(f"{PW_HASH_VAR_PREFIX}{env_var_suffix(name)}", "").strip()
+        if stored_hash and not verify_password(current, stored_hash):
+            stale.append(name)
+        else:
+            printable.append((name, current))
+    return SeededLoginsReport(printable=tuple(printable), stale=tuple(stale))
 
 
 def _profile_env_defaults(root: Path) -> dict[str, Any]:

--- a/tests/cli/test_connector_shorthand.py
+++ b/tests/cli/test_connector_shorthand.py
@@ -53,8 +53,13 @@ def test_connector_is_a_known_profile_key() -> None:
 
 
 def test_connector_joins_the_shorthand_override_keys() -> None:
-    """The shorthand keys are the model-selection ones plus ``connector``."""
-    assert SHORTHAND_OVERRIDE_KEYS == (*MODEL_SELECTION_OVERRIDE_KEYS, "connector")
+    """The shorthand keys are the model-selection ones plus ``connector`` and
+    ``port_base``."""
+    assert SHORTHAND_OVERRIDE_KEYS == (
+        *MODEL_SELECTION_OVERRIDE_KEYS,
+        "connector",
+        "port_base",
+    )
 
 
 # ── folding into the literal dotted config key ───────────────────────────────

--- a/tests/cli/test_emit_partition.py
+++ b/tests/cli/test_emit_partition.py
@@ -25,7 +25,11 @@ from osprey.cli.build_profile_emit import (
     _FIELD_TO_YAML,
     emit_standalone_profile_yaml,
 )
-from osprey.cli.build_profile_load import _PROFILE_SCHEMA_MIN_OSPREY, CONNECTOR_PROFILE_KEY
+from osprey.cli.build_profile_load import (
+    _PROFILE_SCHEMA_MIN_OSPREY,
+    CONNECTOR_PROFILE_KEY,
+    PORT_BASE_PROFILE_KEY,
+)
 
 _FIELDS = frozenset(f.name for f in dataclasses.fields(BuildProfile))
 
@@ -297,11 +301,14 @@ def test_known_profile_keys_equals_the_partition_plus_inheritance_keys() -> None
     fourth cannot be added without a reader deciding it belongs: the
     inheritance keys, consumed by ``extends`` resolution; the YAML-surface
     spellings of fields the loader renames; and the top-level shorthands
-    (``connector``), folded into ``config:`` before parsing and therefore never
-    emitted as keys of their own.
+    (``connector``, ``port_base``), folded into ``config:`` before parsing and
+    therefore never emitted as keys of their own.
     """
     expected = (
-        _FIELDS | {"extends", "exclude"} | set(_FIELD_TO_YAML.values()) | {CONNECTOR_PROFILE_KEY}
+        _FIELDS
+        | {"extends", "exclude"}
+        | set(_FIELD_TO_YAML.values())
+        | {CONNECTOR_PROFILE_KEY, PORT_BASE_PROFILE_KEY}
     )
 
     assert set(_KNOWN_PROFILE_KEYS) == expected

--- a/tests/cli/test_port_base_shorthand.py
+++ b/tests/cli/test_port_base_shorthand.py
@@ -1,0 +1,95 @@
+"""Tests for the top-level ``port_base`` profile shorthand.
+
+``port_base: 42000`` is the short spelling of
+``config: {deployment.port_base: 42000}`` — the convenient way to move a whole
+deployment off the default 10000 block (``osprey init --set port_base=42000``),
+so a dev or CI stack can never collide with a real deployment running on the
+defaults. Like ``connector``, the shorthand is folded into the literal dotted
+config key on every path a profile can arrive by, and its value is range-checked
+by the same resolver every runtime consumer uses, so a base whose thousand-port
+block cannot exist fails the parse instead of the deploy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.cli.build_profile import _KNOWN_PROFILE_KEYS, _parse_profile
+from osprey.cli.build_profile_load import PORT_BASE_PROFILE_KEY
+from osprey.cli.build_profile_resolve import (
+    SHORTHAND_OVERRIDE_KEYS,
+    merge_cli_overrides,
+)
+from osprey.errors import BuildProfileError
+from osprey.port_layout import PORT_BASE_CONFIG_KEY
+
+pytestmark = pytest.mark.unit
+
+
+def _minimal(**extra) -> dict:
+    return {"name": "demo", **extra}
+
+
+# ── the shorthand is part of the schema ──────────────────────────────────────
+
+
+def test_port_base_is_a_known_profile_key() -> None:
+    """A profile spelling ``port_base:`` is not rejected as an unknown key."""
+    assert PORT_BASE_PROFILE_KEY in _KNOWN_PROFILE_KEYS
+
+
+def test_port_base_joins_the_shorthand_override_keys() -> None:
+    assert PORT_BASE_PROFILE_KEY in SHORTHAND_OVERRIDE_KEYS
+
+
+# ── folding into the literal dotted config key ───────────────────────────────
+
+
+def test_parse_folds_shorthand_into_dotted_config_key() -> None:
+    profile = _parse_profile(_minimal(port_base=42000))
+
+    assert profile.config[PORT_BASE_CONFIG_KEY] == 42000
+
+
+def test_parse_consumes_the_shorthand_key() -> None:
+    raw = _minimal(port_base=42000)
+    _parse_profile(raw)
+
+    assert PORT_BASE_PROFILE_KEY not in raw
+
+
+def test_shorthand_overrides_an_existing_literal_key() -> None:
+    profile = _parse_profile(_minimal(port_base=42000, config={PORT_BASE_CONFIG_KEY: 11000}))
+
+    assert profile.config[PORT_BASE_CONFIG_KEY] == 42000
+
+
+def test_merge_cli_overrides_folds_set_shorthand() -> None:
+    raw = merge_cli_overrides(_minimal(), (), ("port_base=42000",))
+
+    assert raw["config"][PORT_BASE_CONFIG_KEY] == 42000
+    assert PORT_BASE_PROFILE_KEY not in raw
+
+
+# ── validation: the resolver's rules apply at parse time ─────────────────────
+
+
+@pytest.mark.parametrize("bad", ["a-string", True, 12.5, None])
+def test_a_non_integer_base_is_refused(bad) -> None:
+    with pytest.raises(BuildProfileError, match="port_base"):
+        _parse_profile(_minimal(port_base=bad))
+
+
+@pytest.mark.parametrize("bad", [500, 65000])
+def test_an_impossible_block_is_refused(bad) -> None:
+    """Below 1024, or a block running past 65535 — the same rule
+    ``resolve_port_base`` enforces for every runtime consumer."""
+    with pytest.raises(BuildProfileError, match="port_base"):
+        _parse_profile(_minimal(port_base=bad))
+
+
+def test_the_resolved_base_reaches_the_deployment_ports() -> None:
+    """The folded key is the one every derived port is computed from."""
+    profile = _parse_profile(_minimal(port_base=42000))
+
+    assert profile._resolved_port_base() == 42000

--- a/tests/cli/test_summary_card.py
+++ b/tests/cli/test_summary_card.py
@@ -892,3 +892,43 @@ def test_the_card_flags_dangerously_allow_bash(repo: Path):
     lines = format_summary_card(repo, "running")
     flagged = [line for line in lines if "dangerously_allow_bash" in line]
     assert flagged and "Bash" in flagged[0] and "launch token" in flagged[0]
+
+
+class TestStaleSeededLogins:
+    """A seeded default the deployed hash contradicts is never printed as a
+    working login — the card says what happened and which verb fixes it."""
+
+    def test_a_contradicted_default_is_dropped_and_named(
+        self, repo_with_logins: Path, recorder: Recorded
+    ) -> None:
+        from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
+        from osprey.services.auth_sidecar.passwords import hash_password
+
+        (repo_with_logins / AUTH_ENV_FILENAME).write_text(
+            f"OSPREY_AUTH_PW_HASH_ALICE={hash_password('alice')}\n"
+            f"OSPREY_AUTH_PW_HASH_BOB={hash_password('minted-by-an-older-deploy')}\n"
+        )
+
+        print_summary_card(repo_with_logins, "running")
+
+        printed = "\n".join(recorder.lines)
+        assert "alice / alice" in printed
+        assert "bob / bob" not in printed
+        assert "osprey users passwd bob" in printed
+
+    def test_no_stale_note_when_every_default_verifies(
+        self, repo_with_logins: Path, recorder: Recorded
+    ) -> None:
+        from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
+        from osprey.services.auth_sidecar.passwords import hash_password
+
+        (repo_with_logins / AUTH_ENV_FILENAME).write_text(
+            f"OSPREY_AUTH_PW_HASH_ALICE={hash_password('alice')}\n"
+            f"OSPREY_AUTH_PW_HASH_BOB={hash_password('bob')}\n"
+        )
+
+        print_summary_card(repo_with_logins, "running")
+
+        printed = "\n".join(recorder.lines)
+        assert "alice / alice · bob / bob" in printed
+        assert "passwd" not in printed

--- a/tests/deployment/test_reset_scoping.py
+++ b/tests/deployment/test_reset_scoping.py
@@ -838,7 +838,6 @@ def _kept_section(repo: Path) -> str:
     ("filename", "phrase"),
     [
         (".env.users", "runtime secrets every web-terminal container reads"),
-        (".env.auth", "password hashes and cookie-signing secrets"),
     ],
 )
 def test_the_plan_discloses_a_web_credential_file_it_will_keep(repo, filename, phrase):
@@ -865,32 +864,34 @@ def test_a_web_credential_file_that_is_not_there_is_not_disclosed(repo, filename
     assert filename not in _kept_section(repo)
 
 
-def test_the_two_web_credential_files_disclose_different_refreshes(repo):
-    """One removal costs a registry deploy its secrets, the other everyone's password.
-
-    Mutually exclusive wording, pinned: a shared clause would be wrong for one
-    of them, and this is the section an operator reads before typing a
-    confirmation.
-    """
+def test_the_two_web_credential_files_land_on_opposite_sides_of_the_plan(repo):
+    """`.env.users` is kept and says so; `.env.auth` is removed and says what
+    that costs. A shared clause would be wrong for one of them, and this is
+    what an operator reads before typing a confirmation."""
     (repo / ".env.users").write_text("OSPREY_API_KEY=x\n", encoding="utf-8")
     (repo / ".env.auth").write_text("OSPREY_AUTH_PW_HASH_ALICE=x\n", encoding="utf-8")
 
+    plan = plan_reset(repo, probe=make_probe(FakeRuntime()))
+    rendered = "\n".join(plan.render())
     kept = _kept_section(repo)
 
     assert "registry-mode deploy expects it to be there already" in kept
-    assert "mints a NEW password for every user" in kept
-    assert "osprey users decommission" in kept
+    assert ".env.auth" not in kept
+    assert repo / ".env.auth" in plan.paths
+    assert "osprey users passwd" in rendered
 
 
-def test_reset_keeps_both_web_credential_files_on_disk(repo, no_down):
-    """The disclosure and the behaviour, asserted against each other."""
+def test_reset_keeps_users_env_and_removes_auth_env(repo, no_down):
+    """The disclosure and the behaviour, asserted against each other: the kept
+    file survives byte-identical, the removed one is gone — not truncated, not
+    recreated as anything."""
     (repo / ".env.users").write_text("OSPREY_API_KEY=x\n", encoding="utf-8")
     (repo / ".env.auth").write_text("OSPREY_AUTH_PW_HASH_ALICE=x\n", encoding="utf-8")
 
     run_reset(repo, FakeRuntime())
 
     assert (repo / ".env.users").read_text(encoding="utf-8") == "OSPREY_API_KEY=x\n"
-    assert (repo / ".env.auth").read_text(encoding="utf-8") == "OSPREY_AUTH_PW_HASH_ALICE=x\n"
+    assert not (repo / ".env.auth").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -1841,3 +1842,34 @@ def _unidentified_section(plan) -> str:
     """Just the "NOT REMOVED" block, without the network note that follows it."""
     rendered = "\n".join(plan.render())
     return rendered.split("NOT REMOVED", 1)[1].split("Networks are removed", 1)[0]
+
+
+# ---------------------------------------------------------------------------
+# .env.auth: reset means no stale login credentials survive
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_removes_env_auth_when_it_exists(repo):
+    """A reset deployment is a throwaway: keeping the previous generation's
+    password hashes while `osprey init` re-seeds the profile defaults is how a
+    banner comes to print a login the sidecar refuses (2026-08-30). The next
+    deploy re-mints every hash from `.env`."""
+    from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
+
+    env_auth = repo / AUTH_ENV_FILENAME
+    env_auth.write_text("OSPREY_AUTH_PW_HASH_ALICE=scrypt.16384.8.1.x.y\n", encoding="utf-8")
+
+    plan = plan_reset(repo, probe=make_probe(FakeRuntime()))
+
+    assert env_auth in plan.paths
+    assert any(AUTH_ENV_FILENAME in line for line in plan.render())
+
+
+def test_the_plan_skips_env_auth_when_it_is_absent(repo):
+    """Like every other planned path: never promise a removal that has nothing
+    to remove."""
+    from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
+
+    plan = plan_reset(repo, probe=make_probe(FakeRuntime()))
+
+    assert all(AUTH_ENV_FILENAME not in str(path) for path in plan.paths)

--- a/tests/deployment/web_terminals/test_auth_credentials.py
+++ b/tests/deployment/web_terminals/test_auth_credentials.py
@@ -25,12 +25,14 @@ from osprey.deployment.web_terminals.auth_credentials import (
     purge_orphan_terminal_secrets,
     purge_terminal_secret,
     seeded_logins,
+    seeded_logins_report,
     set_auth_password,
 )
 from osprey.services.auth_sidecar.passwords import (
     FIELD_SEP,
     SCHEME,
     generation_tag,
+    hash_password,
     verify_password,
 )
 from osprey.utils.dotenv import (
@@ -1397,3 +1399,61 @@ def test_a_purge_holds_the_lock_a_concurrent_append_must_wait_for(tmp_path: Path
     assert stored["CONCURRENT_WRITER"] == "kept"
     assert f"{TERMINAL_SECRET_VAR_PREFIX}ALICE" not in stored
     assert stored[f"{TERMINAL_SECRET_VAR_PREFIX}BOB"]
+
+
+def test_a_default_password_confirmed_by_the_deployed_hash_is_named(tmp_path: Path) -> None:
+    """A stored hash minted from the seeded default keeps the login printable:
+    verification is a gate, not a blanket suppression."""
+    write_seeded_repo(tmp_path, "alice", "alice")
+    (tmp_path / AUTH_ENV_FILENAME).write_text(
+        f"{PW_HASH_VAR_PREFIX}ALICE={hash_password('alice')}\n"
+    )
+
+    assert seeded_logins(tmp_path, ["alice"]) == [("alice", "alice")]
+
+
+def test_a_default_password_contradicted_by_the_deployed_hash_is_not_named(tmp_path: Path) -> None:
+    """The 2026-08-30 field failure: `.env` still carries the profile default,
+    but `.env.auth` holds a hash minted from something else (an older deploy's
+    random mint). Printing "carol / carol" then is a lie the operator debugs at
+    the login wall."""
+    write_seeded_repo(tmp_path, "alice", "alice")
+    (tmp_path / AUTH_ENV_FILENAME).write_text(
+        f"{PW_HASH_VAR_PREFIX}ALICE={hash_password('minted-by-an-older-deploy')}\n"
+    )
+
+    assert seeded_logins(tmp_path, ["alice"]) == []
+
+
+def test_the_report_names_the_contradicted_user_as_stale(tmp_path: Path) -> None:
+    """The card needs to say WHY a seeded login is missing, so the report keeps
+    the contradicted names alongside the printable pairs."""
+    write_seeded_repo(tmp_path, "alice", "alice")
+    (tmp_path / AUTH_ENV_FILENAME).write_text(
+        f"{PW_HASH_VAR_PREFIX}ALICE={hash_password('minted-by-an-older-deploy')}\n"
+    )
+
+    report = seeded_logins_report(tmp_path, ["alice"])
+
+    assert report.printable == ()
+    assert report.stale == ("alice",)
+
+
+def test_a_user_with_no_stored_hash_is_still_named_and_not_stale(tmp_path: Path) -> None:
+    """Before the first deploy no hash exists and nothing contradicts the
+    seeded default — `ensure_auth_credentials` will hash exactly this value."""
+    write_seeded_repo(tmp_path, "alice", "alice")
+
+    report = seeded_logins_report(tmp_path, ["alice"])
+
+    assert report.printable == (("alice", "alice"),)
+    assert report.stale == ()
+
+
+def test_an_unreadable_env_auth_stays_advisory(tmp_path: Path) -> None:
+    """A malformed `.env.auth` must not fail the closing card; the login is
+    printed exactly as it was before verification existed."""
+    write_seeded_repo(tmp_path, "alice", "alice")
+    (tmp_path / AUTH_ENV_FILENAME).write_bytes(b"\xff\xfe not a dotenv file")
+
+    assert seeded_logins(tmp_path, ["alice"]) == [("alice", "alice")]

--- a/tests/e2e/_orm_stack.py
+++ b/tests/e2e/_orm_stack.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import time
@@ -71,10 +72,20 @@ if TYPE_CHECKING:
 # `control_system.connector.virtual_accelerator.gateways.*.port` UNSET, so the
 # connector follows `services.virtual_accelerator.port` and moving the deployed
 # soft-IOC's port is a one-place edit that carries the connector with it.
-# Callers that must coexist with another VA deploy on the same host -- 5064 is
-# the tutorial's default and routinely held -- should pass an explicit
-# `va_port=` rather than assume this default is free.
-VA_CA_PORT = 5064
+# The default is an ephemeral free port rather than 5064: the tutorial default
+# is routinely held by a real deployment on a dev host (`port_layout.
+# CA_DEFAULT_PORT` keeps VA instance 1 there on purpose), and every caller of
+# this module already gets the one value plumbed through both the service port
+# and the connector. Pass an explicit `va_port=` to pin one.
+
+
+def _reserve_free_va_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+VA_CA_PORT = _reserve_free_va_port()
 
 # Bluesky bridge HTTP port. Distinct from the other e2e modules' pinned
 # ports (test_bluesky_deploy.py's 18090, test_va_substrate_equivalence.py's
@@ -271,6 +282,7 @@ def init_args(
     output_dir: Path,
     bridge_port: int = BRIDGE_PORT,
     va_port: int = VA_CA_PORT,
+    port_base: int | None = None,
     provider: str | None = None,
     model: str | None = None,
     extra_config: dict[str, Any] | None = None,
@@ -325,6 +337,14 @@ def init_args(
         "--set",
         "bluesky.tiled_enabled=true",
     ]
+    if port_base is not None:
+        # Every framework port the caller does NOT pin explicitly follows this
+        # block (`deployment.port_base`); a caller that actually starts the
+        # stack passes its own thousand-port block so the deploy cannot land
+        # on a real deployment's default 10000 block (openobserve, tiled,
+        # live-standin, the stores). Build-only callers may leave it unset —
+        # a render binds nothing.
+        args += ["--set", f"port_base={port_base}"]
     if provider is not None:
         args += ["--set", f"provider={provider}"]
     if model is not None:
@@ -412,6 +432,7 @@ def build_project_subprocess(
     output_dir: Path,
     bridge_port: int = BRIDGE_PORT,
     va_port: int = VA_CA_PORT,
+    port_base: int | None = None,
     timeout: int = BUILD_TIMEOUT_SEC,
     provider: str | None = None,
     model: str | None = None,
@@ -455,6 +476,7 @@ def build_project_subprocess(
             output_dir=output_dir,
             bridge_port=bridge_port,
             va_port=va_port,
+            port_base=port_base,
             provider=provider,
             model=model,
             extra_config=extra_config,

--- a/tests/e2e/_orm_stack.py
+++ b/tests/e2e/_orm_stack.py
@@ -85,6 +85,8 @@ def _reserve_free_va_port() -> int:
         return sock.getsockname()[1]
 
 
+# import-time required because VA_CA_PORT binds into `va_port=` default
+# arguments across the importing e2e modules, which evaluate at import.
 VA_CA_PORT = _reserve_free_va_port()
 
 # Bluesky bridge HTTP port. Distinct from the other e2e modules' pinned

--- a/tests/e2e/fixtures/multi_user_config.yml
+++ b/tests/e2e/fixtures/multi_user_config.yml
@@ -57,6 +57,13 @@ modules:
     artifact_base_port: 19200
     ariel_base_port: 19300
     lattice_base_port: 19400
+    # The remaining panel families too, even though this roster does not enable
+    # them today: an omitted family defaults straight into the live default
+    # block (10500/10600/10700), so enabling one here later must not be the
+    # edit that starts squatting a real deployment's panels.
+    channel_finder_base_port: 19500
+    okf_base_port: 19600
+    system_health_base_port: 19700
     users:
       - alice
       - bob

--- a/tests/e2e/test_bluesky_queue_e2e.py
+++ b/tests/e2e/test_bluesky_queue_e2e.py
@@ -754,6 +754,12 @@ def stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[QueueStack]:
             f"bluesky.tiled_port={TILED_PORT}",
             "--set",
             f"bluesky_web.port={PANELS_PORT}",
+            # This module's own thousand-port block (see
+            # test_dispatch_deploy.py's 20700 note): everything not pinned
+            # explicitly follows it instead of landing on a real deployment's
+            # default 10000 block.
+            "--set",
+            "port_base=22000",
         ],
         cwd=base,
         timeout=BUILD_TIMEOUT_SEC,

--- a/tests/e2e/test_bluesky_sandbox_escape_e2e.py
+++ b/tests/e2e/test_bluesky_sandbox_escape_e2e.py
@@ -508,6 +508,10 @@ def deployed_sandbox_stack(
         PROJECT_NAME,
         output_dir=base,
         bridge_port=BRIDGE_PORT,
+        # This module's own thousand-port block (see test_dispatch_deploy.py's
+        # 20700 note): everything not pinned explicitly follows it instead of
+        # landing on a real deployment's default 10000 block.
+        port_base=21400,
         timeout=BUILD_TIMEOUT_SEC,
         pre_build=author_devices,
     )

--- a/tests/e2e/test_bluesky_web_deploy.py
+++ b/tests/e2e/test_bluesky_web_deploy.py
@@ -464,6 +464,10 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
         output_dir=base,
         bridge_port=BRIDGE_PORT,
         va_port=VA_CA_PORT,
+        # This module's own thousand-port block (see test_dispatch_deploy.py's
+        # 20700 note): everything not pinned explicitly follows it instead of
+        # landing on a real deployment's default 10000 block.
+        port_base=21700,
     )
     args += ["--set", f"bluesky_web.port={BLUESKY_WEB_PORT}"]
 

--- a/tests/e2e/test_bump_roundtrip.py
+++ b/tests/e2e/test_bump_roundtrip.py
@@ -522,6 +522,10 @@ def deployed_bump_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[De
         output_dir=base,
         bridge_port=BRIDGE_PORT,
         va_port=VA_CA_PORT,
+        # This module's own thousand-port block (see test_dispatch_deploy.py's
+        # 20700 note): everything not pinned explicitly follows it instead of
+        # landing on a real deployment's default 10000 block.
+        port_base=21900,
         timeout=BUILD_TIMEOUT_SEC,
         extra_config=EXTRA_CONFIG,
         pre_build=author_devices,

--- a/tests/e2e/test_dispatch_overlay_visibility.py
+++ b/tests/e2e/test_dispatch_overlay_visibility.py
@@ -65,7 +65,14 @@ from osprey.deployment.compose_generator import resolve_project_name
 from osprey.port_layout import default_port
 from tests.e2e._volumes import remove_project_volumes
 
-DISPATCHER_URL = f"http://localhost:{default_port('dispatcher')}"
+#: This deploy's own thousand-port block — same convention as
+#: test_dispatch_deploy.py (20700) and test_web_bind.py (21000): a real
+#: control-assistant stack owns the default 10000 block on a dev host, so a
+#: test deploy that landed there would crash-loop the live stack's terminals
+#: against its own dispatcher and panels.
+PORT_BASE = 21100
+
+DISPATCHER_URL = f"http://localhost:{default_port('dispatcher', base=PORT_BASE)}"
 TOKEN = "dev-token"  # matches the .env tokens written below
 
 # Container image build (Node + Claude CLI install) is slow on a cold cache.
@@ -306,6 +313,8 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
             "provider=als-apg",
             "--set",
             "model=haiku",
+            "--set",
+            f"port_base={PORT_BASE}",
         ],
         cwd=base,
         timeout=300,

--- a/tests/e2e/test_grid_scan_roundtrip.py
+++ b/tests/e2e/test_grid_scan_roundtrip.py
@@ -170,6 +170,10 @@ def deployed_grid_scan_stack(
         PROJECT_NAME,
         output_dir=base,
         bridge_port=BRIDGE_PORT,
+        # This module's own thousand-port block (see test_dispatch_deploy.py's
+        # 20700 note): everything not pinned explicitly follows it instead of
+        # landing on a real deployment's default 10000 block.
+        port_base=21300,
         timeout=BUILD_TIMEOUT_SEC,
         pre_build=author_devices,
     )

--- a/tests/e2e/test_orm_roundtrip.py
+++ b/tests/e2e/test_orm_roundtrip.py
@@ -221,7 +221,14 @@ def deployed_orm_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Dep
     # The deployment REPO: `osprey up` runs here, `.env` lives here, and the
     # render `osprey build` produced is `<repo>/build`.
     repo = _orm_stack.build_project_subprocess(
-        PROJECT_NAME, output_dir=base, timeout=BUILD_TIMEOUT_SEC, pre_build=author_devices
+        PROJECT_NAME,
+        output_dir=base,
+        timeout=BUILD_TIMEOUT_SEC,
+        pre_build=author_devices,
+        # This module's own thousand-port block (see test_dispatch_deploy.py's
+        # 20700 note): everything not pinned explicitly follows it instead of
+        # landing on a real deployment's default 10000 block.
+        port_base=21200,
     )
     _orm_stack.assert_devices_authored(correctors, bpms)
 

--- a/tests/e2e/test_plan_stack_agentic.py
+++ b/tests/e2e/test_plan_stack_agentic.py
@@ -2499,6 +2499,10 @@ def deployed_scan_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[De
         output_dir=base,
         bridge_port=BRIDGE_PORT,
         va_port=VA_CA_PORT,
+        # This module's own thousand-port block (see test_dispatch_deploy.py's
+        # 20700 note): everything not pinned explicitly follows it instead of
+        # landing on a real deployment's default 10000 block.
+        port_base=21800,
         timeout=BUILD_TIMEOUT_SEC,
         provider=JUDGE_PROVIDER,
         extra_config=_EXTRA_CONFIG,

--- a/tests/e2e/test_tiled_roundtrip.py
+++ b/tests/e2e/test_tiled_roundtrip.py
@@ -237,6 +237,12 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
             f"bluesky.tiled_port={TILED_PORT}",
             "--set",
             f"virtual_accelerator.port={VA_CA_PORT}",
+            # This module's own thousand-port block (see
+            # test_dispatch_deploy.py's 20700 note): everything not pinned
+            # explicitly follows it instead of landing on a real deployment's
+            # default 10000 block.
+            "--set",
+            "port_base=21600",
         ],
         cwd=base,
         timeout=BUILD_TIMEOUT_SEC,

--- a/tests/e2e/test_va_substrate_equivalence.py
+++ b/tests/e2e/test_va_substrate_equivalence.py
@@ -751,11 +751,20 @@ def test_p2_full_manifest_liveness(deployed_stack: DeployedStack) -> None:
     # main-thread pyepics operation into a process that also drives CA off an
     # asyncio.to_thread() executor is a documented deadlock risk (see
     # tests/va/e2e/conftest.py's `_readiness_pv_served`).
+    # The sweep script defaults EPICS_CA_NAME_SERVERS to localhost:5064; this
+    # stack serves CA on the module's ephemeral VA_CA_PORT, so the subprocess
+    # must be told explicitly (the in-process connectors get it via
+    # _VA_GATEWAY instead).
     proc = subprocess.run(
         [sys.executable, str(SWEEP_SCRIPT)],
         capture_output=True,
         text=True,
         timeout=SWEEP_TIMEOUT_SEC,
+        env={
+            **os.environ,
+            "EPICS_CA_NAME_SERVERS": f"localhost:{VA_CA_PORT}",
+            "EPICS_CA_AUTO_ADDR_LIST": "NO",
+        },
     )
     assert proc.returncode == 0, (
         f"full-manifest CA sweep failed:\n--- stdout ---\n{proc.stdout}\n"

--- a/tests/e2e/test_va_substrate_equivalence.py
+++ b/tests/e2e/test_va_substrate_equivalence.py
@@ -104,6 +104,8 @@ def _reserve_free_port() -> int:
         return sock.getsockname()[1]
 
 
+# import-time required because VA_CA_PORT seeds module-level constants
+# (_VA_GATEWAY, the fixture's --set args) built while the module imports.
 VA_CA_PORT = _reserve_free_port()
 # The deployment repo's directory name IS the deployment's name; the compose
 # templates render each service's container_name AND its locally-built image as

--- a/tests/e2e/test_va_substrate_equivalence.py
+++ b/tests/e2e/test_va_substrate_equivalence.py
@@ -62,6 +62,7 @@ import asyncio
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import time
@@ -89,13 +90,21 @@ HOST_CA_OP_SCRIPT = Path(__file__).resolve().parent / "_va_host_ca_op.py"
 # imported -- tests/e2e is a package, so the helper is not on sys.path).
 HOST_CA_RESULT_MARKER = "__HOST_CA_RESULT__"
 
-# Channel Access port the Virtual Accelerator serves on. NOT freely
-# overridable here: the Control Assistant preset's config.yml.j2 hardcodes
-# `control_system.connector.virtual_accelerator.gateways.*.port: 5064` (it is
-# not templated from `services.virtual_accelerator.port`) — so the host-side
-# connector config below and the container's published port must both stay
-# at this value, or the two silently drift apart.
-VA_CA_PORT = 5064
+
+# Channel Access port the Virtual Accelerator serves on. An ephemeral free
+# port, not 5064: this module already plumbs the one value everywhere it
+# matters (`--set virtual_accelerator.port=` at init, and the name-server
+# gateway below), and 5064 on a dev host belongs to whatever real deployment
+# the operator is running — `port_layout.CA_DEFAULT_PORT` keeps VA instance 1
+# there on purpose. The shipped 5064 default is covered at render level by
+# tests/cli/test_va_default_config.py and tests/cli/test_rendered_va_block.py.
+def _reserve_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+VA_CA_PORT = _reserve_free_port()
 # The deployment repo's directory name IS the deployment's name; the compose
 # templates render each service's container_name AND its locally-built image as
 # ``<project>-<service>`` (services/*/docker-compose.yml.j2), so derive both
@@ -393,6 +402,12 @@ def deployed_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Deploye
             f"virtual_accelerator.port={VA_CA_PORT}",
             "--set",
             f"bluesky.port={BRIDGE_PORT}",
+            # This module's own thousand-port block (see
+            # test_dispatch_deploy.py's 20700 note): everything not pinned
+            # explicitly follows it instead of landing on a real deployment's
+            # default 10000 block.
+            "--set",
+            "port_base=21500",
         ],
         cwd=base,
         timeout=BUILD_TIMEOUT_SEC,

--- a/tests/infrastructure/test_import_time_audit.py
+++ b/tests/infrastructure/test_import_time_audit.py
@@ -29,6 +29,12 @@ WHITELIST: dict[str, set[str]] = {
     # ones at the same moment for the same reason.
     "va/test_record_factory.py": {"os.environ", "socket"},
     "va/test_apply_fault.py": {"os.environ", "socket"},
+    # Deploying suites reserve their CA / gallery ports at import: the value
+    # binds into module-level constants and function default arguments (which
+    # evaluate at import), so a fixture would run after those bindings exist.
+    "e2e/_orm_stack.py": {"socket"},
+    "e2e/test_va_substrate_equivalence.py": {"socket"},
+    "interfaces/_panel_launch.py": {"socket"},
     # docs/source/_ext is not an installed package, and the extension under
     # test is imported at module top level.
     "documentation/test_workflow_autodoc.py": {"sys.path"},
@@ -40,7 +46,7 @@ WHITELIST: dict[str, set[str]] = {
     "scripts/test_config_key_guard.py": {"sys.modules"},
     "scripts/test_changelog_fragments.py": {"sys.modules"},
     "scripts/test_docs_publish.py": {"sys.modules"},
-    "va/e2e/conftest.py": {"sys.modules"},
+    "va/e2e/conftest.py": {"socket", "sys.modules"},
     # the root conftest scrubs FORCE_COLOR/CLICOLOR_FORCE before collection
     # imports any osprey module: osprey.cli.styles builds its Console at import
     # time, so a fixture would un-force a console that already exists.

--- a/tests/interfaces/_panel_launch.py
+++ b/tests/interfaces/_panel_launch.py
@@ -33,6 +33,8 @@ def _reserve_unserved_port() -> int:
 
 #: The address the faked gallery launch publishes in these tests — deliberately
 #: an address nothing serves on; see :func:`_reserve_unserved_port`.
+# import-time required because DEFAULT_ARTIFACT_URL is a default argument of
+# publish_artifact_url below, and defaults evaluate when the module imports.
 DEFAULT_ARTIFACT_URL = f"http://127.0.0.1:{_reserve_unserved_port()}"
 
 

--- a/tests/interfaces/_panel_launch.py
+++ b/tests/interfaces/_panel_launch.py
@@ -9,12 +9,31 @@ companion panel unlaunched — are stated once instead of re-derived per file.
 
 from __future__ import annotations
 
+import socket
 from typing import Any
 
 from osprey.registry.web import panel_url_state_attr
 
-#: The address the pre-launched/faked gallery is reachable at in these tests.
-DEFAULT_ARTIFACT_URL = "http://127.0.0.1:10200"
+
+def _reserve_unserved_port() -> int:
+    """A loopback port that nothing serves on, reserved once per process.
+
+    The published URL must point at NOTHING: the hub dials it server-side with
+    the process operator secret the moment a browser opens the WORKSPACE tab,
+    so a fixed default-block address (the gallery's own 10200) would, on a dev
+    host running a real deployment, proxy the developer's live artifacts into
+    the test — a false green — and hand that gallery the test's secret. An
+    ephemeral port that was just free reproduces everywhere what CI sees:
+    connection refused, panel advertised but unhealthy.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+#: The address the faked gallery launch publishes in these tests — deliberately
+#: an address nothing serves on; see :func:`_reserve_unserved_port`.
+DEFAULT_ARTIFACT_URL = f"http://127.0.0.1:{_reserve_unserved_port()}"
 
 
 def publish_artifact_url(url: str | None = DEFAULT_ARTIFACT_URL):

--- a/tests/interfaces/web_terminal/test_panels_browser.py
+++ b/tests/interfaces/web_terminal/test_panels_browser.py
@@ -70,8 +70,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import requests
 
-from osprey.port_layout import default_port
-from tests.interfaces._panel_launch import publish_artifact_url
+from tests.interfaces._panel_launch import DEFAULT_ARTIFACT_URL, publish_artifact_url
 from tests.interfaces.conftest import _free_port, _run_app_server
 
 # ---------------------------------------------------------------------------
@@ -143,7 +142,9 @@ def _live_server(
     enabled_panels,
     custom_panels=None,
     allow_runtime: bool = False,
-    artifact_url: str | None = f"http://127.0.0.1:{default_port('artifact')}",
+    # The shared unserved address — never the artifact slot at the default
+    # base, which a real deployment on this host serves for real.
+    artifact_url: str | None = DEFAULT_ARTIFACT_URL,
     artifact_config_delay: float = 0.0,
     project_cwd: str | None = None,
     ui_mode: str | None = None,

--- a/tests/va/e2e/conftest.py
+++ b/tests/va/e2e/conftest.py
@@ -100,6 +100,10 @@ def _reserve_free_port() -> int:
         return sock.getsockname()[1]
 
 
+# import-time required because CA_PORT is per-process module state: every
+# fixture and helper in this package must agree on the one reserved number,
+# and a fixture-scoped reservation would hand xdist workers different ports
+# for constants already bound at collection.
 CA_PORT = _reserve_free_port()
 # Generous on purpose. Boot-to-first-served-answer measured 9-15 s across six
 # container boots on this host -- the VA images are pinned ``linux/amd64`` and

--- a/tests/va/e2e/conftest.py
+++ b/tests/va/e2e/conftest.py
@@ -42,6 +42,7 @@ import importlib.util
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import time
@@ -74,14 +75,32 @@ IMAGE = "osprey-va-full:latest"
 # container -- see the module docstring. Everything that creates, inspects or
 # removes the container uses this one name.
 CONTAINER_NAME = f"osprey-va-e2e-{os.getpid()}"
-# 5064 stays pinned, and deliberately so: the Control Assistant preset's
-# config.yml.j2 hardcodes ``control_system.connector.virtual_accelerator.
-# gateways.*.port: 5064`` rather than templating it, so this is the only
-# coverage of the port the shipped default actually serves on. (Contrast
-# test_serving_parity.py in this directory, which binds an ephemeral port
-# because it boots two containers of its own and asserts nothing about
-# preset-rendered configuration.)
-CA_PORT = 5064
+# The CONTAINER serves Channel Access on the protocol default, which the image
+# fixes; the HOST side of the publish is an ephemeral free port, because 5064
+# on this host belongs to whatever real deployment the operator is running
+# (`port_layout.CA_DEFAULT_PORT` keeps VA instance 1 there on purpose, so a
+# dev machine routinely holds it). Name-server mode (`use_name_server: true`,
+# EPICS_CA_NAME_SERVERS) carries the remap: the client dials the mapped host
+# port over TCP and never needs the container's own number. The shipped 5064
+# default itself is covered at render level — tests/cli/test_va_default_config.py
+# and tests/cli/test_rendered_va_block.py pin it — so nothing here has to
+# squat the live port to keep that contract tested.
+CONTAINER_CA_PORT = 5064
+
+
+def _reserve_free_port() -> int:
+    """A host port that was free at reservation time.
+
+    The bind is released before docker publishes the port, so a racing process
+    could take it in between; per-process module state keeps every user of
+    ``CA_PORT`` in this run on the one reserved number.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+CA_PORT = _reserve_free_port()
 # Generous on purpose. Boot-to-first-served-answer measured 9-15 s across six
 # container boots on this host -- the VA images are pinned ``linux/amd64`` and
 # the host is Apple Silicon, so every local boot is emulated. A 30 s ceiling is
@@ -350,7 +369,7 @@ def va_container(va_project: VaProject) -> Iterator[VaProject]:
             "--name",
             CONTAINER_NAME,
             "-p",
-            f"127.0.0.1:{CA_PORT}:{CA_PORT}/tcp",
+            f"127.0.0.1:{CA_PORT}:{CONTAINER_CA_PORT}/tcp",
             "-v",
             f"{va_project.data_dir}:/data/simulation:ro",
             # Scenario state is a SEPARATE mount: the host writes it at run

--- a/tests/va/e2e/test_bluesky_lanes.py
+++ b/tests/va/e2e/test_bluesky_lanes.py
@@ -452,6 +452,12 @@ def _init_and_build(base: Path, name: str, *, second_lane: bool) -> Path:
         f"bluesky.tiled_port={TILED_PORT}",
         "--set",
         f"bluesky_web.port={PANELS_PORT}",
+        # This module's own thousand-port block (see
+        # test_dispatch_deploy.py's 20700 note): everything not pinned
+        # explicitly follows it instead of landing on a real deployment's
+        # default 10000 block.
+        "--set",
+        "port_base=22100",
     ]
     if second_lane:
         argv += ["--set", "bluesky.second_lane=true"]


### PR DESCRIPTION
An e2e run on the same host as a live deployment could take the deployment down. Every deploying fixture inherited the default port layout, so a test's `osprey up` bound the live 10000 panel block and EPICS CA 5064 — crash-looping the real panels it collided with — and the browser suites pointed their fake artifact-gallery URL at live 10200, where a running gallery silently served real artifacts to the tests and received the test operator secret. Independently, `.env.auth` survived `--reset`, so the closing card could print a seeded login the auth sidecar refuses.

- Every deploying e2e module is pinned to its own thousand-port block (21100–22100, extending the 20700/21000 convention); the VA harnesses take an ephemeral CA port; the fake gallery URL moves to a reserved unserved port; the multi-user fixture gains the three omitted panel families so enabling one later cannot land back on the live block.
- The closing card verifies each seeded login against the deployed `.env.auth` hash and prints `osprey users passwd <user>` for the ones it contradicts; `--reset` now removes `.env.auth` with the generation, so the next deploy re-mints hashes from `.env`.
- New `osprey init --set port_base=<n>` shorthand (folds into `config: deployment.port_base`, range-checked at parse) so a second stack on one host can move off the default block without a hand-edited override.

Deliberately untouched, for the reviewer: `test_deploy_lifecycle`'s hand-managed port dicts also omit the three panel families, but nothing enables them there and its ranges are delicately disjoint — separate follow-up; `test_graph_mcp_smoke` still publishes bolt 7687 (outside the osprey block, collides only with a local Neo4j).

## How it hangs together

```text
── port isolation (tests) ────────────────────────────────────────────────
 11 `osprey up` e2e modules ─each─► own 1000-port block in 21100..22100
 3 VA harnesses: EPICS CA :5064 ──► ephemeral port
 browser suites' fake gallery URL ► reserved UNSERVED port
                                    (was live :10200 — tests sent the
                                     operator secret to a real, live gallery)
   net: no test now binds the live deployment's default :10000 panel block

── credential honesty (src) ──────────────────────────────────────────────
 .env (profile defaults) ────┐
 .env.auth (stored hashes) ──┴─► seeded_logins_report() [auth_credentials.py]
                                 verify_password() per profile-default login
                             ▼
                             ClosingFacts [deploy_summary.py]
                             ▼
                             closing summary card [cli/summary_card.py]
                               verified     ─► kept in "sign in as"
                               contradicted ─► `osprey users passwd <user>`

 osprey init --reset [reset.py] ──deletes──► .env.auth
                                (next deploy re-mints hashes from .env)

── CLI shorthand ─────────────────────────────────────────────────────────
 osprey init --set port_base=<n> ──range-checked──► config:
                                                    deployment.port_base
```
