### PR TITLE
feat(deploy): seed Claude Code first-run state at container start

### DIFF
--- a/changelog.d/container-first-run.added.md
+++ b/changelog.d/container-first-run.added.md
@@ -1,0 +1,9 @@
+Containers now open their first terminal session on the control-room prompt
+instead of the agent CLI's own setup: the entrypoint seeds the missing
+first-run state (onboarding, workspace trust, and — under a raw-key
+provider — API-key approval) into the session volume at start, merge-only,
+so a returning operator's choices are never rewritten. Seeding trust also
+means the rendered permission allow-list applies from the very first
+session rather than waiting on a dialog. A deployment whose `web.theme`
+pins a mode (a concrete theme id such as `desy-light`) now renders the
+matching terminal theme too, so one config key governs both surfaces.

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -446,7 +446,40 @@ def config_derived_context(config: dict, project_dir: Path) -> dict[str, Any]:
         # absent key renders as nothing at all — the same way hook_config.json
         # once shipped with an empty write-tool list and no error to say so.
         "mixed_read_write_tools": [],
+        # The terminal theme `web.theme` pins, if any — settings.json.j2
+        # renders it so one config key governs the look of both surfaces.
+        "terminal_theme": _terminal_theme(config),
     }
+
+
+def _terminal_theme(config: dict) -> str | None:
+    """The Claude Code terminal theme the deployment's ``web.theme`` pins.
+
+    ``web.theme`` may name a concrete theme id (``"desy-light"`` — a palette
+    *and* a mode) or a family (``"desy"`` — light/dark left to each viewer's
+    OS). Only a pinned mode maps onto Claude Code's ``theme`` key: a terminal
+    cannot follow the OS, so a family renders nothing and Claude Code's own
+    default applies rather than this render inventing a pin the operator never
+    stated. Same distinction, same resolver, as the web surfaces —
+    :func:`osprey.interfaces.design_system.theme_config.resolve_pinned_mode`.
+
+    Never raises: a broken theme registry must not take down a render, exactly
+    as it must not take down a server's startup.
+    """
+    configured = (config.get("web") or {}).get("theme")
+    if not configured:
+        return None
+    try:
+        from osprey.interfaces.design_system.theme_config import (
+            load_theme_registry,
+            resolve_pinned_mode,
+        )
+
+        entries, _ = load_theme_registry()
+        return resolve_pinned_mode(str(configured), entries)
+    except Exception as exc:  # noqa: BLE001 — cosmetic key, never render-blocking
+        logger.warning("Could not resolve web.theme %r for the terminal (%r)", configured, exc)
+        return None
 
 
 def _renders_the_target_switch(control_system: dict) -> bool:

--- a/src/osprey/deployment/claude_state_seed.py
+++ b/src/osprey/deployment/claude_state_seed.py
@@ -1,0 +1,248 @@
+"""Seed Claude Code's first-run state so a container's first session starts clean.
+
+Claude Code keeps per-machine application state in ``.claude.json`` — under
+``$CLAUDE_CONFIG_DIR`` when that is set, beside ``$HOME`` otherwise. A fresh
+container volume holds neither, so the first interactive session walks the
+operator through the CLI's own onboarding: a theme picker, security notes, a
+terminal-setup offer, then the workspace-trust dialog, and — when the provider
+hands Claude Code a raw ``ANTHROPIC_API_KEY`` — an approval prompt for that
+key. For a developer on their own machine those are real questions; for an
+operator dropped into a deployment OSPREY rendered they are noise at best,
+and the trust dialog is a genuine defect: Claude Code applies a project's
+``permissions.allow`` rules only after the folder is trusted, so the render's
+carefully-built allow list is inert until the operator clicks through a dialog
+they have no context to evaluate.
+
+This module writes the state Claude Code would have recorded had the operator
+answered, once, from the container entrypoint's root phase — the same phase
+that regenerates drifted artifacts and restores scaffold bodies, and for the
+same reason: it is a write into state the serving process must find already
+in place. Three of the four keys are documented ground
+(``projects[<path>].hasTrustDialogAccepted`` is the documented manual-trust
+mechanism; ``theme`` never needs seeding because skipping onboarding lands on
+Claude Code's default); ``customApiKeyResponses`` is observed app state, so
+that one seed is best-effort by design.
+
+The contract, asserted in ``tests/deployment/test_claude_state_seed.py``:
+
+- **Merge-only**: a key that exists is never rewritten, so a returning
+  operator's volume keeps every choice they made.
+- **Never clobber**: a file that does not parse is left alone — losing an
+  operator's OAuth state would be strictly worse than showing the prompts.
+- **Fail open**: like the entrypoint's other maintenance steps, any failure
+  is reported and the container still starts, prompts and all.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.claude_state_seed")
+
+#: Claude Code's per-machine state file, relative to the config dir / HOME.
+CLAUDE_STATE_FILENAME = ".claude.json"
+
+#: The one auth shape whose interactive session prompts for key approval.
+#: Token-auth providers (``ANTHROPIC_AUTH_TOKEN``) never see the prompt.
+_PROMPTED_AUTH_ENV_VAR = "ANTHROPIC_API_KEY"
+
+#: How Claude Code digests a key into ``customApiKeyResponses``: the trimmed
+#: key's last 20 characters. Observed in the pinned CLI, not documented — the
+#: reason this particular seed stays best-effort.
+_API_KEY_DIGEST_CHARS = 20
+
+
+def seed_claude_state(
+    render_dir: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+    owner_user: str | None = None,
+) -> list[str]:
+    """Write the missing first-run keys into Claude Code's state file.
+
+    Args:
+        render_dir: The rendered project directory — the cwd every launcher
+            starts Claude Code in, and therefore the exact path Claude Code
+            keys workspace trust on (the render ships no ``.git``, so trust is
+            keyed on the directory itself, not a repository root).
+        env: The environment to resolve ``CLAUDE_CONFIG_DIR``/``HOME`` and the
+            provider's key from. Defaults to ``os.environ``; injectable for
+            tests.
+        owner_user: When set and the process runs as root, ``chown`` the state
+            file (and the config dir, if this call created it) to this user —
+            the entrypoint's privilege-drop target. Root's file in a volume
+            the dropped process must rewrite would be worse than no seed.
+
+    Returns:
+        Human-readable descriptions of the keys seeded, for the entrypoint
+        log. Empty when everything was already in place — or when nothing
+        could be done, each case having logged why.
+    """
+    if env is None:
+        env = os.environ
+
+    base = env.get("CLAUDE_CONFIG_DIR", "").strip() or env.get("HOME", "").strip()
+    if not base:
+        logger.warning(
+            "Neither CLAUDE_CONFIG_DIR nor HOME is set; cannot locate Claude Code's "
+            "state file, so the first session will show the interactive setup prompts."
+        )
+        return []
+
+    render_dir = Path(render_dir).resolve()
+    base_dir = Path(base)
+    target = base_dir / CLAUDE_STATE_FILENAME
+
+    state, ok = _load_state(target)
+    if not ok:
+        return []
+
+    seeded: list[str] = []
+
+    if "hasCompletedOnboarding" not in state:
+        state["hasCompletedOnboarding"] = True
+        seeded.append("onboarding marked complete")
+
+    cli_version = _pinned_cli_version(render_dir)
+    if cli_version and "lastOnboardingVersion" not in state:
+        state["lastOnboardingVersion"] = cli_version
+        seeded.append(f"onboarding version {cli_version}")
+
+    projects = state.setdefault("projects", {})
+    entry = projects.setdefault(str(render_dir), {})
+    if "hasTrustDialogAccepted" not in entry:
+        entry["hasTrustDialogAccepted"] = True
+        seeded.append(f"workspace trust for {render_dir}")
+
+    digest = _api_key_digest(render_dir, env)
+    if digest is not None:
+        responses = state.setdefault("customApiKeyResponses", {})
+        approved = responses.setdefault("approved", [])
+        rejected = responses.setdefault("rejected", [])
+        if digest not in approved and digest not in rejected:
+            approved.append(digest)
+            seeded.append("provider API key pre-approved")
+
+    if not seeded:
+        return []
+
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    # Atomic replace: Claude Code itself rewrites this file through a tmp +
+    # rename, and a torn write here would trip its corrupt-config recovery on
+    # the very first launch this seed exists to smooth.
+    tmp = target.with_name(target.name + ".osprey-seed")
+    tmp.write_text(json.dumps(state, indent=2) + "\n")
+    os.replace(tmp, target)
+
+    _hand_ownership(target, base_dir, owner_user)
+    return seeded
+
+
+def _load_state(target: Path) -> tuple[dict, bool]:
+    """Read the existing state file. ``(state, ok)``; ``ok=False`` means abort.
+
+    Missing file → empty state, proceed. Unparseable or non-object content →
+    abort without touching the file: this seed must never be the reason an
+    operator's OAuth session or MCP registrations are lost.
+    """
+    if not target.is_file():
+        return {}, True
+    try:
+        state = json.loads(target.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "Existing %s could not be parsed (%s); leaving it untouched — the "
+            "first session may show the interactive setup prompts.",
+            target,
+            exc,
+        )
+        return {}, False
+    if not isinstance(state, dict):
+        logger.warning("Existing %s is not a JSON object; leaving it untouched.", target)
+        return {}, False
+    return state, True
+
+
+def _pinned_cli_version(render_dir: Path) -> str | None:
+    """The render's ``claude_code.cli_version`` pin, if it states one."""
+    config_path = render_dir / "config.yml"
+    if not config_path.is_file():
+        return None
+    try:
+        import yaml
+
+        config = yaml.safe_load(config_path.read_text()) or {}
+        version = (config.get("claude_code") or {}).get("cli_version")
+        return version.strip() if isinstance(version, str) and version.strip() else None
+    except Exception as exc:  # noqa: BLE001 — a version is nice-to-have, never blocking
+        logger.warning("Could not read cli_version from %s (%r)", config_path, exc)
+        return None
+
+
+def _api_key_digest(render_dir: Path, env: Mapping[str, str]) -> str | None:
+    """The approval digest for the provider's key, when the prompt would fire.
+
+    Only a resolved provider whose auth reaches Claude Code as
+    ``ANTHROPIC_API_KEY`` triggers the interactive approval prompt, and only
+    when the container actually carries a key value. Everything here fails
+    open to ``None``: no provider, no resolvable config, no key — no seed.
+    """
+    config_path = render_dir / "config.yml"
+    if not config_path.is_file():
+        return None
+    try:
+        import yaml
+
+        from osprey.build.claude_code_resolver import ClaudeCodeModelResolver
+
+        config = yaml.safe_load(config_path.read_text()) or {}
+        spec = ClaudeCodeModelResolver.resolve(
+            config.get("claude_code") or {},
+            (config.get("api") or {}).get("providers") or {},
+            include_telemetry=False,
+        )
+    except Exception as exc:  # noqa: BLE001 — the other seeds must still land
+        logger.warning("Could not resolve the provider spec from %s (%r)", config_path, exc)
+        return None
+    if spec is None or spec.auth_env_var != _PROMPTED_AUTH_ENV_VAR:
+        return None
+    key = env.get(spec.auth_secret_env or _PROMPTED_AUTH_ENV_VAR, "").strip()
+    if not key:
+        return None
+    return key[-_API_KEY_DIGEST_CHARS:]
+
+
+def _hand_ownership(target: Path, base_dir: Path, owner_user: str | None) -> None:
+    """Chown the seed's writes to the privilege-drop target, when root wrote them.
+
+    Mirrors the entrypoint's state-zone hand-back: any root-phase step that
+    writes where the dropped process must later write hands its files over
+    before the drop. The directory is handed over too (non-recursively, like
+    the CLAUDE.md seeder's chown of the same mount): Claude Code rewrites the
+    state file through a tmp + rename, and a rename needs write on the
+    DIRECTORY — a fresh named volume mounts root-owned, so an osprey-owned
+    file in a root-owned directory would still be one Claude Code cannot
+    update. A no-op when unprivileged (tests, ``--user`` starts) or when no
+    owner was named.
+    """
+    if not owner_user or os.name != "posix" or os.geteuid() != 0:
+        return
+    try:
+        import pwd
+
+        record = pwd.getpwnam(owner_user)
+        os.chown(target, record.pw_uid, record.pw_gid)
+        os.chown(base_dir, record.pw_uid, record.pw_gid)
+    except (KeyError, OSError) as exc:
+        logger.warning(
+            "Could not hand %s to user %r (%s); the session may be unable to update it.",
+            target,
+            owner_user,
+            exc,
+        )

--- a/src/osprey/templates/claude_code/claude/settings.json.j2
+++ b/src/osprey/templates/claude_code/claude/settings.json.j2
@@ -21,6 +21,12 @@
 {%- endmacro -%}
 {
   "showThinkingSummaries": true,
+{%- if terminal_theme %}
+{#- The terminal follows the deployment's `web.theme`, and only when that
+    value PINS a mode (a concrete theme id like "desy-light"). A family pins
+    nothing and this line is absent — Claude Code's own default applies. -#}
+  "theme": {{ terminal_theme | tojson }},
+{%- endif %}
   "outputStyle": ".claude/output-styles/control-operator.md",
   "statusLine": {
     "type": "command",

--- a/src/osprey/templates/project/entrypoint.sh
+++ b/src/osprey/templates/project/entrypoint.sh
@@ -2,13 +2,18 @@
 #
 # OSPREY container entrypoint.
 #
-# Five steps, in this order and no other:
+# Six steps, in this order and no other:
 #
 #   1. Regen      Re-render the Claude Code artifacts that config.yml drives,
 #                 and only those that have actually drifted.
 #   2. Restore    Put volume-owned scaffold bodies back into the render, so the
 #                 agent runs the operator's claimed artifacts rather than the
 #                 framework's originals.
+#   2b. Seed      Write Claude Code's missing first-run state (onboarding,
+#                 workspace trust, key approval) so the first session opens on
+#                 the control-room prompt instead of the CLI's own setup — and
+#                 so the render's permissions.allow list, which Claude Code
+#                 holds until the folder is trusted, applies from the start.
 #   3. Join       Give this image an /etc/group entry for the group that owns
 #                 each bind-mounted directory the render named, and add
 #                 `osprey` to it — because `gosu` re-derives the dropped
@@ -145,6 +150,28 @@ try:
         log("no user-owned artifact bodies to restore")
 except Exception as exc:  # noqa: BLE001 — never block the container on restore
     log(f"WARNING: scaffold restore failed ({exc!r}); the image's own artifacts stay in place")
+
+# 2b. First-run state seed. A fresh claude-config volume is a brand-new
+#     machine to Claude Code, and its interactive first session would open on
+#     the CLI's own onboarding, the workspace-trust dialog, and (under a
+#     raw-key provider) a key-approval prompt — questions the render already
+#     answered. Trust is the load-bearing one: the rendered permissions.allow
+#     list is held until the folder is trusted. Merge-only: a returning
+#     operator's volume keeps every choice they made, and a file that does not
+#     parse is left alone. Ownership goes to `osprey` — this phase runs as
+#     root, and the volume is the dropped user's to rewrite (the state-zone
+#     hand-back below covers var/, not $CLAUDE_CONFIG_DIR, so the seed hands
+#     back its own writes).
+try:
+    from osprey.deployment.claude_state_seed import seed_claude_state
+
+    seeded = seed_claude_state(render_dir, owner_user="osprey")
+    if seeded:
+        log(f"seeded Claude Code first-run state: {'; '.join(seeded)}")
+    else:
+        log("Claude Code first-run state already in place")
+except Exception as exc:  # noqa: BLE001 — never block the container on the seed
+    log(f"WARNING: first-run state seed failed ({exc!r}); the first session will show the setup prompts")
 PY
 }
 

--- a/tests/cli/test_entrypoint_script.py
+++ b/tests/cli/test_entrypoint_script.py
@@ -107,15 +107,23 @@ class TestScriptShape:
         assert text.startswith("#!/bin/sh\n")
         assert re.search(r"^set -eu$", text, flags=re.MULTILINE)
 
-    def test_regen_then_restore_then_drop(self, text: str):
+    def test_regen_then_restore_then_seed_then_drop(self, text: str):
         """The order that makes the render's root ownership meaningful."""
-        # The call sites, not the prose: the header comment names both steps
+        # The call sites, not the prose: the header comment names the steps
         # while explaining the order, in whatever sequence reads best there.
         regen = text.index("regen_if_drift(render_dir)")
         restore = text.index("restore_scaffold_bodies(render_dir)")
+        seed = text.index("seed_claude_state(render_dir")
         drop = _EXEC_FORM.search(text)
         assert drop is not None, 'no `exec gosu osprey "$@"` privilege drop'
-        assert regen < restore < drop.start()
+        assert regen < restore < seed < drop.start()
+
+    def test_seed_hands_its_writes_to_the_dropped_user(self, text: str):
+        """The first-run seed writes into the claude-config volume, which the
+        state-zone hand-back does not cover — so the seed must name the
+        privilege-drop target itself, or its file stays root-owned in a volume
+        the dropped process has to rewrite."""
+        assert 'seed_claude_state(render_dir, owner_user="osprey")' in text
 
     def test_exec_form(self, text: str):
         assert len(_EXEC_FORM.findall(text)) == 1

--- a/tests/cli/test_terminal_theme_render.py
+++ b/tests/cli/test_terminal_theme_render.py
@@ -1,0 +1,72 @@
+"""``web.theme`` drives the rendered terminal theme — one key, both surfaces.
+
+The deployment's ``web.theme`` already decides how the web UI looks. Claude
+Code's ``theme`` settings key has scope "any file", so the render can state it
+in ``build/.claude/settings.json`` and the terminal follows the same
+deployment decision — no second knob, and no seeding into volume state.
+
+The mapping honors the family/id distinction ``theme_config`` maintains: a
+concrete theme id (``desy-light``) *pins* a mode, and only a pin is rendered.
+A family (``desy``) deliberately leaves light/dark to each viewer's OS — a
+terminal cannot follow the OS, so the render stays silent and Claude Code's
+own default applies rather than OSPREY inventing a pin the operator never
+stated.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from osprey.cli.templates.claude_code import config_derived_context
+from osprey.cli.templates.manager import TemplateManager
+
+
+def _regen_with_web_theme(tmp_path, theme: str | None):
+    manager = TemplateManager()
+    project_dir = manager.create_project(
+        project_name="theme-test",
+        output_dir=tmp_path,
+        data_bundle="control_assistant",
+        context={"channel_finder_mode": "hierarchical"},
+    )
+    if theme is not None:
+        config = yaml.safe_load((project_dir / "config.yml").read_text())
+        config.setdefault("web", {})["theme"] = theme
+        (project_dir / "config.yml").write_text(yaml.dump(config))
+    manager.regenerate_claude_code(project_dir)
+    return json.loads((project_dir / ".claude" / "settings.json").read_text())
+
+
+def test_pinned_theme_id_renders_the_terminal_theme(tmp_path):
+    settings = _regen_with_web_theme(tmp_path, "desy-light")
+    assert settings["theme"] == "light"
+
+
+def test_family_value_renders_no_terminal_theme(tmp_path):
+    """A family pins no mode, so the render must not invent one."""
+    settings = _regen_with_web_theme(tmp_path, "desy")
+    assert "theme" not in settings
+
+
+def test_absent_web_theme_renders_no_terminal_theme(tmp_path):
+    settings = _regen_with_web_theme(tmp_path, None)
+    assert "theme" not in settings
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("dark", "dark"),  # the main family's concrete ids pin too
+        ("light", "light"),
+        ("high-contrast", None),  # family
+        ("no-such-theme", None),  # unknown is not a pin
+        (None, None),
+    ],
+)
+def test_context_derivation(tmp_path, configured, expected):
+    config = {"web": {"theme": configured}} if configured is not None else {}
+    ctx = config_derived_context(config, tmp_path)
+    assert ctx["terminal_theme"] == expected

--- a/tests/deployment/test_claude_state_seed.py
+++ b/tests/deployment/test_claude_state_seed.py
@@ -1,0 +1,222 @@
+"""Seeding Claude Code's first-run state for containerized deployments.
+
+A fresh container volume is, from Claude Code's point of view, a brand-new
+machine: the interactive CLI walks the operator through onboarding (theme
+picker, security notes, terminal setup), asks whether to trust the project
+folder, and — under a raw-key provider — whether to use the ambient API key.
+None of that is an operator's decision in a deployment OSPREY rendered: the
+render already states the theme, the permissions, and the provider. Worse, the
+trust dialog is not cosmetic: the rendered ``permissions.allow`` list does not
+apply until the folder is trusted, so an unseeded first session runs with a
+degraded permission surface.
+
+:func:`osprey.deployment.claude_state_seed.seed_claude_state` writes the state
+Claude Code would have recorded had the operator answered, into the
+``.claude.json`` the container's ``CLAUDE_CONFIG_DIR``/``HOME`` names. The
+properties asserted here:
+
+- **Merge-only.** A key that exists is never rewritten — a returning
+  operator's live volume keeps every choice they made, including an explicit
+  ``hasCompletedOnboarding: false``.
+- **Never clobber.** A file that does not parse is left byte-for-byte alone;
+  losing an operator's OAuth state to a seed step would be strictly worse
+  than showing the prompts.
+- **Deterministic trust key.** Trust is recorded against the resolved render
+  directory — the cwd every launcher starts Claude Code in — exactly as
+  Claude Code keys it for a non-git directory.
+- **Provider-conditional key approval.** Only a provider whose auth reaches
+  Claude Code as ``ANTHROPIC_API_KEY`` triggers the CLI's key-approval
+  prompt, so only that shape is seeded; token-auth proxies get nothing.
+- **Idempotent.** A second run against its own output writes nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment.claude_state_seed import CLAUDE_STATE_FILENAME, seed_claude_state
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def render_dir(tmp_path: Path) -> Path:
+    """A minimal render: a directory holding a config.yml with a pinned CLI."""
+    render = tmp_path / "build"
+    render.mkdir()
+    (render / "config.yml").write_text(
+        "claude_code:\n  provider: anthropic\n  cli_version: '2.1.239'\n"
+    )
+    return render
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> Path:
+    """The volume-backed directory ``CLAUDE_CONFIG_DIR`` points at."""
+    d = tmp_path / "claude-config"
+    d.mkdir()
+    return d
+
+
+def _seed(render: Path, config_dir: Path, **env: str) -> list[str]:
+    return seed_claude_state(render, env={"CLAUDE_CONFIG_DIR": str(config_dir), **env})
+
+
+def _state(config_dir: Path) -> dict:
+    return json.loads((config_dir / CLAUDE_STATE_FILENAME).read_text())
+
+
+# ── fresh volume ─────────────────────────────────────────────────────────────
+
+
+def test_fresh_volume_gets_onboarding_trust_and_version(render_dir, config_dir):
+    seeded = _seed(render_dir, config_dir)
+
+    state = _state(config_dir)
+    assert state["hasCompletedOnboarding"] is True
+    assert state["lastOnboardingVersion"] == "2.1.239"
+    assert state["projects"][str(render_dir)]["hasTrustDialogAccepted"] is True
+    assert seeded  # every action is reported for the entrypoint log
+
+
+def test_config_dir_is_created_when_missing(render_dir, tmp_path):
+    """A named volume mounts as an existing dir, but a bare HOME may not hold one."""
+    config_dir = tmp_path / "not-yet"
+    seed_claude_state(render_dir, env={"CLAUDE_CONFIG_DIR": str(config_dir)})
+    assert (config_dir / CLAUDE_STATE_FILENAME).is_file()
+
+
+def test_home_fallback_when_config_dir_unset(render_dir, tmp_path):
+    """The single-user image sets HOME only; state lands at ~/.claude.json."""
+    home = tmp_path / "home"
+    home.mkdir()
+    seed_claude_state(render_dir, env={"HOME": str(home)})
+    assert (home / CLAUDE_STATE_FILENAME).is_file()
+
+
+def test_no_target_dir_is_a_reported_noop(render_dir):
+    """Neither CLAUDE_CONFIG_DIR nor HOME: nowhere to write, and no crash."""
+    assert seed_claude_state(render_dir, env={}) == []
+
+
+# ── merge-only semantics ─────────────────────────────────────────────────────
+
+
+def test_existing_keys_and_unrelated_state_survive(render_dir, config_dir):
+    """The seed adds what is missing and rewrites nothing that exists."""
+    (config_dir / CLAUDE_STATE_FILENAME).write_text(
+        json.dumps(
+            {
+                "hasCompletedOnboarding": False,  # an explicit choice, kept
+                "oauthAccount": {"email": "op@example.org"},  # untouched
+                "projects": {
+                    "/somewhere/else": {"hasTrustDialogAccepted": False},
+                },
+            }
+        )
+    )
+
+    _seed(render_dir, config_dir)
+
+    state = _state(config_dir)
+    assert state["hasCompletedOnboarding"] is False
+    assert state["oauthAccount"] == {"email": "op@example.org"}
+    assert state["projects"]["/somewhere/else"] == {"hasTrustDialogAccepted": False}
+    # ...while the render's own trust entry is still added beside it.
+    assert state["projects"][str(render_dir)]["hasTrustDialogAccepted"] is True
+
+
+def test_existing_project_entry_gains_only_the_missing_key(render_dir, config_dir):
+    (config_dir / CLAUDE_STATE_FILENAME).write_text(
+        json.dumps({"projects": {str(render_dir): {"exampleFiles": ["a.py"]}}})
+    )
+
+    _seed(render_dir, config_dir)
+
+    entry = _state(config_dir)["projects"][str(render_dir)]
+    assert entry["exampleFiles"] == ["a.py"]
+    assert entry["hasTrustDialogAccepted"] is True
+
+
+def test_corrupt_state_file_is_left_untouched(render_dir, config_dir):
+    """A parse failure must not cost the operator their file."""
+    corrupt = '{"oauthAccount": '  # truncated write
+    (config_dir / CLAUDE_STATE_FILENAME).write_text(corrupt)
+
+    assert _seed(render_dir, config_dir) == []
+    assert (config_dir / CLAUDE_STATE_FILENAME).read_text() == corrupt
+
+
+def test_second_run_is_a_silent_noop(render_dir, config_dir):
+    _seed(render_dir, config_dir)
+    before = (config_dir / CLAUDE_STATE_FILENAME).read_text()
+
+    assert _seed(render_dir, config_dir) == []
+    assert (config_dir / CLAUDE_STATE_FILENAME).read_text() == before
+
+
+# ── provider-conditional API-key approval ────────────────────────────────────
+
+
+def test_anthropic_key_is_pre_approved_by_its_last_20_chars(render_dir, config_dir):
+    key = "sk-ant-api03-" + "x" * 40
+    _seed(render_dir, config_dir, ANTHROPIC_API_KEY=key)
+
+    approved = _state(config_dir)["customApiKeyResponses"]["approved"]
+    assert approved == [key[-20:]]
+
+
+def test_token_auth_provider_seeds_no_key_approval(config_dir, tmp_path):
+    """A proxy provider authenticates with ANTHROPIC_AUTH_TOKEN — no prompt exists."""
+    render = tmp_path / "build"
+    render.mkdir()
+    (render / "config.yml").write_text(
+        "claude_code:\n"
+        "  provider: cborg\n"
+        "api:\n"
+        "  providers:\n"
+        "    cborg:\n"
+        "      models: {haiku: anthropic/claude-haiku}\n"
+    )
+
+    _seed(render, config_dir, CBORG_API_KEY="cborg-secret", ANTHROPIC_AUTH_TOKEN="cborg-secret")
+
+    assert "customApiKeyResponses" not in _state(config_dir)
+
+
+def test_missing_key_value_seeds_no_approval(render_dir, config_dir):
+    """Provider says ANTHROPIC_API_KEY but the container got no key: nothing to approve."""
+    _seed(render_dir, config_dir)
+    assert "customApiKeyResponses" not in _state(config_dir)
+
+
+def test_already_rejected_digest_is_respected(render_dir, config_dir):
+    key = "sk-ant-api03-" + "y" * 40
+    (config_dir / CLAUDE_STATE_FILENAME).write_text(
+        json.dumps({"customApiKeyResponses": {"approved": [], "rejected": [key[-20:]]}})
+    )
+
+    _seed(render_dir, config_dir, ANTHROPIC_API_KEY=key)
+
+    responses = _state(config_dir)["customApiKeyResponses"]
+    assert responses["approved"] == []
+    assert responses["rejected"] == [key[-20:]]
+
+
+# ── degraded configs ─────────────────────────────────────────────────────────
+
+
+def test_render_without_config_still_seeds_onboarding_and_trust(config_dir, tmp_path):
+    """No config.yml: no version, no provider — the universal keys still land."""
+    render = tmp_path / "bare"
+    render.mkdir()
+
+    _seed(render, config_dir)
+
+    state = _state(config_dir)
+    assert state["hasCompletedOnboarding"] is True
+    assert "lastOnboardingVersion" not in state
+    assert state["projects"][str(render)]["hasTrustDialogAccepted"] is True


### PR DESCRIPTION
A fresh claude-config volume is a brand-new machine to Claude Code, so a container's first interactive session opened on the CLI's own onboarding (theme picker, security notes, terminal setup), the workspace-trust dialog, and — under a raw-key provider — an API-key approval prompt. Trust is the load-bearing one: the rendered `permissions.allow` list is held until the folder is trusted, so first sessions ran with the allow list inert.

The entrypoint's root phase now seeds the missing state into `$CLAUDE_CONFIG_DIR/.claude.json` (HOME fallback), merge-only and fail-open: existing keys are never rewritten, an unparseable file is left alone, and a failed seed still starts the container. Ownership of the file *and* the directory is handed to the privilege-drop user — Claude Code rewrites `.claude.json` via tmp+rename, which needs a writable directory, and the state-zone hand-back does not cover the claude-config volume.

The terminal also follows the deployment's `web.theme` now: a value that pins a mode (a concrete theme id such as `desy-light`) renders Claude Code's theme key into `settings.json`; a family pins nothing and renders nothing.

## How it hangs together

```text
 CONTAINER FIRST START
 ─────────────────────────────────────────────────────────────────────────
                          entrypoint.sh (root phase)
   config.yml ──┐    1 regen ─→ 2 restore ─→ 2b SEED ─→ join ─→ gosu osprey
   web.theme ───┤                              │
       │        │                              ▼  claude_state_seed.py
       ▼        │              $CLAUDE_CONFIG_DIR/.claude.json   (merge-only,
  settings.json │                ├ hasCompletedOnboarding: true   fail-open,
   "theme":     │                ├ lastOnboardingVersion          never
   light/dark ──┘                │   (from cli_version pin)       clobbers)
  (only when web.theme           ├ projects[<p>].hasTrustDialogAccepted
   pins a mode)                  └ customApiKeyResponses.approved
                                     (only raw-key providers)
                                           │
                                           ▼
              first session: straight to the control-room prompt,
              rendered permissions.allow live from turn one
 ─────────────────────────────────────────────────────────────────────────
```
