### PR TITLE
fix(web-terminals): reach the identity provider through a site proxy

### DIFF
--- a/changelog.d/792.fixed.md
+++ b/changelog.d/792.fixed.md
@@ -1,0 +1,5 @@
+Logins on a multi-user deployment behind a site proxy no longer fail while the
+stack looks healthy. The login service now receives `HTTP_PROXY`, `HTTPS_PROXY`
+and `NO_PROXY` from the deployment's env chain, so its call to the identity
+provider goes through the proxy; proxy lines hand-written into `.env.auth` are
+no longer needed.

--- a/docs/source/how-to/deploy-project/env-chain.rst
+++ b/docs/source/how-to/deploy-project/env-chain.rst
@@ -171,6 +171,64 @@ are.
    the minted password, remove the ``ariel_postgres_data`` volume and redeploy
    (this deletes the stored logbook data — re-ingest afterwards).
 
+Egress through a site proxy
+---------------------------
+
+A site that reaches the outside world only through a proxy sets the three
+standard names in the chain — in ``.env.shared`` when every host goes through
+the same proxy, in ``.env`` when this one differs:
+
+.. code-block:: bash
+
+   HTTP_PROXY=http://proxy.example.com:8080
+   HTTPS_PROXY=http://proxy.example.com:8080
+   NO_PROXY=localhost,127.0.0.1
+
+**Spell them in uppercase.** The login service is handed exactly these three
+names and nothing else from the chain, so a lowercase ``https_proxy`` never
+reaches it. (Inside a container that does receive the whole chain, an empty
+lowercase name is worse than absent — it turns the proxy off for that scheme —
+which is why only the uppercase spelling is passed through.)
+
+On a multi-user deployment the login service reads this set from the chain as
+well, and it is the one worth remembering, because it makes a call of its own:
+at the first login it fetches the identity provider's discovery document. On a
+proxied host without these names that call goes out directly, so the stack
+comes up, the health check is green, and every login fails. Nothing
+proxy-related belongs in ``.env.auth``. That file is the login service's
+credential store; proxy settings are configuration rather than secrets, and the
+chain already delivers them (see :ref:`multi-user-require-a-login`).
+
+**The trust store is not carried across.** A proxy that re-signs TLS with a
+site certificate authority needs that authority's certificate inside the
+container, and nothing puts it there yet. ``SSL_CERT_FILE`` and
+``REQUESTS_CA_BUNDLE`` in the chain do not reach the login service at all — it
+receives only the three proxy names. Uncommenting the site-CA block
+``osprey init`` writes into ``.env.shared`` therefore changes nothing for
+logins; the stack still starts and the identity-provider fetch still fails at
+TLS. (Routing a CA variable into the sidecar is not a fix either: one naming a
+path the image does not carry stops httpx from constructing a client at all.)
+Delivering a custom CA is a mount plus a variable, and separate work.
+
+**A changed value lands at the next start.** These values are filled in when a
+container is created, so editing the chain does not reach a running stack:
+``osprey up`` is what puts a new proxy into force. Because the value is
+interpolated into the sidecar's ``environment:``, a changed value is a
+service-definition change, so Docker Compose recreates the login service and
+leaves the running terminals alone; podman-compose bounces the whole project.
+``osprey restart`` also works, but it is a full stop-and-start on either
+provider, so every live web-terminal session drops. Pick the moment for it.
+
+.. warning::
+
+   No value in the chain may contain a ``$``, and a proxy URL carrying a
+   password is the usual way to meet that rule. Container stacks substitute
+   ``$`` sequences on the way through, so what reaches the container is
+   silently not what you wrote. ``osprey up`` scans ``.env.shared`` and
+   ``.env`` before it starts anything, refuses, and names the variable. The
+   remedy is a value without the character — ask for a credential that has
+   none.
+
 .. _deployment-pinned-env:
 
 Pinning a variable to the chain

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -368,6 +368,16 @@
      mapping) come from the template variables above and stay in
      `environment:`.
 
+     The proxy settings the sidecar's OIDC fetches need (`HTTP_PROXY`,
+     `HTTPS_PROXY`, `NO_PROXY`) are non-secret in the same sense and reach it
+     the same way: `${VAR:-}` passthrough in `environment:`, interpolated from
+     the deploy env chain, NOT a second `env_file`. `.env.auth` therefore
+     remains the sidecar's only env file and rule 1 above is untouched. An
+     operator who puts credentials in a proxy URL is opting that value into
+     `docker inspect` like any other `environment:` value; see the EGRESS
+     comment on those three entries for the rest, including why they are
+     uppercase-only.
+
   ----------------------------------------------------------------------------
   OPERATOR SECRET (the per-user carrier, and why no VALUE is rendered here)
 
@@ -656,6 +666,31 @@ services:
          the per-user containers and nginx locations come from, so a user can
          never exist in one and be missing from the other. #}
       - OSPREY_AUTH_USERS={{ services | map(attribute="user") | join(",") }}
+      {#- EGRESS. The sidecar's only outbound traffic is the OIDC discovery,
+         token and userinfo fetches below, and on a site behind a corporate
+         proxy they fail unless the host's proxy settings reach this container.
+         They are not secrets, so they arrive as `${VAR:-}` passthrough
+         interpolated from the deploy env chain (`.env.shared`/`.env`, where
+         `osprey init` writes the commented-out block that documents them);
+         the `env_file` chain stays `.env.auth` and nothing else.
+
+         UPPERCASE ONLY, deliberately. httpx — Authlib's transport for every
+         fetch above, with `trust_env` left at its default — and requests read
+         the UPPERCASE names. CPython's own
+         `urllib.request.getproxies_environment` reads both, lowercase last and
+         winning: a present-but-EMPTY lowercase `http_proxy` reads as "this
+         scheme is configured, to nothing" and POPS the scheme the uppercase
+         pass just set, while an empty UPPERCASE variable is skipped. Adding
+         the lowercase pair here would therefore hand every stdlib caller a
+         cancelled proxy on any host that sets none — which is exactly what
+         `${VAR:-}` renders when the host has no proxy. No CA-bundle variable
+         joins them: nothing mounts a CA into this image, `SSL_CERT_FILE`
+         naming a path that does not exist crashes httpx at client
+         construction, and nothing in the sidecar reads `REQUESTS_CA_BUNDLE`.
+         Custom-CA support is a mount plus a variable, and its own change. #}
+      - HTTP_PROXY=${HTTP_PROXY:-}
+      - HTTPS_PROXY=${HTTPS_PROXY:-}
+      - NO_PROXY=${NO_PROXY:-}
 {#- Everything OIDC — issuer, credential-variable names, claim, and the per-user
    subject mapping — is gated on the mode, so a `password` deployment carries no
    OIDC settings at all even if a roster entry still declares an `oidc_subject`

--- a/tests/deployment/web_terminals/test_auth_serving.py
+++ b/tests/deployment/web_terminals/test_auth_serving.py
@@ -34,6 +34,10 @@ external origin are all read out of ``render_web_terminals()``'s output;
 preflight and ``osprey users passwd`` call) and handed to the container through
 ``--env-file``, matching the rendered ``env_file:``. Only the passwords
 themselves are chosen here, because minting deliberately never returns one.
+The one thing this file must do that compose would otherwise have done is
+*interpolate*: a bare ``docker run`` resolves no ``${...}``, so
+:func:`_resolved_env_flags` replays that substitution against the deployment's
+env chain before either service is started.
 
 PASSWORD MODE ONLY, deliberately. The OIDC handshake is proven in process
 against a real signing provider in ``tests/services/auth_sidecar/test_oidc_flow.py``;
@@ -67,6 +71,7 @@ to that Dockerfile would reach a deployment without a test noticing.
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import shutil
 import socket
@@ -74,7 +79,7 @@ import subprocess
 import textwrap
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from importlib.metadata import requires as distribution_requires
@@ -100,7 +105,12 @@ from osprey.deployment.web_terminals.render import render_web_terminals
 from osprey.interfaces._serving import free_port
 from osprey.services.auth_sidecar.passwords import generation_tag, hash_password
 from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME, SessionCodec
-from osprey.utils.dotenv import ENV_LOCAL_FILENAME, parse_dotenv_file
+from osprey.utils.dotenv import (
+    ENV_LOCAL_FILENAME,
+    ENV_SHARED_FILENAME,
+    merge_chain,
+    parse_dotenv_file,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SRC_DIR = _REPO_ROOT / "src"
@@ -116,6 +126,21 @@ window without locking out the user every other test logs in as — the throttle
 is per-user and process-local, and the stack is shared across this module."""
 
 _PASSWORDS = {"alice": "alice-pw-correct", "bob": "bob-pw-correct", "carol": "carol-pw-correct"}
+
+_SHARED_PROXY = "http://proxy.invalid:3128"
+"""A site-wide egress proxy, written into ``.env.shared`` by the stack below.
+
+``.env.shared`` is the committed half of the env chain — the file ``osprey
+init`` writes the commented-out ``HTTP_PROXY``/``HTTPS_PROXY``/``NO_PROXY``
+block into, because a proxy is a setting the whole site shares rather than one
+host's secret. The sidecar reaches it through ``${HTTPS_PROXY:-}``
+passthrough, which is worth nothing unless a value living in *that* file
+survives the trip into the container; :func:`_resolved_env_flags` is what
+carries it, and
+:func:`test_sidecar_environment_carries_the_proxy_resolved_from_the_env_chain`
+is what proves it arrived. Unreachable by construction (``.invalid`` is
+reserved): password-mode serving makes no outbound request, so the value is
+only ever read back, never dialled."""
 
 _PACKAGES = (
     "fastapi",
@@ -439,6 +464,74 @@ def _wait_for(url: str, *, names: list[str], what: str, timeout: float = 60.0) -
     raise AssertionError(f"{what} never became ready ({last})\n{logs}")
 
 
+_COMPOSE_INTERPOLATION = re.compile(
+    r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}"
+)
+"""The ``${VAR}`` / ``${VAR:-default}`` references compose resolves for itself."""
+
+
+def _resolved_env_flags(service: dict[str, Any], chain_env: Mapping[str, str]) -> list[str]:
+    """A rendered service's ``environment:`` block as ``docker run -e`` flags.
+
+    A **docker-run replay of compose interpolation**, and the one place in this
+    file that performs one. Compose resolves every ``${...}`` in a service
+    definition at container-create time, from the env chain its lifecycle verbs
+    pass as ``--env-file``; a bare ``docker run`` resolves nothing, so an
+    unreplayed entry reaches the container as the literal characters
+    ``${VAR:-}`` and every assertion about that variable is then about a
+    placeholder rather than about the value a deployment would deliver.
+
+    Both interpolating services come through here. nginx carries one
+    ``${OSPREY_TERMINAL_SECRET_<user>:-}`` per roster user; the auth sidecar
+    carries the OIDC egress passthrough (``HTTP_PROXY``, ``HTTPS_PROXY``,
+    ``NO_PROXY``). One resolver for the two, because a second implementation
+    would be a second thing to keep true — and the sidecar's variables were the
+    ones that had no replay at all until this helper covered both.
+
+    Resolution order, matching what compose does with the chain:
+
+    1. the **merged env chain** — ``.env.shared`` under ``.env``, the later file
+       winning (:func:`osprey_connectors.dotenv.merge_chain`, reached here
+       through the ``osprey.utils.dotenv`` re-export shim). Resolving against
+       ``.env`` alone would silently drop every value an operator put in the
+       committed half of the chain, which is exactly where a site-wide proxy
+       lives;
+    2. the entry's own ``:-`` default, when the chain has no non-empty value —
+       compose's ``:-`` fires on unset *and* on empty;
+    3. the empty string, for a reference that declares no default.
+
+    One deliberate divergence: compose would consult the shell environment ahead
+    of the chain, and this replay does not, so the resolved value is a property
+    of the deployment's files alone and a proxy exported on the CI host cannot
+    change what the assertions see.
+
+    :param service: A rendered compose service definition.
+    :param chain_env: The deployment's merged env chain.
+    :return: Alternating ``-e`` / ``NAME=value`` docker-run arguments.
+    :raises AssertionError: If a resolved value still contains a ``$`` — an
+        interpolation shape this replay does not implement (a bare ``$VAR``, a
+        ``$$`` escape, or a nested ``${...}``). ``$`` is the whole class rather
+        than ``${`` alone because production refuses any chain value carrying
+        one (``compose_unsafe_vars_in_chain``), so no legitimate resolved value
+        has one to lose. Failing here is the point: the alternative is a
+        container that reads the placeholder as a literal value and a green test
+        that means nothing.
+    """
+
+    def _substitute(match: re.Match[str]) -> str:
+        return chain_env.get(match["name"], "") or (match["default"] or "")
+
+    flags: list[str] = []
+    for entry in service.get("environment") or []:
+        name, _, raw = entry.partition("=")
+        value = _COMPOSE_INTERPOLATION.sub(_substitute, raw)
+        assert "$" not in value, (
+            f"{name} still carries an unresolved interpolation after the replay: {value!r}"
+        )
+        flags += ["-e", f"{name}={value}"]
+    return flags
+
+
 @contextmanager
 def serving_stack(tmp_path: Path) -> Iterator[Stack]:
     """Bring the rendered perimeter up, and take it down again.
@@ -475,6 +568,17 @@ def serving_stack(tmp_path: Path) -> Iterator[Stack]:
     ensure_terminal_secrets(deployment_root, _USERS)
     env_local = parse_dotenv_file(deployment_root / ENV_LOCAL_FILENAME)
     terminal_secrets = {user: env_local[terminal_secret_var(user)] for user in _USERS}
+
+    # The committed half of the chain, which no credential function writes: a
+    # site-wide proxy is the operator-authored shape `osprey init` documents
+    # there, and it is the value the sidecar's `${HTTPS_PROXY:-}` passthrough
+    # has to survive the trip with. Written before the merge below, because
+    # that merge is what every `${...}` in the rendered stack resolves against.
+    (deployment_root / ENV_SHARED_FILENAME).write_text(f"HTTPS_PROXY={_SHARED_PROXY}\n")
+
+    # This deployment's env chain as compose would read it: `.env.shared` under
+    # `.env`, the local file winning on any key both set.
+    chain_env = merge_chain(deployment_root)
 
     env_auth = parse_dotenv_file(deployment_root / AUTH_ENV_FILENAME)
     session_secret = env_auth["OSPREY_AUTH_SESSION_SECRET"]
@@ -552,9 +656,13 @@ def serving_stack(tmp_path: Path) -> Iterator[Stack]:
         )
         assert external_origin == f"http://127.0.0.1:{nginx_port}", external_origin
 
-        auth_env: list[str] = []
-        for value in auth_service["environment"]:
-            auth_env += ["-e", value]
+        # The sidecar's environment is mostly literal, but the egress
+        # passthrough (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) is `${VAR:-}`
+        # that compose would resolve from the deploy env chain. Handing those
+        # through verbatim would set the variables to the literal placeholder
+        # inside the container — a proxy URL of `${HTTPS_PROXY:-}`, which is
+        # worse than unset. Same replay as nginx's, same helper.
+        auth_env = _resolved_env_flags(auth_service, chain_env)
         # Kept as an argv the Stack can replay: a credential change obliges a
         # force-recreate, and the recreated container has to be the same one.
         auth_run_argv = [
@@ -597,17 +705,10 @@ def serving_stack(tmp_path: Path) -> Iterator[Stack]:
         # The rendered compose declares the templates mount and the envsubst
         # environment on the nginx service, but its per-user secret values are
         # `${OSPREY_TERMINAL_SECRET_<user>:-}` — resolved by compose from the
-        # deploy `.env`, which a bare `docker run` does not do. Resolve them the
-        # way compose would (from the minted values read above) and hand the rest
-        # of the service's environment through verbatim, so the entrypoint
-        # envsubsts each snippet with the real secret.
-        nginx_env: list[str] = []
-        for value in nginx_service["environment"]:
-            name, _, rendered = value.partition("=")
-            if rendered.startswith("${"):
-                nginx_env += ["-e", f"{name}={env_local.get(name, '')}"]
-            else:
-                nginx_env += ["-e", value]
+        # deploy env chain, which a bare `docker run` does not do. The replay
+        # does it here (the minted secrets are in that chain), so the
+        # entrypoint envsubsts each snippet with the real secret.
+        nginx_env = _resolved_env_flags(nginx_service, chain_env)
 
         # The envsubst output directory (NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/osprey)
         # must exist and be writable before the base image's entrypoint runs, or
@@ -1230,3 +1331,70 @@ def test_login_post_parses_its_form_body_in_the_container(stack: Stack) -> None:
         assert response.status_code == 303, response.text
         assert response.headers["location"] == "/u/alice/"
         assert client.get("/u/alice/", headers=_navigation()).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 10. The docker-run replay of compose interpolation
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_environment_carries_the_proxy_resolved_from_the_env_chain(stack: Stack) -> None:
+    """A site-wide `HTTPS_PROXY` in `.env.shared` reaches the running sidecar.
+
+    The sidecar's only outbound traffic is the OIDC discovery/token/userinfo
+    fetches, and on a site behind a corporate proxy they fail unless the host's
+    proxy settings are in the container's environment. The compose definition
+    carries them as `${HTTPS_PROXY:-}` — a reference, not a value — so what has
+    to be proven is the whole path: a value an operator wrote in the *committed*
+    half of the env chain, merged the way compose merges it, resolved by
+    :func:`_resolved_env_flags`, and read back out of the process environment of
+    the container that is actually serving. Reading it back with `os.environ`
+    rather than `docker inspect` is deliberate: inspect shows what was
+    requested, `os.environ` is what httpx will read.
+
+    The empty pair matters as much as the set one. `${HTTP_PROXY:-}` with
+    nothing in the chain must arrive as a variable that is SET and empty, which
+    is how a proxy-less scheme is spelled — not as the literal `${HTTP_PROXY:-}`,
+    which httpx would read as a proxy URL and fail every fetch against.
+    """
+    # Arrange
+    probe = (
+        "import json, os; "
+        "print(json.dumps({name: os.environ.get(name) "
+        "for name in ('HTTPS_PROXY', 'HTTP_PROXY', 'NO_PROXY')}))"
+    )
+
+    # Act
+    result = subprocess.run(
+        ["docker", "exec", stack.auth_container, "python", "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    seen = json.loads(result.stdout)
+    assert seen["HTTPS_PROXY"] == _SHARED_PROXY, seen
+    assert seen["HTTP_PROXY"] == "", seen
+    assert seen["NO_PROXY"] == "", seen
+    # And the resolution happened in the replay rather than by accident: the
+    # argv the container was created from carries the value, not the reference.
+    assert f"HTTPS_PROXY={_SHARED_PROXY}" in stack.auth_run_argv, stack.auth_run_argv
+
+
+def test_no_argument_handed_to_docker_run_survives_as_an_interpolation(stack: Stack) -> None:
+    """Nothing in the sidecar's argv still reads `${...}`.
+
+    :func:`_resolved_env_flags` refuses one value at a time; this is the same
+    property over the whole assembled command line, which also covers the
+    arguments that do not come from `environment:` — the mounts, the
+    `--env-file` path and the rendered `command`. A placeholder that reaches
+    `docker run` is not an error there: it becomes a literal value in the
+    container, and every test above it goes green while asserting on a string
+    no deployment would ever have produced. nginx is held to the same rule by
+    the helper itself, on the way to its own `docker run`.
+    """
+    # Assert
+    unresolved = [argument for argument in stack.auth_run_argv if "${" in argument]
+    assert not unresolved, unresolved

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -3187,6 +3187,10 @@ def test_auth_sidecar_service_environment_is_exactly_the_non_secret_settings() -
         ENV_TLS_ENABLED,
         ENV_EXTERNAL_ORIGIN,
         ENV_USERS,
+        # The egress passthrough, non-secret in the same sense as the rest of
+        # this block and pinned in render order. Its own shape — values, case,
+        # and what deliberately does NOT join it — is asserted below.
+        *_PROXY_NAMES,
     ]
 
 
@@ -3399,6 +3403,144 @@ def test_auth_env_isolation_no_web_service_carries_an_auth_variable() -> None:
         assert service["env_file"] == ".env.users"
         assert AUTH_ENV_FILENAME not in str(service["env_file"])
         assert not [env for env in _env_names(service) if env.startswith("OSPREY_AUTH")]
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2: the sidecar's egress passthrough — the proxy settings its OIDC
+# fetches need behind a corporate proxy, and the three shapes that ruling took
+# ---------------------------------------------------------------------------
+
+# Rendered verbatim, `${VAR:-}` and all: these are compose interpolation
+# directives, not values. Spelled out rather than imported because there is
+# nothing to import — the sidecar reads none of them itself, the HTTP client
+# libraries inside it do, so the template is their only definition.
+_PROXY_ENTRIES = [
+    "HTTP_PROXY=${HTTP_PROXY:-}",
+    "HTTPS_PROXY=${HTTPS_PROXY:-}",
+    "NO_PROXY=${NO_PROXY:-}",
+]
+_PROXY_NAMES = [entry.split("=", 1)[0] for entry in _PROXY_ENTRIES]
+_LOWERCASE_PROXY_NAMES = [name.lower() for name in _PROXY_NAMES]
+# The CA-bundle family that looks like it belongs beside the proxy trio and does
+# not: nothing mounts a CA into this image, so each of these can only ever name
+# a path that is not there.
+_CA_BUNDLE_NAMES = ["SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE"]
+
+
+def _oidc_auth_config() -> dict:
+    """`_auth_config()` in the posture the egress passthrough exists for."""
+    return _auth_config(method="oidc", oidc={"issuer": "https://sso.dls.example.org"})
+
+
+@pytest.mark.parametrize(
+    "config_factory", [_auth_config, _oidc_auth_config], ids=["password", "oidc"]
+)
+def test_auth_sidecar_egress_passes_the_proxy_settings_through_verbatim(config_factory) -> None:
+    """The sidecar's OIDC discovery, token and userinfo fetches are its only
+    outbound traffic, and behind a corporate proxy they fail unless the host's
+    proxy settings reach the container. They arrive as `${VAR:-}` passthrough,
+    which is asserted by VALUE and not merely by name: the whole mechanism is the
+    interpolation directive, and an entry rendered with a baked literal — or with
+    a default other than empty — would satisfy a name-only pin while pinning the
+    deploy host's proxy into the committed compose artifact.
+
+    Rendered in both postures, not gated on `oidc`. The gate would be wrong even
+    though OIDC is the motivating traffic: a `password` sidecar behind a proxy
+    that suddenly needed an outbound fetch would fail in a way no operator could
+    read off the compose file, and an empty passthrough on a host with no proxy
+    costs nothing.
+    """
+    # Act
+    auth = _compose(config_factory())["services"]["auth"]
+
+    # Assert
+    assert [entry for entry in auth["environment"] if entry.split("=", 1)[0] in _PROXY_NAMES] == (
+        _PROXY_ENTRIES
+    )
+
+
+def test_auth_sidecar_egress_is_uppercase_only() -> None:
+    """UPPERCASE only, and the lowercase pair is not an oversight to be tidied up
+    later — adding it would BREAK the no-proxy case. httpx (Authlib's transport
+    for every fetch above, `trust_env` at its default) and requests read the
+    uppercase names. CPython's own `urllib.request.getproxies_environment` reads
+    both, lowercase last and winning, and treats a present-but-EMPTY lowercase
+    `http_proxy` as "this scheme is configured, to nothing" — popping the scheme
+    the uppercase pass just set, while an empty uppercase variable is skipped.
+    Since `${VAR:-}` renders exactly that empty value on every host without a
+    proxy, a lowercase entry here would hand every stdlib caller a cancelled
+    proxy on the common case."""
+    # Act
+    auth = _compose(_auth_config())["services"]["auth"]
+
+    # Assert
+    names = _env_names(auth)
+    assert [name for name in names if name in _PROXY_NAMES] == _PROXY_NAMES
+    assert not [
+        name
+        for name in names
+        if name not in _PROXY_NAMES and name.lower() in _LOWERCASE_PROXY_NAMES
+    ]
+
+
+def test_auth_sidecar_egress_is_proxy_only_and_carries_no_ca_bundle_variable() -> None:
+    """The egress block stops at the proxy trio. A custom CA is the other half of
+    the corporate-network story and is deliberately NOT here: nothing mounts a CA
+    into this image, so `SSL_CERT_FILE` would name a path that does not exist —
+    which crashes httpx at client construction, turning a working plain-HTTP
+    deployment into a sidecar that cannot build a client at all — and nothing in
+    the sidecar reads `REQUESTS_CA_BUNDLE`. Custom-CA support is a mount plus a
+    variable, and its own change."""
+    # Act
+    auth = _compose(_oidc_auth_config())["services"]["auth"]
+
+    # Assert
+    names = _env_names(auth)
+    assert [name for name in names if name in _PROXY_NAMES] == _PROXY_NAMES
+    assert not [name for name in names if name in _CA_BUNDLE_NAMES]
+
+
+def test_auth_sidecar_egress_adds_no_second_env_file() -> None:
+    """The passthrough travels in `environment:` and leaves the sidecar's env_file
+    chain a scalar `.env.auth`. That is the isolation rule pinned above, restated
+    from the other direction: `.env.auth` is 0600 and sidecar-only, and a second
+    env_file for the proxy settings would both widen that surface and hand the
+    values a file whose content compose does NOT interpolate — so `${HTTP_PROXY}`
+    would reach httpx as a literal seven-character string."""
+    # Act
+    auth = _compose(_auth_config())["services"]["auth"]
+
+    # Assert
+    assert auth["env_file"] == AUTH_ENV_FILENAME
+    assert [entry for entry in auth["environment"] if entry.split("=", 1)[0] in _PROXY_NAMES] == (
+        _PROXY_ENTRIES
+    )
+
+
+def test_no_other_service_carries_a_proxy_passthrough() -> None:
+    """The passthrough is the sidecar's alone. The per-user containers reach the
+    outside through the settings their own image and `.env.users` already carry;
+    injecting a second, deploy-time proxy here would silently redirect every
+    agent's provider traffic on any host that sets one, which is a change to the
+    agent tier's egress and not to the login surface's.
+
+    Every service in the rendered project is checked, with `auth` the only
+    exemption, so nginx — and whatever service the module renders next — is
+    covered without anyone having to remember to widen this test.
+    """
+    # Act
+    services = _compose(_auth_config())["services"]
+
+    # Assert
+    assert [name for name in _env_names(services["auth"]) if name in _PROXY_NAMES] == _PROXY_NAMES
+    for name, service in services.items():
+        if name == "auth":
+            continue
+        assert not [
+            env
+            for env in _env_names(service)
+            if env in _PROXY_NAMES or env in _LOWERCASE_PROXY_NAMES
+        ], f"{name} carries a proxy passthrough that belongs to the login sidecar alone"
 
 
 def _session_lifetime_config(method: str, **auth: object) -> dict:


### PR DESCRIPTION
On a multi-user deployment behind a corporate proxy, the auth sidecar
received no proxy settings. Its OIDC discovery, token and userinfo calls
went out directly and never arrived, so the stack started, the health
check stayed green, and every login failed. The only workaround was
hand-writing proxy lines into `.env.auth`, which is the sidecar's
credential file and not where configuration belongs.

## The change

Three entries are interpolated from the deploy env chain into the
sidecar's `environment:`:

    HTTP_PROXY=${HTTP_PROXY:-}
    HTTPS_PROXY=${HTTPS_PROXY:-}
    NO_PROXY=${NO_PROXY:-}

They are configuration rather than secrets, so they arrive by
passthrough and the `env_file` chain stays `.env.auth` and nothing else.
Because the value is interpolated into the service definition, a changed
proxy recreates the login service at the next start and leaves running
terminals alone.

**Uppercase only, deliberately.** httpx (Authlib's transport, with
`trust_env` at its default) and requests read the uppercase names.
CPython's `urllib.request.getproxies_environment` reads both, lowercase
last and winning — so a present-but-empty lowercase `http_proxy` reads
as "this scheme is configured, to nothing" and pops the scheme the
uppercase pass just set, while an empty uppercase variable is skipped.
Adding the lowercase pair would hand every stdlib caller a cancelled
proxy on any host that sets no proxy, which is exactly what `${VAR:-}`
renders there.

**No CA-bundle variable joins them.** Nothing mounts a certificate
authority into this image; `SSL_CERT_FILE` naming a path the image does
not carry stops httpx from constructing a client at all; and nothing in
the sidecar reads `REQUESTS_CA_BUNDLE`. A proxy that re-signs TLS with a
site CA therefore still fails, and the docs say so plainly. Delivering a
custom CA is a mount plus a variable, and separate work.

## What the tests pin

- The three entries render, in uppercase, with `${VAR:-}` defaulting.
- The lowercase spellings are absent — the regression that would
  reintroduce the cancelled-scheme bug.
- The sidecar's `env_file` list stays exactly `.env.auth`.
- The exact-list pin on the sidecar environment is updated, so a future
  addition has to be declared rather than slipping in.
- A shared compose-interpolation replay helper resolves the chain the
  way the container stack does, with a `.env.shared` proxy fixture, and
  a docker-exec assertion checks the values that actually land inside
  the running container.
- The `$`-guard covers proxy URLs, since a password in a proxy URL is
  the usual way to hit that rule.

Docs: a new "Egress through a site proxy" section in the env-chain
how-to covers the spelling, the trust-store gap, and when a changed
value takes effect.

Closes #792
