### PR TITLE
feat(web-terminal): redesign the control-target popover

### DIFF
--- a/changelog.d/approval-store-defer.fixed.md
+++ b/changelog.d/approval-store-defer.fixed.md
@@ -1,0 +1,5 @@
+The hardware-write approval prompt no longer appears for a target the operator
+has sandboxed from the control-target chip. The approval hook now reads the
+same per-(session, target) posture store as the write gate, so a narrowed
+target gets the write refusal alone instead of an approval dialog for a write
+that would be refused anyway.

--- a/changelog.d/popover-redesign.changed.md
+++ b/changelog.d/popover-redesign.changed.md
@@ -1,0 +1,10 @@
+The web terminal's control-target popover is calmer and speaks the
+operator's language. Each row carries one identity line (the machine's
+label), the posture and Switch columns align across rows, and a target that
+cannot be switched to shows a short phrase — `not configured`, `needs
+gateway ack`, `stand-in not deployed` — instead of a raw machine code, with
+the server's full sentence on the tooltip. The switch and allow-writes
+dialogs say each fact once: the posture the session arrives in, the
+endpoint, and the guards that stay up. Read-only refusals from the executor
+now name the narrowed control target and the header chip that lifts the
+narrowing, in the same words on every surface.

--- a/changelog.d/posture-addressability.fixed.md
+++ b/changelog.d/posture-addressability.fixed.md
@@ -1,0 +1,5 @@
+Setting a control target's write posture from the header chip works the moment
+a session opens. The route refused a session that had not answered a prompt
+yet ("send one prompt first"); that gate guarded nothing — the posture store
+only narrows, and both spawn paths read it before the first write — and is
+gone for terminals and chats alike.

--- a/changelog.d/switch-capable-two-targets.changed.md
+++ b/changelog.d/switch-capable-two-targets.changed.md
@@ -1,0 +1,7 @@
+A deployment is switch-capable when it configures at least two control
+targets, whichever two they are — no longer only the `live`/`va` pair. A
+stand-in beside the virtual accelerator, with no live machine authored yet,
+now gets the connector-host child, the target switch and the per-target
+posture toggles like any other two-machine deployment. Single-target
+renders, and a mock deployment carrying stray connector blocks, stay
+non-switchable.

--- a/changelog.d/template-archiver-strip.changed.md
+++ b/changelog.d/template-archiver-strip.changed.md
@@ -1,0 +1,6 @@
+The Control Assistant template no longer ships the ALS Archiver Appliance
+URL in its `epics_archiver` block. The block ships as a commented
+placeholder, and authoring it with your facility's values travels with the
+flip to `archiver.type: epics_archiver`. Until then the connector refuses
+to start without a `url`, which is the truthful state of a fresh
+deployment.

--- a/changelog.d/template-gateway-strip.changed.md
+++ b/changelog.d/template-gateway-strip.changed.md
@@ -1,0 +1,7 @@
+The Control Assistant template no longer ships ALS production gateway
+addresses in its `epics` block. A stock build carries no live gateway
+config at all — the gateways, `probe_channel` and
+`live_gateway_acknowledged` ship as commented placeholders, and authoring
+them with your facility's values is the go-live edit. Until then the live
+target reads `not configured` in the roster, which is the truthful state of
+a fresh deployment.

--- a/docs/source/how-to/control-systems/switch-control-target.rst
+++ b/docs/source/how-to/control-systems/switch-control-target.rst
@@ -308,7 +308,7 @@ has actually measured it — whether its gateway answered.
        on and unlisted channels refused — which is what the ``limits_posture``
        gate above requires. Rows can disagree here too, but only from the
        deployment's config: a deployment can relax unlisted channels for its
-       simulator alone. Unlike ``writes_permitted``, no session narrowing
+       simulator alone. Unlike ``writes_permitted``, no chip toggle
        moves it. A target whose config states neither setting reads
        ``false``, because a deployment that has stated nothing has refused
        nothing.

--- a/docs/source/how-to/control-systems/switch-control-target.rst
+++ b/docs/source/how-to/control-systems/switch-control-target.rst
@@ -139,6 +139,14 @@ Moving toward the live machine is the direction with the extra gates. The switch
 checks them in this order and reports the first one that fails, so the answer
 names the nearest thing to fix rather than the whole list.
 
+**The gateways** (``gateways_missing``).
+``control_system.connector.epics.gateways`` names where the live machine is
+reached. Like everything else about that machine it ships commented out — a
+facility's gateways cannot be guessed, and shipped values would point a stock
+deployment at hardware it never configured — so on a fresh deployment this is
+the first gate, and the live target reads *not configured* until you author
+it. Uncomment the block with your facility's gateway addresses.
+
 **A probe channel** (``probe_channel_missing``).
 ``control_system.connector.epics.probe_channel`` names the channel the switch
 reads to prove the machine answered before the session moves onto it. It ships

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -121,11 +121,15 @@ anything. Optional keys: ``auth.port`` (the port layout's ``10001`` unless you
 set it — see :ref:`reference-ports`),
 ``auth.session_lifetime`` in whole seconds (default ``43200``), and
 ``auth.image``, required with ``image_source: registry``.
-``auth.session_lifetime`` also reaches past this page: it sets how long a
-terminal session cookie lasts wherever that cookie is used — ``osprey web``,
-``auth.method: token``, and ``login: false`` roster entries. For everyone who
-does go through the login page, nginx rather than that cookie is what lets
-them through, so here the key sets the login page's cookie.
+
+.. dropdown:: Where ``auth.session_lifetime`` applies
+   :icon: gear
+
+   The key reaches past this page: it sets how long a terminal session cookie
+   lasts wherever that cookie is used — ``osprey web``, ``auth.method:
+   token``, and ``login: false`` roster entries. For everyone who does go
+   through the login page, nginx rather than that cookie is what lets them
+   through, so here the key sets the login page's cookie.
 
 .. warning::
 

--- a/docs/source/how-to/web-terminal/multi-user/tiers.rst
+++ b/docs/source/how-to/web-terminal/multi-user/tiers.rst
@@ -500,7 +500,7 @@ Related pages
 - :ref:`What executed code may not change <python-executor-protected-paths>`
   — the Python executor's zone boundary, enforced in both execution modes.
 - :ref:`The control-target chip <web-terminal-session-posture>` — how an
-  operator narrows one control target for a write-capable session, and never
-  widens past what the tier permits.
+  operator takes writes away from one control target for their own session,
+  and can never gain more than the tier permits.
 - :doc:`../../build-profiles` — personas: what a delta file may contain, and how
   the floor is written so that one persona can lift it.

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -110,11 +110,11 @@ One row per machine
 
 Each row names a machine and carries the two things you can do to it:
 
-- **What it is** --- the name the deployment gave it, and a plain word for the
-  kind of machine behind it: *live machine*, *stand-in*, *virtual accelerator*
-  or *simulated*. That word comes from what the connector actually is, so a
-  stand-in never renders as the facility's own machine. The row you are on is
-  tagged ``current``.
+- **What it is** --- the name the deployment gave it, which already says what
+  kind of machine it names (*LIVE MACHINE*, *LIVE MACHINE (stand-in)*,
+  *virtual accelerator (simulation)*). That label comes from what the
+  connector actually is, so a stand-in never renders as the facility's own
+  machine. The row you are on is tagged ``current``.
 - **Whether it is answering** --- ``connected``, ``unreachable`` or ``unknown``,
   with how long ago that was measured. ``unknown`` means nothing has vouched for
   it yet, not that it is down.
@@ -122,8 +122,11 @@ Each row names a machine and carries the two things you can do to it:
   a two-segment toggle. It is the readout as well as the control: where it
   cannot move it still shows which state holds, with the reason beside it.
 - **Switch** --- moves this session onto that machine. Where a switch is not
-  available the button is replaced by the reason word, so the gap is explained
-  rather than merely empty.
+  available the button is replaced by a short phrase for the reason ---
+  ``not configured``, ``needs gateway ack`` --- so the gap is explained rather
+  than merely empty, and the server's full sentence sits on the tooltip. On a
+  fresh deployment the live machine reading ``not configured`` is the normal
+  state, not a fault: authoring its gateways is the go-live edit.
 
 The foot of the popover has **Sandbox everything**, which narrows every target
 that can be narrowed in one gesture, and the sentence that bounds the whole
@@ -190,11 +193,13 @@ Switch this session to another machine
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Switch** on a row moves the session onto that machine, after a confirmation
-that names it and its endpoint. The web server does not perform the switch: it
-records the request, and the control-system server that owns the connector
-picks it up, re-checks eligibility and reachability at that moment, and
-publishes the outcome back. The row then reads ``✓ switched``, or ``✗`` with the
-refusal word --- the same word the agent is given for the same refusal. While a
+that names it and says which write posture the session arrives in there ---
+posture is per target, and it does not travel with you. The web server does
+not perform the switch: it records the request, and the control-system server
+that owns the connector picks it up, re-checks eligibility and reachability at
+that moment, and publishes the outcome back. The row then reads ``✓ switched``,
+or ``✗`` with the phrase for the refusal --- the same refusal, by the same
+code, the agent is given. While a
 request is out the chip reads ``switching…``, and one request is outstanding at
 a time. If nothing answers within 30 seconds the row reads ``request_expired``:
 the request was written, and nothing that could act on it was alive.
@@ -206,8 +211,8 @@ Simple and Expert
 ~~~~~~~~~~~~~~~~~
 
 The popover follows the session's density setting (the Simple/Expert control in
-the display menu; see :doc:`theming`). Simple mode shows the machine, the plain
-kind word, whether it is answering, the toggle and **Switch**. Expert mode adds
+the display menu; see :doc:`theming`). Simple mode shows the machine's name,
+whether it is answering, the toggle and **Switch**. Expert mode adds
 the endpoint, the gateway role, the age of the last probe, and the notes under a
 locked toggle. The controls and the confirmations are the same in both: the
 density changes what is on screen, never what a click does.

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -182,12 +182,10 @@ cannot move it is locked and carries the reason:
        configured, leaving the target unusable. You are told before you act,
        not after.
 
-Two more refusals arrive on the gesture rather than on the toggle. A session
-that has never been sent a prompt has nothing to record a posture against:
-*"This session has not started yet --- send one prompt first, then set its
-posture."* And widening while an execution is running is refused --- a run is
-pinned to the posture it launched under, so a widening could not reach it
-anyway, and saying so beats a silent no-op.
+One more refusal arrives on the gesture rather than on the toggle: you cannot
+turn writes back on while the agent is still running something. The run keeps
+the posture it started with, so wait for it to finish, or stop it, and try
+again.
 
 Switch this session to another machine
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -128,34 +128,33 @@ Each row names a machine and carries the two things you can do to it:
   fresh deployment the live machine reading ``not configured`` is the normal
   state, not a fault: authoring its gateways is the go-live edit.
 
-The foot of the popover has **Sandbox everything**, which narrows every target
-that can be narrowed in one gesture, and the sentence that bounds the whole
-surface: nothing here changes the deployment's config.
+The foot of the popover has **Sandbox everything**, which puts every target it
+can into the sandbox in one click, and a reminder of the boundary: nothing here
+changes the deployment's config.
 
-Narrow a target, or widen it
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Take writes away, or give them back
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The posture is **per target**. Narrowing the live machine leaves a session
-working on the virtual accelerator alone, which is the point: you can put the
-machine you are worried about out of reach without giving up the one you are
-working on.
+The posture is **per target**. Sandbox the live machine and the session keeps
+working on the virtual accelerator, which is the point: you put the machine you
+are worried about out of reach without giving up the one you are working on.
 
-Narrowing applies as you click it --- taking reach away needs no ceremony.
-Widening a target back to writes asks you to confirm first, every time and with
-nothing remembered between clicks, and the confirmation names the machine and
-the endpoint the agent would then be able to write to.
+Taking writes away applies as you click --- it needs no ceremony. Turning
+writes back on asks you to confirm first, every time and with nothing
+remembered between clicks, and the confirmation names the machine and the
+endpoint the agent would then be able to write to.
 
 **Nothing is restarted.** Every gate reads the posture at the moment of the
-write, so a narrowing lands on the conversation that is already running: the
+write, so the change lands on the conversation that is already running: the
 agent obeys it on its very next write, and the turn in flight is not
-interrupted. The one lag worth knowing about is a narrowing on the target the
-session is *on* --- it reaches the agent when the connector is rebuilt, which
+interrupted. One lag is worth knowing about: sandbox the target the session is
+*on* and the change reaches the agent when the connector is rebuilt, which
 waits for a running execution to finish, and the row says so rather than
 leaving a toggle that appears to have done nothing.
 
-**It narrows, and never widens.** Only narrowings are recorded, so the chip can
-tighten what the deployment permits and never loosen it. Where the toggle
-cannot move it is locked and carries the reason:
+**The chip only takes writes away.** What you set here tightens what the
+deployment permits; it can never hand out writes the deployment did not arm.
+Where the toggle cannot move it is locked and carries the reason:
 
 .. list-table::
    :header-rows: 1
@@ -170,37 +169,37 @@ cannot move it is locked and carries the reason:
      - The whole deployment is running read-only
        (``OSPREY_EXECUTION_MODE=readonly``), which sits above any one session.
    * - ``not enforceable``
-     - This session's control-system server is not one this web server can
-       address, so a narrowing recorded here would be read by nobody. The
+     - This page has no way to deliver a posture change to this session's
+       control-system server, so a toggle set here would be read by nobody. The
        roster still renders --- it is worth reading --- but the toggles govern
        nothing.
    * - ``store unavailable``
-     - The deployment's agent-data root does not resolve, so there is nowhere to
-       record a posture the agent would read back. Nothing was changed.
+     - The folder where postures are recorded is missing or unreadable, so
+       there is nowhere to keep a setting the agent would read back. Nothing
+       was changed.
    * - ``no read-only endpoint``
-     - Narrowing this target would select a gateway role the deployment has not
-       configured, leaving the target unusable. You are told before you act,
-       not after.
+     - Read-only on this target would route it through a gateway the deployment
+       has not configured, leaving the target unusable. You are told before you
+       act, not after.
 
-One more refusal arrives on the gesture rather than on the toggle: you cannot
-turn writes back on while the agent is still running something. The run keeps
-the posture it started with, so wait for it to finish, or stop it, and try
-again.
+One more refusal can meet the click itself: you cannot turn writes back on
+while the agent is still running something. The run keeps the posture it
+started with, so wait for it to finish, or stop it, and try again.
 
 Switch this session to another machine
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Switch** on a row moves the session onto that machine, after a confirmation
 that names it and says which write posture the session arrives in there ---
-posture is per target, and it does not travel with you. The web server does
-not perform the switch: it records the request, and the control-system server
-that owns the connector picks it up, re-checks eligibility and reachability at
-that moment, and publishes the outcome back. The row then reads ``✓ switched``,
-or ``✗`` with the phrase for the refusal --- the same refusal, by the same
-code, the agent is given. While a
-request is out the chip reads ``switching…``, and one request is outstanding at
-a time. If nothing answers within 30 seconds the row reads ``request_expired``:
-the request was written, and nothing that could act on it was alive.
+posture is per target, and it does not travel with you. The browser does not
+perform the switch: it records the request, and the part of the deployment that
+owns the connection to the machines picks it up, re-checks at that moment that
+the move is allowed and the machine answers, and reports the outcome back. The
+row then reads ``✓ switched``, or ``✗`` with the phrase for the refusal ---
+the same refusal, for the same reason, the agent is given. While a request is
+out the chip reads ``switching…``, and one request is outstanding at a time. If
+nothing answers within 30 seconds the row reads ``request_expired``: nothing
+that could carry out the switch was alive to pick it up.
 
 What the switch itself is gated on --- the approval prompt, the limits posture,
 the archive --- is :doc:`../control-systems/switch-control-target`.
@@ -220,20 +219,20 @@ Where the posture lives
 
 The posture belongs to **one session**, not to the deployment. Nothing is
 written to ``config.yml``. Two people working in two sessions of the same
-deployment hold their own postures, and one of them narrowing theirs does not
-touch the other.
+deployment hold their own postures, and one of them sandboxing a target does
+not touch the other.
 
-Narrowings are recorded in
+Your settings are recorded in
 ``var/agent_data/control_target/session-postures.json``, written as soon as you
 click and read back when the server starts, so restarting the container never
-quietly returns a narrowed session to writes.
+quietly returns a sandboxed session to writes.
 
 What refuses a write, and how firmly
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Nothing about the posture is a single choke point --- each write route is
 refused by the layer that owns it. The difference between those layers is worth
-knowing, because one of them is a belt rather than the buckle:
+knowing, because one of them is best-effort rather than enforced:
 
 .. list-table::
    :header-rows: 1
@@ -274,7 +273,7 @@ sends you to the wrong control:
   saying to set that target back to writes from the chip if the write is
   intended.
 
-Those three are what a narrowing you made from the chip sounds like, and the
+Those three are what a posture you set from the chip sounds like, and the
 chip is where you lift it. A **deployment-wide read-only run** is a different
 story and says so, because no click lifts that one:
 
@@ -301,25 +300,32 @@ and says nothing about postures.
 
    **The other two surfaces.** Simple mode's chat and the operator websocket run
    their agent through the Agent SDK rather than a terminal. Both read the same
-   record at write time, so a narrowing reaches them exactly as it reaches a
-   terminal session. Where they differ is in what the chip can do for them.
+   record at write time, so a posture you set reaches them exactly as it reaches
+   a terminal session. Where they differ is in what the chip can do for them.
 
-   A **chat session's toggles work** --- its writes meet the same ceiling and the
-   same narrowing a terminal's do --- but it is offered no **Switch**: a chat has
-   no control-system server of its own for a switch request to be addressed to,
-   and every row says ``chat_session`` where the button would be. One thing is
-   worth knowing before relying on a chat's posture: the chat page mints a new
-   chat id every time it loads, so a chat's posture lasts as long as that page
-   does rather than following the conversation.
+   A **chat session's toggles work** --- its writes meet the same ceiling and
+   the same read-only setting a terminal's do --- but it is offered no
+   **Switch**: a chat has no machine connection of its own to move, and every
+   row says ``chat_session`` where the button would be. Know one thing before
+   relying on a chat's posture: the chat page starts a fresh chat every time it
+   loads, so a posture you set for it lasts as long as that page does rather
+   than following the conversation.
 
-   An **operator websocket session cannot be addressed from the chip.** Its id is
-   minted when the connection is accepted and names nothing afterwards, so no
-   narrowing can ever be recorded against it and there is nothing to restore
-   across a restart. That stays true until an operator client exists to define
-   its reconnect protocol. Every audit record such a session emits is labelled
-   ``posture_source=spawn``, which is the trail's way of saying the posture was
-   fixed when the session started rather than read from a live setting --- see
-   the record fields in :ref:`the audit trail contract <audit-trail-record>`.
+   An **operator websocket session's toggles govern nothing**: the chip has no
+   way to hand a posture to that kind of session, so what you set here never
+   reaches it.
+
+.. dropdown:: Why the websocket session is out of the chip's reach
+   :icon: gear
+
+   The websocket session's identifier is created when the connection is
+   accepted and identifies nothing once the connection ends, so no posture can
+   be recorded against it and there is nothing to restore across a restart.
+   That stays true until an operator client exists to define its reconnect
+   protocol. Every audit record such a session emits is labelled
+   ``posture_source=spawn`` --- the trail's way of saying the posture was fixed
+   when the session started rather than read from a live setting; see the
+   record fields in :ref:`the audit trail contract <audit-trail-record>`.
 
 Documentation and feedback settings
 -----------------------------------

--- a/packages/osprey-connectors/src/osprey_connectors/types.py
+++ b/packages/osprey-connectors/src/osprey_connectors/types.py
@@ -240,7 +240,7 @@ def baseline_target(section: Any) -> str:
 
 
 def switch_capable(section: Any) -> bool:
-    """Whether a deployment can be pointed at either target.
+    """Whether a deployment gives a session more than one target to be pointed at.
 
     The predicate itself, in the module that already owns "which connector type
     does a target mean here". Two layers ask the question and must never answer
@@ -250,28 +250,29 @@ def switch_capable(section: Any) -> bool:
     that promises a switch the runtime will not perform is worse than one that
     never mentions it.
 
-    Three conditions, none of which is sufficient alone:
+    Two conditions, neither sufficient alone:
 
-    1. **Both targets resolve** to a connector type at all
-       (:func:`resolve_target`, which raises rather than guess a live machine).
-    2. **The deployment's baseline target resolves back to its own control
+    1. **The deployment's baseline target resolves back to its own control
        system.** ``resolve_target`` answers ``live`` for configs with no
        business switching: a ``mock`` deployment that happens to carry an
        ``epics`` block resolves ``live`` to ``epics``, and treating that as
        switchable would point a session at a real machine the config never
        selected. Requiring :func:`baseline_target` to resolve back to
        ``control_system.type`` rules it out. The baseline is *resolved*, never
-       looked up among the two above: a deployment may be baselined on a third
-       target — a ``live_standin`` one is baselined on ``standin`` — and is no
-       less switchable for it.
-    3. **Both types have a non-empty connector block**, since that block is what
-       a connector is configured from. Conditions 1 and 3 are one question and
-       are asked as one, by :func:`target_configured`.
+       assumed to be ``live`` or ``va``: a ``live_standin`` deployment is
+       baselined on ``standin`` and is no less switchable for it.
+    2. **At least two targets are configured** (:func:`configured_targets`,
+       the same resolve-and-read-the-block enumeration every roster walks).
+       Which two is not this predicate's business: a facility rehearsing on a
+       stand-in beside its simulator, with no live machine authored yet, has
+       exactly the two-machine world the switch exists for — demanding the
+       ``live``/``va`` pair specifically would lock that deployment's posture
+       toggles for want of a machine it never claimed to have.
 
     Deliberately *not* checked: ``probe_channel``, the gateways table, the
     operator acknowledgment. Those decide whether a target may be switched *to*
     — a per-switch question answered with a reason the operator is told. This is
-    the coarser question of whether the deployment is in the two-target world.
+    the coarser question of whether the deployment is in the multi-target world.
 
     Args:
         section: The ``control_system:`` config section, in the same shape
@@ -279,8 +280,9 @@ def switch_capable(section: Any) -> bool:
             rendered config pass ``config.get("control_system")``.
 
     Returns:
-        ``True`` when both targets are configured and consistent. Never raises:
-        every malformed, partial or contradictory config is simply not capable.
+        ``True`` when the section is consistent and configures at least two
+        targets. Never raises: every malformed, partial or contradictory config
+        is simply not capable.
     """
     if not isinstance(section, dict):
         return False
@@ -291,7 +293,7 @@ def switch_capable(section: Any) -> bool:
             return False
     except ValueError:
         return False
-    return all(target_configured(section, target) for target in (TARGET_LIVE, TARGET_VA))
+    return len(configured_targets(section)) >= 2
 
 
 def target_configured(section: Any, target: Any) -> bool:
@@ -305,11 +307,12 @@ def target_configured(section: Any, target: Any) -> bool:
     configured from. A target that does not resolve is not one this deployment
     has, and an empty block is not a configured one.
 
-    The one spelling of a question every enumerator asks: :func:`switch_capable`
-    of the two switchable machines, :func:`configured_targets` of each machine
-    that is not the baseline, and the deployment layer's Reach Contracts of the
-    target a projected port would serve. Three predicates over one pair of keys
-    is three chances to disagree about which machines a deployment has.
+    The one spelling of a question every enumerator asks:
+    :func:`configured_targets` of each machine that is not the baseline —
+    which is also what :func:`switch_capable` counts — and the deployment
+    layer's Reach Contracts of the target a projected port would serve. Two
+    predicates over one pair of keys would already be two chances to disagree
+    about which machines a deployment has.
 
     Args:
         section: The ``control_system:`` config section, in the same shape

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -855,9 +855,16 @@ keys:
   archiver.type: {evidence: 'archiver\.type is not set'}
   # Point budget behind archiver_read's span-derived default bin (issue #117).
   archiver.auto_bin_points: {evidence: 'archiver\.auto_bin_points'}
-  archiver.epics_archiver: {evidence: 'epics_archiver'}
-  archiver.epics_archiver.url: {covered-by: archiver.epics_archiver}
-  archiver.epics_archiver.timeout: {covered-by: archiver.epics_archiver}
+  archiver.epics_archiver:
+    rendered: false
+    evidence: 'epics_archiver'
+    note: >-
+      Commented placeholder since the ALS-URL strip: a facility's Archiver
+      Appliance cannot be guessed, so authoring the block travels with the
+      flip to `type: epics_archiver`. The connector refuses to start without
+      a `url`, which keeps the unauthored state honest.
+  archiver.epics_archiver.url: {covered-by: archiver.epics_archiver, rendered: false}
+  archiver.epics_archiver.timeout: {covered-by: archiver.epics_archiver, rendered: false}
   # The stored archive's connection block, rendered by the control_assistant
   # template and written from the profile's `va_archiver:` block at build time.
   archiver.mongodb_archiver: {evidence: 'mongodb_archiver'}

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -213,41 +213,6 @@ def _chat_pool_answers_to(app, session_id: str) -> bool:
     return _holds_a_chat_pool_entry(app, session_id)
 
 
-def _posture_key_is_addressable(app, session_id: str) -> bool:
-    """Whether some real session answers to *session_id* on either topology.
-
-    The posture is per session, so a key that names no session is a key nothing
-    will ever spawn under. Three answers count, cheapest first:
-
-    * a **chat session the pool would answer to** — pooled, or still inside
-      ``start()`` (:func:`_chat_pool_answers_to`). The SDK topology's key
-      exists from the moment the pool accepts the creation and never appears
-      in the JSONL stems the discovery walks.
-    * a **key the posture store already holds an entry for**. The chat pool is
-      LRU-capped, idle-reaped, and evicted by the flip itself, so pool
-      membership is a fact with an end — and without this clause a chat
-      sandboxed once could never be brought back out, because the successful
-      flip is what removed it from the pool. An entry in the store is the
-      operator's own earlier, accepted decision about this key; letting them
-      revise it grants nothing new (the store only ever *narrows* a spawn, and
-      a key nothing spawns under is inert), while refusing it would strand a
-      session in the sandbox.
-    * a **PTY session discovered on disk** — a Claude session-file stem, which
-      only exists once the operator has sent a prompt. Checked last: it walks
-      the session directory, while the other two are in-memory reads.
-
-    Checking only the stems is what made a chat session's posture unsettable:
-    the chat spawn already honours the store (``_acquire_chat_turn`` passes the
-    key to ``build_operator_child_env``), so the store was readable on that
-    surface and not writable — a badge the operator could not act on.
-    """
-    if _chat_pool_answers_to(app, session_id):
-        return True
-    if _posture_entry(app, session_id):
-        return True
-    return session_id in SessionDiscovery(app.state.project_cwd).snapshot_session_ids()
-
-
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
     """Serialize *data* to *path* as JSON, atomically.
 
@@ -1803,15 +1768,13 @@ ALL_TARGETS = "all"
 class _PostureRequestFacts:
     """Everything ``POST /api/terminal/posture`` needs off the event loop.
 
-    One worker-thread hop for the whole ladder: the render parse, the session
-    discovery walk, the store-path resolution, the hypothetical narrowing
-    derivation and — only when the request widens — the execution-marker sweep.
-    Answers drawn from separate hops could straddle each other: a ceiling read
-    from one render beside a narrowing verdict taken from the next.
+    One worker-thread hop for the whole ladder: the render parse, the
+    store-path resolution, the hypothetical narrowing derivation and — only
+    when the request widens — the execution-marker sweep. Answers drawn from
+    separate hops could straddle each other: a ceiling read from one render
+    beside a narrowing verdict taken from the next.
     """
 
-    #: Whether some real session answers to this key on either topology.
-    addressable: bool
     #: Target names this render configures — the 400's vocabulary.
     configured: tuple[str, ...]
     #: The targets this request actually touches (``all`` expands here).
@@ -1922,10 +1885,10 @@ def _posture_post_facts(
 ) -> _PostureRequestFacts:
     """Read everything the posture ladder decides on. BLOCKING.
 
-    Called through ``run_in_threadpool``: it parses ``config.yml``, walks the
-    session directory and globs the state directory. None of that may happen on
-    the event loop, where one slow shared volume would stall every request this
-    server is serving, the terminal websocket included.
+    Called through ``run_in_threadpool``: it parses ``config.yml`` and globs
+    the state directory. None of that may happen on the event loop, where one
+    slow shared volume would stall every request this server is serving, the
+    terminal websocket included.
     """
     config = _rendered_config(config_path)
     section = _section_of(config)
@@ -1941,7 +1904,6 @@ def _posture_post_facts(
     changing = tuple(t for t in wanted if current.get(t) != POSTURE_SANDBOX)
 
     return _PostureRequestFacts(
-        addressable=_posture_key_is_addressable(app, session_key),
         configured=configured,
         wanted=wanted,
         ceilings=_session_ceilings(section),
@@ -1994,9 +1956,8 @@ def _posture_refusal(
     BEFORE that threadpool hop stays in the handler, where it can be reached
     without paying for the facts.
 
-    The order is load-bearing and is documented on the route: 400 before 409
-    before 503 before 403, because each rung answers a question the next
-    one assumes.
+    The order is load-bearing and is documented on the route: 400 before 503
+    before 403, because each rung answers a question the next one assumes.
 
     Returns the exception rather than raising it, for the same reason
     :func:`_refuse_gesture` does: the audit record is filed here, and the
@@ -2013,21 +1974,6 @@ def _posture_refusal(
             status_code=400,
             error="unknown_target",
             message=_unknown_target_message(facts.configured),
-            detail=gesture,
-        )
-
-    if not facts.addressable:
-        return _refuse_gesture(
-            app,
-            session_id,
-            subject=subject,
-            status_code=409,
-            error="session_not_started",
-            message=(
-                "This session has not started yet — send one prompt first, then set "
-                "its posture. A chat session becomes addressable again on its next "
-                "prompt."
-            ),
             detail=gesture,
         )
 
@@ -2113,14 +2059,21 @@ async def set_terminal_posture(body: PostureRequest, request: Request):
     store, so memory and disk disagreeing is a session the popover shows as
     narrowed whose next write is still permitted — or the reverse.
 
+    **Any well-formed session id is accepted, spoken-to or not.** The posture
+    must never depend on whether the operator has talked to the agent: both
+    spawn paths read the store at spawn (``_acquire_chat_turn`` for a chat,
+    ``build_operator_child_env`` for a PTY), so a narrowing recorded before
+    the first prompt binds that session's very first write. An entry under a
+    key nothing ever spawns is inert — the store only narrows, so the worst a
+    stale or mistyped key can do is restrict a session that does not exist —
+    and the ``operator-`` filter in :func:`_load_postures` is the hygiene
+    boundary for keys that cannot come back. An earlier gate here refused
+    fresh sessions with "send one prompt first"; it guarded nothing.
+
     The ladder, in order:
 
     * **400** — an id outside the closed key grammar; a target this render does
       not configure; or :data:`ALL_TARGETS` with ``writes``.
-    * **409** ``session_not_started`` — the id names no session at all: no chat
-      the pool would answer to, no entry already in the store, no Claude
-      session file on disk (:func:`_posture_key_is_addressable`). Sending one
-      prompt is the entire remedy, and the message says so.
     * **503** — the store has no location, or the write failed. The toggle was
       refused and nothing changed.
     * **403** ``writes_disabled`` — ``writes`` on a target this render does not

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -2547,13 +2547,16 @@ def _row_narrowing_refusal(config: Any, target: str) -> str | None:
 
 def _row_availability(
     config: Any, target: str, session_target: str, baseline: str, writes_enabled: bool
-) -> tuple[bool, str | None]:
-    """Whether a switch to *target* is offered now, and the word for why not.
+) -> tuple[bool, str | None, str | None]:
+    """Whether a switch to *target* is offered now, plus the reason and its sentence.
 
     :func:`~osprey.mcp_server.control_system.target_eligibility.target_availability`
     and nothing else, so the reason under a missing Switch button is the reason
     the reconciler would refuse with, character for character. Re-deriving it
     here would be a second opinion about the same machine, phrased differently.
+    The verdict's two voices travel together: ``reason`` is the machine code
+    the popover and the switch tool key on, and the ``detail`` sentence is what
+    the popover puts on the operator's tooltip.
 
     An unreadable render offers no switch and names
     :data:`~osprey.mcp_server.control_system.target_eligibility.REASON_TARGET_UNRESOLVABLE`:
@@ -2566,18 +2569,23 @@ def _row_availability(
         )
     except Exception:  # noqa: BLE001 — no eligibility module, no switch offered
         logger.warning("Could not import the target eligibility rules", exc_info=True)
-        return False, None
+        return False, None, None
 
     if config is _UNREADABLE_SECTION:
-        return False, REASON_TARGET_UNRESOLVABLE
+        return False, REASON_TARGET_UNRESOLVABLE, None
     try:
         verdict = target_availability(
             config, target, session_target, baseline, writes_enabled=writes_enabled
         )
     except Exception:  # noqa: BLE001 — an unjudgeable target is not an available one
         logger.warning("Could not judge availability for control target %s", target)
-        return False, REASON_TARGET_UNRESOLVABLE
-    return bool(verdict.available_now), verdict.reason
+        return False, REASON_TARGET_UNRESOLVABLE, None
+    # The verdict narrates an offered target too ("Target 'live' is
+    # configured…"), but this field explains a REASON: with no refusal there
+    # is nothing for a tooltip to explain, and publishing the happy sentence
+    # would put prose on rows whose whole answer is the Switch button.
+    detail = (verdict.detail or None) if verdict.reason else None
+    return bool(verdict.available_now), verdict.reason, detail
 
 
 def _target_display(config: Any, record: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
@@ -2698,9 +2706,9 @@ def _posture_view(app: Any, session_key: str, config_path: Path | None) -> dict[
         # would lock the toggle that brings it back.
         narrowing = None if posture == POSTURE_SANDBOX else _row_narrowing_refusal(config, target)
         if is_chat:
-            available_now, reason = False, REASON_CHAT_SESSION
+            available_now, reason, reason_detail = False, REASON_CHAT_SESSION, None
         else:
-            available_now, reason = _row_availability(
+            available_now, reason, reason_detail = _row_availability(
                 config, target, session_target, baseline, effective
             )
         rows.append(
@@ -2715,6 +2723,7 @@ def _posture_view(app: Any, session_key: str, config_path: Path | None) -> dict[
                 "is_baseline": target == baseline,
                 "available_now": available_now,
                 "reason": reason,
+                "reason_detail": reason_detail,
                 "ceiling_writes": ceiling_writes,
                 "posture": posture,
                 "effective": effective,
@@ -2775,9 +2784,12 @@ async def get_terminal_posture(session_id: str, request: Request):
       route would refuse are decided by one function. ``null`` on a row already
       narrowed: that toggle brings the target BACK, and nothing about it can
       strand anything.
-    * ``active`` / ``is_baseline`` / ``available_now`` / ``reason`` — where the
-      session is standing and whether a switch is offered, with the switch
-      tool's own refusal word where the button would be.
+    * ``active`` / ``is_baseline`` / ``available_now`` / ``reason`` /
+      ``reason_detail`` — where the session is standing and whether a switch is
+      offered. ``reason`` is the switch tool's own machine code, so the popover
+      and the agent keep agreeing about the same refusal; ``reason_detail`` is
+      the eligibility verdict's operator sentence, which the popover renders as
+      the tooltip behind its short phrase.
     * ``reachability`` — the state of the gateway role this target would
       actually select under its effective posture, aged server-side, with the
       other roles named beside it (see :func:`_collapse_reachability`).

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -629,19 +629,27 @@ osprey-display-menu .display-menu-logout-icon {
   color: var(--color-error);
 }
 
-.ctc-rows {
-  display: flex;
-  flex-direction: column;
-}
-
 /* Four columns: the dot, who the target is, the posture this session holds on
    it, and the one action available. Status and action stay in separate
-   columns — reading the popover and changing it are different gestures. */
+   columns — reading the popover and changing it are different gestures.
+
+   The COLUMNS belong to the list, not to the row: `.ctc-rows` owns the track
+   sizing and each row subgrids into it, so the posture and action columns
+   share one width across every row and the toggles line up as a column
+   instead of ragged per-row boxes. */
+.ctc-rows {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) max-content max-content;
+  column-gap: 10px;
+}
+
 .ctc-row {
   display: grid;
-  grid-template-columns: 10px minmax(0, 1fr) auto auto;
-  column-gap: 10px;
-  align-items: center;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  /* Start, not center: the toggle and Switch align with the row's first
+     (label) line, and stay put when a row grows an outcome line below it. */
+  align-items: start;
   padding: 8px 2px;
   border-bottom: 1px solid var(--border-default);
 }
@@ -651,7 +659,10 @@ osprey-display-menu .display-menu-logout-icon {
 }
 
 /* The row this session is on, bled past the popover's padding so the tint
-   reads as a highlighted row rather than an inset card. */
+   reads as a highlighted row rather than an inset card. The -6px/8px pair
+   nets to the 2px inset every other row has, and subgrid keeps that
+   arithmetic: a subgridded row's own margin and padding are taken out of its
+   edge tracks, so the content still lands on the shared columns. */
 .ctc-row[data-active="true"] {
   margin: 0 -6px;
   padding-left: 8px;
@@ -692,20 +703,6 @@ osprey-display-menu .display-menu-logout-icon {
 .ctc-row[data-target-kind="simulated"] .ctc-label {
   color: var(--text-secondary);
   font-weight: var(--weight-regular);
-}
-
-/* The plain-language kind word under the name — simple mode's replacement for
-   the endpoint and gateway role. An operator who does not think in endpoints
-   still needs to know a row is the real machine. Hidden in expert, which has
-   the meta line instead. */
-.ctc-kind {
-  display: none;
-  font-family: var(--font-display);
-  font-size: var(--text-sm);
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .ctc-tag {
@@ -803,9 +800,10 @@ osprey-display-menu .display-menu-logout-icon {
 }
 
 /* A target reachability does not apply to loses the LED entirely rather than
-   showing an unlit one, which would read as "down". */
+   showing an unlit one, which would read as "down" — but keeps its box, so
+   the reach text starts on the same column as every other row's. */
 .ctc-reach[data-state="not_applicable"] .ctc-reach-dot {
-  display: none;
+  visibility: hidden;
 }
 
 /* What the last switch or posture request on this row did. Feedback, so it
@@ -958,6 +956,9 @@ osprey-display-menu .display-menu-logout-icon {
   background: var(--error-tint-08);
 }
 
+/* Deliberately quiet, `not configured` above all: on a stock deployment the
+   live target is unconfigured on purpose — authoring it is the go-live edit —
+   and an error tone here would flag a healthy render as broken. */
 .ctc-reason {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
@@ -1013,12 +1014,14 @@ osprey-display-menu .display-menu-logout-icon {
    Expert (the attribute absent, or `expert`) is the resting state and shows
    everything above.
 
-   Simple keeps the four things an operator acts on — which target, whether it
-   is reachable, the posture, and Switch — and drops the detail that belongs to
-   whoever runs the deployment: endpoints, gateway roles, probe ages, the head
-   note, the config disclaimer, and the lock wording (which survives in the
-   `title`). The chip itself, and both confirms, are identical in either mode:
-   a readout and a safety gesture do not get a density. */
+   Simple keeps the four things an operator acts on — which target (the label
+   is the row's one identity line, and it already says what kind of machine it
+   names), whether it is reachable, the posture, and Switch — and drops the
+   detail that belongs to whoever runs the deployment: endpoints, gateway
+   roles, probe ages, the head note, the config disclaimer, and the lock
+   wording (which survives in the `title`). The chip itself, and both
+   confirms, are identical in either mode: a readout and a safety gesture do
+   not get a density. */
 html[data-ui-mode="simple"] .ctc-popover {
   width: 380px;
 }
@@ -1031,10 +1034,6 @@ html[data-ui-mode="simple"] .ctc-popover .ctc-foot-note,
 html[data-ui-mode="simple"] .ctc-popover .ctc-lock,
 html[data-ui-mode="simple"] .ctc-popover .ctc-baseline {
   display: none;
-}
-
-html[data-ui-mode="simple"] .ctc-popover .ctc-kind {
-  display: block;
 }
 
 /* Reachability collapses to the LED alone. The word and the age beside the dot

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-chip.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-chip.js
@@ -67,7 +67,9 @@ import { getCurrentSessionId, onSessionChange } from './terminal.js';
  * @property {boolean} active  the target this session stands on
  * @property {boolean} is_baseline
  * @property {boolean} available_now  whether a Switch is offered
- * @property {string|null} reason  the switch tool's own refusal word when not
+ * @property {string|null} reason  the switch tool's own refusal code when not
+ * @property {string|null} reason_detail  the eligibility verdict's operator
+ *   sentence for that code — the popover's tooltip, never its row text
  * @property {boolean} ceiling_writes  what the persona render permits
  * @property {'writes'|'sandbox'} posture  this session's own narrowing
  * @property {boolean} effective  the whole rule the connector applies

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
@@ -1,0 +1,155 @@
+// @ts-check
+/* OSPREY Web Terminal — Control-Target Derived Facts
+ *
+ * The pure half of the control-target popover: every function here derives a
+ * fact an operator reads — a refusal phrase, a lock reason, the head note, a
+ * reachability word — from the state the chip publishes, and nothing here
+ * touches the DOM, the chip, or any module state. The popover
+ * (control-target-popover.js) owns the rows, the gestures and the confirms;
+ * this module owns what the rows SAY, so the wording can be read (and tested)
+ * without a popover on screen.
+ */
+
+/** `available_now` reason a chat session's rows carry (routes/websocket.py). */
+export const REASON_CHAT_SESSION = 'chat_session';
+
+/** The refusal word for a row whose Switch is missing because the store is. */
+export const REASON_STORE_UNAVAILABLE = 'store_unavailable';
+
+/**
+ * Refusal code → the short phrase the operator reads.
+ *
+ * The route publishes the switch tool's machine codes so the popover and the
+ * agent keep agreeing about the same refusal; what an OPERATOR reads is this
+ * map's phrase, with the server's own sentence (`reason_detail`) on the
+ * element's `title`. A code this map does not know renders verbatim — failing
+ * informative is better than a blank where the reason should be, and it is how
+ * a future code reaches the operator before this file has a phrase for it.
+ *
+ * The three `not configured` codes are one phrase on purpose: all three mean
+ * the deployment has not authored this machine yet, which on a stock render is
+ * the live target's DELIBERATE state (authoring it is the go-live edit), and
+ * the distinction between them belongs to the tooltip, not the row.
+ * @type {Record<string, string>}
+ */
+export const REASON_PHRASES = {
+  connector_block_missing: 'not configured',
+  gateways_missing: 'not configured',
+  probe_channel_missing: 'not configured',
+  target_unresolvable: 'unavailable',
+  limits_posture: 'needs strict limits',
+  operator_ack_missing: 'needs gateway ack',
+  archive_belongs_to_standin: 'archive conflict',
+  invented_history: 'no archive',
+  standin_not_deployed: 'stand-in not deployed',
+  selected_role_missing: 'no endpoint for role',
+  [REASON_STORE_UNAVAILABLE]: 'store unavailable',
+};
+
+/**
+ * The operator phrase for one refusal code. Sentences pass through untouched —
+ * the gesture notes hold the server's own refusal sentences as well as codes,
+ * and a sentence is already the most operator-readable form there is.
+ * @param {unknown} code
+ * @returns {string}
+ */
+export function reasonPhrase(code) {
+  const word = String(code ?? '');
+  return REASON_PHRASES[word] || word;
+}
+
+/**
+ * Whether this session is a chat.
+ *
+ * A chat has no PTY and so no controls server of its own to address a switch
+ * request to, which the route says by giving EVERY row `chat_session` as its
+ * unavailability reason. Its toggles are untouched — the posture store is
+ * keyed on the session, not on the topology.
+ * @param {any[]} rows
+ */
+export function isChatSession(rows) {
+  return rows.length > 0 && rows.every((row) => row.reason === REASON_CHAT_SESSION);
+}
+
+/**
+ * Whether nothing this session can do would arm this row.
+ *
+ * The signature of a read-only run, read off the columns the route publishes:
+ * the render's ceiling is up and this session has not narrowed the row, and
+ * writes are STILL off. `effective` is `ceiling ∧ ¬readonly_run ∧ entry ≠
+ * sandbox`, so with the other two terms true only the run can be holding it —
+ * and the toggle is a readout either way, which is the whole of what the lock
+ * has to say.
+ * @param {any} row
+ */
+export function writesHeldByTheRun(row) {
+  return Boolean(row.ceiling_writes) && row.posture !== 'sandbox' && !row.effective;
+}
+
+/**
+ * Why this row's toggle cannot move, or `null` when it can.
+ *
+ * Ordered from the widest cause to the narrowest, so an operator reads the one
+ * they could act on: a store that cannot record anything outranks a run that
+ * would ignore it, which outranks a persona that never armed this target,
+ * which outranks a gateway table with nowhere to narrow TO.
+ * @param {any} row
+ * @param {any} state
+ * @returns {string|null}
+ */
+export function lockReason(row, state) {
+  if (!state?.store_available) return 'store unavailable';
+  if (!state.enforceable) return 'not enforceable';
+  if (writesHeldByTheRun(row)) return 'readonly run';
+  if (!row.ceiling_writes) return 'persona ceiling';
+  // Narrowing this row would select a gateway role the deployment has not
+  // configured. The route only reports it for a row a narrowing would CHANGE,
+  // so when it is set the only move the toggle offers is the blocked one.
+  if (row.narrowing_refusal) return 'no read-only endpoint';
+  return null;
+}
+
+/**
+ * The right of the head, which is empty in the plain case: absence is the good
+ * news. Same order as {@link lockReason} — the widest fact about the session
+ * that is not plain.
+ * @param {any} state
+ * @param {any[]} rows
+ * @returns {{text: string, tone: string|null}}
+ */
+export function headNote(state, rows) {
+  if (!state.store_available) return { text: 'posture store unavailable', tone: 'error' };
+  if (!state.enforceable) {
+    return { text: `not enforceable · ${state.enforceable_reason ?? 'unknown'}`, tone: 'warn' };
+  }
+  if (rows.length > 0 && rows.every(writesHeldByTheRun)) {
+    return { text: 'readonly run · deployment-wide', tone: 'warn' };
+  }
+  if (isChatSession(rows)) return { text: 'chat session', tone: null };
+  if (state.execution_in_flight) return { text: 'execution running', tone: 'warn' };
+  return { text: '', tone: null };
+}
+
+/**
+ * The reachability word and the age beside it.
+ *
+ * ONE vocabulary in the visible line, in the words an operator who has never
+ * met a gateway can read: `connected`, `unreachable`, and `unknown` for
+ * everything the prober could not vouch for. The measured word — `reached`,
+ * `down`, `stale`, `not_applicable` — and the role it was measured on stay on
+ * the element's `title`, which is where simple mode's LED-only row keeps the
+ * whole sentence too.
+ * @param {any} reachability
+ * @returns {{state: string, text: string, title: string}}
+ */
+export function reachText(reachability) {
+  const rc = reachability && typeof reachability === 'object' ? reachability : {};
+  const measured = typeof rc.state === 'string' && rc.state ? rc.state : 'unknown';
+  const word =
+    measured === 'reached' ? 'connected' : measured === 'down' ? 'unreachable' : 'unknown';
+  const age = typeof rc.age_s === 'number' ? ` · ${rc.age_s} s` : '';
+  const parts = [`${measured}${age}`];
+  if (rc.role) parts.push(`${rc.role} endpoint`);
+  if (measured === 'stale') parts.push('last probe older than the prober interval');
+  return { state: measured, text: `${word}${age}`, title: parts.join(' · ') };
+}

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-popover.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-popover.js
@@ -12,15 +12,16 @@
  * machine, where it points, whether anything is reaching it, the ceiling the
  * deployment rendered, this session's own narrowing, and what a switch would
  * do. Status and action stay in separate columns because reading the popover
- * and changing it are different gestures.
+ * and changing it are different gestures — and every element carries one fact,
+ * once: the row's single identity line is the server's label, which already
+ * says what kind of machine it names.
  *
  * **One DOM, two densities.** `html[data-ui-mode]` is a CSS concern and only a
- * CSS concern: every row renders the plain-language kind word, the endpoint
- * and role line, the reachability word and age, the baseline tag, the lock
- * reason and the foot note, in both modes, and terminal.css hides what simple
- * mode drops. Nothing here reads `data-ui-mode` — a JS branch on it would make
- * a live toggle-back rebuild the DOM, and would put the density rule in two
- * files that could drift.
+ * CSS concern: every row renders the endpoint and role line, the reachability
+ * word and age, the baseline tag, the lock reason and the foot note, in both
+ * modes, and terminal.css hides what simple mode drops. Nothing here reads
+ * `data-ui-mode` — a JS branch on it would make a live toggle-back rebuild the
+ * DOM, and would put the density rule in two files that could drift.
  *
  * **The popover stays open beneath a confirm.** Arming writes and switching
  * both raise a `.posture-modal-overlay` at `--z-modal`, a full layer above the
@@ -80,6 +81,48 @@ const REASON_CHAT_SESSION = 'chat_session';
 
 /** The refusal word for a row whose Switch is missing because the store is. */
 const REASON_STORE_UNAVAILABLE = 'store_unavailable';
+
+/**
+ * Refusal code → the short phrase the operator reads.
+ *
+ * The route publishes the switch tool's machine codes so the popover and the
+ * agent keep agreeing about the same refusal; what an OPERATOR reads is this
+ * map's phrase, with the server's own sentence (`reason_detail`) on the
+ * element's `title`. A code this map does not know renders verbatim — failing
+ * informative is better than a blank where the reason should be, and it is how
+ * a future code reaches the operator before this file has a phrase for it.
+ *
+ * The three `not configured` codes are one phrase on purpose: all three mean
+ * the deployment has not authored this machine yet, which on a stock render is
+ * the live target's DELIBERATE state (authoring it is the go-live edit), and
+ * the distinction between them belongs to the tooltip, not the row.
+ * @type {Record<string, string>}
+ */
+const REASON_PHRASES = {
+  connector_block_missing: 'not configured',
+  gateways_missing: 'not configured',
+  probe_channel_missing: 'not configured',
+  target_unresolvable: 'unavailable',
+  limits_posture: 'needs strict limits',
+  operator_ack_missing: 'needs gateway ack',
+  archive_belongs_to_standin: 'archive conflict',
+  invented_history: 'no archive',
+  standin_not_deployed: 'stand-in not deployed',
+  selected_role_missing: 'no endpoint for role',
+  [REASON_STORE_UNAVAILABLE]: 'store unavailable',
+};
+
+/**
+ * The operator phrase for one refusal code. Sentences pass through untouched —
+ * the gesture notes hold the server's own refusal sentences as well as codes,
+ * and a sentence is already the most operator-readable form there is.
+ * @param {unknown} code
+ * @returns {string}
+ */
+function reasonPhrase(code) {
+  const word = String(code ?? '');
+  return REASON_PHRASES[word] || word;
+}
 
 /** @type {HTMLElement|null} */
 let popover = null;
@@ -363,7 +406,7 @@ function reachText(reachability) {
  * row that did not take part in it has nothing to report.
  * @param {any} row
  * @param {any} state
- * @returns {{status: string, text: string}|null}
+ * @returns {{status: string, text: string, title?: string}|null}
  */
 function switchOutcome(row, state) {
   if (isPending() && pendingTarget === row.target) {
@@ -376,11 +419,13 @@ function switchOutcome(row, state) {
     const age = typeof last.age_s === 'number' ? ` · ${last.age_s} s ago` : '';
     return { status: 'success', text: `✓ switched${age}` };
   }
-  // refused / failed / expired all render the word the gate (or the client's
-  // own deadline, for a request nothing ever answered) put on them.
+  // refused / failed / expired render the operator phrase for the word the
+  // gate (or the client's own deadline, for a request nothing ever answered)
+  // put on them, with the gate's own sentence on the title where it sent one.
   return {
     status: last.status === 'expired' ? 'expired' : 'refused',
-    text: `✗ ${last.reason || last.status}`,
+    text: `✗ ${reasonPhrase(last.reason || last.status)}`,
+    title: typeof last.detail === 'string' && last.detail ? last.detail : undefined,
   };
 }
 
@@ -440,7 +485,7 @@ function render() {
   // A gesture that named every target has no row of its own to report on.
   const allNote = gestureNotes.get(ALL_TARGETS);
   if (allNote) {
-    const outcome = el('div', 'ctc-outcome', `✗ ${allNote}`);
+    const outcome = el('div', 'ctc-outcome', `✗ ${reasonPhrase(allNote)}`);
     outcome.dataset.status = 'refused';
     popover.append(outcome);
   }
@@ -468,15 +513,14 @@ function renderRow(row, state, rows) {
   node.append(el('span', 'ctc-dot'));
 
   const ident = el('div', 'ctc-ident');
+  // The row's ONE identity line: the server's label, which already carries the
+  // kind of machine it names ("LIVE MACHINE (stand-in)", "virtual accelerator
+  // (simulation)"). A subtitle restating it would be the same fact twice on
+  // the one surface whose job is to be read at a glance.
   const name = el('div', 'ctc-name');
   name.append(el('span', 'ctc-label', row.label || row.target));
   if (row.active) name.append(el('span', 'ctc-tag ctc-tag-current', 'current'));
   ident.append(name);
-
-  // Always rendered, in both densities: simple mode shows this instead of the
-  // meta line below, and terminal.css decides which. An operator who does not
-  // think in endpoints still has to be able to tell the real machine.
-  ident.append(el('div', 'ctc-kind', row.kind || ''));
 
   const meta = el('div', 'ctc-meta');
   meta.append(el('span', 'ctc-endpoint', row.endpoint || ''));
@@ -496,11 +540,12 @@ function renderRow(row, state, rows) {
   if (outcome) {
     const line = el('div', 'ctc-outcome', outcome.text);
     line.dataset.status = outcome.status;
+    if (outcome.title) line.title = outcome.title;
     ident.append(line);
   }
   const gestureNote = gestureNotes.get(row.target);
   if (gestureNote) {
-    const line = el('div', 'ctc-outcome', `✗ ${gestureNote}`);
+    const line = el('div', 'ctc-outcome', `✗ ${reasonPhrase(gestureNote)}`);
     line.dataset.status = 'refused';
     ident.append(line);
   }
@@ -562,12 +607,14 @@ function renderPosture(row, state, word, lock) {
 }
 
 /**
- * Column 4: Switch, or the word for why there is no Switch.
+ * Column 4: Switch, or the phrase for why there is no Switch.
  *
- * The refusal word is the switch tool's own, published by the route and
- * rendered verbatim — so the gap where the button would be is explained
- * rather than merely empty, and the popover and the agent name the same
- * refusal the same way.
+ * The refusal is keyed on the switch tool's own machine code, published by the
+ * route — so the popover and the agent agree about the same refusal — and
+ * rendered as {@link REASON_PHRASES}' operator phrase, with the route's
+ * `reason_detail` sentence (falling back to the code) on the `title`. The gap
+ * where the button would be is explained rather than merely empty, and never
+ * in a vocabulary only the tool speaks.
  * @param {any} row
  * @param {any} state
  * @param {any[]} rows
@@ -588,8 +635,11 @@ function renderAction(row, state, rows) {
     action.append(swap);
     return action;
   }
-  const reason = row.reason || (state.store_available ? '' : REASON_STORE_UNAVAILABLE);
-  action.append(el('span', 'ctc-reason', reason));
+  const code = row.reason || (state.store_available ? '' : REASON_STORE_UNAVAILABLE);
+  const reason = el('span', 'ctc-reason', reasonPhrase(code));
+  const detail = typeof row.reason_detail === 'string' && row.reason_detail ? row.reason_detail : '';
+  if (detail || code) reason.title = detail || String(code);
+  action.append(reason);
   return action;
 }
 
@@ -801,6 +851,10 @@ function dismissConfirm() {
  *
  * Only this direction asks. Narrowing removes reach and is undone by a click;
  * arming is the gesture after which a write the agent makes can land.
+ *
+ * The title already names the machine, so the body does not name it again:
+ * each line is one fact the title does not carry — the scope and the endpoint,
+ * then the guards that stay up and when it takes hold.
  * @param {any} row
  * @param {any} state
  */
@@ -809,7 +863,7 @@ function confirmArming(row, state) {
   showConfirm({
     title: `Allow writes on ${label}?`,
     body: [
-      ["This session's agent will be able to write to ", strong(label), ` (${row.endpoint}).`],
+      ['Arms writes for ', strong('this session'), ` · ${row.endpoint}.`],
       [
         'Per-write approval and channel limits still apply. Takes effect on the next write — ' +
           'no restart.',
@@ -824,9 +878,12 @@ function confirmArming(row, state) {
 /**
  * The confirm for switching this session onto another machine.
  *
- * It names the posture the session will have THERE, because that is the fact
+ * It names the posture the session will ARRIVE in, because that is the fact
  * the chip will read a moment later and the one an operator is most likely to
- * assume travels with them: posture is per-target, and it does not.
+ * assume travels with them: posture is per-target, and it does not. The word
+ * is {@link stateWord}'s own, so the dialog and the chip a moment later can
+ * never disagree. The title already names the machine, so the body does not
+ * name it again.
  * @param {any} row
  * @param {any} state
  */
@@ -842,8 +899,8 @@ function confirmSwitch(row, state) {
   showConfirm({
     title: `Switch to ${label}?`,
     body: [
-      ["The session's control target moves to ", strong(label), ` at ${row.endpoint}.`],
-      ['Session posture there: ', strong(word), '. The agent keeps its conversation.'],
+      ['Arrives in the ', strong(word), ` posture · ${row.endpoint}.`],
+      ['The conversation continues.'],
     ],
     live,
     confirmLabel: 'Switch',

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-popover.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-popover.js
@@ -41,7 +41,19 @@
  * the operator reads the server's own wording rather than "[object Object]".
  */
 
+import {
+  REASON_STORE_UNAVAILABLE,
+  headNote,
+  isChatSession,
+  lockReason,
+  reachText,
+  reasonPhrase,
+} from './control-target-facts.js';
 import { fadeOutOverlay, mountOverlay } from './modal-overlay.js';
+
+// Re-exported so the popover's public surface stays what it was before the
+// derived-facts split; the wording itself lives in control-target-facts.js.
+export { lockReason };
 import {
   CHIP_TOGGLE_EVENT,
   getAnchorElement,
@@ -75,54 +87,6 @@ export const ALL_TARGETS = 'all';
  * machine rather than re-announcing a switch nobody is waiting on.
  */
 export const OUTCOME_MAX_AGE_S = 60;
-
-/** `available_now` reason a chat session's rows carry (routes/websocket.py). */
-const REASON_CHAT_SESSION = 'chat_session';
-
-/** The refusal word for a row whose Switch is missing because the store is. */
-const REASON_STORE_UNAVAILABLE = 'store_unavailable';
-
-/**
- * Refusal code → the short phrase the operator reads.
- *
- * The route publishes the switch tool's machine codes so the popover and the
- * agent keep agreeing about the same refusal; what an OPERATOR reads is this
- * map's phrase, with the server's own sentence (`reason_detail`) on the
- * element's `title`. A code this map does not know renders verbatim — failing
- * informative is better than a blank where the reason should be, and it is how
- * a future code reaches the operator before this file has a phrase for it.
- *
- * The three `not configured` codes are one phrase on purpose: all three mean
- * the deployment has not authored this machine yet, which on a stock render is
- * the live target's DELIBERATE state (authoring it is the go-live edit), and
- * the distinction between them belongs to the tooltip, not the row.
- * @type {Record<string, string>}
- */
-const REASON_PHRASES = {
-  connector_block_missing: 'not configured',
-  gateways_missing: 'not configured',
-  probe_channel_missing: 'not configured',
-  target_unresolvable: 'unavailable',
-  limits_posture: 'needs strict limits',
-  operator_ack_missing: 'needs gateway ack',
-  archive_belongs_to_standin: 'archive conflict',
-  invented_history: 'no archive',
-  standin_not_deployed: 'stand-in not deployed',
-  selected_role_missing: 'no endpoint for role',
-  [REASON_STORE_UNAVAILABLE]: 'store unavailable',
-};
-
-/**
- * The operator phrase for one refusal code. Sentences pass through untouched —
- * the gesture notes hold the server's own refusal sentences as well as codes,
- * and a sentence is already the most operator-readable form there is.
- * @param {unknown} code
- * @returns {string}
- */
-function reasonPhrase(code) {
-  const word = String(code ?? '');
-  return REASON_PHRASES[word] || word;
-}
 
 /** @type {HTMLElement|null} */
 let popover = null;
@@ -300,103 +264,7 @@ function closePopover() {
   detachDocumentListeners();
 }
 
-/* ---- derived facts ---- */
-
-/**
- * Whether this session is a chat.
- *
- * A chat has no PTY and so no controls server of its own to address a switch
- * request to, which the route says by giving EVERY row `chat_session` as its
- * unavailability reason. Its toggles are untouched — the posture store is
- * keyed on the session, not on the topology.
- * @param {any[]} rows
- */
-function isChatSession(rows) {
-  return rows.length > 0 && rows.every((row) => row.reason === REASON_CHAT_SESSION);
-}
-
-/**
- * Whether nothing this session can do would arm this row.
- *
- * The signature of a read-only run, read off the columns the route publishes:
- * the render's ceiling is up and this session has not narrowed the row, and
- * writes are STILL off. `effective` is `ceiling ∧ ¬readonly_run ∧ entry ≠
- * sandbox`, so with the other two terms true only the run can be holding it —
- * and the toggle is a readout either way, which is the whole of what the lock
- * has to say.
- * @param {any} row
- */
-function writesHeldByTheRun(row) {
-  return Boolean(row.ceiling_writes) && row.posture !== 'sandbox' && !row.effective;
-}
-
-/**
- * Why this row's toggle cannot move, or `null` when it can.
- *
- * Ordered from the widest cause to the narrowest, so an operator reads the one
- * they could act on: a store that cannot record anything outranks a run that
- * would ignore it, which outranks a persona that never armed this target,
- * which outranks a gateway table with nowhere to narrow TO.
- * @param {any} row
- * @param {any} state
- * @returns {string|null}
- */
-export function lockReason(row, state) {
-  if (!state?.store_available) return 'store unavailable';
-  if (!state.enforceable) return 'not enforceable';
-  if (writesHeldByTheRun(row)) return 'readonly run';
-  if (!row.ceiling_writes) return 'persona ceiling';
-  // Narrowing this row would select a gateway role the deployment has not
-  // configured. The route only reports it for a row a narrowing would CHANGE,
-  // so when it is set the only move the toggle offers is the blocked one.
-  if (row.narrowing_refusal) return 'no read-only endpoint';
-  return null;
-}
-
-/**
- * The right of the head, which is empty in the plain case: absence is the good
- * news. Same order as {@link lockReason} — the widest fact about the session
- * that is not plain.
- * @param {any} state
- * @param {any[]} rows
- * @returns {{text: string, tone: string|null}}
- */
-function headNote(state, rows) {
-  if (!state.store_available) return { text: 'posture store unavailable', tone: 'error' };
-  if (!state.enforceable) {
-    return { text: `not enforceable · ${state.enforceable_reason ?? 'unknown'}`, tone: 'warn' };
-  }
-  if (rows.length > 0 && rows.every(writesHeldByTheRun)) {
-    return { text: 'readonly run · deployment-wide', tone: 'warn' };
-  }
-  if (isChatSession(rows)) return { text: 'chat session', tone: null };
-  if (state.execution_in_flight) return { text: 'execution running', tone: 'warn' };
-  return { text: '', tone: null };
-}
-
-/**
- * The reachability word and the age beside it.
- *
- * ONE vocabulary in the visible line, in the words an operator who has never
- * met a gateway can read: `connected`, `unreachable`, and `unknown` for
- * everything the prober could not vouch for. The measured word — `reached`,
- * `down`, `stale`, `not_applicable` — and the role it was measured on stay on
- * the element's `title`, which is where simple mode's LED-only row keeps the
- * whole sentence too.
- * @param {any} reachability
- * @returns {{state: string, text: string, title: string}}
- */
-function reachText(reachability) {
-  const rc = reachability && typeof reachability === 'object' ? reachability : {};
-  const measured = typeof rc.state === 'string' && rc.state ? rc.state : 'unknown';
-  const word =
-    measured === 'reached' ? 'connected' : measured === 'down' ? 'unreachable' : 'unknown';
-  const age = typeof rc.age_s === 'number' ? ` · ${rc.age_s} s` : '';
-  const parts = [`${measured}${age}`];
-  if (rc.role) parts.push(`${rc.role} endpoint`);
-  if (measured === 'stale') parts.push('last probe older than the prober interval');
-  return { state: measured, text: `${word}${age}`, title: parts.join(' · ') };
-}
+/* ---- derived facts (the pure ones live in control-target-facts.js) ---- */
 
 /**
  * What the last switch did to THIS row, when it is still news.

--- a/src/osprey/mcp_server/control_system/connector_host_manager.py
+++ b/src/osprey/mcp_server/control_system/connector_host_manager.py
@@ -402,7 +402,7 @@ def baseline_target(config: Any) -> str:
 
 
 def switch_capable(config: Any) -> bool:
-    """Whether this deployment can be pointed at either target at runtime.
+    """Whether this deployment gives a session more than one runtime target.
 
     The predicate itself lives in :func:`osprey_connectors.types.switch_capable`,
     beside the target resolution it is built from, so that the runtime and the

--- a/src/osprey/mcp_server/control_system/server_context.py
+++ b/src/osprey/mcp_server/control_system/server_context.py
@@ -26,8 +26,8 @@ Where a tool's connector comes from
 There are two serving paths, and which one a deployment gets is decided once,
 by :func:`~osprey.mcp_server.control_system.connector_host_manager.switch_capable`:
 
-* **Switch-capable** (both targets configured, and the deployment's own control
-  system is one of them): ``control_system()`` returns the proxy onto the
+* **Switch-capable** (at least two targets configured, and the deployment's own
+  control system is one of them): ``control_system()`` returns the proxy onto the
   connector-host child. The in-process connector is never built — this server
   holds no control-system client library at all, which is the only way a target
   switch can actually move where tool calls land. A child that has died is not

--- a/src/osprey/mcp_server/python_executor/tools/_execution_gates.py
+++ b/src/osprey/mcp_server/python_executor/tools/_execution_gates.py
@@ -256,20 +256,31 @@ def _enforce_session_store_term(target: str | None) -> None:
     if permitted:
         return
 
-    scope = (
-        f"control target '{target}'"
-        if target
-        else "this session (its control target could not be identified, so the "
-        "most restrictive posture applies)"
-    )
+    # The wording is enforce_posture_clamp's, deliberately: this is the same
+    # refusal met one layer down, and an operator who meets both gates in one
+    # session should not have to work out that they are the same answer.
+    if target is None:
+        make_error(
+            "safety_error",
+            "This session's write posture is read-only for at least one control "
+            "target (the run's target could not be identified, so the most "
+            "restrictive decides) — set from the control-target chip in the header.",
+            [
+                'Re-run with execution_mode="readonly" — reads are unaffected by the posture.',
+                "Lift that narrowing from the control-target chip in the header if "
+                "the write is intended; the deployment config is not the gate here.",
+            ],
+            details={"active_target": target},
+        )
     make_error(
         "safety_error",
-        f"This session's write posture for {scope} is read-only, which refuses "
-        "control-system writes regardless of what the run asks for.",
+        f"This session's write posture for the '{target}' control target is "
+        "read-only — set from the control-target chip in the header, and in "
+        "force for this session only.",
         [
             'Re-run with execution_mode="readonly" — reads are unaffected by the posture.',
-            "To allow writes, switch this target to the writes posture from the "
-            "control-target chip in the header; the deployment config is not the "
+            f"Set '{target}' back to writes from the control-target chip in the "
+            "header if the write is intended; the deployment config is not the "
             "gate here.",
         ],
         details={"active_target": target},

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -186,8 +186,9 @@ config:
   # sandbox simulator, "epics" your own control system, "mock" needs no
   # containers but cannot complete a plan.
   # `control_target_set live` moves a session onto the machine authored under
-  # `epics:`: it probes that target, then requires the strict limits pair
-  # below, then your own
+  # `epics:`. The template ships that block unconfigured — author its
+  # `gateways` and `probe_channel` first — then the switch probes that target,
+  # requires the strict limits pair below, then your own
   # `control_system.target_switch.live_gateway_acknowledged` — the operator
   # saying those gateways really are this facility's — and it still refuses
   # while this deployment records its own archive from the stand-in, because

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -677,10 +677,17 @@ archiver:
   # mock_archiver:
   #   simulation_file: data/simulation/machine.json
 
-  # EPICS Archiver Appliance (production mode)
-  epics_archiver:
-    url: https://archiver.als.lbl.gov:8443
-    timeout: 60              # Timeout for archiver requests in seconds
+  # EPICS Archiver Appliance (production mode) — ships unconfigured on purpose.
+  #
+  # Nothing here names an appliance: a facility's archiver cannot be guessed,
+  # and shipping someone else's URL would make a flip to `type: epics_archiver`
+  # look ready while reading history from a machine you never configured.
+  # Authoring this block travels with that flip — uncomment it with your
+  # facility's values. Until then the connector refuses to start without a
+  # `url`, which is the truthful state of a fresh deployment.
+  # epics_archiver:
+  #   url: https://your-archiver.example.com:8443
+  #   timeout: 60            # Timeout for archiver requests in seconds
 
   # MongoDB archiver. Its client ships with OSPREY, so there is nothing extra to
   # install. Every key here except timeout is required; the connector raises on

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -395,7 +395,7 @@ control_system:
   #     Channel Access. Requires the VA service running first — add
   #     virtual_accelerator to deployed_services and run `osprey up`
   #     (see the "Use the Virtual Accelerator" how-to in the OSPREY docs).
-  #   - epics: Production EPICS control system (ALS values below)
+  #   - epics: Production EPICS control system (authored below at go-live)
   type: mock  # <-- Change to 'virtual_accelerator' or 'epics' for other modes
 
   # Write Access Control - Master safety switch for hardware control
@@ -555,7 +555,16 @@ control_system:
           # port: {{ osprey_ports.va_standin + 1 }}
           use_name_server: true
 
-    # EPICS connector (production mode) — ALS production values.
+    # EPICS connector (production mode) — ships unconfigured on purpose.
+    #
+    # Nothing here names a machine: a facility's gateways cannot be guessed,
+    # and shipping someone else's would make a stock deployment's `live` target
+    # look ready while pointing at hardware you never configured. Authoring
+    # this block is the go-live edit — uncomment `gateways` (and `probe_channel`
+    # below) with your facility's values, and set
+    # `control_system.target_switch.live_gateway_acknowledged` further down to
+    # confirm them. Until then the live target shows as not configured, which
+    # is the truthful state of a fresh deployment.
     #
     # PVAccess (PVA) read routing: addresses matching any glob in `pva_channels`
     # are read through the p4p client — the transport NTNDArray camera frames
@@ -599,18 +608,18 @@ control_system:
       #   address: your-pva-gateway.example.com  # Replace with your PVA gateway
       #   port: 5075
       #   use_name_server: false  # Set true for SSH tunnels
-      gateways:
-        read_only:
-          address: cagw-alsdmz.als.lbl.gov
-          port: 5064
-          # use_name_server: Set to true for SSH tunnels (uses EPICS_CA_NAME_SERVERS)
-          #                 Set to false for direct gateway (uses EPICS_CA_ADDR_LIST)
-          #                 Defaults to false. Can be overridden via environment variable.
-          use_name_server: false
-        write_access:
-          address: cagw-alsdmz.als.lbl.gov
-          port: 5084
-          use_name_server: false
+      # use_name_server: Set to true for SSH tunnels (uses EPICS_CA_NAME_SERVERS)
+      #                  Set to false for direct gateway (uses EPICS_CA_ADDR_LIST)
+      #                  Defaults to false. Can be overridden via environment variable.
+      # gateways:
+      #   read_only:
+      #     address: your-ca-gateway.example.com
+      #     port: 5064
+      #     use_name_server: false
+      #   write_access:
+      #     address: your-ca-gateway.example.com
+      #     port: 5084
+      #     use_name_server: false
 
   # Control-System Target Switch (Layer 2)
   # Bounds how a running session moves between the connector targets above.
@@ -625,7 +634,7 @@ control_system:
                             # old target before it is torn down regardless
     probe_interval_s: 30    # Seconds between background reachability probes of
                             # every target's gateways
-    # live_gateway_acknowledged: cagw-alsdmz.als.lbl.gov
+    # live_gateway_acknowledged: your-ca-gateway.example.com
 
 # Archiver Configuration
 archiver:

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -68,8 +68,10 @@ Ahead of all of that, a write tool whose target this deployment has not armed
 exits with NO decision at all, so that the layer which refuses it — the
 `osprey_writes_check` deny, or `queue_start`'s own lane gate — is not reopened
 by an approval prompt. Posture is per target, so the same tool on the same
-deployment can defer on one target and prompt on the other. A config that
-states no posture anywhere prompts exactly as it always has.
+deployment can defer on one target and prompt on the other; the operator's own
+per-(session, target) narrowing in the posture store counts the same way as a
+config disarm, because `osprey_writes_check` reads the same store. A config
+that states no posture anywhere prompts exactly as it always has.
 
 ## Write-approval stamps
 
@@ -2069,7 +2071,19 @@ def _lane_posture(config, section, tool_input):
 
 
 def _session_posture(section, hook_input):
-    """Posture for the target this SESSION is pointed at."""
+    """Posture for the target this SESSION is pointed at.
+
+    Two layers, composed in the store's own direction — it only ever narrows:
+
+    * the DEPLOYMENT ceiling, from the rendered config. ``None`` (no posture
+      stated anywhere) survives untouched: with no ceiling there is no
+      guaranteed deny to defer into, so the prompt stays.
+    * the OPERATOR's narrowing of this (session, target), from the posture
+      store. ``osprey_writes_check`` reads the same store on the same shape
+      (its ``effective_writes_for`` call), so an armed target the operator
+      sandboxed is still a guaranteed deny — and keeping the prompt there
+      would ask the human to approve a write the next hook refuses.
+    """
     result = _target_state.read_session_target(hook_input)
     if _target_state.is_baseline(result):
         # A baseline fallback still NAMES the deployment's baseline target, and
@@ -2078,8 +2092,16 @@ def _session_posture(section, hook_input):
         # REACH agrees on is the only one that cannot become a guess in favour
         # of hardware — the same call `osprey_writes_check` makes on the same
         # shape, so the two cannot part company over an unidentified session.
-        return _target_state.most_restrictive_posture(section)
-    return _target_state.writes_posture(section, result.get("target"))
+        target = None
+        ceiling = _target_state.most_restrictive_posture(section)
+    else:
+        target = result.get("target")
+        ceiling = _target_state.writes_posture(section, target)
+    if ceiling is not True:
+        return ceiling
+    if _target_state.session_sandboxed(hook_input, target):
+        return False
+    return True
 
 
 def _call_write_posture(config, tool_name, short_name, tool_input, hook_input):

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_target_state.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_target_state.py
@@ -941,34 +941,24 @@ def _baseline_target(section):
 
 
 def _switch_capable(section):
-    """Whether a session on this deployment can be pointed at either target.
+    """Whether this deployment gives a session more than one target to point at.
 
     The stdlib restatement of ``osprey_connectors.types.switch_capable``, whose
-    three conditions are mirrored here in order: both targets resolve to a type
-    at all; the deployment's OWN type is what its baseline target resolves back
-    to, which is what keeps a mock that happens to carry an ``epics`` block out
-    of the two-target world; and both types carry a non-empty connector block,
-    since that block is what a connector is configured from.
+    two conditions are mirrored here in order: the deployment's OWN type is
+    what its baseline target resolves back to, which is what keeps a mock that
+    happens to carry an ``epics`` block out of the multi-target world; and at
+    least two targets are configured (:func:`_configured_targets`, the same
+    enumeration every roster walks).
 
-    The pair it asks about is ``live`` and ``va``, deliberately and in step with
-    the framework: the question is whether this deployment is in the switching
-    world at all, and the stand-in is a target a switching deployment may or may
-    not also carry. Which targets it then HAS is :func:`_configured_targets`.
+    Which two is deliberately not asked, in step with the framework: a
+    stand-in beside a simulator with no live machine authored is exactly the
+    switching world, and demanding the ``live``/``va`` pair would deny it.
     """
     if not isinstance(section, dict):
         return False
-    types_by_target = {target: target_type(section, target) for target in (TARGET_LIVE, TARGET_VA)}
-    if any(name is None for name in types_by_target.values()):
+    if target_type(section, _baseline_target(section)) != _resolved_type(section):
         return False
-    if types_by_target[_baseline_target(section)] != _resolved_type(section):
-        return False
-    connector = section.get("connector")
-    if not isinstance(connector, dict):
-        return False
-    return all(
-        isinstance(connector.get(name), dict) and bool(connector.get(name))
-        for name in types_by_target.values()
-    )
+    return len(_configured_targets(section)) >= 2
 
 
 def _configured_targets(section):

--- a/src/osprey/utils/config_writer.py
+++ b/src/osprey/utils/config_writer.py
@@ -1076,9 +1076,11 @@ def get_facility_from_gateway_config(config_path: Path) -> str | None:
             ):
                 return preset["name"]
 
+    # The template ships no gateway values, so any authored address that
+    # matched no facility preset above is the operator's own.
     if "read_only" in current_gateways:
         read_addr = current_gateways["read_only"].get("address", "")
-        if read_addr and read_addr != "cagw-alsdmz.als.lbl.gov":
+        if read_addr:
             return "Custom"
 
     return None

--- a/tests/cli/test_inject_va_gateways.py
+++ b/tests/cli/test_inject_va_gateways.py
@@ -399,7 +399,7 @@ class TestNoStandinChangesNothing:
             "  target_switch:\n" + template.split("  target_switch:\n", 1)[1].split("\n\n", 1)[0]
         )
         assert block in text
-        assert "# live_gateway_acknowledged: cagw-alsdmz.als.lbl.gov" in text
+        assert "# live_gateway_acknowledged: your-ca-gateway.example.com" in text
         assert "live_gateway_acknowledged" not in _target_switch(text)
 
 
@@ -466,7 +466,7 @@ class TestTheAcknowledgmentIsNeverWritten:
         """It is the template author's example; nothing wrote a value beside it."""
         text = _inject_standin(tmp_path)
 
-        assert "    # live_gateway_acknowledged: cagw-alsdmz.als.lbl.gov\n" in text
+        assert "    # live_gateway_acknowledged: your-ca-gateway.example.com\n" in text
         assert text.count("    live_gateway_acknowledged:") == 0
 
     def test_the_build_hangs_no_note_of_its_own_in_the_config(self, tmp_path):
@@ -514,7 +514,7 @@ class TestTheAcknowledgmentIsNeverWritten:
     def test_an_operator_authored_acknowledgment_is_left_exactly_as_written(self, tmp_path):
         """It names their own machine, and this build has no opinion about it."""
         template = _render_control_assistant_template().replace(
-            "    # live_gateway_acknowledged: cagw-alsdmz.als.lbl.gov\n",
+            "    # live_gateway_acknowledged: your-ca-gateway.example.com\n",
             "    live_gateway_acknowledged: cagw.example.com   # ours, checked\n",
             1,
         )

--- a/tests/cli/test_live_standin_overrides.py
+++ b/tests/cli/test_live_standin_overrides.py
@@ -59,22 +59,13 @@ VA_PROBE_CHANNEL = "SR:VAC:GAUGE:SR01:PRESSURE:RB"
 #: The rendered subtree the ``standin`` target is configured from.
 STANDIN_PREFIX = "control_system.connector.live_standin"
 
-#: The shipped ALS production ``epics`` gateways. These are the ``live``
-#: target's, and the whole point of the third target is that they read the same
-#: whether or not a stand-in was asked for — pinned the same way
-#: tests/cli/test_rendered_va_block.py pins them.
-SHIPPED_EPICS_GATEWAYS = {
-    "read_only": {
-        "address": "cagw-alsdmz.als.lbl.gov",
-        "port": 5064,
-        "use_name_server": False,
-    },
-    "write_access": {
-        "address": "cagw-alsdmz.als.lbl.gov",
-        "port": 5084,
-        "use_name_server": False,
-    },
-}
+#: The ``epics`` block the template ships. This is the ``live`` target's, and
+#: the whole point of the third target is that it reads the same whether or
+#: not a stand-in was asked for — pinned the same way
+#: tests/cli/test_rendered_va_block.py pins it. The gateways ship commented
+#: out (authoring them is the go-live edit), so the shipped block is the
+#: timeout and nothing else.
+SHIPPED_EPICS_BLOCK = {"timeout": 5.0}
 
 
 def _va(live_standin: int | None) -> VAConfig:
@@ -425,7 +416,7 @@ class TestTheRenderedDeploymentDialsTheStandIn:
         control_system = yaml.safe_load((lifecycle_repo / "build" / "config.yml").read_text())[
             "control_system"
         ]
-        assert control_system["connector"]["epics"]["gateways"] == SHIPPED_EPICS_GATEWAYS
+        assert control_system["connector"]["epics"] == SHIPPED_EPICS_BLOCK
         assert "probe_channel" not in control_system["connector"]["epics"]
 
     def test_live_standin_overrides_take_the_limits_posture_from_the_profile(
@@ -524,7 +515,7 @@ class TestTheRenderedDeploymentDialsTheStandIn:
         config = yaml.safe_load(rendered)
         control_system = config["control_system"]
         assert "live_standin" not in control_system["connector"]
-        assert control_system["connector"]["epics"]["gateways"] == SHIPPED_EPICS_GATEWAYS
+        assert control_system["connector"]["epics"] == SHIPPED_EPICS_BLOCK
         assert "probe_channel" not in control_system["connector"]["epics"]
         # Still the profile's own pair, unchanged by the stand-in going away:
         # nothing about the limits posture was ever the stand-in's to decide.

--- a/tests/cli/test_live_standin_render.py
+++ b/tests/cli/test_live_standin_render.py
@@ -84,20 +84,11 @@ BLUESKY_PORT = default_port("bluesky")
 #: ``standin`` target must prove too.
 VA_PROBE_CHANNEL = "SR:VAC:GAUGE:SR01:PRESSURE:RB"
 
-#: The shipped ALS production ``epics`` gateways — the ``live`` target's, which
-#: a build must render untouched whether or not a stand-in was asked for.
-SHIPPED_EPICS_GATEWAYS = {
-    "read_only": {
-        "address": "cagw-alsdmz.als.lbl.gov",
-        "port": 5064,
-        "use_name_server": False,
-    },
-    "write_access": {
-        "address": "cagw-alsdmz.als.lbl.gov",
-        "port": 5084,
-        "use_name_server": False,
-    },
-}
+#: The ``epics`` block the template ships — the ``live`` target's, which a
+#: build must render untouched whether or not a stand-in was asked for. The
+#: gateways and probe channel ship commented out (authoring them is the
+#: go-live edit), so untouched means the timeout and nothing else.
+SHIPPED_EPICS_BLOCK = {"timeout": 5.0}
 
 #: The opening of the note ``osprey build`` used to write above an
 #: acknowledgment it derived for the operator. Nothing derives one now — the
@@ -348,7 +339,7 @@ class TestTheRenderedConfigDescribesTheStandIn:
         """
         epics = _config(standin_build)["control_system"]["connector"]["epics"]
 
-        assert epics["gateways"] == SHIPPED_EPICS_GATEWAYS
+        assert epics == SHIPPED_EPICS_BLOCK
         assert "probe_channel" not in epics
 
     def test_live_standin_render_takes_its_limits_posture_from_the_profile(
@@ -613,10 +604,10 @@ class TestABuildWithoutTheKeyIsUntouched:
         assert recorder["environment"]["EPICS_CA_NAME_SERVERS"] == f"virtual-accelerator:{VA_PORT}"
 
     def test_live_standin_render_off_keeps_the_facilitys_own_epics_block(self, plain_build) -> None:
-        """The shipped production gateways, and no probe channel copied in."""
+        """The shipped block, untouched — no gateways invented, no probe channel copied in."""
         control_system = _config(plain_build)["control_system"]
 
-        assert control_system["connector"]["epics"]["gateways"] == SHIPPED_EPICS_GATEWAYS
+        assert control_system["connector"]["epics"] == SHIPPED_EPICS_BLOCK
         assert "probe_channel" not in control_system["connector"]["epics"]
         # The profile's own strict pair, unchanged by the stand-in going away:
         # the limits posture was never the stand-in's to decide either way.

--- a/tests/cli/test_profile_card.py
+++ b/tests/cli/test_profile_card.py
@@ -92,7 +92,7 @@ def test_each_user_row_carries_rights_auth_and_port(exemplar_lines: list[str]) -
     band rather than at whatever the profile happened to spell.
     """
     alice = line_with(exemplar_lines, "alice")
-    assert "readwrite · rights approval-gated" in alice
+    assert "readwrite · va rights approval-gated · standin rights approval-gated" in alice
     assert "password" in alice
     assert alice.rstrip().endswith(f":{_PORTS['web']}")
 
@@ -120,14 +120,21 @@ def test_the_card_shows_every_family_the_deployment_publishes(exemplar_lines: li
     assert numbers == sorted(numbers)
 
 
-def test_a_single_target_render_keeps_one_unqualified_write_right(
-    exemplar_lines: list[str],
-) -> None:
-    # The readwrite tier's render builds the simulator and nothing else, so a
-    # session on it reaches one machine. Naming that machine on the row would
-    # describe a target-by-target posture the render has no second half of.
-    alice = line_with(exemplar_lines, "alice")
-    assert "readwrite · rights approval-gated" in alice
+def test_a_single_target_render_keeps_one_unqualified_write_right() -> None:
+    # A render that reaches one machine names no target on the rights item —
+    # a target-by-target posture needs a second half the render does not have.
+    # Every one of the exemplar's write tiers now reaches two machines, so the
+    # one-target reading is pinned at the renderer's own seam instead.
+    from types import SimpleNamespace
+
+    from osprey.cli.profile_card import _write_rights
+
+    armed = SimpleNamespace(
+        config={"control_system.type": "mock", "control_system.writes_enabled": True}
+    )
+    cold = SimpleNamespace(config={"control_system.type": "mock"})
+    assert _write_rights(armed, {}, "readwrite") == ["rights approval-gated"]
+    assert _write_rights(cold, {}, "readonly") == []
 
 
 def test_a_switch_capable_render_answers_per_target(exemplar_lines: list[str]) -> None:

--- a/tests/cli/test_rendered_va_block.py
+++ b/tests/cli/test_rendered_va_block.py
@@ -68,24 +68,10 @@ PROJECT_ORIGINAL_EPICS_BLOCK = {
     },
 }
 
-#: The Control Assistant template's epics connector — the untouched ALS
-#: production configuration (same constant as
-#: tests/templates/test_preset_va_block.py pins).
-CONTROL_ASSISTANT_ORIGINAL_EPICS_BLOCK = {
-    "timeout": 5.0,
-    "gateways": {
-        "read_only": {
-            "address": "cagw-alsdmz.als.lbl.gov",
-            "port": 5064,
-            "use_name_server": False,
-        },
-        "write_access": {
-            "address": "cagw-alsdmz.als.lbl.gov",
-            "port": 5084,
-            "use_name_server": False,
-        },
-    },
-}
+#: The Control Assistant template's epics connector — the timeout and nothing
+#: else. The gateways ship commented out: authoring them is the go-live edit
+#: (same constant as tests/templates/test_preset_va_block.py pins).
+CONTROL_ASSISTANT_SHIPPED_EPICS_BLOCK = {"timeout": 5.0}
 
 
 def _render_project_template() -> str:
@@ -355,7 +341,7 @@ def test_acknowledgment_example_is_a_real_hostname_shape():
         assert "<" not in value and ">" not in value, f"{name}: {value!r} is a sentinel"
 
 
-# ── The production connector configuration is untouched ─────────────────────
+# ── The production connector configuration is what each template promises ────
 
 
 def test_project_template_epics_block_is_unchanged():
@@ -363,6 +349,6 @@ def test_project_template_epics_block_is_unchanged():
     assert epics == PROJECT_ORIGINAL_EPICS_BLOCK
 
 
-def test_control_assistant_epics_block_is_unchanged():
+def test_control_assistant_epics_block_ships_no_gateway_values():
     epics = _control_system(_render_control_assistant_template())["connector"]["epics"]
-    assert epics == CONTROL_ASSISTANT_ORIGINAL_EPICS_BLOCK
+    assert epics == CONTROL_ASSISTANT_SHIPPED_EPICS_BLOCK

--- a/tests/cli/test_va_default_config.py
+++ b/tests/cli/test_va_default_config.py
@@ -44,29 +44,17 @@ from osprey.connectors.factory import (
 # The epics block a scaffolded Control Assistant renders: the app template's
 # own values, verbatim, and the same block
 # tests/templates/test_preset_va_block.py pins on the raw render as
-# ORIGINAL_EPICS_BLOCK. The stand-in has its own connector block —
+# SHIPPED_EPICS_BLOCK. The stand-in has its own connector block —
 # `control_system.connector.live_standin`, seven leaves the build derives from
 # `virtual_accelerator.live_standin` — so `epics:` stays the machine the
 # facility authors. `live` means that machine on a deployment running a
 # stand-in exactly as on one that is not, which is why pointing this repo at a
-# real facility is one edit here and nothing else. `probe_channel` is commented
-# out in the template (facility-specific, nothing shipped set), so a scaffolded
-# block carries the two gateways and the timeout and no third key.
-SCAFFOLDED_EPICS_BLOCK = {
-    "timeout": 5.0,
-    "gateways": {
-        "read_only": {
-            "address": "cagw-alsdmz.als.lbl.gov",
-            "port": 5064,
-            "use_name_server": False,
-        },
-        "write_access": {
-            "address": "cagw-alsdmz.als.lbl.gov",
-            "port": 5084,
-            "use_name_server": False,
-        },
-    },
-}
+# real facility is one edit here and nothing else. The gateways, the
+# `probe_channel` and the operator acknowledgment are all commented out
+# (facility-specific, nothing shipped set), so a scaffolded block carries the
+# timeout and nothing else — a stock deployment's live target reads "not
+# configured" until the go-live edit authors it.
+SCAFFOLDED_EPICS_BLOCK = {"timeout": 5.0}
 
 
 @pytest.fixture

--- a/tests/connectors/test_target_writes_enabled.py
+++ b/tests/connectors/test_target_writes_enabled.py
@@ -506,14 +506,98 @@ def test_a_standin_baseline_is_switch_capable_and_does_not_raise():
 
 
 @pytest.mark.unit
-def test_a_standin_baseline_with_no_live_block_is_not_switch_capable():
-    """``live`` is underivable from a stand-in and a simulator, so there is no switch."""
+def test_a_standin_beside_a_simulator_is_switch_capable_without_a_live_block():
+    """Two configured targets are the switching world, whichever two they are.
+
+    A facility rehearsing on its stand-in beside the simulator, with no live
+    machine authored yet, has exactly the multi-target world the switch — and
+    the popover's per-target posture toggles behind it — exist for. ``live``
+    stays underivable and simply is not on the roster.
+    """
     # Arrange
     section = _section(
         LIVE_STANDIN,
         connector={
             "virtual_accelerator": {"writes_enabled": True},
             LIVE_STANDIN: {"port": 5074},
+        },
+    )
+
+    # Act / Assert
+    assert switch_capable(section) is True
+    assert configured_targets(section) == [TARGET_VA, TARGET_STANDIN]
+
+
+@pytest.mark.unit
+def test_a_va_baseline_beside_a_standin_is_switch_capable():
+    """The same two-machine world, baselined on the simulator."""
+    # Arrange
+    section = _section(
+        VIRTUAL_ACCELERATOR,
+        connector={
+            "virtual_accelerator": {"writes_enabled": True},
+            LIVE_STANDIN: {"port": 5074},
+        },
+    )
+
+    # Act / Assert
+    assert switch_capable(section) is True
+    assert configured_targets(section) == [TARGET_VA, TARGET_STANDIN]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "section",
+    [
+        pytest.param(_section(EPICS, connector={"epics": {"gateways": {}}}), id="live-only"),
+        pytest.param(
+            _section(VIRTUAL_ACCELERATOR, connector={"virtual_accelerator": {"port": 5064}}),
+            id="va-only",
+        ),
+        pytest.param(
+            _section(LIVE_STANDIN, connector={LIVE_STANDIN: {"port": 5074}}), id="standin-only"
+        ),
+        pytest.param(_section(MOCK), id="bare-mock"),
+    ],
+)
+def test_a_single_target_render_is_not_switch_capable(section):
+    """One configured target is nowhere to switch to."""
+    assert switch_capable(section) is False
+
+
+@pytest.mark.unit
+def test_the_live_and_va_pair_is_still_switch_capable():
+    """The original two-target shape answers as it always did."""
+    # Arrange
+    section = _section(
+        EPICS,
+        connector={
+            "epics": {"gateways": {"read_only": {"address": "gw"}}},
+            "virtual_accelerator": {"port": 5064},
+        },
+    )
+
+    # Act / Assert
+    assert switch_capable(section) is True
+
+
+@pytest.mark.unit
+def test_a_mock_carrying_other_blocks_is_still_not_switch_capable():
+    """The baseline-consistency guard survives the target count.
+
+    A ``mock`` deployment that happens to carry an ``epics`` and a
+    ``virtual_accelerator`` block enumerates two targets, but its baseline
+    resolves to a machine its own type never selected — treating it as
+    switchable would point a session at a real machine on the strength of a
+    stray block.
+    """
+    # Arrange
+    section = _section(
+        MOCK,
+        connector={
+            "mock": {},
+            "epics": {"gateways": {"read_only": {"address": "gw"}}},
+            "virtual_accelerator": {"port": 5064},
         },
     )
 

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -324,8 +324,9 @@ config:
   # sandbox simulator, "epics" your own control system, "mock" needs no
   # containers but cannot complete a plan.
   # `control_target_set live` moves a session onto the machine authored under
-  # `epics:`: it probes that target, then requires the strict limits pair
-  # below, then your own
+  # `epics:`. The template ships that block unconfigured — author its
+  # `gateways` and `probe_channel` first — then the switch probes that target,
+  # requires the strict limits pair below, then your own
   # `control_system.target_switch.live_gateway_acknowledged` — the operator
   # saying those gateways really are this facility's — and it still refuses
   # while this deployment records its own archive from the stand-in, because

--- a/tests/hooks/test_approval_hook.py
+++ b/tests/hooks/test_approval_hook.py
@@ -1520,3 +1520,45 @@ def test_a_defer_is_never_the_last_word(
         assert approval_deferred is True
     if guarantor == _BY_WRITES_CHECK:
         assert run("osprey_writes_check.py") == "deny"
+
+
+@pytest.mark.unit
+def test_a_store_narrowed_target_defers_and_writes_check_denies(
+    tmp_path, hook_runner, make_config, monkeypatch
+):
+    """An operator narrowing composes like a config disarm: defer, with the deny behind it.
+
+    The deployment arms this machine, so the config half of the posture answers
+    "armed" — the per-(session, target) store is the only thing refusing here,
+    and ``osprey_writes_check`` reads the same store
+    (``effective_writes_for``). Keeping the prompt would ask the human to
+    approve a write the next hook is guaranteed to refuse; the matrix above
+    pins the config half of this rule, this test pins the store half.
+    """
+    session_key = "4f1c2a7e-0000-4000-8000-000000000001"
+    config = _posture_config(make_config, ARMED_LIVE_ONLY_CONFIG)
+    _write_session_state(tmp_path, target="live")
+    monkeypatch.setenv("OSPREY_POSTURE_SESSION", session_key)
+
+    def run(hook):
+        return _decision(
+            hook_runner(
+                hook,
+                "mcp__controls__channel_write",
+                {"operations": [{"channel": "SR:QF:SP", "value": 1.5}]},
+                config_path=config,
+                cwd=tmp_path,
+                hook_config=POSTURE_HOOK_CONFIG,
+            )
+        )
+
+    # Control: with no narrowing in the store, the armed machine keeps its prompt.
+    assert run("osprey_approval.py") == "ask"
+
+    store = tmp_path / "var" / "agent_data" / "control_target" / "session-postures.json"
+    store.write_text(json.dumps({session_key: {"live": "sandbox"}}), encoding="utf-8")
+
+    assert run("osprey_approval.py") is None, (
+        "the narrowing is refused by writes_check, so the prompt must defer to that deny"
+    )
+    assert run("osprey_writes_check.py") == "deny"

--- a/tests/hooks/test_approval_target_identity.py
+++ b/tests/hooks/test_approval_target_identity.py
@@ -1080,6 +1080,30 @@ def test_both_targets_are_reachable_only_on_a_switch_capable_render(reader):
 
 
 @pytest.mark.unit
+def test_a_standin_beside_a_simulator_reaches_both_without_a_live_block(reader):
+    """Two configured targets are the switching world, whichever two they are.
+
+    Mirrors ``osprey_connectors.types.switch_capable``: a deployment rehearsing
+    on its stand-in beside the simulator has two machines a session can be
+    pointed at, and ``live`` — underivable here — is simply not among them.
+    """
+    section = {
+        "type": "live_standin",
+        "writes_enabled": False,
+        "connector": {
+            "virtual_accelerator": {"writes_enabled": True},
+            "live_standin": {"writes_enabled": True, "port": 5074},
+        },
+    }
+
+    assert reader.session_types(section) == {
+        "standin": "live_standin",
+        "va": "virtual_accelerator",
+    }
+    assert reader.most_restrictive_posture(section) is True
+
+
+@pytest.mark.unit
 def test_the_target_to_type_mapping_is_public(reader):
     """`osprey_writes_check` spells its refusal keys from this mapping.
 

--- a/tests/interfaces/web_terminal/control-target-popover.test.mjs
+++ b/tests/interfaces/web_terminal/control-target-popover.test.mjs
@@ -23,6 +23,9 @@
  * - Switch POSTs, shows `switching…` on that row, and renders the outcome the
  *   route publishes for the `request_id` — success, refusal, and the expiry a
  *   dead controls server never answers;
+ * - a refusal code renders as its operator phrase, never raw: the machine code
+ *   keys the presentation map, the route's `reason_detail` sentence rides on
+ *   the `title`, and a code the map does not know renders verbatim;
  * - a chat session's rows offer no Switch and live toggles;
  * - `Sandbox everything` POSTs `all` and renders every target the store
  *   `skipped`;
@@ -112,6 +115,7 @@ const rowOf = (kind, o = {}) => ({
   is_baseline: false,
   available_now: true,
   reason: null,
+  reason_detail: null,
   ceiling_writes: true,
   narrowing_refusal: null,
   reachability: {
@@ -364,7 +368,9 @@ describe('rows', () => {
     await bootOpen();
     const va = /** @type {HTMLElement} */ (rowEl('va'));
     expect(va.querySelector('.ctc-label')?.textContent).toBe('virtual accelerator (simulation)');
-    expect(va.querySelector('.ctc-kind')?.textContent).toBe('virtual accelerator');
+    // ONE identity line: the label already says what kind of machine it names,
+    // and the retired `.ctc-kind` subtitle must not come back to restate it.
+    expect(va.querySelector('.ctc-kind')).toBeNull();
     expect(va.querySelector('.ctc-endpoint')?.textContent).toBe('127.0.0.1:10064');
     expect(va.querySelector('.ctc-role')?.textContent).toBe('write_access');
 
@@ -561,6 +567,19 @@ describe('narrowing and arming', () => {
     expect(confirmBtn()?.textContent).toBe('Allow writes');
   });
 
+  test('the arming body says each fact once and never repeats the title', async () => {
+    // The title names the machine; the body carries what the title does not —
+    // the scope, the endpoint, the guards that stay up, when it takes hold.
+    await bootOpen();
+    segEl('live', 'writes')?.click();
+    await flush();
+
+    const body = inConfirm('.posture-modal-body').textContent ?? '';
+    expect(body).toContain('Arms writes for this session · als-gw.lbl.gov:5064.');
+    expect(body).toContain('Per-write approval and channel limits still apply.');
+    expect(body).not.toContain('LIVE MACHINE');
+  });
+
   test('the simulator arms without the hardware notice', async () => {
     await bootOpen(viewOf({ targets: [rowOf(KINDS.va, { ...STATES.sandbox })] }));
     segEl('va', 'writes')?.click();
@@ -651,7 +670,8 @@ describe('Sandbox everything', () => {
     await flush();
 
     expect(posts()[0].body).toEqual({ session_id: SESSION, target: 'all', posture: 'sandbox' });
-    expect(outcomes('va')).toContain('✗ selected_role_missing');
+    // The skip reason is the store's machine code, rendered as its phrase.
+    expect(outcomes('va')).toContain('✗ no endpoint for role');
   });
 
   test('it is disabled when there is nothing left to lift', async () => {
@@ -676,6 +696,14 @@ describe('switching', () => {
 
     expect(confirmTitle()).toBe('Switch to virtual accelerator (simulation)?');
     expect(confirmBtn()?.textContent).toBe('Switch');
+
+    // The title names the machine; the body carries the fact an operator is
+    // most likely to get wrong — the posture the session ARRIVES in (posture
+    // is per-target and does not travel) — and does not repeat the label.
+    const body = inConfirm('.posture-modal-body').textContent ?? '';
+    expect(body).toContain('Arrives in the writes posture · 127.0.0.1:10064.');
+    expect(body).toContain('The conversation continues.');
+    expect(body).not.toContain('virtual accelerator');
 
     postAnswers.push({ ok: true, body: { request_id: 'req-1', target: 'va' } });
     confirmBtn()?.click();
@@ -784,24 +812,72 @@ describe('switching', () => {
     expect(outcomes('va')).toHaveLength(0);
   });
 
-  test('no Switch where the route offers none; the refusal word takes its place', async () => {
+  test('no Switch where the route offers none; the refusal phrase takes its place', async () => {
     await bootOpen();
     // The active row says `current` and offers nothing.
     expect(switchEl('standin')).toBeNull();
     expect(rowEl('standin')?.querySelector('.ctc-reason')).toBeNull();
 
+    // A code the presentation map does not know renders verbatim — failing
+    // informative — and stands in for its own tooltip.
     await bootOpen(
       viewOf({ targets: [rowOf(KINDS.live, { available_now: false, reason: 'unreachable' })] })
     );
     expect(switchEl('live')).toBeNull();
-    expect(rowEl('live')?.querySelector('.ctc-reason')?.textContent).toBe('unreachable');
+    const reason = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-reason'));
+    expect(reason.textContent).toBe('unreachable');
+    expect(reason.title).toBe('unreachable');
+  });
+
+  test('an unconfigured target reads as a quiet phrase, with the sentence on the title', async () => {
+    // The three not-configured codes are one phrase: on a stock deployment the
+    // live target is deliberately unconfigured (authoring it is the go-live
+    // edit), and a raw `gateways_missing` would read as a fault.
+    for (const code of ['connector_block_missing', 'gateways_missing', 'probe_channel_missing']) {
+      await bootOpen(
+        viewOf({
+          targets: [
+            rowOf(KINDS.live, {
+              available_now: false,
+              reason: code,
+              reason_detail: 'The epics block configures no gateways.',
+            }),
+          ],
+        })
+      );
+      const reason = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-reason'));
+      expect(reason.textContent).toBe('not configured');
+      expect(reason.title).toBe('The epics block configures no gateways.');
+      popoverModule.teardownControlTargetPopover();
+      chipModule.teardownControlTargetChip();
+    }
+  });
+
+  test('every published refusal code has an operator phrase', async () => {
+    const phrases = {
+      target_unresolvable: 'unavailable',
+      limits_posture: 'needs strict limits',
+      operator_ack_missing: 'needs gateway ack',
+      archive_belongs_to_standin: 'archive conflict',
+      invented_history: 'no archive',
+      standin_not_deployed: 'stand-in not deployed',
+      selected_role_missing: 'no endpoint for role',
+    };
+    for (const [code, phrase] of Object.entries(phrases)) {
+      await bootOpen(
+        viewOf({ targets: [rowOf(KINDS.live, { available_now: false, reason: code })] })
+      );
+      expect(rowEl('live')?.querySelector('.ctc-reason')?.textContent).toBe(phrase);
+      popoverModule.teardownControlTargetPopover();
+      chipModule.teardownControlTargetChip();
+    }
   });
 
   test('a store that cannot be resolved explains the missing Switch', async () => {
     await bootOpen(
       viewOf({ store_available: false, targets: [rowOf(KINDS.live, { reason: null })] })
     );
-    expect(rowEl('live')?.querySelector('.ctc-reason')?.textContent).toBe('store_unavailable');
+    expect(rowEl('live')?.querySelector('.ctc-reason')?.textContent).toBe('store unavailable');
   });
 
   test('switching onto the facility machine says what a write would do there', async () => {
@@ -949,7 +1025,6 @@ describe('simple and expert are one DOM', () => {
     expect(simple).toBe(expert);
     // And every expert-only piece is present in BOTH: terminal.css hides them.
     expect(simple).toContain('ctc-meta');
-    expect(simple).toContain('ctc-kind');
     expect(simple).toContain('ctc-reach-text');
     expect(simple).toContain('ctc-baseline');
     expect(simple).toContain('ctc-foot-note');

--- a/tests/interfaces/web_terminal/test_posture_get_contract.py
+++ b/tests/interfaces/web_terminal/test_posture_get_contract.py
@@ -80,6 +80,7 @@ ROW_FIELDS = {
     "is_baseline",
     "available_now",
     "reason",
+    "reason_detail",
     "ceiling_writes",
     "posture",
     "effective",
@@ -639,6 +640,53 @@ class TestTheThreePostureColumns:
         assert row_for(payload, "va")["ceiling_writes"] is False
         assert row_for(payload, "va")["effective"] is False
 
+    def test_a_va_plus_standin_render_reports_the_standins_own_ceiling(self, make_client, tmp_path):
+        """Two configured targets are switch-capable with no live machine at all.
+
+        The stand-in row carries its own armed ceiling, which is what keeps the
+        popover's posture toggle on that row unlocked — a render rehearsing on
+        its stand-in beside the simulator must not lock the one toggle it
+        exists to offer.
+        """
+        config = tmp_path / "va_standin.yml"
+        config.write_text(
+            yaml.safe_dump(
+                {
+                    "control_system": {
+                        "type": "virtual_accelerator",
+                        "writes_enabled": False,
+                        "connector": {
+                            "virtual_accelerator": {
+                                "simulation_file": "data/sim.json",
+                                "probe_channel": "SIM:PROBE",
+                                "writes_enabled": True,
+                                "gateways": {"read_only": {"address": "gw", "port": 5064}},
+                            },
+                            "live_standin": {
+                                "probe_channel": "SR:PROBE",
+                                "writes_enabled": True,
+                                "gateways": {
+                                    "read_only": {"address": "localhost", "port": STANDIN_PORT},
+                                    "write_access": {"address": "localhost", "port": STANDIN_PORT},
+                                },
+                            },
+                        },
+                    },
+                    "services": {"live_standin": {"port": STANDIN_PORT}},
+                    "deployed_services": ["virtual_accelerator", "live_standin"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with make_client(config) as client:
+            payload = get_posture(client)
+
+        assert {row["target"] for row in payload["targets"]} == {"va", "standin"}
+        standin = row_for(payload, "standin")
+        assert standin["ceiling_writes"] is True
+        assert standin["effective"] is True
+        assert standin["narrowing_refusal"] is None
+
 
 class TestNarrowingRefusal:
     """What narrowing a row would cost — the one lock reason the rest of the
@@ -742,6 +790,35 @@ class TestAvailability:
         standin = row_for(payload, "standin")
         assert standin["available_now"] is False
         assert standin["reason"] in vocabulary
+
+    def test_a_refusal_carries_the_verdicts_own_sentence(self, client):
+        """``reason_detail`` is the eligibility detail, not a second opinion.
+
+        The popover renders a short phrase keyed on the code and puts this
+        sentence on the tooltip; pinning it to the shared verdict keeps the
+        tooltip, the 409 and the switch tool's answer one wording.
+        """
+        from osprey.mcp_server.control_system.target_eligibility import target_availability
+
+        with live_session(client, target="va"):
+            payload = get_posture(client)
+
+        standin = row_for(payload, "standin")
+        expected = target_availability(
+            yaml.safe_load(Path(client.app.state.config_path).read_text(encoding="utf-8")),
+            "standin",
+            "va",
+            "standin",
+            writes_enabled=False,
+        )
+        assert standin["reason_detail"] == expected.detail
+        assert standin["reason_detail"]
+
+    def test_an_offered_target_carries_no_detail(self, client):
+        with live_session(client, target="va"):
+            payload = get_posture(client)
+
+        assert row_for(payload, "live")["reason_detail"] is None
 
     def test_an_unreadable_render_offers_nothing(self, make_client):
         with make_client(None) as client:

--- a/tests/interfaces/web_terminal/test_posture_routes.py
+++ b/tests/interfaces/web_terminal/test_posture_routes.py
@@ -201,8 +201,9 @@ def ledger():
 def known_sessions(*session_ids):
     """Make ``SessionDiscovery`` report *session_ids* as started on disk.
 
-    A posture can only be set on a session that exists — a PTY session's file
-    appears once the operator has sent a prompt.
+    The posture route no longer consults the discovery walk, but the GET
+    surface and the terminate/respawn paths still do; pinning it keeps every
+    test's disk state explicit either way.
     """
     with patch(
         "osprey.interfaces.web_terminal.session_discovery.SessionDiscovery.snapshot_session_ids",
@@ -407,19 +408,28 @@ class TestGrammar:
         assert resp.json()["detail"]["error"] == "unknown_target"
 
 
-class TestSessionNotStarted:
-    def test_an_id_no_session_backs_is_409(self, client):
-        with known_sessions(SESSION_B):
-            resp = post_posture(client)
-        assert resp.status_code == 409
-        assert resp.json()["detail"]["error"] == "session_not_started"
-        assert "send one prompt first" in json.dumps(resp.json()["detail"])
+class TestUnspokenSessions:
+    """The posture never depends on whether the operator has talked to the agent.
 
-    def test_a_refused_session_stores_nothing(self, client, agent_data_root):
+    Both spawn paths read the store at spawn, so a narrowing recorded before
+    the first prompt binds that session's very first write — and the store
+    only narrows, so an entry under a key nothing spawns is inert. The gate
+    that refused these gestures with "send one prompt first" guarded nothing
+    and is gone.
+    """
+
+    def test_a_key_with_no_session_behind_it_still_narrows(self, client, agent_data_root):
+        with known_sessions():  # nothing on disk, nothing pooled
+            resp = post_posture(client)
+        assert resp.status_code == 200
+        assert read_store(agent_data_root) == {SESSION_A: {"standin": "sandbox"}}
+
+    def test_a_fresh_chat_key_narrows_before_its_first_prompt(self, client, agent_data_root):
+        """The page mints its chat id at load; the toggle must work from then on."""
         with known_sessions():
-            assert post_posture(client).status_code == 409
-        assert SESSION_A not in getattr(client.app.state, "session_postures", {})
-        assert read_store(agent_data_root) is None
+            resp = post_posture(client, session_id=CHAT_A, target="va")
+        assert resp.status_code == 200
+        assert read_store(agent_data_root) == {CHAT_A: {"va": "sandbox"}}
 
 
 class TestStoreUnavailable:
@@ -959,6 +969,20 @@ class TestTopologies:
                 resp = post_posture(client, session_id=CHAT_A, target="standin")
         assert resp.status_code == 200
         assert read_store(agent_data_root) == {CHAT_A: {"standin": "sandbox"}}
+
+    def test_a_prompt_less_pty_session_narrows(self, client, agent_data_root):
+        """A just-opened terminal, zero prompts sent: the toggle works.
+
+        The regression that motivated dropping the started-session gate — an
+        operator opened a terminal and was told to talk to the agent before
+        they could take writes away from it.
+        """
+        registry = client.app.state.pty_registry
+        registry.get_or_create_session(SESSION_A, "echo")
+        with known_sessions():  # nothing on disk: no prompt has been sent
+            resp = post_posture(client, target="standin")
+        assert resp.status_code == 200
+        assert read_store(agent_data_root) == {SESSION_A: {"standin": "sandbox"}}
 
     def test_a_key_the_store_already_holds_stays_addressable(self, client, agent_data_root):
         """Otherwise a chat sandboxed once could never be brought back out."""

--- a/tests/interfaces/web_terminal/test_posture_routes.py
+++ b/tests/interfaces/web_terminal/test_posture_routes.py
@@ -563,6 +563,34 @@ class TestCeiling:
             "control_system.connector.epics.writes_enabled" in unarmed.json()["detail"]["message"]
         )
 
+    def test_a_va_plus_standin_render_arms_its_standin(self, client, tmp_path):
+        """Two configured targets are switch-capable with no live machine at all.
+
+        ``session_posture`` answers per target on any switch-capable render, so
+        a deployment rehearsing on its stand-in beside the simulator gets the
+        stand-in's own ceiling — not a 403 for want of an ``epics`` block it
+        never claimed to have.
+        """
+        section = {
+            "type": "virtual_accelerator",
+            "writes_enabled": False,
+            "connector": {
+                "virtual_accelerator": {
+                    "simulation_file": "data/sim.json",
+                    "gateways": _gateways(5064),
+                    "writes_enabled": True,
+                },
+                "live_standin": {
+                    "gateways": _gateways(STANDIN_PORT),
+                    "writes_enabled": True,
+                },
+            },
+        }
+        client.app.state.config_path = write_config(tmp_path, section)
+        with known_sessions(SESSION_A):
+            resp = post_posture(client, target="standin", posture="writes")
+        assert resp.status_code == 200
+
     def test_narrowing_needs_no_ceiling(self, client, tmp_path):
         """A target nothing arms can still be narrowed; narrowing grants nothing."""
         client.app.state.config_path = write_config(tmp_path, control_system_section())

--- a/tests/interfaces/web_terminal/test_posture_toggle_browser.py
+++ b/tests/interfaces/web_terminal/test_posture_toggle_browser.py
@@ -680,27 +680,27 @@ def test_switch_confirms_is_accepted_and_reads_switching(tmp_path, monkeypatch, 
 
 
 # ---------------------------------------------------------------------------
-# (e) a refusal keeps its sentence on screen
+# (e) an unstarted session is already addressable
 # ---------------------------------------------------------------------------
 
 
-def test_an_unstarted_session_surfaces_the_409_remedy_on_the_row(
+def test_an_unstarted_session_accepts_a_narrowing_the_moment_it_opens(
     tmp_path, monkeypatch, chromium_browser
 ):
-    """A session with no file on disk is refused, and the row says why.
+    """A session with no file on disk narrows all the same.
 
     ``known_ids`` stays empty, so the id the chip is on names no session file —
-    the state a terminal is in before its first prompt. The route answers 409
-    with a dict detail, and the chip's request path unwraps ``detail.message``
-    (rather than stringifying the dict to "[object Object]") onto the row the
-    gesture was made on. The remedy sentence is the whole point of the refusal,
-    so it stays on the row the operator is looking at and nothing is written.
+    the state a terminal is in before its first prompt. The store only ever
+    narrows and both spawn paths read it before the first write, so there is
+    nothing an unstarted session could evade: the gesture lands in the store
+    under this session's key, and the row settles into the narrowed state
+    instead of surfacing a remedy sentence.
     """
     known_ids: set[str] = set()
 
     with _chip_hub(tmp_path, monkeypatch, known_ids=known_ids) as (base_url, app):
         # Deliberately NOT _settled_chip: that helper makes the session
-        # addressable, which is the exact fact this case removes.
+        # addressable, and working WITHOUT that fact is the case.
         page = chromium_browser.new_page()
         page.goto(base_url, wait_until="domcontentloaded")
         try:
@@ -715,13 +715,11 @@ def test_an_unstarted_session_surfaces_the_409_remedy_on_the_row(
             _open_popover(page)
             _segment(page, POSTURE_TARGET, "read-only").click()
 
-            outcome = _row(page, POSTURE_TARGET).locator(".ctc-outcome")
-            expect(outcome).to_be_visible(timeout=TIMEOUT)
-            expect(outcome).to_contain_text("send one prompt first", timeout=TIMEOUT)
-
-            # Nothing was applied and nothing was stored.
-            expect(_row(page, POSTURE_TARGET)).to_have_attribute("data-state", "writes")
-            assert _stored_postures() == {}
+            expect(_segment(page, POSTURE_TARGET, "read-only")).to_have_attribute(
+                "aria-pressed", "true", timeout=TIMEOUT
+            )
+            stored = _stored_postures()
+            assert stored == {session_id: {POSTURE_TARGET: "sandbox"}}, stored
         finally:
             page.close()
 

--- a/tests/interfaces/web_terminal/test_posture_toggle_browser.py
+++ b/tests/interfaces/web_terminal/test_posture_toggle_browser.py
@@ -31,7 +31,7 @@ Coverage (one test each):
       and inside the dialog for one raised from a confirm — which stays up to
       carry it.
   (f) both UI modes render the SAME row DOM and differ only in what is shown:
-      simple keeps the dot, the name, the plain-language kind word, the
+      simple keeps the dot, the name (the one identity line), the
       reachability LED, the toggle and Switch; expert keeps the endpoint/role
       line, the reachability word, the head note and the config sentence.
 
@@ -148,7 +148,7 @@ POSTURE_TARGET = "standin"
 SWITCH_TARGET = "live"
 
 #: What the render names each target. The controls server mints these once and
-#: every reader renders that one string; the popover's confirms quote them.
+#: every reader renders that one string; the popover's confirm titles quote them.
 LABELS = {
     "live": "LIVE MACHINE",
     "va": "virtual accelerator (simulation)",
@@ -657,7 +657,7 @@ def test_switch_confirms_is_accepted_and_reads_switching(tmp_path, monkeypatch, 
             # The posture that travels is the one held on the target being
             # switched TO, because posture is per target and does not follow.
             expect(page.locator(f"{OPEN_MODAL} .posture-modal-body")).to_contain_text(
-                "Session posture there: writes"
+                "Arrives in the writes posture"
             )
             page.locator(MODAL_CONFIRM).click()
 
@@ -792,11 +792,11 @@ def test_both_ui_modes_render_the_same_row_and_differ_only_in_density(
     — every gated node is *attached* either way — and that the difference is
     which of them the stylesheet shows:
 
-    * simple keeps the dot, the name, the plain-language kind word, the
-      reachability LED, the posture toggle and Switch;
+    * simple keeps the dot, the name (the row's one identity line — the label
+      already says what kind of machine it names), the reachability LED, the
+      posture toggle and Switch;
     * expert keeps the endpoint/role line, the reachability word, the head note
-      and the sentence that bounds the popover, and drops the kind word (the
-      endpoint says it more precisely).
+      and the sentence that bounds the popover.
 
     The mode is driven the way the deployment drives it — ``web.ui_mode``
     reaching the page as the server-rendered ``<html data-ui-mode>`` attribute
@@ -817,8 +817,11 @@ def test_both_ui_modes_render_the_same_row_and_differ_only_in_density(
             row = _row(page, SWITCH_TARGET)
 
             # --- the same DOM in both modes ---
-            for selector in (*_EXPERT_ONLY, ".ctc-kind"):
+            for selector in _EXPERT_ONLY:
                 assert row.locator(selector).count() == 1, f"{selector} missing in {ui_mode}"
+            # The retired kind subtitle stays retired: the label is the row's
+            # one identity line, in either density.
+            assert row.locator(".ctc-kind").count() == 0
             expect(page.locator(HEAD_NOTE)).to_have_count(1)
             expect(page.locator(FOOT_NOTE)).to_have_count(1)
 
@@ -837,15 +840,6 @@ def test_both_ui_modes_render_the_same_row_and_differ_only_in_density(
                     expect(node).to_be_hidden()
                 else:
                     expect(node).to_be_visible()
-            kind = row.locator(".ctc-kind")
-            if simple:
-                # The plain-language word is what replaces the endpoint line for
-                # an operator who does not think in endpoints.
-                expect(kind).to_be_visible()
-                expect(kind).to_have_text("live machine")
-            else:
-                expect(kind).to_be_hidden()
-
             # The head note carries no text in the plain case, so "dropped" is
             # a question about the computed style rather than a bounding box.
             head_note_display = _display(page, HEAD_NOTE)

--- a/tests/interfaces/web_terminal/test_terminate_respawn.py
+++ b/tests/interfaces/web_terminal/test_terminate_respawn.py
@@ -1,10 +1,13 @@
-"""The chat pool's terminate, and the probe that says a chat key is live.
+"""The chat pool's terminate, and the registry facades the chat surfaces use.
 
 Terminating a chat child used to be half of applying a posture: the posture
 travelled in the child's environment, so a flip had to kill the child and let
 it come back. It does not any more — the per-target posture is recorded in the
 store and read at write time, so a narrowing lands on a chat already
-mid-conversation and ``POST /api/terminal/posture`` terminates nothing.
+mid-conversation and ``POST /api/terminal/posture`` terminates nothing. (The
+posture route asks no addressability question at all any more: any well-formed
+key is accepted, because the store only narrows and both spawn paths read it
+before the first write.)
 
 What survives is everything that was never about the posture:
 
@@ -13,10 +16,9 @@ What survives is everything that was never about the posture:
   the 409 the chat route maps that supersede to;
 * **the env fingerprint**, the SDK counterpart of the PTY registry's: a reuse
   must not hand back a child built with a different environment;
-* **the addressability probe** the posture route still asks, which has to see a
-  chat that has been accepted but not yet registered — refusing an operator's
-  toggle on a session starting in front of them would be a 409 that stores
-  nothing.
+* **the registry facades** (``has_chat_key`` and friends) the GET roster and
+  the reset route still call, pinned by name because their renames fail
+  quietly.
 
 Harness mirrors ``test_posture_routes.py``: each test builds its own app
 through ``create_app`` under a patched ``_load_web_config``, entered as a
@@ -109,15 +111,15 @@ def known_sessions(*session_ids):
 
 
 class TestAChatKeyIsAddressable:
-    """The posture surface can name a chat, including one still starting."""
+    """The registry facades the chat surfaces rely on stay pinned by name."""
 
     def test_the_shipped_registry_exposes_the_facades_the_callers_use(self):
         """A rename of any of these is silent in its own way.
 
         * ``has_chat_key`` — :func:`_chat_pool_answers_to` would fall back to
           the session-map read, which cannot see a creation still inside
-          ``start()``, and an operator toggling a chat on its first prompt
-          would be refused with a 409 that stores nothing;
+          ``start()``, and the GET roster would stop marking a starting chat's
+          rows as ``chat_session``;
         * ``get_chat_session`` — that fallback itself would answer ``False``
           for every key; and
         * ``terminate_chat_session`` — the chat reset route would stop tearing
@@ -127,42 +129,6 @@ class TestAChatKeyIsAddressable:
         """
         for name in ("terminate_chat_session", "get_chat_session", "has_chat_key"):
             assert callable(getattr(OperatorRegistry, name, None)), name
-
-    def test_the_addressability_probe_sees_a_creation_still_starting(self, client):
-        """The pool answers to a key it has accepted but not yet registered.
-
-        The gate's own unit: ``get_chat_session`` still says "nothing here"
-        during ``start()`` — that is what it is for — while ``has_chat_key``
-        says the pool will answer to this key. Only the second is a safe basis
-        for refusing an operator's toggle.
-        """
-        created: list[_FakeChatSession] = []
-        registry = OperatorRegistry()
-        client.app.state.operator_registry = registry
-
-        async def _probe_mid_creation():
-            with patch(
-                "osprey.interfaces.web_terminal.operator_session.OperatorSession",
-                _slow_session_class(created),
-            ):
-                creation = asyncio.create_task(
-                    registry.get_or_create_chat_session(CHAT_A, "/tmp", None)
-                )
-                await created_first(created)
-                seen = (
-                    registry.get_chat_session(CHAT_A),
-                    registry.has_chat_key(CHAT_A),
-                    websocket_routes._posture_key_is_addressable(client.app, CHAT_A),
-                )
-                await creation
-                return seen
-
-        with known_sessions():
-            pooled, has_key, addressable = asyncio.run(_probe_mid_creation())
-
-        assert pooled is None
-        assert has_key is True
-        assert addressable is True
 
 
 class _FakeChatSession:
@@ -377,24 +343,6 @@ class TestChatRouteMapsTheRefusal:
 
         assert excinfo.value.status_code == 409
         assert excinfo.value.detail["error"] == "chat_terminated"
-
-
-def _slow_session_class(created: list, delay: float = 0.05):
-    """A chat-session class whose ``start()`` is still running on the next tick.
-
-    The registry's factory builds ``OperatorSession(cwd=..., env=...)`` by
-    resolving the name in ``operator_session`` at call time, so patching that
-    name with this class is enough to put a REAL ``ChatSessionPool`` and a real
-    ``OperatorRegistry`` under the route with a session that cannot start.
-    """
-
-    class _Slow(_FakeChatSession):
-        def __init__(self, cwd="/tmp", env=None):
-            super().__init__(cwd=cwd, env=env)
-            self.start_delay = delay
-            created.append(self)
-
-    return _Slow
 
 
 class TestChatPoolEnvFingerprint:

--- a/tests/mcp_server/test_activity_target_events.py
+++ b/tests/mcp_server/test_activity_target_events.py
@@ -479,9 +479,12 @@ GATE_CASES = [
         False,
     ),
     (
-        "empty live block",
+        # The baseline is a configured target whether or not its block carries
+        # keys — a session sits on it either way — so an epics deployment with
+        # an empty epics block still has two machines once the VA is beside it.
+        "empty live block beside a va",
         {"type": "epics", "connector": {"epics": {}, "virtual_accelerator": _VA_BLOCK}},
-        False,
+        True,
     ),
     ("no connector section", {"type": "epics"}, False),
     (

--- a/tests/mcp_server/test_channel_write_tool.py
+++ b/tests/mcp_server/test_channel_write_tool.py
@@ -1112,11 +1112,14 @@ async def test_emitted_key_is_the_constant_the_rules_name(tmp_path, monkeypatch)
 
 #: A deployment that relaxed unlisted channels for its simulator alone: the
 #: deployment-wide block refuses them, and only the ``virtual_accelerator``
-#: block allows them. ``live`` resolves to ``epics``, which wrote no block, so
-#: the two targets genuinely read two different postures out of one config.
+#: block allows them, so two postures genuinely coexist in one config. The
+#: baseline type is per-test: the serving target must be the baseline here,
+#: because a deployment serving anything else is switch-capable by
+#: construction and runs the connector-host path, where the host republishes
+#: its own target record over the one this fixture writes.
 _SPLIT_POSTURE_CONFIG = """\
 control_system:
-  type: epics
+  type: {cs_type}
   limits_checking:
     enabled: true
     allow_unlisted_channels: false
@@ -1154,7 +1157,13 @@ def _prepare_split_posture(tmp_path, monkeypatch, target):
         json.dumps({"LISTED:PV": {"min_value": 0.0, "max_value": 100.0, "writable": True}})
     )
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "config.yml").write_text(_SPLIT_POSTURE_CONFIG.format(db_path=db_path))
+    cs_type = "virtual_accelerator" if target == "va" else "epics"
+    config_text = _SPLIT_POSTURE_CONFIG.format(cs_type=cs_type, db_path=db_path)
+    if cs_type == "virtual_accelerator":
+        # A simulated machine may not pair with the synthesizing mock archiver
+        # (the invented-history startup guard); name the store the preset deploys.
+        config_text += "archiver:\n  type: mongodb_archiver\n"
+    (tmp_path / "config.yml").write_text(config_text)
     root = tmp_path / "var" / "agent_data"
     monkeypatch.setattr(target_state, "resolve_shared_data_root", lambda: root)
     target_state.write_on_start(target, _SPLIT_POSTURE_TARGETS_META, generation=0)

--- a/tests/templates/test_preset_va_block.py
+++ b/tests/templates/test_preset_va_block.py
@@ -8,8 +8,8 @@ block uses the probe-proven CA name-server gateway shape (task 1.1's
 empirical finding, mirrored in the "simulation" facility-gateway preset —
 see tests/templates/test_gateway_presets.py) plus a `simulation_file` key at
 the exact path (`connector.virtual_accelerator.simulation_file`) that the
-type-aware simulation lookup (task 4.2) resolves, and the `epics` block's
-values are unchanged from its pre-change (ALS production) rendering.
+type-aware simulation lookup (task 4.2) resolves, and the `epics` block ships
+no gateway values — authoring them is the go-live edit.
 """
 
 import yaml
@@ -27,23 +27,11 @@ PROBE_PROVEN_GATEWAY_SHAPE = {
     "use_name_server": True,
 }
 
-# The `epics` block's values as committed prior to this task's edit — the
-# untouched ALS production configuration.
-ORIGINAL_EPICS_BLOCK = {
-    "timeout": 5.0,
-    "gateways": {
-        "read_only": {
-            "address": "cagw-alsdmz.als.lbl.gov",
-            "port": 5064,
-            "use_name_server": False,
-        },
-        "write_access": {
-            "address": "cagw-alsdmz.als.lbl.gov",
-            "port": 5084,
-            "use_name_server": False,
-        },
-    },
-}
+# The `epics` block a stock render ships: the timeout and nothing else. The
+# gateways, `probe_channel` and the operator acknowledgment are all commented
+# out — a facility's machine cannot be guessed, so authoring them is the
+# go-live edit and a fresh deployment's live target reads "not configured".
+SHIPPED_EPICS_BLOCK = {"timeout": 5.0}
 
 
 def _render_connector_config():
@@ -95,6 +83,6 @@ def test_virtual_accelerator_simulation_file_matches_mock_connector():
     )
 
 
-def test_epics_block_is_unchanged():
+def test_epics_block_ships_no_gateway_values():
     epics = _render_connector_config()["connector"]["epics"]
-    assert epics == ORIGINAL_EPICS_BLOCK
+    assert epics == SHIPPED_EPICS_BLOCK

--- a/tests/utils/test_config_writer_anchored_put_comment.py
+++ b/tests/utils/test_config_writer_anchored_put_comment.py
@@ -50,7 +50,7 @@ control_system:
                             # old target before it is torn down regardless
     probe_interval_s: 30    # Seconds between background reachability probes of
                             # every target's gateways
-    # live_gateway_acknowledged: cagw-alsdmz.als.lbl.gov
+    # live_gateway_acknowledged: your-ca-gateway.example.com
 
 # Archiver Configuration
 archiver:
@@ -120,7 +120,7 @@ class TestCommentPlacement:
             "    # Written by osprey build for the stand-in.\n"
             "    # Replace by hand when going live.\n"
             "    live_gateway_acknowledged: localhost:5074\n"
-            "    # live_gateway_acknowledged: cagw-alsdmz.als.lbl.gov\n"
+            "    # live_gateway_acknowledged: your-ca-gateway.example.com\n"
             "\n"
             "# Archiver Configuration\n"
             "archiver:\n"
@@ -169,7 +169,7 @@ class TestNeighbouringComments:
         text = _round_trip(TARGET_SWITCH, _inject)
 
         assert text.count("# The `live_gateway_acknowledged` key below is the operator") == 1
-        assert text.count("# live_gateway_acknowledged: cagw-alsdmz.als.lbl.gov") == 1
+        assert text.count("# live_gateway_acknowledged: your-ca-gateway.example.com") == 1
         assert text.count("live_gateway_acknowledged: localhost:5074") == 1
         assert text.count("# Written by osprey build for the stand-in.") == 1
         # The header prose keeps introducing the block it documents.


### PR DESCRIPTION
The control-target popover grew up piecemeal, and it showed: rows mixed a
machine's label with raw status codes the operator had to decode, the switch
and allow-writes dialogs said the same fact in several wordings, and every
surface — popover row, executor refusal, docs — described a narrowed target
its own way.

Four deeper problems sat behind the UI:

- The write-posture route refused any session that had not sent a prompt yet
  ("send one prompt first", 409). That gate guarded nothing — the posture
  store only narrows, and both spawn paths read it before the first write —
  so its sole effect was to strand the header chip on fresh sessions.
- The approval hook did not read the per-(session, target) posture store the
  write gate reads, so a target the operator had sandboxed still raised an
  approval dialog for a write that would be refused anyway.
- `switch_capable` demanded the `live`/`va` pair specifically. A stand-in
  beside the simulator — no live machine authored yet — is exactly the
  two-machine world the switch exists for, and got neither the switch nor
  the per-target posture toggles.
- The Control Assistant template shipped ALS production gateway addresses,
  so every fresh deployment claimed a live machine it did not have.

The redesign gives each row one identity line with aligned posture/switch
columns and a short phrase (full sentence on the tooltip) for a target that
cannot be switched to; the dialogs state the arriving posture, the endpoint
and the standing guards once each. The posture route serves GET/PUT from the
moment a session opens; the approval hook defers to the posture store;
switch-capable is any two configured targets (single-target renders and a
mock deployment carrying stray connector blocks stay non-switchable); and
the template ships its gateways as commented placeholders, so a stock
build's live target truthfully reads `not configured` until go-live.

## How it hangs together

```text
operator ── header chip · popover rows · confirm dialogs
   │
   ▼
┌──────────────────────────────┐    what a row shows:
│  control-target popover (JS) │◄── switch_capable(): any two
└──────────────┬───────────────┘    configured targets
               │ posture GET/PUT    (connectors/types.py)
               ▼                    + template ships gateways
┌──────────────────────────────┐    commented, so a stock live
│  posture routes (web term.)  │    target reads "not configured"
│  served from session open —  │
│  the 409 "speak first" gate  │
│  is gone                     │
└──────────────┬───────────────┘
               ▼
┌──────────────────────────────┐
│ per-(session, target) store  │  the single source of narrowing
└───────┬──────────────┬───────┘
        ▼              ▼
┌───────────────┐ ┌───────────────┐
│ approval hook │ │ executor      │
│ defers to the │ │ write gates   │
│ store         │ │               │
└───────┬───────┘ └───────┬───────┘
        └───────┬─────────┘
                ▼
   one refusal wording on every surface:
   it names the narrowed target and the
   header chip that lifts the narrowing
```
