### PR TITLE
fix(auth): forward the roster account beside the login subject

### DIFF
--- a/changelog.d/793.fixed.md
+++ b/changelog.d/793.fixed.md
@@ -1,0 +1,13 @@
+Web-terminal audit records under `auth.method: oidc` no longer mark requests
+as an account mismatch. Audited requests wrote a false `expected_account=` key
+and logged a warning, because the container compared its own user against the
+identity provider's subject, which is typically an opaque id or an email rather
+than a roster name. The login service now also sends
+`X-Osprey-Auth-Account`, naming the roster card the request is on, and the
+audit trail compares that instead; `X-Osprey-Auth-Subject` is unchanged and
+still names who proved the login. In the ledger, `account=` holds the roster
+account, `expected_account=` appears only on a real mismatch, and the
+provider's subject moves to `oidc_subject=`, written only where it differs
+from the account — so password deployments see no new key. The fix arrives
+with this release's login-service image: a deployment pinning an older one
+with `auth.image` keeps the previous behaviour until it is rebuilt.

--- a/docs/source/reference/contracts/audit-trail.rst
+++ b/docs/source/reference/contracts/audit-trail.rst
@@ -122,7 +122,8 @@ and a refused control-system write alike. One JSON object per line:
    * - ``detail``
      - Surface-specific context: for a protected-set refusal, the file the
        write was aimed at (``target=``) and the channel that owns it, named
-       the same way the refusal message names it
+       the same way the refusal message names it; on the web surfaces, the
+       login the request came from --- see :ref:`audit-trail-identity-keys`
 
 A ``PUT`` that would have changed many protected keys at once names the first
 ten and counts the rest in the message, but **every changed key gets its own
@@ -137,6 +138,51 @@ again.
    unreachable activity feed degrades the trail and never turns a refusal into
    a server error --- an error that reads like the gate malfunctioned is the one
    shape an operator could mistake for a gate that failed open.
+
+.. _audit-trail-identity-keys:
+
+The login behind the record
+---------------------------
+
+Where a deployment has a login wall, the two web surfaces ---
+``http_mutation.jsonl`` and ``web_auth.jsonl`` --- record who the request came
+from in ``detail``, as up to three keys. Which of them are present is itself
+part of the message:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Key
+     - What it holds
+   * - ``account=``
+     - The roster account the request is on --- the card named in the URL, and
+       the name the login service checked the session against. Present on
+       every record where the request carried a login at all
+   * - ``expected_account=``
+     - The account this container serves, written **only when the forwarded
+       account is not it**. Its presence is the whole signal: one person's
+       authorization arrived at another person's container. A request on the
+       right card never writes the key. The same case logs a warning, and it
+       is recorded rather than refused
+   * - ``oidc_subject=``
+     - Who proved the login, as the provider asserted it --- an opaque id or an
+       email. Written only where that differs from the account, so a password
+       deployment never sees this key, and a shared card records the person
+       beside the card they opened
+
+Two forwarded headers carry that from the login service through nginx:
+``X-Osprey-Auth-Account`` names the card, ``X-Osprey-Auth-Subject`` names the
+login that proved it. Under ``auth.method: password`` they hold the same value,
+because the roster username *is* the proof; under ``oidc`` they part, and only
+the account is a name a container can compare itself against.
+
+A deployment that pins an older login-service image with ``auth.image`` gets no
+account header. The container then falls back to comparing the subject, as it
+did before this release. Where the mapped subject is not the roster name --- an
+opaque ``sub`` or an email, the usual case --- it never matches, so
+``expected_account=`` and a warning ride every audited request. Building against
+this release's image is what clears it.
 
 Who can read it
 ===============

--- a/src/osprey/interfaces/common_middleware.py
+++ b/src/osprey/interfaces/common_middleware.py
@@ -34,7 +34,7 @@ import json
 import logging
 import os
 from collections.abc import Callable, Iterable, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import parse_qs, parse_qsl, urlencode
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -52,8 +52,10 @@ logger = logging.getLogger("osprey.interfaces.middleware")
 
 __all__ = [
     "AUDITED_REFUSAL_STATUSES",
+    "AUDIT_ACCOUNT_HEADER",
     "AUDIT_ACCOUNT_KEY",
     "AUDIT_EXPECTED_ACCOUNT_KEY",
+    "AUDIT_OIDC_SUBJECT_KEY",
     "AUDIT_ROLE_HEADER",
     "AUDIT_ROLE_SOURCE_HEADER",
     "AUDIT_SUBJECT_HEADER",
@@ -80,6 +82,7 @@ __all__ = [
     "WEB_AUTH_SURFACE",
     "WEB_PORT_ENV",
     "ExceptionLoggingMiddleware",
+    "ForwardedIdentity",
     "HttpAuditMiddleware",
     "NoCacheStaticMiddleware",
     "WebAuthMiddleware",
@@ -321,16 +324,27 @@ REASON_ROUTE_REFUSED: str = "route_refused"
 #: should not require also parsing ``detail`` for ``status=none``.
 REASON_MUTATION_UNANSWERED: str = "mutation_unanswered"
 
-#: Names the account behind an authorized request, as nginx forwards it from
-#: the auth sidecar's ``auth_request`` answer.
+#: Names *who proved* the login behind an authorized request, as nginx forwards
+#: it from the auth sidecar's ``auth_request`` answer. In a password session
+#: that is the roster username; in an OIDC session it is the provider's
+#: subject, which names a person and not a roster card — see
+#: :data:`AUDIT_ACCOUNT_HEADER` for the card itself.
 #:
 #: Spelled here rather than imported from
 #: :mod:`osprey.services.auth_sidecar.identity_headers`, which owns it: an
 #: interface app has no business pulling a service package into its import
-#: closure for three string constants. ``tests/interfaces/test_http_audit_emitters.py``
-#: pins the three spellings against each other, the same trade the rest of the
+#: closure for four string constants. ``tests/interfaces/test_http_audit_emitters.py``
+#: pins the four spellings against each other, the same trade the rest of the
 #: audit work makes for a cross-package constant.
 AUDIT_SUBJECT_HEADER: str = "X-Osprey-Auth-Subject"
+
+#: Names the roster account an authorized request is on — the card ``/verify``
+#: checked the session against, and the one this container can compare with the
+#: user it believes it is serving. Coincides with :data:`AUDIT_SUBJECT_HEADER`
+#: in a password session, where the roster username *is* the proof, and
+#: diverges in an OIDC session, where a shared card may be opened by any of
+#: several people. Absent from an older sidecar image that does not emit it.
+AUDIT_ACCOUNT_HEADER: str = "X-Osprey-Auth-Account"
 
 #: Names the role that account holds. Absent means *no* role, never a default
 #: one — the deny-safe reading the sidecar documents.
@@ -357,6 +371,18 @@ AUDIT_ACCOUNT_KEY: str = "account"
 #: The ``detail`` key naming this container's own user, present **only** when
 #: the forwarded account is not it. Its presence *is* the mismatch signal.
 AUDIT_EXPECTED_ACCOUNT_KEY: str = "expected_account"
+
+#: The ``detail`` key naming *who proved* the login, when that is not the
+#: account itself — the OIDC subject on a shared card.
+#:
+#: Spelled ``oidc_subject`` and deliberately **not** ``identity``. The audit
+#: writer owns ``identity`` for the ledger's directory component, so a key of
+#: that name inside ``detail`` would put one word on two different things in
+#: the same record — the folder a record is filed under, and a person named
+#: inside it. ``subject`` was unavailable for the reason
+#: :data:`AUDIT_ACCOUNT_KEY` records: the envelope's top-level ``subject`` on
+#: these surfaces is the route.
+AUDIT_OIDC_SUBJECT_KEY: str = "oidc_subject"
 
 #: The longest forwarded identity value that may be recorded verbatim.
 #:
@@ -562,7 +588,7 @@ def _recordable(value: str) -> bool:
 
     Printable ASCII, no space anywhere, and at most
     :data:`MAX_FORWARDED_VALUE_CHARS` characters. The first two are the
-    sidecar's own contract for all three identity headers (see
+    sidecar's own contract for all four identity headers (see
     :mod:`osprey.services.auth_sidecar.identity_headers`, which refuses to mint
     or emit anything outside printable ASCII, or anything space-padded); two
     rules are added for this ledger. A value carrying an *interior* space
@@ -571,9 +597,9 @@ def _recordable(value: str) -> bool:
     the keys appended after it past the envelope's silent truncation — so the
     one input a forger fully controls would be the one that erases the mismatch
     marker from the record. Nothing real is lost by either: an OIDC ``sub`` is
-    a short URL-safe identifier, a role name is constrained to
-    ``USERNAME_CHARSET_RE`` by the render-time lint, and a role source is one
-    of two framework constants.
+    a short URL-safe identifier, a roster account and a role name are both
+    constrained to ``USERNAME_CHARSET_RE`` by the render-time lint, and a role
+    source is one of two framework constants.
 
     A value that fails this did not come from the sidecar, or cannot be written
     down unambiguously; either way, copying it verbatim would put a forged or
@@ -586,23 +612,54 @@ def _recordable(value: str) -> bool:
     )
 
 
-def forwarded_identity(headers: Mapping[str, str]) -> tuple[str | None, str | None, str | None]:
-    """The ``(subject, role, role_source)`` nginx forwarded on this request, if any.
+class ForwardedIdentity(NamedTuple):
+    """What nginx forwarded about the login behind one request.
 
-    Each is ``None`` when the header is absent or empty — the sidecar omits a
-    header it has no value for, so absence is a state of its own and must not
-    be flattened into a blank string. A value that fails :func:`_recordable`
-    becomes :data:`UNSAFE_FORWARDED_VALUE`: present, and named as unusable.
+    A named tuple rather than four positional values because ``subject`` and
+    ``account`` answer two questions that read alike and are not the same one:
+    *who proved the login* and *whose roster card the request is on*. Every
+    reader here says which it meant.
+
+    Attributes:
+        subject: Who proved the login — the OIDC provider's subject, or the
+            roster username in a password session.
+        account: The roster account the request is on. ``None`` from a sidecar
+            image that predates the header; readers fall back to ``subject``.
+        role: The privilege that account holds, or ``None`` for no role.
+        role_source: ``roster`` or ``claim``, present only beside a role.
+    """
+
+    subject: str | None
+    account: str | None
+    role: str | None
+    role_source: str | None
+
+
+def forwarded_identity(headers: Mapping[str, str]) -> ForwardedIdentity:
+    """The :class:`ForwardedIdentity` nginx forwarded on this request, if any.
+
+    Each field is ``None`` when its header is absent or empty — the sidecar
+    omits a header it has no value for, so absence is a state of its own and
+    must not be flattened into a blank string. ``account`` is additionally
+    ``None`` against a sidecar image built before that header existed, which is
+    why a reader comparing accounts has to keep a subject fallback. A value
+    that fails :func:`_recordable` becomes :data:`UNSAFE_FORWARDED_VALUE`:
+    present, and named as unusable.
 
     Public because it is the ONE decoder for these headers: the audit emitters
-    record the subject and the role it returns, and the web terminal's page
+    record the account and the role it returns, and the web terminal's page
     shows the role and where it came from. A second reader with its own bound
     would let a value the ledger refuses reach the screen, or the reverse.
     ``headers`` is read by lower-cased name, so a plain dict of lower-cased
     keys and Starlette's case-insensitive ``Headers`` both work.
     """
     resolved: list[str | None] = []
-    for header in (AUDIT_SUBJECT_HEADER, AUDIT_ROLE_HEADER, AUDIT_ROLE_SOURCE_HEADER):
+    for header in (
+        AUDIT_SUBJECT_HEADER,
+        AUDIT_ACCOUNT_HEADER,
+        AUDIT_ROLE_HEADER,
+        AUDIT_ROLE_SOURCE_HEADER,
+    ):
         raw = (headers.get(header.lower()) or "").strip()
         if not raw:
             resolved.append(None)
@@ -610,7 +667,7 @@ def forwarded_identity(headers: Mapping[str, str]) -> tuple[str | None, str | No
             resolved.append(raw)
         else:
             resolved.append(UNSAFE_FORWARDED_VALUE)
-    return resolved[0], resolved[1], resolved[2]
+    return ForwardedIdentity(*resolved)
 
 
 def _container_user() -> str:
@@ -627,39 +684,62 @@ def _audit_detail(scope: Scope, headers: dict[str, str], **extra: str) -> tuple[
     """The record's ``detail`` string and the role to put in its own field.
 
     ``detail`` is a space-separated run of ``key=value`` identifiers, which is
-    what makes it greppable without being parsed. Two keys are conditional and
-    both say something by being there:
+    what makes it greppable without being parsed. Three keys come from the
+    forwarded identity, and each says something by being there — or by not:
 
-    * :data:`AUDIT_ACCOUNT_KEY` — the forwarded account, present whenever nginx
-      named one. Not spelled ``subject``: on these surfaces the envelope's own
-      ``subject`` field is the route.
+    * :data:`AUDIT_ACCOUNT_KEY` — the roster **account** the request is on,
+      present whenever nginx named an identity at all. Not spelled ``subject``:
+      on these surfaces the envelope's own ``subject`` field is the route.
     * :data:`AUDIT_EXPECTED_ACCOUNT_KEY` — this container's own user, present
       **only** when the forwarded account is not it. Its presence *is* the
       mismatch: one user's authorization arrived at another user's container.
+    * :data:`AUDIT_OIDC_SUBJECT_KEY` — *who proved* the login, present only
+      when that is not the account itself. A password session, where the roster
+      username is the proof, therefore gains no key at all; an OIDC session
+      records the provider's subject beside the card it opened.
 
-    The mismatch key is written *before* the account it disagrees with. The
-    account is bounded at :data:`MAX_FORWARDED_VALUE_CHARS`, so nothing a
-    caller sends can reach the envelope's ``detail`` truncation today; writing
-    the marker first means that stays true however the ``extra`` keys grow.
+    **The comparison is on the account, never on the subject.** Under
+    ``auth.method: oidc`` the subject is the IdP's assertion about a person —
+    an opaque id or an email — while ``OSPREY_TERMINAL_USER`` is the roster
+    name of the card, so comparing those two disagreed by construction and
+    marked every request of every card as a mismatch. Only
+    :data:`AUDIT_ACCOUNT_HEADER` names something this container can be the
+    container *for*. When that header is absent — a deployment pinning a
+    sidecar image built before it existed — the subject is compared exactly as
+    it was before, so such a deployment keeps its old behaviour rather than
+    losing the check altogether.
+
+    The mismatch key is written *before* the account it disagrees with. Each
+    forwarded value is bounded at :data:`MAX_FORWARDED_VALUE_CHARS`, so nothing
+    a caller sends can reach the envelope's ``detail`` truncation today;
+    writing the marker first means that stays true however the ``extra`` keys
+    grow, and putting the subject *last* keeps the same true of the account.
 
     The mismatch is recorded and logged, never enforced. Refusing on it would
     be a behaviour change smuggled in under an audit heading, and the gate has
     never treated these headers as a credential.
     """
-    subject, role, _ = forwarded_identity(headers)
+    forwarded = forwarded_identity(headers)
+    subject, role = forwarded.subject, forwarded.role
+    # The account when the sidecar named one, else the subject — which is what
+    # the account header carries in a password session anyway, and is the whole
+    # of the fallback against an older image.
+    account = forwarded.account if forwarded.account is not None else subject
     parts = [f"{key}={value}" for key, value in extra.items()]
-    if subject is not None:
+    if account is not None:
         container_user = _container_user()
-        if container_user and subject != container_user:
+        if container_user and account != container_user:
             parts.append(f"{AUDIT_EXPECTED_ACCOUNT_KEY}={container_user}")
             logger.warning(
-                "Forwarded subject %r does not name this container's user %r on %s; "
+                "Forwarded account %r does not name this container's user %r on %s; "
                 "recorded, not refused",
-                subject,
+                account,
                 container_user,
                 _audit_subject(scope),
             )
-        parts.append(f"{AUDIT_ACCOUNT_KEY}={subject}")
+        parts.append(f"{AUDIT_ACCOUNT_KEY}={account}")
+        if subject is not None and subject != account:
+            parts.append(f"{AUDIT_OIDC_SUBJECT_KEY}={subject}")
     return " ".join(parts), role
 
 
@@ -1456,11 +1536,13 @@ class WebAuthMiddleware:
 
         The record's *actor* is this container's own audit identity, filled in
         by the writer from :func:`~osprey.utils.identity.acting_identity` (this
-        layer names none) — never the forwarded subject. The two are different questions: the actor says which
-        deployment identity's ledger this belongs in (and which file it can be
-        written to), while the subject is a claim that arrived on the request
-        and is recorded as such, inside ``detail``. Letting a header choose the
-        actor would let a caller file records under somebody else's name.
+        layer names none) — never the forwarded account. The two are different
+        questions: the actor says which deployment identity's ledger this
+        belongs in (and which file it can be written to), while the account is
+        a claim that arrived on the request and is recorded as such, inside
+        ``detail`` — with the provider's subject beside it as ``oidc_subject=``
+        only where it differs. Letting a header choose the actor would let a
+        caller file records under somebody else's name.
 
         ``session`` is ``None`` and stays that way: no posture-store key exists
         for a request that never reached a session, and inventing one would

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -1417,7 +1417,8 @@ def create_app(
         # send these headers, and the chip is a display, not an authorization
         # surface. The source is shown only through :data:`_ROLE_SOURCE_LABELS`,
         # so a value outside the sidecar's vocabulary renders nothing.
-        _, auth_role, auth_role_source = forwarded_identity(request.headers)
+        forwarded = forwarded_identity(request.headers)
+        auth_role, auth_role_source = forwarded.role, forwarded.role_source
         if auth_role == UNSAFE_FORWARDED_VALUE:
             auth_role = None
         if auth_role_source == UNSAFE_FORWARDED_VALUE:

--- a/src/osprey/services/auth_sidecar/identity_headers.py
+++ b/src/osprey/services/auth_sidecar/identity_headers.py
@@ -1,10 +1,11 @@
-"""The three identity headers an authorized subrequest may carry, and their charset.
+"""The four identity headers an authorized subrequest may carry, and their charset.
 
-nginx turns the sidecar's ``auth_request`` answer into three forwarded headers —
-:data:`SUBJECT_HEADER` naming the account behind the request,
+nginx turns the sidecar's ``auth_request`` answer into four forwarded headers —
+:data:`ACCOUNT_HEADER` naming the roster card the request is on,
+:data:`SUBJECT_HEADER` naming who proved the login,
 :data:`ROLE_HEADER` naming the privilege it holds and
 :data:`ROLE_SOURCE_HEADER` naming where that role came from — and every terminal
-behind that boundary reads its authorization from them. All three names and the
+behind that boundary reads its authorization from them. All four names and the
 one rule about what may travel in them live here rather than in the route,
 because three layers have to agree on it: the session model (which refuses to
 *store* a value that could not be carried), the verify route (which emits
@@ -14,13 +15,13 @@ be carried).
 **ASCII only, and that is not a deferral.** An HTTP header value is latin-1 on
 the wire, so ``jörg@example.org`` survives one hop and arrives at the terminal
 as mojibake — or, one proxy later, as nothing. Osprey therefore requires the
-stricter ASCII of both values, which costs nothing real: an OIDC ``sub`` is
-ASCII by specification, and a role name is already constrained to
-``USERNAME_CHARSET_RE`` by the render-time lint *for this reason*. Control
-characters are refused on top of that, so a value can never split a header or
-inject a second one, and a leading or trailing space is refused because an HTTP
-parser strips it — the value that arrives would not be the value that was
-authorized.
+stricter ASCII of every value, which costs nothing real: an OIDC ``sub`` is
+ASCII by specification, and a roster username and a role name are already
+constrained to ``USERNAME_CHARSET_RE`` by the render-time lint *for this
+reason*. Control characters are refused on top of that, so a value can never
+split a header or inject a second one, and a leading or trailing space is
+refused because an HTTP parser strips it — the value that arrives would not be
+the value that was authorized.
 
 **An unsafe value is never carried, and never quietly dropped either.** Each of
 the three layers refuses in the way that is closed for it: the model raises
@@ -34,19 +35,37 @@ module exists to prevent.
 from __future__ import annotations
 
 __all__ = [
+    "ACCOUNT_HEADER",
     "ROLE_HEADER",
     "ROLE_SOURCE_HEADER",
     "SUBJECT_HEADER",
     "is_header_safe",
 ]
 
+ACCOUNT_HEADER = "X-Osprey-Auth-Account"
+"""Names the roster card an authorized request is on.
+
+The account is the roster entry whose card was clicked — the name ``/verify``
+checked the session against, and the one a consumer can compare with the
+account it believes it is serving. :data:`SUBJECT_HEADER` answers a different
+question: who proved the login. The two coincide in a password session, where
+the roster username *is* the proof, and diverge in an OIDC session, where the
+provider asserts an opaque id or an email that names a person and not a card.
+
+On a shared card that difference is the whole point: the account names the
+card, the subject names whoever opened it. Emitted on every authorized answer —
+an authorized request always has a card — so a consumer seeing no account
+header is talking to a sidecar older than this release, not to a request
+without an account.
+"""
+
 SUBJECT_HEADER = "X-Osprey-Auth-Subject"
-"""Names the account behind an authorized request.
+"""Names who proved the login behind an authorized request.
 
 An OIDC session carries the provider's subject; a password session carries the
 roster username, which *is* the account in that method. Emitted only when the
-session holds one, so its presence always means a known account and no consumer
-has to tell an empty value from an absent one.
+session holds one, so its presence always means a known identity and no
+consumer has to tell an empty value from an absent one.
 """
 
 ROLE_HEADER = "X-Osprey-Auth-Role"

--- a/src/osprey/services/auth_sidecar/routes/verify.py
+++ b/src/osprey/services/auth_sidecar/routes/verify.py
@@ -5,10 +5,12 @@ calls, websocket handshakes alike — and turns any non-2xx answer into a denial
 It is therefore on the hot path of the whole deployment and says as little as
 possible: a bodyless 200 or a bare 401, with no redirect and no
 ``WWW-Authenticate``. The only things an authorized answer may carry are the
-three identity headers of
-:mod:`~osprey.services.auth_sidecar.identity_headers` — the account behind the
-request, the role it holds and where that role came from, all opaque
-identifiers and never a credential — and each only when the session holds one.
+four identity headers of
+:mod:`~osprey.services.auth_sidecar.identity_headers` — the roster card the
+request is on, who proved the login, the role that holds and where the role
+came from, all opaque identifiers and never a credential. The card rides every
+authorized answer, because an authorized request always has one; the other
+three ride only when the session holds them.
 Where an unauthenticated browser should be *sent* is
 nginx's decision (``error_page 401``, content-negotiated), not this route's; a
 redirect issued here would be followed by the subrequest instead of the user.
@@ -40,7 +42,13 @@ from fastapi import APIRouter, Cookie, Depends, Query, Response
 
 from ..app import AuthSettings, get_revocation_store, get_session_codec, get_settings
 from ..exceptions import InvalidSessionError
-from ..identity_headers import ROLE_HEADER, ROLE_SOURCE_HEADER, SUBJECT_HEADER, is_header_safe
+from ..identity_headers import (
+    ACCOUNT_HEADER,
+    ROLE_HEADER,
+    ROLE_SOURCE_HEADER,
+    SUBJECT_HEADER,
+    is_header_safe,
+)
 from ..passwords import verify_generation_tag
 from ..revocation import RevocationStore
 from ..sessions import SESSION_COOKIE_NAME, SessionCodec, UnlockedUser
@@ -129,9 +137,9 @@ async def verify(
 
     Returns:
         An empty 200 when the request is authorized, a bare 401 otherwise. An
-        authorized answer additionally carries the identity headers the session
-        can fill — the account behind the request and the role it holds (see
-        :func:`_authorized`).
+        authorized answer additionally carries the identity headers — always the
+        roster card the request is on, plus whichever of the login's subject,
+        role and role source the session can fill (see :func:`_authorized`).
     """
     requested = user or []
     if len(requested) != 1:
@@ -220,19 +228,29 @@ def _subject_for(username: str, entry: UnlockedUser | None, settings: AuthSettin
 
 
 def _authorized(username: str, entry: UnlockedUser | None, settings: AuthSettings) -> Response:
-    """The bare 200, carrying whichever identity headers the session can fill.
+    """The bare 200, carrying the account and whatever else the session can fill.
 
     ``is_unlocked`` has already established that ``entry`` exists, so ``None`` is
     only a defensive guard.
 
-    Three headers may ride the 200. ``X-Osprey-Auth-Subject`` names the account —
-    the provider subject under OIDC, the roster username otherwise — so a later
-    layer can tell who is behind the request without re-reading the cookie.
-    ``X-Osprey-Auth-Role`` names the role that account holds. Each is *omitted*
-    rather than emitted empty when the session has nothing to put in it, so a
-    present header always means a known value and no consumer has to tell blank
-    from absent: presence of the subject means a known account, and absence of
-    the role means no privileges.
+    Four headers may ride the 200. ``X-Osprey-Auth-Account`` names the roster
+    card the request is on — the username this subrequest authorized, which a
+    consumer can compare against the account it believes it is serving.
+    ``X-Osprey-Auth-Subject`` names who proved the login — the provider subject
+    under OIDC, the roster username otherwise — so a later layer can tell who is
+    behind the request without re-reading the cookie. The two coincide in
+    password mode and diverge on a shared card under OIDC, which is the case
+    they exist separately for. ``X-Osprey-Auth-Role`` names the role that
+    account holds.
+
+    **The account is the one header that always rides.** An authorized request
+    is by definition on a card, so there is no session state that can leave it
+    empty; the other three are *omitted* rather than emitted empty when the
+    session has nothing to put in them, so a present header always means a known
+    value and no consumer has to tell blank from absent: presence of the subject
+    means a known login, and absence of the role means no privileges. An
+    authorized answer with no account header therefore means a sidecar older
+    than this release, not a request without an account.
 
     **The role is the one the login granted, not the roster's current answer.**
     It is read off the session and never re-derived here, so a retired role
@@ -282,11 +300,15 @@ def _authorized(username: str, entry: UnlockedUser | None, settings: AuthSetting
         settings: The deployment's frozen settings.
 
     Returns:
-        A 200 carrying as many of the three identity headers as this session
-        can fill — or a 401 if an identity this deployment cannot carry was
-        about to be reported.
+        A 200 carrying the account and as many of the other three identity
+        headers as this session can fill — or a 401 if an identity this
+        deployment cannot carry was about to be reported.
     """
     headers: dict[str, str] = {}
+    if not is_header_safe(username):
+        return _deny(username, "the roster account cannot be carried in an identity header")
+    headers[ACCOUNT_HEADER] = username
+
     subject = _subject_for(username, entry, settings)
     if subject:
         if not is_header_safe(subject):

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -127,10 +127,10 @@
       In neither case does the browser's whole jar — which names every other
       terminal it has unlocked, and the sidecar's origin-wide session — reach a
       container running agent-generated code.
-    * `X-Osprey-Auth-Subject` / `X-Osprey-Auth-Role` /
-      `X-Osprey-Auth-Role-Source` — who the request belongs to, what privilege
-      it holds and where that privilege came from — are written by EVERY
-      proxying location:
+    * `X-Osprey-Auth-Account` / `X-Osprey-Auth-Subject` /
+      `X-Osprey-Auth-Role` / `X-Osprey-Auth-Role-Source` — which roster card the
+      request is on, who proved the login, what privilege it holds and where
+      that privilege came from — are written by EVERY proxying location:
       a gated `/u/<user>/` SETS them from `auth_request_set` variables carrying
       what the sidecar returned, and every other proxying location CLEARS them
       — the ungated `/u/<user>/` branch, the internal `/_osprey_auth/<user>`
@@ -475,6 +475,7 @@ server {
         # the `proxy_set_header` below send nothing at all, which is the
         # deny-safe answer — a consumer reads an absent role as no privileges,
         # never as a default one.
+        auth_request_set $osprey_auth_account $upstream_http_x_osprey_auth_account;
         auth_request_set $osprey_auth_subject $upstream_http_x_osprey_auth_subject;
         auth_request_set $osprey_auth_role $upstream_http_x_osprey_auth_role;
         auth_request_set $osprey_auth_role_source $upstream_http_x_osprey_auth_role_source;
@@ -557,11 +558,12 @@ server {
         # and clearing the header costs it nothing. Unconditional, unlike the
         # two below: the header is never legitimate here in any auth mode.
         proxy_set_header Authorization "";
-        # The three identity headers — who the request belongs to, what
-        # privilege it holds and where that privilege came from. All three
-        # names are written into EVERY proxying location's own header set, by
-        # whichever arm of the branch below renders: gated, from the values the
-        # sidecar just returned; ungated, as an explicit clear.
+        # The four identity headers — which roster card the request is on, who
+        # proved the login, what privilege it holds and where that privilege
+        # came from. All four names are written into EVERY proxying location's
+        # own header set, by whichever arm of the branch below renders: gated,
+        # from the values the sidecar just returned; ungated, as an explicit
+        # clear.
         #
         # Naming them is what drops the client's own. nginx builds one
         # proxy-headers table per location and copies the client's remaining
@@ -594,6 +596,7 @@ server {
         # sidecar omits a header it has no value for — and an empty one is not
         # sent at all, which is the deny-safe answer and still not the
         # client's: the name is claimed by this directive either way.
+        proxy_set_header X-Osprey-Auth-Account $osprey_auth_account;
         proxy_set_header X-Osprey-Auth-Subject $osprey_auth_subject;
         proxy_set_header X-Osprey-Auth-Role $osprey_auth_role;
         proxy_set_header X-Osprey-Auth-Role-Source $osprey_auth_role_source;
@@ -627,17 +630,18 @@ server {
 {%- if inject_secret and not svc.login_exempt %}
         # No sidecar vouched for this request; nginx itself injects this
         # user's operator secret below. There is no authorization to speak
-        # for, so all three identity names are CLEARED here rather than
+        # for, so all four identity names are CLEARED here rather than
         # forwarded: forwarding would announce a subject the perimeter never
         # checked, and leaving the names unwritten would let the client supply
         # them itself.
 {%- else %}
         # Ungated — authentication is off, or this entry declared
-        # `login: false`. There is no authorization to speak for, so all three
+        # `login: false`. There is no authorization to speak for, so all four
         # identity names are CLEARED here rather than forwarded: forwarding
         # would announce a subject the perimeter never checked, and leaving the
         # names unwritten would let the client supply them itself.
 {%- endif %}
+        proxy_set_header X-Osprey-Auth-Account "";
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
         proxy_set_header X-Osprey-Auth-Role-Source "";
@@ -735,6 +739,7 @@ server {
         # rather than at server level because a location-level
         # `proxy_set_header` — the ones below — replaces the whole inherited
         # set, so a server-level clear would be discarded right here.
+        proxy_set_header X-Osprey-Auth-Account "";
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
         proxy_set_header X-Osprey-Auth-Role-Source "";
@@ -804,6 +809,7 @@ server {
         # always reach, and so the one it would forge an identity into. The
         # login flow establishes identity from credentials it verifies;
         # nothing it serves may read one out of the request.
+        proxy_set_header X-Osprey-Auth-Account "";
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
         proxy_set_header X-Osprey-Auth-Role-Source "";

--- a/tests/deployment/web_terminals/golden/nginx.conf
+++ b/tests/deployment/web_terminals/golden/nginx.conf
@@ -107,11 +107,12 @@ server {
         # and clearing the header costs it nothing. Unconditional, unlike the
         # two below: the header is never legitimate here in any auth mode.
         proxy_set_header Authorization "";
-        # The three identity headers — who the request belongs to, what
-        # privilege it holds and where that privilege came from. All three
-        # names are written into EVERY proxying location's own header set, by
-        # whichever arm of the branch below renders: gated, from the values the
-        # sidecar just returned; ungated, as an explicit clear.
+        # The four identity headers — which roster card the request is on, who
+        # proved the login, what privilege it holds and where that privilege
+        # came from. All four names are written into EVERY proxying location's
+        # own header set, by whichever arm of the branch below renders: gated,
+        # from the values the sidecar just returned; ungated, as an explicit
+        # clear.
         #
         # Naming them is what drops the client's own. nginx builds one
         # proxy-headers table per location and copies the client's remaining
@@ -138,10 +139,11 @@ server {
         # warning is most expensive: it is the one an operator learns to scroll
         # past.
         # Ungated — authentication is off, or this entry declared
-        # `login: false`. There is no authorization to speak for, so all three
+        # `login: false`. There is no authorization to speak for, so all four
         # identity names are CLEARED here rather than forwarded: forwarding
         # would announce a subject the perimeter never checked, and leaving the
         # names unwritten would let the client supply them itself.
+        proxy_set_header X-Osprey-Auth-Account "";
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
         proxy_set_header X-Osprey-Auth-Role-Source "";
@@ -213,11 +215,12 @@ server {
         # and clearing the header costs it nothing. Unconditional, unlike the
         # two below: the header is never legitimate here in any auth mode.
         proxy_set_header Authorization "";
-        # The three identity headers — who the request belongs to, what
-        # privilege it holds and where that privilege came from. All three
-        # names are written into EVERY proxying location's own header set, by
-        # whichever arm of the branch below renders: gated, from the values the
-        # sidecar just returned; ungated, as an explicit clear.
+        # The four identity headers — which roster card the request is on, who
+        # proved the login, what privilege it holds and where that privilege
+        # came from. All four names are written into EVERY proxying location's
+        # own header set, by whichever arm of the branch below renders: gated,
+        # from the values the sidecar just returned; ungated, as an explicit
+        # clear.
         #
         # Naming them is what drops the client's own. nginx builds one
         # proxy-headers table per location and copies the client's remaining
@@ -244,10 +247,11 @@ server {
         # warning is most expensive: it is the one an operator learns to scroll
         # past.
         # Ungated — authentication is off, or this entry declared
-        # `login: false`. There is no authorization to speak for, so all three
+        # `login: false`. There is no authorization to speak for, so all four
         # identity names are CLEARED here rather than forwarded: forwarding
         # would announce a subject the perimeter never checked, and leaving the
         # names unwritten would let the client supply them itself.
+        proxy_set_header X-Osprey-Auth-Account "";
         proxy_set_header X-Osprey-Auth-Subject "";
         proxy_set_header X-Osprey-Auth-Role "";
         proxy_set_header X-Osprey-Auth-Role-Source "";

--- a/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
+++ b/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
@@ -27,12 +27,14 @@ exceptions:
      records what its agents did, and a posture that only writes a trail when
      someone opted into logins would have the trail missing exactly where it is
      least supervised.
-  2. **the identity-header clears** — ``proxy_set_header X-Osprey-Auth-Subject
-     ""``/``X-Osprey-Auth-Role ""`` in every proxying location. Under ``token``
-     there is no sidecar to answer for a subject, so nginx must claim both names
-     anyway: a location that names neither would hand a client's own
-     ``X-Osprey-Auth-Subject: root`` straight to a terminal container, which
-     reads that header to learn who is on the other end.
+  2. **the identity-header clears** — ``proxy_set_header X-Osprey-Auth-Account
+     ""``/``X-Osprey-Auth-Subject ""``/``X-Osprey-Auth-Role ""``/
+     ``X-Osprey-Auth-Role-Source ""`` in every proxying location. Under
+     ``token`` there is no sidecar to answer for an account or a subject, so
+     nginx must claim all four names anyway: a location that names none of them
+     would hand a client's own ``X-Osprey-Auth-Subject: root`` straight to a
+     terminal container, which reads that header to learn who is on the other
+     end.
   3. **the terminal session lifetime** — ``OSPREY_TERMINAL_SESSION_LIFETIME``
      on every per-user container. ``token`` mints a session cookie of its own
      (the ``?token=`` exchange trades the magic link for one), so the setting
@@ -304,11 +306,12 @@ _REWORDED_COMPOSE_LINES = frozenset(
     }
 )
 
-#: Task 4.7 (nginx-identity-headers), ungated arm. Three clears per `/u/<user>/`
+#: Task 4.7 (nginx-identity-headers), ungated arm. Four clears per `/u/<user>/`
 #: location, and NOTHING else: no `auth_request_set`, no forward, no `/auth/`
 #: location — those render only with authentication on.
 _ALLOWED_NGINX_LINES = Counter(
     {
+        '        proxy_set_header X-Osprey-Auth-Account "";': 2,
         '        proxy_set_header X-Osprey-Auth-Subject "";': 2,
         '        proxy_set_header X-Osprey-Auth-Role "";': 2,
         '        proxy_set_header X-Osprey-Auth-Role-Source "";': 2,
@@ -509,8 +512,8 @@ def test_compose_adds_exactly_the_audit_emitters_and_mounts() -> None:
     _assert_added_directives_are_exactly_allowed("docker-compose.web.yml")
 
 
-def test_nginx_adds_exactly_the_three_identity_header_clears() -> None:
-    """The nginx config's whole SC6 exception: the three clears, once each in
+def test_nginx_adds_exactly_the_four_identity_header_clears() -> None:
+    """The nginx config's whole SC6 exception: the four clears, once each in
     each of the two ungated `/u/<user>/` locations, from task 4.7. Nothing from
     the gated arm may appear here — no `auth_request_set`, no forward — and the
     count catches a clear that reached only one of the two locations."""

--- a/tests/deployment/web_terminals/test_nginx_auth_surface.py
+++ b/tests/deployment/web_terminals/test_nginx_auth_surface.py
@@ -1,7 +1,9 @@
 """The identity headers the nginx perimeter forwards — and refuses to relay.
 
-The auth sidecar answers an authorized ``auth_request`` with three headers naming
-who the request belongs to (:data:`~osprey.services.auth_sidecar.identity_headers.SUBJECT_HEADER`),
+The auth sidecar answers an authorized ``auth_request`` with four headers naming
+which roster card the request is on
+(:data:`~osprey.services.auth_sidecar.identity_headers.ACCOUNT_HEADER`),
+who proved the login (:data:`~osprey.services.auth_sidecar.identity_headers.SUBJECT_HEADER`),
 what privilege they hold (:data:`~osprey.services.auth_sidecar.identity_headers.ROLE_HEADER`)
 and where that privilege came from
 (:data:`~osprey.services.auth_sidecar.identity_headers.ROLE_SOURCE_HEADER`).
@@ -63,6 +65,7 @@ from osprey.deployment.web_terminals.render import (
 )
 from osprey.port_layout import default_port
 from osprey.services.auth_sidecar.identity_headers import (
+    ACCOUNT_HEADER,
     ROLE_HEADER,
     ROLE_SOURCE_HEADER,
     SUBJECT_HEADER,
@@ -201,13 +204,15 @@ def _upstream_var(header: str) -> str:
     return "$upstream_http_" + header.lower().replace("-", "_")
 
 
+_ACCOUNT_VAR = "$osprey_auth_account"
 _SUBJECT_VAR = "$osprey_auth_subject"
 _ROLE_VAR = "$osprey_auth_role"
 _ROLE_SOURCE_VAR = "$osprey_auth_role_source"
 
-#: The three identity headers, each paired with the variable a gated location
+#: The four identity headers, each paired with the variable a gated location
 #: forwards it from.
 _IDENTITY = (
+    (ACCOUNT_HEADER, _ACCOUNT_VAR),
     (SUBJECT_HEADER, _SUBJECT_VAR),
     (ROLE_HEADER, _ROLE_VAR),
     (ROLE_SOURCE_HEADER, _ROLE_SOURCE_VAR),
@@ -286,7 +291,7 @@ _EXEMPT_ROSTER = [
 
 def test_rendered_header_names_are_the_sidecar_s_own_spelling() -> None:
     """The template writes the header names as literals — nginx conf has no way
-    to import a Python constant — so the three spellings are held together by
+    to import a Python constant — so the four spellings are held together by
     this assertion instead. A rename on the sidecar side that stopped here would
     leave nginx forwarding a header nothing reads and clearing one nothing sets.
     """
@@ -294,9 +299,11 @@ def test_rendered_header_names_are_the_sidecar_s_own_spelling() -> None:
     nginx_conf = _render_nginx(_auth_config(_ONE_USER))
 
     # Assert
+    assert ACCOUNT_HEADER == "X-Osprey-Auth-Account"
     assert SUBJECT_HEADER == "X-Osprey-Auth-Subject"
     assert ROLE_HEADER == "X-Osprey-Auth-Role"
     assert ROLE_SOURCE_HEADER == "X-Osprey-Auth-Role-Source"
+    assert _clear(ACCOUNT_HEADER) in nginx_conf
     assert _clear(SUBJECT_HEADER) in nginx_conf
     assert _clear(ROLE_HEADER) in nginx_conf
     assert _clear(ROLE_SOURCE_HEADER) in nginx_conf
@@ -311,19 +318,25 @@ def test_gated_user_location_forwards_every_identity_header_from_the_auth_answer
     """A gated `/u/<user>/` reads every value off its own `auth_request`'s
     response and sets them on the proxied request. `auth_request_set` is the
     only construct that can do this: the subrequest's response headers are
-    otherwise not visible to the parent request at all."""
+    otherwise not visible to the parent request at all.
+
+    Written over `_IDENTITY` rather than name by name: a capture that named the
+    wrong upstream variable would leave that header forwarding empty, and for
+    the account that fails OPEN — the container falls back to comparing the
+    subject and marks the request a mismatch."""
     # Arrange / Act
     body = _location_body(_render_nginx(_auth_config(_TWO_USERS)), "/u/alice/")
 
-    # Assert — the values are lifted out of alice's own subrequest…
-    assert f"auth_request_set {_SUBJECT_VAR} {_upstream_var(SUBJECT_HEADER)};" in body
-    assert f"auth_request_set {_ROLE_VAR} {_upstream_var(ROLE_HEADER)};" in body
-    assert f"auth_request_set {_ROLE_SOURCE_VAR} {_upstream_var(ROLE_SOURCE_HEADER)};" in body
-
-    # Assert — …and put on the request that reaches alice's container.
-    assert f"proxy_set_header {SUBJECT_HEADER} {_SUBJECT_VAR};" in body
-    assert f"proxy_set_header {ROLE_HEADER} {_ROLE_VAR};" in body
-    assert f"proxy_set_header {ROLE_SOURCE_HEADER} {_ROLE_SOURCE_VAR};" in body
+    # Assert
+    for header, variable in _IDENTITY:
+        # …the value is lifted out of alice's own subrequest…
+        assert f"auth_request_set {variable} {_upstream_var(header)};" in body, (
+            f"/u/alice/ does not capture {header} off its own auth_request"
+        )
+        # …and put on the request that reaches alice's container.
+        assert _forward(header, variable) in body, (
+            f"/u/alice/ captures {header} but does not forward it"
+        )
 
 
 def test_the_forward_is_emitted_once_per_gated_user_and_nowhere_else() -> None:
@@ -336,12 +349,13 @@ def test_the_forward_is_emitted_once_per_gated_user_and_nowhere_else() -> None:
     directives = _directives(_render_nginx(_auth_config(_TWO_USERS)))
 
     # Assert
-    assert directives.count(f"proxy_set_header {SUBJECT_HEADER} {_SUBJECT_VAR};") == 2
-    assert directives.count(f"proxy_set_header {ROLE_HEADER} {_ROLE_VAR};") == 2
-    assert directives.count(f"proxy_set_header {ROLE_SOURCE_HEADER} {_ROLE_SOURCE_VAR};") == 2
-    assert directives.count(f"auth_request_set {_SUBJECT_VAR} ") == 2
-    assert directives.count(f"auth_request_set {_ROLE_VAR} ") == 2
-    assert directives.count(f"auth_request_set {_ROLE_SOURCE_VAR} ") == 2
+    for header, variable in _IDENTITY:
+        assert directives.count(_forward(header, variable)) == 2, (
+            f"{header} is not forwarded exactly once per gated user"
+        )
+        assert directives.count(f"auth_request_set {variable} ") == 2, (
+            f"{header} is not captured exactly once per gated user"
+        )
 
 
 def test_login_exempt_location_forwards_no_identity_at_all() -> None:
@@ -503,15 +517,12 @@ def test_the_gated_location_forwards_instead_of_also_clearing() -> None:
     # Arrange / Act
     body = _location_body(_render_nginx(_auth_config(_ONE_USER)), "/u/alice/")
 
-    # Assert — claimed, by the forward…
-    assert _forward(SUBJECT_HEADER, _SUBJECT_VAR) in body
-    assert _forward(ROLE_HEADER, _ROLE_VAR) in body
-    assert _forward(ROLE_SOURCE_HEADER, _ROLE_SOURCE_VAR) in body
-
-    # Assert — …and by nothing else.
-    assert _clear(SUBJECT_HEADER) not in body
-    assert _clear(ROLE_HEADER) not in body
-    assert _clear(ROLE_SOURCE_HEADER) not in body
+    # Assert
+    for header, variable in _IDENTITY:
+        # …claimed, by the forward…
+        assert _forward(header, variable) in body, f"/u/alice/ does not forward {header}"
+        # …and by nothing else.
+        assert _clear(header) not in body, f"/u/alice/ clears {header} beside its forward"
 
 
 def test_no_location_writes_the_same_proxy_set_header_name_twice() -> None:

--- a/tests/e2e/test_full_chain_auth.py
+++ b/tests/e2e/test_full_chain_auth.py
@@ -1,6 +1,6 @@
 """Acceptance proof for the WHOLE identity chain on real artifacts: a password
 login at the deployed sidecar, an ``authorization:`` role that decides which
-persona a user's container runs, the three identity headers nginx forwards
+persona a user's container runs, the four identity headers nginx forwards
 from the sidecar's answer, and the audit records those decisions leave behind in
 each identity's OWN ledger subdirectory.
 
@@ -42,20 +42,32 @@ user       role           persona     what only this entry can prove
 ``alice``  ``operator``   REAL app    A password login reaches HER container,
                                       and an in-container protected-key refusal
                                       lands in ``var/audit/alice/``.
-``bob``    ``observer``   probe stub  Subject, role AND role source arrive at
-                                      the upstream, exactly once each, carrying
-                                      the sidecar's values — and client-forged
-                                      headers do not.
+``bob``    ``observer``   probe stub  Account, subject, role AND role source
+                                      arrive at the upstream, exactly once
+                                      each, carrying the sidecar's values —
+                                      and client-forged headers do not.
 ``carol``  (none)         probe stub  A session with no role forwards the
-                                      subject and NEITHER a role nor a
-                                      role-source header at all — absent, never
-                                      present-and-blank.
+                                      account and subject but NEITHER a role
+                                      nor a role-source header at all —
+                                      absent, never present-and-blank.
 ``kiosk``  (none)         probe stub  ``login: false``: the ungated branch
-                                      forwards NONE of the three.
+                                      forwards NONE of the four.
 ``dave``   (none)         probe stub  A role the boundary cannot carry refuses
                                       the login 403 instead of poisoning a
                                       header (see FAULT INJECTION below).
 =========  =============  ==========  =========================================
+
+WHAT THE ACCOUNT HEADER ASSERTIONS HERE DO AND DO NOT PROVE
+-----------------------------------------------------------
+This lane is password-only, and in a password deployment the account IS the
+subject: both headers carry the roster username, so every assertion below
+compares the two against the same value. That makes these assertions a proof
+of nginx TRANSPORT — that the sidecar's ``X-Osprey-Auth-Account`` is captured
+from the ``/verify`` answer, forwarded exactly once, replaces a client-forged
+copy rather than joining it, and is cleared on the ungated arm — and NOT a
+proof of OIDC semantics, where an account and a subject actually diverge. The
+OIDC half is unit-covered instead, because the repo has no OIDC e2e harness to
+drive a real IdP login through this chain.
 
 **The persona each user runs is decided by the ROLE, never by a ``persona:``
 pin.** That is not incidental to the fixture — it is the FR6 mechanism under
@@ -172,6 +184,7 @@ import yaml
 from osprey.audit.protected import SURFACE_HTTP_CONFIG
 from osprey.port_layout import default_port
 from osprey.services.auth_sidecar.identity_headers import (
+    ACCOUNT_HEADER,
     ROLE_HEADER,
     ROLE_SOURCE_HEADER,
     SUBJECT_HEADER,
@@ -1341,7 +1354,7 @@ def test_a_password_login_reaches_that_users_own_terminal(deployment: dict[str, 
     )
 
 
-def test_the_upstream_receives_exactly_one_subject_and_one_role_and_one_role_source_header(
+def test_the_upstream_receives_exactly_one_of_each_identity_header(
     deployment: dict[str, Any],
 ) -> None:
     """SC4: the sidecar's identity arrives at the container, once, unduplicated.
@@ -1365,8 +1378,17 @@ def test_the_upstream_receives_exactly_one_subject_and_one_role_and_one_role_sou
     rides that same binding one step further: ``roster`` is the only provenance
     a password deployment can produce, so its arrival proves the third header
     travels the whole chain and is not merely rendered into the config.
+
+    The account header is asserted against the same value as the subject
+    because this lane is password-only, where the account IS the subject. So
+    what its arrival proves is nginx TRANSPORT — captured from ``/verify``,
+    forwarded once, uncorrupted — and not OIDC semantics, where the two
+    diverge; that half is unit-covered, there being no OIDC e2e harness.
     """
     report = _probe_report(HEADER_USER, opener=deployment["sessions"][HEADER_USER])
+    assert _forwarded(report, ACCOUNT_HEADER) == [HEADER_USER], (
+        f"{ACCOUNT_HEADER} did not arrive exactly once carrying the roster account: {report}"
+    )
     assert _forwarded(report, SUBJECT_HEADER) == [HEADER_USER], (
         f"{SUBJECT_HEADER} did not arrive exactly once carrying the roster username: {report}"
     )
@@ -1396,19 +1418,29 @@ def test_a_client_forged_identity_header_never_reaches_the_upstream(
     assert honest; the unconditional empty clears this lane also relies on are
     in the ungated locations and are proved by
     ``test_the_exempt_branch_forwards_no_identity_header``. The forged
-    role-source is the sharpest of the three: a client that could name its own
+    role-source is the sharpest of the four: a client that could name its own
     provenance would be able to dress a roster role up as an IdP claim, so the
     gated forward has to win over the forgery there too.
+
+    The forged account is the one a downstream authorization check would read
+    as "who is this", so the forward has to REPLACE it rather than append a
+    second copy — an upstream reading the first of two would be reading the
+    client's. Password-only lane, so the honest value here equals the subject.
     """
     report = _probe_report(
         HEADER_USER,
         opener=deployment["sessions"][HEADER_USER],
         headers={
             **_navigation(),
+            ACCOUNT_HEADER: "root",
             SUBJECT_HEADER: "root",
             ROLE_HEADER: "admin",
             ROLE_SOURCE_HEADER: "claim",
         },
+    )
+    assert _forwarded(report, ACCOUNT_HEADER) == [HEADER_USER], (
+        f"a forged {ACCOUNT_HEADER} survived the gated location — replaced, never"
+        f" appended to: {report}"
     )
     assert _forwarded(report, SUBJECT_HEADER) == [HEADER_USER], (
         f"a forged {SUBJECT_HEADER} survived the gated location: {report}"
@@ -1421,7 +1453,7 @@ def test_a_client_forged_identity_header_never_reaches_the_upstream(
     )
 
 
-def test_a_session_with_no_role_forwards_a_subject_and_no_role_header(
+def test_a_session_with_no_role_forwards_an_account_and_subject_and_no_role_header(
     deployment: dict[str, Any],
 ) -> None:
     """The deny-safe contract: an absent role is ABSENT, never present-and-blank.
@@ -1434,9 +1466,14 @@ def test_a_session_with_no_role_forwards_a_subject_and_no_role_header(
     role-source header is absent for the same reason and by the same rule: it
     describes where a role came from, so with no role there is nothing for it
     to describe and an empty ``roster`` would be a provenance claim about a
-    privilege nobody holds.
+    privilege nobody holds. The account rides the opposite rule and is asserted
+    here for it: it names WHO the request is, not what they may do, so it
+    arrives for every authorized session whether or not a role was resolved.
     """
     report = _probe_report(NO_ROLE_USER, opener=deployment["sessions"][NO_ROLE_USER])
+    assert _forwarded(report, ACCOUNT_HEADER) == [NO_ROLE_USER], (
+        f"{ACCOUNT_HEADER} did not arrive for a role-less session: {report}"
+    )
     assert _forwarded(report, SUBJECT_HEADER) == [NO_ROLE_USER], (
         f"{SUBJECT_HEADER} did not arrive for a role-less session: {report}"
     )
@@ -1453,24 +1490,30 @@ def test_the_exempt_branch_forwards_no_identity_header(deployment: dict[str, Any
 
     ``kiosk`` sits on the ungated branch: nginx runs no ``auth_request`` for it,
     so there is no sidecar answer to forward — and the unconditional clears mean
-    the terminal receives none of the three headers rather than empty ones.
+    the terminal receives none of the four headers rather than empty ones.
     Reached with no credential at all, which is what ``login: false`` means.
 
     Forged headers are sent on the same request: the ungated branch is the one
     where a client could most plausibly hope to supply its own identity, and the
-    clears are the only thing stopping it. All three identity headers are
-    forged and all three have to be absent — the role-source clear included,
+    clears are the only thing stopping it. All four identity headers are
+    forged and all four have to be absent — the role-source clear included,
     since a provenance arriving where no identity was established would be a
-    claim about a role the branch never resolved.
+    claim about a role the branch never resolved, and the account clear most of
+    all, since an account arriving on the ungated arm is an unauthenticated
+    client naming itself to the upstream.
     """
     report = _probe_report(
         EXEMPT_USER,
         headers={
             **_navigation(),
+            ACCOUNT_HEADER: "root",
             SUBJECT_HEADER: "root",
             ROLE_HEADER: "admin",
             ROLE_SOURCE_HEADER: "claim",
         },
+    )
+    assert _forwarded(report, ACCOUNT_HEADER) == [], (
+        f"the exempt branch forwarded {ACCOUNT_HEADER}: {report}"
     )
     assert _forwarded(report, SUBJECT_HEADER) == [], (
         f"the exempt branch forwarded {SUBJECT_HEADER}: {report}"

--- a/tests/interfaces/test_http_audit_emitters.py
+++ b/tests/interfaces/test_http_audit_emitters.py
@@ -43,8 +43,10 @@ from osprey.audit.envelope import (
 from osprey.interfaces import common_middleware
 from osprey.interfaces._app_setup import configure_interface_app
 from osprey.interfaces.common_middleware import (
+    AUDIT_ACCOUNT_HEADER,
     AUDIT_ACCOUNT_KEY,
     AUDIT_EXPECTED_ACCOUNT_KEY,
+    AUDIT_OIDC_SUBJECT_KEY,
     AUDIT_ROLE_HEADER,
     AUDIT_ROLE_SOURCE_HEADER,
     AUDIT_SUBJECT_HEADER,
@@ -400,12 +402,12 @@ class TestRefusalRecordProvenance:
 
 
 class TestForwardedIdentity:
-    def test_the_forwarded_subject_and_role_ride_the_record(self, app_stub, records):
+    def test_the_forwarded_account_and_role_ride_the_record(self, app_stub, records):
         drive(
             WebAuthMiddleware(RecordingApp()),
             http_scope(
                 app=app_stub,
-                headers={AUDIT_SUBJECT_HEADER: "alice", AUDIT_ROLE_HEADER: "operator"},
+                headers={AUDIT_ACCOUNT_HEADER: "alice", AUDIT_ROLE_HEADER: "operator"},
             ),
         )
 
@@ -418,44 +420,122 @@ class TestForwardedIdentity:
 
         record = only(records)
         assert AUDIT_ACCOUNT_KEY not in detail_parts(record)
+        assert AUDIT_OIDC_SUBJECT_KEY not in detail_parts(record)
         assert record["role"] is None
 
-    def test_the_decoder_returns_the_source_beside_the_subject_and_role(self):
-        """The third name is decoded under the same bound as the first two.
+    def test_the_decoder_names_each_of_the_four_headers_it_returns(self):
+        """Four names, each decoded under the same bound, each reachable by name.
 
-        Asserted on the decoder directly, not through an emitter: the ledger
-        reads the tuple and records only its first two values, so a third name
-        that quietly stopped being decoded would leave every record in this
-        module exactly as it is today, and only the terminal's chip would go
-        blank.
+        Asserted on the decoder directly, not through an emitter, and by field
+        rather than by tuple position: ``subject`` and ``account`` read alike
+        and are not the same question, so a swap of the two would be invisible
+        to a positional assertion while inverting what the ledger compares. The
+        role source is here for the same reason it always was — the ledger
+        reads it and records nothing from it, so a name that quietly stopped
+        being decoded would leave every record in this module exactly as it is
+        and only the terminal's chip would go blank.
         """
         base = {
-            AUDIT_SUBJECT_HEADER.lower(): "alice",
+            AUDIT_SUBJECT_HEADER.lower(): "idp|alice",
+            AUDIT_ACCOUNT_HEADER.lower(): "alice",
             AUDIT_ROLE_HEADER.lower(): "operator",
         }
 
-        assert forwarded_identity(base) == ("alice", "operator", None)
-        assert forwarded_identity({**base, AUDIT_ROLE_SOURCE_HEADER.lower(): "roster"}) == (
-            "alice",
-            "operator",
-            "roster",
-        )
-        assert forwarded_identity({**base, AUDIT_ROLE_SOURCE_HEADER.lower(): "ro ster"}) == (
-            "alice",
-            "operator",
-            UNSAFE_FORWARDED_VALUE,
-        )
+        decoded = forwarded_identity(base)
+        assert decoded.subject == "idp|alice"
+        assert decoded.account == "alice"
+        assert decoded.role == "operator"
+        assert decoded.role_source is None
 
-    def test_a_subject_matching_this_container_is_not_flagged(self, app_stub, records, monkeypatch):
+        with_source = forwarded_identity({**base, AUDIT_ROLE_SOURCE_HEADER.lower(): "roster"})
+        assert with_source.role_source == "roster"
+
+        unsafe_source = forwarded_identity({**base, AUDIT_ROLE_SOURCE_HEADER.lower(): "ro ster"})
+        assert unsafe_source.role_source == UNSAFE_FORWARDED_VALUE
+
+    def test_an_absent_account_header_decodes_as_none_not_as_the_subject(self):
+        """Absence is a state of its own, and the readers' fallback depends on it.
+
+        A sidecar image built before :data:`AUDIT_ACCOUNT_HEADER` existed sends
+        no account at all. Flattening that to the subject here would hide the
+        one fact ``_audit_detail`` needs in order to know it is on the fallback
+        path rather than looking at a password session.
+        """
+        decoded = forwarded_identity({AUDIT_SUBJECT_HEADER.lower(): "alice"})
+        assert decoded.subject == "alice"
+        assert decoded.account is None
+
+    def test_an_unsafe_account_is_named_unsafe_under_the_same_bound(self):
+        """The fourth header is not exempt from the guard the other three carry."""
+        decoded = forwarded_identity({AUDIT_ACCOUNT_HEADER.lower(): "ali ce"})
+        assert decoded.account == UNSAFE_FORWARDED_VALUE
+
+    def test_an_account_matching_this_container_is_not_flagged(
+        self, app_stub, records, monkeypatch
+    ):
         monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
         drive(
             WebAuthMiddleware(RecordingApp()),
-            http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: "alice"}),
+            http_scope(app=app_stub, headers={AUDIT_ACCOUNT_HEADER: "alice"}),
         )
 
         assert AUDIT_EXPECTED_ACCOUNT_KEY not in detail_parts(only(records))
 
-    def test_a_subject_mismatching_this_container_is_audited(
+    def test_an_oidc_subject_beside_a_matching_account_is_not_a_mismatch(
+        self, app_stub, records, monkeypatch, caplog
+    ):
+        """The live defect this comparison exists to fix.
+
+        Under ``auth.method: oidc`` the subject is the IdP's assertion about a
+        person and ``OSPREY_TERMINAL_USER`` is the roster name of the card, so
+        comparing those two disagreed by construction: every audited request of
+        every card wrote a false mismatch marker and a WARNING, forever. The
+        account is the only forwarded name this container can be the container
+        *for*, so it is the only one compared. The subject is still recorded —
+        under its own key, which is the point of having one.
+        """
+        monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
+        with caplog.at_level("WARNING", logger=MIDDLEWARE_LOGGER):
+            drive(
+                WebAuthMiddleware(RecordingApp()),
+                http_scope(
+                    app=app_stub,
+                    headers={
+                        AUDIT_ACCOUNT_HEADER: "alice",
+                        AUDIT_SUBJECT_HEADER: "idp|8f21c0",
+                    },
+                ),
+            )
+
+        parts = detail_parts(only(records))
+        assert parts[AUDIT_ACCOUNT_KEY] == "alice"
+        assert AUDIT_EXPECTED_ACCOUNT_KEY not in parts
+        assert parts[AUDIT_OIDC_SUBJECT_KEY] == "idp|8f21c0"
+        assert caplog.messages == []
+
+    def test_a_subject_equal_to_the_account_adds_no_subject_key(
+        self, app_stub, records, monkeypatch
+    ):
+        """A password deployment's records do not change at all.
+
+        There the roster username *is* the proof, so the two headers carry the
+        same string and a second key naming it would be noise in every record
+        of every password deployment.
+        """
+        monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
+        drive(
+            WebAuthMiddleware(RecordingApp()),
+            http_scope(
+                app=app_stub,
+                headers={AUDIT_ACCOUNT_HEADER: "alice", AUDIT_SUBJECT_HEADER: "alice"},
+            ),
+        )
+
+        parts = detail_parts(only(records))
+        assert parts[AUDIT_ACCOUNT_KEY] == "alice"
+        assert AUDIT_OIDC_SUBJECT_KEY not in parts
+
+    def test_an_account_mismatching_this_container_is_audited(
         self, app_stub, records, monkeypatch, caplog
     ):
         """One user's authorization reaching another user's container.
@@ -469,13 +549,41 @@ class TestForwardedIdentity:
         with caplog.at_level("WARNING", logger=MIDDLEWARE_LOGGER):
             drive(
                 WebAuthMiddleware(RecordingApp()),
-                http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: "alice"}),
+                http_scope(app=app_stub, headers={AUDIT_ACCOUNT_HEADER: "alice"}),
             )
 
         parts = detail_parts(only(records))
         assert parts[AUDIT_ACCOUNT_KEY] == "alice"
         assert parts[AUDIT_EXPECTED_ACCOUNT_KEY] == "bob"
         assert any("alice" in message and "bob" in message for message in caplog.messages)
+
+    def test_a_genuine_mismatch_under_oidc_still_records_both_names(
+        self, app_stub, records, monkeypatch, caplog
+    ):
+        """Someone reaching another user's card keeps both the marker and the warning.
+
+        The fix removes the false mismatch, not the real one — and the subject
+        rides along, because "which login opened it" is the first question
+        asked of a record that says a card was reached by the wrong account.
+        """
+        monkeypatch.setenv(TERMINAL_USER_ENV, "bob")
+        with caplog.at_level("WARNING", logger=MIDDLEWARE_LOGGER):
+            drive(
+                WebAuthMiddleware(RecordingApp()),
+                http_scope(
+                    app=app_stub,
+                    headers={
+                        AUDIT_ACCOUNT_HEADER: "alice",
+                        AUDIT_SUBJECT_HEADER: "idp|8f21c0",
+                    },
+                ),
+            )
+
+        parts = detail_parts(only(records))
+        assert parts[AUDIT_EXPECTED_ACCOUNT_KEY] == "bob"
+        assert parts[AUDIT_ACCOUNT_KEY] == "alice"
+        assert parts[AUDIT_OIDC_SUBJECT_KEY] == "idp|8f21c0"
+        assert len([m for m in caplog.messages if "alice" in m and "bob" in m]) == 1
 
     @pytest.mark.parametrize(
         "forged",
@@ -489,7 +597,7 @@ class TestForwardedIdentity:
     def test_an_unrecordable_forwarded_value_is_named_unsafe(self, app_stub, records, forged):
         """A forged header never becomes the text of the record.
 
-        The subject arrives over the wire and nothing upstream of this gate is
+        The account arrives over the wire and nothing upstream of this gate is
         obliged to have produced it. The first two below are outside the
         sidecar's printable-ASCII contract and so cannot have come from it; the
         third would silently become a second ``key=value`` field in a
@@ -501,7 +609,7 @@ class TestForwardedIdentity:
             WebAuthMiddleware(RecordingApp()),
             http_scope(
                 app=app_stub,
-                headers={AUDIT_SUBJECT_HEADER: forged, AUDIT_ROLE_HEADER: forged},
+                headers={AUDIT_ACCOUNT_HEADER: forged, AUDIT_ROLE_HEADER: forged},
             ),
         )
 
@@ -509,11 +617,30 @@ class TestForwardedIdentity:
         assert detail_parts(record)[AUDIT_ACCOUNT_KEY] == UNSAFE_FORWARDED_VALUE
         assert record["role"] == UNSAFE_FORWARDED_VALUE
 
+    def test_an_unrecordable_subject_is_named_unsafe_under_its_own_key(self, app_stub, records):
+        """The new key is guarded like the one it sits beside.
+
+        The subject is now written under :data:`AUDIT_OIDC_SUBJECT_KEY`, so it
+        is a second caller-controlled value reaching ``detail`` — and would be
+        the easy way back in if only the account were bounded.
+        """
+        drive(
+            WebAuthMiddleware(RecordingApp()),
+            http_scope(
+                app=app_stub,
+                headers={AUDIT_ACCOUNT_HEADER: "alice", AUDIT_SUBJECT_HEADER: "alice bob"},
+            ),
+        )
+
+        parts = detail_parts(only(records))
+        assert parts[AUDIT_ACCOUNT_KEY] == "alice"
+        assert parts[AUDIT_OIDC_SUBJECT_KEY] == UNSAFE_FORWARDED_VALUE
+
     def test_the_unsafe_marker_is_itself_one_detail_token(self):
         """Otherwise the guard would break the format it exists to protect."""
         assert " " not in UNSAFE_FORWARDED_VALUE
 
-    def test_an_unsafe_subject_still_counts_as_a_mismatch(self, app_stub, records, monkeypatch):
+    def test_an_unsafe_account_still_counts_as_a_mismatch(self, app_stub, records, monkeypatch):
         """A value the sidecar could not have produced is not this container's user.
 
         The guard replaces the text, not the comparison: ``bob\x01`` is not
@@ -523,19 +650,44 @@ class TestForwardedIdentity:
         monkeypatch.setenv(TERMINAL_USER_ENV, "bob")
         drive(
             WebAuthMiddleware(RecordingApp()),
-            http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: "bob\x01"}),
+            http_scope(app=app_stub, headers={AUDIT_ACCOUNT_HEADER: "bob\x01"}),
         )
 
         parts = detail_parts(only(records))
         assert parts[AUDIT_ACCOUNT_KEY] == UNSAFE_FORWARDED_VALUE
         assert parts[AUDIT_EXPECTED_ACCOUNT_KEY] == "bob"
 
+    def test_a_forged_subject_beside_a_matching_account_buys_no_mismatch(
+        self, app_stub, records, monkeypatch, caplog
+    ):
+        """And the reverse: the subject is recorded, never compared.
+
+        A caller who can set headers can set the subject to anything at all.
+        Now that only the account is compared, that must not be a way to
+        manufacture a mismatch marker against a container whose real account
+        is the one it was rendered for.
+        """
+        monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
+        with caplog.at_level("WARNING", logger=MIDDLEWARE_LOGGER):
+            drive(
+                WebAuthMiddleware(RecordingApp()),
+                http_scope(
+                    app=app_stub,
+                    headers={AUDIT_ACCOUNT_HEADER: "alice", AUDIT_SUBJECT_HEADER: "mallory"},
+                ),
+            )
+
+        parts = detail_parts(only(records))
+        assert AUDIT_EXPECTED_ACCOUNT_KEY not in parts
+        assert parts[AUDIT_OIDC_SUBJECT_KEY] == "mallory"
+        assert caplog.messages == []
+
     def test_a_value_at_the_cap_is_still_recorded_verbatim(self, app_stub, records):
         """The bound is on forgery-scale input, not on anything real."""
         at_cap = "a" * MAX_FORWARDED_VALUE_CHARS
         drive(
             WebAuthMiddleware(RecordingApp()),
-            http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: at_cap}),
+            http_scope(app=app_stub, headers={AUDIT_ACCOUNT_HEADER: at_cap}),
         )
 
         assert detail_parts(only(records))[AUDIT_ACCOUNT_KEY] == at_cap
@@ -566,7 +718,7 @@ class TestForwardedIdentity:
             WebAuthMiddleware(RecordingApp()),
             http_scope(
                 app=app_stub,
-                headers={AUDIT_SUBJECT_HEADER: "a" * (MAX_DETAIL_CHARS + 200)},
+                headers={AUDIT_ACCOUNT_HEADER: "a" * (MAX_DETAIL_CHARS + 200)},
             ),
         )
 
@@ -585,47 +737,145 @@ class TestForwardedIdentity:
         the forwarded account ``subject=`` inside ``detail`` would have put
         both meanings in one record, one level apart, and made "every record
         for account alice" a per-surface question.
+
+        Driven with both identity headers, because the subject now has a key of
+        its own inside ``detail`` and ``oidc_subject`` was chosen partly so that
+        neither key is bare ``subject``.
         """
         drive(
             WebAuthMiddleware(RecordingApp()),
-            http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: "alice"}),
+            http_scope(
+                app=app_stub,
+                headers={AUDIT_ACCOUNT_HEADER: "alice", AUDIT_SUBJECT_HEADER: "idp|8f21c0"},
+            ),
         )
 
         record = only(records)
+        parts = detail_parts(record)
         assert record["subject"] == "GET /api/config"
         assert AUDIT_ACCOUNT_KEY != "subject"
-        assert "subject" not in detail_parts(record)
-        assert detail_parts(record)[AUDIT_ACCOUNT_KEY] == "alice"
+        assert AUDIT_OIDC_SUBJECT_KEY != "subject"
+        assert "subject" not in parts
+        assert parts[AUDIT_ACCOUNT_KEY] == "alice"
+        assert parts[AUDIT_OIDC_SUBJECT_KEY] == "idp|8f21c0"
+
+    def test_the_oidc_subject_key_is_not_the_writer_s_identity(self):
+        """The audit writer owns ``identity`` for the ledger's directory component.
+
+        A ``detail`` key of that name would put one word on the folder a record
+        is filed under and on a person named inside it.
+        """
+        assert AUDIT_OIDC_SUBJECT_KEY == "oidc_subject"
+        assert AUDIT_OIDC_SUBJECT_KEY not in {"identity", "subject", AUDIT_ACCOUNT_KEY}
 
     def test_the_mismatch_marker_is_written_before_the_account(
         self, app_stub, records, monkeypatch
     ):
-        """Belt to the cap's braces: the signal survives any future truncation."""
+        """Belt to the cap's braces: the signal survives any future truncation.
+
+        The subject comes last for the same reason — it is a second value a
+        caller controls, and appending it ahead of the account would put it
+        between the marker and what the marker disagrees with.
+        """
         monkeypatch.setenv(TERMINAL_USER_ENV, "bob")
         drive(
             WebAuthMiddleware(RecordingApp()),
-            http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: "alice"}),
+            http_scope(
+                app=app_stub,
+                headers={AUDIT_ACCOUNT_HEADER: "alice", AUDIT_SUBJECT_HEADER: "idp|8f21c0"},
+            ),
         )
 
         keys = [part.split("=", 1)[0] for part in only(records)["detail"].split()]
         assert keys.index(AUDIT_EXPECTED_ACCOUNT_KEY) < keys.index(AUDIT_ACCOUNT_KEY)
+        assert keys.index(AUDIT_ACCOUNT_KEY) < keys.index(AUDIT_OIDC_SUBJECT_KEY)
 
     def test_the_header_names_are_the_sidecar_s_own(self):
         """The names are spelled locally; this is what keeps them in step.
 
         Importing them would put a service package in the interfaces' import
-        closure for three string constants, so the drift check is a test — the
+        closure for four string constants, so the drift check is a test — the
         same trade the rest of the audit work makes.
         """
         from osprey.services.auth_sidecar.identity_headers import (
+            ACCOUNT_HEADER,
             ROLE_HEADER,
             ROLE_SOURCE_HEADER,
             SUBJECT_HEADER,
         )
 
         assert AUDIT_SUBJECT_HEADER == SUBJECT_HEADER
+        assert AUDIT_ACCOUNT_HEADER == ACCOUNT_HEADER
         assert AUDIT_ROLE_HEADER == ROLE_HEADER
         assert AUDIT_ROLE_SOURCE_HEADER == ROLE_SOURCE_HEADER
+
+    def test_the_two_identity_headers_are_not_the_same_name(self):
+        """The comparison's whole premise: they name two different things."""
+        assert AUDIT_ACCOUNT_HEADER != AUDIT_SUBJECT_HEADER
+
+
+# --------------------------------------------------------------------------- #
+# The mixed-version fallback
+# --------------------------------------------------------------------------- #
+
+
+class TestOlderSidecarFallback:
+    """A deployment pinning ``auth.image`` to a build with no account header.
+
+    The header is what the fix compares, so an image that does not send it must
+    keep the behaviour it has today — the subject compared against
+    ``OSPREY_TERMINAL_USER``, recorded under ``account=`` — rather than lose
+    the mismatch check altogether. Such a deployment also keeps today's false
+    mismatch under OIDC; that is the bounded cost of the pin, and it is named
+    in the changelog.
+    """
+
+    def test_a_subject_only_match_is_recorded_as_the_account(
+        self, app_stub, records, monkeypatch, caplog
+    ):
+        monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
+        with caplog.at_level("WARNING", logger=MIDDLEWARE_LOGGER):
+            drive(
+                WebAuthMiddleware(RecordingApp()),
+                http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: "alice"}),
+            )
+
+        parts = detail_parts(only(records))
+        assert parts[AUDIT_ACCOUNT_KEY] == "alice"
+        assert AUDIT_EXPECTED_ACCOUNT_KEY not in parts
+        assert caplog.messages == []
+
+    def test_a_subject_only_mismatch_is_still_flagged_and_warned(
+        self, app_stub, records, monkeypatch, caplog
+    ):
+        monkeypatch.setenv(TERMINAL_USER_ENV, "bob")
+        with caplog.at_level("WARNING", logger=MIDDLEWARE_LOGGER):
+            drive(
+                WebAuthMiddleware(RecordingApp()),
+                http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: "alice"}),
+            )
+
+        parts = detail_parts(only(records))
+        assert parts[AUDIT_EXPECTED_ACCOUNT_KEY] == "bob"
+        assert parts[AUDIT_ACCOUNT_KEY] == "alice"
+        assert len([m for m in caplog.messages if "alice" in m and "bob" in m]) == 1
+
+    def test_a_subject_only_record_gains_no_second_key(self, app_stub, records, monkeypatch):
+        """The fallback records exactly the keys it recorded before the fix.
+
+        ``oidc_subject=`` names the subject *when it differs from the account*;
+        with no account forwarded the subject is what stands in for one, so
+        there is nothing for a second key to add.
+        """
+        monkeypatch.setenv(TERMINAL_USER_ENV, "bob")
+        drive(
+            WebAuthMiddleware(RecordingApp()),
+            http_scope(app=app_stub, headers={AUDIT_SUBJECT_HEADER: "alice"}),
+        )
+
+        assert only(records)["detail"] == (
+            f"{AUDIT_EXPECTED_ACCOUNT_KEY}=bob {AUDIT_ACCOUNT_KEY}=alice"
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -748,12 +998,22 @@ class TestAdmittedMutations:
         assert any(message["type"] == "http.response.body" for message in sent)
 
     def test_the_forwarded_identity_rides_the_mutation_record(self, records, monkeypatch):
+        """Both emitters read the same decoder, so both compare the account.
+
+        The inner layer is where an *admitted* request is filed, which is the
+        record the OIDC defect polluted on every card; a fix that reached only
+        the gate would have left the noisier half of the ledger untouched.
+        """
         monkeypatch.setenv(TERMINAL_USER_ENV, "bob")
         drive(
             HttpAuditMiddleware(RecordingApp()),
             http_scope(
                 method="POST",
-                headers={AUDIT_SUBJECT_HEADER: "alice", AUDIT_ROLE_HEADER: "operator"},
+                headers={
+                    AUDIT_ACCOUNT_HEADER: "alice",
+                    AUDIT_SUBJECT_HEADER: "idp|8f21c0",
+                    AUDIT_ROLE_HEADER: "operator",
+                },
             ),
         )
 
@@ -761,7 +1021,21 @@ class TestAdmittedMutations:
         parts = detail_parts(record)
         assert parts[AUDIT_ACCOUNT_KEY] == "alice"
         assert parts[AUDIT_EXPECTED_ACCOUNT_KEY] == "bob"
+        assert parts[AUDIT_OIDC_SUBJECT_KEY] == "idp|8f21c0"
         assert record["role"] == "operator"
+
+    def test_a_matching_account_leaves_the_mutation_record_unflagged(self, records, monkeypatch):
+        """The defect's own shape on the inner layer: the rightful owner's card."""
+        monkeypatch.setenv(TERMINAL_USER_ENV, "alice")
+        drive(
+            HttpAuditMiddleware(RecordingApp()),
+            http_scope(
+                method="POST",
+                headers={AUDIT_ACCOUNT_HEADER: "alice", AUDIT_SUBJECT_HEADER: "idp|8f21c0"},
+            ),
+        )
+
+        assert AUDIT_EXPECTED_ACCOUNT_KEY not in detail_parts(only(records))
 
     def test_an_audit_failure_never_costs_the_request(self, audit_writer, monkeypatch):
         """The ledger degrades; the mutation does not."""

--- a/tests/services/auth_sidecar/test_role_payload.py
+++ b/tests/services/auth_sidecar/test_role_payload.py
@@ -9,10 +9,14 @@ identity this sidecar will authorise with.*
   gained a ``role`` and then a ``role_source``, both additively and deny-safe:
   absent means ``""``, a cookie minted before either field existed still
   decodes, and no payload version was burned for either.
-* **All three identity headers are emitted, or no value is invented.** A
-  password session names the roster user in ``X-Osprey-Auth-Subject`` (presence
-  still means a known account); an OIDC session names the provider subject; a
-  session that holds neither leaves the header absent rather than blank.
+* **All four identity headers are emitted, or no value is invented.** The
+  account is the one that always rides — an authorized request is by definition
+  on a roster card — so an answer without it means a sidecar older than this
+  release, not a session with nothing to say. The rest are omitted rather than
+  blank: a password session names the roster user in ``X-Osprey-Auth-Subject``
+  (presence still means a known account); an OIDC session names the provider
+  subject; a session that holds neither leaves the header absent rather than
+  blank.
 * **Only header-safe values ever exist.** The mint path refuses to store a
   non-ASCII subject or role, the decode path refuses to return one, and the
   verify path refuses to authorise on one. A non-ASCII OIDC subject therefore

--- a/tests/services/auth_sidecar/test_verify.py
+++ b/tests/services/auth_sidecar/test_verify.py
@@ -374,6 +374,70 @@ class TestSubjectHeader:
         assert self.SUBJECT_HEADER.lower() not in response.headers
 
 
+class TestAccountHeader:
+    """An authorized request always names the roster card it is on."""
+
+    ACCOUNT_HEADER = "X-Osprey-Auth-Account"
+    SUBJECT_HEADER = "X-Osprey-Auth-Subject"
+    ALICE_SUBJECT = "idp|alice"
+
+    def test_password_authorization_names_the_roster_account(self) -> None:
+        """In password mode the card and the proof are the same name, so both
+        headers say ``alice`` — the account still rides on its own header
+        rather than leaving a consumer to infer it from the subject."""
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            response = _verify(client, "alice", cookie)
+        assert response.status_code == 200
+        assert response.headers[self.ACCOUNT_HEADER] == "alice"
+
+    def test_oidc_authorization_names_the_card_not_the_person(self) -> None:
+        """Under OIDC the two headers answer different questions: the account is
+        the roster card the request is on, the subject is whoever proved the
+        login. A shared card is exactly where they diverge."""
+        cookie = _mint(_unlocked("alice", stored=None, subject=self.ALICE_SUBJECT))
+        with TestClient(_app(OIDC_ENV)) as client:
+            response = _verify(client, "alice", cookie)
+        assert response.status_code == 200
+        assert response.headers[self.ACCOUNT_HEADER] == "alice"
+        assert response.headers[self.SUBJECT_HEADER] == self.ALICE_SUBJECT
+
+    def test_an_oidc_session_naming_nobody_still_names_the_account(self) -> None:
+        """The account does not depend on the session holding an identity: the
+        request is on a card whether or not the cookie says who opened it."""
+        cookie = _mint(_unlocked("alice", stored=None, subject=""))
+        with TestClient(_app(OIDC_ENV)) as client:
+            response = _verify(client, "alice", cookie)
+        assert response.status_code == 200
+        assert response.headers[self.ACCOUNT_HEADER] == "alice"
+        assert self.SUBJECT_HEADER.lower() not in response.headers
+
+    def test_a_denied_request_never_carries_the_account_header(self) -> None:
+        """The header rides only on the 200. A refusal says nothing at all, so a
+        consumer can never read a card off a request that was not authorized."""
+        cookie = _mint(_unlocked("alice"))
+        with TestClient(_app()) as client:
+            response = _verify(client, "bob", cookie)
+        assert response.status_code == 401
+        assert self.ACCOUNT_HEADER.lower() not in response.headers
+
+    def test_a_non_ascii_roster_username_denies(self) -> None:
+        """Defense in depth, and unreachable in a real deployment: the render
+        holds roster names to ``USERNAME_CHARSET_RE``, so a username that could
+        not cross the nginx boundary never reaches a rendered sidecar. The
+        roster username is also the one identity value that arrives here without
+        having passed through the session codec's own charset refusal, so this
+        route checks it itself and denies rather than emitting a header that
+        would arrive mangled — or dropping it and leaving the terminal running
+        with less identity than the deployment believes it forwarded."""
+        env = {**OIDC_ENV, "OSPREY_AUTH_USERS": "j\u00f6rg,bob"}
+        cookie = _mint(_unlocked("j\u00f6rg", stored=None, subject=""))
+        with TestClient(_app(env)) as client:
+            response = _verify(client, "j\u00f6rg", cookie)
+        assert response.status_code == 401
+        assert self.ACCOUNT_HEADER.lower() not in response.headers
+
+
 class TestLogging:
     """Denials are diagnosable without disclosing anything."""
 


### PR DESCRIPTION
Under `auth.method: oidc`, every audited web-terminal request was recorded as
an account mismatch. The terminal container compared its own roster user
against the forwarded `X-Osprey-Auth-Subject`, which the identity provider
fills with an opaque id or an email rather than a roster name — so the two
disagreed by construction, and the ledger wrote `expected_account=` plus a
warning on every request of every card, indefinitely. Under
`auth.method: password` the subject happens to be the roster username, which
is why the defect never showed there.

The cause is that one header was carrying two different questions. This
separates them:

* **`X-Osprey-Auth-Account`** (new) names the **roster card the request is
  on** — the username `/verify` just checked the session against, and the only
  name a container can compare itself against. It rides every authorized
  answer, because an authorized request always has a card.
* **`X-Osprey-Auth-Subject`** (unchanged) names **who proved the login** — the
  provider's subject under OIDC, the roster username under password. It is
  still emitted only when the session holds one.

The two coincide in a password session and part on a shared card under OIDC,
which is the case they exist separately for.

The account is minted under the same `is_header_safe` rule as the other
identity headers: an unsafe value yields a bare 401 rather than a header.
nginx captures it with `auth_request_set` on the gated location and clears it
on the exempt, internal and login locations, exactly as it does the existing
three names — so a client cannot supply its own.

## The ledger

The comparison moves to the account, and `detail` gains one conditional key:

* `account=` — the roster account, present whenever nginx named an identity.
* `expected_account=` — this container's user, present **only** on a real
  mismatch. Its presence is the whole signal.
* `oidc_subject=` — who proved the login, written only where that differs from
  the account. A password deployment therefore gains no key; an OIDC session
  records the person beside the card they opened.

The envelope's own top-level `subject` field, which the audit writer owns as
the ledger's directory component, is untouched. The mismatch is still recorded
and logged, never enforced — these headers have never been treated as a
credential.

## Older images

A deployment pinning an older login service with `auth.image` receives no
account header. The middleware then falls back to comparing the subject
exactly as it does today, so such a deployment keeps its current behaviour
rather than losing the check. Rebuilding against this release's image is what
clears the spurious marker.

Closes #793
