### PR TITLE
fix(deploy): record the container runtime in the as-built config

### DIFF
--- a/changelog.d/runtime-pin.fixed.md
+++ b/changelog.d/runtime-pin.fixed.md
@@ -1,0 +1,9 @@
+`osprey build` now records the container runtime it used in
+`build/config.yml` (`container_runtime: docker` or `podman`) instead of
+copying `auto` into the render. `down`, `restart`, `reset` and the port
+preflight act on that runtime and refuse if it is not running; they no longer
+re-detect one per invocation, which on a host with both Docker and Podman
+installed could let one slow `docker ps` send a `down` to Podman, where it
+found nothing, exited 0 and reported the still-running Docker stack as
+stopped. Auto-detection also warns when it skips an installed runtime, naming
+the probe that failed.

--- a/docs/source/how-to/deploy-project/index.rst
+++ b/docs/source/how-to/deploy-project/index.rst
@@ -144,10 +144,23 @@ one explicitly.
 Container Runtime Selection
 ===========================
 
-The runtime is auto-detected: if Docker's daemon is reachable it is
-preferred, otherwise Podman is used. Force a specific runtime with the
-``CONTAINER_RUNTIME`` environment variable or by setting
-``container_runtime: docker|podman|auto`` at the root of ``config.yml``.
+The runtime is chosen once, by ``osprey build``, and recorded in
+``build/config.yml`` as ``container_runtime: docker`` or ``podman``. With the
+default ``container_runtime: auto`` the build takes Docker when its daemon
+answers and Podman otherwise; an explicit ``docker`` or ``podman`` in the
+profile's ``config:`` block is taken as written. Every later verb — ``up``,
+``down``, ``restart``, ``reset``, the port preflight — reads the recorded
+runtime and talks only to it. If that runtime is not running, the verb refuses
+and says so; it never switches to the other runtime, because a stack started
+under Docker is invisible from Podman and a ``down`` served there would report
+it stopped while it keeps running.
+
+To move a deployment to the other runtime, stop it where it runs, then build
+again on the new runtime. ``CONTAINER_RUNTIME=docker|podman`` in the
+environment overrides the recorded value for one invocation; use it only for
+a stack you know runs there. When a host has both runtimes installed and
+``auto`` skips one because its probe failed, the build logs a warning naming
+the probe.
 
 .. _compose-provider-compatibility:
 

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1267,6 +1267,56 @@ def _resolve_rendered_execution_method(render_dir: Path) -> list[str]:
     return []
 
 
+def _resolve_rendered_container_runtime(render_dir: Path, progress: Any) -> None:
+    """Answer ``container_runtime: auto`` in a render with the runtime that served it.
+
+    ``auto`` is a question, and every deployment template ships it as the
+    default. Left in ``build/config.yml`` — the as-built config every lifecycle
+    verb reads — it is asked again, from scratch, by ``down``, ``reset``,
+    ``restart`` and the port preflight on every invocation. Detection is
+    docker-then-podman with a short probe timeout, so on a host with both
+    installed one slow ``docker ps`` is enough for a ``down`` to run under
+    podman, find nothing, exit 0, and report the still-running docker stack as
+    stopped.
+
+    So the build answers it once, here, and writes the answer into the render.
+    Every later verb then reads a pinned runtime, and
+    :func:`~osprey.deployment.runtime_helper.get_runtime_command` narrows its
+    probe to that one: a pinned runtime that does not answer is a refusal
+    naming that runtime, never a switch to the other. The same seam as
+    :func:`_resolve_rendered_execution_method`, for the same reason — it is the
+    render, not the profile, that the verbs load.
+
+    An explicit ``docker``/``podman`` is the operator's answer and is left as
+    written. A host where no runtime answers keeps ``auto``: there is nothing
+    to pin to, such a host cannot start anything, and a build there is still
+    a valid thing to do.
+    """
+    from osprey.deployment import runtime_helper
+
+    config_path = render_dir / "config.yml"
+    config = _rendered_config(render_dir)
+    written = str(config.get("container_runtime") or "auto").lower()
+    if written in ("docker", "podman"):
+        return
+
+    try:
+        runtime = runtime_helper.get_runtime_command(config)[0]
+    except RuntimeError as e:
+        logger.debug("Leaving container_runtime: auto in the render — %s", e)
+        return
+
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    with config_path.open("r", encoding="utf-8") as fh:
+        document = yaml.load(fh)
+    document["container_runtime"] = runtime
+    with config_path.open("w", encoding="utf-8") as fh:
+        yaml.dump(document, fh)
+    progress("  ✓ container_runtime: %s (resolved from auto; the runtime this build used)", runtime)
+
+
 def _incomplete_limits_errors(render_dir: Path) -> list[str]:
     """Every ``limits_checking`` block in a render that fails to state a leaf, named.
 
@@ -1618,6 +1668,10 @@ def _render_project(
     ]
     if unrunnable:
         raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(unrunnable))
+    # And the runtime, for the same reason once more: the verbs that stop,
+    # restart and preflight this deployment read the render, and must act on
+    # the runtime that owns the containers rather than re-detect one.
+    _resolve_rendered_container_runtime(render_dir, progress)
 
     applied = _apply_conventions(
         repo_root,

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -24,6 +24,14 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from osprey.utils.logger import get_logger
+
+logger = get_logger("deployment.runtime")
+
+#: How long each detection probe (``<runtime> compose version``, ``<runtime> ps``)
+#: may take before the runtime is treated as not answering.
+_DETECTION_PROBE_TIMEOUT = 5
+
 #: Memoized detections, keyed on the runtimes a call would probe — which folds in
 #: both ``CONTAINER_RUNTIME`` and the config's ``container_runtime``. Keying on
 #: those inputs rather than memoizing a single answer per process keeps a
@@ -55,6 +63,31 @@ def _runtimes_to_try(config: Mapping[str, Any] | None) -> tuple[str, ...]:
     return ("docker", "podman")
 
 
+def _probe_runtime(runtime: str) -> str | None:
+    """Why ``runtime`` cannot serve a compose invocation, or ``None`` when it can.
+
+    Two probes: ``<runtime> compose version`` (a compose implementation is
+    reachable through it) and ``<runtime> ps`` (its daemon answers — a docker
+    CLI with no daemon behind it passes the first and fails the second). The
+    reason is worded for the warning that names a skipped runtime, so it says
+    which probe failed and how.
+    """
+    try:
+        version = subprocess.run(
+            [runtime, "compose", "version"], capture_output=True, timeout=_DETECTION_PROBE_TIMEOUT
+        )
+        if version.returncode != 0:
+            return f"`{runtime} compose version` exited {version.returncode}"
+        ps = subprocess.run([runtime, "ps"], capture_output=True, timeout=_DETECTION_PROBE_TIMEOUT)
+        if ps.returncode != 0:
+            return f"`{runtime} ps` exited {ps.returncode}"
+        return None
+    except subprocess.TimeoutExpired as e:
+        return f"`{' '.join(str(part) for part in e.cmd)}` timed out after {e.timeout:g}s"
+    except FileNotFoundError:
+        return f"`{runtime}` is on PATH but could not be executed"
+
+
 def get_runtime_command(config: Mapping[str, Any] | None = None) -> list[str]:
     """Get container compose command.
 
@@ -78,29 +111,39 @@ def get_runtime_command(config: Mapping[str, Any] | None = None) -> list[str]:
     if cached is not None:
         return cached.copy()
 
-    # Try each runtime
+    # Try each runtime. An INSTALLED runtime that fails its probe is skipped,
+    # but never quietly: the skip is recorded and, if a later candidate is
+    # selected, warned with the probe that failed. Falling from docker to
+    # podman on one slow `docker ps` is a decision the operator has to be able
+    # to see — a lifecycle verb served by the other runtime cannot see the
+    # containers it was asked about, and reports a running stack as stopped.
+    skipped: list[tuple[str, str]] = []
     for runtime in candidates:
         if not shutil.which(runtime):
             continue
 
-        try:
-            # Check if compose subcommand works
-            result = subprocess.run([runtime, "compose", "version"], capture_output=True, timeout=5)
-
-            if result.returncode != 0:
-                continue
-
-            # Also verify daemon is actually running
-            # This prevents selecting Docker when only Docker CLI is installed but daemon isn't running
-            ps_result = subprocess.run([runtime, "ps"], capture_output=True, timeout=5)
-
-            if ps_result.returncode == 0:
-                cmd = [runtime, "compose"]
-                _runtime_cmd_cache[candidates] = cmd
-                return cmd.copy()
-
-        except (subprocess.TimeoutExpired, FileNotFoundError):
+        why = _probe_runtime(runtime)
+        if why is not None:
+            skipped.append((runtime, why))
             continue
+
+        cmd = [runtime, "compose"]
+        _runtime_cmd_cache[candidates] = cmd
+        for other, reason in skipped:
+            logger.warning(
+                "container_runtime: auto chose %s after skipping %s — %s is installed but %s. "
+                "Containers running under %s are not visible from %s; if this deployment's "
+                "are, start %s and retry with CONTAINER_RUNTIME=%s.",
+                runtime,
+                other,
+                other,
+                reason,
+                other,
+                runtime,
+                other,
+                other,
+            )
+        return cmd.copy()
 
     # No runtime found - check if any are installed but not running
     docker_installed = shutil.which("docker") is not None

--- a/tests/cli/test_build_container_runtime.py
+++ b/tests/cli/test_build_container_runtime.py
@@ -1,0 +1,93 @@
+"""The container runtime is resolved at build, on the rendered config.
+
+``container_runtime: auto`` is a *question*, and every deployment template
+ships it as the default. Copying the question into ``build/config.yml`` — the
+as-built config every lifecycle verb reads — meant that ``down``, ``reset``,
+``restart`` and the port preflight each asked it again, from scratch, on every
+invocation. Detection is docker-then-podman with a short probe timeout, so on
+a host with both installed one slow ``docker ps`` was enough for a ``down`` to
+run under podman, find nothing, exit 0, and report the still-running docker
+stack as stopped.
+
+The build now answers the question once, with the runtime that served the
+build, and writes the answer into the render. A verb that later reads
+``docker`` there is pinned to docker, and a docker that does not answer is a
+refusal — never a silent switch to the other runtime. An explicitly pinned
+value is left as written, and a build on a host where no runtime answers keeps
+``auto``: there is nothing to pin to, and such a host cannot start anything
+anyway.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from osprey.cli.build_cmd import build
+from osprey.deployment import runtime_helper
+
+CI_FLAGS = ["--skip-deps", "--skip-lifecycle"]
+
+PROFILE = """\
+name: Runtime Pin
+app_template: hello_world
+provider: anthropic
+config:
+{override}"""
+
+
+def _build_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, override: str = ""):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "profile.yml").write_text(PROFILE.format(override=override))
+    monkeypatch.chdir(repo)
+    result = CliRunner().invoke(build, CI_FLAGS)
+    return repo, result
+
+
+def _rendered_runtime(repo: Path) -> str:
+    config = yaml.safe_load((repo / "build" / "config.yml").read_text())
+    return config["container_runtime"]
+
+
+def _fake_detection(monkeypatch: pytest.MonkeyPatch, runtime: str) -> None:
+    """Answer every detection with ``runtime``."""
+    monkeypatch.setattr(
+        runtime_helper, "get_runtime_command", lambda config=None: [runtime, "compose"]
+    )
+
+
+def test_auto_is_resolved_into_the_runtime_that_answered(tmp_path: Path, monkeypatch):
+    _fake_detection(monkeypatch, "podman")
+
+    repo, result = _build_repo(tmp_path, monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    assert _rendered_runtime(repo) == "podman"
+
+
+def test_a_pinned_runtime_is_written_as_pinned(tmp_path: Path, monkeypatch):
+    """An explicit pin is the operator's answer; detection cannot overrule it."""
+    _fake_detection(monkeypatch, "podman")
+
+    repo, result = _build_repo(tmp_path, monkeypatch, "  container_runtime: docker\n")
+
+    assert result.exit_code == 0, result.output
+    assert _rendered_runtime(repo) == "docker"
+
+
+def test_no_runtime_answering_leaves_auto_in_place(tmp_path: Path, monkeypatch):
+    """A host with no runtime can still build; the question stays open."""
+
+    def _nothing(config=None):
+        raise RuntimeError("No container runtime found.")
+
+    monkeypatch.setattr(runtime_helper, "get_runtime_command", _nothing)
+
+    repo, result = _build_repo(tmp_path, monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    assert _rendered_runtime(repo) == "auto"

--- a/tests/deployment/test_down_pinned_runtime.py
+++ b/tests/deployment/test_down_pinned_runtime.py
@@ -1,0 +1,75 @@
+"""``down`` acts on the runtime the as-built config names, or refuses.
+
+The as-built ``build/config.yml`` records the runtime that served the build.
+A lifecycle verb reading ``docker`` there must talk to docker: when docker does
+not answer it refuses with docker's own remedy, and never lets detection fall
+through to a podman that is also installed. The alternative is the failure this
+pins: a ``down`` served by podman-compose finds no containers, exits 0, and
+reports a stack still running under docker as stopped.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from osprey.deployment import container_lifecycle, runtime_helper
+
+_RENDERED_CONFIG = """\
+project_name: pinned
+build_dir: ./build
+container_runtime: docker
+deployed_services:
+  - event_dispatcher
+services:
+  event_dispatcher:
+    path: services/event_dispatcher
+"""
+
+
+@pytest.fixture
+def pinned_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "pinned"
+    build = repo / "build"
+    (build / "services" / "event_dispatcher").mkdir(parents=True)
+    (repo / "profile.yml").write_text("name: pinned\n")
+    (build / "config.yml").write_text(_RENDERED_CONFIG)
+    (build / "services" / "docker-compose.yml").write_text("networks:\n  osprey-network:\n")
+    (build / "services" / "event_dispatcher" / "docker-compose.yml").write_text(
+        "services:\n  event-dispatcher:\n    image: x\n"
+    )
+    return repo
+
+
+def _host_where_docker_hangs_and_podman_answers(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Both runtimes on PATH; docker's daemon probe times out, podman's succeed."""
+    probed: list[list[str]] = []
+
+    def _run(cmd, **kwargs):
+        probed.append(list(cmd))
+        if cmd[0] == "docker" and cmd[1] == "ps":
+            raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 5))
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(runtime_helper.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(runtime_helper.subprocess, "run", _run)
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+    return probed
+
+
+def test_down_refuses_when_the_pinned_runtime_does_not_answer(monkeypatch, pinned_repo):
+    probed = _host_where_docker_hangs_and_podman_answers(monkeypatch)
+    compose_runs: list[list[str]] = []
+    monkeypatch.setattr(
+        container_lifecycle,
+        "run_captured",
+        lambda cmd, **kwargs: compose_runs.append(list(cmd)),
+    )
+
+    with pytest.raises(RuntimeError, match="[Dd]ocker"):
+        container_lifecycle.down_deployment(pinned_repo)
+
+    assert compose_runs == [], "no compose command may run against a runtime that was not pinned"
+    assert all(cmd[0] == "docker" for cmd in probed), probed

--- a/tests/deployment/test_runtime_detection.py
+++ b/tests/deployment/test_runtime_detection.py
@@ -523,3 +523,101 @@ class TestNotRunningMessages:
 
         monkeypatch.setattr(platform, "system", lambda: "Linux")
         assert "podman.socket" in runtime_helper._get_podman_not_running_message()
+
+
+class TestFallThroughIsAnnounced:
+    """``auto`` may pick the second runtime, but never quietly.
+
+    Skipping an installed runtime whose probe failed is a decision the
+    operator has to be able to see: a ``down`` served by the other runtime
+    reports a stack it cannot see as stopped. The warning names the runtime
+    that was skipped, the probe that failed, and the one selected instead.
+    """
+
+    @staticmethod
+    def _warnings(caplog) -> list[str]:
+        import logging
+
+        return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_skipping_an_installed_runtime_is_warned_with_the_failed_probe(
+        self, monkeypatch, caplog
+    ):
+        import logging
+
+        monkeypatch.setattr(runtime_helper.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            runtime_helper.subprocess,
+            "run",
+            _make_run(
+                {
+                    ("docker", "compose"): 0,
+                    ("docker", "ps"): 1,
+                    ("podman", "compose"): 0,
+                    ("podman", "ps"): 0,
+                }
+            ),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="deployment.runtime"):
+            assert get_runtime_command() == ["podman", "compose"]
+
+        warnings = self._warnings(caplog)
+        assert len(warnings) == 1, warnings
+        assert "docker" in warnings[0] and "podman" in warnings[0]
+        assert "docker ps" in warnings[0]
+
+    def test_a_probe_timeout_is_named_as_such(self, monkeypatch, caplog):
+        import logging
+
+        def _run(cmd, **kwargs):
+            if cmd[0] == "docker" and cmd[1] == "ps":
+                raise subprocess.TimeoutExpired(cmd, 5)
+            return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(runtime_helper.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(runtime_helper.subprocess, "run", _run)
+
+        with caplog.at_level(logging.WARNING, logger="deployment.runtime"):
+            assert get_runtime_command() == ["podman", "compose"]
+
+        warnings = self._warnings(caplog)
+        assert len(warnings) == 1, warnings
+        assert "timed out" in warnings[0]
+
+    def test_an_absent_runtime_is_not_a_fall_through(self, monkeypatch, caplog):
+        """Only docker on PATH is not a choice between two; nothing is warned."""
+        import logging
+
+        monkeypatch.setattr(
+            runtime_helper.shutil,
+            "which",
+            lambda name: f"/usr/bin/{name}" if name == "podman" else None,
+        )
+        monkeypatch.setattr(
+            runtime_helper.subprocess,
+            "run",
+            _make_run({("podman", "compose"): 0, ("podman", "ps"): 0}),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="deployment.runtime"):
+            assert get_runtime_command() == ["podman", "compose"]
+
+        assert self._warnings(caplog) == []
+
+    def test_a_pinned_runtime_never_falls_through(self, monkeypatch, caplog):
+        """The pin narrows the candidates to one; nothing is skipped, so nothing is warned."""
+        import logging
+
+        monkeypatch.setattr(runtime_helper.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            runtime_helper.subprocess,
+            "run",
+            _make_run({("podman", "compose"): 0, ("podman", "ps"): 0}),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="deployment.runtime"):
+            with pytest.raises(RuntimeError):
+                get_runtime_command({"container_runtime": "docker"})
+
+        assert self._warnings(caplog) == []


### PR DESCRIPTION
`container_runtime: auto` was copied verbatim into `build/config.yml`, the as-built file every lifecycle verb reads, so `down`, `restart`, `reset` and the port preflight each re-detected a runtime per invocation. On a host with both Docker and Podman installed, one slow `docker ps` sent a `down` to Podman, which found nothing, exited 0 and reported the still-running Docker stack as stopped.

`osprey build` now resolves `auto` into the runtime that served the build and writes it into `build/config.yml`, the way the execution method is already resolved into the render. The lifecycle verbs act on that runtime and refuse when it is not running instead of silently switching. Auto-detection warns when it skips an installed runtime, naming the probe that failed and the remedy.

`CONTAINER_RUNTIME` still overrides the recorded value: it is an explicit operator act, and the Podman CI lane relies on it. Builds made before this change keep `auto` until their next `osprey build`; the new warning covers that window.

## How it hangs together

```text
 config.yml                osprey build                      build/config.yml
 container_runtime: auto ─► _resolve_rendered_container_runtime() ─► container_runtime: docker
                            (probes once, records the answer)

 down / restart / reset / port preflight
   └─► runtime_selection_config() reads build/config.yml
         └─► _runtimes_to_try() → [docker] only
               ├─ docker healthy  → compose runs against docker
               └─ docker probe fails → refuse, naming the probe (no fallback to podman)

 detect_container_runtime()  (auto, unpinned)
   └─► _probe_runtime() returns a reason → warn when an installed runtime is skipped
```
