### PR TITLE
feat(deploy): configurable web_terminals TLS listener port

### DIFF
--- a/changelog.d/794.added.md
+++ b/changelog.d/794.added.md
@@ -1,0 +1,5 @@
+The multi-user web terminal's HTTPS listener no longer has to be 443:
+`modules.web_terminals.tls.port` names the port nginx serves TLS on. A
+non-default port becomes part of the address browsers reach, so under
+`auth.method: oidc` the callback `https://<fqdn>:<port>/auth/oidc/callback` has
+to be registered with the identity provider.

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -131,6 +131,15 @@ set it — see :ref:`reference-ports`),
    through the login page, nginx rather than that cookie is what lets them
    through, so here the key sets the login page's cookie.
 
+``tls.port`` is optional in the same way: nginx serves HTTPS on 443 unless you
+name another port, for a host that cannot bind 443 or already carries another
+deployment's HTTPS. It is HTTPS's own default rather than a port-layout slot,
+so :ref:`reference-ports` does not list it, and a non-default value changes the
+address browsers reach — see :ref:`multi-user-https`. A ``tls.port`` or
+``auth.port`` that is not a whole number between 1 and 65535 falls back to that
+key's default, which ``osprey scaffold web-terminals lint`` reports as
+``web_terminals.invalid_listener_port``.
+
 .. warning::
 
    No secret may contain a ``$`` — not in ``.env.auth``, ``.env`` or
@@ -219,11 +228,24 @@ render with ``tls.enabled: false`` unless something else encrypts the
 connection. Two shapes:
 
 **This nginx terminates TLS.** Set ``tls.enabled: true`` with a certificate
-and key; nginx serves HTTPS on 443 and redirects the plain port.
-``host_cert_dir`` is the only key that names a path on the deploy host — it is
-bind-mounted, read-only, where ``cert`` and ``key`` (paths inside the
-container) sit, so both must be in that one directory and the path must be
-absolute. Leave ``host_cert_dir`` out to mount the certificate your own way.
+and key; nginx serves HTTPS on 443 — or on ``tls.port`` when you set one — and
+redirects the plain port to it. ``host_cert_dir`` is the only key that names a
+path on the deploy host — it is bind-mounted, read-only, where ``cert`` and
+``key`` (paths inside the container) sit, so both must be in that one directory
+and the path must be absolute. Leave ``host_cert_dir`` out to mount the
+certificate your own way.
+
+A non-default ``tls.port`` also becomes part of the address browsers reach.
+The deployment's origin is then ``https://<fqdn>:<port>``, built from
+``deploy.fqdn`` unless ``external_origin`` names the address itself, and
+everything derived from it carries the port: the landing
+link, the address each terminal checks a state-changing request came from, and
+under ``oidc`` the callback the authentication service sends to your provider.
+Register ``https://<fqdn>:<port>/auth/oidc/callback`` with the identity
+provider, or change an existing registration to match — a provider refuses a
+callback that is not character-for-character the registered one. On 443 the
+port stays out of the origin and the callback is
+``https://<fqdn>/auth/oidc/callback``.
 
 **Something in front terminates TLS** — a facility load balancer or ingress:
 

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -56,6 +56,7 @@ from osprey.deployment.web_terminals.ports import (
     resolve_nginx_port,
 )
 from osprey.deployment.web_terminals.render import (
+    _AUTH_PORT_SLOT,
     _RESERVED_AUDIT_IDENTITY_RE,
     AUTH_SIDECAR_AUDIT_IDENTITY,
     SUPPORTED_AUTH_METHODS,
@@ -64,18 +65,23 @@ from osprey.deployment.web_terminals.render import (
     _authorization_context,
     _configured_external_origin,
     _external_origin,
+    _port_int,
 )
 from osprey.interfaces.web_auth import DEFAULT_SESSION_LIFETIME
-from osprey.port_layout import resolve_port_base
+from osprey.port_layout import _MAX_PORT, default_port, resolve_port_base
 from osprey_connectors.types import TYPE_WRITES_ENABLED_LEAF, WRITES_ENABLED_KEY
 
-# The TLS seam's listener port (`listen 443 ssl` in the gated nginx block) is
-# `render.TLS_LISTEN_PORT`, imported above rather than restated: the render
-# stamps the same port into the perimeter deny-list, and a second literal here
-# could come to reserve a port the template does not listen on. The auth
-# sidecar's listener needs no constant at all: it is config-driven
-# (`auth.port`), and its effective value is read from render's parsed auth
-# context.
+# Both listeners in the gated auth/TLS seam are config-driven: nginx's TLS
+# listener is `tls.port` and the auth sidecar's is `auth.port`. Neither default
+# is restated here. `render.TLS_LISTEN_PORT` is imported because the render
+# stamps that same fallback into both `listen` lines and the perimeter
+# deny-list, and a second literal here could come to reserve a port the template
+# does not listen on; the sidecar's default is the port layout's `auth` slot,
+# read off render's parsed auth context or derived from the same layout. So is
+# `render._port_int`, the one reader that says which values reach a `listen`
+# directive at all — the checks below resolve a configured port exactly as
+# render resolves it, which is what makes a finding that says "render falls
+# back" true across the whole invalid domain.
 
 # The credential env-var stem a roster username is keyed into
 # (`OSPREY_AUTH_PW_HASH_<SUFFIX>`), quoted only inside this module's collision
@@ -238,6 +244,7 @@ def lint_web_terminals(
     findings.extend(_check_external_origin(web_terminals))
     findings.extend(_check_auth_method(web_terminals))
     findings.extend(_check_auth_session_lifetime(web_terminals))
+    findings.extend(_check_listener_ports(root, web_terminals))
     findings.extend(_check_auth_transport(root, web_terminals))
     findings.extend(_check_auth_oidc(root, web_terminals))
     findings.extend(_check_auth_credential_collisions(web_terminals, users))
@@ -740,7 +747,8 @@ def _check_port_overlap(
     with each other but with every port the ``services:`` block publishes. The
     collision set is therefore: the per-user port families over the N configured
     users, nginx's own listener, every published service port, and the TLS
-    listener when that seam is enabled.
+    listener (``tls.port``, defaulting to :data:`TLS_LISTEN_PORT`) when that
+    seam is enabled.
     """
     entries: list[tuple[int, str]] = []
 
@@ -790,10 +798,18 @@ def _check_port_overlap(
 
     # S5: the gated auth/TLS seam's port(s) — only join the collision set when
     # the seam is actually enabled by config; the default (tls disabled, no
-    # sidecar) must not reserve 443 or the sidecar port against ordinary configs.
+    # sidecar) must not reserve the TLS listener or the sidecar port against
+    # ordinary configs.
+    #
+    # The TLS listener is read straight off the raw stanza rather than through
+    # `_auth_context`: that context is None for a config whose `auth.method`
+    # names no method, and a port this deployment's nginx will bind belongs in
+    # the collision set whether or not the auth stanza parses. `_port_int`
+    # resolves it the way render does, so an unusable `tls.port` reserves the
+    # default nginx will actually listen on rather than a port nothing binds.
     tls = as_dict(web_terminals.get("tls"))
     if bool(tls.get("enabled", False)):
-        entries.append((TLS_LISTEN_PORT, "web_terminals.tls (listen 443 ssl)"))
+        entries.append((_port_int(tls.get("port"), TLS_LISTEN_PORT), "web_terminals.tls.port"))
     # The deployment's own base, the same one the port families above were
     # allocated at: a sidecar port resolved at the layout default would land in
     # a different block and make this collision set mixed-base — missing a real
@@ -2878,6 +2894,73 @@ def _check_auth_session_lifetime(web_terminals: dict[str, Any]) -> list[Finding]
     ]
 
 
+def _check_listener_ports(root: dict[str, Any], web_terminals: dict[str, Any]) -> list[Finding]:
+    """``tls.port`` and ``auth.port`` must name a TCP port that exists.
+
+    The two listeners the gated auth/TLS seam binds are both config-driven, and
+    render reads both defensively (see
+    :func:`~osprey.deployment.web_terminals.render._port_int`): anything that is
+    not a whole number in ``1..65535`` — ``0``, a negative, ``true``, ``'8443'``
+    as a string, ``70000`` — is substituted with the default. A deployment that
+    meant to move nginx off 443, or the sidecar off its layout slot, therefore
+    comes up on the port it was trying to leave, and nothing downstream sees
+    the mistake: the render is well-formed, nginx starts, and the only symptom
+    is a listener in the wrong place. Like :func:`_check_auth_method` and
+    :func:`_check_auth_session_lifetime` this module is the only surface that
+    can report it, so the rule reads the raw stanzas rather than render's
+    parsed context — by the time that context exists the bad value is gone.
+
+    An absent key, and a ``port:`` written with no value at all (``None`` after
+    YAML load), are the documented default and are not flagged. A non-mapping
+    ``tls`` or ``auth`` stanza has no keys to read and is passed over; the
+    ``auth`` case is :func:`_check_auth_method`'s finding rather than this
+    one's.
+
+    Both ports are checked whether or not their seam is enabled. An unusable
+    value is an authoring mistake in either case, and the config that turns the
+    seam on is often the next edit.
+
+    Args:
+        root: The whole config, for the port base the sidecar's layout default
+            is derived at — quoting the default block's port for a deployment
+            that resolved another base would name a port it never binds.
+        web_terminals: The ``modules.web_terminals`` block being linted.
+
+    Returns:
+        One finding per unusable port value.
+    """
+    base = resolve_port_base(root)
+    stanzas = (
+        ("tls", "tls.port", TLS_LISTEN_PORT),
+        ("auth", "auth.port", default_port(_AUTH_PORT_SLOT, base=base)),
+    )
+    findings: list[Finding] = []
+    for stanza_key, dotted, default in stanzas:
+        stanza = web_terminals.get(stanza_key)
+        if not isinstance(stanza, dict) or "port" not in stanza:
+            continue
+        port = stanza["port"]
+        if port is None:
+            continue
+        # `bool` is excluded for render's reason (see `render._positive_int`):
+        # it passes `isinstance(..., int)`, and `tls.port: true` becoming a
+        # listener on port 1 would be a baffling deployment.
+        if isinstance(port, int) and not isinstance(port, bool) and 0 < port <= _MAX_PORT:
+            continue
+        findings.append(
+            Finding(
+                severity="error",
+                code="web_terminals.invalid_listener_port",
+                message=(
+                    f"modules.web_terminals.{dotted} {port!r} is not a whole number "
+                    f"between 1 and {_MAX_PORT}; render would silently fall back to the "
+                    f"default ({default})"
+                ),
+            )
+        )
+    return findings
+
+
 def _check_auth_transport(root: dict[str, Any], web_terminals: dict[str, Any]) -> list[Finding]:
     """Authentication over cleartext HTTP: an ERROR, or a WARN once accepted.
 
@@ -3044,6 +3127,7 @@ def _check_auth_oidc(root: dict[str, Any], web_terminals: dict[str, Any]) -> lis
             root,
             nginx_port,
             tls_enabled=bool(context["tls_enabled"]),
+            tls_port=int(context["tls_port"]),
         )
     except ValueError as exc:
         findings.append(

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -60,7 +60,7 @@ from osprey.deployment.web_terminals.ports import (
 # The one definition of the session-lifetime default lives in web_auth, which is
 # stdlib-only, so importing it here cannot cycle.
 from osprey.interfaces.web_auth import DEFAULT_SESSION_LIFETIME
-from osprey.port_layout import default_port, resolve_port_base
+from osprey.port_layout import _MAX_PORT, default_port, resolve_port_base
 from osprey.utils.facility import resolve_facility_name
 from osprey.utils.workspace import AUDIT_DIR_RELPATH, agent_data_base_dir
 
@@ -93,13 +93,18 @@ _LOOPBACK_BIND_HOST = "127.0.0.1"
 # an absent config value renders the same image from either side.
 _DEFAULT_NGINX_IMAGE = "nginx:1.27-alpine"
 
-#: The TLS seam's listener port. A literal because the template makes it one:
-#: there is no ``tls.port`` key to read, the ``443`` is spelled inside
-#: nginx.conf.j2's block gated on ``tls_enabled``. Defined here, beside the
-#: render that stamps it into the perimeter deny-list, and imported by ``lint``
-#: for its port-collision check — never restated there, since two spellings of
-#: one hard-coded listener is exactly how a collision check comes to reserve a
-#: port the template does not use.
+#: The TLS seam's listener port when ``modules.web_terminals.tls.port`` is
+#: unset: HTTPS's own default rather than a slot in this deployment's port
+#: block, since a facility serving the standard port should not have to
+#: configure one. A host that cannot bind 443 — unprivileged, or already
+#: carrying another deployment's perimeter — names its own port instead, and
+#: every consumer of the seam follows the ``tls_port`` value
+#: :func:`_auth_tls_context` derives: both ``listen`` lines, the cleartext
+#: redirect, the external origin the IdP is registered against and the
+#: perimeter deny-list. Defined here, beside the render that stamps it, and
+#: imported by ``lint`` for its port-collision check — never restated there,
+#: since two spellings of one default is exactly how a collision check comes to
+#: reserve a port the template does not use.
 TLS_LISTEN_PORT = 443
 
 #: The authentication methods this deployment can actually serve: ``none``
@@ -1119,8 +1124,8 @@ def render_web_terminals(
     if auth_tls_ctx["tls_enabled"] and not (auth_tls_ctx["tls_cert"] and auth_tls_ctx["tls_key"]):
         raise ValueError(
             "modules.web_terminals.tls.enabled is true but tls.cert/tls.key are not both "
-            "set — the gated `listen 443 ssl` seam needs both paths to emit a "
-            "coherent ssl_certificate/ssl_certificate_key pair"
+            f"set — the gated `listen {auth_tls_ctx['tls_port']} ssl` seam needs both "
+            "paths to emit a coherent ssl_certificate/ssl_certificate_key pair"
         )
     _check_tls_host_cert_dir(auth_tls_ctx)
     if (
@@ -1166,16 +1171,21 @@ def render_web_terminals(
     )
 
     tls_enabled = auth_tls_ctx["tls_enabled"]
+    tls_port = auth_tls_ctx["tls_port"]
     # The one origin every absolute URL in this deployment is built from (see
     # _external_origin). Derived only when something actually needs it: a
     # roster-less config with no sidecar has no absolute URL to build, and must
     # keep rendering without a deploy.fqdn.
     external_origin = (
-        _external_origin(root, nginx_port, tls_enabled=tls_enabled)
+        _external_origin(root, nginx_port, tls_enabled=tls_enabled, tls_port=tls_port)
         if services or auth_tls_ctx["sidecar_active"]
         else ""
     )
-    landing_url = _landing_url(root, nginx_port, tls_enabled=tls_enabled) if services else ""
+    landing_url = (
+        _landing_url(root, nginx_port, tls_enabled=tls_enabled, tls_port=tls_port)
+        if services
+        else ""
+    )
 
     # Every service is told the deployment's external origin, because the app
     # inside each container checks a mutating request's `Origin` against it —
@@ -1218,13 +1228,16 @@ def render_web_terminals(
     # addresses them legitimately, and none of them fronts a terminal, an agent
     # session, or an approval prompt, which is what this deny-list guards.
     perimeter_open = auth_tls_ctx["open_perimeter"]
-    # The TLS seam's listener (`TLS_LISTEN_PORT`) joins the set only when
-    # `tls.enabled` is on. There nginx.conf.j2 renders `listen 443 ssl` as the
-    # SOLE content server and demotes `nginx_port` to a redirect — so a list
-    # carrying only `nginx_port` would name the door that redirects and miss the
-    # one that serves. `nginx_port` stays in either way: the redirect listener
-    # still accepts the connection, and the redirect it answers with is the map
-    # to everything else.
+    # The TLS seam's listener (`tls.port`, default `TLS_LISTEN_PORT`) joins the
+    # set only when `tls.enabled` is on. There nginx.conf.j2 renders that port's
+    # `listen ... ssl` as the SOLE content server and demotes `nginx_port` to a
+    # redirect — so a list carrying only `nginx_port` would name the door that
+    # redirects and miss the one that serves. The parsed port is used rather
+    # than the constant, because a deployment on a non-default TLS port would
+    # otherwise deny 443 (which serves nothing) and leave its real content
+    # listener reachable from inside a container. `nginx_port` stays in either
+    # way: the redirect listener still accepts the connection, and the redirect
+    # it answers with is the map to everything else.
     #
     # Sorted and de-duplicated, so the rendered line is a function of the
     # roster and not of dict iteration order — this file is diffed between
@@ -1232,7 +1245,7 @@ def render_web_terminals(
     perimeter_deny_ports = sorted(
         {
             nginx_port,
-            *([TLS_LISTEN_PORT] if tls_enabled else []),
+            *([tls_port] if tls_enabled else []),
             *(service["web"] for service in services),
         }
     )
@@ -1514,7 +1527,13 @@ def _configured_external_origin(root: dict[str, Any]) -> str:
     return origin
 
 
-def _external_origin(root: dict[str, Any], nginx_port: int, *, tls_enabled: bool) -> str:
+def _external_origin(
+    root: dict[str, Any],
+    nginx_port: int,
+    *,
+    tls_enabled: bool,
+    tls_port: int = TLS_LISTEN_PORT,
+) -> str:
     """Build the one origin every absolute URL this deployment emits is derived from.
 
     Three consumers need an absolute URL that a browser will actually resolve:
@@ -1538,12 +1557,15 @@ def _external_origin(root: dict[str, Any], nginx_port: int, *, tls_enabled: bool
     configuration gap.
 
     Otherwise the origin is derived. Scheme and port follow ``tls.enabled``:
-    with TLS on, the 443 server is the sole content server (the plain listener
-    only redirects to it), and 443 is left implicit, which is both the canonical
-    origin serialization and the form an IdP client registration is normally
-    written in. With TLS off the origin is plain HTTP on the published
-    ``nginx_port``. A default port left explicit here is not a mismatch: both
-    ends of the ``Origin`` check normalize it away
+    with TLS on, the TLS server is the sole content server (the plain listener
+    only redirects to it), so the origin is ``https`` on ``tls.port``. The
+    default 443 is left implicit — both the canonical origin serialization and
+    the form an IdP client registration is normally written in — while any other
+    ``tls.port`` is spelled out, because a browser reaching a non-default port
+    sends it in the ``Origin`` header and an IdP would reject a
+    ``redirect_uri`` that omitted it. With TLS off the origin is plain HTTP on
+    the published ``nginx_port``. A default port left explicit here is not a
+    mismatch: both ends of the ``Origin`` check normalize it away
     (:func:`osprey.interfaces.common_middleware._normalize_origin`).
 
     The derived host comes from ``deploy.fqdn``: the schema documents that field
@@ -1557,6 +1579,9 @@ def _external_origin(root: dict[str, Any], nginx_port: int, *, tls_enabled: bool
         nginx_port: The published plain-HTTP port, used only when TLS is off and
             no origin is configured.
         tls_enabled: The parsed ``tls.enabled`` (see :func:`_auth_tls_context`).
+        tls_port: The parsed ``tls.port`` (see :func:`_auth_tls_context`), used
+            only when TLS is on and no origin is configured. Left out of the
+            origin when it is :data:`TLS_LISTEN_PORT`.
 
     Raises:
         ValueError: If ``modules.web_terminals.external_origin`` is set to
@@ -1577,7 +1602,9 @@ def _external_origin(root: dict[str, Any], nginx_port: int, *, tls_enabled: bool
             "front of this nginx is what browsers actually reach — set "
             "modules.web_terminals.external_origin to that address"
         )
-    return f"https://{host}" if tls_enabled else f"http://{host}:{nginx_port}"
+    if not tls_enabled:
+        return f"http://{host}:{nginx_port}"
+    return f"https://{host}" if tls_port == TLS_LISTEN_PORT else f"https://{host}:{tls_port}"
 
 
 def deployment_external_origin(config: Any) -> str:
@@ -1595,7 +1622,8 @@ def deployment_external_origin(config: Any) -> str:
 
     Returns:
         ``modules.web_terminals.external_origin`` verbatim when it is set;
-        otherwise ``https://<fqdn>`` with TLS on and
+        otherwise ``https://<fqdn>`` with TLS on (``https://<fqdn>:<tls_port>``
+        when ``tls.port`` is not the default 443) and
         ``http://<fqdn>:<nginx_port>`` without.
 
     Raises:
@@ -1608,8 +1636,13 @@ def deployment_external_origin(config: Any) -> str:
     root = as_dict(config)
     web_terminals = as_dict(as_dict(root.get("modules")).get("web_terminals"))
     nginx_port = resolve_nginx_port(root)
-    tls_enabled = bool(_auth_tls_context(web_terminals)["tls_enabled"])
-    return _external_origin(root, nginx_port, tls_enabled=tls_enabled)
+    auth_tls_ctx = _auth_tls_context(web_terminals)
+    return _external_origin(
+        root,
+        nginx_port,
+        tls_enabled=bool(auth_tls_ctx["tls_enabled"]),
+        tls_port=int(auth_tls_ctx["tls_port"]),
+    )
 
 
 def terminal_login_url(config: Any, username: str, secret: str) -> str:
@@ -1647,7 +1680,13 @@ def terminal_login_url(config: Any, username: str, secret: str) -> str:
     return f"{origin}/u/{username}/?token={quote(secret, safe='')}"
 
 
-def _landing_url(root: dict[str, Any], nginx_port: int, *, tls_enabled: bool = False) -> str:
+def _landing_url(
+    root: dict[str, Any],
+    nginx_port: int,
+    *,
+    tls_enabled: bool = False,
+    tls_port: int = TLS_LISTEN_PORT,
+) -> str:
     """The absolute origin baked into every service's ``OSPREY_TERMINAL_LANDING_URL``.
 
     Per-user containers only get this value once, at container start (env vars, not
@@ -1656,7 +1695,7 @@ def _landing_url(root: dict[str, Any], nginx_port: int, *, tls_enabled: bool = F
     origin verbatim (:func:`_external_origin`), which is what keeps a "back to
     landing" link and an OIDC ``redirect_uri`` on the same origin by construction.
     """
-    return _external_origin(root, nginx_port, tls_enabled=tls_enabled)
+    return _external_origin(root, nginx_port, tls_enabled=tls_enabled, tls_port=tls_port)
 
 
 def _user_card(resolved_user: dict[str, Any]) -> dict[str, Any]:
@@ -1806,8 +1845,8 @@ def _auth_tls_context(web_terminals: dict[str, Any], *, base: int | None = None)
     template, the compose overlay and the lint rules all read the keys returned
     here rather than the raw config, so there is one definition of what an
     ``auth`` stanza means. **This function renders nothing** — it derives values;
-    the templates turn ``tls_enabled``/``auth_method`` into actual `listen 443
-    ssl` / `auth_request` directives.
+    the templates turn ``tls_enabled``/``tls_port``/``auth_method`` into the
+    actual `listen <tls_port> ssl` / `auth_request` directives.
 
     Both stanzas remain entirely optional. ``tls`` defaults to off; ``auth``
     defaults to ``token``, today's magic-link posture. Every value is read defensively (wrong-typed entries
@@ -1870,7 +1909,11 @@ def _auth_tls_context(web_terminals: dict[str, Any], *, base: int | None = None)
         *names* the sidecar reads its OIDC client credentials from — never the
         credentials themselves) and ``auth_oidc_claim`` (str or ``None``, the
         ID-token claim carrying the identity to map onto a roster user); plus
-        the TLS keys ``tls_enabled`` (bool) and
+        the TLS keys ``tls_enabled`` (bool), ``tls_port`` (int, the listener
+        both nginx ``listen`` lines and the derived external origin follow,
+        defaulting to :data:`TLS_LISTEN_PORT`), ``tls_default_port`` (that
+        constant itself, so the template's port-in-redirect test and
+        :func:`_external_origin` compare against one value) and
         ``tls_cert``/``tls_key`` (str path or ``None``, read only when
         ``tls_enabled``).
 
@@ -1899,7 +1942,7 @@ def _auth_tls_context(web_terminals: dict[str, Any], *, base: int | None = None)
         "walled": sidecar_active,
         "token_exchange": auth_method == "token",
         "open_perimeter": auth_method == "none",
-        "auth_port": _positive_int(auth.get("port"), default_port(_AUTH_PORT_SLOT, base=base)),
+        "auth_port": _port_int(auth.get("port"), default_port(_AUTH_PORT_SLOT, base=base)),
         "auth_session_lifetime": _positive_int(
             auth.get("session_lifetime"), DEFAULT_SESSION_LIFETIME
         ),
@@ -1918,6 +1961,11 @@ def _auth_tls_context(web_terminals: dict[str, Any], *, base: int | None = None)
         # sidecar's own documented default applies — one default, in one place.
         "auth_oidc_claim": _non_empty_str(oidc.get("claim"), "") or None,
         "tls_enabled": bool(tls.get("enabled", False)),
+        "tls_port": _port_int(tls.get("port"), TLS_LISTEN_PORT),
+        # Carried alongside so the template's "is this the port a browser
+        # assumes for https://" test reads the same constant `_external_origin`
+        # does, rather than restating 443 as a literal.
+        "tls_default_port": TLS_LISTEN_PORT,
         "tls_cert": tls.get("cert"),
         "tls_key": tls.get("key"),
         # The HOST directory holding the certificate and key. Optional, and the
@@ -2160,6 +2208,20 @@ def _positive_int(value: Any, default: int) -> int:
     if isinstance(value, int) and not isinstance(value, bool) and value > 0:
         return value
     return default
+
+
+def _port_int(value: Any, default: int) -> int:
+    """A config value read as a TCP port, falling back to ``default``.
+
+    :func:`_positive_int` bounded above by the highest port there is, so the
+    whole invalid domain — non-int, ``bool``, ``0``, negative, and anything past
+    :data:`osprey.port_layout._MAX_PORT` — lands on the same default. That is
+    what makes lint's finding for a bad ``tls.port``/``auth.port`` honest when it
+    says the render falls back: a value of ``70000`` would otherwise reach a
+    ``listen`` directive nginx refuses at startup.
+    """
+    port = _positive_int(value, 0)
+    return port if 0 < port <= _MAX_PORT else default
 
 
 def _non_empty_str(value: Any, default: str) -> str:

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -157,14 +157,15 @@
     perimeter_deny_ports: str, required (never empty — always contains at
     least the nginx port)
       The deployment's own web ports as a comma-separated, ascending list of
-      integers ("10000,10100,10101") — nginx's published port, 443 when
-      `tls.enabled` puts the real content server behind the TLS listener, and
-      every roster user's terminal port. Nothing else: companion panel families
-      are excluded because they are not what the injected secret opens, the
-      in-container panel proxy addresses them legitimately, and none of them
-      fronts a terminal, an agent session, or an approval prompt — which is
-      what this deny-list guards. Emitted as OSPREY_WEB_PERIMETER_DENY_PORTS
-      beside the OSPREY_WEB_PERIMETER=open marker, gated on `perimeter_open`.
+      integers ("10000,10100,10101") — nginx's published port, the TLS listener
+      (`tls.port`, default 443) when `tls.enabled` puts the real content server
+      behind it, and every roster user's terminal port. Nothing else: companion
+      panel families are excluded because they are not what the injected secret
+      opens, the in-container panel proxy addresses them legitimately, and none
+      of them fronts a terminal, an agent session, or an approval prompt —
+      which is what this deny-list guards. Emitted as
+      OSPREY_WEB_PERIMETER_DENY_PORTS beside the OSPREY_WEB_PERIMETER=open
+      marker, gated on `perimeter_open`.
 
       These are LITERALS, not credentials — a port list, held by a container
       that already knows its own port — so they travel as plain

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -30,10 +30,25 @@
     tls_enabled: bool, required (defaults to False)
       When true, emit TWO server blocks: a redirect-only one on nginx_port
       whose entire content is `return 301 https://$host$request_uri;`, and the
-      real content server on `listen 443 ssl` with
+      real content server on `listen <tls_port> ssl` with
       `ssl_certificate`/`ssl_certificate_key` pointing at tls_cert/tls_key.
       When false, nothing TLS-related is emitted and the single server listens
       on nginx_port — the plain-http posture.
+    tls_port: int, required (defaults to 443, render.py's TLS_LISTEN_PORT)
+      The port BOTH `listen ... ssl` lines bind, parsed from `tls.port`. Only
+      read when tls_enabled is true. A value render.py cannot use as a port
+      (non-integer, boolean, outside 1-65535) falls back to the default and
+      lint reports it, so the listener never renders a value the deploy chain
+      could not bind. render.py follows the same value into `external_origin`
+      and into the perimeter deny list, so the listener, the render-time links
+      and the deny-list are one number and not three.
+    tls_default_port: int, required (render.py's TLS_LISTEN_PORT, 443)
+      The port a browser already goes to for an `https://` URL with no port in
+      it. At that port the redirect below stays a bare `$host`; on any other
+      port the redirect must name it (`$host:<tls_port>`), or the bounce lands
+      on a port nothing listens on. Passed in rather than restated here so the
+      redirect and render.py's `external_origin` decide "is a port needed"
+      against the same constant.
     tls_cert, tls_key: str | None
       Absolute paths inside the nginx container. Only read when tls_enabled
       is true; render.py already refuses to render (ValueError) if
@@ -213,9 +228,11 @@
   The two seams are opt-in, and each is gated independently:
 
   - `tls_enabled` (default False) emits nothing. When true, the plain port
-    becomes a redirect-only server and a second `listen 443 ssl` server —
-    carrying `ssl_certificate`/`ssl_certificate_key` from the configured
-    paths — becomes the sole content server. render.py refuses to render at
+    becomes a redirect-only server and a second `listen <tls_port> ssl` server
+    — `tls_port` is 443 unless the deployment set `tls.port`, which is what a
+    rootless nginx needs — carrying `ssl_certificate`/`ssl_certificate_key`
+    from the configured paths, becomes the sole content server. The redirect
+    names that port too whenever it is not 443. render.py refuses to render at
     all if either path is missing, so this template never has to guard against
     an incoherent pair.
   - without `sidecar_active` ("token", the default, and "none") the login
@@ -367,6 +384,13 @@ map $uri $osprey_auth_next {
 # certificate they cannot match. `external_origin` is for values that must be
 # fixed at render time (env-baked links, an IdP-registered redirect_uri); a
 # per-request redirect is not one of them.
+#
+# The PORT, unlike the host, does come from render time: `$host` carries the
+# name a client asked for but never the port it should be sent to, and on a
+# non-default `tls.port` a bare `$host` would bounce every client to 443,
+# where this deployment has nothing listening. So the target names the TLS
+# listener whenever it is not 443 — and at 443 says nothing, because that is
+# the port an `https://` URL with no port already means.
 server {
     listen {{ nginx_port }};
     listen [::]:{{ nginx_port }};
@@ -377,15 +401,15 @@ server {
     # sanitizing next door.
     access_log /dev/stdout osprey_sanitized;
 
-    return 301 https://$host$request_uri;
+    return 301 https://$host{% if tls_port != tls_default_port %}:{{ tls_port }}{% endif %}$request_uri;
 }
 {% endif %}
 server {
 {%- if tls_enabled %}
     # The sole content server: with TLS on, everything below is reachable only
     # over the encrypted listener.
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen {{ tls_port }} ssl;
+    listen [::]:{{ tls_port }} ssl;
     ssl_certificate {{ tls_cert }};
     ssl_certificate_key {{ tls_key }};
 {% else %}

--- a/tests/deployment/web_terminals/golden/tls_custom_port/nginx.conf
+++ b/tests/deployment/web_terminals/golden/tls_custom_port/nginx.conf
@@ -1,0 +1,339 @@
+
+# The access log, with the query string cut out of it.
+#
+# nginx's built-in `combined` format logs `$request` — the raw request line,
+# query string and all. Under this deployment that is a credential store: the
+# ONLY way into an auth-off multi-user terminal is
+# `/u/<user>/?token=<that user's operator secret>` (the app exchanges the token
+# for a session cookie and redirects to the clean URL), so with the default
+# format every login writes a working credential in cleartext to nginx's stdout
+# — readable by `docker logs`, and shipped verbatim by any log collector
+# scraping container output. A log is not a place a credential can be revoked
+# from.
+#
+# `$osprey_log_path` instead (mapped below): `$request_uri` with everything from
+# the first `?` onward cut off. Still percent-encoded, so it is safe to emit —
+# and `log_format` escapes control characters in every variable anyway (nginx
+# >= 1.11.8, the default `escape`). `$uri` would also be query-free but is the
+# post-rewrite path, so a landing-page hit would log as `/landing.html` rather
+# than as the `/` the client asked for. `$request_method` and `$server_protocol`
+# restore the two other pieces `$request` carried, so this stays a line the
+# usual log parsers read.
+#
+# `$http_referer` is dropped rather than logged: a browser that lands on the
+# `?token=` URL sends that whole URL as the Referer of everything the page then
+# fetches, so the field is a second copy of the same secret. Nothing else here
+# needs it.
+#
+# This covers the access log only. nginx's ERROR log is not formattable, and its
+# entries carry `request: "GET /uri?args ..."` — so a token can still reach it
+# when a request fails at the proxy (an upstream that is down, a timeout).
+# Narrowing that is not something a config can do; it is the reason the
+# `?token=` URL is one-shot in practice — the app redirects to the clean URL as
+# soon as it has set the cookie.
+# The requested path with the query string cut off. Anchored and greedy-free:
+# `[^?]*` stops at the first `?`, which is where the query starts, so nothing
+# after it can be carried into the value. A request with no query at all falls
+# to the default and is logged whole.
+map $request_uri $osprey_log_path {
+    default $request_uri;
+    "~^([^?]*)\?" $1;
+}
+
+log_format osprey_sanitized '$remote_addr - $remote_user [$time_local] '
+                            '"$request_method $osprey_log_path $server_protocol" '
+                            '$status $body_bytes_sent "$http_user_agent"';
+
+# The `access_log` that selects it is emitted per SERVER, not here at http
+# level, and that placement is the load-bearing part. The base image's own main
+# config already carries `access_log /var/log/nginx/access.log main;` at http
+# level (with that path symlinked to /dev/stdout), and nginx does not replace a
+# same-level directive — every `access_log` on one level is written. A second
+# one here would ADD the sanitized line beside the `combined`-format one that
+# still holds the token. A `server`-level directive is what actually suppresses
+# the inherited default: access_log is inherited from the level above ONLY when
+# the current level defines none.
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+# TLS is on, so the plain port serves NOTHING but the way to the secure one.
+# A single server listening on both ports would answer the same content over
+# cleartext — and any session cookie it set there would cross the network in
+# the clear, which is the whole thing TLS was turned on to prevent. Splitting
+# the listeners means there is no plain-http code path left to issue one.
+#
+# The redirect target is `$host` — the name the client actually asked for —
+# and NOT the render-time external origin, deliberately. A deployment is
+# reachable under more names than the one config knows about (an alias, an
+# internal DNS name, a bare IP), and rewriting the host on the way to https
+# would bounce those clients to a name they may not resolve or whose
+# certificate they cannot match. `external_origin` is for values that must be
+# fixed at render time (env-baked links, an IdP-registered redirect_uri); a
+# per-request redirect is not one of them.
+#
+# The PORT, unlike the host, does come from render time: `$host` carries the
+# name a client asked for but never the port it should be sent to, and on a
+# non-default `tls.port` a bare `$host` would bounce every client to 443,
+# where this deployment has nothing listening. So the target names the TLS
+# listener whenever it is not 443 — and at 443 says nothing, because that is
+# the port an `https://` URL with no port already means.
+server {
+    listen 10000;
+    listen [::]:10000;
+    server_name _;
+
+    # Here too: this server sees the same URLs the content server does, tokens
+    # included, and one that logged them in the default format would undo the
+    # sanitizing next door.
+    access_log /dev/stdout osprey_sanitized;
+
+    return 301 https://$host:8443$request_uri;
+}
+
+server {
+    # The sole content server: with TLS on, everything below is reachable only
+    # over the encrypted listener.
+    listen 8443 ssl;
+    listen [::]:8443 ssl;
+    ssl_certificate /etc/nginx/certs/dls.crt;
+    ssl_certificate_key /etc/nginx/certs/dls.key;
+
+    server_name _;
+
+    # Server level, which is what makes it REPLACE the base image's http-level
+    # `access_log ... main;` rather than run alongside it (see the log_format
+    # above). Every request this deployment answers is logged through the
+    # sanitized format, or not logged at all.
+    access_log /dev/stdout osprey_sanitized;
+
+    root /usr/share/nginx/html;
+
+    # Exact match: ONLY the root serves the landing page. Any other path
+    # outside a /u/<user>/ mount is a hard 404 — a prefix-catch-all here would
+    # answer stray API calls (a panel fetch that lost its /u/<user> prefix)
+    # with 200 + landing HTML, hiding the bug behind a JSON parse error.
+    location = / {
+        try_files /landing.html =404;
+    }
+
+
+    # Reverse proxy to alice's loopback upstream (the per-user app's
+    # `web` family, bound to loopback only). Trailing slashes on both the
+    # location and proxy_pass target strip /u/alice before the
+    # request reaches the upstream.
+    location /u/alice/ {
+
+        proxy_pass http://127.0.0.1:10100/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Nothing this perimeter did not itself put there.
+        #
+        # `Authorization` is a credential nginx never sets on this path, so
+        # whatever arrives in it came from the client and means nothing here.
+        # The app DOES accept an `Authorization: Bearer` — the panel token, the
+        # narrow tier its own tooling authenticates with — and that traffic is
+        # loopback INSIDE the container (the workspace hooks post to
+        # `http://127.0.0.1:<web>/api/panels`), so it never crosses this proxy
+        # and clearing the header costs it nothing. Unconditional, unlike the
+        # two below: the header is never legitimate here in any auth mode.
+        proxy_set_header Authorization "";
+        # The four identity headers — which roster card the request is on, who
+        # proved the login, what privilege it holds and where that privilege
+        # came from. All four names are written into EVERY proxying location's
+        # own header set, by whichever arm of the branch below renders: gated,
+        # from the values the sidecar just returned; ungated, as an explicit
+        # clear.
+        #
+        # Naming them is what drops the client's own. nginx builds one
+        # proxy-headers table per location and copies the client's remaining
+        # headers around it, so a name in that table is answered by its
+        # directive and never by the request — including when the directive
+        # evaluates EMPTY, which sends nothing rather than falling back to what
+        # arrived. A location naming none of them would hand a client's values
+        # straight to a container.
+        #
+        # Only this perimeter may name a user to a terminal: these headers are
+        # what a container reads to know who is on the other end of the session,
+        # so a client that simply types them would be choosing its own identity
+        # — and with authentication off there is no sidecar answer to contradict
+        # it. That is why the branch below is EXHAUSTIVE, unlike the cookie
+        # handling it shares: no topology this template can render accepts a
+        # client-supplied identity, and an auth-off deployment least of all.
+        #
+        # One directive per name per location, never two. A clear written
+        # alongside the forward would be harmless at request time — nginx skips
+        # an empty-valued `proxy_set_header` — but it enters the same name in
+        # this location's header table twice, which costs a `could not build
+        # optimal proxy_headers_hash` warning on every start and every reload,
+        # emitted by the security perimeter itself. That is where a recurring
+        # warning is most expensive: it is the one an operator learns to scroll
+        # past.
+        # Ungated — authentication is off, or this entry declared
+        # `login: false`. There is no authorization to speak for, so all four
+        # identity names are CLEARED here rather than forwarded: forwarding
+        # would announce a subject the perimeter never checked, and leaving the
+        # names unwritten would let the client supply them itself.
+        proxy_set_header X-Osprey-Auth-Account "";
+        proxy_set_header X-Osprey-Auth-Subject "";
+        proxy_set_header X-Osprey-Auth-Role "";
+        proxy_set_header X-Osprey-Auth-Role-Source "";
+        # No operator secret is injected into this location — authentication is
+        # off, or this entry declared `login: false` — so the two headers that
+        # carry one are handled the other way round from the gated branch above.
+        #
+        # The secret header is CLEARED rather than left alone. nginx sets it on
+        # gated locations only, so a value arriving here came from the client;
+        # forwarding it would let anyone who can reach this port present a
+        # credential the app trusts absolutely, which is the one thing this
+        # carrier exists to make impossible.
+        proxy_set_header X-Osprey-Terminal-Secret "";
+        # Exactly ONE cookie is forwarded: the session cookie alice's own
+        # app issues. It cannot be cut — with nothing injected here, that cookie
+        # IS the only gate left in front of this terminal — but the rest of the
+        # jar has no business travelling. Cookies ignore ports, so one jar
+        # serves this whole origin: the raw `Cookie` header names every OTHER
+        # terminal this browser has unlocked (`osprey_terminal_session_<port>`,
+        # one per user) and, with auth on, the sidecar's origin-wide
+        # `osprey_auth_session` as well. These containers run agent-generated
+        # code, so anything readable inside one is a credential that has left
+        # the perimeter.
+        #
+        # The name is a render-time literal from the app's own
+        # `session_cookie_name()` (render.py resolves `svc.session_cookie`), so
+        # the perimeter and the app cannot spell it differently. An absent
+        # cookie substitutes to empty, which the app reads as no credential —
+        # the same answer it gives to a request that sent none.
+        proxy_set_header Cookie "osprey_terminal_session_10100=$cookie_osprey_terminal_session_10100";
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        # Nginx's own default (1m) is smaller than the feedback form's upload
+        # cap — a screenshot attached to a bug report would 413 here before
+        # the request ever reaches alice's app. Stated explicitly so
+        # the limit is this proxy's contract, not an inherited default that
+        # would silently shrink if the base image's own default ever changes.
+        client_max_body_size 4m;
+    }
+
+    # Stable bookmark for alice without a trailing slash.
+    location = /u/alice {
+        return 301 /u/alice/;
+    }
+
+
+    # Reverse proxy to bob's loopback upstream (the per-user app's
+    # `web` family, bound to loopback only). Trailing slashes on both the
+    # location and proxy_pass target strip /u/bob before the
+    # request reaches the upstream.
+    location /u/bob/ {
+
+        proxy_pass http://127.0.0.1:10101/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Nothing this perimeter did not itself put there.
+        #
+        # `Authorization` is a credential nginx never sets on this path, so
+        # whatever arrives in it came from the client and means nothing here.
+        # The app DOES accept an `Authorization: Bearer` — the panel token, the
+        # narrow tier its own tooling authenticates with — and that traffic is
+        # loopback INSIDE the container (the workspace hooks post to
+        # `http://127.0.0.1:<web>/api/panels`), so it never crosses this proxy
+        # and clearing the header costs it nothing. Unconditional, unlike the
+        # two below: the header is never legitimate here in any auth mode.
+        proxy_set_header Authorization "";
+        # The four identity headers — which roster card the request is on, who
+        # proved the login, what privilege it holds and where that privilege
+        # came from. All four names are written into EVERY proxying location's
+        # own header set, by whichever arm of the branch below renders: gated,
+        # from the values the sidecar just returned; ungated, as an explicit
+        # clear.
+        #
+        # Naming them is what drops the client's own. nginx builds one
+        # proxy-headers table per location and copies the client's remaining
+        # headers around it, so a name in that table is answered by its
+        # directive and never by the request — including when the directive
+        # evaluates EMPTY, which sends nothing rather than falling back to what
+        # arrived. A location naming none of them would hand a client's values
+        # straight to a container.
+        #
+        # Only this perimeter may name a user to a terminal: these headers are
+        # what a container reads to know who is on the other end of the session,
+        # so a client that simply types them would be choosing its own identity
+        # — and with authentication off there is no sidecar answer to contradict
+        # it. That is why the branch below is EXHAUSTIVE, unlike the cookie
+        # handling it shares: no topology this template can render accepts a
+        # client-supplied identity, and an auth-off deployment least of all.
+        #
+        # One directive per name per location, never two. A clear written
+        # alongside the forward would be harmless at request time — nginx skips
+        # an empty-valued `proxy_set_header` — but it enters the same name in
+        # this location's header table twice, which costs a `could not build
+        # optimal proxy_headers_hash` warning on every start and every reload,
+        # emitted by the security perimeter itself. That is where a recurring
+        # warning is most expensive: it is the one an operator learns to scroll
+        # past.
+        # Ungated — authentication is off, or this entry declared
+        # `login: false`. There is no authorization to speak for, so all four
+        # identity names are CLEARED here rather than forwarded: forwarding
+        # would announce a subject the perimeter never checked, and leaving the
+        # names unwritten would let the client supply them itself.
+        proxy_set_header X-Osprey-Auth-Account "";
+        proxy_set_header X-Osprey-Auth-Subject "";
+        proxy_set_header X-Osprey-Auth-Role "";
+        proxy_set_header X-Osprey-Auth-Role-Source "";
+        # No operator secret is injected into this location — authentication is
+        # off, or this entry declared `login: false` — so the two headers that
+        # carry one are handled the other way round from the gated branch above.
+        #
+        # The secret header is CLEARED rather than left alone. nginx sets it on
+        # gated locations only, so a value arriving here came from the client;
+        # forwarding it would let anyone who can reach this port present a
+        # credential the app trusts absolutely, which is the one thing this
+        # carrier exists to make impossible.
+        proxy_set_header X-Osprey-Terminal-Secret "";
+        # Exactly ONE cookie is forwarded: the session cookie bob's own
+        # app issues. It cannot be cut — with nothing injected here, that cookie
+        # IS the only gate left in front of this terminal — but the rest of the
+        # jar has no business travelling. Cookies ignore ports, so one jar
+        # serves this whole origin: the raw `Cookie` header names every OTHER
+        # terminal this browser has unlocked (`osprey_terminal_session_<port>`,
+        # one per user) and, with auth on, the sidecar's origin-wide
+        # `osprey_auth_session` as well. These containers run agent-generated
+        # code, so anything readable inside one is a credential that has left
+        # the perimeter.
+        #
+        # The name is a render-time literal from the app's own
+        # `session_cookie_name()` (render.py resolves `svc.session_cookie`), so
+        # the perimeter and the app cannot spell it differently. An absent
+        # cookie substitutes to empty, which the app reads as no credential —
+        # the same answer it gives to a request that sent none.
+        proxy_set_header Cookie "osprey_terminal_session_10101=$cookie_osprey_terminal_session_10101";
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        # Nginx's own default (1m) is smaller than the feedback form's upload
+        # cap — a screenshot attached to a bug report would 413 here before
+        # the request ever reaches bob's app. Stated explicitly so
+        # the limit is this proxy's contract, not an inherited default that
+        # would silently shrink if the base image's own default ever changes.
+        client_max_body_size 4m;
+    }
+
+    # Stable bookmark for bob without a trailing slash.
+    location = /u/bob {
+        return 301 /u/bob/;
+    }
+
+
+}

--- a/tests/deployment/web_terminals/test_auth_tls_seams.py
+++ b/tests/deployment/web_terminals/test_auth_tls_seams.py
@@ -49,6 +49,11 @@ _TLS_STANZA = {
     "key": "/etc/nginx/certs/dls.key",
 }
 
+#: The TLS listener a rootless nginx can bind, for the non-default-port seam
+#: case. Outside this deployment's port block, so a number in the rendered
+#: config can only have come from `tls.port`.
+_ALT_TLS_PORT = 8443
+
 
 def _config(users: list[str]) -> dict:
     """Minimal-but-complete facility config that exercises render_web_terminals()."""
@@ -436,6 +441,43 @@ def test_seam_tls_enabled_with_both_cert_and_key_emits_ssl_listen_and_paths() ->
     assert "ssl_certificate /etc/nginx/certs/dls.crt;" in content
     assert "ssl_certificate_key /etc/nginx/certs/dls.key;" in content
     assert "location = / {" in content
+
+
+def test_seam_tls_on_a_non_default_port_moves_the_whole_encrypted_seam() -> None:
+    """SEAM 2 (the seam survives a rootless listener): `tls.port` must move the
+    two `listen ... ssl` lines AND the cleartext server's redirect target
+    together.
+
+    Each half alone reopens the seam it was built to close. Listeners moved
+    without the redirect leave the front door bouncing every client to 443,
+    where this deployment listens on nothing — so the only reachable surface is
+    the cleartext one. A redirect moved without the listeners points at a port
+    nginx never binds. The encrypted server stays the sole content server either
+    way: the plain port keeps carrying nothing but the 301.
+    """
+    # Arrange
+    config = _auth_config(tls=True)
+    config["modules"]["web_terminals"]["tls"]["port"] = _ALT_TLS_PORT
+    users = config["modules"]["web_terminals"]["users"]
+
+    # Act
+    redirect, content = _server_blocks(_render_nginx(config))
+
+    # Assert — both listeners follow the configured port, and 443 is gone
+    assert f"listen {_ALT_TLS_PORT} ssl;" in content
+    assert f"listen [::]:{_ALT_TLS_PORT} ssl;" in content
+    assert "listen 443 ssl;" not in content
+    assert "listen [::]:443 ssl;" not in content
+
+    # Assert — the redirect names the port the content server is actually on
+    assert f"return 301 https://$host:{_ALT_TLS_PORT}$request_uri;" in redirect
+    assert "return 301 https://$host$request_uri;" not in redirect
+
+    # Assert — the split itself is unchanged: cleartext redirects, TLS serves
+    assert "location" not in redirect
+    assert _directives(content).count("auth_request ") == len(users)
+    assert "ssl_certificate /etc/nginx/certs/dls.crt;" in content
+    assert "ssl_certificate_key /etc/nginx/certs/dls.key;" in content
 
 
 def _nginx_volumes(config: dict) -> list[str]:

--- a/tests/deployment/web_terminals/test_golden_render.py
+++ b/tests/deployment/web_terminals/test_golden_render.py
@@ -24,7 +24,22 @@ runtime surprise in a downstream lifecycle/e2e test.
     below) and overwrite `golden/docker-compose.web.yml`,
     `golden/nginx.conf`, and `golden/landing.html` with the three returned
     values (`docker-compose.web.yml`, `nginx/nginx.conf`, and
-    `nginx/landing.html` respectively). Do not hand-edit the golden files.
+    `nginx/landing.html` respectively). The `golden/tls_custom_port/`
+    variant regenerates the same way from `_tls_custom_port_config()`, and
+    holds `nginx.conf` alone. Do not hand-edit the golden files.
+
+`golden/tls_custom_port/` is the ONE variant this module keeps: the same
+facility with TLS terminated on a non-default port. It exists because the
+listener port is the one value that reaches three separate places in the
+rendered nginx.conf at once — both `listen ... ssl` lines and the cleartext
+server's `301` target — and a default-port baseline pins none of them (at 443
+the redirect deliberately names no port at all, so the redirect's port arm is
+invisible to the default golden). Only `nginx.conf` is committed for the
+variant: `tls.port` changes nothing in the landing output, and the two places
+it does reach in the compose output — each user's `OSPREY_TERMINAL_LANDING_URL`
+and `OSPREY_TERMINAL_EXTERNAL_ORIGIN` — are already pinned by `test_render.py`'s
+non-default-TLS-port origin tests, so a second compose golden would only be
+another file to regenerate.
 
 ``EXAMPLE_CONFIG`` is the reference "no-personas" shape a facility profile's
 web-terminals section is patterned on: two bare-string users, the `users` +
@@ -100,7 +115,13 @@ EXAMPLE_CONFIG: dict = {
 
 
 def _read_golden(name: str) -> str:
-    """The committed baseline, with its one per-checkout sentinel resolved."""
+    """The committed baseline, with its one per-checkout sentinel resolved.
+
+    `name` is relative to `golden/`, so a variant subdirectory's file is read
+    through the SAME sentinel substitution as the default baseline
+    (``_read_golden("tls_custom_port/nginx.conf")``) rather than through a
+    second reader that could drift from this one.
+    """
     return (_GOLDEN_DIR / name).read_text().replace(_REPO_ID_SENTINEL, _rendered_repo_id())
 
 
@@ -136,6 +157,67 @@ def test_golden_compose_is_valid_yaml_with_expected_services() -> None:
     the byte-equality checks above by accident (e.g. both sides empty)."""
     compose = yaml.safe_load(_read_golden("docker-compose.web.yml"))
     assert set(compose["services"].keys()) == {"nginx", "web-alice", "web-bob"}
+
+
+#: The variant's TLS listener. 8443 is the conventional unprivileged HTTPS
+#: alternate — the port a rootless deployment actually terminates on — and it is
+#: deliberately outside every band OSPREY owns: it is not in the port-block
+#: layout (a default deployment's block is `port_base`..`port_base + 999`, and
+#: `tls.port` is not a layout slot at all), and it is not one of the retired
+#: framework literals `tests/test_port_literals.py` guards (the 8085-8097 and
+#: 9070-9100 bands, the 9x00 family anchors, the loose bluesky/qmd/VA numbers).
+#: So at the default base the number is outside every band OSPREY owns, and
+#: `tls.port` is not a layout slot at any base.
+_TLS_CUSTOM_PORT = 8443
+
+#: Where the variant's single rendered file lives, relative to `golden/`.
+_TLS_CUSTOM_PORT_GOLDEN = "tls_custom_port/nginx.conf"
+
+
+def _tls_custom_port_config() -> dict:
+    """EXAMPLE_CONFIG with TLS terminated on a NON-default port.
+
+    Everything else is the baseline facility, so a diff between this variant's
+    golden and the default one is exactly what `tls.port` moves and nothing
+    else. The cert/key paths are the in-container mount points the TLS seam
+    tests use; they are rendered as literal strings and no file is read.
+    """
+    config = copy.deepcopy(EXAMPLE_CONFIG)
+    config["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "port": _TLS_CUSTOM_PORT,
+        "cert": "/etc/nginx/certs/dls.crt",
+        "key": "/etc/nginx/certs/dls.key",
+    }
+    return config
+
+
+def test_golden_tls_custom_port_fixture_exists() -> None:
+    """The variant baseline is present before the comparison below runs — a
+    missing file must fail loudly here rather than be misread as a byte-match
+    against an empty string."""
+    assert (_GOLDEN_DIR / _TLS_CUSTOM_PORT_GOLDEN).is_file(), (
+        f"missing golden fixture: {_TLS_CUSTOM_PORT_GOLDEN}"
+    )
+
+
+def test_render_matches_golden_tls_custom_port_nginx_conf_byte_for_byte() -> None:
+    """`nginx/nginx.conf` for the non-default-TLS-port facility is byte-identical
+    to its committed variant baseline."""
+    artifacts = render_web_terminals(_tls_custom_port_config())
+    assert artifacts["nginx/nginx.conf"] == _read_golden(_TLS_CUSTOM_PORT_GOLDEN)
+
+
+def test_golden_tls_custom_port_binds_and_redirects_to_the_custom_port() -> None:
+    """The committed variant itself must still carry the three places the custom
+    port lands — both `listen ... ssl` lines and the cleartext server's 301
+    target. Guards against a truncated or stale variant passing the byte-equality
+    check above by matching an equally wrong render."""
+    conf = _read_golden(_TLS_CUSTOM_PORT_GOLDEN)
+
+    assert f"listen {_TLS_CUSTOM_PORT} ssl;" in conf
+    assert f"listen [::]:{_TLS_CUSTOM_PORT} ssl;" in conf
+    assert f"return 301 https://$host:{_TLS_CUSTOM_PORT}$request_uri;" in conf
 
 
 def _persona_config() -> dict:

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -14,7 +14,14 @@ from osprey.deployment.web_terminals.lint import (
     lint_web_terminals,
     profile_config_errors,
 )
-from osprey.port_layout import DEFAULT_PORT_BASE, INDEX_MAX, SLOTS_BY_NAME, default_port
+from osprey.deployment.web_terminals.render import TLS_LISTEN_PORT
+from osprey.port_layout import (
+    _MAX_PORT,
+    DEFAULT_PORT_BASE,
+    INDEX_MAX,
+    SLOTS_BY_NAME,
+    default_port,
+)
 
 # A second, non-default base whose block the explicit per-family overrides
 # below sit in — proves the lint reads a config override rather than assuming
@@ -2508,6 +2515,166 @@ def test_lint_auth_port_absent_from_overlap_set_when_method_is_none() -> None:
     # Assert
     overlap_findings = [f for f in _errors(findings) if f.code == "web_terminals.port_overlap"]
     assert not any("web_terminals.auth.port" in f.message for f in overlap_findings)
+
+
+# --- tls.port / auth.port: the listener-port range rule and the collision set -
+
+
+def _tls_config(tls: dict[str, object]) -> dict:
+    """A clean config with an enabled `tls` stanza carrying the given keys."""
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["deploy"] = {"fqdn": "web.example.org"}
+    config["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "cert": "/etc/osprey/tls/facility.crt",
+        "key": "/etc/osprey/tls/facility.key",
+        **tls,
+    }
+    return config
+
+
+def _listener_port_findings(findings: list[Finding]) -> list[Finding]:
+    return [f for f in _errors(findings) if f.code == "web_terminals.invalid_listener_port"]
+
+
+#: The whole domain `render._port_int` substitutes a default for: a negative,
+#: zero, a `bool` (which passes `isinstance(..., int)`), a port written as a
+#: string, and one past the top of the TCP range. Spelled once because the two
+#: listener keys are held to ONE rule — a shape added to only one of the two
+#: lists would leave the other key's silent fallback unreported.
+_UNUSABLE_PORTS = [-1, 0, True, "8443", _MAX_PORT + 1]
+
+
+@pytest.mark.parametrize("value", _UNUSABLE_PORTS)
+def test_lint_unusable_tls_port_is_an_error(value: object) -> None:
+    """render substitutes 443 for anything that is not a real TCP port, so a
+    deployment that meant to move its listener silently stays on 443."""
+    # Arrange
+    config = _tls_config({"port": value})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _listener_port_findings(findings)
+    assert errors, [f.code for f in findings]
+    assert "modules.web_terminals.tls.port" in errors[0].message
+    assert repr(value) in errors[0].message
+    assert str(TLS_LISTEN_PORT) in errors[0].message
+
+
+@pytest.mark.parametrize("value", _UNUSABLE_PORTS)
+def test_lint_unusable_auth_port_is_an_error(value: object) -> None:
+    """The same rule covers the sidecar's listener, whose silent fallback is the
+    port layout's `auth` slot rather than 443."""
+    # Arrange
+    config = _auth_config({"method": "password", "port": value})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _listener_port_findings(findings)
+    assert errors, [f.code for f in findings]
+    assert "modules.web_terminals.auth.port" in errors[0].message
+    assert repr(value) in errors[0].message
+    assert str(_DEFAULT_AUTH_PORT) in errors[0].message
+
+
+def test_lint_valid_listener_ports_report_no_findings() -> None:
+    """A rootless deployment on unprivileged ports is exactly what the keys are
+    for, and must lint clean."""
+    # Arrange
+    config = _tls_config({"port": 8443})
+    config["modules"]["web_terminals"]["auth"] = {"method": "password", "port": 8444}
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert _errors(findings) == []
+
+
+@pytest.mark.parametrize("spelling", [{}, {"port": None}], ids=["absent", "empty"])
+def test_lint_unset_listener_ports_report_no_findings(spelling: dict[str, object]) -> None:
+    """An absent key, and a `port:` written with no value, are the documented
+    defaults rather than type mistakes."""
+    # Arrange
+    config = _tls_config(spelling)
+    config["modules"]["web_terminals"]["auth"] = {"method": "password", **spelling}
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert _listener_port_findings(findings) == []
+    assert _errors(findings) == []
+
+
+def test_lint_tls_port_collides_with_the_plain_listener() -> None:
+    """nginx cannot bind its HTTP listener and its TLS listener to one port; the
+    collision names `tls.port` rather than a literal 443."""
+    # Arrange
+    nginx_port = default_port("nginx", base=_OVERRIDE_PORT_BASE)
+    config = _tls_config({"port": nginx_port})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    overlap_findings = [f for f in _errors(findings) if f.code == "web_terminals.port_overlap"]
+    assert any("web_terminals.tls.port" in f.message for f in overlap_findings)
+    assert any("web_terminals.nginx_port" in f.message for f in overlap_findings)
+
+
+def test_lint_tls_port_collides_with_the_auth_sidecar_port() -> None:
+    """Both listeners in the same seam, both published on the host: putting them
+    on one port is a collision reported by both names."""
+    # Arrange
+    config = _tls_config({"port": _DEFAULT_AUTH_PORT})
+    config["modules"]["web_terminals"]["auth"] = {"method": "password"}
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    overlap_findings = [f for f in _errors(findings) if f.code == "web_terminals.port_overlap"]
+    assert any("web_terminals.tls.port" in f.message for f in overlap_findings)
+    assert any("web_terminals.auth.port" in f.message for f in overlap_findings)
+
+
+def test_lint_tls_port_joins_the_overlap_set_when_the_auth_method_is_unknown() -> None:
+    """`_auth_context` degrades to None for a method render cannot parse, but
+    nginx still binds the TLS listener — so the entry is read off the raw stanza
+    and survives."""
+    # Arrange
+    config = _tls_config({"port": 8443})
+    config["modules"]["web_terminals"]["auth"] = {"method": "basic"}
+    config["services"]["conflicting"] = {"port": 8443}
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    overlap_findings = [f for f in _errors(findings) if f.code == "web_terminals.port_overlap"]
+    assert any("web_terminals.tls.port" in f.message for f in overlap_findings)
+    assert any("services.conflicting.port" in f.message for f in overlap_findings)
+
+
+def test_lint_unusable_tls_port_reserves_the_port_render_falls_back_to() -> None:
+    """The collision entry is resolved the way render resolves it, so a value
+    nginx would never listen on reserves 443 rather than itself."""
+    # Arrange
+    config = _tls_config({"port": _MAX_PORT + 1})
+    config["services"]["conflicting"] = {"port": TLS_LISTEN_PORT}
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    overlap_findings = [f for f in _errors(findings) if f.code == "web_terminals.port_overlap"]
+    assert any(f"Port {TLS_LISTEN_PORT} " in f.message for f in overlap_findings)
+    assert any("web_terminals.tls.port" in f.message for f in overlap_findings)
 
 
 def test_lint_auth_without_tls_is_an_error() -> None:

--- a/tests/deployment/web_terminals/test_nginx_validate.py
+++ b/tests/deployment/web_terminals/test_nginx_validate.py
@@ -14,6 +14,10 @@ uses) against each render shape the auth/TLS seams can produce:
   blocks, the plain port's `return 301 https://…`, `listen 443 ssl` +
   `ssl_certificate*`, the two `map`s, a per-user `auth_request` and `internal`
   verify target, the shared named 401 handler, and the public `/auth/` prefix.
+- that same enabled render moved off 443 by `tls.port` — the rootless shape,
+  where both `listen ... ssl` lines bind an unprivileged port and the cleartext
+  server's 301 has to name that port in its `Location` or the bounce lands
+  where nothing is serving.
 - the cleartext-auth render (`auth.method: password` with
   `allow_insecure_http`, the shape a facility behind its own TLS terminator
   deploys): the same auth surface inside a *single* server block.
@@ -45,6 +49,7 @@ import pytest
 from osprey.deployment.web_terminals.render import (
     NGINX_TEMPLATES_OUTPUT_DIR,
     TERMINAL_SECRET_HEADER,
+    TLS_LISTEN_PORT,
     render_web_terminals,
     terminal_secret_env_var,
 )
@@ -55,6 +60,11 @@ from osprey.port_layout import default_port
 #: proxy_pass target asserted further down follows a slot that moves.
 _BASE_PORTS = {slot: default_port(slot) for slot in ("web", "artifact", "ariel", "lattice")}
 _NGINX_IMAGE = "nginx:1.27-alpine"
+
+#: The `tls.port` a rootless deployment names: above 1024, so an unprivileged
+#: nginx can bind it, and pointedly not `TLS_LISTEN_PORT` — the whole point of
+#: the case below is the render shape the default never produces.
+_UNPRIVILEGED_TLS_PORT = 8443
 
 #: Where the base image's entrypoint writes the envsubst'd per-user snippets, and
 #: which variables it may substitute — kept byte-identical to the values the
@@ -377,6 +387,78 @@ def test_enabled_tls_and_auth_render_passes_nginx_t() -> None:
         assert f"ssl_certificate /etc/nginx/certs/{cert_path.name};" in nginx_conf
         assert f"ssl_certificate_key /etc/nginx/certs/{key_path.name};" in nginx_conf
         assert "return 301 https://$host$request_uri;" in nginx_conf
+
+        (conf_dir / "default.conf").write_text(nginx_conf)
+        _write_secret_templates(artifacts, templates_dir)
+        secret_env = {terminal_secret_env_var(user): value for user, value in secrets.items()}
+
+        # Act
+        result = _run_nginx_t(
+            conf_dir,
+            certs_dir=certs_dir,
+            templates_dir=templates_dir,
+            secret_env=secret_env,
+        )
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+
+
+def test_tls_render_on_an_unprivileged_port_passes_nginx_t() -> None:
+    """C2b: the same enabled render with `tls.port: 8443` — the shape a host
+    that cannot bind 443 deploys — is a config nginx accepts, not a string match.
+
+    Three directives move together off the default and nothing else re-derives
+    them: both `listen ... ssl` lines (the IPv4 one and the IPv6 one, which is
+    where a port substituted into only one of a pair goes wrong), and the
+    cleartext server's `return 301`, which has to carry `:8443` in its
+    `Location` or every plain-http visitor is bounced to a port nothing serves.
+    Run through real nginx because a port stitched into a listener is exactly
+    the kind of edit that produces a plausible-looking string and an
+    unparseable directive.
+    """
+    assert _UNPRIVILEGED_TLS_PORT != TLS_LISTEN_PORT
+    users = ["alice", "bob"]
+    secrets = _terminal_secrets(users)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        conf_dir = tmp_path / "conf"
+        certs_dir = tmp_path / "certs"
+        templates_dir = tmp_path / "templates"
+        conf_dir.mkdir()
+        certs_dir.mkdir()
+        templates_dir.mkdir()
+
+        cert_path, key_path = _generate_self_signed_cert(certs_dir)
+
+        # Arrange — same cert/key discipline as the default-port TLS render:
+        # the paths are where the pair is MOUNTED in the container, and the
+        # per-user snippets are rendered so the authenticated locations'
+        # `include` resolves at start.
+        artifacts = render_web_terminals(
+            _config(
+                users=users,
+                tls={
+                    "enabled": True,
+                    "port": _UNPRIVILEGED_TLS_PORT,
+                    "cert": f"/etc/nginx/certs/{cert_path.name}",
+                    "key": f"/etc/nginx/certs/{key_path.name}",
+                },
+                auth={"method": "password"},
+            ),
+            terminal_secrets=secrets,
+        )
+        nginx_conf = artifacts["nginx/nginx.conf"]
+        # Guard against a vacuous green twice over: the gated surface is still
+        # there, and this really is the moved-port shape rather than the
+        # default one wearing a different config key.
+        _assert_auth_surface_present(nginx_conf, users)
+        assert f"listen {_UNPRIVILEGED_TLS_PORT} ssl;" in nginx_conf
+        assert f"listen [::]:{_UNPRIVILEGED_TLS_PORT} ssl;" in nginx_conf
+        assert f"listen {TLS_LISTEN_PORT} ssl;" not in nginx_conf
+        assert f"return 301 https://$host:{_UNPRIVILEGED_TLS_PORT}$request_uri;" in nginx_conf
+        assert "return 301 https://$host$request_uri;" not in nginx_conf
 
         (conf_dir / "default.conf").write_text(nginx_conf)
         _write_secret_templates(artifacts, templates_dir)

--- a/tests/deployment/web_terminals/test_perimeter_stamp.py
+++ b/tests/deployment/web_terminals/test_perimeter_stamp.py
@@ -45,6 +45,10 @@ _ARIEL_BASE_PORT = default_port("ariel", base=_MOVED_BASE) + 1
 _LATTICE_BASE_PORT = default_port("lattice", base=_MOVED_BASE) + 1
 #: A web base UNDER the front door, for the ordering test below.
 _BELOW_NGINX_WEB_BASE = _NGINX_PORT - 1000
+#: A TLS listener a rootless nginx can bind, for the non-default-`tls.port`
+#: case. Below this deployment's block numerically and above it lexically, so
+#: the deny-list's ordering assertion fails on a list sorted as strings.
+_ALT_TLS_PORT = 8443
 
 #: The marker and list names, spelled once. The executor reads these back from
 #: the container's environment; a rename on either side is a stamp nobody reads.
@@ -209,6 +213,36 @@ def test_tls_deployment_denies_the_tls_listener() -> None:
 
     # Assert
     assert denied == f"443,{_NGINX_PORT},{_WEB_BASE_PORT}"
+
+
+def test_tls_deployment_on_a_non_default_port_denies_that_listener_and_not_443() -> None:
+    """The list names the port that serves, which is `tls.port` when one is set.
+
+    A deny-list built from the 443 constant rather than the parsed port would
+    deny a port this deployment never binds while leaving the real content
+    listener — the one that injects the operator secret — reachable from inside
+    a sandbox that shares the host network namespace.
+
+    The exact string is asserted, and the TLS port here is numerically below the
+    deployment's block while lexically above it: a list sorted as strings would
+    put it last, so this pins ascending NUMERIC order rather than sortedness by
+    luck.
+    """
+    # Arrange
+    config = _config(["alice"], method="none")
+    config["modules"]["web_terminals"]["tls"] = {
+        "enabled": True,
+        "port": _ALT_TLS_PORT,
+        "cert": "/etc/nginx/certs/tls.crt",
+        "key": "/etc/nginx/certs/tls.key",
+    }
+
+    # Act
+    denied = _env(_user_services(config)["web-alice"])[_DENY_PORTS_VAR]
+
+    # Assert
+    assert denied == f"{_ALT_TLS_PORT},{_NGINX_PORT},{_WEB_BASE_PORT}"
+    assert "443" not in denied.split(",")
 
 
 def test_plain_http_deployment_does_not_deny_443() -> None:

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -22,6 +22,7 @@ from osprey.deployment.web_terminals.ports import (
 from osprey.deployment.web_terminals.render import (
     AUTH_ENV_DIGEST_LABEL,
     TERMINAL_SECRET_HEADER,
+    TLS_LISTEN_PORT,
     _auth_tls_context,
     _terminal_secret_artifacts,
     clear_nginx_templates_dir,
@@ -833,13 +834,27 @@ def test_render_missing_deploy_fqdn_is_fine_with_zero_users() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _tls_config(users: list[str] | None = None) -> dict:
-    """A config with TLS terminated at nginx (cert/key set, as the render demands)."""
+#: A TLS listener a rootless nginx can actually bind, for the non-default-port
+#: cases below. Deliberately outside every deployment port block (the layout's
+#: default base is 10000 and this module's second base sits above it), so a
+#: number appearing in a render can only have come from `tls.port` — and, being
+#: numerically below those bases while lexically above them, it is also what
+#: makes the perimeter deny-list's ordering assertions non-vacuous.
+_ALT_TLS_PORT = 8443
+
+
+def _tls_config(users: list[str] | None = None, *, port: int | None = None) -> dict:
+    """A config with TLS terminated at nginx (cert/key set, as the render demands).
+
+    ``port`` names a non-default ``tls.port``; left out, the stanza carries no
+    port key at all, which is the shape every default-port test above renders.
+    """
     config = copy.deepcopy(_config(users) if users is not None else _MULTI_USER_CONFIG)
     config["modules"]["web_terminals"]["tls"] = {
         "enabled": True,
         "cert": "/etc/nginx/certs/dls.crt",
         "key": "/etc/nginx/certs/dls.key",
+        **({"port": port} if port is not None else {}),
     }
     return config
 
@@ -889,6 +904,48 @@ def test_external_origin_with_tls_is_https_with_443_left_implicit() -> None:
 
     # Assert — the nginx_port never appears in a TLS origin
     assert contexts["nginx.conf.j2"]["external_origin"] == "https://dls-deploy.dls.example.org"
+
+
+def test_external_origin_with_a_non_default_tls_port_spells_that_port_out() -> None:
+    """A `tls.port` other than 443 belongs IN the origin, unlike 443 itself.
+
+    443 is left implicit because that is what an `https://` URL with no port
+    already means; any other port is not implied by anything, and a browser that
+    reached this deployment on it sends it in the `Origin` header. An origin that
+    omitted it would be compared against a string no browser sends, and the
+    `redirect_uri` built from it would be one the IdP was never registered for.
+    """
+    # Arrange
+    config = _tls_config(port=_ALT_TLS_PORT)
+
+    # Act
+    contexts = _capture_render_contexts(config)
+
+    # Assert — one derivation, so every consumer carries the port
+    origin = f"https://dls-deploy.dls.example.org:{_ALT_TLS_PORT}"
+    assert contexts["nginx.conf.j2"]["external_origin"] == origin
+    assert contexts["docker-compose.web.yml.j2"]["external_origin"] == origin
+    assert deployment_external_origin(_tls_config(port=_ALT_TLS_PORT)) == origin
+
+
+def test_landing_url_baked_into_containers_carries_a_non_default_tls_port() -> None:
+    """The "back to landing" link has to name the port the content server is on.
+
+    It is baked in at container start and never recomputed, so an origin missing
+    the port ships every terminal a link to 443 — where this deployment listens
+    on nothing at all.
+    """
+    # Arrange
+    config = _tls_config(port=_ALT_TLS_PORT)
+
+    # Act
+    compose = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+
+    # Assert
+    assert (
+        f"OSPREY_TERMINAL_LANDING_URL=https://dls-deploy.dls.example.org:{_ALT_TLS_PORT}"
+        in compose["services"]["web-alice"]["environment"]
+    )
 
 
 def test_external_origin_is_exported_to_both_the_nginx_and_compose_contexts() -> None:
@@ -1729,6 +1786,7 @@ def test_tls_default_off() -> None:
     assert context["tls_enabled"] is False
     assert context["tls_cert"] is None
     assert context["tls_key"] is None
+    assert context["tls_port"] == TLS_LISTEN_PORT
 
 
 def test_tls_default_off_reads_configured_stanza() -> None:
@@ -1748,6 +1806,25 @@ def test_tls_default_off_reads_configured_stanza() -> None:
     assert context["tls_enabled"] is True
     assert context["tls_cert"] == "/etc/nginx/certs/dls.crt"
     assert context["tls_key"] == "/etc/nginx/certs/dls.key"
+
+
+def test_tls_port_reads_a_configured_listener() -> None:
+    """A host that cannot bind 443 names its own TLS port; the parser reads it through,
+    and every consumer of the seam follows that value instead of the default."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    web_terminals["tls"] = {
+        "enabled": True,
+        "port": 8443,
+        "cert": "/etc/nginx/certs/dls.crt",
+        "key": "/etc/nginx/certs/dls.key",
+    }
+
+    # Act
+    context = _auth_tls_context(web_terminals)
+
+    # Assert
+    assert context["tls_port"] == 8443
 
 
 # ---------------------------------------------------------------------------
@@ -1883,6 +1960,29 @@ def test_auth_context_malformed_scalars_fall_back_to_defaults() -> None:
     assert context["auth_image"] is None
     assert context["auth_oidc_issuer"] is None
     assert context["auth_oidc_client_id_env"] == "OSPREY_AUTH_OIDC_CLIENT_ID"
+
+
+@pytest.mark.parametrize(
+    "bad_port",
+    [0, -1, 65536, 70000, True, "8443"],
+    ids=["zero", "negative", "one-past-the-top", "far-past-the-top", "bool", "string"],
+)
+def test_port_keys_outside_the_tcp_range_fall_back_to_their_defaults(bad_port: object) -> None:
+    """Both port keys read through the same bounded reader, so the whole invalid domain
+    — not an int, `bool`, zero, negative, or past 65535 — lands on the default rather
+    than reaching a `listen` directive nginx refuses at startup. That is what makes
+    lint's "the render falls back" finding true of `tls.port` and `auth.port` alike."""
+    # Arrange
+    web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+    web_terminals["auth"] = {"port": bad_port}
+    web_terminals["tls"] = {"enabled": True, "port": bad_port}
+
+    # Act
+    context = _auth_tls_context(web_terminals)
+
+    # Assert
+    assert context["auth_port"] == _DEFAULT_AUTH_PORT
+    assert context["tls_port"] == TLS_LISTEN_PORT
 
 
 def test_auth_context_never_reads_a_credential_out_of_config() -> None:
@@ -2969,6 +3069,60 @@ def test_tls_redirect_target_is_the_requested_host_not_the_render_time_origin() 
     # Assert
     assert "https://$host$request_uri" in redirect
     assert fqdn not in redirect
+
+
+def test_tls_content_server_listens_on_a_configured_non_default_port() -> None:
+    """`tls.port` moves BOTH `listen ... ssl` lines, IPv4 and IPv6 alike.
+
+    A host that cannot bind 443 — rootless, or already carrying another
+    deployment's perimeter — names its own port. One line following it and the
+    other left at 443 would render a server that either fails to start (443 is
+    privileged) or answers on a port nothing else in the deployment knows about.
+    """
+    # Act
+    redirect, content = _server_blocks(_render_nginx(_tls_config(port=_ALT_TLS_PORT)))
+
+    # Assert — the content server is entirely on the configured port
+    assert f"listen {_ALT_TLS_PORT} ssl;" in content
+    assert f"listen [::]:{_ALT_TLS_PORT} ssl;" in content
+    assert "listen 443 ssl;" not in content
+    assert "listen [::]:443 ssl;" not in content
+    # Assert — the plain listener is untouched by the TLS port, and still only redirects
+    assert f"listen {_NGINX_PORT};" in redirect
+    assert f"listen {_ALT_TLS_PORT}" not in redirect
+
+
+def test_tls_redirect_names_a_non_default_port_in_its_bounce_target() -> None:
+    """The 301 has to carry the port as well as the scheme.
+
+    `$host` is the name the client asked for and never the port it should be
+    sent to, so a bare `https://$host` bounces every cleartext client to 443 —
+    where a deployment serving on its own `tls.port` has nothing listening, and
+    the front door becomes a redirect into a connection refusal.
+    """
+    # Act
+    redirect = _server_blocks(_render_nginx(_tls_config(port=_ALT_TLS_PORT)))[0]
+
+    # Assert
+    assert f"return 301 https://$host:{_ALT_TLS_PORT}$request_uri;" in redirect
+    assert "return 301 https://$host$request_uri;" not in redirect
+    # Still the requested host, not the render-time fqdn: only the port is fixed here.
+    assert "dls-deploy.dls.example.org" not in redirect
+
+
+def test_tls_port_left_at_the_default_keeps_the_port_out_of_the_redirect() -> None:
+    """Explicitly configuring 443 renders exactly what configuring nothing does.
+
+    The redirect names a port only when a browser would not already assume it,
+    so the default spelled out by hand must not start emitting `:443` — the same
+    value, in the canonical form, from either config.
+    """
+    # Act
+    explicit = _render_nginx(_tls_config(port=TLS_LISTEN_PORT))
+
+    # Assert
+    assert explicit == _render_nginx(_tls_config())
+    assert "return 301 https://$host$request_uri;" in _server_blocks(explicit)[0]
 
 
 def test_tls_redirect_content_server_holds_the_cert_and_every_user_route() -> None:


### PR DESCRIPTION
nginx's TLS listener was hard-wired to 443, so a rootless deployment — one that cannot bind a privileged port, or a host already serving HTTPS elsewhere — had no way to terminate TLS at all.

`modules.web_terminals.tls.port` now names the listener. One value reaches every place the port matters: both `listen … ssl` lines, the cleartext server's `301` target (which names the port whenever it is not 443, since a bare `$host` would bounce clients to a port nothing listens on), the external origin — and with it each terminal's landing link, its origin check, and under `oidc` the callback URI registered with the provider — and the perimeter deny list. A value that cannot be a port falls back to 443 and `osprey scaffold web-terminals lint` reports it as `web_terminals.invalid_listener_port`, so the listener never renders something the deploy chain could not bind.

A `golden/tls_custom_port/` variant pins the 8443 shape of `nginx.conf`, because at 443 the redirect's port arm is deliberately invisible to the default golden.

Closes #794

## How it hangs together

```text
  config: modules.web_terminals.tls.port ──► render.py (TLS_LISTEN_PORT fallback + lint)
                                                 │
                 ┌───────────────────────────────┼─────────────────────────────┐
                 ▼                               ▼                             ▼
      nginx.conf.j2                     external_origin                 compose template
      listen <port> ssl  (x2)           https://<fqdn>[:<port>]         perimeter deny list
      301 https://$host[:<port>]        ├─► landing / origin check       (nginx port, tls.port,
                                        └─► OIDC redirect URI            terminal ports)
```
