### PR TITLE
refactor(web-terminals): require the TLS port at every origin derivation

### DIFF
--- a/changelog.d/803.changed.md
+++ b/changelog.d/803.changed.md
@@ -1,0 +1,6 @@
+The web terminals' TLS listener port is now passed explicitly wherever the
+deployment's external origin is derived: `tls_port` is a required argument
+rather than one defaulting to 443, so a caller that omits it fails loudly
+instead of advertising an origin that points at a port nothing listens on. The
+port a URL omits because `https` implies it is also kept distinct from the
+default this framework picks for an unset `modules.web_terminals.tls.port`.

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -107,6 +107,16 @@ _DEFAULT_NGINX_IMAGE = "nginx:1.27-alpine"
 #: reserve a port the template does not use.
 TLS_LISTEN_PORT = 443
 
+#: The port the ``https`` scheme itself implies, which a URL therefore omits.
+#: Spelled apart from :data:`TLS_LISTEN_PORT` even though both are 443 today:
+#: that one is this framework's default for an unset ``tls.port`` and is a
+#: choice, while this one is what the scheme means and cannot be chosen.
+#: Collapsing them would let a change to the default silently rewrite every
+#: derived origin's serialization — a deployment defaulted to 8443 would still
+#: advertise ``https://<fqdn>``, an address pointing at 443 where nothing
+#: listens.
+_HTTPS_DEFAULT_PORT = 443
+
 #: The authentication methods this deployment can actually serve: ``none``
 #: (open — every terminal is navigation-only, nginx vouches for every request),
 #: ``token`` (the default: no login wall, each user's terminal is entered once
@@ -1546,7 +1556,7 @@ def _external_origin(
     nginx_port: int,
     *,
     tls_enabled: bool,
-    tls_port: int = TLS_LISTEN_PORT,
+    tls_port: int,
 ) -> str:
     """Build the one origin every absolute URL this deployment emits is derived from.
 
@@ -1595,7 +1605,11 @@ def _external_origin(
         tls_enabled: The parsed ``tls.enabled`` (see :func:`_auth_tls_context`).
         tls_port: The parsed ``tls.port`` (see :func:`_auth_tls_context`), used
             only when TLS is on and no origin is configured. Left out of the
-            origin when it is :data:`TLS_LISTEN_PORT`.
+            origin when it is :data:`_HTTPS_DEFAULT_PORT`. Required rather than
+            defaulted: a caller that forgot it would silently derive the 443
+            origin for a deployment listening somewhere else, and the symptom —
+            every write refused while every page loads — points at neither this
+            function nor the caller.
 
     Raises:
         ValueError: If ``modules.web_terminals.external_origin`` is set to
@@ -1618,7 +1632,9 @@ def _external_origin(
         )
     if not tls_enabled:
         return f"http://{host}:{nginx_port}"
-    return f"https://{host}" if tls_port == TLS_LISTEN_PORT else f"https://{host}:{tls_port}"
+    if tls_port == _HTTPS_DEFAULT_PORT:
+        return f"https://{host}"
+    return f"https://{host}:{tls_port}"
 
 
 def deployment_external_origin(config: Any) -> str:
@@ -1699,7 +1715,7 @@ def _landing_url(
     nginx_port: int,
     *,
     tls_enabled: bool = False,
-    tls_port: int = TLS_LISTEN_PORT,
+    tls_port: int,
 ) -> str:
     """The absolute origin baked into every service's ``OSPREY_TERMINAL_LANDING_URL``.
 
@@ -1955,9 +1971,9 @@ def _auth_tls_context(web_terminals: dict[str, Any], *, base: int | None = None)
         ID-token claim carrying the identity to map onto a roster user); plus
         the TLS keys ``tls_enabled`` (bool), ``tls_port`` (int, the listener
         both nginx ``listen`` lines and the derived external origin follow,
-        defaulting to :data:`TLS_LISTEN_PORT`), ``tls_default_port`` (that
-        constant itself, so the template's port-in-redirect test and
-        :func:`_external_origin` compare against one value) and
+        defaulting to :data:`TLS_LISTEN_PORT`), ``https_default_port``
+        (:data:`_HTTPS_DEFAULT_PORT`, so the template's port-in-redirect test
+        and :func:`_external_origin` compare against one value) and
         ``tls_cert``/``tls_key`` (str path or ``None``, read only when
         ``tls_enabled``).
 
@@ -2008,8 +2024,10 @@ def _auth_tls_context(web_terminals: dict[str, Any], *, base: int | None = None)
         "tls_port": _port_int(tls.get("port"), TLS_LISTEN_PORT),
         # Carried alongside so the template's "is this the port a browser
         # assumes for https://" test reads the same constant `_external_origin`
-        # does, rather than restating 443 as a literal.
-        "tls_default_port": TLS_LISTEN_PORT,
+        # does, rather than restating 443 as a literal. It is the scheme's port,
+        # not this framework's default for an unset `tls.port` — the two are
+        # equal today and mean different things.
+        "https_default_port": _HTTPS_DEFAULT_PORT,
         "tls_cert": tls.get("cert"),
         "tls_key": tls.get("key"),
         # The HOST directory holding the certificate and key. Optional, and the

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -42,7 +42,7 @@
       could not bind. render.py follows the same value into `external_origin`
       and into the perimeter deny list, so the listener, the render-time links
       and the deny-list are one number and not three.
-    tls_default_port: int, required (render.py's TLS_LISTEN_PORT, 443)
+    https_default_port: int, required (render.py's _HTTPS_DEFAULT_PORT, 443)
       The port a browser already goes to for an `https://` URL with no port in
       it. At that port the redirect below stays a bare `$host`; on any other
       port the redirect must name it (`$host:<tls_port>`), or the bounce lands
@@ -401,7 +401,7 @@ server {
     # sanitizing next door.
     access_log /dev/stdout osprey_sanitized;
 
-    return 301 https://$host{% if tls_port != tls_default_port %}:{{ tls_port }}{% endif %}$request_uri;
+    return 301 https://$host{% if tls_port != https_default_port %}:{{ tls_port }}{% endif %}$request_uri;
 }
 {% endif %}
 server {

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -500,13 +500,19 @@ class TestControlAssistantWebTier:
         """The rendered config passes the exact check ``osprey up`` runs —
         ``_landing_url`` raises without ``deploy.fqdn``, aborting ``osprey up``
         for the otherwise zero-config tutorial."""
-        from osprey.deployment.web_terminals.render import _landing_url
+        from osprey.deployment.web_terminals.render import TLS_LISTEN_PORT, _landing_url
 
         rendered = _render_config_overrides(tmp_path, {"system": {}})
         fqdn = rendered["deploy"]["fqdn"]
         nginx_port = resolve_nginx_port(rendered)
         assert nginx_port == default_port("nginx")
-        assert _landing_url(rendered, nginx_port) == f"http://{fqdn}:{nginx_port}"
+        # `tls_port` is required even here, where the preset renders TLS off and
+        # the port is never read: the default it would otherwise take is the one
+        # value a caller must not guess (see `_external_origin`).
+        assert (
+            _landing_url(rendered, nginx_port, tls_port=TLS_LISTEN_PORT)
+            == f"http://{fqdn}:{nginx_port}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refines the configurable TLS listener port landed for #794.

## The port argument is required now

`_external_origin` and `_landing_url` defaulted `tls_port` to 443. Every call
site in the tree passes it explicitly, so nothing is broken today — this is a
latent hazard rather than a live defect. But a call site added later can omit
the argument and receive the 443 origin for a deployment listening somewhere
else. That origin serves every page correctly and refuses every mutating
request, because each app compares a request's `Origin` against a value naming
a port nothing is bound to. The symptom points at neither the function nor the
caller.

Making the argument required moves that failure to the call site, where it is
visible, instead of into a deployment that half works.

## The scheme's port and this framework's default are separate constants

`TLS_LISTEN_PORT` carried two meanings: the default chosen for an unset
`modules.web_terminals.tls.port`, and the port an `https` URL omits because the
scheme implies it. They are equal today and they are not the same fact.
Changing the default would silently rewrite every derived origin — a deployment
defaulted to 8443 would still advertise `https://<fqdn>`, an address pointing
at 443, where nothing would be listening.

The scheme's port is now `_HTTPS_DEFAULT_PORT`, and the template's context key
is renamed `https_default_port` to match.

## Scope

Three files. No behavior change at any supported configuration: both the
default and `tls_custom_port` nginx goldens render byte-for-byte as before, and
the one call site that relied on the old default is updated.
