### PR TITLE
feat: operator-facing control-target names, one write-state vocabulary

### DIFF
--- a/changelog.d/control-target-display-names.added.md
+++ b/changelog.d/control-target-display-names.added.md
@@ -1,0 +1,6 @@
+Control targets now carry an operator-facing display name on the web
+terminal's control-target chip, minted server-side from what each target is:
+"Real machine", "Rehearsal" for a deployed stand-in, "Simulator" for the
+virtual accelerator, "Demo" on a simulated connector. A deployment renames
+any of them per target via the new optional
+`control_system.target_display_names` mapping.

--- a/changelog.d/control-target-vocabulary.changed.md
+++ b/changelog.d/control-target-vocabulary.changed.md
@@ -1,0 +1,8 @@
+The web terminal's control-target chip and popover now name machines by what
+they are — Real machine, Rehearsal, Simulator, Demo, or per-target names set
+with `control_system.target_display_names` — and speak one write-state
+vocabulary (writes on / off / locked) across the chip, the popover, the
+confirmation dialogs, and the agent's refusal messages. The popover shows the
+machine the agent is on as a card with one write control, other machines as
+rows with Turn writes on/off and Switch to, and reports reachability only when
+a machine is not answering.

--- a/docs/source/architecture/python-executor.rst
+++ b/docs/source/architecture/python-executor.rst
@@ -293,28 +293,28 @@ Two layers enforce the set:
 Session posture
 ---------------
 
-An operator can narrow a Web Terminal session's write posture on one control
+An operator can turn a Web Terminal session's writes off on one control
 target from the control-target chip in the header (see
-:ref:`web-terminal-session-posture`). This server reads that narrowing at the
+:ref:`web-terminal-session-posture`). This server reads that setting at the
 moment a run asks for writes --- not from the environment it was started with,
-so a narrowing made mid-conversation applies to the next run --- and a
-``readwrite`` ``execute`` on a narrowed target is refused by the executor's own
+so a change made mid-conversation applies to the next run --- and a
+``readwrite`` ``execute`` on such a target is refused by the executor's own
 posture gate, whatever the deployment itself permits:
 
-   This session's write posture for the '<target>' control target is read-only
-   --- set from the control-target chip in the header, and in force for this
+   Writes are off for the '<target>' control target in this session --- turned
+   off from the control-target chip in the header, and in force for this
    session only.
 
-Where the run's target cannot be identified, the most restrictive posture
-recorded for the session decides, and the message says so --- *"This session's
-write posture is read-only for at least one control target (the run's target
-could not be identified, so the most restrictive decides) --- set from the
+Where the run's target cannot be identified, the most restrictive state
+recorded for the session decides, and the message says so --- *"Writes are off
+for at least one control target in this session (the run's target could not be
+identified, so the most restrictive decides) --- turned off from the
 control-target chip in the header."* --- rather than granting the run the most
 permissive answer.
 
-The agent is told to re-run as ``readonly`` --- reads are untouched by the
-posture --- or to set that target back to writes from the chip. The deployment's
-``config.yml`` is not the gate here and the message says so.
+The agent is told to re-run as ``readonly`` --- reads are untouched --- or to
+turn writes back on from the chip. The deployment's ``config.yml`` is not the
+gate here and the message says so.
 
 A run that has already started cannot be *widened*: it keeps the launch pin it
 started under, so a script cannot gain write access to a machine the operator

--- a/docs/source/how-to/control-systems/switch-control-target.rst
+++ b/docs/source/how-to/control-systems/switch-control-target.rst
@@ -434,7 +434,10 @@ The switch would be a hazard if it were quiet. It is not:
   ``LIVE MACHINE`` with the gateway the session actually holds; the stand-in as
   ``LIVE MACHINE (stand-in)``; the simulator as
   ``virtual accelerator (simulation)``. If the target cannot be read at all, the
-  line says so explicitly instead of disappearing.
+  line says so explicitly instead of disappearing. (The web terminal names the
+  same machines by what they are --- *Real machine*, *Rehearsal*, *Simulator*,
+  or the deployment's own configured names --- and keeps these technical labels
+  on its tooltips.)
 - **Results and artifacts are stamped.** Archive reads carry the session's
   target and the archiver that served them, so a saved plot still says what it
   is about a week later.
@@ -442,12 +445,11 @@ The switch would be a hazard if it were quiet. It is not:
   work happens, and on the :ref:`control-target chip
   <web-terminal-session-posture>` in the header, which names the machine the
   session stands on and the write state on *that* machine ---
-  ``● VIRTUAL · writes``, ``● LIVE · read-only``. Write posture is per target, so
-  a deployment can arm its simulator and leave the live machine read-only; the
-  chip is where that shows. It catches up with a switch a few seconds after one
-  is made, whoever made it. The popover tags the deployment's default row
-  ``baseline``, and the chip falls back to that row when no target can be
-  resolved for the session.
+  ``● Simulator · writes on``, ``● Real machine · writes locked``. The write
+  state is per machine, so a deployment can arm its simulator and leave the
+  live machine read-only; the chip is where that shows. It catches up with a
+  switch a few seconds after one is made, whoever made it, and falls back to
+  the deployment's default target when none can be resolved for the session.
 - **Nothing survives the session.** Every controls-server start returns to the
   deployment baseline. There is no saved preference that could quietly point a
   later session at the real machine.

--- a/docs/source/how-to/web-terminal/multi-user/tiers.rst
+++ b/docs/source/how-to/web-terminal/multi-user/tiers.rst
@@ -210,8 +210,8 @@ read-only tier.
         - 403 (read OK)
         - enabled
         - 403 (read OK)
-      * - Control-target chip: a target's toggle → *writes*
-        - locked (``persona ceiling``)
+      * - Control-target chip: *Turn writes on* for a machine
+        - locked (*kept read-only by the deployment*)
         - confirm modal
         - confirm modal
         - confirm modal

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -84,155 +84,161 @@ The control-target chip
 -----------------------
 
 The header carries a chip that answers, at a glance, the question every write
-depends on: *if the agent writes now, which machine does it land on, and will
-it be refused?* It reads like this::
+depends on: *if the agent writes now, which machine does it land on, and may
+it?* It reads like this::
 
-   ● STAND-IN · writes ▾
+   ● Rehearsal · writes on ▾
 
-The first word is the machine this session stands on --- ``LIVE`` for the
-facility's own machine, ``STAND-IN`` for a rehearsal machine that is operated
-like one, ``VIRTUAL`` for the virtual accelerator, ``SIMULATED`` for anything
-else simulated. The second is the write state **on that machine**:
+The first part names the machine this session stands on, by what it **is**:
 
-- **writes** --- the agent may write there, under the deployment's usual
-  approval and write-safety rules. This is the baseline.
-- **read-only** --- the deployment does not arm writes on that target, or the
-  whole deployment is running read-only. Nothing in the browser lifts this.
-- **sandbox** --- *you* narrowed that target for this session. Reads are
+- **Real machine** --- the facility's own. Writes move hardware.
+- **Rehearsal** --- a copy of the real machine's controls, same channel names,
+  no hardware behind it. Nothing moves.
+- **Simulator** --- the virtual accelerator: a physics model with beam in it.
+  Nothing moves.
+- **Demo** --- mock data. Nothing moves.
+
+A deployment can put its own names on its machines
+(``control_system.target_display_names`` in ``config.yml`` --- *ALS storage
+ring* rather than *Real machine*); what the machine is stays on the popover's
+descriptor line and the tooltips either way, and the tooltip also keeps the
+controls server's own technical label.
+
+The second part is the write state **on that machine**, for **your session**:
+
+- **writes on** --- the agent may write there, under whatever write gates the
+  deployment configures.
+- **writes off** --- *you* turned writes off for this session. Reads are
   untouched: the agent keeps its full view of the control system and of the
-  project, and can still run analysis, plots and readonly Python.
+  project, and can still run analysis, plots and read-only Python. One click
+  turns writes back on.
+- **writes locked** --- the deployment does not arm writes on that target, or
+  the whole deployment is running read-only. Nothing in the browser lifts
+  this.
 
 Click the chip and a popover opens on **every** control target the deployment
 configures, not only the one you are standing on.
 
-One row per machine
-~~~~~~~~~~~~~~~~~~~
+The machine you are on, and the others
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Each row names a machine and carries the two things you can do to it:
+The machine the agent stands on is a card at the top: its name, what writing
+there means (*Writes move hardware*, or one of the *nothing moves* lines), the
+write state, and the one button that changes it. Every other machine is a row
+below the card, carrying the same two facts, its write-state pill, and the
+actions:
 
-- **What it is** --- the name the deployment gave it, which already says what
-  kind of machine it names (*LIVE MACHINE*, *LIVE MACHINE (stand-in)*,
-  *virtual accelerator (simulation)*). That label comes from what the
-  connector actually is, so a stand-in never renders as the facility's own
-  machine. The row you are on is tagged ``current``.
-- **Whether it is answering** --- ``connected``, ``unreachable`` or ``unknown``,
-  with how long ago that was measured. ``unknown`` means nothing has vouched for
-  it yet, not that it is down.
-- **writes | read-only** --- the posture *this session* holds on that target, as
-  a two-segment toggle. It is the readout as well as the control: where it
-  cannot move it still shows which state holds, with the reason beside it.
-- **Switch** --- moves this session onto that machine. Where a switch is not
-  available the button is replaced by a short phrase for the reason ---
-  ``not configured``, ``needs gateway ack`` --- so the gap is explained rather
-  than merely empty, and the server's full sentence sits on the tooltip. On a
-  fresh deployment the live machine reading ``not configured`` is the normal
-  state, not a fault: authoring its gateways is the go-live edit.
+- **Turn writes off / Turn writes on** --- per machine, for your session.
+- **Switch to** --- moves this session onto that machine. Where a switch is
+  not available, the button's place is taken by a short phrase for the reason
+  --- ``not set up``, ``needs gateway ack`` --- with the server's full
+  sentence on the tooltip. On a fresh deployment the real machine reading
+  ``not set up`` is the normal state, not a fault: authoring its gateways is
+  the go-live edit.
 
-The foot of the popover has **Sandbox everything**, which puts every target it
-can into the sandbox in one click, and a reminder of the boundary: nothing here
-changes the deployment's config.
+A machine that stops answering says so --- ``not answering``, in red, next to
+its name. A machine that answers says nothing about it. Endpoints, gateway
+roles and the age of the last probe stay on the tooltips and in the
+confirmation dialogs, where the decision is actually made.
+
+The foot has **Turn all writes off**, which takes writes away from every
+machine it can in one click, and the popover's scope, said once: *your
+session only*.
 
 Take writes away, or give them back
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The posture is **per target**. Sandbox the live machine and the session keeps
-working on the virtual accelerator, which is the point: you put the machine you
-are worried about out of reach without giving up the one you are working on.
+The write state is **per machine**. Turn writes off on the real machine and
+the session keeps working on the simulator, which is the point: you put the
+machine you are worried about out of reach without giving up the one you are
+working on.
 
 Taking writes away applies as you click --- it needs no ceremony. Turning
 writes back on asks you to confirm first, every time and with nothing
 remembered between clicks, and the confirmation names the machine and the
 endpoint the agent would then be able to write to.
 
-**Nothing is restarted.** Every gate reads the posture at the moment of the
-write, so the change lands on the conversation that is already running: the
-agent obeys it on its very next write, and the turn in flight is not
-interrupted. One lag is worth knowing about: sandbox the target the session is
-*on* and the change reaches the agent when the connector is rebuilt, which
-waits for a running execution to finish, and the row says so rather than
-leaving a toggle that appears to have done nothing.
+**Nothing is restarted.** Every gate reads the write state at the moment of
+the write, so the change lands on the conversation that is already running:
+the agent obeys it on its very next write, and the turn in flight is not
+interrupted. One lag is worth knowing about: turn writes off on the machine
+the session is *on* and the change reaches the agent when the connector is
+rebuilt, which waits for a running execution to finish --- and the card says
+so rather than leaving a button that appears to have done nothing.
 
 **The chip only takes writes away.** What you set here tightens what the
 deployment permits; it can never hand out writes the deployment did not arm.
-Where the toggle cannot move it is locked and carries the reason:
+Where the state is locked the button stays on screen, disabled, and the
+reason is on its tooltip:
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 70
+   :widths: 35 65
 
-   * - Reason
+   * - Reason (on the tooltip)
      - What it means
-   * - ``persona ceiling``
-     - This deployment does not arm writes on that target at all. Only a
+   * - *kept read-only by the deployment*
+     - This deployment does not arm writes on that machine at all. Only a
        rebuild changes that, not a click.
-   * - ``readonly run``
-     - The whole deployment is running read-only
-       (``OSPREY_EXECUTION_MODE=readonly``), which sits above any one session.
-   * - ``not enforceable``
-     - This page has no way to deliver a posture change to this session's
-       control-system server, so a toggle set here would be read by nobody. The
-       roster still renders --- it is worth reading --- but the toggles govern
-       nothing.
-   * - ``store unavailable``
-     - The folder where postures are recorded is missing or unreadable, so
-       there is nowhere to keep a setting the agent would read back. Nothing
-       was changed.
-   * - ``no read-only endpoint``
-     - Read-only on this target would route it through a gateway the deployment
-       has not configured, leaving the target unusable. You are told before you
-       act, not after.
+   * - *the whole deployment is running read-only*
+     - ``OSPREY_EXECUTION_MODE=readonly`` is set, which sits above any one
+       session.
+   * - *changes here would not reach the agent*
+     - This page has no way to deliver a change to this session's
+       control-system server, so a state set here would be read by nobody.
+       The roster still renders --- it is worth reading --- but the buttons
+       govern nothing, and a banner across the top of the popover says so.
+   * - *changes cannot be recorded right now*
+     - The folder where write states are recorded is missing or unreadable,
+       so there is nowhere to keep a setting the agent would read back.
+       Nothing was changed.
+   * - *no read-only endpoint configured*
+     - Read-only on this machine would route it through a gateway the
+       deployment has not configured, leaving the machine unusable. You are
+       told before you act, not after.
 
 One more refusal can meet the click itself: you cannot turn writes back on
-while the agent is still running something. The run keeps the posture it
+while the agent is still running something. The run keeps the write state it
 started with, so wait for it to finish, or stop it, and try again.
 
 Switch this session to another machine
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Switch** on a row moves the session onto that machine, after a confirmation
-that names it and says which write posture the session arrives in there ---
-posture is per target, and it does not travel with you. The browser does not
-perform the switch: it records the request, and the part of the deployment that
-owns the connection to the machines picks it up, re-checks at that moment that
-the move is allowed and the machine answers, and reports the outcome back. The
+**Switch to** on a row moves the session onto that machine, after a
+confirmation that says where every control read and write goes next and
+whether writes are on or off for you there --- the write state is per
+machine, and it does not travel with you. The browser does not perform the
+switch: it records the request, and the part of the deployment that owns the
+connection to the machines picks it up, re-checks at that moment that the
+move is allowed and the machine answers, and reports the outcome back. The
 row then reads ``✓ switched``, or ``✗`` with the phrase for the refusal ---
 the same refusal, for the same reason, the agent is given. While a request is
-out the chip reads ``switching…``, and one request is outstanding at a time. If
-nothing answers within 30 seconds the row reads ``request_expired``: nothing
-that could carry out the switch was alive to pick it up.
+out the chip reads ``switching…``, and one request is outstanding at a time.
+If nothing answers within 30 seconds the row reads ``request_expired``:
+nothing that could carry out the switch was alive to pick it up.
 
-What the switch itself is gated on --- the approval prompt, the limits posture,
-the archive --- is :doc:`../control-systems/switch-control-target`.
+What the switch itself is gated on --- the approval prompt, the limits
+posture, the archive --- is :doc:`../control-systems/switch-control-target`.
 
-Simple and Expert
-~~~~~~~~~~~~~~~~~
+Where the write state lives
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The popover follows the session's density setting (the Simple/Expert control in
-the display menu; see :doc:`theming`). Simple mode shows the machine's name,
-whether it is answering, the toggle and **Switch**. Expert mode adds
-the endpoint, the gateway role, the age of the last probe, and the notes under a
-locked toggle. The controls and the confirmations are the same in both: the
-density changes what is on screen, never what a click does.
-
-Where the posture lives
-~~~~~~~~~~~~~~~~~~~~~~~
-
-The posture belongs to **one session**, not to the deployment. Nothing is
+The write state belongs to **one session**, not to the deployment. Nothing is
 written to ``config.yml``. Two people working in two sessions of the same
-deployment hold their own postures, and one of them sandboxing a target does
-not touch the other.
+deployment hold their own settings, and one of them turning writes off on a
+machine does not touch the other.
 
 Your settings are recorded in
-``var/agent_data/control_target/session-postures.json``, written as soon as you
-click and read back when the server starts, so restarting the container never
-quietly returns a sandboxed session to writes.
+``var/agent_data/control_target/session-postures.json``, written as soon as
+you click and read back when the server starts, so restarting the container
+never quietly turns a session's writes back on.
 
 What refuses a write, and how firmly
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Nothing about the posture is a single choke point --- each write route is
-refused by the layer that owns it. The difference between those layers is worth
-knowing, because one of them is best-effort rather than enforced:
+Turning writes off is not a single choke point --- each write route is
+refused by the layer that owns it. The difference between those layers is
+worth knowing, because one of them is best-effort rather than enforced:
 
 .. list-table::
    :header-rows: 1
@@ -247,84 +253,82 @@ knowing, because one of them is best-effort rather than enforced:
        connector is the layer that holds if the hook does not run.
    * - ``execute`` with ``execution_mode="readwrite"``
      - The Python executor's own gate
-     - **Enforced.** The run is refused outright; a ``readonly`` ``execute`` is
-       unaffected and runs normally.
+     - **Enforced.** The run is refused outright; a ``readonly`` ``execute``
+       is unaffected and runs normally.
    * - Any other write tool the writes-check hook covers --- for example the
        Bluesky queue's arming tools, where that server is enabled
      - The writes-check hook
      - **Best-effort.** It is the first hook in the chain and the only
-       posture-aware layer those tools have; a hook that fails to run does not
+       state-aware layer those tools have; a hook that fails to run does not
        refuse.
 
 Each layer says which gate refused, in its own words, so the message never
 sends you to the wrong control:
 
-- The hook --- *"SANDBOX POSTURE --- this session refuses control-system writes
-  to the <target> target. Switch it back to writes on the control-target chip in
+- The hook --- *"WRITES OFF --- this session refuses control-system writes
+  to the <target> target. Turn writes back on from the control-target chip in
   the header; config.yml is not the gate here."*
-- The connector --- *"Write to '<channel>' blocked: this session's posture for
-  the '<target>' control target is read-only --- set from the control-target
-  chip in the header, and in force for this session only. Set '<target>' back to
-  writes from the chip if the write is intended; config.yml is not the gate
-  here."*
-- The executor --- *"This session's write posture for the '<target>' control
-  target is read-only --- set from the control-target chip in the header, and in
+- The connector --- *"Write to '<channel>' blocked: writes are off for the
+  '<target>' control target in this session --- turned off from the
+  control-target chip in the header, and in force for this session only. Turn
+  writes back on for '<target>' from the chip if the write is intended;
+  config.yml is not the gate here."*
+- The executor --- *"Writes are off for the '<target>' control target in this
+  session --- turned off from the control-target chip in the header, and in
   force for this session only."* --- offering a re-run as ``readonly``, and
-  saying to set that target back to writes from the chip if the write is
-  intended.
+  saying to turn writes back on from the chip if the write is intended.
 
-Those three are what a posture you set from the chip sounds like, and the
-chip is where you lift it. A **deployment-wide read-only run** is a different
-story and says so, because no click lifts that one:
+Those three are what writes you turned off from the chip sound like, and the
+chip is where you turn them back on. A **deployment-wide read-only run** is a
+different story and says so, because no click lifts that one:
 
 - The connector --- *"Write to '<channel>' blocked: this deployment is running
   in readonly execution mode (OSPREY_EXECUTION_MODE=readonly), which refuses
   control-system writes for every session. The control-target chip in the
   header cannot lift it."*
 - The executor --- *"This deployment is running in readonly execution mode,
-  which refuses control-system writes regardless of what the run asks for."* ---
-  offering the same re-run as ``readonly``, and saying that writes need the
-  deployment started without the variable.
+  which refuses control-system writes regardless of what the run asks for."*
+  --- offering the same re-run as ``readonly``, and saying that writes need
+  the deployment started without the variable.
 
-The chip shows the same thing: every toggle locked, with ``readonly run`` as the
-reason.
+The chip shows the same thing: every button locked, with *the whole
+deployment is running read-only* as the reason.
 
-No posture refusal mentions the deployment's ``writes_enabled`` keys,
-deliberately: changing one would not lift a posture refusal, and a message that
-pointed at one would send an operator to rebuild a deployment when a single
-click was the remedy. The reverse holds too --- a write refused because this
-target is not armed says so in its own words, names the key that would arm it,
-and says nothing about postures.
+No writes-off refusal mentions the deployment's ``writes_enabled`` keys,
+deliberately: changing one would not lift it, and a message that pointed at
+one would send an operator to rebuild a deployment when a single click was
+the remedy. The reverse holds too --- a write refused because this target is
+not armed says so in its own words, names the key that would arm it, and
+says nothing about the chip.
 
 .. note::
 
    **The other two surfaces.** Simple mode's chat and the operator websocket run
    their agent through the Agent SDK rather than a terminal. Both read the same
-   record at write time, so a posture you set reaches them exactly as it reaches
+   record at write time, so a write state you set reaches them exactly as it reaches
    a terminal session. Where they differ is in what the chip can do for them.
 
-   A **chat session's toggles work** --- its writes meet the same ceiling and
-   the same read-only setting a terminal's do --- but it is offered no
-   **Switch**: a chat has no machine connection of its own to move, and every
-   row says ``chat_session`` where the button would be. Know one thing before
-   relying on a chat's posture: the chat page starts a fresh chat every time it
-   loads, so a posture you set for it lasts as long as that page does rather
-   than following the conversation.
+   A **chat session's write controls work** --- its writes meet the same ceiling
+   and the same locks a terminal's do --- but it is offered no **Switch to**: a
+   chat has no machine connection of its own to move. Know one thing before
+   relying on a chat's write state: the chat page starts a fresh chat every
+   time it loads, so a state you set for it lasts as long as that page does
+   rather than following the conversation.
 
-   An **operator websocket session's toggles govern nothing**: the chip has no
-   way to hand a posture to that kind of session, so what you set here never
-   reaches it.
+   An **operator websocket session's write controls govern nothing**: the chip
+   has no way to hand a write state to that kind of session, so what you set
+   here never reaches it.
 
 .. dropdown:: Why the websocket session is out of the chip's reach
    :icon: gear
 
    The websocket session's identifier is created when the connection is
-   accepted and identifies nothing once the connection ends, so no posture can
-   be recorded against it and there is nothing to restore across a restart.
+   accepted and identifies nothing once the connection ends, so no write state
+   can be recorded against it and there is nothing to restore across a restart.
    That stays true until an operator client exists to define its reconnect
    protocol. Every audit record such a session emits is labelled
-   ``posture_source=spawn`` --- the trail's way of saying the posture was fixed
-   when the session started rather than read from a live setting; see the
+   ``posture_source=spawn`` --- the trail's way of saying the write state was
+   fixed when the session started rather than read from a live setting; see the
    record fields in :ref:`the audit trail contract <audit-trail-record>`.
 
 Documentation and feedback settings

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
@@ -459,11 +459,11 @@ def _writes_disabled_result(
       to lift: the remedy is to re-run the script. Asked BEFORE the store
       clause, because ``store_permits`` already includes the launch pin, so
       without this fork the refusal would point at a chip that already reads
-      writes. Its two wordings separate "this target was read-only when the run
-      started" from "nothing could be resolved at launch, so the run was pinned
-      everywhere" — the second is nobody's decision and must not be reported as
-      one.
-    * this **session's posture for one control target** is read-only. The
+      writes. Its two wordings separate "writes were off for this target when
+      the run started" from "nothing could be resolved at launch, so the run
+      was pinned everywhere" — the second is nobody's decision and must not be
+      reported as one.
+    * this **session has writes off for one control target**. The
       deployment arms this connector and no readonly run is in force; an
       operator narrowed this one machine for this one session from the
       control-target chip in the header, and the chip is where it lifts.
@@ -519,8 +519,8 @@ def _writes_disabled_result(
         deployment_arms = _deployment_writes_enabled(connector_type)
         # The launch pin is asked FIRST, because ``store_permits`` above already
         # includes it and a run refused by the pin would otherwise be reported
-        # as a live narrowing — telling an operator to set a target back to
-        # writes that already reads writes. Re-read rather than handed down:
+        # as a live narrowing — telling an operator to turn writes back on for
+        # a target whose writes are already on. Re-read rather than handed down:
         # ``launch_permits`` is one environment read and touches no file, so the
         # one-store-read-per-write memo is untouched.
         if not launch_permits(control_target) and deployment_arms:
@@ -532,36 +532,36 @@ def _writes_disabled_result(
                 # a decision they never made.
                 message = (
                     f"Write to '{channel_address}' blocked: this run launched under the "
-                    "most restrictive write posture — at launch neither its control "
-                    "target nor this session's posture for it could be resolved, so the "
-                    "run was pinned read-only for every target. A posture set since "
-                    "applies to the next run, not to one already in flight. Re-run the "
-                    "script to pick up the current posture."
+                    "most restrictive write state — at launch neither its control "
+                    "target nor this session's write state for it could be resolved, "
+                    "so the run was pinned with writes off for every target. A write "
+                    "state set since applies to the next run, not to one already in "
+                    "flight. Re-run the script to pick up the current write state."
                 )
             else:
                 message = (
                     f"Write to '{channel_address}' blocked: this run launched while "
-                    f"'{launched}' was read-only for this session; the posture set since "
-                    "applies to the next run, not to one already in flight. Re-run the "
-                    "script to pick it up."
+                    f"writes were off for '{launched}' in this session; a write state "
+                    "set since applies to the next run, not to one already in flight. "
+                    "Re-run the script to pick it up."
                 )
         elif not store_permits and deployment_arms:
             if control_target:
-                where = f"the '{control_target}' control target"
-                remedy = f"Set '{control_target}' back to writes from the chip"
+                where = f"the '{control_target}' control target in this session"
+                remedy = f"Turn writes back on for '{control_target}' from the chip"
             else:
                 # No stamp, so the most restrictive entry decided and this
                 # connector genuinely cannot say which target that was. Naming
                 # one would be a guess an operator then acts on.
                 where = (
-                    "at least one control target (this connector was built without one, "
-                    "so the most restrictive of them decides)"
+                    "at least one control target in this session (this connector was "
+                    "built without one, so the most restrictive of them decides)"
                 )
-                remedy = "Lift that narrowing from the chip"
+                remedy = "Turn writes back on from the chip"
             message = (
-                f"Write to '{channel_address}' blocked: this session's posture for "
-                f"{where} is read-only — set from the control-target chip in the header, "
-                f"and in force for this session only. {remedy} if the write is intended; "
+                f"Write to '{channel_address}' blocked: writes are off for {where} — "
+                f"turned off from the control-target chip in the header, and in force "
+                f"for this session only. {remedy} if the write is intended; "
                 "config.yml is not the gate here."
             )
         else:

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -585,6 +585,19 @@ keys:
       hook reads it from there. Tools named here are refused per call and never
       enter `permissions.deny`, which is why a mixed-posture render can gate
       them at all.
+  control_system.target_display_names:
+    rendered: false
+    evidence: 'section\.get\("target_display_names"\)'
+    note: >-
+      Operator-facing display names for the web terminal's control-target chip,
+      commented in the three templates that carry a control_system block. The
+      one reader is `_display_name` in connector_host_manager, which folds a
+      non-empty per-target string over the derived default at the
+      display-metadata mint point; state-file and roster readers render the
+      name they are handed and never read this key again.
+  control_system.target_display_names.live: {covered-by: control_system.target_display_names, rendered: false}
+  control_system.target_display_names.standin: {covered-by: control_system.target_display_names, rendered: false}
+  control_system.target_display_names.va: {covered-by: control_system.target_display_names, rendered: false}
   control_system.read_inline_max_elements:
     evidence: '"control_system\.read_inline_max_elements"'
   control_system.channel_read_artifact_retention:

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -2668,6 +2668,7 @@ def _posture_view(app: Any, session_key: str, config_path: Path | None) -> dict[
             {
                 "target": target,
                 "label": label,
+                "display_name": str(meta.get("display_name") or ""),
                 "short_label": short_label,
                 "kind": kind,
                 "endpoint": str(meta.get("endpoint") or ""),
@@ -2717,12 +2718,15 @@ async def get_terminal_posture(session_id: str, request: Request):
     configured control target, each answering the whole of what the operator
     needs about that machine:
 
-    * ``label`` / ``short_label`` / ``kind`` / ``endpoint`` / ``real_machine`` —
-      what to call it and what it is. The label is the one the controls server
-      published for the target it is running, or the one this render derives for
-      a session that has not started one; ``short_label`` and ``kind`` come from
-      ``real_machine`` and the label's shape, never from the target name, so a
-      stand-in never renders as the facility's own machine.
+    * ``label`` / ``display_name`` / ``short_label`` / ``kind`` / ``endpoint``
+      / ``real_machine`` — what to call it and what it is. The label is the one
+      the controls server published for the target it is running, or the one
+      this render derives for a session that has not started one;
+      ``display_name`` is the operator-facing name minted beside it
+      (``control_system.target_display_names`` renames it per deployment);
+      ``short_label`` and ``kind`` come from ``real_machine`` and the label's
+      shape, never from the target name, so a stand-in never renders as the
+      facility's own machine.
     * ``ceiling_writes`` / ``posture`` / ``effective`` — the three terms of the
       write decision, kept separate on purpose. The ceiling is the deployment's
       (``session_posture``); the posture is this session's own narrowing; the

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -435,9 +435,15 @@ osprey-display-menu .display-menu-logout-icon {
   opacity: 0.72;
 }
 
-/* The short label — derived from the target's own kind and label, never the
-   raw target name, so the chip cannot grow with a long deployment string. */
+/* The machine's name — the kind's own word (Real machine, Rehearsal,
+   Simulator, Demo) or the deployment's configured display name. A configured
+   name is free text, so the chip caps it with an ellipsis rather than letting
+   one long name push the header's other actions off screen; the full name
+   stays on the chip's title. */
 .ctc-short {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-weight: var(--weight-medium);
   letter-spacing: 0.04em;
   color: var(--text-primary);
@@ -593,16 +599,162 @@ osprey-display-menu .display-menu-logout-icon {
   animation: ctc-menu-in var(--wt-transition-fast);
 }
 
-.ctc-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-2);
-  padding: 0 2px 6px;
-  border-bottom: 1px solid var(--border-default);
+/* The one abnormal banner across the top. Absent in the plain case — absence
+   is the good news — and worded in control-target-facts.js, whose bannerNote
+   picks the widest abnormal fact about the session. */
+.ctc-banner {
+  padding: 6px 8px;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  border-radius: var(--radius-sm);
 }
 
-.ctc-head-title {
+.ctc-banner[data-tone="warn"] {
+  color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 10%, transparent);
+}
+
+.ctc-banner[data-tone="error"] {
+  color: var(--color-error);
+  background: var(--error-tint-08);
+}
+
+/* ---- The card: the machine the agent stands on ----
+
+   "Where am I" is the first thing read, so it is not the middle row of an
+   equal list: it is a card, with the name, the consequence line, the write
+   state, and the one verb that changes it. The accent tint is the same one
+   the old active row wore — quiet, not a warning. */
+.ctc-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  row-gap: 3px;
+  column-gap: 10px;
+  align-items: center;
+  padding: 9px 10px 10px;
+  background: var(--accent-tint-04);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-md);
+}
+
+.ctc-card-eyebrow {
+  grid-column: 1 / -1;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-accent-light);
+}
+
+.ctc-card-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+.ctc-card-title .ctc-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ctc-card-verb {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.ctc-card > .ctc-desc,
+.ctc-card-state,
+.ctc-card > .ctc-outcome {
+  grid-column: 1 / -1;
+}
+
+/* The consequence line under a name: what writing to this machine does.
+   Wording in control-target-facts.js (KIND_DESCRIPTORS); the live machine's
+   line carries the error tone because it is the one sentence in the popover
+   that names hardware moving. */
+.ctc-desc {
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ctc-desc[data-tone="hazard"] {
+  color: var(--color-error);
+}
+
+.ctc-card-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+/* The state phrase: on takes the colour of what a write here would mean (the
+   error tone on a real machine, success on a simulator), off is the warning
+   the operator can lift, locked stays muted — no gesture here moves it. */
+.ctc-card[data-real="true"] .ctc-state-phrase[data-state="writes"] {
+  color: var(--color-error);
+}
+
+.ctc-card[data-real="false"] .ctc-state-phrase[data-state="writes"] {
+  color: var(--color-success);
+}
+
+.ctc-state-phrase[data-state="sandbox"] {
+  color: var(--color-warning);
+}
+
+.ctc-state-phrase[data-state="read-only"] {
+  color: var(--text-muted);
+}
+
+.ctc-state-note {
+  color: var(--text-muted);
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+/* The reachability exception. "Connected" is never rendered — the only
+   reachability fact that changes a decision is that a machine is not
+   answering, and the measured detail stays on the title. */
+.ctc-reach-word {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.ctc-reach-word[data-state="down"] {
+  color: var(--color-error);
+}
+
+.ctc-reach-word[data-state="stale"] {
+  color: var(--color-warning);
+}
+
+/* ---- The other machines ----
+
+   Four columns owned by the list, subgridded per row so the pills and verbs
+   line up as columns: who it is and what writing there means, the state pill,
+   the verb that changes it, and Switch to. */
+.ctc-list-title {
+  padding: 2px 2px 0;
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
@@ -611,46 +763,19 @@ osprey-display-menu .display-menu-logout-icon {
   color: var(--text-muted);
 }
 
-/* The right of the head is empty in the plain case and only fills when the
-   session is not plain — nothing enforceable behind it, a readonly run, an
-   execution in flight. Absence is the good news. */
-.ctc-head-note {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  letter-spacing: 0.02em;
-  color: var(--text-muted);
-}
-
-.ctc-head-note[data-tone="warn"] {
-  color: var(--color-warning);
-}
-
-.ctc-head-note[data-tone="error"] {
-  color: var(--color-error);
-}
-
-/* Four columns: the dot, who the target is, the posture this session holds on
-   it, and the one action available. Status and action stay in separate
-   columns — reading the popover and changing it are different gestures.
-
-   The COLUMNS belong to the list, not to the row: `.ctc-rows` owns the track
-   sizing and each row subgrids into it, so the posture and action columns
-   share one width across every row and the toggles line up as a column
-   instead of ragged per-row boxes. */
 .ctc-rows {
   display: grid;
-  grid-template-columns: 10px minmax(0, 1fr) max-content max-content;
-  column-gap: 10px;
+  grid-template-columns: minmax(0, 1fr) max-content max-content max-content;
+  column-gap: 8px;
 }
 
 .ctc-row {
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1 / -1;
-  /* Start, not center: the toggle and Switch align with the row's first
-     (label) line, and stay put when a row grows an outcome line below it. */
-  align-items: start;
-  padding: 8px 2px;
+  align-items: center;
+  min-height: 40px;
+  padding: 4px 2px;
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -658,41 +783,21 @@ osprey-display-menu .display-menu-logout-icon {
   border-bottom: 0;
 }
 
-/* The row this session is on, bled past the popover's padding so the tint
-   reads as a highlighted row rather than an inset card. The -6px/8px pair
-   nets to the 2px inset every other row has, and subgrid keeps that
-   arithmetic: a subgridded row's own margin and padding are taken out of its
-   edge tracks, so the content still lands on the shared columns. */
-.ctc-row[data-active="true"] {
-  margin: 0 -6px;
-  padding-left: 8px;
-  padding-right: 8px;
-  background: var(--accent-tint-04);
-  border-radius: var(--radius-md);
-}
-
-/* The dot aligns with the name line, not with the middle of a three-line
-   identity block. */
-.ctc-row > .ctc-dot {
-  align-self: start;
-  margin-top: 5px;
-}
-
 .ctc-ident {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
 }
 
-.ctc-name {
+.ctc-name-line {
   display: flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
 }
 
-.ctc-label {
+.ctc-name {
   color: var(--text-primary);
   font-weight: var(--weight-medium);
   white-space: nowrap;
@@ -700,114 +805,111 @@ osprey-display-menu .display-menu-logout-icon {
   text-overflow: ellipsis;
 }
 
-.ctc-row[data-target-kind="simulated"] .ctc-label {
+/* A simulator is the unremarkable case: it drops to the secondary weight so
+   the eye skips it, exactly as the chip's short label does. */
+.ctc-row[data-target-kind="va"] .ctc-name,
+.ctc-row[data-target-kind="simulated"] .ctc-name {
   color: var(--text-secondary);
   font-weight: var(--weight-regular);
 }
 
-.ctc-tag {
-  padding: 1px 5px;
-  font-family: var(--font-mono);
-  font-size: var(--text-2xs);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-muted);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-xs);
-}
-
-.ctc-tag-current {
-  color: var(--color-accent-light);
-  border-color: var(--border-accent);
-  background: var(--accent-tint-08);
-}
-
-.ctc-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: nowrap;
-  min-width: 0;
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  color: var(--text-muted);
-}
-
-.ctc-endpoint {
-  white-space: nowrap;
-}
-
-.ctc-role,
-.ctc-baseline {
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
-.ctc-role::before,
-.ctc-baseline::before {
-  content: "·";
-  margin-right: 8px;
-}
-
-/* Reachability, as the prober last saw it. The LED is the constant; the word
-   and the age beside it are what simple mode drops. */
-.ctc-reach {
+/* The state pill: the same colour map as the card's state phrase. */
+.ctc-pill {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  white-space: nowrap;
+  height: 18px;
+  padding: 0 7px;
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  color: var(--text-muted);
-}
-
-.ctc-reach-dot {
-  width: 6px;
-  height: 6px;
-  flex-shrink: 0;
-  background: var(--text-muted);
-  border: 1px solid var(--text-muted);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   border-radius: var(--radius-full);
+  white-space: nowrap;
 }
 
-.ctc-reach[data-state="reached"] .ctc-reach-dot {
-  background: var(--color-success);
-  border-color: var(--color-success);
-}
-
-.ctc-reach[data-state="down"] {
+.ctc-row[data-real="true"] .ctc-pill[data-state="writes"] {
   color: var(--color-error);
+  background: var(--error-tint-10);
 }
 
-.ctc-reach[data-state="down"] .ctc-reach-dot {
-  background: var(--color-error);
-  border-color: var(--color-error);
+.ctc-row[data-real="false"] .ctc-pill[data-state="writes"] {
+  color: var(--color-success);
+  background: var(--success-tint-08);
 }
 
-.ctc-reach[data-state="stale"] {
+.ctc-pill[data-state="sandbox"] {
   color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 10%, transparent);
 }
 
-.ctc-reach[data-state="stale"] .ctc-reach-dot {
-  background: var(--color-warning);
+.ctc-pill[data-state="read-only"] {
+  color: var(--text-muted);
+  background: var(--neutral-tint-06);
+}
+
+/* ---- Verbs ----
+
+   Named for their outcome, so the asymmetry — off applies on click, on
+   confirms first — is visible before the click. Locked, the verb stays on
+   screen, disabled, with the reason on hover: the gap where the control would
+   be is explained rather than merely empty. */
+.ctc-verb,
+.ctc-card-verb {
+  height: 22px;
+  padding: 0 10px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color var(--wt-transition-fast), border-color var(--wt-transition-fast),
+    background var(--wt-transition-fast);
+}
+
+/* Row verbs are quiet — the pill beside them already carries the state. */
+.ctc-verb {
+  color: var(--text-muted);
+  border-color: transparent;
+  padding: 0 4px;
+}
+
+.ctc-verb:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+/* The card's verb is the popover's one prominent control. Off hovers to the
+   warning it applies; on hovers to the error tone the confirm will carry. */
+.ctc-card-verb {
+  color: var(--text-secondary);
+}
+
+.ctc-card-verb[data-direction="off"]:hover:not(:disabled) {
+  color: var(--color-warning);
   border-color: var(--color-warning);
 }
 
-/* Never probed: a hollow LED, the same "nothing is holding this" shape the
-   target dot uses for read-only. */
-.ctc-reach[data-state="unknown"] .ctc-reach-dot {
-  background: transparent;
+.ctc-card-verb[data-direction="on"],
+.ctc-verb[data-direction="on"]:not(:disabled) {
+  color: var(--color-error);
 }
 
-/* A target reachability does not apply to loses the LED entirely rather than
-   showing an unlit one, which would read as "down" — but keeps its box, so
-   the reach text starts on the same column as every other row's. */
-.ctc-reach[data-state="not_applicable"] .ctc-reach-dot {
-  visibility: hidden;
+.ctc-card-verb[data-direction="on"]:hover:not(:disabled) {
+  border-color: var(--error-tint-40);
+  background: var(--error-tint-08);
 }
 
-/* What the last switch or posture request on this row did. Feedback, so it
-   survives into simple mode unchanged. */
+.ctc-verb:disabled,
+.ctc-card-verb:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* What the last switch or write-state request on this row did. */
 .ctc-outcome {
   margin-top: 2px;
   font-family: var(--font-mono);
@@ -832,93 +934,12 @@ osprey-display-menu .display-menu-logout-icon {
   color: var(--color-warning);
 }
 
-/* ---- Posture toggle (column 3) ----
+/* ---- Switch (column 4) ----
 
-   Two named segments rather than a switch, so the row says what it is as well
-   as what it would become. */
-.ctc-posture {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 3px;
-}
-
-.ctc-toggle {
-  display: inline-flex;
-  overflow: hidden;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-sm);
-}
-
-.ctc-seg {
-  height: 22px;
-  padding: 0 9px;
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-  background: transparent;
-  border: 0;
-  cursor: pointer;
-  transition: color var(--wt-transition-fast), background var(--wt-transition-fast);
-}
-
-.ctc-seg + .ctc-seg {
-  border-left: 1px solid var(--border-default);
-}
-
-.ctc-seg:hover:not(:disabled) {
-  color: var(--text-primary);
-  background: var(--neutral-tint-06);
-}
-
-.ctc-seg[aria-pressed="true"] {
-  color: var(--text-primary);
-  background: var(--neutral-tint-12);
-}
-
-/* Pressed `writes` takes the colour of what a write there would mean: the
-   error tone on a real machine, the success tone on the simulator, where
-   writing is simply the tool working. */
-.ctc-row[data-real="true"] .ctc-seg[data-seg="writes"][aria-pressed="true"] {
-  color: var(--color-error);
-  background: var(--error-tint-10);
-}
-
-.ctc-row[data-real="false"] .ctc-seg[data-seg="writes"][aria-pressed="true"] {
-  color: var(--color-success);
-  background: var(--success-tint-08);
-}
-
-.ctc-seg[data-seg="read-only"][aria-pressed="true"] {
-  color: var(--color-warning);
-}
-
-/* Locked: the toggle still shows which state holds — it is the readout too —
-   and only loses its affordance. The reason sits under it. */
-.ctc-toggle[data-locked="true"] {
-  opacity: 0.45;
-}
-
-.ctc-toggle[data-locked="true"] .ctc-seg {
-  cursor: not-allowed;
-}
-
-.ctc-lock {
-  font-family: var(--font-mono);
-  font-size: var(--text-2xs);
-  letter-spacing: 0.04em;
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
-/* ---- Action (column 4) ----
-
-   Either a Switch button or, where a button cannot be, the tool's own refusal
-   word in its place — so the gap where the action would be is explained
-   rather than merely empty. */
+   Either the button or, where a switch cannot be offered, the tool's own
+   refusal in the operator phrase — so the gap where the action would be is
+   explained rather than merely empty, and never in a vocabulary only the
+   tool speaks. */
 .ctc-action {
   min-width: 64px;
   display: flex;
@@ -956,9 +977,9 @@ osprey-display-menu .display-menu-logout-icon {
   background: var(--error-tint-08);
 }
 
-/* Deliberately quiet, `not configured` above all: on a stock deployment the
-   live target is unconfigured on purpose — authoring it is the go-live edit —
-   and an error tone here would flag a healthy render as broken. */
+/* Deliberately quiet, `not set up` above all: on a stock deployment the live
+   machine is unauthored on purpose — authoring it is the go-live edit — and
+   an error tone here would flag a healthy render as broken. */
 .ctc-reason {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
@@ -971,13 +992,13 @@ osprey-display-menu .display-menu-logout-icon {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  padding: 8px 2px 0;
+  padding: 6px 2px 0;
   border-top: 1px solid var(--border-default);
 }
 
 /* The one-gesture narrowing: it only ever removes reach, so it applies on
    click without a confirm, and it hovers warning rather than error. */
-.ctc-sandbox-all {
+.ctc-all-off {
   height: 22px;
   padding: 0 10px;
   font-family: var(--font-mono);
@@ -991,62 +1012,23 @@ osprey-display-menu .display-menu-logout-icon {
   cursor: pointer;
 }
 
-.ctc-sandbox-all:hover:not(:disabled) {
+.ctc-all-off:hover:not(:disabled) {
   color: var(--color-warning);
   border-color: var(--color-warning);
 }
 
-.ctc-sandbox-all:disabled {
+.ctc-all-off:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }
 
+/* The popover's scope, said once. Everything above is per session and per
+   machine; the deployment's own config is not reachable from here. */
 .ctc-foot-note {
+  font-family: var(--font-mono);
   font-size: var(--text-sm);
   color: var(--text-muted);
   text-align: right;
-}
-
-/* ---- Popover density: simple vs expert ----
-
-   One DOM and one JS path; only what is SHOWN differs, gated on the shell's
-   existing html[data-ui-mode] exactly like the simple-mode shell rules below.
-   Expert (the attribute absent, or `expert`) is the resting state and shows
-   everything above.
-
-   Simple keeps the four things an operator acts on — which target (the label
-   is the row's one identity line, and it already says what kind of machine it
-   names), whether it is reachable, the posture, and Switch — and drops the
-   detail that belongs to whoever runs the deployment: endpoints, gateway
-   roles, probe ages, the head note, the config disclaimer, and the lock
-   wording (which survives in the `title`). The chip itself, and both
-   confirms, are identical in either mode: a readout and a safety gesture do
-   not get a density. */
-html[data-ui-mode="simple"] .ctc-popover {
-  width: 380px;
-}
-
-html[data-ui-mode="simple"] .ctc-popover .ctc-meta,
-html[data-ui-mode="simple"] .ctc-popover .ctc-endpoint,
-html[data-ui-mode="simple"] .ctc-popover .ctc-role,
-html[data-ui-mode="simple"] .ctc-popover .ctc-head-note,
-html[data-ui-mode="simple"] .ctc-popover .ctc-foot-note,
-html[data-ui-mode="simple"] .ctc-popover .ctc-lock,
-html[data-ui-mode="simple"] .ctc-popover .ctc-baseline {
-  display: none;
-}
-
-/* Reachability collapses to the LED alone. The word and the age beside the dot
-   are a bare text node rather than an element of their own, so the text is
-   collapsed by zeroing the line's font size — the dot keeps its own explicit
-   6px box — and the full phrase stays on the element's `title`. */
-html[data-ui-mode="simple"] .ctc-popover .ctc-reach {
-  font-size: 0; /* hygiene-allow-scale: collapses an unwrappable text node, not a type-scale choice */
-  gap: var(--space-0);
-}
-
-html[data-ui-mode="simple"] .ctc-popover .ctc-reach-text {
-  display: none;
 }
 
 /* ---- Simple-mode shell density (frame 2b) ----

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-chip.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-chip.js
@@ -3,7 +3,7 @@
  *
  * The one-glance answer to "if the agent writes now, where does it land, and
  * will it be refused?". A 28 px chip in the global header reading
- * `● STAND-IN · writes ▾`: the short word for the machine this session stands
+ * `● Rehearsal · writes on ▾`: the name of the machine this session stands
  * on, the effective write state on THAT machine, and a dot whose colour says
  * how much a write there matters and whose shape says who is holding writes
  * back. The popover behind it (control-target-popover.js) lists every
@@ -47,6 +47,7 @@
  * already handled.
  */
 
+import { displayName, statePhrase } from './control-target-facts.js';
 import { withPrefix, createEventSource } from './api.js';
 import { AGENT_ACTIVITY_FRAME } from './activity-format.js';
 import { getCurrentSessionId, onSessionChange } from './terminal.js';
@@ -747,15 +748,15 @@ function render() {
       chip.dataset.enforceable = String(Boolean(state.enforceable && state.store_available));
       if (pending) chip.dataset.pending = 'true';
       else chip.removeAttribute('data-pending');
-      shortEl.textContent = row.short_label || row.target;
+      shortEl.textContent = displayName(row, kindAttr(row));
       // `data-state` keeps the real state under a pending request: the dot and
       // the border still describe the machine the session is on until the
       // switch actually lands.
-      stateEl.textContent = pending ? 'switching…' : word;
+      stateEl.textContent = pending ? 'switching…' : statePhrase(word);
       chip.title = row.label || row.target;
       chip.setAttribute(
         'aria-label',
-        `Control target: ${row.label || row.target} · ${pending ? 'switching' : word}`
+        `Control target: ${displayName(row, kindAttr(row))} · ${pending ? 'switching' : statePhrase(word)}`
       );
     }
   }

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
@@ -2,12 +2,25 @@
 /* OSPREY Web Terminal — Control-Target Derived Facts
  *
  * The pure half of the control-target popover: every function here derives a
- * fact an operator reads — a refusal phrase, a lock reason, the head note, a
+ * fact an operator reads — a machine's display name and what writing to it
+ * means, a state phrase, a refusal phrase, a lock reason, the banner note, a
  * reachability word — from the state the chip publishes, and nothing here
  * touches the DOM, the chip, or any module state. The popover
  * (control-target-popover.js) owns the rows, the gestures and the confirms;
  * this module owns what the rows SAY, so the wording can be read (and tested)
  * without a popover on screen.
+ *
+ * **One naming rule.** Every machine is named by what writing to it does and
+ * what it is for — never by how it is wired. The deployment may override the
+ * name per target (`control_system.target_display_names`, published by the
+ * route as `display_name`); the defaults live in {@link KIND_WORDS}. The
+ * server's own label ("LIVE MACHINE (stand-in)") stays on tooltips, where the
+ * implementation vocabulary belongs.
+ *
+ * **No process claims.** Nothing here says whether a write will ask for
+ * approval, what limits apply, or who is prompted — all of that is deployment
+ * configuration this module cannot see. What it may state is consequence:
+ * writes move hardware, or nothing moves.
  */
 
 /** `available_now` reason a chat session's rows carry (routes/websocket.py). */
@@ -15,6 +28,103 @@ export const REASON_CHAT_SESSION = 'chat_session';
 
 /** The refusal word for a row whose Switch is missing because the store is. */
 export const REASON_STORE_UNAVAILABLE = 'store_unavailable';
+
+/**
+ * The operator word for each machine kind, keyed on the `data-target-kind`
+ * value {@link module:control-target-chip.kindAttr} derives. Used wherever a
+ * row has no configured `display_name`. Consequence-first on purpose: an
+ * operator who has never met a soft-IOC can still tell the machine that moves
+ * from the ones that cannot.
+ * @type {Record<string, string>}
+ */
+export const KIND_WORDS = {
+  live: 'Real machine',
+  standin: 'Rehearsal',
+  va: 'Simulator',
+  simulated: 'Demo',
+};
+
+/**
+ * The one-line descriptor under each name: what writing to this machine does.
+ * These are statements of consequence, not of process — nothing about
+ * approvals or limits, which are configuration this file cannot see.
+ * @type {Record<string, string>}
+ */
+export const KIND_DESCRIPTORS = {
+  live: 'Writes move hardware',
+  standin: "Copy of the real machine's controls · nothing moves",
+  va: 'Physics model · nothing moves',
+  simulated: 'Mock data · nothing moves',
+};
+
+/**
+ * The `reason` codes that all mean "the deployment has not authored this
+ * machine yet". On a stock render this is the live target's DELIBERATE state —
+ * authoring it is the go-live edit — so the descriptor says "not set up"
+ * rather than implying a fault.
+ */
+export const NOT_SET_UP_REASONS = new Set([
+  'connector_block_missing',
+  'gateways_missing',
+  'probe_channel_missing',
+]);
+
+/**
+ * The name a row renders: the deployment's configured name where one is set,
+ * the kind's own word otherwise. The server label survives untouched for the
+ * tooltip; falling back to it here would put "LIVE MACHINE (stand-in)" back on
+ * the one surface this vocabulary exists to clean up, so the label is last.
+ * @param {any} row
+ * @param {string} kind  a `data-target-kind` value (kindAttr's answer)
+ * @returns {string}
+ */
+export function displayName(row, kind) {
+  const configured = String(row?.display_name || '').trim();
+  if (configured) return configured;
+  return KIND_WORDS[kind] || String(row?.label || row?.target || '');
+}
+
+/**
+ * The consequence line under the name. A live machine nothing has authored
+ * yet reads "Not set up yet" instead of promising hardware that is not there.
+ * @param {any} row
+ * @param {string} kind
+ * @returns {string}
+ */
+export function descriptor(row, kind) {
+  if (kind === 'live' && NOT_SET_UP_REASONS.has(String(row?.reason || ''))) {
+    return 'Not set up yet';
+  }
+  return KIND_DESCRIPTORS[kind] || '';
+}
+
+/**
+ * The tone the descriptor renders in: `hazard` for the one line that names
+ * hardware moving, `null` for every line that promises nothing moves. A live
+ * machine nothing has authored yet is not a hazard — its descriptor says "not
+ * set up", and painting that red would flag a healthy render as broken.
+ * @param {any} row
+ * @param {string} kind
+ * @returns {'hazard'|null}
+ */
+export function descriptorTone(row, kind) {
+  return kind === 'live' && descriptor(row, kind) === KIND_DESCRIPTORS.live ? 'hazard' : null;
+}
+
+/**
+ * The display phrase for a state word. The internal three-word vocabulary
+ * (`writes` / `sandbox` / `read-only`, {@link module:control-target-chip.stateWord})
+ * stays the wire and CSS truth; what an operator reads is on / off / locked —
+ * off is the state you put it in and one click undoes, locked is the
+ * deployment's and no click here moves it.
+ * @param {'writes'|'sandbox'|'read-only'|string} word
+ * @returns {string}
+ */
+export function statePhrase(word) {
+  if (word === 'writes') return 'writes on';
+  if (word === 'sandbox') return 'writes off';
+  return 'writes locked';
+}
 
 /**
  * Refusal code → the short phrase the operator reads.
@@ -26,16 +136,15 @@ export const REASON_STORE_UNAVAILABLE = 'store_unavailable';
  * informative is better than a blank where the reason should be, and it is how
  * a future code reaches the operator before this file has a phrase for it.
  *
- * The three `not configured` codes are one phrase on purpose: all three mean
- * the deployment has not authored this machine yet, which on a stock render is
- * the live target's DELIBERATE state (authoring it is the go-live edit), and
- * the distinction between them belongs to the tooltip, not the row.
+ * The three `not set up` codes are one phrase on purpose: all three mean the
+ * deployment has not authored this machine yet, and the distinction between
+ * them belongs to the tooltip, not the row.
  * @type {Record<string, string>}
  */
 export const REASON_PHRASES = {
-  connector_block_missing: 'not configured',
-  gateways_missing: 'not configured',
-  probe_channel_missing: 'not configured',
+  connector_block_missing: 'not set up',
+  gateways_missing: 'not set up',
+  probe_channel_missing: 'not set up',
   target_unresolvable: 'unavailable',
   limits_posture: 'needs strict limits',
   operator_ack_missing: 'needs gateway ack',
@@ -63,8 +172,8 @@ export function reasonPhrase(code) {
  *
  * A chat has no PTY and so no controls server of its own to address a switch
  * request to, which the route says by giving EVERY row `chat_session` as its
- * unavailability reason. Its toggles are untouched — the posture store is
- * keyed on the session, not on the topology.
+ * unavailability reason. Its write toggles are untouched — the posture store
+ * is keyed on the session, not on the topology.
  * @param {any[]} rows
  */
 export function isChatSession(rows) {
@@ -72,14 +181,12 @@ export function isChatSession(rows) {
 }
 
 /**
- * Whether nothing this session can do would arm this row.
+ * Whether nothing this session can do would turn this row's writes on.
  *
  * The signature of a read-only run, read off the columns the route publishes:
  * the render's ceiling is up and this session has not narrowed the row, and
  * writes are STILL off. `effective` is `ceiling ∧ ¬readonly_run ∧ entry ≠
- * sandbox`, so with the other two terms true only the run can be holding it —
- * and the toggle is a readout either way, which is the whole of what the lock
- * has to say.
+ * sandbox`, so with the other two terms true only the run can be holding it.
  * @param {any} row
  */
 export function writesHeldByTheRun(row) {
@@ -87,69 +194,164 @@ export function writesHeldByTheRun(row) {
 }
 
 /**
- * Why this row's toggle cannot move, or `null` when it can.
+ * Why this row's writes cannot be turned on or off, or `null` when they can.
  *
  * Ordered from the widest cause to the narrowest, so an operator reads the one
  * they could act on: a store that cannot record anything outranks a run that
- * would ignore it, which outranks a persona that never armed this target,
- * which outranks a gateway table with nowhere to narrow TO.
+ * would ignore it, which outranks a deployment that never arms this target,
+ * which outranks a gateway table with nowhere to narrow TO. Spoken in the
+ * operator's words; the machine vocabulary stays in the route payload.
  * @param {any} row
  * @param {any} state
  * @returns {string|null}
  */
 export function lockReason(row, state) {
-  if (!state?.store_available) return 'store unavailable';
-  if (!state.enforceable) return 'not enforceable';
-  if (writesHeldByTheRun(row)) return 'readonly run';
-  if (!row.ceiling_writes) return 'persona ceiling';
+  if (!state?.store_available) return 'changes cannot be recorded right now';
+  if (!state.enforceable) return 'changes here would not reach the agent';
+  if (writesHeldByTheRun(row)) return 'the whole deployment is running read-only';
+  if (!row.ceiling_writes) return 'kept read-only by the deployment';
   // Narrowing this row would select a gateway role the deployment has not
   // configured. The route only reports it for a row a narrowing would CHANGE,
-  // so when it is set the only move the toggle offers is the blocked one.
-  if (row.narrowing_refusal) return 'no read-only endpoint';
+  // so when it is set the only move on offer is the blocked one.
+  if (row.narrowing_refusal) return 'no read-only endpoint configured';
   return null;
 }
 
 /**
- * The right of the head, which is empty in the plain case: absence is the good
- * news. Same order as {@link lockReason} — the widest fact about the session
- * that is not plain.
+ * The banner across the top of the popover, which does not exist in the plain
+ * case: absence is the good news, and only a session that is not plain gets a
+ * sentence. Same order as {@link lockReason} — the widest abnormal fact wins.
  * @param {any} state
  * @param {any[]} rows
- * @returns {{text: string, tone: string|null}}
+ * @returns {{text: string, tone: string}|null}
  */
-export function headNote(state, rows) {
-  if (!state.store_available) return { text: 'posture store unavailable', tone: 'error' };
+export function bannerNote(state, rows) {
+  if (!state.store_available) {
+    return { text: 'Changes cannot be recorded right now — the posture store is unavailable.', tone: 'error' };
+  }
   if (!state.enforceable) {
-    return { text: `not enforceable · ${state.enforceable_reason ?? 'unknown'}`, tone: 'warn' };
+    return { text: 'Changes here will not reach the agent yet.', tone: 'warn' };
   }
   if (rows.length > 0 && rows.every(writesHeldByTheRun)) {
-    return { text: 'readonly run · deployment-wide', tone: 'warn' };
+    return { text: 'The whole deployment is running read-only.', tone: 'warn' };
   }
-  if (isChatSession(rows)) return { text: 'chat session', tone: null };
-  if (state.execution_in_flight) return { text: 'execution running', tone: 'warn' };
-  return { text: '', tone: null };
+  return null;
 }
 
 /**
- * The reachability word and the age beside it.
+ * The reachability exception, or `null` for every state that needs no words.
  *
- * ONE vocabulary in the visible line, in the words an operator who has never
- * met a gateway can read: `connected`, `unreachable`, and `unknown` for
- * everything the prober could not vouch for. The measured word — `reached`,
- * `down`, `stale`, `not_applicable` — and the role it was measured on stay on
- * the element's `title`, which is where simple mode's LED-only row keeps the
- * whole sentence too.
+ * "Connected" on every row is noise an operator learns to skip; the only
+ * reachability fact that changes a decision is that a machine is NOT
+ * answering, so that is the only one rendered. The measured word (`down`,
+ * `stale`), the age and the role stay on the element's `title` for whoever
+ * runs the deployment.
  * @param {any} reachability
- * @returns {{state: string, text: string, title: string}}
+ * @returns {{state: string, text: string, title: string}|null}
  */
-export function reachText(reachability) {
+export function reachException(reachability) {
   const rc = reachability && typeof reachability === 'object' ? reachability : {};
   const measured = typeof rc.state === 'string' && rc.state ? rc.state : 'unknown';
-  const word =
-    measured === 'reached' ? 'connected' : measured === 'down' ? 'unreachable' : 'unknown';
+  if (measured !== 'down' && measured !== 'stale') return null;
   const age = typeof rc.age_s === 'number' ? ` · ${rc.age_s} s` : '';
   const parts = [`${measured}${age}`];
   if (rc.role) parts.push(`${rc.role} endpoint`);
   if (measured === 'stale') parts.push('last probe older than the prober interval');
-  return { state: measured, text: `${word}${age}`, title: parts.join(' · ') };
+  return {
+    state: measured,
+    text: measured === 'down' ? 'not answering' : 'may be stale',
+    title: parts.join(' · '),
+  };
+}
+
+/**
+ * One emphasised run inside a confirm body line. The popover renders it as a
+ * `<strong>`; kept as data here so this module stays DOM-free and the whole
+ * of a confirm's wording can be asserted without a dialog on screen.
+ * @typedef {string | {em: string}} ConfirmRun
+ */
+
+/**
+ * The consequence sentence a confirm about the facility's own machine
+ * carries, and only that machine: writing there moves hardware. Deliberately
+ * the whole of what the confirms say about safety — whether a write prompts
+ * for approval, and what limits apply, are deployment configuration this
+ * module cannot see, so it makes no claim about them.
+ * @param {string} kind
+ * @returns {string|null}
+ */
+export function hardwareNote(kind) {
+  return kind === 'live' ? 'Real machine — writes move hardware.' : null;
+}
+
+/**
+ * The tooltip a machine's name carries: the server's own label (the
+ * implementation truth — "LIVE MACHINE (stand-in)"), the endpoint, and the
+ * measured reachability. The at-rest surface names consequences; hover is
+ * where the machine vocabulary lives.
+ * @param {any} row
+ * @returns {string}
+ */
+export function identTitle(row) {
+  const parts = [];
+  if (row.label) parts.push(String(row.label));
+  if (row.endpoint) parts.push(String(row.endpoint));
+  const reach = reachException(row.reachability);
+  if (reach) parts.push(reach.title);
+  return parts.join(' · ');
+}
+
+/**
+ * Everything the turn-writes-on confirm says. Only this direction asks —
+ * turning off removes reach and is undone by a click; turning on is the
+ * gesture after which a write the agent makes can land. The title names the
+ * machine, so the body does not name it again: one line for the scope and
+ * the endpoint, one for when it takes hold.
+ * @param {any} row
+ * @param {string} kind
+ * @returns {{title: string, body: ConfirmRun[][], live: string|null, confirmLabel: string}}
+ */
+export function turnOnConfirm(row, kind) {
+  return {
+    title: `Turn writes on for ${displayName(row, kind)}?`,
+    body: [
+      ['For ', { em: 'your session' }, row.endpoint ? ` · ${row.endpoint}.` : '.'],
+      ['Takes effect at the next write — nothing restarts.'],
+    ],
+    live: hardwareNote(kind),
+    confirmLabel: 'Turn writes on',
+  };
+}
+
+/**
+ * Everything the switch confirm says. The first line states the consequence —
+ * where every control read and write goes next. The second names the write
+ * state the session will ARRIVE in, because writes on/off is per machine and
+ * does not travel; the word is stateWord's own, so the dialog and the chip a
+ * moment later can never disagree.
+ * @param {any} row
+ * @param {string} kind
+ * @param {'writes'|'sandbox'|'read-only'} word  stateWord's answer for the row
+ * @returns {{title: string, body: ConfirmRun[][], live: string|null, confirmLabel: string}}
+ */
+export function switchConfirm(row, kind, word) {
+  const arrival =
+    word === 'writes'
+      ? ['Writes are ', { em: 'on' }, ' there for your session.']
+      : word === 'sandbox'
+        ? [
+            'Writes are ',
+            { em: 'off' },
+            ' there for your session — nothing moves until you turn them on.',
+          ]
+        : ['Writes are ', { em: 'locked' }, ' read-only there by the deployment.'];
+  return {
+    title: `Switch to ${displayName(row, kind)}?`,
+    body: [
+      ['All control reads and writes go to ', { em: String(row.endpoint || row.target) }, '.'],
+      arrival,
+    ],
+    live: word === 'writes' ? hardwareNote(kind) : null,
+    confirmLabel: 'Switch',
+  };
 }

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-popover.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-popover.js
@@ -1,39 +1,38 @@
 // @ts-check
 /* OSPREY Web Terminal — Control-Target Popover
  *
- * The panel behind the header chip: one row per configured control target,
- * and every gesture that CHANGES where this session writes. The chip
- * (control-target-chip.js) owns the read, the poll and the state; this module
- * owns the rows and the actions, and never fetches the roster itself — it
- * subscribes to the chip and re-renders from `getState()`, so the popover and
- * the chip can never disagree about the same machine.
+ * The panel behind the header chip, answering the three questions an operator
+ * opens it with: which machine is the agent on and does writing there move
+ * anything real; are writes on, off (their own doing, one click undoes it) or
+ * locked (the deployment's, no click here moves it); and where else can the
+ * session go. The chip (control-target-chip.js) owns the read, the poll and
+ * the state; this module owns the card, the rows and the actions, and never
+ * fetches the roster itself — it subscribes to the chip and re-renders from
+ * `getState()`, so the popover and the chip can never disagree about the same
+ * machine.
  *
- * Each row answers the whole of what an operator needs to act on it: which
- * machine, where it points, whether anything is reaching it, the ceiling the
- * deployment rendered, this session's own narrowing, and what a switch would
- * do. Status and action stay in separate columns because reading the popover
- * and changing it are different gestures — and every element carries one fact,
- * once: the row's single identity line is the server's label, which already
- * says what kind of machine it names.
+ * **Two shapes, not one list.** The machine the agent stands on is a card —
+ * name, consequence line, write state, and the one button that changes it.
+ * Every other machine is a row: name and consequence, a state pill, a verb,
+ * and Switch to. Where a control cannot act it stays visible and says why on
+ * hover; the machine vocabulary (lock codes, endpoints, the server's own
+ * label) lives on tooltips, never at rest.
  *
- * **One DOM, two densities.** `html[data-ui-mode]` is a CSS concern and only a
- * CSS concern: every row renders the endpoint and role line, the reachability
- * word and age, the baseline tag, the lock reason and the foot note, in both
- * modes, and terminal.css hides what simple mode drops. Nothing here reads
- * `data-ui-mode` — a JS branch on it would make a live toggle-back rebuild the
- * DOM, and would put the density rule in two files that could drift.
+ * **Verbs, not toggles.** Turning writes off applies on click — it only ever
+ * removes reach. Turning writes on confirms first, because it is the gesture
+ * after which a write can land somewhere new. The button names the outcome,
+ * so that asymmetry is visible before the click.
  *
- * **The popover stays open beneath a confirm.** Arming writes and switching
- * both raise a `.posture-modal-overlay` at `--z-modal`, a full layer above the
- * popover's `--z-sticky`. The outside-click handler ignores clicks inside that
- * overlay, Escape dismisses an open confirm before it closes the popover, and
- * a confirmed change re-renders the rows in place. An operator changing
- * several rows never has to reopen it.
+ * **No process claims.** Nothing rendered here says whether a write will ask
+ * for approval or what limits apply — that is deployment configuration this
+ * module cannot see. Confirms state scope, endpoint and consequence only.
  *
- * **Only widening confirms.** Arming a target (read-only → writes) and
- * switching onto one are the two gestures that can end with a write landing
- * somewhere new, so both ask. Narrowing and `Sandbox everything` only ever
- * remove reach and apply on click.
+ * **The popover stays open beneath a confirm.** Both confirms raise a
+ * `.posture-modal-overlay` at `--z-modal`, a full layer above the popover's
+ * `--z-sticky`. The outside-click handler ignores clicks inside that overlay,
+ * Escape dismisses an open confirm before it closes the popover, and a
+ * confirmed change re-renders in place. An operator changing several rows
+ * never has to reopen it.
  *
  * Every request goes through the chip's `targetRequest`, which unwraps this
  * route family's dict-detail refusals and runs through api.js's `withPrefix`
@@ -43,11 +42,18 @@
 
 import {
   REASON_STORE_UNAVAILABLE,
-  headNote,
+  bannerNote,
+  descriptor,
+  descriptorTone,
+  displayName,
+  identTitle,
   isChatSession,
   lockReason,
-  reachText,
+  reachException,
   reasonPhrase,
+  statePhrase,
+  switchConfirm,
+  turnOnConfirm,
 } from './control-target-facts.js';
 import { fadeOutOverlay, mountOverlay } from './modal-overlay.js';
 
@@ -72,7 +78,7 @@ import {
 /**
  * The `target` value that narrows every configured target at once. Mirrors
  * `ALL_TARGETS` in routes/websocket.py; there is deliberately no matching
- * "arm everything", because each target's ceiling is its own.
+ * "turn everything on", because each target's ceiling is its own.
  */
 export const ALL_TARGETS = 'all';
 
@@ -97,8 +103,8 @@ let open = false;
 
 /**
  * The confirm currently on screen, if any. One at a time: both confirms are
- * raised from a row of the same popover, and a second overlay would bury the
- * first without dismissing it.
+ * raised from the same popover, and a second overlay would bury the first
+ * without dismissing it.
  * @type {HTMLElement|null}
  */
 let activeConfirm = null;
@@ -118,7 +124,7 @@ let pendingTarget = null;
  *
  * Two things live here and nothing else: a refusal the POST came back with
  * (the operator clicked something and is owed the server's own sentence), and
- * a target `Sandbox everything` reported in `skipped`. Both are facts about a
+ * a target `Turn all writes off` reported in `skipped`. Both are facts about a
  * click, not about the session, so they are cleared by the next gesture rather
  * than by the next read — a re-render from the 5 s poll must not silently
  * swallow the reason a click did nothing.
@@ -322,10 +328,10 @@ function button(cls, text) {
 /**
  * Repaint the popover from the chip's current answer.
  *
- * Whole-subtree, on every render: the rows are a projection of one payload and
- * nothing in them is worth diffing, and rebuilding is what lets a confirmed
- * change land in place without the popover closing. Rendering while closed is
- * cheap and keeps the first frame after an open correct.
+ * Whole-subtree, on every render: the card and rows are a projection of one
+ * payload and nothing in them is worth diffing, and rebuilding is what lets a
+ * confirmed change land in place without the popover closing. Rendering while
+ * closed is cheap and keeps the first frame after an open correct.
  */
 function render() {
   if (!popover) return;
@@ -334,21 +340,23 @@ function render() {
   if (!state) return;
   const rows = Array.isArray(state.targets) ? state.targets : [];
 
-  const head = el('div', 'ctc-head');
-  const title = el('span', 'ctc-head-title', 'Control target · this session');
-  title.id = 'ctc-head-title';
-  head.append(title);
-  popover.setAttribute('aria-labelledby', title.id);
-  const note = el('span', 'ctc-head-note');
-  const { text: noteText, tone } = headNote(state, rows);
-  note.textContent = noteText;
-  if (tone) note.dataset.tone = tone;
-  head.append(note);
-  popover.append(head);
+  const banner = bannerNote(state, rows);
+  if (banner) {
+    const note = el('div', 'ctc-banner', banner.text);
+    note.dataset.tone = banner.tone;
+    popover.append(note);
+  }
 
-  const list = el('div', 'ctc-rows');
-  for (const row of rows) list.append(renderRow(row, state, rows));
-  popover.append(list);
+  const active = rows.find((row) => row.active) || null;
+  if (active) popover.append(renderCard(active, state));
+
+  const others = rows.filter((row) => row !== active);
+  if (others.length > 0) {
+    popover.append(el('div', 'ctc-list-title', active ? 'Other machines' : 'Machines'));
+    const list = el('div', 'ctc-rows');
+    for (const row of others) list.append(renderRow(row, state, rows));
+    popover.append(list);
+  }
 
   // A gesture that named every target has no row of its own to report on.
   const allNote = gestureNotes.get(ALL_TARGETS);
@@ -362,143 +370,201 @@ function render() {
 }
 
 /**
- * One target's row: the dot, who it is, the posture this session holds on it,
- * and the one action available.
+ * The card: the machine the agent stands on. Name, consequence line, the
+ * write state in a sentence, and the one button that changes it.
+ * @param {any} row
+ * @param {any} state
+ */
+function renderCard(row, state) {
+  const kind = kindAttr(row);
+  const word = stateWord(row);
+  const lock = lockReason(row, state);
+  const card = el('div', 'ctc-card');
+  card.dataset.target = row.target;
+  card.dataset.targetKind = kind;
+  card.dataset.state = word;
+  card.dataset.real = String(Boolean(row.real_machine));
+
+  card.append(el('div', 'ctc-card-eyebrow', 'The agent is on'));
+
+  const title = el('div', 'ctc-card-title');
+  title.dataset.targetKind = kind;
+  title.dataset.state = word;
+  title.append(el('span', 'ctc-dot'));
+  title.append(el('span', 'ctc-name', displayName(row, kind)));
+  title.title = identTitle(row);
+  card.append(title);
+
+  card.append(renderVerb(row, state, word, lock, 'ctc-card-verb'));
+
+  const desc = descriptor(row, kind);
+  if (desc) card.append(descLine(row, kind, desc));
+
+  const sub = el('div', 'ctc-card-state');
+  const phrase = el('span', 'ctc-state-phrase', statePhrase(word));
+  phrase.dataset.state = word;
+  if (lock) phrase.title = lock;
+  sub.append(phrase);
+  if (word === 'sandbox') sub.append(el('span', 'ctc-state-note', '— you turned them off'));
+  const reach = reachException(row.reachability);
+  if (reach) {
+    const bad = el('span', 'ctc-reach-word', reach.text);
+    bad.dataset.state = reach.state;
+    bad.title = reach.title;
+    sub.append(bad);
+  }
+  card.append(sub);
+
+  for (const line of outcomeLines(row, state)) card.append(line);
+  // Turning writes off on the machine the agent is ON only reaches it once
+  // the connector is rebuilt, and that waits for the run in flight. Said out
+  // loud, rather than leaving a button that appears to have done nothing.
+  if (state.last_posture_realign?.state === 'pending') {
+    const line = el('div', 'ctc-outcome', 'takes effect when the running execution finishes');
+    line.dataset.status = 'realign';
+    card.append(line);
+  }
+  return card;
+}
+
+/**
+ * One other machine's row: who it is and what writing there means, the state
+ * pill, the verb that changes it, and Switch to.
  * @param {any} row
  * @param {any} state
  * @param {any[]} rows
  */
 function renderRow(row, state, rows) {
+  const kind = kindAttr(row);
   const word = stateWord(row);
   const lock = lockReason(row, state);
   const node = el('div', 'ctc-row');
   node.dataset.target = row.target;
-  node.dataset.targetKind = kindAttr(row);
+  node.dataset.targetKind = kind;
   node.dataset.state = word;
   node.dataset.real = String(Boolean(row.real_machine));
-  node.dataset.active = String(Boolean(row.active));
-
-  node.append(el('span', 'ctc-dot'));
 
   const ident = el('div', 'ctc-ident');
-  // The row's ONE identity line: the server's label, which already carries the
-  // kind of machine it names ("LIVE MACHINE (stand-in)", "virtual accelerator
-  // (simulation)"). A subtitle restating it would be the same fact twice on
-  // the one surface whose job is to be read at a glance.
-  const name = el('div', 'ctc-name');
-  name.append(el('span', 'ctc-label', row.label || row.target));
-  if (row.active) name.append(el('span', 'ctc-tag ctc-tag-current', 'current'));
+  const name = el('div', 'ctc-name-line');
+  name.append(el('span', 'ctc-name', displayName(row, kind)));
+  name.title = identTitle(row);
+  const reach = reachException(row.reachability);
+  if (reach) {
+    const bad = el('span', 'ctc-reach-word', reach.text);
+    bad.dataset.state = reach.state;
+    bad.title = reach.title;
+    name.append(bad);
+  }
   ident.append(name);
-
-  const meta = el('div', 'ctc-meta');
-  meta.append(el('span', 'ctc-endpoint', row.endpoint || ''));
-  const reach = reachText(row.reachability);
-  if (row.reachability?.role) meta.append(el('span', 'ctc-role', String(row.reachability.role)));
-  ident.append(meta);
-
-  const reachNode = el('div', 'ctc-reach');
-  reachNode.dataset.state = reach.state;
-  reachNode.title = reach.title;
-  reachNode.append(el('i', 'ctc-reach-dot'));
-  reachNode.append(el('span', 'ctc-reach-text', reach.text));
-  if (row.is_baseline) reachNode.append(el('span', 'ctc-baseline', 'baseline'));
-  ident.append(reachNode);
-
-  const outcome = switchOutcome(row, state);
-  if (outcome) {
-    const line = el('div', 'ctc-outcome', outcome.text);
-    line.dataset.status = outcome.status;
-    if (outcome.title) line.title = outcome.title;
-    ident.append(line);
-  }
-  const gestureNote = gestureNotes.get(row.target);
-  if (gestureNote) {
-    const line = el('div', 'ctc-outcome', `✗ ${reasonPhrase(gestureNote)}`);
-    line.dataset.status = 'refused';
-    ident.append(line);
-  }
-  // A narrowing on the target the session is ON only reaches the agent once
-  // the connector is rebuilt, and that waits for the run in flight. Said out
-  // loud, rather than leaving a toggle that appears to have done nothing.
-  if (row.active && state.last_posture_realign?.state === 'pending') {
-    const line = el('div', 'ctc-outcome', 'read-only applies after the running execution finishes');
-    line.dataset.status = 'realign';
-    ident.append(line);
-  }
+  const desc = descriptor(row, kind);
+  if (desc) ident.append(descLine(row, kind, desc));
+  for (const line of outcomeLines(row, state)) ident.append(line);
   node.append(ident);
 
-  node.append(renderPosture(row, state, word, lock));
+  const pill = el('span', 'ctc-pill', word === 'writes' ? 'writes on' : word === 'sandbox' ? 'writes off' : 'locked');
+  pill.dataset.state = word;
+  if (lock) pill.title = lock;
+  node.append(pill);
+
+  node.append(renderVerb(row, state, word, lock, 'ctc-verb'));
   node.append(renderAction(row, state, rows));
   return node;
 }
 
 /**
- * Column 3: the two-segment posture toggle, and the reason it cannot move.
+ * The consequence line, toned: the one descriptor that names hardware moving
+ * carries the error tone; every "nothing moves" (and "not set up") stays
+ * muted.
+ * @param {any} row
+ * @param {string} kind
+ * @param {string} desc
+ * @returns {HTMLElement}
+ */
+function descLine(row, kind, desc) {
+  const line = el('div', 'ctc-desc', desc);
+  const tone = descriptorTone(row, kind);
+  if (tone) line.dataset.tone = tone;
+  return line;
+}
+
+/**
+ * The feedback lines a row or the card carries: the last switch's outcome
+ * while it is news, and the reason the last click did nothing.
+ * @param {any} row
+ * @param {any} state
+ * @returns {HTMLElement[]}
+ */
+function outcomeLines(row, state) {
+  const lines = [];
+  const outcome = switchOutcome(row, state);
+  if (outcome) {
+    const line = el('div', 'ctc-outcome', outcome.text);
+    line.dataset.status = outcome.status;
+    if (outcome.title) line.title = outcome.title;
+    lines.push(line);
+  }
+  const gestureNote = gestureNotes.get(row.target);
+  if (gestureNote) {
+    const line = el('div', 'ctc-outcome', `✗ ${reasonPhrase(gestureNote)}`);
+    line.dataset.status = 'refused';
+    lines.push(line);
+  }
+  return lines;
+}
+
+/**
+ * The verb that changes a machine's write state, named for its outcome.
  *
- * Locked, the toggle keeps showing which state holds — it is the readout as
- * well as the control — and only loses its affordance. The reason goes both
- * under it and on its `title`, because simple mode drops the line and keeps
- * the tooltip.
+ * Locked it stays on screen, disabled, with the reason on hover — the gap
+ * where the control would be is explained rather than merely empty. Turning
+ * off applies on click; turning on confirms first.
  * @param {any} row
  * @param {any} state
  * @param {string} word
  * @param {string|null} lock
+ * @param {string} cls
+ * @returns {HTMLButtonElement}
  */
-function renderPosture(row, state, word, lock) {
-  const posture = el('div', 'ctc-posture');
-  const toggle = el('div', 'ctc-toggle');
-  toggle.setAttribute('role', 'group');
-  toggle.setAttribute('aria-label', `Session posture on ${row.label || row.target}`);
-  toggle.dataset.locked = String(Boolean(lock));
-  if (lock) toggle.title = lock;
-
-  for (const seg of ['writes', 'read-only']) {
-    const segment = button('ctc-seg', seg);
-    segment.dataset.seg = seg;
-    const pressed = seg === 'writes' ? word === 'writes' : word !== 'writes';
-    segment.setAttribute('aria-pressed', String(pressed));
-    if (lock) {
-      segment.disabled = true;
-      segment.title = lock;
-    } else if (!pressed) {
-      segment.addEventListener('click', (event) => {
-        event.stopPropagation();
-        if (seg === 'writes') confirmArming(row, state);
-        else void setPosture(row.target, 'sandbox', state);
-      });
-    }
-    toggle.append(segment);
+function renderVerb(row, state, word, lock, cls) {
+  const on = word === 'writes';
+  const verb = button(cls, on ? 'Turn writes off' : 'Turn writes on');
+  verb.dataset.direction = on ? 'off' : 'on';
+  if (lock) {
+    verb.disabled = true;
+    verb.title = lock;
+    return verb;
   }
-  posture.append(toggle);
-  if (lock) posture.append(el('span', 'ctc-lock', lock));
-  return posture;
+  verb.addEventListener('click', (event) => {
+    event.stopPropagation();
+    if (on) void setPosture(row.target, 'sandbox', state);
+    else confirmTurnOn(row, state);
+  });
+  return verb;
 }
 
 /**
- * Column 4: Switch, or the phrase for why there is no Switch.
+ * The Switch slot: the button, or the phrase for why there is no button.
  *
  * The refusal is keyed on the switch tool's own machine code, published by the
  * route — so the popover and the agent agree about the same refusal — and
  * rendered as {@link REASON_PHRASES}' operator phrase, with the route's
- * `reason_detail` sentence (falling back to the code) on the `title`. The gap
- * where the button would be is explained rather than merely empty, and never
- * in a vocabulary only the tool speaks.
+ * `reason_detail` sentence (falling back to the code) on the `title`.
  * @param {any} row
  * @param {any} state
  * @param {any[]} rows
  */
 function renderAction(row, state, rows) {
   const action = el('div', 'ctc-action');
-  // The current row says so with its `current` tag; a chat session has no
-  // controls server to address a request to; and one request is outstanding at
-  // a time, so while it is out no row offers a second.
-  if (row.active || isChatSession(rows) || isPending()) return action;
+  // A chat session has no controls server to address a request to; and one
+  // request is outstanding at a time, so while it is out no row offers a
+  // second.
+  if (isChatSession(rows) || isPending()) return action;
   if (row.available_now && state.store_available) {
-    const swap = button('ctc-switch', 'Switch');
-    swap.title = `Switch this session to ${row.label || row.target}`;
+    const swap = button('ctc-switch', 'Switch to');
+    swap.title = `Move this session's reads and writes to ${displayName(row, kindAttr(row))}`;
     swap.addEventListener('click', (event) => {
       event.stopPropagation();
-      confirmSwitch(row, state);
+      confirmSwitchTo(row, state);
     });
     action.append(swap);
     return action;
@@ -512,15 +578,15 @@ function renderAction(row, state, rows) {
 }
 
 /**
- * The foot: the one-gesture narrowing, and the sentence that bounds the whole
- * popover. `Sandbox everything` only ever removes reach, so it applies on
- * click; it is disabled when there is nothing left to lift.
+ * The foot: the one-gesture narrowing, and the popover's scope said once.
+ * `Turn all writes off` only ever removes reach, so it applies on click; it is
+ * disabled when there is nothing left to turn off.
  * @param {any} state
  * @param {any[]} rows
  */
 function renderFoot(state, rows) {
   const foot = el('div', 'ctc-foot');
-  const all = button('ctc-sandbox-all', 'Sandbox everything');
+  const all = button('ctc-all-off', 'Turn all writes off');
   const liftable = rows.some((row) => !lockReason(row, state) && stateWord(row) === 'writes');
   all.disabled = !liftable;
   all.addEventListener('click', (event) => {
@@ -528,14 +594,14 @@ function renderFoot(state, rows) {
     void setPosture(ALL_TARGETS, 'sandbox', state);
   });
   foot.append(all);
-  foot.append(el('span', 'ctc-foot-note', "Nothing here changes the deployment's config."));
+  foot.append(el('span', 'ctc-foot-note', 'Your session only'));
   return foot;
 }
 
 /* ---- gestures ---- */
 
 /**
- * Narrow or widen one target (or every target), then re-read.
+ * Turn one target's writes off or on (or every target's off), then re-read.
  *
  * The re-read is the whole point: the store is shared by every tab and
  * survives a restart, so what the popover shows next is what the server says,
@@ -566,8 +632,9 @@ async function setPosture(target, posture, state, ui) {
       json: { session_id: state.session_id, target, posture },
     });
     // `all` narrows what it can and reports the rest rather than dropping it:
-    // a target that stayed writable is exactly what an operator who just
-    // clicked "Sandbox everything" must not be left believing otherwise about.
+    // a target whose writes stayed on is exactly what an operator who just
+    // clicked "Turn all writes off" must not be left believing otherwise
+    // about.
     for (const skip of Array.isArray(body?.skipped) ? body.skipped : []) {
       if (skip?.target) gestureNotes.set(String(skip.target), String(skip.reason || 'skipped'));
     }
@@ -651,8 +718,10 @@ function strong(text) {
  * and one `done()` runs on every dismissal path. What differs is where Escape
  * is handled — this popover owns it, so a confirm and the rows behind it are
  * dismissed in the order they were opened.
- * @param {{title: string, body: (string|Node)[][], live: string|null,
- *          confirmLabel: string, onConfirm: (ui: ConfirmUi) => void}} spec
+ * @param {{title: string,
+ *          body: (import('./control-target-facts.js').ConfirmRun)[][],
+ *          live: string|null, confirmLabel: string,
+ *          onConfirm: (ui: ConfirmUi) => void}} spec
  */
 function showConfirm(spec) {
   dismissConfirm();
@@ -672,11 +741,14 @@ function showConfirm(spec) {
   heading.id = 'posture-modal-title';
 
   const body = el('div', 'posture-modal-body');
-  // Assembled node by node (no innerHTML) so the emphasis can sit on the label
-  // and the state word without any string ever being parsed as markup.
+  // Assembled node by node (no innerHTML) so the emphasis can sit on the name
+  // and the state word without any string ever being parsed as markup. An
+  // `{em}` run is the facts module's DOM-free spelling of a `<strong>`.
   for (const line of spec.body) {
     const paragraph = el('p');
-    paragraph.append(...line);
+    for (const run of line) {
+      paragraph.append(typeof run === 'string' ? run : strong(run.em));
+    }
     body.append(paragraph);
   }
   if (spec.live) body.append(el('div', 'posture-modal-live', spec.live));
@@ -715,63 +787,29 @@ function dismissConfirm() {
 }
 
 /**
- * The confirm for arming one target.
- *
- * Only this direction asks. Narrowing removes reach and is undone by a click;
- * arming is the gesture after which a write the agent makes can land.
- *
- * The title already names the machine, so the body does not name it again:
- * each line is one fact the title does not carry — the scope and the endpoint,
- * then the guards that stay up and when it takes hold.
+ * The confirm for turning one machine's writes on. Wording lives in
+ * control-target-facts.js ({@link turnOnConfirm}); this only wires the
+ * gesture.
  * @param {any} row
  * @param {any} state
  */
-function confirmArming(row, state) {
-  const label = row.label || row.target;
+function confirmTurnOn(row, state) {
   showConfirm({
-    title: `Allow writes on ${label}?`,
-    body: [
-      ['Arms writes for ', strong('this session'), ` · ${row.endpoint}.`],
-      [
-        'Per-write approval and channel limits still apply. Takes effect on the next write — ' +
-          'no restart.',
-      ],
-    ],
-    live: kindAttr(row) === 'live' ? 'Real machine. A confirmed write moves hardware.' : null,
-    confirmLabel: 'Allow writes',
+    ...turnOnConfirm(row, kindAttr(row)),
     onConfirm: (ui) => void setPosture(row.target, 'writes', state, ui),
   });
 }
 
 /**
- * The confirm for switching this session onto another machine.
- *
- * It names the posture the session will ARRIVE in, because that is the fact
- * the chip will read a moment later and the one an operator is most likely to
- * assume travels with them: posture is per-target, and it does not. The word
- * is {@link stateWord}'s own, so the dialog and the chip a moment later can
- * never disagree. The title already names the machine, so the body does not
- * name it again.
+ * The confirm for switching this session onto another machine. Wording lives
+ * in control-target-facts.js ({@link switchConfirm}); this only wires the
+ * gesture.
  * @param {any} row
  * @param {any} state
  */
-function confirmSwitch(row, state) {
-  const label = row.label || row.target;
-  const word = stateWord(row);
-  const live =
-    kindAttr(row) === 'live'
-      ? word === 'writes'
-        ? 'Real machine, writes armed. The next write the agent makes lands on hardware.'
-        : 'Real machine. Writes are sandboxed on it for this session.'
-      : null;
+function confirmSwitchTo(row, state) {
   showConfirm({
-    title: `Switch to ${label}?`,
-    body: [
-      ['Arrives in the ', strong(word), ` posture · ${row.endpoint}.`],
-      ['The conversation continues.'],
-    ],
-    live,
-    confirmLabel: 'Switch',
+    ...switchConfirm(row, kindAttr(row), stateWord(row)),
     onConfirm: (ui) => void requestSwitch(row, state, ui),
   });
 }

--- a/src/osprey/mcp_server/audit_middleware.py
+++ b/src/osprey/mcp_server/audit_middleware.py
@@ -607,23 +607,23 @@ def _posture_refusal_wording() -> tuple[str, list[str]]:
 
     if target is None:
         return (
-            "this session's write posture is read-only for at least one control "
-            "target (this call's target could not be identified, so the most "
-            "restrictive decides) — set from the control-target chip in the header.",
+            "writes are off for at least one control target in this session (this "
+            "call's target could not be identified, so the most restrictive "
+            "decides) — turned off from the control-target chip in the header.",
             [
-                "Lift that narrowing from the control-target chip in the header if "
+                "Turn writes back on from the control-target chip in the header if "
                 "the write is intended; the deployment config is not the gate here.",
             ],
         )
 
     return (
-        f"this session's write posture for the '{target}' control target is "
-        "read-only — set from the control-target chip in the header, and in "
-        "force for this session only.",
+        f"writes are off for the '{target}' control target in this session — "
+        "turned off from the control-target chip in the header, and in force "
+        "for this session only.",
         [
-            f"Set '{target}' back to writes from the control-target chip in the "
-            "header if the write is intended; the deployment config is not the "
-            "gate here.",
+            f"Turn writes back on for '{target}' from the control-target chip in "
+            "the header if the write is intended; the deployment config is not "
+            "the gate here.",
         ],
     )
 

--- a/src/osprey/mcp_server/bluesky/tools/queue.py
+++ b/src/osprey/mcp_server/bluesky/tools/queue.py
@@ -539,7 +539,7 @@ def _refuse_writes_disabled(
                 "The deployment config is not the gate here: what refused is the "
                 "narrowing an operator set for THIS session, so no config edit, "
                 "rebuild or redeploy lifts it.",
-                f"An operator setting {machine} back to writes on the header chip "
+                f"An operator turning writes back on for {machine} on the header chip "
                 f"does lift it, and it reaches this session immediately — the session "
                 f"does not have to be restarted.",
                 f"Until then, hand the action to the operator, who can perform "
@@ -1335,7 +1335,7 @@ async def queue_add(draft_revision: int, lane: str | None = None) -> str:
                     f"posture (header chip) is read-only for the {bound.target!r} "
                     f"target that this deployment's {bound.key!r} plan lane serves. "
                     f"No config edit and no different token unblocks it; an operator "
-                    f"setting that target back to writes on the header chip does, and "
+                    f"turning writes back on for that target on the header chip does, and "
                     f"it reaches this session immediately.",
                 ]
             else:

--- a/src/osprey/mcp_server/control_system/connector_host_manager.py
+++ b/src/osprey/mcp_server/control_system/connector_host_manager.py
@@ -172,6 +172,21 @@ REASON_NO_CHILD = "no_connector_host"
 #: only to label the state file's per-target display metadata.
 _SIMULATED_TYPES = (MOCK, VIRTUAL_ACCELERATOR)
 
+#: The operator-facing name each display branch defaults to — one word per way
+#: a target can be derived, not per target name, because that is what the name
+#: describes: the simulator is a Simulator whichever target selected it, and a
+#: ``live`` target with no connector configured is still the Real machine (the
+#: "not set up" nuance is the reader's to render, never the name's to carry).
+#: A deployment renames any of them per target via
+#: ``control_system.target_display_names``; these words are what a config that
+#: says nothing gets.
+_DISPLAY_NAME_DEFAULTS = {
+    "machine": "Real machine",
+    "standin": "Rehearsal",
+    "simulated": "Demo",
+    "va": "Simulator",
+}
+
 
 class SwitchError(RuntimeError):
     """A switch that did not happen, and the stage it stopped at.
@@ -432,9 +447,10 @@ def target_display_metadata(config: Any) -> dict[str, dict[str, Any]]:
     render the identity line straight from the state file and never re-derive
     it, so this is the only place the three targets get described.
 
-    Each entry carries ``label``, ``endpoint``, ``real_machine`` and
-    ``probe_channel`` — the destination's probe channel travels with the
-    metadata so a describer can name it without opening ``config.yml``.
+    Each entry carries ``label``, ``display_name``, ``endpoint``,
+    ``real_machine`` and ``probe_channel`` — the destination's probe channel
+    travels with the metadata so a describer can name it without opening
+    ``config.yml``.
 
     One entry per name in :data:`~osprey.mcp_server.control_system.target_state.TARGET_NAMES`,
     walked from that tuple rather than from a list spelled again here: the
@@ -451,6 +467,7 @@ def target_display_metadata(config: Any) -> dict[str, dict[str, Any]]:
             # slot: "unknown" is a truthful rendering, an absent key is not.
             metadata[target] = {
                 "label": _label(target, None),
+                "display_name": _display_name(config, target, None),
                 "endpoint": "",
                 "real_machine": False,
                 "probe_channel": "",
@@ -458,11 +475,11 @@ def target_display_metadata(config: Any) -> dict[str, dict[str, Any]]:
             continue
         endpoint = derivation.selected_endpoint()
         block = _connector_block(config, derivation.connector_type)
+        standin = _is_live_standin(config, target, endpoint)
         metadata[target] = {
-            "label": _label(
-                target,
-                derivation.connector_type,
-                standin=_is_live_standin(config, target, endpoint),
+            "label": _label(target, derivation.connector_type, standin=standin),
+            "display_name": _display_name(
+                config, target, derivation.connector_type, standin=standin
             ),
             "endpoint": f"{endpoint.host}:{endpoint.port}" if endpoint else "",
             # True for the stand-in as well as the facility's machine, and the
@@ -527,6 +544,34 @@ def _label(target: str, connector_type: str | None, *, standin: bool = False) ->
     # is the direction this stack must never fail in: telling an operator the
     # machine in front of them is only a stand-in when it is not.
     return "LIVE MACHINE (stand-in)" if (target == TARGET_STANDIN and standin) else "LIVE MACHINE"
+
+
+def _display_name(
+    config: Any, target: str, connector_type: str | None, *, standin: bool = False
+) -> str:
+    """The operator-facing name for *target*: configured, or the branch default.
+
+    Walks the same branches as :func:`_label`, from the same inputs, so the two
+    names cannot describe different machines — the label is the identity line's
+    truth, this is the word an operator reads on the chip. A non-empty
+    ``control_system.target_display_names.<target>`` string wins verbatim
+    (stripped); empty or absent falls to :data:`_DISPLAY_NAME_DEFAULTS`. The
+    override is per target name rather than per branch on purpose: the operator
+    names the thing they select, and the derivation still decides what that
+    thing defaults to.
+    """
+    section = _control_system_section(config)
+    configured = section.get("target_display_names") if isinstance(section, dict) else None
+    override = configured.get(target) if isinstance(configured, dict) else None
+    if isinstance(override, str) and override.strip():
+        return override.strip()
+    if target == TARGET_VA:
+        return _DISPLAY_NAME_DEFAULTS["va"]
+    if connector_type in _SIMULATED_TYPES:
+        return _DISPLAY_NAME_DEFAULTS["simulated"]
+    if target == TARGET_STANDIN and standin:
+        return _DISPLAY_NAME_DEFAULTS["standin"]
+    return _DISPLAY_NAME_DEFAULTS["machine"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/mcp_server/python_executor/tools/_execution_gates.py
+++ b/src/osprey/mcp_server/python_executor/tools/_execution_gates.py
@@ -262,26 +262,26 @@ def _enforce_session_store_term(target: str | None) -> None:
     if target is None:
         make_error(
             "safety_error",
-            "This session's write posture is read-only for at least one control "
-            "target (the run's target could not be identified, so the most "
-            "restrictive decides) — set from the control-target chip in the header.",
+            "Writes are off for at least one control target in this session (the "
+            "run's target could not be identified, so the most restrictive "
+            "decides) — turned off from the control-target chip in the header.",
             [
                 'Re-run with execution_mode="readonly" — reads are unaffected by the posture.',
-                "Lift that narrowing from the control-target chip in the header if "
+                "Turn writes back on from the control-target chip in the header if "
                 "the write is intended; the deployment config is not the gate here.",
             ],
             details={"active_target": target},
         )
     make_error(
         "safety_error",
-        f"This session's write posture for the '{target}' control target is "
-        "read-only — set from the control-target chip in the header, and in "
-        "force for this session only.",
+        f"Writes are off for the '{target}' control target in this session — "
+        "turned off from the control-target chip in the header, and in force "
+        "for this session only.",
         [
             'Re-run with execution_mode="readonly" — reads are unaffected by the posture.',
-            f"Set '{target}' back to writes from the control-target chip in the "
-            "header if the write is intended; the deployment config is not the "
-            "gate here.",
+            f"Turn writes back on for '{target}' from the control-target chip in "
+            "the header if the write is intended; the deployment config is not "
+            "the gate here.",
         ],
         details={"active_target": target},
     )
@@ -433,26 +433,26 @@ def enforce_posture_clamp(execution_mode: str, *, tool: str) -> None:
     if target is None:
         make_error(
             "safety_error",
-            "This session's write posture is read-only for at least one control "
-            "target (the run's target could not be identified, so the most "
-            "restrictive decides) — set from the control-target chip in the header.",
+            "Writes are off for at least one control target in this session (the "
+            "run's target could not be identified, so the most restrictive "
+            "decides) — turned off from the control-target chip in the header.",
             [
                 'Re-run with execution_mode="readonly" — reads are unaffected by the posture.',
-                "Lift that narrowing from the control-target chip in the header if "
+                "Turn writes back on from the control-target chip in the header if "
                 "the write is intended; the deployment config is not the gate here.",
             ],
         )
 
     make_error(
         "safety_error",
-        f"This session's write posture for the '{target}' control target is "
-        "read-only — set from the control-target chip in the header, and in "
-        "force for this session only.",
+        f"Writes are off for the '{target}' control target in this session — "
+        "turned off from the control-target chip in the header, and in force "
+        "for this session only.",
         [
             'Re-run with execution_mode="readonly" — reads are unaffected by the posture.',
-            f"Set '{target}' back to writes from the control-target chip in the "
-            "header if the write is intended; the deployment config is not the "
-            "gate here.",
+            f"Turn writes back on for '{target}' from the control-target chip in "
+            "the header if the write is intended; the deployment config is not "
+            "the gate here.",
         ],
     )
 

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -421,6 +421,15 @@ control_system:
   # write_tools:
   #   - "mcp__my_server__dangerous_write"
 
+  # Operator-facing names for the control targets, shown on the web terminal's
+  # control-target chip. Defaults come from what each target is — real machine
+  # "Real machine" ("Demo" on a simulated connector), stand-in "Rehearsal",
+  # virtual accelerator "Simulator". Uncomment to rename any of them.
+  # target_display_names:
+  #   live: "Real machine"
+  #   standin: "Rehearsal"
+  #   va: "Simulator"
+
   # Runtime Channel Limits Checking
   limits_checking:
     enabled: true

--- a/src/osprey/templates/apps/hello_world/config.yml.j2
+++ b/src/osprey/templates/apps/hello_world/config.yml.j2
@@ -152,6 +152,15 @@ control_system:
   # write_tools:
   #   - "mcp__my_server__dangerous_write"
 
+  # Operator-facing names for the control targets, shown on the web terminal's
+  # control-target chip. Defaults come from what each target is — real machine
+  # "Real machine" ("Demo" on a simulated connector), stand-in "Rehearsal",
+  # virtual accelerator "Simulator". Uncomment to rename any of them.
+  # target_display_names:
+  #   live: "Real machine"
+  #   standin: "Rehearsal"
+  #   va: "Simulator"
+
   # Channel limits — the SECOND guard. Every write is checked against
   # data/channel_limits.json (relative to this file's directory) —
   # per-channel min/max values and writable flags. That file is a build

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_writes_check.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_writes_check.py
@@ -27,7 +27,7 @@ stdin ──► Parse JSON
               │◄────────────────────────┘
               ▼
   STAGE 1  Deployment-wide
-           read-only run?   ──YES──► DENY: sandbox posture
+           read-only run?   ──YES──► DENY: writes off
               │
              NO
               │
@@ -147,9 +147,9 @@ _LANE_ADDRESSED_KEY = "lane_addressed_tools"
 #: one machine, and a refusal that named none would describe the session-wide
 #: sandbox this deployment may not be in.
 _POSTURE_DENY_REASON = (
-    "\U0001f512 SANDBOX POSTURE — this session refuses control-system "
+    "\U0001f512 WRITES OFF — this session refuses control-system "
     "writes{scope}.\n\n"
-    "Switch it back to writes on the control-target chip in the header; "
+    "Turn writes back on from the control-target chip in the header; "
     "config.yml is not the gate here."
 )
 
@@ -162,9 +162,10 @@ _POSTURE_DENY_SCOPE = " to the {target} target"
 #: read there proves nothing, and an unreadable posture is not a permissive one.
 #: See ``osprey_target_state.posture_unknown``.
 _POSTURE_UNKNOWN_DENY_REASON = (
-    "\U0001f512 POSTURE UNKNOWN — this session carries a posture key, but no "
-    "live control-target state was found where this hook looks, so the posture "
-    "set on the control-target chip in the header cannot be read.\n\n"
+    "\U0001f512 WRITE STATE UNKNOWN — this session carries a posture key, but "
+    "no live control-target state was found where this hook looks, so the "
+    "write state set on the control-target chip in the header cannot be "
+    "read.\n\n"
     "Writes stay refused until the controls MCP server is running; config.yml "
     "is not the gate here."
 )

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -210,6 +210,15 @@ control_system:
   # write_tools:                # Additional tools blocked by writes kill switch
   #   - "mcp__my_server__dangerous_write"
 
+  # Operator-facing names for the control targets, shown on the web terminal's
+  # control-target chip. Defaults come from what each target is - real machine
+  # "Real machine" ("Demo" on a simulated connector), stand-in "Rehearsal",
+  # virtual accelerator "Simulator". Uncomment to rename any of them.
+  # target_display_names:
+  #   live: "Real machine"
+  #   standin: "Rehearsal"
+  #   va: "Simulator"
+
   # Runtime Channel Limits Checking
   limits_checking:
     enabled: false  # Enable for production safety

--- a/tests/connectors/test_target_writes_enabled.py
+++ b/tests/connectors/test_target_writes_enabled.py
@@ -1023,7 +1023,7 @@ class TestTheConnectorReferenceMonitor:
         # Assert
         message = result.error_message
         assert TARGET_STANDIN in message
-        assert "read-only" in message
+        assert "writes are off" in message
         assert "control-target chip in the header" in message
         assert "writes_enabled" not in message
         assert "resubmit" not in message.lower()
@@ -1426,11 +1426,11 @@ class TestALaunchPinnedRunSaysSoInsteadOfBlamingTheChip:
         assert result.outcome is WriteOutcome.REFUSED
         assert result.refusal_reason == "WRITES_DISABLED"
         # ...and a story about the RUN, with a remedy that exists
-        assert f"launched while '{TARGET_STANDIN}' was read-only" in result.error_message
+        assert f"launched while writes were off for '{TARGET_STANDIN}'" in result.error_message
         assert "not to one already in flight" in result.error_message
         assert "Re-run the script" in result.error_message
         # The message an operator could not act on is exactly what must be gone.
-        assert "back to writes from the chip" not in result.error_message
+        assert "Turn writes back on" not in result.error_message
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -1457,8 +1457,8 @@ class TestALaunchPinnedRunSaysSoInsteadOfBlamingTheChip:
 
         # Assert
         assert result.outcome is WriteOutcome.REFUSED
-        assert "most restrictive write posture" in result.error_message
-        assert "neither its control target nor this session's posture" in result.error_message
+        assert "most restrictive write state" in result.error_message
+        assert "neither its control target nor this session's write state" in result.error_message
         assert "could be resolved" in result.error_message
         assert "Re-run the script" in result.error_message
         assert "chip" not in result.error_message

--- a/tests/hooks/test_writes_check_hook.py
+++ b/tests/hooks/test_writes_check_hook.py
@@ -376,7 +376,7 @@ def test_posture_message_names_the_posture_not_writes_enabled(
     )
 
     reason = result["hookSpecificOutput"]["permissionDecisionReason"]
-    assert "SANDBOX POSTURE" in reason
+    assert "WRITES OFF" in reason
     assert "writes_enabled" not in reason
     assert "WRITES DISABLED" not in reason
     assert "control-target chip in the header" in reason
@@ -384,7 +384,7 @@ def test_posture_message_names_the_posture_not_writes_enabled(
     # The two sentences the operator needs, verbatim.
     assert "this session refuses control-system writes." in reason
     assert (
-        "Switch it back to writes on the control-target chip in the header; "
+        "Turn writes back on from the control-target chip in the header; "
         "config.yml is not the gate here." in reason
     )
 
@@ -506,7 +506,7 @@ def test_posture_deny_survives_an_unreadable_config(tmp_path, hook_runner_raw, m
     assert "Traceback" not in stderr
     decision = json.loads(stdout.strip().split("\n")[-1])
     assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "SANDBOX POSTURE" in decision["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "WRITES OFF" in decision["hookSpecificOutput"]["permissionDecisionReason"]
 
 
 @pytest.mark.unit
@@ -524,7 +524,7 @@ def test_posture_deny_survives_an_absent_config(tmp_path, hook_runner, monkeypat
 
     assert result is not None
     assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "SANDBOX POSTURE" in result["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "WRITES OFF" in result["hookSpecificOutput"]["permissionDecisionReason"]
 
 
 # -- Deployment posture, per target (stage 2) --
@@ -840,7 +840,7 @@ def test_sandbox_posture_denies_a_queue_tool_on_an_armed_deployment(
     assert result is not None
     output = result["hookSpecificOutput"]
     assert output["permissionDecision"] == "deny"
-    assert "SANDBOX POSTURE" in output["permissionDecisionReason"]
+    assert "WRITES OFF" in output["permissionDecisionReason"]
 
 
 @pytest.mark.unit

--- a/tests/hooks/test_writes_check_per_target.py
+++ b/tests/hooks/test_writes_check_per_target.py
@@ -139,7 +139,7 @@ def test_a_narrowed_target_denies_and_names_the_chip_and_the_target(
     reason = reason_of(channel_write(tmp_path, hook_runner, config))
 
     # Assert
-    assert "SANDBOX POSTURE" in reason
+    assert "WRITES OFF" in reason
     assert "control-target chip in the header" in reason
     assert f"to the {target} target" in reason
     assert "writes_enabled" not in reason
@@ -162,9 +162,9 @@ def test_the_verbatim_sentences_of_the_per_target_refusal(
 
     # Assert
     assert reason == (
-        "\U0001f512 SANDBOX POSTURE — this session refuses control-system "
+        "\U0001f512 WRITES OFF — this session refuses control-system "
         "writes to the va target.\n\n"
-        "Switch it back to writes on the control-target chip in the header; "
+        "Turn writes back on from the control-target chip in the header; "
         "config.yml is not the gate here."
     )
 
@@ -232,7 +232,7 @@ def test_the_legacy_bare_sandbox_narrows_the_session_target(
     reason = reason_of(channel_write(tmp_path, hook_runner, config))
 
     # Assert
-    assert "SANDBOX POSTURE" in reason
+    assert "WRITES OFF" in reason
     assert "to the live target" in reason
 
 
@@ -269,7 +269,7 @@ def test_an_operator_key_narrows_like_any_other(tmp_path, hook_runner, make_conf
     reason = reason_of(channel_write(tmp_path, hook_runner, config))
 
     # Assert
-    assert "SANDBOX POSTURE" in reason
+    assert "WRITES OFF" in reason
     assert "to the live target" in reason
 
 
@@ -304,9 +304,9 @@ def test_an_unidentified_target_takes_the_most_restrictive_entry(
 
     # Assert — the scope phrase is absent, because no target was decided
     assert reason == (
-        "\U0001f512 SANDBOX POSTURE — this session refuses control-system "
+        "\U0001f512 WRITES OFF — this session refuses control-system "
         "writes.\n\n"
-        "Switch it back to writes on the control-target chip in the header; "
+        "Turn writes back on from the control-target chip in the header; "
         "config.yml is not the gate here."
     )
 
@@ -332,7 +332,7 @@ def test_an_unarmed_deployment_still_names_the_config_key(
     # Assert
     assert "WRITES DISABLED" in reason
     assert "control_system.connector.epics.writes_enabled: true" in reason
-    assert "SANDBOX POSTURE" not in reason
+    assert "WRITES OFF" not in reason
     assert "control-target chip" not in reason
 
 
@@ -356,7 +356,7 @@ def test_a_narrowing_wins_the_wording_over_an_unarmed_deployment(
     reason = reason_of(channel_write(tmp_path, hook_runner, config))
 
     # Assert
-    assert "SANDBOX POSTURE" in reason
+    assert "WRITES OFF" in reason
     assert "to the live target" in reason
     assert "WRITES DISABLED" not in reason
 
@@ -385,10 +385,10 @@ def test_posture_unknown_fires_unstamped_with_no_live_record(
 
     # Assert
     assert reason == (
-        "\U0001f512 POSTURE UNKNOWN — this session carries a posture key, but "
-        "no live control-target state was found where this hook looks, so the "
-        "posture set on the control-target chip in the header cannot be "
-        "read.\n\n"
+        "\U0001f512 WRITE STATE UNKNOWN — this session carries a posture key, "
+        "but no live control-target state was found where this hook looks, so "
+        "the write state set on the control-target chip in the header cannot "
+        "be read.\n\n"
         "Writes stay refused until the controls MCP server is running; "
         "config.yml is not the gate here."
     )
@@ -458,7 +458,7 @@ def test_posture_unknown_outranks_an_unarmed_deployment(
     reason = reason_of(channel_write(tmp_path, hook_runner, config))
 
     # Assert
-    assert "POSTURE UNKNOWN" in reason
+    assert "WRITE STATE UNKNOWN" in reason
     assert "WRITES DISABLED" not in reason
 
 
@@ -481,7 +481,7 @@ def test_a_readonly_run_still_refuses_before_stage_two(
     reason = reason_of(channel_write(tmp_path, hook_runner, config))
 
     # Assert
-    assert "SANDBOX POSTURE" in reason
+    assert "WRITES OFF" in reason
     assert "control-target chip in the header" in reason
     assert "target." not in reason
 

--- a/tests/interfaces/web_terminal/control-target-chip.test.mjs
+++ b/tests/interfaces/web_terminal/control-target-chip.test.mjs
@@ -323,6 +323,11 @@ describe('mount', () => {
 describe('state matrix', () => {
   /** @type {Record<string, string>} */
   const KIND_ATTR = { live: 'live', standin: 'standin', va: 'va', simulated: 'simulated' };
+  /** The consequence word each kind renders when no display_name is configured. */
+  /** @type {Record<string, string>} */
+  const WORDS = { live: 'Real machine', standin: 'Rehearsal', va: 'Simulator', simulated: 'Demo' };
+  /** @type {Record<string, string>} */
+  const PHRASES = { writes: 'writes on', sandbox: 'writes off', 'read-only': 'writes locked' };
 
   for (const [kindName, kind] of Object.entries(KINDS)) {
     for (const [stateName, state] of Object.entries(STATES)) {
@@ -337,8 +342,8 @@ describe('state matrix', () => {
         expect(chip.hidden).toBe(false);
         expect(chip.dataset.targetKind).toBe(KIND_ATTR[kindName]);
         expect(chip.dataset.state).toBe(stateName);
-        expect(shortText()).toBe(kind.short_label);
-        expect(stateText()).toBe(stateName);
+        expect(shortText()).toBe(WORDS[kindName]);
+        expect(stateText()).toBe(PHRASES[stateName]);
         // The tooltip is the FULL label; the chip's own word is the short one.
         expect(chip.title).toBe(kind.label);
       });
@@ -349,13 +354,13 @@ describe('state matrix', () => {
     await boot(
       viewOf({ targets: [rowOf({ ...KINDS.va, ...STATES.sandbox, active: true })] })
     );
-    expect(stateText()).toBe('sandbox');
+    expect(stateText()).toBe('writes off');
 
     served = viewOf({
       targets: [rowOf({ ...KINDS.va, ...STATES['read-only'], ceiling_writes: false, active: true })],
     });
     await chipModule.refetch();
-    expect(stateText()).toBe('read-only');
+    expect(stateText()).toBe('writes locked');
   });
 
   test('kind falls back to real_machine + the label shape when the route sends none', async () => {
@@ -391,6 +396,18 @@ describe('state matrix', () => {
     expect(chipEl()?.dataset.targetKind).toBe('live');
   });
 
+  test("the deployment's configured display_name wins over the kind default", async () => {
+    await boot(
+      viewOf({
+        targets: [
+          rowOf({ ...KINDS.live, display_name: 'ALS storage ring', active: true }),
+        ],
+      })
+    );
+    expect(shortText()).toBe('ALS storage ring');
+    expect(chipEl()?.dataset.targetKind).toBe('live');
+  });
+
   test('data-enforceable folds in the store, and a dimmed chip still renders', async () => {
     await boot();
     expect(chipEl()?.dataset.enforceable).toBe('true');
@@ -419,7 +436,7 @@ describe('active row', () => {
         ],
       })
     );
-    expect(shortText()).toBe('VIRTUAL');
+    expect(shortText()).toBe('Simulator');
     expect(chipEl()?.dataset.targetKind).toBe('va');
   });
 
@@ -430,7 +447,7 @@ describe('active row', () => {
         targets: [rowOf(KINDS.live), rowOf({ ...KINDS.standin, is_baseline: true })],
       })
     );
-    expect(shortText()).toBe('STAND-IN');
+    expect(shortText()).toBe('Rehearsal');
   });
 
   test('hides itself rather than guessing when the roster is empty', async () => {
@@ -460,7 +477,7 @@ describe('agent-activity hint', () => {
     await boot(
       viewOf({ targets: [rowOf({ ...KINDS.standin, active: true, is_baseline: true })] })
     );
-    expect(shortText()).toBe('STAND-IN');
+    expect(shortText()).toBe('Rehearsal');
     // The frame narrates a switch to the facility's own machine, and the route
     // — the only truth — still says stand-in. A chip that read the prose would
     // now claim LIVE on a session that never moved.
@@ -471,7 +488,7 @@ describe('agent-activity hint', () => {
       ts: Date.now(),
     });
     await flush();
-    expect(shortText()).toBe('STAND-IN');
+    expect(shortText()).toBe('Rehearsal');
     expect(chipEl()?.dataset.targetKind).toBe('standin');
   });
 
@@ -530,8 +547,8 @@ describe('polling', () => {
 
     expect(chipModule.isPending()).toBe(false);
     expect(chipEl()?.dataset.pending).toBeUndefined();
-    expect(stateText()).toBe('writes');
-    expect(shortText()).toBe('LIVE');
+    expect(stateText()).toBe('writes on');
+    expect(shortText()).toBe('Real machine');
 
     const settled = getCount();
     vi.advanceTimersByTime(chipModule.FAST_POLL_MS * 4);
@@ -613,7 +630,7 @@ describe('polling', () => {
 describe('read ordering', () => {
   test('a slow read cannot repaint over a newer one', async () => {
     await boot();
-    expect(shortText()).toBe('STAND-IN');
+    expect(shortText()).toBe('Rehearsal');
 
     // Park a read carrying the CURRENT (stand-in) roster.
     holdNextGet = true;
@@ -626,13 +643,13 @@ describe('read ordering', () => {
       targets: [rowOf({ ...KINDS.live, active: true })],
     });
     await chipModule.refetch();
-    expect(shortText()).toBe('LIVE');
+    expect(shortText()).toBe('Real machine');
 
     // The parked read finally resolves, carrying history.
     heldGets.shift()?.();
     await slow;
     await flush();
-    expect(shortText()).toBe('LIVE');
+    expect(shortText()).toBe('Real machine');
     expect(chipEl()?.dataset.targetKind).toBe('live');
   });
 

--- a/tests/interfaces/web_terminal/control-target-popover.test.mjs
+++ b/tests/interfaces/web_terminal/control-target-popover.test.mjs
@@ -3,36 +3,37 @@
  * Unit tests for the control-target popover (control-target-popover.js):
  *   npx vitest run tests/interfaces/web_terminal/control-target-popover.test.mjs
  *
- * The popover is the panel behind the header chip: one row per configured
- * control target, and every gesture that CHANGES where this session writes. It
- * fetches nothing of its own — it subscribes to the chip and renders
- * `getState()` — so these tests drive it the way the page does: stub the
- * roster route, boot the chip, click the chip.
+ * The popover is the panel behind the header chip: a card for the machine the
+ * agent stands on, a row per other configured target, and every gesture that
+ * CHANGES where this session writes. It fetches nothing of its own — it
+ * subscribes to the chip and renders `getState()` — so these tests drive it
+ * the way the page does: stub the roster route, boot the chip, click the chip.
  *
  * What they pin down, in the order a reviewer would ask about it:
  *
- * - the toggle LOCKS for each of the five reasons, in the documented order,
- *   and the reason reaches both `.ctc-lock` and the `title` (simple mode drops
- *   the line and keeps the tooltip);
- * - arming (read-only → writes) raises a confirm and narrowing does NOT: only
- *   a gesture that can end with a write landing somewhere new asks;
- * - a confirmed change leaves the popover OPEN and re-renders the row in
- *   place, so an operator changing several rows never reopens it;
+ * - machines are named by consequence (`Real machine`, `Rehearsal`,
+ *   `Simulator`), the deployment's configured `display_name` wins, and the
+ *   server's implementation label survives only on the tooltip;
+ * - NO PROCESS CLAIMS: nothing rendered — rows, card, either confirm — states
+ *   whether a write asks for approval or what limits apply, because that is
+ *   deployment configuration the browser cannot see;
+ * - the verb locks for each of the five reasons, in the documented order, and
+ *   the reason reaches the `title` in operator words;
+ * - turning writes on raises a confirm and turning them off does NOT: only a
+ *   gesture that can end with a write landing somewhere new asks;
+ * - a confirmed change leaves the popover OPEN and re-renders in place, so an
+ *   operator changing several machines never reopens it;
  * - Escape dismisses an open confirm BEFORE it closes the popover, and a click
  *   inside the confirm is not an outside click;
- * - Switch POSTs, shows `switching…` on that row, and renders the outcome the
- *   route publishes for the `request_id` — success, refusal, and the expiry a
- *   dead controls server never answers;
- * - a refusal code renders as its operator phrase, never raw: the machine code
- *   keys the presentation map, the route's `reason_detail` sentence rides on
- *   the `title`, and a code the map does not know renders verbatim;
- * - a chat session's rows offer no Switch and live toggles;
- * - `Sandbox everything` POSTs `all` and renders every target the store
+ * - Switch to confirms, POSTs, shows `switching…` on that row, and renders the
+ *   outcome the route publishes for the `request_id` — success, refusal, and
+ *   the expiry a dead controls server never answers;
+ * - a refusal code renders as its operator phrase, never raw; a code the map
+ *   does not know renders verbatim;
+ * - a chat session's rows offer no Switch and live verbs;
+ * - `Turn all writes off` POSTs `all` and renders every target the store
  *   `skipped`;
- * - FR5b: ONE DOM for both `ui_mode`s. The same markup is produced with
- *   `html[data-ui-mode]` set to `simple` and to `expert` — the density lives
- *   entirely in terminal.css, and a JS branch on it would be a second place
- *   for the rule to drift.
+ * - ONE DOM for both `ui_mode`s: the same markup under `simple` and `expert`.
  *
  * Seams: terminal.js is mocked (it owns the session id); `fetch` is stubbed
  * the way the other suites here stub it; the chip's SSE factory is injected,
@@ -76,6 +77,7 @@ const KINDS = {
     label: 'LIVE MACHINE',
     short_label: 'LIVE',
     kind: 'live machine',
+    display_name: '',
     endpoint: 'als-gw.lbl.gov:5064',
     real_machine: true,
   },
@@ -84,6 +86,7 @@ const KINDS = {
     label: 'LIVE MACHINE (stand-in)',
     short_label: 'STAND-IN',
     kind: 'stand-in',
+    display_name: '',
     endpoint: '127.0.0.1:10090',
     real_machine: true,
   },
@@ -92,6 +95,7 @@ const KINDS = {
     label: 'virtual accelerator (simulation)',
     short_label: 'VIRTUAL',
     kind: 'virtual accelerator',
+    display_name: '',
     endpoint: '127.0.0.1:10064',
     real_machine: false,
   },
@@ -99,7 +103,7 @@ const KINDS = {
 
 /**
  * The three effective states in the route's columns. `read-only` and `sandbox`
- * are the same "no"; which one it is decides whether a toggle can undo it.
+ * are the same "no"; which one it is decides whether a verb can undo it.
  */
 const STATES = {
   writes: { effective: true, posture: 'writes' },
@@ -230,20 +234,35 @@ const chipEl = () =>
   /** @type {HTMLButtonElement|null} */ (document.querySelector('.control-target-chip'));
 const popEl = () => /** @type {HTMLElement|null} */ (document.querySelector('.ctc-popover'));
 const isOpen = () => Boolean(popEl()?.classList.contains('open'));
+const cardEl = () => /** @type {HTMLElement|null} */ (document.querySelector('.ctc-card'));
+const cardVerb = () =>
+  /** @type {HTMLButtonElement|null} */ (document.querySelector('.ctc-card-verb'));
+const bannerEl = () => /** @type {HTMLElement|null} */ (document.querySelector('.ctc-banner'));
 /** @param {string} target */
 const rowEl = (target) =>
   /** @type {HTMLElement|null} */ (document.querySelector(`.ctc-row[data-target="${target}"]`));
-/** @param {string} target @param {string} seg */
-const segEl = (target, seg) =>
-  /** @type {HTMLButtonElement|null} */ (
-    rowEl(target)?.querySelector(`.ctc-seg[data-seg="${seg}"]`) ?? null
+/** The card or the row that carries this target. @param {string} target */
+const surfaceEl = (target) => {
+  const card = cardEl();
+  if (card?.dataset.target === target) return card;
+  return rowEl(target);
+};
+/** @param {string} target */
+const verbEl = (target) => {
+  const surface = surfaceEl(target);
+  return /** @type {HTMLButtonElement|null} */ (
+    surface?.querySelector('.ctc-verb, .ctc-card-verb') ?? null
   );
+};
+/** @param {string} target */
+const pillEl = (target) =>
+  /** @type {HTMLElement|null} */ (rowEl(target)?.querySelector('.ctc-pill') ?? null);
 /** @param {string} target */
 const switchEl = (target) =>
   /** @type {HTMLButtonElement|null} */ (rowEl(target)?.querySelector('.ctc-switch') ?? null);
 /** @param {string} target */
 const outcomes = (target) =>
-  [...(rowEl(target)?.querySelectorAll('.ctc-outcome') ?? [])].map((n) => n.textContent);
+  [...(surfaceEl(target)?.querySelectorAll('.ctc-outcome') ?? [])].map((n) => n.textContent);
 /** A confirm that is up — one on its way out carries `data-closing`. */
 const confirmEl = () =>
   /** @type {HTMLElement|null} */ (
@@ -328,7 +347,7 @@ describe('open and close', () => {
 
   test('a click inside the popover does not close it', async () => {
     await bootOpen();
-    /** @type {HTMLElement} */ (document.querySelector('.ctc-head-title')).click();
+    /** @type {HTMLElement} */ (document.querySelector('.ctc-list-title')).click();
     expect(isOpen()).toBe(true);
   });
 
@@ -340,210 +359,256 @@ describe('open and close', () => {
   });
 });
 
-/* ---- rows --------------------------------------------------------------- */
+/* ---- the card ------------------------------------------------------------ */
 
-describe('rows', () => {
-  test('one row per configured target, keyed on kind, state and realness', async () => {
+describe('the card', () => {
+  test('the machine the agent stands on is the card, not a row', async () => {
     await bootOpen();
-    expect(document.querySelectorAll('.ctc-row')).toHaveLength(3);
-
-    const live = /** @type {HTMLElement} */ (rowEl('live'));
-    expect(live.dataset.targetKind).toBe('live');
-    expect(live.dataset.state).toBe('sandbox');
-    expect(live.dataset.real).toBe('true');
-    expect(live.dataset.active).toBe('false');
-
-    const standin = /** @type {HTMLElement} */ (rowEl('standin'));
-    expect(standin.dataset.targetKind).toBe('standin');
-    expect(standin.dataset.active).toBe('true');
-    expect(standin.querySelector('.ctc-tag-current')?.textContent).toBe('current');
-
-    const va = /** @type {HTMLElement} */ (rowEl('va'));
-    expect(va.dataset.targetKind).toBe('va');
-    expect(va.dataset.real).toBe('false');
-    expect(va.dataset.state).toBe('writes');
+    const card = /** @type {HTMLElement} */ (cardEl());
+    expect(card.dataset.target).toBe('standin');
+    expect(card.dataset.targetKind).toBe('standin');
+    expect(card.dataset.state).toBe('writes');
+    expect(card.dataset.real).toBe('true');
+    expect(rowEl('standin')).toBeNull();
+    expect(card.querySelector('.ctc-card-eyebrow')?.textContent).toBe('The agent is on');
   });
 
-  test('a row names the machine, where it points and what reached it', async () => {
+  test('the card names the machine by consequence and keeps the label on hover', async () => {
     await bootOpen();
-    const va = /** @type {HTMLElement} */ (rowEl('va'));
-    expect(va.querySelector('.ctc-label')?.textContent).toBe('virtual accelerator (simulation)');
-    // ONE identity line: the label already says what kind of machine it names,
-    // and the retired `.ctc-kind` subtitle must not come back to restate it.
-    expect(va.querySelector('.ctc-kind')).toBeNull();
-    expect(va.querySelector('.ctc-endpoint')?.textContent).toBe('127.0.0.1:10064');
-    expect(va.querySelector('.ctc-role')?.textContent).toBe('write_access');
-
-    const reach = /** @type {HTMLElement} */ (va.querySelector('.ctc-reach'));
-    expect(reach.dataset.state).toBe('reached');
-    expect(reach.querySelector('.ctc-reach-text')?.textContent).toBe('connected · 3 s');
-    // The measured word and the role stay on the title, which is the whole of
-    // what simple mode's LED-only row carries.
-    expect(reach.title).toContain('reached · 3 s');
-    expect(reach.title).toContain('write_access endpoint');
+    const title = /** @type {HTMLElement} */ (cardEl()?.querySelector('.ctc-card-title'));
+    expect(title.querySelector('.ctc-name')?.textContent).toBe('Rehearsal');
+    // The implementation vocabulary lives on the tooltip, never at rest.
+    expect(title.title).toContain('LIVE MACHINE (stand-in)');
+    expect(title.title).toContain('127.0.0.1:10090');
+    expect(cardEl()?.querySelector('.ctc-desc')?.textContent).toBe(
+      "Copy of the real machine's controls · nothing moves"
+    );
+    expect(cardEl()?.querySelector('.ctc-state-phrase')?.textContent).toBe('writes on');
   });
 
-  test('the reach LED is a direct child of .ctc-ident, never inside .ctc-meta', async () => {
-    // FR5b hangs on this. Simple mode hides `.ctc-meta` WHOLESALE (terminal.css
-    // "simple-mode gating") and keeps `.ctc-reach` as the row's LED — nested
-    // inside the meta line the LED would vanish with it, silently, and simple
-    // mode would lose the one signal that says whether the machine is there.
-    // The word and age live in `.ctc-reach-text`, which is the supported shape:
-    // a bare text node would only collapse through the `font-size: 0` rule.
-    await bootOpen();
-    for (const row of document.querySelectorAll('.ctc-row')) {
-      const ident = /** @type {HTMLElement} */ (row.querySelector('.ctc-ident'));
-      const reach = /** @type {HTMLElement} */ (row.querySelector('.ctc-reach'));
-      expect(reach.parentElement).toBe(ident);
-      expect(row.querySelector('.ctc-meta')?.contains(reach)).toBe(false);
-      expect(reach.querySelector('.ctc-reach-dot')).not.toBeNull();
-      expect(reach.querySelector('.ctc-reach-text')).not.toBeNull();
-    }
-  });
-
-  test('no row ever claims the kind that never renders', async () => {
-    // `_label()` can produce "live machine (not configured)", but
-    // `configured_targets()` never lists such a target and no session can sit
-    // on one, so `unconfigured` is a stylesheet fallback with no data behind it.
-    await bootOpen();
-    expect(document.querySelectorAll('[data-target-kind="unconfigured"]')).toHaveLength(0);
-    for (const row of document.querySelectorAll('.ctc-row')) {
-      expect(['live', 'standin', 'va', 'simulated']).toContain(
-        /** @type {HTMLElement} */ (row).dataset.targetKind
-      );
-    }
-  });
-
-  test('down and stale collapse to the plain words, keeping the measured state', async () => {
+  test('writes off on the card says whose doing it was', async () => {
     await bootOpen(
       viewOf({
         targets: [
-          rowOf(KINDS.live, { reachability: { state: 'down', role: 'read_only', age_s: 12 } }),
+          rowOf(KINDS.live, { ...STATES.sandbox }),
+          rowOf(KINDS.standin, {
+            ...STATES.sandbox,
+            active: true,
+            available_now: false,
+            reason: 'already_active',
+          }),
+          rowOf(KINDS.va),
+        ],
+      })
+    );
+    expect(cardEl()?.querySelector('.ctc-state-phrase')?.textContent).toBe('writes off');
+    expect(cardEl()?.querySelector('.ctc-state-note')?.textContent).toBe('— you turned them off');
+    expect(cardVerb()?.textContent).toBe('Turn writes on');
+  });
+});
+
+/* ---- names and descriptors ----------------------------------------------- */
+
+describe('names', () => {
+  test('every machine is named by what it is, not how it is wired', async () => {
+    await bootOpen();
+    expect(rowEl('live')?.querySelector('.ctc-name')?.textContent).toBe('Real machine');
+    expect(rowEl('va')?.querySelector('.ctc-name')?.textContent).toBe('Simulator');
+    // No raw server label reaches a resting surface.
+    expect(popEl()?.textContent).not.toContain('LIVE MACHINE');
+    expect(popEl()?.textContent).not.toContain('virtual accelerator');
+  });
+
+  test("the deployment's configured display_name wins over the default", async () => {
+    await bootOpen(
+      viewOf({
+        targets: [
+          rowOf(KINDS.live, { ...STATES.sandbox, display_name: 'ALS storage ring' }),
+          rowOf(KINDS.standin, { active: true, available_now: false, reason: 'already_active' }),
+          rowOf(KINDS.va),
+        ],
+      })
+    );
+    expect(rowEl('live')?.querySelector('.ctc-name')?.textContent).toBe('ALS storage ring');
+  });
+
+  test('the live machine carries the one hazard descriptor', async () => {
+    await bootOpen();
+    const desc = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-desc'));
+    expect(desc.textContent).toBe('Writes move hardware');
+    expect(desc.dataset.tone).toBe('hazard');
+    // Nothing-moves machines never carry the tone.
+    const va = /** @type {HTMLElement} */ (rowEl('va')?.querySelector('.ctc-desc'));
+    expect(va.textContent).toBe('Physics model · nothing moves');
+    expect(va.dataset.tone).toBeUndefined();
+  });
+
+  test('a live machine nothing has authored reads not set up, without the hazard tone', async () => {
+    await bootOpen(
+      viewOf({
+        targets: [
+          rowOf(KINDS.live, {
+            ...STATES['read-only'],
+            available_now: false,
+            reason: 'gateways_missing',
+          }),
+          rowOf(KINDS.standin, { active: true, available_now: false, reason: 'already_active' }),
+        ],
+      })
+    );
+    const desc = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-desc'));
+    expect(desc.textContent).toBe('Not set up yet');
+    expect(desc.dataset.tone).toBeUndefined();
+  });
+});
+
+/* ---- reachability -------------------------------------------------------- */
+
+describe('reachability', () => {
+  test('a machine that answers says nothing about it', async () => {
+    await bootOpen();
+    expect(document.querySelectorAll('.ctc-reach-word')).toHaveLength(0);
+  });
+
+  test('down renders as not answering, with the measured detail on the title', async () => {
+    await bootOpen(
+      viewOf({
+        targets: [
+          rowOf(KINDS.live, {
+            ...STATES.sandbox,
+            reachability: { state: 'down', role: 'read_only', age_s: 12 },
+          }),
+          rowOf(KINDS.standin, { active: true, available_now: false, reason: 'already_active' }),
           rowOf(KINDS.va, { reachability: { state: 'stale', role: null, age_s: 90 } }),
         ],
       })
     );
-    const live = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-reach'));
-    expect(live.dataset.state).toBe('down');
-    expect(live.querySelector('.ctc-reach-text')?.textContent).toBe('unreachable · 12 s');
+    const down = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-reach-word'));
+    expect(down.textContent).toBe('not answering');
+    expect(down.dataset.state).toBe('down');
+    expect(down.title).toContain('down · 12 s');
+    expect(down.title).toContain('read_only endpoint');
 
-    const va = /** @type {HTMLElement} */ (rowEl('va')?.querySelector('.ctc-reach'));
-    expect(va.dataset.state).toBe('stale');
-    expect(va.querySelector('.ctc-reach-text')?.textContent).toBe('unknown · 90 s');
-    expect(va.title).toContain('last probe older than the prober interval');
-  });
-
-  test('the baseline row is tagged on the reach line', async () => {
-    await bootOpen();
-    expect(rowEl('standin')?.querySelector('.ctc-baseline')?.textContent).toBe('baseline');
-    expect(rowEl('va')?.querySelector('.ctc-baseline')).toBeNull();
-  });
-
-  test('the head note is empty in the plain case', async () => {
-    await bootOpen();
-    expect(document.querySelector('.ctc-head-title')?.textContent).toBe(
-      'Control target · this session'
-    );
-    const note = /** @type {HTMLElement} */ (document.querySelector('.ctc-head-note'));
-    expect(note.textContent).toBe('');
-    expect(note.dataset.tone).toBeUndefined();
-  });
-
-  test('the foot carries the one-gesture narrowing and the config sentence', async () => {
-    await bootOpen();
-    expect(document.querySelector('.ctc-sandbox-all')?.textContent).toBe('Sandbox everything');
-    expect(document.querySelector('.ctc-foot-note')?.textContent).toBe(
-      "Nothing here changes the deployment's config."
-    );
+    const stale = /** @type {HTMLElement} */ (rowEl('va')?.querySelector('.ctc-reach-word'));
+    expect(stale.textContent).toBe('may be stale');
+    expect(stale.title).toContain('last probe older than the prober interval');
   });
 });
 
-/* ---- locks -------------------------------------------------------------- */
+/* ---- the banner ---------------------------------------------------------- */
 
-describe('the toggle locks, one reason at a time', () => {
+describe('the banner', () => {
+  test('absent in the plain case — absence is the good news', async () => {
+    await bootOpen();
+    expect(bannerEl()).toBeNull();
+  });
+
+  test('an unavailable store speaks first, in the error tone', async () => {
+    await bootOpen(viewOf({ store_available: false, enforceable: false }));
+    expect(bannerEl()?.textContent).toContain('cannot be recorded');
+    expect(bannerEl()?.dataset.tone).toBe('error');
+  });
+
+  test('a session nothing enforces warns that changes will not reach the agent', async () => {
+    await bootOpen(viewOf({ enforceable: false, enforceable_reason: 'no_session_record' }));
+    expect(bannerEl()?.textContent).toBe('Changes here will not reach the agent yet.');
+    expect(bannerEl()?.dataset.tone).toBe('warn');
+  });
+
+  test('a readonly run is named deployment-wide', async () => {
+    const readonly = { ceiling_writes: true, posture: 'writes', effective: false };
+    await bootOpen(
+      viewOf({
+        targets: [
+          rowOf(KINDS.live, readonly),
+          rowOf(KINDS.standin, {
+            ...readonly,
+            active: true,
+            available_now: false,
+            reason: 'already_active',
+          }),
+          rowOf(KINDS.va, readonly),
+        ],
+      })
+    );
+    expect(bannerEl()?.textContent).toBe('The whole deployment is running read-only.');
+    expect(bannerEl()?.dataset.tone).toBe('warn');
+  });
+});
+
+/* ---- locks --------------------------------------------------------------- */
+
+describe('the verb locks, one reason at a time', () => {
   /** @param {any} view @param {string} target */
   async function lockOn(view, target) {
     await bootOpen(view);
-    const toggle = /** @type {HTMLElement} */ (rowEl(target)?.querySelector('.ctc-toggle'));
-    return {
-      toggle,
-      lock: rowEl(target)?.querySelector('.ctc-lock')?.textContent ?? null,
-    };
+    const verb = verbEl(target);
+    return { verb, reason: verb?.title ?? '' };
   }
 
-  test('store unavailable outranks everything else', async () => {
-    const { toggle, lock } = await lockOn(
+  test('an unrecordable store outranks everything else', async () => {
+    const { verb, reason } = await lockOn(
       viewOf({ store_available: false, enforceable: false }),
       'va'
     );
-    expect(lock).toBe('store unavailable');
-    expect(toggle.dataset.locked).toBe('true');
-    expect(toggle.title).toBe('store unavailable');
-    expect(segEl('va', 'writes')?.disabled).toBe(true);
-    expect(segEl('va', 'read-only')?.disabled).toBe(true);
-    // The reason reaches the title too: simple mode drops the line and keeps
-    // the tooltip.
-    expect(segEl('va', 'writes')?.title).toBe('store unavailable');
+    expect(verb?.disabled).toBe(true);
+    expect(reason).toBe('changes cannot be recorded right now');
   });
 
   test('not enforceable, when the store is there but nothing reads it', async () => {
-    const { lock } = await lockOn(
+    const { reason } = await lockOn(
       viewOf({ enforceable: false, enforceable_reason: 'no_session_record' }),
       'va'
     );
-    expect(lock).toBe('not enforceable');
-    expect(document.querySelector('.ctc-head-note')?.textContent).toBe(
-      'not enforceable · no_session_record'
-    );
+    expect(reason).toBe('changes here would not reach the agent');
   });
 
   test('a readonly run: the ceiling is up, nothing is narrowed, writes are still off', async () => {
     const readonly = { ceiling_writes: true, posture: 'writes', effective: false };
-    const { lock } = await lockOn(
-      viewOf({
-        targets: [rowOf(KINDS.live, readonly), rowOf(KINDS.va, readonly)],
-      }),
+    const { reason } = await lockOn(
+      viewOf({ targets: [rowOf(KINDS.live, readonly), rowOf(KINDS.va, readonly)] }),
       'va'
     );
-    expect(lock).toBe('readonly run');
-    expect(document.querySelector('.ctc-head-note')?.textContent).toBe(
-      'readonly run · deployment-wide'
-    );
+    expect(reason).toBe('the whole deployment is running read-only');
   });
 
-  test('a persona ceiling that never armed the target', async () => {
-    const { lock } = await lockOn(
+  test('a ceiling that never armed the target reads as the deployment holding it', async () => {
+    const { verb, reason } = await lockOn(
       viewOf({ targets: [rowOf(KINDS.va, { ...STATES['read-only'] })] }),
       'va'
     );
-    expect(lock).toBe('persona ceiling');
+    expect(reason).toBe('kept read-only by the deployment');
+    expect(verb?.disabled).toBe(true);
+    // The pill says locked, not off: nothing this session did holds it.
+    expect(pillEl('va')?.textContent).toBe('locked');
+    expect(pillEl('va')?.title).toBe('kept read-only by the deployment');
   });
 
   test('no read-only endpoint: narrowing would select a role nothing configures', async () => {
-    const { lock } = await lockOn(
+    const { reason } = await lockOn(
       viewOf({ targets: [rowOf(KINDS.va, { narrowing_refusal: 'selected_role_missing' })] }),
       'va'
     );
-    expect(lock).toBe('no read-only endpoint');
+    expect(reason).toBe('no read-only endpoint configured');
   });
 
-  test('an unlocked toggle carries no lock line and stays live', async () => {
+  test('an unlocked verb stays live and names its outcome', async () => {
     await bootOpen();
-    const toggle = /** @type {HTMLElement} */ (rowEl('va')?.querySelector('.ctc-toggle'));
-    expect(toggle.dataset.locked).toBe('false');
-    expect(rowEl('va')?.querySelector('.ctc-lock')).toBeNull();
-    expect(segEl('va', 'writes')?.getAttribute('aria-pressed')).toBe('true');
-    expect(segEl('va', 'read-only')?.getAttribute('aria-pressed')).toBe('false');
+    const verb = /** @type {HTMLButtonElement} */ (verbEl('va'));
+    expect(verb.disabled).toBe(false);
+    expect(verb.textContent).toBe('Turn writes off');
+    expect(verb.dataset.direction).toBe('off');
+    expect(pillEl('va')?.textContent).toBe('writes on');
   });
 });
 
-/* ---- posture gestures --------------------------------------------------- */
+/* ---- write-state gestures ------------------------------------------------ */
 
-describe('narrowing and arming', () => {
-  test('narrowing applies on click, with no confirm', async () => {
+describe('turning writes off and on', () => {
+  test('turning writes off applies on click, with no confirm', async () => {
     await bootOpen();
     postAnswers.push({ ok: true, body: { entry: { va: 'sandbox' }, skipped: [] } });
-    segEl('va', 'read-only')?.click();
+    verbEl('va')?.click();
     await flush();
 
     expect(confirmEl()).toBeNull();
@@ -552,44 +617,52 @@ describe('narrowing and arming', () => {
     expect(posts()[0].body).toEqual({ session_id: SESSION, target: 'va', posture: 'sandbox' });
   });
 
-  test('arming raises a confirm and POSTs nothing until it is confirmed', async () => {
+  test('turning writes on raises a confirm and POSTs nothing until it is confirmed', async () => {
     await bootOpen();
-    segEl('live', 'writes')?.click();
+    verbEl('live')?.click();
     await flush();
 
-    expect(confirmTitle()).toBe('Allow writes on LIVE MACHINE?');
+    expect(confirmTitle()).toBe('Turn writes on for Real machine?');
     expect(posts()).toHaveLength(0);
     // The facility's own machine, and only it, carries the hardware notice.
     expect(confirmEl()?.querySelector('.posture-modal-live')?.textContent).toBe(
-      'Real machine. A confirmed write moves hardware.'
+      'Real machine — writes move hardware.'
     );
     expect(confirmBtn()?.dataset.live).toBe('true');
-    expect(confirmBtn()?.textContent).toBe('Allow writes');
+    expect(confirmBtn()?.textContent).toBe('Turn writes on');
   });
 
-  test('the arming body says each fact once and never repeats the title', async () => {
-    // The title names the machine; the body carries what the title does not —
-    // the scope, the endpoint, the guards that stay up, when it takes hold.
+  test('the confirm body states scope and endpoint, and claims nothing about process', async () => {
+    // Whether a write prompts for approval, and what limits apply, are
+    // deployment configuration the browser cannot see — the dialog must not
+    // state either as fact.
     await bootOpen();
-    segEl('live', 'writes')?.click();
+    verbEl('live')?.click();
     await flush();
 
     const body = inConfirm('.posture-modal-body').textContent ?? '';
-    expect(body).toContain('Arms writes for this session · als-gw.lbl.gov:5064.');
-    expect(body).toContain('Per-write approval and channel limits still apply.');
-    expect(body).not.toContain('LIVE MACHINE');
+    expect(body).toContain('For your session · als-gw.lbl.gov:5064.');
+    expect(body).toContain('Takes effect at the next write — nothing restarts.');
+    expect(body).not.toMatch(/approval|asks you|limits/i);
+    // The title names the machine; the body's own sentences do not repeat it.
+    // (The hardware notice below them is the one deliberate exception.)
+    const paragraphs = [...(confirmEl()?.querySelectorAll('.posture-modal-body p') ?? [])]
+      .map((n) => n.textContent)
+      .join(' ');
+    expect(paragraphs).not.toContain('Real machine');
   });
 
-  test('the simulator arms without the hardware notice', async () => {
+  test('the simulator turns on without the hardware notice', async () => {
     await bootOpen(viewOf({ targets: [rowOf(KINDS.va, { ...STATES.sandbox })] }));
-    segEl('va', 'writes')?.click();
+    verbEl('va')?.click();
     await flush();
+    expect(confirmTitle()).toBe('Turn writes on for Simulator?');
     expect(confirmEl()?.querySelector('.posture-modal-live')).toBeNull();
   });
 
   test('cancelling the confirm changes nothing and leaves the popover open', async () => {
     await bootOpen();
-    segEl('live', 'writes')?.click();
+    verbEl('live')?.click();
     await flush();
     inConfirm('.posture-modal-cancel').click();
     await flush();
@@ -599,9 +672,9 @@ describe('narrowing and arming', () => {
     expect(isOpen()).toBe(true);
   });
 
-  test('confirming POSTs, keeps the popover open, and re-renders the row in place', async () => {
+  test('confirming POSTs, keeps the popover open, and re-renders in place', async () => {
     await bootOpen();
-    segEl('live', 'writes')?.click();
+    verbEl('live')?.click();
     await flush();
 
     postAnswers.push({ ok: true, body: { entry: {}, skipped: [] } });
@@ -621,7 +694,7 @@ describe('narrowing and arming', () => {
     expect(confirmEl()).toBeNull();
     expect(isOpen()).toBe(true);
     expect(rowEl('live')?.dataset.state).toBe('writes');
-    expect(segEl('live', 'writes')?.getAttribute('aria-pressed')).toBe('true');
+    expect(pillEl('live')?.textContent).toBe('writes on');
   });
 
   test('a refused narrowing keeps the server sentence on the row', async () => {
@@ -631,15 +704,15 @@ describe('narrowing and arming', () => {
       status: 409,
       body: { detail: { error: 'execution_in_flight', message: 'An execution is running.' } },
     });
-    segEl('va', 'read-only')?.click();
+    verbEl('va')?.click();
     await flush();
 
     expect(outcomes('va')).toContain('✗ An execution is running.');
   });
 
-  test('a refused arming keeps the dialog up carrying the reason', async () => {
+  test('a refused turn-on keeps the dialog up carrying the reason', async () => {
     await bootOpen();
-    segEl('live', 'writes')?.click();
+    verbEl('live')?.click();
     await flush();
     postAnswers.push({
       ok: false,
@@ -659,14 +732,14 @@ describe('narrowing and arming', () => {
   });
 });
 
-describe('Sandbox everything', () => {
+describe('Turn all writes off', () => {
   test('POSTs the all-targets narrowing and renders what the store skipped', async () => {
     await bootOpen();
     postAnswers.push({
       ok: true,
       body: { entry: {}, skipped: [{ target: 'va', reason: 'selected_role_missing' }] },
     });
-    /** @type {HTMLButtonElement} */ (document.querySelector('.ctc-sandbox-all')).click();
+    /** @type {HTMLButtonElement} */ (document.querySelector('.ctc-all-off')).click();
     await flush();
 
     expect(posts()[0].body).toEqual({ session_id: SESSION, target: 'all', posture: 'sandbox' });
@@ -674,36 +747,41 @@ describe('Sandbox everything', () => {
     expect(outcomes('va')).toContain('✗ no endpoint for role');
   });
 
-  test('it is disabled when there is nothing left to lift', async () => {
+  test('it is disabled when there is nothing left to turn off', async () => {
     await bootOpen(
       viewOf({
         targets: [rowOf(KINDS.live, { ...STATES.sandbox }), rowOf(KINDS.va, { ...STATES.sandbox })],
       })
     );
     expect(
-      /** @type {HTMLButtonElement} */ (document.querySelector('.ctc-sandbox-all')).disabled
+      /** @type {HTMLButtonElement} */ (document.querySelector('.ctc-all-off')).disabled
     ).toBe(true);
+  });
+
+  test('the foot bounds the popover to the session, once', async () => {
+    await bootOpen();
+    expect(document.querySelector('.ctc-all-off')?.textContent).toBe('Turn all writes off');
+    expect(document.querySelector('.ctc-foot-note')?.textContent).toBe('Your session only');
   });
 });
 
-/* ---- switching ---------------------------------------------------------- */
+/* ---- switching ----------------------------------------------------------- */
 
 describe('switching', () => {
-  test('Switch confirms, POSTs, and shows switching… on that row', async () => {
+  test('Switch to confirms, POSTs, and shows switching… on that row', async () => {
     await bootOpen();
     switchEl('va')?.click();
     await flush();
 
-    expect(confirmTitle()).toBe('Switch to virtual accelerator (simulation)?');
+    expect(confirmTitle()).toBe('Switch to Simulator?');
     expect(confirmBtn()?.textContent).toBe('Switch');
 
-    // The title names the machine; the body carries the fact an operator is
-    // most likely to get wrong — the posture the session ARRIVES in (posture
-    // is per-target and does not travel) — and does not repeat the label.
+    // The first line states the consequence; the second names the write state
+    // the session ARRIVES in — it is per machine and does not travel.
     const body = inConfirm('.posture-modal-body').textContent ?? '';
-    expect(body).toContain('Arrives in the writes posture · 127.0.0.1:10064.');
-    expect(body).toContain('The conversation continues.');
-    expect(body).not.toContain('virtual accelerator');
+    expect(body).toContain('All control reads and writes go to 127.0.0.1:10064.');
+    expect(body).toContain('Writes are on there for your session.');
+    expect(body).not.toMatch(/approval|asks you/i);
 
     postAnswers.push({ ok: true, body: { request_id: 'req-1', target: 'va' } });
     confirmBtn()?.click();
@@ -716,6 +794,27 @@ describe('switching', () => {
     // One outstanding gesture at a time: no row offers a second Switch.
     expect(document.querySelectorAll('.ctc-switch')).toHaveLength(0);
     expect(isOpen()).toBe(true);
+  });
+
+  test('arriving with writes off is said as the nothing-moves sentence', async () => {
+    await bootOpen();
+    switchEl('live')?.click();
+    await flush();
+    const body = inConfirm('.posture-modal-body').textContent ?? '';
+    expect(body).toContain(
+      'Writes are off there for your session — nothing moves until you turn them on.'
+    );
+    // Off means off: no hardware notice until writes are actually on there.
+    expect(confirmEl()?.querySelector('.posture-modal-live')).toBeNull();
+  });
+
+  test('switching onto the live machine with writes on carries the hardware notice', async () => {
+    await bootOpen(viewOf({ targets: [rowOf(KINDS.live)] }));
+    switchEl('live')?.click();
+    await flush();
+    expect(confirmEl()?.querySelector('.posture-modal-live')?.textContent).toBe(
+      'Real machine — writes move hardware.'
+    );
   });
 
   test('the outcome the route publishes for that request lands on the row', async () => {
@@ -765,7 +864,7 @@ describe('switching', () => {
     expect(line.dataset.status).toBe('refused');
   });
 
-  test('an outcome that names no target renders on no row', async () => {
+  test('an outcome that names no target renders on no surface', async () => {
     // The other half of the contract. The reconciler publishes `target` with
     // every terminus, and a block that arrives without one is not spread over
     // the roster as a guess about which machine it meant.
@@ -812,16 +911,15 @@ describe('switching', () => {
     expect(outcomes('va')).toHaveLength(0);
   });
 
-  test('no Switch where the route offers none; the refusal phrase takes its place', async () => {
-    await bootOpen();
-    // The active row says `current` and offers nothing.
-    expect(switchEl('standin')).toBeNull();
-    expect(rowEl('standin')?.querySelector('.ctc-reason')).toBeNull();
-
-    // A code the presentation map does not know renders verbatim — failing
-    // informative — and stands in for its own tooltip.
+  test('a code the phrase map does not know renders verbatim', async () => {
+    // Failing informative: the raw code stands in for its own tooltip.
     await bootOpen(
-      viewOf({ targets: [rowOf(KINDS.live, { available_now: false, reason: 'unreachable' })] })
+      viewOf({
+        targets: [
+          rowOf(KINDS.live, { ...STATES.sandbox, available_now: false, reason: 'unreachable' }),
+          rowOf(KINDS.standin, { active: true, available_now: false, reason: 'already_active' }),
+        ],
+      })
     );
     expect(switchEl('live')).toBeNull();
     const reason = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-reason'));
@@ -829,24 +927,26 @@ describe('switching', () => {
     expect(reason.title).toBe('unreachable');
   });
 
-  test('an unconfigured target reads as a quiet phrase, with the sentence on the title', async () => {
-    // The three not-configured codes are one phrase: on a stock deployment the
-    // live target is deliberately unconfigured (authoring it is the go-live
+  test('an unauthored target reads as a quiet phrase, with the sentence on the title', async () => {
+    // The three not-set-up codes are one phrase: on a stock deployment the
+    // live target is deliberately unauthored (authoring it is the go-live
     // edit), and a raw `gateways_missing` would read as a fault.
     for (const code of ['connector_block_missing', 'gateways_missing', 'probe_channel_missing']) {
       await bootOpen(
         viewOf({
           targets: [
             rowOf(KINDS.live, {
+              ...STATES.sandbox,
               available_now: false,
               reason: code,
               reason_detail: 'The epics block configures no gateways.',
             }),
+            rowOf(KINDS.standin, { active: true, available_now: false, reason: 'already_active' }),
           ],
         })
       );
       const reason = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-reason'));
-      expect(reason.textContent).toBe('not configured');
+      expect(reason.textContent).toBe('not set up');
       expect(reason.title).toBe('The epics block configures no gateways.');
       popoverModule.teardownControlTargetPopover();
       chipModule.teardownControlTargetChip();
@@ -865,7 +965,12 @@ describe('switching', () => {
     };
     for (const [code, phrase] of Object.entries(phrases)) {
       await bootOpen(
-        viewOf({ targets: [rowOf(KINDS.live, { available_now: false, reason: code })] })
+        viewOf({
+          targets: [
+            rowOf(KINDS.live, { ...STATES.sandbox, available_now: false, reason: code }),
+            rowOf(KINDS.standin, { active: true, available_now: false, reason: 'already_active' }),
+          ],
+        })
       );
       expect(rowEl('live')?.querySelector('.ctc-reason')?.textContent).toBe(phrase);
       popoverModule.teardownControlTargetPopover();
@@ -875,25 +980,15 @@ describe('switching', () => {
 
   test('a store that cannot be resolved explains the missing Switch', async () => {
     await bootOpen(
-      viewOf({ store_available: false, targets: [rowOf(KINDS.live, { reason: null })] })
+      viewOf({
+        store_available: false,
+        targets: [
+          rowOf(KINDS.live, { ...STATES.sandbox, reason: null }),
+          rowOf(KINDS.standin, { active: true, available_now: false, reason: 'already_active' }),
+        ],
+      })
     );
     expect(rowEl('live')?.querySelector('.ctc-reason')?.textContent).toBe('store unavailable');
-  });
-
-  test('switching onto the facility machine says what a write would do there', async () => {
-    await bootOpen(viewOf({ targets: [rowOf(KINDS.live)] }));
-    switchEl('live')?.click();
-    await flush();
-    expect(confirmEl()?.querySelector('.posture-modal-live')?.textContent).toBe(
-      'Real machine, writes armed. The next write the agent makes lands on hardware.'
-    );
-
-    await bootOpen(viewOf({ targets: [rowOf(KINDS.live, { ...STATES.sandbox })] }));
-    switchEl('live')?.click();
-    await flush();
-    expect(confirmEl()?.querySelector('.posture-modal-live')?.textContent).toBe(
-      'Real machine. Writes are sandboxed on it for this session.'
-    );
   });
 
   test('a refused switch keeps the dialog up carrying the server sentence', async () => {
@@ -926,7 +1021,7 @@ describe('switching', () => {
 describe('a confirm and the popover beneath it', () => {
   test('a click inside the confirm is not an outside click', async () => {
     await bootOpen();
-    segEl('live', 'writes')?.click();
+    verbEl('live')?.click();
     await flush();
 
     inConfirm('.posture-modal-body').click();
@@ -936,7 +1031,7 @@ describe('a confirm and the popover beneath it', () => {
 
   test('Escape dismisses the confirm first and the popover only after', async () => {
     await bootOpen();
-    segEl('live', 'writes')?.click();
+    verbEl('live')?.click();
     await flush();
 
     pressEscape();
@@ -959,7 +1054,7 @@ describe('a confirm and the popover beneath it', () => {
   });
 });
 
-/* ---- chat sessions ------------------------------------------------------ */
+/* ---- chat sessions ------------------------------------------------------- */
 
 describe('a chat session', () => {
   const chatView = () =>
@@ -974,36 +1069,55 @@ describe('a chat session', () => {
     await bootOpen(chatView());
     expect(document.querySelectorAll('.ctc-switch')).toHaveLength(0);
     expect(document.querySelectorAll('.ctc-reason')).toHaveLength(0);
-    expect(document.querySelector('.ctc-head-note')?.textContent).toBe('chat session');
+    expect(bannerEl()).toBeNull();
   });
 
-  test('keeps its toggles live — posture is keyed on the session, not the topology', async () => {
+  test('keeps its verbs live — the write state is keyed on the session, not the topology', async () => {
     await bootOpen(chatView());
-    expect(segEl('live', 'read-only')?.disabled).toBe(false);
+    expect(verbEl('live')?.disabled).toBe(false);
 
     postAnswers.push({ ok: true, body: { entry: { live: 'sandbox' }, skipped: [] } });
-    segEl('live', 'read-only')?.click();
+    verbEl('live')?.click();
     await flush();
     expect(posts()[0].body).toEqual({ session_id: SESSION, target: 'live', posture: 'sandbox' });
   });
 });
 
-/* ---- realign and the execution in flight --------------------------------- */
+/* ---- realign and the execution in flight ---------------------------------- */
 
 describe('a narrowing that has not reached the agent yet', () => {
-  test('the active row says the read-only applies after the run', async () => {
+  test('the card says it takes effect after the run', async () => {
     await bootOpen(
       viewOf({ execution_in_flight: true, last_posture_realign: { state: 'pending' } })
     );
-    expect(outcomes('standin')).toContain(
-      'read-only applies after the running execution finishes'
-    );
+    expect(outcomes('standin')).toContain('takes effect when the running execution finishes');
     expect(outcomes('va')).toHaveLength(0);
-    expect(document.querySelector('.ctc-head-note')?.textContent).toBe('execution running');
   });
 });
 
-/* ---- FR5b: one DOM for both densities ------------------------------------ */
+/* ---- no process claims, anywhere ------------------------------------------ */
+
+describe('no process claims', () => {
+  test('no resting surface and neither confirm states approval behavior', async () => {
+    // Whether a write prompts for approval is deployment configuration the
+    // browser cannot see; a blanket sentence about it is false for some
+    // configurations. The popover states consequence only.
+    await bootOpen();
+    const forbidden = /approval|asks you|ask for permission|still apply/i;
+    expect(popEl()?.textContent ?? '').not.toMatch(forbidden);
+
+    verbEl('live')?.click();
+    await flush();
+    expect(confirmEl()?.textContent ?? '').not.toMatch(forbidden);
+    pressEscape();
+
+    switchEl('va')?.click();
+    await flush();
+    expect(confirmEl()?.textContent ?? '').not.toMatch(forbidden);
+  });
+});
+
+/* ---- one DOM for both densities ------------------------------------------- */
 
 describe('simple and expert are one DOM', () => {
   /**
@@ -1023,11 +1137,6 @@ describe('simple and expert are one DOM', () => {
     const simple = await markupUnder('simple', viewOf());
     const expert = await markupUnder('expert', viewOf());
     expect(simple).toBe(expert);
-    // And every expert-only piece is present in BOTH: terminal.css hides them.
-    expect(simple).toContain('ctc-meta');
-    expect(simple).toContain('ctc-reach-text');
-    expect(simple).toContain('ctc-baseline');
-    expect(simple).toContain('ctc-foot-note');
   });
 
   test('a locked, unreachable, not-enforceable roster is identical too', async () => {
@@ -1046,19 +1155,17 @@ describe('simple and expert are one DOM', () => {
     const simple = await markupUnder('simple', view());
     const expert = await markupUnder('expert', view());
     expect(simple).toBe(expert);
-    expect(simple).toContain('ctc-lock');
-    expect(simple).toContain('ctc-head-note');
   });
 });
 
-/* ---- request plumbing ---------------------------------------------------- */
+/* ---- request plumbing ----------------------------------------------------- */
 
 describe('request plumbing', () => {
   test('every request goes through the per-user mount prefix', async () => {
     /** @type {any} */ (window).__OSPREY_PREFIX__ = '/u/alice';
     await bootOpen();
     postAnswers.push({ ok: true, body: { entry: {}, skipped: [] } });
-    segEl('va', 'read-only')?.click();
+    verbEl('va')?.click();
     await flush();
 
     expect(fetchCalls.length).toBeGreaterThan(0);

--- a/tests/interfaces/web_terminal/test_posture_get_contract.py
+++ b/tests/interfaces/web_terminal/test_posture_get_contract.py
@@ -72,6 +72,7 @@ TARGET_META = {
 ROW_FIELDS = {
     "target",
     "label",
+    "display_name",
     "short_label",
     "kind",
     "endpoint",
@@ -157,6 +158,7 @@ def render(
     global_writes=False,
     va_writes=None,
     standin_roles=("read_only", "write_access"),
+    display_names=None,
     name="config.yml",
     tmp_path=None,
 ):
@@ -171,6 +173,10 @@ def render(
     ``read_only`` from it is the deployment shape that makes narrowing that
     target cost something: the session would select a role the config does not
     configure and the target would stop being usable at all.
+
+    ``display_names`` is written verbatim as
+    ``control_system.target_display_names``, the deployment's renaming of the
+    chip's per-target words.
     """
     gateway = {"address": "gw", "port": 5064, "use_name_server": True}
     standin_gateway = {"address": "localhost", "port": STANDIN_PORT, "use_name_server": True}
@@ -181,41 +187,39 @@ def render(
     }
     if va_writes is not None:
         va["writes_enabled"] = va_writes
-    path = tmp_path / name
-    path.write_text(
-        yaml.safe_dump(
-            {
-                "control_system": {
-                    "type": "live_standin",
-                    "writes_enabled": global_writes,
-                    # The keys a switch is judged on besides the gateways: a
-                    # channel to probe, strict limits (required toward the live
-                    # family) and the operator's acknowledgement of the live
-                    # gateway. Without them every row would answer with an
-                    # eligibility refusal and the roster could not be exercised.
-                    "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
-                    "target_switch": {"live_gateway_acknowledged": "operator@example"},
-                    "connector": {
-                        "epics": {
-                            "probe_channel": "SR:PROBE",
-                            "gateways": {
-                                "read_only": dict(gateway),
-                                "write_access": dict(gateway),
-                            },
-                        },
-                        "live_standin": {
-                            "probe_channel": "SR:PROBE",
-                            "gateways": {role: dict(standin_gateway) for role in standin_roles},
-                        },
-                        "virtual_accelerator": va,
+    config = {
+        "control_system": {
+            "type": "live_standin",
+            "writes_enabled": global_writes,
+            # The keys a switch is judged on besides the gateways: a
+            # channel to probe, strict limits (required toward the live
+            # family) and the operator's acknowledgement of the live
+            # gateway. Without them every row would answer with an
+            # eligibility refusal and the roster could not be exercised.
+            "limits_checking": {"enabled": True, "allow_unlisted_channels": False},
+            "target_switch": {"live_gateway_acknowledged": "operator@example"},
+            "connector": {
+                "epics": {
+                    "probe_channel": "SR:PROBE",
+                    "gateways": {
+                        "read_only": dict(gateway),
+                        "write_access": dict(gateway),
                     },
                 },
-                "services": {"live_standin": {"port": STANDIN_PORT}},
-                "deployed_services": ["virtual_accelerator", "live_standin"],
-            }
-        ),
-        encoding="utf-8",
-    )
+                "live_standin": {
+                    "probe_channel": "SR:PROBE",
+                    "gateways": {role: dict(standin_gateway) for role in standin_roles},
+                },
+                "virtual_accelerator": va,
+            },
+        },
+        "services": {"live_standin": {"port": STANDIN_PORT}},
+        "deployed_services": ["virtual_accelerator", "live_standin"],
+    }
+    if display_names is not None:
+        config["control_system"]["target_display_names"] = display_names
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
     return path
 
 
@@ -462,6 +466,40 @@ class TestIdentity:
         assert row_for(payload, "standin")["label"] == "LIVE MACHINE (stand-in)"
         assert row_for(payload, "live")["label"] == "LIVE MACHINE"
         assert row_for(payload, "va")["label"] == "virtual accelerator (simulation)"
+        assert row_for(payload, "live")["display_name"] == "Real machine"
+        assert row_for(payload, "standin")["display_name"] == "Rehearsal"
+        assert row_for(payload, "va")["display_name"] == "Simulator"
+
+    def test_an_older_published_record_does_not_erase_the_display_name(self, client):
+        """``TARGET_META`` predates the key; the derived word must survive it.
+
+        A record's fields win where they exist — the label above proves that —
+        but a writer from an older build publishes no ``display_name`` at all,
+        and the merge in ``_target_display`` keeps the derived one rather than
+        rendering an unnamed chip.
+        """
+        with live_session(client):
+            payload = get_posture(client)
+
+        assert row_for(payload, "standin")["display_name"] == "Rehearsal"
+        assert row_for(payload, "live")["display_name"] == "Real machine"
+        assert row_for(payload, "va")["display_name"] == "Simulator"
+
+    def test_a_configured_display_name_reaches_the_row(self, make_client, tmp_path):
+        """``control_system.target_display_names`` renames the chip's word only."""
+        path = render(
+            tmp_path=tmp_path,
+            display_names={"standin": "Shadow ring", "va": ""},
+        )
+        with make_client(path) as client:
+            payload = get_posture(client)
+
+        assert row_for(payload, "standin")["display_name"] == "Shadow ring"
+        # The label the safety surfaces render is not the operator's to rename.
+        assert row_for(payload, "standin")["label"] == "LIVE MACHINE (stand-in)"
+        # An empty override is no name at all: the default answers.
+        assert row_for(payload, "va")["display_name"] == "Simulator"
+        assert row_for(payload, "live")["display_name"] == "Real machine"
 
     def test_active_follows_the_published_target_and_baseline_does_not(self, client):
         with live_session(client, target="va"):

--- a/tests/interfaces/web_terminal/test_posture_toggle_browser.py
+++ b/tests/interfaces/web_terminal/test_posture_toggle_browser.py
@@ -1,26 +1,28 @@
 """Browser tests: the control-target header chip, end to end.
 
-The chip in the page header — ``● VIRTUAL · writes ▾`` — and the popover behind
-it are the operator's only route between ``writes`` and ``read-only`` on a live
-session, and now the only route onto another control target. Every interesting
-part of that is client-side behavior a FastAPI TestClient cannot observe: the
-chip only exists once ``terminal.js`` has reported a session id, the rows and
-both confirms are built in the DOM by ``control-target-popover.js``, and every
+The chip in the page header — ``● Simulator · writes on ▾`` — and the popover
+behind it are the operator's only route between writes on and writes off on a
+live session, and now the only route onto another control target. Every
+interesting part of that is client-side behavior a FastAPI TestClient cannot
+observe: the chip only exists once ``terminal.js`` has reported a session id,
+the card, the rows and both confirms are built in the DOM by
+``control-target-popover.js``, and every
 one of them repaints from a *re-read* of ``GET /api/terminal/posture`` rather
 than from what the module last POSTed. A real browser is what proves the chip
 an operator looks at agrees with the store the connector will read.
 
 Coverage (one test each):
 
-  (a) the chip names the machine the session stands on, and its popover lists
-      every configured target with the identity the route published.
-  (b) narrowing a target to read-only asks nothing, lands in the server's own
+  (a) the chip names the machine the session stands on by its display name,
+      and the popover renders that machine as the card and every other
+      configured target as a row, the server's own label demoted to tooltips.
+  (b) turning a target's writes off asks nothing, lands in the server's own
       store under the key that session answers to, and respawns nothing — the
       posture is read live, so the PTY the operator is talking to is the same
       process afterwards.
-  (c) widening back is the direction that confirms: the dialog names the
-      target, Cancel is a true no-op on the row *and* in the store, and only a
-      confirmed dialog widens.
+  (c) turning writes back on is the direction that confirms: the dialog names
+      the machine, Cancel is a true no-op on the row *and* in the store, and
+      only a confirmed dialog widens.
   (d) Switch confirms, is accepted as ``202``, and puts the chip and the row
       into ``switching…`` with a request file addressed to the controls server
       — this route only *asks*; the reconciler that would answer is not running
@@ -30,10 +32,9 @@ Coverage (one test each):
       session the server has never seen, refused with "send one prompt first"),
       and inside the dialog for one raised from a confirm — which stays up to
       carry it.
-  (f) both UI modes render the SAME row DOM and differ only in what is shown:
-      simple keeps the dot, the name (the one identity line), the
-      reachability LED, the toggle and Switch; expert keeps the endpoint/role
-      line, the reachability word, the head note and the config sentence.
+  (f) both UI modes render the SAME popover DOM and show all of it: the
+      redesign leaves no popover node for the density stylesheet to gate —
+      endpoints and the server's label are hover vocabulary in both modes.
 
 Session bootstrapping. The chip needs a session id, and one arrives the way it
 does in production: a plain page load opens a NEW terminal WebSocket, and the
@@ -111,8 +112,8 @@ CHIP = "#control-target-chip"
 CHIP_SHORT = f"{CHIP} .ctc-short"
 CHIP_STATE = f"{CHIP} .ctc-state"
 POPOVER = ".ctc-popover.open"
+CARD = f"{POPOVER} .ctc-card"
 FOOT_NOTE = f"{POPOVER} .ctc-foot-note"
-HEAD_NOTE = f"{POPOVER} .ctc-head-note"
 
 # `:not([data-closing])` is the contract for "the dialog is OPEN". Dismissal is
 # marked by the attribute and the node is only detached after the fade (~300ms),
@@ -147,12 +148,21 @@ POSTURE_TARGET = "standin"
 #: The row Switch is exercised on — the only one this render offers it for.
 SWITCH_TARGET = "live"
 
-#: What the render names each target. The controls server mints these once and
-#: every reader renders that one string; the popover's confirm titles quote them.
+#: The server's own labels. The controls server mints these once, and this
+#: render keeps them where the machine vocabulary now lives: on tooltips.
 LABELS = {
     "live": "LIVE MACHINE",
     "va": "virtual accelerator (simulation)",
     "standin": "LIVE MACHINE (stand-in)",
+}
+
+#: What the popover and the chip NAME each target: the kind's own word, since
+#: this render configures no ``control_system.target_display_names``. The
+#: confirm titles quote these — never the labels above.
+NAMES = {
+    "live": "Real machine",
+    "va": "Simulator",
+    "standin": "Rehearsal",
 }
 
 
@@ -386,23 +396,9 @@ def _row(page: Page, target: str) -> Any:
     return page.locator(f'{POPOVER} .ctc-row[data-target="{target}"]')
 
 
-def _segment(page: Page, target: str, seg: str) -> Any:
-    return _row(page, target).locator(f'.ctc-seg[data-seg="{seg}"]')
-
-
-def _display(page: Page, selector: str) -> str | None:
-    """The computed ``display`` of the first match, or ``None`` when absent.
-
-    The density delta between the two UI modes is pure ``display`` gating, and
-    two of the gated nodes (the head note in the plain case) legitimately carry
-    no text — so "hidden" has to be read off the computed style rather than off
-    a bounding box that would be empty either way.
-    """
-    return page.evaluate(
-        "(sel) => { const el = document.querySelector(sel);"
-        " return el ? getComputedStyle(el).display : null; }",
-        selector,
-    )
+def _verb(page: Page, target: str) -> Any:
+    """The row's one write verb — reads ``Turn writes off`` or ``Turn writes on``."""
+    return _row(page, target).locator(".ctc-verb")
 
 
 def _settled_chip(
@@ -446,16 +442,20 @@ def _settled_chip(
 
 
 def _open_popover(page: Page) -> None:
-    """Click the chip open and wait for the rows to be on screen."""
+    """Click the chip open and wait for the card to be on screen."""
     page.locator(CHIP).click()
     expect(page.locator(POPOVER)).to_be_visible(timeout=TIMEOUT)
     expect(page.locator(CHIP)).to_have_attribute("aria-expanded", "true", timeout=TIMEOUT)
-    expect(_row(page, ACTIVE_TARGET)).to_be_visible(timeout=TIMEOUT)
+    expect(page.locator(CARD)).to_be_visible(timeout=TIMEOUT)
 
 
 def _narrow(page: Page, target: str) -> None:
-    """Narrow *target* to read-only through the popover, and wait for the row."""
-    _segment(page, target, "read-only").click()
+    """Turn *target*'s writes off through the popover, and wait for the row.
+
+    Applies on click — turning off only ever removes reach, so no confirm is
+    in the way, and the row's ``data-state`` flipping is the re-read landing.
+    """
+    _verb(page, target).click()
     expect(_row(page, target)).to_have_attribute("data-state", "sandbox", timeout=TIMEOUT)
 
 
@@ -470,9 +470,10 @@ def test_the_chip_names_the_session_target_and_lists_every_row(
     """The chip speaks for the machine the session stands on; the popover lists all.
 
     The record puts the session on the simulator, so the chip reads
-    ``VIRTUAL · writes`` — the short word the route derived, not the target
-    name — and the popover carries one row per configured target with the label
-    the render published. The active row is tagged ``current`` and offers no
+    ``Simulator · writes on`` — the display name the render minted, not the
+    target name — and the popover renders that machine as the card ("The agent
+    is on") and each other configured target as a row named the same way, the
+    server's own label demoted to the identity tooltip. The card offers no
     Switch; switching to the target you are on is a no-op.
     """
     known_ids: set[str] = set()
@@ -489,21 +490,28 @@ def test_the_chip_names_the_session_target_and_lists_every_row(
             expect(page.locator(".terminal-header .posture-badge")).to_have_count(0)
             expect(page.locator(f".terminal-header {CHIP}")).to_have_count(0)
 
-            expect(page.locator(CHIP_SHORT)).to_have_text("VIRTUAL", timeout=TIMEOUT)
-            expect(page.locator(CHIP_STATE)).to_have_text("writes", timeout=TIMEOUT)
+            expect(page.locator(CHIP_SHORT)).to_have_text(NAMES[ACTIVE_TARGET], timeout=TIMEOUT)
+            expect(page.locator(CHIP_STATE)).to_have_text("writes on", timeout=TIMEOUT)
             expect(page.locator(CHIP)).to_have_attribute("data-target-kind", "va")
             expect(page.locator(CHIP)).to_have_attribute("aria-expanded", "false")
 
             _open_popover(page)
 
-            expect(page.locator(f"{POPOVER} .ctc-row")).to_have_count(3, timeout=TIMEOUT)
-            for target, label in LABELS.items():
-                expect(_row(page, target).locator(".ctc-label")).to_have_text(label)
+            # The machine the agent is on is the card; every other machine a row.
+            card = page.locator(CARD)
+            expect(card).to_have_attribute("data-target", ACTIVE_TARGET)
+            expect(card.locator(".ctc-card-eyebrow")).to_have_text("The agent is on")
+            expect(card.locator(".ctc-name")).to_have_text(NAMES[ACTIVE_TARGET])
+            expect(page.locator(f"{POPOVER} .ctc-row")).to_have_count(2, timeout=TIMEOUT)
+            for target in (SWITCH_TARGET, POSTURE_TARGET):
+                row = _row(page, target)
+                expect(row.locator(".ctc-name")).to_have_text(NAMES[target])
+                expect(row.locator(".ctc-pill")).to_have_text("writes on")
+                # The server's own label is hover vocabulary now, not rest copy.
+                title = row.locator(".ctc-name-line").get_attribute("title")
+                assert title and LABELS[target] in title, title
 
-            active = _row(page, ACTIVE_TARGET)
-            expect(active).to_have_attribute("data-active", "true")
-            expect(active.locator(".ctc-tag-current")).to_have_text("current")
-            expect(active.locator(".ctc-switch")).to_have_count(0)
+            expect(card.locator(".ctc-switch")).to_have_count(0)
             # The one target this render will switch onto.
             expect(_row(page, SWITCH_TARGET).locator(".ctc-switch")).to_be_visible()
         finally:
@@ -540,20 +548,17 @@ def test_narrowing_asks_nothing_lands_in_the_store_and_respawns_nothing(
             _open_popover(page)
             row = _row(page, POSTURE_TARGET)
             expect(row).to_have_attribute("data-state", "writes")
+            expect(_verb(page, POSTURE_TARGET)).to_have_text("Turn writes off")
 
             _narrow(page, POSTURE_TARGET)
 
-            # Nothing asked, and the toggle is the readout as well as the
-            # control: both segments moved.
+            # Nothing asked, and the row is the readout as well as the
+            # control: the pill flipped and the verb reversed.
             expect(page.locator(OPEN_MODAL)).to_have_count(0)
-            expect(_segment(page, POSTURE_TARGET, "read-only")).to_have_attribute(
-                "aria-pressed", "true"
-            )
-            expect(_segment(page, POSTURE_TARGET, "writes")).to_have_attribute(
-                "aria-pressed", "false"
-            )
-            # The other rows are untouched: a posture is per target.
-            expect(_row(page, ACTIVE_TARGET)).to_have_attribute("data-state", "writes")
+            expect(_row(page, POSTURE_TARGET).locator(".ctc-pill")).to_have_text("writes off")
+            expect(_verb(page, POSTURE_TARGET)).to_have_text("Turn writes on")
+            # The card is untouched: a posture is per target.
+            expect(page.locator(CARD)).to_have_attribute("data-state", "writes")
 
             # A session that was never rekeyed answers to ONE key:
             # PtyRegistry.audit_session_key returns its argument unchanged.
@@ -595,10 +600,10 @@ def test_arming_confirms_and_cancel_changes_nothing(tmp_path, monkeypatch, chrom
             _open_popover(page)
             _narrow(page, POSTURE_TARGET)
 
-            # --- widening, cancelled ---
-            _segment(page, POSTURE_TARGET, "writes").click()
+            # --- turning on, cancelled ---
+            _verb(page, POSTURE_TARGET).click()
             expect(page.locator(MODAL_TITLE)).to_have_text(
-                f"Allow writes on {LABELS[POSTURE_TARGET]}?", timeout=TIMEOUT
+                f"Turn writes on for {NAMES[POSTURE_TARGET]}?", timeout=TIMEOUT
             )
             # The rows stay readable underneath: the confirm is a layer above
             # the popover, not a replacement for it.
@@ -609,9 +614,9 @@ def test_arming_confirms_and_cancel_changes_nothing(tmp_path, monkeypatch, chrom
             expect(_row(page, POSTURE_TARGET)).to_have_attribute("data-state", "sandbox")
             assert _stored_postures()[session_id] == {POSTURE_TARGET: "sandbox"}
 
-            # --- widening, confirmed ---
-            _segment(page, POSTURE_TARGET, "writes").click()
-            expect(page.locator(MODAL_CONFIRM)).to_have_text("Allow writes", timeout=TIMEOUT)
+            # --- turning on, confirmed ---
+            _verb(page, POSTURE_TARGET).click()
+            expect(page.locator(MODAL_CONFIRM)).to_have_text("Turn writes on", timeout=TIMEOUT)
             page.locator(MODAL_CONFIRM).click()
 
             expect(_row(page, POSTURE_TARGET)).to_have_attribute(
@@ -652,12 +657,16 @@ def test_switch_confirms_is_accepted_and_reads_switching(tmp_path, monkeypatch, 
             _row(page, SWITCH_TARGET).locator(".ctc-switch").click()
 
             expect(page.locator(MODAL_TITLE)).to_have_text(
-                f"Switch to {LABELS[SWITCH_TARGET]}?", timeout=TIMEOUT
+                f"Switch to {NAMES[SWITCH_TARGET]}?", timeout=TIMEOUT
             )
-            # The posture that travels is the one held on the target being
-            # switched TO, because posture is per target and does not follow.
+            # The write state named is the one held on the machine being
+            # switched TO, because writes on/off is per machine and does not
+            # follow — and only the real machine carries the hardware sentence.
             expect(page.locator(f"{OPEN_MODAL} .posture-modal-body")).to_contain_text(
-                "Arrives in the writes posture"
+                "Writes are on there for your session"
+            )
+            expect(page.locator(f"{OPEN_MODAL} .posture-modal-live")).to_have_text(
+                "Real machine — writes move hardware."
             )
             page.locator(MODAL_CONFIRM).click()
 
@@ -713,10 +722,10 @@ def test_an_unstarted_session_accepts_a_narrowing_the_moment_it_opens(
             )
 
             _open_popover(page)
-            _segment(page, POSTURE_TARGET, "read-only").click()
+            _verb(page, POSTURE_TARGET).click()
 
-            expect(_segment(page, POSTURE_TARGET, "read-only")).to_have_attribute(
-                "aria-pressed", "true", timeout=TIMEOUT
+            expect(_row(page, POSTURE_TARGET)).to_have_attribute(
+                "data-state", "sandbox", timeout=TIMEOUT
             )
             stored = _stored_postures()
             assert stored == {session_id: {POSTURE_TARGET: "sandbox"}}, stored
@@ -761,7 +770,7 @@ def test_a_refused_switch_keeps_its_sentence_inside_the_confirm(
             expect(error).to_contain_text("has not been answered yet", timeout=TIMEOUT)
             expect(page.locator(OPEN_MODAL)).to_have_count(1)
             expect(page.locator(CHIP)).not_to_have_attribute("data-pending", "true")
-            expect(page.locator(CHIP_STATE)).to_have_text("writes")
+            expect(page.locator(CHIP_STATE)).to_have_text("writes on")
         finally:
             page.close()
 
@@ -770,38 +779,27 @@ def test_a_refused_switch_keeps_its_sentence_inside_the_confirm(
 # (f) one DOM, two densities
 # ---------------------------------------------------------------------------
 
-#: Nodes simple mode drops and expert keeps. Every one is rendered in BOTH —
-#: the popover reads no `data-ui-mode` at all — so the whole delta is CSS, and
-#: a live mode flip rebuilds nothing.
-_EXPERT_ONLY = (
-    ".ctc-meta",  # the endpoint, and the gateway role beside it
-    ".ctc-reach-text",  # the reachability word and its age; the LED stays
-)
-
 
 @pytest.mark.parametrize("ui_mode", ["expert", "simple"])
 def test_both_ui_modes_render_the_same_row_and_differ_only_in_density(
     tmp_path, monkeypatch, chromium_browser, ui_mode
 ):
-    """Simple keeps what an operator acts on; expert adds the deployment detail.
+    """The popover renders one DOM and shows the whole of it in either mode.
 
-    The rule the popover is built on is that ``html[data-ui-mode]`` is a CSS
-    concern and only a CSS concern. So this asserts the same DOM in both modes
-    — every gated node is *attached* either way — and that the difference is
-    which of them the stylesheet shows:
-
-    * simple keeps the dot, the name (the row's one identity line — the label
-      already says what kind of machine it names), the reachability LED, the
-      posture toggle and Switch;
-    * expert keeps the endpoint/role line, the reachability word, the head note
-      and the sentence that bounds the popover.
+    ``html[data-ui-mode]`` stays a CSS concern and only a CSS concern — and
+    this design leaves it nothing in the popover to gate. The endpoint and the
+    server's own label are hover vocabulary in BOTH modes, reachability only
+    speaks when a machine is not answering, and what remains at rest — the
+    name, the consequence line, the pill, the verb, Switch — is what an
+    operator acts on and is shown in either density. So the invariant pinned
+    here is the stronger one: same DOM, same visibility, and the confirms
+    identical, whichever mode the deployment renders.
 
     The mode is driven the way the deployment drives it — ``web.ui_mode``
     reaching the page as the server-rendered ``<html data-ui-mode>`` attribute
     — not by poking the attribute from the test.
     """
     known_ids: set[str] = set()
-    simple = ui_mode == "simple"
 
     with _chip_hub(tmp_path, monkeypatch, known_ids=known_ids, ui_mode=ui_mode) as (
         base_url,
@@ -814,49 +812,25 @@ def test_both_ui_modes_render_the_same_row_and_differ_only_in_density(
 
             row = _row(page, SWITCH_TARGET)
 
-            # --- the same DOM in both modes ---
-            for selector in _EXPERT_ONLY:
-                assert row.locator(selector).count() == 1, f"{selector} missing in {ui_mode}"
-            # The retired kind subtitle stays retired: the label is the row's
-            # one identity line, in either density.
-            assert row.locator(".ctc-kind").count() == 0
-            expect(page.locator(HEAD_NOTE)).to_have_count(1)
-            expect(page.locator(FOOT_NOTE)).to_have_count(1)
-
-            # --- what every mode shows: the four things an operator acts on ---
-            expect(row.locator(".ctc-dot")).to_be_visible()
-            expect(row.locator(".ctc-label")).to_have_text(LABELS[SWITCH_TARGET])
-            expect(row.locator(".ctc-reach .ctc-reach-dot")).to_be_visible()
-            expect(row.locator('.ctc-seg[data-seg="writes"]')).to_be_visible()
-            expect(row.locator('.ctc-seg[data-seg="read-only"]')).to_be_visible()
+            # --- what an operator acts on, at rest, in either density ---
+            expect(row.locator(".ctc-name")).to_have_text(NAMES[SWITCH_TARGET])
+            expect(row.locator(".ctc-desc")).to_have_text("Writes move hardware")
+            expect(row.locator(".ctc-pill")).to_have_text("writes on")
+            expect(row.locator(".ctc-verb")).to_be_visible()
             expect(row.locator(".ctc-switch")).to_be_visible()
+            expect(page.locator(FOOT_NOTE)).to_have_text("Your session only")
 
-            # --- and the density delta ---
-            for selector in _EXPERT_ONLY:
-                node = row.locator(selector)
-                if simple:
-                    expect(node).to_be_hidden()
-                else:
-                    expect(node).to_be_visible()
-            # The head note carries no text in the plain case, so "dropped" is
-            # a question about the computed style rather than a bounding box.
-            head_note_display = _display(page, HEAD_NOTE)
-            if simple:
-                assert head_note_display == "none", head_note_display
-            else:
-                assert head_note_display != "none", head_note_display
-            if simple:
-                expect(page.locator(FOOT_NOTE)).to_be_hidden()
-            else:
-                expect(page.locator(FOOT_NOTE)).to_have_text(
-                    "Nothing here changes the deployment's config."
-                )
+            # --- the machine vocabulary stays on hover, in either density ---
+            title = row.locator(".ctc-name-line").get_attribute("title")
+            assert title and LABELS[SWITCH_TARGET] in title, title
+            # No endpoint/role line exists at rest for a stylesheet to gate.
+            assert row.locator(".ctc-meta").count() == 0
 
             # Both confirms are identical in either mode: a safety gesture does
             # not get a density.
             row.locator(".ctc-switch").click()
             expect(page.locator(MODAL_TITLE)).to_have_text(
-                f"Switch to {LABELS[SWITCH_TARGET]}?", timeout=TIMEOUT
+                f"Switch to {NAMES[SWITCH_TARGET]}?", timeout=TIMEOUT
             )
             page.locator(MODAL_CANCEL).click()
             expect(page.locator(OPEN_MODAL)).to_have_count(0, timeout=TIMEOUT)

--- a/tests/mcp_server/test_audit_middleware.py
+++ b/tests/mcp_server/test_audit_middleware.py
@@ -1250,14 +1250,14 @@ def session(project, monkeypatch):
 POSTURE_REMEDIES = {
     "deployment": (
         "the control-target chip in the header cannot lift a deployment-wide read-only run",
-        "this session's write posture",
+        "writes are off for",
     ),
     "store": (
-        "set 'live' back to writes from the control-target chip in the header",
+        "turn writes back on for 'live' from the control-target chip in the header",
         "cannot lift a deployment-wide read-only run",
     ),
     "store_unknown_target": (
-        "lift that narrowing from the control-target chip in the header",
+        "turn writes back on from the control-target chip in the header",
         "cannot lift a deployment-wide read-only run",
     ),
 }

--- a/tests/mcp_server/test_channel_write_tool.py
+++ b/tests/mcp_server/test_channel_write_tool.py
@@ -718,9 +718,9 @@ async def test_a_single_refusal_envelope_says_what_the_refusal_said(tmp_path, mo
     _prepare(tmp_path, monkeypatch)
 
     refusal = (
-        "Write to 'PV:A' blocked: this session's posture for the 'standin' control "
-        "target is read-only — set from the control-target chip in the header, and "
-        "in force for this session only."
+        "Write to 'PV:A' blocked: writes are off for the 'standin' control target "
+        "in this session — turned off from the control-target chip in the header, "
+        "and in force for this session only."
     )
     result = _make_write_result(
         channel="PV:A",

--- a/tests/mcp_server/test_control_target_roster.py
+++ b/tests/mcp_server/test_control_target_roster.py
@@ -21,7 +21,10 @@ import json
 import pytest
 
 from osprey.mcp_server.control_system import target_state
-from osprey.mcp_server.control_system.connector_host_manager import target_display_metadata
+from osprey.mcp_server.control_system.connector_host_manager import (
+    _display_name,
+    target_display_metadata,
+)
 from osprey.mcp_server.control_system.target_eligibility import (
     ACK_LEAF,
     REASON_ALREADY_ACTIVE,
@@ -917,6 +920,87 @@ class TestLiveStandinLabel:
         assert metadata["live"]["real_machine"] is True
         assert metadata["standin"]["real_machine"] is True
         assert metadata["va"]["real_machine"] is False
+
+
+class TestDisplayName:
+    """The operator-facing word minted beside each label, and who may rename it.
+
+    ``display_name`` walks the same branches as the label, from the same
+    inputs, at the same single writer — so the word on the chip and the
+    identity line the prompt hook renders cannot describe different machines.
+    Unlike the label, a deployment may rename it per target via
+    ``control_system.target_display_names``; only a non-empty string does,
+    because an empty name on the chip is a target the operator cannot tell
+    apart from the others.
+    """
+
+    def test_defaults_follow_the_label_branches(self):
+        """Real machine, Rehearsal, Simulator — one word per derivation."""
+        metadata = target_display_metadata(standin_config())
+
+        assert metadata["live"]["display_name"] == "Real machine"
+        assert metadata["standin"]["display_name"] == "Rehearsal"
+        assert metadata["va"]["display_name"] == "Simulator"
+
+    def test_an_underivable_live_target_is_still_the_real_machine(self):
+        """The "not set up" nuance is the reader's to render, not the name's."""
+        metadata = target_display_metadata({"control_system": {"type": "virtual_accelerator"}})
+
+        assert metadata["live"]["label"] == "live machine (not configured)"
+        assert metadata["live"]["display_name"] == "Real machine"
+
+    def test_a_simulated_connector_is_a_demo(self):
+        """The branch mirrors the label's "live target on a simulated connector".
+
+        Asserted on the helper directly: :func:`resolve_target` never answers a
+        live-family target with a simulated type today, so the branch is
+        reachable only the way the label's own simulated branch is — kept so
+        the two names cannot diverge if that ever changes.
+        """
+        assert _display_name({}, "live", "mock") == "Demo"
+        assert _display_name({}, "live", "virtual_accelerator") == "Demo"
+
+    def test_a_standin_that_fails_the_predicate_is_the_real_machine(self):
+        """Same conjuncts as the parenthesis: no deployed stand-in, no Rehearsal."""
+        metadata = target_display_metadata(standin_config(standin_port=None))
+
+        assert metadata["standin"]["label"] == "LIVE MACHINE"
+        assert metadata["standin"]["display_name"] == "Real machine"
+
+    def test_a_configured_name_wins_verbatim_stripped(self):
+        raw = standin_config()
+        raw["control_system"]["target_display_names"] = {
+            "live": "  Storage ring ",
+            "standin": "Shadow ring",
+            "va": "Digital twin",
+        }
+
+        metadata = target_display_metadata(raw)
+
+        assert metadata["live"]["display_name"] == "Storage ring"
+        assert metadata["standin"]["display_name"] == "Shadow ring"
+        assert metadata["va"]["display_name"] == "Digital twin"
+
+    def test_an_empty_or_blank_override_falls_back_to_the_default(self):
+        raw = standin_config()
+        raw["control_system"]["target_display_names"] = {"live": "", "standin": "   ", "va": None}
+
+        metadata = target_display_metadata(raw)
+
+        assert metadata["live"]["display_name"] == "Real machine"
+        assert metadata["standin"]["display_name"] == "Rehearsal"
+        assert metadata["va"]["display_name"] == "Simulator"
+
+    def test_an_override_never_touches_the_label(self):
+        """The identity line is the safety surface; the name is cosmetic."""
+        raw = standin_config()
+        raw["control_system"]["target_display_names"] = {"standin": "Shadow ring"}
+
+        metadata = target_display_metadata(raw)
+
+        assert metadata["standin"]["display_name"] == "Shadow ring"
+        assert metadata["standin"]["label"] == "LIVE MACHINE (stand-in)"
+        assert metadata["standin"]["real_machine"] is True
 
 
 # ------------------------------------------------------ the limits posture

--- a/tests/mcp_server/test_switch_lifecycle.py
+++ b/tests/mcp_server/test_switch_lifecycle.py
@@ -1451,6 +1451,7 @@ class TestConfigDerivedFacts:
 
         assert metadata["live"] == {
             "label": "live machine (not configured)",
+            "display_name": "Real machine",
             "endpoint": "",
             "real_machine": False,
             "probe_channel": "",

--- a/tests/services/python_executor/test_launch_posture_pin.py
+++ b/tests/services/python_executor/test_launch_posture_pin.py
@@ -127,7 +127,7 @@ class TestLaunchPinAnddedWithTheStore:
         """The whole point: the operator widened, the running script did not follow."""
         # Arrange — the run launched while standin was narrowed...
         monkeypatch.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "standin=sandbox")
-        # ...and the operator has since flipped it back to writes (an entry that
+        # ...and the operator has since turned writes back on (an entry that
         # is gone IS the writes posture — nothing is ever stored to widen).
         write_store(data_root, {SESSION_KEY: {"live": "sandbox"}})
 
@@ -320,7 +320,7 @@ class TestDeploymentGateStoreTerm:
             gates.enforce_deployment_writes_gate("readwrite", None)
 
         message = str(excinfo.value)
-        assert "read-only" in message
+        assert "Writes are off" in message
         assert "control-target chip in the header" in message
         assert "could not be identified" in message
 

--- a/tests/services/python_executor/test_posture_clamp.py
+++ b/tests/services/python_executor/test_posture_clamp.py
@@ -251,7 +251,7 @@ def test_a_narrowed_target_refusal_names_that_target(session, _audit_zone):
     assert "'live' control target" in message
     assert "for this session only" in message
     assert "This terminal session is in the sandbox posture" not in message
-    assert "Set 'live' back to writes from the control-target chip in the header" in " ".join(
+    assert "Turn writes back on for 'live' from the control-target chip in the header" in " ".join(
         envelope["suggestions"]
     )
 
@@ -290,7 +290,7 @@ def test_a_target_lost_between_the_two_reads_names_no_machine(session, _audit_zo
     assert "most restrictive" in message
     assert "control-target chip in the header" in message
     assert "'live'" not in message
-    assert "Lift that narrowing from the control-target chip in the header" in " ".join(
+    assert "Turn writes back on from the control-target chip in the header" in " ".join(
         envelope["suggestions"]
     )
 

--- a/tests/services/python_executor/test_tool_gates.py
+++ b/tests/services/python_executor/test_tool_gates.py
@@ -334,10 +334,10 @@ POSTURE_REMEDIES = {
         "the control-target chip in the header cannot lift a deployment-wide read-only run",
         # A live discriminator, not a dead string: this is how BOTH store-derived
         # wordings open, so borrowing either one here fails.
-        "this session's write posture",
+        "writes are off for",
     ),
     "store": (
-        "set 'live' back to writes from the control-target chip in the header",
+        "turn writes back on for 'live' from the control-target chip in the header",
         "cannot lift a deployment-wide read-only run",
     ),
 }

--- a/tests/va/e2e/test_per_target_posture.py
+++ b/tests/va/e2e/test_per_target_posture.py
@@ -1059,7 +1059,7 @@ class TestTheNarrowingLandsWithoutARespawn:
         assert row["outcome"] == "refused"
         assert row["refusal_reason"] == "WRITES_DISABLED"
         assert f"'{TARGET_STANDIN}' control target" in row["error"]
-        assert "read-only" in row["error"]
+        assert "writes are off" in row["error"]
         assert "control-target chip in the header" in row["error"]
 
     def test_the_raised_envelope_carries_that_sentence_too(self, session) -> None:


### PR DESCRIPTION
The web terminal named control targets by their raw identity labels (LIVE MACHINE, MOCK), and every surface spelled its own words for the same machine — the chip, the popover, the confirm dialogs, and the agent's refusal messages each said something different. A facility had no way to call its live target "ALS storage ring". Worse, the popover's confirm copy made process claims ("OSPREY will ask for approval") that are deployment configuration, not fact.

The name is now minted once, server-side: `target_display_metadata()` emits a `display_name` per target — a per-target override from the new optional `control_system.target_display_names` mapping, or a default derived from what the target is (Real machine / Rehearsal / Simulator / Demo). The identity label stays untouched as the identity line's truth.

The popover is rebuilt around that vocabulary: the machine the agent is on is a card with one write control, other machines are rows with writes on/off/locked pills and action verbs, endpoints and identity labels are demoted to tooltips and confirms, reachability is reported only when a machine is not answering, and the banner appears only when the posture is abnormal. All user-visible wording comes from the pure facts module and states no process claims — a vitest guard fails the suite if any surface says "approval", "asks you", or "still apply".

Every refusing layer speaks the same words when a write is blocked: the executor gates, the audit middleware, the writes-check hook, the Bluesky queue remedies, and the connector refusal. Machine words — audit reasons, store values, config keys — are unchanged. Docs are rewritten in the same vocabulary, with quoted strings verified verbatim against the shipped copy.

## How it hangs together

```text
 ┌────────────────────────────────┐  ┌────────────────────────────────┐
 │ config override                │  │ derived default                │
 │ control_system.                │  │ Real machine / Rehearsal /     │
 │ target_display_names           │  │ Simulator / Demo               │
 └───────────────┬────────────────┘  └───────────────┬────────────────┘
                 │ if set                            │ else
                 └─────────────────┬─────────────────┘
                                   ▼
               ┌─────────────────────────────────────────┐
               │ target_display_metadata()               │
               │ connector_host_manager.py               │
               │ mints one display_name per target       │
               └───────────────────┬─────────────────────┘
                                   ▼
               ┌─────────────────────────────────────────┐
               │ _posture_view (routes/websocket.py)     │
               │ display_name to the client, verbatim    │
               └───────────────────┬─────────────────────┘
                                   ▼
               ┌─────────────────────────────────────────┐
               │ control-target-facts.js                 │
               │ pure facts module — mints all the       │
               │ user-visible wording, incl. confirm     │
               │ dialogs; no process claims              │
               └─────────┬─────────────────────┬─────────┘
                         ▼                     ▼
       ┌──────────────────────────┐  ┌──────────────────────────────┐
       │ control-target-chip.js   │  │ control-target-popover.js    │
       │ header chip              │  │ "The agent is on" card +     │
       └──────────────────────────┘  │ rows: on/off/locked pills,   │
                                     │ Turn writes on/off·Switch to │
                                     └──────────────────────────────┘
      vitest guard fails the suite on "approval"/"asks you"/"still apply"

   same writes on / off / locked vocabulary at every refusing layer
   (machine words — audit reasons, store values, config keys — untouched)
 ┌─────────────────────────────────────────────────────────────────────┐
 │ python executor gates (_execution_gates.py) · audit middleware      │
 │ Bluesky queue remedies · osprey-connectors base.py refusal          │
 │ writes-check hook (WRITES OFF / WRITE STATE UNKNOWN)                │
 └─────────────────────────────────────────────────────────────────────┘
```
