### PR TITLE
fix(deploy): stop deployment surfaces claiming what is not true

### DIFF
--- a/changelog.d/deploy-summary-panels.fixed.md
+++ b/changelog.d/deploy-summary-panels.fixed.md
@@ -1,0 +1,4 @@
+The deploy summary and `osprey status` now list panel families together with
+the users who actually serve them, and print no row for a band that no
+persona serves — one trailing note covers reserved-but-unserved bands. The
+token-login note also reads correctly when only one user has a token.

--- a/changelog.d/landing-badges.changed.md
+++ b/changelog.d/landing-badges.changed.md
@@ -1,0 +1,2 @@
+Landing cards for users without a login page now carry a badge and a hint
+naming `osprey users login-url <user>`.

--- a/changelog.d/login-redirect.fixed.md
+++ b/changelog.d/login-redirect.fixed.md
@@ -1,0 +1,3 @@
+A browser opening the login page without a user in the URL is now redirected
+to the landing page instead of receiving a raw JSON error. API clients keep
+getting the JSON 400.

--- a/changelog.d/port-probe.fixed.md
+++ b/changelog.d/port-probe.fixed.md
@@ -1,0 +1,9 @@
+Companion-panel preflight and web-terminal server launch now decide whether a
+port is free by binding the exact host and port the server will use, instead
+of a `connect()` probe. A listener visible only through Docker Desktop's host
+pass-through no longer refuses startup or crash-loops a persona terminal.
+Adopting an already-running panel now requires proof it belongs to this
+deployment (a matching `OSPREY_TERMINAL_SECRET`); a `/health` 200 alone never
+decides adoption. A process with no operator identity to offer — an agent-side
+MCP server, for example — refuses to adopt instead of latching on silently; the
+refusal is logged once as a warning and thereafter at info.

--- a/changelog.d/preflight-status.added.md
+++ b/changelog.d/preflight-status.added.md
@@ -1,0 +1,2 @@
+When a web-terminal container is restarting because its preflight refused to
+start, `osprey status` now shows the refusal reason on the container's row.

--- a/changelog.d/storage-scope.fixed.md
+++ b/changelog.d/storage-scope.fixed.md
@@ -1,0 +1,7 @@
+Per-user web terminals on one origin no longer share browser-stored UI
+state — mode, theme, dock layout, rail position, drawer width, terminal
+session, palette history, panel-attention acknowledgements, the one-time rail
+hint, and the settings-acknowledgement flag. Each user's choices are now scoped
+to their own terminal. Previously stored values are not carried over: on a
+multi-user deployment each user starts from the server defaults once and their
+choices persist from there.

--- a/src/osprey/cli/summary_card.py
+++ b/src/osprey/cli/summary_card.py
@@ -245,8 +245,15 @@ def print_call_to_action(repo_root: Path | str, state: str) -> None:
             "",
             [("open a terminal with", f"osprey users login-url {facts.token_login_users[0]}")],
         )
-        output.note(
-            "these terminals have no login page: "
-            f"{', '.join(facts.token_login_users)} each need their own "
-            "login URL, which carries that user's secret -- treat it like a password"
-        )
+        if len(facts.token_login_users) == 1:
+            output.note(
+                "this terminal has no login page: "
+                f"{facts.token_login_users[0]} needs its own login URL, which carries "
+                "that user's secret -- treat it like a password"
+            )
+        else:
+            output.note(
+                "these terminals have no login page: "
+                f"{', '.join(facts.token_login_users)} each need their own "
+                "login URL, which carries that user's secret -- treat it like a password"
+            )

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -22,6 +22,7 @@ command serves.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import signal
 import socket
@@ -66,6 +67,99 @@ DECLARED_SESSION_LIFETIME_ENV = "OSPREY_TERMINAL_SESSION_LIFETIME"
 #: name the serving process reads. ``test_web_session_lifetime.py`` pins the two
 #: spellings equal so this copy cannot drift.
 DECLARED_SESSION_STORE_DIR_ENV = "OSPREY_TERMINAL_SESSION_STORE_DIR"
+#: The carrier for THIS user's audit directory. The multi-user compose sets it
+#: on every per-user web container (``docker-compose.web.yml.j2``) alongside the
+#: ``var/audit/<identity>`` bind mount it names, so the value is a real,
+#: host-visible, group-writable directory inside the container. Spelled
+#: literally for the same reason the carriers above are — this module keeps its
+#: ``osprey`` imports function-local — and deliberately read, never written,
+#: here: ``osprey web`` is a consumer of the deployment's declaration.
+AUDIT_DIR_ENV = "OSPREY_AUDIT_DIR"
+#: File name of the pre-flight refusal marker inside :data:`AUDIT_DIR_ENV`.
+#: Exported so ``osprey status`` reads the same name this writes instead of
+#: duplicating the literal; the format is deliberately trivial (line 1 = an
+#: ISO-8601 UTC timestamp, the rest = the refusal findings verbatim) so the
+#: reader needs no parser and no schema version.
+PREFLIGHT_REFUSED_MARKER = "preflight-refused"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _preflight_marker_path() -> Path | None:
+    """Where this container's pre-flight refusal marker lives, or ``None``.
+
+    ``None`` means "nothing to record": no :data:`AUDIT_DIR_ENV` is declared,
+    which is the bare-laptop launch — no container, no supervisor restarting
+    the process, and so nobody downstream to explain a refusal to. Under
+    ``restart: unless-stopped`` the variable is always set, because the compose
+    that supervises the container is the same file that declares it.
+    """
+    declared = os.environ.get(AUDIT_DIR_ENV)
+    if not declared:
+        return None
+    return Path(declared) / PREFLIGHT_REFUSED_MARKER
+
+
+def _refusal_body(failures: list[str]) -> str:
+    """The refusal findings as the one bullet list both the report and the marker carry."""
+    return "\n".join(f"- {finding}" for finding in failures)
+
+
+def _write_preflight_marker(body: str) -> None:
+    """Record a pre-flight refusal for ``osprey status`` to render.
+
+    A supervised container that refuses pre-flight exits 1 and is restarted, so
+    the refusal text scrolls past in a log nobody is tailing and the only
+    outward sign is a service flapping. This marker is the durable half of that
+    story: ``osprey status`` turns it into a "restarting (pre-flight: ...)" row.
+
+    Rewritten in full on every attempt rather than appended to — each restart
+    re-runs pre-flight, and the operator needs to know what is failing *now*,
+    not the archaeology of every attempt since the deploy.
+
+    Strictly advisory. An audit directory that is absent, root-owned or on a
+    read-only mount must not turn one honest failure into a second, more
+    confusing one, so every filesystem error here is logged and swallowed; the
+    caller goes on to report the refusal and exit as it would have anyway.
+    """
+    marker = _preflight_marker_path()
+    if marker is None:
+        _LOGGER.debug("no %s declared; skipping pre-flight refusal marker", AUDIT_DIR_ENV)
+        return
+
+    from datetime import UTC, datetime
+
+    # `osprey status` reads this file from the host while a supervised container
+    # rewrites it on every restart attempt; swap it in whole so a concurrent
+    # reader never sees a truncated timestamp line.
+    staging = marker.with_name(marker.name + ".tmp")
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        staging.write_text(f"{datetime.now(UTC).isoformat()}\n{body}\n", encoding="utf-8")
+        os.replace(staging, marker)
+    except OSError as e:
+        _LOGGER.debug("could not write pre-flight refusal marker %s: %s", marker, e)
+
+
+def _clear_preflight_marker() -> None:
+    """Remove a marker left by an earlier refusal, now that pre-flight passed.
+
+    Called ONLY on a real pass. ``--skip-preflight`` deliberately leaves any
+    marker standing: it forces past checks it never re-ran, so clearing there
+    would erase the record of the very refusal the operator is overriding while
+    the underlying fault is still present. The staleness that costs — a marker
+    outliving the refusal it describes — is bounded on the reading side, where
+    ``osprey status`` ignores markers older than the container's ``StartedAt``.
+
+    Swallows filesystem errors for the same reason the writer does.
+    """
+    marker = _preflight_marker_path()
+    if marker is None:
+        return
+    try:
+        marker.unlink(missing_ok=True)
+    except OSError as e:
+        _LOGGER.debug("could not clear pre-flight refusal marker %s: %s", marker, e)
 
 
 def resolve_bind_host(
@@ -942,12 +1036,19 @@ def web(
         for warning in warnings:
             output.warn(warning)
         if failures:
+            # Record BEFORE the exit, not after the report: under container
+            # supervision this process is about to be killed and restarted, and
+            # the marker is the only thing that survives to tell `osprey status`
+            # why the service is flapping.
+            body = _refusal_body(failures)
+            _write_preflight_marker(body)
             output.fail(
                 "Pre-flight checks failed",
-                "\n".join(f"- {finding}" for finding in failures),
+                body,
                 "fix the findings above, or pass --skip-preflight to start anyway",
             )
             raise SystemExit(1)
+        _clear_preflight_marker()
 
     if detach:
         _start_detached(host, port, user_shell_override, repo_root)

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -410,7 +410,7 @@ def _companion_roster_failure(
 
 
 def _probe_companion_ports() -> list[str]:
-    """Probe 1: TCP-connect-probe every companion panel port the lifespan will bind.
+    """Probe 1: bind-probe every companion panel port the lifespan will bind.
 
     Resolves the panel set the same way ``_create_lifespan`` does: enabled via
     ``web.panels`` (or a UNIVERSAL panel, which is always launched) AND actually
@@ -423,14 +423,16 @@ def _probe_companion_ports() -> list[str]:
     use (``artifact``/``artifacts``, ``channel_finder``/``channel-finder``), and
     a local translation table here drifted from the health category's copy.
 
-    A listener already bound to a companion port before we start ours is
+    The verdict is bindability, asked by attempting the very bind the lifespan
+    will attempt: a port we can bind is free, whatever else may answer there.
+    Something already holding a companion port so that our bind fails is
     usually foreign: at best it steals the panel's tab, at worst it silently
     reverse-proxies another project's data into this UI. The one case it is
     NOT foreign is this deployment's own multi-user roster — see
     :func:`_companion_roster_failure` — which is why the probe resolves the
     base and reads ``modules.web_terminals.enabled`` before it words a
-    failure. Zero network I/O beyond the local TCP connect probe itself — no
-    server starts, no registry init, no LLM calls.
+    failure. Zero network I/O beyond the local bind and connect probes
+    themselves — no server starts, no registry init, no LLM calls.
     """
     from osprey.infrastructure.server_launcher import (
         _launchers,
@@ -472,7 +474,20 @@ def _probe_companion_ports() -> list[str]:
             # of pre-flight, so `osprey web` names the key and the fix.
             failures.append(str(exc))
             continue
-        if not _launchers[key]._port_has_listener(host, port):
+        launcher = _launchers[key]
+        if launcher._port_is_bindable(host, port):
+            # Bindable == free: the lifespan's own bind will succeed, so there
+            # is no clash to report. Something may still answer a connect there
+            # without contending for the bind (a Docker Desktop host-loopback
+            # pass-through, where a Mac-side listener is visible to a connect
+            # but does not block the container's bind). Name it so the operator
+            # is not left wondering why `curl` answers and pre-flight is clean.
+            if launcher._port_answers_connect(host, port):
+                output.note(
+                    f"Companion panel '{key}' port {port} answers a TCP connect but does not "
+                    "block the bind. That is a foreign host-side listener, not an owner of "
+                    "this port."
+                )
             continue
         if roster_enabled and port == framework_web_port_default(key, base=base):
             failures.append(

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -21,6 +21,19 @@ stores, facility — in ascending offset order. Sorting the same addresses by
 service name would have hidden that shape behind a spelling, and left an
 operator with no way to see that the port they do not recognise is simply the
 next slot along.
+
+Reserved is not served
+----------------------
+The panel bands are the exception the block's own arithmetic creates: every
+roster user is allocated a port in every family whether or not the persona
+they run ever starts that server. Listing the whole roster beside every band —
+and listing a band no persona serves at all — told an operator that people
+answer at addresses nothing listens on. So each band names only the users whose
+rendered project declares that panel, a family nobody serves gets no row, and
+one closing note says which bands the block still reserves. Where the personas
+cannot be read the wide, pre-persona reading comes back: it is the honest
+answer when nothing on disk says otherwise, and this module never fails a
+deploy that otherwise succeeded.
 """
 
 from __future__ import annotations
@@ -334,6 +347,24 @@ def _service_address(service: str, bindings: list[HostPortBinding]) -> str:
 #: facility would push the row past any width and say nothing a count does not.
 _ROSTER_NAMES_SHOWN = 4
 
+#: The port family the terminal itself takes, as
+#: :data:`~osprey.deployment.web_terminals.ports.FAMILY_BASE_FIELDS` names it.
+#: The one family with no companion server behind it and no panel id to declare:
+#: every roster user has a terminal, which is what having a roster entry MEANS,
+#: so no persona's ``web.panels`` can add or remove it.
+_TERMINAL_FAMILY = "web"
+
+#: The service column of the one row that reports the bands nothing serves.
+#: Public because the tests key on it rather than on its spelling, and because
+#: a reader filtering the entries (the summary card keeps only ``http://``
+#: addresses) should be able to name it rather than pattern-match the text.
+RESERVED_BANDS_LABEL = "(reserved)"
+
+#: Sort position of that row inside the panels tier. Above every real family
+#: offset, so the note trails the bands it is a footnote to rather than landing
+#: among them.
+_RESERVED_SORT = 1_000_000_000
+
 
 def _roster(config: dict) -> list[tuple[str, int]]:
     """This deployment's web-terminal roster as ``(name, index)``, in order.
@@ -362,8 +393,179 @@ def _roster(config: dict) -> list[tuple[str, int]]:
     return roster or [("", 0)]
 
 
-def _panel_entries(config: dict) -> list[tuple[tuple[int, int, int, str], str, str, str]]:
-    """One row per port family, covering the whole roster's band.
+def _who_serves(names: list[str]) -> str:
+    """The ``(who)`` suffix of one band: the names, or how many there are.
+
+    Args:
+        names: The roster names on this band, in roster order. Empty for the
+            single-user deployment, whose one entry has no name to print.
+
+    Returns:
+        The names joined, a count past :data:`_ROSTER_NAMES_SHOWN`, or ``""``.
+    """
+    if len(names) > _ROSTER_NAMES_SHOWN:
+        return f"{len(names)} users"
+    return ", ".join(names)
+
+
+def _families_a_project_serves(project_config: object) -> set[str]:
+    """The port families one rendered project's panels actually listen on.
+
+    Read off ``web.panels`` exactly as the terminal reads it
+    (``web_terminal.app._load_panel_config``, and the health probe's
+    :func:`~osprey.health.core.web_panels._resolve_targets` beside it): a
+    built-in id is on when it is ``true`` or a mapping that has not switched
+    itself off, and :data:`~osprey.profiles.web_panels.UNIVERSAL_PANELS` is on
+    whatever the config says. A fourth reading of that block here would let the
+    summary claim a panel the container never starts.
+
+    Panel ids and port families are two namespaces (``artifacts`` is served by
+    registry key ``artifact`` on family ``artifact``; ``lattice`` by
+    ``lattice_dashboard`` on family ``lattice``), so the crossing goes through
+    :data:`~osprey.registry.web.PANEL_ID_TO_REGISTRY_KEY` and the definition's
+    own ``port_family`` rather than through a table kept here.
+
+    Args:
+        project_config: A persona's parsed rendered ``config.yml``. Anything
+            that is not a mapping reads as a project declaring no panels.
+
+    Returns:
+        Family names, always including :data:`_TERMINAL_FAMILY` — a project
+        that declares nothing still has the terminal the roster entry IS.
+    """
+    from osprey.profiles.web_panels import BUILTIN_PANELS, UNIVERSAL_PANELS
+    from osprey.registry.web import FRAMEWORK_WEB_SERVERS, PANEL_ID_TO_REGISTRY_KEY
+
+    web = project_config.get("web") if isinstance(project_config, dict) else None
+    declared = web.get("panels") if isinstance(web, dict) else None
+
+    enabled = set(UNIVERSAL_PANELS)
+    for panel_id, spec in (declared if isinstance(declared, dict) else {}).items():
+        if panel_id in BUILTIN_PANELS and (
+            spec is True or (isinstance(spec, dict) and spec.get("enabled", True))
+        ):
+            enabled.add(panel_id)
+
+    families = {_TERMINAL_FAMILY}
+    for panel_id in enabled:
+        key = PANEL_ID_TO_REGISTRY_KEY.get(panel_id)
+        if key is not None:
+            definition = FRAMEWORK_WEB_SERVERS[key]
+            families.add(definition.port_family or key)
+    return families
+
+
+def _families_by_user(config: dict, project_root: Path | str | None) -> dict[str, set[str]] | None:
+    """Which port families each roster user actually serves, or ``None``.
+
+    The narrowing behind :func:`_panel_entries`: a user's persona names a
+    rendered project, and that project's ``web.panels`` says which companion
+    servers its container starts. Every user is allocated a port in every
+    family regardless — the allocator reserves the whole block whatever the
+    roster runs — so without this walk the summary names every user beside
+    every band and tells an operator that people answer where they do not.
+
+    ALL OR NOTHING, deliberately. ``None`` means "nothing on disk answers this
+    question", and the caller then reports the wide, pre-persona bands. A
+    partial answer would be worse than either: a user whose persona could not
+    be resolved would silently vanish from every band he might be on, which
+    reads as "he serves nothing" rather than as "nothing here knows".
+
+    Advisory at every step, like everything else this module derives — an
+    unbuilt persona project, a catalog entry with no ``project_path``, an
+    ``authorization`` stanza that does not parse, a roster entry
+    :func:`~osprey.deployment.web_terminals.personas.normalize_users` cannot
+    place — each degrades to ``None`` rather than failing the summary that a
+    successful deploy ends with. Nothing here raises: two of this module's
+    three entry points call it without a guard, and a summary that crashes
+    after a deploy has already succeeded reports a failure that did not happen.
+
+    Args:
+        config: Loaded configuration dictionary.
+        project_root: The deployment repo, against which a catalog entry's
+            ``project_path`` resolves. ``None`` falls back to the rendered
+            config's own ``project_root``, which is the only anchor
+            ``osprey status`` has — it is handed a config and compose files and
+            no root at all.
+
+    Returns:
+        ``{user: families}`` covering the whole roster, or ``None`` when any
+        part of the roster cannot be placed.
+    """
+    from osprey.deployment.web_terminals.personas import (
+        effective_persona,
+        freeze_user_indices,
+        rendered_persona_configs,
+        resolve_authorization_roles,
+    )
+
+    root = project_root if project_root is not None else config.get("project_root")
+    if not root:
+        return None
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    users = web_terminals.get("users")
+    if not isinstance(users, list) or not users:
+        return None
+
+    # ONE reader of this roster's shape, shared with `_roster`.
+    # `freeze_user_indices` IS `normalize_users`' output with the keys the
+    # author wrote re-attached, which is what this walk needs and the bare
+    # normalizer cannot give it: `normalize_users` carries `role` through but
+    # drops `persona:`, and `effective_persona` reads both. Walking the raw
+    # list here instead would be a second spelling of "what a roster entry
+    # looks like" — one that could drift from the normalizer, and did: an
+    # entry the normalizer drops but a raw `.get("name")` chokes on (`- 42`)
+    # raised out of an advisory summary instead of degrading.
+    entries = freeze_user_indices(users)
+    if len(entries) != len(users):
+        # Some entry the file declares could not be placed at all. The roster
+        # this walk can describe is then not the roster that was written, and
+        # the all-or-nothing rule above says so rather than narrowing around
+        # the gap.
+        logger.debug("Panel bands not narrowed to their personas: unplaceable roster entry")
+        return None
+
+    try:
+        roles = resolve_authorization_roles(web_terminals)
+        serves = {
+            persona: _families_a_project_serves(project_config)
+            for persona, project_config in rendered_persona_configs(config, root).items()
+        }
+    except Exception as exc:
+        logger.debug(f"Panel bands not narrowed to their personas: {exc}")
+        return None
+
+    default_persona = web_terminals.get("default_persona")
+    by_user: dict[str, set[str]] = {}
+    for entry in entries:
+        name = entry["name"]
+        if not name:
+            # A nameless entry is the single-user shape, which reaches this
+            # walk only as a roster that spells it out; nothing here can say
+            # whose panels those are.
+            return None
+        try:
+            persona = effective_persona(entry, roles, default_persona, strict=False)
+        except Exception as exc:
+            logger.debug(f"Panel bands not narrowed to their personas: {exc}")
+            return None
+        if persona not in serves:
+            # No persona in effect (every pre-catalog roster), or one whose
+            # project is unset, unrendered or unreadable. Either way nothing
+            # says what this user serves, and a guess is not an answer.
+            return None
+        if name in by_user:
+            # Two entries under one name (lint refuses it; reachable past
+            # --no-lint) cannot be placed on their bands as written.
+            return None
+        by_user[name] = serves[persona]
+    return by_user
+
+
+def _panel_entries(
+    config: dict, project_root: Path | str | None = None
+) -> list[tuple[tuple[int, int, int, str], str, str, str]]:
+    """One row per port family, covering the band of the users who serve it.
 
     The panels are the largest stretch of the block and reach neither of the
     two binding sources: the per-user containers run on the host namespace, so
@@ -377,8 +579,20 @@ def _panel_entries(config: dict) -> list[tuple[tuple[int, int, int, str], str, s
     contribute twenty-eight rows to a list whose whole point is to show the
     shape of the block at a glance.
 
+    But only the users who SERVE it, wherever the personas can be read
+    (:func:`_families_by_user`). A band's address is a thing to open, and the
+    names beside it are the claim about who answers there; a persona that never
+    starts the LATTICE server has a port reserved in that band and nothing
+    listening on it. A family no persona serves gets no row at all, because a
+    row hedged with "reserved" would still carry the address that does not
+    answer — the same claim in smaller type. What the whole tier owes instead is
+    one closing note naming those bands, so a reader who counts six families
+    where the layout has seven knows the seventh was not lost.
+
     Args:
         config: Loaded configuration dictionary.
+        project_root: The deployment repo, for resolving the persona projects;
+            see :func:`_families_by_user`.
 
     Returns:
         Sortable rows in :func:`endpoint_entries`' own shape. Empty when the
@@ -399,29 +613,53 @@ def _panel_entries(config: dict) -> list[tuple[tuple[int, int, int, str], str, s
         # panel rows rather than the whole summary.
         return []
 
-    names = [name for name, _index in roster if name]
-    if len(names) > _ROSTER_NAMES_SHOWN:
-        who = f"{len(names)} users"
-    else:
-        who = ", ".join(names)
+    served = _families_by_user(config, project_root)
+    if served is not None and any(name not in served for name, _index in roster):
+        # `_roster` normalizes the raw list this walk read; a name that survived
+        # one and not the other leaves part of the roster unplaced, which is the
+        # all-or-nothing case _families_by_user documents.
+        served = None
 
     rows: list[tuple[tuple[int, int, int, str], str, str, str]] = []
+    unserved: list[str] = []
     for family in base_ports:
-        ports = sorted(user[family] for user in allocated)
-        first, last = ports[0], ports[-1]
+        members = [
+            (name, ports[family])
+            for (name, _index), ports in zip(roster, allocated, strict=True)
+            if served is None or family in served[name]
+        ]
+        if not members:
+            unserved.append(family)
+            continue
+        ports_on_band = sorted(port for _name, port in members)
+        first, last = ports_on_band[0], ports_on_band[-1]
         # A range is not an address anything can open, and the renderer would
         # linkify it into a URL that 404s on the dash. So the scheme goes on
         # only where there is one port to open — the same rule that keeps
         # `http://` off the graph store's bolt address.
         address = f"http://127.0.0.1:{first}" if first == last else f"127.0.0.1:{first}-{last}"
+        who = _who_serves([name for name, _port in members if name])
         if who:
             address = f"{address}  ({who})"
         tier, offset = _placement(family, first, None)
         rows.append(((_TIER_ORDER.index(tier), offset, first, family), tier, family, address))
+
+    if unserved:
+        tier, _offset = _placement(_TERMINAL_FAMILY)
+        rows.append(
+            (
+                (_TIER_ORDER.index(tier), _RESERVED_SORT, _RESERVED_SORT, ""),
+                tier,
+                RESERVED_BANDS_LABEL,
+                f"{', '.join(unserved)} — reserved by the block, served by no user",
+            )
+        )
     return rows
 
 
-def endpoint_entries(config: dict, compose_files: list[str]) -> list[tuple[str, str, str]]:
+def endpoint_entries(
+    config: dict, compose_files: list[str], *, project_root: Path | str | None = None
+) -> list[tuple[str, str, str]]:
     """Where a deployment's services are reachable, as ``(tier, service, address)``.
 
     The single derivation of "what answers where": the text summary below lays
@@ -450,6 +688,14 @@ def endpoint_entries(config: dict, compose_files: list[str]) -> list[tuple[str, 
         config: Loaded configuration dictionary.
         compose_files: Rendered compose file paths, spelled absolutely or
             resolvable from the working directory — they are opened here.
+        project_root: The deployment repo, for resolving the persona projects
+            that say which panel bands each roster user actually serves
+            (:func:`_families_by_user`). Optional because the caller that has
+            it (:func:`as_built_endpoint_entries`) and the caller that does not
+            (``osprey status``, which is handed a config and compose files)
+            must reach the same rows: unset falls back to the rendered config's
+            own ``project_root``, so both surfaces narrow the bands the same
+            way.
 
     Returns:
         One row per service, in block order, each ``(tier, service, address)``.
@@ -475,7 +721,9 @@ def endpoint_entries(config: dict, compose_files: list[str]) -> list[tuple[str, 
         # job; see `summary_title`.
         base = None
 
-    rows: list[tuple[tuple[int, int, int, str], str, str, str]] = _panel_entries(config)
+    rows: list[tuple[tuple[int, int, int, str], str, str, str]] = _panel_entries(
+        config, project_root
+    )
     for service, service_bindings in by_service.items():
         first_port = min(binding.host_port for binding in service_bindings)
         tier, offset = _placement(service, first_port, base)
@@ -562,6 +810,12 @@ def as_built_endpoint_entries(repo_root: Path | str) -> list[tuple[str, str, str
 
     Compose paths come back relative to the repo root and are anchored on it
     here, because :func:`endpoint_entries` opens them itself.
+
+    The repo is handed down as the persona root too, rather than left to the
+    ``project_root`` the rendered config declares: this caller was POINTED at a
+    deployment, and a build that ran somewhere else — a repo copied to another
+    host, a checkout moved — wrote a path belonging to a machine this one is
+    not. The live answer wins over the recorded one.
     """
     from osprey.deployment.container_lifecycle import as_built_compose_files
 
@@ -573,7 +827,7 @@ def as_built_endpoint_entries(repo_root: Path | str) -> list[tuple[str, str, str
         str(path if path.is_absolute() else root / path)
         for path in (Path(name) for name in as_built_compose_files(config, root))
     ]
-    return endpoint_entries(config, files)
+    return endpoint_entries(config, files, project_root=root)
 
 
 def _as_built_config(root: Path) -> dict | None:

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -34,6 +34,7 @@ from osprey.cli import output
 from osprey.cli.styles import Styles, data_table
 from osprey.deployment.compose_generator import (
     REPO_ID_LABEL,
+    audit_identity_dir,
     repo_identity,
     resolve_project_name,
     resolve_user_volume_names,
@@ -54,8 +55,15 @@ logger = get_logger("deployment.status")
 #: containers filed under the wrong project.
 PROJECT_LABEL = "osprey.project.name"
 
+#: How much of a pre-flight refusal reason a state cell carries. The findings
+#: are written for a log line and can be a sentence each; the Container column
+#: shares a table with two volume columns, and a cell that grows without bound
+#: reflows the whole table. Long enough to name the refusal, short enough that
+#: it stays one line — ``osprey logs`` has the untruncated text.
+PREFLIGHT_REASON_MAX_CHARS = 60
 
-def _format_state(state):
+
+def _format_state(state, preflight_reason=None):
     """Format a container ``State`` value as a colored status label.
 
     Shared by the project/other container tables (``_add_container_to_table``)
@@ -67,19 +75,179 @@ def _format_state(state):
     renderable, so a cell holding ``"[success]● Running[/success]"`` would print
     those brackets literally and take the column widths with it.
 
+    *preflight_reason* appends why the container's ``osprey web`` refused to
+    start. It defaults to ``None`` — the label of a row with nothing to add is
+    byte-identical to what it always was.
+
     :param state: Raw ``State`` value from the container runtime's ps output
     :type state: str
+    :param preflight_reason: Refusal reason from a fresh pre-flight marker, or
+        ``None`` when this container has none
+    :type preflight_reason: str | None
     :return: The label, styled for the state
     :rtype: rich.text.Text
     """
     if state == "running":
-        return Text("● Running", style=Styles.SUCCESS)
+        label = Text("● Running", style=Styles.SUCCESS)
     elif state == "exited":
-        return Text("● Stopped", style=Styles.ERROR)
+        label = Text("● Stopped", style=Styles.ERROR)
     elif state == "restarting":
-        return Text("● Restarting", style=Styles.WARNING)
+        label = Text("● Restarting", style=Styles.WARNING)
     else:
-        return Text(f"● {state}", style=Styles.DIM)
+        label = Text(f"● {state}", style=Styles.DIM)
+    if preflight_reason:
+        label.append(f" (preflight: {preflight_reason})", style=Styles.ERROR)
+    return label
+
+
+# ---------------------------------------------------------------------------
+# The pre-flight refusal marker
+# ---------------------------------------------------------------------------
+
+
+def _parse_container_time(raw):
+    """A timezone-aware UTC datetime from a runtime or marker timestamp, or ``None``.
+
+    Three shapes reach this, and none of them is negotiable at the source:
+    podman's ``ps`` reports ``StartedAt`` as a Unix epoch, ``docker inspect``
+    reports ``.State.StartedAt`` as RFC 3339 with NANOsecond precision (which
+    :meth:`~datetime.datetime.fromisoformat` will not parse), and the refusal
+    marker's first line is a plain ``datetime.now(UTC).isoformat()``.
+
+    Fails to ``None`` on anything else rather than raising: every caller's
+    fallback is "say nothing extra", and a status verb must not break on a
+    timestamp it did not recognise.
+
+    :param raw: Epoch number, epoch string, or ISO-8601/RFC-3339 text
+    :return: The instant, in UTC, or ``None``
+    :rtype: datetime.datetime | None
+    """
+    from datetime import UTC, datetime
+
+    if isinstance(raw, bool) or raw is None:
+        return None
+    if isinstance(raw, int | float):
+        try:
+            return datetime.fromtimestamp(float(raw), UTC)
+        except (OSError, OverflowError, ValueError):
+            return None
+    if not isinstance(raw, str):
+        return None
+
+    text = raw.strip()
+    if not text:
+        return None
+    if text.lstrip("-").isdigit():
+        return _parse_container_time(int(text))
+
+    text = text.replace("Z", "+00:00")
+    # RFC 3339 nanoseconds -> microseconds. `fromisoformat` accepts 3 or 6
+    # fractional digits and nothing else, and docker emits 9.
+    if "." in text:
+        head, _, tail = text.partition(".")
+        digits = ""
+        for char in tail:
+            if char.isdigit():
+                digits += char
+            else:
+                break
+        text = f"{head}.{digits[:6]}{tail[len(digits) :]}" if digits else head + tail[len(digits) :]
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _container_started_at(container, config):
+    """When this container's CURRENT incarnation started, or ``None``.
+
+    Free when the runtime already said so: podman's ``ps --format json`` carries
+    ``StartedAt``, and that record is already in hand. Docker's does not, so one
+    ``inspect`` is issued as a fallback — and only ever from the marker path
+    below, which asks after it exclusively for a container that HAS a refusal
+    marker. A healthy deployment therefore pays nothing for this.
+
+    :param container: One decoded ``ps`` record
+    :param config: Rendered config, for runtime selection; may be ``None``
+    :return: The start instant in UTC, or ``None`` when it could not be read
+    """
+    started = _parse_container_time(container.get("StartedAt"))
+    if started is not None:
+        return started
+
+    name = _container_display_name(container)
+    if name == "unknown":
+        return None
+    try:
+        runtime_bin = get_runtime_command(config)[0]
+        result = subprocess.run(
+            [runtime_bin, "inspect", "-f", "{{.State.StartedAt}}", name],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        return _parse_container_time(result.stdout.strip())
+    except Exception as exc:
+        logger.debug("Could not read StartedAt for %s: %s", name, exc)
+        return None
+
+
+def _preflight_refusal_reason(repo_root, identity, container, config):
+    """Why *identity*'s web terminal refused to start, when it just did.
+
+    The read half of the contract ``osprey web`` writes: on a pre-flight refusal
+    it writes ``<audit dir>/preflight-refused`` with an ISO-8601 UTC timestamp on
+    line 1 and the findings, ``- `` prefixed, below it. Under
+    ``restart: unless-stopped`` the container is then restarted forever, and a
+    status table that says only "Restarting" makes an operator go read logs to
+    learn something the deployment already wrote down.
+
+    Freshness is decided against the container's own start time, because
+    ``osprey web --skip-preflight`` deliberately leaves a stale marker in place:
+    a marker older than the incarnation on screen describes a launch that is no
+    longer running, and reporting it would attribute a refusal to a container
+    that did not refuse. A marker whose timestamp cannot be parsed is treated as
+    no marker at all.
+
+    Every failure — an unreadable audit zone, an identity that is not a legal
+    path segment, a runtime that will not answer — degrades to ``None``. This is
+    an annotation on a read-only report and must never be able to take it down.
+
+    :param repo_root: The deployment repo root, which the audit zone hangs off
+    :param identity: The roster username, which is also its audit identity
+    :param container: The user's decoded ``ps`` record
+    :param config: Rendered config, for runtime selection; may be ``None``
+    :return: The reason, truncated to :data:`PREFLIGHT_REASON_MAX_CHARS`, or ``None``
+    :rtype: str | None
+    """
+    # Function-local, like every other cross-package import in this module: the
+    # name is a constant on a click command module, and a deployment module that
+    # imports the CLI's verbs at module scope buys an import cycle for it.
+    from osprey.cli.web_cmd import PREFLIGHT_REFUSED_MARKER
+
+    try:
+        marker = audit_identity_dir(repo_root, identity) / PREFLIGHT_REFUSED_MARKER
+        if not marker.is_file():
+            return None
+        lines = marker.read_text(encoding="utf-8").splitlines()
+        written = _parse_container_time(lines[0]) if lines else None
+        if written is None:
+            return None
+        started = _container_started_at(container, config)
+        if started is not None and written < started:
+            return None
+
+        findings = [line.removeprefix("- ").strip() for line in lines[1:] if line.strip()]
+        reason = "; ".join(findings) if findings else "no reason recorded"
+        if len(reason) > PREFLIGHT_REASON_MAX_CHARS:
+            reason = reason[: PREFLIGHT_REASON_MAX_CHARS - 3] + "..."
+        return reason
+    except Exception as exc:
+        logger.debug("Could not read the pre-flight marker for %s: %s", identity, exc)
+        return None
 
 
 def _extract_web_terminal_user_names(users_raw):
@@ -289,7 +457,7 @@ def _container_table(containers):
     return table
 
 
-def _show_web_terminal_users(config, all_containers):
+def _show_web_terminal_users(config, all_containers, repo_root=None):
     """Print the per-user web terminal table, when this deployment has one.
 
     One row per rostered user: whether their container exists and what state it
@@ -298,6 +466,10 @@ def _show_web_terminal_users(config, all_containers):
 
     Silently does nothing when web terminals are off or the roster is empty:
     there is no table to draw, and an empty one would suggest otherwise.
+
+    :param repo_root: The deployment repo, whose ``var/audit/<user>`` holds the
+        pre-flight refusal markers. ``None`` means "not known here", and the
+        state cells are then exactly what they have always been.
     """
     modules_cfg = config.get("modules", {})
     web_terminals_cfg = (
@@ -340,11 +512,19 @@ def _show_web_terminal_users(config, all_containers):
     for user in user_names:
         container = by_name.get(web_container_name(facility_prefix, user))
         claude_config_volume, agent_data_volume = resolve_user_volume_names(config, user)
+        # Only for a container that EXISTS: a marker names why a launch refused,
+        # and there is no launch to explain for a user whose container was never
+        # created — nor any start time to date the marker against.
+        preflight_reason = (
+            _preflight_refusal_reason(repo_root, user, container, config)
+            if (container is not None and repo_root is not None)
+            else None
+        )
         table.add_row(
             user,
             Text("● Not created", style=Styles.DIM)
             if container is None
-            else _format_state(container.get("State", "unknown")),
+            else _format_state(container.get("State", "unknown"), preflight_reason),
             _format_volume_status(claude_config_volume),
             _format_volume_status(agent_data_volume),
         )
@@ -420,7 +600,10 @@ def show_status(config_path, *, console=None, styles=None):
         output.section("Other Osprey Containers:", ())
         output.table(_container_table(other_containers))
 
-    _show_web_terminal_users(config, all_containers)
+    # Same derivation of the repo root as the staleness check above: this legacy
+    # verb is handed the project's own config.yml, and the audit zone hangs off
+    # the directory holding it.
+    _show_web_terminal_users(config, all_containers, Path(config_path).resolve().parent)
 
     output.report("")
 
@@ -641,7 +824,7 @@ def _absolute_compose_files(compose_files, repo_root):
     ]
 
 
-def _print_endpoints_section(config, compose_files):
+def _print_endpoints_section(config, compose_files, repo_root=None):
     """Print where this deployment's services are reachable, as ``build/`` declares it.
 
     Derived from the published ports in the rendered compose files — the same
@@ -654,12 +837,19 @@ def _print_endpoints_section(config, compose_files):
     the renderer's section vocabulary rather than by a second one — and the
     heading and the tier grouping come from that module too, so status cannot
     section the same endpoints differently from the deploy that printed them.
+
+    *repo_root* is the LIVE checkout, and it is passed for the same reason
+    :func:`_absolute_compose_files` anchors the compose files on it: the panel
+    rows are narrowed against each persona's rendered project, and a checkout
+    that was moved or copied records a ``project_root`` pointing at the other
+    copy. ``None`` leaves ``endpoint_entries`` on that recorded key, which is
+    the right answer for a caller with no root to offer.
     """
     from osprey.deployment.deploy_summary import endpoint_entries, summary_rows, summary_title
 
     output.report("")
     try:
-        entries = endpoint_entries(config, compose_files)
+        entries = endpoint_entries(config, compose_files, project_root=repo_root)
     except Exception as exc:
         output.warn("The endpoint list could not be read from the build", str(exc))
         return
@@ -1021,9 +1211,9 @@ def show_repo_status(repo_root, *, console=None, styles=None, show_agents=False)
             as_built_compose_files(config, repo_root), repo_root
         )
         if compose_files:
-            _print_endpoints_section(config, compose_files)
+            _print_endpoints_section(config, compose_files, repo_root)
         if all_containers is not None:
-            _show_web_terminal_users(config, all_containers)
+            _show_web_terminal_users(config, all_containers, repo_root)
         _print_agent_section(repo_root, build_dir, config, show_agents=show_agents)
 
     output.report("")

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -1339,9 +1339,23 @@ def render_web_terminals(
         **auth_tls_ctx,
     }
     landing_cfg = as_dict(web_terminals.get("landing"))
+    # Which users reach their terminal by opening a `?token=` URL rather than by
+    # signing in — the auth posture, per user, that the landing cards carry.
+    # Derived by the ONE function that answers that question, the same one
+    # `osprey users login-url` refuses on the complement of, so the page and the
+    # CLI cannot end up disagreeing about who has a login. Resolved once for the
+    # whole roster here and threaded down as a name set, because the answer is a
+    # property of the deployment's posture, not of the card being built.
+    #
+    # Imported function-locally: deploy_summary reaches back into this module
+    # for `_auth_tls_context` (function-locally, for the same reason), so a
+    # module-level import here would close that loop.
+    from osprey.deployment.deploy_summary import token_login_users
+
+    token_login_names = frozenset(token_login_users(root))
     landing_ctx = {
         "facility_name": resolve_facility_name(root, ""),
-        "groups": _build_groups(landing_cfg, resolved_users),
+        "groups": _build_groups(landing_cfg, resolved_users, token_login_names),
         "theme_blocks": _landing_theme_blocks(root),
         "notices": _build_notices(landing_cfg, root),
         "footer": _landing_footer(landing_cfg),
@@ -1698,12 +1712,19 @@ def _landing_url(
     return _external_origin(root, nginx_port, tls_enabled=tls_enabled, tls_port=tls_port)
 
 
-def _user_card(resolved_user: dict[str, Any]) -> dict[str, Any]:
+def _user_card(resolved_user: dict[str, Any], token_login_names: frozenset[str]) -> dict[str, Any]:
     """Build one auto-populated ``users``-group landing card from a resolved roster entry.
 
-    The base shape is unchanged (``{label, url}``); a ``sublabel`` key is added
-    only when the entry resolved to a persona, so a no-persona roster keeps
-    producing exactly the same two-key items landing.html.j2 rendered before.
+    Every card carries ``token_login``, the auth posture this user's terminal is
+    entered under: ``True`` when the way in is that user's ``?token=`` URL,
+    ``False`` when a login page stands in front of it. Unlike ``sublabel`` it is
+    always present rather than added-when-set, because it answers a question
+    every card has an answer to — an absent key would read as "no posture"
+    rather than "signs in".
+
+    A ``sublabel`` key is added only when the entry resolved to a persona, so a
+    no-persona roster keeps producing exactly the same optional-key shape
+    landing.html.j2 rendered before.
 
     One case drops the badge even though a persona is in effect: when the
     persona name and the roster name are the same word. The badge exists to say
@@ -1718,14 +1739,21 @@ def _user_card(resolved_user: dict[str, Any]) -> dict[str, Any]:
     Args:
         resolved_user: One :func:`osprey.deployment.web_terminals.personas.resolve_personas`
             entry (``name`` and ``persona`` are read).
+        token_login_names: The roster names
+            :func:`osprey.deployment.deploy_summary.token_login_users` returned for
+            this deployment, membership in which is this card's ``token_login``.
 
     Returns:
-        ``{"label", "url"}`` for a persona-less user, plus ``"sublabel"`` (the
-        persona name) when ``persona`` is a non-empty string that differs from
-        the user's own name.
+        ``{"label", "url", "token_login"}`` for a persona-less user, plus
+        ``"sublabel"`` (the persona name) when ``persona`` is a non-empty string
+        that differs from the user's own name.
     """
     name = resolved_user["name"]
-    card: dict[str, Any] = {"label": name, "url": f"/u/{name}/"}
+    card: dict[str, Any] = {
+        "label": name,
+        "url": f"/u/{name}/",
+        "token_login": name in token_login_names,
+    }
     persona = resolved_user.get("persona")
     if isinstance(persona, str) and persona and persona.casefold() != name.casefold():
         card["sublabel"] = persona
@@ -1733,7 +1761,9 @@ def _user_card(resolved_user: dict[str, Any]) -> dict[str, Any]:
 
 
 def _build_groups(
-    landing_cfg: dict[str, Any], resolved_users: list[dict[str, Any]]
+    landing_cfg: dict[str, Any],
+    resolved_users: list[dict[str, Any]],
+    token_login_names: frozenset[str],
 ) -> list[dict[str, Any]]:
     """Transform config ``landing.groups`` into the template's ``groups`` shape:
     plain dicts with a ``label`` and an ``items`` key, since landing.html.j2
@@ -1748,8 +1778,10 @@ def _build_groups(
     persona name, shown as a secondary badge on the card; users with no persona
     in effect (every bare-string roster) omit the key entirely, so
     landing.html.j2's ``{% if item["sublabel"] %}`` guard renders them without
-    one. ``{type: "links", label, links}`` passes ``links`` straight through as
-    ``items`` (link cards never carry a ``sublabel``). Unrecognized/malformed
+    one. Every user card also carries ``token_login`` (see :func:`_user_card`),
+    the auth posture that user's terminal is entered under.
+    ``{type: "links", label, links}`` passes ``links`` straight through as
+    ``items`` (link cards carry neither a ``sublabel`` nor a posture). Unrecognized/malformed
     group entries are dropped rather than raising: lint is the authoritative
     gate on schema well-formedness, this is just the render-time adapter.
 
@@ -1779,6 +1811,11 @@ def _build_groups(
             and ``/u/<name>/`` url, its ``persona`` (when not ``None``) the
             optional ``sublabel``, and its ``landing_group`` (when present) the
             section it is lifted into.
+        token_login_names: The roster names
+            :func:`osprey.deployment.deploy_summary.token_login_users` returned for
+            this deployment, threaded down onto each user card as ``token_login``.
+            ``links`` groups get no posture — a link is not a terminal — so this
+            reaches ``users`` groups only.
     """
     groups_raw = landing_cfg.get("groups")
     if not isinstance(groups_raw, list) or not groups_raw:
@@ -1789,7 +1826,7 @@ def _build_groups(
         entry = as_dict(entry)
         group_type = entry.get("type")
         if group_type == "users":
-            groups.extend(_user_groups(resolved_users, entry.get("label")))
+            groups.extend(_user_groups(resolved_users, entry.get("label"), token_login_names))
         elif group_type == "links":
             links = entry.get("links")
             items = [as_dict(link) for link in links] if isinstance(links, list) else []
@@ -1797,7 +1834,11 @@ def _build_groups(
     return groups
 
 
-def _user_groups(resolved_users: list[dict[str, Any]], default_label: Any) -> list[dict[str, Any]]:
+def _user_groups(
+    resolved_users: list[dict[str, Any]],
+    default_label: Any,
+    token_login_names: frozenset[str],
+) -> list[dict[str, Any]]:
     """Split one ``{type: "users"}`` entry into its default section plus a tray
     section per distinct persona ``landing_group``.
 
@@ -1813,6 +1854,9 @@ def _user_groups(resolved_users: list[dict[str, Any]], default_label: Any) -> li
         default_label: The ``{type: "users"}`` entry's own ``label``, used as the
             heading for the ungrouped users. Anything that is not a non-empty
             string falls back to ``"Terminals"``.
+        token_login_names: Passed straight to :func:`_user_card`, which turns
+            membership into that card's ``token_login``. Sectioning is
+            presentation; the posture is the same wherever a user's card lands.
 
     Returns:
         ``[{label, items}, {label, items, variant: "tray"}, ...]``.
@@ -1824,7 +1868,7 @@ def _user_groups(resolved_users: list[dict[str, Any]], default_label: Any) -> li
     trays: dict[str, list[dict[str, Any]]] = {}
     for user in resolved_users:
         group = user.get("landing_group")
-        card = _user_card(user)
+        card = _user_card(user, token_login_names)
         if isinstance(group, str) and group:
             trays.setdefault(group, []).append(card)
         else:

--- a/src/osprey/infrastructure/server_launcher.py
+++ b/src/osprey/infrastructure/server_launcher.py
@@ -8,11 +8,14 @@ at call time so the infrastructure layer never imports from interfaces/.
 
 from __future__ import annotations
 
+import errno
 import importlib
 import logging
+import os
 import socket
 import threading
 import time
+import urllib.error
 import urllib.request
 from collections.abc import Callable
 from functools import partial
@@ -28,18 +31,47 @@ from osprey.utils.workspace import load_osprey_config
 
 logger = logging.getLogger("osprey.infrastructure.server_launcher")
 
-# When a port is already held on first check, it may be a predecessor that is
-# still shutting down after a restart. Wait a bounded grace period for it to
-# release the port so we can bind (own) it ourselves rather than trusting a
-# possibly-dying external responder. See issue #327.
+# When a port is genuinely unbindable on first check, it may be a predecessor
+# that is still shutting down after a restart. Wait a bounded grace period for
+# it to release the port so we can bind (own) it ourselves rather than trusting
+# a possibly-dying external responder. See issue #327. A socket left in
+# TIME_WAIT is *bindable* (the probe mirrors uvicorn's ``SO_REUSEADDR``), so it
+# never reaches this loop and never delays startup.
 _PORT_RELEASE_GRACE_ATTEMPTS = 5
 _PORT_RELEASE_GRACE_INTERVAL = 0.5
 
-# When a port stays held by a process that does not answer /health, we cannot
-# bind it now, but it may free up later (a lazy caller like artifact_store
+# After any refusal verdict in _adopt_or_refuse — the listener could not be
+# attributed to this deployment, whatever the probes said — we cannot bind the
+# port now, but it may free up later (a lazy caller like artifact_store
 # re-invokes ensure_running on every save). Re-probe at most this often so a
-# panel can self-heal without paying the grace cost on every call.
+# panel can self-heal without paying the probe cost on every call.
 _HELD_PORT_RETRY_COOLDOWN = 30.0
+
+#: The route the adoption probes ask, and it must NOT be an exempt one.
+#: ``/health`` and the rest of
+#: :data:`osprey.interfaces.common_middleware.EXEMPT_PATHS` are reachable with
+#: no credential at all — any OSPREY checkout on the machine answers ``/health``
+#: with a 200 — so they carry no information about *whose* server is listening.
+#: ``/`` is not exempt, and the auth gate answers it before routing, so the
+#: probe reads the gate's verdict rather than a panel's route table: a panel
+#: that happens not to serve an index still answers 401 unauthenticated and a
+#: non-401 (404) credentialed, which is exactly the discrimination this needs.
+_ADOPTION_PROBE_PATH = "/"
+
+#: Seconds either adoption probe waits. Both run only on the already-degraded
+#: path where the port could not be bound, never on a clean start.
+_ADOPTION_PROBE_TIMEOUT = 1.0
+
+#: The header the credentialed probe carries the operator secret in. Mirrors
+#: :data:`osprey.interfaces.common_middleware.OPERATOR_SECRET_HEADER` rather
+#: than importing it, because infrastructure/ does not import interfaces/; the
+#: two spellings are pinned equal by a test.
+_OPERATOR_SECRET_HEADER = "x-osprey-terminal-secret"
+
+#: The environment carrier for this process's operator secret. Mirrors
+#: :data:`osprey.interfaces.web_auth.OPERATOR_SECRET_ENV`, pinned by the same
+#: test. Only a *carrier*: see :meth:`ServerLauncher._operator_secret`.
+_OPERATOR_SECRET_ENV = "OSPREY_TERMINAL_SECRET"
 
 
 def _loopback_for(host: str) -> str:
@@ -54,6 +86,57 @@ def _loopback_for(host: str) -> str:
     if host == "::":
         return "::1"
     return host
+
+
+def _probe_url(host: str, port: int, path: str) -> str:
+    """The URL a probe of *host:port* opens, with the client-side rules applied.
+
+    Two of them, and both belong to every probe this module makes rather than to
+    any one of them: a wildcard bind host is addressed via its loopback (see
+    :func:`_loopback_for`, because the wildcard is not a valid destination), and
+    an IPv6 literal is bracketed so the ``:port`` suffix is not read as part of
+    the address.
+    """
+    probe_host = _loopback_for(host)
+    netloc = f"[{probe_host}]" if ":" in probe_host else probe_host
+    return f"http://{netloc}:{port}{path}"
+
+
+def _describe_status(status: int | None) -> str:
+    """Render one adoption-probe outcome for the operator-facing log line."""
+    return "no answer" if status is None else f"HTTP {status}"
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """A redirect handler that refuses to follow, so a 3xx is its own status.
+
+    The adoption verdict is about the listener *on this port*, and the default
+    opener would destroy exactly that: it follows a 3xx transparently and
+    reports the final hop's status as if the port had answered it. Worse, it
+    re-sends every header it was given — including
+    :data:`_OPERATOR_SECRET_HEADER` — to whatever host the ``Location`` names,
+    which would hand this process's operator secret to a destination chosen by
+    the very listener under suspicion.
+
+    Returning ``None`` from ``redirect_request`` makes urllib fall through to
+    ``HTTPDefaultErrorHandler``, which raises ``HTTPError`` carrying the 3xx
+    code — so :meth:`ServerLauncher._probe_status` reports the redirect itself.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        """Never follow: the listener's own first response is the verdict."""
+        return None
+
+
+def _probe_opener(*extra: urllib.request.BaseHandler) -> urllib.request.OpenerDirector:
+    """Build the opener the adoption probes use, redirect-following removed.
+
+    ``build_opener`` drops a default handler when a supplied one subclasses it,
+    so passing :class:`_NoRedirectHandler` replaces the redirect-following
+    default rather than stacking on top of it. *extra* handlers let a test
+    substitute the transport without rebuilding the rest of the chain.
+    """
+    return urllib.request.build_opener(_NoRedirectHandler(), *extra)
 
 
 class ServerLauncher:
@@ -94,18 +177,79 @@ class ServerLauncher:
         self._held_port_retry_cooldown = held_port_retry_cooldown
         self._launched = False
         # Monotonic deadline before which ensure_running() short-circuits after
-        # a "port held by a non-responder" outcome (see ensure_running).
+        # a refusal verdict (see ensure_running).
         self._retry_not_before = 0.0
+        # Set once _adopt_or_refuse has refused. The grace window exists for a
+        # shutting-down predecessor, and a predecessor gets exactly one; after a
+        # refusal the holder is established, so later calls skip straight to the
+        # verdict instead of sleeping through the window on every save. Reset by
+        # _launch_in_thread: a committed launch ends the episode this describes.
+        self._refused_once = False
+        # The (unauthenticated status, credentialed outcome) pair of the last
+        # refusal, so an unchanged verdict logs at info rather than warning.
+        # Reset alongside _refused_once, and for the same reason.
+        self._last_refusal: tuple[int | None, str] | None = None
         self._lock = threading.Lock()
 
-    def _port_has_listener(self, host: str, port: int) -> bool:
-        """Return True if a live TCP listener is bound to *host:port*.
+    def _port_is_bindable(self, host: str, port: int) -> bool:
+        """Return True if this process could bind *host:port* right now.
 
-        This is a truer "is the port taken?" signal than a ``/health`` 200:
-        it answers the ownership question directly instead of conflating
-        "the port is bound" with "the bound thing is a healthy HTTP server".
-        A wildcard bind host is probed via loopback, which the same listener
-        also accepts.
+        This is the ownership verdict, and it is the only question that
+        matters before a launch: not "can something be reached there?" but
+        "will our own ``bind()`` succeed?". It is asked by performing exactly
+        that bind, so probe and server cannot disagree:
+
+        * the address family follows the SPELLING of the host string, not a
+          name lookup: a host containing ``:`` is probed as ``AF_INET6``, every
+          other as ``AF_INET``. A hostname such as ``localhost`` therefore gets
+          an IPv4-only probe even where it resolves to both families, so a
+          listener holding only its IPv6 address is invisible here; that
+          conflict surfaces at launch instead, as the "thread exited before
+          health check passed" warning from :meth:`_launch_in_thread`;
+        * the EXACT ``(host, port)`` the server will bind is probed — a
+          wildcard host binds the wildcard, never a substituted loopback,
+          because a wildcard bind conflicts with listeners a loopback probe
+          would miss;
+        * ``SO_REUSEADDR`` is set to mirror uvicorn's listener, so a socket
+          left in ``TIME_WAIT`` reads as bindable for the probe exactly as it
+          is for the server;
+        * only ``EADDRINUSE`` and ``EACCES`` mean the port is taken. Any other
+          ``OSError`` says the probe itself could not answer — that is logged
+          as a diagnostic and does NOT count as taken, so a probe defect can
+          never silently suppress a launch.
+
+        A listener that answers a connect but does not block this bind (a
+        Docker Desktop host-loopback pass-through, say) is a foreign host-side
+        listener, not an owner of this port: see :meth:`_port_answers_connect`.
+        """
+        family = socket.AF_INET6 if ":" in host else socket.AF_INET
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as sock:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.bind((host, port))
+            return True
+        except OSError as exc:
+            if exc.errno in (errno.EADDRINUSE, errno.EACCES):
+                return False
+            logger.warning(
+                "%s bind probe of %s:%s was inconclusive (%s); treating the port as free",
+                self._name,
+                host,
+                port,
+                exc,
+            )
+            return True
+
+    def _port_answers_connect(self, host: str, port: int) -> bool:
+        """Return True if a TCP connect to *host:port* is accepted.
+
+        Diagnostics only — never a verdict. A connect can succeed against a
+        listener that does not block our bind at all (the Docker Desktop
+        host-loopback pass-through), and it can fail against a listener that
+        does. Ownership is decided by :meth:`_port_is_bindable`; this probe
+        exists to explain what an operator can otherwise see with ``curl``.
+        A wildcard bind host is probed via loopback, which a listener on the
+        wildcard also accepts.
         """
         try:
             with socket.create_connection((_loopback_for(host), port), timeout=1):
@@ -115,15 +259,251 @@ class ServerLauncher:
 
     def _is_running(self, host: str, port: int) -> bool:
         """Check the /health endpoint (quick, no dependencies)."""
-        probe_host = _loopback_for(host)
-        netloc = f"[{probe_host}]" if ":" in probe_host else probe_host
         try:
-            url = f"http://{netloc}:{port}/health"
-            req = urllib.request.Request(url, method="GET")
+            req = urllib.request.Request(_probe_url(host, port, "/health"), method="GET")
             with urllib.request.urlopen(req, timeout=1) as resp:
                 return resp.status == 200
         except Exception:
             return False
+
+    def _operator_secret(self) -> str | None:
+        """Return this process's operator secret, or None if it holds none.
+
+        Two sources, in this order, because the environment variable is a
+        *carrier* rather than the store: ``osprey web`` publishes the minted
+        secret into ``OSPREY_TERMINAL_SECRET`` so whatever it spawns or becomes
+        inherits one value, and the receiving process then POPS it into a
+        process-wide holder at app construction (``web_auth._populate``, and
+        ``close_env_carriers`` on the direct-serve path) precisely so no agent
+        subprocess inherits it. Reading only the environment would therefore
+        find nothing in the hub that has been serving for any length of time —
+        the one process for which adoption is worth deciding.
+
+        So: the carrier first (a process that has not populated yet, which is
+        also the only case where the two could differ in timing), then the
+        in-process holder — read with ``peek_web_credentials``, which returns
+        what is already there and NEVER populates.
+
+        Populating here would be a bug, not a slower path. The most frequent
+        caller of ``ensure_*_server`` is the MCP server the agent spawns, on
+        every artifact save, and its environment deliberately carries a
+        re-introduced panel token and no operator secret at all. In that process
+        ``get_web_credentials`` would MINT a fresh operator secret and panel
+        token that nothing else in the deployment recognises — a fabricated
+        identity offered to the credentialed probe, and a misdiagnosed warning
+        when the probe then fails — and would pop the panel token out of
+        ``os.environ`` on the way, racing the panel-auth latch and stripping the
+        carrier from every child spawned afterwards. "This process holds no
+        operator identity" is the honest answer here, and the caller refuses on
+        it.
+
+        The holder is reached by a call-time import, the same deferral
+        :func:`_make_app_factory` uses, so this module still has no import-time
+        dependency on interfaces/.
+        """
+        carried = (os.environ.get(_OPERATOR_SECRET_ENV) or "").strip()
+        if carried:
+            return carried
+        try:
+            from osprey.interfaces.web_auth import peek_web_credentials
+
+            credentials = peek_web_credentials()
+        except Exception as exc:
+            logger.debug("%s could not read this process's operator secret (%s)", self._name, exc)
+            return None
+        if credentials is None:
+            return None
+        return (credentials.operator_secret or "").strip() or None
+
+    def _probe_status(self, host: str, port: int, secret: str | None = None) -> int | None:
+        """GET :data:`_ADOPTION_PROBE_PATH` on *host:port*; return its HTTP status.
+
+        Returns None when nothing answered with HTTP at all (connection
+        refused, timeout, a non-HTTP process holding the port) — distinct from
+        any status, because "did not answer" and "answered 401" support
+        opposite conclusions about what is listening.
+
+        Redirects are NOT followed (see :class:`_NoRedirectHandler`): the
+        verdict must be the listener's own first response, and following a 3xx
+        would both mask it and re-send the secret header to a destination that
+        listener chose.
+
+        Args:
+            host: The configured bind host; a wildcard is probed via loopback.
+            port: The configured port.
+            secret: When given, carried in :data:`_OPERATOR_SECRET_HEADER`.
+                The value itself is never logged.
+        """
+        url = _probe_url(host, port, _ADOPTION_PROBE_PATH)
+        headers = {_OPERATOR_SECRET_HEADER: secret} if secret else {}
+        req = urllib.request.Request(url, method="GET", headers=headers)
+        try:
+            with _probe_opener().open(req, timeout=_ADOPTION_PROBE_TIMEOUT) as resp:
+                return int(resp.status)
+        except urllib.error.HTTPError as exc:
+            # A 401 is the informative answer here, and urllib raises it.
+            return int(exc.code)
+        except Exception:
+            return None
+
+    def _adopt_or_refuse(self, host: str, port: int) -> None:
+        """Decide what a port we could not bind is, and act on the verdict.
+
+        Called only after the release grace window has passed, so something is
+        holding this port for good. The question is whether that something is
+        this deployment's own panel — in which case there is nothing to launch
+        and we should stop trying — or a stranger, in which case adopting it
+        would hand the operator a panel backed by a server this process cannot
+        talk to.
+
+        ``/health`` cannot answer that question and takes no part in it: it is
+        exempt from the auth gate by design, so every OSPREY checkout on the
+        machine answers it 200. Credentials can, and the evidence is two-sided:
+
+        * unauthenticated probe 401 **and** credentialed probe non-401 — the
+          listener demands a credential and accepts *ours*, so it is our own
+          panel under a shared ``OSPREY_TERMINAL_SECRET``. Adopt it: latch, so
+          a per-call caller stops re-probing;
+        * anything else — a 200 to the unauthenticated probe (an open server
+          that gates nothing), a 401 to both (a server holding a different
+          secret), no answer at all, or no operator secret in this process to
+          probe with — is not attributable. Refuse: do not latch, warn naming
+          the listener and both probe outcomes, and set the cooldown so the
+          launcher self-heals when the port frees.
+
+        The credentialed probe runs ONLY when the unauthenticated one answered
+        401. That is both a saving and a rule: a listener that just served an
+        ungated 200 has demonstrated it does not check credentials, and this
+        process must not hand its operator secret to it to find that out twice.
+
+        For the same reason the local secret is *looked up* only in that branch.
+        Consulting the credential holder is not free — it is the one question
+        whose asking can change the answer (see :meth:`_operator_secret`) — so a
+        listener that answered 200, 503 or nothing is refused without this
+        process ever asking who it is.
+
+        Two refusals carry their own advice rather than the generic one, because
+        the generic advice ("a foreign server, or one holding a different
+        secret — stop it") would be a fabrication for them: a 503 is an OSPREY
+        gate that could not populate its own credentials, so the fault named is
+        that service's configuration; and a listener this process holds no
+        identity to question at all is equally consistent with our own panel.
+
+        Repeat refusals are demoted to ``info``: the default topology re-enters
+        this path on every artifact save once the cooldown expires, and an
+        unchanged verdict is not news. A *changed* outcome pair warns again.
+        """
+        unauthenticated = self._probe_status(host, port)
+        no_identity = False
+
+        if unauthenticated is None:
+            credentialed_outcome = "not attempted (nothing answered the first probe)"
+            credentialed = None
+        elif unauthenticated == 503:
+            credentialed_outcome = (
+                "not attempted — the listener's auth gate is unavailable, HTTP 503"
+            )
+            credentialed = None
+        elif unauthenticated != 401:
+            credentialed_outcome = (
+                f"not attempted (the listener answered HTTP {unauthenticated} "
+                "without demanding a credential)"
+            )
+            credentialed = None
+        else:
+            secret = self._operator_secret()
+            if secret is None:
+                no_identity = True
+                credentialed_outcome = "not attempted (this process holds no operator secret)"
+                credentialed = None
+            else:
+                credentialed = self._probe_status(host, port, secret)
+                credentialed_outcome = _describe_status(credentialed)
+
+        if unauthenticated == 401 and credentialed is not None and credentialed != 401:
+            logger.info(
+                "%s: adopting the server already listening at %s:%s — it refused an "
+                "unauthenticated %s (401) and accepted this process's operator secret "
+                "(%s), so it is this deployment's own panel. Not launching a second one.",
+                self._name,
+                host,
+                port,
+                _ADOPTION_PROBE_PATH,
+                credentialed_outcome,
+            )
+            self._launched = True
+            return
+
+        # Warn once per DISTINCT verdict. The first refusal, and any later one
+        # that says something new, is operator-facing news; a repeat of the same
+        # pair on the next save is not, and warning on every save would train the
+        # operator to ignore the channel that carries the real change.
+        outcomes = (unauthenticated, credentialed_outcome)
+        emit = logger.info if outcomes == self._last_refusal else logger.warning
+
+        if no_identity:
+            # The listener gates, and this process cannot say whose gate it is.
+            # It must not guess out loud: from here the listener is equally
+            # consistent with this deployment's own hub-owned panel (in which
+            # case the panel is fine and there is nothing to stop) and with a
+            # stranger's server. Advice either way would be a fabrication.
+            emit(
+                "%s: %s:%s is held by a listener that demands a credential "
+                "(unauthenticated probe of %s: HTTP 401), but this process holds no "
+                "operator secret: none in the %s carrier, and no populated credential "
+                "holder. Without an operator identity it cannot attribute that "
+                "listener to this deployment or to a stranger. Not launching a second "
+                "server on that port, and not guessing what the listener serves. "
+                "Will retry on a later call.",
+                self._name,
+                host,
+                port,
+                _ADOPTION_PROBE_PATH,
+                _OPERATOR_SECRET_ENV,
+            )
+        elif unauthenticated == 503:
+            # A 503 to the gate's own route is an OSPREY auth gate that could
+            # not populate its credentials — it is answering for nobody, so it
+            # cannot be attributed either way, and the generic advice would be
+            # wrong twice over: this is very likely not a "foreign" server, and
+            # telling the operator to stop it hides the configuration fault
+            # that is the actual thing to fix.
+            emit(
+                "%s: %s:%s is held by a listener whose auth gate answered HTTP 503 to an "
+                "unauthenticated probe of %s, which is an OSPREY gate that could not populate "
+                "its own credentials. A gate answering for nobody cannot be attributed to this "
+                "deployment or to a stranger, and this process will not offer its operator "
+                "secret to it to find out. Check that service's %s and bind-host "
+                "configuration. Not launching a second server on that port. Will retry on a "
+                "later call.",
+                self._name,
+                host,
+                port,
+                _ADOPTION_PROBE_PATH,
+                _OPERATOR_SECRET_ENV,
+            )
+        else:
+            emit(
+                "%s: %s:%s is held by a listener this process cannot attribute to itself. "
+                "Unauthenticated probe of %s: %s; credentialed probe: %s. Only a 401 to the "
+                "first and a non-401 to the second identify it as this deployment's own panel; "
+                "anything else is a foreign server, or one holding a different "
+                "%s than this process, so credentialed calls between them would be refused. "
+                "The panel will be unbacked (502) until the port is free. Stop the other "
+                "server and let this process own it, or point both at the same deployment. "
+                "Will retry on a later call.",
+                self._name,
+                host,
+                port,
+                _ADOPTION_PROBE_PATH,
+                _describe_status(unauthenticated),
+                credentialed_outcome,
+                _OPERATOR_SECRET_ENV,
+            )
+
+        self._last_refusal = outcomes
+        self._refused_once = True
+        self._retry_not_before = time.monotonic() + self._held_port_retry_cooldown
 
     def _launch_in_thread(self, host: str, port: int) -> None:
         """Start uvicorn in a daemon thread."""
@@ -145,6 +525,16 @@ class ServerLauncher:
             except Exception:
                 logger.exception("%s thread crashed", self._name)
                 self._launched = False
+
+        # Committing to a launch ends the held-port episode the refusal memory
+        # describes: the port was ours to take, so whatever was holding it is
+        # gone. Both fields are scoped to ONE continuous episode — carrying them
+        # across a launch would deny the next episode its grace window (a fresh
+        # predecessor is exactly what that window is for) and demote its first
+        # refusal to ``info`` for matching a verdict about a listener that no
+        # longer exists.
+        self._refused_once = False
+        self._last_refusal = None
 
         t = threading.Thread(target=_run, daemon=True, name=self._name.lower().replace(" ", "-"))
         t.start()
@@ -181,18 +571,30 @@ class ServerLauncher:
 
         Safe to call multiple times — no-op after first launch.
 
-        Ownership is decided by whether a live TCP listener holds the port,
-        not by a bare ``/health`` 200. A ``/health`` 200 from a stale or
-        foreign responder is a false positive: acting on it makes the manager
-        skip the launch and leave the panel unbacked (proxy 502) after a
-        restart. Instead:
+        Ownership is decided by whether we can actually bind the port, not by
+        a bare ``/health`` 200 and not by whether something answers a connect.
+        A ``/health`` 200 from a stale or foreign responder is a false
+        positive: acting on it makes the manager skip the launch and leave the
+        panel unbacked (proxy 502) after a restart. And a connect that is
+        answered by a listener which does not block our bind (a Docker Desktop
+        host-loopback pass-through) is not an owner at all. Instead:
 
-        * port free            -> launch and own it;
-        * port held then freed -> a shutting-down predecessor; waited out,
-          then launched;
-        * port held throughout  -> defer to a legitimate external server if it
-          serves ``/health`` (latched); else warn and retry on a later call so a
-          lazily-relaunched panel can self-heal once the port frees.
+        * port bindable          -> launch and own it, whatever answers a
+          connect there;
+        * unbindable then freed  -> a shutting-down predecessor; waited out,
+          then launched. A ``TIME_WAIT`` remnant is bindable and never reaches
+          this branch, so it no longer delays startup, and the wait is offered
+          once per held-port episode: after a refusal the holder is
+          established, so later calls go straight from the bind check to the
+          verdict — until a launch is committed, which ends the episode and
+          restores the window for the next predecessor;
+        * unbindable throughout  -> adopt the listener only if a credentialed
+          probe pair attributes it to this deployment (latched); otherwise
+          refuse it, warn (repeat refusals with an unchanged verdict drop to
+          ``info``), and retry on a later call so a lazily-relaunched panel can
+          self-heal once the port frees. See :meth:`_adopt_or_refuse`;
+          ``/health`` takes no part in that verdict, because it is exempt from
+          the auth gate and so answers 200 for any OSPREY process at all.
         """
         if not self._auto_launch_checker():
             return
@@ -212,59 +614,43 @@ class ServerLauncher:
 
             host, port = self._config_reader()
 
-            # Nothing listening -> the port is ours to take.
-            if not self._port_has_listener(host, port):
+            # We can bind it -> the port is ours to take. Something may still
+            # answer a connect there (a host-side listener the container's bind
+            # does not contend with); say so, then launch anyway.
+            if self._port_is_bindable(host, port):
+                if self._port_answers_connect(host, port):
+                    logger.info(
+                        "%s: %s:%s answers a TCP connect but does not block our bind — a "
+                        "foreign host-side listener (e.g. a Docker Desktop loopback "
+                        "pass-through), not an owner of this port. Launching.",
+                        self._name,
+                        host,
+                        port,
+                    )
                 self._launch_in_thread(host, port)
                 return
 
-            # Held on first check. Give a shutting-down predecessor a bounded
-            # grace period to release the port so we can bind it ourselves.
-            for _attempt in range(self._release_grace_attempts):
-                time.sleep(self._release_grace_interval)
-                if not self._port_has_listener(host, port):
-                    self._launch_in_thread(host, port)
-                    return
+            # Unbindable on first check. Give a shutting-down predecessor a
+            # bounded grace period to release the port so we can bind it
+            # ourselves. Only a genuinely unbindable port waits here — and only
+            # the first time: once we have refused this port, the holder is
+            # established rather than departing, and a per-save caller must not
+            # pay the whole window (holding self._lock) again on every call. A
+            # port that has since been freed still launches, via the bindable
+            # check above that every call makes first.
+            if not self._refused_once:
+                for _attempt in range(self._release_grace_attempts):
+                    time.sleep(self._release_grace_interval)
+                    if self._port_is_bindable(host, port):
+                        self._launch_in_thread(host, port)
+                        return
 
-            # Still held after the grace window. A live /health responder is a
-            # legitimate server owned by another process — defer to it (latched).
-            if self._is_running(host, port):
-                logger.info(
-                    "%s already served by another process at %s:%s — deferring launch",
-                    self._name,
-                    host,
-                    port,
-                )
-                # That external server is a DIFFERENT process, so it minted its
-                # own OSPREY_TERMINAL_SECRET (and panel token) — not the ones
-                # this hub holds. A companion launched in-thread would share this
-                # process's credentials; a deferred external one does not, so the
-                # panel/operator calls this hub authenticates with its own
-                # secret will be refused (401) by that server. Name the variable
-                # so an operator debugging the mismatch knows which credential
-                # diverged and that re-launching under one hub is the fix.
-                logger.warning(
-                    "%s at %s:%s is an external process this hub does not own; it holds a "
-                    "different OSPREY_TERMINAL_SECRET than this process, so credentialed calls "
-                    "between them will be rejected. Stop the external server and let this hub "
-                    "own it, or point both at the same deployment, if panels do not authenticate.",
-                    self._name,
-                    host,
-                    port,
-                )
-                self._launched = True
-            else:
-                # Held by something that does not answer /health; we cannot bind
-                # now. Do not latch — throttle and retry so the panel recovers if
-                # the port frees later.
-                logger.warning(
-                    "%s port %s:%s is held by a process that does not answer /health; "
-                    "the panel will be unbacked (502) until the port is free. "
-                    "Will retry on a later call.",
-                    self._name,
-                    host,
-                    port,
-                )
-                self._retry_not_before = time.monotonic() + self._held_port_retry_cooldown
+            # Still unbindable after the grace window: something holds this port
+            # for good. Whether we stand down for it is a question about WHOSE
+            # server it is, and only a credential can answer that — see
+            # _adopt_or_refuse. Credentialed probes are paid only here, on this
+            # already-degraded path; a clean start never reaches them.
+            self._adopt_or_refuse(host, port)
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/interfaces/design_system/generator/emit_js.py
+++ b/src/osprey/interfaces/design_system/generator/emit_js.py
@@ -54,6 +54,7 @@ from osprey.interfaces.design_system.generator.validate import VALID_THEME_MODES
 
 __all__ = [
     "GENERATED_HEADER_LINES",
+    "SCOPE_ATTRIBUTE",
     "STORAGE_KEY",
     "ThemeManifestEntry",
     "ThemeFamilyDefaultsError",
@@ -64,11 +65,33 @@ __all__ = [
     "render_theme_boot_js",
 ]
 
-#: localStorage key theme-manager.js (hub role) persists the user's choice
-#: under. Duplicated here (not imported from anywhere) because it must be
-#: baked into theme-boot.js as a literal; kept as a named constant so the
-#: two occurrences below can't drift from each other.
+#: Base localStorage key theme-manager.js (hub role) persists the user's
+#: choice under. Duplicated here (not imported from anywhere) because it must
+#: be baked into theme-boot.js as a literal; kept as a named constant so the
+#: two occurrences below can't drift from each other. theme-manager.js's
+#: module-level ``const STORAGE_KEY`` declares the SAME literal a third time,
+#: deliberately — it is a hand-written
+#: ES module and this is a Python constant, so neither can import the other.
+#: Keep the pair in sync, INCLUDING the scoping rule: both sides derive the
+#: real key from this base plus :data:`SCOPE_ATTRIBUTE` (see below), so a
+#: change to either the base or the rule has to land on both.
 STORAGE_KEY = "osprey-theme"
+
+#: The ``<html>`` attribute the server stamps on a multi-user mount, naming the
+#: persona a page is served for. localStorage is origin-scoped, not
+#: path-scoped, so on such a deployment (every persona under ``/u/<user>/`` on
+#: one origin) the bare :data:`STORAGE_KEY` is a single shared slot and the last
+#: picker decides what everybody else boots into. When the attribute is present,
+#: theme-boot.js reads ``osprey-theme--<scope>`` instead — and never falls back
+#: to the bare key, which is precisely the polluted slot the scoping exists to
+#: escape. When it is absent (single-user serving, and every other interface
+#: that loads this script) the bare key is used unchanged.
+#:
+#: ``static/js/storage-scope.js`` is the written-down definition of this rule;
+#: theme-boot.js is a pre-paint IIFE that cannot import it, so the generated
+#: source below inlines a mirror of its ``scopedStorageKey()``, exactly as the
+#: hand-written mode-boot.js does. Change the rule there and here together.
+SCOPE_ATTRIBUTE = "data-osprey-storage-scope"
 
 #: Shared do-not-edit preamble for both generated files, as ``//`` line
 #: comments (both outputs are plain JS/ESM, so ``//`` works for either).
@@ -376,6 +399,24 @@ def render_theme_boot_js(tree: TokenTree) -> str:
     concrete valid id) — a URL carries a single value, never the
     structured pair.
 
+    Both storage rungs are read under a PER-PERSONA key when the server
+    stamped :data:`SCOPE_ATTRIBUTE` on ``<html>``: ``osprey-theme--<scope>``
+    rather than the bare ``osprey-theme``, with no fallback to the bare key
+    when the scoped one is missing. localStorage is origin-scoped, so on a
+    multi-user mount the bare key is one slot shared by every persona and
+    falling back to it would hand the last writer's theme to everyone who has
+    not yet picked — the exact cross-persona bug the scoping closes. A scoped
+    page with no scoped value simply has no stored preference, and resolution
+    falls through to the server attribute and then to ``'auto'``. With the
+    attribute absent (single-user serving, and every other interface that
+    loads this script) both rungs read the bare key exactly as before, legacy
+    bare token included. The stored VALUE shape is untouched by any of this.
+
+    The emitted ``storageKey()`` inlines ``storage-scope.js``'s
+    ``scopedStorageKey()`` rather than importing it — this script imports
+    nothing — mirroring what the hand-written ``mode-boot.js`` does for the
+    UI-mode axis.
+
     Server-attribute contract (for whoever renders ``<html>`` server-side,
     e.g. the web_terminal server): the boot script reads
     ``document.documentElement.getAttribute("data-theme")`` — i.e. the
@@ -424,6 +465,7 @@ def render_theme_boot_js(tree: TokenTree) -> str:
         json.dumps(family_by_id, indent=2, ensure_ascii=True), "  "
     )
     storage_key_json = json.dumps(STORAGE_KEY, ensure_ascii=True)
+    scope_attribute_json = json.dumps(SCOPE_ATTRIBUTE, ensure_ascii=True)
     default_family_json = json.dumps(default_family, ensure_ascii=True)
 
     body = f"""\
@@ -431,10 +473,22 @@ def render_theme_boot_js(tree: TokenTree) -> str:
 // module scripts are deferred, which would let a pre-theme flash slip
 // through. Duplicates THEMES/DEFAULTS identity from tokens.js as inline
 // literals for the same reason: this script must not import anything.
+//
+// Storage rungs, scoped: localStorage is origin-scoped, so on a multi-user
+// deployment (every persona served from one origin under `/u/<user>/`) a bare
+// key is a single shared slot and the last picker decides what everyone else
+// boots into. When the server stamps data-osprey-storage-scope on <html>, the
+// storage rungs read `osprey-theme--<scope>` instead — and do NOT fall back to
+// the bare key, since that polluted slot is the very thing being escaped; a
+// scoped page with no scoped value simply falls through to the server rung.
+// With the attribute absent (single-user serving, and every non-web_terminal
+// interface that loads this script) the legacy bare key is used unchanged,
+// legacy bare-token format included.
 (function () {{
   "use strict";
 
   const STORAGE_KEY = {storage_key_json};
+  const SCOPE_ATTRIBUTE = {scope_attribute_json};
   const VALID_IDS = {valid_ids_json};
   // Per-family {{mode: id}} map: DEFAULTS[family][mode]. Typed as a
   // Record (not the narrower literal shape object-literal inference would
@@ -481,9 +535,22 @@ def render_theme_boot_js(tree: TokenTree) -> str:
     }}
   }}
 
+  // Inline mirror of storage-scope.js's `scopedStorageKey()`. An empty
+  // attribute value counts as unscoped: the server omits the attribute rather
+  // than rendering `=""`, so this only guards against a key ending in a bare
+  // "--" that would belong to no persona.
+  function storageKey() {{
+    try {{
+      const scope = document.documentElement.getAttribute(SCOPE_ATTRIBUTE);
+      return scope ? STORAGE_KEY + "--" + scope : STORAGE_KEY;
+    }} catch {{
+      return STORAGE_KEY;
+    }}
+  }}
+
   function readStoredTheme() {{
     try {{
-      return window.localStorage.getItem(STORAGE_KEY);
+      return window.localStorage.getItem(storageKey());
     }} catch {{
       return null;
     }}

--- a/src/osprey/interfaces/design_system/static/js/components/osprey-display-menu.js
+++ b/src/osprey/interfaces/design_system/static/js/components/osprey-display-menu.js
@@ -20,7 +20,8 @@
  *     `getTheme()`/`getFamily()` + `subscribe()`.
  *   - **View** (Expert/Simple) — the mechanism app.js's `initModeToggle()`
  *     uses, minus the hub-only dock/panel follow-ups: persist the explicit
- *     choice under `localStorage['osprey-ui-mode']`, call frame-params.js's
+ *     choice under the per-persona `osprey-ui-mode` key (scoped through
+ *     storage-scope.js's `scopedStorageKey()`), call frame-params.js's
  *     `stripQueryMode()` so a leftover one-shot `?mode=` deep-link cannot
  *     out-rank that choice on the next reload, then post
  *     `{type: 'osprey-mode-change', mode}` to this element's OWN window.
@@ -98,6 +99,7 @@
  */
 
 import { onModeChange, stripQueryMode } from '/design-system/js/frame-params.js';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 import {
   getFamily,
   getTheme,
@@ -110,7 +112,12 @@ import {
 
 const STYLE_ID = 'osprey-display-menu-style';
 
-/** Shared, origin-scoped Expert/Simple key — the one mode-boot.js resolves from. */
+/**
+ * Base Expert/Simple key — the one mode-boot.js resolves from. Never used
+ * bare: it goes through `scopedStorageKey()` so that on a multi-user mount the
+ * pick lands in this persona's own slot instead of the shared origin-wide one
+ * every persona would otherwise overwrite in turn.
+ */
 const MODE_STORAGE_KEY = 'osprey-ui-mode';
 
 /**
@@ -601,7 +608,9 @@ export class OspreyDisplayMenu extends HTMLElement {
     if (mode !== 'expert' && mode !== 'simple') return;
 
     try {
-      window.localStorage.setItem(MODE_STORAGE_KEY, mode);
+      // Key resolved at write time, not at module load: the scope attribute is
+      // a property of the document this element ended up in.
+      window.localStorage.setItem(scopedStorageKey(MODE_STORAGE_KEY), mode);
     } catch { /* storage blocked — the mode still applies for this session */ }
     stripQueryMode();
     window.postMessage({ type: 'osprey-mode-change', mode }, window.location.origin);

--- a/src/osprey/interfaces/design_system/static/js/components/osprey-drawer.js
+++ b/src/osprey/interfaces/design_system/static/js/components/osprey-drawer.js
@@ -138,6 +138,7 @@ import {
   installFocusTrap,
   removeFocusTrap,
 } from '/design-system/js/focus-trap.js';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 
 const BACKDROP_ID = 'drawer-backdrop';
 
@@ -507,7 +508,9 @@ export class OspreyDrawer extends HTMLElement {
     this._splitter = initSplitter({
       handle,
       pane: this,
-      storageKey: DRAWER_WIDTH_STORAGE_KEY,
+      // Per-persona on a multi-user mount: the drawer lives in the shell page,
+      // which shares one origin (and one localStorage) across every user.
+      storageKey: scopedStorageKey(DRAWER_WIDTH_STORAGE_KEY),
       axis: 'x',
       anchor: 'end',
       sizing: 'box',

--- a/src/osprey/interfaces/design_system/static/js/mode-boot.js
+++ b/src/osprey/interfaces/design_system/static/js/mode-boot.js
@@ -16,7 +16,7 @@
  * invalid value at any rung is ignored and resolution falls through to the
  * next:
  *   1. the `?mode=` URL query param
- *   2. localStorage['osprey-ui-mode']
+ *   2. localStorage['osprey-ui-mode'], per-persona scoped — see below
  *   3. the data-ui-mode attribute the server already rendered on <html>
  *      (web_terminal stamps it from config; artifacts renders none, so this
  *      rung is simply absent there and resolution falls through to 4)
@@ -24,11 +24,27 @@
  * The resolved mode is stamped as data-ui-mode on <html>. theme-manager.js
  * is unaffected: the theme axis (data-theme) and the mode axis
  * (data-ui-mode) are independent.
+ *
+ * Storage rung, scoped: localStorage is origin-scoped, so on a multi-user
+ * deployment (every persona served from one origin under `/u/<user>/`) a bare
+ * key is a single shared slot and the last picker decides what everyone else
+ * boots into. When the server stamps data-osprey-storage-scope on <html>, rung
+ * 2 reads `osprey-ui-mode--<scope>` instead — and does NOT fall back to the
+ * bare key, since that polluted slot is the very thing being escaped; a scoped
+ * page with no scoped value simply falls through to rung 3. With the attribute
+ * absent (single-user serving, and every non-web_terminal interface that loads
+ * this script) the legacy bare key is used unchanged.
+ *
+ * This duplicates storage-scope.js's `scopedStorageKey()` inline: as a
+ * pre-paint IIFE this file imports nothing, so it mirrors the rule rather than
+ * calling it. storage-scope.js is the written-down definition — keep them in
+ * step.
  */
 (function () {
   "use strict";
 
-  const STORAGE_KEY = "osprey-ui-mode";
+  const STORAGE_KEY_BASE = "osprey-ui-mode";
+  const SCOPE_ATTRIBUTE = "data-osprey-storage-scope";
   const VALID_MODES = ["expert", "simple"];
   const DEFAULT_MODE = "expert";
 
@@ -45,9 +61,22 @@
     }
   }
 
+  // Inline mirror of storage-scope.js's `scopedStorageKey()`. An empty
+  // attribute value counts as unscoped: the server omits the attribute rather
+  // than rendering `=""`, so this only guards against a key ending in a bare
+  // "--" that would belong to no persona.
+  function storageKey() {
+    try {
+      const scope = document.documentElement.getAttribute(SCOPE_ATTRIBUTE);
+      return scope ? STORAGE_KEY_BASE + "--" + scope : STORAGE_KEY_BASE;
+    } catch {
+      return STORAGE_KEY_BASE;
+    }
+  }
+
   function readStoredMode() {
     try {
-      return window.localStorage.getItem(STORAGE_KEY);
+      return window.localStorage.getItem(storageKey());
     } catch {
       return null;
     }

--- a/src/osprey/interfaces/design_system/static/js/rail-boot.js
+++ b/src/osprey/interfaces/design_system/static/js/rail-boot.js
@@ -19,17 +19,35 @@
  * invalid value at any rung is ignored and resolution falls through to the
  * next:
  *   1. the `?rail=` URL query param
- *   2. localStorage['osprey-rail-position']
+ *   2. localStorage['osprey-rail-position'], per-persona scoped — see below
  *   3. the data-rail-position attribute the server already rendered on
  *      <html> (web_terminal stamps it from web.rail_position config)
  *   4. 'left' — the default
  * The resolved position is stamped as data-rail-position on <html>. The
  * theme (data-theme) and mode (data-ui-mode) axes are independent.
+ *
+ * Storage rung, scoped: localStorage is origin-scoped, so on a multi-user
+ * deployment (every persona served from one origin under `/u/<user>/`) a bare
+ * key is a single shared slot and the last persona to flip the rail decides
+ * where everyone else's sits. When the server stamps
+ * data-osprey-storage-scope on <html>, rung 2 reads
+ * `osprey-rail-position--<scope>` instead — and does NOT fall back to the bare
+ * key, since that polluted slot is the very thing being escaped; a scoped page
+ * with no scoped value simply falls through to rung 3. With the attribute
+ * absent (single-user serving, and every non-web_terminal interface that loads
+ * this script) the legacy bare key is used unchanged.
+ *
+ * This duplicates storage-scope.js's `scopedStorageKey()` inline: as a
+ * pre-paint IIFE this file imports nothing, so it mirrors the rule rather than
+ * calling it. storage-scope.js is the written-down definition — keep them in
+ * step. rail-position.js (web_terminal) is the WRITER of this same key and
+ * derives it through that module, so the two must stay byte-identical.
  */
 (function () {
   "use strict";
 
-  const STORAGE_KEY = "osprey-rail-position";
+  const STORAGE_KEY_BASE = "osprey-rail-position";
+  const SCOPE_ATTRIBUTE = "data-osprey-storage-scope";
   const VALID_POSITIONS = ["left", "top"];
   const DEFAULT_POSITION = "left";
 
@@ -46,9 +64,22 @@
     }
   }
 
+  // Inline mirror of storage-scope.js's `scopedStorageKey()`. An empty
+  // attribute value counts as unscoped: the server omits the attribute rather
+  // than rendering `=""`, so this only guards against a key ending in a bare
+  // "--" that would belong to no persona.
+  function storageKey() {
+    try {
+      const scope = document.documentElement.getAttribute(SCOPE_ATTRIBUTE);
+      return scope ? STORAGE_KEY_BASE + "--" + scope : STORAGE_KEY_BASE;
+    } catch {
+      return STORAGE_KEY_BASE;
+    }
+  }
+
   function readStoredPosition() {
     try {
-      return window.localStorage.getItem(STORAGE_KEY);
+      return window.localStorage.getItem(storageKey());
     } catch {
       return null;
     }

--- a/src/osprey/interfaces/design_system/static/js/storage-scope.js
+++ b/src/osprey/interfaces/design_system/static/js/storage-scope.js
@@ -1,0 +1,71 @@
+// @ts-check
+/* OSPREY Design System — localStorage scope
+ *
+ * localStorage is origin-scoped, not path-scoped. On a multi-user deployment
+ * every persona is served from the SAME origin under a different path mount
+ * (`/u/alice/`, `/u/bob/`), so a bare key like `osprey-ui-mode` is one shared
+ * slot: whoever picks last decides what everybody else boots into. The server
+ * therefore stamps `data-osprey-storage-scope="<user>"` on `<html>` whenever it
+ * serves under such a mount, and every browser-side reader and writer derives
+ * its key from that attribute.
+ *
+ * The attribute is ABSENT — never empty — for single-user serving, and the
+ * other interfaces (artifacts, ariel, channel_finder, the dispatch dashboard)
+ * load these same scripts and never stamp it at all. Absent therefore has to
+ * mean "use the legacy bare key", which is exactly what keeps those pages, and
+ * every existing single-user browser profile, working unchanged.
+ *
+ * NO LEGACY FALLBACK WHEN SCOPED. A scoped read must NOT fall back to the bare
+ * key when its own key is missing. The bare key is precisely the polluted slot
+ * the scoping exists to escape: reading it as a fallback would hand the last
+ * writer's preference to every persona who has not yet made a pick — the
+ * original cross-persona bug, re-inflicted once per persona. A scoped page with
+ * no scoped value has no stored preference, and resolution falls through to the
+ * next rung (the server-rendered attribute, then the built-in default).
+ *
+ * The pre-paint boot scripts (mode-boot.js, rail-boot.js, the generated
+ * theme-boot.js) cannot import this module: they are non-module, dependency-free
+ * IIFEs that must run synchronously in <head> ahead of every stylesheet. They
+ * INLINE the same two rules — read the attribute, suffix the key, never fall
+ * back — and this module is the written-down definition they mirror. Change the
+ * rule here and the inline copies must change with it.
+ *
+ * @module storage-scope
+ */
+
+/** The `<html>` attribute the server stamps on a multi-user mount. */
+const SCOPE_ATTRIBUTE = 'data-osprey-storage-scope';
+
+/**
+ * The storage scope this document is served under, or `null` when it is not
+ * scoped at all.
+ *
+ * An empty attribute value is treated as unscoped. The server never emits one
+ * (it omits the attribute entirely rather than rendering `=""`), so this is
+ * purely defensive: an empty scope would otherwise produce the key
+ * `osprey-ui-mode--`, a third slot belonging to nobody.
+ *
+ * @returns {string|null}
+ */
+export function storageScope() {
+  try {
+    return document.documentElement.getAttribute(SCOPE_ATTRIBUTE) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The localStorage key to use for `base` in this document.
+ *
+ * Scoped: `base + '--' + scope`. Unscoped: `base`, unchanged — the legacy key.
+ * There is deliberately no third case; see the no-legacy-fallback rule in the
+ * module docstring for why a scoped reader must never consult `base`.
+ *
+ * @param {string} base the bare, historically-used key (e.g. `'osprey-ui-mode'`)
+ * @returns {string}
+ */
+export function scopedStorageKey(base) {
+  const scope = storageScope();
+  return scope === null ? base : `${base}--${scope}`;
+}

--- a/src/osprey/interfaces/design_system/static/js/theme-boot.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-boot.js
@@ -7,10 +7,22 @@
 // module scripts are deferred, which would let a pre-theme flash slip
 // through. Duplicates THEMES/DEFAULTS identity from tokens.js as inline
 // literals for the same reason: this script must not import anything.
+//
+// Storage rungs, scoped: localStorage is origin-scoped, so on a multi-user
+// deployment (every persona served from one origin under `/u/<user>/`) a bare
+// key is a single shared slot and the last picker decides what everyone else
+// boots into. When the server stamps data-osprey-storage-scope on <html>, the
+// storage rungs read `osprey-theme--<scope>` instead — and do NOT fall back to
+// the bare key, since that polluted slot is the very thing being escaped; a
+// scoped page with no scoped value simply falls through to the server rung.
+// With the attribute absent (single-user serving, and every non-web_terminal
+// interface that loads this script) the legacy bare key is used unchanged,
+// legacy bare-token format included.
 (function () {
   "use strict";
 
   const STORAGE_KEY = "osprey-theme";
+  const SCOPE_ATTRIBUTE = "data-osprey-storage-scope";
   const VALID_IDS = ["dark", "desy-dark", "desy-light", "high-contrast-dark", "high-contrast-light", "light", "retro-dark", "retro-light"];
   // Per-family {mode: id} map: DEFAULTS[family][mode]. Typed as a
   // Record (not the narrower literal shape object-literal inference would
@@ -83,9 +95,22 @@
     }
   }
 
+  // Inline mirror of storage-scope.js's `scopedStorageKey()`. An empty
+  // attribute value counts as unscoped: the server omits the attribute rather
+  // than rendering `=""`, so this only guards against a key ending in a bare
+  // "--" that would belong to no persona.
+  function storageKey() {
+    try {
+      const scope = document.documentElement.getAttribute(SCOPE_ATTRIBUTE);
+      return scope ? STORAGE_KEY + "--" + scope : STORAGE_KEY;
+    } catch {
+      return STORAGE_KEY;
+    }
+  }
+
   function readStoredTheme() {
     try {
-      return window.localStorage.getItem(STORAGE_KEY);
+      return window.localStorage.getItem(storageKey());
     } catch {
       return null;
     }

--- a/src/osprey/interfaces/design_system/static/js/theme-manager.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-manager.js
@@ -7,7 +7,8 @@
  *
  * Two roles, chosen by the page at init time via initTheme({role}):
  *   'hub'      — web-terminal only. Persists the user's preference to
- *                localStorage['osprey-theme'], live-follows the OS
+ *                localStorage['osprey-theme'] (per-persona scoped on a
+ *                multi-user mount — see storage-scope.js), live-follows the OS
  *                color-scheme preference while that preference is 'auto',
  *                and broadcasts every resolved change to every same-origin
  *                <iframe> panel via postMessage.
@@ -67,6 +68,8 @@
  * silently returning colors it can't vouch for.
  */
 
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
+
 import {
   DEFAULT_FAMILY as _EMITTED_DEFAULT_FAMILY,
   DEFAULTS,
@@ -78,6 +81,12 @@ import {
 /** @typedef {'auto'|'dark'|'light'} ModePreference */
 /** @typedef {{family: string, mode: ModePreference}} Preference */
 
+// The BASE localStorage key, never used bare: every read and write resolves it
+// through scopedStorageKey() so a multi-user mount gets a per-persona slot (see
+// storage-scope.js). Deliberately duplicated in generator/emit_js.py's
+// STORAGE_KEY, which bakes the same literal — and the same scoping rule — into
+// the generated theme-boot.js that reads this slot pre-paint. Neither side can
+// import the other, so the two must be changed together.
 const STORAGE_KEY = 'osprey-theme';
 const MESSAGE_TYPE = 'osprey-theme-change';
 
@@ -365,13 +374,18 @@ function _parsePreferenceToken(token) {
  * ('auto' or a concrete id like 'dark') forward via _parsePreferenceToken.
  * Never throws -- storage errors, malformed JSON, and unrecognized values
  * all resolve to null (caller falls back to auto within DEFAULT_FAMILY).
+ *
+ * Reads the per-persona key on a scoped page, resolved here rather than at
+ * module load so the writer below and this reader always agree. A scoped page
+ * whose own key is empty has NO stored preference: it must not fall back to
+ * the bare key, which on a multi-user mount holds whichever persona wrote last.
  * @returns {Preference|null}
  */
 function _readStoredPreference() {
   /** @type {string|null} */
   let raw;
   try {
-    raw = window.localStorage.getItem(STORAGE_KEY);
+    raw = window.localStorage.getItem(scopedStorageKey(STORAGE_KEY));
   } catch {
     return null;
   }
@@ -396,13 +410,18 @@ function _readStoredPreference() {
 
 /**
  * Persist the (family, mode) preference as `{"family":..., "mode":...}`
- * JSON under STORAGE_KEY.
+ * JSON under STORAGE_KEY -- scoped per persona, resolved at write time through
+ * the same scopedStorageKey(STORAGE_KEY) the reader above uses. The stored
+ * VALUE shape is unaffected by scoping; only the key changes.
  * @param {string} family
  * @param {ModePreference} mode
  */
 function _persistPreference(family, mode) {
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ family, mode }));
+    window.localStorage.setItem(
+      scopedStorageKey(STORAGE_KEY),
+      JSON.stringify({ family, mode })
+    );
   } catch {
     // Storage unavailable (private browsing, quota) -- non-fatal; the
     // preference just won't survive a reload this session.

--- a/src/osprey/interfaces/web_auth.py
+++ b/src/osprey/interfaces/web_auth.py
@@ -98,6 +98,7 @@ __all__ = [
     "get_web_credentials",
     "mint_and_announce",
     "mint_secret",
+    "peek_web_credentials",
     "reset_web_credentials",
 ]
 
@@ -927,6 +928,32 @@ def get_web_credentials(app: Any = None) -> WebCredentials:
         if state is not None:
             state.web_credentials = credentials
     return credentials
+
+
+def peek_web_credentials() -> WebCredentials | None:
+    """Return this process's credentials if it already holds them, else ``None``.
+
+    The side-effect-free companion to :func:`get_web_credentials`, and the only
+    safe way for a caller that merely wants to *know* whether this process has
+    an identity to ask. It never calls :func:`_populate`, so it never pops
+    :data:`OPERATOR_SECRET_ENV` or :data:`PANEL_TOKEN_ENV` out of
+    ``os.environ``, never harvests the roster carriers, never mints a secret,
+    and never raises the container-shape ``RuntimeError``.
+
+    That distinction is load-bearing, not hygiene. ``get_web_credentials`` in a
+    process that never held a carrier does two damaging things: it MINTS an
+    operator secret and panel token that no other process in the deployment
+    recognises — a fabricated identity, which is worse than none — and it
+    removes the panel token from the environment on the way, so children spawned
+    afterwards (the MCP server the agent runs, and whatever it spawns) lose the
+    carrier they were deliberately given. A caller asking "do I have an
+    identity?" must therefore never be the caller that creates one.
+
+    Reads the holder under :data:`_POPULATION_LOCK` so it cannot observe a
+    half-built value while another thread is populating.
+    """
+    with _POPULATION_LOCK:
+        return _CREDENTIALS
 
 
 def close_env_carriers() -> None:

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -187,6 +187,40 @@ def resolve_ui_mode(configured: str) -> str:
     return DEFAULT_UI_MODE
 
 
+def resolve_storage_scope(terminal_user: str | None) -> str:
+    """Resolve the per-user namespace for the browser's ``localStorage``.
+
+    Multi-user deployments put one container per user behind a shared nginx
+    front door at ``/u/<user>/`` — **same origin**, so every user shares one
+    ``localStorage``. Without a namespace, one user's dock layout, rail
+    position, palette history and active PTY session id are read and
+    overwritten by the next user to log in on that browser.
+
+    The namespace is decided here rather than in the browser: the served
+    documents stamp it onto ``<html data-osprey-storage-scope>`` and every JS
+    storage site reads it from there, so no client-side code has to parse
+    ``location.pathname`` to work out which mount it is running under (a page
+    fetched through a rewriting proxy, or opened at a path nginx normalised,
+    would parse the wrong answer out of it).
+
+    Reads the same value :func:`~osprey.interfaces.common_middleware.compute_url_prefix`
+    reads, with the same blank-means-unset rule, so the scope and the
+    ``/u/<user>`` prefix can never name different users.
+
+    Args:
+        terminal_user: The deployment's mount user (``OSPREY_TERMINAL_USER``,
+            as captured on ``app.state.terminal_user``). ``None``, empty or
+            blank is a single-user/dev deployment.
+
+    Returns:
+        The namespace token, or ``""`` when there is no mount user. Callers
+        must render the attribute **only** for a truthy result: an empty
+        ``data-osprey-storage-scope=""`` reads as "scoped to nothing" rather
+        than "unscoped", and single-user markup must stay exactly as it was.
+    """
+    return str(terminal_user or "").strip()
+
+
 #: The two supported rail positions. ``left`` is the icon-rail column;
 #: ``top`` renders the same rail as a horizontal strip under the header.
 RAIL_POSITIONS = ("left", "top")
@@ -1434,6 +1468,11 @@ def create_app(
                 "web_ui_mode": web_ui_mode,
                 "web_rail_position": web_rail_position,
                 "terminal_user": terminal_user,
+                # Namespace for everything this page keeps in localStorage.
+                # Empty on a single-user deployment, and the template omits
+                # the attribute entirely in that case — see
+                # resolve_storage_scope().
+                "storage_scope": resolve_storage_scope(terminal_user),
                 "landing_url": landing_url,
                 "auth_role": auth_role or "",
                 "auth_role_source_label": auth_role_source_label,
@@ -1453,7 +1492,21 @@ def create_app(
     # so the handler only ever renders the page.
     @app.get("/static/session.html")
     async def session_page(request: Request):
-        return templates.TemplateResponse(request, "session.html", {"url_prefix": url_prefix})
+        # The storage scope travels with this page too, not just the index:
+        # session.js's import closure reaches the modules that own the PTY
+        # session id, the dock layout and the rail position, so an unstamped
+        # session page would write those keys unscoped and collide with the
+        # neighbouring user's on the shared origin.
+        return templates.TemplateResponse(
+            request,
+            "session.html",
+            {
+                "url_prefix": url_prefix,
+                "storage_scope": resolve_storage_scope(
+                    getattr(request.app.state, "terminal_user", "")
+                ),
+            },
+        )
 
     configure_interface_app(app, static_dir=STATIC_DIR)
 

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -3,7 +3,13 @@
     i.e. the deployment pinned light/dark rather than just a palette. Its
     absence is meaningful: it tells theme-manager.js's hub to leave the mode on
     'auto' and follow the operator's OS. Never emit it empty. -#}
-<html lang="en" data-theme="{{ web_theme_id }}"{% if web_theme_mode %} data-theme-mode="{{ web_theme_mode }}"{% endif %} data-ui-mode="{{ web_ui_mode }}" data-rail-position="{{ web_rail_position }}">
+{#- data-osprey-storage-scope is likewise present ONLY on a multi-user mount
+    (/u/<user>/), where every user shares one origin and therefore one
+    localStorage. It is THE source of truth for the storage namespace — JS
+    storage sites read this attribute and never parse the URL. Its absence
+    means single-user: keys stay unscoped, exactly as they were. Never emit
+    it empty. See resolve_storage_scope() in app.py. -#}
+<html lang="en" data-theme="{{ web_theme_id }}"{% if web_theme_mode %} data-theme-mode="{{ web_theme_mode }}"{% endif %} data-ui-mode="{{ web_ui_mode }}" data-rail-position="{{ web_rail_position }}"{% if storage_scope %} data-osprey-storage-scope="{{ storage_scope }}"{% endif %}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
@@ -5,6 +5,7 @@ import { fetchJSON } from './api.js';
 import { reconcile, PLACEHOLDER_PREFIX } from './dock-reconcile.js';
 import { createTileTab, OSPREY_TAB_COMPONENT, setTerminalHeaderSource } from './dock-tab.js';
 import { subscribe } from '/design-system/js/theme-manager.js';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 
 /** @typedef {import('./dock-reconcile.js').PanelDescriptor} PanelDescriptor */
 
@@ -35,10 +36,18 @@ const TERMINAL_TITLE = 'SESSION';
  *  so one browser origin persists a separate expert layout per project. */
 const LAYOUT_KEY_PREFIX = 'osprey-dock-layout-';
 
-/** Resolved localStorage key (prefix + project_key), or null until initPersistence
- *  has fetched the project key. No key ⇒ persistence is inert this session.
+/** Per-project layout key BASE (prefix + project_key), or null until
+ *  initPersistence has fetched the project key. No key ⇒ persistence is inert
+ *  this session.
+ *
+ *  Never used bare: every read and write suffixes it per persona through
+ *  `scopedStorageKey()`. Project key alone is not enough on a multi-user mount,
+ *  where every persona shares one origin and would otherwise inherit — and
+ *  overwrite — whichever arrangement another operator left behind for the same
+ *  project. Resolved at each use, never stored resolved, so the key always
+ *  reflects the document actually being served (see storage-scope.js).
  *  @type {string|null} */
-let layoutStorageKey = null;
+let layoutStorageKeyBase = null;
 
 /** Pending debounce handle for a persist write (see schedulePersist).
  *  @type {ReturnType<typeof setTimeout>|null} */
@@ -490,9 +499,9 @@ function currentUiMode() {
  * expert layout, so a reload in simple mode restores the arrangement intact.
  */
 function persistCurrentLayout() {
-  if (!dockApi || !layoutStorageKey || currentUiMode() !== 'expert') return;
+  if (!dockApi || !layoutStorageKeyBase || currentUiMode() !== 'expert') return;
   try {
-    localStorage.setItem(layoutStorageKey, JSON.stringify(dockApi.toJSON()));
+    localStorage.setItem(scopedStorageKey(layoutStorageKeyBase), JSON.stringify(dockApi.toJSON()));
   } catch { /* storage blocked/full — the layout still lives for this session */ }
 }
 
@@ -517,10 +526,10 @@ function schedulePersist() {
  * @param {any} api
  */
 function applyStoredLayout(api) {
-  if (!layoutStorageKey) return;
+  if (!layoutStorageKeyBase) return;
   let raw;
   try {
-    raw = localStorage.getItem(layoutStorageKey);
+    raw = localStorage.getItem(scopedStorageKey(layoutStorageKeyBase));
   } catch {
     return;
   }
@@ -538,7 +547,7 @@ function applyStoredLayout(api) {
   } catch (err) {
     console.error('dock: stored layout failed to apply; keeping default', err);
     try {
-      localStorage.removeItem(layoutStorageKey);
+      localStorage.removeItem(scopedStorageKey(layoutStorageKeyBase));
     } catch { /* non-fatal */ }
   }
 }
@@ -568,7 +577,7 @@ async function initPersistence(api) {
     announceLayoutRestored();
     return;
   }
-  layoutStorageKey = LAYOUT_KEY_PREFIX + projectKey;
+  layoutStorageKeyBase = LAYOUT_KEY_PREFIX + projectKey;
 
   // Boot into the mode the server rendered. In simple mode the locked layout is
   // synthesized fresh (leaving the stored EXPERT value untouched for a later flip
@@ -590,9 +599,9 @@ async function initPersistence(api) {
  * exercises it as the canonical reset path.
  */
 export function resetDockLayout() {
-  if (layoutStorageKey) {
+  if (layoutStorageKeyBase) {
     try {
-      localStorage.removeItem(layoutStorageKey);
+      localStorage.removeItem(scopedStorageKey(layoutStorageKeyBase));
     } catch { /* non-fatal */ }
   }
   if (dockApi) arrangeDefaultLayout(dockApi);
@@ -631,9 +640,9 @@ export function applyDockMode(mode) {
  * @param {any} api
  */
 function stashExpertLayout(api) {
-  if (!layoutStorageKey) return;
+  if (!layoutStorageKeyBase) return;
   try {
-    localStorage.setItem(layoutStorageKey, JSON.stringify(api.toJSON()));
+    localStorage.setItem(scopedStorageKey(layoutStorageKeyBase), JSON.stringify(api.toJSON()));
   } catch { /* storage blocked — simple→expert will fall back to the default */ }
 }
 
@@ -680,9 +689,9 @@ function applySimpleLayout(api) {
  */
 function restoreExpertLayout(api) {
   let raw = null;
-  if (layoutStorageKey) {
+  if (layoutStorageKeyBase) {
     try {
-      raw = localStorage.getItem(layoutStorageKey);
+      raw = localStorage.getItem(scopedStorageKey(layoutStorageKeyBase));
     } catch { /* storage blocked — fall through to default */ }
   }
   const next = raw ? reconcile(raw, currentRegisteredPanels(api)) : null;

--- a/src/osprey/interfaces/web_terminal/static/js/palette.js
+++ b/src/osprey/interfaces/web_terminal/static/js/palette.js
@@ -36,6 +36,7 @@ import { buildRegistry } from './palette-registry.js';
 import { fetchJSON } from './api.js';
 import { fuzzyMatch } from '/design-system/js/fuzzy.js';
 import { el } from '/design-system/js/dom.js';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 
 /** @typedef {import('./palette-registry.js').Item} Item */
 
@@ -76,8 +77,11 @@ import { el } from '/design-system/js/dom.js';
 /** Fixed outer group order — matches the registry and the stylesheet. */
 const GROUP_ORDER = /** @type {const} */ (['Settings', 'Panels', 'Layouts', 'Actions']);
 
-/** localStorage key + cap for the most-recently-executed item keys. */
-const RECENT_STORAGE_KEY = 'osprey-palette-recent-v1';
+/** localStorage key base + cap for the most-recently-executed item keys. The
+ *  list is per persona: localStorage is origin-scoped, so on a multi-user mount
+ *  a bare key would show every operator whatever the last one ran. Resolved
+ *  through scopedStorageKey() at each use — see storage-scope.js. */
+const RECENT_STORAGE_KEY_BASE = 'osprey-palette-recent-v1'; // gitleaks:allow - a localStorage key name, not a secret
 const RECENT_LIMIT = 5;
 
 /** Namespace prefix keeping a Recent row's nav key distinct from its original. */
@@ -132,7 +136,7 @@ function itemKey(/** @type {NavItem} */ item) {
 function readRecent() {
   let raw = null;
   try {
-    raw = localStorage.getItem(RECENT_STORAGE_KEY);
+    raw = localStorage.getItem(scopedStorageKey(RECENT_STORAGE_KEY_BASE));
   } catch {
     return [];
   }
@@ -155,7 +159,7 @@ function readRecent() {
 function recordRecent(key) {
   const next = [key, ...readRecent().filter((k) => k !== key)].slice(0, RECENT_LIMIT);
   try {
-    localStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(next));
+    localStorage.setItem(scopedStorageKey(RECENT_STORAGE_KEY_BASE), JSON.stringify(next));
   } catch { /* storage blocked — Recent stays empty, execution is unaffected */ }
 }
 

--- a/src/osprey/interfaces/web_terminal/static/js/panel-agent-attention.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-agent-attention.js
@@ -21,6 +21,7 @@ import { fetchJSON } from './api.js';
 import { getEntry, setEntryAttention } from './panel-rail.js';
 import { glowPanel } from './dock-iframe.js';
 import { flashElement } from '/design-system/js/highlight.js';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 
 /** @type {HTMLElement} */
 let railEl = /** @type {HTMLElement} */ (/** @type {unknown} */ (null));
@@ -54,7 +55,17 @@ export function flashAgentTile(panelId) { flashAgentGlow(panelId); glowPanel(pan
  *  @type {Map<string, number>} */
 const badgeTs = new Map();
 
+/** Key prefix for a panel's acknowledged ts. Panel ids are deployment-wide, so
+ *  on a multi-user mount (one origin, one localStorage) the prefix alone would
+ *  make one operator's acknowledgement suppress another's badge for the same
+ *  panel. The resolved key is scoped per persona — see storage-scope.js. */
 const ACK_KEY_PREFIX = 'agent-ack:';
+
+/** This document's ack key for `panelId`, resolved at the point of use.
+ *  @param {string} panelId @returns {string} */
+function ackStorageKey(panelId) {
+  return scopedStorageKey(ACK_KEY_PREFIX + panelId);
+}
 
 /**
  * Record a badge's server ts, keeping the newest. The history ring replays a
@@ -77,7 +88,7 @@ function noteBadgeTs(panelId, ts) {
  */
 function ackedTs(panelId) {
   let raw = null;
-  try { raw = localStorage.getItem(ACK_KEY_PREFIX + panelId); } catch { return -Infinity; }
+  try { raw = localStorage.getItem(ackStorageKey(panelId)); } catch { return -Infinity; }
   const ts = raw === null ? NaN : Number(raw);
   return Number.isFinite(ts) ? ts : -Infinity;
 }
@@ -92,7 +103,7 @@ export function clearBadge(panelId) {
   setEntryAttention(railEl, panelId, false);
   const ts = badgeTs.get(panelId);
   if (ts === undefined) return;
-  try { localStorage.setItem(ACK_KEY_PREFIX + panelId, String(ts)); } catch { /* storage denied */ }
+  try { localStorage.setItem(ackStorageKey(panelId), String(ts)); } catch { /* storage denied */ }
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/rail-hint.js
+++ b/src/osprey/interfaces/web_terminal/static/js/rail-hint.js
@@ -10,11 +10,18 @@
  * Self-registering module, wired like activity-strip.js: the template loads
  * it, it finds its own anchor (.panel-rail-region) and no-ops harmlessly on
  * pages without one.
+ *
+ * "Once EVER" means once per PERSONA. localStorage is origin-scoped, so on a
+ * multi-user mount a bare flag would be one shared slot and the first operator
+ * to dismiss the hint would silently swallow it for everyone else arriving
+ * from the old UI — see storage-scope.js for the rule and why a scoped read
+ * never falls back to the bare key.
  */
 
 import { getRailPosition, setRailPosition } from './rail-position.js';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 
-const FLAG = 'osprey-rail-hint-dismissed-v1';
+const FLAG_BASE = 'osprey-rail-hint-dismissed-v1';
 
 /**
  * Show the hint if this browser has never seen it and the rail is still the
@@ -25,7 +32,7 @@ const FLAG = 'osprey-rail-hint-dismissed-v1';
 export function maybeShowRailHint() {
   let seen = null;
   try {
-    seen = localStorage.getItem(FLAG);
+    seen = localStorage.getItem(scopedStorageKey(FLAG_BASE));
   } catch {
     // Storage unavailable: never show rather than nag on every load.
     return false;
@@ -49,7 +56,7 @@ export function maybeShowRailHint() {
 
   const dismissHint = () => {
     try {
-      localStorage.setItem(FLAG, '1');
+      localStorage.setItem(scopedStorageKey(FLAG_BASE), '1');
     } catch { /* storage blocked — the hint may reappear next load, harmless */ }
     hint.remove();
   };

--- a/src/osprey/interfaces/web_terminal/static/js/rail-position.js
+++ b/src/osprey/interfaces/web_terminal/static/js/rail-position.js
@@ -19,9 +19,20 @@
  *     switching back to another family moves the rail back. The coupling
  *     itself is served by GET /api/panels (app.FAMILY_RAIL_DEFAULTS), so
  *     this module holds no opinion about which family implies which rail.
+ *
+ * The pin is per persona. localStorage is origin-scoped, so on a multi-user
+ * mount one bare key would be a single shared slot: the last persona to flip
+ * the rail would pin it for everyone. Both ends here go through
+ * `scopedStorageKey()`, resolved per call so the key always reflects the
+ * document actually being served. This module is the WRITER half of a pair —
+ * the design system's rail-boot.js reads the same key before first paint from
+ * its own inline mirror of the rule, so the two derivations must agree
+ * byte-for-byte.
  */
 
-const STORAGE_KEY = 'osprey-rail-position';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
+
+const STORAGE_KEY_BASE = 'osprey-rail-position';
 const VALID_POSITIONS = ['left', 'top'];
 const DEFAULT_POSITION = 'left';
 
@@ -49,7 +60,7 @@ export function setRailPosition(position) {
   if (!VALID_POSITIONS.includes(position)) return;
   document.documentElement.setAttribute('data-rail-position', position);
   try {
-    localStorage.setItem(STORAGE_KEY, position);
+    localStorage.setItem(scopedStorageKey(STORAGE_KEY_BASE), position);
   } catch { /* storage blocked — the flip still applies for this session */ }
   stripQueryRail();
   window.dispatchEvent(new Event('resize'));
@@ -76,7 +87,7 @@ export function initRailThemeCoupling(payload) {
  */
 function hasUserPin() {
   try {
-    return VALID_POSITIONS.includes(String(localStorage.getItem(STORAGE_KEY)));
+    return VALID_POSITIONS.includes(String(localStorage.getItem(scopedStorageKey(STORAGE_KEY_BASE))));
   } catch {
     return false; // storage blocked — treat as unpinned
   }

--- a/src/osprey/interfaces/web_terminal/static/js/settings.js
+++ b/src/osprey/interfaces/web_terminal/static/js/settings.js
@@ -4,6 +4,7 @@ import { fetchJSON, apiRequest } from './api.js';
 import { restartTerminal, startTerminal } from './terminal.js';
 import { showSettingsNotice } from './settings-notice.js';
 import { mountOverlay, fadeOutOverlay } from './modal-overlay.js';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 
 /**
  * The config document returned by GET /api/config.
@@ -38,8 +39,12 @@ let agentPanel = null;
 /** @type {DrawerElement|null} */
 let settingsDrawer = null;
 
-// Per-session warning for the settings drawer (resets on server restart)
-const SETTINGS_WARNING_KEY = 'osprey-settings-warning-ack';
+// Per-session warning for the settings drawer (resets on server restart), and
+// per PERSONA: localStorage is origin-scoped, so on a multi-user mount a bare
+// key would let whoever acknowledged the safety warning first wave it away for
+// everyone else on the box. Resolved through scopedStorageKey() at each use —
+// see storage-scope.js.
+const SETTINGS_WARNING_KEY_BASE = 'osprey-settings-warning-ack';
 
 // True from the moment a trigger click starts the gate (health check in
 // flight, or the warning dialog itself is up) until it resolves one way or
@@ -171,7 +176,7 @@ async function runWarningGate() {
     clearTimeout(timeoutId);
     serverSession = health.session_id ?? null;
     // Already acknowledged this server session — proceed without the dialog.
-    if (serverSession && localStorage.getItem(SETTINGS_WARNING_KEY) === serverSession) {
+    if (serverSession && localStorage.getItem(scopedStorageKey(SETTINGS_WARNING_KEY_BASE)) === serverSession) {
       warningGatePending = false;
       return true;
     }
@@ -251,7 +256,7 @@ function showSettingsWarning(serverSession) {
 
     /** @type {HTMLElement} */ (dialog.querySelector('.settings-warning-proceed')).addEventListener('click', () => {
       if (serverSession) {
-        localStorage.setItem(SETTINGS_WARNING_KEY, serverSession);
+        localStorage.setItem(scopedStorageKey(SETTINGS_WARNING_KEY_BASE), serverSession);
       }
       cleanup();
       resolve(true);

--- a/src/osprey/interfaces/web_terminal/static/js/terminal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal.js
@@ -2,6 +2,7 @@
 
 import { createWebSocket, wsUrl, withPrefix } from './api.js';
 import { subscribe, xtermPalette } from '/design-system/js/theme-manager.js';
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 
 /** @type {any} */
 let term = null;
@@ -15,8 +16,25 @@ let currentSessionId = null;
 
 // localStorage key for persisting the active PTY session ID across page
 // loads, so a kept-warm session survives a logout -> landing page ->
-// return round trip. Scoped to the terminal origin.
-const PTY_SESSION_STORAGE_KEY = 'osprey-pty-session';
+// return round trip.
+//
+// Per persona, not per origin. localStorage is origin-scoped, so on a
+// multi-user mount (`/u/alice/`, `/u/bob/`) a bare key would be one shared
+// pointer — and a session id is not a preference that can be shared: replaying
+// one persona's id would attach another persona's terminal to a PTY that is
+// not theirs. Every read, write and clear resolves the key through
+// ptySessionStorageKey() below.
+const PTY_SESSION_STORAGE_KEY_BASE = 'osprey-pty-session';
+
+/**
+ * This document's PTY-pointer key. Resolved per call rather than once at
+ * module load: the scope lives on the served document, and reading it at the
+ * point of use is what keeps the key honest.
+ * @returns {string}
+ */
+function ptySessionStorageKey() {
+  return scopedStorageKey(PTY_SESSION_STORAGE_KEY_BASE);
+}
 
 // A resume connection gets a 'session_info' confirmation too —
 // routes/websocket.py discovers the attached id on the stale-resume path (a
@@ -63,7 +81,7 @@ let autoResumeFailoverId = null;
  */
 function loadStoredSessionId() {
   try {
-    return localStorage.getItem(PTY_SESSION_STORAGE_KEY);
+    return localStorage.getItem(ptySessionStorageKey());
   } catch {
     return null;
   }
@@ -75,7 +93,7 @@ function loadStoredSessionId() {
  */
 function storeSessionId(sessionId) {
   try {
-    localStorage.setItem(PTY_SESSION_STORAGE_KEY, sessionId);
+    localStorage.setItem(ptySessionStorageKey(), sessionId);
   } catch {
     // Ignore — private browsing / storage disabled. Persistence is a
     // convenience; the terminal still works without it.
@@ -90,7 +108,7 @@ function storeSessionId(sessionId) {
  */
 export function clearStoredSessionId() {
   try {
-    localStorage.removeItem(PTY_SESSION_STORAGE_KEY);
+    localStorage.removeItem(ptySessionStorageKey());
   } catch {
     // Ignore — see storeSessionId().
   }

--- a/src/osprey/interfaces/web_terminal/static/session.html
+++ b/src/osprey/interfaces/web_terminal/static/session.html
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+{# data-osprey-storage-scope is present ONLY on a multi-user mount
+    (/u/<user>/), where every user shares one origin and therefore one
+    localStorage. It is THE source of truth for the storage namespace — this
+    page's module closure reaches the PTY-session, dock-layout and
+    rail-position keys, and those readers take the namespace from here rather
+    than parsing the URL. Absent means single-user: keys stay unscoped. Never
+    emit it empty. See resolve_storage_scope() in app.py. -#}
+<html lang="en"{% if storage_scope %} data-osprey-storage-scope="{{ storage_scope }}"{% endif %}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -353,7 +353,8 @@ config:
         index: 2
         persona: ariel
         display_name: "ARIEL Logbook Research"
-        # Read-only research service, open without a login on purpose.
+        # Outside the login wall on purpose — entered through its own login URL
+        # instead (`osprey users login-url ariel`), not open to anyone.
         login: false
       # The one login that can change this deployment's configuration — the web
       # Config panel, the scaffold gallery's editors, and the agent's own setup

--- a/src/osprey/services/auth_sidecar/routes/login.py
+++ b/src/osprey/services/auth_sidecar/routes/login.py
@@ -107,6 +107,7 @@ from ..return_to import safe_return_to
 from ..revocation import RevocationStore
 from ..sessions import SESSION_COOKIE_NAME, SessionCodec, SessionState
 from ..throttle import AttemptThrottle
+from .logout import LANDING_PATH
 from .recheck import RecheckRefused, recheck_login, roster_roles
 
 logger = logging.getLogger(__name__)
@@ -287,6 +288,28 @@ def _only(values: list[str] | None) -> str | None:
     if not values or len(values) != 1:
         return None
     return values[0] or None
+
+
+def _prefers_html(request: Request) -> bool:
+    """Whether this caller is a browser navigating rather than a client parsing.
+
+    Deliberately not a content negotiator. Only one distinction is drawn here —
+    a top-level navigation, which sends
+    ``text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8``, against
+    everything else: ``curl``'s ``*/*``, a client that asked for
+    ``application/json``, and a request that states no preference at all. So the
+    test is simply whether ``text/html`` is listed, and listed ahead of
+    ``application/json``. Quality values are not read, because nothing that
+    matters here distinguishes itself from the other by one, and a parser that
+    did read them would be a larger surface than the single question it answers.
+    """
+    header = request.headers.get("accept", "")
+    accepted = [part.split(";", 1)[0].strip().lower() for part in header.split(",")]
+    if "text/html" not in accepted:
+        return False
+    if "application/json" not in accepted:
+        return True
+    return accepted.index("text/html") < accepted.index("application/json")
 
 
 def _page(
@@ -488,6 +511,25 @@ async def login_page(
     ``Location`` — would otherwise let an anonymous link decide how much this
     service emits.
 
+    **A browser that names no user is sent to the landing page**, rather than
+    shown a JSON 400 it cannot act on. A person who arrives here without a
+    username has one useful destination — the page that lists the roster cards,
+    which is where the link they should have followed lives — and
+    :data:`~osprey.services.auth_sidecar.routes.logout.LANDING_PATH` is the same
+    origin-relative ``/`` logout already returns browsers to. That target is the
+    landing page **nginx serves in front of this sidecar**; reached on a bare
+    sidecar port, which is the dev-only ``allow_insecure_http`` shape, nothing
+    serves ``/`` and the browser meets a 404 there instead. The redirect is
+    written for the deployment nginx fronts, which is every deployment an
+    operator logs in to.
+
+    The redirect is emitted *before* the OIDC dispatch below, so it is the answer
+    under both methods — a lost browser has no user to hand the OIDC route
+    either. A link naming *two or more* users is a different thing and keeps its
+    400 for every caller, browser included: that request is ambiguous rather than
+    empty, and resolving it to a landing page would be the same guess this route
+    refuses to make when it picks neither of two names.
+
     Args:
         request: The inbound request.
         settings: The deployment's frozen settings.
@@ -496,23 +538,27 @@ async def login_page(
             usable one.
 
     Returns:
-        The rendered prompt in password mode, or a redirect to the OIDC login
-        route on a deployment that authenticates that way — nginx's 401 handler
-        sends every method's browsers here, and a password form is unanswerable
-        under OIDC.
+        The rendered prompt in password mode; a redirect to the OIDC login route
+        on a deployment that authenticates that way — nginx's 401 handler sends
+        every method's browsers here, and a password form is unanswerable under
+        OIDC; or a 302 to the landing page when a browser named no user at all.
 
     Raises:
-        HTTPException: 400 when the link does not name exactly one user; 404
-            when this deployment serves no password login, or when ``user`` is
-            not on the roster.
+        HTTPException: 400 when the link names two or more users, or names none
+            and the caller did not ask for HTML; 404 when this deployment serves
+            no password login, or when ``user`` is not on the roster.
     """
     username = _only(user)
     if username is None:
         # Counts and lengths, never values: this is the one part of the request a
         # client chose freely.
-        logger.warning(
-            "login page requested without exactly one user parameter (got %d)", len(user or [])
-        )
+        named = len(user or [])
+        logger.warning("login page requested without exactly one user parameter (got %d)", named)
+        if named < 2 and _prefers_html(request):
+            # Fewer than two values means the link named nobody — an empty
+            # `?user=` included. A browser gets the roster instead of a body it
+            # would render as text.
+            return RedirectResponse(LANDING_PATH, status_code=302, headers=_NO_STORE_HEADERS)
         raise HTTPException(
             status_code=400,
             detail="the login link must name exactly one user",
@@ -595,6 +641,23 @@ async def login_submit(
     exact-matches it against the roster — normalising it here would open the
     chain rather than close it.
 
+    **A browser whose form named no user is sent to the landing page**, the same
+    302 to :data:`~osprey.services.auth_sidecar.routes.logout.LANDING_PATH` the
+    ``GET`` above answers with, and for the same reason: there is no credential
+    to evaluate and nothing to render a prompt about, so the person belongs back
+    at the roster cards. As there, the target is the landing page nginx serves in
+    front of this sidecar — on a bare sidecar port, the dev-only
+    ``allow_insecure_http`` shape, that path is a 404 — and a form naming *two or
+    more* users keeps its 400 for every caller, browser included: that is an
+    ambiguous submission rather than an empty one. The origin check still runs
+    first, so a cross-site POST is refused before this is reached and cannot be
+    turned into a redirect.
+
+    None of this touches the credential-refusal path: a wrong password, an
+    uncredentialed roster user and a name that is not on the roster still produce
+    one status, one page and one message. A form that named no user was never a
+    credential attempt.
+
     Args:
         request: The inbound request, carrying the submitted form.
         settings: The deployment's frozen settings.
@@ -608,12 +671,13 @@ async def login_submit(
         A 303 to the validated return-to carrying the re-issued session cookie;
         the prompt again with 401 and one fixed message when the credential is
         refused; the prompt with 429 and ``Retry-After`` when the attempt
-        arrived inside an open window.
+        arrived inside an open window; a 302 to the landing page when a browser
+        submitted a form that named no user.
 
     Raises:
-        HTTPException: 400 when the form arrives from another origin or does not
-            name exactly one user; 404 when this deployment serves no password
-            login.
+        HTTPException: 400 when the form arrives from another origin, names two
+            or more users, or names none and the caller did not ask for HTML;
+            404 when this deployment serves no password login.
     """
     if settings.method != "password":
         raise HTTPException(
@@ -641,9 +705,13 @@ async def login_submit(
     submitted_users = _form_values(form, FIELD_USER)
     username = _only(submitted_users)
     if username is None:
-        logger.warning(
-            "login submitted without exactly one user field (got %d)", len(submitted_users)
-        )
+        named = len(submitted_users)
+        logger.warning("login submitted without exactly one user field (got %d)", named)
+        if named < 2 and _prefers_html(request):
+            # The GET's answer, for the same reason: a form that carried no user
+            # cannot be evaluated, and the browser that posted it belongs on the
+            # roster page rather than in front of a JSON body.
+            return RedirectResponse(LANDING_PATH, status_code=302, headers=_NO_STORE_HEADERS)
         raise HTTPException(
             status_code=400,
             detail="the login form must name exactly one user",

--- a/src/osprey/templates/modules/web_terminals/landing.html.j2
+++ b/src/osprey/templates/modules/web_terminals/landing.html.j2
@@ -49,6 +49,15 @@
       persona badge on the card; when absent the card renders exactly as a plain
       `{label, url}` card (bracket-subscripting a missing key yields Jinja
       `Undefined`, which is falsy — see the `{% if item["sublabel"] %}` guard).
+      `token_login` is present on every auto-populated user card and on no other
+      item: true when that user's terminal is entered by opening their own
+      `?token=` URL rather than through a login the perimeter serves. A true card
+      renders a badge and one hint line naming `osprey users login-url <name>`,
+      the verb that mints the URL, and KEEPS its href (the token exchange leaves
+      a session cookie, so the link is a real return path). Operator-supplied
+      `landing.groups` items carry no such key, and the same `Undefined`-is-falsy
+      reading that governs `sublabel` leaves them rendering as they always did.
+
       A group whose `items` list is empty renders nothing — no heading, no empty
       section. This is the ONLY suppression rule, and it is generic to every group:
       it's what makes the 0-user case disappear cleanly (an empty/omitted `users`
@@ -271,6 +280,41 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    /* The two marks a card carries when its terminal is entered by opening
+       that user's own `?token=` URL rather than through a login the perimeter
+       serves. Deliberately quieter than the persona chip beside it — muted
+       border and text rather than the accent — because it is a fact about how
+       the door opens, not a category the page is sorting people into. Both
+       colors are theme tokens, so the mark follows the page into either mode.
+       The card itself stays a live link and is styled as one: the `?token=`
+       exchange leaves a session cookie, so this IS the return path for anyone
+       who has opened the URL once. */
+    .landing-card-token {
+      align-self: flex-start;
+      max-width: 100%;
+      margin: 0.05rem 0 0.1rem;
+      padding: 0.12rem 0.55rem;
+      border: 1px solid var(--border-default);
+      border-radius: 999px;
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .landing-card-token-hint {
+      max-width: 100%;
+      color: var(--text-secondary);
+      font-size: 0.72rem;
+      line-height: 1.35;
+    }
+    .landing-card-token-hint code {
+      font-family: ui-monospace, "JetBrains Mono", monospace;
+      word-break: break-all;
+    }
     .landing-card-url {
       font-family: ui-monospace, "JetBrains Mono", monospace;
       font-size: 0.78rem;
@@ -388,6 +432,29 @@
             <span class="landing-card-label">{{ item["label"]|e }}</span>
             {%- if item["sublabel"] %}
             <span class="landing-card-sublabel">{{ item["sublabel"]|e }}</span>
+            {%- endif %}
+            {#- The card is honest about how this terminal is entered. `token_login`
+               is true for a roster user whose way in is that user's own `?token=`
+               URL, and the URL is not on this page — it carries a live credential,
+               and it is minted by `osprey users login-url <name>`, which nobody
+               guesses. Without this line the card is indistinguishable from one
+               behind a login wall, and a first-time visitor clicks it, is refused,
+               and has no idea what to do next.
+               The href STAYS: the `?token=` exchange leaves a session cookie
+               behind, so this link is the return path for a browser that has
+               opened the URL once. Naming the verb is the fix; disabling the link
+               would be a different wrong answer.
+               Only on the navigable branch — an inert card's link cannot be
+               followed at all, so a note about which door it is would be noise
+               under a card whose real problem is its scheme.
+               `item["label"]` IS the roster name (`_user_card` builds the card
+               from it), so the command names this card's own user; escaped like
+               every other user-sourced value here. A `landing.groups` link item
+               carries no `token_login` key, so the subscript is Undefined —
+               falsy — and the group renders exactly as it did before. #}
+            {%- if item["token_login"] %}
+            <span class="landing-card-token">login link</span>
+            <span class="landing-card-token-hint">entered via a login link — <code>osprey users login-url {{ item["label"]|e }}</code></span>
             {%- endif %}
             <span class="landing-card-url">{{ safe_url|e }}</span>
           </a>

--- a/tests/cli/test_summary_card.py
+++ b/tests/cli/test_summary_card.py
@@ -831,11 +831,14 @@ class TestTokenLoginClosingLine:
     def test_an_auth_off_roster_is_told_the_verb(
         self, repo_with_token_logins: Path, recorder: Recorded
     ) -> None:
+        """Two token-login users get the plural phrasing: `each need`."""
         print_summary_card(repo_with_token_logins, "running")
 
         printed = "\n".join(recorder.lines)
         assert "osprey users login-url alice" in printed
         assert "alice, bob" in printed
+        assert "these terminals have no login page" in printed
+        assert "alice, bob each need their own login URL" in printed
 
     def test_the_urls_themselves_are_never_printed(
         self, repo_with_token_logins: Path, recorder: Recorded
@@ -865,7 +868,7 @@ class TestTokenLoginClosingLine:
         self, repo_with_logins: Path, recorder: Recorded
     ) -> None:
         """`login: false` puts one entry outside the wall, and that terminal is
-        reached exactly the way an auth-off one is."""
+        reached exactly the way an auth-off one is -- singular phrasing: `needs`."""
         config = repo_with_logins / "build" / "config.yml"
         config.write_text(
             config.read_text() + "      - name: kiosk\n        index: 2\n        login: false\n"
@@ -875,6 +878,8 @@ class TestTokenLoginClosingLine:
 
         printed = "\n".join(recorder.lines)
         assert "osprey users login-url kiosk" in printed
+        assert "this terminal has no login page" in printed
+        assert "kiosk needs its own login URL" in printed
         # ...and only that entry: alice and bob still have a login page.
         assert "alice" not in printed.split("no login page")[1]
 

--- a/tests/cli/test_web_preflight_marker.py
+++ b/tests/cli/test_web_preflight_marker.py
@@ -1,0 +1,191 @@
+"""The pre-flight refusal marker ``osprey web`` leaves in the per-user audit dir.
+
+Under container supervision (``restart: unless-stopped``) a pre-flight refusal
+is invisible: the container exits 1, the runtime restarts it, it refuses again,
+and from the outside all anyone sees is a service flapping. The marker is the
+only surface that says *why* — ``osprey status`` reads it to render a
+"restarting (pre-flight: ...)" row instead of a bare restart count.
+
+The marker is deliberately advisory: an absent or unwritable audit directory
+must never turn a pre-flight refusal into a second, different failure, and a
+bare laptop launch (no ``OSPREY_AUDIT_DIR``, no supervisor) writes nothing at
+all.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.web_cmd import AUDIT_DIR_ENV, PREFLIGHT_REFUSED_MARKER, web
+from tests.cli._lifecycle_build import stub_build
+
+#: One refusal finding, in the shape ``_preflight`` actually returns them.
+FINDING = "port 8081 is already in use by another process (artifact server)"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def deployment(lifecycle_repo: Path) -> Path:
+    """An exemplar repo with a render — the shape every launch test needs."""
+    stub_build(lifecycle_repo, config="web: {}\n")
+    return lifecycle_repo
+
+
+@pytest.fixture(autouse=True)
+def _isolate_launch_env(monkeypatch):
+    """Roll back every env key a launch writes directly into ``os.environ``.
+
+    ``web()`` writes ``OSPREY_CONFIG``, ``OSPREY_WEB_PORT`` and the operator
+    secret itself, not through monkeypatch, so a plain ``delenv`` on an
+    already-absent key would record no undo entry and let those writes leak
+    into later tests. setenv-then-delenv forces the undo entry (same trick as
+    ``test_web_cmd.py``); ``AUDIT_DIR_ENV`` joins the list so no ambient
+    export from the developer's shell decides where a marker lands.
+    """
+    from osprey.interfaces.web_auth import OPERATOR_SECRET_ENV, reset_web_credentials
+
+    for key in ("OSPREY_CONFIG", "OSPREY_WEB_PORT", OPERATOR_SECRET_ENV, AUDIT_DIR_ENV):
+        monkeypatch.setenv(key, "__unset_by_test_fixture__")
+        monkeypatch.delenv(key)
+    reset_web_credentials()
+    yield
+    reset_web_credentials()
+
+
+def _stub_launch(monkeypatch) -> None:
+    """Stop a passing pre-flight from starting a real server."""
+    monkeypatch.setattr("osprey.interfaces.web_terminal.run_web", lambda **_kw: None)
+    monkeypatch.setattr("osprey.mcp_env.load_dotenv_from_project", lambda: None)
+
+
+def _invoke(runner, deployment, *extra):
+    return runner.invoke(
+        web,
+        ["--repo", str(deployment), "--shell", "true", *extra],
+        catch_exceptions=False,
+    )
+
+
+def _seed_marker(audit_dir: Path) -> Path:
+    """Leave a marker from a previous, already-answered refusal."""
+    marker = audit_dir / PREFLIGHT_REFUSED_MARKER
+    marker.write_text("2000-01-01T00:00:00+00:00\n- a stale finding\n", encoding="utf-8")
+    return marker
+
+
+class TestPreflightRefusalWritesTheMarker:
+    """A refusal records itself where the supervisor's reader can find it."""
+
+    @patch("osprey.cli.web_cmd._preflight", return_value=([FINDING], []))
+    def test_marker_carries_a_utc_timestamp_then_the_refusal_findings(
+        self, _mock_preflight, runner, monkeypatch, deployment, tmp_path
+    ):
+        audit_dir = tmp_path / "audit"
+        audit_dir.mkdir()
+        monkeypatch.setenv(AUDIT_DIR_ENV, str(audit_dir))
+
+        result = _invoke(runner, deployment)
+
+        assert result.exit_code == 1
+        assert "Pre-flight checks failed" in result.output
+
+        marker = audit_dir / PREFLIGHT_REFUSED_MARKER
+        first_line, _, body = marker.read_text(encoding="utf-8").partition("\n")
+        stamp = datetime.fromisoformat(first_line)
+        assert stamp.tzinfo is not None and stamp.utcoffset().total_seconds() == 0
+        assert FINDING in body
+
+    @patch("osprey.cli.web_cmd._preflight", return_value=([FINDING], []))
+    def test_a_second_refusal_refreshes_the_marker_rather_than_appending(
+        self, _mock_preflight, runner, monkeypatch, deployment, tmp_path
+    ):
+        """Each supervised restart re-runs pre-flight, so the marker must read
+        as *this* attempt, not as a growing pile of every attempt."""
+        audit_dir = tmp_path / "audit"
+        audit_dir.mkdir()
+        monkeypatch.setenv(AUDIT_DIR_ENV, str(audit_dir))
+        stale = _seed_marker(audit_dir)
+
+        assert _invoke(runner, deployment).exit_code == 1
+
+        text = stale.read_text(encoding="utf-8")
+        assert "2000-01-01" not in text
+        assert text.count(FINDING) == 1
+
+
+class TestPreflightMarkerLifecycle:
+    """Who clears the marker, and — deliberately — who does not."""
+
+    @patch("osprey.cli.web_cmd._preflight", return_value=([], []))
+    def test_a_passing_preflight_clears_a_stale_marker(
+        self, _mock_preflight, runner, monkeypatch, deployment, tmp_path
+    ):
+        audit_dir = tmp_path / "audit"
+        audit_dir.mkdir()
+        monkeypatch.setenv(AUDIT_DIR_ENV, str(audit_dir))
+        stale = _seed_marker(audit_dir)
+        _stub_launch(monkeypatch)
+
+        assert _invoke(runner, deployment).exit_code == 0
+        assert not stale.exists()
+
+    def test_skip_preflight_leaves_the_marker_alone(
+        self, runner, monkeypatch, deployment, tmp_path
+    ):
+        """``--skip-preflight`` forces past a refusal it never re-ran. Clearing
+        the marker there would erase the evidence of the very refusal the
+        operator is overriding, so the record stands until a real pre-flight
+        passes."""
+        audit_dir = tmp_path / "audit"
+        audit_dir.mkdir()
+        monkeypatch.setenv(AUDIT_DIR_ENV, str(audit_dir))
+        stale = _seed_marker(audit_dir)
+        before = stale.read_text(encoding="utf-8")
+        _stub_launch(monkeypatch)
+
+        assert _invoke(runner, deployment, "--skip-preflight").exit_code == 0
+        assert stale.read_text(encoding="utf-8") == before
+
+
+class TestPreflightMarkerNeverBecomesASecondFailure:
+    """The marker is advisory: it may be skipped, never escalated."""
+
+    @patch("osprey.cli.web_cmd._preflight", return_value=([FINDING], []))
+    def test_unwritable_audit_dir_still_reports_the_refusal_and_exits_one(
+        self, _mock_preflight, runner, monkeypatch, deployment, tmp_path
+    ):
+        """A regular file where the audit directory should be — the cheapest
+        deterministic stand-in for a root-owned or read-only mount."""
+        blocked = tmp_path / "not-a-directory"
+        blocked.write_text("", encoding="utf-8")
+        monkeypatch.setenv(AUDIT_DIR_ENV, str(blocked / "alice"))
+
+        result = _invoke(runner, deployment)
+
+        assert result.exit_code == 1
+        assert "Pre-flight checks failed" in result.output
+        assert FINDING in result.output
+
+    @patch("osprey.cli.web_cmd._preflight", return_value=([FINDING], []))
+    def test_no_audit_dir_env_writes_no_marker_anywhere(
+        self, _mock_preflight, runner, monkeypatch, deployment, tmp_path
+    ):
+        """A bare ``osprey web`` on a laptop has no supervisor to explain the
+        refusal to, and no per-user audit directory to explain it in."""
+        monkeypatch.chdir(tmp_path)
+
+        result = _invoke(runner, deployment)
+
+        assert result.exit_code == 1
+        assert "Pre-flight checks failed" in result.output
+        assert list(tmp_path.rglob(PREFLIGHT_REFUSED_MARKER)) == []
+        assert list(deployment.rglob(PREFLIGHT_REFUSED_MARKER)) == []

--- a/tests/deployment/test_deploy_summary.py
+++ b/tests/deployment/test_deploy_summary.py
@@ -24,6 +24,7 @@ import logging
 import re
 
 import pytest
+import yaml
 from rich.console import Console
 from rich.logging import RichHandler
 
@@ -758,6 +759,12 @@ def test_a_single_user_deployment_shows_every_panel_band(tmp_path, base):
     ``services.<name>``, so neither binding source can see them. Without a third
     derivation the seven largest bands of the block are simply missing from
     ``osprey up`` and ``osprey status``.
+
+    EVERY band, deliberately: this roster names no persona, so nothing on disk
+    says which panels its user actually serves, and the whole-roster reading is
+    the honest one. The bands are narrowed to who serves them only where a
+    persona project answers the question — see
+    ``test_a_band_lists_only_the_users_whose_persona_serves_it``.
     """
     empty = tmp_path / "docker-compose.yml"
     empty.write_text("services: {}\n", encoding="utf-8")
@@ -795,6 +802,10 @@ def test_a_roster_shows_each_family_as_one_band_not_one_row_per_user(tmp_path, b
     No ``http://`` on a range: the renderer linkifies a whitespace-delimited
     address, so a scheme here would hand the operator a link that 404s on the
     dash — the same rule that keeps a URL off the graph store's bolt address.
+
+    All three users on every band, deliberately: a bare-string roster names no
+    persona, so no rendered project says which panels any of them serves and
+    the whole roster is what this deployment can honestly claim.
     """
     empty = tmp_path / "docker-compose.yml"
     empty.write_text("services: {}\n", encoding="utf-8")
@@ -855,6 +866,386 @@ def test_a_roster_index_past_its_band_costs_the_panels_not_the_summary(tmp_path)
 
     assert _panel_rows(entries) == {}
     assert any(service == "web terminal" for _tier, service, _address in entries)
+
+
+# ---------------------------------------------------------------------------
+# Whose band it is: the panels a persona actually serves
+# ---------------------------------------------------------------------------
+
+
+def _persona_deployment(tmp_path, personas, users, base=DEFAULT_PORT_BASE):
+    """A deploy repo whose personas' rendered projects are on disk.
+
+    The shape ``osprey build`` leaves behind: a catalog under
+    ``modules.web_terminals.personas`` whose ``project_path`` names a rendered
+    project inside ``build/``, and each of those projects carrying the
+    ``web.panels`` block its own profile asked for.
+
+    Args:
+        tmp_path: The deploy repo root.
+        personas: ``{persona: [panel_id, ...]}`` — the panels that persona's
+            rendered project declares. An empty list is a project that declares
+            none, which still serves the universal WORKSPACE panel.
+        users: The roster, raw, exactly as ``modules.web_terminals.users``.
+        base: The deployment's port base.
+
+    Returns:
+        ``(config, compose_file_path)`` ready for :func:`endpoint_entries`.
+    """
+    for persona, panel_ids in personas.items():
+        project_dir = tmp_path / "build" / f"demo-{persona}"
+        project_dir.mkdir(parents=True)
+        (project_dir / "config.yml").write_text(
+            yaml.safe_dump({"web": {"panels": dict.fromkeys(panel_ids, True)}}),
+            encoding="utf-8",
+        )
+    empty = tmp_path / "docker-compose.yml"
+    empty.write_text("services: {}\n", encoding="utf-8")
+    config = {
+        "project_name": "demo",
+        # What `osprey build` writes into the rendered config, and the only
+        # anchor `osprey status` has for the persona projects: it hands
+        # `endpoint_entries` a config and compose files, never a root.
+        "project_root": str(tmp_path),
+        "deployment": {"port_base": base},
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "users": users,
+                "personas": {
+                    persona: {
+                        "project": f"demo-{persona}",
+                        "project_path": f"build/demo-{persona}",
+                    }
+                    for persona in personas
+                },
+            }
+        },
+    }
+    return config, str(empty)
+
+
+#: The two-persona roster every test below shares: alice runs a persona whose
+#: project declares only the ARIEL panel, bob one that declares the channel
+#: finder and the health dashboard. Neither declares LATTICE or KNOWLEDGE.
+_SPLIT_PERSONAS = {"ariel": ["ariel"], "readonly": ["channel-finder", "system-health"]}
+_SPLIT_ROSTER = [
+    {"name": "alice", "index": 0, "persona": "ariel"},
+    {"name": "bob", "index": 1, "persona": "readonly"},
+]
+
+
+@pytest.mark.parametrize("base", [DEFAULT_PORT_BASE, 20000])
+def test_a_band_lists_only_the_users_whose_persona_serves_it(tmp_path, base):
+    """A band names the users who answer on it, not everyone who has a port there.
+
+    Every user is allocated a port in every family — the allocator reserves the
+    whole block whatever the roster runs — but only the users whose persona
+    declares that panel ever listen on theirs. Naming the whole roster beside
+    the ARIEL band told an operator that bob answers there, and he does not:
+    his container never starts the server.
+    """
+    config, compose = _persona_deployment(tmp_path, _SPLIT_PERSONAS, _SPLIT_ROSTER, base)
+
+    panels = _panel_rows(deploy_summary.endpoint_entries(config, [compose]))
+
+    ports = layout_ports(base)
+    # One user on the band, so one port to open — and the scheme goes back on,
+    # by the same rule that keeps it off a range.
+    assert panels["ariel"] == f"http://127.0.0.1:{ports['ariel']}  (alice)"
+    assert panels["channel_finder"] == f"http://127.0.0.1:{ports['channel_finder'] + 1}  (bob)"
+    assert panels["system_health"] == f"http://127.0.0.1:{ports['system_health'] + 1}  (bob)"
+    # The terminal itself and the universal WORKSPACE panel are served by
+    # everyone: no persona can switch off the tab it cannot switch off.
+    assert panels["web"] == f"127.0.0.1:{ports['web']}-{ports['web'] + 1}  (alice, bob)"
+    assert panels["artifact"] == (
+        f"127.0.0.1:{ports['artifact']}-{ports['artifact'] + 1}  (alice, bob)"
+    )
+
+
+def test_a_family_no_persona_serves_prints_no_band_at_all(tmp_path):
+    """A band nothing listens on is not a quieter row — it is not a row.
+
+    LATTICE and KNOWLEDGE are reserved by the layout for every deployment, and
+    neither persona here declares them. Printing their bands with a hedge
+    beside them would be the same claim in smaller type: the address would
+    still be there to copy, and nothing answers at it.
+    """
+    config, compose = _persona_deployment(tmp_path, _SPLIT_PERSONAS, _SPLIT_ROSTER)
+
+    panels = _panel_rows(deploy_summary.endpoint_entries(config, [compose]))
+
+    assert "lattice" not in panels
+    assert "okf" not in panels
+    assert str(layout_ports(DEFAULT_PORT_BASE)["lattice"]) not in "".join(panels.values())
+
+
+def test_the_reserved_but_unserved_bands_are_one_note_not_a_row_each(tmp_path):
+    """Said once, at the end of the tier: the block still reserves them.
+
+    An operator who reads six families where the layout has seven needs to know
+    the seventh was not lost — but a per-family row for each would re-introduce
+    exactly the addresses the rows above deliberately dropped.
+    """
+    config, compose = _persona_deployment(tmp_path, _SPLIT_PERSONAS, _SPLIT_ROSTER)
+
+    entries = deploy_summary.endpoint_entries(config, [compose])
+    notes = [
+        address
+        for tier, service, address in entries
+        if tier == "panels" and service == deploy_summary.RESERVED_BANDS_LABEL
+    ]
+
+    assert len(notes) == 1
+    assert notes[0].startswith("lattice, okf ")
+    # Last in its tier, so it reads as a footnote to the bands above it rather
+    # than as a band between them.
+    panel_services = [service for tier, service, _address in entries if tier == "panels"]
+    assert panel_services[-1] == deploy_summary.RESERVED_BANDS_LABEL
+
+
+def test_a_deployment_every_persona_serves_carries_no_note(tmp_path):
+    """Nothing reserved-and-unserved is nothing to say; a note would be noise."""
+    every_panel = ["ariel", "channel-finder", "lattice", "okf", "system-health"]
+    config, compose = _persona_deployment(
+        tmp_path,
+        {"admin": every_panel},
+        [{"name": "alice", "index": 0, "persona": "admin"}],
+    )
+
+    entries = deploy_summary.endpoint_entries(config, [compose])
+    panels = _panel_rows(entries)
+
+    assert deploy_summary.RESERVED_BANDS_LABEL not in panels
+    assert len(panels) == 7
+
+
+def test_an_unbuilt_persona_project_degrades_to_the_whole_roster(tmp_path):
+    """Advisory to the end: an unreadable persona costs the narrowing, not the summary.
+
+    A catalog naming a project that has not been rendered — a repo cloned but
+    not built, a persona added since the last build — leaves nothing on disk to
+    read. Guessing which panels its users serve would be worse than the wide
+    answer, and failing the summary would be worse than both.
+    """
+    config, compose = _persona_deployment(tmp_path, _SPLIT_PERSONAS, _SPLIT_ROSTER)
+    (tmp_path / "build" / "demo-readonly" / "config.yml").unlink()
+
+    panels = _panel_rows(deploy_summary.endpoint_entries(config, [compose]))
+
+    ports = layout_ports(DEFAULT_PORT_BASE)
+    assert len(panels) == 7
+    assert panels["lattice"] == f"127.0.0.1:{ports['lattice']}-{ports['lattice'] + 1}  (alice, bob)"
+    assert deploy_summary.RESERVED_BANDS_LABEL not in panels
+
+
+def test_a_persona_whose_project_declares_no_panels_still_serves_the_universal_one(tmp_path):
+    """WORKSPACE is not a panel a project can decline, so its band is always served."""
+    config, compose = _persona_deployment(
+        tmp_path,
+        {"minimal": []},
+        [{"name": "alice", "index": 0, "persona": "minimal"}],
+    )
+
+    panels = _panel_rows(deploy_summary.endpoint_entries(config, [compose]))
+
+    ports = layout_ports(DEFAULT_PORT_BASE)
+    assert panels["artifact"] == f"http://127.0.0.1:{ports['artifact']}  (alice)"
+    assert panels["web"] == f"http://127.0.0.1:{ports['web']}  (alice)"
+    assert set(panels) == {"web", "artifact", deploy_summary.RESERVED_BANDS_LABEL}
+
+
+def test_a_panel_switched_off_by_a_persona_is_not_served(tmp_path):
+    """``enabled: false`` is a declaration too, and it is a declaration of absence."""
+    tmp_path.joinpath("build", "demo-readonly").mkdir(parents=True)
+    tmp_path.joinpath("build", "demo-readonly", "config.yml").write_text(
+        yaml.safe_dump({"web": {"panels": {"ariel": True, "okf": {"enabled": False}}}}),
+        encoding="utf-8",
+    )
+    empty = tmp_path / "docker-compose.yml"
+    empty.write_text("services: {}\n", encoding="utf-8")
+    config = {
+        "project_name": "demo",
+        "project_root": str(tmp_path),
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "users": [{"name": "alice", "index": 0, "persona": "readonly"}],
+                "personas": {"readonly": {"project_path": "build/demo-readonly"}},
+            }
+        },
+    }
+
+    panels = _panel_rows(deploy_summary.endpoint_entries(config, [str(empty)]))
+
+    assert "ariel" in panels
+    assert "okf" not in panels
+
+
+def test_the_narrowing_reaches_status_through_the_entries_it_shares(tmp_path):
+    """``osprey status`` and the deploy summary move together, or they contradict.
+
+    Status hands :func:`endpoint_entries` a config and compose files and no
+    root, so the persona projects are found through the rendered config's own
+    ``project_root``. If that anchor were dropped, the deploy that printed the
+    narrow bands would be followed by a status printing the wide ones, and the
+    operator would have no way to tell which surface was lying.
+    """
+    config, compose = _persona_deployment(tmp_path, _SPLIT_PERSONAS, _SPLIT_ROSTER)
+
+    entries = deploy_summary.endpoint_entries(config, [compose])
+    rows = dict(deploy_summary.summary_rows(entries))
+
+    ports = layout_ports(DEFAULT_PORT_BASE)
+    assert rows["  ariel"] == f"http://127.0.0.1:{ports['ariel']}  (alice)"
+    assert "  lattice" not in rows
+
+
+def test_a_root_in_hand_beats_the_one_the_config_declares(tmp_path):
+    """A moved repo is read where it IS, for a caller that knows where that is.
+
+    ``as_built_endpoint_entries`` holds the repo it was pointed at; the
+    ``project_root`` inside a rendered config was written wherever the build
+    happened to run. When the two disagree the caller's is the live one — a
+    deployment copied to another host would otherwise resolve its personas
+    against a path that belongs to a different machine.
+    """
+    config, _compose = _persona_deployment(tmp_path, _SPLIT_PERSONAS, _SPLIT_ROSTER)
+    config["project_root"] = str(tmp_path / "somewhere-else")
+    (tmp_path / "build" / "config.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    panels = _panel_rows(deploy_summary.as_built_endpoint_entries(tmp_path))
+
+    ports = layout_ports(DEFAULT_PORT_BASE)
+    assert panels["ariel"] == f"http://127.0.0.1:{ports['ariel']}  (alice)"
+    assert "lattice" not in panels
+
+
+def test_a_roster_user_the_catalog_cannot_place_degrades_the_whole_tier(tmp_path):
+    """One unplaceable user is not narrowed around — the tier goes wide.
+
+    Reporting the bands the OTHER users serve would silently drop this one from
+    every band he might be on, which reads as "carol serves nothing" rather
+    than as "nothing here knows what carol serves".
+    """
+    config, compose = _persona_deployment(
+        tmp_path,
+        _SPLIT_PERSONAS,
+        [*_SPLIT_ROSTER, {"name": "carol", "index": 2}],
+    )
+
+    panels = _panel_rows(deploy_summary.endpoint_entries(config, [compose]))
+
+    ports = layout_ports(DEFAULT_PORT_BASE)
+    assert len(panels) == 7
+    assert panels["lattice"] == (
+        f"127.0.0.1:{ports['lattice']}-{ports['lattice'] + 2}  (alice, bob, carol)"
+    )
+
+
+def _unparseable_persona_config(tmp_path, config):
+    """A rendered ``config.yml`` that is not YAML — a build interrupted mid-write."""
+    path = tmp_path / "build" / "demo-readonly" / "config.yml"
+    path.write_text("web: [unclosed\n", encoding="utf-8")
+
+
+def _catalog_entry_without_a_project_path(tmp_path, config):
+    """A persona declared but never pointed at a project."""
+    config["modules"]["web_terminals"]["personas"]["readonly"].pop("project_path")
+
+
+def _roster_entry_that_is_not_a_user(tmp_path, config):
+    """A bare scalar where a roster entry belongs — a hand-edited config, or ``--no-lint``."""
+    config["modules"]["web_terminals"]["users"] = [*_SPLIT_ROSTER, 42]
+
+
+def _authorization_stanza_that_does_not_parse(tmp_path, config):
+    """A declared role that names no persona — one of the parser's refusals.
+
+    Not a scalar ``authorization: 42``: that one parses to the inert defaults
+    (``as_dict`` reads a non-mapping as empty), so it degrades nothing and is
+    not a case. What the parser genuinely refuses is a binding it cannot
+    resolve, and a personaless role is the shortest of the three.
+    """
+    config["modules"]["web_terminals"]["authorization"] = {"roles": {"operator": {}}}
+
+
+@pytest.mark.parametrize(
+    "break_it",
+    [
+        _unparseable_persona_config,
+        _catalog_entry_without_a_project_path,
+        _roster_entry_that_is_not_a_user,
+        _authorization_stanza_that_does_not_parse,
+    ],
+    ids=["unparseable-project", "no-project-path", "roster-entry-is-a-scalar", "bad-authorization"],
+)
+def test_anything_that_cannot_be_read_degrades_the_tier_rather_than_narrowing(tmp_path, break_it):
+    """Every way the persona walk can fail ends in the wide bands, not in a traceback.
+
+    The narrowing reads config the deploy has already accepted and a directory
+    tree it does not own, so each step has a way to come back with nothing:
+    an unparseable rendered project, a catalog entry pointing nowhere, a roster
+    entry that is not a user, a role table that is not a table. All four are
+    reachable past ``--no-lint`` or by hand-editing ``build/config.yml``, and
+    all four must cost the *claim about who answers where* — never the summary
+    that a successful deploy ends with.
+    """
+    config, compose = _persona_deployment(tmp_path, _SPLIT_PERSONAS, _SPLIT_ROSTER)
+    break_it(tmp_path, config)
+
+    panels = _panel_rows(deploy_summary.endpoint_entries(config, [compose]))
+
+    ports = layout_ports(DEFAULT_PORT_BASE)
+    assert len(panels) == 7
+    assert deploy_summary.RESERVED_BANDS_LABEL not in panels
+    assert panels["lattice"] == f"127.0.0.1:{ports['lattice']}-{ports['lattice'] + 1}  (alice, bob)"
+
+
+def test_a_roster_entry_that_is_not_a_user_reaches_no_caller_as_an_exception(tmp_path):
+    """The two surfaces that do not wrap this call are the ones that must not raise.
+
+    ``format_endpoint_summary`` and the closing card's
+    ``as_built_endpoint_entries`` both call the derivation bare, so an
+    exception out of it replaces a finished deploy's report with a traceback
+    and tells the operator the deploy failed when it did not. Asserted through
+    both, because the crash was in a helper neither of them can see.
+    """
+    config, compose = _persona_deployment(
+        tmp_path, _SPLIT_PERSONAS, [*_SPLIT_ROSTER, 42], base=DEFAULT_PORT_BASE
+    )
+    (tmp_path / "build" / "config.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    text = deploy_summary.format_endpoint_summary(config, [compose])
+    card_rows = deploy_summary.as_built_endpoint_entries(tmp_path)
+
+    ports = layout_ports(DEFAULT_PORT_BASE)
+    # Degraded, and degraded to something that still says where the block is.
+    assert f"127.0.0.1:{ports['lattice']}-{ports['lattice'] + 1}  (alice, bob)" in text
+    assert len(_panel_rows(card_rows)) == 7
+
+
+def test_a_persona_project_with_no_web_block_serves_the_universal_bands(tmp_path):
+    """A project that declares nothing is an ANSWER, not a failure to read one.
+
+    ``web:`` missing entirely is what a rendered project without any panel
+    configuration looks like, and the terminal's own reading of that is
+    unambiguous: it starts the WORKSPACE panel and nothing else. So this narrows
+    to two bands rather than degrading to seven — degrading here would report
+    five addresses that this deployment genuinely does not answer on.
+    """
+    config, compose = _persona_deployment(
+        tmp_path, {"minimal": []}, [{"name": "alice", "index": 0, "persona": "minimal"}]
+    )
+    (tmp_path / "build" / "demo-minimal" / "config.yml").write_text(
+        yaml.safe_dump({"project_name": "demo-minimal"}), encoding="utf-8"
+    )
+
+    panels = _panel_rows(deploy_summary.endpoint_entries(config, [compose]))
+
+    ports = layout_ports(DEFAULT_PORT_BASE)
+    assert set(panels) == {"web", "artifact", deploy_summary.RESERVED_BANDS_LABEL}
+    assert panels["artifact"] == f"http://127.0.0.1:{ports['artifact']}  (alice)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_status_display.py
+++ b/tests/deployment/test_status_display.py
@@ -383,3 +383,29 @@ services:
     assert output.index("stores") < output.index("postgresql")
     assert f"http://127.0.0.1:{ports['openobserve']}" in output
     assert f"127.0.0.1:{ports['postgres']}" in output
+
+
+def test_the_endpoints_section_resolves_personas_against_the_live_checkout(
+    tmp_path, monkeypatch, rendered
+):
+    """Status hands ``endpoint_entries`` the repo it is reporting on.
+
+    The panel rows are narrowed per persona by reading each persona's rendered
+    project, and a checkout that was moved or copied records a ``project_root``
+    pointing at the OTHER copy — which would narrow this deployment's bands
+    against somebody else's roster. The compose files in the same call are
+    already anchored on the live root; the persona lookup has to be too.
+    """
+    from osprey.deployment import deploy_summary
+
+    seen = {}
+
+    def _fake_endpoint_entries(config, compose_files, *, project_root=None):
+        seen["project_root"] = project_root
+        return []
+
+    monkeypatch.setattr(deploy_summary, "endpoint_entries", _fake_endpoint_entries)
+
+    status_display._print_endpoints_section({"project_name": "demo"}, [], tmp_path)
+
+    assert seen["project_root"] == tmp_path

--- a/tests/deployment/test_status_preflight.py
+++ b/tests/deployment/test_status_preflight.py
@@ -1,0 +1,310 @@
+"""``osprey status`` reads the pre-flight refusal marker ``osprey web`` writes.
+
+The container half of this contract lives in :mod:`osprey.cli.web_cmd`: on a
+pre-flight refusal the web entrypoint writes ``$OSPREY_AUDIT_DIR/preflight-refused``
+— line 1 an ISO-8601 UTC timestamp, the rest the findings, each prefixed ``- ``.
+Under ``restart: unless-stopped`` the container is then restarted forever, and
+the reason is invisible to anyone reading the status table. These tests pin the
+read side: a FRESH marker annotates the user's state cell, and everything else
+(no marker, a marker older than the container's current incarnation, an
+unparseable one) leaves the row exactly as it was.
+
+The container runtime is mocked entirely — ``subprocess.run`` returns canned
+``ps``/``volume ls``/``inspect`` output — so nothing here touches a real runtime.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from rich.console import Console
+
+from osprey.cli import styles
+from osprey.cli.phase_reporter import PhaseReporter, install_reporter
+from osprey.cli.styles import osprey_theme
+from osprey.cli.web_cmd import PREFLIGHT_REFUSED_MARKER
+from osprey.deployment import status_display
+
+_CONFIGS: dict[str, dict] = {}
+
+_STARTED_AT = datetime(2026, 8, 30, 12, 0, 0, tzinfo=UTC)
+
+
+def _fake_load_project_config(config_path, **kwargs):
+    """Stand-in for the shared project-config loader keyed by the path passed in."""
+    return _CONFIGS[config_path]
+
+
+def _base_config(users):
+    return {
+        "project_name": "demo-project",
+        "facility": {"prefix": "dls"},
+        "modules": {"web_terminals": {"enabled": True, "users": users}},
+    }
+
+
+def _ps_container(name, state, *, started_at=_STARTED_AT):
+    """One ``ps --format json`` record; ``started_at=None`` omits the field.
+
+    Podman's ``ps`` carries ``StartedAt``, docker's does not — omitting it is
+    how these tests reach the ``inspect`` fallback.
+    """
+    record = {
+        "Names": [name],
+        "Labels": {},
+        "State": state,
+        "Ports": [],
+        "Image": "img",
+    }
+    if started_at is not None:
+        record["StartedAt"] = int(started_at.timestamp())
+    return record
+
+
+def _write_marker(repo_root, user, written, findings):
+    """Write a pre-flight refusal marker the way ``osprey web`` writes one."""
+    audit_dir = repo_root / "var" / "audit" / user
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    body = "\n".join([written, *(f"- {finding}" for finding in findings)]) + "\n"
+    (audit_dir / PREFLIGHT_REFUSED_MARKER).write_text(body, encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _patch_config_loader(monkeypatch):
+    monkeypatch.setattr(status_display, "load_project_config", _fake_load_project_config)
+    yield
+    _CONFIGS.clear()
+
+
+@pytest.fixture(autouse=True)
+def rendered(monkeypatch):
+    """Capture both renderer streams into one wide recording console."""
+    console = Console(record=True, width=200, theme=osprey_theme)
+
+    class _Recording(PhaseReporter):
+        # Untyped on purpose: rich's ``Console`` is Any to this repo's mypy
+        # settings, so an annotated override trips ``no-any-return``.
+        def out(self):
+            return console
+
+    previous = install_reporter(_Recording(color=False))
+    monkeypatch.setattr(styles, "err_console", console)
+    yield console
+    install_reporter(previous)
+
+
+@pytest.fixture
+def runtime_calls(monkeypatch):
+    """Patch the runtime command builders and ``subprocess.run``.
+
+    ``ps`` answers ``ps_stdout``, ``volume ls`` answers ``""`` (this file is not
+    about volumes), and ``inspect`` answers ``inspect_stdout`` — which is the
+    fallback path for a runtime whose ``ps`` carries no ``StartedAt``.
+    """
+    calls: dict[str, object] = {"argvs": [], "ps_stdout": "", "inspect_stdout": ""}
+
+    monkeypatch.setattr(
+        status_display,
+        "get_ps_command",
+        lambda config, all_containers=False: ["docker", "ps", "-a", "--format", "json"],
+    )
+    monkeypatch.setattr(status_display, "get_runtime_command", lambda config=None: ["docker"])
+
+    class _Result:
+        def __init__(self, stdout, returncode=0):
+            self.stdout = stdout
+            self.returncode = returncode
+            self.stderr = ""
+
+    def _fake_run(cmd, capture_output=True, text=True, timeout=10):
+        calls["argvs"].append(cmd)  # type: ignore[union-attr]
+        if cmd[:2] == ["docker", "ps"]:
+            return _Result(calls["ps_stdout"])
+        if cmd[:2] == ["docker", "volume"]:
+            return _Result("")
+        if cmd[:2] == ["docker", "inspect"]:
+            return _Result(calls["inspect_stdout"])
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(status_display.subprocess, "run", _fake_run)
+    return calls
+
+
+def _run_status(tmp_path, runtime_calls, containers, users=("alice",)):
+    """Render ``show_status`` against a repo rooted at *tmp_path*.
+
+    The legacy verb derives its repo root from the directory holding the config
+    it was handed, which is what puts the audit zone at ``tmp_path/var/audit``.
+    Output is read off the ``rendered`` console fixture.
+    """
+    config_path = str(tmp_path / "config.yml")
+    _CONFIGS[config_path] = _base_config(list(users))
+    runtime_calls["ps_stdout"] = json.dumps(list(containers))
+    status_display.show_status(config_path)
+
+
+# ---------------------------------------------------------------------------
+# The annotated cell
+# ---------------------------------------------------------------------------
+
+
+def test_status_annotates_the_state_cell_from_a_fresh_preflight_marker(
+    tmp_path, runtime_calls, rendered
+):
+    """A marker written AFTER the container started explains the restart loop."""
+    _write_marker(
+        tmp_path,
+        "alice",
+        (_STARTED_AT + timedelta(seconds=5)).isoformat(),
+        ["control writes are armed but no write token was minted"],
+    )
+
+    _run_status(tmp_path, runtime_calls, [_ps_container("dls-web-alice", "restarting")])
+    output = rendered.export_text()
+
+    assert "(preflight:" in output
+    assert "control writes are armed" in output
+
+
+def test_status_truncates_a_long_preflight_reason_to_keep_the_table_shape(
+    tmp_path, runtime_calls, rendered
+):
+    """A findings line is arbitrarily long; the Container column is not."""
+    finding = "the roster names a persona that the rendered compose file does not declare anywhere"
+    _write_marker(tmp_path, "alice", (_STARTED_AT + timedelta(seconds=5)).isoformat(), [finding])
+
+    _run_status(tmp_path, runtime_calls, [_ps_container("dls-web-alice", "restarting")])
+    output = rendered.export_text()
+
+    assert "(preflight:" in output
+    assert "..." in output
+    assert finding not in output
+    assert finding[:20] in output
+
+
+def test_status_joins_multiple_preflight_findings_into_one_reason(
+    tmp_path, runtime_calls, rendered
+):
+    """Several findings are one cell, joined with ``; `` and truncated as one."""
+    _write_marker(
+        tmp_path,
+        "alice",
+        (_STARTED_AT + timedelta(seconds=5)).isoformat(),
+        ["control writes armed with no token", "no archiver URL", "no roster grant"],
+    )
+
+    _run_status(tmp_path, runtime_calls, [_ps_container("dls-web-alice", "restarting")])
+    output = rendered.export_text()
+
+    assert "control writes armed with no token; no" in output
+    assert "..." in output  # the tail is past the cap
+    assert "no roster grant" not in output
+
+
+def test_status_reads_started_at_from_inspect_when_ps_omits_it(tmp_path, runtime_calls, rendered):
+    """docker's ``ps`` carries no ``StartedAt``; one ``inspect`` supplies it.
+
+    And only when a marker exists — a deployment with no refusals must not pay
+    an inspect per container.
+    """
+    runtime_calls["inspect_stdout"] = "2026-08-30T12:00:00.123456789Z\n"
+    _write_marker(
+        tmp_path, "alice", (_STARTED_AT + timedelta(seconds=5)).isoformat(), ["no write token"]
+    )
+
+    _run_status(
+        tmp_path, runtime_calls, [_ps_container("dls-web-alice", "restarting", started_at=None)]
+    )
+    output = rendered.export_text()
+
+    assert "(preflight: no write token)" in output
+    inspects = [c for c in runtime_calls["argvs"] if c[:2] == ["docker", "inspect"]]
+    assert len(inspects) == 1
+
+
+# ---------------------------------------------------------------------------
+# Every other case leaves the row exactly as it was
+# ---------------------------------------------------------------------------
+
+
+def test_status_leaves_the_row_unchanged_when_there_is_no_preflight_marker(
+    tmp_path, runtime_calls, rendered
+):
+    _run_status(tmp_path, runtime_calls, [_ps_container("dls-web-alice", "running")])
+    output = rendered.export_text()
+
+    assert "● Running" in output
+    assert "preflight" not in output
+    # No marker, no inspect: the read side costs nothing on a healthy deployment.
+    assert [c for c in runtime_calls["argvs"] if c[:2] == ["docker", "inspect"]] == []
+
+
+def test_status_ignores_a_preflight_marker_older_than_the_container(
+    tmp_path, runtime_calls, rendered
+):
+    """A marker from a previous incarnation (or a ``--skip-preflight`` launch).
+
+    ``osprey web --skip-preflight`` deliberately leaves a stale marker in place,
+    so the container's own start time is what bounds its staleness here.
+    """
+    _write_marker(
+        tmp_path, "alice", (_STARTED_AT - timedelta(hours=3)).isoformat(), ["no write token"]
+    )
+
+    _run_status(tmp_path, runtime_calls, [_ps_container("dls-web-alice", "running")])
+    output = rendered.export_text()
+
+    assert "● Running" in output
+    assert "preflight" not in output
+
+
+@pytest.mark.parametrize(
+    "first_line",
+    ["", "   ", "not-a-timestamp", "2026-13-45T99:99:99"],
+    ids=["empty", "blank", "garbage", "impossible"],
+)
+def test_status_ignores_an_unparseable_preflight_marker(
+    tmp_path, runtime_calls, rendered, first_line
+):
+    """A torn or hand-edited marker is treated as no marker, never as a crash."""
+    _write_marker(tmp_path, "alice", first_line, ["no write token"])
+
+    _run_status(tmp_path, runtime_calls, [_ps_container("dls-web-alice", "running")])
+    output = rendered.export_text()
+
+    assert "● Running" in output
+    assert "preflight" not in output
+
+
+def test_status_leaves_an_uncreated_container_unchanged_despite_a_preflight_marker(
+    tmp_path, runtime_calls, rendered
+):
+    """No container, no incarnation to date the marker against — say nothing."""
+    _write_marker(
+        tmp_path, "alice", (_STARTED_AT + timedelta(seconds=5)).isoformat(), ["no write token"]
+    )
+
+    _run_status(tmp_path, runtime_calls, [])
+    output = rendered.export_text()
+
+    assert "Not created" in output
+    assert "preflight" not in output
+
+
+def test_status_survives_an_unreadable_preflight_marker_directory(
+    tmp_path, runtime_calls, rendered, monkeypatch
+):
+    """The marker path must never be able to take ``osprey status`` down."""
+
+    def _boom(*args, **kwargs):
+        raise OSError("audit zone is not readable")
+
+    monkeypatch.setattr(status_display, "audit_identity_dir", _boom)
+
+    _run_status(tmp_path, runtime_calls, [_ps_container("dls-web-alice", "running")])
+    output = rendered.export_text()
+
+    assert "● Running" in output
+    assert "preflight" not in output

--- a/tests/deployment/web_terminals/golden/landing.html
+++ b/tests/deployment/web_terminals/golden/landing.html
@@ -198,6 +198,41 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    /* The two marks a card carries when its terminal is entered by opening
+       that user's own `?token=` URL rather than through a login the perimeter
+       serves. Deliberately quieter than the persona chip beside it — muted
+       border and text rather than the accent — because it is a fact about how
+       the door opens, not a category the page is sorting people into. Both
+       colors are theme tokens, so the mark follows the page into either mode.
+       The card itself stays a live link and is styled as one: the `?token=`
+       exchange leaves a session cookie, so this IS the return path for anyone
+       who has opened the URL once. */
+    .landing-card-token {
+      align-self: flex-start;
+      max-width: 100%;
+      margin: 0.05rem 0 0.1rem;
+      padding: 0.12rem 0.55rem;
+      border: 1px solid var(--border-default);
+      border-radius: 999px;
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .landing-card-token-hint {
+      max-width: 100%;
+      color: var(--text-secondary);
+      font-size: 0.72rem;
+      line-height: 1.35;
+    }
+    .landing-card-token-hint code {
+      font-family: ui-monospace, "JetBrains Mono", monospace;
+      word-break: break-all;
+    }
     .landing-card-url {
       font-family: ui-monospace, "JetBrains Mono", monospace;
       font-size: 0.78rem;
@@ -298,6 +333,8 @@
           
           <a class="landing-card" href="/u/alice/">
             <span class="landing-card-label">alice</span>
+            <span class="landing-card-token">login link</span>
+            <span class="landing-card-token-hint">entered via a login link — <code>osprey users login-url alice</code></span>
             <span class="landing-card-url">/u/alice/</span>
           </a>
           
@@ -309,6 +346,8 @@
           
           <a class="landing-card" href="/u/bob/">
             <span class="landing-card-label">bob</span>
+            <span class="landing-card-token">login link</span>
+            <span class="landing-card-token-hint">entered via a login link — <code>osprey users login-url bob</code></span>
             <span class="landing-card-url">/u/bob/</span>
           </a>
           

--- a/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
+++ b/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
@@ -18,7 +18,7 @@ describes ``none``; its render is pinned by ``test_nginx_auth_surface.py``.
 
 So: a facility whose ``modules.web_terminals`` declares ``auth.method: token``
 (or no ``auth:`` block at all) and no ``authorization:`` block must render
-byte-for-byte what it rendered before this feature, with exactly three
+byte-for-byte what it rendered before this feature, with exactly four
 exceptions:
 
   1. **the audit emitters and mounts** — ``OSPREY_AUDIT_IDENTITY``,
@@ -45,6 +45,19 @@ exceptions:
      re-renders would otherwise see nothing change. The value emitted here is
      the default an absent ``auth:`` block already resolved to, so nothing
      about a baseline deployment's behaviour moves.
+  4. **the landing page's token-login badge** — a chip and one hint line on
+     every user card, naming ``osprey users login-url <name>``. This is the one
+     exception that changes what an operator SEES, and it is here because under
+     ``token`` the page was making a claim it could not keep: every card looked
+     like a door you could walk through, when every one of them needs a URL that
+     is minted by a verb nobody guesses and appears nowhere on the page. The
+     posture did not move — nginx vouches for nobody under ``token`` before and
+     after — only the page's honesty about it. The cards keep their hrefs (the
+     ``?token=`` exchange leaves a session cookie, so the link is a real return
+     path), so nothing about navigation changes either. Under ``password``, the
+     posture whose cards this baseline does not cover, the marks appear on the
+     ``login: false`` entries alone; ``test_landing_token_badge.py`` pins that
+     split.
 
 Everything else — every volume, header, ``location`` block, comment and blank
 line, and every port *site* (see the mask below) — must be untouched, with one
@@ -318,9 +331,54 @@ _ALLOWED_NGINX_LINES = Counter(
     }
 )
 
-#: Landing page: no exception at all. The audit trail and the identity headers
-#: are both invisible to it, so it must match the baseline byte for byte.
-_ALLOWED_LANDING_LINES: Counter[str] = Counter()
+#: The token-login badge — SC6 exception 4, and the only one an operator sees.
+#: The audit trail and the identity headers are still invisible to this page;
+#: what is added is the badge's three style rules and the two spans each user
+#: card renders (EXAMPLE_CONFIG's roster is alice + bob, and under `token` every
+#: card is a token-login card, which is the whole reason the badge exists).
+#:
+#: The declaration lines are pinned as difflib aligns them, which is why a few
+#: read oddly: `max-width: 100%;` and `color: var(--text-secondary);` appear
+#: twice and `}` three times, while `overflow`/`text-overflow`/`white-space`
+#: appear once each — the rest matched identical declarations already in the
+#: stylesheet and are not insertions at all. That is a property of the edit
+#: script, not of the rules; the rules themselves are readable in
+#: `landing.html.j2` and in `golden/landing.html`.
+_ALLOWED_LANDING_LINES: Counter[str] = Counter(
+    {
+        "    .landing-card-token {": 1,
+        "      align-self: flex-start;": 1,
+        "      max-width: 100%;": 2,
+        "      margin: 0.05rem 0 0.1rem;": 1,
+        "      padding: 0.12rem 0.55rem;": 1,
+        "      border: 1px solid var(--border-default);": 1,
+        "      border-radius: 999px;": 1,
+        "      font-size: 0.68rem;": 1,
+        "      font-weight: 600;": 1,
+        "      letter-spacing: 0.05em;": 1,
+        "      text-transform: uppercase;": 1,
+        "      color: var(--text-secondary);": 2,
+        "      overflow: hidden;": 1,
+        "      text-overflow: ellipsis;": 1,
+        "      white-space: nowrap;": 1,
+        "    }": 3,
+        "    .landing-card-token-hint {": 1,
+        "      font-size: 0.72rem;": 1,
+        "      line-height: 1.35;": 1,
+        "    .landing-card-token-hint code {": 1,
+        '      font-family: ui-monospace, "JetBrains Mono", monospace;': 1,
+        "      word-break: break-all;": 1,
+        '            <span class="landing-card-token">login link</span>': 2,
+        (
+            '            <span class="landing-card-token-hint">entered via a login link'
+            " — <code>osprey users login-url alice</code></span>"
+        ): 1,
+        (
+            '            <span class="landing-card-token-hint">entered via a login link'
+            " — <code>osprey users login-url bob</code></span>"
+        ): 1,
+    }
+)
 
 _ALLOWED = {
     "docker-compose.web.yml": _ALLOWED_COMPOSE_LINES,
@@ -352,9 +410,44 @@ def _explicit_token_render() -> dict[str, str]:
 
 
 def _is_comment(line: str) -> bool:
-    """True for a comment or blank line in either dialect (both use ``#``)."""
+    """True for a comment or blank line in the two ``#`` dialects (compose, nginx)."""
     stripped = line.strip()
     return not stripped or stripped.startswith("#")
+
+
+def _comment_mask(lines: list[str]) -> list[bool]:
+    """Which of *lines* are comment or blank, for the artifact they came from.
+
+    The third artifact is a stylesheet inside a page, and CSS comments SPAN
+    lines: ``/*`` opens one and ``*/`` closes it, with prose in between that
+    starts with an ordinary word. A per-line predicate cannot see that, so the
+    block state is carried down the artifact here instead. Without it the
+    interior of a rule's explanatory comment reads as inserted directives, and
+    the allowlist below would have to pin prose line by line — the one thing
+    :func:`_assert_added_directives_are_exactly_allowed` exists to avoid.
+
+    Args:
+        lines: One whole artifact's lines, in order — not a slice, since the
+            state is only correct when the opener was seen.
+
+    Returns:
+        One boolean per input line, true where the line is blank, a ``#``
+        comment, or any part of a ``/* … */`` block including its delimiters.
+    """
+    mask: list[bool] = []
+    in_block = False
+    for line in lines:
+        stripped = line.strip()
+        if in_block:
+            mask.append(True)
+            in_block = "*/" not in stripped
+            continue
+        if stripped.startswith("/*"):
+            mask.append(True)
+            in_block = "*/" not in stripped[2:]
+            continue
+        mask.append(_is_comment(line))
+    return mask
 
 
 def _opcodes(
@@ -499,10 +592,24 @@ def test_no_pre_feature_line_is_removed_or_reworded() -> None:
         )
 
 
-def test_landing_page_is_byte_identical_to_the_pre_feature_render() -> None:
-    """The strictest form of SC6, available for the one artifact with no
-    exception: an operator's landing page must not have moved by one byte."""
-    assert _token_render()["nginx/landing.html"] == _baseline("landing.html")
+def test_landing_page_adds_exactly_the_token_login_badge() -> None:
+    """The landing page's whole SC6 exception: the badge, and nothing else.
+
+    This assertion used to be byte identity — the strictest form of SC6, back
+    when this artifact had no exception at all. It has one now (exception 4 in
+    the module docstring), and the change was deliberate: the page's silence
+    about `token` was not fidelity to the pre-feature render, it was the page
+    telling an operator that every terminal is one click away when not one of
+    them is reachable without a URL `osprey users login-url` mints. The bytes it
+    was pinned to were dishonest bytes.
+
+    What the pin becomes is the same guarantee one step weaker and stated
+    exactly: today's `token` landing page is the frozen one PLUS the badge's
+    style rules and the two spans per user card, and nothing at all besides.
+    Anything else that appears on this page — a role, a login form, a claim —
+    still fails here, which is what SC6 was ever protecting.
+    """
+    _assert_added_directives_are_exactly_allowed("landing.html")
 
 
 def test_compose_adds_exactly_the_audit_emitters_and_mounts() -> None:
@@ -582,12 +689,13 @@ def _assert_added_directives_are_exactly_allowed(
     (which reads the comment text for the vocabulary that must not appear).
     """
     _old, new, opcodes = _opcodes(name, artifacts)
+    is_comment = _comment_mask(new)
     inserted = Counter(
-        line
+        new[j]
         for tag, _i1, _i2, j1, j2 in opcodes
         if tag in ("insert", "replace")
-        for line in new[j1:j2]
-        if not _is_comment(line)
+        for j in range(j1, j2)
+        if not is_comment[j]
     )
 
     unexpected = inserted - _ALLOWED[name]

--- a/tests/deployment/web_terminals/test_landing_token_badge.py
+++ b/tests/deployment/web_terminals/test_landing_token_badge.py
@@ -1,0 +1,204 @@
+"""The landing page says which terminals are entered through a login URL.
+
+A card whose user reaches their terminal by opening that user's own ``?token=``
+URL looks, on the page alone, exactly like a card behind a login wall: same
+chip, same link, same hover. It is not the same thing. Nobody can open it from
+the landing page cold — the URL carries the credential, and it is minted by
+``osprey users login-url <name>``, a verb an operator has no reason to guess.
+
+So a token-login card carries two honesty marks: a badge naming the posture,
+and one muted line naming the verb. It KEEPS its href — the ``?token=``
+exchange leaves a session cookie behind, so the card is a real return path for
+a browser that has opened the URL once, and disabling it would be a second lie
+in the other direction.
+
+These tests pin the two postures the marks distinguish (``password`` with one
+login-exempt entry, and ``token`` where the whole roster is exempt by
+construction), that the hint names the RIGHT user per card, and the one
+precondition the derivation carries (see the scaffold test at the bottom).
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+
+from osprey.deployment.web_terminals.render import render_web_terminals
+
+from .test_render import _MULTI_USER_CONFIG, _body, _config
+
+#: One navigable card: its href and everything between the anchor tags.
+_CARD_RE = re.compile(r'<a class="landing-card" href="([^"]*)">(.*?)</a>', re.DOTALL)
+
+#: The chip and the hint line the badge renders as.
+_BADGE_RE = re.compile(r'<span class="landing-card-token">([^<]*)</span>')
+_HINT_RE = re.compile(r'<span class="landing-card-token-hint">(.*?)</span>', re.DOTALL)
+
+
+def _cards(landing_html: str) -> dict[str, tuple[str, str]]:
+    """Every navigable card on the page, keyed by its label.
+
+    Parsed out of the markup (below the stylesheet, which defines every rule the
+    page could use whatever this render emitted) rather than read off the
+    landing context, because what an operator is misled by is the rendered page.
+
+    Returns:
+        ``{label: (href, inner markup)}``.
+    """
+    cards = {}
+    for href, inner in _CARD_RE.findall(_body(landing_html)):
+        label = re.search(r'<span class="landing-card-label">([^<]*)</span>', inner)
+        assert label is not None, inner
+        cards[label.group(1)] = (href, inner)
+    return cards
+
+
+def _badged(landing_html: str) -> set[str]:
+    """The labels of the cards carrying the token-login badge."""
+    return {label for label, (_, inner) in _cards(landing_html).items() if _BADGE_RE.search(inner)}
+
+
+def _hint_of(landing_html: str, label: str) -> str:
+    """The hint line on one card, as rendered."""
+    _, inner = _cards(landing_html)[label]
+    hint = _HINT_RE.search(inner)
+    assert hint is not None, f"no token-login hint on card {label!r}: {inner}"
+    return hint.group(1)
+
+
+def _password_config() -> dict:
+    """A password-walled roster with exactly one login-exempt entry.
+
+    The shipped control-assistant shape in miniature: operators sign in, and the
+    standalone research service beside them (`login: false`) does not.
+    """
+    config = copy.deepcopy(
+        _config([{"name": "alice", "index": 0}, {"name": "ariel", "index": 1, "login": False}])
+    )
+    config["modules"]["web_terminals"]["auth"] = {
+        "method": "password",
+        "allow_insecure_http": True,
+    }
+    return config
+
+
+def test_only_the_login_exempt_card_is_badged_behind_a_password_wall() -> None:
+    """Exactly the entry nginx does not vouch for gets the marks.
+
+    Badging the signed-in card too would make the page say every terminal needs
+    a URL nobody has, which is the same failure this badge exists to fix, only
+    inverted.
+    """
+    # Act
+    landing_html = render_web_terminals(_password_config())["nginx/landing.html"]
+
+    # Assert
+    assert _badged(landing_html) == {"ariel"}
+
+
+def test_the_badged_card_keeps_its_href_behind_a_password_wall() -> None:
+    """The badge labels the card; it does not disable it.
+
+    The `?token=` exchange mints a session cookie, so an operator who has opened
+    the login URL once returns through this very link. A card rendered inert
+    would strand them.
+    """
+    # Act
+    landing_html = render_web_terminals(_password_config())["nginx/landing.html"]
+
+    # Assert
+    href, _ = _cards(landing_html)["ariel"]
+    assert href.endswith("/u/ariel/"), href
+
+
+def test_every_card_is_badged_and_navigable_under_the_token_posture() -> None:
+    """With `auth.method` at its `token` default nginx vouches for nobody, so the
+    whole roster is entered through its own URL — and every card says so while
+    staying a link."""
+    # Act
+    landing_html = render_web_terminals(copy.deepcopy(_MULTI_USER_CONFIG))["nginx/landing.html"]
+
+    # Assert
+    cards = _cards(landing_html)
+    assert _badged(landing_html) == {"alice", "bob", "carol"}
+    assert all(href.endswith(f"/u/{label}/") for label, (href, _) in cards.items()), cards
+
+
+def test_the_hint_names_the_verb_and_this_card_s_own_user() -> None:
+    """The hint's whole point is the command an operator can run. A hint that
+    named the wrong user would send them to another person's terminal with
+    another person's live credential in the URL."""
+    # Act
+    landing_html = render_web_terminals(copy.deepcopy(_MULTI_USER_CONFIG))["nginx/landing.html"]
+
+    # Assert
+    for name in ("alice", "bob", "carol"):
+        hint = _hint_of(landing_html, name)
+        assert f"osprey users login-url {name}" in hint, hint
+        for other in {"alice", "bob", "carol"} - {name}:
+            assert other not in hint, hint
+
+
+def test_a_card_behind_the_login_wall_carries_neither_mark() -> None:
+    """Neither class appears on a card nginx vouches for — asserted on the body,
+    not the whole page, since the stylesheet always defines both rules."""
+    # Act
+    landing_html = render_web_terminals(_password_config())["nginx/landing.html"]
+
+    # Assert
+    _, alice = _cards(landing_html)["alice"]
+    assert "landing-card-token" not in alice
+
+
+def test_an_operator_supplied_link_card_is_never_badged() -> None:
+    """Only roster cards carry the key at all: a `landing.groups` entry is a
+    `{label, url}` dict the operator wrote, and `item["token_login"]` is Jinja
+    `Undefined` there. The badge must not leak onto it under the posture where
+    every roster card has one."""
+    # Arrange
+    config = copy.deepcopy(
+        _config(
+            ["alice"],
+            groups=[
+                {"type": "users"},
+                {
+                    "type": "links",
+                    "label": "Dashboards",
+                    "links": [{"label": "Archiver", "url": "/archiver"}],
+                },
+            ],
+        )
+    )
+
+    # Act
+    landing_html = render_web_terminals(config)["nginx/landing.html"]
+
+    # Assert
+    assert set(_cards(landing_html)) == {"alice", "Archiver"}
+    assert _badged(landing_html) == {"alice"}
+
+
+def test_a_scaffold_render_of_a_disabled_module_badges_nothing() -> None:
+    """The derivation's one precondition, documented rather than worked around.
+
+    `token_login_users` answers `[]` for a config whose
+    `modules.web_terminals.enabled` is falsy — it is the deploy summary's
+    reader, and a module nobody enabled deploys nothing. `render_web_terminals`
+    has no such gate (`osprey scaffold web-terminals render` renders a
+    not-yet-enabled config on purpose, so an operator can look at the artifacts
+    before turning it on), so that render shows an unbadged page for a
+    deployment that, once enabled, is entirely token-login.
+
+    Pinned as the behaviour it is: a scaffold preview is not the deployed page,
+    and every fixture that asks this module about postures enables it. If the
+    preview is ever made to badge, this test is the one that says so.
+    """
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["enabled"] = False
+
+    # Act
+    landing_html = render_web_terminals(config)["nginx/landing.html"]
+
+    # Assert
+    assert _badged(landing_html) == set()

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -11,6 +11,7 @@ import pytest
 import yaml
 from jinja2 import Environment, Template
 
+from osprey.deployment.web_terminals import render as render_module
 from osprey.deployment.web_terminals.artifacts import web_artifacts_dir
 from osprey.deployment.web_terminals.auth_credentials import AUTH_ENV_FILENAME
 from osprey.deployment.web_terminals.personas import env_var_suffix
@@ -5614,3 +5615,95 @@ def test_envsubst_output_tmpfs_is_not_world_readable() -> None:
     assert all(isinstance(volume, str) for volume in compose["services"]["nginx"]["volumes"]), (
         compose["services"]["nginx"]["volumes"]
     )
+
+
+# --- Landing cards carry each user's auth posture -----------------------------
+
+
+def _landing_cards(config: dict) -> dict[str, dict]:
+    """Every auto-populated user card `render_web_terminals` put in the landing context.
+
+    Captured off the real `_build_groups` (wrapped, not replaced) instead of
+    being rebuilt by the test, so the threading through `render_web_terminals`
+    is itself under test: the posture is a property of the deployment, and a
+    render that derived it from the wrong config would still produce
+    self-consistent cards if the test built them itself. Read from the context
+    rather than from the markup, which is a separate question with its own
+    module (`test_landing_token_badge.py` pins what the page does with the flag;
+    these two pin what the flag is).
+
+    Returns:
+        The cards of every section, keyed by label.
+    """
+    real = render_module._build_groups
+    captured: list[list[dict]] = []
+
+    def _spy(*args: object, **kwargs: object) -> list[dict]:
+        groups = real(*args, **kwargs)  # type: ignore[arg-type]
+        captured.append(groups)
+        return groups
+
+    with patch.object(render_module, "_build_groups", _spy):
+        render_web_terminals(config)
+    return {item["label"]: item for group in captured[0] for item in group["items"]}
+
+
+def test_landing_cards_mark_every_user_token_login_under_the_default_posture() -> None:
+    """With `auth.method` left at its `token` default, nginx vouches for nobody, so
+    every terminal is entered by opening its own `?token=` URL — and every card
+    says so.
+    """
+    # Act
+    cards = _landing_cards(copy.deepcopy(_MULTI_USER_CONFIG))
+
+    # Assert
+    assert {label: card["token_login"] for label, card in cards.items()} == {
+        "alice": True,
+        "bob": True,
+        "carol": True,
+    }
+
+
+def test_landing_cards_mark_a_login_exempt_user_token_login_behind_a_password_wall() -> None:
+    """Under `auth.method: password` the roster signs in — except the `login: false`
+    entry, which sits outside nginx's vouching and still reaches its terminal
+    through its `?token=` URL. The two postures coexist on one page, which is
+    exactly why the flag is per card and not per deployment.
+    """
+    # Arrange
+    config = copy.deepcopy(
+        _config([{"name": "alice", "index": 0}, {"name": "ariel", "index": 1, "login": False}])
+    )
+    config["modules"]["web_terminals"]["auth"] = {
+        "method": "password",
+        "allow_insecure_http": True,
+    }
+
+    # Act
+    cards = _landing_cards(config)
+
+    # Assert
+    assert cards["alice"]["token_login"] is False
+    assert cards["ariel"]["token_login"] is True
+
+
+def test_token_login_reaches_the_rendered_page_as_a_badge() -> None:
+    """The key is no longer inert data: landing.html.j2 now reads it.
+
+    This assertion used to pin the opposite — that no rendered byte mentioned
+    the key — which was true only while the page had no reader for it. That pin
+    existed to hand ownership to the badge, so the badge inherits it: the two
+    marks a token-login card carries must reach the page for every card the
+    context flagged, or the page is back to claiming a terminal is one click
+    away when it needs a URL nobody has.
+
+    The postures behind the flag, the hint's wording and the card's continued
+    navigability are pinned in `test_landing_token_badge.py`; what is checked
+    here is only that the threading reaches the markup at all.
+    """
+    # Act
+    landing_html = render_web_terminals(copy.deepcopy(_MULTI_USER_CONFIG))["nginx/landing.html"]
+
+    # Assert
+    assert _body(landing_html).count('class="landing-card-token"') == 3
+    assert _body(landing_html).count('class="landing-card-token-hint"') == 3

--- a/tests/e2e/_orm_stack.py
+++ b/tests/e2e/_orm_stack.py
@@ -46,6 +46,7 @@ turn-key derived one from ever disagreeing about what the worker is handed.
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import shutil
@@ -354,6 +355,97 @@ def init_args(
     return args
 
 
+def _calling_module() -> str:
+    """The module that called into this one — for a guard's failure message.
+
+    A shared helper's assertion is read by whoever owns the LANE, not by
+    whoever owns the helper, so the message has to say which lane it is
+    talking about. The stack is the only thing that knows: the first frame
+    outside this file is the caller's.
+    """
+    frame = inspect.currentframe()
+    try:
+        while frame is not None:
+            if frame.f_code.co_filename != __file__:
+                return str(frame.f_globals.get("__name__") or frame.f_code.co_filename)
+            frame = frame.f_back
+        return __name__
+    finally:
+        # Frames hold references to this one; dropping the local keeps the
+        # cycle off the collector's desk.
+        del frame
+
+
+def assert_off_default_block(repo: Path, project_name: str) -> None:
+    """Refuse a rendered deployment that would bind the framework's DEFAULT
+    thousand-port block.
+
+    ``deployment.port_base`` names the first port of the block a deployment
+    claims, and :data:`~osprey.port_layout.DEFAULT_PORT_BASE` (10000) is where
+    a deployment lands when nobody moves it — including the real deployment a
+    developer is already running on the host, and every e2e lane that forgot to
+    pick a band. Two stacks in one block do not fail cleanly: they fail as a
+    connection error or a wrong-service answer, minutes into a container build,
+    in a lane that looks broken rather than colliding.
+
+    So the check happens HERE, on the render, before anything binds. It reads
+    the base back out of ``<repo>/build/config.yml`` rather than trusting the
+    ``port_base=`` argument that was passed in: an overlay key that failed to
+    land looks identical at the call site and only differs on disk, and that is
+    precisely the failure this exists to catch.
+
+    Deliberately a ``!=`` default check and not an ``==`` some-expected-value
+    one: this is the shared seam, and it cannot know which band a given lane
+    booked. A lane that knows its own number should assert that number too (see
+    ``tests/e2e/test_full_chain_auth.py``'s ``_make_repo``) — the two checks
+    are complementary, and this one is the floor.
+
+    :param repo: The deployment REPO (the directory holding ``build/``), as
+        :func:`build_project_subprocess` returns.
+    :param project_name: The name the stack was built under, for the message.
+    :raises AssertionError: If the render produced no config, or resolved the
+        default base — whether by naming it or by never setting one.
+    """
+    from osprey.port_layout import (
+        BLOCK_SIZE,
+        DEFAULT_PORT_BASE,
+        PORT_BASE_CONFIG_KEY,
+        resolve_port_base,
+    )
+
+    caller = _calling_module()
+    config_path = repo / "build" / "config.yml"
+    if not config_path.is_file():
+        raise AssertionError(
+            f"{project_name} (built by {caller}) rendered no config at {config_path}, so "
+            f"nothing can say which port block this deployment would claim"
+        )
+
+    rendered = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(rendered, dict):
+        raise AssertionError(f"{config_path} is not a config mapping: {rendered!r}")
+
+    declared = (rendered.get("deployment") or {}).get("port_base")
+    if resolve_port_base(rendered) != DEFAULT_PORT_BASE:
+        return
+
+    block_top = DEFAULT_PORT_BASE + BLOCK_SIZE - 1
+    raise AssertionError(
+        f"{project_name} (built by {caller}) resolved "
+        f"{PORT_BASE_CONFIG_KEY}={declared!r} — the framework DEFAULT block "
+        f"{DEFAULT_PORT_BASE}-{block_top}, which a real deployment on this host "
+        f"already claims and which every lane that books no band of its own lands "
+        f"in together. Starting this stack would collide with them, and the first "
+        f"symptom would be a connection error minutes into a container build.\n"
+        f"Fix in {caller}: give this lane its own thousand-port band — pass "
+        f"`port_base=<band>` to this module's builder (which emits "
+        f"`--set port_base=<band>`, the profile shorthand for "
+        f"`{PORT_BASE_CONFIG_KEY}=<band>`), or set `{PORT_BASE_CONFIG_KEY}=<band>` "
+        f"in the lane's --override config block. Bands in use are listed at the "
+        f"top of each e2e lane that pins one."
+    )
+
+
 def build_via_cli_runner(
     runner: CliRunner,
     tmp_path: Path,
@@ -519,6 +611,14 @@ def build_project_subprocess(
             "--dev",
         ],
     )
+
+    # The render is done and nothing is bound yet — the one moment a port-block
+    # mistake is still cheap. See :func:`assert_off_default_block`. Checked here
+    # rather than on the ``port_base=`` argument because only the render knows
+    # whether the override actually landed, and checked in THIS builder rather
+    # than in ``init_args`` because ``build_via_cli_runner`` renders without
+    # binding anything and may legitimately leave the base alone.
+    assert_off_default_block(repo, project_name)
     return repo
 
 

--- a/tests/e2e/test_full_chain_auth.py
+++ b/tests/e2e/test_full_chain_auth.py
@@ -182,7 +182,7 @@ import pytest
 import yaml
 
 from osprey.audit.protected import SURFACE_HTTP_CONFIG
-from osprey.port_layout import default_port
+from osprey.port_layout import DEFAULT_PORT_BASE, PORT_BASE_CONFIG_KEY, default_port
 from osprey.services.auth_sidecar.identity_headers import (
     ACCOUNT_HEADER,
     ROLE_HEADER,
@@ -198,6 +198,16 @@ from tests.e2e._volumes import remove_project_volumes
 #: of the layout, which ``Dockerfile.j2`` renders into its ``EXPOSE`` line. The
 #: image is built from a config that never moves ``deployment.port_base``, so
 #: the layout's default base is the right one to derive it at.
+#:
+#: Still true after the DEPLOYMENT moved to :data:`PORT_BASE` below, for two
+#: independent reasons, and it is worth knowing both: the persona image comes
+#: from :func:`_render_reference_project`, whose own override sets no base at
+#: all, so its ``EXPOSE`` really is at the default base; and nothing binds this
+#: number anyway, because the per-user compose service sets
+#: ``OSPREY_TERMINAL_WEB_PORT``/``OSPREY_WEB_PORT`` explicitly to that user's
+#: port off the DEPLOYMENT's base (``docker-compose.web.yml.j2``, which is also
+#: what the healthcheck probes). This is the stub's fallback for the case that
+#: never happens here, not the port it serves on.
 _WEB_SLOT = default_port("web")
 
 pytestmark = [pytest.mark.e2e, pytest.mark.dockerbuild]
@@ -250,20 +260,28 @@ USERS = (REAL_USER, HEADER_USER, NO_ROLE_USER, EXEMPT_USER, UNSAFE_ROLE_USER)
 #: provisioning mints none for a ``login: false`` entry.
 LOGIN_USERS = (REAL_USER, HEADER_USER, NO_ROLE_USER, UNSAFE_ROLE_USER)
 
-#: Ports in a band no other stack in the suite touches (the tutorial stacks hold
-#: 5064/5080/5432, the lifecycle fixtures the 9000s/19081, the auth perimeter
-#: lane the 191xx–195xx band and the auth-off multiuser lane the 196xx–199xx
-#: one). Five roster users take five consecutive ports per family, so the
-#: families are spaced by ten.
-NGINX_PORT = 20080
-AUTH_PORT = 20070
-BASE_PORTS = {
-    "web": 20001,
-    "artifact": 20011,
-    "ariel": 20021,
-    "lattice": 20031,
-    "channel_finder": 20041,
-}
+#: This module's own thousand-port block (see test_dispatch_deploy.py's 20700
+#: note): everything not pinned explicitly follows it instead of landing on a
+#: real deployment's default 10000 block. Set once at render, as
+#: ``deployment.port_base`` in this lane's ``-O`` overlay, and read back here to
+#: derive every host port the assertions reach for — so a slot that moves in the
+#: layout moves here without an edit, and no number below is a hand-assigned
+#: literal that could drift from what the render actually binds.
+#:
+#: One knob replaces the old hand-pinned 200xx list, and the family spacing
+#: changes with it: those families were spaced by TEN (20001/20011/20021…),
+#: which held only because this roster is five users long. The layout spaces
+#: per-user families by ONE HUNDRED — ``INDEX_MAX`` is 99 — so the five roster
+#: users occupy the first five ports of each family's band and the bands cannot
+#: run into each other however long a roster gets.
+PORT_BASE = 23000
+
+#: The two gateway ports this lane drives from the host, derived the same way
+#: the render derives them: nginx at the base and the auth sidecar one above it.
+#: The per-user families (``web``, ``artifact``, ``ariel``, ``lattice``,
+#: ``channel_finder``) are NOT listed — nothing here reaches them directly, and
+#: the render places them off the same base.
+HOST_PORTS = {slot: default_port(slot, base=PORT_BASE) for slot in ("nginx", "auth")}
 
 AUTH_IMAGE_TAG = f"{PREFIX}-assistant-auth:local"
 # `<catalog project>:local`, exactly as resolve_personas derives a local-mode
@@ -717,6 +735,13 @@ def _override_text() -> str:
     with a nested value, so it sets that subtree without replacing the rendered
     ``modules:`` mapping around it.
 
+    ``deployment.port_base`` is the ONE port knob: nginx, the auth sidecar and
+    every per-user family follow it, so this lane's whole stack moves into
+    :data:`PORT_BASE`'s block with nothing else renumbered. Nothing here pins an
+    individual port — a pinned port is a second source of truth for a number the
+    render already derives, and the pair silently disagrees the moment the
+    layout moves.
+
     ``allow_insecure_http`` is what lets ``auth.method: password`` render
     without TLS. That is the documented posture for a deployment behind a TLS
     terminator, and here it keeps the lane off certificate management — the TLS
@@ -739,6 +764,7 @@ def _override_text() -> str:
                 "deploy.fqdn": "127.0.0.1",
                 "deployed_services": [],
                 "claude_code.telemetry.enabled": False,
+                PORT_BASE_CONFIG_KEY: PORT_BASE,
                 "modules.web_terminals": {
                     "enabled": True,
                     "image_source": "local",
@@ -746,16 +772,9 @@ def _override_text() -> str:
                     # persona is the default and the expensive one is reached
                     # only through a role.
                     "default_persona": PROBE_PERSONA,
-                    "nginx_port": NGINX_PORT,
-                    "web_base_port": BASE_PORTS["web"],
-                    "artifact_base_port": BASE_PORTS["artifact"],
-                    "ariel_base_port": BASE_PORTS["ariel"],
-                    "lattice_base_port": BASE_PORTS["lattice"],
-                    "channel_finder_base_port": BASE_PORTS["channel_finder"],
                     "users": _roster(),
                     "auth": {
                         "method": "password",
-                        "port": AUTH_PORT,
                         "allow_insecure_http": True,
                     },
                     # The static half of the authorization stanza. No `claims:`
@@ -881,6 +900,33 @@ def _make_repo(tmp_path: Path, osprey_bin: Path) -> Path:
     )
     assert build.returncode == 0, _fmt("osprey build (full-chain auth)", build)
 
+    # The one knob, read back off the render before anything binds. Every host
+    # port this lane reaches is `default_port(slot, base=PORT_BASE)`, and that
+    # derivation is only true if the render actually resolved the same base: an
+    # overlay key that failed to land leaves the deploy on the default 10000
+    # block, where it collides with a real deployment and every assertion below
+    # then fails as a connection error thirty minutes into a container build.
+    # Cheaper to fail here, naming the cause.
+    rendered = yaml.safe_load((repo / "build" / "config.yml").read_text(encoding="utf-8"))
+    resolved_base = (rendered.get("deployment") or {}).get("port_base")
+    # Stricter than the shared `_orm_stack.assert_off_default_block` floor (which
+    # only refuses the default block): this lane knows its own band, so it says
+    # so. The two messages are written to read the same way on purpose.
+    on_default_block = (
+        " — they would be in the framework DEFAULT block, shared with every real "
+        "deployment on this host"
+        if resolved_base in (None, DEFAULT_PORT_BASE)
+        else ""
+    )
+    assert resolved_base == PORT_BASE, (
+        f"{PROJECT_NAME} (built by {__name__}) resolved "
+        f"{PORT_BASE_CONFIG_KEY}={resolved_base!r}, not {PORT_BASE}: this lane's ports would "
+        f"not be in its own block{on_default_block}.\n"
+        f"Fix in {__name__}: `_override_text` sets `{PORT_BASE_CONFIG_KEY}=<band>` in this "
+        f"lane's --override config block and PORT_BASE is the band it books — that key "
+        f"failing to land is what this reads back."
+    )
+
     # The repo root's .env is this deployment's secret store: the auth
     # provisioning reads each user's chosen OSPREY_AUTH_PW_<USER> from it, the
     # provider-secret gate reads the key, and `osprey up` refuses to start
@@ -960,7 +1006,7 @@ def _request(
     method: str = "GET",
     headers: dict[str, str] | None = None,
     data: bytes | None = None,
-    port: int = NGINX_PORT,
+    port: int = HOST_PORTS["nginx"],
     opener: urllib.request.OpenerDirector | None = None,
 ) -> tuple[int, dict[str, str], str]:
     """One HTTP request, returning (status, headers, body); never raises on 4xx/5xx.
@@ -1008,7 +1054,7 @@ def _login(user: str) -> tuple[urllib.request.OpenerDirector, http.cookiejar.Coo
         headers={
             "Content-Type": "application/x-www-form-urlencoded",
             # The sidecar refuses a submission declaring no origin at all.
-            "Origin": f"http://127.0.0.1:{NGINX_PORT}",
+            "Origin": f"http://127.0.0.1:{HOST_PORTS['nginx']}",
             **_navigation(),
         },
         opener=client,
@@ -1093,7 +1139,7 @@ def _wait_for_health(timeout: float) -> dict[str, Any]:
     last = "(no attempt yet)"
     while time.monotonic() < deadline:
         try:
-            status, _, body = _request("/health", port=AUTH_PORT)
+            status, _, body = _request("/health", port=HOST_PORTS["auth"])
             if status == 200:
                 return json.loads(body)
             last = f"HTTP {status}: {body[:200]}"
@@ -1344,7 +1390,7 @@ def test_a_password_login_reaches_that_users_own_terminal(deployment: dict[str, 
         headers={
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "Origin": f"http://127.0.0.1:{NGINX_PORT}",
+            "Origin": f"http://127.0.0.1:{HOST_PORTS['nginx']}",
         },
         opener=deployment["sessions"][REAL_USER],
     )
@@ -1678,7 +1724,7 @@ def test_the_protected_key_refusal_lands_in_that_users_own_ledger(
         headers={
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "Origin": f"http://127.0.0.1:{NGINX_PORT}",
+            "Origin": f"http://127.0.0.1:{HOST_PORTS['nginx']}",
         },
         opener=deployment["sessions"][REAL_USER],
     )
@@ -1825,3 +1871,97 @@ def test_no_record_carries_a_value_only_an_identifier(deployment: dict[str, Any]
     assert _PROTECTED_VALUE not in haystack, "a refused write's VALUE was recorded"
     for password in _PASSWORDS.values():
         assert password not in haystack, "a password reached the audit trail"
+
+
+# ---------------------------------------------------------------------------
+# The shared default-block guard — no deploy, no Docker
+# ---------------------------------------------------------------------------
+#
+# This lane pins its OWN base by asserting `deployment.port_base == PORT_BASE`
+# in `_make_repo` (stricter than the shared guard, which only refuses the
+# default block). The shared guard covers the lanes that render through
+# `tests/e2e/_orm_stack.build_project_subprocess` instead, and its unit
+# coverage lives here because this is the module whose render-time check it is
+# modelled on — the two failure messages are deliberately written to read the
+# same way, and keeping them in one file is what stops one from drifting.
+#
+# Nothing below builds, renders or starts anything: the guard reads one file,
+# so a synthetic `build/config.yml` in `tmp_path` is the whole fixture.
+
+
+def _synthetic_render(tmp_path: Path, port_base: int | None) -> Path:
+    """A repo whose ``build/config.yml`` names ``port_base`` — the one file the
+    shared guard reads back.
+
+    ``None`` writes a ``deployment:`` block that sets no base at all, which is
+    exactly how a dropped overlay or a forgotten ``port_base=`` argument looks
+    on disk: the key is simply absent and the deployment resolves the
+    framework default.
+    """
+    repo = tmp_path / "synthetic-render"
+    build = repo / "build"
+    build.mkdir(parents=True)
+    deployment: dict[str, Any] = {} if port_base is None else {"port_base": port_base}
+    build.joinpath("config.yml").write_text(
+        yaml.safe_dump({"deployment": deployment}), encoding="utf-8"
+    )
+    return repo
+
+
+@pytest.mark.parametrize(
+    "port_base",
+    [
+        pytest.param(DEFAULT_PORT_BASE, id="explicit-default"),
+        pytest.param(None, id="unset"),
+    ],
+)
+def test_the_shared_guard_refuses_a_render_on_the_default_block(
+    tmp_path: Path, port_base: int | None
+) -> None:
+    """A stack rendered on the default block is refused before anything binds.
+
+    Both spellings are the same fault and must both fail: a lane that never
+    passed a base, and a lane that passed the default one. Whichever it is, the
+    render would bind 10000-10999 — the block a real deployment on the host
+    already claims — and the first symptom without this guard is a connection
+    error deep inside a container build.
+    """
+    from tests.e2e import _orm_stack
+
+    repo = _synthetic_render(tmp_path, port_base)
+
+    with pytest.raises(AssertionError) as excinfo:
+        _orm_stack.assert_off_default_block(repo, "some-e2e-lane")
+
+    message = str(excinfo.value)
+    # The three things the message must carry to be actionable: WHICH stack,
+    # WHO built it, and the one-line fix.
+    assert "some-e2e-lane" in message, message
+    assert "test_full_chain_auth" in message, message
+    assert f"{PORT_BASE_CONFIG_KEY}=<band>" in message, message
+    assert str(DEFAULT_PORT_BASE) in message, message
+
+
+def test_the_shared_guard_passes_a_render_in_its_own_band(tmp_path: Path) -> None:
+    """A render that moved off the default block is accepted.
+
+    The negative half: without it the guard could refuse everything and the
+    test above would still pass.
+    """
+    from tests.e2e import _orm_stack
+
+    _orm_stack.assert_off_default_block(_synthetic_render(tmp_path, PORT_BASE), "some-e2e-lane")
+
+
+def test_the_shared_guard_refuses_a_render_that_never_happened(tmp_path: Path) -> None:
+    """No ``build/config.yml`` at all fails as a missing render, not as a
+    crash — a build that silently produced nothing is its own fault, and
+    reading the base off a file that is not there must not surface as a
+    ``FileNotFoundError`` from inside a helper."""
+    from tests.e2e import _orm_stack
+
+    repo = tmp_path / "never-rendered"
+    repo.mkdir()
+
+    with pytest.raises(AssertionError, match="rendered no config"):
+        _orm_stack.assert_off_default_block(repo, "some-e2e-lane")

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -489,7 +489,8 @@ config:
         index: 2
         persona: ariel
         display_name: "ARIEL Logbook Research"
-        # Read-only research service, open without a login on purpose.
+        # Outside the login wall on purpose — entered through its own login URL
+        # instead (`osprey users login-url ariel`), not open to anyone.
         login: false
       # The one login that can change this deployment's configuration — the web
       # Config panel, the scaffold gallery's editors, and the agent's own setup

--- a/tests/infrastructure/test_server_launcher.py
+++ b/tests/infrastructure/test_server_launcher.py
@@ -11,10 +11,17 @@ disabled, already launched).
 
 from __future__ import annotations
 
+import email.message
+import errno
 import inspect
+import io
+import os
 import socket
+import urllib.error
+import urllib.request
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from urllib.response import addinfourl
 
 import pytest
 
@@ -39,6 +46,123 @@ def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return sock.getsockname()[1]
+
+
+def _make_launcher(host: str = "127.0.0.1", port: int | None = None) -> ServerLauncher:
+    """Build a ServerLauncher wired to a fixed (host, port), auto-launch on."""
+    settled = _free_port() if port is None else port
+    return ServerLauncher(
+        name="Test Server",
+        config_reader=lambda: (host, settled),
+        auto_launch_checker=lambda: True,
+        app_factory=lambda: object(),
+    )
+
+
+def _probes(unauthenticated: int | None, credentialed: int | None = None):
+    """Return a ``_probe_status`` stand-in answering per credential.
+
+    The credentialed answer is keyed on the ``secret`` argument, which is also
+    how a test can see whether the secret was offered at all.
+    """
+
+    def _probe(_host, _port, secret=None):
+        return credentialed if secret else unauthenticated
+
+    return _probe
+
+
+def _rendered(mock_log) -> str:
+    """Render a lazily-formatted ``logger`` call into the line an operator reads."""
+    call = mock_log.call_args
+    return call.args[0] % call.args[1:]
+
+
+def _lines(mock_log) -> list[str]:
+    """Render every call to a lazily-formatted ``logger`` method, in order."""
+    return [call.args[0] % call.args[1:] for call in mock_log.call_args_list]
+
+
+class _FakeSocket:
+    """A stand-in for a socket that answers ``bind`` from a script.
+
+    Records what the probe asked for — family, socket type, every ``setsockopt``
+    and the exact address handed to ``bind`` — so a test can pin the syscall
+    shape on a host whose kernel would answer differently.
+    """
+
+    def __init__(self, family, sock_type, log, bind_error):
+        self._log = log
+        self._bind_error = bind_error
+        log["family"] = family
+        log["type"] = sock_type
+
+    def __enter__(self) -> _FakeSocket:
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        self._log["closed"] = True
+        return False
+
+    def setsockopt(self, level, option, value) -> None:
+        self._log["sockopts"].append((level, option, value))
+
+    def bind(self, address) -> None:
+        self._log["bound"] = address
+        # Snapshot the options as they stood when bind was called: an option set
+        # afterwards would not have applied to this bind, so ordering is part of
+        # the contract, not an incidental detail.
+        self._log["sockopts_at_bind"] = list(self._log["sockopts"])
+        if self._bind_error is not None:
+            raise self._bind_error
+
+
+def _fake_socket(bind_error: OSError | None = None):
+    """Return a ``socket.socket`` stand-in and the log it writes to."""
+    log: dict = {
+        "family": None,
+        "type": None,
+        "sockopts": [],
+        "sockopts_at_bind": [],
+        "bound": None,
+        "closed": False,
+    }
+
+    def _factory(family, sock_type):
+        return _FakeSocket(family, sock_type, log, bind_error)
+
+    return _factory, log
+
+
+def _require_ipv6_loopback() -> None:
+    """Skip unless this host can actually bind ``::1`` — CI images vary.
+
+    Asked from inside the test rather than from a ``skipif`` condition: a
+    ``skipif`` argument is evaluated at import, and opening a socket while the
+    module is merely being collected is what ``test_import_time_audit`` forbids.
+    """
+    if not socket.has_ipv6:
+        pytest.skip("host has no IPv6 support")
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
+            sock.bind(("::1", 0))
+    except OSError as exc:
+        pytest.skip(f"host has no usable IPv6 loopback ({exc})")
+
+
+class _Fake302Handler(urllib.request.HTTPHandler):
+    """Answer any ``http://`` request with a 302, opening no socket.
+
+    Subclasses ``HTTPHandler`` so ``build_opener`` drops the real transport,
+    which is what keeps this test off the network.
+    """
+
+    def http_open(self, req):  # noqa: D102 - the class docstring says it
+        headers = email.message.Message()
+        headers["Location"] = "http://127.0.0.1:9/somewhere-else"
+        response = addinfourl(io.BytesIO(b""), headers, req.full_url, 302)
+        response.msg = "Found"
+        return response
 
 
 def _defn(**overrides) -> WebServerDefinition:
@@ -310,15 +434,816 @@ class TestIsRunning:
 
 
 # ---------------------------------------------------------------------------
-# getsource drift guard — ownership is decided by a TCP connect-probe
+# Adoption — a held port is stood down for only on credentialed attribution
 # ---------------------------------------------------------------------------
 
 
-def test_ownership_probe_uses_tcp_connect_not_health():
-    """Regression guard for issue #327: ``_port_has_listener`` must answer the
-    ownership question by opening a TCP connection, never by trusting a
-    ``/health`` 200 (which a stale/foreign responder can fake)."""
-    src = inspect.getsource(ServerLauncher._port_has_listener)
-    assert "create_connection" in src
-    # Must not fall back to the urllib ``/health`` request used by ``_is_running``.
-    assert "urlopen" not in src
+class TestHeldPortAdoption:
+    """A port we cannot bind is adopted only when a credential says it is ours.
+
+    Standing down for a listener means the panel is served by a process this
+    one does not own. That is right when the listener is this deployment's own
+    panel under a shared operator secret, and wrong for anything else — an
+    unrelated server, or one holding a different secret, leaves the operator
+    with a panel whose calls are refused. The evidence is two-sided: a 401 to
+    an unauthenticated probe (it gates) AND a non-401 to a credentialed one (it
+    accepts OUR credential). ``/health`` cannot supply either half.
+    """
+
+    @staticmethod
+    def _run(launcher, probe, secret="operator-secret"):
+        """Drive ensure_running down the held-port path with *probe* answering."""
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=False),
+            patch.object(launcher, "_operator_secret", return_value=secret),
+            patch.object(launcher, "_probe_status", side_effect=probe),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+            patch("osprey.infrastructure.server_launcher.logger.warning") as mock_warn,
+            patch("osprey.infrastructure.server_launcher.logger.info") as mock_info,
+        ):
+            launcher.ensure_running()
+        return mock_launch, mock_warn, mock_info
+
+    def test_gated_listener_accepting_our_secret_is_adopted(self):
+        """401 unauthenticated + 200 credentialed → our own panel; stand down and latch."""
+        launcher = _make_launcher()
+
+        mock_launch, mock_warn, mock_info = self._run(launcher, _probes(401, 200))
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is True
+        mock_warn.assert_not_called()
+        assert "adopting" in _rendered(mock_info)
+
+    def test_ungated_listener_answering_200_is_refused(self):
+        """An open remote serving anyone is not ours, however healthy it looks."""
+        host, port = "127.0.0.1", _free_port()
+        launcher = _make_launcher(host, port)
+
+        mock_launch, mock_warn, _ = self._run(launcher, _probes(200))
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+        mock_warn.assert_called_once()
+        line = _rendered(mock_warn)
+        assert f"{host}:{port}" in line
+        assert "HTTP 200" in line
+        assert "not attempted" in line
+
+    def test_listener_holding_a_different_secret_is_refused(self):
+        """401 to both probes: it gates, but not for us — the credentials diverged."""
+        launcher = _make_launcher()
+
+        mock_launch, mock_warn, _ = self._run(launcher, _probes(401, 401))
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+        mock_warn.assert_called_once()
+        assert "HTTP 401" in _rendered(mock_warn)
+
+    def test_listener_that_never_answers_is_refused(self):
+        """A non-HTTP process holding the port cannot be attributed either."""
+        launcher = _make_launcher()
+
+        mock_launch, mock_warn, _ = self._run(launcher, _probes(None))
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+        mock_warn.assert_called_once()
+        assert "no answer" in _rendered(mock_warn)
+
+    def test_a_credentialed_probe_that_goes_unanswered_is_refused(self):
+        """401 then silence: the listener gates, but stopped answering mid-verdict.
+
+        Attribution needs a non-401 *answer* to the credentialed probe, and no
+        answer is not one — a listener that gates and then times out is exactly
+        as unattributable as one that refuses our secret.
+        """
+        launcher = _make_launcher()
+
+        mock_launch, mock_warn, _ = self._run(launcher, _probes(401, None))
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+        mock_warn.assert_called_once()
+        line = _rendered(mock_warn)
+        assert "HTTP 401" in line
+        assert "credentialed probe: no answer" in line
+
+    def test_missing_local_operator_secret_is_refused(self):
+        """With no credential of our own there is no attribution to make."""
+        launcher = _make_launcher()
+
+        mock_launch, mock_warn, _ = self._run(launcher, _probes(401, 200), secret=None)
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+        mock_warn.assert_called_once()
+        assert "no operator secret" in _rendered(mock_warn)
+
+    def test_our_secret_is_never_offered_to_an_ungated_listener(self):
+        """A listener that served an ungated 200 must not be handed the secret.
+
+        It has already demonstrated that it checks no credential, so sending
+        one teaches us nothing and discloses it to a stranger.
+        """
+        launcher = _make_launcher()
+        offered: list[str | None] = []
+
+        def _record(_host, _port, secret=None):
+            offered.append(secret)
+            return 200 if secret is None else 200
+
+        self._run(launcher, _record)
+
+        assert offered == [None]
+
+    def test_a_refusal_does_not_latch_and_self_heals_when_the_port_frees(self):
+        """The per-save caller must recover once the conflicting listener exits."""
+        launcher = _make_launcher()
+
+        self._run(launcher, _probes(200))
+        assert launcher._launched is False
+        assert launcher._retry_not_before > 0
+
+        launcher._retry_not_before = 0.0
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=True),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+        ):
+            launcher.ensure_running()
+        mock_launch.assert_called_once()
+
+    def test_a_health_200_alone_never_suppresses_a_launch(self):
+        """Issue #327, restated against the adoption path: /health is not evidence.
+
+        The port is bindable, so it is ours to take — and no probe of any kind,
+        credentialed or not, may be consulted to talk us out of the launch.
+        """
+        launcher = _make_launcher()
+
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=True),
+            patch.object(launcher, "_port_answers_connect", return_value=False),
+            patch.object(launcher, "_is_running", return_value=True),
+            patch.object(launcher, "_probe_status") as mock_probe,
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+        ):
+            launcher.ensure_running()
+
+        mock_launch.assert_called_once()
+        mock_probe.assert_not_called()
+
+    def test_a_clean_start_pays_for_no_credentialed_probe(self):
+        """The probes are a cost of the degraded path only."""
+        launcher = _make_launcher()
+
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=True),
+            patch.object(launcher, "_port_answers_connect", return_value=False),
+            patch.object(launcher, "_operator_secret") as mock_secret,
+            patch.object(launcher, "_launch_in_thread"),
+        ):
+            launcher.ensure_running()
+
+        mock_secret.assert_not_called()
+
+
+class TestAdoptionProbeContract:
+    """The probe must read the auth gate, not a credential-free surface."""
+
+    def test_the_probe_path_is_not_exempt_from_the_gate(self):
+        """An exempt path answers 200 for any OSPREY process, so it proves nothing.
+
+        The set pin and the predicate pin are both needed: ``is_exempt_path`` is
+        what the gate actually asks, and it exempts more than the set — every
+        ``STATIC_MOUNT_PREFIXES`` mount too — so a probe path that stayed out of
+        the set could still be waved through by the predicate.
+        """
+        from osprey.interfaces.common_middleware import EXEMPT_PATHS, is_exempt_path
+
+        assert server_launcher._ADOPTION_PROBE_PATH not in EXEMPT_PATHS
+        assert is_exempt_path(server_launcher._ADOPTION_PROBE_PATH) is False
+
+    def test_the_probe_carries_the_secret_in_the_header_the_gate_reads(self):
+        """Mirrored rather than imported (infrastructure/ does not import interfaces/),
+        so the two spellings need a pin."""
+        from osprey.interfaces.common_middleware import OPERATOR_SECRET_HEADER
+        from osprey.interfaces.web_auth import OPERATOR_SECRET_ENV
+
+        assert server_launcher._OPERATOR_SECRET_HEADER == OPERATOR_SECRET_HEADER
+        assert server_launcher._OPERATOR_SECRET_ENV == OPERATOR_SECRET_ENV
+
+    def test_the_environment_carrier_is_read_when_it_is_still_present(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_TERMINAL_SECRET", "  carried-secret  ")
+        assert _make_launcher()._operator_secret() == "carried-secret"
+
+    def test_an_unanswered_probe_is_no_status_rather_than_a_status(self, monkeypatch):
+        """A transport-level failure is None, not a status. No socket is opened:
+        the point under test is the mapping, and a real connect to a "free" port
+        is a race against whatever the OS hands out next."""
+        opener = MagicMock()
+        opener.open.side_effect = urllib.error.URLError("connection refused")
+        monkeypatch.setattr(server_launcher, "_probe_opener", lambda *extra: opener)
+
+        assert _make_launcher()._probe_status("127.0.0.1", 9) is None
+
+    def test_a_redirect_is_the_listeners_own_status_and_is_not_followed(self, monkeypatch):
+        """A 3xx must be reported as itself.
+
+        The default opener would follow it and report the *destination's*
+        status as though this port had answered it — and would re-send the
+        operator-secret header to a host the listener under suspicion chose.
+        Both are settled by refusing to redirect, so the 302 surfaces as 302.
+        """
+        real_opener = server_launcher._probe_opener
+        monkeypatch.setattr(
+            server_launcher,
+            "_probe_opener",
+            lambda *extra: real_opener(_Fake302Handler(), *extra),
+        )
+
+        assert _make_launcher()._probe_status("127.0.0.1", 9, "operator-secret") == 302
+
+
+class TestRepeatRefusalsAreCheapAndQuiet:
+    """The default topology re-enters the refusal path on every artifact save.
+
+    Once the cooldown expires, ``artifact_store`` calls ``ensure_running`` again
+    on the next save — for as long as the conflicting listener holds the port.
+    The first refusal is news and must cost what it costs; every repeat of the
+    same verdict must cost neither the grace window (2.5s of sleeps under the
+    launcher's lock) nor another warning in the operator's log.
+    """
+
+    @staticmethod
+    def _refuse(launcher, probe, sleep_mock, secret="operator-secret"):
+        """Run one full held-port pass with *probe* answering; return the loggers."""
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=False),
+            patch.object(launcher, "_operator_secret", return_value=secret),
+            patch.object(launcher, "_probe_status", side_effect=probe),
+            patch.object(launcher, "_launch_in_thread"),
+            patch("osprey.infrastructure.server_launcher.time.sleep", sleep_mock),
+            patch("osprey.infrastructure.server_launcher.logger.warning") as mock_warn,
+            patch("osprey.infrastructure.server_launcher.logger.info") as mock_info,
+        ):
+            launcher.ensure_running()
+        return mock_warn, mock_info
+
+    def test_the_second_refusal_pays_no_grace_window(self):
+        """A refused port is held by an established listener, not a departing one."""
+        launcher = _make_launcher()
+        sleep = MagicMock()
+
+        self._refuse(launcher, _probes(200), sleep)
+        assert sleep.call_count == launcher._release_grace_attempts
+
+        sleep.reset_mock()
+        launcher._retry_not_before = 0.0
+        self._refuse(launcher, _probes(200), sleep)
+        sleep.assert_not_called()
+
+    def test_an_unchanged_repeat_verdict_drops_to_info(self):
+        launcher = _make_launcher()
+        sleep = MagicMock()
+
+        first_warn, _ = self._refuse(launcher, _probes(200), sleep)
+        first_warn.assert_called_once()
+
+        launcher._retry_not_before = 0.0
+        repeat_warn, repeat_info = self._refuse(launcher, _probes(200), sleep)
+        repeat_warn.assert_not_called()
+        repeat_info.assert_called_once()
+        assert "cannot attribute" in _rendered(repeat_info)
+
+    def test_a_changed_verdict_warns_again(self):
+        """Demotion is per verdict, not per port: new evidence is new news."""
+        launcher = _make_launcher()
+        sleep = MagicMock()
+        answers = {"unauthenticated": 200, "credentialed": None}
+
+        def _probe(_host, _port, secret=None):
+            return answers["credentialed"] if secret else answers["unauthenticated"]
+
+        first_warn, _ = self._refuse(launcher, _probe, sleep)
+        first_warn.assert_called_once()
+        assert "HTTP 200" in _rendered(first_warn)
+
+        answers.update(unauthenticated=401, credentialed=401)
+        launcher._retry_not_before = 0.0
+        second_warn, _ = self._refuse(launcher, _probe, sleep)
+        second_warn.assert_called_once()
+        assert "HTTP 401" in _rendered(second_warn)
+
+    def test_a_freed_port_still_launches_after_a_refusal(self):
+        """Skipping the grace window must not cost the self-heal: every call
+        re-asks the bind question first, and that is the one that matters."""
+        launcher = _make_launcher()
+        self._refuse(launcher, _probes(200), MagicMock())
+
+        launcher._retry_not_before = 0.0
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=True),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+        ):
+            launcher.ensure_running()
+        mock_launch.assert_called_once()
+
+    def test_an_unattributable_listener_is_not_declared_unbacked(self):
+        """With no identity of its own, the launcher must not narrate the panel.
+
+        A gating listener on this port is equally consistent with this
+        deployment's own hub-owned panel — the common case when the caller is
+        the MCP server the agent spawned, which never held a carrier — and with
+        a stranger's server. Advising the operator to stop it, or telling them
+        the panel is unbacked, would be a guess stated as fact.
+        """
+        # Pinned port: the line renders host:port, and an OS-assigned port whose
+        # digits happen to contain "502" would fail the status-code assertion.
+        launcher = _make_launcher(port=8080)
+        _, mock_warn, _ = TestHeldPortAdoption._run(launcher, _probes(401, 200), secret=None)
+
+        line = _rendered(mock_warn)
+        assert "no operator secret" in line
+        assert "502" not in line
+        assert "unbacked" not in line
+        assert "stop the other" not in line
+
+
+class TestOperatorSecretIsSideEffectFree:
+    """Asking "do I hold an identity?" must never be what creates one.
+
+    ``get_web_credentials`` populates: in a process that never held a carrier it
+    MINTS an operator secret and panel token nothing else in the deployment
+    recognises, and pops ``OSPREY_PANEL_TOKEN`` out of ``os.environ`` on the
+    way. The most frequent caller of ``ensure_*_server`` is exactly such a
+    process — the MCP server spawned under the agent, on every artifact save —
+    so the launcher reads the holder with the peeking accessor instead.
+    """
+
+    @staticmethod
+    def _unpopulated_holder(monkeypatch):
+        """Point the process holder at "not populated", restoring it afterwards."""
+        from osprey.interfaces import web_auth
+
+        for name in (
+            "OSPREY_TERMINAL_SECRET",
+            "OSPREY_TERMINAL_BIND_HOST",
+            "OSPREY_TERMINAL_SESSION_LIFETIME",
+            "OSPREY_TERMINAL_SESSION_STORE_DIR",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("OSPREY_PANEL_TOKEN", "carried-panel-token")
+        # ``monkeypatch.setattr`` restores the real holder at teardown, so a
+        # test here cannot decide the credentials for the tests that follow.
+        monkeypatch.setattr(web_auth, "_CREDENTIALS", None)
+        return web_auth
+
+    def test_no_carrier_and_no_holder_is_no_secret(self, monkeypatch):
+        web_auth = self._unpopulated_holder(monkeypatch)
+
+        assert _make_launcher()._operator_secret() is None
+        assert web_auth._CREDENTIALS is None
+
+    def test_reading_the_secret_leaves_the_panel_token_carrier_alone(self, monkeypatch):
+        """``_populate`` pops it unconditionally; peeking must not.
+
+        The MCP process is handed a re-introduced panel token deliberately, and
+        popping it here would race the panel-auth latch and strip the carrier
+        from every child spawned after the probe.
+        """
+        self._unpopulated_holder(monkeypatch)
+
+        _make_launcher()._operator_secret()
+
+        assert os.environ["OSPREY_PANEL_TOKEN"] == "carried-panel-token"
+
+    def test_peek_web_credentials_never_populates(self, monkeypatch):
+        web_auth = self._unpopulated_holder(monkeypatch)
+
+        assert web_auth.peek_web_credentials() is None
+        assert web_auth._CREDENTIALS is None
+        assert os.environ["OSPREY_PANEL_TOKEN"] == "carried-panel-token"
+
+    def test_peek_web_credentials_returns_a_populated_holder_unchanged(self, monkeypatch):
+        """Peeking is not "always None": it reports what is genuinely there."""
+        web_auth = self._unpopulated_holder(monkeypatch)
+        settled = web_auth.get_web_credentials()
+
+        assert web_auth.peek_web_credentials() is settled
+        assert _make_launcher()._operator_secret() == settled.operator_secret
+
+
+class TestAnUnavailableAuthGateGetsItsOwnAdvice:
+    """A 503 is an OSPREY gate that could not populate its own credentials.
+
+    The generic refusal advice — "a foreign server, or one holding a different
+    secret; the panel will be unbacked (502); stop the other server" — is wrong
+    twice over for that listener. It is almost certainly not foreign, and the
+    thing to fix is its configuration, not its existence. Naming the wrong
+    remedy costs the operator the debugging session, so the 503 verdict says
+    what it actually knows and nothing more.
+    """
+
+    def test_a_503_names_the_configuration_fault_not_a_foreign_server(self):
+        # Pinned port: the line renders host:port, and an OS-assigned port whose
+        # digits happen to contain "502" would fail the status-code assertion.
+        launcher = _make_launcher(port=8080)
+
+        _, mock_warn, _ = TestHeldPortAdoption._run(launcher, _probes(503))
+
+        line = _rendered(mock_warn)
+        assert "HTTP 503" in line
+        assert "OSPREY_TERMINAL_SECRET" in line
+        assert "502" not in line
+        assert "unbacked" not in line
+        assert "stop the other" not in line
+        assert "foreign server" not in line
+
+    def test_the_recorded_503_outcome_reads_flat_rather_than_nested(self):
+        """The outcome phrase is the demotion key AND a fragment of prose.
+
+        It is compared against the next refusal to decide warn-vs-info, and it
+        is written to be read: spelling it "not attempted (the gate is
+        unavailable (503))" nested one parenthesis inside another.
+        """
+        launcher = _make_launcher()
+
+        TestHeldPortAdoption._run(launcher, _probes(503))
+
+        status, outcome = launcher._last_refusal
+        assert status == 503
+        assert "unavailable, HTTP 503" in outcome
+        assert "(503)" not in outcome
+
+    def test_a_503_is_refused_without_the_secret_ever_being_offered(self):
+        """A gate answering for nobody is not handed this process's identity."""
+        launcher = _make_launcher()
+        offered: list[str | None] = []
+
+        def _record(_host, _port, secret=None):
+            offered.append(secret)
+            return 503
+
+        mock_launch, _, _ = TestHeldPortAdoption._run(launcher, _record)
+
+        assert offered == [None]
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+
+
+class TestRefusalMemoryIsScopedToOneHeldPortEpisode:
+    """A committed launch ends the episode that ``_refused_once`` describes.
+
+    Both suppressions the refusal memory drives are correct only WITHIN one
+    continuous held-port episode: the grace window is skipped because the holder
+    is established, and the repeat warning is demoted because the verdict is
+    unchanged. Once this process has bound the port itself, the holder is gone —
+    so a later conflict is a new episode, with a fresh predecessor that deserves
+    its window and a verdict that is news again even if it reads the same.
+    """
+
+    def test_committing_a_launch_clears_the_refusal_memory(self):
+        launcher = _make_launcher()
+        launcher._refused_once = True
+        launcher._last_refusal = (200, "not attempted")
+
+        with (
+            patch("osprey.infrastructure.server_launcher.threading.Thread"),
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+            patch.object(launcher, "_is_running", return_value=True),
+        ):
+            launcher._launch_in_thread("127.0.0.1", 4321)
+
+        assert launcher._refused_once is False
+        assert launcher._last_refusal is None
+
+    def test_a_launch_between_two_refusals_restores_the_window_and_the_warning(self):
+        launcher = _make_launcher()
+        sleep = MagicMock()
+
+        first_warn, _ = TestRepeatRefusalsAreCheapAndQuiet._refuse(launcher, _probes(200), sleep)
+        first_warn.assert_called_once()
+        assert sleep.call_count == launcher._release_grace_attempts
+
+        # The port frees and we take it — then the thread dies (a crashing app
+        # factory, say), so the launcher is eligible to try again.
+        launcher._retry_not_before = 0.0
+        dead_thread = MagicMock()
+        dead_thread.is_alive.return_value = False
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=True),
+            patch.object(launcher, "_port_answers_connect", return_value=False),
+            patch(
+                "osprey.infrastructure.server_launcher.threading.Thread",
+                return_value=dead_thread,
+            ),
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+        ):
+            launcher.ensure_running()
+        assert launcher._launched is False
+
+        # A new listener takes the port and returns the SAME verdict as the
+        # first one. It is still news, and it still gets a predecessor's window.
+        sleep.reset_mock()
+        second_warn, second_info = TestRepeatRefusalsAreCheapAndQuiet._refuse(
+            launcher, _probes(200), sleep
+        )
+        assert sleep.call_count == launcher._release_grace_attempts
+        second_warn.assert_called_once()
+        second_info.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _port_is_bindable — the ownership verdict, pinned syscall-shape then errno
+# ---------------------------------------------------------------------------
+
+
+class TestPortIsBindableAsksTheKernelToBind:
+    """What the probe ASKS is pinned without asking a real kernel.
+
+    The verdict must read the same on macOS and Linux, and the two genuinely
+    disagree about which real binds collide — BSD refuses a wildcard bind
+    against a specific listener, Linux allows it when both sockets set
+    ``SO_REUSEADDR`` — so the syscall shape and the errno mapping are pinned
+    against a stand-in socket. Real sockets appear once per family below, as a
+    smoke test that the stand-in describes the real thing.
+    """
+
+    @staticmethod
+    def _probe(host: str, port: int = 4321, bind_error: OSError | None = None):
+        """Run ``_port_is_bindable`` against a scripted socket; return (verdict, log).
+
+        The launcher is built OUTSIDE the patch: the stand-in answers only the
+        probe's use of the socket API, and nothing else may be routed into it.
+        """
+        launcher = _make_launcher(host, port)
+        factory, log = _fake_socket(bind_error)
+        with patch("osprey.infrastructure.server_launcher.socket.socket", factory):
+            verdict = launcher._port_is_bindable(host, port)
+        return verdict, log
+
+    @pytest.mark.parametrize(
+        ("host", "family"),
+        [
+            ("127.0.0.1", socket.AF_INET),
+            ("0.0.0.0", socket.AF_INET),
+            ("", socket.AF_INET),
+            ("localhost", socket.AF_INET),
+            ("::1", socket.AF_INET6),
+            ("::", socket.AF_INET6),
+            ("fe80::1%en0", socket.AF_INET6),
+        ],
+    )
+    def test_the_address_family_follows_the_host_spelling(self, host, family):
+        """``AF_INET6`` iff the host string contains ``':'`` — no name lookup.
+
+        Deliberate: the probe must ask the same question uvicorn will, and
+        uvicorn is handed this same string. A hostname therefore gets an
+        IPv4-only probe even where it resolves to both families; the launcher
+        documents that, and the conflict surfaces at launch instead.
+        """
+        _verdict, log = self._probe(host)
+
+        assert log["family"] == family
+        assert log["type"] == socket.SOCK_STREAM
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "0.0.0.0", "", "::", "::1", "10.0.0.5"])
+    def test_the_exact_configured_address_is_bound_with_no_loopback_substitution(self, host):
+        """A wildcard probe binds the wildcard, never a substituted loopback.
+
+        Probing ``127.0.0.1`` on behalf of a ``0.0.0.0`` bind would miss every
+        listener holding another local address — the server's bind would then
+        fail where the probe said it would succeed, which is precisely the
+        disagreement between probe and server that #327 was about.
+        """
+        _verdict, log = self._probe(host, port=4321)
+
+        assert log["bound"] == (host, 4321)
+
+    def test_so_reuseaddr_is_set_before_the_bind_is_attempted(self):
+        """Mirrors uvicorn's listener, so a ``TIME_WAIT`` remnant reads as bindable
+        for the probe exactly as it is for the server — and never delays startup
+        in the grace loop. Set after the bind it would answer a question about a
+        socket that no longer exists."""
+        _verdict, log = self._probe("127.0.0.1")
+
+        assert (socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) in log["sockopts_at_bind"]
+
+    @pytest.mark.parametrize("bind_error", [None, OSError(errno.EADDRINUSE, "in use")])
+    def test_the_probe_socket_is_always_closed(self, bind_error):
+        """The probe runs on every ``ensure_running`` call, including the per-save
+        ones — a leaked descriptor per call would outlive the answer."""
+        _verdict, log = self._probe("127.0.0.1", bind_error=bind_error)
+
+        assert log["closed"] is True
+
+    @pytest.mark.parametrize(
+        ("bind_error", "bindable"),
+        [
+            (None, True),
+            (OSError(errno.EADDRINUSE, "Address already in use"), False),
+            (OSError(errno.EACCES, "Permission denied"), False),
+            (OSError(errno.EAFNOSUPPORT, "Address family not supported"), True),
+            (OSError(errno.EADDRNOTAVAIL, "Can't assign requested address"), True),
+            (OSError(errno.EINVAL, "Invalid argument"), True),
+            (OSError(None, "an OSError carrying no errno at all"), True),
+        ],
+        ids=["bound", "eaddrinuse", "eacces", "eafnosupport", "eaddrnotavail", "einval", "noerrno"],
+    )
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1"], ids=["ipv4", "ipv6"])
+    def test_only_eaddrinuse_and_eacces_mean_the_port_is_taken(self, bind_error, bindable, host):
+        """Everything else says the PROBE could not answer, not that the port is held.
+
+        The asymmetry is deliberate and load-bearing: a probe defect that read
+        as "taken" would silently suppress the launch and leave the panel
+        unbacked with no listener at all — the #327 failure by another route.
+        Read as "free", the launch goes ahead and any real conflict surfaces as
+        uvicorn's own bind failure, which is a diagnosable event.
+        """
+        verdict, _log = self._probe(host, bind_error=bind_error)
+
+        assert verdict is bindable
+
+    @pytest.mark.parametrize(
+        ("bind_error", "warns"),
+        [
+            (None, False),
+            (OSError(errno.EADDRINUSE, "Address already in use"), False),
+            (OSError(errno.EACCES, "Permission denied"), False),
+            (OSError(errno.EAFNOSUPPORT, "Address family not supported"), True),
+            (OSError(errno.EINVAL, "Invalid argument"), True),
+        ],
+        ids=["bound", "eaddrinuse", "eacces", "eafnosupport", "einval"],
+    )
+    def test_an_inconclusive_probe_says_so_once_and_a_verdict_says_nothing(self, bind_error, warns):
+        """Treating a port as free on an unanswerable probe is auditable, not silent."""
+        launcher = _make_launcher("127.0.0.1", 4321)
+        factory, _log = _fake_socket(bind_error)
+        with (
+            patch("osprey.infrastructure.server_launcher.socket.socket", factory),
+            patch("osprey.infrastructure.server_launcher.logger.warning") as mock_warn,
+        ):
+            launcher._port_is_bindable("127.0.0.1", 4321)
+
+        assert mock_warn.called is warns
+        if warns:
+            line = _rendered(mock_warn)
+            assert "127.0.0.1:4321" in line
+            assert "treating the port as free" in line
+
+
+class TestPortIsBindableAgainstARealKernel:
+    """One smoke row per family: the stand-in above must describe the real thing.
+
+    Only the two unambiguous cases are asked of a real kernel — an exact-address
+    listener holds its own address, and a released port is free — because those
+    are the rows macOS and Linux answer identically. The platform-divergent ones
+    (a wildcard probe against a specific listener) stay mocked.
+    """
+
+    def test_an_ipv4_listener_holds_its_own_address(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
+            srv.bind(("127.0.0.1", 0))
+            srv.listen(1)
+            port = srv.getsockname()[1]
+            assert _make_launcher()._port_is_bindable("127.0.0.1", port) is False
+
+    def test_a_released_ipv4_port_is_bindable(self):
+        assert _make_launcher()._port_is_bindable("127.0.0.1", _free_port()) is True
+
+    def test_an_ipv6_listener_holds_its_own_address(self):
+        _require_ipv6_loopback()
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as srv:
+            srv.bind(("::1", 0))
+            srv.listen(1)
+            port = srv.getsockname()[1]
+            assert _make_launcher()._port_is_bindable("::1", port) is False
+
+    def test_a_released_ipv6_port_is_bindable(self):
+        _require_ipv6_loopback()
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
+            sock.bind(("::1", 0))
+            port = sock.getsockname()[1]
+        assert _make_launcher()._port_is_bindable("::1", port) is True
+
+
+class TestPortAnswersConnectIsDiagnosticOnly:
+    """The connect probe answers a different question, and substitutes for it."""
+
+    @pytest.mark.parametrize(
+        ("host", "destination"),
+        [
+            ("0.0.0.0", "127.0.0.1"),
+            ("", "127.0.0.1"),
+            ("::", "::1"),
+            ("10.0.0.5", "10.0.0.5"),
+        ],
+    )
+    def test_a_wildcard_is_substituted_here_and_only_here(self, host, destination):
+        """The contrast with the bind probe is the point, not an inconsistency.
+
+        A wildcard is not a valid client destination on macOS/BSD, and a server
+        on the wildcard accepts the loopback anyway — so the *reachability*
+        question is asked at the loopback. The *ownership* question is not:
+        see ``test_the_exact_configured_address_is_bound_with_no_loopback_substitution``.
+        """
+        launcher = _make_launcher(host, 4321)
+        seen: dict = {}
+
+        def _connect(address, timeout=None):
+            seen["address"] = address
+            seen["timeout"] = timeout
+            raise OSError(errno.ECONNREFUSED, "connection refused")
+
+        with patch("osprey.infrastructure.server_launcher.socket.create_connection", _connect):
+            assert launcher._port_answers_connect(host, 4321) is False
+
+        assert seen["address"] == (destination, 4321)
+        assert seen["timeout"] == 1
+
+    def test_an_accepted_connect_is_reported_as_answered(self):
+        launcher = _make_launcher("127.0.0.1", 4321)
+        with patch(
+            "osprey.infrastructure.server_launcher.socket.create_connection",
+            return_value=MagicMock(),
+        ):
+            assert launcher._port_answers_connect("127.0.0.1", 4321) is True
+
+
+class TestBindableAndConnectableTogetherDecideTheLaunch:
+    """The bind decides; the connect only narrates. Four rows, both families."""
+
+    @staticmethod
+    def _run(host: str, bindable: bool, answers_connect: bool):
+        launcher = _make_launcher(host, 4321)
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=bindable),
+            patch.object(
+                launcher, "_port_answers_connect", return_value=answers_connect
+            ) as mock_connect,
+            patch.object(launcher, "_operator_secret", return_value=None),
+            patch.object(launcher, "_probe_status", side_effect=_probes(None)),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+            patch("osprey.infrastructure.server_launcher.logger.warning"),
+            patch("osprey.infrastructure.server_launcher.logger.info") as mock_info,
+        ):
+            launcher.ensure_running()
+        return launcher, mock_launch, mock_connect, mock_info
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1"], ids=["ipv4", "ipv6"])
+    @pytest.mark.parametrize("answers_connect", [True, False], ids=["connectable", "silent"])
+    def test_a_bindable_port_launches_whatever_answers_a_connect(self, host, answers_connect):
+        """A listener that does not contend for the bind does not own the port.
+
+        A Docker Desktop host-loopback pass-through answers a connect on a port
+        the container can still bind. Standing down for it would leave the panel
+        with no server of its own.
+        """
+        _launcher, mock_launch, _mock_connect, mock_info = self._run(
+            host, bindable=True, answers_connect=answers_connect
+        )
+
+        mock_launch.assert_called_once()
+        narrated = any("does not block our bind" in line for line in _lines(mock_info))
+        assert narrated is answers_connect
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1"], ids=["ipv4", "ipv6"])
+    def test_an_unbindable_port_goes_to_the_adoption_verdict_without_a_connect(self, host):
+        """Reachability has no vote once the bind has failed, so it is not asked."""
+        launcher, mock_launch, mock_connect, _mock_info = self._run(
+            host, bindable=False, answers_connect=True
+        )
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+        mock_connect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# getsource drift guard — ownership is decided by a bind, not by reachability
+# ---------------------------------------------------------------------------
+
+
+def test_the_ownership_verdict_is_a_bind_and_the_connect_is_only_a_diagnostic():
+    """Source-level backstop for issue #327, behind the behavioural pins above.
+
+    The behaviour tests fix what the probe answers; this fixes how it may find
+    out. A future refactor that reintroduced a ``/health`` request or a connect
+    into the verdict could still satisfy a mocked matrix while restoring exactly
+    the false positive #327 was about — a stale or foreign responder talking the
+    launcher out of owning a port it could have bound.
+    """
+    verdict = inspect.getsource(ServerLauncher._port_is_bindable)
+    # ``.bind(`` rather than ``bind``: the docstring says "bind" a dozen times,
+    # so the bare substring would pass on a body that no longer binds anything.
+    assert ".bind(" in verdict
+    assert "urlopen" not in verdict
+    assert "create_connection" not in verdict
+
+    diagnostic = inspect.getsource(ServerLauncher._port_answers_connect)
+    assert "create_connection" in diagnostic
+    assert "urlopen" not in diagnostic

--- a/tests/interfaces/channel_finder/test_server_launcher.py
+++ b/tests/interfaces/channel_finder/test_server_launcher.py
@@ -1,4 +1,13 @@
-"""Tests for data-driven web server launcher (registry.web + server_launcher)."""
+"""Tests for data-driven web server launcher (registry.web + server_launcher).
+
+This module is the launcher's ownership STATE MACHINE: which of the three
+outcomes — launch, adopt, refuse — each situation reaches, and what a second
+call does afterwards. The probes those transitions are built from have their
+own matrices in ``tests/infrastructure/test_server_launcher.py`` (family and
+errno rows for ``_port_is_bindable``, the adoption verdict rows, the repeat
+refusal accounting); they are not repeated here, and the probes are mocked
+throughout so the transitions do not depend on a kernel.
+"""
 
 from __future__ import annotations
 
@@ -26,6 +35,15 @@ def _make_launcher(host: str, port: int):
         auto_launch_checker=lambda: True,
         app_factory=lambda: object(),
     )
+
+
+def _probes(unauthenticated: int | None, credentialed: int | None = None):
+    """Return a ``_probe_status`` stand-in answering per credential offered."""
+
+    def _probe(_host, _port, secret=None):
+        return credentialed if secret else unauthenticated
+
+    return _probe
 
 
 class TestLauncherConfigReader:
@@ -128,19 +146,24 @@ class TestEnsureRunningOwnership:
 
     Regression coverage for the false-positive described in issue #327: a
     stale/foreign responder answering /health made the launcher skip binding,
-    leaving the panel unbacked (proxy 502) after a restart.
+    leaving the panel unbacked (proxy 502) after a restart. Ownership is now
+    decided by whether ``_port_is_bindable`` says this process could bind the
+    port; a held port is stood down for only when a credentialed probe pair
+    attributes the listener to this deployment.
     """
 
-    def test_launches_when_port_free_despite_health_200(self):
-        """A /health 200 with no real listener must NOT suppress the launch.
+    def test_launches_when_port_bindable_despite_health_200(self):
+        """A /health 200 over a bindable port must NOT suppress the launch.
 
-        This is the core bug: `_is_running()` returning True (stale/foreign
-        responder) must not short-circuit the launch when nothing is actually
-        bound to the port.
+        This is the core of #327: ``/health`` is exempt from the auth gate, so
+        every OSPREY checkout on the machine answers it 200 and it says nothing
+        about whether this port is ours. The bind question is the only one asked.
         """
         launcher = _make_launcher("127.0.0.1", _free_port())
 
         with (
+            patch.object(launcher, "_port_is_bindable", return_value=True),
+            patch.object(launcher, "_port_answers_connect", return_value=False),
             patch.object(launcher, "_is_running", return_value=True),
             patch.object(launcher, "_launch_in_thread") as mock_launch,
         ):
@@ -149,10 +172,12 @@ class TestEnsureRunningOwnership:
         mock_launch.assert_called_once()
 
     def test_launches_when_port_genuinely_free(self):
-        """No listener + no responder → launch and own the port."""
+        """Bindable, nothing answering → launch and own the port."""
         launcher = _make_launcher("127.0.0.1", _free_port())
 
         with (
+            patch.object(launcher, "_port_is_bindable", return_value=True),
+            patch.object(launcher, "_port_answers_connect", return_value=False),
             patch.object(launcher, "_is_running", return_value=False),
             patch.object(launcher, "_launch_in_thread") as mock_launch,
         ):
@@ -163,15 +188,16 @@ class TestEnsureRunningOwnership:
     def test_waits_out_dying_predecessor_then_launches(self):
         """A predecessor that releases the port during the grace window is waited out."""
         launcher = _make_launcher("127.0.0.1", _free_port())
-        # Held on the first probe, released on the second (predecessor shut down).
-        listener_states = iter([True, False])
+        # Unbindable on the first probe, bindable on the second (predecessor gone).
+        bindable = iter([False, True])
 
         with (
             patch.object(
                 launcher,
-                "_port_has_listener",
-                side_effect=lambda *_: next(listener_states, False),
+                "_port_is_bindable",
+                side_effect=lambda *_: next(bindable, True),
             ),
+            patch.object(launcher, "_port_answers_connect", return_value=False),
             patch.object(launcher, "_launch_in_thread") as mock_launch,
             patch("osprey.infrastructure.server_launcher.time.sleep"),
         ):
@@ -179,28 +205,19 @@ class TestEnsureRunningOwnership:
 
         mock_launch.assert_called_once()
 
-    def test_defers_to_persistent_external_server(self):
-        """A port held for the full grace window that serves /health → defer, don't launch."""
+    def test_adopts_a_held_port_whose_listener_accepts_our_secret(self):
+        """401 unauthenticated + non-401 credentialed → our own panel; stand down.
+
+        This is the only shape that justifies not launching: the listener gates,
+        and it accepts THIS process's operator secret, so it is this deployment's
+        panel under a shared ``OSPREY_TERMINAL_SECRET``.
+        """
         launcher = _make_launcher("127.0.0.1", _free_port())
 
         with (
-            patch.object(launcher, "_port_has_listener", return_value=True),
-            patch.object(launcher, "_is_running", return_value=True),
-            patch.object(launcher, "_launch_in_thread") as mock_launch,
-            patch("osprey.infrastructure.server_launcher.time.sleep"),
-        ):
-            launcher.ensure_running()
-
-        mock_launch.assert_not_called()
-        assert launcher._launched is True
-
-    def test_warns_when_port_held_by_non_responder(self):
-        """Port held for the full grace window with no /health → loud warning, no silent skip."""
-        launcher = _make_launcher("127.0.0.1", _free_port())
-
-        with (
-            patch.object(launcher, "_port_has_listener", return_value=True),
-            patch.object(launcher, "_is_running", return_value=False),
+            patch.object(launcher, "_port_is_bindable", return_value=False),
+            patch.object(launcher, "_operator_secret", return_value="operator-secret"),
+            patch.object(launcher, "_probe_status", side_effect=_probes(401, 200)),
             patch.object(launcher, "_launch_in_thread") as mock_launch,
             patch("osprey.infrastructure.server_launcher.time.sleep"),
             patch("osprey.infrastructure.server_launcher.logger.warning") as mock_warn,
@@ -208,10 +225,55 @@ class TestEnsureRunningOwnership:
             launcher.ensure_running()
 
         mock_launch.assert_not_called()
+        assert launcher._launched is True
+        mock_warn.assert_not_called()
+
+    def test_refuses_a_held_port_that_serves_health_but_cannot_be_attributed(self):
+        """A /health 200 does not earn a stand-down either — it is refused, not adopted.
+
+        The superseded contract deferred to any listener that answered /health,
+        which handed the operator a panel backed by a server this process cannot
+        talk to. An ungated 200 to the adoption probe now refuses: no launch (the
+        port is not ours to take), no latch, and a warning naming the conflict.
+        """
+        launcher = _make_launcher("127.0.0.1", _free_port())
+
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=False),
+            patch.object(launcher, "_operator_secret", return_value="operator-secret"),
+            patch.object(launcher, "_probe_status", side_effect=_probes(200)),
+            patch.object(launcher, "_is_running", return_value=True),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+            patch("osprey.infrastructure.server_launcher.logger.warning") as mock_warn,
+        ):
+            launcher.ensure_running()
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+        assert launcher._retry_not_before > 0
         mock_warn.assert_called_once()
 
-    def test_non_responder_does_not_latch_and_self_heals(self):
-        """A non-responder outcome must not latch, so a later call can self-heal.
+    def test_warns_when_port_held_by_a_listener_that_never_answers(self):
+        """Held for the full grace window, nothing answering → warn, no silent skip."""
+        launcher = _make_launcher("127.0.0.1", _free_port())
+
+        with (
+            patch.object(launcher, "_port_is_bindable", return_value=False),
+            patch.object(launcher, "_operator_secret", return_value="operator-secret"),
+            patch.object(launcher, "_probe_status", side_effect=_probes(None)),
+            patch.object(launcher, "_launch_in_thread") as mock_launch,
+            patch("osprey.infrastructure.server_launcher.time.sleep"),
+            patch("osprey.infrastructure.server_launcher.logger.warning") as mock_warn,
+        ):
+            launcher.ensure_running()
+
+        mock_launch.assert_not_called()
+        assert launcher._launched is False
+        mock_warn.assert_called_once()
+
+    def test_a_refusal_does_not_latch_and_self_heals(self):
+        """A refusal must not latch, so a later call can self-heal.
 
         Regression guard for the artifact_store per-save relaunch pattern: if the
         first call hit a foreign holder, a later call (after the port frees) must
@@ -219,10 +281,11 @@ class TestEnsureRunningOwnership:
         """
         launcher = _make_launcher("127.0.0.1", _free_port())
 
-        # First call: held by a non-responder → warn, throttle, no launch, no latch.
+        # First call: held by an unattributable listener → warn, throttle, no latch.
         with (
-            patch.object(launcher, "_port_has_listener", return_value=True),
-            patch.object(launcher, "_is_running", return_value=False),
+            patch.object(launcher, "_port_is_bindable", return_value=False),
+            patch.object(launcher, "_operator_secret", return_value="operator-secret"),
+            patch.object(launcher, "_probe_status", side_effect=_probes(None)),
             patch.object(launcher, "_launch_in_thread") as mock_launch,
             patch("osprey.infrastructure.server_launcher.time.sleep"),
         ):
@@ -230,14 +293,42 @@ class TestEnsureRunningOwnership:
         mock_launch.assert_not_called()
         assert launcher._launched is False
 
-        # Cooldown elapsed and the port is now free → launch (self-heal).
+        # Cooldown elapsed and the port is now bindable → launch (self-heal).
         launcher._retry_not_before = 0.0
         with (
-            patch.object(launcher, "_port_has_listener", return_value=False),
+            patch.object(launcher, "_port_is_bindable", return_value=True),
+            patch.object(launcher, "_port_answers_connect", return_value=False),
             patch.object(launcher, "_launch_in_thread") as mock_launch2,
         ):
             launcher.ensure_running()
         mock_launch2.assert_called_once()
+
+    def test_a_second_held_port_pass_skips_the_grace_window(self):
+        """The window is a predecessor's, and a refused port has no predecessor.
+
+        Once a refusal has established that the holder is staying, a per-save
+        caller must not pay 2.5s of sleeps under the launcher's lock on every
+        call. The bind question is still re-asked first, so a freed port still
+        launches (covered above).
+        """
+        launcher = _make_launcher("127.0.0.1", _free_port())
+        sleep = MagicMock()
+
+        for _pass in range(2):
+            launcher._retry_not_before = 0.0
+            with (
+                patch.object(launcher, "_port_is_bindable", return_value=False),
+                patch.object(launcher, "_operator_secret", return_value="operator-secret"),
+                patch.object(launcher, "_probe_status", side_effect=_probes(None)),
+                patch.object(launcher, "_launch_in_thread"),
+                patch("osprey.infrastructure.server_launcher.time.sleep", sleep),
+            ):
+                launcher.ensure_running()
+            if _pass == 0:
+                assert sleep.call_count == launcher._release_grace_attempts
+                sleep.reset_mock()
+
+        sleep.assert_not_called()
 
     def test_cooldown_short_circuits_reprobe(self):
         """Within the retry cooldown, ensure_running must not re-probe (avoids grace cost)."""
@@ -245,7 +336,7 @@ class TestEnsureRunningOwnership:
         launcher._retry_not_before = time.monotonic() + 1000  # far future
 
         with (
-            patch.object(launcher, "_port_has_listener") as mock_probe,
+            patch.object(launcher, "_port_is_bindable") as mock_probe,
             patch.object(launcher, "_launch_in_thread") as mock_launch,
         ):
             launcher.ensure_running()
@@ -293,18 +384,27 @@ class TestLoopbackFor:
         assert _loopback_for("127.0.0.1") == "127.0.0.1"
 
 
-class TestPortHasListener:
-    """The connect-probe distinguishes a bound port from a free one."""
+class TestTheTwoProbesAnswerDifferentQuestions:
+    """One verdict, one diagnostic — the split the state machine is built on.
 
-    def test_returns_false_for_free_port(self):
+    Only the contrast is pinned here, on the one situation where both probes
+    agree there is a real listener. The family, address and errno rows for each
+    probe live in ``tests/infrastructure/test_server_launcher.py``.
+    """
+
+    def test_a_free_port_is_bindable_and_answers_nothing(self):
         launcher = _make_launcher("127.0.0.1", _free_port())
         host, port = launcher._config_reader()
-        assert launcher._port_has_listener(host, port) is False
 
-    def test_returns_true_for_bound_port(self):
+        assert launcher._port_is_bindable(host, port) is True
+        assert launcher._port_answers_connect(host, port) is False
+
+    def test_a_bound_port_is_unbindable_and_answers_a_connect(self):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
             srv.bind(("127.0.0.1", 0))
             srv.listen(1)
             port = srv.getsockname()[1]
             launcher = _make_launcher("127.0.0.1", port)
-            assert launcher._port_has_listener("127.0.0.1", port) is True
+
+            assert launcher._port_is_bindable("127.0.0.1", port) is False
+            assert launcher._port_answers_connect("127.0.0.1", port) is True

--- a/tests/interfaces/design_system/js/boot-harness.mjs
+++ b/tests/interfaces/design_system/js/boot-harness.mjs
@@ -1,0 +1,43 @@
+/**
+ * Shared harness for the pre-paint boot scripts (mode-boot.js, rail-boot.js,
+ * theme-boot.js).
+ *
+ * Those files are non-module, dependency-free IIFEs — they export nothing and
+ * do their whole job on load — so a test cannot import them. Instead each
+ * scenario arranges window.location / localStorage / the <html> attributes and
+ * then re-executes the exact on-disk source against the happy-dom globals.
+ *
+ * Two details are load-bearing and easy to get wrong when this is copied by
+ * hand, which is why it lives here once:
+ *
+ *   - `import.meta.dirname` (a plain string) rather than
+ *     `fileURLToPath(new URL(...))`: happy-dom overrides the global URL, which
+ *     breaks the fileURLToPath spelling under this environment.
+ *   - `window`/`document` passed as explicit `new Function` parameters, so the
+ *     source's free references bind to the test's DOM without a global `eval`.
+ *
+ * The source is re-read from disk on every call, so a test that runs the same
+ * boot script repeatedly always executes what is actually on disk.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** design_system's served JS directory, relative to this file. */
+const BOOT_SCRIPT_DIR = join(
+  import.meta.dirname,
+  '../../../../src/osprey/interfaces/design_system/static/js'
+);
+
+/**
+ * Execute a pre-paint boot IIFE against the current happy-dom globals.
+ *
+ * @param {string} relPath path relative to design_system/static/js —
+ *   e.g. `'mode-boot.js'`.
+ * @returns {void}
+ */
+export function runBootScript(relPath) {
+  const source = readFileSync(join(BOOT_SCRIPT_DIR, relPath), 'utf8');
+  const boot = new Function('window', 'document', source);
+  boot(globalThis.window, globalThis.document);
+}

--- a/tests/interfaces/design_system/js/display-menu-scope.test.mjs
+++ b/tests/interfaces/design_system/js/display-menu-scope.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * Writer-side counterpart to mode-boot-scope.test.mjs: <osprey-display-menu>'s
+ * View row must persist the pick under the SAME per-persona key mode-boot.js
+ * reads. A reader that scopes and a writer that does not would be worse than
+ * neither — the pick would land in the shared slot and then never be read back.
+ *
+ * Kept out of display-menu-component.test.mjs because that file's beforeEach
+ * establishes an unscoped document, which is exactly the baseline its other
+ * assertions depend on.
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/design_system/js/display-menu-scope.test.mjs
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+import { qs } from '../../_support/dom.mjs';
+import { runBootScript } from './boot-harness.mjs';
+
+import * as ThemeManager from '/design-system/js/theme-manager.js';
+import '/design-system/js/components/osprey-display-menu.js';
+
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+const LEGACY_KEY = 'osprey-ui-mode';
+
+function mount() {
+  const el = document.createElement('osprey-display-menu');
+  document.body.appendChild(el);
+  return /** @type {HTMLElement} */ (el);
+}
+
+/** @param {HTMLElement} el @param {'expert'|'simple'} mode */
+function pickView(el, mode) {
+  qs(el, `.display-menu-view .display-seg-option[data-mode="${mode}"]`).click();
+}
+
+describe('<osprey-display-menu> View row storage scoping', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-ui-mode');
+    document.documentElement.removeAttribute(SCOPE_ATTR);
+    document.body.innerHTML = '';
+    document.body.className = '';
+    window.history.replaceState({}, '', '/');
+    ThemeManager.initTheme({ role: 'hub' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+    document.body.className = '';
+  });
+
+  test('a scoped page writes the scoped key and leaves the shared slot alone', () => {
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+    const el = mount();
+
+    pickView(el, 'simple');
+
+    expect(window.localStorage.getItem(`${LEGACY_KEY}--bob`)).toBe('simple');
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  test("one persona's pick does not overwrite another's", () => {
+    window.localStorage.setItem(`${LEGACY_KEY}--carol`, 'simple');
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+    const el = mount();
+
+    pickView(el, 'expert');
+
+    expect(window.localStorage.getItem(`${LEGACY_KEY}--bob`)).toBe('expert');
+    expect(window.localStorage.getItem(`${LEGACY_KEY}--carol`)).toBe('simple');
+  });
+
+  test('an existing polluted shared slot is not repaired, and not read back either', () => {
+    // Writing the scoped key deliberately leaves the legacy value in place:
+    // other, still-unscoped surfaces on this origin may depend on it, and no
+    // scoped reader will ever consult it.
+    window.localStorage.setItem(LEGACY_KEY, 'simple');
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+    const el = mount();
+
+    pickView(el, 'expert');
+
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBe('simple');
+    expect(window.localStorage.getItem(`${LEGACY_KEY}--bob`)).toBe('expert');
+  });
+
+  test('an unscoped page still writes the bare legacy key', () => {
+    const el = mount();
+
+    pickView(el, 'simple');
+
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBe('simple');
+  });
+
+  test('the scope is read at write time, so it tracks the document it lands in', () => {
+    const el = mount();
+    pickView(el, 'simple');
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBe('simple');
+
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+    pickView(el, 'expert');
+
+    expect(window.localStorage.getItem(`${LEGACY_KEY}--bob`)).toBe('expert');
+    // The earlier unscoped write is untouched by the scoped one.
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBe('simple');
+  });
+
+  // The writer and mode-boot.js each spell the scoped key inline. The two
+  // key-name pins above would both stay green if the spelling drifted in step;
+  // a real write-then-boot round trip fails whatever the literal is.
+  test("a pick under one scope is what mode-boot.js reads back on that persona's next load", () => {
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+    const el = mount();
+    pickView(el, 'simple');
+
+    document.documentElement.setAttribute('data-ui-mode', 'expert');
+    runBootScript('mode-boot.js');
+
+    expect(document.documentElement.getAttribute('data-ui-mode')).toBe('simple');
+  });
+
+  test("a pick under one scope does not reach another persona's boot", () => {
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+    const el = mount();
+    pickView(el, 'simple');
+
+    document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+    document.documentElement.setAttribute('data-ui-mode', 'expert');
+    runBootScript('mode-boot.js');
+
+    expect(document.documentElement.getAttribute('data-ui-mode')).toBe('expert');
+  });
+});

--- a/tests/interfaces/design_system/js/mode-boot-scope.test.mjs
+++ b/tests/interfaces/design_system/js/mode-boot-scope.test.mjs
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for mode-boot.js's per-persona scoping of the storage rung.
+ *
+ * The ladder itself (?mode= > storage > server data-ui-mode > 'expert') is
+ * pinned in tests/interfaces/design_system/mode-boot.test.mjs. This file pins
+ * only what the scope attribute changes about rung 2:
+ *
+ *   - scoped pages read `osprey-ui-mode--<scope>`
+ *   - a scoped page NEVER falls back to the bare `osprey-ui-mode`, even when it
+ *     holds a valid mode — that shared slot is the cross-persona bug the
+ *     scoping exists to escape, and consulting it would re-inflict the bug once
+ *     per persona
+ *   - with no attribute, the bare key is honoured exactly as before
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/design_system/js/mode-boot-scope.test.mjs
+ */
+
+import { test, expect, describe, beforeEach } from 'vitest';
+
+import { runBootScript } from './boot-harness.mjs';
+
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+const LEGACY_KEY = 'osprey-ui-mode';
+
+function runBoot() {
+  runBootScript('mode-boot.js');
+}
+
+function currentMode() {
+  return document.documentElement.getAttribute('data-ui-mode');
+}
+
+describe('mode-boot.js storage scoping', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-ui-mode');
+    document.documentElement.removeAttribute(SCOPE_ATTR);
+    window.history.replaceState({}, '', '/');
+  });
+
+  describe('a polluted legacy key does not leak across personas', () => {
+    test("bob boots his server mode, not the shared slot's 'simple'", () => {
+      // The shared origin-wide slot someone else wrote last.
+      window.localStorage.setItem(LEGACY_KEY, 'simple');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-ui-mode', 'expert');
+
+      runBoot();
+
+      expect(currentMode()).toBe('expert');
+    });
+
+    test("carol, same polluted slot, boots HER server mode", () => {
+      window.localStorage.setItem(LEGACY_KEY, 'expert');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      document.documentElement.setAttribute('data-ui-mode', 'simple');
+
+      runBoot();
+
+      expect(currentMode()).toBe('simple');
+    });
+
+    test('with no server rung either, a scoped page falls through to the default', () => {
+      // The point of "no legacy fallback": absent a scoped value there is no
+      // stored preference at all, so resolution continues down the ladder
+      // rather than borrowing the last writer's.
+      window.localStorage.setItem(LEGACY_KEY, 'simple');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+
+      runBoot();
+
+      expect(currentMode()).toBe('expert');
+    });
+  });
+
+  describe('a scoped page reads its own key', () => {
+    test("bob's scoped 'simple' applies over a differing server attribute", () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'simple');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-ui-mode', 'expert');
+
+      runBoot();
+
+      expect(currentMode()).toBe('simple');
+    });
+
+    test("carol's key is not bob's — one persona's pick leaves the other alone", () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'simple');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      document.documentElement.setAttribute('data-ui-mode', 'expert');
+
+      runBoot();
+
+      expect(currentMode()).toBe('expert');
+    });
+
+    test('an invalid scoped value still falls through to the server rung', () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'bogus');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-ui-mode', 'simple');
+
+      runBoot();
+
+      expect(currentMode()).toBe('simple');
+    });
+
+    test('?mode= still outranks the scoped storage rung', () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'simple');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      window.history.replaceState({}, '', '/?mode=expert');
+
+      runBoot();
+
+      expect(currentMode()).toBe('expert');
+    });
+  });
+
+  describe('unscoped serving is unchanged', () => {
+    test('with no attribute the legacy key is honoured as before', () => {
+      window.localStorage.setItem(LEGACY_KEY, 'simple');
+
+      runBoot();
+
+      expect(currentMode()).toBe('simple');
+    });
+
+    test('an unscoped page ignores a scoped key left behind by a scoped visit', () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'simple');
+      document.documentElement.setAttribute('data-ui-mode', 'expert');
+
+      runBoot();
+
+      expect(currentMode()).toBe('expert');
+    });
+
+    test('an empty attribute value is treated as unscoped, not as scope ""', () => {
+      // The server omits the attribute rather than emitting `=""`; this pins
+      // the boot script's inline guard against minting `osprey-ui-mode--`.
+      window.localStorage.setItem(LEGACY_KEY, 'simple');
+      document.documentElement.setAttribute(SCOPE_ATTR, '');
+
+      runBoot();
+
+      expect(currentMode()).toBe('simple');
+    });
+  });
+});

--- a/tests/interfaces/design_system/js/rail-boot-scope.test.mjs
+++ b/tests/interfaces/design_system/js/rail-boot-scope.test.mjs
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for rail-boot.js's per-persona scoping of the storage rung.
+ *
+ * The ladder itself (?rail= > storage > server data-rail-position > 'left') is
+ * pinned in tests/interfaces/design_system/rail-boot.test.mjs. This file pins
+ * only what the scope attribute changes about rung 2, exactly as
+ * mode-boot-scope.test.mjs does for the ui-mode axis:
+ *
+ *   - scoped pages read `osprey-rail-position--<scope>`
+ *   - a scoped page NEVER falls back to the bare `osprey-rail-position`, even
+ *     when it holds a valid position — that shared slot is the cross-persona
+ *     bug the scoping exists to escape
+ *   - with no attribute, the bare key is honoured exactly as before
+ *
+ * rail-boot.js is the READER half of a pair: rail-position.js (web_terminal)
+ * writes the key this script reads, and the two must derive byte-identical
+ * keys for the same scope. The writer's half is pinned in
+ * tests/interfaces/web_terminal/js/storage-scope-keys.test.js.
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/design_system/js/rail-boot-scope.test.mjs
+ */
+
+import { test, expect, describe, beforeEach } from 'vitest';
+
+import { runBootScript } from './boot-harness.mjs';
+
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+const LEGACY_KEY = 'osprey-rail-position';
+
+function runBoot() {
+  runBootScript('rail-boot.js');
+}
+
+function currentPosition() {
+  return document.documentElement.getAttribute('data-rail-position');
+}
+
+describe('rail-boot.js storage scoping', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-rail-position');
+    document.documentElement.removeAttribute(SCOPE_ATTR);
+    window.history.replaceState({}, '', '/');
+  });
+
+  describe('a polluted legacy key does not leak across personas', () => {
+    test("bob boots his server rail, not the shared slot's 'top'", () => {
+      // The shared origin-wide slot whichever persona flipped the rail last.
+      window.localStorage.setItem(LEGACY_KEY, 'top');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-rail-position', 'left');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('left');
+    });
+
+    test('carol, same polluted slot, boots HER server rail', () => {
+      window.localStorage.setItem(LEGACY_KEY, 'left');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      document.documentElement.setAttribute('data-rail-position', 'top');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('top');
+    });
+
+    test('with no server rung either, a scoped page falls through to the default', () => {
+      window.localStorage.setItem(LEGACY_KEY, 'top');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('left');
+    });
+  });
+
+  describe('a scoped page reads its own key', () => {
+    test("bob's scoped 'top' applies over a differing server attribute", () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'top');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-rail-position', 'left');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('top');
+    });
+
+    test("carol's key is not bob's — one persona's pick leaves the other alone", () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'top');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      document.documentElement.setAttribute('data-rail-position', 'left');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('left');
+    });
+
+    test('an invalid scoped value still falls through to the server rung', () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'bogus');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-rail-position', 'top');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('top');
+    });
+
+    test('?rail= still outranks the scoped storage rung', () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'top');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      window.history.replaceState({}, '', '/?rail=left');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('left');
+    });
+  });
+
+  describe('unscoped serving is unchanged', () => {
+    test('with no attribute the legacy key is honoured as before', () => {
+      window.localStorage.setItem(LEGACY_KEY, 'top');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('top');
+    });
+
+    test('an unscoped page ignores a scoped key left behind by a scoped visit', () => {
+      window.localStorage.setItem(`${LEGACY_KEY}--bob`, 'top');
+      document.documentElement.setAttribute('data-rail-position', 'left');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('left');
+    });
+
+    test('an empty attribute value is treated as unscoped, not as scope ""', () => {
+      // The server omits the attribute rather than emitting `=""`; this pins
+      // the boot script's inline guard against minting `osprey-rail-position--`.
+      window.localStorage.setItem(LEGACY_KEY, 'top');
+      document.documentElement.setAttribute(SCOPE_ATTR, '');
+
+      runBoot();
+
+      expect(currentPosition()).toBe('top');
+    });
+  });
+});

--- a/tests/interfaces/design_system/js/storage-scope.test.mjs
+++ b/tests/interfaces/design_system/js/storage-scope.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for storage-scope.js — the one written-down definition of how a
+ * localStorage key is derived from `<html data-osprey-storage-scope>`.
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/design_system/js/storage-scope.test.mjs
+ */
+
+import { test, expect, describe, beforeEach } from 'vitest';
+
+import { storageScope, scopedStorageKey } from '/design-system/js/storage-scope.js';
+
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+
+describe('storage-scope.js', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute(SCOPE_ATTR);
+  });
+
+  describe('storageScope()', () => {
+    test('returns null when the attribute is absent (single-user serving)', () => {
+      expect(storageScope()).toBeNull();
+    });
+
+    test('returns the attribute value when the server stamped one', () => {
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      expect(storageScope()).toBe('bob');
+    });
+
+    test('treats an empty attribute value as unscoped', () => {
+      // The server omits the attribute rather than rendering `=""`, so this is
+      // defensive: an empty scope would otherwise mint `<base>--`, a slot
+      // belonging to no persona.
+      document.documentElement.setAttribute(SCOPE_ATTR, '');
+      expect(storageScope()).toBeNull();
+    });
+  });
+
+  describe('scopedStorageKey()', () => {
+    test('returns the bare legacy key when unscoped', () => {
+      expect(scopedStorageKey('osprey-ui-mode')).toBe('osprey-ui-mode');
+    });
+
+    test('suffixes the scope with a double dash when scoped', () => {
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      expect(scopedStorageKey('osprey-ui-mode')).toBe('osprey-ui-mode--bob');
+    });
+
+    test('an empty attribute value never mints a trailing-dash key', () => {
+      document.documentElement.setAttribute(SCOPE_ATTR, '');
+      expect(scopedStorageKey('osprey-ui-mode')).toBe('osprey-ui-mode');
+    });
+
+    test('two personas on one origin get two distinct keys', () => {
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      const bob = scopedStorageKey('osprey-ui-mode');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      const carol = scopedStorageKey('osprey-ui-mode');
+
+      expect(bob).not.toBe(carol);
+      // ...and neither of them is the shared slot they exist to escape.
+      expect(bob).not.toBe('osprey-ui-mode');
+      expect(carol).not.toBe('osprey-ui-mode');
+    });
+
+    test('the scope is read per call, not captured at module load', () => {
+      expect(scopedStorageKey('osprey-rail-position')).toBe('osprey-rail-position');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      expect(scopedStorageKey('osprey-rail-position')).toBe('osprey-rail-position--bob');
+    });
+
+    test('is base-agnostic — every axis derives its key the same way', () => {
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      expect(scopedStorageKey('osprey-theme')).toBe('osprey-theme--bob');
+      expect(scopedStorageKey('osprey-dock-layout')).toBe('osprey-dock-layout--bob');
+    });
+  });
+});

--- a/tests/interfaces/design_system/js/theme-boot-scope.test.mjs
+++ b/tests/interfaces/design_system/js/theme-boot-scope.test.mjs
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for theme-boot.js's per-persona scoping of the storage rungs.
+ *
+ * The full ladder (?theme= > stored {family,mode} JSON > legacy bare token >
+ * server data-theme > 'auto') is pinned in
+ * tests/interfaces/design_system/theme-boot.test.mjs. This file pins only what
+ * the scope attribute changes about the two storage rungs:
+ *
+ *   - a scoped page reads `osprey-theme--<scope>`
+ *   - a scoped page NEVER falls back to the bare `osprey-theme`, in either
+ *     storage format — that shared origin-wide slot is the cross-persona bug
+ *     the scoping exists to escape, and consulting it would hand the last
+ *     writer's theme to every persona who has not yet picked one
+ *   - with no attribute, the bare key is honoured exactly as before, legacy
+ *     bare token included
+ *
+ * theme-boot.js is generated (generator/emit_js.py) as a non-module,
+ * dependency-free IIFE, so each scenario arranges the DOM/storage and re-runs
+ * the on-disk source through the shared boot harness.
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/design_system/js/theme-boot-scope.test.mjs
+ */
+
+import { test, expect, describe, beforeEach, vi } from 'vitest';
+
+import { runBootScript } from './boot-harness.mjs';
+
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+const LEGACY_KEY = 'osprey-theme';
+
+function runBoot() {
+  runBootScript('theme-boot.js');
+}
+
+function currentTheme() {
+  return document.documentElement.getAttribute('data-theme');
+}
+
+/**
+ * Force the OS preference so every 'auto' fall-through resolves to a known id
+ * rather than to whatever the host machine happens to prefer.
+ * @param {boolean} prefersDark
+ */
+function stubOSPreference(prefersDark) {
+  vi.stubGlobal('matchMedia', (/** @type {string} */ query) => ({
+    matches: query.includes('dark') ? prefersDark : !prefersDark,
+    media: query,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+  }));
+}
+
+/** @param {string} key @param {{family: string, mode: string}|string} preference */
+function store(key, preference) {
+  window.localStorage.setItem(
+    key,
+    typeof preference === 'string' ? preference : JSON.stringify(preference)
+  );
+}
+
+describe('theme-boot.js storage scoping', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute(SCOPE_ATTR);
+    window.history.replaceState({}, '', '/');
+    stubOSPreference(true);
+  });
+
+  describe('a polluted legacy key does not leak across personas', () => {
+    test("bob boots his server theme, not the shared slot's retro", () => {
+      // The origin-wide slot whoever picked last wrote.
+      store(LEGACY_KEY, { family: 'retro', mode: 'dark' });
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('light');
+    });
+
+    test('carol, same polluted slot, boots HER server theme', () => {
+      store(LEGACY_KEY, { family: 'retro', mode: 'dark' });
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      document.documentElement.setAttribute('data-theme', 'desy-dark');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('desy-dark');
+    });
+
+    test('a polluted legacy BARE token is ignored on a scoped page too', () => {
+      // The legacy bare-token rung is part of the same shared slot; scoping
+      // has to close both storage rungs, not just the structured one.
+      store(LEGACY_KEY, 'retro-light');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('light');
+    });
+
+    test('with no server rung either, a scoped page falls through to auto', () => {
+      // The point of "no legacy fallback": absent a scoped value there is no
+      // stored preference at all, so resolution continues down the ladder to
+      // 'auto' within DEFAULT_FAMILY rather than borrowing the last writer's.
+      store(LEGACY_KEY, { family: 'retro', mode: 'light' });
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('dark');
+    });
+  });
+
+  describe('a scoped page reads its own key', () => {
+    test("bob's scoped preference applies over a differing server attribute", () => {
+      store(`${LEGACY_KEY}--bob`, { family: 'retro', mode: 'dark' });
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('retro-dark');
+    });
+
+    test('a scoped legacy bare token is honoured under the scoped key', () => {
+      store(`${LEGACY_KEY}--bob`, 'high-contrast-light');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('high-contrast-light');
+    });
+
+    test("carol's key is not bob's — one persona's pick leaves the other alone", () => {
+      store(`${LEGACY_KEY}--bob`, { family: 'retro', mode: 'dark' });
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('light');
+    });
+
+    test('an unparseable scoped value still falls through to the server rung', () => {
+      store(`${LEGACY_KEY}--bob`, 'not-a-theme');
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-theme', 'desy-light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('desy-light');
+    });
+
+    test('?theme= still outranks the scoped storage rung', () => {
+      store(`${LEGACY_KEY}--bob`, { family: 'retro', mode: 'dark' });
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      window.history.replaceState({}, '', '/?theme=light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('light');
+    });
+  });
+
+  describe('unscoped serving is unchanged', () => {
+    test('with no attribute the legacy structured preference is honoured', () => {
+      store(LEGACY_KEY, { family: 'retro', mode: 'dark' });
+
+      runBoot();
+
+      expect(currentTheme()).toBe('retro-dark');
+    });
+
+    test('with no attribute the legacy bare token is honoured', () => {
+      store(LEGACY_KEY, 'high-contrast-light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('high-contrast-light');
+    });
+
+    test('an unscoped page ignores a scoped key left behind by a scoped visit', () => {
+      store(`${LEGACY_KEY}--bob`, { family: 'retro', mode: 'dark' });
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('light');
+    });
+
+    test('an empty attribute value is treated as unscoped, not as scope ""', () => {
+      // The server omits the attribute rather than emitting `=""`; this pins
+      // the boot script's inline guard against minting `osprey-theme--`.
+      store(LEGACY_KEY, { family: 'retro', mode: 'dark' });
+      document.documentElement.setAttribute(SCOPE_ATTR, '');
+
+      runBoot();
+
+      expect(currentTheme()).toBe('retro-dark');
+    });
+  });
+});

--- a/tests/interfaces/design_system/js/theme-manager-scope.test.mjs
+++ b/tests/interfaces/design_system/js/theme-manager-scope.test.mjs
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for theme-manager.js's per-persona scoping of its localStorage
+ * preference slot.
+ *
+ * theme-manager is the hub-role writer for the same key theme-boot.js reads
+ * pre-paint, so the two must agree on the key or a persisted pick would be
+ * invisible on the next reload. What is pinned here:
+ *
+ *   - a scoped page WRITES `osprey-theme--<scope>` and leaves the bare key alone
+ *   - it READS that same key back, so a pick survives a reload
+ *   - it never falls back to the polluted bare key when its own is missing
+ *   - unscoped serving still uses the bare key, unchanged
+ *   - the key is resolved per call, not captured at module load — the scope
+ *     attribute is on the server-rendered document, which is in place before
+ *     any of this runs, but a load-time capture would silently pin the wrong
+ *     key for any page that imports the module before init
+ *
+ * theme-manager.js keeps role/preference state as module-level singletons, so
+ * each test resets the module registry and re-imports fresh through the
+ * `/design-system/js/*` alias (see vitest.config.js).
+ *
+ * Pure DOM/logic guard, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/design_system/js/theme-manager-scope.test.mjs
+ */
+
+import { test, expect, describe, beforeEach, vi } from 'vitest';
+
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+const LEGACY_KEY = 'osprey-theme';
+
+/**
+ * Force the OS preference so every 'auto' resolution lands on a known id.
+ * @param {boolean} prefersDark
+ */
+function stubOSPreference(prefersDark) {
+  vi.stubGlobal('matchMedia', (/** @type {string} */ query) => ({
+    matches: query.includes('dark') ? prefersDark : !prefersDark,
+    media: query,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+  }));
+}
+
+describe('theme-manager.js storage scoping', () => {
+  /** @type {typeof import('/design-system/js/theme-manager.js')} */
+  let ThemeManager;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-theme-mode');
+    document.documentElement.removeAttribute(SCOPE_ATTR);
+    document.body.innerHTML = '';
+    window.history.replaceState({}, '', '/');
+    stubOSPreference(false);
+    ThemeManager = await import('/design-system/js/theme-manager.js');
+  });
+
+  describe('writing', () => {
+    test('a scoped hub persists under its own key and leaves the bare one alone', () => {
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      ThemeManager.initTheme({ role: 'hub' });
+
+      ThemeManager.setTheme('retro-dark');
+
+      expect(window.localStorage.getItem(`${LEGACY_KEY}--bob`)).toBe(
+        JSON.stringify({ family: 'retro', mode: 'dark' })
+      );
+      expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
+    });
+
+    test("one persona's write does not land in another's slot", () => {
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      ThemeManager.initTheme({ role: 'hub' });
+
+      ThemeManager.setTheme('retro-dark');
+
+      expect(window.localStorage.getItem(`${LEGACY_KEY}--bob`)).toBeNull();
+      expect(window.localStorage.getItem(`${LEGACY_KEY}--carol`)).not.toBeNull();
+    });
+
+    test('an unscoped hub still writes the bare legacy key', () => {
+      ThemeManager.initTheme({ role: 'hub' });
+
+      ThemeManager.setTheme('retro-dark');
+
+      expect(window.localStorage.getItem(LEGACY_KEY)).toBe(
+        JSON.stringify({ family: 'retro', mode: 'dark' })
+      );
+    });
+
+    test('the key is resolved per call, not captured when the module loaded', () => {
+      // The module was imported in beforeEach with no attribute present; a
+      // load-time capture would write the bare key here.
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      ThemeManager.initTheme({ role: 'hub' });
+
+      ThemeManager.setTheme('retro-dark');
+
+      expect(window.localStorage.getItem(`${LEGACY_KEY}--bob`)).not.toBeNull();
+      expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
+    });
+  });
+
+  describe('reading', () => {
+    test("a scoped hub reads back what it wrote — the writer's key is the reader's", async () => {
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      ThemeManager.initTheme({ role: 'hub' });
+      ThemeManager.setTheme('retro-dark');
+
+      // A fresh module instance, as on the next page load.
+      vi.resetModules();
+      const reloaded = await import('/design-system/js/theme-manager.js');
+      reloaded.initTheme({ role: 'hub' });
+
+      expect(reloaded.getTheme()).toBe('retro-dark');
+    });
+
+    test('a scoped hub ignores a polluted bare key and takes the server default', () => {
+      window.localStorage.setItem(
+        LEGACY_KEY,
+        JSON.stringify({ family: 'retro', mode: 'dark' })
+      );
+      document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      ThemeManager.initTheme({ role: 'hub' });
+
+      expect(ThemeManager.getTheme()).toBe('light');
+    });
+
+    test("a scoped hub does not see another persona's stored preference", () => {
+      window.localStorage.setItem(
+        `${LEGACY_KEY}--bob`,
+        JSON.stringify({ family: 'retro', mode: 'dark' })
+      );
+      document.documentElement.setAttribute(SCOPE_ATTR, 'carol');
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      ThemeManager.initTheme({ role: 'hub' });
+
+      expect(ThemeManager.getTheme()).toBe('light');
+    });
+
+    test('an unscoped hub still reads the bare legacy key', () => {
+      window.localStorage.setItem(
+        LEGACY_KEY,
+        JSON.stringify({ family: 'retro', mode: 'dark' })
+      );
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      ThemeManager.initTheme({ role: 'hub' });
+
+      expect(ThemeManager.getTheme()).toBe('retro-dark');
+    });
+  });
+});

--- a/tests/interfaces/design_system/mode-boot.test.mjs
+++ b/tests/interfaces/design_system/mode-boot.test.mjs
@@ -12,32 +12,22 @@
  * generated theme-boot.js) — it exports nothing and runs on load — so
  * rather than importing it, each scenario sets up
  * window.location/localStorage/data-ui-mode and then re-executes the exact
- * on-disk source against those happy-dom globals. Pure DOM/logic guard,
- * happy-dom environment (configured globally in vitest.config.js):
+ * on-disk source against those happy-dom globals, via the shared
+ * ./js/boot-harness.mjs. Pure DOM/logic guard, happy-dom environment
+ * (configured globally in vitest.config.js):
  *   npx vitest run tests/interfaces/design_system/mode-boot.test.mjs
+ *
+ * The per-persona scoping of the storage rung is pinned separately, in
+ * ./js/mode-boot-scope.test.mjs.
  */
 
 import { test, expect, describe, beforeEach, vi } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
-// Resolve the on-disk source relative to this test file. `import.meta.dirname`
-// is a plain string, so it sidesteps happy-dom's override of the global URL
-// (which breaks `fileURLToPath(new URL(...))` under this environment).
-const MODE_BOOT_PATH = join(
-  import.meta.dirname,
-  '../../../src/osprey/interfaces/design_system/static/js/mode-boot.js'
-);
-const modeBootSource = readFileSync(MODE_BOOT_PATH, 'utf8');
+import { runBootScript } from './js/boot-harness.mjs';
 
-/**
- * Execute the pre-paint boot IIFE against the current happy-dom globals.
- * `window`/`document` are passed as explicit parameters so the source's
- * free references bind to the test's DOM without a global `eval`.
- */
+/** Execute the pre-paint boot IIFE against the current happy-dom globals. */
 function runBoot() {
-  const boot = new Function('window', 'document', modeBootSource);
-  boot(globalThis.window, globalThis.document);
+  runBootScript('mode-boot.js');
 }
 
 /** @param {string} search e.g. '' or '?mode=simple' */

--- a/tests/interfaces/design_system/rail-boot.test.mjs
+++ b/tests/interfaces/design_system/rail-boot.test.mjs
@@ -18,27 +18,10 @@
  */
 
 import { test, expect, describe, beforeEach, vi } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { runBootScript } from './js/boot-harness.mjs';
 
-// Resolve the on-disk source relative to this test file. `import.meta.dirname`
-// is a plain string, so it sidesteps happy-dom's override of the global URL
-// (which breaks `fileURLToPath(new URL(...))` under this environment).
-const RAIL_BOOT_PATH = join(
-  import.meta.dirname,
-  '../../../src/osprey/interfaces/design_system/static/js/rail-boot.js'
-);
-const railBootSource = readFileSync(RAIL_BOOT_PATH, 'utf8');
-
-/**
- * Execute the pre-paint boot IIFE against the current happy-dom globals.
- * `window`/`document` are passed as explicit parameters so the source's
- * free references bind to the test's DOM without a global `eval`.
- */
-function runBoot() {
-  const boot = new Function('window', 'document', railBootSource);
-  boot(globalThis.window, globalThis.document);
-}
+/** Re-execute the on-disk rail-boot.js against the current happy-dom globals. */
+const runBoot = () => runBootScript('rail-boot.js');
 
 /** @param {string} search e.g. '' or '?rail=top' */
 function setSearch(search) {

--- a/tests/interfaces/design_system/test_emit_js.py
+++ b/tests/interfaces/design_system/test_emit_js.py
@@ -26,6 +26,7 @@ import pytest
 import osprey.interfaces.design_system as design_system_pkg
 from osprey.interfaces.design_system.generator.emit_js import (
     GENERATED_HEADER_LINES,
+    SCOPE_ATTRIBUTE,
     STORAGE_KEY,
     ThemeFamilyDefaultsError,
     ThemeManifestEntry,
@@ -486,6 +487,29 @@ def test_render_theme_boot_js_bakes_in_storage_key_and_manifest() -> None:
     assert literals["DEFAULTS"] == {"main": {"dark": "dark", "light": "light"}}
     assert literals["FAMILY_BY_ID"] == {"dark": "main", "light": "main"}
     assert literals["DEFAULT_FAMILY"] == "main"
+
+
+def test_render_theme_boot_js_bakes_in_the_storage_scope_rule() -> None:
+    # The behavior is pinned in js/theme-boot-scope.test.mjs against the
+    # generated file; this pins that the GENERATOR is what puts it there --
+    # the scope attribute name, the "--" separator, and a storage read that
+    # goes through the derived key rather than the bare STORAGE_KEY.
+    tree = _tree(
+        {
+            "dark": {"id": "dark", "label": "Dark", "mode": "dark", "family": "main"},
+            "light": {"id": "light", "label": "Light", "mode": "light", "family": "main"},
+        }
+    )
+
+    content = render_theme_boot_js(tree)
+
+    assert SCOPE_ATTRIBUTE == "data-osprey-storage-scope"
+    baked = re.search(r'const SCOPE_ATTRIBUTE = ("(?:[^"\\]|\\.)*");', content)
+    assert baked and json.loads(baked.group(1)) == SCOPE_ATTRIBUTE
+    # The separator, however the emitter spells the concatenation.
+    assert re.search(r'STORAGE_KEY\s*\+\s*"--"|\$\{STORAGE_KEY\}--', content)
+    assert "window.localStorage.getItem(storageKey())" in content
+    assert "window.localStorage.getItem(STORAGE_KEY)" not in content
 
 
 def test_render_theme_boot_js_default_family_is_first_declared_family() -> None:

--- a/tests/interfaces/design_system/theme-boot.test.mjs
+++ b/tests/interfaces/design_system/theme-boot.test.mjs
@@ -22,29 +22,12 @@
  */
 
 import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
-// Resolve the on-disk source relative to this test file. `import.meta.dirname`
-// is a plain string, so it sidesteps happy-dom's override of the global URL
-// (which breaks `fileURLToPath(new URL(...))` under this environment).
-const THEME_BOOT_PATH = join(
-  import.meta.dirname,
-  '../../../src/osprey/interfaces/design_system/static/js/theme-boot.js'
-);
-const themeBootSource = readFileSync(THEME_BOOT_PATH, 'utf8');
+import { runBootScript } from './js/boot-harness.mjs';
 
 const STORAGE_KEY = 'osprey-theme';
 
-/**
- * Execute the pre-paint boot IIFE against the current happy-dom globals.
- * `window`/`document` are passed as explicit parameters so the source's
- * free references bind to the test's DOM without a global `eval`.
- */
-function runBoot() {
-  const boot = new Function('window', 'document', themeBootSource);
-  boot(globalThis.window, globalThis.document);
-}
+/** Re-execute the on-disk theme-boot.js against the current happy-dom globals. */
+const runBoot = () => runBootScript('theme-boot.js');
 
 /** @param {string} search e.g. '' or '?theme=light' */
 function setSearch(search) {

--- a/tests/interfaces/web_terminal/js/storage-scope-keys.test.js
+++ b/tests/interfaces/web_terminal/js/storage-scope-keys.test.js
@@ -1,0 +1,352 @@
+// @ts-check
+/**
+ * Per-persona scoping of the web terminal's remaining shared-origin
+ * localStorage keys:
+ *   npx vitest run tests/interfaces/web_terminal/js/storage-scope-keys.test.js
+ *
+ * localStorage is origin-scoped, not path-scoped, so on a multi-user mount
+ * (`/u/alice/`, `/u/bob/`) every persona shares one slot per bare key. The
+ * server stamps `data-osprey-storage-scope` on <html>; each reader and writer
+ * derives its key through storage-scope.js's `scopedStorageKey()`, and a scoped
+ * read NEVER falls back to the bare key (that polluted slot is the whole bug).
+ *
+ * One test file per behaviour would repeat the same three-line arrangement five
+ * times, so the modules whose storage paths are reachable without mocking the
+ * API layer share this file. Two things they do NOT share are the observable:
+ * each block asserts through the module's own public surface, never by reaching
+ * into a private key helper.
+ *
+ * settings.js needs a stubbed `/health`, so it lives in the sibling
+ * storage-scope-settings.test.js. dock-workspace.js's layout key is exercised
+ * only by the Playwright suite (its storage path runs behind a live dockview
+ * instance); its derivation is the same one-line `scopedStorageKey()` call as
+ * every module here.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  setRailPosition,
+  followThemeFamily,
+  initRailThemeCoupling,
+} from '../../../../src/osprey/interfaces/web_terminal/static/js/rail-position.js';
+import { maybeShowRailHint } from '../../../../src/osprey/interfaces/web_terminal/static/js/rail-hint.js';
+import { clearStoredSessionId } from '../../../../src/osprey/interfaces/web_terminal/static/js/terminal.js';
+import {
+  initAgentAttention,
+  badgePanelActivity,
+  clearBadge,
+  restoreAgentBadges,
+} from '../../../../src/osprey/interfaces/web_terminal/static/js/panel-agent-attention.js';
+import {
+  openPalette,
+  closePalette,
+} from '../../../../src/osprey/interfaces/web_terminal/static/js/palette.js';
+
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+
+/** Serve this document as `user` would be served on a multi-user mount.
+ * @param {string} user */
+function serveAs(user) {
+  document.documentElement.setAttribute(SCOPE_ATTR, user);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute(SCOPE_ATTR);
+  document.documentElement.removeAttribute('data-rail-position');
+  document.body.innerHTML = '';
+  document.body.className = '';
+  window.history.replaceState(null, '', '/');
+  // happy-dom does not implement scrollIntoView — the rail badge path calls it.
+  Element.prototype.scrollIntoView = () => {};
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute(SCOPE_ATTR);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('rail-position.js (the writer half of the rail-boot pair)', () => {
+  const BASE = 'osprey-rail-position';
+
+  test('a scoped flip pins bob, and only bob', () => {
+    serveAs('bob');
+
+    setRailPosition('top');
+
+    expect(localStorage.getItem(`${BASE}--bob`)).toBe('top');
+    expect(localStorage.getItem(BASE)).toBe(null);
+  });
+
+  test('an unscoped flip writes the legacy key unchanged', () => {
+    setRailPosition('top');
+
+    expect(localStorage.getItem(BASE)).toBe('top');
+  });
+
+  test("another persona's pin does not pin bob's rail against the theme coupling", () => {
+    // The shared slot, written by whoever flipped the rail last. Read as bob's
+    // own pin it would freeze his rail wherever that persona left it.
+    localStorage.setItem(BASE, 'top');
+    serveAs('bob');
+    initRailThemeCoupling({ family_rail_defaults: { retro: 'top' } });
+    document.documentElement.setAttribute('data-rail-position', 'left');
+
+    followThemeFamily('retro');
+
+    // Moved: bob has no pin of his own, so the family coupling applies.
+    expect(document.documentElement.getAttribute('data-rail-position')).toBe('top');
+  });
+
+  test("bob's own pin still outranks the theme coupling", () => {
+    localStorage.setItem(`${BASE}--bob`, 'left');
+    serveAs('bob');
+    initRailThemeCoupling({ family_rail_defaults: { retro: 'top' } });
+    document.documentElement.setAttribute('data-rail-position', 'left');
+
+    followThemeFamily('retro');
+
+    expect(document.documentElement.getAttribute('data-rail-position')).toBe('left');
+  });
+});
+
+describe('rail-hint.js', () => {
+  const BASE = 'osprey-rail-hint-dismissed-v1';
+
+  /** Mount the anchor the hint attaches to, rail in its (new) left column. */
+  function mountRail() {
+    document.body.innerHTML = '<div class="shell-body"><div class="panel-rail-region"></div></div>';
+    document.documentElement.setAttribute('data-rail-position', 'left');
+  }
+
+  /** @param {string} selector */
+  function click(selector) {
+    const el = document.querySelector(selector);
+    if (!(el instanceof HTMLElement)) throw new Error(`expected ${selector}`);
+    el.click();
+  }
+
+  test('a persona still gets the one-time hint another persona dismissed', () => {
+    localStorage.setItem(BASE, '1');
+    serveAs('bob');
+    mountRail();
+
+    expect(maybeShowRailHint()).toBe(true);
+  });
+
+  test('dismissing marks only this persona as having seen it', () => {
+    serveAs('bob');
+    mountRail();
+    maybeShowRailHint();
+
+    click('.rail-hint-dismiss');
+
+    expect(localStorage.getItem(`${BASE}--bob`)).toBe('1');
+    expect(localStorage.getItem(BASE)).toBe(null);
+    expect(maybeShowRailHint()).toBe(false);
+  });
+
+  test('unscoped serving keeps writing the legacy flag', () => {
+    mountRail();
+    maybeShowRailHint();
+
+    click('.rail-hint-dismiss');
+
+    expect(localStorage.getItem(BASE)).toBe('1');
+  });
+});
+
+describe('terminal.js PTY session pointer', () => {
+  const BASE = 'osprey-pty-session';
+
+  // Read, write and clear all resolve the key through one module-private
+  // helper, so pinning the clear path pins the derivation all three use. The
+  // stakes on this key are the highest in the file: a session id replayed into
+  // another persona's container would attach that persona's terminal to a PTY
+  // that is not theirs. The READ half — a bare stale id must not become this
+  // persona's auto-resume — needs initTerminal()'s xterm/WebSocket harness and
+  // is pinned where that harness lives: terminal-resume.test.mjs ('per-persona
+  // pointer scope'). test_logout_resume_browser.py proves the same round trip
+  // in a real multi-user page.
+  test('clearing removes this persona\'s pointer and leaves the shared slot alone', () => {
+    localStorage.setItem(BASE, 'someone-elses-session');
+    localStorage.setItem(`${BASE}--bob`, 'bobs-session');
+    serveAs('bob');
+
+    clearStoredSessionId();
+
+    expect(localStorage.getItem(`${BASE}--bob`)).toBe(null);
+    expect(localStorage.getItem(BASE)).toBe('someone-elses-session');
+  });
+
+  test('unscoped serving clears the legacy key unchanged', () => {
+    localStorage.setItem(BASE, 'my-session');
+
+    clearStoredSessionId();
+
+    expect(localStorage.getItem(BASE)).toBe(null);
+  });
+});
+
+describe('panel-agent-attention.js acknowledgements', () => {
+  const PANEL = 'okf';
+
+  /** Mount a rail carrying one entry the badge can anchor to. */
+  function mountRail() {
+    document.body.innerHTML =
+      `<div id="rail"><button class="panel-rail-button" data-panel-id="${PANEL}"></button></div>`;
+    const rail = document.getElementById('rail');
+    if (!rail) throw new Error('expected the rail fixture');
+    initAgentAttention(rail);
+  }
+
+  test('an ack is stored per persona — panel ids are shared, personas are not', () => {
+    serveAs('bob');
+    mountRail();
+    expect(badgePanelActivity(PANEL, 42)).toBe(true);
+
+    clearBadge(PANEL);
+
+    expect(localStorage.getItem(`agent-ack:${PANEL}--bob`)).toBe('42');
+    expect(localStorage.getItem(`agent-ack:${PANEL}`)).toBe(null);
+  });
+
+  test('unscoped serving keeps the legacy per-panel key', () => {
+    mountRail();
+    expect(badgePanelActivity(PANEL, 42)).toBe(true);
+
+    clearBadge(PANEL);
+
+    expect(localStorage.getItem(`agent-ack:${PANEL}`)).toBe('42');
+  });
+
+  // The read side lives in restoreAgentBadges(): an event at or below the
+  // stored ack is skipped, anything newer is re-badged on reload.
+  /** Stub the recent-activity endpoint with one panel event at `ts`.
+   * @param {number} ts */
+  function serveRecent(ts) {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ events: [{ target: { kind: 'panel', panel: PANEL }, ts }] }),
+    })));
+  }
+
+  function isBadged() {
+    return document.querySelector('.panel-rail-button')?.classList.contains('agent-attention') ?? false;
+  }
+
+  test("another persona's acknowledgement does not silence bob's badge on reload", async () => {
+    localStorage.setItem(`agent-ack:${PANEL}`, '42');
+    serveAs('bob');
+    mountRail();
+    serveRecent(42);
+
+    await restoreAgentBadges();
+
+    expect(isBadged()).toBe(true);
+  });
+
+  test("bob's own acknowledgement does", async () => {
+    localStorage.setItem(`agent-ack:${PANEL}--bob`, '42');
+    serveAs('bob');
+    mountRail();
+    serveRecent(42);
+
+    await restoreAgentBadges();
+
+    expect(isBadged()).toBe(false);
+  });
+});
+
+describe('palette.js recent commands', () => {
+  const BASE = 'osprey-palette-recent-v1';
+  /** The stable key of the fixture's one action row (group + label). */
+  const RESTART = 'Actions\x1fRestart terminal';
+
+  /** Flush pending microtasks (the palette's config fetch). */
+  function flushMicro() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  /** A deps bundle with one action and a config fetch that hits no network. */
+  function makeDeps() {
+    return {
+      getHiddenPanels: () => [],
+      getVisiblePanels: () => [],
+      getPresets: () => [],
+      showPanel: vi.fn(),
+      focusPanel: vi.fn(),
+      applyPreset: vi.fn(),
+      revealSetting: vi.fn(),
+      actions: [{ label: 'Restart terminal', run: vi.fn() }],
+      fetchConfig: () => Promise.resolve({ sections: {} }),
+    };
+  }
+
+  /** @param {string} value */
+  function typeQuery(value) {
+    const el = /** @type {HTMLInputElement} */ (document.querySelector('.command-palette-input'));
+    el.value = value;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function pressEnter() {
+    document
+      .querySelector('.command-palette-input')
+      ?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+  }
+
+  /** @returns {(string|null)[]} the visible section headings, in DOM order. */
+  function headings() {
+    return [...document.querySelectorAll('.command-palette-group-heading')].map((h) => h.textContent);
+  }
+
+  afterEach(() => {
+    closePalette();
+    document.body.innerHTML = '';
+  });
+
+  test('executing a command records it under this persona\'s key', async () => {
+    serveAs('bob');
+    openPalette(makeDeps());
+    await flushMicro();
+
+    typeQuery('restart terminal');
+    pressEnter();
+
+    expect(JSON.parse(localStorage.getItem(`${BASE}--bob`) || 'null')).toEqual([RESTART]);
+    expect(localStorage.getItem(BASE)).toBe(null);
+  });
+
+  test("another persona's Recent list is never read", async () => {
+    localStorage.setItem(BASE, JSON.stringify([RESTART]));
+    serveAs('bob');
+
+    openPalette(makeDeps());
+    await flushMicro();
+
+    expect(headings()).not.toContain('Recent');
+  });
+
+  test('this persona\'s own Recent list renders', async () => {
+    localStorage.setItem(`${BASE}--bob`, JSON.stringify([RESTART]));
+    serveAs('bob');
+
+    openPalette(makeDeps());
+    await flushMicro();
+
+    expect(headings()[0]).toBe('Recent');
+  });
+
+  test('unscoped serving still reads and writes the legacy key', async () => {
+    openPalette(makeDeps());
+    await flushMicro();
+
+    typeQuery('restart terminal');
+    pressEnter();
+
+    expect(JSON.parse(localStorage.getItem(BASE) || 'null')).toEqual([RESTART]);
+  });
+});

--- a/tests/interfaces/web_terminal/js/storage-scope-settings.test.js
+++ b/tests/interfaces/web_terminal/js/storage-scope-settings.test.js
@@ -1,0 +1,143 @@
+// @ts-check
+/**
+ * Per-persona scoping of the settings drawer's warning acknowledgement:
+ *   npx vitest run tests/interfaces/web_terminal/js/storage-scope-settings.test.js
+ *
+ * The drawer is gated behind a "these settings control agent behavior, safety
+ * hooks, and security policies" dialog, acknowledged once per SERVER session and
+ * remembered in localStorage. On a shared origin that memory was one slot for
+ * everybody: whoever acknowledged first silently waved the warning away for
+ * every other persona on the box. The ack is now keyed per persona.
+ *
+ * The gate is driven through `openDrawerTab()` (the exported seam that routes
+ * through it) and observed through the dialog's own presence in the DOM, which
+ * is exactly what the ack decides. `/health` is stubbed — the module's only
+ * network call on this path — so nothing dials out.
+ *
+ * Lives apart from storage-scope-keys.test.js because mocking api.js is
+ * file-wide, and the modules pinned there must run against the real one.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+const health = vi.hoisted(() => ({ sessionId: /** @type {string|null} */ ('server-session-1') }));
+
+// api.js is stubbed whole: settings.js takes fetchJSON/apiRequest from it, and
+// terminal.js (imported by settings.js) takes the WebSocket helpers, so every
+// name either module imports has to exist on the mock. The path is spelled out
+// rather than held in a const — vi.mock is hoisted above every binding.
+vi.mock('../../../../src/osprey/interfaces/web_terminal/static/js/api.js', () => ({
+  fetchJSON: vi.fn(async (path) => {
+    if (path === '/health') return { session_id: health.sessionId };
+    return {};
+  }),
+  apiRequest: vi.fn(async () => ({})),
+  createWebSocket: vi.fn(() => ({ send() {}, close() {} })),
+  wsUrl: vi.fn((path) => `ws://localhost${path}`),
+  withPrefix: vi.fn((path) => path),
+}));
+
+const { openDrawerTab } = await import(
+  '../../../../src/osprey/interfaces/web_terminal/static/js/settings.js'
+);
+
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+const BASE = 'osprey-settings-warning-ack';
+
+/** Serve this document as `user` would be served on a multi-user mount.
+ * @param {string} user */
+function serveAs(user) {
+  document.documentElement.setAttribute(SCOPE_ATTR, user);
+}
+
+/** Let the /health race and the gate's awaits settle. */
+async function settleGate() {
+  for (let i = 0; i < 3; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+/** @returns {boolean} whether the warning dialog is currently mounted. */
+function warningShown() {
+  return document.querySelector('.settings-warning-dialog') !== null;
+}
+
+/** Dismiss whatever dialog is up, so the gate's pending flag always resets.
+ * @param {'proceed'|'cancel'} how */
+function dismiss(how) {
+  const btn = document.querySelector(`.settings-warning-${how}`);
+  if (!(btn instanceof HTMLElement)) throw new Error(`expected the ${how} button`);
+  btn.click();
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.body.innerHTML = '';
+  document.documentElement.removeAttribute(SCOPE_ATTR);
+  health.sessionId = 'server-session-1';
+});
+
+afterEach(() => {
+  // The gate's pending flag only clears on a dismissal, so a test that fails
+  // with a dialog up would otherwise wedge every later one. Settle it here.
+  const cancel = document.querySelector('.settings-warning-cancel');
+  if (cancel instanceof HTMLElement) cancel.click();
+  document.documentElement.removeAttribute(SCOPE_ATTR);
+});
+
+describe('settings warning acknowledgement', () => {
+  test("another persona's acknowledgement does not wave the warning away", async () => {
+    // The shared slot: someone else already clicked Proceed on this server.
+    localStorage.setItem(BASE, 'server-session-1');
+    serveAs('bob');
+
+    const gate = openDrawerTab('config');
+    await settleGate();
+
+    expect(warningShown()).toBe(true);
+    dismiss('cancel');
+    await gate;
+  });
+
+  test('this persona\'s own acknowledgement is honoured', async () => {
+    localStorage.setItem(`${BASE}--bob`, 'server-session-1');
+    serveAs('bob');
+
+    const gate = openDrawerTab('config');
+    await settleGate();
+
+    expect(warningShown()).toBe(false);
+    await gate;
+  });
+
+  test('Proceed records the acknowledgement under this persona\'s key', async () => {
+    serveAs('bob');
+
+    const gate = openDrawerTab('config');
+    await settleGate();
+    expect(warningShown()).toBe(true);
+
+    dismiss('proceed');
+    await gate;
+
+    expect(localStorage.getItem(`${BASE}--bob`)).toBe('server-session-1');
+    expect(localStorage.getItem(BASE)).toBe(null);
+  });
+
+  test('unscoped serving reads and writes the legacy key unchanged', async () => {
+    const first = openDrawerTab('config');
+    await settleGate();
+    expect(warningShown()).toBe(true);
+    dismiss('proceed');
+    await first;
+
+    expect(localStorage.getItem(BASE)).toBe('server-session-1');
+
+    // And the stored ack now short-circuits the gate, exactly as before.
+    document.body.innerHTML = '';
+    const second = openDrawerTab('config');
+    await settleGate();
+    expect(warningShown()).toBe(false);
+    await second;
+  });
+});

--- a/tests/interfaces/web_terminal/terminal-resume.test.mjs
+++ b/tests/interfaces/web_terminal/terminal-resume.test.mjs
@@ -134,8 +134,41 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  document.documentElement.removeAttribute('data-osprey-storage-scope');
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe('per-persona pointer scope', () => {
+  // On a multi-user mount every `/u/<user>/` shares one origin, so the bare
+  // key is a slot any persona may have written. The server stamps the persona
+  // on <html>; auto-resume must read only that persona's key — a stale id in
+  // the shared slot would attach this terminal to a PTY that is not theirs.
+  // (The clear half of this contract is pinned in js/storage-scope-keys.test.js.)
+  const SCOPE_ATTR = 'data-osprey-storage-scope';
+
+  test("a bare id left by another persona does not become bob's auto-resume", () => {
+    localStorage.setItem(STORAGE_KEY, 'someone-elses-session');
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+
+    terminal.initTerminal('terminal-container');
+
+    const url = /** @type {FakeWebSocket} */ (FakeWebSocket.last).url;
+    expect(url).not.toContain('mode=resume');
+    expect(url).not.toContain('session_id=');
+  });
+
+  test("bob's own scoped id is what auto-resume asks for", () => {
+    localStorage.setItem(STORAGE_KEY, 'someone-elses-session');
+    localStorage.setItem(`${STORAGE_KEY}--bob`, 'bobs-session');
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+
+    terminal.initTerminal('terminal-container');
+
+    const url = /** @type {FakeWebSocket} */ (FakeWebSocket.last).url;
+    expect(url).toContain('mode=resume');
+    expect(url).toContain('session_id=bobs-session');
+  });
 });
 
 describe('resume confirmation: stale id self-correction', () => {

--- a/tests/interfaces/web_terminal/test_logout_resume_browser.py
+++ b/tests/interfaces/web_terminal/test_logout_resume_browser.py
@@ -13,10 +13,16 @@ frontend JS nor persists ``localStorage`` across navigations:
     client's stored PTY session id, THEN navigates to the configured landing
     origin;
   * returning to the terminal origin does NOT resume the prior warm PTY —
-    ``localStorage['osprey-pty-session']`` stays empty across the round trip and
-    the client opens a brand-new WebSocket (no ``mode=resume``, no stale
+    this persona's stored pointer stays empty across the round trip and the
+    client opens a brand-new WebSocket (no ``mode=resume``, no stale
     ``session_id``) rather than reconnecting to the old session. This is M2:
     logout is a real station reset, not just a client-side navigation.
+  * the pointer is the PER-PERSONA key. On a multi-user mount every ``/u/<user>/``
+    shares one origin and so one ``localStorage``; the server stamps
+    ``data-osprey-storage-scope`` on ``<html>`` and terminal.js reads, writes
+    and clears ``osprey-pty-session--<user>`` (design_system/storage-scope.js),
+    never the bare shared slot. This is the only multi-user browser suite, so it
+    is also the live proof that the scoped clear is what logout performs.
   * plain ``osprey web`` (no landing_url) omits the logout control entirely.
 
 Scope note — no live model turn. A genuinely live PTY session id is minted by
@@ -207,8 +213,15 @@ def test_logout_and_return_starts_fresh_session(tmp_path, monkeypatch, chromium_
         expect(logout).to_be_hidden()
 
         # --- Represent an established (warm) PTY session (see module docstring) ---
-        page.evaluate("(id) => localStorage.setItem('osprey-pty-session', id)", stored_id)
-        captured = page.evaluate("() => localStorage.getItem('osprey-pty-session')")
+        # Seed the key the client actually reads: derived from the scope the
+        # server stamped for this persona, exactly as storage-scope.js derives it.
+        scope = page.evaluate(
+            "() => document.documentElement.getAttribute('data-osprey-storage-scope')"
+        )
+        assert scope == user, f"multi-user page must be stamped with its persona, got {scope!r}"
+        session_key = f"osprey-pty-session--{scope}"
+        page.evaluate("([k, id]) => localStorage.setItem(k, id)", [session_key, stored_id])
+        captured = page.evaluate("(k) => localStorage.getItem(k)", session_key)
         assert captured == stored_id
 
         # Record the auth-sidecar chaining request. This deployment has NO
@@ -274,7 +287,10 @@ def test_logout_and_return_starts_fresh_session(tmp_path, monkeypatch, chromium_
         assert f"session_id={stored_id}" not in fresh_url
 
         # No re-adoption of the old id: the prior warm PTY is not inherited.
-        assert page.evaluate("() => localStorage.getItem('osprey-pty-session')") != stored_id
+        assert page.evaluate("(k) => localStorage.getItem(k)", session_key) != stored_id
+        # And a scoped page never touches the shared slot — neither the seed nor
+        # the fresh session's confirmation lands under the bare key.
+        assert page.evaluate("() => localStorage.getItem('osprey-pty-session')") is None
 
         page.close()
 

--- a/tests/interfaces/web_terminal/test_storage_scope.py
+++ b/tests/interfaces/web_terminal/test_storage_scope.py
@@ -1,0 +1,221 @@
+"""Tests for the per-user browser-storage scope stamp (Task 3.1).
+
+Multi-user deployments run one Web Terminal container per user behind a shared
+nginx front door, each mounted at ``/u/<user>/``. Same origin, one shared
+``localStorage`` — so every stored key (dock layout, rail position, recent
+palette items, the active PTY session id, per-panel agent acks, …) collides
+between users unless it is namespaced.
+
+The namespace is decided **server side** and stamped onto ``<html>`` as
+``data-osprey-storage-scope="<user>"``. That attribute is the single source of
+truth every JS storage site reads; no JS parses ``location.pathname`` for the
+mount user. Two properties make it usable as such:
+
+- **Present exactly when there is a mount.** Under ``/u/<user>/`` the attribute
+  carries the user; on a single-user / non-mounted deployment it is *absent*,
+  not empty — so a reader can branch on presence alone, and the unscoped
+  single-user markup stays byte-identical to what it was before this stamp.
+- **On both served documents.** ``index.html`` and ``static/session.html`` are
+  both Jinja-rendered, and the session page's module-import closure reaches the
+  storage-owning modules (``terminal.js``, ``dock-workspace.js``,
+  ``rail-position.js``, ``panel-agent-attention.js``, ``dock-reconcile.js``), so
+  a stamp on only the index page would leave that page unscoped.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.web_terminal.app import create_app, resolve_storage_scope
+
+#: The attribute under test.
+ATTR = "data-osprey-storage-scope"
+
+# (page id, request path) -- both served HTML documents in scope, same set the
+# prefix contract (test_prefix_injection.py) covers.
+_PAGES = [
+    ("index", "/"),
+    ("session", "/static/session.html"),
+]
+_PAGE_IDS = [p[0] for p in _PAGES]
+
+
+@pytest.fixture
+def workspace_dir(tmp_path):
+    """Temporary workspace directory for the app to watch."""
+    ws = tmp_path / "_agent_data"
+    ws.mkdir()
+    return ws
+
+
+def _html_tag(body: str) -> str:
+    """The document's opening ``<html …>`` tag.
+
+    The stamp is only useful to a pre-paint reader if it sits on the root
+    element, so the render assertions match against this rather than against
+    the whole document.
+    """
+    match = re.search(r"<html\b[^>]*>", body)
+    assert match, "served document has no <html> element"
+    return match.group(0)
+
+
+def _serve(workspace_dir, terminal_user: str | None):
+    """Render both pages with ``OSPREY_TERMINAL_USER`` set to *terminal_user*.
+
+    ``None`` removes the variable entirely (the single-user / non-mounted
+    case). The env patch must wrap ``create_app`` as well as the requests: the
+    URL prefix is computed at construction time and the terminal user is read
+    during the lifespan, so a patch applied later would exercise neither.
+
+    Returns:
+        ``{page_id: response_body}`` for every page in :data:`_PAGES`.
+    """
+    env = {} if terminal_user is None else {"OSPREY_TERMINAL_USER": terminal_user}
+    with (
+        patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value={"watch_dir": str(workspace_dir)},
+        ),
+        patch.dict("os.environ", env),
+    ):
+        if terminal_user is None:
+            os.environ.pop("OSPREY_TERMINAL_USER", None)
+        app = create_app(shell_command="echo")
+        with TestClient(app) as client:
+            bodies = {}
+            for page_id, path in _PAGES:
+                response = client.get(path)
+                assert response.status_code == 200, f"{page_id} did not render"
+                bodies[page_id] = response.text
+            return bodies
+
+
+class TestResolveStorageScope:
+    """Pure resolver: deployment identity -> storage namespace token."""
+
+    def test_user_passes_through(self):
+        assert resolve_storage_scope("alice") == "alice"
+
+    def test_none_is_unscoped(self):
+        """No mount user at all is the single-user deployment: no scope."""
+        assert resolve_storage_scope(None) == ""
+
+    def test_empty_is_unscoped(self):
+        assert resolve_storage_scope("") == ""
+
+    def test_whitespace_only_is_unscoped(self):
+        """A blank env var means unset, exactly as ``compute_url_prefix`` reads it.
+
+        The two must agree: a deployment that gets no ``/u/<user>`` prefix must
+        also get no storage scope, or the attribute would claim a mount that
+        does not exist.
+        """
+        assert resolve_storage_scope("   ") == ""
+
+    def test_surrounding_whitespace_is_stripped(self):
+        assert resolve_storage_scope("  alice\n") == "alice"
+
+    def test_never_raises(self):
+        for value in ("alice", "", "   ", None):
+            try:
+                resolve_storage_scope(value)  # type: ignore[arg-type]
+            except Exception as exc:  # pragma: no cover - failure path
+                pytest.fail(f"resolve_storage_scope({value!r}) raised: {exc}")
+
+
+class TestMountedRender:
+    """``OSPREY_TERMINAL_USER=alice`` -> the scope is stamped on both pages."""
+
+    @pytest.mark.parametrize("page_id", _PAGE_IDS)
+    def test_scope_stamped_on_html_element(self, workspace_dir, page_id):
+        body = _serve(workspace_dir, "alice")[page_id]
+        assert f'{ATTR}="alice"' in _html_tag(body)
+
+    @pytest.mark.parametrize("page_id", _PAGE_IDS)
+    def test_stamped_exactly_once(self, workspace_dir, page_id):
+        """One authoritative stamp — a second would make "the" source ambiguous."""
+        body = _serve(workspace_dir, "alice")[page_id]
+        assert body.count(ATTR) == 1
+
+    def test_index_keeps_its_existing_stamps(self, workspace_dir):
+        """The new attribute joins the existing ones; it does not displace them."""
+        tag = _html_tag(_serve(workspace_dir, "alice")["index"])
+        assert "data-ui-mode=" in tag
+        assert "data-theme=" in tag
+        assert "data-rail-position=" in tag
+
+
+class TestUnmountedRender:
+    """Single-user / non-mounted serving -> the attribute is absent entirely."""
+
+    @pytest.mark.parametrize("page_id", _PAGE_IDS)
+    def test_attribute_absent_when_user_unset(self, workspace_dir, page_id):
+        body = _serve(workspace_dir, None)[page_id]
+        assert ATTR not in body
+
+    @pytest.mark.parametrize("page_id", _PAGE_IDS)
+    def test_attribute_absent_when_user_blank(self, workspace_dir, page_id):
+        """A blank value is unset, and must not stamp an empty scope.
+
+        ``data-osprey-storage-scope=""`` would be present-but-meaningless: a
+        reader branching on presence would namespace every key with the empty
+        string instead of leaving storage unscoped.
+        """
+        body = _serve(workspace_dir, "   ")[page_id]
+        assert ATTR not in body
+
+    @pytest.mark.parametrize("page_id", _PAGE_IDS)
+    def test_html_element_still_renders(self, workspace_dir, page_id):
+        """Guard against the conditional swallowing the tag it decorates."""
+        assert _html_tag(_serve(workspace_dir, None)[page_id]).startswith("<html")
+
+
+class TestUnusualUsernames:
+    """Roster-legal names must round-trip through the attribute exactly."""
+
+    # Shapes a deploy roster can legitimately produce: dots, dashes,
+    # underscores, digits, and mixed case (the scope is compared verbatim by
+    # the JS readers, so case must survive).
+    ROSTER_NAMES = [
+        "first.last",
+        "jean-luc",
+        "op_2",
+        "McTavish",
+        "A.B-c_9",
+    ]
+
+    @pytest.mark.parametrize("user", ROSTER_NAMES)
+    @pytest.mark.parametrize("page_id", _PAGE_IDS)
+    def test_value_round_trips_verbatim(self, workspace_dir, user, page_id):
+        body = _serve(workspace_dir, user)[page_id]
+        assert f'{ATTR}="{user}"' in _html_tag(body)
+
+    @pytest.mark.parametrize("page_id", _PAGE_IDS)
+    def test_scope_matches_the_url_prefix_user(self, workspace_dir, page_id):
+        """The stamped scope is the same user the ``/u/<user>`` prefix names.
+
+        These are the two halves of one deployment identity; a divergence would
+        namespace storage under a user the page is not actually mounted for.
+        """
+        body = _serve(workspace_dir, "first.last")[page_id]
+        assert 'window.__OSPREY_PREFIX__ = "/u/first.last";' in body
+        assert f'{ATTR}="first.last"' in _html_tag(body)
+
+    @pytest.mark.parametrize("page_id", _PAGE_IDS)
+    def test_value_is_html_escaped(self, workspace_dir, page_id):
+        """Autoescape stays on for the value.
+
+        Names come from the deploy roster, not from a request, so this is not
+        the last line of defence — but a value that could close the attribute
+        would rewrite the document's root element, and the template must never
+        be the reason that is possible.
+        """
+        body = _serve(workspace_dir, 'a"><script>x</script>')[page_id]
+        assert "<script>x</script>" not in body
+        assert f'{ATTR}="a&#34;&gt;&lt;script&gt;' in _html_tag(body)

--- a/tests/services/auth_sidecar/test_login.py
+++ b/tests/services/auth_sidecar/test_login.py
@@ -81,6 +81,14 @@ OIDC_ENV = {
 }
 
 
+BROWSER_ACCEPT = {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
+"""What a top-level navigation sends. The header Chrome, Firefox and Safari all
+put on a link click, which is the only thing the route's HTML branch keys on."""
+
+JSON_ACCEPT = {"Accept": "application/json"}
+"""What a client that will parse the answer sends, and must keep getting."""
+
+
 def _client(env: dict[str, str] | None = None) -> TestClient:
     """A test client over a sidecar built from ``env`` (password mode by default).
 
@@ -258,6 +266,61 @@ def test_an_off_origin_next_is_discarded(hostile: str) -> None:
 def test_a_link_without_exactly_one_user_is_refused(params: dict[str, object]) -> None:
     """Never a 422: a malformed link gets this route's own refusal."""
     response = _client().get(LOGIN_PATH, params=params)
+
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("params", [{}, {"user": ""}])
+def test_a_browser_that_arrives_without_a_user_is_sent_to_the_landing_page(
+    params: dict[str, object],
+) -> None:
+    """A person cannot act on a JSON body; the roster cards are where they belong."""
+    response = _client().get(
+        LOGIN_PATH, params=params, headers=BROWSER_ACCEPT, follow_redirects=False
+    )
+
+    assert response.status_code == 302
+    # Origin-relative, matching what logout answers with: nginx serves the
+    # landing page at exactly this path in front of the sidecar.
+    assert response.headers["location"] == "/"
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_a_browser_link_naming_two_users_is_refused_rather_than_redirected() -> None:
+    """Ambiguous is not empty: a landing page here would be a guess between them."""
+    response = _client().get(
+        LOGIN_PATH,
+        params={"user": ["alice", "bob"]},
+        headers=BROWSER_ACCEPT,
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("params", [{}, {"user": ["alice", "bob"]}])
+def test_a_client_that_did_not_ask_for_html_gets_the_unchanged_refusal(
+    params: dict[str, object],
+) -> None:
+    """The JSON 400 is byte-identical to what this route answered before."""
+    asked_for_json = _client().get(
+        LOGIN_PATH, params=params, headers=JSON_ACCEPT, follow_redirects=False
+    )
+    stated_no_preference = _client().get(
+        LOGIN_PATH, params=params, headers={"Accept": "*/*"}, follow_redirects=False
+    )
+
+    assert asked_for_json.status_code == 400
+    assert asked_for_json.json() == {"detail": "the login link must name exactly one user"}
+    assert (stated_no_preference.status_code, stated_no_preference.content) == (
+        asked_for_json.status_code,
+        asked_for_json.content,
+    )
+
+
+def test_a_request_that_states_no_media_preference_is_not_treated_as_a_browser() -> None:
+    """The HTML branch is opt-in: silence is not a navigation."""
+    response = _client().get(LOGIN_PATH, headers={"Accept": ""}, follow_redirects=False)
 
     assert response.status_code == 400
 
@@ -812,6 +875,62 @@ def test_a_form_without_exactly_one_user_is_refused(form: dict[str, object]) -> 
 
     assert response.status_code == 400
     assert "set-cookie" not in response.headers
+
+
+@pytest.mark.parametrize(
+    "form",
+    [{"password": ALICE_PASSWORD}, {"user": "", "password": ALICE_PASSWORD}],
+)
+def test_a_browser_posting_a_form_without_a_user_is_sent_to_the_landing_page(
+    form: dict[str, object],
+) -> None:
+    """No user means no credential to evaluate — the roster page, not a JSON body."""
+    response = _post(_client(), form, headers=BROWSER_ACCEPT)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+    assert response.headers["cache-control"] == "no-store"
+    # Nothing was evaluated, so nothing may be unlocked.
+    assert "set-cookie" not in response.headers
+
+
+def test_a_browser_posting_two_users_is_refused_rather_than_redirected() -> None:
+    """The form is ambiguous, and this route resolves neither name."""
+    response = _post(
+        _client(), {"user": ["alice", "bob"], "password": ALICE_PASSWORD}, headers=BROWSER_ACCEPT
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "form",
+    [{"password": ALICE_PASSWORD}, {"user": ["alice", "bob"], "password": ALICE_PASSWORD}],
+)
+def test_a_json_client_posting_without_exactly_one_user_gets_the_unchanged_refusal(
+    form: dict[str, object],
+) -> None:
+    """The JSON 400 is byte-identical to what this route answered before."""
+    asked_for_json = _post(_client(), form, headers=JSON_ACCEPT)
+    stated_no_preference = _post(_client(), form, headers={"Accept": "*/*"})
+
+    assert asked_for_json.status_code == 400
+    assert asked_for_json.json() == {"detail": "the login form must name exactly one user"}
+    assert (stated_no_preference.status_code, stated_no_preference.content) == (
+        asked_for_json.status_code,
+        asked_for_json.content,
+    )
+
+
+def test_a_cross_site_post_is_still_refused_when_the_browser_asks_for_html() -> None:
+    """The origin check runs first: a hostile form cannot be answered with a redirect."""
+    response = _post(
+        _client(),
+        {"password": ALICE_PASSWORD},
+        headers={**BROWSER_ACCEPT, "Origin": "https://evil.example"},
+    )
+
+    assert response.status_code == 400
 
 
 # --- Logging ----------------------------------------------------------------


### PR DESCRIPTION
Several deployment surfaces claimed things that were not true, and each false claim cost an operator a real debugging session:

- **Port probes mistook visibility for ownership.** The launch/pre-flight probes TCP-connected to a port and treated any answer as a squatter — on Docker Desktop, a Mac-side listener answers a connect into the container without contending for the bind, so persona terminals refused free ports and crash-looped. Conversely, a `/health` 200 was enough to *adopt* a stranger's server as our own. Ownership is now decided by attempting the very bind the lifespan will attempt, and adoption requires the server to prove this deployment's identity via the terminal secret (read through a new side-effect-free `peek_web_credentials()`; the minting accessor must never run in a probe).
- **A refused container died silently.** Pre-flight refusal under `restart: unless-stopped` scrolled past in an untailed log; the only outward sign was a flapping service. `osprey web` now writes an atomic `preflight-refused` marker into the audit dir before exiting; `osprey status` renders it as `Restarting (preflight: …)`, ignoring markers older than the container's `StartedAt`. Marker writes are strictly advisory — filesystem errors are swallowed rather than compounding the refusal.
- **The deploy summary invented rows** for personas no server backs; it now builds panel rows only from the roster that actually serves.
- **A browser with no user hit a JSON 400 dead end** at `/auth/login`. Top-level navigations naming no user are 302'd to the landing page; API callers, and any request naming 2+ users, keep the 400.
- **Token-gated landing cards looked open.** Cards whose posture requires a token now carry a badge; clicks still navigate.
- **Browser storage leaked between personas.** All personas share one origin, so theme, layout, session-resume id and panel acks collided across users. Every page now stamps `data-osprey-storage-scope`; a shared `storage-scope.js` suffixes each localStorage key with `--<scope>` (boot IIFEs inline a mirror; `theme-boot.js` regenerated from `emit_js.py`). Logout clears only the persona's own keys. No migration of bare-key values — each persona resets to defaults once.
- **The full-chain e2e stack squatted a claimed port band** (22200 is the bluesky-queue artifact band, and collided with a live deployment's 10600/10700 proxy pair via the shared loopback). It moves to 23000, and `_orm_stack` now refuses subprocess-built projects left on the default port base.

## How it hangs together

```text
osprey web preflight: bind-probe, not connect-probe
        │
        ├── pass ──► clear marker
        │
        └── refuse ──┐
                     ▼
                     ┌────────────────────────────┐
                     │  preflight-refused marker  │
                     │ (OSPREY_AUDIT_DIR, atomic) │
                     └────────────────────────────┘
                         │ skip if stale vs container StartedAt  ▼
          osprey status: "Restarting (preflight: ...)"

server_launcher adopts a running server only if
peek_web_credentials() proves the terminal secret header ──►
deploy_summary: panel rows only for the roster it backs

browser nav, no user  ──►  /auth/login  ──302──►  landing page
API call / 2+ users   ──►  JSON 400                    │
                                     posture needs token  ▼
                                           card gets a badge

server stamps persona  ──►  data-osprey-storage-scope="<persona>"
                                        │
               storage-scope.js suffixes every localStorage key
               with --<scope> (13 JS modules; boot IIFEs mirror it)
                                        │
               scoped logout clears only that persona's keys
```

## Design decisions a reviewer may want to challenge

1. Full-chain e2e sits at port base 23000, not the originally chosen 22200 — 22200 is `test_bluesky_queue_e2e`'s artifact-family band.
2. The default-port-base guard names the two real override spellings (`--set port_base=` / the override block); `--set deployment.port_base=` is not a valid CLI spelling.
3. `tests/interfaces/channel_finder/test_server_launcher.py` is rewritten rather than left untouched: it patched the removed `_port_has_listener` by name and encoded the superseded health-deferral contract. The #327 property is preserved.
4. Credentialed adoption probes `/` (answered by `WebAuthMiddleware` pre-routing) with the `x-osprey-terminal-secret` header, only after an unauthenticated probe got a 401. Probes follow no redirects. 503 and no-identity verdicts get their own wording — no "unbacked / stop the other server" claims they cannot support.
5. The login redirect fires only when *fewer than two* users were supplied; 2+ users keep the JSON 400 for browsers too — that request is ambiguous, not empty.
6. The auth-off landing baseline byte-pin legitimately changed: the example config uses the token posture, so every card in it is badged.
7. Storage scoping reaches beyond the seven core keys: panel-attention acks (`agent-ack:<panelId>`), the rail-hint dismissal, and the design-system drawer width were the same leak and are scoped too.
8. `osprey status` threads the live `repo_root` into `endpoint_entries()`; `StartedAt` comes off `podman ps`, with a single lazy `docker inspect` only for containers that have a marker.
9. Agent-side MCP processes carry no operator secret and now **refuse adoption** (warn once, then info) instead of silently latching onto a `/health` 200 — this is the user-visible behavior change of the wave.

## Known gaps left open (follow-ups, not blockers)

- Panel-app splitter keys (`okf_panel`, `lattice_dashboard`, `bluesky_web`, `artifacts` browse layout) are shared-origin but those pages never receive the scope stamp — design call: stamp panel pages too, or accept.
- Sibling Docker-starting e2e modules render outside `_orm_stack.build_project_subprocess` and bypass the new default-base guard (`test_bluesky_web_deploy`, `test_dispatch_deploy`, `test_va_substrate_equivalence`, `test_tiled_roundtrip`, `test_bluesky_queue_e2e`) — each is a one-line adoption.
- The guard's four unit tests inherit `test_full_chain_auth.py`'s `dockerbuild` marker and run only in the heavy job; move them to a Docker-free home if fast-lane coverage is wanted.
- `web.panels` is now read independently in four places — a shared "which panels are enabled" helper is warranted.
- `_port_is_bindable` probes hostnames IPv4-only; a v6-side conflict surfaces only at launch (matters only if a preset ships `host: localhost`).
- Other `get_web_credentials()` callers that only need to *read* an identity should move to `peek_web_credentials()`.
- The preflight annotation appears only in the per-user table, not the main Service Status table.
- Stale hand-maintained port inventories remain in `test_gchat_bridge_e2e.py` / `test_nextcloud_talk_bridge_e2e.py` docstrings.
