### PR TITLE
feat(web-terminals): roster entry access: own|any — share a card with the roster

### DIFF
--- a/changelog.d/807.added.md
+++ b/changelog.d/807.added.md
@@ -1,0 +1,5 @@
+A web-terminal roster entry can now be shared with the whole roster:
+`access: any` marks a card that any roster login may open with their own
+credential, under both `password` and `oidc`. The session carries who opened
+the card and re-checks them on every request, and the audit ledger records
+the opener beside the card.

--- a/docs/source/how-to/web-terminal/multi-user/index.rst
+++ b/docs/source/how-to/web-terminal/multi-user/index.rst
@@ -201,7 +201,10 @@ The config block
          becomes that user's browser tab title. An entry may name a **role**
          instead of a persona — one mapping written once rather than a persona
          pinned per user, and the half a single sign-on provider's groups can
-         decide; see :ref:`multi-user-role-from-sso`. The roster sets no ports.
+         decide; see :ref:`multi-user-role-from-sso`. Behind a login wall an
+         entry may also set ``access: any``, opening it to every roster login
+         as a shared card — see :ref:`multi-user-shared-card`. The roster sets
+         no ports.
          Each user's host ports come from the deployment's port layout — one
          hundred-port family per companion panel (artifact gallery, ARIEL,
          channel finder, lattice dashboard, …) plus the terminal itself, and

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -218,6 +218,96 @@ entry is still gated the way every terminal is under ``token``, by its own
 login URL. A ``login: false`` entry whose persona can edit the deployment
 (``setup_patch`` or the Config panel) is refused at build and at ``osprey up``.
 
+.. _multi-user-shared-card:
+
+Share a card with the whole roster
+==================================
+
+A roster entry admits one person. ``access:`` is the key that changes that —
+``own``, the default, is that rule spelled out: the entry's own login and
+nobody else's. ``any`` marks a **shared card**: one terminal, one persona,
+one audit directory, that anyone on the roster opens with their own
+credential:
+
+.. code-block:: yaml
+
+   modules:
+     web_terminals:
+       tls:
+         enabled: true
+         host_cert_dir: /etc/ssl/facility
+         cert: /etc/osprey/tls/facility.crt
+         key: /etc/osprey/tls/facility.key
+       auth:
+         method: oidc
+         oidc:
+           issuer: https://sso.example.org/realms/accelerator
+           client_id_env: OSPREY_AUTH_OIDC_CLIENT_ID
+           client_secret_env: OSPREY_AUTH_OIDC_CLIENT_SECRET
+           claim: sub
+       users:
+         - name: alice
+           index: 0
+           persona: readwrite
+           oidc_subject: "8f4c1e02-..."
+         - name: bob
+           index: 1
+           persona: readonly
+           oidc_subject: "41ab97d0-..."
+         - name: ops-desk
+           index: 2
+           persona: readonly
+           access: any                # any roster login opens this card
+
+Who can open it: anyone this deployment can authenticate. Under ``password``
+that is every roster entry with a provisioned password; under ``oidc``, every
+entry that carries an ``oidc_subject:`` — ``login: false`` entries included,
+and the shared card itself when it carries one. On a shared card the password
+form gains a username field: the person types their *own* roster name beside
+the password, and it is that name's stored password that is checked — and that
+name the rate limit counts against. A card that never had a password of its
+own has no credential to offer here; one flipped from ``own`` still does,
+until you decommission it — see
+:ref:`Removing someone <multi-user-shared-card-removal>` below.
+
+The session carries who opened it — the *opener* — and re-checks that person
+against the roster on every request. Rotating the opener's password or
+decommissioning them ends every shared session they opened at the next
+request, and under ``oidc`` so does editing or removing their
+``oidc_subject:`` — that per-person revocation is how a shared card is taken
+away from one user without touching the rest. Flipping the ``access`` key
+settles the same way: a card flipped to ``any`` refuses sessions minted while
+it was its owner's, and a card flipped back to ``own`` refuses the shared
+ones. The ledger records the opener beside the card
+(:ref:`audit-trail-identity-keys`), so a shared terminal's records still say
+who did what.
+
+The card's role rides the card. The claims binding
+(:ref:`multi-user-role-from-sso`) is not consulted on a shared card — the
+card's terminal is only ever built as its own tier — so a person the binding
+would refuse for their own card can still open a shared one. If the binding
+is your membership gate, do not share a card.
+
+Two rosters are refused by ``osprey scaffold web-terminals lint`` and the
+build verbs that run it:
+
+- **A deployment-editing card cannot be shared**
+  (``web_terminals.shared_card_privileged``). A persona holding the setup
+  tool or the Config panel was lifted for named people behind their own
+  cards; ``access: any`` would hand it to every login the deployment has.
+- **With a shared card on an** ``oidc`` **roster, two entries must not carry
+  the same** ``oidc_subject`` (``web_terminals.shared_card_duplicate_subject``).
+  One person could always hold two cards — the same ``oidc_subject:`` on
+  both, every login arriving through the card that was clicked. A shared card
+  changes the question: the login service must resolve each identity to a
+  single roster entry to know who opened it, so once any card is shared, such
+  a person keeps ``oidc_subject:`` on one card only — a login by that
+  identity would otherwise be ambiguous, and is refused.
+
+``login: false`` remains the ungated option — no login wall at all, the entry
+gated only by its own login URL. ``access: any`` is the gated one: everyone
+can reach the card, but only by logging in as themselves.
+
 .. _multi-user-https:
 
 Serve it over HTTPS
@@ -281,9 +371,13 @@ only. On every ``osprey up``, for each user in order:
 #. Otherwise a password is generated, hashed, and printed once. Capture it.
 
 To change one later, ``osprey users passwd alice`` prompts, rewrites that hash
-and ends alice's sessions; nobody else is touched. Password login is
-rate-limited per user but never locks anyone out — a control-room operator
-must not be shut out of the terminals.
+and ends alice's sessions — her own card's, and every shared-card
+(:ref:`access: any <multi-user-shared-card>`) session she opened, since those
+are held open by this same credential. Sessions held open by other people's
+passwords stay up. Password login is rate-limited per user but never locks
+anyone out — a control-room operator must not be shut out of the terminals.
+
+.. _multi-user-shared-card-removal:
 
 Removing someone, and turning it off
 ====================================
@@ -295,6 +389,20 @@ A credential can outlive an account, so:
   name back months later revives her password. ``decommission`` (or
   ``prune``, for names already edited out) retires the credential and, under
   OIDC, ends the session.
+- **A shared card is revoked per person, through their own credential.**
+  ``osprey users passwd alice`` ends every shared-card session alice opened
+  along with her own (see above); under ``oidc``, editing or removing her
+  ``oidc_subject:`` ends her shared-card sessions at the next request — her
+  *own* card's session is different, lapsing at expiry or logout as it always
+  has, unless ``osprey users decommission alice`` ends it now.
+
+- **Flipping a card to** ``access: any`` **does not retire the card's own
+  password** — the hash stays in ``.env.auth`` and still works: anyone who
+  knows it can open the shared card by typing the card's own name into the
+  username field. Run ``osprey users decommission <card>`` when you share a
+  card that used to have its own password; flipping back to ``own`` revives
+  an unretired hash. ``osprey users passwd <card>`` is refused while the card
+  is shared — there is no password of its own to change.
 - **A plaintext** ``OSPREY_AUTH_PW_ALICE`` **in** ``.env`` **survives
   decommission** and would be hashed straight back in for the next alice.
   Delete the line by hand when the person leaves.

--- a/docs/source/reference/contracts/audit-trail.rst
+++ b/docs/source/reference/contracts/audit-trail.rst
@@ -166,16 +166,20 @@ part of the message:
        right card never writes the key. The same case logs a warning, and it
        is recorded rather than refused
    * - ``oidc_subject=``
-     - Who proved the login, as the provider asserted it --- an opaque id or an
-       email. Written only where that differs from the account, so a password
-       deployment never sees this key, and a shared card records the person
-       beside the card they opened
+     - Who proved the login. Under ``oidc`` that is the identity the provider
+       asserted --- an opaque id or an email; on a shared
+       (:ref:`access: any <multi-user-shared-card>`) card under ``password``
+       it is the opener's roster name. Written only where it differs from the
+       account, so a password deployment sees the key on shared cards alone,
+       recording the person beside the card they opened
 
 Two forwarded headers carry that from the login service through nginx:
 ``X-Osprey-Auth-Account`` names the card, ``X-Osprey-Auth-Subject`` names the
-login that proved it. Under ``auth.method: password`` they hold the same value,
-because the roster username *is* the proof; under ``oidc`` they part, and only
-the account is a name a container can compare itself against.
+login that proved it. Under ``auth.method: password`` they hold the same value
+on a person's own card, because the roster username *is* the proof; on a shared
+card the subject header names the opener instead, and under ``oidc`` the two
+part on every card. Either way only the account is a name a container can
+compare itself against.
 
 A deployment that pins an older login-service image with ``auth.image`` gets no
 account header. The container then falls back to comparing the subject, as it

--- a/src/osprey/cli/summary_card.py
+++ b/src/osprey/cli/summary_card.py
@@ -257,3 +257,20 @@ def print_call_to_action(repo_root: Path | str, state: str) -> None:
                 f"{', '.join(facts.token_login_users)} each need their own "
                 "login URL, which carries that user's secret -- treat it like a password"
             )
+    if facts.shared_cards:
+        # Names, never URLs, for the same reason as the token-login line above.
+        # Without this line a shared card looks unreachable: it is in neither
+        # the sign-in pairs nor the login-url list, because it holds no
+        # credential of its own.
+        if len(facts.shared_cards) == 1:
+            output.note(
+                f"{facts.shared_cards[0]} is a shared card with no login of its "
+                "own -- open it by signing in with another roster user's name "
+                "and credential"
+            )
+        else:
+            output.note(
+                f"{', '.join(facts.shared_cards)} are shared cards with no "
+                "login of their own -- open each by signing in with another "
+                "roster user's name and credential"
+            )

--- a/src/osprey/cli/users_cmd.py
+++ b/src/osprey/cli/users_cmd.py
@@ -856,7 +856,9 @@ def login_url(user: str, repo: Path | None) -> None:
 def passwd(user: str, repo: Path | None) -> None:
     """Change one web-terminal user's login password.
 
-    Prompts for the new password and ends that user's sessions.
+    Prompts for the new password and ends that user's sessions. A shared
+    (`access: any`) card has no password of its own — rotate the opener's
+    instead.
     """
     with _users_session(repo) as session:
         from osprey.deployment.web_terminals.lifecycle import rotate_user_password

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -905,6 +905,13 @@ class ClosingFacts:
     #: them instead. See
     #: :func:`~osprey.deployment.web_terminals.auth_credentials.seeded_logins_report`.
     stale_logins: tuple[str, ...] = ()
+    #: Roster entries marked ``access: any`` — shared cards, in roster order.
+    #: A shared card carries no credential of its own: it is opened with
+    #: another roster user's name and credential, so it appears in neither
+    #: ``logins`` nor ``token_login_users`` and the card has to say how it IS
+    #: reached. Populated only when the auth method stands a login wall;
+    #: names, never URLs, as everywhere on this card.
+    shared_cards: tuple[str, ...] = ()
 
 
 def as_built_closing_facts(repo_root: Path | str) -> ClosingFacts:
@@ -931,6 +938,7 @@ def as_built_closing_facts(repo_root: Path | str) -> ClosingFacts:
             token_login_users=tuple(token_login_users(config)),
             landing_url_is_external_origin=_external_origin_is_derivable(config),
             stale_logins=seeded.stale,
+            shared_cards=tuple(_shared_cards(config)),
         )
     except Exception as exc:
         logger.debug(f"Closing facts skipped: {exc}")
@@ -963,13 +971,20 @@ def _seeded_logins(root: Path, config: dict) -> SeededLoginsReport:
     them), so a password
     named here would be one nothing ever checks. Roster entries carrying
     ``login: false`` sit outside the wall and are skipped for the same reason --
-    the same predicate credential provisioning itself uses.
+    the same predicate credential provisioning itself uses. Shared entries
+    (``access: any``) are skipped too: a shared card holds no password of its
+    own -- it is opened with another roster user's credential -- so no login
+    exists under its name for this report to print.
     """
     from osprey.deployment.web_terminals.auth_credentials import (
         SeededLoginsReport,
         seeded_logins_report,
     )
-    from osprey.deployment.web_terminals.personas import entry_requires_login, normalize_users
+    from osprey.deployment.web_terminals.personas import (
+        entry_is_shared,
+        entry_requires_login,
+        normalize_users,
+    )
     from osprey.deployment.web_terminals.render import _auth_tls_context
 
     web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
@@ -980,7 +995,7 @@ def _seeded_logins(root: Path, config: dict) -> SeededLoginsReport:
     names = [
         entry["name"]
         for entry in normalize_users(web_terminals.get("users"))
-        if entry_requires_login(entry)
+        if entry_requires_login(entry) and not entry_is_shared(entry)
     ]
     return seeded_logins_report(root, names)
 
@@ -988,9 +1003,14 @@ def _seeded_logins(root: Path, config: dict) -> SeededLoginsReport:
 def token_login_users(config: dict) -> list[str]:
     """The roster users whose terminal is entered through its ``?token=`` URL.
 
-    The complement of :func:`_seeded_logins`, and derived from the same
-    predicates nginx renders under so the two cannot disagree about who needs a
-    login URL. Public because ``osprey users login-url`` asks the same question
+    Derived from the same predicates nginx renders under as
+    :func:`_seeded_logins`, so the two cannot disagree about who needs a login
+    URL — but not its complement: a walled roster splits three ways. Entries
+    with their own required login go to the seeded-logins report; ``login:
+    false`` entries land here, reached through their ``?token=`` URL; shared
+    entries (``access: any``) appear in neither, because they hold no
+    credential of their own and are opened with another roster user's
+    credential. Public because ``osprey users login-url`` asks the same question
     before it prints anything: the URL is inert for a user nginx vouches for, so
     the verb refuses there, and a second spelling of "who has a login page"
     could send an operator a live secret the deployment would then ignore.
@@ -1017,6 +1037,34 @@ def token_login_users(config: dict) -> list[str]:
         entry["name"]
         for entry in normalize_users(web_terminals.get("users"))
         if not (inject_secret and entry_requires_login(entry))
+    ]
+
+
+def _shared_cards(config: dict) -> list[str]:
+    """The roster's shared cards (``access: any``), in roster order.
+
+    The third leg of the roster split :func:`_seeded_logins` and
+    :func:`token_login_users` carry between them: a shared card has no seeded
+    login (it holds no credential of its own) and no ``?token=`` URL (it sits
+    behind the wall like any other gated entry) — it is opened with another
+    roster user's name and credential, and the closing card has to say so or
+    the entry looks unreachable. Gated on the wall standing (``walled``:
+    ``password``/``oidc``): without one the sharing marker changes nothing
+    about how the entry is reached, so naming it would be noise. Names, never
+    URLs, for the same reason :func:`token_login_users` gives.
+    """
+    from osprey.deployment.web_terminals.personas import entry_is_shared, normalize_users
+    from osprey.deployment.web_terminals.render import _auth_tls_context
+
+    web_terminals = (config.get("modules") or {}).get("web_terminals") or {}
+    if not web_terminals.get("enabled"):
+        return []
+    if not _auth_tls_context(web_terminals)["walled"]:
+        return []
+    return [
+        entry["name"]
+        for entry in normalize_users(web_terminals.get("users"))
+        if entry_is_shared(entry)
     ]
 
 

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -109,6 +109,7 @@ from osprey.deployment.web_terminals.naming import web_container_name, web_conta
 from osprey.deployment.web_terminals.personas import (
     as_dict,
     effective_image_source,
+    entry_is_shared,
     entry_requires_login,
     env_var_suffix,
     freeze_user_indices,
@@ -878,7 +879,10 @@ def rotate_user_password(config_path: str | Path, user: str, password: str) -> N
     Every one of that user's live sessions dies as a side effect — the session
     cookie carries the generation tag of the hash it was issued against — which
     is what makes this usable as a revocation: rotating a password ends the
-    access it granted. No other user's session is affected.
+    access it granted. That includes every shared-card (``access: any``)
+    session this user opened, since those sessions are held open by this same
+    credential; sessions authenticated by other users' passwords are
+    untouched.
 
     The password is never logged, printed, or echoed on this path.
 
@@ -937,6 +941,18 @@ def rotate_user_password(config_path: str | Path, user: str, password: str) -> N
             f"User {user!r} has 'login: false' in modules.web_terminals.users, so its "
             "terminal is served without authentication and has no password to change. "
             "Remove that key to put the entry behind the login wall; nothing was modified."
+        )
+    # On the roster and behind the wall, but shared: /verify checks the
+    # OPENER's credential for a shared card, so no hash of its own is ever
+    # provisioned or consulted — "changing its password" would store a
+    # credential nothing checks while telling the operator it took effect.
+    if any(entry["name"] == user and entry_is_shared(entry) for entry in roster):
+        raise ValueError(
+            f"User {user!r} has 'access: any' in modules.web_terminals.users, so its "
+            "card is opened with another roster user's password and has no password of "
+            "its own to change. Rotate the opener's password to end their shared "
+            "sessions, or remove the 'access' key to make the card its own again; "
+            "nothing was modified."
         )
 
     _require_running_runtime(config)

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -38,6 +38,7 @@ from osprey.deployment.web_terminals.personas import (
     deployment_wide_privileged_exposure_problems,
     effective_image_source,
     effective_persona,
+    entry_is_shared,
     entry_requires_login,
     env_var_suffix_collisions,
     persona_privileges,
@@ -47,6 +48,7 @@ from osprey.deployment.web_terminals.personas import (
     rendered_persona_configs,
     resolve_image_tag,
     resolve_personas,
+    shared_card_privileged_problems,
     unauthenticated_privileged_terminal_problems,
 )
 from osprey.deployment.web_terminals.ports import (
@@ -172,6 +174,7 @@ def lint_web_terminals(
     findings.extend(_check_display_name(users))
     findings.extend(_check_user_theme(users))
     findings.extend(_check_user_login(web_terminals, users))
+    findings.extend(_check_user_access(web_terminals, users))
     findings.extend(_check_invalid_index(users))
     findings.extend(_check_duplicate_index(users))
     findings.extend(_check_bare_list_port_drift_risk(users))
@@ -248,6 +251,7 @@ def lint_web_terminals(
     findings.extend(_check_auth_transport(root, web_terminals))
     findings.extend(_check_auth_oidc(root, web_terminals))
     findings.extend(_check_auth_credential_collisions(web_terminals, users))
+    findings.extend(_check_shared_card_duplicate_subject(web_terminals, users))
     findings.extend(_check_authorization(web_terminals))
     findings.extend(_check_claims_without_oidc(web_terminals))
     findings.extend(_check_role_charset(web_terminals))
@@ -574,6 +578,95 @@ def _check_user_login(web_terminals: dict[str, Any], users: list[Any]) -> list[F
                     "exempt from — no login wall, and no injected operator secret; "
                     "the key changes nothing until auth.method is none, password "
                     "or oidc"
+                ),
+            )
+        )
+    return findings
+
+
+def _check_user_access(web_terminals: dict[str, Any], users: list[Any]) -> list[Finding]:
+    """An object-form entry's optional ``access`` must be the literal ``own`` or
+    ``any``, and ``any`` only does anything where the sidecar stands a wall.
+
+    Two findings, for the two ways the key can lie:
+
+    * Anything but exactly the string ``"own"`` or ``"any"`` is an ERROR. The
+      normalizer keeps only the literal ``"any"`` and drops everything else —
+      deliberately fail-closed to ``own`` — so ``access: ANY`` (or ``true``, or
+      a number) never widens an entry's reach, but the author who wrote it
+      believes the opposite of what deploys.
+    * ``access: any`` is a WARN when it cannot change anything: either the
+      deployment stands no wall at all (``sidecar_active`` is false — under
+      ``token`` and ``none`` alike no login gates the roster, so every entry is
+      as reachable as the key promises to make this one), or the same entry
+      also carries ``login: false`` (nginx proxies it with no ``auth_request``,
+      so there is no authenticated identity for ``access`` to widen). One code
+      for both; the message names the cause.
+
+    ``access: own`` explicit is silent — a valid spelling of the default, even
+    though the normalizer drops it.
+    """
+    findings: list[Finding] = []
+    # `sidecar_active`, not `inject_secret`: `access` reads the identity the
+    # auth sidecar established, so it is inert under `none` too — where
+    # `login: false` still means something (it withholds the injected secret).
+    context = _auth_context(web_terminals)
+    inert = context is None or not context["sidecar_active"]
+
+    any_declared = False
+    for user in users:
+        if not isinstance(user, dict) or "access" not in user:
+            continue
+        access = user.get("access")
+        if isinstance(access, str) and access == "own":
+            continue
+        if isinstance(access, str) and access == "any":
+            any_declared = True
+            # Only where the wall stands: with no sidecar the deployment-level
+            # warning below already covers this entry, and reporting both
+            # causes for one key would double-count a single inertness.
+            if not inert and user.get("login") is False:
+                name = user.get("name", user)
+                findings.append(
+                    Finding(
+                        severity="warn",
+                        code="web_terminals.user_access_inert",
+                        message=(
+                            f"modules.web_terminals.users entry {name!r} sets "
+                            f"access: any together with login: false; nginx proxies "
+                            f"a login-exempt entry with no auth_request, so there is "
+                            f"no authenticated identity for access to widen — the "
+                            f"key claims a distinction this entry does not have"
+                        ),
+                    )
+                )
+            continue
+        name = user.get("name", user)
+        findings.append(
+            Finding(
+                severity="error",
+                code="web_terminals.invalid_user_access",
+                message=(
+                    f"modules.web_terminals.users entry {name!r} has an invalid "
+                    f"access {access!r}; access must be the string 'own' (default: "
+                    f"this entry reaches only its own terminal) or 'any' (may reach "
+                    f"every roster entry's terminal). Anything else deploys as 'own'"
+                ),
+            )
+        )
+
+    if any_declared and inert:
+        method = "unset" if context is None else repr(context["auth_method"])
+        findings.append(
+            Finding(
+                severity="warn",
+                code="web_terminals.user_access_inert",
+                message=(
+                    "a modules.web_terminals.users entry sets access: any, but "
+                    f"auth.method is {method} so no login wall stands between "
+                    "entries — every terminal is already as reachable as the key "
+                    "promises to make this one; the key changes nothing until "
+                    "auth.method is password or oidc"
                 ),
             )
         )
@@ -1608,6 +1701,19 @@ def _check_privileged_persona_exposure(
                 severity="error",
                 code="web_terminals.unauthenticated_privileged_terminal",
                 message=problem + (_STALE_RENDER_REMEDY if rendered_project else ""),
+            )
+        )
+
+    # A shared card is judged on the same ABSOLUTE answer, and only reported
+    # where a wall stands: with no sidecar there is no authenticated identity
+    # for `access: any` to widen (`user_access_inert` says so), and the
+    # deployment-wide arm above already names every privileged entry once.
+    for problem in shared_card_privileged_problems(resolved, absolute):
+        findings.append(
+            Finding(
+                severity="error",
+                code="web_terminals.shared_card_privileged",
+                message=problem,
             )
         )
     return findings
@@ -3176,6 +3282,63 @@ def _check_auth_credential_collisions(
             ),
         )
         for suffix, colliding in env_var_suffix_collisions(names).items()
+    ]
+
+
+def _check_shared_card_duplicate_subject(
+    web_terminals: dict[str, Any], users: list[Any]
+) -> list[Finding]:
+    """OIDC with a shared card on the roster: one subject may not map to two entries.
+
+    Without a shared card a duplicated ``oidc_subject`` is legitimate — one
+    person holding two cards, where every login arrives through the card that
+    was clicked and the sidecar only confirms the asserted identity matches
+    that one entry. A shared card changes the question: the sidecar must
+    resolve the identity to a single roster entry on its own to know who
+    opened it, and a subject carried by two entries has no one answer. The
+    sidecar refuses such a login outright (``ambiguous_identity`` in the audit
+    log) rather than minting a session whose roster identity nobody decided
+    on; this is the same refusal at scaffold time, where dropping one
+    ``oidc_subject:`` is still cheap.
+
+    Scoped to ``method: oidc`` — no other method reads the subject mapping —
+    and grouped like :func:`_check_auth_credential_collisions`: exact strings
+    (stripped of surrounding whitespace) across the raw roster, one finding
+    per colliding subject. The message names the entries, never the subject —
+    same reasoning as the ``$`` scan above: echoing a value invites pasting
+    it, and the names are what the operator edits.
+    """
+    context = _auth_context(web_terminals)
+    if context is None or context["auth_method"] != "oidc":
+        return []
+    # Only the literal `access: "any"` survives normalization, so reading it
+    # off the raw entry through the shared predicate cannot disagree with
+    # what deploys.
+    if not any(isinstance(user, dict) and entry_is_shared(user) for user in users):
+        return []
+    by_subject: dict[str, list[str]] = {}
+    for user in users:
+        if not isinstance(user, dict):
+            continue
+        name = _user_name(user)
+        subject = user.get("oidc_subject")
+        if name is None or not isinstance(subject, str) or not subject.strip():
+            continue
+        by_subject.setdefault(subject.strip(), []).append(name)
+    return [
+        Finding(
+            severity="error",
+            code="web_terminals.shared_card_duplicate_subject",
+            message=(
+                f"modules.web_terminals.users entries {colliding} all carry the same "
+                "oidc_subject. With a shared card on the roster the auth sidecar must "
+                "resolve every login to a single roster entry, so a login by that "
+                "identity is ambiguous and refused (ambiguous_identity). A person "
+                "holding two cards must carry oidc_subject: on one of them only"
+            ),
+        )
+        for colliding in by_subject.values()
+        if len(colliding) > 1
     ]
 
 

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -1022,6 +1022,16 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
     the typo separately). See :func:`entry_requires_login` for the single
     consumer-side reading of the carried key.
 
+    An object entry's optional ``access`` (whether this entry is a shared card
+    any authenticated roster user may open, rather than one owned by a single
+    user) is carried through only when it is the literal string ``"any"`` — the
+    one value that changes anything. ``"own"``, absence, and every malformed
+    spelling (``"ANY"``, a boolean, a number) all mean "owner only", so
+    dropping them is both the fail-closed reading and what keeps a config typo
+    from silently sharing an entry (lint reports the typo separately). See
+    :func:`entry_is_shared` for the single consumer-side reading of the
+    carried key.
+
     Malformed entries — anything that isn't a string, and any dict missing a
     string ``name`` or an int ``index`` — are dropped rather than raising
     (well-formedness is lint.py's job). ``bool`` is a subclass of ``int`` in
@@ -1039,8 +1049,8 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
     Returns:
         New ``{"name": str, "index": int}`` dicts (plus optional
         ``"display_name"``, ``"theme"``, ``"oidc_subject"`` and ``"role"`` string
-        keys and a ``"login": False`` marker when the entry carried them) in
-        config-declaration order. Input dicts are never mutated or returned by
+        keys, a ``"login": False`` marker and an ``"access": "any"`` marker
+        when the entry carried them) in config-declaration order. Input dicts are never mutated or returned by
         reference.
     """
     if not isinstance(users_raw, list):
@@ -1078,6 +1088,13 @@ def normalize_users(users_raw: Any) -> list[dict[str, Any]]:
                 # can never open an entry to the world.
                 if entry.get("login") is False:
                     normalized_entry["login"] = False
+                # Only the literal string "any" is carried: absence and "own"
+                # both mean "owner only", and any other value is a config typo
+                # (reported by lint) whose safe reading is the same. Carrying
+                # only the sharing value keeps the gate fail-closed — a typo
+                # can never share an entry with the whole roster.
+                if entry.get("access") == "any":
+                    normalized_entry["access"] = "any"
                 normalized.append(normalized_entry)
     return normalized
 
@@ -1099,6 +1116,24 @@ def entry_requires_login(entry: dict[str, Any]) -> bool:
     already normalized back to "login required".
     """
     return entry.get("login") is not False
+
+
+def entry_is_shared(entry: dict[str, Any]) -> bool:
+    """Whether this normalized roster entry is a shared card, open to the roster.
+
+    ``access: any`` on a roster entry marks it as shared: any authenticated
+    roster user may open it, instead of only the one user the entry belongs
+    to. The single reading of that key, shared by credential provisioning
+    (which decides whose logins may mint a session for it), the deploy summary
+    (which reports the seeded logins), the ``users passwd`` verb's refusal
+    path, the render's per-entry service dict, and lint's privileged/duplicate
+    checks — call sites that must never disagree about who may open an entry.
+
+    Reads the *normalized* entry, so only the literal ``"any"``
+    :func:`normalize_users` carries through shares; every malformed spelling
+    already normalized back to "owner only".
+    """
+    return entry.get("access") == "any"
 
 
 def freeze_user_indices(users_raw: Any) -> list[dict[str, Any]]:
@@ -1748,6 +1783,53 @@ def deployment_wide_privileged_exposure_problems(
     return problems
 
 
+def shared_card_privileged_problems(
+    resolved_entries: Iterable[Mapping[str, Any]],
+    privileges_by_persona: Mapping[str, Sequence[str]],
+) -> list[str]:
+    """Every SHARED roster entry whose persona can edit the deployment.
+
+    ``access: any`` opens a card to the whole roster: any authenticated login
+    may mint a session for it (see :func:`entry_is_shared`). On an unprivileged
+    persona that is the feature — one control-room terminal everybody on shift
+    opens. On a privileged one it undoes the tier split the roster declared:
+    the setup tool or the Config panel was lifted for named people behind their
+    own cards, and the one key hands it to every login the deployment has.
+
+    **Judged on what the persona ABSOLUTELY holds**, like the ``login: false``
+    rule above and for the same reason: sharing is an authored claim about one
+    entry, made deliberately, and a deployment that floors neither surface
+    hands both of them through the shared card — the widest version of this
+    exposure, not an exempt one. See :func:`privileges_beyond_baseline` for the
+    rules that read the relative answer.
+
+    Args:
+        resolved_entries: :func:`resolve_personas`' output (or anything with
+            the same ``name``/``persona``/``access`` keys).
+        privileges_by_persona: Persona name → :func:`persona_privileges` — the
+            ABSOLUTE answer; see :func:`_privileged_entries` for what a missing
+            persona means.
+
+    Returns:
+        One message per offending entry, in roster order, each naming the user,
+        the persona, what it holds and the remedy.
+    """
+    problems: list[str] = []
+    for entry, persona, privileges in _privileged_entries(resolved_entries, privileges_by_persona):
+        if not entry_is_shared(dict(entry)):
+            continue
+        name = entry.get("name")
+        problems.append(
+            f"modules.web_terminals user {name!r} is a shared card (access: any), but "
+            f"resolves to persona {persona!r}, which holds {privilege_phrase(privileges)}. "
+            f"Any authenticated roster login may open that terminal, so every user on the "
+            f"roster edits this deployment. Set access: own for {name!r} — or drop the key, "
+            f"since owner-only is the default — or point {name!r} at a persona that holds "
+            f"neither (the bundled stack's {UNPRIVILEGED_TIER_EXAMPLE!r})"
+        )
+    return problems
+
+
 def env_var_suffix(username: str) -> str:
     """Map a roster username to the suffix its per-user env vars are keyed by.
 
@@ -2026,7 +2108,9 @@ def resolve_personas(
         resolved entry as everything else rather than re-derived from the raw
         roster. An optional ``"login": False`` marker rides through likewise —
         present only when the roster entry opted out of the login wall (see
-        :func:`entry_requires_login`). An optional ``"landing_group"`` key — the catalog entry's own
+        :func:`entry_requires_login`). An optional ``"access": "any"`` marker
+        rides through on the same terms — present only when the roster entry is
+        a shared card (see :func:`entry_is_shared`). An optional ``"landing_group"`` key — the catalog entry's own
         ``landing_group``, present only for a non-empty string — names the
         landing-page section this entry's card belongs in; it is read by
         :func:`osprey.deployment.web_terminals.render._build_groups` and affects
@@ -2097,6 +2181,9 @@ def resolve_personas(
         # normalize_users already reduced every other spelling to absence.
         if source.get("login") is False:
             entry["login"] = False
+        # `access: "any"` likewise: only the sharing value is ever present.
+        if source.get("access") == "any":
+            entry["access"] = "any"
         return entry
 
     def _zero_migration_entry(

--- a/src/osprey/deployment/web_terminals/provision.py
+++ b/src/osprey/deployment/web_terminals/provision.py
@@ -79,6 +79,7 @@ from osprey.deployment.web_terminals.persona_images import (
 )
 from osprey.deployment.web_terminals.personas import (
     effective_image_source,
+    entry_is_shared,
     entry_requires_login,
     normalize_users,
     resolve_personas,
@@ -554,11 +555,14 @@ def _provision_auth_secrets(web_terminals: dict, repo_root: str) -> None:
         # `login: false` entries are left out on purpose: no gate ever asks the
         # sidecar about them, so a hash here would be a credential nothing
         # checks — and a minted password printed for an entry that has no login
-        # would tell the operator the opposite of the truth.
+        # would tell the operator the opposite of the truth. Shared entries
+        # (`access: any`) are left out for the same reason: a shared card holds
+        # no password of its own — verify checks the opener's credential — so a
+        # hash minted under its name would likewise be one nothing ever checks.
         usernames = [
             entry["name"]
             for entry in normalize_users(web_terminals.get("users"))
-            if entry_requires_login(entry)
+            if entry_requires_login(entry) and not entry_is_shared(entry)
         ]
         credentials = ensure_auth_credentials(usernames, repo_root, echo=_mint_echo())
         _report_unshown_mints(credentials)

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -44,6 +44,7 @@ from osprey.deployment.web_terminals.personas import (
     config_needs_graphdb_password,
     config_needs_launch_token_for,
     effective_image_source,
+    entry_is_shared,
     entry_requires_login,
     env_var_suffix,
     env_var_suffix_collisions,
@@ -980,6 +981,14 @@ def render_web_terminals(
                 # and credential provisioning can never disagree about who has
                 # a login. With auth off the template never consults it.
                 "login_exempt": not entry_requires_login(entry),
+                # Whether this entry is a shared card (`access: any` on the
+                # roster entry): any authenticated roster user may open it,
+                # not only the one it belongs to. Read through the shared
+                # predicate rather than off the raw key so the sidecar's env
+                # line and credential provisioning can never disagree about
+                # which cards are shared. With auth off the template never
+                # consults it.
+                "shared": entry_is_shared(entry),
                 # The env-var name that subject is emitted under, resolved HERE
                 # through env_var_suffix() — the single definition of the
                 # username->env-var mapping, shared with credential
@@ -1009,6 +1018,16 @@ def render_web_terminals(
                 # OIDC group binding, so a roster user named `claim` or `map`
                 # would otherwise have read that binding as their own role.
                 "role_env": f"OSPREY_AUTH_ROSTER_ROLE_{env_var_suffix(entry['name'])}",
+                # The env-var name the shared-card marker travels under,
+                # resolved HERE for exactly the reason `role_env` is: one
+                # definition of the username->env-var mapping (never a
+                # template-side `upper|replace`), so this user's access
+                # marker, role, password hash and mapped IdP subject cannot
+                # be keyed four ways. The `ROSTER_` infix follows the role
+                # precedent above: OSPREY_AUTH_ROSTER_* is the per-entry
+                # table, kept clear of the deployment-wide OSPREY_AUTH_*
+                # knobs a short username could otherwise collide with.
+                "access_env": f"OSPREY_AUTH_ROSTER_ACCESS_{env_var_suffix(entry['name'])}",
                 # The env-var NAME this user's operator secret travels in — the
                 # credential nginx injects as a request header and the app
                 # authenticates every request against. A name, never a value:

--- a/src/osprey/interfaces/common_middleware.py
+++ b/src/osprey/interfaces/common_middleware.py
@@ -694,9 +694,10 @@ def _audit_detail(scope: Scope, headers: dict[str, str], **extra: str) -> tuple[
       **only** when the forwarded account is not it. Its presence *is* the
       mismatch: one user's authorization arrived at another user's container.
     * :data:`AUDIT_OIDC_SUBJECT_KEY` — *who proved* the login, present only
-      when that is not the account itself. A password session, where the roster
-      username is the proof, therefore gains no key at all; an OIDC session
-      records the provider's subject beside the card it opened.
+      when that is not the account itself. A password session on a user's own
+      card, where the roster username is the proof, gains no key; on a shared
+      card the key holds the opener's roster name, whichever the method; an
+      OIDC session records the provider's subject beside the card it opened.
 
     **The comparison is on the account, never on the subject.** Under
     ``auth.method: oidc`` the subject is the IdP's assertion about a person —

--- a/src/osprey/services/auth_sidecar/app.py
+++ b/src/osprey/services/auth_sidecar/app.py
@@ -134,6 +134,11 @@ ENV_OIDC_CLAIM = "OSPREY_AUTH_OIDC_CLAIM"
 ENV_OIDC_SUBJECT_PREFIX = "OSPREY_AUTH_OIDC_SUBJECT_"
 """Per-user expected IdP identity: ``OSPREY_AUTH_OIDC_SUBJECT_<SUFFIX>``."""
 
+ENV_ROSTER_ACCESS_PREFIX = "OSPREY_AUTH_ROSTER_ACCESS_"
+"""Per-user access rule: ``OSPREY_AUTH_ROSTER_ACCESS_<SUFFIX>``. The ``ROSTER_``
+infix matches ``OSPREY_AUTH_ROSTER_ROLE_``: both describe the roster entry
+itself rather than a credential belonging to the user."""
+
 DEFAULT_OIDC_CLIENT_ID_ENV = "OSPREY_AUTH_OIDC_CLIENT_ID"
 DEFAULT_OIDC_CLIENT_SECRET_ENV = "OSPREY_AUTH_OIDC_CLIENT_SECRET"
 DEFAULT_OIDC_CLAIM = "sub"
@@ -244,6 +249,10 @@ class AuthSettings:
         oidc_claim: Which ID-token claim carries the identity to map onto a
             roster user.
         oidc_subjects: ``{username: expected claim value}`` from the roster.
+        shared_users: Roster usernames whose terminal any authenticated roster
+            user may open (``access: any``). Membership is granted only by the
+            exact value ``any`` — anything else, including the default
+            ``own``, reads as not shared, so a typo fails closed.
     """
 
     method: str = "none"
@@ -261,6 +270,7 @@ class AuthSettings:
     oidc_client_secret_var: str = DEFAULT_OIDC_CLIENT_SECRET_ENV
     oidc_claim: str = DEFAULT_OIDC_CLAIM
     oidc_subjects: Mapping[str, str] = field(default_factory=dict)
+    shared_users: frozenset[str] = frozenset()
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> AuthSettings:
@@ -291,6 +301,7 @@ class AuthSettings:
         users = _roster(source.get(ENV_USERS))
         password_hashes: dict[str, str] = {}
         oidc_subjects: dict[str, str] = {}
+        shared_users: set[str] = set()
         for user in users:
             suffix = env_var_suffix(user)
             stored = (source.get(f"{ENV_PW_HASH_PREFIX}{suffix}") or "").strip()
@@ -299,6 +310,11 @@ class AuthSettings:
             subject = (source.get(f"{ENV_OIDC_SUBJECT_PREFIX}{suffix}") or "").strip()
             if subject:
                 oidc_subjects[user] = subject
+            access = (source.get(f"{ENV_ROSTER_ACCESS_PREFIX}{suffix}") or "").strip()
+            if access == "any":
+                # Only the exact value grants sharing; anything else — the
+                # default ``own`` included — fails closed to per-user access.
+                shared_users.add(user)
 
         client_id_var = (
             source.get(ENV_OIDC_CLIENT_ID_ENV) or ""
@@ -325,6 +341,7 @@ class AuthSettings:
             oidc_client_secret_var=client_secret_var,
             oidc_claim=(source.get(ENV_OIDC_CLAIM) or "").strip() or DEFAULT_OIDC_CLAIM,
             oidc_subjects=oidc_subjects,
+            shared_users=frozenset(shared_users),
         )
 
     def missing_requirements(self) -> tuple[str, ...]:
@@ -409,6 +426,14 @@ class AuthSettings:
     def oidc_subject(self, user: str) -> str | None:
         """The IdP identity mapped to ``user``, or ``None`` if unmapped."""
         return self.oidc_subjects.get(user)
+
+    def shared(self, user: str) -> bool:
+        """Whether ``user``'s terminal is open to the whole roster.
+
+        ``False`` for a user not on the roster, and for every roster user whose
+        access rule is anything but the exact value ``any``.
+        """
+        return user in self.shared_users
 
     def knows_user(self, user: str) -> bool:
         """Whether ``user`` is on this deployment's roster."""

--- a/src/osprey/services/auth_sidecar/audit.py
+++ b/src/osprey/services/auth_sidecar/audit.py
@@ -76,6 +76,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "AUDIT_DIR_ENV",
     "LOGIN_REASONS",
+    "REASON_AMBIGUOUS_IDENTITY",
     "REASON_AMBIGUOUS_ROLE_CLAIM",
     "REASON_BAD_CREDENTIAL",
     "REASON_IDENTITY_MISMATCH",
@@ -161,6 +162,17 @@ Its own category rather than a shade of :data:`REASON_UNMAPPED_USER`: this is a
 login that authenticated successfully and was still refused, which is the one
 denial an operator should be able to count separately — a run of them is either
 a misconfigured subject mapping or somebody clicking a card that is not theirs.
+"""
+
+REASON_AMBIGUOUS_IDENTITY = "ambiguous_identity"
+"""The asserted identity matches more than one roster entry on a shared card.
+
+A configuration fault, not a hostile login: two roster entries were mapped to
+the same provider subject, so the token proves who arrived but cannot say which
+entry they are. Refused rather than resolved — picking either entry would mint
+a session whose roster identity nobody decided on — and mirrored at build time
+by scaffold lint's duplicate-subject refusal, so reaching here means the
+deployment's config bypassed that check.
 """
 
 REASON_UNVALIDATED_TOKEN = "unvalidated_token"
@@ -258,6 +270,7 @@ _GENERIC_LOGIN = "login"
 
 LOGIN_REASONS: frozenset[str] = frozenset(
     {
+        REASON_AMBIGUOUS_IDENTITY,
         REASON_AMBIGUOUS_ROLE_CLAIM,
         REASON_BAD_CREDENTIAL,
         REASON_IDENTITY_MISMATCH,
@@ -333,7 +346,13 @@ def ledger_path() -> Path | None:
     return directory / f"{SURFACE}{writer.LEDGER_SUFFIX}"
 
 
-def record_login_success(*, user: str, method: str, role: str = "") -> None:
+def record_login_success(
+    *,
+    user: str,
+    method: str,
+    detail: str | None = None,
+    role: str = "",
+) -> None:
     """Record that ``user`` logged in, and how.
 
     Recorded for the same reason refusals are: "who is in this deployment, and
@@ -344,6 +363,9 @@ def record_login_success(*, user: str, method: str, role: str = "") -> None:
         user: The roster user who logged in — the record's *subject*.
         method: The deployment's auth method (``password`` or ``oidc``), which
             names the category the success is recorded under.
+        detail: Optional supplementary context — identifiers and config keys
+            only, on the same terms as a refusal's ``detail``. A shared-card
+            login records the opener here (``opener=<name>``).
         role: The role the session was minted with, where the deployment binds
             one. Empty is the deny-safe value and is recorded as no role at all,
             never as a role named ``""``.
@@ -352,6 +374,7 @@ def record_login_success(*, user: str, method: str, role: str = "") -> None:
         user=user,
         decision=DECISION_ALLOWED,
         reason=_SUCCESS_REASONS.get(method, _GENERIC_LOGIN),
+        detail=detail,
         role=role,
     )
 

--- a/src/osprey/services/auth_sidecar/identity_headers.py
+++ b/src/osprey/services/auth_sidecar/identity_headers.py
@@ -30,9 +30,14 @@ verify route denies the subrequest. A header silently omitted from an otherwise
 successful authorization would leave the terminal running with less identity
 than the deployment thinks it forwarded, which is exactly the failure this
 module exists to prevent.
+
+The module also owns :func:`same_value`, the constant-time comparator every
+check of an identity value uses.
 """
 
 from __future__ import annotations
+
+import secrets
 
 __all__ = [
     "ACCOUNT_HEADER",
@@ -40,6 +45,7 @@ __all__ = [
     "ROLE_SOURCE_HEADER",
     "SUBJECT_HEADER",
     "is_header_safe",
+    "same_value",
 ]
 
 ACCOUNT_HEADER = "X-Osprey-Auth-Account"
@@ -48,9 +54,8 @@ ACCOUNT_HEADER = "X-Osprey-Auth-Account"
 The account is the roster entry whose card was clicked — the name ``/verify``
 checked the session against, and the one a consumer can compare with the
 account it believes it is serving. :data:`SUBJECT_HEADER` answers a different
-question: who proved the login. The two coincide in a password session, where
-the roster username *is* the proof, and diverge in an OIDC session, where the
-provider asserts an opaque id or an email that names a person and not a card.
+question: who proved the login. The two coincide on an own card under either
+login method and diverge on a shared card under both.
 
 On a shared card that difference is the whole point: the account names the
 card, the subject names whoever opened it. Emitted on every authorized answer —
@@ -63,9 +68,10 @@ SUBJECT_HEADER = "X-Osprey-Auth-Subject"
 """Names who proved the login behind an authorized request.
 
 An OIDC session carries the provider's subject; a password session carries the
-roster username, which *is* the account in that method. Emitted only when the
-session holds one, so its presence always means a known identity and no
-consumer has to tell an empty value from an absent one.
+roster username of whoever proved the login. Under either method the value
+matches the account on an own card and differs from it on a shared card.
+Emitted only when the session holds one, so its presence always means a known
+identity and no consumer has to tell an empty value from an absent one.
 """
 
 ROLE_HEADER = "X-Osprey-Auth-Role"
@@ -110,3 +116,16 @@ def is_header_safe(value: str) -> bool:
     if value[0] == " " or value[-1] == " ":
         return False
     return all(_LOWEST_PRINTABLE <= ord(char) <= _HIGHEST_PRINTABLE for char in value)
+
+
+def same_value(left: str, right: str) -> bool:
+    """Whether two text values are equal, compared in constant time.
+
+    As UTF-8 bytes, never as ``str``: :func:`secrets.compare_digest` raises
+    ``TypeError`` the moment either side carries a non-ASCII character, and both
+    things compared here can. A ``state`` parameter is unauthenticated input, so
+    one accented character in it would be an unhandled 500 rather than a
+    refusal; a mapped identity like ``jörg@example.org`` would raise on the
+    comparison that was about to *succeed*, locking that operator out for good.
+    """
+    return secrets.compare_digest(left.encode("utf-8"), right.encode("utf-8"))

--- a/src/osprey/services/auth_sidecar/routes/login.py
+++ b/src/osprey/services/auth_sidecar/routes/login.py
@@ -8,9 +8,12 @@ password-mode session comes from.
 
 **The clicked card is the username.** The landing page offers one card per roster
 user, so this page is addressed per user and asks for a password and nothing
-else. There is no username field: a name typed here could only disagree with the
-one the link named, and the page would then either lie about who is being
-unlocked or refuse an operator who typed their own name correctly.
+else. On an own card there is no username field: a name typed here could only
+disagree with the one the link named, and the page would then either lie about
+who is being unlocked or refuse an operator who typed their own name correctly.
+The one exception is a card whose access rule is ``any``: there the person
+opening it types their OWN roster name (:data:`FIELD_OPENER`) — naming
+themselves, never the terminal, which the clicked card still names.
 
 **Every method's unauthenticated browser arrives here.** nginx's 401 handler
 knows nothing about how this deployment authenticates, so it emits the same
@@ -135,6 +138,11 @@ FIELD_NEXT = "next"
 FIELD_PASSWORD = "password"
 """Form field names, matching the hidden inputs and the password input in
 ``login.html``. The browser test and the composed-stack test drive these."""
+
+FIELD_OPENER = "username"
+"""The shared-card form's visible username field, where the person opening the
+card types their OWN roster name. An own-card form has no such field at all —
+there the clicked card is the username, carried in the hidden ``user`` input."""
 
 DENIAL_MESSAGE = "That password was not accepted. Please try again."
 """The one refusal message. Names no user, no roster and no reason: an unknown
@@ -320,6 +328,8 @@ def _page(
     status_code: int = 200,
     error: str | None = None,
     headers: dict[str, str] | None = None,
+    shared: bool,
+    opener: str,
 ) -> Response:
     """Render the password prompt.
 
@@ -335,6 +345,14 @@ def _page(
         status_code: 200 for the prompt, 401 for a refusal, 429 when throttled.
         error: The message to show, or ``None`` for a first prompt.
         headers: Extra response headers, merged over the no-store default.
+        shared: Whether this card admits any roster user (``access: any``), in
+            which case the template shows a username field for the person
+            opening it. Required, no default: every render of this page states
+            which of the two shapes it is, so no re-render can silently drop
+            the username field on a retry.
+        opener: What to prefill that field with — the opener's own roster name
+            on a re-render, empty on a first prompt and everywhere ``shared``
+            is false. Required for the same reason.
 
     Returns:
         The rendered page.
@@ -348,6 +366,8 @@ def _page(
             "error": error,
             "login_path": LOGIN_PATH,
             "theme_blocks": _theme_blocks(),
+            "shared": shared,
+            "opener": opener,
         },
         status_code=status_code,
         headers={**_NO_STORE_HEADERS, **(headers or {})},
@@ -606,7 +626,7 @@ async def login_page(
         # where a credential *is* evaluated, deliberately does not distinguish.
         raise HTTPException(status_code=404, detail="no such user", headers=_NO_STORE_HEADERS)
 
-    return _page(request, user=username, target=target)
+    return _page(request, user=username, target=target, shared=settings.shared(username), opener="")
 
 
 @router.post(LOGIN_PATH)
@@ -657,6 +677,20 @@ async def login_submit(
     uncredentialed roster user and a name that is not on the roster still produce
     one status, one page and one message. A form that named no user was never a
     credential attempt.
+
+    **A shared card (``access: any``) is opened by someone else's credential.**
+    The form gains one field — the opener's own roster name — and exactly two
+    things change hands: the credential checked is the *opener's* stored hash,
+    looked up under the opener's unclamped name on the same oversize rule as the
+    card's, and the throttle keys on the opener's bounded name — the same bucket
+    that user's own card charges, so a guessing run cannot shop between the two
+    surfaces for a fresh window. Everything else stays card-keyed: the session
+    entry, the granted role and the return-to all belong to the card, with the
+    opener riding along in the entry and the audit record (``opener=<name>``) as
+    identity, never privilege. A form that did not name exactly one opener is
+    handled exactly like one that did not name exactly one user, before the
+    throttle is touched; a present-but-empty opener is an evaluated attempt that
+    meets the one shared refusal.
 
     Args:
         request: The inbound request, carrying the submitted form.
@@ -729,13 +763,55 @@ async def login_submit(
     if oversize:
         logger.warning("login submitted an impossible username of %d characters", len(username))
 
+    # The UNCLAMPED name decides whether this is a shared card, on the rule the
+    # credential lookup below already follows: an over-long submission must
+    # never take the shared branch, where a prefix of it could name a real
+    # shared card the browser never posted to. It stays on the ordinary deny
+    # path instead, exactly as it did before shared cards existed.
+    card_shared = not oversize and settings.shared(username)
+
+    opener = ""
+    opener_oversize = False
+    shown_opener = ""
+    if card_shared:
+        opener_values = _form_values(form, FIELD_OPENER)
+        if len(opener_values) != 1:
+            # The user field's own discipline, and before the throttle is
+            # touched: a form that did not name exactly one opener was never a
+            # credential attempt. Missing sends a browser back to the roster
+            # cards; repeated is ambiguous and keeps its 400 for every caller.
+            named = len(opener_values)
+            logger.warning(
+                "shared-card login submitted without exactly one opener field (got %d)", named
+            )
+            if named < 2 and _prefers_html(request):
+                return RedirectResponse(LANDING_PATH, status_code=302, headers=_NO_STORE_HEADERS)
+            raise HTTPException(
+                status_code=400,
+                detail="the login form must name exactly one opener",
+                headers=_NO_STORE_HEADERS,
+            )
+        # A present-but-empty opener proceeds: it is an evaluated attempt that
+        # fails the credential check below, on the one refusal every miss gets.
+        opener = opener_values[0]
+        opener_oversize = len(opener) > MAX_USERNAME_LENGTH
+        shown_opener = opener[:MAX_USERNAME_LENGTH]
+        if opener_oversize:
+            logger.warning(
+                "shared-card login submitted an impossible opener of %d characters", len(opener)
+            )
+
     target = safe_return_to(_only(_form_values(form, FIELD_NEXT)), shown)
     # A missing, repeated or non-string password is simply not a password: it
     # takes the ordinary refusal path rather than a distinguishable one, and
     # `verify_password` answers False for an empty string without deriving a key.
     password = _only(_form_values(form, FIELD_PASSWORD)) or ""
 
-    delay = throttle.retry_after(shown)
+    # On a shared card the credential under test is the OPENER's, so the
+    # opener's bounded name keys the throttle — the same window that user's own
+    # card grows and clears. An own-card attempt keeps keying on the card.
+    throttle_key = shown_opener if card_shared else shown
+    delay = throttle.retry_after(throttle_key)
     if delay > 0:
         # Before evaluation, and without recording a failure: counting attempts
         # that were never evaluated is how a flood of parallel guesses would
@@ -750,28 +826,73 @@ async def login_submit(
             status_code=429,
             error=THROTTLE_MESSAGE,
             headers={"Retry-After": str(math.ceil(delay))},
+            shared=card_shared,
+            opener=shown_opener,
         )
 
-    stored = None if oversize else settings.password_hash(username)
+    # Two lookup spellings, one rule. An own card checks the card's own stored
+    # hash under the UNCLAMPED submitted name; a shared card checks the
+    # OPENER's, under the opener's unclamped name. Clamping either before the
+    # lookup could resolve a prefix of an over-long submission to a real roster
+    # user and unlock a credential the browser never named — so oversize forces
+    # None on both spellings instead.
+    if card_shared:
+        stored = None if opener_oversize else settings.password_hash(opener)
+    else:
+        stored = None if oversize else settings.password_hash(username)
     # `stored is None` covers a roster user with no provisioned credential, a
     # username that is not on the roster at all, and one too long to be either.
     # None derives a key — see the module docstring — and all three leave through
     # the identical refusal below, including the same call into the throttle.
     if stored is None or not verify_password(password, stored):
-        throttle.record_failure(shown)
+        throttle.record_failure(throttle_key)
+        if card_shared:
+            logger.warning(
+                "shared-card login for %r refused: the credential submitted for opener %r "
+                "did not verify",
+                shown,
+                shown_opener,
+            )
+            # The same refusal as the own-card one — one status, one page, one
+            # message — with the username field re-rendered and the bounded
+            # opener riding in `detail`. Only a non-empty opener is recorded:
+            # an empty one would put an empty value in an identifiers-only
+            # envelope field, so that refusal carries no detail at all.
+            audit.record_login_refusal(
+                user=shown,
+                reason=audit.REASON_BAD_CREDENTIAL,
+                detail=f"opener={shown_opener}" if shown_opener else None,
+            )
+            return _page(
+                request,
+                user=shown,
+                target=target,
+                status_code=401,
+                error=DENIAL_MESSAGE,
+                shared=True,
+                opener=shown_opener,
+            )
         logger.warning("login refused for %r: the submitted credential did not verify", shown)
         # `shown` for the same reason the log line and the throttle use it: the
         # ledger is not the caller's to size either. One category for all three
         # ways this branch is reached — see `audit.REASON_BAD_CREDENTIAL`; the
         # record must not say which of them it was any more than the page does.
         audit.record_login_refusal(user=shown, reason=audit.REASON_BAD_CREDENTIAL)
-        return _page(request, user=shown, target=target, status_code=401, error=DENIAL_MESSAGE)
+        return _page(
+            request,
+            user=shown,
+            target=target,
+            status_code=401,
+            error=DENIAL_MESSAGE,
+            shared=False,
+            opener="",
+        )
 
-    # `shown` here too, not `username`: on this path they are the same string —
-    # an over-long name never gets a stored hash — and keying both throttle calls
-    # the same way is what makes "the window this attempt was checked against" and
-    # "the window it clears" provably the same entry.
-    throttle.record_success(shown)
+    # The key the window was checked against — `shown` on an own card, where it
+    # is the same string as `username` (an over-long name never gets a stored
+    # hash), the bounded opener on a shared one — so "the window this attempt
+    # was checked against" and "the window it clears" are provably one entry.
+    throttle.record_success(throttle_key)
 
     # The credential is settled; what it is *worth* is the matrix's answer, and
     # it is asked before anything is minted so a refusal cannot leave the
@@ -819,6 +940,10 @@ async def login_submit(
         # reading of the method here.
         role=role,
         role_source=grant.role_source,
+        # Who proved this login: the opener's own name on a shared card, empty
+        # for an own-card entry. Identity, never privilege — it rides an
+        # identity header and the audit trail, and grants nothing.
+        opener=opener,
     )
 
     response = RedirectResponse(target, status_code=303, headers=_NO_STORE_HEADERS)
@@ -834,9 +959,19 @@ async def login_submit(
         # signed expiry inside it, which is the only one the sidecar can enforce.
         path="/",
     )
-    logger.info("password login succeeded for %r", username)
+    if card_shared:
+        logger.info("password login succeeded for %r, opened by %r", username, opener)
+    else:
+        logger.info("password login succeeded for %r", username)
     # Recorded after the cookie is set and before the response leaves: a ledger
     # that holds only refusals cannot answer "who is in this deployment, and
-    # since when", which is the first question asked of a login trail.
-    audit.record_login_success(user=username, method=settings.method, role=role)
+    # since when", which is the first question asked of a login trail. A shared
+    # card also names who opened it — an empty opener never reaches this line,
+    # because an empty name fails the credential check above.
+    audit.record_login_success(
+        user=username,
+        method=settings.method,
+        role=role,
+        detail=f"opener={opener}" if card_shared else None,
+    )
     return response

--- a/src/osprey/services/auth_sidecar/routes/oidc.py
+++ b/src/osprey/services/auth_sidecar/routes/oidc.py
@@ -15,7 +15,13 @@ The identity the IdP asserts is compared against
 user and nothing else: an identity that maps to no roster user, or to a
 different one, is refused with 403. Searching the roster for whichever user the
 subject happens to match would turn a mis-click into someone else's terminal,
-which is exactly the isolation this sidecar exists to establish.
+which is exactly the isolation this sidecar exists to establish. The one
+deliberate exception is a *shared* card — a roster entry whose rendered access
+rule is ``any`` (:meth:`~osprey.services.auth_sidecar.app.AuthSettings.shared`):
+any roster entry's mapped identity may open it, so the callback reverse-matches
+the asserted identity against every configured subject, refuses an identity
+matching none or more than one, and records who opened the card. The card's
+role still rides the card: the claims binding decides nothing on a shared card.
 
 **Which user was clicked is server-side state.** It travels in the pinned
 Starlette session cookie (:data:`PENDING_FLOW_SESSION_KEY`) alongside Authlib's
@@ -64,7 +70,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import secrets
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
@@ -83,7 +88,7 @@ from ..app import (
     get_settings,
 )
 from ..exceptions import InvalidSessionError
-from ..identity_headers import is_header_safe
+from ..identity_headers import is_header_safe, same_value
 from ..return_to import safe_return_to
 from ..sessions import SESSION_COOKIE_NAME, SessionState
 from ..throttle import AttemptThrottle
@@ -614,19 +619,6 @@ def _oauth_client(request: Request) -> Any:
     return client
 
 
-def _same_value(left: str, right: str) -> bool:
-    """Whether two text values are equal, compared in constant time.
-
-    As UTF-8 bytes, never as ``str``: :func:`secrets.compare_digest` raises
-    ``TypeError`` the moment either side carries a non-ASCII character, and both
-    things compared here can. A ``state`` parameter is unauthenticated input, so
-    one accented character in it would be an unhandled 500 rather than a
-    refusal; a mapped identity like ``jörg@example.org`` would raise on the
-    comparison that was about to *succeed*, locking that operator out for good.
-    """
-    return secrets.compare_digest(left.encode("utf-8"), right.encode("utf-8"))
-
-
 def _claims_options(settings: AuthSettings) -> dict[str, dict[str, list[str]]]:
     """Which ID-token claims Authlib must check, and against what.
 
@@ -723,7 +715,8 @@ async def oidc_login(
     Raises:
         HTTPException: 404 when this deployment is not in OIDC mode or ``user``
             is not on the roster; 403 when ``user`` has no mapped IdP identity
-            (the handshake could only end in a refusal, so it does not start);
+            — for a shared card, when no roster entry has one — because the
+            handshake could only end in a refusal, so it does not start;
             502 when the issuer's discovery document cannot be fetched or read.
     """
     settings = get_settings(request)
@@ -738,7 +731,25 @@ async def oidc_login(
         # credential was evaluated, and refusing to say which of three reasons
         # applied is what keeps the ledger from enumerating accounts.
         raise HTTPException(status_code=404, detail="no such user")
-    if settings.oidc_subject(user) is None:
+    if settings.shared(user):
+        # A shared card is opened by whichever roster entry's mapped identity
+        # the IdP asserts, so its own mapping is not what decides whether the
+        # handshake is worth starting — one mapped entry anywhere on the
+        # roster is. Only a roster with no mapped identity at all could end
+        # nowhere but in a refusal.
+        if not settings.oidc_subjects:
+            logger.warning(
+                "oidc login refused for shared card %r: no roster entry carries a mapped identity",
+                user,
+            )
+            raise _refuse_login(
+                user,
+                reason=REASON_UNMAPPED_USER,
+                message="no roster entry carries a mapped identity",
+                # Reachable by an unauthenticated GET, one request per record.
+                bound=_ledger_bound(request),
+            )
+    elif settings.oidc_subject(user) is None:
         logger.warning("oidc login refused for %r: no IdP identity is mapped to that user", user)
         raise _refuse_login(
             user,
@@ -802,7 +813,9 @@ async def oidc_callback(request: Request) -> Response:
             that started it, or when the IdP reports an error; 403 when the
             clicked user has no mapped identity, when that identity cannot be
             carried in an identity header, when the asserted identity is not the
-            one mapped to the clicked user, or when a bound role cannot be
+            one mapped to the clicked user (on a shared card: matches no roster
+            entry, more than one, or one whose identity cannot be carried), or
+            when a bound role cannot be
             resolved to exactly one carryable role; 502 when the IdP is
             unreachable or its response does not validate. Every 403 is recorded
             under its own audited category.
@@ -827,50 +840,59 @@ async def oidc_callback(request: Request) -> Response:
     # user. Without it a browser holding two half-finished flows could complete
     # one of them under the other's username.
     returned_state = request.query_params.get("state") or ""
-    if not _same_value(str(pending["state"]), returned_state):
+    if not same_value(str(pending["state"]), returned_state):
         logger.warning("oidc callback rejected: returned state does not match the login in flight")
         raise HTTPException(status_code=400, detail="login state mismatch")
 
     user = str(pending["user"])
+    # A shared card's own mapping decides nothing — not even whether it has
+    # one. Which entry's identity opened it is settled AFTER the token
+    # exchange, by the reverse match below, so both pre-exchange gates on
+    # `expected_subject` are the own-card path's alone.
+    shared = settings.shared(user)
     expected_subject = settings.oidc_subject(user)
-    if expected_subject is None:
-        # Unreachable through the login route, which refuses first; re-checked
-        # because this is the decision that must never fall through to "some
-        # other user's subject matched".
-        logger.warning("oidc callback refused for %r: no IdP identity is mapped to that user", user)
-        raise _refuse_login(
-            user,
-            reason=REASON_UNMAPPED_USER,
-            message="this user has no mapped identity provider",
-            # Pre-exchange, and the state cookie that gets here is minted by a
-            # free GET — two requests per record without the bound.
-            bound=_ledger_bound(request),
-        )
+    if not shared:
+        if expected_subject is None:
+            # Unreachable through the login route, which refuses first;
+            # re-checked because this is the decision that must never fall
+            # through to "some other user's subject matched".
+            logger.warning(
+                "oidc callback refused for %r: no IdP identity is mapped to that user", user
+            )
+            raise _refuse_login(
+                user,
+                reason=REASON_UNMAPPED_USER,
+                message="this user has no mapped identity provider",
+                # Pre-exchange, and the state cookie that gets here is minted
+                # by a free GET — two requests per record without the bound.
+                bound=_ledger_bound(request),
+            )
 
-    if not is_header_safe(expected_subject):
-        # The mapped identity has to reach the terminal as an
-        # `X-Osprey-Auth-Subject` header, which is latin-1 on the wire and
-        # ASCII by this deployment's stricter rule. A subject that cannot make
-        # that trip is refused *here*, before the token exchange: the login
-        # could only have ended in a mangled identity or a dropped header, and
-        # a login that silently grants less identity than it says is worse than
-        # one that does not happen. An OIDC `sub` is ASCII by specification, so
-        # this is a configuration fault — the deployment mapped a claim
-        # spelling the boundary cannot carry — and the audited category says
-        # exactly that. The value itself stays out of both the record and the
-        # log line; the operator has it in their own config.
-        logger.warning(
-            "oidc callback refused for %r: the mapped identity cannot be carried in an "
-            "identity header",
-            user,
-        )
-        raise _refuse_login(
-            user,
-            reason=audit.REASON_NON_ASCII_SUBJECT,
-            message="this user's mapped identity cannot be carried",
-            # Pre-exchange, same bound as the refusal above.
-            bound=_ledger_bound(request),
-        )
+        if not is_header_safe(expected_subject):
+            # The mapped identity has to reach the terminal as an
+            # `X-Osprey-Auth-Subject` header, which is latin-1 on the wire and
+            # ASCII by this deployment's stricter rule. A subject that cannot
+            # make that trip is refused *here*, before the token exchange: the
+            # login could only have ended in a mangled identity or a dropped
+            # header, and a login that silently grants less identity than it
+            # says is worse than one that does not happen. An OIDC `sub` is
+            # ASCII by specification, so this is a configuration fault — the
+            # deployment mapped a claim spelling the boundary cannot carry —
+            # and the audited category says exactly that. The value itself
+            # stays out of both the record and the log line; the operator has
+            # it in their own config.
+            logger.warning(
+                "oidc callback refused for %r: the mapped identity cannot be carried in an "
+                "identity header",
+                user,
+            )
+            raise _refuse_login(
+                user,
+                reason=audit.REASON_NON_ASCII_SUBJECT,
+                message="this user's mapped identity cannot be carried",
+                # Pre-exchange, same bound as the refusal above.
+                bound=_ledger_bound(request),
+            )
 
     client = _oauth_client(request)
     try:
@@ -947,41 +969,125 @@ async def oidc_callback(request: Request) -> Response:
             detail=settings.oidc_claim,
         )
 
-    if not _same_value(asserted, expected_subject):
-        # No search of the roster for a user this identity *would* match: the
-        # card that was clicked is the only user this login can unlock.
-        logger.warning(
-            "oidc callback refused for %r: the asserted identity is mapped to a different user "
-            "or to none",
-            user,
-        )
-        raise _refuse_login(
-            user,
-            reason=REASON_IDENTITY_MISMATCH,
-            message="this identity is not permitted for this user",
-        )
+    if shared:
+        # The one deliberate exception to the anti-lookup rule in the branch
+        # below: a shared card may be opened by ANY roster entry whose
+        # configured subject the IdP asserted, so this is a reverse match over
+        # the configured subjects — gated on `settings.shared`, and living
+        # nowhere else in this service. Every entry is compared, each in
+        # constant time, with no early break: stopping at the first hit would
+        # let the comparison count say which entry matched and how early it
+        # sits in the roster, and a subject two entries share must surface as
+        # ambiguity rather than be resolved by declaration order. The card's
+        # own subject, when it carries one, participates like every other
+        # entry's.
+        matches = [
+            (name, configured)
+            for name, configured in settings.oidc_subjects.items()
+            if same_value(asserted, configured)
+        ]
+        if not matches:
+            logger.warning(
+                "oidc callback refused for shared card %r: the asserted identity is mapped to "
+                "no roster entry",
+                user,
+            )
+            raise _refuse_login(
+                user,
+                reason=REASON_IDENTITY_MISMATCH,
+                message="this identity is not permitted for this user",
+            )
+        if len(matches) > 1:
+            # Two entries mapped to one identity is a configuration fault, and
+            # picking either would make who-opened-this-card depend on roster
+            # declaration order. Refused under its own category so the ledger
+            # says what the operator has to fix.
+            logger.warning(
+                "oidc callback refused for shared card %r: the asserted identity is mapped to "
+                "more than one roster entry",
+                user,
+            )
+            raise _refuse_login(
+                user,
+                reason=audit.REASON_AMBIGUOUS_IDENTITY,
+                message="this identity matches more than one roster entry",
+            )
+        opener_name, matched_subject = matches[0]
+        if not is_header_safe(matched_subject):
+            # The own-card path refuses this before the token exchange; here
+            # the entry it belongs to is only known now, so it is refused
+            # post-match — and refused HERE rather than left to `with_user`,
+            # whose ValueError would surface as a 500 on what is a denial.
+            logger.warning(
+                "oidc callback refused for shared card %r: the matched identity cannot be "
+                "carried in an identity header",
+                user,
+            )
+            raise _refuse_login(
+                user,
+                reason=audit.REASON_NON_ASCII_SUBJECT,
+                message="the matched identity cannot be carried",
+            )
 
-    # Identity first, privilege second, and both from the same validated token:
-    # the role question is only worth asking about a login that already proved
-    # it is the user whose card was clicked.
-    claim_role = _resolved_role(request, user=user, claims=claims)
+        # The claims binding is not consulted on a shared card: the card's
+        # role rides the card, so a person the binding would refuse for their
+        # own card can still open a shared one. Membership gating and shared
+        # cards do not compose — the binding answers "which role is THIS
+        # person's terminal built as", and a shared card's terminal is only
+        # ever its own. `claim_role=""` is the matrix's binds-no-roles row,
+        # which grants the card's roster role with source `roster`.
+        try:
+            grant = recheck_login(
+                method=settings.method,
+                user=user,
+                roster_roles=roster_roles(request),
+                asserted_subject=matched_subject,
+                claim_role="",
+            )
+        except RecheckRefused as refused:
+            logger.warning("oidc callback refused for %r: %s", user, refused.reason)
+            raise _refuse_login(user, reason=refused.reason, message=refused.message) from None
+    else:
+        opener_name = ""
+        if not same_value(asserted, expected_subject):
+            # No search of the roster for a user this identity *would* match:
+            # on an own card, the clicked card is the only user this login can
+            # unlock, so the asserted identity is compared against that user's
+            # mapped subject and nothing else. The one deliberate exception is
+            # the shared branch above — a reverse match over the configured
+            # subjects, gated on `settings.shared`, with ambiguity refused.
+            logger.warning(
+                "oidc callback refused for %r: the asserted identity is mapped to a different "
+                "user or to none",
+                user,
+            )
+            raise _refuse_login(
+                user,
+                reason=REASON_IDENTITY_MISMATCH,
+                message="this identity is not permitted for this user",
+            )
 
-    # The same matrix the password path is held to, asked the same way and
-    # before anything is minted. `expected_subject` and `claim_role` are what
-    # this method is *allowed* to supply; a deployment that binds no roles
-    # supplies `""`, which is an answer, and the re-check refuses a caller that
-    # supplies neither.
-    try:
-        grant = recheck_login(
-            method=settings.method,
-            user=user,
-            roster_roles=roster_roles(request),
-            asserted_subject=expected_subject,
-            claim_role=claim_role,
-        )
-    except RecheckRefused as refused:
-        logger.warning("oidc callback refused for %r: %s", user, refused.reason)
-        raise _refuse_login(user, reason=refused.reason, message=refused.message) from None
+        # Identity first, privilege second, and both from the same validated
+        # token: the role question is only worth asking about a login that
+        # already proved it is the user whose card was clicked.
+        claim_role = _resolved_role(request, user=user, claims=claims)
+
+        # The same matrix the password path is held to, asked the same way and
+        # before anything is minted. `expected_subject` and `claim_role` are
+        # what this method is *allowed* to supply; a deployment that binds no
+        # roles supplies `""`, which is an answer, and the re-check refuses a
+        # caller that supplies neither.
+        try:
+            grant = recheck_login(
+                method=settings.method,
+                user=user,
+                roster_roles=roster_roles(request),
+                asserted_subject=expected_subject,
+                claim_role=claim_role,
+            )
+        except RecheckRefused as refused:
+            logger.warning("oidc callback refused for %r: %s", user, refused.reason)
+            raise _refuse_login(user, reason=refused.reason, message=refused.message) from None
     role = grant.role
 
     codec = get_session_codec(request)
@@ -991,14 +1097,23 @@ async def oidc_callback(request: Request) -> Response:
     # expiry and by logout alone. It carries the asserted subject instead — an
     # opaque account identifier, not a credential — so a later verify subrequest
     # can name which provider account is behind this unlocked user without
-    # re-contacting the IdP. `expected_subject` and `asserted` are byte-equal
-    # here (the constant-time check above just proved it); the configured value
-    # is stored so the cookie carries the deployment's own canonical spelling.
+    # re-contacting the IdP. `grant.subject` and `asserted` are byte-equal here
+    # (the constant-time check above just proved it, against the clicked card's
+    # own mapping or against the matched entry's on a shared card); the
+    # configured value is stored so the cookie carries the deployment's own
+    # canonical spelling.
     session = _current_session(request).with_user(
         user,
         expires_at=now + settings.session_lifetime,
         generation_tag="",
         oidc_subject=grant.subject,
+        # The roster entry whose mapped identity opened a shared card — the
+        # card itself when its own subject matched — and `""` on an own card,
+        # exactly as the password path sets it. Verify re-validates it per
+        # request; under OIDC the subject header still names the provider
+        # account (`oidc_subject`), so the opener is the session's record of
+        # WHICH roster entry that account was matched to.
+        opener=opener_name,
         # The matrix's answer, not this route's: the claim's role where this
         # deployment binds claims (cross-checked there against the role the
         # render bound for this user), and the roster's own where it binds
@@ -1029,9 +1144,17 @@ async def oidc_callback(request: Request) -> Response:
     # a credential (the cookie already carries it, signed not encrypted), so it
     # is recorded on this success line. `%r` quotes it, so a value carrying a
     # newline cannot forge a second log line.
-    logger.info("oidc login succeeded for %r (subject %r)", user, expected_subject)
+    logger.info("oidc login succeeded for %r (subject %r)", user, grant.subject)
     # The counterpart of `_refuse_login`: the same seam, one record, the roster
     # user as the subject. The asserted subject stays out of it — it is a claim
-    # value, and the record names the roster user the login unlocked.
-    audit.record_login_success(user=user, method=settings.method, role=role)
+    # value, and the record names the roster user the login unlocked. A shared
+    # card additionally names its opener in `detail`: a roster name, not a
+    # claim value, and the one fact "who is in this deployment" needs on a
+    # card the whole roster can open.
+    audit.record_login_success(
+        user=user,
+        method=settings.method,
+        role=role,
+        detail=f"opener={opener_name}" if shared else None,
+    )
     return response

--- a/src/osprey/services/auth_sidecar/routes/recheck.py
+++ b/src/osprey/services/auth_sidecar/routes/recheck.py
@@ -85,6 +85,13 @@ refusal, never in somebody else's terminal. Pinned structurally rather than by
 spelling: :data:`__all__` declares the whole public surface and a test asserts
 it equals what the module defines, so a reverse lookup cannot arrive under a
 name nobody predicted.
+
+The single exception lives in :mod:`.oidc`, not here: on a card whose rendered
+access rule is ``any``, the callback reverse-matches the asserted identity
+against every configured subject — gated on
+:meth:`~osprey.services.auth_sidecar.app.AuthSettings.shared`, with an identity
+matching more than one entry refused as ambiguous. Nothing in THIS module
+searches; the matrix is still asked by the username whose card was clicked.
 """
 
 from __future__ import annotations

--- a/src/osprey/services/auth_sidecar/routes/recheck.py
+++ b/src/osprey/services/auth_sidecar/routes/recheck.py
@@ -14,7 +14,8 @@ The matrix, one row per posture:
 method               subject                                role                   source
 ===================  =====================================  =====================  ==========
 ``none``             — (no session is minted)               — (no login events)    — (none)
-``password``         the roster username                    the roster ``role:``   ``roster``
+``password``         the roster username, or the opener     the roster ``role:``   ``roster``
+                     on a shared card
 ``oidc``, unbound    the asserted IdP subject               the roster ``role:``   ``roster``
 ``oidc``, bound      the asserted IdP subject               the claim's role,      ``claim``
                                                             cross-checked
@@ -439,20 +440,24 @@ def session_subject(*, method: str, username: str, entry: UnlockedUser | None) -
     account this login never asserted.
 
     Written as "not OIDC" so the fallback branch is the one naming an identity
-    this service verified itself, never a stored claim.
+    this service verified itself, never a stored claim. On a shared card that
+    identity is the entry's ``opener`` — the roster user whose password proved
+    the login — so the header names who opened the card, not the card itself.
 
     Args:
         method: The deployment's auth method.
         username: The roster user this subrequest authorized, already checked
             against the roster and byte-identical to the entry's own username.
-        entry: The unlocked entry, or ``None`` on the defensive path.
+        entry: The unlocked entry — carrying the opener on a shared card — or
+            ``None`` on the defensive path.
 
     Returns:
-        The subject to report, or ``""`` when this session names no account.
+        The subject to report — the opener, on a shared card — or ``""`` when
+        this session names no account.
     """
     if method == METHOD_OIDC:
         return entry.oidc_subject if entry is not None else ""
-    return username
+    return entry.opener if entry is not None and entry.opener else username
 
 
 def session_role(*, method: str, entry: UnlockedUser | None) -> str:

--- a/src/osprey/services/auth_sidecar/routes/verify.py
+++ b/src/osprey/services/auth_sidecar/routes/verify.py
@@ -233,12 +233,23 @@ async def verify(
         # holder of the signing secret could have put a tag there in the first
         # place — a session that survives that check has already proved more
         # than the tag could.
-        stored = settings.password_hash(username)
+        # On a shared card the session's tag was minted from the *opener's*
+        # hash, so that is the hash the tag is checked against; the card's own
+        # hash — which may exist as a stale leftover from before the card was
+        # shared — is deliberately not consulted. On an own card the opener is
+        # empty and the owner is the username itself, unchanged.
+        hash_owner = entry.opener or username
+        stored = settings.password_hash(hash_owner)
         if stored is None:
             # A roster user with no provisioned credential. An individual
             # denial, not a deployment-wide fault: the other users still
-            # authenticate, so this is a 401 rather than the guard's 503.
-            return _deny(username, "user has no stored credential")
+            # authenticate, so this is a 401 rather than the guard's 503. Two
+            # reasons, one per fault, so the log names whose credential is
+            # missing — the card's own, or its opener's (which also covers an
+            # opener taken off the roster: the hashes are roster-scoped).
+            if hash_owner == username:
+                return _deny(username, "user has no stored credential")
+            return _deny(username, "the opener has no stored credential")
 
         if not verify_generation_tag(entry.generation_tag, stored):
             # A tag that no longer matches means the password was rotated under

--- a/src/osprey/services/auth_sidecar/routes/verify.py
+++ b/src/osprey/services/auth_sidecar/routes/verify.py
@@ -48,6 +48,7 @@ from ..identity_headers import (
     ROLE_SOURCE_HEADER,
     SUBJECT_HEADER,
     is_header_safe,
+    same_value,
 )
 from ..passwords import verify_generation_tag
 from ..revocation import RevocationStore
@@ -109,6 +110,13 @@ async def verify(
     one stops verifying — without server-side session state, and surviving the
     container recreate that rotation performs (which is also what clears the
     revocation store).
+
+    In every mode the session's shared-card story must also match the roster's
+    current one: a shared (``access: any``) card authorizes only a session that
+    names an opener, an own card only one that names none, and under OIDC the
+    opener must still map to the subject the session stored — re-checked on
+    every subrequest, so a shared card closes for the whole roster the moment
+    its opener's own login would stop working.
 
     The parameters are missing-tolerant on purpose. ``user`` defaults to absent
     and the cookie to ``None`` rather than being required, because FastAPI would
@@ -178,6 +186,42 @@ async def verify(
     if revocations.is_revoked(state.session_id):
         return _deny(username, "session was revoked by a logout")
 
+    entry = state.entry(username)
+    if entry is None:
+        # `is_unlocked` above means the entry exists; the guard is here so
+        # nothing below — the opener checks and the tag comparison — can be
+        # reached with `None`.
+        return _deny(username, "session carries no entry for this user")
+
+    # A shared (``access: any``) card's session names its opener — the roster
+    # entry whose credential proved the login — and an own card's session names
+    # none. That correspondence is minted into the entry, so a session whose
+    # story disagrees with the roster's *current* access rule was minted under
+    # a rule an operator has since flipped, and it retires now rather than
+    # lapsing: flipping a card to ``any`` must not widen sessions already
+    # outstanding, and flipping it back must not leave the roster's sessions
+    # holding the card open.
+    if settings.shared(username) and not entry.opener:
+        return _deny(username, "card is shared but the session names no opener")
+    if entry.opener and not settings.shared(username):
+        return _deny(username, "session names an opener but the card is not shared")
+
+    if entry.opener and settings.method == "oidc":
+        # Opener re-validation, the shared card's counterpart of the generation
+        # tag: the card stays open only while whoever opened it could still
+        # open it today. Unlike the role, this *is* re-derived on every
+        # subrequest — deliberately, because a shared card multiplies one login
+        # across the whole roster, so an opener taken off the roster or
+        # remapped at the IdP must lose every terminal at once, not at each
+        # session's own expiry.
+        expected = settings.oidc_subject(entry.opener)
+        if expected is None:
+            # Checked explicitly, and first, so the comparison below can never
+            # run against ``None``.
+            return _deny(username, "the opener is no longer a mapped roster user")
+        if not same_value(expected, entry.oidc_subject):
+            return _deny(username, "the opener's mapped subject has changed")
+
     if settings.method != "oidc":
         # Password mode. Written as "not OIDC" rather than "is password" so the
         # stricter branch is the default one: the guard admits only the two
@@ -196,14 +240,12 @@ async def verify(
             # authenticate, so this is a 401 rather than the guard's 503.
             return _deny(username, "user has no stored credential")
 
-        entry = state.entry(username)
-        if entry is None or not verify_generation_tag(entry.generation_tag, stored):
-            # `is_unlocked` above means the entry exists; the check is here so
-            # the tag comparison cannot be reached with `None`. A tag that no
-            # longer matches means the password was rotated under this session.
+        if not verify_generation_tag(entry.generation_tag, stored):
+            # A tag that no longer matches means the password was rotated under
+            # this session.
             return _deny(username, "credential generation tag does not match")
 
-    return _authorized(username, state.entry(username), settings)
+    return _authorized(username, entry, settings)
 
 
 def _subject_for(username: str, entry: UnlockedUser | None, settings: AuthSettings) -> str:
@@ -238,10 +280,10 @@ def _authorized(username: str, entry: UnlockedUser | None, settings: AuthSetting
     consumer can compare against the account it believes it is serving.
     ``X-Osprey-Auth-Subject`` names who proved the login — the provider subject
     under OIDC, the roster username otherwise — so a later layer can tell who is
-    behind the request without re-reading the cookie. The two coincide in
-    password mode and diverge on a shared card under OIDC, which is the case
-    they exist separately for. ``X-Osprey-Auth-Role`` names the role that
-    account holds.
+    behind the request without re-reading the cookie. The two coincide on an own
+    card under either method and diverge on a shared card under both, which is
+    the case they exist separately for. ``X-Osprey-Auth-Role`` names the role
+    that account holds.
 
     **The account is the one header that always rides.** An authorized request
     is by definition on a card, so there is no session state that can leave it
@@ -263,7 +305,10 @@ def _authorized(username: str, entry: UnlockedUser | None, settings: AuthSetting
     hot path. If retiring a role must retire outstanding sessions too, the
     generation tag is the mechanism to copy: it already revokes on a credential
     change, and it does so by invalidating the session rather than by rewriting
-    what it says.
+    what it says. A shared card's opener is exactly such a copy: :func:`verify`
+    re-validates it against the roster's current mapping on every subrequest,
+    so a shared-card session retires the moment its opener is unmapped or
+    remapped, by refusing rather than by rewriting.
 
     **A changed METHOD is a different question, and it does not lapse.** The
     paragraph above is about a role that is no longer *granted*; switching

--- a/src/osprey/services/auth_sidecar/sessions.py
+++ b/src/osprey/services/auth_sidecar/sessions.py
@@ -6,7 +6,7 @@ lives in a single :mod:`itsdangerous`-signed cookie::
 
     {"v": 1, "sid": "<session id>", "iat": <epoch>, "users": {
         "alice": {"exp": <epoch>, "tag": "0123456789abcdef", "sub": "",
-                  "role": "", "source": ""}
+                  "role": "", "source": "", "opener": ""}
     }}
 
 **Signed, not encrypted.** Anyone holding the cookie can read the payload; they
@@ -35,6 +35,14 @@ The ``"sub"``, ``"role"`` and ``"source"`` keys are read with defaults rather
 than being made mandatory, and none of them was added with a
 :data:`PAYLOAD_VERSION` bump: a cookie minted before any of them existed still
 decodes, with an empty subject, no role and no provenance for it.
+
+Shared-card entries also carry the ``"opener"`` — the roster username whose
+entry proved the login behind a shared password card, or ``""`` for an own-card
+session. It follows the same additive pattern: read with a default and added
+without a :data:`PAYLOAD_VERSION` bump, so a cookie minted before shared cards
+named their opener decodes with an empty one. And because the opener rides
+``X-Osprey-Auth-Subject`` on shared password cards, it is header-checked at the
+same two points as the subject, the role and its source.
 
 **A value that cannot cross the nginx boundary is never stored.** The subject,
 the role and its source all leave as HTTP headers (see
@@ -135,6 +143,11 @@ class UnlockedUser:
             holding no role carries and what any session minted before
             provenance travelled carries. Provenance only: it says where a
             privilege came from, never that one is held.
+        opener: The roster username whose entry proved the login behind this
+            unlock — the opener of a shared password card — or ``""`` for an
+            own-card session, and for any session minted before the opener
+            travelled. Identity, never privilege: it names who unlocked the
+            card, and it rides an identity header, so it must be header-safe.
     """
 
     username: str
@@ -143,6 +156,7 @@ class UnlockedUser:
     oidc_subject: str = ""
     role: str = ""
     role_source: str = ""
+    opener: str = ""
 
     def is_expired(self, now: float) -> bool:
         """Whether this entry has reached its expiry at ``now``."""
@@ -217,6 +231,7 @@ class SessionState:
         oidc_subject: str = "",
         role: str = "",
         role_source: str = "",
+        opener: str = "",
     ) -> SessionState:
         """Return this state with ``username`` unlocked until ``expires_at``.
 
@@ -239,6 +254,8 @@ class SessionState:
                 none.
             role_source: Where that role came from, or ``""`` for none — which
                 is what a login resolving no role passes.
+            opener: The roster username whose entry proved this login — set
+                for a shared password card, ``""`` for an own-card login.
 
         Raises:
             ValueError: If ``username`` is empty, or if the subject, the role or
@@ -246,7 +263,8 @@ class SessionState:
                 caller is refusing a login at that point, not repairing a
                 value: a substitute identity would authorize the wrong thing,
                 and a silently dropped role would authorize *something* under
-                a privilege nobody granted.
+                a privilege nobody granted. An uncarryable opener is refused
+                on the same grounds: it rides an identity header too.
         """
         if not username:
             raise ValueError("username must not be empty")
@@ -256,6 +274,8 @@ class SessionState:
             raise ValueError("role cannot be carried in an identity header")
         if role_source and not is_header_safe(role_source):
             raise ValueError("role source cannot be carried in an identity header")
+        if opener and not is_header_safe(opener):
+            raise ValueError("opener cannot be carried in an identity header")
 
         entry = UnlockedUser(
             username=username,
@@ -264,6 +284,7 @@ class SessionState:
             oidc_subject=oidc_subject,
             role=role,
             role_source=role_source,
+            opener=opener,
         )
         if self.entry(username) is None:
             return replace(self, users=(*self.users, entry))
@@ -371,6 +392,7 @@ class SessionCodec:
                     "sub": user.oidc_subject,
                     "role": user.role,
                     "source": user.role_source,
+                    "opener": user.opener,
                 }
                 for user in state.users
             },
@@ -436,9 +458,10 @@ class SessionCodec:
         ``tag``, ``sub``, ``role`` and ``source`` all default to ``""`` when
         absent, so a cookie minted before any of those keys existed decodes at
         the current payload version instead of signing that browser out.
+        ``opener`` defaults the same way.
 
-        A subject, role or role source that could not be carried in an identity
-        header invalidates the whole cookie. Only this sidecar can have signed
+        A subject, role, role source or opener that could not be carried in an
+        identity header invalidates the whole cookie. Only this sidecar can have signed
         it, and :meth:`SessionState.with_user` refuses to store such a value —
         so a cookie carrying one is not a session to salvage, and refusing it
         here is what keeps the verify route's answer a plain 401 rather than an
@@ -486,6 +509,13 @@ class SessionCodec:
                 raise InvalidSessionError(
                     f"session entry for {username!r} carries an uncarryable role source"
                 )
+            opener = entry.get("opener", "")
+            if not isinstance(opener, str):
+                raise InvalidSessionError(f"session entry for {username!r} has a non-string opener")
+            if opener and not is_header_safe(opener):
+                raise InvalidSessionError(
+                    f"session entry for {username!r} carries an uncarryable opener"
+                )
             users.append(
                 UnlockedUser(
                     username=username,
@@ -494,6 +524,7 @@ class SessionCodec:
                     oidc_subject=subject,
                     role=role,
                     role_source=role_source,
+                    opener=opener,
                 )
             )
         return tuple(users)

--- a/src/osprey/services/auth_sidecar/templates/login.html
+++ b/src/osprey/services/auth_sidecar/templates/login.html
@@ -11,9 +11,21 @@
 
     user: str, required
       The roster user whose card was clicked. Shown in the prompt and carried in
-      a hidden field — there is NO username input on this page, because the page
-      is addressed per user and typing a different name here would only produce
-      a login the server refuses.
+      a hidden field. On an own card there is NO username input on this page,
+      because the page is addressed per user and typing a different name here
+      would only produce a login the server refuses; a SHARED card is the one
+      exception — see `shared` below.
+
+    shared: bool
+      Whether this card is open to the whole roster (`access: any`). Off by
+      default. When true, the form gains a visible `username` input where the
+      person opening the card types their OWN roster name, and the heading reads
+      "Sign in to <user>" rather than "Enter password for <user>".
+
+    opener: str
+      Prefill for the shared card's `username` input — the opener's own roster
+      name on a re-render, empty on a first prompt. Unused when `shared` is
+      false.
 
     next: str, required
       The validated same-origin return-to. Already checked by
@@ -164,8 +176,13 @@
 <body>
   <main class="login-card">
     <p class="login-mark">OSPREY</p>
-    {#- The acceptance gate: the username is stated, never asked for. #}
+    {#- The acceptance gate: the username is stated, never asked for — except on
+        a shared card, where the person opening it names themselves below. #}
+    {%- if shared %}
+    <h1 class="login-prompt">Sign in to <span class="login-user">{{ user|e }}</span></h1>
+    {%- else %}
     <h1 class="login-prompt">Enter password for <span class="login-user">{{ user|e }}</span></h1>
+    {%- endif %}
     <p class="login-hint">You are signing in to this terminal only.</p>
     {%- if error %}
     <p class="login-error" role="alert">{{ error|e }}</p>
@@ -175,9 +192,22 @@
           re-validates both values on arrival. #}
       <input type="hidden" name="user" value="{{ user|e }}">
       <input type="hidden" name="next" value="{{ next|e }}">
+      {%- if shared %}
+      {#- The shared-card exception: anyone on the roster may open this card, so
+          the opener names themselves here. `username` is the field the POST
+          route reads the opener from. #}
+      <label class="login-label" for="username">Your roster username</label>
+      <input class="login-input" id="username" name="username" type="text"
+             value="{{ opener|e }}" autocomplete="username" autocapitalize="none"
+             spellcheck="false" autofocus required>
+      <label class="login-label" for="password">Password</label>
+      <input class="login-input" id="password" name="password" type="password"
+             autocomplete="current-password" required>
+      {%- else %}
       <label class="login-label" for="password">Password</label>
       <input class="login-input" id="password" name="password" type="password"
              autocomplete="current-password" autofocus required>
+      {%- endif %}
       <button class="login-submit" type="submit">Unlock terminal</button>
     </form>
     <a class="login-back" href="/">&larr; Choose a different user</a>

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -295,6 +295,19 @@
       OSPREY_AUTH_ROLE_CLAIM / OSPREY_AUTH_ROLE_MAP above are the deployment's
       group binding, so a user named `claim` or `map` under a plain
       OSPREY_AUTH_ROLE_ prefix would have read that binding as their own role.
+    services[].shared: bool, required — whether this entry is a shared card
+      (`access: any` on the roster entry), read through
+      personas.entry_is_shared() -> one OSPREY_AUTH_ROSTER_ACCESS_<SUFFIX>=any
+      line on the sidecar, telling it any authenticated roster user may open
+      this card. False (the default, owner-only) emits no line at all, and the
+      sidecar resolves "" — owner-only — for that entry. Emitted under BOTH
+      login methods, ungated exactly like the role table and for the same
+      structural reason: only the enclosing `sidecar_active` decides it.
+    services[].access_env: str — the env-var name the above is emitted under,
+      pre-resolved by render.py through personas.env_var_suffix(). Always
+      present; read only when `shared` is set. Pre-resolved for the same
+      reason `oidc_subject_env` is, and the `ROSTER_` infix follows the
+      `role_env` precedent above.
     services[].terminal_secret_env: str, required
       The env-var NAME this user's operator secret travels in
       (`OSPREY_TERMINAL_SECRET_<SUFFIX>`), pre-resolved by render.py through
@@ -781,7 +794,10 @@ services:
    filtered out here: they are on OSPREY_AUTH_USERS above, which is the roster
    this table is keyed from, and a role table that disagreed with that roster is
    the drift worth avoiding. Nothing is granted by it — an exempt entry has no
-   password provisioned, so no login of theirs ever reaches the lookup.
+   password provisioned, so no login of theirs ever reaches the lookup. (A
+   password-mode argument that turns load-bearing under `oidc` once shared
+   cards exist: a `login: false` entry with a mapped subject IS an eligible
+   opener, and its login does reach this table.)
 
    The variable NAME arrives pre-resolved as `svc.role_env` (render.py, via
    personas.env_var_suffix()) and is emitted verbatim, for the reason spelled
@@ -797,6 +813,29 @@ services:
 {%- for svc in services %}
 {%- if svc.role %}
       - {{ (svc.role_env ~ "=" ~ svc.role) | tojson }}
+{%- endif %}
+{%- endfor %}
+{#- The roster's shared cards -> OSPREY_AUTH_ROSTER_ACCESS_<SUFFIX>=any: one
+   line per entry that declares `access: any`, telling the sidecar any
+   authenticated roster user may open this card. An owner-only entry (the
+   default) emits nothing and the sidecar resolves "" for it — owner-only,
+   not a sharing value named "". The value is the literal `any` — the only
+   sharing value normalize_users carries through — so the sidecar re-reads
+   the same vocabulary the roster was written in.
+
+   The variable NAME arrives pre-resolved as `svc.access_env` (render.py, via
+   personas.env_var_suffix()) and is emitted verbatim, for the reason spelled
+   out on `oidc_subject_env` above; the `ROSTER_` infix follows the role
+   table's precedent. tojson quotes the whole `KEY=value` for symmetry with
+   its neighbours, though here the value is a fixed token.
+
+   Method-UNGATED exactly like the role table above and for the same
+   structural reason: the enclosing `sidecar_active` is what keeps it out of
+   a login-free deployment, and both sidecar methods mint sessions that must
+   know which cards are open to the roster. #}
+{%- for svc in services %}
+{%- if svc.shared %}
+      - {{ (svc.access_env ~ "=any") | tojson }}
 {%- endif %}
 {%- endfor %}
     volumes:

--- a/tests/cli/test_summary_card.py
+++ b/tests/cli/test_summary_card.py
@@ -884,6 +884,57 @@ class TestTokenLoginClosingLine:
         assert "alice" not in printed.split("no login page")[1]
 
 
+class TestSharedCardClosingLine:
+    """A shared card is in neither the sign-in pairs nor the login-url list.
+
+    It holds no credential of its own — verify checks the OPENER's credential —
+    so without its own line the card would present a roster entry with no way
+    in at all. The line names the way in: another roster user's name and
+    credential. Names only, never URLs, like everything else on this card.
+    """
+
+    def test_a_shared_card_is_told_how_it_is_opened(
+        self, repo_with_logins: Path, recorder: Recorded
+    ) -> None:
+        """One shared entry gets the singular phrasing: `is a shared card`."""
+        config = repo_with_logins / "build" / "config.yml"
+        config.write_text(
+            config.read_text() + "      - name: ops\n        index: 2\n        access: any\n"
+        )
+
+        print_summary_card(repo_with_logins, "running")
+
+        printed = "\n".join(recorder.lines)
+        assert "ops is a shared card with no login of its own" in printed
+        assert "another roster user's name and credential" in printed
+        # ...and it reached neither of the other two legs of the split.
+        assert "ops /" not in printed
+        assert "login-url ops" not in printed
+
+    def test_two_shared_cards_get_the_plural_phrasing(
+        self, repo_with_logins: Path, recorder: Recorded
+    ) -> None:
+        config = repo_with_logins / "build" / "config.yml"
+        config.write_text(
+            config.read_text()
+            + "      - name: ops\n        index: 2\n        access: any\n"
+            + "      - name: crew\n        index: 3\n        access: any\n"
+        )
+
+        print_summary_card(repo_with_logins, "running")
+
+        printed = "\n".join(recorder.lines)
+        assert "ops, crew are shared cards with no login of their own" in printed
+
+    def test_a_roster_without_shared_cards_gets_no_such_line(
+        self, repo_with_logins: Path, recorder: Recorded
+    ) -> None:
+        """Every entry there has its own way in, already named above it."""
+        print_summary_card(repo_with_logins, "running")
+
+        assert "shared card" not in "\n".join(recorder.lines)
+
+
 def test_the_card_flags_dangerously_allow_bash(repo: Path):
     """A deployment running under the waiver says so on the card operators read
     after every deploy; one absent from the config leaves no trace."""

--- a/tests/deployment/test_deploy_summary.py
+++ b/tests/deployment/test_deploy_summary.py
@@ -1360,3 +1360,64 @@ def test_every_deploy_exit_path_shares_this_one_seam():
     from osprey.deployment import container_lifecycle
 
     assert container_lifecycle.log_endpoint_summary is deploy_summary.log_endpoint_summary
+
+
+# ---------------------------------------------------------------------------
+# The roster's three-way split behind a login wall: an entry with its own
+# required login reaches the seeded-logins report, a `login: false` entry
+# reaches the token-URL list, and a shared entry (`access: any`) reaches
+# NEITHER — it holds no credential of its own and is opened with another
+# roster user's name and credential, which is what `_shared_cards` exists to
+# say.
+# ---------------------------------------------------------------------------
+
+
+def _walled_roster_config(method: str = "password") -> dict:
+    return {
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "nginx_port": 8080,
+                "auth": {"method": method},
+                "users": [
+                    {"name": "alice", "index": 0},
+                    {"name": "ariel", "index": 1, "login": False},
+                    {"name": "ops", "index": 2, "access": "any"},
+                ],
+            }
+        }
+    }
+
+
+@pytest.fixture
+def walled_roster_root(tmp_path):
+    """A root whose profile still seeds alice's password, so the seeded-logins
+    report has something to print for the one entry that owns a login."""
+    (tmp_path / "profile.yml").write_text("env:\n  defaults:\n    OSPREY_AUTH_PW_ALICE: alice\n")
+    (tmp_path / ".env").write_text("OSPREY_AUTH_PW_ALICE=alice\n")
+    return tmp_path
+
+
+def test_a_shared_entry_is_in_neither_the_seeded_logins_nor_the_token_list(
+    walled_roster_root,
+):
+    """The split, pinned whole: were `ops` in the seeded report the card would
+    print a password nothing checks, and were it in the token list the card
+    would name a login URL the wall makes inert. It belongs to the third leg
+    alone."""
+    config = _walled_roster_config()
+
+    seeded = deploy_summary._seeded_logins(walled_roster_root, config)
+    tokens = deploy_summary.token_login_users(config)
+
+    assert [user for user, _ in seeded.printable] == ["alice"]
+    assert tokens == ["ariel"]
+    assert deploy_summary._shared_cards(config) == ["ops"]
+
+
+def test_shared_cards_are_reported_only_while_a_wall_stands():
+    """Without a login wall the sharing marker changes nothing about how the
+    entry is reached — under `token` every terminal is entered through its own
+    URL, shared or not — so naming it would be noise."""
+    assert deploy_summary._shared_cards(_walled_roster_config("token")) == []
+    assert deploy_summary._shared_cards(_walled_roster_config("oidc")) == ["ops"]

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -1516,6 +1516,22 @@ def test_passwd_refuses_a_login_false_user(tmp_path, monkeypatch, fake_runtime):
     assert fake_runtime == []
 
 
+def test_passwd_refuses_a_shared_card(tmp_path, monkeypatch, fake_runtime):
+    """A shared (`access: any`) card is opened with another roster user's
+    password — /verify checks the OPENER's credential — so it has no password
+    of its own, and "changing" it would store a hash nothing ever checks."""
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_config(
+        tmp_path, _auth_config(["alice", {"name": "ops", "index": 1, "access": "any"}])
+    )
+
+    with pytest.raises(ValueError, match="access: any"):
+        lifecycle.rotate_user_password(str(config_path), "ops", "some-password")
+
+    assert not (tmp_path / AUTH_ENV_FILENAME).exists()
+    assert fake_runtime == []
+
+
 def test_passwd_refuses_before_writing_when_the_runtime_is_down(tmp_path, monkeypatch):
     """Gate on the runtime BEFORE the write: otherwise the operator is handed a
     password the deployment was never told about."""

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -631,6 +631,169 @@ def test_lint_login_false_with_auth_on_reports_nothing() -> None:
     assert not any(f.code == "web_terminals.user_login_inert" for f in findings)
 
 
+def test_lint_non_literal_user_access_is_an_error() -> None:
+    """An `access` value that is not exactly 'own' or 'any' deploys fail-closed
+    as `own`, which may be the opposite of what the author believes — so the
+    typo is an ERROR rather than a silent narrowing."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "access": "maybe"}
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.invalid_user_access" for f in _errors(findings))
+
+
+def test_lint_wrong_case_user_access_is_an_error() -> None:
+    """The normalizer keeps only the literal lowercase 'any' — `access: ANY`
+    silently deploys as `own`, so lint must call the spelling out."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "access": "ANY"}
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.invalid_user_access" for f in _errors(findings))
+
+
+def test_lint_boolean_user_access_is_an_error() -> None:
+    """`access: true` (a plausible YAML slip for 'any') is not a literal and
+    deploys as `own` — an ERROR, not a widened entry."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0, "access": True}]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.invalid_user_access" for f in _errors(findings))
+
+
+def test_lint_user_access_skips_non_dict_entries() -> None:
+    """Bare-string (and otherwise malformed) roster entries carry no `access`
+    key — the check skips them without crashing and reports nothing."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = ["thellert", 42]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.invalid_user_access" for f in findings)
+    assert not any(f.code == "web_terminals.user_access_inert" for f in findings)
+
+
+def test_lint_access_any_without_sidecar_is_an_inert_key_warning() -> None:
+    """`access: any` under the default `auth.method: token` changes nothing —
+    no sidecar stands a login wall, so every terminal is already as reachable
+    as the key promises to make this one."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "access": "any"}
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.user_access_inert" for f in _warnings(findings))
+
+
+def test_lint_access_any_under_auth_none_is_an_inert_key_warning() -> None:
+    """Under `auth.method: none` the key is inert too: `login: false` still
+    means something there (it withholds the injected secret), but `access`
+    reads the sidecar-established identity, and there is none."""
+    # Arrange
+    config = _auth_config({"method": "none"}, tls=False, fqdn=None)
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "access": "any"}
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.user_access_inert" for f in _warnings(findings))
+
+
+def test_lint_access_any_on_a_login_exempt_entry_is_an_inert_key_warning() -> None:
+    """`access: any` together with `login: false` under a walled deployment:
+    nginx proxies the login-exempt entry with no auth_request, so there is no
+    authenticated identity for `access` to widen."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    web_terminals = config["modules"]["web_terminals"]
+    web_terminals["auth"] = {"method": "password", "allow_insecure_http": True}
+    web_terminals["users"] = [
+        {"name": "thellert", "index": 0, "access": "any", "login": False},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert any(f.code == "web_terminals.user_access_inert" for f in _warnings(findings))
+
+
+def test_lint_access_any_under_walled_auth_reports_nothing() -> None:
+    """The intended use — a privileged entry in an authenticated deployment —
+    is clean."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    web_terminals = config["modules"]["web_terminals"]
+    web_terminals["auth"] = {"method": "password", "allow_insecure_http": True}
+    web_terminals["users"] = [{"name": "thellert", "index": 0, "access": "any"}]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.invalid_user_access" for f in findings)
+    assert not any(f.code == "web_terminals.user_access_inert" for f in findings)
+
+
+def test_lint_explicit_access_own_reports_nothing() -> None:
+    """`access: own` is a valid spelling of the default — silent, even though
+    the normalizer drops it."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "access": "own"}
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.invalid_user_access" for f in findings)
+    assert not any(f.code == "web_terminals.user_access_inert" for f in findings)
+
+
+def test_lint_roster_without_access_keys_reports_no_access_findings() -> None:
+    """An all-default roster (no entry declares `access`) introduces neither of
+    the new finding codes."""
+    # Arrange
+    config = copy.deepcopy(_CLEAN_CONFIG)
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.invalid_user_access" for f in findings)
+    assert not any(f.code == "web_terminals.user_access_inert" for f in findings)
+
+
 def test_lint_non_string_user_theme_is_an_error() -> None:
     """A non-string `theme` (a config typo) is rejected — the renderer would
     otherwise drop it silently."""
@@ -3023,6 +3186,89 @@ def test_lint_auth_credential_collision_not_reported_when_auth_is_off() -> None:
     assert not any(f.code == "web_terminals.auth_credential_collision" for f in _errors(findings))
 
 
+def test_lint_duplicate_subject_with_a_shared_card_is_an_error() -> None:
+    """One person holding two cards (same subject, one per role) is fine on an
+    owner-only roster — but with a shared card present the sidecar must resolve
+    every login to a single entry, so the duplicate becomes a refused login
+    (`ambiguous_identity`) and lint says so while the fix is still cheap.
+    Stripped-exact comparison: surrounding whitespace does not hide a match."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "thellert-admin", "index": 1, "oidc_subject": " thorsten@example.org "},
+        {"name": "control", "index": 2, "access": "any", "oidc_subject": "svc@example.org"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    offenders = [
+        f for f in _errors(findings) if f.code == "web_terminals.shared_card_duplicate_subject"
+    ]
+    assert len(offenders) == 1
+    assert "thellert" in offenders[0].message
+    assert "thellert-admin" in offenders[0].message
+    assert "control" not in offenders[0].message
+    assert "ambiguous_identity" in offenders[0].message
+    assert "one of them only" in offenders[0].message
+
+
+def test_lint_duplicate_subject_without_a_shared_card_reports_nothing() -> None:
+    """The same two-cards-one-person roster with no shared entry is silent:
+    every login still arrives through the card that was clicked, so nothing
+    is ambiguous — the documented behaviour change, pinned from both sides."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "thellert-admin", "index": 1, "oidc_subject": "thorsten@example.org"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.shared_card_duplicate_subject" for f in findings)
+
+
+def test_lint_distinct_subjects_with_a_shared_card_report_nothing() -> None:
+    """A shared card alone is not the finding — every subject mapping to one
+    entry resolves unambiguously."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "gmartino", "index": 1, "oidc_subject": "gmartino@example.org"},
+        {"name": "control", "index": 2, "access": "any"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.shared_card_duplicate_subject" for f in findings)
+
+
+def test_lint_duplicate_subject_check_is_mode_gated() -> None:
+    """Password mode reads no subject mapping at all — leftover subjects from
+    an earlier oidc posture cannot collide."""
+    # Arrange
+    config = _auth_config({"method": "password"})
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "thellert-admin", "index": 1, "oidc_subject": "thorsten@example.org"},
+        {"name": "control", "index": 2, "access": "any"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.shared_card_duplicate_subject" for f in findings)
+
+
 # --- profile altitude: the same engine over a build profile's `config:` block -
 
 
@@ -3825,3 +4071,68 @@ def test_lint_open_mode_with_the_shipped_deny_list_reports_nothing(tmp_path) -> 
 
     # Assert
     assert not any(f.code == "web_terminals.open_mode_egress" for f in findings)
+
+
+# --- shared cards on privileged personas --------------------------------------
+
+
+def _shipped_profile_config() -> dict:
+    """The shipped `control-assistant` host preset, resolved and deep-copied.
+
+    The one roster shape the shared-card guard exists for: a privileged
+    `admin` tier (carol) behind a login, unprivileged tiers beside it.
+    """
+    from osprey.cli.build_profile import resolve_build_profile
+
+    resolved, _profile_dir = resolve_build_profile(None, "control-assistant")
+    return copy.deepcopy(resolved.config)
+
+
+def test_lint_shared_card_on_a_privileged_persona_is_an_error() -> None:
+    """`access: any` on the card that resolves to the setup-patch-capable
+    `admin` persona hands the deployment-editing surfaces to every roster
+    login — an ERROR naming the entry, the privileges and the remedy."""
+    # Arrange
+    config = _shipped_profile_config()
+    for user in config["modules.web_terminals"]["users"]:
+        if user["name"] == "carol":
+            user["access"] = "any"
+
+    # Act
+    findings = lint_profile_config(config)
+
+    # Assert
+    offenders = [f for f in _errors(findings) if f.code == "web_terminals.shared_card_privileged"]
+    assert len(offenders) == 1
+    assert "'carol'" in offenders[0].message
+    assert "'admin'" in offenders[0].message
+    assert "access: own" in offenders[0].message
+    assert "[" not in offenders[0].message
+
+
+def test_lint_shared_card_on_an_unprivileged_persona_reports_nothing() -> None:
+    """Sharing bob's `readonly` card is the feature — no finding."""
+    # Arrange
+    config = _shipped_profile_config()
+    for user in config["modules.web_terminals"]["users"]:
+        if user["name"] == "bob":
+            user["access"] = "any"
+
+    # Act
+    findings = lint_profile_config(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.shared_card_privileged" for f in findings)
+
+
+def test_lint_owner_only_privileged_card_draws_no_shared_finding() -> None:
+    """The shipped preset unchanged: carol's admin card is owner-only, which
+    is the existing login rule's domain — this rule stays silent."""
+    # Arrange
+    config = _shipped_profile_config()
+
+    # Act
+    findings = lint_profile_config(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.shared_card_privileged" for f in findings)

--- a/tests/deployment/web_terminals/test_personas.py
+++ b/tests/deployment/web_terminals/test_personas.py
@@ -19,6 +19,7 @@ from osprey.deployment.web_terminals.personas import (
     config_needs_launch_token,
     config_needs_launch_token_for,
     effective_persona,
+    entry_is_shared,
     entry_requires_login,
     env_var_suffix,
     env_var_suffix_collisions,
@@ -34,6 +35,7 @@ from osprey.deployment.web_terminals.personas import (
     resolve_authorization_roles,
     resolve_personas,
     settings_json_denies_bash,
+    shared_card_privileged_problems,
 )
 from osprey.registry.mcp import FRAMEWORK_SERVERS
 
@@ -1225,6 +1227,129 @@ def test_resolve_personas_threads_login_false_through_both_branches() -> None:
     assert zero_migration[0]["login"] is False
     assert persona_branch[0]["login"] is False
     assert "login" not in undeclared[0]
+
+
+def test_normalize_users_carries_access_any_through() -> None:
+    """`access: any` — the one value that changes anything — rides onto the
+    normalized entry."""
+    # Act
+    result = normalize_users([{"name": "control", "index": 3, "access": "any"}])
+
+    # Assert
+    assert result == [{"name": "control", "index": 3, "access": "any"}]
+
+
+def test_normalize_users_drops_every_other_access_spelling() -> None:
+    """`own`, absence, and every malformed spelling all normalize to "owner
+    only" — a typo can lock an entry down, never share it with the roster."""
+    # Act / Assert — the explicit default and non-string spellings alike leave
+    # the plain two-key shape, so downstream reads them all as owner-only
+    for spelling in ("own", "ANY", "Any", True, 1, None, ["any"], ""):
+        result = normalize_users([{"name": "control", "index": 3, "access": spelling}])
+        assert result == [{"name": "control", "index": 3}], repr(spelling)
+
+
+def test_shared_card_privileged_problems_names_entry_privileges_and_remedy() -> None:
+    """A shared card on a privileged persona is reported with the user, the
+    persona, what it holds, and both halves of the remedy — in rich-safe
+    prose (`osprey build` renders refusals through rich, which eats `[...]`)."""
+    # Arrange
+    resolved = [
+        {"name": "control", "index": 0, "persona": "admin", "access": "any"},
+        {"name": "carol", "index": 1, "persona": "admin"},
+    ]
+
+    # Act
+    problems = shared_card_privileged_problems(resolved, {"admin": ("the web Config panel",)})
+
+    # Assert
+    assert len(problems) == 1
+    assert "'control'" in problems[0]
+    assert "'admin'" in problems[0]
+    assert "the web Config panel" in problems[0]
+    assert "access: own" in problems[0]
+    assert "carol" not in problems[0]
+    assert "[" not in problems[0]
+
+
+def test_shared_card_privileged_problems_silent_for_an_unprivileged_persona() -> None:
+    """Sharing an unprivileged card is the feature, not the finding — a persona
+    absent from the privilege map (or mapped to nothing) draws no message."""
+    # Arrange
+    resolved = [
+        {"name": "control", "index": 0, "persona": "ariel", "access": "any"},
+        {"name": "gui", "index": 1, "persona": "readonly", "access": "any"},
+    ]
+
+    # Act / Assert
+    assert shared_card_privileged_problems(resolved, {"admin": ("the web Config panel",)}) == []
+    assert shared_card_privileged_problems(resolved, {"readonly": ()}) == []
+
+
+def test_shared_card_privileged_problems_silent_for_an_owner_only_card() -> None:
+    """A privileged persona behind an owner-only card is the login rule's
+    domain, not this one's — no `access: any`, no message. An entry with no
+    persona in effect has no tier to be privileged either way."""
+    # Arrange
+    privileges = {"admin": ("the web Config panel",)}
+    owner_only = [{"name": "carol", "index": 0, "persona": "admin"}]
+    no_persona = [{"name": "control", "index": 1, "persona": None, "access": "any"}]
+
+    # Act / Assert
+    assert shared_card_privileged_problems(owner_only, privileges) == []
+    assert shared_card_privileged_problems(no_persona, privileges) == []
+
+
+def test_entry_is_shared_reads_only_the_literal_any() -> None:
+    """The shared predicate: one reading of the key for provisioning, the
+    deploy summary, the passwd refusal, the render, and lint."""
+    assert entry_is_shared({"name": "alice", "index": 0}) is False
+    assert entry_is_shared({"name": "control", "index": 3, "access": "any"}) is True
+    assert entry_is_shared({"name": "control", "index": 3, "access": "own"}) is False
+    assert entry_is_shared({"name": "control", "index": 3, "access": "ANY"}) is False
+    assert entry_is_shared({"name": "control", "index": 3, "access": True}) is False
+
+
+def test_resolve_personas_threads_access_any_through_both_branches() -> None:
+    """The sharing marker survives resolution on the zero-migration path and
+    the persona-catalog path alike, and stays absent when never declared."""
+    # Act
+    zero_migration = resolve_personas(
+        {"users": [{"name": "control", "index": 0, "access": "any"}]}, _REGISTRY, "als"
+    )
+    persona_branch = resolve_personas(
+        {
+            "users": [{"name": "control", "index": 0, "persona": "gui", "access": "any"}],
+            "personas": {"gui": {"project": "als-gui"}},
+        },
+        _REGISTRY,
+        "als",
+    )
+    undeclared = resolve_personas({"users": ["alice"]}, _REGISTRY, "als")
+
+    # Assert
+    assert zero_migration[0]["access"] == "any"
+    assert persona_branch[0]["access"] == "any"
+    assert "access" not in undeclared[0]
+
+
+def test_freeze_user_indices_access_any_survives_a_freeze_round_trip() -> None:
+    """The decommission write-back keeps `access: any` on a survivor: freezing
+    re-attaches the authored key verbatim, so a user removal never quietly
+    un-shares another entry."""
+    # Arrange
+    users_raw = ["alice", {"name": "control", "index": 1, "access": "any"}]
+
+    # Act
+    frozen = freeze_user_indices(users_raw)
+    refrozen = freeze_user_indices(frozen)
+
+    # Assert
+    assert frozen == [
+        {"name": "alice", "index": 0},
+        {"name": "control", "index": 1, "access": "any"},
+    ]
+    assert refrozen == frozen
 
 
 def test_resolve_personas_exposes_oidc_subject_when_set() -> None:

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -448,6 +448,37 @@ def test_preflight_mints_no_credential_for_a_login_false_entry(monkeypatch, tmp_
     assert calls == [["alice", "bob"]]
 
 
+def test_preflight_mints_no_credential_for_a_shared_entry(monkeypatch, tmp_path):
+    """A roster entry with `access: any` is left out of the password mint: a
+    shared card holds no password of its own — verify checks the OPENER's
+    credential — so a hash under its name would be a credential nothing ever
+    checks, and a minted password printed for it would misdescribe how the
+    card is opened."""
+    calls: list[list[str]] = []
+    env_auth = tmp_path / AUTH_ENV_FILENAME
+
+    def _fake_credentials(usernames, project_root, **kwargs):
+        calls.append(list(usernames))
+        return _credentials_result(env_auth, users=usernames)
+
+    monkeypatch.setattr(provision, "ensure_auth_credentials", _fake_credentials)
+    monkeypatch.setattr(
+        provision, "ensure_auth_session_secrets", lambda root: _secrets_result(env_auth)
+    )
+
+    config = _auth_config(
+        "password",
+        users=[
+            "alice",
+            {"name": "ops", "index": 1, "access": "any"},
+            {"name": "bob", "index": 2},
+        ],
+    )
+    _run_preflight(monkeypatch, tmp_path, config)
+
+    assert calls == [["alice", "bob"]]
+
+
 # ---------------------------------------------------------------------------
 # preflight_web_terminals -- per-user terminal secrets. Provisioned for EVERY
 # deployment, outside the `auth.method: none` early return that governs the

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -3459,6 +3459,55 @@ def test_auth_sidecar_service_omits_the_oidc_claim_unless_the_facility_names_one
     assert not [line for line in auth_env if line.startswith("OSPREY_AUTH_OIDC_CLAIM")]
 
 
+@pytest.mark.parametrize("method", ["password", "oidc"])
+def test_auth_sidecar_service_marks_each_shared_card_from_the_roster(method: str) -> None:
+    """A roster entry with `access: any` renders exactly one
+    `OSPREY_AUTH_ROSTER_ACCESS_<SUFFIX>=any` line on the sidecar — under BOTH
+    sidecar methods, because both mint sessions that must know which cards are
+    open to the roster. Owner-only entries (the default) emit no line at all,
+    rather than an explicit owner-only value the sidecar would have to parse.
+
+    The suffix is whatever env_var_suffix() says it is — asserted for a
+    hyphenated name, which is where a hand-rolled second mapping would drift.
+    """
+    # Arrange
+    config = _auth_config(
+        ["alice", {"name": "ops-review", "index": 1, "access": "any"}, "bob"],
+        method=method,
+    )
+
+    # Act
+    compose = _compose(config)
+
+    # Assert — the shared entry's line carries the literal sharing value, and no
+    # owner-only entry gets a line of its own.
+    suffix = env_var_suffix("ops-review")
+    assert _service_env(compose, "auth")[f"OSPREY_AUTH_ROSTER_ACCESS_{suffix}"] == "any"
+    access_names = [
+        name
+        for name in _env_names(compose["services"]["auth"])
+        if name.startswith("OSPREY_AUTH_ROSTER_ACCESS_")
+    ]
+    assert access_names == [f"OSPREY_AUTH_ROSTER_ACCESS_{suffix}"]
+
+
+@pytest.mark.parametrize("method", ["token", "none"])
+def test_no_roster_access_line_renders_for_a_method_that_stands_no_wall(method: str) -> None:
+    """`token` and `none` render no sidecar, and the shared-card marker rides only
+    on the sidecar — so a shared roster under a wall-less posture leaves no
+    OSPREY_AUTH_ROSTER_ACCESS reference anywhere in the overlay. Nothing else
+    could read one: with no login wall there is no session to open a card with."""
+    # Arrange
+    config = _config(["alice", {"name": "ops-review", "index": 1, "access": "any"}])
+    config["modules"]["web_terminals"]["auth"] = {"method": method}
+
+    # Act
+    rendered = render_web_terminals(config)["docker-compose.web.yml"]
+
+    # Assert
+    assert "OSPREY_AUTH_ROSTER_ACCESS" not in rendered
+
+
 def test_auth_sidecar_service_names_a_configured_non_default_oidc_claim() -> None:
     """An IdP that carries the mappable identity somewhere other than `sub` (a
     facility SSO keyed on `email` or `preferred_username`) is configured by name, and

--- a/tests/deployment/web_terminals/test_sidecar_role_env.py
+++ b/tests/deployment/web_terminals/test_sidecar_role_env.py
@@ -29,6 +29,12 @@ table the sidecar's own parser builds from it — because either end alone can b
 self-consistently wrong. Every variable name is imported from the sidecar rather
 than spelled out here, so a rename on that side fails here instead of silently
 rendering a variable nothing reads.
+
+The roster's `access: any` marker rides the same seam under its own family
+(`OSPREY_AUTH_ROSTER_ACCESS_<SUFFIX>`, read back by `AuthSettings.from_env`),
+and is pinned here the same way — the render spells the prefix literally for
+the same import-weight reason the role prefix is, so this round trip is the
+only thing that fails when either side renames it.
 """
 
 from __future__ import annotations
@@ -42,7 +48,7 @@ import yaml
 from osprey.deployment.web_terminals import render as render_module
 from osprey.deployment.web_terminals.personas import env_var_suffix
 from osprey.deployment.web_terminals.render import render_web_terminals
-from osprey.services.auth_sidecar.app import ENV_USERS
+from osprey.services.auth_sidecar.app import ENV_ROSTER_ACCESS_PREFIX, ENV_USERS, AuthSettings
 from osprey.services.auth_sidecar.routes.oidc import ENV_ROLE_CLAIM, ENV_ROLE_MAP, RoleBinding
 from osprey.services.auth_sidecar.routes.recheck import ENV_ROSTER_ROLE_PREFIX, RosterRoles
 
@@ -493,3 +499,70 @@ class TestTheRosterRoleReachesTheSidecar:
         # Assert — one scalar, and still the whole role name.
         assert _roster_role_lines(env_lines) == [f"{_role_var('alice')}={_SEPARATOR_ROLE}"]
         assert _roster_roles(env_lines).role_for("alice") == _SEPARATOR_ROLE
+
+
+# ---------------------------------------------------------------------------
+# The shared card: the roster's own `access: any`
+# ---------------------------------------------------------------------------
+
+#: One shared card beside one owner-only entry, because the two shapes coexist
+#: in a real roster and the render walks them in a single pass. The shared
+#: entry's name carries a `-` so the expected variable exercises the real
+#: suffix mapping (`-` maps to `_`), not just an uppercasing.
+_ACCESS_ROSTER = [
+    {"name": "control-room", "index": 0, "access": "any"},
+    {"name": "alice", "index": 1},
+]
+
+
+def _access_lines(env_lines: list[str]) -> list[str]:
+    return [line for line in env_lines if line.startswith(ENV_ROSTER_ACCESS_PREFIX)]
+
+
+def _access_var(username: str) -> str:
+    """The variable one entry's access rule is expected under, derived the one way."""
+    return f"{ENV_ROSTER_ACCESS_PREFIX}{env_var_suffix(username)}"
+
+
+def _settings(env_lines: list[str]) -> AuthSettings:
+    """The settings the sidecar builds from exactly what the render handed it."""
+    return AuthSettings.from_env(dict(line.split("=", 1) for line in env_lines))
+
+
+class TestTheSharedCardMarkerReachesTheSidecar:
+    """One `OSPREY_AUTH_ROSTER_ACCESS_<SUFFIX>=any` per shared entry, none otherwise."""
+
+    def test_a_shared_entry_is_emitted_under_its_own_access_variable(self) -> None:
+        """The exact line, with the variable name derived rather than spelled.
+
+        The value is the literal `any` — the only sharing vocabulary
+        `normalize_users` carries through — and the owner-only entry emits no
+        line under any spelling: an absent variable is what the sidecar reads
+        as owner-only, so a dead `=own` line would be a second spelling of the
+        default for every deployment that never shares a card.
+        """
+        # Act
+        env_lines = _sidecar_env(_config(method="password", users=_ACCESS_ROSTER))
+        access_lines = _access_lines(env_lines)
+
+        # Assert
+        assert access_lines == [f"{_access_var('control-room')}=any"]
+        assert f"{ENV_ROSTER_ACCESS_PREFIX}CONTROL_ROOM=any" in env_lines
+        assert not [line for line in access_lines if line.startswith(_access_var("alice"))]
+        assert not [line for line in access_lines if "ALICE" in line]
+
+    def test_the_rendered_marker_round_trips_through_the_sidecars_own_settings(self) -> None:
+        """What the render emits is what `AuthSettings.from_env()` reads back.
+
+        The assertion that matters end to end: not that an env line exists, but
+        that the settings the sidecar builds answer `shared()` with the sharing
+        the facility wrote, against the entry it wrote it for — the both-ends
+        agreement that makes a rename on either side fail here.
+        """
+        # Act
+        settings = _settings(_sidecar_env(_config(method="password", users=_ACCESS_ROSTER)))
+
+        # Assert
+        assert settings.shared("control-room") is True
+        assert settings.shared("alice") is False
+        assert settings.shared_users == frozenset({"control-room"})

--- a/tests/services/auth_sidecar/test_app.py
+++ b/tests/services/auth_sidecar/test_app.py
@@ -547,6 +547,36 @@ class TestSettingsParsing:
         assert isinstance(app.state.settings, AuthSettings)
         assert app.state.settings.method == "password"
 
+    def test_nobody_is_shared_when_no_access_rule_is_set(self) -> None:
+        settings = AuthSettings.from_env(PASSWORD_ENV)
+        assert settings.shared("alice") is False
+        assert settings.shared("nobody") is False
+
+    def test_roster_access_any_marks_the_user_shared(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_ROSTER_ACCESS_ALICE="any")
+        settings = AuthSettings.from_env(env)
+        assert settings.shared("alice") is True
+        assert settings.shared("bob") is False
+
+    @pytest.mark.parametrize("value", ["own", "ANY", "Any", "yes", "any-thing", ""])
+    def test_any_other_access_value_fails_closed(self, value: str) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_ROSTER_ACCESS_ALICE=value)
+        assert AuthSettings.from_env(env).shared("alice") is False
+
+    def test_access_rules_outside_the_roster_are_not_loaded(self) -> None:
+        env = dict(PASSWORD_ENV, OSPREY_AUTH_ROSTER_ACCESS_MALLORY="any")
+        settings = AuthSettings.from_env(env)
+        assert settings.shared("mallory") is False
+        assert settings.shared_users == frozenset()
+
+    def test_roster_access_uses_the_shared_suffix_mapping(self) -> None:
+        env = dict(
+            PASSWORD_ENV,
+            OSPREY_AUTH_USERS="shift-console",
+            OSPREY_AUTH_ROSTER_ACCESS_SHIFT_CONSOLE="any",
+        )
+        assert AuthSettings.from_env(env).shared("shift-console") is True
+
 
 class TestSharedStores:
     """The revocation store and attempt throttle follow the codec's pattern.

--- a/tests/services/auth_sidecar/test_identity_headers.py
+++ b/tests/services/auth_sidecar/test_identity_headers.py
@@ -1,0 +1,46 @@
+"""Tests for the identity-headers module's constant-time comparator.
+
+:func:`~osprey.services.auth_sidecar.identity_headers.same_value` is the one
+equality check every identity decision in the sidecar goes through, so what is
+pinned here is small and load-bearing: equal values match, unequal values do
+not, and a non-ASCII value on either side is *compared* rather than raising —
+the exact failure mode that motivated encoding to UTF-8 bytes before handing
+the pair to :func:`secrets.compare_digest`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.services.auth_sidecar.identity_headers import same_value
+
+
+def test_equal_values_match() -> None:
+    assert same_value("alice", "alice") is True
+
+
+def test_unequal_values_do_not_match() -> None:
+    assert same_value("alice", "alicia") is False
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ("jörg@example.org", "jörg@example.org", True),
+        ("jörg@example.org", "jorg@example.org", False),
+        ("ascii", "jörg", False),
+    ],
+)
+def test_non_ascii_values_compare_instead_of_raising(left: str, right: str, expected: bool) -> None:
+    assert same_value(left, right) is expected
+
+
+def test_empty_against_nonempty_does_not_match() -> None:
+    assert same_value("", "alice") is False
+    assert same_value("", "") is True
+
+
+def test_public_name_is_importable() -> None:
+    from osprey.services.auth_sidecar.identity_headers import same_value as imported
+
+    assert imported is same_value

--- a/tests/services/auth_sidecar/test_login.py
+++ b/tests/services/auth_sidecar/test_login.py
@@ -3,10 +3,12 @@
 Three properties carry most of the weight here, and each is pinned from several
 directions:
 
-* **The page is addressed per user.** It states the username and never asks for
-  one, and the username it unlocks travels into the session cookie byte for byte
-  — verify exact-matches it against the roster, so any normalisation here would
-  break the chain open rather than closed.
+* **The page is addressed per user.** It states the username and — on an own
+  card — never asks for one; the one exception is a shared card (``access:
+  any``), where the opener names *themselves*, never the terminal. The username
+  it unlocks travels into the session cookie byte for byte — verify
+  exact-matches it against the roster, so any normalisation here would break
+  the chain open rather than closed.
 * **Every refusal is the same refusal.** A wrong password, a roster user with no
   provisioned credential and a username that is not on the roster at all produce
   the same status, the same page and the same call into the throttle. The
@@ -40,6 +42,7 @@ from osprey.services.auth_sidecar.routes.login import (
     OIDC_LOGIN_PATH,
     THROTTLE_MESSAGE,
 )
+from osprey.services.auth_sidecar.routes.recheck import RosterRoles
 from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME, SessionCodec, SessionState
 from osprey.services.auth_sidecar.throttle import AttemptThrottle
 
@@ -344,6 +347,272 @@ def test_the_refusals_that_are_not_pages_are_uncacheable_too() -> None:
     ):
         assert response.status_code in (400, 404)
         assert response.headers["cache-control"] == "no-store"
+
+
+# --- Shared cards -----------------------------------------------------------
+
+SHARED_ENV = {**PASSWORD_ENV, "OSPREY_AUTH_ROSTER_ACCESS_BOB": "any"}
+"""The default roster with bob's card opened to the whole roster (``any``).
+
+Alice keeps the default own-card rule, so one env pins both page shapes — and
+pins that opening one card changes nothing about the others.
+"""
+
+
+def test_a_shared_card_asks_the_opener_to_name_themselves() -> None:
+    """A shared card's page gains a visible username field, and says "Sign in to"."""
+    response = _client(SHARED_ENV).get(LOGIN_PATH, params={"user": "bob", "next": "/u/bob/"})
+
+    assert response.status_code == 200
+    assert "Sign in to" in response.text
+    assert "Enter password for" not in response.text
+
+    fields = _inputs(response.text)
+    opener = [field for field in fields if 'name="username"' in field]
+    assert len(opener) == 1
+    assert 'type="text"' in opener[0]
+    assert "required" in opener[0]
+    # The card's own name still travels hidden: the opener names themselves,
+    # never the terminal they are opening.
+    assert any('type="hidden"' in field and 'name="user"' in field for field in fields)
+
+
+def test_a_shared_neighbour_does_not_leak_into_an_own_cards_page() -> None:
+    """Alice's page is the same page whether or not bob's card is shared.
+
+    Both renders are post-change, so the byte comparison pins NON-LEAKAGE — a
+    shared card on the roster changes nothing about its neighbours — not
+    identity to the pre-change template. The explicit content assertions below
+    are the stand-in for that: the own-card heading, exactly as the template
+    spells it, and no username field anywhere on the page.
+    """
+    params = {"user": "alice", "next": "/u/alice/"}
+    with_shared_neighbour = _client(SHARED_ENV).get(LOGIN_PATH, params=params)
+    without = _client().get(LOGIN_PATH, params=params)
+
+    assert with_shared_neighbour.status_code == 200
+    assert with_shared_neighbour.text == without.text
+    assert (
+        '<h1 class="login-prompt">Enter password for '
+        '<span class="login-user">alice</span></h1>' in with_shared_neighbour.text
+    )
+    assert "Sign in to" not in with_shared_neighbour.text
+    assert 'name="username"' not in with_shared_neighbour.text
+
+
+def _shared_login(
+    client: TestClient,
+    *,
+    card: str = "bob",
+    opener: str = "alice",
+    password: str = ALICE_PASSWORD,
+    next_value: str = "",
+) -> httpx.Response:
+    """POST one shared-card attempt: the opener's own name, the opener's password."""
+    return _post(
+        client,
+        {"user": card, "username": opener, "next": next_value, "password": password},
+    )
+
+
+def test_a_shared_card_opens_with_the_openers_credential() -> None:
+    """The card is unlocked, the opener is recorded, and the role is the card's.
+
+    Everything stays keyed on the card — the session entry, the role, the
+    return-to — while the credential evaluated and the generation tag stamped
+    are the opener's. The opener themselves is NOT unlocked: their name proved
+    the login, it did not join the session.
+    """
+    app = create_app(SHARED_ENV)
+    # The role table is read from the process env by the module that owns it,
+    # so the test seeds the app.state cache the route consults — a role on
+    # bob's CARD, none for the opener.
+    app.state.roster_roles = RosterRoles({"bob": "operator"})
+    client = TestClient(app, base_url="https://testserver")
+
+    response = _shared_login(client, next_value="/u/bob/files")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/bob/files"
+
+    state = _codec().decode(_issued_cookie(response))
+    entry = state.entry("bob")
+    assert entry is not None
+    assert entry.opener == "alice"
+    assert entry.generation_tag == generation_tag(ALICE_HASH)
+    assert entry.role == "operator"
+    assert entry.role_source == "roster"
+    # Proving bob's card does not unlock alice's terminal.
+    assert state.entry("alice") is None
+    # And verify accepts what this login minted: the chain closes end to end.
+    assert client.get("/verify", params={"user": "bob"}).status_code == 200
+
+
+def test_every_shared_refusal_is_the_same_refusal() -> None:
+    """Unknown opener, uncredentialed opener, wrong password and empty opener
+    are one answer, compared byte for byte against the empty-opener body once
+    the echoed opener is removed — the only thing that may differ between them
+    is the caller's own input coming back in the username field."""
+    client = _client(SHARED_ENV)
+    wrong = _shared_login(client, opener="alice", password="not-the-password")
+    uncredentialed = _shared_login(client, opener="carol", password="anything")
+    unknown = _shared_login(client, opener="mally", password="anything")
+    empty = _shared_login(client, opener="", password="anything")
+
+    assert (
+        wrong.status_code
+        == uncredentialed.status_code
+        == unknown.status_code
+        == empty.status_code
+        == 401
+    )
+    assert DENIAL_MESSAGE in empty.text
+    # The refusal keeps the shared card's shape: the opener can correct their
+    # own name, prefilled exactly as they typed it.
+    assert "Sign in to" in wrong.text
+    assert 'name="username"' in wrong.text
+    assert 'value="alice"' in wrong.text
+    for other, name in ((wrong, "alice"), (uncredentialed, "carol"), (unknown, "mally")):
+        assert other.text.replace(name, "") == empty.text
+        assert other.headers["content-type"] == empty.headers["content-type"]
+        assert other.headers["cache-control"] == empty.headers["cache-control"]
+        assert "set-cookie" not in other.headers
+    assert "set-cookie" not in empty.headers
+
+
+def test_a_browser_missing_the_opener_is_sent_to_the_roster_without_a_charge() -> None:
+    """No opener means no credential attempt: the browser goes back to the
+    cards, and no throttle window anywhere records that it happened."""
+    client, throttle, _ = _throttled_client(SHARED_ENV)
+
+    response = _post(
+        client,
+        {"user": "bob", "next": "", "password": ALICE_PASSWORD},
+        headers=BROWSER_ACCEPT,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+    assert response.headers["cache-control"] == "no-store"
+    assert "set-cookie" not in response.headers
+    assert throttle.retry_after("bob") == 0.0
+    assert throttle.retry_after("") == 0.0
+
+
+def test_a_json_client_missing_the_opener_gets_a_400() -> None:
+    """The user field's own split, applied to the opener field."""
+    response = _post(
+        _client(SHARED_ENV),
+        {"user": "bob", "next": "", "password": ALICE_PASSWORD},
+        headers=JSON_ACCEPT,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "the login form must name exactly one opener"}
+    assert "set-cookie" not in response.headers
+
+
+def test_a_repeated_opener_is_refused_for_every_caller() -> None:
+    """Two openers is ambiguous, not empty — a 400 even for a browser, exactly
+    as a form naming two users is."""
+    client, throttle, _ = _throttled_client(SHARED_ENV)
+
+    response = _post(
+        client,
+        {"user": "bob", "username": ["alice", "carol"], "password": ALICE_PASSWORD},
+        headers=BROWSER_ACCEPT,
+    )
+
+    assert response.status_code == 400
+    assert "set-cookie" not in response.headers
+    assert throttle.retry_after("alice") == 0.0
+    assert throttle.retry_after("carol") == 0.0
+
+
+def test_the_shared_throttle_charges_the_opener_not_the_card() -> None:
+    """The credential under test is the opener's, so the opener's window grows
+    — the same bucket their own card charges, which is what stops a guessing
+    run shopping between the two surfaces for a fresh window."""
+    client, throttle, _ = _throttled_client(SHARED_ENV)
+
+    assert _shared_login(client, opener="carol", password="a-guess").status_code == 401
+
+    assert throttle.retry_after("carol") > 0.0
+    assert throttle.retry_after("bob") == 0.0
+    # The opener's own-card attempt lands inside the window the shared attempt
+    # opened, and a second shared attempt keeps the shared card's page shape.
+    assert _login(client, user="carol", password="anything").status_code == 429
+
+
+def test_a_throttled_shared_attempt_still_renders_the_username_field() -> None:
+    """A 429 inside the window must keep the shared card's shape: were it the
+    own-card page, the username field would vanish on exactly the retry the
+    page invites, and the corrected attempt could never be submitted."""
+    client, throttle, _ = _throttled_client(SHARED_ENV)
+    assert _shared_login(client, opener="carol", password="a-guess").status_code == 401
+
+    throttled = _shared_login(client, opener="carol", password="a-guess")
+
+    assert throttled.status_code == 429
+    assert THROTTLE_MESSAGE in throttled.text
+    assert "Sign in to" in throttled.text
+    assert 'name="username"' in throttled.text
+    assert 'value="carol"' in throttled.text
+
+
+def test_an_over_long_user_never_reaches_a_shared_cards_credential() -> None:
+    """An over-long name whose prefix is a shared card stays on the own-card
+    deny path: were the shared branch taken on the clamped name, the correct
+    opener credential below would mint a session for a card the browser never
+    posted to."""
+    name = "a" * MAX_USERNAME_LENGTH
+    suffix = "A" * MAX_USERNAME_LENGTH
+    env = {
+        **PASSWORD_ENV,
+        "OSPREY_AUTH_USERS": f"alice,{name}",
+        f"OSPREY_AUTH_PW_HASH_{suffix}": ALICE_HASH,
+        f"OSPREY_AUTH_ROSTER_ACCESS_{suffix}": "any",
+    }
+
+    response = _post(
+        _client(env),
+        {"user": name + "a", "username": "alice", "next": "", "password": ALICE_PASSWORD},
+    )
+
+    assert response.status_code == 401
+    assert "set-cookie" not in response.headers
+    # The own-card refusal, not the shared card's: no username field came back.
+    assert 'name="username"' not in response.text
+
+
+def test_an_over_long_opener_is_never_looked_up_as_a_roster_user() -> None:
+    """Truncating the opener for display must not become truncating it for
+    authorisation: a roster user whose name is exactly the clamped prefix must
+    not have their credential evaluated under a name the browser never sent."""
+    prefix = "a" * MAX_USERNAME_LENGTH
+    env = {
+        **SHARED_ENV,
+        "OSPREY_AUTH_USERS": f"alice,bob,carol,{prefix}",
+        f"OSPREY_AUTH_PW_HASH_{'A' * MAX_USERNAME_LENGTH}": ALICE_HASH,
+    }
+
+    response = _shared_login(_client(env), opener=prefix + "a", password=ALICE_PASSWORD)
+
+    assert response.status_code == 401
+    assert "set-cookie" not in response.headers
+
+
+def test_a_shared_cards_return_to_belongs_to_the_card() -> None:
+    """Empty or hostile, the fallback is the CARD's terminal — the opener's
+    name never chooses where the browser lands."""
+    client = _client(SHARED_ENV)
+
+    empty = _shared_login(client, next_value="")
+    hostile = _shared_login(client, next_value="https://evil.example/")
+
+    assert empty.status_code == hostile.status_code == 303
+    assert empty.headers["location"] == "/u/bob/"
+    assert hostile.headers["location"] == "/u/bob/"
 
 
 # --- Nothing a client sends is assumed to be small --------------------------

--- a/tests/services/auth_sidecar/test_login_audit.py
+++ b/tests/services/auth_sidecar/test_login_audit.py
@@ -355,6 +355,18 @@ class TestASuccessfulLogin:
         assert _callback(_oidc_app()).status_code == 303
         assert "role" not in _records(zone)[0]
 
+    def test_a_detail_is_carried_when_given(self, zone: Path) -> None:
+        """A shared-card login names its opener in ``detail`` — identifiers
+        only, on the same terms as a refusal's detail."""
+        audit.record_login_success(user="alice", method="password", detail="opener=alice")
+        assert _records(zone)[0]["detail"] == "opener=alice"
+
+    def test_no_detail_means_the_key_is_omitted(self, zone: Path) -> None:
+        """Absent, not null: a record with nothing to add carries no key, so a
+        reader never has to distinguish ``null`` from missing."""
+        audit.record_login_success(user="alice", method="password")
+        assert "detail" not in _records(zone)[0]
+
 
 # --- what a refused login records -------------------------------------------
 
@@ -407,6 +419,65 @@ class TestARefusedPasswordLogin:
             assert _login(client, password="wrong").status_code == 401
             assert _login(client, password="wrong").status_code == 429
         assert len(_records(zone)) == 1
+
+
+SHARED_ENV = {**PASSWORD_ENV, "OSPREY_AUTH_ROSTER_ACCESS_BOB": "any"}
+"""The password roster with bob's card opened to the whole roster, so a shared
+login's ledger records can be pinned: alice's credential opens bob's card."""
+
+
+def _shared_login(
+    client: TestClient, opener: str, password: str = ALICE_PASSWORD
+) -> httpx.Response:
+    """POST one shared-card attempt against bob's card."""
+    return client.post(
+        "/auth/login",
+        data={"user": "bob", "username": opener, "next": "", "password": password},
+        headers={"Origin": EXTERNAL_ORIGIN},
+        follow_redirects=False,
+    )
+
+
+class TestASharedCardInTheLedger:
+    """A shared card's records are the card's, with the opener in ``detail``.
+
+    The subject stays the card — that is whose terminal was entered — and the
+    opener rides in ``detail`` as an identifier, so "who is in bob's terminal,
+    and whose credential put them there" are both one line's answer.
+    """
+
+    def test_a_success_names_its_opener(self, zone: Path) -> None:
+        with TestClient(create_app(SHARED_ENV), base_url="https://testserver") as client:
+            assert _shared_login(client, "alice").status_code == 303
+        record = _records(zone)[0]
+        assert record["decision"] == "allowed"
+        assert record["reason"] == audit.REASON_PASSWORD_LOGIN
+        assert record["subject"] == "bob"
+        assert record["detail"] == "opener=alice"
+
+    def test_a_refusal_names_its_opener(self, zone: Path) -> None:
+        """Same category as every other bad credential — the record must not
+        say whether the opener exists any more than the page does — but the
+        bounded opener name is carried so the ledger can answer who was
+        knocking."""
+        with TestClient(create_app(SHARED_ENV), base_url="https://testserver") as client:
+            assert _shared_login(client, "mally", password="a-guess").status_code == 401
+        record = _records(zone)[0]
+        assert record["decision"] == "refused"
+        assert record["reason"] == audit.REASON_BAD_CREDENTIAL
+        assert record["subject"] == "bob"
+        assert record["detail"] == "opener=mally"
+
+    def test_an_empty_opener_refusal_carries_no_detail(self, zone: Path) -> None:
+        """An empty opener is refused like any other miss, but ``opener=`` with
+        nothing after it would put an empty value in an identifiers-only field
+        — so that refusal carries no detail key at all."""
+        with TestClient(create_app(SHARED_ENV), base_url="https://testserver") as client:
+            assert _shared_login(client, "", password="a-guess").status_code == 401
+        record = _records(zone)[0]
+        assert record["decision"] == "refused"
+        assert record["reason"] == audit.REASON_BAD_CREDENTIAL
+        assert "detail" not in record
 
 
 class TestARefusedOidcLogin:
@@ -688,6 +759,9 @@ class TestTheCategorySetIsClosed:
             if name.startswith("REASON_") and isinstance(value, str)
         }
         assert named <= audit.LOGIN_REASONS
+        # Categories no route files yet are pinned here by name, so the
+        # vars() sweep above is not their only tie to the closed set.
+        assert audit.REASON_AMBIGUOUS_IDENTITY in audit.LOGIN_REASONS
 
     def test_the_oidc_routes_name_the_same_categories(self) -> None:
         """The route module keeps its own spellings for readability at the point

--- a/tests/services/auth_sidecar/test_login_recheck.py
+++ b/tests/services/auth_sidecar/test_login_recheck.py
@@ -687,6 +687,29 @@ class TestTheAntiLookupInvariant:
             ("alice", audit.REASON_IDENTITY_MISMATCH)
         ]
 
+    def test_a_shared_card_is_the_one_deliberate_reverse_match(
+        self, zone: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exception the test above is stated against — and it lives in
+        ``oidc.py``, not in this module. On a card whose rendered access rule
+        is ``any``, bob's subject arriving on alice's handshake opens alice's
+        card: the entry is keyed by the card, the opener records who proved the
+        login, the role is the card's own roster role, and the ledger names the
+        opener. Alice's own card above stays a refusal — the reverse match is
+        gated on :meth:`AuthSettings.shared`."""
+        _bind_roster_roles(monkeypatch, alice="operator")
+        env = {**OIDC_ENV, "OSPREY_AUTH_ROSTER_ACCESS_ALICE": "any"}
+        response = _callback(_oidc_app(env, userinfo={"sub": BOB_SUBJECT}), user="alice")
+        assert response.status_code == 303
+        entry = _minted_entry(_issued_cookie(response), "alice")
+        assert entry.oidc_subject == BOB_SUBJECT
+        assert entry.opener == "bob"
+        assert entry.role == "operator"
+        assert entry.role_source == ROLE_SOURCE_ROSTER
+        record = _records(zone)[-1]
+        assert record["subject"] == "alice"
+        assert record["detail"] == "opener=bob"
+
     #: Every public name the matrix module is allowed to define.
     #:
     #: Deliberately the whole surface rather than a pattern. A guard that
@@ -953,9 +976,34 @@ class TestVerifyReadsTheSameMatrix:
         entry = UnlockedUser(username="alice", expires_at=0, generation_tag="", oidc_subject="")
         assert session_subject(method=METHOD_PASSWORD, username="alice", entry=entry) == "alice"
 
+    def test_a_shared_card_session_names_its_opener(self) -> None:
+        """A shared card's entry is keyed by the card but was proved by the
+        opener's password, and the opener is the account the header names."""
+        entry = UnlockedUser(
+            username="controls", expires_at=0, generation_tag="", oidc_subject="", opener="alice"
+        )
+        assert session_subject(method=METHOD_PASSWORD, username="controls", entry=entry) == "alice"
+
+    def test_a_missing_entry_under_password_names_the_roster_user(self) -> None:
+        """The defensive path: with no entry to read an opener from, the
+        fallback is still the locally verified roster username."""
+        assert session_subject(method=METHOD_PASSWORD, username="alice", entry=None) == "alice"
+
     def test_an_oidc_session_names_the_provider_account(self) -> None:
         entry = UnlockedUser(
             username="alice", expires_at=0, generation_tag="", oidc_subject=ALICE_SUBJECT
+        )
+        assert session_subject(method=METHOD_OIDC, username="alice", entry=entry) == ALICE_SUBJECT
+
+    def test_the_opener_never_reaches_the_oidc_arm(self) -> None:
+        """An opener is password-path bookkeeping: the OIDC arm keeps naming
+        the provider account, never a roster username stored beside it."""
+        entry = UnlockedUser(
+            username="alice",
+            expires_at=0,
+            generation_tag="",
+            oidc_subject=ALICE_SUBJECT,
+            opener="bob",
         )
         assert session_subject(method=METHOD_OIDC, username="alice", entry=entry) == ALICE_SUBJECT
 

--- a/tests/services/auth_sidecar/test_oidc.py
+++ b/tests/services/auth_sidecar/test_oidc.py
@@ -245,6 +245,38 @@ def test_login_refuses_a_user_with_no_mapped_identity(caplog: pytest.LogCaptureF
     assert "bob" in caplog.text
 
 
+def test_login_starts_a_shared_cards_handshake_when_any_entry_is_mapped() -> None:
+    """bob's shared card has no mapped identity of its own — but alice and
+    carol do, and either of them could open it, so the handshake starts. The
+    unmapped-user refusal above is the own-card rule; a shared card only asks
+    whether SOMEBODY on the roster is mapped."""
+    env = {**OIDC_ENV, "OSPREY_AUTH_ROSTER_ACCESS_BOB": "any"}
+    with _client(_app(env)) as client:
+        response = client.get(LOGIN_PATH, params={"user": "bob"}, follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == IDP_AUTHORIZE_URL
+
+
+def test_login_refuses_a_shared_card_when_no_entry_is_mapped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A roster on which nobody carries a mapped identity cannot open a shared
+    card either: the handshake could only end in a refusal, so it never
+    starts — same category as the own-card rule, its own message."""
+    env = {
+        key: value
+        for key, value in OIDC_ENV.items()
+        if not key.startswith("OSPREY_AUTH_OIDC_SUBJECT_")
+    }
+    env["OSPREY_AUTH_ROSTER_ACCESS_BOB"] = "any"
+    with caplog.at_level(logging.WARNING), _client(_app(env)) as client:
+        response = client.get(LOGIN_PATH, params={"user": "bob"}, follow_redirects=False)
+
+    assert response.status_code == 403
+    assert "no roster entry carries a mapped identity" in caplog.text
+
+
 def test_login_refuses_a_user_who_is_not_on_the_roster() -> None:
     with _client(_app()) as client:
         response = client.get(LOGIN_PATH, params={"user": "mallory"}, follow_redirects=False)

--- a/tests/services/auth_sidecar/test_oidc_flow.py
+++ b/tests/services/auth_sidecar/test_oidc_flow.py
@@ -27,6 +27,7 @@ import json
 import logging
 from base64 import b64decode
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -35,7 +36,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from osprey.deployment.web_terminals.personas import env_var_suffix
 from osprey.interfaces._serving import run_app_server
+from osprey.services.auth_sidecar import audit
 from osprey.services.auth_sidecar.app import STATE_COOKIE_NAME, create_app
 from osprey.services.auth_sidecar.routes.oidc import (
     CALLBACK_PATH,
@@ -44,7 +47,9 @@ from osprey.services.auth_sidecar.routes.oidc import (
     LOGIN_PATH,
     PENDING_FLOW_SESSION_KEY,
 )
+from osprey.services.auth_sidecar.routes.recheck import ENV_ROSTER_ROLE_PREFIX, ROLE_SOURCE_ROSTER
 from osprey.services.auth_sidecar.sessions import SESSION_COOKIE_NAME, SessionCodec, SessionState
+from osprey.utils.identity import AUDIT_IDENTITY_ENV, TERMINAL_USER_ENV
 from tests.services.auth_sidecar.mock_idp import (
     DISCOVERY_AS_HTML,
     DISCOVERY_WITHOUT_AUTHORIZATION_ENDPOINT,
@@ -95,6 +100,39 @@ def _reset_idp(idp: MockIdP) -> Iterator[None]:
     """Give every test an unmodified provider with no recorded requests."""
     idp.reset()
     yield
+
+
+@pytest.fixture
+def zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """The sidecar's own bound audit subdirectory, as compose gives it.
+
+    Only the shared-card tests ask for it: they pin the *categories* the ledger
+    files a refusal under, which no assertion on the response alone can see.
+    """
+    directory = tmp_path / "var" / "audit" / "sidecar"
+    directory.mkdir(parents=True)
+    monkeypatch.setenv(audit.AUDIT_DIR_ENV, str(directory))
+    monkeypatch.setenv(AUDIT_IDENTITY_ENV, "sidecar")
+    monkeypatch.delenv(TERMINAL_USER_ENV, raising=False)
+    return directory
+
+
+def _records(zone: Path) -> list[dict[str, Any]]:
+    path = zone / f"{audit.SURFACE}.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text("utf-8").splitlines() if line]
+
+
+def _bind_roster_role(monkeypatch: pytest.MonkeyPatch, user: str, role: str) -> None:
+    """Bind a static role to ``user`` the way the container's environment does.
+
+    On the process environment, like the role binding: the sidecar reads this
+    table from ``os.environ``, not from the mapping ``create_app`` was handed.
+    The suffix comes from ``env_var_suffix`` — the one derivation the render
+    emits the variable under — never a re-spelled ``upper()``.
+    """
+    monkeypatch.setenv(f"{ENV_ROSTER_ROLE_PREFIX}{env_var_suffix(user)}", role)
 
 
 # --- the sidecar -------------------------------------------------------------
@@ -639,3 +677,205 @@ def test_a_refusal_never_echoes_the_token_or_the_client_secret(
     for value in (idp.client_secret, issued, CAROL_SUBJECT):
         assert value not in response.text
         assert value not in _osprey_log(caplog)
+
+
+# --- shared cards: the access rule is `any` ----------------------------------
+#
+# `OSPREY_AUTH_ROSTER_ACCESS_<SUFFIX>=any` is the rendered access rule. A card
+# carrying it may be opened by ANY roster entry whose configured subject the
+# IdP asserts — the one deliberate exception to "the clicked card is the only
+# user a login can unlock", so these walk real handshakes for both halves:
+# who gets in, and every way the reverse match refuses.
+
+
+def test_an_opener_with_a_mapped_identity_opens_a_shared_card(
+    idp: MockIdP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """alice's real, verified identity opens bob's shared card — as bob.
+
+    bob has no mapped identity of his own, which is exactly the case the
+    own-card rule refuses as ``unmapped_user``: a shared card never asks for
+    one. The entry is keyed by the card; the opener records whose identity
+    proved the login; the role is the CARD's roster role, from the roster.
+    """
+    _bind_roster_role(monkeypatch, "bob", "observer")
+    app = _sidecar(idp, OSPREY_AUTH_ROSTER_ACCESS_BOB="any")
+    with _browser(app) as client:
+        response = _log_in(client, "bob", next_target="/u/bob/")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/u/bob/"
+    session = _session_from(response)
+    assert session.unlocked_usernames(now=0.0) == ("bob",)
+    entry = session.entry("bob")
+    assert entry is not None
+    assert entry.oidc_subject == ALICE_SUBJECT
+    assert entry.opener == "alice"
+    assert entry.role == "observer"
+    assert entry.role_source == ROLE_SOURCE_ROSTER
+
+
+@pytest.mark.parametrize(
+    ("asserted", "opener"),
+    [("idp|alice", "alice"), ("idp|carol", "carol")],
+    ids=["another-entry", "the-card-itself"],
+)
+def test_a_shared_card_with_its_own_identity_admits_any_mapped_entry(
+    idp: MockIdP, asserted: str, opener: str
+) -> None:
+    """carol's shared card carries a subject of its own, and that changes
+    nothing: another entry's identity still opens it, and carol's own identity
+    opens it too — matched through the same reverse match as everybody else's,
+    so the opener is then the card itself."""
+    idp.subject = asserted
+    app = _sidecar(idp, OSPREY_AUTH_ROSTER_ACCESS_CAROL="any")
+    with _browser(app) as client:
+        response = _log_in(client, "carol")
+
+    assert response.status_code == 303
+    entry = _session_from(response).entry("carol")
+    assert entry is not None
+    assert entry.oidc_subject == asserted
+    assert entry.opener == opener
+
+
+def test_an_entry_that_never_logs_into_its_own_card_can_open_a_shared_one(idp: MockIdP) -> None:
+    """A ``login: false`` roster entry keeps its mapped identity.
+
+    From this service's side such an entry is simply a mapped roster user with
+    no card of its own on the landing page — dave here — and its identity
+    participates in the reverse match like every other entry's.
+    """
+    idp.subject = "idp|dave"
+    app = _sidecar(
+        idp,
+        OSPREY_AUTH_USERS="alice,bob,carol,dave",
+        OSPREY_AUTH_OIDC_SUBJECT_DAVE="idp|dave",
+        OSPREY_AUTH_ROSTER_ACCESS_BOB="any",
+    )
+    with _browser(app) as client:
+        response = _log_in(client, "bob")
+
+    assert response.status_code == 303
+    entry = _session_from(response).entry("bob")
+    assert entry is not None
+    assert entry.opener == "dave"
+
+
+def test_an_identity_matching_no_entry_is_refused_on_a_shared_card(
+    idp: MockIdP, zone: Path
+) -> None:
+    """A verified stranger is still a stranger: zero matches is the same
+    ``identity_mismatch`` an own card refuses with, filed post-exchange."""
+    idp.subject = "idp|stranger"
+    app = _sidecar(idp, OSPREY_AUTH_ROSTER_ACCESS_BOB="any")
+    with _browser(app) as client:
+        response = _log_in(client, "bob")
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert [(r["subject"], r["reason"]) for r in _records(zone)] == [
+        ("bob", audit.REASON_IDENTITY_MISMATCH)
+    ]
+
+
+def test_an_identity_mapped_to_two_entries_is_refused_as_ambiguous(
+    idp: MockIdP, zone: Path
+) -> None:
+    """alice and carol both mapped to one identity: opening a shared card with
+    it must not be resolved by roster order, so it is refused under its own
+    category — the configuration fault the ledger has to name."""
+    app = _sidecar(
+        idp,
+        OSPREY_AUTH_ROSTER_ACCESS_BOB="any",
+        OSPREY_AUTH_OIDC_SUBJECT_CAROL=ALICE_SUBJECT,
+    )
+    with _browser(app) as client:
+        response = _log_in(client, "bob")
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert [(r["subject"], r["reason"]) for r in _records(zone)] == [
+        ("bob", audit.REASON_AMBIGUOUS_IDENTITY)
+    ]
+
+
+def test_a_matched_identity_that_cannot_be_carried_is_refused_not_a_crash(
+    idp: MockIdP, zone: Path
+) -> None:
+    """The uncarryable-subject refusal moves post-match on a shared card.
+
+    An own card refuses this before the token exchange; a shared card only
+    knows WHICH entry matched afterwards, so the handshake completes and the
+    matched value is then refused under the same category — a clean 403, never
+    the 500 ``with_user`` would raise on it.
+    """
+    idp.subject = "jörg@example.org"
+    app = _sidecar(
+        idp,
+        OSPREY_AUTH_ROSTER_ACCESS_BOB="any",
+        OSPREY_AUTH_OIDC_SUBJECT_ALICE="jörg@example.org",
+    )
+    with _browser(app) as client:
+        response = _log_in(client, "bob")
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+    # Post-exchange: the token endpoint was genuinely reached first.
+    assert idp.token_requests
+    assert [(r["subject"], r["reason"]) for r in _records(zone)] == [
+        ("bob", audit.REASON_NON_ASCII_SUBJECT)
+    ]
+
+
+def test_a_shared_card_on_an_unmapped_roster_never_reaches_the_provider(idp: MockIdP) -> None:
+    """Nobody on the roster is mapped, so nobody could open the shared card:
+    the handshake could only end in a refusal and does not start."""
+    app = _sidecar(
+        idp,
+        OSPREY_AUTH_ROSTER_ACCESS_BOB="any",
+        OSPREY_AUTH_OIDC_SUBJECT_ALICE="",
+        OSPREY_AUTH_OIDC_SUBJECT_CAROL="",
+    )
+    with _browser(app) as client:
+        response = _start_login(client, "bob")
+
+    assert response.status_code == 403
+    assert idp.authorize_requests == []
+
+
+def test_the_claims_binding_is_not_consulted_on_a_shared_card(
+    idp: MockIdP, zone: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Membership gating and shared cards do not compose.
+
+    A bound deployment; alice's groups map to NO role. On her OWN card that is
+    the ``unmapped_role_claim`` refusal — the binding answers "which role is
+    this person's terminal built as", and hers resolves to none. The shared
+    card's terminal is only ever its own: the card's role rides the card, so
+    the same alice opens it and the binding is never asked.
+    """
+    monkeypatch.setenv("OSPREY_AUTH_ROLE_CLAIM", "groups")
+    monkeypatch.setenv("OSPREY_AUTH_ROLE_MAP", '{"als-operators":"operator"}')
+    _bind_roster_role(monkeypatch, "bob", "observer")
+    idp.extra_claims = {"groups": ["als-visitors"]}
+
+    shared = _sidecar(idp, OSPREY_AUTH_ROSTER_ACCESS_BOB="any")
+    with _browser(shared) as client:
+        opened = _log_in(client, "bob")
+    assert opened.status_code == 303
+    entry = _session_from(opened).entry("bob")
+    assert entry is not None
+    assert entry.opener == "alice"
+    assert entry.role == "observer"
+    assert entry.role_source == ROLE_SOURCE_ROSTER
+
+    own = _sidecar(idp)
+    with _browser(own) as client:
+        refused = _log_in(client, "alice")
+    assert refused.status_code == 403
+
+    assert [(r["subject"], r["reason"]) for r in _records(zone)] == [
+        ("bob", audit.REASON_OIDC_LOGIN),
+        ("alice", audit.REASON_UNMAPPED_ROLE_CLAIM),
+    ]

--- a/tests/services/auth_sidecar/test_sessions.py
+++ b/tests/services/auth_sidecar/test_sessions.py
@@ -614,3 +614,127 @@ def test_re_adding_a_user_refreshes_the_subject_in_place(
     assert alice is not None
     assert alice.oidc_subject == "provider|new"
     assert len(decoded.users) == 1
+
+
+# --- the shared-card opener --------------------------------------------------
+
+
+def test_round_trip_preserves_the_opener(codec: SessionCodec, clock: FakeClock) -> None:
+    """The roster entry that proved a shared-card login survives the round trip."""
+    state = codec.new_state().with_user(
+        "beamline", expires_at=clock.now + HOUR, generation_tag="0123456789abcdef", opener="alice"
+    )
+
+    decoded = codec.decode(codec.encode(state))
+
+    assert decoded.users == (
+        UnlockedUser(
+            username="beamline",
+            expires_at=clock.now + HOUR,
+            generation_tag="0123456789abcdef",
+            opener="alice",
+        ),
+    )
+
+
+def test_an_entry_carries_no_opener_by_default(codec: SessionCodec, clock: FakeClock) -> None:
+    """An own-card login names no opener, so the field stays empty."""
+    state = codec.new_state().with_user(
+        "alice", expires_at=clock.now + HOUR, generation_tag="0123456789abcdef"
+    )
+
+    entry = codec.decode(codec.encode(state)).entry("alice")
+
+    assert entry is not None
+    assert entry.opener == ""
+
+
+def test_the_opener_is_written_into_the_payload(codec: SessionCodec, clock: FakeClock) -> None:
+    """Pinning the wire key: a later reader looks for ``opener``, not a rename."""
+    encoded = codec.encode(
+        codec.new_state().with_user("beamline", expires_at=clock.now + HOUR, opener="alice")
+    )
+
+    payload = URLSafeSerializer(SECRET, salt=SIGNATURE_SALT).loads(encoded)
+
+    assert payload["users"]["beamline"]["opener"] == "alice"
+
+
+def test_a_payload_without_an_opener_decodes_as_empty() -> None:
+    """Cookies minted before ``opener`` existed keep working, at the same version.
+
+    The opener was added without a :data:`PAYLOAD_VERSION` bump on purpose, so
+    a browser holding a pre-upgrade cookie stays logged in instead of being
+    silently signed out.
+    """
+    encoded = sign_payload(
+        {
+            "v": PAYLOAD_VERSION,
+            "sid": "s",
+            "iat": 0.0,
+            "users": {"alice": {"exp": 1_000_000_000.0, "tag": "0123456789abcdef"}},
+        }
+    )
+
+    entry = SessionCodec(SECRET, clock=FakeClock()).decode(encoded).entry("alice")
+
+    assert entry is not None
+    assert entry.generation_tag == "0123456789abcdef"
+    assert entry.opener == ""
+
+
+@pytest.mark.parametrize("opener", ["a\nb", " alice", "alice ", "jörg"])
+def test_an_uncarryable_opener_is_refused_at_login(
+    codec: SessionCodec, clock: FakeClock, opener: str
+) -> None:
+    """The opener rides an identity header, so the mint path refuses it early."""
+    with pytest.raises(ValueError, match="opener cannot be carried"):
+        codec.new_state().with_user("beamline", expires_at=clock.now + HOUR, opener=opener)
+
+
+@pytest.mark.parametrize("opener", ["a\nb", " alice", "alice ", "jörg"])
+def test_an_uncarryable_opener_invalidates_the_cookie(opener: str) -> None:
+    """Only this sidecar signs cookies, and it never stores such a value."""
+    encoded = sign_payload(
+        {
+            "v": PAYLOAD_VERSION,
+            "sid": "s",
+            "iat": 0.0,
+            "users": {"beamline": {"exp": 1_000_000_000.0, "opener": opener}},
+        }
+    )
+
+    with pytest.raises(InvalidSessionError, match="uncarryable opener"):
+        SessionCodec(SECRET, clock=FakeClock()).decode(encoded)
+
+
+def test_a_non_string_opener_is_rejected() -> None:
+    encoded = sign_payload(
+        {
+            "v": PAYLOAD_VERSION,
+            "sid": "s",
+            "iat": 0.0,
+            "users": {"beamline": {"exp": 1_000_000_000.0, "opener": 9}},
+        }
+    )
+
+    with pytest.raises(InvalidSessionError, match="non-string opener"):
+        SessionCodec(SECRET, clock=FakeClock()).decode(encoded)
+
+
+def test_re_adding_a_user_replaces_the_opener_wholesale(
+    codec: SessionCodec, clock: FakeClock
+) -> None:
+    """A login naming no opener clears the one the previous login carried."""
+    state = (
+        codec.new_state()
+        .with_user("beamline", expires_at=clock.now + 60, opener="alice")
+        .with_user("beamline", expires_at=clock.now + HOUR)
+    )
+
+    decoded = codec.decode(codec.encode(state))
+
+    beamline = decoded.entry("beamline")
+    assert beamline is not None
+    assert beamline.opener == ""
+    assert len(decoded.users) == 1

--- a/tests/services/auth_sidecar/test_verify.py
+++ b/tests/services/auth_sidecar/test_verify.py
@@ -94,6 +94,7 @@ def _unlocked(
     stored: str | None = ALICE_HASH,
     ttl: float = 600.0,
     subject: str = "",
+    opener: str = "",
 ) -> UnlockedUser:
     """An unlocked-user entry expiring ``ttl`` seconds from now.
 
@@ -104,12 +105,15 @@ def _unlocked(
         ttl: Seconds until the entry lapses; negative for an expired one.
         subject: The OIDC subject the entry carries, or ``""`` for a password
             entry and any session minted before the subject was carried.
+        opener: The roster user whose credential proved the login, for an entry
+            on a shared card, or ``""`` for an own-card entry.
     """
     return UnlockedUser(
         username=username,
         expires_at=SessionCodec(SESSION_SECRET).now() + ttl,
         generation_tag="" if stored is None else generation_tag(stored),
         oidc_subject=subject,
+        opener=opener,
     )
 
 
@@ -436,6 +440,168 @@ class TestAccountHeader:
             response = _verify(client, "j\u00f6rg", cookie)
         assert response.status_code == 401
         assert self.ACCOUNT_HEADER.lower() not in response.headers
+
+
+class TestSharedCardOpener:
+    """A shared card's session lives and dies with the entry that opened it.
+
+    A shared (``access: any``) card's session names its opener — the roster
+    entry whose credential proved the login — and verify re-validates that
+    opener against the roster's current mapping on every subrequest. Both
+    directions of the correspondence are pinned too: a shared card refuses a
+    session naming no opener, and a card no longer shared refuses one that
+    does, so flipping the access rule in either direction retires the sessions
+    minted under the old one instead of letting them lapse.
+    """
+
+    ACCOUNT_HEADER = "X-Osprey-Auth-Account"
+    SUBJECT_HEADER = "X-Osprey-Auth-Subject"
+    BOB_SUBJECT = "idp|bob"
+
+    SHARED_ENV = {
+        **OIDC_ENV,
+        "OSPREY_AUTH_ROSTER_ACCESS_ALICE": "any",
+        "OSPREY_AUTH_OIDC_SUBJECT_BOB": BOB_SUBJECT,
+    }
+
+    def test_a_valid_opener_authorizes_and_names_both_identities(self) -> None:
+        """The account is the card the request is on, the subject the opener's
+        login — the shared card is exactly where the two headers diverge."""
+        cookie = _mint(_unlocked("alice", stored=None, subject=self.BOB_SUBJECT, opener="bob"))
+        with TestClient(_app(self.SHARED_ENV)) as client:
+            response = _verify(client, "alice", cookie)
+        assert response.status_code == 200
+        assert response.headers[self.ACCOUNT_HEADER] == "alice"
+        assert response.headers[self.SUBJECT_HEADER] == self.BOB_SUBJECT
+
+    def test_an_opener_whose_mapping_was_removed_is_denied(self) -> None:
+        """Taking the opener's subject out of the config closes the shared card
+        immediately, not at each outstanding session's expiry."""
+        cookie = _mint(_unlocked("alice", stored=None, subject=self.BOB_SUBJECT, opener="bob"))
+        env = {k: v for k, v in self.SHARED_ENV.items() if k != "OSPREY_AUTH_OIDC_SUBJECT_BOB"}
+        with TestClient(_app(env)) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_an_opener_whose_mapping_changed_is_denied(self) -> None:
+        """Remapping the opener's suffix to another IdP identity is a new
+        person; the sessions the old one opened stop verifying."""
+        cookie = _mint(_unlocked("alice", stored=None, subject=self.BOB_SUBJECT, opener="bob"))
+        env = {**self.SHARED_ENV, "OSPREY_AUTH_OIDC_SUBJECT_BOB": "idp|somebody-else"}
+        with TestClient(_app(env)) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_a_shared_card_session_naming_no_opener_is_denied(self) -> None:
+        """Flipping a card to ``any`` must not widen sessions minted while it
+        was an own card — they carry no opener to re-validate."""
+        cookie = _mint(_unlocked("alice", stored=None, subject=""))
+        with TestClient(_app(self.SHARED_ENV)) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_an_opener_on_a_card_no_longer_shared_is_denied(self) -> None:
+        """Flipping ``any`` back to own retires every shared session at once."""
+        cookie = _mint(_unlocked("alice", stored=None, subject=self.BOB_SUBJECT, opener="bob"))
+        with TestClient(_app(OIDC_ENV)) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
+    def test_only_the_shared_session_dies_when_the_opener_is_remapped(self) -> None:
+        """The asymmetry, pinned side by side. An own card's subject is read
+        off the session and never re-derived, so changing alice's configured
+        subject leaves her own session verifying until it lapses — the
+        documented lapse-with-the-session rule. A shared session keyed on that
+        same opener dies on the next subrequest, because a shared card
+        multiplies one login across the roster."""
+        env = {
+            **OIDC_ENV,
+            "OSPREY_AUTH_OIDC_SUBJECT_ALICE": "idp|changed",
+            "OSPREY_AUTH_ROSTER_ACCESS_BOB": "any",
+        }
+        own = _mint(_unlocked("alice", stored=None, subject="idp|alice"))
+        shared = _mint(_unlocked("bob", stored=None, subject="idp|alice", opener="alice"))
+        with TestClient(_app(env)) as client:
+            assert _verify(client, "alice", own).status_code == 200
+            assert _verify(client, "bob", shared).status_code == 401
+
+
+class TestSharedCardPassword:
+    """A password shared card lives and dies with the *opener's* stored hash.
+
+    The login mints a shared card's generation tag from the opener's hash, so
+    verify checks the tag against that hash and never against the card's own —
+    which may still exist as a stale leftover from before the card was shared.
+    Everything that can happen to the opener's credential (rotation, removal,
+    the opener leaving the roster) therefore closes the card, and nothing that
+    happens to the card's own leftover hash changes the answer either way.
+    """
+
+    ACCOUNT_HEADER = "X-Osprey-Auth-Account"
+    SUBJECT_HEADER = "X-Osprey-Auth-Subject"
+
+    SHARED_ENV = {
+        **PASSWORD_ENV,
+        "OSPREY_AUTH_ROSTER_ACCESS_BOB": "any",
+    }
+    STALE_BOB_HASH = hash_password("bob-old-password")
+
+    def test_a_valid_opener_authorizes_and_names_both_identities(self) -> None:
+        """The account is the card the request is on, the subject the opener —
+        the shared card is where the two headers diverge under password too."""
+        cookie = _mint(_unlocked("bob", opener="alice"))
+        with TestClient(_app(self.SHARED_ENV)) as client:
+            response = _verify(client, "bob", cookie)
+        assert response.status_code == 200
+        assert response.headers[self.ACCOUNT_HEADER] == "bob"
+        assert response.headers[self.SUBJECT_HEADER] == "alice"
+
+    def test_a_rotated_opener_password_is_denied(self) -> None:
+        """Rotating the opener's password retires every shared session it
+        opened, exactly as it retires the opener's own."""
+        cookie = _mint(_unlocked("bob", opener="alice"))
+        env = {**self.SHARED_ENV, "OSPREY_AUTH_PW_HASH_ALICE": ROTATED_ALICE_HASH}
+        with TestClient(_app(env)) as client:
+            assert _verify(client, "bob", cookie).status_code == 401
+
+    def test_an_opener_whose_hash_was_removed_is_denied(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The log names the actual fault: the opener's missing credential,
+        not the card's."""
+        cookie = _mint(_unlocked("bob", opener="alice"))
+        env = {k: v for k, v in self.SHARED_ENV.items() if k != "OSPREY_AUTH_PW_HASH_ALICE"}
+        caplog.set_level(logging.DEBUG)
+        with TestClient(_app(env)) as client:
+            assert _verify(client, "bob", cookie).status_code == 401
+        assert "the opener has no stored credential" in caplog.text
+
+    def test_an_opener_removed_from_the_roster_is_denied(self) -> None:
+        """Stored hashes are roster-scoped, so taking the opener off the
+        roster closes the shared card even while its hash lingers in the env."""
+        cookie = _mint(_unlocked("bob", opener="alice"))
+        env = {**self.SHARED_ENV, "OSPREY_AUTH_USERS": "bob"}
+        with TestClient(_app(env)) as client:
+            assert _verify(client, "bob", cookie).status_code == 401
+
+    def test_a_stale_card_hash_does_not_close_a_valid_shared_session(self) -> None:
+        """The card's own leftover hash disagrees with the tag, and it must not
+        matter: the tag was minted from the opener's hash and that still
+        matches."""
+        cookie = _mint(_unlocked("bob", opener="alice"))
+        env = {**self.SHARED_ENV, "OSPREY_AUTH_PW_HASH_BOB": self.STALE_BOB_HASH}
+        with TestClient(_app(env)) as client:
+            assert _verify(client, "bob", cookie).status_code == 200
+
+    def test_a_stale_card_hash_does_not_keep_a_shared_session_open(self) -> None:
+        """The sharpest pin: the tag *matches* the card's own leftover hash,
+        and the opener's hash is gone. An implementation consulting the card's
+        hash would answer 200 here; the opener's hash is the only authority,
+        so the answer is 401."""
+        cookie = _mint(_unlocked("bob", stored=self.STALE_BOB_HASH, opener="alice"))
+        env = {
+            k: v
+            for k, v in {**self.SHARED_ENV, "OSPREY_AUTH_PW_HASH_BOB": self.STALE_BOB_HASH}.items()
+            if k != "OSPREY_AUTH_PW_HASH_ALICE"
+        }
+        with TestClient(_app(env)) as client:
+            assert _verify(client, "bob", cookie).status_code == 401
 
 
 class TestLogging:


### PR DESCRIPTION
Closes #807 (references #662, #798).

A roster entry in `modules.web_terminals.users` gains `access: own | any` under
`auth.method: oidc` and `password`. `own` (the default) is today's behaviour,
byte-for-byte — goldens and the auth-off baseline pin are untouched. `any` lets any
roster user the deployment can authenticate open the card with their **own**
credential: the login is proved by some eligible roster entry (the *opener*), the
session carries the opener beside the card, and the opener is re-validated on every
`/verify` subrequest — rotating or decommissioning the opener ends their shared
sessions at the next request. No new header: `X-Osprey-Auth-Account` stays the card,
`X-Osprey-Auth-Subject` becomes the opener (#798 contract). The audit ledger records
the opener beside the card on both success and refusal.

**How it works, per method**

- **oidc** — a shared card skips its own `oidc_subject` gate; post-exchange, the
  asserted claim is reverse-matched (constant-time) against every configured
  `oidc_subject`. Zero hits → `identity_mismatch`; two or more → new
  `ambiguous_identity`; exactly one → that entry is the opener. `login: false`
  entries carrying a subject are valid openers, and the card can open itself.
- **password** — the login page for a shared card gains a required username field;
  the typed name's stored hash is checked, the rate limit counts against that name,
  and all refusal bodies stay byte-identical to each other. Own-card page bytes are
  unchanged.
- **verify** — denies when the sharedness of the card and the presence of an opener
  disagree in either direction, and re-checks the opener's credential (hash or
  configured subject) on every request.

The card's role rides the card (`role_source=roster`); a verify-time alternative —
evaluating `access` per request at the sidecar instead of minting the opener into the
session at login — was declined so revocation and the ledger stay per-person.

**Two documented behaviour changes**

1. **Duplicate-subject refusal** (`web_terminals.shared_card_duplicate_subject`): once
   any card on an `oidc` roster is shared, two entries may no longer carry the same
   `oidc_subject` — the reverse match must resolve each identity to one entry. The
   "one person, two cards, one subject" roster that lint accepted before is now
   refused when a card is shared (runtime backstop: `ambiguous_identity`).
2. **Claims binding not consulted on shared cards**: a person the `claims:` binding
   would refuse for their own card can still open a shared card. Named in code, docs,
   and a pin test; the docs say plainly — if the binding is your membership gate, do
   not share a card.

**Guard rails**

- Lint: `invalid_user_access` (non-literal values fail closed to `own`),
  `user_access_inert` (`any` under token/none or beside `login: false`),
  `shared_card_privileged` (a deployment-editing card cannot be shared), and the
  duplicate-subject refusal above.
- Provisioning parity: shared cards leave the mint list, the seeded-logins summary,
  and `users passwd` (refused with the reason); the deploy summary names them.

**Commit shape** — two commits per the design split: schema + OIDC half, then the
password half. The spanning test files (`test_verify`, `test_login_recheck`,
`test_login_audit`) ride wholly in commit 2 with the password arm they exercise. At
commit 1 a shared password card fails closed at verify — intended interim, not a
bisect target; CI judges the PR head.

**Follow-up candidates** (not in this PR)

- A deploy-time twin of the scaffold-lint refusals.
- A method-neutral rename of the `oidc_subject=` ledger key (it now carries the
  opener's roster name in password deployments — documented honestly; #798 contract).
- Container-lane (`test_auth_serving.py`) coverage of shared cards — the mechanism is
  proved in-process at both the mint and verify ends.

- E2E lane hardening, surfaced by this PR's CI cycle but not caused by it: a
  per-worker gallery port (or `auto_launch: false`) in the e2e claude_code fixtures,
  so a plot-saving test on one xdist worker cannot own the single gallery port and
  401 every other worker's `artifact_focus`; and a look at `@flaky` retry stacking —
  three retries of one agentic test (~18 min) can push the lane past its 35-minute
  step timeout, which kills pytest before the FAILURES section prints and hides the
  traceback the retry was meant to expose.
