### PR TITLE
feat(connectors): surface alarm severity on the read path

### DIFF
--- a/changelog.d/read-alarm-severity.changed.md
+++ b/changelog.d/read-alarm-severity.changed.md
@@ -1,0 +1,4 @@
+`channel_read` now reports `alarm_severity` beside `alarm_status` when metadata
+is requested (0 healthy, higher is worse, absent when the control system reports
+none) — the same alarm fields a write already carried, so alarm state can be
+judged before a write, not only after it.

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
@@ -58,7 +58,12 @@ class ChannelMetadata:
 
     units: str = ""
     precision: int | None = None
+    #: Alarm name reported for the reading, e.g. "NO_ALARM"/"HIHI"; None if not reported.
     alarm_status: str | None = None
+    #: Alarm severity: 0 healthy, higher is worse; ``None`` means "not reported",
+    #: which stays distinct from a reported healthy value (``alarm_severity=0``) —
+    #: the same convention as :attr:`ChannelWriteResult.alarm_severity`.
+    alarm_severity: int | None = None
     timestamp: datetime | None = None
     description: str | None = None
     display_low: float | None = None

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -130,6 +130,21 @@ def _ca_enum_labels(pv: Any, index: Any) -> tuple[list[str] | None, str | None]:
     return _enum_label_fields(labels, index)
 
 
+def _severity_int(severity: Any) -> int | None:
+    """Coerce a reported alarm severity to ``int``, or ``None`` if unreported.
+
+    ``None`` means "the protocol carried no severity" and is deliberately
+    distinct from a reported healthy ``0``, so a consumer can tell "no alarm"
+    from "no information".
+    """
+    if severity is None:
+        return None
+    try:
+        return int(severity)
+    except (TypeError, ValueError):
+        return None
+
+
 def _readback_alarm_fields(readback: Any) -> tuple[str | None, int | None]:
     """Alarm name and severity of a readback, or ``(None, None)`` if unreported.
 
@@ -143,12 +158,7 @@ def _readback_alarm_fields(readback: Any) -> tuple[str | None, int | None]:
 
     status = getattr(metadata, "alarm_status", None)
     raw = getattr(metadata, "raw_metadata", None) or {}
-    severity = raw.get("severity") if isinstance(raw, dict) else None
-    if severity is not None:
-        try:
-            severity = int(severity)
-        except (TypeError, ValueError):
-            severity = None
+    severity = _severity_int(raw.get("severity") if isinstance(raw, dict) else None)
 
     return (str(status) if status is not None else None, severity)
 
@@ -616,6 +626,7 @@ class EPICSConnector(ControlSystemConnector):
             units=getattr(pv, "units", "") or "",
             precision=getattr(pv, "precision", None),
             alarm_status=_alarm_name(alarm_code),
+            alarm_severity=_severity_int(getattr(pv, "severity", None)),
             timestamp=timestamp,
             enum_labels=labels,
             enum_label=label,
@@ -743,6 +754,7 @@ class EPICSConnector(ControlSystemConnector):
             units=str(units),
             precision=int(precision) if isinstance(precision, int | float) else None,
             alarm_status=raw_metadata.get("alarm_message") or None,
+            alarm_severity=_severity_int(raw_metadata.get("severity")),
             timestamp=timestamp,
             description=str(description) if description else None,
             display_low=float(display_low) if isinstance(display_low, int | float) else None,
@@ -1141,6 +1153,7 @@ class EPICSConnector(ControlSystemConnector):
                 metadata=ChannelMetadata(
                     units=kwargs.get("units", ""),
                     alarm_status=_alarm_name(alarm_code),
+                    alarm_severity=_severity_int(kwargs.get("severity")),
                     enum_labels=labels,
                     enum_label=label,
                     raw_metadata={

--- a/src/osprey/mcp_server/control_system/tools/channel_read.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_read.py
@@ -705,7 +705,9 @@ async def channel_read(
         # Only fields the connectors actually populate. No connector reports the
         # channel's display range, so this tool does not claim to either — and a
         # write bound is a limits-database question, not a control-system read.
-        metadata_fields = ("units", "precision", "alarm_status", "description")
+        # alarm_severity follows the write-path convention: 0 healthy, higher is
+        # worse, None = the control system reported no severity.
+        metadata_fields = ("units", "precision", "alarm_status", "alarm_severity", "description")
         # Enum-only, and reported only when the control system had them: an
         # ordinary analogue channel would otherwise grow two permanently-null
         # keys in every reading, which reads as "this channel has no labels"

--- a/tests/connectors/test_epics_connector.py
+++ b/tests/connectors/test_epics_connector.py
@@ -755,8 +755,53 @@ class TestChannelAccessAlarmNames:
         await asyncio.sleep(0.01)  # let call_soon_threadsafe flush
 
         assert received[0].metadata.alarm_status == "HIGH"
+        assert received[0].metadata.alarm_severity == 1
         assert received[0].metadata.raw_metadata["status"] == 4
         assert received[0].metadata.raw_metadata["severity"] == 1
+
+
+class TestReadAlarmSeverity:
+    """Reads carry the typed severity, not just the alarm name.
+
+    ``ChannelMetadata.alarm_severity`` follows the write-path convention
+    (``ChannelWriteResult.alarm_severity``): 0 healthy, higher is worse,
+    ``None`` = the control system reported no severity. Before this field the
+    severity reached only ``raw_metadata``, which the ``channel_read`` tool
+    never surfaces — so the agent could see MAJOR-vs-MINOR after a write but
+    not on the read it based the write on.
+    """
+
+    @pytest.mark.asyncio
+    async def test_read_reports_the_typed_severity(self):
+        epics = MagicMock()
+        epics.PV.return_value = _connected_pv(status=3, severity=2)
+        connector = _connector(epics=epics)
+
+        result = await connector.read_channel("SR:CH", timeout=1.0)
+
+        assert result.metadata.alarm_severity == 2
+
+    @pytest.mark.asyncio
+    async def test_a_reported_healthy_severity_stays_zero(self):
+        epics = MagicMock()
+        epics.PV.return_value = _connected_pv(status=0, severity=0)
+        connector = _connector(epics=epics)
+
+        result = await connector.read_channel("SR:CH", timeout=1.0)
+
+        assert result.metadata.alarm_severity == 0  # not None: healthy is a report
+
+    @pytest.mark.asyncio
+    async def test_an_unreported_severity_reads_as_none(self):
+        epics = MagicMock()
+        pv = _connected_pv(status=0)
+        pv.severity = None  # PV answered its value but carried no severity
+        epics.PV.return_value = pv
+        connector = _connector(epics=epics)
+
+        result = await connector.read_channel("SR:CH", timeout=1.0)
+
+        assert result.metadata.alarm_severity is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/connectors/test_pva_read_mapping.py
+++ b/tests/connectors/test_pva_read_mapping.py
@@ -143,6 +143,7 @@ class TestNtScalarMapping:
         assert result.metadata.display_low == 0.0
         assert result.metadata.display_high == 10.0
         assert result.metadata.alarm_status == "HIGH"
+        assert result.metadata.alarm_severity == 1
         assert result.metadata.raw_metadata["nt_id"] == "epics:nt/NTScalar:1.0"
         assert result.metadata.raw_metadata["severity"] == 1
         assert result.metadata.raw_metadata["status"] == 3
@@ -204,6 +205,8 @@ class TestNtScalarMapping:
         assert result.value == 3.25
         assert result.metadata.precision == 4
         assert result.metadata.units == "mm"
+        # A reported healthy severity stays 0 — distinct from "not reported".
+        assert result.metadata.alarm_severity == 0
 
     def test_absent_display_leaves_metadata_empty_rather_than_failing(self):
         value = FakeValue("epics:nt/NTScalar:1.0", {"value": 7.0})
@@ -214,6 +217,7 @@ class TestNtScalarMapping:
         assert result.metadata.units == ""
         assert result.metadata.precision is None
         assert result.metadata.alarm_status is None
+        assert result.metadata.alarm_severity is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp_server/conftest.py
+++ b/tests/mcp_server/conftest.py
@@ -366,6 +366,7 @@ def mock_channel_value():
         cv.metadata = MagicMock()
         cv.metadata.units = units
         cv.metadata.alarm_status = alarm_status
+        cv.metadata.alarm_severity = 0
         cv.metadata.precision = 3
         cv.metadata.description = "Test channel"
         cv.metadata.min_value = 0.0

--- a/tests/mcp_server/python_executor/test_executor_limits_target.py
+++ b/tests/mcp_server/python_executor/test_executor_limits_target.py
@@ -83,6 +83,10 @@ def _run_local(tmp_path, monkeypatch) -> _LocalRun:
         targets.append(target)
         return _validator_for(target)
 
+    # _execute_via_local writes its in-flight marker under target_state.state_dir(),
+    # which resolves through the stamped agent-data root — without this the marker
+    # directory lands in the repository and trips the agent-data guard.
+    monkeypatch.setenv("OSPREY_AGENT_DATA_ROOT", str(tmp_path / "agent_data"))
     monkeypatch.setattr(host_executor, "_session_target_record", fake_record)
     # Resolvability is a config question, answered elsewhere and pinned in
     # tests/runtime/test_executor_target_stamp.py; here it only has to not

--- a/tests/mcp_server/test_channel_read_series_payload.py
+++ b/tests/mcp_server/test_channel_read_series_payload.py
@@ -31,6 +31,7 @@ def _make_channel_value(value, timestamp="2024-01-15T10:30:00"):
     cv.metadata.units = "counts"
     cv.metadata.precision = 3
     cv.metadata.alarm_status = "NO_ALARM"
+    cv.metadata.alarm_severity = 0
     cv.metadata.description = "Test channel"
     # Not an enum channel: a bare MagicMock attribute would be truthy, and the
     # read tool ships the enum keys only when they are not None.

--- a/tests/mcp_server/test_channel_read_size_rule.py
+++ b/tests/mcp_server/test_channel_read_size_rule.py
@@ -26,6 +26,7 @@ def _make_channel_value(value, timestamp="2024-01-15T10:30:00"):
     cv.metadata.units = "counts"
     cv.metadata.precision = 3
     cv.metadata.alarm_status = "NO_ALARM"
+    cv.metadata.alarm_severity = 0
     cv.metadata.description = "Test channel"
     # Not an enum channel: a bare MagicMock attribute would be truthy, and the
     # read tool ships the enum keys only when they are not None.

--- a/tests/mcp_server/test_channel_read_tool.py
+++ b/tests/mcp_server/test_channel_read_tool.py
@@ -20,6 +20,7 @@ def _make_channel_value(
     value=500.2,
     units="mA",
     alarm_status="NO_ALARM",
+    alarm_severity=0,
     timestamp="2024-01-15T10:30:00",
     enum_label=None,
     enum_labels=None,
@@ -30,6 +31,7 @@ def _make_channel_value(
     cv.metadata = MagicMock()
     cv.metadata.units = units
     cv.metadata.alarm_status = alarm_status
+    cv.metadata.alarm_severity = alarm_severity
     cv.metadata.precision = 3
     cv.metadata.description = "Test channel"
     cv.metadata.display_low = 0.0
@@ -164,6 +166,7 @@ async def test_channel_read_metadata_disabled(tmp_path, monkeypatch):
     assert "value" in channel
     assert "units" not in channel
     assert "alarm_status" not in channel
+    assert "alarm_severity" not in channel
 
 
 @pytest.mark.unit
@@ -190,6 +193,7 @@ async def test_channel_read_with_metadata(tmp_path, monkeypatch):
     assert channel["units"] == "mA"
     assert channel["value"] == 500.2
     assert channel["alarm_status"] == "NO_ALARM"
+    assert channel["alarm_severity"] == 0  # reported healthy, distinct from None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
EPICS reads captured `pv.severity` into `raw_metadata` but never surfaced it typed, while the write path already reports `alarm_status` + `alarm_severity` — so alarm state could be judged after a write but not on the read it was based on.

Lift the typed severity onto `ChannelMetadata.alarm_severity` across all four EPICS read surfaces (CA read, PVA read, CA monitor, PVA monitor) and ship it from the `channel_read` tool when metadata is requested. `None` means the control system reported no severity, kept distinct from a reported healthy `0` — the same convention as `ChannelWriteResult`. DOOCS and Mock keep reporting `None`.

Also fixes a test-harness leak found in passing: the local-executor limits tests never redirected the agent-data root, so their in-flight markers landed in the repository's `var/agent_data` and tripped the suite's agent-data guard on sequential runs.

## How it hangs together

```text
      EPICS (CA)              EPICS (PVA)
   read  ·  monitor        read  ·  monitor
       │                        │
       └───────────┬────────────┘
                   ▼
   ChannelMetadata.alarm_severity
     None = not reported  ≠  0 = reported healthy
     (same convention as ChannelWriteResult)
                   ▼
   channel_read ── metadata payload gains
   alarm_severity + the served-fields list
```
