### PR TITLE
feat(connectors): add in-tree TANGO Controls connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ renders the ready-to-run deployment into `build/`.
   approval gates.
 - **Control-system safety** — Pattern detection, channel boundary checking, and mandatory
   human approval for every hardware write.
-- **Protocol-agnostic integration** — EPICS and Mock connectors ship in-tree; LabVIEW, Tango,
-  and other stacks connect through the
-  [connector interface](https://als-apg.github.io/osprey/how-to/add-connector.html).
+- **Protocol-agnostic integration** — EPICS, DOOCS, TANGO, and Mock connectors ship in-tree;
+  LabVIEW and other stacks connect through the
+  [connector interface](https://als-apg.github.io/osprey/contributing/extending-osprey.html).
 - **Replaceable backends** — The agent harness, the underlying model, and the compute backend
   are each swappable by configuration, without changing what the operator sees.
 - **Scalable capability management** — Dynamic classification prevents prompt explosion as

--- a/changelog.d/tango-connector.added.md
+++ b/changelog.d/tango-connector.added.md
@@ -1,0 +1,7 @@
+A TANGO Controls connector now ships in-tree: `control_system.type: tango`
+reads and writes TANGO device attributes through PyTango, addressed as
+`domain/family/member/attribute`. Attribute quality is reported as the
+channel's alarm state, `DevEnum` attributes read with their state labels, and
+writes confirm with one fresh read like every other connector. PyTango is
+imported at `connect()`, so the type registers everywhere and fails with a
+clear `ImportError` only where a TANGO environment is genuinely absent.

--- a/docs/source/how-to/control-systems/use-connectors.rst
+++ b/docs/source/how-to/control-systems/use-connectors.rst
@@ -198,6 +198,51 @@ Pick a control system
          reading that is not a number -- a string, a name -- confirms by
          plain equality.
 
+   .. tab-item:: TANGO
+      :sync: tango
+
+      TANGO Controls. A channel address is a TANGO device name plus the
+      attribute served by it (``domain/family/member/attribute``, e.g.
+      ``sr/power_supply/ps01/Current``), optionally prefixed with an explicit
+      database as ``tango://host:port/domain/family/member/attribute``.
+      Without a prefix the connector reaches the database named by
+      ``TANGO_HOST``, exactly as every other TANGO client does; ``tango_host``
+      in the connector block overrides that environment for this connector
+      alone:
+
+      .. code-block:: yaml
+
+         control_system:
+           type: tango
+           connector:
+             tango:
+               tango_host: db.facility.edu:10000   # optional; default TANGO_HOST
+               timeout: 5.0                        # seconds per device call
+
+      Only **attributes** are exposed. TANGO *commands* (``command_inout``)
+      carry arbitrary payloads the limits database cannot bound, so they have
+      no seam in the connector contract -- the same reason the EPICS connector
+      refuses PVA RPC.
+
+      Reads report the attribute quality as the channel's alarm state
+      (``ATTR_WARNING`` → ``WARNING``, ``ATTR_ALARM`` → ``ALARM``, and so on),
+      and a ``DevEnum`` attribute reads as its integer index with the state
+      labels alongside it, like an EPICS ``mbbi``.
+
+      The connector requires PyTango (the ``pytango`` package). The import is
+      deferred to ``connect()``, so the name registers everywhere and only
+      fails -- with a clear ``ImportError`` instead of a silent degradation --
+      where a TANGO environment is genuinely absent.
+
+      .. note::
+
+         TANGO confirms a write the way every connector does: one fresh read
+         of the attribute, compared exactly against the value that was sent.
+         An ``ATTR_CHANGING`` quality on the readback never softens the
+         verdict -- a readback that does not yet hold the value sent is a
+         ``mismatch``, and the quality rides on the result's alarm fields for
+         the operator to interpret.
+
    .. tab-item:: Virtual Accelerator
       :sync: va
 
@@ -217,7 +262,7 @@ Pick a control system
    .. tab-item:: Your own
       :sync: custom
 
-      LabVIEW, Tango, MOAT, or any other stack OSPREY does not ship a
+      LabVIEW, MOAT, or any other stack OSPREY does not ship a
       connector for: write a custom connector against the same interface and
       register it with ``ConnectorFactory``. It then selects by name exactly
       like the in-tree ones. The seam -- the class to subclass, the pinning

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Osprey Framework Documentation
 
 The **Osprey Framework** is an agentic interface and harness for scientific facilities managing complex technical infrastructure, such as particle accelerators. It wraps a coding agent in an operator-facing safety policy, a hook-based approval chain, and an MCP-server multiplexer, so the agent layer, the underlying LLM, and the compute backend are each replaceable without changing what the operator sees. The current reference implementation is a browser-based operator workstation; other surfaces (control-room consoles, chat clients, headless services) are possible.
 
-Osprey addresses control-specific challenges: semantic addressing across large channel namespaces, :doc:`protocol-agnostic integration with control stacks </how-to/control-systems/use-connectors>` (EPICS and Mock ship in-tree; LabVIEW, Tango, and other stacks are supported via custom connectors), :doc:`logbook search <how-to/ariel/index>` across facility electronic logbooks, and mandatory human oversight for safety-critical operations.
+Osprey addresses control-specific challenges: semantic addressing across large channel namespaces, :doc:`protocol-agnostic integration with control stacks </how-to/control-systems/use-connectors>` (EPICS, DOOCS, TANGO, and Mock ship in-tree; LabVIEW and other stacks are supported via custom connectors), :doc:`logbook search <how-to/ariel/index>` across facility electronic logbooks, and mandatory human oversight for safety-critical operations.
 
 .. figure:: _static/resources/architecture.png
    :alt: Osprey system architecture — from operator to facility, with the safety gate and approval workflow in-line.

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -205,9 +205,9 @@ sections in their own ``config.yml.j2``.
    **Connector types whose name contains a dot** are the one place the flat form
    does not work. A custom connector is named by its module path, and the build
    splits only the *first* key of each ``config:`` entry on dots — so
-   ``control_system.connector.mypkg.TangoConnector.limits_checking.enabled``
+   ``control_system.connector.mypkg.MoatConnector.limits_checking.enabled``
    renders the type's module path as two nested keys, ``mypkg`` and
-   ``TangoConnector``, instead of the one key the connector is actually called.
+   ``MoatConnector``, instead of the one key the connector is actually called.
    ``osprey build`` and ``osprey validate`` refuse that entry by name rather
    than letting it render somewhere nothing reads. Write such a type as its own
    map key under a dotted prefix, which is the one spelling that puts the block
@@ -217,7 +217,7 @@ sections in their own ``config.yml.j2``.
 
       config:
         control_system.connector:
-          mypkg.TangoConnector:
+          mypkg.MoatConnector:
             limits_checking:
               enabled: true
               allow_unlisted_channels: false

--- a/docs/source/reference/contracts/connectors.rst
+++ b/docs/source/reference/contracts/connectors.rst
@@ -178,7 +178,7 @@ A connector type that carries no ``writes_enabled`` of its own inherits
 never falls back. Both default to blocked when omitted, and **only a literal**
 ``true`` **arms writes** — the quoted string ``'true'`` and the number ``1`` do
 not. A custom connector's block is keyed by the same dotted module path that
-selects it, so ``mypackage.TangoConnector`` names one block and is never split
+selects it, so ``mypackage.MoatConnector`` names one block and is never split
 on its dots.
 
 Write posture is a **launch-time deployment posture, not a live kill-switch**:

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/tango_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/tango_connector.py
@@ -1,0 +1,548 @@
+"""
+TANGO Controls control system connector using PyTango.
+
+Provides read/write access to TANGO device attributes. A channel address is
+``domain/family/member/attribute`` — the TANGO device name plus the attribute
+served by it — optionally prefixed with an explicit database,
+``tango://host:port/domain/family/member/attribute``. Without the prefix the
+connector reaches the database named by ``TANGO_HOST``, exactly as every other
+TANGO client does.
+
+Only attributes are exposed. TANGO *commands* (``command_inout``) carry
+arbitrary payloads the limits database cannot bound, so they have no seam in
+the connector contract — the same reason the EPICS connector refuses PVA RPC.
+"""
+
+import asyncio
+import secrets
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+from osprey_connectors.config import get_facility_timezone
+from osprey_connectors.control_system.base import (
+    ChannelMetadata,
+    ChannelValue,
+    ChannelWriteResult,
+    ControlSystemConnector,
+    WriteOutcome,
+    values_match,
+)
+from osprey_connectors.control_system.limits_validator import LimitsValidator
+from osprey_connectors.logger import get_logger
+
+logger = get_logger("tango_connector")
+
+_ADDRESS_FORM = "domain/family/member/attribute"
+
+#: TANGO attribute quality mapped onto the protocol-agnostic alarm fields:
+#: the name OSPREY reports and an integer severity (0 healthy, higher worse).
+#: ``ATTR_CHANGING`` is a healthy reading whose value is in motion; it is
+#: reported like any other alarm state and NEVER changes a write outcome —
+#: the write contract is one put, one read, one word, with no settling
+#: concept (a mid-ramp readback is a ``mismatch``, exactly as on EPICS).
+_QUALITY_ALARM_FIELDS: dict[str, tuple[str, int]] = {
+    "ATTR_VALID": ("NO_ALARM", 0),
+    "ATTR_CHANGING": ("CHANGING", 0),
+    "ATTR_WARNING": ("WARNING", 1),
+    "ATTR_ALARM": ("ALARM", 2),
+    "ATTR_INVALID": ("INVALID", 3),
+}
+
+
+def _split_address(channel_address: str) -> tuple[str, str]:
+    """Split a channel address into (device name, attribute name).
+
+    The last path segment is the attribute; everything before it is the TANGO
+    device name, with an optional ``tango://host:port/`` database prefix kept
+    on the device so an explicitly-addressed proxy stays explicitly addressed.
+
+    Raises:
+        ValueError: If the address does not name a device and an attribute.
+    """
+    address = channel_address.strip()
+    prefix = ""
+    body = address
+    if address.lower().startswith("tango://"):
+        rest = address[len("tango://") :]
+        host, sep, body = rest.partition("/")
+        if not sep or not host:
+            raise ValueError(
+                f"Invalid TANGO channel address '{channel_address}': expected "
+                f"'tango://host:port/{_ADDRESS_FORM}'"
+            )
+        prefix = f"tango://{host}/"
+    parts = body.split("/")
+    if len(parts) != 4 or not all(parts):
+        raise ValueError(
+            f"Invalid TANGO channel address '{channel_address}': expected '{_ADDRESS_FORM}'"
+        )
+    return prefix + "/".join(parts[:3]), parts[3]
+
+
+def _quality_fields(quality: Any) -> tuple[str | None, int | None]:
+    """Alarm name and severity for a TANGO attribute quality, or ``(None, None)``.
+
+    ``None`` means "not reported" — deliberately distinct from a reported
+    healthy reading (``NO_ALARM`` / severity ``0``), matching the contract on
+    :class:`~osprey_connectors.control_system.base.ChannelWriteResult`.
+    """
+    if quality is None:
+        return None, None
+    name = getattr(quality, "name", None) or str(quality)
+    fields = _QUALITY_ALARM_FIELDS.get(str(name))
+    if fields is None:
+        return "UNKNOWN", None
+    return fields
+
+
+def _attribute_timestamp(attr: Any, tz: Any) -> datetime:
+    """The reading's own timestamp, or now when the device reported none."""
+    time_val = getattr(attr, "time", None)
+    tv_sec = getattr(time_val, "tv_sec", None)
+    if tv_sec is None:
+        return datetime.now(tz)
+    tv_usec = getattr(time_val, "tv_usec", 0) or 0
+    return datetime.fromtimestamp(tv_sec + tv_usec / 1e6, tz)
+
+
+def _enum_label_for(labels: list[str] | None, index: Any) -> str | None:
+    """The label this reading's index resolves to, or ``None``.
+
+    Fails soft on anything unresolvable: the integer index alone is still a
+    correct, complete answer, exactly as on the EPICS connector.
+    """
+    if not labels:
+        return None
+    if isinstance(index, bool):
+        index = int(index)
+    if isinstance(index, int) and 0 <= index < len(labels):
+        return labels[index]
+    return None
+
+
+class TangoConnector(ControlSystemConnector):
+    """
+    TANGO Controls control system connector using PyTango.
+
+    Provides read/write access to TANGO device attributes through cached
+    ``DeviceProxy`` instances. Every PyTango call is a blocking device round
+    trip, so each one runs in a thread; a read is therefore always fresh —
+    there is no client-side monitor cache for a confirming read to bypass.
+    """
+
+    def __init__(self):
+        self._connected: bool = False
+        self._proxies: dict[str, Any] = {}
+        self._subscriptions: dict[str, tuple[Any, int]] = {}
+        self._enum_labels: dict[str, list[str] | None] = {}
+        self._timeout: float = 5.0
+
+    async def connect(self, config: dict[str, Any]) -> None:
+        """
+        Import PyTango and verify the TANGO database is reachable.
+
+        Args:
+            config: Optional keys — ``tango_host`` (overrides the ``TANGO_HOST``
+                environment for this connector's proxies, spelled ``host:port``)
+                and ``timeout`` (seconds, per proxy call; default 5.0).
+
+        Raises:
+            ImportError: If PyTango is not installed.
+            ConnectionError: If the TANGO database does not answer.
+        """
+        # Import PyTango here and give a clear error if not installed. The
+        # deferred import is what lets the type register unconditionally on
+        # machines with no TANGO environment (same pattern as DOOCS/MongoDB).
+        try:
+            import tango
+
+            self._tango = tango
+            logger.debug(
+                f"TANGO connector: PyTango {getattr(tango, '__version__', 'unknown')} loaded"
+            )
+        except ImportError:
+            raise ImportError("PyTango (the 'pytango' package) is required.") from None
+
+        self._tango_host: str | None = config.get("tango_host") or None
+        self._timeout = float(config.get("timeout", 5.0))
+
+        # Initialize limits validator for automatic validation and confirm policy
+        self._limits_validator = LimitsValidator.from_config(connector_type=self._connector_type)
+        if self._limits_validator:
+            logger.debug("TANGO connector: limits validator initialized")
+
+        # Test the database connection now, so a bad TANGO_HOST fails the
+        # deployment's startup instead of its first tool call.
+        try:
+            if self._tango_host:
+                host, _, port = self._tango_host.partition(":")
+                database = await asyncio.to_thread(self._tango.Database, host, port or "10000")
+            else:
+                database = await asyncio.to_thread(self._tango.Database)
+            info = await asyncio.to_thread(database.get_info)
+            logger.debug(f"TANGO connector: database reachable — {str(info).splitlines()[0]}")
+        except Exception as e:
+            raise ConnectionError(f"TANGO connector failed to reach the TANGO database: {e}") from e
+
+        self._connected = True
+        logger.debug("TANGO connector initialized")
+
+    async def disconnect(self) -> None:
+        """Cleanup TANGO subscriptions and drop the proxy cache."""
+        for sub_id in list(self._subscriptions.keys()):
+            try:
+                await self.unsubscribe(sub_id)
+            except Exception as e:  # a dead device must not wedge shutdown
+                logger.debug(f"TANGO unsubscribe failed during disconnect: {e}")
+        self._proxies.clear()
+        self._enum_labels.clear()
+        self._connected = False
+        logger.info("TANGO connector disconnected")
+
+    def _get_proxy(self, device_name: str) -> Any:
+        """The cached ``DeviceProxy`` for a device, created on first use."""
+        proxy = self._proxies.get(device_name)
+        if proxy is None:
+            name = device_name
+            if self._tango_host and not device_name.lower().startswith("tango://"):
+                name = f"tango://{self._tango_host}/{device_name}"
+            proxy = self._tango.DeviceProxy(name)
+            try:
+                proxy.set_timeout_millis(int(self._timeout * 1000))
+            except Exception:  # a proxy that cannot take a timeout keeps its default
+                logger.debug(f"TANGO proxy for '{device_name}' kept its default timeout")
+            self._proxies[device_name] = proxy
+        return proxy
+
+    def _labels_for(self, proxy: Any, device_name: str, attribute: str) -> list[str] | None:
+        """Enum labels for a ``DevEnum`` attribute, cached per attribute.
+
+        Fails soft to ``None``: labels are an enrichment, never a precondition
+        of the read.
+        """
+        key = f"{device_name}/{attribute}"
+        if key in self._enum_labels:
+            return self._enum_labels[key]
+        labels: list[str] | None
+        try:
+            info = proxy.get_attribute_config(attribute)
+            raw = getattr(info, "enum_labels", None)
+            labels = [str(label) for label in raw] if raw else None
+        except Exception as exc:
+            logger.debug(f"Could not fetch enum labels for '{key}': {exc}")
+            labels = None
+        self._enum_labels[key] = labels
+        return labels
+
+    def _read_channel_sync(self, channel_address: str) -> ChannelValue:
+        """Synchronous TANGO read (runs in a thread)."""
+        device_name, attribute = _split_address(channel_address)
+        proxy = self._get_proxy(device_name)
+
+        attr = proxy.read_attribute(attribute)
+        value = attr.value
+        quality = getattr(attr, "quality", None)
+        alarm_status, severity = _quality_fields(quality)
+        timestamp = _attribute_timestamp(attr, get_facility_timezone())
+
+        enum_labels: list[str] | None = None
+        enum_label: str | None = None
+        attr_type = getattr(attr, "type", None)
+        if attr_type is not None and "DevEnum" in str(attr_type):
+            enum_labels = self._labels_for(proxy, device_name, attribute)
+            enum_label = _enum_label_for(enum_labels, value)
+
+        metadata = ChannelMetadata(
+            units="",
+            precision=None,
+            alarm_status=alarm_status,
+            timestamp=timestamp,
+            enum_labels=enum_labels,
+            enum_label=enum_label,
+            raw_metadata={
+                # Severity rides in raw_metadata exactly as on the EPICS read
+                # path; the write path lifts it onto the result.
+                "severity": severity,
+                "quality": str(getattr(quality, "name", None) or quality)
+                if quality is not None
+                else None,
+            },
+        )
+        # ChannelMetadata grows a first-class alarm_severity field
+        # independently of this connector; populate it where it exists rather
+        # than depending on it.
+        if hasattr(metadata, "alarm_severity"):
+            metadata.alarm_severity = severity
+        return ChannelValue(value=value, timestamp=timestamp, metadata=metadata)
+
+    async def read_channel(
+        self, channel_address: str, timeout: float | None = None
+    ) -> ChannelValue:
+        """
+        Read the current value of a TANGO device attribute.
+
+        Args:
+            channel_address: ``domain/family/member/attribute``
+            timeout: Optional per-call ceiling in seconds; the proxy's own
+                timeout (``timeout`` in the connector config) applies beneath it
+
+        Returns:
+            ChannelValue with value, timestamp, alarm state and (on ``DevEnum``
+            attributes) the state labels
+
+        Raises:
+            ValueError: If the address does not name a device and an attribute
+            TimeoutError: If the per-call ceiling elapses
+        """
+        call = asyncio.to_thread(self._read_channel_sync, channel_address)
+        if timeout is not None:
+            return await asyncio.wait_for(call, timeout)
+        return await call
+
+    async def write_channel(
+        self,
+        channel_address: str,
+        value: Any,
+        timeout: float | None = None,
+        confirm: bool | None = None,
+    ) -> ChannelWriteResult:
+        """
+        Write a value to a TANGO attribute, confirming it unless asked not to.
+
+        A confirmed write is the value sent followed by one fresh read of the
+        same attribute — every PyTango read is a device round trip, so the
+        confirming read is fresh by construction — compared with
+        :func:`~osprey_connectors.control_system.base.values_match`. On a
+        ``DevEnum`` attribute a value written as text is compared against the
+        readback's resolved label, exactly as on EPICS.
+
+        The readback's attribute quality is reported on the result
+        (``alarm_status`` / ``alarm_severity``), never raised on — and
+        ``ATTR_CHANGING`` does not soften the verdict: a readback that does not
+        yet hold the value sent is a ``mismatch``, whatever its quality says.
+
+        Args:
+            channel_address: ``domain/family/member/attribute``
+            value: Value to write
+            timeout: Optional per-call ceiling for the confirming read
+            confirm: Whether to re-read and compare, or ``None`` to resolve the
+                policy for this channel from the limits database
+
+        Returns:
+            ChannelWriteResult carrying the outcome and what the attribute was
+            seen to hold
+
+        Raises:
+            ChannelLimitsViolationError: If limits validation fails (when enabled)
+            ValueError: If the address does not name a device and an attribute
+        """
+        # The address must parse before anything is validated or sent.
+        device_name, attribute = _split_address(channel_address)
+
+        # Step 1: Validate limits (if enabled)
+        if self._limits_validator:
+            try:
+                self._limits_validator.validate(channel_address, value)
+                logger.debug(f"✓ Limits validation passed: {channel_address}={value}")
+            except Exception as e:
+                # Import here to avoid circular dependency
+                from osprey_connectors.errors import ChannelLimitsViolationError
+
+                # Re-raise limits violations
+                if isinstance(e, ChannelLimitsViolationError):
+                    raise
+
+                # Log unexpected errors but don't block (fail-open for non-limit errors)
+                logger.warning(f"Limits validation error (non-blocking): {e}")
+
+        # Step 2: Resolve the confirmation policy. An explicit confirm — False
+        # every bit as much as True — is an answer and is taken as given; only
+        # an omitted one is resolved from the limits database.
+        if confirm is None:
+            confirm = self._resolve_confirm(channel_address)
+
+        # Step 3: Send the value. Creating a DeviceProxy is itself a database
+        # round trip, so a cold cache is filled in the thread too.
+        try:
+            proxy = await asyncio.to_thread(self._get_proxy, device_name)
+            await asyncio.to_thread(proxy.write_attribute, attribute, value)
+        except Exception as e:
+            return ChannelWriteResult(
+                channel_address=channel_address,
+                value_written=value,
+                outcome=WriteOutcome.FAILED,
+                error_message=f"Failed to write to '{channel_address}': {e}",
+                notes="TANGO did not take the value",
+            )
+
+        if not confirm:
+            logger.debug(f"TANGO write (unconfirmed by request): {channel_address} = {value}")
+            return ChannelWriteResult(
+                channel_address=channel_address,
+                value_written=value,
+                outcome=WriteOutcome.UNREQUESTED,
+                notes="No confirmation requested",
+            )
+
+        # Step 4: Confirm with one fresh read
+        try:
+            readback = await self.read_channel(channel_address, timeout=timeout)
+        except Exception as e:
+            logger.warning(f"TANGO confirming read failed for {channel_address}: {e}")
+            return ChannelWriteResult(
+                channel_address=channel_address,
+                value_written=value,
+                outcome=WriteOutcome.UNCONFIRMED,
+                error_message=f"Confirming read of '{channel_address}' failed: {e}",
+                notes="The value was sent; what the attribute holds is unknown",
+            )
+
+        observed = readback.value
+        confirmed = values_match(value, observed, enum_label=readback.metadata.enum_label)
+        raw = readback.metadata.raw_metadata or {}
+
+        logger.debug(
+            f"TANGO write ({'confirmed' if confirmed else 'mismatch'}): "
+            f"{channel_address} = {value!r}, observed {observed!r}"
+        )
+
+        return ChannelWriteResult(
+            channel_address=channel_address,
+            value_written=value,
+            outcome=WriteOutcome.CONFIRMED if confirmed else WriteOutcome.MISMATCH,
+            observed_value=observed,
+            alarm_status=readback.metadata.alarm_status,
+            alarm_severity=raw.get("severity"),
+            notes=(
+                f"Observed {observed!r}" if confirmed else f"Observed {observed!r}, sent {value!r}"
+            ),
+        )
+
+    async def read_multiple_channels(
+        self, channel_addresses: list[str], timeout: float | None = None
+    ) -> dict[str, ChannelValue]:
+        """Read multiple channels concurrently."""
+        tasks = [self.read_channel(ch_addr, timeout) for ch_addr in channel_addresses]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        return {
+            ch_addr: result
+            for ch_addr, result in zip(channel_addresses, results, strict=False)
+            if not isinstance(result, Exception)
+        }
+
+    async def subscribe(
+        self, channel_address: str, callback: Callable[[ChannelValue], None]
+    ) -> str:
+        """
+        Subscribe to attribute change events.
+
+        Requires the device to have change events configured — TANGO refuses
+        the subscription otherwise, and that refusal propagates.
+
+        Args:
+            channel_address: ``domain/family/member/attribute``
+            callback: Function to call when the value changes
+
+        Returns:
+            Subscription ID for later unsubscription
+        """
+        device_name, attribute = _split_address(channel_address)
+        proxy = await asyncio.to_thread(self._get_proxy, device_name)
+        loop = asyncio.get_event_loop()
+        tz = get_facility_timezone()
+
+        def tango_callback(event: Any) -> None:
+            """Wrapper converting a TANGO change event to OSPREY format."""
+            if getattr(event, "err", False):
+                return
+            attr = getattr(event, "attr_value", None)
+            if attr is None:
+                return
+            alarm_status, severity = _quality_fields(getattr(attr, "quality", None))
+            timestamp = _attribute_timestamp(attr, tz)
+            metadata = ChannelMetadata(
+                alarm_status=alarm_status,
+                timestamp=timestamp,
+                raw_metadata={"severity": severity},
+            )
+            if hasattr(metadata, "alarm_severity"):
+                metadata.alarm_severity = severity
+            channel_value = ChannelValue(value=attr.value, timestamp=timestamp, metadata=metadata)
+            loop.call_soon_threadsafe(callback, channel_value)
+
+        event_id = await asyncio.to_thread(
+            proxy.subscribe_event,
+            attribute,
+            self._tango.EventType.CHANGE_EVENT,
+            tango_callback,
+        )
+
+        sub_id = f"{channel_address}_{secrets.token_hex(8)}"
+        self._subscriptions[sub_id] = (proxy, event_id)
+        logger.debug(f"TANGO subscription created: {sub_id}")
+        return sub_id
+
+    async def unsubscribe(self, subscription_id: str) -> None:
+        """Unsubscribe from TANGO attribute change events."""
+        if subscription_id in self._subscriptions:
+            proxy, event_id = self._subscriptions.pop(subscription_id)
+            await asyncio.to_thread(proxy.unsubscribe_event, event_id)
+            logger.debug(f"TANGO subscription removed: {subscription_id}")
+
+    async def get_metadata(self, channel_address: str) -> ChannelMetadata:
+        """Get metadata for a channel, enriched from the attribute config.
+
+        The attribute config carries what a reading does not: units and the
+        description. TANGO's ``min_value``/``max_value`` are write limits, not
+        a display range, so they ride in ``raw_metadata`` rather than being
+        reported as ``display_low``/``display_high`` — OSPREY's enforced
+        bounds live in the limits database, not here.
+        """
+        channel_value = await self.read_channel(channel_address)
+        metadata = channel_value.metadata
+
+        device_name, attribute = _split_address(channel_address)
+        try:
+            proxy = self._get_proxy(device_name)
+            info = await asyncio.to_thread(proxy.get_attribute_config, attribute)
+        except Exception as exc:  # the reading's own metadata still stands
+            logger.debug(f"Could not fetch attribute config for '{channel_address}': {exc}")
+            return metadata
+
+        unit = getattr(info, "unit", "") or ""
+        if unit.lower() in ("no unit", "none"):  # TANGO's spellings of "unitless"
+            unit = ""
+        metadata.units = unit
+        metadata.description = getattr(info, "description", None) or None
+        if metadata.description in ("No description",):
+            metadata.description = None
+        raw = metadata.raw_metadata or {}
+        raw.update(
+            {
+                "min_value": getattr(info, "min_value", None),
+                "max_value": getattr(info, "max_value", None),
+                "format": getattr(info, "format", None),
+                "writable": str(getattr(info, "writable", None)),
+            }
+        )
+        metadata.raw_metadata = raw
+        return metadata
+
+    async def validate_channel(self, channel_address: str) -> bool:
+        """
+        Check if the attribute exists and is readable.
+
+        Args:
+            channel_address: ``domain/family/member/attribute``
+
+        Returns:
+            True if the channel can be read
+        """
+        try:
+            await self.read_channel(channel_address)
+            return True
+        except Exception as e:
+            logger.debug(f"TANGO channel validation failed for {channel_address}: {e}")
+            return False

--- a/packages/osprey-connectors/src/osprey_connectors/factory.py
+++ b/packages/osprey-connectors/src/osprey_connectors/factory.py
@@ -397,6 +397,7 @@ _BUILTIN_CONTROL_SYSTEMS = (
     types.EPICS,
     types.VIRTUAL_ACCELERATOR,
     types.DOOCS,
+    types.TANGO,
     types.LIVE_STANDIN,
 )
 _BUILTIN_ARCHIVERS = (
@@ -442,6 +443,7 @@ def register_builtin_connectors() -> None:
     from osprey_connectors.control_system.doocs_connector import DOOCSConnector
     from osprey_connectors.control_system.epics_connector import EPICSConnector
     from osprey_connectors.control_system.mock_connector import MockConnector
+    from osprey_connectors.control_system.tango_connector import TangoConnector
     from osprey_connectors.control_system.va_connector import VirtualAcceleratorConnector
 
     control_systems: list[tuple[str, type[ControlSystemConnector]]] = [
@@ -449,6 +451,7 @@ def register_builtin_connectors() -> None:
         (types.EPICS, EPICSConnector),
         (types.VIRTUAL_ACCELERATOR, VirtualAcceleratorConnector),
         (types.DOOCS, DOOCSConnector),
+        (types.TANGO, TangoConnector),
         # The live stand-in is a soft IOC, so the EPICS connector is what reaches
         # it — but it registers under its own name rather than sharing 'epics'.
         # The registry key is what build_control_system_connector() stamps onto

--- a/packages/osprey-connectors/src/osprey_connectors/types.py
+++ b/packages/osprey-connectors/src/osprey_connectors/types.py
@@ -1,7 +1,7 @@
 """Connector type constants, and the fallbacks a factory applies to them.
 
 Single source of truth for built-in connector type name strings.
-Custom connectors use dotted module paths (e.g., 'mypackage.TangoConnector')
+Custom connectors use dotted module paths (e.g., 'mypackage.MoatConnector')
 and don't need constants here.
 
 The resolvers at the bottom are here rather than in
@@ -56,6 +56,7 @@ MOCK = "mock"
 EPICS = "epics"
 VIRTUAL_ACCELERATOR = "virtual_accelerator"
 DOOCS = "doocs"
+TANGO = "tango"
 
 #: The live stand-in: a facility-shaped soft IOC a deployment runs for itself.
 #: A connector type of its own — served by the EPICS connector, but keyed apart
@@ -71,7 +72,7 @@ MONGODB_ARCHIVER = "mongodb_archiver"
 DOOCS_ARCHIVER = "doocs_archiver"
 
 # -- CLI choice lists (only types with implementations) --
-CLI_CONTROL_SYSTEM_TYPES = [MOCK, EPICS, VIRTUAL_ACCELERATOR, DOOCS]
+CLI_CONTROL_SYSTEM_TYPES = [MOCK, EPICS, VIRTUAL_ACCELERATOR, DOOCS, TANGO]
 CLI_ARCHIVER_TYPES = [MOCK_ARCHIVER, EPICS_ARCHIVER, MONGODB_ARCHIVER, DOOCS_ARCHIVER]
 
 #: Settable, not initable. A deployment may be pointed at its stand-in once it
@@ -381,7 +382,7 @@ def type_writes_enabled(section: Any, connector_type: str) -> bool:
 
     A tri-state on ``control_system.connector.<type>.writes_enabled``, where
     *connector_type* is one key. A custom connector's dotted module path
-    (``'mypackage.TangoConnector'``) names a single block, never a path through
+    (``'mypackage.MoatConnector'``) names a single block, never a path through
     several, so the type is looked up whole and never split on its dots:
 
     - **Absent** — no connector table, no block for this type, a block that is
@@ -611,7 +612,7 @@ class LimitsPosture:
         ``control_system.connector.<type>.limits_checking.<leaf>`` when a
         connector block answered, and ``control_system.limits_checking.<leaf>``
         when the deployment-wide block did. A custom connector's dotted module
-        path (``'mypackage.TangoConnector'``) is one key and is interpolated
+        path (``'mypackage.MoatConnector'``) is one key and is interpolated
         whole, never split on its dots.
 
         A posture holding no type at all — the deployment-wide answer, and the
@@ -664,7 +665,7 @@ def type_limits_posture(section: Any, connector_type: str | None) -> LimitsPostu
     ``control_system.connector.<type>.limits_checking`` when that block is
     there, and ``control_system.limits_checking`` when it is not, where
     *connector_type* is one key. A custom connector's dotted module path
-    (``'mypackage.TangoConnector'``) names a single block, never a path through
+    (``'mypackage.MoatConnector'``) names a single block, never a path through
     several, so the type is looked up whole and never split on its dots.
 
     The per-type block overrides **whole**, and that is the rule the rest of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -509,6 +509,7 @@ module = [
     "podman.*",
     "pymongo.*",
     "doocs4py.*",
+    "tango.*",
 ]
 ignore_missing_imports = true
 

--- a/src/osprey/cli/build_profile_deploy.py
+++ b/src/osprey/cli/build_profile_deploy.py
@@ -423,7 +423,7 @@ def limits_block_errors(config: Mapping[str, Any]) -> list[str]:
             f"a dotted custom type as its own map key:\n"
             f"  config:\n"
             f"    control_system.connector:\n"
-            f"      mypkg.TangoConnector:\n"
+            f"      mypkg.MoatConnector:\n"
             f"        limits_checking:\n"
             f"          enabled: true\n"
             f"          allow_unlisted_channels: false"

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1215,8 +1215,8 @@ def _reject_shorthand_flags(command: Callable) -> Callable:
     help="Inline scalar/list override baked into the emitted profile (repeatable). "
     "RHS parsed as YAML. Top-level shorthands: provider, model, "
     "channel_finder_mode, connector (the control system to talk to — mock, "
-    "epics, virtual_accelerator, doocs; a deployment being pointed at its "
-    "stand-in may also set live_standin), port_base (move the whole "
+    "epics, virtual_accelerator, doocs, tango; a deployment being pointed at "
+    "its stand-in may also set live_standin), port_base (move the whole "
     "deployment off the default 10000 port block, e.g. --set port_base=42000).",
 )
 @click.option(

--- a/src/osprey/connectors/control_system/tango_connector.py
+++ b/src/osprey/connectors/control_system/tango_connector.py
@@ -1,0 +1,7 @@
+"""Compatibility shim: this module now lives in osprey_connectors."""
+
+import sys
+
+from osprey_connectors.control_system import tango_connector as _mod
+
+sys.modules[__name__] = _mod

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -1659,7 +1659,7 @@ def _connector_writes_type(path: str) -> str | None:
 
     ``None`` for any other path. The type is everything between the two fixed
     ends rather than one segment, because a custom connector's type key is its
-    dotted module path (``mypackage.TangoConnector``) and rejoining it is what
+    dotted module path (``mypackage.MoatConnector``) and rejoining it is what
     keeps the message naming the key the operator would have to write.
     """
     parts = path.split(".")

--- a/src/osprey/registry/builtins.py
+++ b/src/osprey/registry/builtins.py
@@ -15,6 +15,7 @@ from osprey.connectors.types import (
     MOCK,
     MOCK_ARCHIVER,
     MONGODB_ARCHIVER,
+    TANGO,
     VIRTUAL_ACCELERATOR,
 )
 
@@ -86,6 +87,13 @@ class FrameworkRegistryProvider(RegistryConfigProvider):
                     module_path="osprey.connectors.control_system.doocs_connector",
                     class_name="DOOCSConnector",
                     description="DOOCS control system connector (requires doocs4py)",
+                ),
+                ConnectorRegistration(
+                    name=TANGO,
+                    connector_type="control_system",
+                    module_path="osprey.connectors.control_system.tango_connector",
+                    class_name="TangoConnector",
+                    description="TANGO Controls control system connector (requires PyTango)",
                 ),
                 # The live stand-in is a soft IOC, so the EPICS connector is
                 # what reaches it — but it is registered under its own name,

--- a/src/osprey/templates/apps/control_assistant/README.md.j2
+++ b/src/osprey/templates/apps/control_assistant/README.md.j2
@@ -18,7 +18,7 @@ This application shows how to build an AI assistant for an accelerator control s
 - **Historical Data Analysis** - Retrieve and analyze time-series data from archiver
 - **Benchmarking** - Evaluate channel finder performance
 - **Development Mode** - Works with mock connectors (no hardware required)
-- **Real Hardware** - Switch to EPICS or DOOCS systems by changing config; other stacks connect through custom connectors
+- **Real Hardware** - Switch to EPICS, DOOCS, or TANGO systems by changing config; other stacks connect through custom connectors
 
 {% if channel_finder_mode == 'in_context' %}
 **Channel Finder Mode:** In-Context (Semantic Search)
@@ -368,7 +368,7 @@ This template uses **pluggable connectors**, so moving from development to produ
 
 The template uses the **Osprey Connector Abstraction**, which provides:
 - **Development Mode**: Mock connectors work with any channel names (no hardware required)
-- **Production Mode**: Real connectors (EPICS, DOOCS) with the same API; LabVIEW, Tango and other stacks are supported via custom connectors
+- **Production Mode**: Real connectors (EPICS, DOOCS, TANGO) with the same API; LabVIEW and other stacks are supported via custom connectors
 - **Zero Code Changes**: Switch modes by editing `profile.yml` and running `osprey build`
 
 ### Migration to Production
@@ -456,7 +456,7 @@ await connector.disconnect()
 
 ### Advanced: Custom Connectors
 
-Need to support a different control system (LabVIEW, Tango, etc.)?
+Need to support a different control system (LabVIEW, OPC-UA, etc.)?
 
 **Step 1: Implement your custom connector**
 

--- a/src/osprey/templates/skills/osprey-build-interview/references/upstream-scout.md
+++ b/src/osprey/templates/skills/osprey-build-interview/references/upstream-scout.md
@@ -122,7 +122,7 @@ Otherwise write the report to `upstream/<short-id>.md` in the deployment repo
 line. The entry itself stays four short lines; the write-up never goes inline.
 
 ```markdown
-## <Short imperative title, e.g. "Support Tango as a control-system connector">
+## <Short imperative title, e.g. "Support OPC-UA as a control-system connector">
 
 **Facility:** <name> · **Control system:** <type> · **Found during:** OSPREY build interview
 

--- a/tests/cli/test_build_profile_validate.py
+++ b/tests/cli/test_build_profile_validate.py
@@ -985,10 +985,10 @@ def test_build_refuses_a_profile_writing_only_one_limits_leaf(tmp_path: Path) ->
 
 
 def test_build_refuses_a_flat_dotted_custom_type(tmp_path: Path) -> None:
-    """Flattened, the dots in ``mypkg.TangoConnector`` are indistinguishable
+    """Flattened, the dots in ``mypkg.MoatConnector`` are indistinguishable
     from path separators, so the emitter renders a key no connector reads. The
     build names the offending key instead of rendering the dead spelling."""
-    key = "control_system.connector.mypkg.TangoConnector.limits_checking.enabled"
+    key = "control_system.connector.mypkg.MoatConnector.limits_checking.enabled"
 
     result = _build_with_config(tmp_path, {key: True}, "dotted-type")
 

--- a/tests/cli/test_connector_shorthand.py
+++ b/tests/cli/test_connector_shorthand.py
@@ -213,7 +213,7 @@ def test_wrong_case_connector_suggests_the_exact_spelling() -> None:
 def test_unrecognizable_connector_lists_every_valid_choice() -> None:
     """With nothing close enough to suggest, the full choice list still lands."""
     with pytest.raises(BuildProfileError) as excinfo:
-        _parse_profile({"name": "x", "connector": "tango"})
+        _parse_profile({"name": "x", "connector": "moat"})
 
     message = str(excinfo.value)
     assert "Valid connectors are:" in message
@@ -224,7 +224,7 @@ def test_unrecognizable_connector_lists_every_valid_choice() -> None:
 def test_custom_connector_path_is_pointed_at_the_literal_key() -> None:
     """A dotted module path is not a shorthand value; the error says what is."""
     with pytest.raises(BuildProfileError) as excinfo:
-        _parse_profile({"name": "x", "connector": "mypackage.TangoConnector"})
+        _parse_profile({"name": "x", "connector": "mypackage.MoatConnector"})
 
     assert CONNECTOR_CONFIG_KEY in str(excinfo.value)
 
@@ -370,7 +370,7 @@ def test_misspelled_stand_in_suggests_the_stand_in() -> None:
 def test_invalid_connector_lists_the_stand_in_among_the_choices() -> None:
     """The refusal names every settable type, the stand-in included."""
     with pytest.raises(BuildProfileError) as excinfo:
-        _parse_profile({"name": "x", "connector": "tango"})
+        _parse_profile({"name": "x", "connector": "moat"})
 
     assert LIVE_STANDIN in str(excinfo.value)
 

--- a/tests/cli/test_profile_validate_limits_block.py
+++ b/tests/cli/test_profile_validate_limits_block.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from osprey.cli.build_profile_deploy import limits_block_errors
 
-CUSTOM_TYPE = "mypkg.TangoConnector"
+CUSTOM_TYPE = "mypkg.MoatConnector"
 
 
 def _complete(*, enabled: bool = True, allow_unlisted: bool = False) -> dict[str, Any]:

--- a/tests/connectors/test_cross_connector_parity.py
+++ b/tests/connectors/test_cross_connector_parity.py
@@ -1,9 +1,9 @@
 """Every connector confirms a write the same way.
 
 The write contract's claim is not that each connector *has* a confirm flow —
-it is that the three of them report the **same word** for the same situation.
+it is that the four of them report the **same word** for the same situation.
 A caller that reads ``result.outcome`` must not have to know whether the
-channel behind it is EPICS, DOOCS, or the simulator.
+channel behind it is EPICS, DOOCS, TANGO, or the simulator.
 
 That claim only holds if it is written down once. So the five scenarios below
 each name their expected outcome exactly once, in ``_SCENARIOS``, and every
@@ -20,6 +20,8 @@ deliberately the ones the connector authors left:
   confirming read does differently.
 - **DOOCS** — a fake ``doocs4py`` module whose ``set``/``get`` are the put and
   the confirming read.
+- **TANGO** — a fake ``tango`` module whose ``DeviceProxy`` carries the put
+  (``write_attribute``) and the confirming read (``read_attribute``).
 
 Writes are enabled through each file's existing config-patch idiom, and no
 limits validator is installed anywhere: limits are a different contract, and
@@ -289,10 +291,74 @@ async def _run_doocs(scenario: Scenario, monkeypatch) -> WriteRun:
     return WriteRun(result=result, confirming_reads=mock_d4py.get.call_count)
 
 
+# ---------------------------------------------------------------------------
+# TANGO — seam: a fake tango module serving one DeviceProxy
+# ---------------------------------------------------------------------------
+
+_TANGO_LIMITS_PATCH = "osprey.connectors.control_system.tango_connector.LimitsValidator.from_config"
+_TANGO_TZ_PATCH = "osprey.connectors.control_system.tango_connector.get_facility_timezone"
+
+
+def _device_attribute(value):
+    """A mock DeviceAttribute as returned by ``DeviceProxy.read_attribute()``."""
+    time_val = MagicMock()
+    time_val.tv_sec = 1_700_000_000
+    time_val.tv_usec = 500_000
+
+    attr = MagicMock()
+    attr.value = value
+    attr.quality = None
+    attr.time = time_val
+    attr.type = "DevDouble"
+    return attr
+
+
+def _fake_tango(observed):
+    proxy = MagicMock()
+    proxy.read_attribute.return_value = _device_attribute(observed)
+    proxy.write_attribute.return_value = None
+
+    t = MagicMock()
+    t.__version__ = "10.0.0"
+    t.DeviceProxy.return_value = proxy
+    database = MagicMock()
+    database.get_info.return_value = "TANGO Database sys/database/2"
+    t.Database.return_value = database
+    return t, proxy
+
+
+async def _run_tango(scenario: Scenario, monkeypatch) -> WriteRun:
+    """Drive TangoConnector through ``scenario`` against a fake tango module."""
+    observed = VALUE_HELD_INSTEAD if scenario is VALUE_DIFFERS else VALUE_SENT
+    mock_tango, proxy = _fake_tango(observed)
+    if scenario is READ_RAISES:
+        proxy.read_attribute.side_effect = RuntimeError(READ_ERROR)
+    if scenario is PUT_FAILS:
+        proxy.write_attribute.side_effect = RuntimeError(PUT_ERROR)
+
+    with (
+        patch.dict(sys.modules, {"tango": mock_tango}),
+        patch(_TANGO_LIMITS_PATCH, return_value=None),
+        patch(_TANGO_TZ_PATCH, return_value=UTC),
+        patch("osprey.utils.config.get_config_value", side_effect=_writes_enabled),
+    ):
+        from osprey.connectors.control_system.tango_connector import TangoConnector
+
+        conn = TangoConnector()
+        await conn.connect({})
+        result = await conn.write_channel(
+            "sr/power_supply/ps01/Current", VALUE_SENT, confirm=_confirm_argument(scenario)
+        )
+        await conn.disconnect()
+
+    return WriteRun(result=result, confirming_reads=proxy.read_attribute.call_count)
+
+
 _DRIVERS = {
     "mock": _run_mock,
     "epics": _run_epics,
     "doocs": _run_doocs,
+    "tango": _run_tango,
 }
 
 
@@ -304,7 +370,7 @@ _DRIVERS = {
 @pytest.mark.parametrize("connector_name", list(_DRIVERS), ids=list(_DRIVERS))
 @pytest.mark.parametrize("scenario", _SCENARIOS, ids=[s.name for s in _SCENARIOS])
 class TestWriteOutcomeParity:
-    """The same situation gets the same outcome word from all three connectors."""
+    """The same situation gets the same outcome word from all four connectors."""
 
     async def test_the_outcome_word_is_the_same_for_every_connector(
         self, connector_name, scenario, monkeypatch
@@ -370,11 +436,12 @@ class TestEpicsOnlyConfirmation:
     async def test_an_enum_label_written_as_text_is_confirmed_by_its_index(self, monkeypatch):
         """An mbbo takes "ON" and reads back 1; that is the same state.
 
-        EPICS is the only connector that reports an ``enum_label``, and without
-        it the comparison would see ``"ON" != 1`` and call a write the machine
-        took exactly as sent a mismatch. DOOCS, which has no labels, would
-        report that same pairing as a mismatch — so this is deliberately not a
-        parity row.
+        EPICS reports an ``enum_label`` for the reading, and without it the
+        comparison would see ``"ON" != 1`` and call a write the machine took
+        exactly as sent a mismatch. TANGO resolves labels the same way (its
+        own unit tests pin it); DOOCS and Mock report no labels and would call
+        that same pairing a mismatch — so this is deliberately not a parity
+        row.
         """
         pv = _fake_pv(1, pv_type="time_enum", labels=("OFF", "ON"))
         connector = _epics_connector(monkeypatch, pv=pv)

--- a/tests/connectors/test_dynamic_connector.py
+++ b/tests/connectors/test_dynamic_connector.py
@@ -67,7 +67,7 @@ class TestDynamicConnectorImport:
     @pytest.mark.asyncio
     async def test_simple_unknown_type_error_message(self):
         """Non-dotted unknown type still raises with helpful message."""
-        config = {"type": "tango", "connector": {}}
+        config = {"type": "moat", "connector": {}}
         with pytest.raises(ValueError, match="Use a dotted module path"):
             await ConnectorFactory.create_control_system_connector(config)
 
@@ -106,7 +106,7 @@ class TestControlSystemContextValidation:
         registry = ControlSystemContext()
         registry._config = MCPServerConfig(
             raw={
-                "control_system": {"type": "tango"},
+                "control_system": {"type": "moat"},
                 "archiver": {"type": "custom_archiver"},
             }
         )
@@ -114,7 +114,7 @@ class TestControlSystemContextValidation:
             logging.WARNING, logger="osprey.mcp_server.control_system.server_context"
         ):
             registry._validate()
-        assert "Unknown control_system.type: tango" in caplog.text
+        assert "Unknown control_system.type: moat" in caplog.text
         assert "Unknown archiver.type: custom_archiver" in caplog.text
 
 

--- a/tests/connectors/test_limits_posture.py
+++ b/tests/connectors/test_limits_posture.py
@@ -45,7 +45,7 @@ from osprey_connectors.types import (
     type_limits_posture,
 )
 
-CUSTOM_TYPE = "mypackage.TangoConnector"
+CUSTOM_TYPE = "mypackage.MoatConnector"
 
 #: Leaf values a limits block may carry that no reader can turn into a boolean.
 #: ``"${X}"`` is the one that matters most: environment expansion always yields
@@ -120,7 +120,7 @@ class TestLimitsPosture:
         """A custom connector's dotted module path is one key, never a path."""
         posture = LimitsPosture(enabled=True, allow_unlisted=False, connector_type=CUSTOM_TYPE)
         assert posture.key("enabled") == (
-            "control_system.connector.mypackage.TangoConnector.limits_checking.enabled"
+            "control_system.connector.mypackage.MoatConnector.limits_checking.enabled"
         )
 
     def test_key_treats_an_empty_type_as_no_type(self) -> None:
@@ -400,7 +400,7 @@ class TestTypeLimitsPosture:
         assert type_limits_posture(section, VIRTUAL_ACCELERATOR).strict is False
 
     def test_a_dotted_custom_type_is_one_key_and_not_a_path(self) -> None:
-        """``mypackage.TangoConnector`` names one block, never two nested ones.
+        """``mypackage.MoatConnector`` names one block, never two nested ones.
 
         A connector table that happens to nest the dots is not this type's
         block, so the deployment-wide posture answers rather than a mapping
@@ -408,9 +408,7 @@ class TestTypeLimitsPosture:
         """
         section = _section(
             _block(True, False),
-            connector={
-                "mypackage": {"TangoConnector": {LIMITS_CHECKING_LEAF: _block(False, True)}}
-            },
+            connector={"mypackage": {"MoatConnector": {LIMITS_CHECKING_LEAF: _block(False, True)}}},
         )
         assert type_limits_posture(section, CUSTOM_TYPE) == LimitsPosture(True, False, None)
 
@@ -1215,7 +1213,7 @@ class TestIncompleteBlocks:
         """The connector table's key is the type, dots and all, never a path."""
         section = _section(connector={CUSTOM_TYPE: {LIMITS_CHECKING_LEAF: _block(enabled=True)}})
         assert incomplete_limits_blocks(section) == [
-            "control_system.connector.mypackage.TangoConnector.limits_checking."
+            "control_system.connector.mypackage.MoatConnector.limits_checking."
             "allow_unlisted_channels is missing; a per-type limits block must state "
             "both enabled and allow_unlisted_channels"
         ]

--- a/tests/connectors/test_limits_validator.py
+++ b/tests/connectors/test_limits_validator.py
@@ -203,7 +203,7 @@ def _nested_control_system(values: dict) -> dict:
 
     Nesting on every dot is only correct because these keys name built-in
     leaves. A ``control_system.connector.*`` key would be nested on the dots of
-    the connector type too — ``mypackage.TangoConnector`` becoming two levels —
+    the connector type too — ``mypackage.MoatConnector`` becoming two levels —
     which is exactly the mistake the resolvers refuse to make, so a test that
     needs a per-type block passes ``control_system`` itself rather than adding
     one here.
@@ -919,14 +919,14 @@ class TestFromPosture:
         posture = LimitsPosture(
             enabled=None,
             allow_unlisted=None,
-            connector_type="mypackage.TangoConnector",
+            connector_type="mypackage.MoatConnector",
             incomplete=("enabled", "allow_unlisted_channels"),
         )
 
         validator = LimitsValidator._from_posture(posture)
 
         assert validator.failsafe_reason == (
-            "control_system.connector.mypackage.TangoConnector.limits_checking "
+            "control_system.connector.mypackage.MoatConnector.limits_checking "
             "does not state enabled, allow_unlisted_channels as true/false"
         )
 

--- a/tests/connectors/test_shim_identity.py
+++ b/tests/connectors/test_shim_identity.py
@@ -59,14 +59,20 @@ def test_simulation_core_shims_preserve_module_identity():
 def test_connector_shims_preserve_module_identity():
     import osprey.connectors.archiver.base
     import osprey.connectors.control_system.epics_connector
+    import osprey.connectors.control_system.tango_connector
     import osprey.connectors.factory
     import osprey_connectors.archiver.base
     import osprey_connectors.control_system.epics_connector
+    import osprey_connectors.control_system.tango_connector
     import osprey_connectors.factory
 
     assert (
         osprey.connectors.control_system.epics_connector
         is osprey_connectors.control_system.epics_connector
+    )
+    assert (
+        osprey.connectors.control_system.tango_connector
+        is osprey_connectors.control_system.tango_connector
     )
     assert osprey.connectors.archiver.base is osprey_connectors.archiver.base
     assert osprey.connectors.factory is osprey_connectors.factory

--- a/tests/connectors/test_tango_connector.py
+++ b/tests/connectors/test_tango_connector.py
@@ -1,0 +1,683 @@
+"""
+Unit tests for TangoConnector.
+
+All tests mock PyTango (the ``tango`` module) so no installed TANGO
+environment is required — the same seam the cross-connector parity suite
+drives, and the same reason registration stays safe on machines without
+PyTango.
+"""
+
+import asyncio
+import sys
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osprey.connectors.control_system.base import (
+    ChannelValue,
+    ChannelWriteResult,
+    WriteOutcome,
+)
+from osprey.connectors.control_system.tango_connector import (
+    _quality_fields,
+    _split_address,
+)
+
+# --------------------------------------------------------------------------------------
+# Helpers to build mock PyTango objects
+# --------------------------------------------------------------------------------------
+
+_EPOCH_S = 1_700_000_000  # arbitrary fixed timestamp
+_EPOCH_US = 500_000
+
+# Patch targets used in multiple test classes
+_LIMITS_PATCH = "osprey.connectors.control_system.tango_connector.LimitsValidator.from_config"
+_TZ_PATCH = "osprey.connectors.control_system.tango_connector.get_facility_timezone"
+
+_ADDRESS = "sr/power_supply/ps01/Current"
+
+
+class _Quality:
+    """Stand-in for ``tango.AttrQuality`` members — an object with a name."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return self.name
+
+
+def _make_attribute(value=42.0, quality="ATTR_VALID", attr_type="DevDouble"):
+    """Return a mock DeviceAttribute as returned by ``read_attribute()``."""
+    time_val = MagicMock()
+    time_val.tv_sec = _EPOCH_S
+    time_val.tv_usec = _EPOCH_US
+
+    attr = MagicMock()
+    attr.value = value
+    attr.quality = _Quality(quality) if quality is not None else None
+    attr.time = time_val
+    attr.type = attr_type
+    return attr
+
+
+def _make_proxy(read_value=42.0, quality="ATTR_VALID", attr_type="DevDouble"):
+    """Return a mock DeviceProxy."""
+    proxy = MagicMock()
+    proxy.read_attribute.return_value = _make_attribute(read_value, quality, attr_type)
+    proxy.write_attribute.return_value = None
+    return proxy
+
+
+def _make_tango(proxy=None):
+    """Return a mock ``tango`` module serving one DeviceProxy."""
+    t = MagicMock()
+    t.__version__ = "10.0.0"
+    t.DeviceProxy.return_value = proxy if proxy is not None else _make_proxy()
+    database = MagicMock()
+    database.get_info.return_value = "TANGO Database sys/database/2"
+    t.Database.return_value = database
+    return t
+
+
+def _structured_write_facts(result):
+    """The machine-readable half of a write result — the free text left out."""
+    return (
+        result.outcome,
+        result.observed_value,
+        result.refusal_reason,
+        result.error_message is not None,
+        result.alarm_status,
+        result.alarm_severity,
+    )
+
+
+def _make_limits_validator(confirm=True):
+    """A limits validator that passes validation and reports a confirm policy."""
+    validator = MagicMock()
+    validator.validate.return_value = None
+    validator.resolve_confirm.return_value = confirm
+    return validator
+
+
+def _writes_enabled(key, default=None):
+    if key == "control_system.writes_enabled":
+        return True
+    return default
+
+
+@pytest.fixture
+async def connector():
+    """TangoConnector wired with a mock tango module, limits disabled, writes on."""
+    proxy = _make_proxy()
+    mock_tango = _make_tango(proxy)
+
+    with (
+        patch.dict(sys.modules, {"tango": mock_tango}),
+        patch(_LIMITS_PATCH, return_value=None),
+        patch(_TZ_PATCH, return_value=UTC),
+        patch("osprey.utils.config.get_config_value", side_effect=_writes_enabled),
+    ):
+        from osprey.connectors.control_system.tango_connector import TangoConnector
+
+        conn = TangoConnector()
+        await conn.connect({})
+        yield conn, proxy
+        await conn.disconnect()
+
+
+# --------------------------------------------------------------------------------------
+# Address parsing and quality mapping — the two pure seams
+# --------------------------------------------------------------------------------------
+
+
+class TestSplitAddress:
+    def test_plain_address_splits_device_and_attribute(self):
+        assert _split_address(_ADDRESS) == ("sr/power_supply/ps01", "Current")
+
+    def test_database_prefix_stays_on_the_device(self):
+        device, attribute = _split_address("tango://db:10000/sr/power_supply/ps01/Current")
+        assert device == "tango://db:10000/sr/power_supply/ps01"
+        assert attribute == "Current"
+
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "sr/power_supply/ps01",  # no attribute
+            "sr/power_supply/ps01/Current/extra",  # too many segments
+            "sr//ps01/Current",  # empty segment
+            "tango://db:10000",  # prefix with no device
+            "",
+        ],
+    )
+    def test_malformed_addresses_raise_value_error(self, address):
+        with pytest.raises(ValueError, match="TANGO channel address"):
+            _split_address(address)
+
+
+class TestQualityFields:
+    @pytest.mark.parametrize(
+        ("quality", "expected"),
+        [
+            ("ATTR_VALID", ("NO_ALARM", 0)),
+            ("ATTR_CHANGING", ("CHANGING", 0)),
+            ("ATTR_WARNING", ("WARNING", 1)),
+            ("ATTR_ALARM", ("ALARM", 2)),
+            ("ATTR_INVALID", ("INVALID", 3)),
+        ],
+    )
+    def test_known_qualities_map_to_alarm_fields(self, quality, expected):
+        assert _quality_fields(_Quality(quality)) == expected
+
+    def test_none_is_not_reported(self):
+        """``None`` means "not reported" — distinct from a healthy reading."""
+        assert _quality_fields(None) == (None, None)
+
+    def test_unknown_quality_is_named_unknown_with_no_severity(self):
+        assert _quality_fields(_Quality("ATTR_SOMETHING_NEW")) == ("UNKNOWN", None)
+
+
+# --------------------------------------------------------------------------------------
+# connect / disconnect
+# --------------------------------------------------------------------------------------
+
+
+class TestConnect:
+    async def test_connect_sets_connected(self):
+        mock_tango = _make_tango()
+        with (
+            patch.dict(sys.modules, {"tango": mock_tango}),
+            patch(_LIMITS_PATCH, return_value=None),
+            patch(_TZ_PATCH, return_value=UTC),
+            patch("osprey.utils.config.get_config_value", return_value=False),
+        ):
+            from osprey.connectors.control_system.tango_connector import TangoConnector
+
+            conn = TangoConnector()
+            await conn.connect({})
+            assert conn._connected is True
+            await conn.disconnect()
+
+    async def test_connect_raises_import_error_without_pytango(self):
+        with patch.dict(sys.modules, {"tango": None}):
+            from osprey.connectors.control_system.tango_connector import TangoConnector
+
+            conn = TangoConnector()
+            with pytest.raises(ImportError, match="PyTango"):
+                await conn.connect({})
+
+    async def test_connect_raises_on_unreachable_database(self):
+        mock_tango = _make_tango()
+        mock_tango.Database.side_effect = RuntimeError("no database")
+        with (
+            patch.dict(sys.modules, {"tango": mock_tango}),
+            patch(_LIMITS_PATCH, return_value=None),
+            patch("osprey.utils.config.get_config_value", return_value=False),
+        ):
+            from osprey.connectors.control_system.tango_connector import TangoConnector
+
+            conn = TangoConnector()
+            with pytest.raises(ConnectionError, match="TANGO database"):
+                await conn.connect({})
+
+    async def test_explicit_tango_host_reaches_that_database(self):
+        mock_tango = _make_tango()
+        with (
+            patch.dict(sys.modules, {"tango": mock_tango}),
+            patch(_LIMITS_PATCH, return_value=None),
+            patch("osprey.utils.config.get_config_value", return_value=False),
+        ):
+            from osprey.connectors.control_system.tango_connector import TangoConnector
+
+            conn = TangoConnector()
+            await conn.connect({"tango_host": "db.example.org:10000"})
+            mock_tango.Database.assert_called_once_with("db.example.org", "10000")
+            # ...and unprefixed device names are qualified with it.
+            conn._get_proxy("sr/power_supply/ps01")
+            mock_tango.DeviceProxy.assert_called_once_with(
+                "tango://db.example.org:10000/sr/power_supply/ps01"
+            )
+            await conn.disconnect()
+
+
+class TestDisconnect:
+    async def test_disconnect_clears_connected_and_proxies(self, connector):
+        conn, _proxy = connector
+        await conn.read_channel(_ADDRESS)
+        assert conn._proxies
+        await conn.disconnect()
+        assert conn._connected is False
+        assert not conn._proxies
+
+
+# --------------------------------------------------------------------------------------
+# read_channel
+# --------------------------------------------------------------------------------------
+
+
+class TestReadChannel:
+    async def test_read_returns_channel_value(self, connector):
+        conn, _ = connector
+        result = await conn.read_channel(_ADDRESS)
+        assert isinstance(result, ChannelValue)
+        assert result.value == 42.0
+
+    async def test_read_timestamp_is_the_readings_own(self, connector):
+        conn, _ = connector
+        result = await conn.read_channel(_ADDRESS)
+        expected = datetime.fromtimestamp(_EPOCH_S + _EPOCH_US / 1e6, UTC)
+        assert result.timestamp == expected
+
+    async def test_read_reports_alarm_state_from_quality(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(quality="ATTR_ALARM")
+        result = await conn.read_channel(_ADDRESS)
+        assert result.metadata.alarm_status == "ALARM"
+        assert result.metadata.raw_metadata["severity"] == 2
+
+    async def test_healthy_reading_reports_no_alarm_not_nothing(self, connector):
+        """A reported healthy reading stays distinct from "not reported"."""
+        conn, _ = connector
+        result = await conn.read_channel(_ADDRESS)
+        assert result.metadata.alarm_status == "NO_ALARM"
+        assert result.metadata.raw_metadata["severity"] == 0
+
+    async def test_a_first_class_severity_field_is_populated_when_it_exists(self, connector):
+        """``ChannelMetadata.alarm_severity`` is feature-detected, not assumed.
+
+        The contract may grow the field independently of this connector; a
+        metadata type that carries it gets the severity first-class, and one
+        that does not still carries it in ``raw_metadata``.
+        """
+        from dataclasses import dataclass
+
+        from osprey.connectors.control_system import tango_connector as mod
+        from osprey.connectors.control_system.base import ChannelMetadata
+
+        @dataclass
+        class _MetadataWithSeverity(ChannelMetadata):
+            alarm_severity: int | None = None
+
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(quality="ATTR_ALARM")
+        with patch.object(mod, "ChannelMetadata", _MetadataWithSeverity):
+            result = await conn.read_channel(_ADDRESS)
+        assert result.metadata.alarm_severity == 2
+        assert result.metadata.raw_metadata["severity"] == 2
+
+    async def test_read_reads_the_named_attribute_on_the_named_device(self, connector):
+        conn, proxy = connector
+        await conn.read_channel(_ADDRESS)
+        proxy.read_attribute.assert_called_once_with("Current")
+
+    async def test_the_device_proxy_is_cached_across_reads(self, connector):
+        conn, _ = connector
+        await conn.read_channel(_ADDRESS)
+        await conn.read_channel("sr/power_supply/ps01/Voltage")
+        assert list(conn._proxies) == ["sr/power_supply/ps01"]
+
+    async def test_read_propagates_exception(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.side_effect = RuntimeError("device down")
+        with pytest.raises(RuntimeError, match="device down"):
+            await conn.read_channel(_ADDRESS)
+
+    async def test_malformed_address_raises_before_any_device_call(self, connector):
+        conn, proxy = connector
+        with pytest.raises(ValueError):
+            await conn.read_channel("not-an-address")
+        proxy.read_attribute.assert_not_called()
+
+
+class TestEnumReadings:
+    async def test_enum_reading_resolves_its_label(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=1, attr_type="DevEnum")
+        info = MagicMock()
+        info.enum_labels = ["Closed", "Open"]
+        proxy.get_attribute_config.return_value = info
+
+        result = await conn.read_channel(_ADDRESS)
+        assert result.value == 1
+        assert result.metadata.enum_labels == ["Closed", "Open"]
+        assert result.metadata.enum_label == "Open"
+
+    async def test_enum_labels_are_cached_per_attribute(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=0, attr_type="DevEnum")
+        info = MagicMock()
+        info.enum_labels = ["Closed", "Open"]
+        proxy.get_attribute_config.return_value = info
+
+        await conn.read_channel(_ADDRESS)
+        await conn.read_channel(_ADDRESS)
+        proxy.get_attribute_config.assert_called_once_with("Current")
+
+    async def test_label_fetch_failure_never_loses_the_reading(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=1, attr_type="DevEnum")
+        proxy.get_attribute_config.side_effect = RuntimeError("ctrl fetch failed")
+
+        result = await conn.read_channel(_ADDRESS)
+        assert result.value == 1
+        assert result.metadata.enum_labels is None
+        assert result.metadata.enum_label is None
+
+    async def test_non_enum_reading_carries_no_labels(self, connector):
+        conn, proxy = connector
+        result = await conn.read_channel(_ADDRESS)
+        assert result.metadata.enum_labels is None
+        proxy.get_attribute_config.assert_not_called()
+
+
+# --------------------------------------------------------------------------------------
+# write_channel
+# --------------------------------------------------------------------------------------
+
+
+async def _write_with_validator(validator, value=10.0, readback=10.0, **kwargs):
+    """Drive one write through a connector wired with the given validator."""
+    proxy = _make_proxy(read_value=readback)
+    mock_tango = _make_tango(proxy)
+    with (
+        patch.dict(sys.modules, {"tango": mock_tango}),
+        patch(_LIMITS_PATCH, return_value=validator),
+        patch(_TZ_PATCH, return_value=UTC),
+        patch("osprey.utils.config.get_config_value", side_effect=_writes_enabled),
+    ):
+        from osprey.connectors.control_system.tango_connector import TangoConnector
+
+        conn = TangoConnector()
+        await conn.connect({})
+        result = await conn.write_channel(_ADDRESS, value, **kwargs)
+        await conn.disconnect()
+        return result, proxy
+
+
+class TestWriteChannel:
+    async def test_confirmed_write_reports_what_the_attribute_holds(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=10.0)
+        result = await conn.write_channel(_ADDRESS, 10.0)
+        assert isinstance(result, ChannelWriteResult)
+        assert result.outcome is WriteOutcome.CONFIRMED
+        assert result.observed_value == 10.0
+        proxy.write_attribute.assert_called_once_with("Current", 10.0)
+
+    async def test_confirm_false_is_unrequested_and_reads_nothing(self, connector):
+        conn, proxy = connector
+        result = await conn.write_channel(_ADDRESS, 10.0, confirm=False)
+        assert result.outcome is WriteOutcome.UNREQUESTED
+        assert result.observed_value is None
+        proxy.read_attribute.assert_not_called()
+
+    async def test_failed_put_is_failed_and_never_reads_back(self, connector):
+        conn, proxy = connector
+        proxy.write_attribute.side_effect = RuntimeError("write refused by device")
+        result = await conn.write_channel(_ADDRESS, 10.0)
+        assert result.outcome is WriteOutcome.FAILED
+        assert result.error_message is not None
+        proxy.read_attribute.assert_not_called()
+
+    async def test_read_that_raises_is_unconfirmed(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.side_effect = RuntimeError("read exploded")
+        result = await conn.write_channel(_ADDRESS, 10.0)
+        assert result.outcome is WriteOutcome.UNCONFIRMED
+        assert result.error_message is not None
+
+    async def test_mismatch_carries_both_values_and_no_message(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=9.7)
+        result = await conn.write_channel(_ADDRESS, 10.0)
+        assert result.outcome is WriteOutcome.MISMATCH
+        assert result.value_written == 10.0
+        assert result.observed_value == 9.7
+        assert result.error_message is None
+
+    async def test_a_ramping_readback_is_a_mismatch_not_a_softer_word(self, connector):
+        """``ATTR_CHANGING`` reports beside the verdict, never instead of it.
+
+        The write contract has no settling concept: a readback that does not
+        yet hold the value sent is a ``mismatch``, and the quality that says
+        the value is in motion rides on the alarm fields for the operator to
+        interpret.
+        """
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=3.2, quality="ATTR_CHANGING")
+        result = await conn.write_channel(_ADDRESS, 10.0)
+        assert result.outcome is WriteOutcome.MISMATCH
+        assert result.alarm_status == "CHANGING"
+        assert result.alarm_severity == 0
+
+    async def test_confirmed_write_in_alarm_stays_confirmed(self, connector):
+        """Alarm state is reported with the write, never raised on."""
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=10.0, quality="ATTR_ALARM")
+        result = await conn.write_channel(_ADDRESS, 10.0)
+        assert result.outcome is WriteOutcome.CONFIRMED
+        assert result.alarm_status == "ALARM"
+        assert result.alarm_severity == 2
+
+    async def test_write_refused_when_writes_disabled(self):
+        mock_tango = _make_tango()
+        with (
+            patch.dict(sys.modules, {"tango": mock_tango}),
+            patch(_LIMITS_PATCH, return_value=None),
+            patch(_TZ_PATCH, return_value=UTC),
+            patch("osprey.utils.config.get_config_value", return_value=False),
+        ):
+            from osprey.connectors.control_system.tango_connector import TangoConnector
+
+            conn = TangoConnector()
+            await conn.connect({})
+            result = await conn.write_channel(_ADDRESS, 10.0)
+            assert result.outcome is WriteOutcome.REFUSED
+            assert result.refusal_reason == "WRITES_DISABLED"
+            mock_tango.DeviceProxy.return_value.write_attribute.assert_not_called()
+            await conn.disconnect()
+
+    async def test_enum_setpoint_written_as_text_confirms_by_its_label(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=1, attr_type="DevEnum")
+        info = MagicMock()
+        info.enum_labels = ["Closed", "Open"]
+        proxy.get_attribute_config.return_value = info
+
+        result = await conn.write_channel(_ADDRESS, "Open")
+        assert result.outcome is WriteOutcome.CONFIRMED
+
+
+class TestConfirmResolution:
+    """``confirm=None`` resolves from the limits database; an answer is kept."""
+
+    async def test_omitted_confirm_follows_the_channel_policy_when_true(self):
+        result, proxy = await _write_with_validator(_make_limits_validator(confirm=True))
+        assert result.outcome is WriteOutcome.CONFIRMED
+        assert proxy.read_attribute.call_count == 1
+
+    async def test_omitted_confirm_follows_the_channel_policy_when_false(self):
+        result, proxy = await _write_with_validator(_make_limits_validator(confirm=False))
+        assert result.outcome is WriteOutcome.UNREQUESTED
+        assert proxy.read_attribute.call_count == 0
+
+    async def test_explicit_confirm_false_is_not_resolved_away(self):
+        result, proxy = await _write_with_validator(
+            _make_limits_validator(confirm=True), confirm=False
+        )
+        assert result.outcome is WriteOutcome.UNREQUESTED
+        assert proxy.read_attribute.call_count == 0
+
+    async def test_explicit_confirm_true_is_not_resolved_away(self):
+        result, _ = await _write_with_validator(_make_limits_validator(confirm=False), confirm=True)
+        assert result.outcome is WriteOutcome.CONFIRMED
+
+    async def test_no_limits_validator_confirms_by_default(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=10.0)
+        result = await conn.write_channel(_ADDRESS, 10.0)
+        assert result.outcome is WriteOutcome.CONFIRMED
+        assert proxy.read_attribute.call_count == 1
+
+    async def test_limits_violation_propagates(self):
+        from osprey_connectors.errors import ChannelLimitsViolationError
+
+        validator = MagicMock()
+        validator.validate.side_effect = ChannelLimitsViolationError(
+            _ADDRESS, 1e9, "range", "too big", max_value=200.0
+        )
+        with pytest.raises(ChannelLimitsViolationError):
+            await _write_with_validator(validator, value=1e9)
+
+
+class TestWriteTextIsDisplayOnly:
+    async def test_message_text_does_not_change_the_structured_facts(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.return_value = _make_attribute(value=10.0)
+        result = await conn.write_channel(_ADDRESS, 10.0)
+        assert _structured_write_facts(result) == (
+            WriteOutcome.CONFIRMED,
+            10.0,
+            None,
+            False,
+            "NO_ALARM",
+            0,
+        )
+
+
+# --------------------------------------------------------------------------------------
+# read_multiple_channels
+# --------------------------------------------------------------------------------------
+
+
+class TestReadMultipleChannels:
+    async def test_reads_all_channels(self, connector):
+        conn, _ = connector
+        addresses = [_ADDRESS, "sr/power_supply/ps01/Voltage"]
+        results = await conn.read_multiple_channels(addresses)
+        assert set(results) == set(addresses)
+        assert all(isinstance(v, ChannelValue) for v in results.values())
+
+    async def test_a_failing_channel_is_dropped_not_fatal(self, connector):
+        conn, proxy = connector
+
+        def fail_voltage(attribute):
+            if attribute == "Voltage":
+                raise RuntimeError("bad attribute")
+            return _make_attribute()
+
+        proxy.read_attribute.side_effect = fail_voltage
+        results = await conn.read_multiple_channels([_ADDRESS, "sr/power_supply/ps01/Voltage"])
+        assert list(results) == [_ADDRESS]
+
+
+# --------------------------------------------------------------------------------------
+# subscribe / unsubscribe
+# --------------------------------------------------------------------------------------
+
+
+class TestSubscriptions:
+    async def test_subscribe_registers_a_change_event(self, connector):
+        conn, proxy = connector
+        proxy.subscribe_event.return_value = 7
+        sub_id = await conn.subscribe(_ADDRESS, lambda cv: None)
+        assert sub_id in conn._subscriptions
+        assert proxy.subscribe_event.call_args[0][0] == "Current"
+
+    async def test_unsubscribe_releases_the_event(self, connector):
+        conn, proxy = connector
+        proxy.subscribe_event.return_value = 7
+        sub_id = await conn.subscribe(_ADDRESS, lambda cv: None)
+        await conn.unsubscribe(sub_id)
+        proxy.unsubscribe_event.assert_called_once_with(7)
+        assert sub_id not in conn._subscriptions
+
+    async def test_event_callback_delivers_a_channel_value(self, connector):
+        conn, proxy = connector
+        proxy.subscribe_event.return_value = 7
+        received: list[ChannelValue] = []
+        await conn.subscribe(_ADDRESS, received.append)
+
+        tango_callback = proxy.subscribe_event.call_args[0][2]
+        event = MagicMock()
+        event.err = False
+        event.attr_value = _make_attribute(value=3.14, quality="ATTR_WARNING")
+        tango_callback(event)
+        # call_soon_threadsafe needs the loop to turn once
+        await asyncio.sleep(0)
+
+        assert len(received) == 1
+        assert received[0].value == 3.14
+        assert received[0].metadata.alarm_status == "WARNING"
+
+    async def test_error_events_are_dropped(self, connector):
+        conn, proxy = connector
+        proxy.subscribe_event.return_value = 7
+        received: list[ChannelValue] = []
+        await conn.subscribe(_ADDRESS, received.append)
+
+        event = MagicMock()
+        event.err = True
+        proxy.subscribe_event.call_args[0][2](event)
+        await asyncio.sleep(0)
+        assert received == []
+
+
+# --------------------------------------------------------------------------------------
+# get_metadata / validate_channel
+# --------------------------------------------------------------------------------------
+
+
+class TestGetMetadata:
+    async def test_metadata_is_enriched_from_the_attribute_config(self, connector):
+        conn, proxy = connector
+        info = MagicMock()
+        info.unit = "mA"
+        info.description = "Main coil current"
+        info.min_value = "0.0"
+        info.max_value = "120.0"
+        info.format = "%6.2f"
+        info.writable = "READ_WRITE"
+        proxy.get_attribute_config.return_value = info
+
+        metadata = await conn.get_metadata(_ADDRESS)
+        assert metadata.units == "mA"
+        assert metadata.description == "Main coil current"
+        # TANGO's min/max are write limits, not a display range: raw only.
+        assert metadata.display_low is None
+        assert metadata.display_high is None
+        assert metadata.raw_metadata["min_value"] == "0.0"
+        assert metadata.raw_metadata["max_value"] == "120.0"
+
+    async def test_tangos_unitless_spellings_read_as_no_unit(self, connector):
+        conn, proxy = connector
+        info = MagicMock()
+        info.unit = "No unit"
+        info.description = "No description"
+        proxy.get_attribute_config.return_value = info
+
+        metadata = await conn.get_metadata(_ADDRESS)
+        assert metadata.units == ""
+        assert metadata.description is None
+
+    async def test_config_fetch_failure_keeps_the_readings_metadata(self, connector):
+        conn, proxy = connector
+        proxy.get_attribute_config.side_effect = RuntimeError("config fetch failed")
+        metadata = await conn.get_metadata(_ADDRESS)
+        assert metadata.alarm_status == "NO_ALARM"
+
+
+class TestValidateChannel:
+    async def test_readable_channel_is_valid(self, connector):
+        conn, _ = connector
+        assert await conn.validate_channel(_ADDRESS) is True
+
+    async def test_unreadable_channel_is_invalid(self, connector):
+        conn, proxy = connector
+        proxy.read_attribute.side_effect = RuntimeError("no such attribute")
+        assert await conn.validate_channel(_ADDRESS) is False
+
+    async def test_malformed_address_is_invalid_not_fatal(self, connector):
+        conn, _ = connector
+        assert await conn.validate_channel("not-an-address") is False

--- a/tests/connectors/test_tango_registration.py
+++ b/tests/connectors/test_tango_registration.py
@@ -1,0 +1,131 @@
+"""Tests for the ``tango`` connector type surface.
+
+The TANGO connector ships in-tree, so its name has to agree across every layer
+that speaks it: the type constants, the factory's built-in registration, the
+framework registry, and the CLI entry points. These tests pin that agreement,
+mirroring ``test_doocs_registration.py``.
+
+``tango`` (PyTango) is never imported here — the connector defers that import
+to ``connect()``, which is exactly what makes registering it unconditionally
+safe on machines with no TANGO environment.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.connectors import types
+from osprey.connectors.factory import (
+    ConnectorFactory,
+    isolated_connector_registries,
+    register_builtin_connectors,
+)
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+class TestTypeConstants:
+    """``types.py`` is the single source of truth for the name string."""
+
+    def test_control_system_constant(self):
+        assert types.TANGO == "tango"
+
+    def test_constant_appears_in_cli_choice_list(self):
+        assert types.TANGO in types.CLI_CONTROL_SYSTEM_TYPES
+
+    def test_tango_is_a_live_capable_type(self):
+        """A TANGO deployment's own block is its ``live`` machine.
+
+        ``resolve_target`` refuses to derive ``live`` from simulated or
+        stand-in types; ``tango`` names real hardware and must resolve as
+        written, exactly as ``epics`` and ``doocs`` do.
+        """
+        assert types.resolve_target({"type": types.TANGO}, types.TARGET_LIVE) == types.TANGO
+
+
+class TestBuiltinRegistration:
+    """``register_builtin_connectors()`` mints the name."""
+
+    def test_tango_registers_as_builtin_control_system(self):
+        with isolated_connector_registries(clear=True):
+            register_builtin_connectors()
+
+            assert types.TANGO in ConnectorFactory.list_control_systems()
+            registered = ConnectorFactory._control_system_connectors[types.TANGO]
+            assert registered.__name__ == "TangoConnector"
+
+    def test_registration_needs_no_pytango(self):
+        """Registration must not import PyTango.
+
+        The connector imports ``tango`` inside ``connect()``. If that ever
+        moved to module scope, registering the built-ins would raise
+        ImportError on every machine without a TANGO environment and take the
+        whole framework down with it.
+        """
+        import sys
+
+        with (
+            patch.dict(sys.modules, {"tango": None}),
+            isolated_connector_registries(clear=True),
+        ):
+            register_builtin_connectors()
+
+            assert types.TANGO in ConnectorFactory.list_control_systems()
+
+
+class TestFrameworkRegistryEntries:
+    """The registry provider carries a matching entry for discovery/export."""
+
+    def test_registry_lists_the_tango_connector(self):
+        from osprey.registry.builtins import FrameworkRegistryProvider
+
+        connectors = FrameworkRegistryProvider().get_registry_config().connectors
+        by_name = {c.name: c for c in connectors}
+
+        assert by_name[types.TANGO].connector_type == "control_system"
+        assert by_name[types.TANGO].class_name == "TangoConnector"
+        assert by_name[types.TANGO].module_path == (
+            "osprey.connectors.control_system.tango_connector"
+        )
+
+
+class TestCliSurface:
+    """The CLI can select the type, so a registered connector is reachable.
+
+    Registration alone does not make a connector usable: an operator turns one
+    on with ``osprey set connector=tango``, which folds the shorthand into
+    ``config.control_system.type`` in the deployment's own profile. A type the
+    registry knows and the CLI refuses is a connector nobody can select.
+    """
+
+    def test_the_shorthand_reads_the_registered_type_list(self):
+        """``SET_CONTROL_SYSTEM_TYPES`` is what the shorthand validates
+        against, so a connector missing from it cannot be selected however
+        well it is registered underneath."""
+        assert types.TANGO in types.SET_CONTROL_SYSTEM_TYPES
+
+    def test_set_connector_writes_tango_into_the_profile(self, cli_runner, tmp_path):
+        """End to end through the verb: the shorthand lands as the dotted
+        config key a build renders from, in the source the facility owns."""
+        from osprey.cli.set_cmd import set as set_command
+
+        repo = tmp_path / "tango-deployment"
+        repo.mkdir()
+        (repo / "profile.yml").write_text(
+            "name: TANGO Test\ndata_bundle: hello_world\nprovider: anthropic\n",
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(
+            set_command,
+            ["--repo", str(repo), f"connector={types.TANGO}"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        profile = (repo / "profile.yml").read_text(encoding="utf-8")
+        assert f"control_system.type: {types.TANGO}" in profile

--- a/tests/connectors/test_target_writes_enabled.py
+++ b/tests/connectors/test_target_writes_enabled.py
@@ -45,7 +45,7 @@ from osprey_connectors.types import (
     writes_enabled_key,
 )
 
-CUSTOM_TYPE = "mypackage.TangoConnector"
+CUSTOM_TYPE = "mypackage.MoatConnector"
 
 
 def _section(
@@ -81,7 +81,7 @@ def test_a_type_names_its_own_block_key():
     assert writes_enabled_key(EPICS) == "control_system.connector.epics.writes_enabled"
     assert (
         writes_enabled_key(CUSTOM_TYPE)
-        == "control_system.connector.mypackage.TangoConnector.writes_enabled"
+        == "control_system.connector.mypackage.MoatConnector.writes_enabled"
     )
 
 
@@ -265,14 +265,14 @@ def test_a_config_with_no_posture_anywhere_is_unarmed_for_every_type():
 
 @pytest.mark.unit
 def test_a_dotted_custom_type_is_one_key_and_not_a_path():
-    """``mypackage.TangoConnector`` names one block; the dots are part of it."""
+    """``mypackage.MoatConnector`` names one block; the dots are part of it."""
     # Arrange
     section = _section(
         CUSTOM_TYPE,
         writes_enabled=False,
         connector={
             CUSTOM_TYPE: {"writes_enabled": True},
-            "mypackage": {"TangoConnector": {"writes_enabled": False}},
+            "mypackage": {"MoatConnector": {"writes_enabled": False}},
         },
     )
 
@@ -287,7 +287,7 @@ def test_a_dotted_custom_type_with_no_block_of_its_own_inherits():
     section = _section(
         CUSTOM_TYPE,
         writes_enabled=True,
-        connector={"mypackage": {"TangoConnector": {"writes_enabled": False}}},
+        connector={"mypackage": {"MoatConnector": {"writes_enabled": False}}},
     )
 
     # Act / Assert

--- a/tests/hooks/test_approval_target_identity.py
+++ b/tests/hooks/test_approval_target_identity.py
@@ -1164,9 +1164,9 @@ def test_only_a_literal_true_arms_the_deployment_wide_key(reader, value, expecte
 def test_a_dotted_custom_type_is_one_key_and_not_a_path(reader):
     """A custom connector's module path names a single block, dots and all."""
     section = {
-        "type": "mypackage.TangoConnector",
+        "type": "mypackage.MoatConnector",
         "writes_enabled": False,
-        "connector": {"mypackage.TangoConnector": {"writes_enabled": True}},
+        "connector": {"mypackage.MoatConnector": {"writes_enabled": True}},
     }
 
     assert reader.writes_posture(section, "live") is True


### PR DESCRIPTION
OSPREY ships EPICS and DOOCS connectors in-tree, but a TANGO facility had to write and maintain its own — while the docs used a hypothetical `mypackage.TangoConnector` as the canonical custom-connector example, so the most obvious candidate for in-tree support was also the one the docs told users to build themselves.

The new connector wraps PyTango `DeviceProxy` attribute access behind the connector contract. A channel address is `domain/family/member/attribute`, optionally prefixed `tango://host:port/` for an explicit database; without the prefix it follows `TANGO_HOST` like every other TANGO client. Only attributes are exposed: TANGO commands carry arbitrary payloads the limits database cannot bound, the same reason the EPICS connector refuses PVA RPC. Reads map attribute quality onto the protocol-agnostic alarm fields and resolve DevEnum state labels; writes confirm with one fresh read, and `ATTR_CHANGING` never softens the verdict — a readback that does not yet hold the value sent is a mismatch, reported with the quality beside it.

PyTango imports inside `connect()`, so the `tango` name registers unconditionally across every layer that must agree on it — type constants, factory, framework registry, CLI choice lists — and importing it costs nothing where no TANGO environment exists. The unit suite mocks the `tango` module at the same seam the DOOCS tests mock `doocs4py`, and the cross-connector write-parity matrix gains the TANGO row. With tango now a builtin, the docs' hypothetical custom connector is renamed `MoatConnector`, and the connector how-to gains a TANGO tab.

## How it hangs together

```text
        channel address: domain/family/member/attribute
                (optional tango://host:port/ prefix)
                             │
                             ▼
  ┌──────────────────────────────────┐    name 'tango', agreed on by
  │          TangoConnector          │    every layer that resolves it:
  │  attributes only — TANGO         │   ┌───────────────────────────┐
  │  commands refused (unboundable)  │   │ type constants            │
  └────────────────┬─────────────────┘   │ factory built-ins         │
                   │ connect()           │ framework registry        │
                   │ (PyTango imported   │ CLI choice lists          │
                   │  here, not before)  │  └► profile validate /    │
                   ▼                     │     deploy follow along   │
  ┌──────────────────────────────────┐   └───────────────────────────┘
  │        PyTango DeviceProxy       │
  └──────────┬───────────┬───────────┘
        read │           │ write
             ▼           ▼
  quality → alarm     confirmed by one fresh read;
  fields; DevEnum     ATTR_CHANGING never softens
  labels resolved     a readback mismatch
```