### PR TITLE
fix(phoebus): render the PHOEBUS_BRIDGE_URL fallback from phoebus.host/port

### DIFF
--- a/changelog.d/829.fixed.md
+++ b/changelog.d/829.fixed.md
@@ -1,0 +1,9 @@
+The `phoebus` MCP server now reaches the Phoebus bridge on the port the
+deployment configures. The rendered server definition used to bake the stock
+`http://127.0.0.1:7979` in as the `PHOEBUS_BRIDGE_URL` fallback, and because
+that fallback always materialised the variable, the documented
+`phoebus.host` / `phoebus.port` config resolution was never consulted — a
+deployment that moved the bridge to another port had every Phoebus tool
+fail with "connection refused" while the bridge itself was healthy. The
+fallback is now rendered from `phoebus.host` / `phoebus.port` at build time;
+an explicit `PHOEBUS_BRIDGE_URL` in the container environment still wins.

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -374,6 +374,7 @@ def config_derived_context(config: dict, project_dir: Path) -> dict[str, Any]:
         project_dir: Root of the project being rendered; declared hooks are
             resolved against the files it ships.
     """
+    from osprey.mcp_server.http import phoebus_bridge_default
     from osprey.utils.workspace import agent_data_base_dir
 
     control_system = config.get("control_system", {}) or {}
@@ -419,6 +420,12 @@ def config_derived_context(config: dict, project_dir: Path) -> dict[str, Any]:
         # left out of the render entirely rather than shipped as a tool that
         # can only fail.
         "graphdb_configured": _graphdb_configured(config),
+        # Render-time fallback for the phoebus server's PHOEBUS_BRIDGE_URL env
+        # entry, derived from the same phoebus.host/phoebus.port the backend is
+        # deployed on. One spelling with the runtime resolution (the shared
+        # helper in osprey.mcp_server.http), so the rendered client and the
+        # deployed bridge cannot drift onto different ports (#829).
+        "phoebus_bridge_default": phoebus_bridge_default(config),
         # The device vocabulary the channel-finder terminology partials render
         # their rows from, out of the deployment's own compiled ontology
         # (`facility.ontology`). None when no ontology is declared — the

--- a/src/osprey/mcp_server/http.py
+++ b/src/osprey/mcp_server/http.py
@@ -71,6 +71,23 @@ def web_terminal_url() -> str:
     return f"http://{host}:{port}"
 
 
+def phoebus_bridge_default(config: dict) -> str:
+    """The bridge URL ``phoebus.host``/``phoebus.port`` configure.
+
+    Stock ``http://127.0.0.1:7979`` when the config carries neither key
+    (matches ``bridge_preferences.properties``). This is the ONE spelling of
+    the config half of :func:`phoebus_bridge_url`, shared with the render
+    (``config_derived_context``'s ``phoebus_bridge_default`` context key) so
+    the ``.mcp.json`` fallback the build emits and the resolution the running
+    server performs cannot fork — a fallback rendered from anything else pins
+    the client to a port the backend does not serve (#829).
+    """
+    ph = config.get("phoebus", {}) or {}
+    host = ph.get("host", "127.0.0.1")
+    port = ph.get("port", 7979)
+    return f"http://{host}:{port}"
+
+
 def phoebus_bridge_url() -> str:
     """Build the Phoebus agent-bridge base URL from env or config.
 
@@ -78,9 +95,12 @@ def phoebus_bridge_url() -> str:
     (default ``http://127.0.0.1:7979``). Resolution order:
 
     1. ``PHOEBUS_BRIDGE_URL`` env var (full URL) — set by the framework server
-       definition; wins outright.
+       definition; wins outright. The definition's rendered fallback is
+       :func:`phoebus_bridge_default`, so on a rendered project this step
+       already answers with the configured host/port.
     2. ``PHOEBUS_BRIDGE_PORT`` env var overrides only the port.
-    3. ``phoebus.host`` / ``phoebus.port`` in config.yml.
+    3. ``phoebus.host`` / ``phoebus.port`` in config.yml
+       (:func:`phoebus_bridge_default`).
     4. ``127.0.0.1:7979`` default (matches ``bridge_preferences.properties``).
     """
     import os
@@ -92,10 +112,12 @@ def phoebus_bridge_url() -> str:
         return full.rstrip("/")
 
     config = load_osprey_config()
-    ph = config.get("phoebus", {})
-    host = ph.get("host", "127.0.0.1")
-    port = int(os.environ.get("PHOEBUS_BRIDGE_PORT", ph.get("port", 7979)))
-    return f"http://{host}:{port}"
+    port_env = os.environ.get("PHOEBUS_BRIDGE_PORT")
+    if port_env:
+        ph = config.get("phoebus", {}) or {}
+        host = ph.get("host", "127.0.0.1")
+        return f"http://{host}:{int(port_env)}"
+    return phoebus_bridge_default(config)
 
 
 _PANEL_TOKEN_LATCH: str | None = None

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -179,8 +179,14 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
         env={
             "OSPREY_CONFIG": RENDERED_CONFIG_ENV_VALUE,
             "CONFIG_FILE": RENDERED_CONFIG_ENV_VALUE,
-            # Full-URL override of the in-JVM bridge (default 127.0.0.1:7979).
-            "PHOEBUS_BRIDGE_URL": "${PHOEBUS_BRIDGE_URL:-http://127.0.0.1:7979}",
+            # Full-URL override of the in-JVM bridge. The host env var wins;
+            # the fallback resolves at render time from the deployment's own
+            # phoebus.host/phoebus.port (default 127.0.0.1:7979). A literal
+            # default here would materialize the env var on every launch and —
+            # because the env var wins outright in phoebus_bridge_url() — pin
+            # the client to 7979 while the backend renders onto the configured
+            # port (osprey #829).
+            "PHOEBUS_BRIDGE_URL": "${PHOEBUS_BRIDGE_URL:-{phoebus_bridge_default}}",
             # Instance identity — tools tag UI signals with it (open_panel →
             # panel_focus targets the matching web-terminal tab). extends
             # clones get this auto-rewritten to their own name.
@@ -1409,8 +1415,18 @@ def _resolve_placeholder(value: str, ctx: dict) -> str:
     - ``{project_root}`` → ctx["project_root"]
     - ``{current_python_env}`` → ctx["current_python_env"]
     - ``{channel_finder_pipeline}`` → ctx["channel_finder_pipeline"]
+    - ``{phoebus_bridge_default}`` → ctx["phoebus_bridge_default"], the
+      render-time bridge URL derived from ``phoebus.host``/``phoebus.port``
+      (``http://127.0.0.1:7979`` when the context carries none — a caller
+      that skips config_derived_context keeps the stock default)
     - ``${...}`` env-var references are left untouched (resolved at runtime)
     """
+    if "{phoebus_bridge_default}" in value:
+        value = value.replace(
+            "{phoebus_bridge_default}",
+            str(ctx.get("phoebus_bridge_default", "http://127.0.0.1:7979")),
+        )
+
     if "{channel_finder_pipeline}" in value:
         value = value.replace(
             "{channel_finder_pipeline}",

--- a/tests/cli/test_claude_code_integration.py
+++ b/tests/cli/test_claude_code_integration.py
@@ -1737,5 +1737,60 @@ class TestGraphdbConfiguredContextKey:
         assert ("graph" in captured["enabled_servers"]) is deploy_services
 
 
+class TestPhoebusBridgeDefaultContextKey:
+    """``phoebus_bridge_default``, the phoebus bridge context key (#829).
+
+    The phoebus server's rendered ``PHOEBUS_BRIDGE_URL`` env entry always
+    materializes at launch and wins outright in ``phoebus_bridge_url()``, so
+    its fallback half must be derived from the deployment's own
+    ``phoebus.host``/``phoebus.port`` — one spelling with the runtime
+    resolution, shared via ``osprey.mcp_server.http.phoebus_bridge_default``,
+    so the rendered client and the deployed bridge cannot drift onto
+    different ports.
+    """
+
+    @staticmethod
+    def _derive(config):
+        from pathlib import Path
+
+        from osprey.cli.templates import claude_code
+
+        return claude_code.config_derived_context(config, Path("."))
+
+    def test_derived_from_the_phoebus_block(self):
+        derived = self._derive({"phoebus": {"host": "127.0.0.1", "port": 19921}})
+        assert derived["phoebus_bridge_default"] == "http://127.0.0.1:19921"
+
+    def test_stock_default_without_a_phoebus_block(self):
+        assert self._derive({})["phoebus_bridge_default"] == "http://127.0.0.1:7979"
+
+    def test_build_path_renders_the_configured_port_into_the_server_env(self, tmp_path):
+        """The resolved phoebus server's env fallback is the configured URL."""
+        from osprey.cli.templates import claude_code
+
+        manager = TemplateManager()
+        project_dir = manager.create_project(
+            project_name="phoebus-bridge-port",
+            output_dir=tmp_path,
+            data_bundle="control_assistant",
+            context={"channel_finder_mode": "hierarchical"},
+        )
+        config = yaml.safe_load((project_dir / "config.yml").read_text())
+
+        config["phoebus"] = {"host": "127.0.0.1", "port": 19921}
+        config.setdefault("claude_code", {}).setdefault("servers", {})["phoebus"] = {
+            "enabled": True
+        }
+        ctx = claude_code.build_claude_code_context(
+            manager.template_root, manager.jinja_env, project_dir, config
+        )
+
+        phoebus = [s for s in ctx["servers"] if s["name"] == "phoebus"]
+        assert len(phoebus) == 1
+        assert phoebus[0]["env"]["PHOEBUS_BRIDGE_URL"] == (
+            "${PHOEBUS_BRIDGE_URL:-http://127.0.0.1:19921}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/mcp_server/test_http.py
+++ b/tests/mcp_server/test_http.py
@@ -99,6 +99,26 @@ def test_phoebus_bridge_url_default(patch_config, monkeypatch):
         assert http.phoebus_bridge_url() == "http://127.0.0.1:7979"
 
 
+@pytest.mark.unit
+def test_phoebus_bridge_url_config_values(patch_config, monkeypatch):
+    """With no env overrides, phoebus.host/phoebus.port answer (#829)."""
+    monkeypatch.delenv("PHOEBUS_BRIDGE_URL", raising=False)
+    monkeypatch.delenv("PHOEBUS_BRIDGE_PORT", raising=False)
+    with patch_config({"phoebus": {"host": "127.0.0.1", "port": 19921}}):
+        assert http.phoebus_bridge_url() == "http://127.0.0.1:19921"
+
+
+@pytest.mark.unit
+def test_phoebus_bridge_default_pure():
+    """The shared config-half helper: configured, defaulted, and a bare `phoebus:` key."""
+    assert http.phoebus_bridge_default({}) == "http://127.0.0.1:7979"
+    assert http.phoebus_bridge_default({"phoebus": None}) == "http://127.0.0.1:7979"
+    assert (
+        http.phoebus_bridge_default({"phoebus": {"host": "10.0.0.5", "port": 19921}})
+        == "http://10.0.0.5:19921"
+    )
+
+
 # ---------------------------------------------------------------------------
 # post_json (fire-and-forget)
 # ---------------------------------------------------------------------------

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -832,6 +832,36 @@ class TestExtendsServers:
         )
 
 
+class TestPhoebusBridgeFallback:
+    """The rendered PHOEBUS_BRIDGE_URL fallback follows the deployment (#829).
+
+    The env entry always materializes at launch, and the env var wins outright
+    in phoebus_bridge_url() — so a fallback rendered from anything but the
+    deployment's own phoebus.host/phoebus.port pins the client to a port the
+    backend does not serve.
+    """
+
+    def test_fallback_resolves_from_ctx(self):
+        ctx = _base_ctx(phoebus_bridge_default="http://127.0.0.1:19921")
+        phoebus = _resolve_one({"servers": {"phoebus": {"enabled": True}}}, "phoebus", ctx)
+        assert phoebus["env"]["PHOEBUS_BRIDGE_URL"] == (
+            "${PHOEBUS_BRIDGE_URL:-http://127.0.0.1:19921}"
+        )
+
+    def test_fallback_default_without_ctx_key(self):
+        """A context that skips config_derived_context keeps the stock 7979."""
+        phoebus = _resolve_one({"servers": {"phoebus": {"enabled": True}}}, "phoebus")
+        assert phoebus["env"]["PHOEBUS_BRIDGE_URL"] == (
+            "${PHOEBUS_BRIDGE_URL:-http://127.0.0.1:7979}"
+        )
+
+    def test_clone_spec_env_untouched(self):
+        """A clone's spec-authored bridge URL is the operator's, not the ctx's."""
+        ctx = _base_ctx(phoebus_bridge_default="http://127.0.0.1:19921")
+        p2 = _resolve_one({"servers": {"phoebus2": dict(_PHOEBUS2_SPEC)}}, "phoebus2", ctx)
+        assert p2["env"]["PHOEBUS_BRIDGE_URL"] == ("${PHOEBUS2_BRIDGE_URL:-http://127.0.0.1:7980}")
+
+
 # ---------------------------------------------------------------------------
 # Agent resolution tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #829.

## Problem

The phoebus server definition baked a literal `${PHOEBUS_BRIDGE_URL:-http://127.0.0.1:7979}` into every rendered `.mcp.json`. The fallback half always materializes the env var at launch, and the env var wins outright in `phoebus_bridge_url()` — so the documented `phoebus.host`/`phoebus.port` resolution was unreachable in every render: the client stayed pinned to 7979 while the backend deployed onto the configured port. Health checks probe the backend's own port directly, so a deployment on a non-default layout read green while every `mcp__phoebus__*` tool died with connection refused (found on the ALS deployment, which is on the #777-style 19xxx block).

## Fix

- The definition's fallback is now a `{phoebus_bridge_default}` placeholder resolved at render time by `config_derived_context` (both render paths already merge it before `resolve_servers`).
- The value comes from a new shared pure helper, `osprey.mcp_server.http.phoebus_bridge_default(config)`, which is also the config half of the runtime resolution — one spelling, so the rendered client and the deployed bridge cannot fork.
- A context without the key (callers that skip `config_derived_context`) keeps the stock `http://127.0.0.1:7979`, so behavior is unchanged for unconfigured projects; an `extends` clone's spec-authored URL is untouched.

## Tests

- `tests/mcp_server/test_http.py`: the pure helper (configured / defaulted / bare `phoebus:` key) and config-driven `phoebus_bridge_url()` resolution.
- `tests/registry/test_mcp.py`: the rendered fallback follows the ctx key, keeps 7979 without it, and leaves clone spec env alone.
- `tests/cli/test_claude_code_integration.py`: `config_derived_context` derives the key, and the build path renders the configured port into the resolved server env (the drift regression test).