### PR TITLE
feat(web): facility-configurable feedback trackers

### DIFF
--- a/changelog.d/828.added.md
+++ b/changelog.d/828.added.md
@@ -1,0 +1,6 @@
+Web terminal: the feedback dialog's outbound channels are configurable per
+facility. `web.feedback.trackers` lists issue trackers — GitHub repositories
+and GitLab projects, gitlab.com or self-hosted — and each becomes one channel
+captioned by its `label`, opening a prefilled new-issue form the same way the
+GitHub channel always has. `web.feedback.github_repo` keeps working as a
+single GitHub tracker; blank still retires it.

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -338,9 +338,10 @@ says nothing about the chip.
 Documentation and feedback settings
 -----------------------------------
 
-Four ``web`` keys aim the rail's **Documentation** link and **Feedback** button
-and bound the feedback store. The table, the shipped defaults, and what a blank
-value means are in :ref:`config-web`.
+Five ``web`` keys aim the rail's **Documentation** link and **Feedback** button
+— including the issue trackers the dialog offers — and bound the feedback
+store. The table, the shipped defaults, and what a blank value means are in
+:ref:`config-web`.
 
 .. dropdown:: Under the hood
    :icon: gear

--- a/docs/source/how-to/web-terminal/send-feedback.rst
+++ b/docs/source/how-to/web-terminal/send-feedback.rst
@@ -17,8 +17,10 @@ channel the sender picks. Facility staff read those records back with
 Choose a channel
 ----------------
 
-Switching between the three channels keeps the typed text and both checkboxes
-as they were.
+**Local** and **Email** are always offered; between them sits one channel per
+issue tracker the facility configured — a GitHub repository or a GitLab
+project, captioned however the facility named it. Switching between channels
+keeps the typed text and both checkboxes as they were.
 
 .. list-table::
    :header-rows: 1
@@ -33,13 +35,14 @@ as they were.
      - The report is for the people who run this deployment — the usual case in
        a control room, and the only one that works with outbound access
        blocked.
-   * - **GitHub**
-     - Also opens a new-issue tab on the configured repository. Without session
-       context the issue body arrives complete; with it, the whole report —
-       text, metadata, session context — is copied to the clipboard and the
-       issue body is a single line saying to paste it there, because the
-       context is far too large to prefill.
-     - The report belongs upstream, and the sender has a GitHub account.
+   * - **An issue tracker** (GitHub or GitLab)
+     - Also opens a new-issue tab on that tracker. Without session context the
+       issue body arrives complete; with it, the whole report — text, metadata,
+       session context — is copied to the clipboard and the issue body is a
+       single line saying to paste it there, because the context is far too
+       large to prefill.
+     - The report belongs with the people who read that tracker, and the
+       sender has an account there.
    * - **Email**
      - Also opens a mail draft to the configured address, following the same
        rule: complete when it fits, one paste when session context (or a very
@@ -47,17 +50,19 @@ as they were.
      - There is a maintainer address to write to and no issue tracker in the
        loop.
 
-GitHub and Email never send anything by themselves. OSPREY prefills a tab or a
-draft in the sender's own browser and mail client; the sender still reviews it
-and presses send. The server posts nothing off the host, on any channel.
+The tracker and Email channels never send anything by themselves. OSPREY
+prefills a tab or a draft in the sender's own browser and mail client; the
+sender still reviews it and presses send. The server posts nothing off the
+host, on any channel.
 
 Both outbound channels write the same record on the deployment as a Local send
 does, so the facility keeps its own copy of every report even when the
 conversation continues in a public issue.
 
-If a channel is not configured for the deployment, its radio button still
-appears but the action is refused with a short explanation rather than aiming
-the report somewhere nobody reads. See :ref:`feedback-configuration`.
+A tracker the deployment has not configured is not offered at all; if the
+Email channel has no address behind it, its radio button still appears but the
+action is refused with a short explanation rather than aiming the report
+somewhere nobody reads. See :ref:`feedback-configuration`.
 
 What gets attached
 ------------------
@@ -80,9 +85,9 @@ username, which travel either way.
 **Session context** — the checkbox is **off** by default, and is greyed out with
 "no session yet" when there is no live session to attach. It adds:
 
-- the session's id — on the GitHub and Email channels the issue title or mail
-  subject also carries a short prefix of it, so the message can be matched to
-  the deployment's own record even if the paste step is missed,
+- the session's id — on the tracker and Email channels the issue title or
+  mail subject also carries a short prefix of it, so the message can be matched
+  to the deployment's own record even if the paste step is missed,
 - the session's tool-call and agent event log,
 - its chat history,
 - the terminal scrollback,
@@ -94,7 +99,7 @@ OSPREY does not tag every artifact with the session that produced it, so the
 inventory falls back to a time window: an artifact somebody else made in a
 different tab during the same minutes can be listed. Only its title and id
 appear — never its contents — but a sender attaching context to a **public**
-GitHub issue should know that the list is not strictly their own work.
+issue should know that the list is not strictly their own work.
 
 Session context is triaged newest-first and truncated to fit a size budget, so a
 long session is attached in part rather than in full. The outbound copy — the
@@ -211,10 +216,12 @@ history of what people reported stays complete.
 Point the channels at your facility
 -----------------------------------
 
-Three string keys under ``web`` aim the two rail controls, and a fourth bounds
-the store they fill. The table, the shipped defaults, and what a blank value
-means are in :ref:`config-web`. The Local channel is always available and needs
-no configuration at all.
+``web.feedback.trackers`` lists the issue trackers the dialog offers — a
+self-hosted GitLab, the upstream GitHub repository, both — and
+``web.feedback.email`` names the address behind the Email channel. The table,
+the shipped defaults, and what a blank value means are in :ref:`config-web`;
+the tracker list itself is described in :ref:`feedback-trackers`. The Local
+channel is always available and needs no configuration at all.
 
 .. note::
 

--- a/docs/source/reference/configuration/config.rst
+++ b/docs/source/reference/configuration/config.rst
@@ -448,10 +448,17 @@ Documentation and feedback keys
      - ``https://als-apg.github.io/osprey``
      - Where the **Documentation** control — in the rail and in the status bar
        — points. Set it to your own hosted copy of the docs.
+   * - ``web.feedback.trackers``
+     - unset (no list)
+     - Issue trackers the feedback dialog offers, one channel each. A list of
+       ``{kind, repo | url, label}`` entries: ``kind: github`` with an
+       ``owner/repo``, or ``kind: gitlab`` with the project's base URL
+       (gitlab.com or self-hosted). ``label`` captions the channel; it defaults
+       to the kind's name. See :ref:`feedback-trackers` below.
    * - ``web.feedback.github_repo``
      - ``als-apg/osprey``
-     - ``owner/repo`` the feedback dialog's GitHub channel opens a prefilled
-       new issue against.
+     - ``owner/repo`` of one more GitHub tracker, captioned **GitHub** —
+       shorthand for a ``github`` entry in ``trackers``.
    * - ``web.feedback.email``
      - ``thellert@lbl.gov``
      - Recipient of the prefilled mail draft the dialog's Email channel opens.
@@ -480,18 +487,54 @@ Documentation and feedback keys
    web:
      docs_url: https://docs.example-facility.org/osprey
      feedback:
-       github_repo: example-facility/controls
+       trackers:
+         - kind: gitlab
+           url: https://git.example-facility.org/controls/osprey
+           label: Facility GitLab
+         - kind: github
+           repo: als-apg/osprey
+           label: OSPREY upstream
+       github_repo: ""
        email: controls-support@example.org
        max_store_bytes: 268435456
 
 The last four keys are unset in every shipped template: they are read straight
 from ``config.yml`` when present and fall back to the defaults above when not.
 
+.. _feedback-trackers:
+
+Issue trackers
+~~~~~~~~~~~~~~
+
+The dialog renders one channel per tracker, between **Local** and **Email**,
+in the order listed — ``trackers`` first, then the ``github_repo`` shorthand.
+Every tracker channel works the same way the GitHub channel always has: the
+report is recorded on the deployment, and the browser opens the tracker's
+new-issue form prefilled with it (or with a one-line pointer to the clipboard
+when session context is attached). Nothing is posted on the sender's behalf.
+
+- ``kind: github`` needs ``repo`` (``owner/name``); the form is
+  ``https://github.com/<repo>/issues/new``.
+- ``kind: gitlab`` needs ``url``, the project's base URL; the form is
+  ``<url>/-/issues/new``. The shape is the same on gitlab.com and on a
+  self-hosted instance.
+
+An entry that fits neither — an unknown ``kind``, a GitHub entry with no
+``owner/name``, a GitLab entry whose ``url`` is not ``http(s)://`` — is
+reported in the log and skipped; the rest of the list stands. Two entries
+naming the same target collapse to the first, so listing the upstream
+repository under your own label does not render it twice beside the shorthand.
+
+With no ``trackers`` and no ``github_repo`` written, the one tracker on offer
+is the shipped default, so a bare deployment still reaches the OSPREY
+maintainers. A facility that wants only its own tracker lists it and blanks
+``github_repo``, as in the example above.
+
 Blank, absent, and written-with-no-value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Three ways of writing one of the three **string** keys mean three different
-things:
+Three ways of writing one of the three **string** keys (``docs_url``,
+``github_repo``, ``email``) mean three different things:
 
 - **Leave the key out** and the deployment uses the shipped default above.
 - **Set it to an explicitly blank value** (``docs_url: ""``) and the deployment
@@ -506,8 +549,10 @@ things:
   "there is none" — so you get the default. Write ``""`` when you mean none.
 
 ``max_store_bytes`` takes a positive byte count; anything else — blank
-included — is reported in the log and the default is used. The feedback
-dialog's Local channel is always available and needs no configuration at all.
+included — is reported in the log and the default is used. ``trackers`` has
+no blank posture of its own: an empty list, or none, simply adds no channel.
+The feedback dialog's Local channel is always available and needs no
+configuration at all.
 
 A build profile overrides any of these keys from its ``config:`` block in the
 dotted form, e.g. ``web.feedback.max_store_bytes: 536870912``.

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -1352,6 +1352,12 @@ keys:
       last of them rather than outliving them all.
   web.feedback.github_repo:
     evidence: 'get_config_value\(\s*"web\.feedback\.github_repo",\s*DEFAULT_FEEDBACK_GITHUB_REPO\s*\)'
+  web.feedback.trackers:
+    # Documented in every template as a commented example beside github_repo,
+    # never rendered as a live key: the shipped posture is the github_repo
+    # shorthand alone, and a facility adds trackers by hand.
+    rendered: false
+    evidence: 'get_config_value\(\s*"web\.feedback\.trackers",\s*None\s*\)'
   web.feedback.email:
     evidence: 'get_config_value\(\s*"web\.feedback\.email",\s*DEFAULT_FEEDBACK_EMAIL\s*\)'
   web.feedback.max_store_bytes:

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -284,6 +284,11 @@ DEFAULT_DOCS_URL = "https://als-apg.github.io/osprey"
 #: ``web.feedback.github_repo`` is absent.
 DEFAULT_FEEDBACK_GITHUB_REPO = "als-apg/osprey"
 
+#: Tracker kinds ``web.feedback.trackers`` accepts, each with the radio caption
+#: used when an entry names no ``label`` of its own. The client's URL builders
+#: (``static/js/feedback-prefill.js``) are keyed by the same two words.
+FEEDBACK_TRACKER_LABELS: dict[str, str] = {"github": "GitHub", "gitlab": "GitLab"}
+
 #: Recipient of the prefilled ``mailto:`` draft when ``web.feedback.email``
 #: is absent — the OSPREY maintainers.
 DEFAULT_FEEDBACK_EMAIL = "thellert@lbl.gov"
@@ -341,6 +346,102 @@ def coerce_config_str(key: str, value: object, default: str) -> str:
     if value is not None:
         logger.warning("%s is %r, not a string; using %r instead", key, value, default)
     return default
+
+
+def coerce_feedback_trackers(value: object) -> list[dict[str, str]]:
+    """Return ``web.feedback.trackers`` as a list of normalised tracker entries.
+
+    Each usable entry becomes ``{"kind", "label", "repo"}`` (GitHub, ``repo`` an
+    ``owner/name``) or ``{"kind", "label", "url"}`` (GitLab, ``url`` the
+    project's base URL — gitlab.com or self-hosted, trailing slash dropped).
+    A missing ``label`` takes the kind's own name.
+
+    Lenient per entry, strict per field: one malformed line — an unknown
+    ``kind``, a GitHub entry without an ``owner/name`` repo, a GitLab entry
+    whose ``url`` is not ``http(s)://`` — is reported and dropped while the rest
+    of the list stands, because one typo must not retire every tracker the
+    facility configured. A value that is not a list at all is reported and
+    reads as no list.
+
+    Args:
+        value: Whatever the config reader returned for the key.
+
+    Returns:
+        The usable entries, in the order written.
+    """
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        logger.warning("web.feedback.trackers is %r, not a list; ignoring it", value)
+        return []
+    trackers: list[dict[str, str]] = []
+    for index, entry in enumerate(value):
+        tracker = _coerce_feedback_tracker(entry)
+        if tracker is None:
+            logger.warning("web.feedback.trackers[%d] is %r; dropping it", index, entry)
+            continue
+        trackers.append(tracker)
+    return trackers
+
+
+def _coerce_feedback_tracker(entry: object) -> dict[str, str] | None:
+    """One entry of :func:`coerce_feedback_trackers`, or ``None`` when unusable."""
+    if not isinstance(entry, dict):
+        return None
+    kind = entry.get("kind")
+    if not isinstance(kind, str) or kind.strip() not in FEEDBACK_TRACKER_LABELS:
+        return None
+    kind = kind.strip()
+    label = entry.get("label")
+    label = label.strip() if isinstance(label, str) and label.strip() else ""
+    tracker = {"kind": kind, "label": label or FEEDBACK_TRACKER_LABELS[kind]}
+    if kind == "github":
+        repo = entry.get("repo")
+        repo = repo.strip() if isinstance(repo, str) else ""
+        if repo.count("/") != 1 or any(ch.isspace() for ch in repo) or not all(repo.split("/")):
+            return None
+        tracker["repo"] = repo
+    else:
+        url = entry.get("url")
+        url = url.strip().rstrip("/") if isinstance(url, str) else ""
+        if not url.startswith(("http://", "https://")) or any(ch.isspace() for ch in url):
+            return None
+        tracker["url"] = url
+    return tracker
+
+
+def resolve_feedback_trackers(
+    trackers: list[dict[str, str]], github_repo: str
+) -> list[dict[str, str]]:
+    """The tracker list the dialog offers: the configured list plus the sugar.
+
+    ``web.feedback.github_repo`` keeps its meaning as a single GitHub tracker,
+    appended after the facility-authored list (blank retires it — that is the
+    posture :func:`coerce_config_str` preserves). Two entries naming the same
+    target collapse to the first, so a facility that lists the upstream repo
+    under its own label does not get it rendered twice by the sugar.
+
+    Args:
+        trackers: Output of :func:`coerce_feedback_trackers`.
+        github_repo: Resolved ``web.feedback.github_repo`` (``""`` when blank).
+
+    Returns:
+        The de-duplicated list, in render order.
+    """
+    candidates = list(trackers)
+    if github_repo:
+        candidates.append(
+            {"kind": "github", "label": FEEDBACK_TRACKER_LABELS["github"], "repo": github_repo}
+        )
+    seen: set[tuple[str, str]] = set()
+    resolved: list[dict[str, str]] = []
+    for tracker in candidates:
+        key = (tracker["kind"], tracker.get("repo") or tracker.get("url") or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append(dict(tracker))
+    return resolved
 
 
 #: Words a human writes when they mean a boolean but YAML kept a string —
@@ -1232,6 +1333,7 @@ def _create_lifespan(
                 "web.feedback.github_repo", DEFAULT_FEEDBACK_GITHUB_REPO
             )
             raw_email = get_config_value("web.feedback.email", DEFAULT_FEEDBACK_EMAIL)
+            raw_trackers = get_config_value("web.feedback.trackers", None)
             raw_max_store_bytes = get_config_value(
                 "web.feedback.max_store_bytes", DEFAULT_FEEDBACK_MAX_STORE_BYTES
             )
@@ -1240,10 +1342,13 @@ def _create_lifespan(
                 "Could not read web.docs_url / web.feedback.* config keys; using defaults",
                 exc_info=True,
             )
-            raw_docs_url = raw_github_repo = raw_email = raw_max_store_bytes = None
+            raw_docs_url = raw_github_repo = raw_email = raw_trackers = raw_max_store_bytes = None
         app.state.docs_url = coerce_config_str("web.docs_url", raw_docs_url, DEFAULT_DOCS_URL)
         app.state.feedback_github_repo = coerce_config_str(
             "web.feedback.github_repo", raw_github_repo, DEFAULT_FEEDBACK_GITHUB_REPO
+        )
+        app.state.feedback_trackers = resolve_feedback_trackers(
+            coerce_feedback_trackers(raw_trackers), app.state.feedback_github_repo
         )
         app.state.feedback_email = coerce_config_str(
             "web.feedback.email", raw_email, DEFAULT_FEEDBACK_EMAIL

--- a/src/osprey/interfaces/web_terminal/routes/feedback.py
+++ b/src/osprey/interfaces/web_terminal/routes/feedback.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from osprey.interfaces.web_terminal.feedback_composer import (
     assemble_payload,
@@ -89,9 +89,16 @@ This check is the single-user backstop — a bare uvicorn has no body limit at
 all, and without it the same client could spool an unbounded record there and
 not in production."""
 
-OUTBOUND_CHANNELS = ("github", "email")
+OUTBOUND_CHANNELS = ("github", "gitlab", "email")
 """Channels whose payload leaves this host, and whose record therefore carries
 the size and digest of the exact string the operator pasted."""
+
+TRACKER_CHANNELS = ("github", "gitlab")
+"""Channels that open a prefilled new-issue form on one of the deployment's
+configured trackers (``web.feedback.trackers``); the record names which."""
+
+MAX_TRACKER_CHARS = 512
+"""Ceiling on the ``tracker`` field — an ``owner/name`` or a project URL."""
 
 
 class FeedbackRequest(BaseModel):
@@ -104,11 +111,14 @@ class FeedbackRequest(BaseModel):
     """
 
     text: str
-    channel: Literal["local", "github", "email"]
+    channel: Literal["local", "github", "gitlab", "email"]
     include_metadata: bool = True
     include_context: bool = False
     session_id: str | None = None
     scrollback: str | None = None
+    tracker: str | None = Field(default=None, max_length=MAX_TRACKER_CHARS)
+    """The tracker a ``github``/``gitlab`` send opened: the ``owner/name`` or
+    the project URL, as configured. Ignored on the other channels."""
 
 
 class BundleRequest(BaseModel):
@@ -385,6 +395,8 @@ def submit_feedback(request: Request, body: FeedbackRequest) -> dict[str, Any]:
         "text_truncated": text_truncated,
         "context_truncated": context_truncated,
     }
+    if body.channel in TRACKER_CHANNELS and body.tracker:
+        header["tracker"] = _encodable(body.tracker)
     if body.channel in OUTBOUND_CHANNELS:
         encoded = payload.encode("utf-8", "surrogatepass")
         header["bundle_bytes"] = len(encoded)

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -220,7 +220,7 @@ async def get_panels(request: Request):
             "open_tiles_age_s": float|None,   # seconds since that report (None = never)
             "open_tiles_dock": bool|None,     # reporting client had a dock shell (None = never)
             "docs_url": str,            # target of the rail's Documentation control
-            "feedback_github_repo": str,   # "owner/repo" for the prefilled new-issue URL
+            "feedback_trackers": [...],  # [{"kind", "label", "repo"|"url"}], render order
             "feedback_email": str,      # recipient of the prefilled mailto: draft
         }
 
@@ -291,11 +291,13 @@ async def get_panels(request: Request):
     So ``[]`` always means known-empty and ``null`` always means unknown; the
     age tells the two flavours of unknown apart.
 
-    ``docs_url``, ``feedback_github_repo`` and ``feedback_email`` are the
-    resolved ``web.docs_url`` / ``web.feedback.*`` values that address the two
-    utility controls at the far end of the rail: the Documentation link target,
-    and the two outbound channels the feedback dialog offers (a prefilled
-    GitHub issue and a prefilled ``mailto:`` draft). The store ceiling
+    ``docs_url``, ``feedback_trackers`` and ``feedback_email`` are the resolved
+    ``web.docs_url`` / ``web.feedback.*`` values that address the two utility
+    controls at the far end of the rail: the Documentation link target, and
+    the outbound channels the feedback dialog offers (one prefilled new-issue
+    link per configured tracker — ``web.feedback.trackers`` plus the
+    ``web.feedback.github_repo`` sugar, already merged server-side — and a
+    prefilled ``mailto:`` draft). The store ceiling
     (``web.feedback.max_store_bytes``) is deliberately not echoed — it governs
     server-side pruning and nothing in the browser acts on it.
     """
@@ -361,10 +363,15 @@ async def get_panels(request: Request):
     open_tiles_age = None if open_tiles_ts is None else time.time() - open_tiles_ts
     open_tiles_dock = getattr(request.app.state, "open_tiles_dock", None)
     # Utility-cluster targets. The defaults mirror app.DEFAULT_DOCS_URL /
-    # DEFAULT_FEEDBACK_GITHUB_REPO / DEFAULT_FEEDBACK_EMAIL, spelled as
-    # literals here for the same routes->app import-cycle reason as above.
+    # DEFAULT_FEEDBACK_GITHUB_REPO (as the one sugar tracker) /
+    # DEFAULT_FEEDBACK_EMAIL, spelled as literals here for the same
+    # routes->app import-cycle reason as above.
     docs_url = getattr(request.app.state, "docs_url", "https://als-apg.github.io/osprey")
-    feedback_github_repo = getattr(request.app.state, "feedback_github_repo", "als-apg/osprey")
+    feedback_trackers = getattr(
+        request.app.state,
+        "feedback_trackers",
+        [{"kind": "github", "label": "GitHub", "repo": "als-apg/osprey"}],
+    )
     feedback_email = getattr(request.app.state, "feedback_email", "thellert@lbl.gov")
     # Onboarding tour: the resolved invite policy plus the derived capability
     # list for the "Ask in plain language" card. Both resolved at startup
@@ -395,7 +402,7 @@ async def get_panels(request: Request):
         "open_tiles_age_s": open_tiles_age,
         "open_tiles_dock": open_tiles_dock,
         "docs_url": docs_url,
-        "feedback_github_repo": feedback_github_repo,
+        "feedback_trackers": [dict(tracker) for tracker in feedback_trackers],
         "feedback_email": feedback_email,
         "config_panel_enabled": config_panel_enabled,
         "scaffold_write_enabled": scaffold_write_enabled,

--- a/src/osprey/interfaces/web_terminal/static/css/feedback-modal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/feedback-modal.css
@@ -156,8 +156,9 @@
 
 .feedback-channels {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-4);
+  gap: var(--space-2) var(--space-4);
 }
 
 .feedback-channel-option,

--- a/src/osprey/interfaces/web_terminal/static/js/feedback-boot.js
+++ b/src/osprey/interfaces/web_terminal/static/js/feedback-boot.js
@@ -28,7 +28,7 @@ import { FeedbackModal } from './feedback-modal.js';
 import { applyDocsLink, initRailUtility, onFeedbackClick } from './rail-utility.js';
 import { captureScrollback } from './scrollback-capture.js';
 
-/** Deployment config: rail/status docs target and the two outbound channels. */
+/** Deployment config: rail/status docs target and the outbound channels. */
 const PANELS_PATH = '/api/panels';
 
 /** Carries `osprey.__version__`, the one metadata fact the page cannot know. */
@@ -43,9 +43,13 @@ const NOTICE_CLASS = 'feedback-notice';
 /** Class of the read-only textarea offered when the clipboard refuses. */
 const MANUAL_COPY_CLASS = 'feedback-manual-copy';
 
-/** Shown when the GitHub channel is picked on a deployment that blanked the repo. */
-const NO_GITHUB_REPO =
-  'This deployment has no feedback repository configured — use Local instead.';
+/**
+ * Shown when a tracker channel is actioned without a tracker behind it. The
+ * radios are rendered from the configured list, so this is a belt-and-braces
+ * guard for a list that changed under an open dialog, not a posture a
+ * deployment can configure into.
+ */
+const NO_TRACKER = 'This deployment has no such feedback tracker configured — use Local instead.';
 
 /** Shown when the Email channel is picked on a deployment that blanked the address. */
 const NO_EMAIL = 'This deployment has no feedback address configured — use Local instead.';
@@ -73,7 +77,11 @@ const CONFIG_TIMEOUT_MS = 8000;
 
 /**
  * @typedef {import('./feedback-modal.js').FeedbackFormState} FeedbackFormState
+ * @typedef {import('./feedback-modal.js').FeedbackTracker} FeedbackTracker
  */
+
+/** Tracker kinds the page knows how to open; anything else is dropped. */
+const TRACKER_KINDS = Object.freeze({ github: 'GitHub', gitlab: 'GitLab' });
 
 /**
  * @typedef {object} FeedbackBootOptions
@@ -97,9 +105,10 @@ const CONFIG_TIMEOUT_MS = 8000;
 /**
  * @typedef {object} FeedbackConfig
  * @property {'pending'|'ok'|'unreadable'} status - how the config read went.
- * @property {string} githubRepo - `owner/name`, or "" when this deployment
+ * @property {FeedbackTracker[]} trackers - the issue trackers on offer, in
+ *   render order; empty when this deployment configured none.
+ * @property {string} email - maintainer address, or "" when this deployment
  *   retired the channel.
- * @property {string} email - maintainer address, or "" as above.
  * @property {string} version - `osprey.__version__`, for the metadata block.
  */
 
@@ -124,7 +133,7 @@ const CONFIG_TIMEOUT_MS = 8000;
  */
 export function initFeedback(options = {}) {
   /** @type {FeedbackConfig} */
-  const config = { status: 'pending', githubRepo: '', email: '', version: '' };
+  const config = { status: 'pending', trackers: [], email: '', version: '' };
 
   const modal = createFeedbackModal(config, options);
   onFeedbackClick(() => modal.open());
@@ -143,8 +152,11 @@ export function initFeedback(options = {}) {
   // reading" for up to the timeout because a version line had not arrived.
   const panelsApplied = read(PANELS_PATH).then((panels) => {
     config.status = panels === null ? 'unreadable' : 'ok';
-    config.githubRepo = trimmedString(panels == null ? undefined : panels.feedback_github_repo);
+    config.trackers = normalizeTrackers(panels == null ? undefined : panels.feedback_trackers);
     config.email = trimmedString(panels == null ? undefined : panels.feedback_email);
+    // Handed to the dialog as well as kept here: the radios are built from
+    // the list, and the dialog may already be open when it lands.
+    modal.setTrackers(config.trackers);
     initRailUtility(panels);
     applyStatusDocsLink(panels);
   });
@@ -230,7 +242,7 @@ function createFeedbackModal(config, options) {
   // One action at a time, held as STATE rather than as the disabled buttons.
   // Disabling the row cannot be the guard on its own: the channel radios are
   // not part of it, and switching channel mid-flight makes the dialog rebuild
-  // the action row with fresh, enabled buttons — Send, switch to GitHub, click
+  // the action row with fresh, enabled buttons — Send, switch to a tracker, click
   // and the deployment has two submissions in flight for one report.
   let inFlight = false;
 
@@ -271,21 +283,20 @@ function createFeedbackModal(config, options) {
     // looking at when they pressed the button — and only when it will be sent.
     scrollback: state.contextOn ? captureScrollback(getTerminal()) : '',
     metadata: buildMetadata(config),
-    githubRepo: config.githubRepo,
     email: config.email,
     showSelectableText: (payload) => showManualCopy(modal, payload),
     onNotice: (notice) => showNotice(modal, notice),
   });
 
   /**
-   * The Send / "Open GitHub issue" / "Open email draft" buttons.
+   * The Send / "Open … issue" / "Open email draft" buttons.
    *
    * @param {FeedbackFormState} state
    * @returns {void}
    */
   const submit = (state) => {
     if (inFlight) return;
-    const unavailable = channelGuard(state.channel, config);
+    const unavailable = channelGuard(state, config);
     if (unavailable !== null) {
       startAction(modal);
       // A microtask, not this turn: `startAction` has only just created the
@@ -327,29 +338,64 @@ function createFeedbackModal(config, options) {
 }
 
 /**
- * Whether a channel can be reached at all on this deployment.
+ * Whether an outbound channel can be reached at all on this deployment.
  *
- * Three different answers, deliberately: a blanked `web.feedback.github_repo`
- * / `web.feedback.email` is a legitimate configuration (the same posture as a
- * blanked `web.docs_url`) and reads as "not available here"; a config the page
- * could not read reads as "I do not know"; and the window before the reads
- * land says so rather than guessing. What none of them may do is let the click
- * through, which would open an issue tab on `https://github.com//issues/new`.
+ * Three different answers, deliberately: a blanked `web.feedback.email` is a
+ * legitimate configuration (the same posture as a blanked `web.docs_url`) and
+ * reads as "not available here"; a config the page could not read reads as
+ * "I do not know"; and the window before the reads land says so rather than
+ * guessing. What none of them may do is let the click through, which would
+ * open a `mailto:` with no recipient — or, for a tracker channel whose tracker
+ * is no longer on the list, an issue tab on a URL built from nothing.
+ *
+ * The trackers themselves need no "not configured" answer: a tracker that is
+ * not configured is not rendered, so it cannot be picked.
  *
  * Local is never guarded — it needs no configuration, which is exactly why
  * every one of these notices points at it.
  *
- * @param {string} channel
+ * @param {FeedbackFormState} state
  * @param {FeedbackConfig} config
  * @returns {string|null} the notice to show, or null when the channel is usable.
  */
-function channelGuard(channel, config) {
-  if (channel !== 'github' && channel !== 'email') return null;
+function channelGuard(state, config) {
+  const channel = state.channel;
+  if (channel === 'local') return null;
   if (config.status === 'pending') return CONFIG_PENDING;
   if (config.status === 'unreadable') return CONFIG_UNREADABLE;
-  if (channel === 'github' && config.githubRepo === '') return NO_GITHUB_REPO;
-  if (channel === 'email' && config.email === '') return NO_EMAIL;
+  if (channel === 'email') return config.email === '' ? NO_EMAIL : null;
+  const tracker = state.tracker;
+  if (tracker === null || !config.trackers.some((known) => known.id === tracker.id)) {
+    return NO_TRACKER;
+  }
   return null;
+}
+
+/**
+ * The `/api/panels` tracker list as the dialog wants it: one entry per usable
+ * server entry, in order, with a radio value derived from what it opens.
+ *
+ * The server already validated the list, so a malformed entry here means a
+ * server/page version skew; it is dropped rather than rendered as a radio
+ * that opens nothing.
+ *
+ * @param {unknown} value - `panels.feedback_trackers`
+ * @returns {FeedbackTracker[]}
+ */
+function normalizeTrackers(value) {
+  if (!Array.isArray(value)) return [];
+  /** @type {FeedbackTracker[]} */
+  const trackers = [];
+  for (const entry of value) {
+    if (entry === null || typeof entry !== 'object') continue;
+    const kind = trimmedString(entry.kind);
+    if (kind !== 'github' && kind !== 'gitlab') continue;
+    const target = trimmedString(kind === 'github' ? entry.repo : entry.url);
+    if (target === '') continue;
+    const label = trimmedString(entry.label) || TRACKER_KINDS[kind];
+    trackers.push({ id: `${kind}:${target}`, kind, label, target });
+  }
+  return trackers;
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/feedback-client.js
+++ b/src/osprey/interfaces/web_terminal/static/js/feedback-client.js
@@ -2,14 +2,14 @@
 /* OSPREY Web Terminal — Feedback Client (transport)
  *
  * Everything the feedback dialog does that is not DOM: build the POST bodies,
- * put the unified payload on the clipboard, open the GitHub tab or the mail
- * draft, and turn the outcome into one notice line. No element is created or
+ * put the unified payload on the clipboard, open the tracker's new-issue tab
+ * or the mail draft, and turn the outcome into one notice line. No element is created or
  * read here — the dialog owns the DOM and receives a plain result object (and,
  * optionally, an `onNotice` callback) to render.
  *
  * Two properties are load-bearing and easy to break:
  *
- *   1. ORDER. For the GitHub and Email channels the clipboard write and the
+ *   1. ORDER. For the tracker and Email channels the clipboard write and the
  *      navigation must both be issued inside the click turn, BEFORE the POST
  *      settles. Safari drops the transient user activation across an await, so
  *      a copy issued afterwards is refused and a `window.open` afterwards looks
@@ -35,6 +35,7 @@ import { withPrefix } from './api.js';
 import {
   PASTE_POINTER,
   buildGitHubIssueUrl as defaultGitHubIssueUrl,
+  buildGitLabIssueUrl as defaultGitLabIssueUrl,
   buildMailto as defaultMailto,
   buildPrefillBody as defaultPrefillBody,
   utf8Length,
@@ -97,12 +98,14 @@ export const NOTICE_EMPTY_BUNDLE = 'This deployment returned no session context.
 /**
  * Appended to the outbound confirmation of a POINTER-mode send: the draft
  * opened carrying one line that points at the clipboard, and this repeats the
- * instruction in the dialog for whoever comes back to it before pasting.
+ * instruction in the dialog for whoever comes back to it before pasting. One
+ * wording for every tracker kind — GitHub and GitLab both call it the issue
+ * body.
  */
-export const NOTICE_PASTE_GITHUB =
+export const NOTICE_PASTE_ISSUE =
   'your full report is on your clipboard — paste it into the issue body';
 
-/** Email variant of {@link NOTICE_PASTE_GITHUB}. */
+/** Email variant of {@link NOTICE_PASTE_ISSUE}. */
 export const NOTICE_PASTE_EMAIL =
   'your full report is on your clipboard — paste it into the draft';
 
@@ -120,9 +123,22 @@ const TEXT_MIME = 'text/plain';
 const SESSION_TITLE_CHARS = 8;
 
 /**
+ * One of the deployment's configured issue trackers, as the dialog hands it
+ * over: the kind picks the URL builder, the target is what it builds on — an
+ * `owner/name` for GitHub, the project's base URL for GitLab.
+ *
+ * @typedef {object} FeedbackTrackerTarget
+ * @property {'github'|'gitlab'} kind
+ * @property {string} target
+ */
+
+/**
  * @typedef {object} FeedbackForm
  * @property {string} text - what the user typed
- * @property {'local'|'github'|'email'} channel
+ * @property {'local'|'github'|'gitlab'|'email'} channel
+ * @property {FeedbackTrackerTarget|null} [tracker] - which tracker a
+ *   `github`/`gitlab` send opens; a tracker channel without one is sent as
+ *   Local rather than aimed at a URL built from nothing
  * @property {boolean} metadataOn - deployment-metadata checkbox
  * @property {boolean} contextOn - session-context checkbox
  * @property {string|null} [sessionId] - may be null (no session yet) or stale
@@ -167,11 +183,11 @@ const SESSION_TITLE_CHARS = 8;
  * @property {(url: string) => void} [navigate] - assigns `location.href` (mailto)
  * @property {string} [scrollback] - from `captureScrollback(term)`
  * @property {Record<string, unknown>} [metadata] - deployment metadata block
- * @property {string} [githubRepo] - `owner/name` from `web.feedback.github_repo`
  * @property {string} [email] - maintainer address from `web.feedback.email`
  * @property {(payload: string) => void} [showSelectableText] - last copy rung
  * @property {(notice: FeedbackNotice) => void} [onNotice]
  * @property {typeof defaultGitHubIssueUrl} [buildGitHubIssueUrl]
+ * @property {typeof defaultGitLabIssueUrl} [buildGitLabIssueUrl]
  * @property {typeof defaultMailto} [buildMailto]
  * @property {typeof defaultPrefillBody} [buildPrefillBody]
  */
@@ -179,8 +195,8 @@ const SESSION_TITLE_CHARS = 8;
 /**
  * Send the user's feedback over the selected channel.
  *
- * Local waits for the record and reports its id. GitHub and Email fire one
- * paper-trail POST, feed the clipboard from its promise and hand off to the
+ * Local waits for the record and reports its id. The tracker and Email
+ * channels fire one paper-trail POST, feed the clipboard from its promise and hand off to the
  * browser — both inside the click turn — then report what happened; a failed
  * POST downgrades to a notice and never blocks the handoff.
  *
@@ -189,7 +205,7 @@ const SESSION_TITLE_CHARS = 8;
  * @returns {Promise<FeedbackResult>} never rejects
  */
 export async function sendFeedback(form, deps) {
-  const channel = normalizeChannel(form.channel);
+  const channel = effectiveChannel(form);
   const request = postJson(deps, FEEDBACK_PATH, buildSendBody(form, deps));
 
   if (channel === 'local') {
@@ -218,13 +234,13 @@ export async function sendFeedback(form, deps) {
     copying = copyPayload(deps, payload);
   }
   let opened = false;
-  if (channel === 'github') {
-    if (typeof deps.windowOpen === 'function') {
-      deps.windowOpen(link.url, '_blank', 'noopener');
+  if (channel === 'email') {
+    if (typeof deps.navigate === 'function') {
+      deps.navigate(link.url);
       opened = true;
     }
-  } else if (typeof deps.navigate === 'function') {
-    deps.navigate(link.url);
+  } else if (typeof deps.windowOpen === 'function') {
+    deps.windowOpen(link.url, '_blank', 'noopener');
     opened = true;
   }
   // --- end of the synchronous section ---
@@ -446,13 +462,17 @@ async function fallbackCopy(deps, text) {
  */
 function buildSendBody(form, deps) {
   const contextOn = form.contextOn === true;
+  const channel = effectiveChannel(form);
   /** @type {Record<string, unknown>} */
   const body = {
     text: String(form.text ?? ''),
-    channel: normalizeChannel(form.channel),
+    channel,
     include_metadata: form.metadataOn === true,
     include_context: contextOn,
   };
+  // The record names the tracker: with several configured, "github" alone
+  // no longer says where the report went.
+  if (isTrackerKind(channel) && form.tracker) body.tracker = String(form.tracker.target);
   if (contextOn) {
     if (form.sessionId) body.session_id = String(form.sessionId);
     body.scrollback = String(deps.scrollback ?? '');
@@ -490,9 +510,16 @@ function buildOutboundLink(form, deps) {
   }
   const title = deriveTitle(form);
 
-  if (normalizeChannel(form.channel) === 'github') {
+  const channel = effectiveChannel(form);
+  const target = String(form.tracker?.target ?? '');
+  if (channel === 'github') {
     const build = deps.buildGitHubIssueUrl ?? defaultGitHubIssueUrl;
-    const issue = build(String(deps.githubRepo ?? ''), title, body);
+    const issue = build(target, title, body);
+    return { url: issue.url, needsPaste: contextOn || issue.needsPaste === true };
+  }
+  if (channel === 'gitlab') {
+    const build = deps.buildGitLabIssueUrl ?? defaultGitLabIssueUrl;
+    const issue = build(target, title, body);
     return { url: issue.url, needsPaste: contextOn || issue.needsPaste === true };
   }
   const build = deps.buildMailto ?? defaultMailto;
@@ -560,7 +587,7 @@ function localResult(deps, data) {
 }
 
 /**
- * The one line to show after an outbound (GitHub/Email) submission.
+ * The one line to show after an outbound (tracker/Email) submission.
  *
  * A POINTER-mode send is judged in priority order: a clipboard the user has
  * to act on outranks a missing paper trail, which outranks the ordinary
@@ -574,7 +601,7 @@ function localResult(deps, data) {
  * @param {string|null} id
  * @param {string|null} contextStatus
  * @param {CopyRung} copied
- * @param {'local'|'github'|'email'} channel
+ * @param {'local'|'github'|'gitlab'|'email'} channel
  * @param {boolean} needsPaste - the draft opened in POINTER mode
  * @returns {FeedbackNotice}
  */
@@ -588,7 +615,7 @@ function outboundNotice(ok, id, contextStatus, copied, channel, needsPaste) {
   if (!ok) return { kind: 'warning', message: NOTICE_NOT_RECORDED };
   const base = recordedNotice(id, contextStatus);
   if (base.kind !== 'success') return base;
-  const hint = channel === 'email' ? NOTICE_PASTE_EMAIL : NOTICE_PASTE_GITHUB;
+  const hint = channel === 'email' ? NOTICE_PASTE_EMAIL : NOTICE_PASTE_ISSUE;
   return { kind: 'success', message: `${base.message} — ${hint}` };
 }
 
@@ -657,10 +684,24 @@ function readString(data, key) {
 
 /**
  * @param {unknown} channel
- * @returns {'local'|'github'|'email'}
+ * @returns {channel is 'github'|'gitlab'}
  */
-function normalizeChannel(channel) {
-  if (channel === 'github' || channel === 'email') return channel;
+function isTrackerKind(channel) {
+  return channel === 'github' || channel === 'gitlab';
+}
+
+/**
+ * The channel a form is actually sent on. A tracker kind without a tracker
+ * to aim at collapses to Local: a URL built from an empty target would open
+ * a dead tab, and the record is the one deliverable that needs no target.
+ *
+ * @param {FeedbackForm} form
+ * @returns {'local'|'github'|'gitlab'|'email'}
+ */
+function effectiveChannel(form) {
+  const channel = form.channel;
+  if (channel === 'email') return channel;
+  if (isTrackerKind(channel) && form.tracker && form.tracker.kind === channel) return channel;
   return 'local';
 }
 

--- a/src/osprey/interfaces/web_terminal/static/js/feedback-modal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/feedback-modal.js
@@ -46,7 +46,7 @@ export const NO_SESSION_HINT = 'no session yet';
 
 /**
  * The two-step statement shown between the checkboxes and the action button on
- * the GitHub and Email channels while session context is ticked. It states, in
+ * the tracker and Email channels while session context is ticked. It states, in
  * order and before the click, exactly what the action button will do — the
  * context cannot ride a prefilled URL, so the report travels by clipboard and
  * the draft opens with a line marking where to paste it. Deliberately plain:
@@ -54,9 +54,10 @@ export const NO_SESSION_HINT = 'no session yet';
  */
 export const PASTE_STEP_COPY = 'Your full report is copied to your clipboard.';
 
-/** Step two of {@link PASTE_STEP_COPY}, per outbound channel. */
+/** Step two of {@link PASTE_STEP_COPY}, per outbound channel kind. */
 export const PASTE_STEP_OPEN = Object.freeze({
   github: 'A GitHub issue draft opens — paste the report into the issue body.',
+  gitlab: 'A GitLab issue draft opens — paste the report into the issue body.',
   email: 'An email draft opens — paste the report into the message body.',
 });
 
@@ -94,8 +95,8 @@ export const FEEDBACK_DISCLOSURE_PARAGRAPHS = Object.freeze([
   'Session context (off by default): this session’s id, its tool-call and ' +
     'agent event log, its chat history, and the terminal scrollback. It is ' +
     'triaged newest-first and truncated to fit a size budget, so a long ' +
-    'session is attached in part rather than in full. On the GitHub and ' +
-    'Email channels it travels by paste: sending copies your full report ' +
+    'session is attached in part rather than in full. On the issue-tracker ' +
+    'and Email channels it travels by paste: sending copies your full report ' +
     'to your clipboard, and the draft opens with one line saying to paste ' +
     'it there.',
   'The artifact inventory lists titles and ids only — artifacts tagged to ' +
@@ -108,26 +109,27 @@ export const FEEDBACK_DISCLOSURE_PARAGRAPHS = Object.freeze([
 /** The disclosure as one string — the form the composer can quote. */
 export const FEEDBACK_DISCLOSURE = FEEDBACK_DISCLOSURE_PARAGRAPHS.join('\n\n');
 
-/** Per-channel caveat shown under the channel picker. */
+/** Per-channel-kind caveat shown under the channel picker. */
 export const CHANNEL_HINTS = Object.freeze({
   local: '',
   github: 'Requires a GitHub account',
+  gitlab: 'Requires a GitLab account',
   email: 'If nothing opens, use Local instead',
 });
 
-/** Label of the channel's "open the outside thing" button. */
+/** Label of the channel kind's "open the outside thing" button. */
 const CHANNEL_ACTION_LABELS = Object.freeze({
   local: '',
   github: 'Open GitHub issue',
+  gitlab: 'Open GitLab issue',
   email: 'Open email draft',
 });
 
-/** Radio labels, in render order. */
-const CHANNELS = Object.freeze([
-  { value: 'local', label: 'Local' },
-  { value: 'github', label: 'GitHub' },
-  { value: 'email', label: 'Email' },
-]);
+/** Radio value of the Local channel. */
+const LOCAL = 'local';
+
+/** Radio value of the Email channel. */
+const EMAIL = 'email';
 
 // Every currently open modal. A Set rather than a boolean so `open()`/`close()`
 // stay idempotent per instance and `isFeedbackModalOpen()` cannot be desynced
@@ -136,13 +138,28 @@ const CHANNELS = Object.freeze([
 const _openModals = new Set();
 
 /**
- * @typedef {'local'|'github'|'email'} FeedbackChannel
+ * @typedef {'local'|'github'|'gitlab'|'email'} FeedbackChannel
+ */
+
+/**
+ * One of the deployment's configured issue trackers (`web.feedback.trackers`
+ * plus the `github_repo` sugar), already normalised by the caller. Each
+ * renders as one radio between Local and Email, captioned by `label`.
+ *
+ * @typedef {object} FeedbackTracker
+ * @property {string} id - unique among the list; the radio's value.
+ * @property {'github'|'gitlab'} kind - picks the wording and the URL builder.
+ * @property {string} label - the radio caption, facility-authored.
+ * @property {string} target - `owner/name` (GitHub) or the project URL (GitLab).
  */
 
 /**
  * @typedef {object} FeedbackFormState
  * @property {string} text - the typed feedback.
- * @property {FeedbackChannel} channel - the selected delivery channel.
+ * @property {FeedbackChannel} channel - the selected delivery channel; a
+ *   tracker reports its kind.
+ * @property {FeedbackTracker|null} tracker - the selected tracker, on the
+ *   tracker channels; null on Local and Email.
  * @property {boolean} metadataOn - attach deployment metadata (default true).
  * @property {boolean} contextOn - attach session context (default false;
  *   reported false whenever there is no session to attach).
@@ -158,12 +175,16 @@ const _openModals = new Set();
  * @property {() => string|null} [getSessionId] - the current terminal session
  *   id. Injected rather than imported from `terminal.js` so the dialog has no
  *   dependency on the terminal module. Defaults to "no session".
+ * @property {FeedbackTracker[]} [trackers] - the issue trackers to offer at
+ *   construction; {@link FeedbackModal#setTrackers} replaces the list later,
+ *   which is how boot hands over a configuration that lands after the first
+ *   open. Defaults to none.
  * @property {(state: FeedbackFormState) => void} [onSubmit] - the `submit`
  *   event: the Local channel's Send button.
  * @property {(state: FeedbackFormState) => void} [onCopy] - the `copy` event:
  *   the inline copy button on the session-context row.
  * @property {(state: FeedbackFormState) => void} [onOpenChannel] - the `open`
- *   event: "Open GitHub issue" / "Open email draft".
+ *   event: "Open GitHub issue" / "Open GitLab issue" / "Open email draft".
  * @property {() => void} [onClose] - called once per close, after teardown.
  */
 
@@ -212,8 +233,13 @@ export class FeedbackModal {
     // a channel switch (which re-renders the action row) and a close/reopen —
     // an accidental Escape must not throw away a half-written report.
     this._text = '';
-    /** @type {FeedbackChannel} */
-    this._channel = 'local';
+    /** @type {FeedbackTracker[]} */
+    this._trackers = (options.trackers ?? []).map((tracker) => ({ ...tracker }));
+    // The checked radio's value: `local`, `email`, or a tracker's id. The
+    // channel and tracker the form reports are derived from it on demand, so
+    // a tracker list that changes underneath cannot leave a stale pair.
+    /** @type {string} */
+    this._selection = LOCAL;
     this._metadataOn = true;
     this._contextOn = false;
 
@@ -227,6 +253,8 @@ export class FeedbackModal {
     this._contextCopyEl = null;
     /** @type {HTMLElement|null} */
     this._channelHintEl = null;
+    /** @type {HTMLElement|null} */
+    this._channelGroupEl = null;
     /** @type {HTMLElement|null} */
     this._stepsEl = null;
     /** @type {HTMLElement|null} */
@@ -243,13 +271,37 @@ export class FeedbackModal {
    */
   formState() {
     const sessionId = this._sessionId();
+    const tracker = this._selectedTracker();
     return {
       text: this._text,
-      channel: this._channel,
+      channel: this._channelKind(),
+      tracker,
       metadataOn: this._metadataOn,
       contextOn: this._contextOn && sessionId !== null,
       sessionId,
     };
+  }
+
+  /**
+   * Replace the offered issue trackers.
+   *
+   * Applied in place while the dialog is open — the radios are rebuilt and
+   * the dependent controls re-derived. A selected tracker that the new list
+   * no longer carries falls back to Local rather than lingering as a radio
+   * that no longer exists.
+   *
+   * @param {FeedbackTracker[]} trackers
+   * @returns {void}
+   */
+  setTrackers(trackers) {
+    this._trackers = trackers.map((tracker) => ({ ...tracker }));
+    if (this._selectedTracker() === null && this._selection !== LOCAL && this._selection !== EMAIL) {
+      this._selection = LOCAL;
+    }
+    if (this._channelGroupEl) {
+      this._renderChannelRadios(this._channelGroupEl);
+      this._syncControls();
+    }
   }
 
   /**
@@ -338,6 +390,7 @@ export class FeedbackModal {
     this._contextHintEl = null;
     this._contextCopyEl = null;
     this._channelHintEl = null;
+    this._channelGroupEl = null;
     this._stepsEl = null;
     this._actionsEl = null;
 
@@ -455,25 +508,8 @@ export class FeedbackModal {
     const group = el('div', 'feedback-channels');
     group.setAttribute('role', 'radiogroup');
     group.setAttribute('aria-label', 'Where to send this');
-
-    for (const { value, label } of CHANNELS) {
-      const wrap = el('label', 'feedback-channel-option');
-      const radio = document.createElement('input');
-      radio.type = 'radio';
-      radio.name = 'feedback-channel';
-      radio.value = value;
-      radio.checked = this._channel === value;
-      radio.addEventListener('change', () => {
-        if (!radio.checked) return;
-        this._channel = /** @type {FeedbackChannel} */ (value);
-        this._syncControls();
-      });
-      const caption = el('span', 'feedback-channel-label');
-      caption.textContent = label;
-      wrap.appendChild(radio);
-      wrap.appendChild(caption);
-      group.appendChild(wrap);
-    }
+    this._channelGroupEl = group;
+    this._renderChannelRadios(group);
 
     const hint = el('p', 'feedback-channel-hint');
     this._channelHintEl = hint;
@@ -482,6 +518,63 @@ export class FeedbackModal {
     section.appendChild(group);
     section.appendChild(hint);
     return section;
+  }
+
+  /**
+   * (Re)build the radios: Local, one per configured tracker in the order
+   * given, Email. Idempotent over `group`, so {@link setTrackers} can call it
+   * on an open dialog.
+   *
+   * @param {HTMLElement} group
+   * @returns {void}
+   */
+  _renderChannelRadios(group) {
+    group.replaceChildren();
+    /** @type {{value: string, label: string}[]} */
+    const rows = [
+      { value: LOCAL, label: 'Local' },
+      ...this._trackers.map((tracker) => ({ value: tracker.id, label: tracker.label })),
+      { value: EMAIL, label: 'Email' },
+    ];
+    for (const { value, label } of rows) {
+      const wrap = el('label', 'feedback-channel-option');
+      const radio = document.createElement('input');
+      radio.type = 'radio';
+      radio.name = 'feedback-channel';
+      radio.value = value;
+      radio.checked = this._selection === value;
+      radio.addEventListener('change', () => {
+        if (!radio.checked) return;
+        this._selection = value;
+        this._syncControls();
+      });
+      const caption = el('span', 'feedback-channel-label');
+      caption.textContent = label;
+      wrap.appendChild(radio);
+      wrap.appendChild(caption);
+      group.appendChild(wrap);
+    }
+  }
+
+  /**
+   * The tracker the checked radio stands for, or null on Local and Email —
+   * and null for a tracker id the current list no longer carries.
+   *
+   * @returns {FeedbackTracker|null}
+   */
+  _selectedTracker() {
+    return this._trackers.find((tracker) => tracker.id === this._selection) ?? null;
+  }
+
+  /**
+   * The channel kind the checked radio stands for.
+   *
+   * @returns {FeedbackChannel}
+   */
+  _channelKind() {
+    if (this._selection === EMAIL) return 'email';
+    const tracker = this._selectedTracker();
+    return tracker === null ? 'local' : tracker.kind;
   }
 
   /**
@@ -598,8 +691,9 @@ export class FeedbackModal {
    */
   _syncControls() {
     const sessionId = this._sessionId();
+    const kind = this._channelKind();
 
-    if (this._channelHintEl) this._channelHintEl.textContent = CHANNEL_HINTS[this._channel];
+    if (this._channelHintEl) this._channelHintEl.textContent = CHANNEL_HINTS[kind];
 
     if (this._contextCheckEl) {
       this._contextCheckEl.disabled = sessionId === null;
@@ -613,8 +707,8 @@ export class FeedbackModal {
     // what a send would attach.
     if (this._contextCopyEl) this._contextCopyEl.disabled = sessionId === null;
 
-    this._syncSteps(sessionId);
-    this._renderActions();
+    this._syncSteps(sessionId, kind);
+    this._renderActions(kind);
   }
 
   /**
@@ -622,12 +716,12 @@ export class FeedbackModal {
    * the context box ticked, a session to read it from.
    *
    * @param {string|null} sessionId
+   * @param {FeedbackChannel} channel
    * @returns {void}
    */
-  _syncSteps(sessionId) {
+  _syncSteps(sessionId, channel) {
     const panel = this._stepsEl;
     if (!panel) return;
-    const channel = this._channel;
     const applies = channel !== 'local' && this._contextOn && sessionId !== null;
     panel.toggleAttribute('hidden', !applies);
     const list = panel.querySelector('ol');
@@ -643,16 +737,17 @@ export class FeedbackModal {
 
   /**
    * Rebuild the channel-dependent action row: one button per channel — Send
-   * for Local, the "open the outside thing" button for GitHub and Email.
+   * for Local, the "open the outside thing" button for the trackers and Email.
    *
+   * @param {FeedbackChannel} channel
    * @returns {void}
    */
-  _renderActions() {
+  _renderActions(channel) {
     const row = this._actionsEl;
     if (!row) return;
     row.replaceChildren();
 
-    if (this._channel === 'local') {
+    if (channel === 'local') {
       row.appendChild(
         this._actionButton('feedback-send primary', 'Send', () => this._emit(this._options.onSubmit))
       );
@@ -660,7 +755,7 @@ export class FeedbackModal {
     }
 
     row.appendChild(
-      this._actionButton('feedback-open-channel primary', CHANNEL_ACTION_LABELS[this._channel], () =>
+      this._actionButton('feedback-open-channel primary', CHANNEL_ACTION_LABELS[channel], () =>
         this._emit(this._options.onOpenChannel)
       )
     );

--- a/src/osprey/interfaces/web_terminal/static/js/feedback-prefill.js
+++ b/src/osprey/interfaces/web_terminal/static/js/feedback-prefill.js
@@ -1,7 +1,7 @@
 // @ts-check
 /* OSPREY Web Terminal — Feedback Prefill Builders (pure)
  *
- * Builds the two outbound prefill URLs of the feedback dialog — a GitHub
+ * Builds the outbound prefill URLs of the feedback dialog — a GitHub or GitLab
  * new-issue link and a `mailto:` draft — plus the issue body they carry.
  * Deliberately pure: no DOM, no fetch, no module state. The dialog owns the
  * clipboard, the window.open and the paper-trail POST; this module only does
@@ -32,6 +32,13 @@
 
 /** Percent-encoded length cap for the GitHub new-issue URL. */
 export const GITHUB_URL_LIMIT = 8000;
+
+/**
+ * Percent-encoded length cap for a GitLab new-issue URL. The same figure as
+ * GitHub's: a self-hosted instance sits behind a reverse proxy whose default
+ * request-line budget is 8 KB, and gitlab.com is no more generous.
+ */
+export const GITLAB_URL_LIMIT = 8000;
 
 /**
  * Percent-encoded length cap for a `mailto:` URL. Well under the ~2000-char
@@ -104,6 +111,32 @@ export function buildGitHubIssueUrl(repo, title, body) {
 
   const full = render(sanitize(body));
   if (full.length <= GITHUB_URL_LIMIT) return { url: full, needsPaste: false };
+  return { url: render(PASTE_POINTER), needsPaste: true };
+}
+
+/**
+ * Build a prefilled GitLab new-issue URL.
+ *
+ * The same form serves gitlab.com and a self-hosted instance: the project's
+ * base URL, then `/-/issues/new` with the `issue[title]` and
+ * `issue[description]` parameters GitLab reads. The base is a facility-authored
+ * URL and travels verbatim (minus a trailing slash); only the values are
+ * encoded.
+ *
+ * @param {string} baseUrl - the project URL, e.g. `https://git.example.org/group/project`
+ * @param {string} title - issue title, never truncated
+ * @param {string} body - the desired issue description
+ * @returns {{url: string, needsPaste: boolean}} as {@link buildGitHubIssueUrl}
+ */
+export function buildGitLabIssueUrl(baseUrl, title, body) {
+  const base = sanitize(baseUrl).replace(/\/+$/, '');
+  const encodedTitle = encodeURIComponent(sanitize(title));
+  /** @param {string} candidate */
+  const render = (candidate) =>
+    `${base}/-/issues/new?issue[title]=${encodedTitle}&issue[description]=${encodeURIComponent(candidate)}`;
+
+  const full = render(sanitize(body));
+  if (full.length <= GITLAB_URL_LIMIT) return { url: full, needsPaste: false };
   return { url: render(PASTE_POINTER), needsPaste: true };
 }
 

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -671,8 +671,16 @@ web:
   # `osprey feedback list` / `osprey feedback export`.
   feedback:
     # owner/repo whose new-issue form the GitHub channel prefills. Point it at
-    # the repository your users' reports should land in.
+    # the repository your users' reports should land in. Shorthand for one
+    # `github` entry under `trackers`; set it to "" to offer no GitHub channel.
     github_repo: als-apg/osprey
+    # Further issue trackers, one channel each, captioned by `label`. A
+    # `gitlab` entry takes the project's base URL (gitlab.com or self-hosted);
+    # a `github` entry takes owner/repo.
+    # trackers:
+    #   - kind: gitlab
+    #     url: https://git.example.org/controls/osprey
+    #     label: Facility GitLab
     # Recipient of the prefilled mailto: draft the Email channel opens.
     email: thellert@lbl.gov
     # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the

--- a/src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
@@ -365,8 +365,16 @@ web:
   # `osprey feedback list` / `osprey feedback export`.
   feedback:
     # owner/repo whose new-issue form the GitHub channel prefills. Point it at
-    # the repository your users' reports should land in.
+    # the repository your users' reports should land in. Shorthand for one
+    # `github` entry under `trackers`; set it to "" to offer no GitHub channel.
     github_repo: als-apg/osprey
+    # Further issue trackers, one channel each, captioned by `label`. A
+    # `gitlab` entry takes the project's base URL (gitlab.com or self-hosted);
+    # a `github` entry takes owner/repo.
+    # trackers:
+    #   - kind: gitlab
+    #     url: https://git.example.org/controls/osprey
+    #     label: Facility GitLab
     # Recipient of the prefilled mailto: draft the Email channel opens.
     email: thellert@lbl.gov
     # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -1510,8 +1510,16 @@ web:
   # `osprey feedback list` / `osprey feedback export`.
   feedback:
     # owner/repo whose new-issue form the GitHub channel prefills. Point it at
-    # the repository your users' reports should land in.
+    # the repository your users' reports should land in. Shorthand for one
+    # `github` entry under `trackers`; set it to "" to offer no GitHub channel.
     github_repo: als-apg/osprey
+    # Further issue trackers, one channel each, captioned by `label`. A
+    # `gitlab` entry takes the project's base URL (gitlab.com or self-hosted);
+    # a `github` entry takes owner/repo.
+    # trackers:
+    #   - kind: gitlab
+    #     url: https://git.example.org/controls/osprey
+    #     label: Facility GitLab
     # Recipient of the prefilled mailto: draft the Email channel opens.
     email: thellert@lbl.gov
     # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -573,8 +573,16 @@ web:
   # `osprey feedback list` / `osprey feedback export`.
   feedback:
     # owner/repo whose new-issue form the GitHub channel prefills. Point it at
-    # the repository your users' reports should land in.
+    # the repository your users' reports should land in. Shorthand for one
+    # `github` entry under `trackers`; set it to "" to offer no GitHub channel.
     github_repo: als-apg/osprey
+    # Further issue trackers, one channel each, captioned by `label`. A
+    # `gitlab` entry takes the project's base URL (gitlab.com or self-hosted);
+    # a `github` entry takes owner/repo.
+    # trackers:
+    #   - kind: gitlab
+    #     url: https://git.example.org/controls/osprey
+    #     label: Facility GitLab
     # Recipient of the prefilled mailto: draft the Email channel opens.
     email: thellert@lbl.gov
     # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the

--- a/tests/interfaces/web_terminal/feedback-boot.test.mjs
+++ b/tests/interfaces/web_terminal/feedback-boot.test.mjs
@@ -5,7 +5,7 @@
  * the deployment's configuration only ever meet here, so the properties pinned
  * below are the ones no single-module suite can see.
  *
- *   1. ORDER. For GitHub and Email the clipboard write and the browser handoff
+ *   1. ORDER. For the trackers and Email the clipboard write and the browser handoff
  *      must both be issued inside the click turn, before the POST settles.
  *      Asserted with ZERO awaits after the click — one microtask is already
  *      too late for Safari's transient user activation.
@@ -39,6 +39,15 @@ const indexHtml = readFileSync(join(STATIC_DIR, 'index.html'), 'utf8');
 const DOCS_URL = 'https://docs.example.org/osprey';
 const REPO = 'acme/osprey';
 const EMAIL = 'maintainers@example.org';
+const GITLAB_URL = 'https://git.example.org/controls/osprey';
+
+/** `/api/panels` tracker entries, as the server resolves them. */
+const GH_TRACKER = { kind: 'github', label: 'GitHub', repo: REPO };
+const GL_TRACKER = { kind: 'gitlab', label: 'Facility GitLab', url: GITLAB_URL };
+
+/** The radio values boot derives for them. */
+const GH = `github:${REPO}`;
+const GL = `gitlab:${GITLAB_URL}`;
 const SESSION = '11111111-2222-3333-4444-555555555555';
 
 /**
@@ -127,13 +136,15 @@ function fakeTerm(rows) {
  * @param {any} [over.clipboard]
  * @param {boolean} [over.settle] - false leaves the config reads hanging
  * @param {boolean} [over.hangHealth] - hang `/health` only
+ * @param {Promise<any>} [over.panelsGate] - a promise the `/api/panels` read
+ *   waits on before resolving with `over.panels`
  */
 async function boot(over = {}) {
   document.body.innerHTML = railRegionMarkup() + statusBarMarkup();
 
   const panels =
     over.panels === undefined
-      ? { docs_url: DOCS_URL, feedback_github_repo: REPO, feedback_email: EMAIL }
+      ? { docs_url: DOCS_URL, feedback_trackers: [GH_TRACKER], feedback_email: EMAIL }
       : over.panels;
   const health = over.health === undefined ? { version: '9.9.9' } : over.health;
 
@@ -142,7 +153,9 @@ async function boot(over = {}) {
       if (over.settle === false) return new Promise(() => {});
       if (over.hangHealth === true && path === '/health') return new Promise(() => {});
       const body = path === '/health' ? health : panels;
-      return body === null ? Promise.reject(new Error('HTTP 503')) : Promise.resolve(body);
+      if (body === null) return Promise.reject(new Error('HTTP 503'));
+      if (over.panelsGate !== undefined && path !== '/health') return over.panelsGate.then(() => body);
+      return Promise.resolve(body);
     }
   );
   const fetchSpy = vi.fn(() =>
@@ -167,7 +180,7 @@ async function boot(over = {}) {
   // The boot is synchronous by contract; every test that cares about the
   // deployment's configuration waits for it here instead. `ready` covers both
   // reads, so a test that deliberately hangs one waits on its own signal.
-  if (over.settle !== false && over.hangHealth !== true) await ready;
+  if (over.settle !== false && over.hangHealth !== true && over.panelsGate === undefined) await ready;
   return { modal, ready, loadJSON, fetch: fetchSpy, clipboard, windowOpen, navigate };
 }
 
@@ -188,11 +201,25 @@ function typeReport(value) {
   area.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
-/** Select a delivery channel. @param {string} channel */
+/** Select a delivery channel — `local`, `email` or a tracker's radio value. @param {string} channel */
 function pickChannel(channel) {
   const radio = qs(document, `input[name="feedback-channel"][value="${channel}"]`, HTMLInputElement);
   radio.checked = true;
   radio.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+/** @returns {string[]} the channel radio values, in render order */
+function channelValues() {
+  return Array.from(document.querySelectorAll('input[name="feedback-channel"]')).map((node) =>
+    node instanceof HTMLInputElement ? node.value : ''
+  );
+}
+
+/** @returns {string[]} the channel radio captions, in render order */
+function channelCaptions() {
+  return Array.from(document.querySelectorAll('.feedback-channel-label')).map(
+    (node) => node.textContent ?? ''
+  );
 }
 
 /** Tick the session-context checkbox. */
@@ -237,7 +264,7 @@ describe('documentation affordances', () => {
   });
 
   test('a blank docs_url leaves both links hidden and href-less', async () => {
-    booted = await boot({ panels: { docs_url: '   ', feedback_github_repo: REPO } });
+    booted = await boot({ panels: { docs_url: '   ', feedback_trackers: [GH_TRACKER] } });
 
     for (const id of ['#panel-docs-link', '#docs-link']) {
       expect(qs(document, id).hidden, `${id} still visible`).toBe(true);
@@ -360,13 +387,32 @@ describe('rail button', () => {
   test('an outbound channel says the config is still loading, and opens nothing', async () => {
     booted = await boot({ settle: false });
     clickFeedbackButton();
-    pickChannel('github');
+    pickChannel('email');
 
     qs(document, '.feedback-open-channel').click();
     await vi.waitFor(() => expect(noticeText()).not.toBe(''));
 
     expect(noticeText()).toContain('Still reading');
-    expect(booted.windowOpen).not.toHaveBeenCalled();
+    expect(booted.navigate).not.toHaveBeenCalled();
+  });
+
+  test('no tracker radio is offered before the config lands, and they appear in place once it does', async () => {
+    // A tracker the page does not know yet cannot be rendered — there is no
+    // label to caption it with — so the dialog opens with Local and Email and
+    // grows the trackers the moment the read lands, without a reopen.
+    /** @type {() => void} */
+    let release = () => {};
+    const panelsGate = new Promise((resolve) => {
+      release = () => resolve(undefined);
+    });
+    booted = await boot({ panels: { feedback_trackers: [GL_TRACKER, GH_TRACKER] }, panelsGate });
+    clickFeedbackButton();
+    expect(channelValues()).toEqual(['local', 'email']);
+
+    release();
+    await booted.ready;
+
+    expect(channelValues()).toEqual(['local', GL, GH, 'email']);
   });
 
   test('a hung /health does not withhold the outbound channels', async () => {
@@ -380,7 +426,7 @@ describe('rail button', () => {
     booted.fetch.mockImplementation(() => new Promise(() => {}));
     clickFeedbackButton();
     typeReport('a report');
-    pickChannel('github');
+    pickChannel(GH);
 
     qs(document, '.feedback-open-channel').click();
 
@@ -530,7 +576,7 @@ describe('session context', () => {
     });
     clickFeedbackButton();
     typeReport('nötes');
-    pickChannel('github');
+    pickChannel(GH);
     tickContext();
 
     qs(document, '.feedback-copy-context').click();
@@ -550,7 +596,7 @@ describe('outbound channels', () => {
   test('the clipboard write and the issue tab are issued in the click turn', async () => {
     // A POST that never settles: everything asserted below therefore happened
     // before any response could have arrived.
-    booted = await boot({ panels: { feedback_github_repo: REPO } });
+    booted = await boot({ panels: { feedback_trackers: [GH_TRACKER] } });
     booted.fetch.mockImplementation(() => new Promise(() => {}));
     vi.stubGlobal(
       'ClipboardItem',
@@ -563,7 +609,7 @@ describe('outbound channels', () => {
     );
     clickFeedbackButton();
     typeReport('crash on resize');
-    pickChannel('github');
+    pickChannel(GH);
     tickContext();
 
     qs(document, '.feedback-open-channel').click();
@@ -580,10 +626,10 @@ describe('outbound channels', () => {
   });
 
   test('a full-mode send opens the draft without touching the clipboard', async () => {
-    booted = await boot({ panels: { feedback_github_repo: REPO } });
+    booted = await boot({ panels: { feedback_trackers: [GH_TRACKER] } });
     clickFeedbackButton();
     typeReport('crash on resize');
-    pickChannel('github');
+    pickChannel(GH);
 
     qs(document, '.feedback-open-channel').click();
     await vi.waitFor(() => expect(noticeText()).toContain('fb-1'));
@@ -612,7 +658,7 @@ describe('outbound channels', () => {
     booted.fetch.mockImplementation(() => new Promise(() => {}));
     clickFeedbackButton();
     typeReport('a report');
-    pickChannel('github');
+    pickChannel(GH);
 
     qs(document, '.feedback-open-channel').click();
 
@@ -621,19 +667,56 @@ describe('outbound channels', () => {
     expect(body).toContain('9.9.9');
   });
 
-  test('a channel this deployment never configured refuses instead of 404ing', async () => {
-    booted = await boot({ panels: { docs_url: DOCS_URL, feedback_github_repo: '' } });
+  test('a deployment with no trackers offers no tracker radio at all', async () => {
+    // The blank-`github_repo` posture: the server resolves it to an empty
+    // list, and an empty list is not a channel that refuses — it is no
+    // channel, so nothing can aim a report at the upstream tracker.
+    booted = await boot({ panels: { docs_url: DOCS_URL, feedback_trackers: [] } });
     clickFeedbackButton();
-    pickChannel('github');
+
+    expect(channelValues()).toEqual(['local', 'email']);
+    expect(document.querySelector('.feedback-open-channel')).toBeNull();
+  });
+
+  test('a tracker radio is captioned by the facility-authored label', async () => {
+    booted = await boot({ panels: { feedback_trackers: [GL_TRACKER, GH_TRACKER] } });
+    clickFeedbackButton();
+
+    expect(channelValues()).toEqual(['local', GL, GH, 'email']);
+    expect(channelCaptions()).toEqual(['Local', 'Facility GitLab', 'GitHub', 'Email']);
+  });
+
+  test('a GitLab tracker opens its /-/issues/new form and names itself in the record', async () => {
+    booted = await boot({ panels: { feedback_trackers: [GL_TRACKER] } });
+    clickFeedbackButton();
+    typeReport('crash on resize');
+    pickChannel(GL);
 
     qs(document, '.feedback-open-channel').click();
 
-    // A microtask later, not this turn: the live region has just been created,
-    // and a region written in the turn it is created is never announced.
-    expect(noticeText()).toBe('');
-    await vi.waitFor(() => expect(noticeText()).toContain('no feedback repository configured'));
-    expect(booted.windowOpen).not.toHaveBeenCalled();
-    expect(booted.fetch).not.toHaveBeenCalled();
+    expect(booted.windowOpen).toHaveBeenCalledTimes(1);
+    const [url, target, features] = booted.windowOpen.mock.calls[0];
+    expect(url.startsWith(`${GITLAB_URL}/-/issues/new?issue[title]=`)).toBe(true);
+    expect(url).toContain('crash%20on%20resize');
+    expect(target).toBe('_blank');
+    expect(features).toBe('noopener');
+    expect(postedBody(booted.fetch)).toMatchObject({ channel: 'gitlab', tracker: GITLAB_URL });
+  });
+
+  test('a malformed tracker entry from the server is skipped, the rest stand', async () => {
+    booted = await boot({
+      panels: {
+        feedback_trackers: [
+          { kind: 'github', label: 'no repo' },
+          { kind: 'bitbucket', label: 'x', url: 'https://x' },
+          'not an object',
+          GL_TRACKER,
+        ],
+      },
+    });
+    clickFeedbackButton();
+
+    expect(channelValues()).toEqual(['local', GL, 'email']);
   });
 
   test('an unreadable config says so, rather than asserting a blank posture', async () => {
@@ -673,7 +756,7 @@ describe('outbound channels', () => {
     typeReport('a report');
 
     qs(document, '.feedback-send').click();
-    pickChannel('github');
+    pickChannel(GH);
     qs(document, '.feedback-open-channel').click();
 
     expect(booted.fetch).toHaveBeenCalledTimes(1);
@@ -698,7 +781,7 @@ describe('outbound channels', () => {
     booted = await boot({ sessionId: null });
     clickFeedbackButton();
     typeReport('a report');
-    pickChannel('github');
+    pickChannel(GH);
 
     qs(document, '.feedback-open-channel').click();
     await vi.waitFor(() =>
@@ -712,7 +795,7 @@ describe('outbound channels', () => {
     booted = await boot({ clipboard: {} });
     clickFeedbackButton();
     typeReport('a report');
-    pickChannel('github');
+    pickChannel(GH);
     tickContext();
 
     qs(document, '.feedback-open-channel').click();
@@ -732,7 +815,7 @@ describe('outbound channels', () => {
     booted = await boot({ clipboard: {} });
     clickFeedbackButton();
     typeReport('a report');
-    pickChannel('github');
+    pickChannel(GH);
     tickContext();
     qs(document, '.feedback-open-channel').click();
     await vi.waitFor(() =>

--- a/tests/interfaces/web_terminal/feedback-client.test.mjs
+++ b/tests/interfaces/web_terminal/feedback-client.test.mjs
@@ -34,7 +34,7 @@ import {
   NOTICE_NO_SESSION,
   NOTICE_NO_TRANSCRIPT,
   NOTICE_PASTE_EMAIL,
-  NOTICE_PASTE_GITHUB,
+  NOTICE_PASTE_ISSUE,
   NOTICE_TOO_LARGE,
 } from '../../../src/osprey/interfaces/web_terminal/static/js/feedback-client.js';
 import { PASTE_POINTER } from '../../../src/osprey/interfaces/web_terminal/static/js/feedback-prefill.js';
@@ -165,7 +165,6 @@ function makeDeps(opts = {}) {
     }),
     scrollback: 'line one\nline two',
     metadata: { version: '1.2.3', app_name: 'OSPREY' },
-    githubRepo: 'als-apg/osprey',
     email: 'maintainers@example.org',
   };
 
@@ -189,10 +188,24 @@ function sentBody(/** @type {any} */ fetchSpy, n = 0) {
   return JSON.parse(fetchSpy.mock.calls[n][1].body);
 }
 
-/** @type {{text: string, channel: any, metadataOn: boolean, contextOn: boolean, sessionId: string|null}} */
+/** The deployment's GitHub tracker, as the dialog hands it to the transport. */
+const GITHUB = {
+  channel: /** @type {const} */ ('github'),
+  tracker: { kind: /** @type {const} */ ('github'), target: 'als-apg/osprey' },
+};
+
+/** A self-hosted GitLab tracker. */
+const GITLAB_URL = 'https://git.example.org/controls/osprey';
+const GITLAB = {
+  channel: /** @type {const} */ ('gitlab'),
+  tracker: { kind: /** @type {const} */ ('gitlab'), target: GITLAB_URL },
+};
+
+/** @type {{text: string, channel: any, tracker: any, metadataOn: boolean, contextOn: boolean, sessionId: string|null}} */
 const BASE_FORM = {
   text: 'The rail button does not render in top mode.',
   channel: 'local',
+  tracker: null,
   metadataOn: true,
   contextOn: false,
   sessionId: '11111111-2222-3333-4444-555555555555',
@@ -325,7 +338,7 @@ describe('sendFeedback — GitHub channel', () => {
     const gate = deferred();
     const { deps, order, fetchSpy } = makeDeps({ fetchPromise: gate.promise });
 
-    const pending = sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    const pending = sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
     // Asserted with no await at all: both side effects must have happened in
     // the caller's own turn, not merely "before the POST resolved". A single
     // deferred microtask is already too late for Safari's user activation.
@@ -345,7 +358,7 @@ describe('sendFeedback — GitHub channel', () => {
   test('a full-mode send opens the complete draft and leaves the clipboard alone', async () => {
     const { deps, order } = makeDeps();
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB }, deps);
 
     expect(order).toEqual(['fetch', 'open']);
     expect(deps.clipboard.write).not.toHaveBeenCalled();
@@ -356,7 +369,7 @@ describe('sendFeedback — GitHub channel', () => {
   test('opens a prefilled new-issue URL with noopener', async () => {
     const { deps } = makeDeps();
 
-    await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+    await sendFeedback({ ...BASE_FORM, ...GITHUB }, deps);
 
     expect(deps.windowOpen).toHaveBeenCalledTimes(1);
     const [url, target, features] = deps.windowOpen.mock.calls[0];
@@ -372,7 +385,7 @@ describe('sendFeedback — GitHub channel', () => {
       response: jsonResponse({ id: 'fb-4', payload: 'TEXT\n---\nBUNDLE' }),
     });
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     expect(result.copied).toBe('clipboard');
     expect(await copiedText(written[0])).toBe('TEXT\n---\nBUNDLE');
@@ -385,7 +398,7 @@ describe('sendFeedback — GitHub channel', () => {
       fetchPromise: Promise.reject(new Error('network down')),
     });
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     expect(deps.windowOpen).toHaveBeenCalledTimes(1);
     expect(result.opened).toBe(true);
@@ -399,7 +412,7 @@ describe('sendFeedback — GitHub channel', () => {
   test('a failed POST on a full-mode send says the draft is unaffected', async () => {
     const { deps } = makeDeps({ response: htmlErrorResponse(413) });
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB }, deps);
 
     expect(result.ok).toBe(false);
     expect(result.error).toBe(NOTICE_TOO_LARGE);
@@ -413,7 +426,7 @@ describe('sendFeedback — GitHub channel', () => {
     const { deps, written } = makeDeps();
     const huge = 'x'.repeat(20000);
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', text: huge }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB, text: huge }, deps);
 
     expect(result.needsPaste).toBe(true);
     const url = deps.windowOpen.mock.calls[0][0];
@@ -425,7 +438,7 @@ describe('sendFeedback — GitHub channel', () => {
   test('drops the metadata block from the prefill when the box is unticked', async () => {
     const { deps } = makeDeps();
 
-    await sendFeedback({ ...BASE_FORM, channel: 'github', metadataOn: false }, deps);
+    await sendFeedback({ ...BASE_FORM, ...GITHUB, metadataOn: false }, deps);
 
     const url = deps.windowOpen.mock.calls[0][0];
     expect(url).not.toContain(encodeURIComponent('Deployment metadata'));
@@ -465,7 +478,7 @@ describe('outbound prefill — title, subject and body mode', () => {
   test('the issue title is generic, never the first line of the report', async () => {
     const { deps } = makeDeps();
 
-    await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+    await sendFeedback({ ...BASE_FORM, ...GITHUB }, deps);
 
     expect(param(deps.windowOpen.mock.calls[0][0], 'title')).toBe(DEFAULT_TITLE);
   });
@@ -474,7 +487,7 @@ describe('outbound prefill — title, subject and body mode', () => {
     const { deps } = makeDeps();
     const oneLongLine = 'the beam dropped and the archiver shows nothing '.repeat(25);
 
-    await sendFeedback({ ...BASE_FORM, channel: 'github', text: oneLongLine }, deps);
+    await sendFeedback({ ...BASE_FORM, ...GITHUB, text: oneLongLine }, deps);
 
     expect(param(deps.windowOpen.mock.calls[0][0], 'title')).toBe(DEFAULT_TITLE);
   });
@@ -482,7 +495,7 @@ describe('outbound prefill — title, subject and body mode', () => {
   test('the title names the session when context is attached', async () => {
     const { deps } = makeDeps();
 
-    await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     expect(param(deps.windowOpen.mock.calls[0][0], 'title')).toBe(
       `${DEFAULT_TITLE} (session 11111111)`
@@ -493,7 +506,7 @@ describe('outbound prefill — title, subject and body mode', () => {
     const { deps } = makeDeps();
 
     await sendFeedback(
-      { ...BASE_FORM, channel: 'github', title: 'Rail button dead in top mode' },
+      { ...BASE_FORM, ...GITHUB, title: 'Rail button dead in top mode' },
       deps
     );
 
@@ -513,7 +526,7 @@ describe('outbound prefill — title, subject and body mode', () => {
   test('with context attached the body is the pointer line alone', async () => {
     const { deps } = makeDeps();
 
-    await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     // No text, no metadata block: the whole report travels on the clipboard,
     // so anything prefilled here would be duplicated by the paste.
@@ -531,7 +544,7 @@ describe('outbound prefill — title, subject and body mode', () => {
   test('without context the body carries the text and metadata, no pointer', async () => {
     const { deps } = makeDeps();
 
-    await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+    await sendFeedback({ ...BASE_FORM, ...GITHUB }, deps);
 
     const body = param(deps.windowOpen.mock.calls[0][0], 'body');
     expect(body).toContain(BASE_FORM.text);
@@ -540,15 +553,85 @@ describe('outbound prefill — title, subject and body mode', () => {
   });
 });
 
+describe('sendFeedback — tracker identity', () => {
+  test('a GitLab tracker opens the /-/issues/new form in a new tab', async () => {
+    const { deps, order } = makeDeps();
+
+    const result = await sendFeedback({ ...BASE_FORM, ...GITLAB }, deps);
+
+    expect(order).toEqual(['fetch', 'open']);
+    const [url, target, features] = deps.windowOpen.mock.calls[0];
+    expect(url.startsWith(`${GITLAB_URL}/-/issues/new?issue[title]=`)).toBe(true);
+    expect(url).toContain(encodeURIComponent('The rail button does not render'));
+    expect(target).toBe('_blank');
+    expect(features).toBe('noopener');
+    expect(deps.navigate).not.toHaveBeenCalled();
+    expect(result.opened).toBe(true);
+  });
+
+  test('a GitLab send with context copies first and opens the pointer draft', async () => {
+    const gate = deferred();
+    const { deps, order } = makeDeps({ fetchPromise: gate.promise });
+
+    const pending = sendFeedback({ ...BASE_FORM, ...GITLAB, contextOn: true }, deps);
+    expect(order).toEqual(['fetch', 'write', 'open']);
+    expect(param(deps.windowOpen.mock.calls[0][0], 'issue\\[description\\]')).toBe(
+      PASTE_POINTER
+    );
+
+    gate.resolve(jsonResponse({ id: 'fb-3', payload: 'SERVER PAYLOAD' }));
+    const result = await pending;
+    expect(result.needsPaste).toBe(true);
+    expect(result.notice.message).toBe(
+      `Recorded on this deployment (fb-3) — ${NOTICE_PASTE_ISSUE}`
+    );
+  });
+
+  test('the URL is built from the tracker the form carries, not a fixed repo', async () => {
+    const { deps } = makeDeps();
+    const fork = { kind: /** @type {const} */ ('github'), target: 'facility/fork' };
+
+    await sendFeedback({ ...BASE_FORM, channel: 'github', tracker: fork }, deps);
+
+    expect(deps.windowOpen.mock.calls[0][0].startsWith('https://github.com/facility/fork/')).toBe(
+      true
+    );
+  });
+
+  test('the paper-trail POST names the tracker on tracker channels only', async () => {
+    const { deps, fetchSpy } = makeDeps();
+
+    await sendFeedback({ ...BASE_FORM, ...GITLAB }, deps);
+    await sendFeedback({ ...BASE_FORM, ...GITHUB }, deps);
+    await sendFeedback({ ...BASE_FORM, channel: 'email' }, deps);
+    await sendFeedback({ ...BASE_FORM, channel: 'local' }, deps);
+
+    expect(sentBody(fetchSpy, 0)).toMatchObject({ channel: 'gitlab', tracker: GITLAB_URL });
+    expect(sentBody(fetchSpy, 1)).toMatchObject({ channel: 'github', tracker: 'als-apg/osprey' });
+    expect(sentBody(fetchSpy, 2)).not.toHaveProperty('tracker');
+    expect(sentBody(fetchSpy, 3)).not.toHaveProperty('tracker');
+  });
+
+  test('a tracker channel with no tracker falls back to Local rather than a dead URL', async () => {
+    const { deps, fetchSpy } = makeDeps();
+
+    const result = await sendFeedback({ ...BASE_FORM, channel: 'gitlab', tracker: null }, deps);
+
+    expect(deps.windowOpen).not.toHaveBeenCalled();
+    expect(sentBody(fetchSpy).channel).toBe('local');
+    expect(result.opened).toBe(false);
+  });
+});
+
 describe('outbound notices — the paste step is announced', () => {
   test('a successful GitHub send with context points at the clipboard paste', async () => {
     const { deps } = makeDeps();
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     expect(result.notice.kind).toBe('success');
     expect(result.notice.message).toBe(
-      `Recorded on this deployment (fb-1) — ${NOTICE_PASTE_GITHUB}`
+      `Recorded on this deployment (fb-1) — ${NOTICE_PASTE_ISSUE}`
     );
   });
 
@@ -578,7 +661,7 @@ describe('outbound notices — the paste step is announced', () => {
   test('an outbound send with nothing to paste keeps the plain confirmation', async () => {
     const { deps } = makeDeps();
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github' }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB }, deps);
 
     expect(result.notice.message).toBe('Recorded on this deployment (fb-1)');
   });
@@ -597,7 +680,7 @@ describe('clipboard fallback ladder', () => {
     vi.stubGlobal('ClipboardItem', undefined);
     const { deps, writtenText } = makeDeps();
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     expect(deps.clipboard.write).not.toHaveBeenCalled();
     expect(writtenText).toEqual(['SERVER PAYLOAD']);
@@ -618,7 +701,7 @@ describe('clipboard fallback ladder', () => {
         }),
       },
     });
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     expect(result.copied).toBe('clipboard-text');
     expect(sink).toEqual(['SERVER PAYLOAD']);
@@ -627,7 +710,7 @@ describe('clipboard fallback ladder', () => {
   test('falls back to a selectable payload when the clipboard API is absent', async () => {
     const { deps, selectable } = makeDeps({ clipboard: {} });
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     expect(result.copied).toBe('manual');
     expect(selectable).toEqual(['SERVER PAYLOAD']);
@@ -640,7 +723,7 @@ describe('clipboard fallback ladder', () => {
     // @ts-expect-error - deliberately removing the last rung
     deps.showSelectableText = undefined;
 
-    const result = await sendFeedback({ ...BASE_FORM, channel: 'github', contextOn: true }, deps);
+    const result = await sendFeedback({ ...BASE_FORM, ...GITHUB, contextOn: true }, deps);
 
     expect(result.copied).toBe('none');
     expect(result.notice.kind).toBe('error');

--- a/tests/interfaces/web_terminal/feedback-modal.test.mjs
+++ b/tests/interfaces/web_terminal/feedback-modal.test.mjs
@@ -332,8 +332,21 @@ const spawned = [];
  * @param {ConstructorParameters<typeof FeedbackModal>[0]} [options]
  * @returns {InstanceType<typeof FeedbackModal>}
  */
+/** @typedef {import('../../../src/osprey/interfaces/web_terminal/static/js/feedback-modal.js').FeedbackTracker} FeedbackTracker */
+
+/** The deployment's GitHub tracker, as boot hands it to the dialog. @type {FeedbackTracker} */
+const GH = { id: 'github:als-apg/osprey', kind: 'github', label: 'GitHub', target: 'als-apg/osprey' };
+
+/** A self-hosted GitLab tracker with a facility-authored caption. @type {FeedbackTracker} */
+const GL = {
+  id: 'gitlab:https://git.example.org/controls/osprey',
+  kind: 'gitlab',
+  label: 'Facility GitLab',
+  target: 'https://git.example.org/controls/osprey',
+};
+
 function openForm(options = {}) {
-  const m = new FeedbackModal({ getSessionId: () => 'session-abc', ...options });
+  const m = new FeedbackModal({ getSessionId: () => 'session-abc', trackers: [GH], ...options });
   spawned.push(m);
   m.open();
   return m;
@@ -365,9 +378,10 @@ function setChecked(el, checked) {
 }
 
 /**
- * Select a delivery channel through its radio.
+ * Select a delivery channel through its radio — `local`, `email`, or a
+ * tracker's id.
  *
- * @param {'local'|'github'|'email'} channel
+ * @param {string} channel
  */
 function pickChannel(channel) {
   setChecked(input(`input[name="feedback-channel"][value="${channel}"]`), true);
@@ -377,6 +391,20 @@ function pickChannel(channel) {
 function copyButton() {
   const el = document.querySelector('.feedback-copy-context');
   return el instanceof HTMLButtonElement ? el : null;
+}
+
+/** @returns {string[]} the radio values, in render order */
+function channelValues() {
+  return Array.from(document.querySelectorAll('input[name="feedback-channel"]')).map((node) =>
+    node instanceof HTMLInputElement ? node.value : ''
+  );
+}
+
+/** @returns {string[]} the radio captions, in render order */
+function channelCaptions() {
+  return Array.from(document.querySelectorAll('.feedback-channel-label')).map(
+    (node) => node.textContent ?? ''
+  );
 }
 
 /** @returns {string[]} the visible two-step statement, [] while hidden */
@@ -404,10 +432,80 @@ describe('feedback modal state — defaults and channel switching', () => {
     expect(m.formState()).toEqual({
       text: '',
       channel: 'local',
+      tracker: null,
       metadataOn: true,
       contextOn: false,
       sessionId: 'session-abc',
     });
+  });
+
+  test('state: one radio per configured tracker, captioned by its label, between Local and Email', () => {
+    openForm({ trackers: [GL, GH] });
+
+    expect(channelValues()).toEqual(['local', GL.id, GH.id, 'email']);
+    expect(channelCaptions()).toEqual(['Local', 'Facility GitLab', 'GitHub', 'Email']);
+  });
+
+  test('state: no trackers means Local and Email only', () => {
+    openForm({ trackers: [] });
+    expect(channelValues()).toEqual(['local', 'email']);
+  });
+
+  test('state: picking a tracker reports its kind as the channel and the tracker itself', () => {
+    const m = openForm({ trackers: [GL, GH] });
+
+    pickChannel(GL.id);
+    expect(m.formState()).toMatchObject({ channel: 'gitlab', tracker: GL });
+
+    pickChannel(GH.id);
+    expect(m.formState()).toMatchObject({ channel: 'github', tracker: GH });
+
+    pickChannel('email');
+    expect(m.formState()).toMatchObject({ channel: 'email', tracker: null });
+  });
+
+  test('state: the GitLab row opens an issue and warns about the account', () => {
+    openForm({ trackers: [GL] });
+    pickChannel(GL.id);
+
+    expect(qs(document, '.feedback-open-channel').textContent).toBe('Open GitLab issue');
+    expect(qs(document, '.feedback-channel-hint').textContent).toBe(CHANNEL_HINTS.gitlab);
+    expect(CHANNEL_HINTS.gitlab).toBe('Requires a GitLab account');
+  });
+
+  test('state: trackers arriving while the dialog is open are rendered in place', () => {
+    // The dialog exists before the deployment's configuration does, and the
+    // operator may well open it in between.
+    const m = openForm({ trackers: [] });
+    expect(channelValues()).toEqual(['local', 'email']);
+
+    m.setTrackers([GL]);
+
+    expect(channelValues()).toEqual(['local', GL.id, 'email']);
+    expect(input('input[name="feedback-channel"][value="local"]').checked).toBe(true);
+    pickChannel(GL.id);
+    expect(m.formState()).toMatchObject({ channel: 'gitlab', tracker: GL });
+  });
+
+  test('state: a selected tracker that disappears falls back to Local', () => {
+    const m = openForm({ trackers: [GH] });
+    pickChannel(GH.id);
+
+    m.setTrackers([GL]);
+
+    expect(m.formState()).toMatchObject({ channel: 'local', tracker: null });
+    expect(input('input[name="feedback-channel"][value="local"]').checked).toBe(true);
+    expect(document.querySelector('.feedback-send')).not.toBeNull();
+  });
+
+  test('state: a selected tracker survives a re-render that keeps it', () => {
+    const m = openForm({ trackers: [GH] });
+    pickChannel(GH.id);
+
+    m.setTrackers([GL, GH]);
+
+    expect(m.formState()).toMatchObject({ channel: 'github', tracker: GH });
+    expect(input(`input[name="feedback-channel"][value="${GH.id}"]`).checked).toBe(true);
   });
 
   test('state: the local action row is a single Send button', () => {
@@ -421,7 +519,7 @@ describe('feedback modal state — defaults and channel switching', () => {
     openForm();
     // A utility beside the checkbox, never a step of sending — so it must not
     // sit in the action row, and it must not vanish on the Local channel.
-    for (const channel of /** @type {const} */ (['local', 'github', 'email'])) {
+    for (const channel of ['local', GH.id, 'email']) {
       pickChannel(channel);
       const copy = copyButton();
       expect(copy?.textContent).toBe('Copy');
@@ -434,7 +532,7 @@ describe('feedback modal state — defaults and channel switching', () => {
 
   test('state: the GitHub row opens an issue and warns about the account', () => {
     openForm();
-    pickChannel('github');
+    pickChannel(GH.id);
 
     expect(document.querySelector('.feedback-send')).toBeNull();
     expect(document.querySelector('.feedback-actions .feedback-copy-context')).toBeNull();
@@ -461,7 +559,7 @@ describe('feedback modal state — defaults and channel switching', () => {
     setChecked(input('.feedback-metadata-check'), false);
     setChecked(input('.feedback-context-check'), true);
 
-    pickChannel('github');
+    pickChannel(GH.id);
     pickChannel('email');
     pickChannel('local');
 
@@ -471,6 +569,7 @@ describe('feedback modal state — defaults and channel switching', () => {
     expect(m.formState()).toEqual({
       text: 'the rail button does not respond',
       channel: 'local',
+      tracker: null,
       metadataOn: false,
       contextOn: true,
       sessionId: 'session-abc',
@@ -481,13 +580,13 @@ describe('feedback modal state — defaults and channel switching', () => {
     const m = openForm();
     textBox().value = 'half-written report';
     textBox().dispatchEvent(new Event('input', { bubbles: true }));
-    pickChannel('github');
+    pickChannel(GH.id);
 
     m.close();
     m.open();
 
     expect(textBox().value).toBe('half-written report');
-    expect(input('input[name="feedback-channel"][value="github"]').checked).toBe(true);
+    expect(input(`input[name="feedback-channel"][value="${GH.id}"]`).checked).toBe(true);
   });
 });
 
@@ -504,7 +603,7 @@ describe('feedback modal state — context availability', () => {
     setChecked(input('.feedback-context-check'), false);
     expect(copyButton()?.disabled).toBe(false);
 
-    pickChannel('github');
+    pickChannel(GH.id);
     expect(copyButton()?.disabled).toBe(false);
   });
 
@@ -530,7 +629,7 @@ describe('feedback modal state — context availability', () => {
     setChecked(input('.feedback-context-check'), true);
     expect(pasteSteps()).toEqual([PASTE_STEP_COPY, PASTE_STEP_OPEN.email]);
 
-    pickChannel('github');
+    pickChannel(GH.id);
     expect(pasteSteps()).toEqual([PASTE_STEP_COPY, PASTE_STEP_OPEN.github]);
 
     // Local sends the context inline with the record — nothing to paste.
@@ -547,6 +646,9 @@ describe('feedback modal state — context availability', () => {
     expect(PASTE_STEP_OPEN.github).toBe(
       'A GitHub issue draft opens — paste the report into the issue body.'
     );
+    expect(PASTE_STEP_OPEN.gitlab).toBe(
+      'A GitLab issue draft opens — paste the report into the issue body.'
+    );
     expect(PASTE_STEP_OPEN.email).toBe(
       'An email draft opens — paste the report into the message body.'
     );
@@ -554,7 +656,7 @@ describe('feedback modal state — context availability', () => {
 
   test('state: no session means no two-step statement, whatever was ticked', () => {
     openForm({ getSessionId: () => null });
-    pickChannel('github');
+    pickChannel(GH.id);
     // Force the flag past the disabled control — there is still no session to
     // compose context from, so promising a copy would be false.
     setChecked(input('.feedback-context-check'), true);
@@ -564,7 +666,7 @@ describe('feedback modal state — context availability', () => {
 
   test('state: Copy is disabled with no session even if context was ticked', () => {
     const m = openForm({ getSessionId: () => null });
-    pickChannel('github');
+    pickChannel(GH.id);
     setChecked(input('.feedback-context-check'), true);
 
     expect(copyButton()?.disabled).toBe(true);
@@ -583,6 +685,7 @@ describe('feedback modal state — context availability', () => {
     expect(onSubmit.mock.calls[0][0]).toEqual({
       text: 'no session but still worth reporting',
       channel: 'local',
+      tracker: null,
       metadataOn: true,
       contextOn: false,
       sessionId: null,
@@ -667,6 +770,7 @@ describe('feedback modal state — action events', () => {
     expect(onSubmit.mock.calls[0][0]).toEqual({
       text: 'terminal freezes on resume',
       channel: 'local',
+      tracker: null,
       metadataOn: true,
       contextOn: true,
       sessionId: 'session-abc',
@@ -676,7 +780,7 @@ describe('feedback modal state — action events', () => {
   test('state: Copy emits copy with the current state', () => {
     const onCopy = vi.fn();
     openForm({ onCopy });
-    pickChannel('github');
+    pickChannel(GH.id);
     setChecked(input('.feedback-context-check'), true);
 
     copyButton()?.click();

--- a/tests/interfaces/web_terminal/feedback-prefill.test.mjs
+++ b/tests/interfaces/web_terminal/feedback-prefill.test.mjs
@@ -16,9 +16,11 @@ import { test, expect, describe } from 'vitest';
 
 import {
   GITHUB_URL_LIMIT,
+  GITLAB_URL_LIMIT,
   MAILTO_URL_LIMIT,
   PASTE_POINTER,
   buildGitHubIssueUrl,
+  buildGitLabIssueUrl,
   buildMailto,
   buildPrefillBody,
   utf8Length,
@@ -59,6 +61,43 @@ describe('utf8Length', () => {
 
   test('is additive over concatenation', () => {
     expect(utf8Length('é😀abc')).toBe(utf8Length('é') + utf8Length('😀') + 3);
+  });
+});
+
+describe('buildGitLabIssueUrl', () => {
+  const BASE = 'https://git.example.org/controls/osprey';
+
+  test('builds the /-/issues/new form with issue[title] and issue[description]', () => {
+    const result = buildGitLabIssueUrl(BASE, 'Feedback', 'hello world');
+    expect(result.needsPaste).toBe(false);
+    expect(result.url.startsWith(`${BASE}/-/issues/new?issue[title]=`)).toBe(true);
+    expect(param(result.url, 'issue\\[title\\]')).toBe('Feedback');
+    expect(param(result.url, 'issue\\[description\\]')).toBe('hello world');
+  });
+
+  test('the same shape serves gitlab.com and a self-hosted instance', () => {
+    const hosted = buildGitLabIssueUrl('https://gitlab.com/group/project', 'T', 'b').url;
+    const self = buildGitLabIssueUrl('https://git.example.org/group/project', 'T', 'b').url;
+    expect(hosted.replace('https://gitlab.com', '')).toBe(
+      self.replace('https://git.example.org', '')
+    );
+  });
+
+  test('a trailing slash on the base URL does not double up', () => {
+    const result = buildGitLabIssueUrl(`${BASE}/`, 'T', 'b');
+    expect(result.url.startsWith(`${BASE}/-/issues/new?`)).toBe(true);
+  });
+
+  test('a body over the cap collapses to the pointer line', () => {
+    const result = buildGitLabIssueUrl(BASE, 'Feedback', BIG_ASCII);
+    expect(result.needsPaste).toBe(true);
+    expect(result.url.length).toBeLessThanOrEqual(GITLAB_URL_LIMIT);
+    expect(param(result.url, 'issue\\[description\\]')).toBe(PASTE_POINTER);
+  });
+
+  test('a lone surrogate is replaced instead of throwing', () => {
+    const result = buildGitLabIssueUrl(BASE, 'T', `ok\uD800tail`);
+    expect(param(result.url, 'issue\\[description\\]')).toBe('ok\uFFFDtail');
   });
 });
 

--- a/tests/interfaces/web_terminal/test_feedback_config.py
+++ b/tests/interfaces/web_terminal/test_feedback_config.py
@@ -26,8 +26,10 @@ from osprey.interfaces.web_terminal.app import (
     DEFAULT_FEEDBACK_GITHUB_REPO,
     DEFAULT_FEEDBACK_MAX_STORE_BYTES,
     coerce_config_str,
+    coerce_feedback_trackers,
     coerce_store_ceiling,
     create_app,
+    resolve_feedback_trackers,
 )
 from osprey.interfaces.web_terminal.routes.panels import router as panels_router
 
@@ -107,6 +109,11 @@ class TestFeedbackConfigDefaults:
             assert app.state.feedback_github_repo == DEFAULT_FEEDBACK_GITHUB_REPO
             assert app.state.feedback_email == DEFAULT_FEEDBACK_EMAIL
             assert app.state.feedback_max_store_bytes == DEFAULT_FEEDBACK_MAX_STORE_BYTES
+            # The bare deployment still reaches the maintainers: the shipped
+            # `github_repo` default is the one tracker on offer.
+            assert app.state.feedback_trackers == [
+                {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO}
+            ]
 
     def test_default_ceiling_is_256_mb(self):
         """The documented default, spelled out so a silent change is caught."""
@@ -231,6 +238,7 @@ class TestBadValuesAreContained:
             assert app.state.docs_url == ""
             assert app.state.feedback_github_repo == ""
             assert app.state.feedback_email == ""
+            assert app.state.feedback_trackers == []
 
     def test_absent_config_still_takes_the_defaults(self, project_dir, shared_root):
         """The counterpart: nothing configured is not the same as blanked."""
@@ -287,8 +295,29 @@ class TestPanelsPayload:
         with _lifespan_client(project_dir, shared_root, overrides=overrides) as (client, _app):
             payload = client.get("/api/panels").json()
         assert payload["docs_url"] == "https://docs.example.org/osprey"
-        assert payload["feedback_github_repo"] == "facility/osprey-fork"
+        assert payload["feedback_trackers"] == [
+            {"kind": "github", "label": "GitHub", "repo": "facility/osprey-fork"}
+        ]
         assert payload["feedback_email"] == "controls@example.org"
+        # The sugar key is resolved into the tracker list server-side; the
+        # browser never sees it on its own.
+        assert "feedback_github_repo" not in payload
+
+    def test_configured_trackers_reach_the_browser_in_order(self, project_dir, shared_root):
+        """A facility-authored list travels as written, sugar tracker last."""
+        overrides = {
+            "web.feedback.trackers": [
+                {"kind": "gitlab", "url": "https://git.example.org/ops/osprey", "label": "Ops"},
+                {"kind": "github", "repo": "facility/fork", "label": "Fork"},
+            ],
+        }
+        with _lifespan_client(project_dir, shared_root, overrides=overrides) as (client, _app):
+            payload = client.get("/api/panels").json()
+        assert payload["feedback_trackers"] == [
+            {"kind": "gitlab", "label": "Ops", "url": "https://git.example.org/ops/osprey"},
+            {"kind": "github", "label": "Fork", "repo": "facility/fork"},
+            {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO},
+        ]
 
     def test_ceiling_is_not_exposed_to_the_browser(self, project_dir, shared_root):
         """The store ceiling is server-side only; nothing in the UI reads it."""
@@ -303,5 +332,118 @@ class TestPanelsPayload:
         app.state.project_cwd = "/tmp"
         payload = TestClient(app).get("/api/panels").json()
         assert payload["docs_url"] == DEFAULT_DOCS_URL
-        assert payload["feedback_github_repo"] == DEFAULT_FEEDBACK_GITHUB_REPO
+        assert payload["feedback_trackers"] == [
+            {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO}
+        ]
         assert payload["feedback_email"] == DEFAULT_FEEDBACK_EMAIL
+
+
+GITLAB_URL = "https://git.example.org/controls/osprey"
+
+
+class TestFeedbackTrackers:
+    """``web.feedback.trackers`` — the facility-authored outbound tracker list."""
+
+    def test_absent_list_is_empty(self):
+        assert coerce_feedback_trackers(None) == []
+
+    def test_github_and_gitlab_entries_are_normalised(self):
+        raw = [
+            {"kind": "github", "repo": " facility/fork ", "label": " Fork "},
+            {"kind": "gitlab", "url": GITLAB_URL + "/", "label": "Facility GitLab"},
+        ]
+        assert coerce_feedback_trackers(raw) == [
+            {"kind": "github", "label": "Fork", "repo": "facility/fork"},
+            {"kind": "gitlab", "label": "Facility GitLab", "url": GITLAB_URL},
+        ]
+
+    def test_label_defaults_to_the_kind_name(self):
+        raw = [{"kind": "gitlab", "url": GITLAB_URL}, {"kind": "github", "repo": "a/b"}]
+        assert [t["label"] for t in coerce_feedback_trackers(raw)] == ["GitLab", "GitHub"]
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "not a list",
+            {"kind": "github", "repo": "a/b"},
+            42,
+        ],
+    )
+    def test_a_non_list_is_reported_and_dropped(self, bad):
+        assert coerce_feedback_trackers(bad) == []
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "a/b",
+            {"kind": "bitbucket", "url": GITLAB_URL},
+            {"kind": "github"},
+            {"kind": "github", "repo": ""},
+            {"kind": "github", "repo": "no-slash"},
+            {"kind": "github", "repo": "a/b c"},
+            {"kind": "gitlab"},
+            {"kind": "gitlab", "url": "git.example.org/x"},
+            {"kind": "gitlab", "repo": "a/b"},
+            {"repo": "a/b"},
+        ],
+    )
+    def test_a_malformed_entry_is_dropped_and_the_rest_kept(self, entry):
+        """One bad line must not take the whole channel list down with it."""
+        raw = [entry, {"kind": "github", "repo": "keep/me"}]
+        assert coerce_feedback_trackers(raw) == [
+            {"kind": "github", "label": "GitHub", "repo": "keep/me"}
+        ]
+
+    def test_github_repo_sugar_is_appended_as_a_tracker(self):
+        trackers = [{"kind": "gitlab", "label": "Ops", "url": GITLAB_URL}]
+        assert resolve_feedback_trackers(trackers, "als-apg/osprey") == [
+            {"kind": "gitlab", "label": "Ops", "url": GITLAB_URL},
+            {"kind": "github", "label": "GitHub", "repo": "als-apg/osprey"},
+        ]
+
+    def test_blank_github_repo_adds_nothing(self):
+        """Explicitly blank still retires the sugar channel."""
+        trackers = [{"kind": "gitlab", "label": "Ops", "url": GITLAB_URL}]
+        assert resolve_feedback_trackers(trackers, "") == trackers
+        assert resolve_feedback_trackers([], "") == []
+
+    def test_a_listed_tracker_wins_over_the_sugar_duplicate(self):
+        """Listing the same repo with its own label must not render it twice."""
+        trackers = [{"kind": "github", "label": "OSPREY upstream", "repo": "als-apg/osprey"}]
+        assert resolve_feedback_trackers(trackers, "als-apg/osprey") == trackers
+
+    def test_duplicates_inside_the_list_collapse_to_the_first(self):
+        trackers = [
+            {"kind": "gitlab", "label": "One", "url": GITLAB_URL},
+            {"kind": "gitlab", "label": "Two", "url": GITLAB_URL},
+        ]
+        assert resolve_feedback_trackers(trackers, "") == [trackers[0]]
+
+    def test_lifespan_resolves_the_list_plus_sugar(self, project_dir, shared_root):
+        overrides = {
+            "web.feedback.trackers": [{"kind": "gitlab", "url": GITLAB_URL, "label": "Ops"}],
+            "web.feedback.github_repo": "facility/fork",
+        }
+        with _lifespan_client(project_dir, shared_root, overrides=overrides) as (_client, app):
+            assert app.state.feedback_trackers == [
+                {"kind": "gitlab", "label": "Ops", "url": GITLAB_URL},
+                {"kind": "github", "label": "GitHub", "repo": "facility/fork"},
+            ]
+
+    def test_lifespan_with_list_and_blank_sugar_is_the_list_alone(self, project_dir, shared_root):
+        """The ALS posture: a self-hosted tracker and no upstream channel."""
+        overrides = {
+            "web.feedback.trackers": [{"kind": "gitlab", "url": GITLAB_URL, "label": "Ops"}],
+            "web.feedback.github_repo": "",
+        }
+        with _lifespan_client(project_dir, shared_root, overrides=overrides) as (_client, app):
+            assert app.state.feedback_trackers == [
+                {"kind": "gitlab", "label": "Ops", "url": GITLAB_URL}
+            ]
+
+    def test_malformed_list_in_config_leaves_the_sugar_tracker(self, project_dir, shared_root):
+        overrides = {"web.feedback.trackers": "https://git.example.org/x"}
+        with _lifespan_client(project_dir, shared_root, overrides=overrides) as (_client, app):
+            assert app.state.feedback_trackers == [
+                {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO}
+            ]

--- a/tests/interfaces/web_terminal/test_feedback_routes.py
+++ b/tests/interfaces/web_terminal/test_feedback_routes.py
@@ -138,7 +138,7 @@ def _send_body(**overrides: Any) -> dict[str, Any]:
 # ---- POST /api/feedback: records ----
 
 
-@pytest.mark.parametrize("channel", ["local", "github", "email"])
+@pytest.mark.parametrize("channel", ["local", "github", "gitlab", "email"])
 def test_send_writes_one_record_carrying_its_channel(env: _Env, channel: str) -> None:
     response = env.client.post("/api/feedback", json=_send_body(channel=channel))
 
@@ -171,8 +171,9 @@ def test_send_keeps_the_full_text_and_context_in_the_record(env: _Env) -> None:
     assert env.headers()[0]["excerpt"]
 
 
-def test_send_stamps_the_payload_digest_only_for_outbound_channels(env: _Env) -> None:
-    outbound = env.client.post("/api/feedback", json=_send_body(channel="github")).json()
+@pytest.mark.parametrize("channel", ["github", "gitlab", "email"])
+def test_send_stamps_the_payload_digest_only_for_outbound_channels(env: _Env, channel: str) -> None:
+    outbound = env.client.post("/api/feedback", json=_send_body(channel=channel)).json()
     header = env.headers()[0]
     encoded = outbound["payload"].encode("utf-8")
     assert header["bundle_bytes"] == len(encoded)
@@ -183,6 +184,31 @@ def test_send_stamps_the_payload_digest_only_for_outbound_channels(env: _Env) ->
     env.client.post("/api/feedback", json=_send_body(channel="local"))
     assert "bundle_sha256" not in env.headers()[0]
     assert "bundle_bytes" not in env.headers()[0]
+
+
+@pytest.mark.parametrize(
+    ("channel", "tracker"),
+    [("github", "facility/fork"), ("gitlab", "https://git.example.org/controls/osprey")],
+)
+def test_send_records_which_tracker_the_report_went_to(
+    env: _Env, channel: str, tracker: str
+) -> None:
+    """With several trackers configured, "github" alone no longer says where."""
+    env.client.post("/api/feedback", json=_send_body(channel=channel, tracker=tracker))
+    assert env.headers()[0]["tracker"] == tracker
+
+
+@pytest.mark.parametrize("channel", ["local", "email"])
+def test_tracker_is_not_stamped_on_channels_that_have_none(env: _Env, channel: str) -> None:
+    env.client.post("/api/feedback", json=_send_body(channel=channel, tracker="facility/fork"))
+    assert "tracker" not in env.headers()[0]
+
+
+def test_an_oversized_tracker_string_is_refused(env: _Env) -> None:
+    response = env.client.post(
+        "/api/feedback", json=_send_body(channel="github", tracker="x" * 513)
+    )
+    assert response.status_code == 422
 
 
 # ---- POST /api/feedback: the byte cap ----

--- a/tests/interfaces/web_terminal/test_panels_routes.py
+++ b/tests/interfaces/web_terminal/test_panels_routes.py
@@ -122,7 +122,7 @@ def test_project_key_does_not_disturb_existing_fields(tmp_path):
         "open_tiles_age_s",
         "open_tiles_dock",
         "docs_url",
-        "feedback_github_repo",
+        "feedback_trackers",
         "feedback_email",
         "config_panel_enabled",
         "scaffold_write_enabled",
@@ -143,13 +143,13 @@ def test_blank_utility_targets_reach_the_browser_as_blank(tmp_path):
     """
     app = _make_app(tmp_path)
     app.state.docs_url = ""
-    app.state.feedback_github_repo = ""
+    app.state.feedback_trackers = []
     app.state.feedback_email = ""
 
     body = _panels(app)
 
     assert body["docs_url"] == ""
-    assert body["feedback_github_repo"] == ""
+    assert body["feedback_trackers"] == []
     assert body["feedback_email"] == ""
 
 


### PR DESCRIPTION
Fixes #828

The feedback dialog's outbound channels become a facility-authored tracker list.

**Config** — `web.feedback.trackers`: a list of `{kind: github|gitlab, repo|url, label}`. Each entry is one channel radio, captioned by `label`, between **Local** and **Email**, using the existing two-step copy/paste flow (nothing posts automatically). GitHub prefills `issues/new?title=&body=`; GitLab prefills `<url>/-/issues/new?issue[title]=&issue[description]=` — the same shape on gitlab.com and self-hosted.

**Back-compat** — `web.feedback.github_repo` stays as shorthand for one `github` tracker (appended after the list, deduplicated against it). Explicitly blank still retires it; the shipped default remains `als-apg/osprey`, so a bare deployment still reaches the maintainers. `web.feedback.email`, the `local` channel and the on-disk store are unchanged; the record header additionally names the tracker a `github`/`gitlab` send opened.

**Resilience** — a malformed entry (unknown kind, GitHub without `owner/name`, GitLab without an `http(s)://` URL) is logged and skipped; the rest of the list stands. The dialog rebuilds its radios in place when the config lands after it was opened, so a tracker the page does not know yet is simply not offered rather than refused.

**Surfaces** — `/api/panels` carries `feedback_trackers` in place of `feedback_github_repo`; config reference + how-to pages; a commented `trackers:` example beside `github_repo` in all four templates; manifest entry (`rendered: false`); changelog fragment.

**Verified** — `./scripts/quick_check.sh`, `npm run lint`, `npm run typecheck`, `npx vitest run`, the docs build with `-W`, and the Playwright feedback dialog/rail suites.

ALS profile adoption (its GitLab project + a deliberate GitHub channel) is a follow-up in the als-profiles repo.
