### PR TITLE
Pair setpoints with corpus-stated readbacks; serve them as VA setpoint echoes

### DIFF
--- a/changelog.d/graph-roster-readbacks.changed.md
+++ b/changelog.d/graph-roster-readbacks.changed.md
@@ -1,0 +1,7 @@
+Setpoint/readback pairing in the channel roster now keeps a readback the
+source itself stated and applies the `:SP` -> `:RB` address grammar only to
+the records the source paired nothing with. Before, the graph reader
+assigned no readbacks at all and the grammar was the only pairing, so a
+facility whose addresses carry no `:SP`/`:RB` suffix had every plan device
+read its own setpoint back. On such a facility the bluesky plan devices now
+carry the corpus-stated readback.

--- a/changelog.d/graph-roster-readbacks.changed.md
+++ b/changelog.d/graph-roster-readbacks.changed.md
@@ -5,3 +5,10 @@ assigned no readbacks at all and the grammar was the only pairing, so a
 facility whose addresses carry no `:SP`/`:RB` suffix had every plan device
 read its own setpoint back. On such a facility the bluesky plan devices now
 carry the corpus-stated readback.
+
+The graph reader also yields one record per address: bindings sharing a
+`fullPv` (a channel the corpus hangs under several devices) are one channel,
+with the direction their bindings agree on and no direction when they
+disagree. Before, each binding was a record of its own, and a derived
+plan-device document for such a corpus named the same device several times,
+which the build refuses.

--- a/changelog.d/graph-va-setpoint-echo.added.md
+++ b/changelog.d/graph-va-setpoint-echo.added.md
@@ -1,0 +1,16 @@
+A graph-mode virtual accelerator now serves setpoint-echo channels. The
+channel roster read from the knowledge-graph corpus carries, for every
+settable channel, the readback the corpus itself states for it: a device
+(`narad_p:hasBinding`) whose write binding is named `<stem>Setpoint` and
+whose read binding is named `<stem>Monitor` (`Setpoint`/`Monitor` for a
+magnet's current, `GapSetpoint`/`GapMonitor` for an insertion device's gap).
+`osprey build` turns each stated pair into a setpoint-echo pair in
+`data/simulation/channel_manifest.json`, keyed on the setpoint's own address
+with the other identity keys left empty, so a write to the setpoint is
+echoed onto its readback by the IOC without a hierarchy path or a lattice
+model. Every channel the corpus pairs nothing with is still served pathless
+and static-noisy, and an ambiguous pair (a readback claimed by two setpoints,
+a chain of setpoints) is dropped to static-noisy on both sides rather than
+served as half an echo. The build's manifest fact says how many setpoints
+the corpus paired; a corpus that pairs nothing still gets the "serves 0
+setpoints" sentence.

--- a/src/osprey/channel_roster/graph.py
+++ b/src/osprey/channel_roster/graph.py
@@ -60,6 +60,29 @@ _WRITES_SIGNAL_IRI = _NARAD_P + "writesSignal"
 #: A binding that observes a signal -- a readable channel.
 _READS_SIGNAL_IRI = _NARAD_P + "readsSignal"
 
+#: A device's bindings. The corpus groups a device's channels under its
+#: device node, and that grouping is what pairs a setpoint with the readback
+#: reporting it (see :func:`_corpus_readbacks`).
+_HAS_BINDING_IRI = _NARAD_P + "hasBinding"
+
+#: A binding's identifier, ``narad:binding:<facility>:<system>:<family>:
+#: <index>:<Field>:val`` -- the ``<Field>`` token is the binding's field name.
+_BINDING_ID_IRI = _NARAD_P + "bindingId"
+
+#: The NARAD field vocabulary's setpoint/readback pair: a device's
+#: ``<stem>Setpoint`` binding is reported by its ``<stem>Monitor`` binding
+#: (``Setpoint``/``Monitor`` for a magnet's current, ``GapSetpoint``/
+#: ``GapMonitor`` for an insertion device's gap). The same two field names the
+#: facility-knowledge seeder reads off a binding
+#: (``seeder/ttl_seeder._binding_channel_name``). This is the corpus stating
+#: a pair; the ``:SP``/``:RB`` address grammar in :mod:`.pairing` is the
+#: fallback for the records a corpus groups nothing with.
+SETPOINT_FIELD_SUFFIX = "Setpoint"
+MONITOR_FIELD_SUFFIX = "Monitor"
+
+#: The trailing token of a binding id names its value slot, not its field.
+_BINDING_ID_VALUE_TOKEN = "val"
+
 #: Said to an operator when rdflib is missing. rdflib is a core dependency, so
 #: an environment without it is incomplete rather than differently configured.
 RDFLIB_MISSING_DETAIL = (
@@ -88,9 +111,13 @@ def read_graph_roster(source: RosterSource) -> RosterResult:
         :attr:`~osprey.channel_roster.records.RosterAbsenceReason.EMPTY_SOURCE`
         one when it reads cleanly and binds no channel -- an unseeded corpus is
         a staging gap, and serving it as an empty facility would be a lie with
-        a source attached. Readbacks are not
-        assigned here -- pairing is one heuristic applied to both sources, and
-        lives in :mod:`osprey.channel_roster.pairing`.
+        a source attached. A settable record carries the readback the corpus
+        itself states for it -- the ``<stem>Monitor`` binding beside its
+        ``<stem>Setpoint`` binding on the same device
+        (:func:`_corpus_readbacks`); the records the corpus pairs nothing
+        with are left to the address-grammar pass in
+        :mod:`osprey.channel_roster.pairing`, which never overrides a
+        readback the source stated.
     """
     if not source.path.exists():
         # Not there is not the same as unreadable: a corpus a build has not
@@ -143,6 +170,7 @@ def read_graph_roster(source: RosterSource) -> RosterResult:
             for binding, address in graph.subject_objects(URIRef(_FULL_PV_IRI))
             if isinstance(address, Literal) and str(address)
         ]
+        readbacks = _corpus_readbacks(graph, writes, reads, bindings)
     except Exception as e:
         logger.warning(f"The knowledge-graph corpus at {source.path} could not be read ({e}).")
         return RosterResult(
@@ -155,11 +183,7 @@ def read_graph_roster(source: RosterSource) -> RosterResult:
         )
 
     records = tuple(
-        ChannelRecord(
-            address=address,
-            source=source,
-            direction=_direction(binding, writes, reads),
-        )
+        _record(address, binding, source, writes, reads, readbacks)
         for address, binding in sorted(bindings, key=lambda binding: binding[0])
     )
     if not records:
@@ -175,6 +199,86 @@ def read_graph_roster(source: RosterSource) -> RosterResult:
             )
         )
     return RosterResult(records=records, source=source)
+
+
+def _record(
+    address: str,
+    binding: object,
+    source: RosterSource,
+    writes: set,
+    reads: set,
+    readbacks: dict[str, str],
+) -> ChannelRecord:
+    """One record for a binding, carrying the corpus-stated readback when it is a setpoint."""
+    direction = _direction(binding, writes, reads)
+    readback = readbacks.get(address) if direction == "write" else None
+    return ChannelRecord(address=address, source=source, direction=direction, readback=readback)
+
+
+def _binding_field(binding_id: str) -> str | None:
+    """The field name a binding id carries, or ``None`` when it carries none.
+
+    ``narad:binding:als:SR:BEND:0:Setpoint:val`` names ``Setpoint``: the
+    tokens are colon-separated, and the trailing ``val`` is the binding's
+    value slot rather than its field, so it is dropped when present.
+    """
+    tokens = binding_id.split(":")
+    if tokens and tokens[-1] == _BINDING_ID_VALUE_TOKEN:
+        tokens = tokens[:-1]
+    if len(tokens) < 2 or not tokens[-1]:
+        return None
+    return tokens[-1]
+
+
+def _corpus_readbacks(
+    graph: object, writes: set, reads: set, bindings: list[tuple[str, object]]
+) -> dict[str, str]:
+    """Return ``setpoint address -> readback address`` for every pair the corpus states.
+
+    A pair is stated by the device grouping: a device (``narad_p:hasBinding``)
+    carrying a write binding whose field is ``<stem>Setpoint`` and a read
+    binding whose field is ``<stem>Monitor``. Both halves are checked against
+    the direction sets the corpus declares -- a ``Monitor`` the corpus calls
+    settable is drift, not a readback -- and a binding without a device, an
+    id or an address states no pair. Where two devices state different
+    readbacks for one setpoint address, the first in sorted device order
+    wins, so the answer does not depend on parse order.
+
+    Args:
+        graph: The parsed corpus.
+        writes: Bindings carrying ``writesSignal``.
+        reads: Bindings carrying ``readsSignal``.
+        bindings: ``(address, binding)`` for every binding with an address.
+    """
+    from rdflib import URIRef
+
+    address_of = {binding: address for address, binding in bindings}
+    fields_by_device: dict[object, dict[str, object]] = {}
+    for device, binding in graph.subject_objects(URIRef(_HAS_BINDING_IRI)):
+        binding_id = graph.value(binding, URIRef(_BINDING_ID_IRI))
+        field = _binding_field(str(binding_id)) if binding_id is not None else None
+        if field is None or binding not in address_of:
+            continue
+        fields_by_device.setdefault(device, {})[field] = binding
+
+    readbacks: dict[str, str] = {}
+    for device in sorted(fields_by_device, key=str):
+        fields = fields_by_device[device]
+        for field, setpoint in fields.items():
+            if not field.endswith(SETPOINT_FIELD_SUFFIX):
+                continue
+            if setpoint not in writes or setpoint in reads:
+                continue
+            stem = field[: -len(SETPOINT_FIELD_SUFFIX)]
+            monitor = fields.get(stem + MONITOR_FIELD_SUFFIX)
+            if monitor is None or monitor not in reads or monitor in writes:
+                continue
+            setpoint_address = address_of[setpoint]
+            readback_address = address_of[monitor]
+            if setpoint_address == readback_address:
+                continue
+            readbacks.setdefault(setpoint_address, readback_address)
+    return readbacks
 
 
 def _direction(binding: object, writes: set, reads: set) -> ChannelDirection | None:

--- a/src/osprey/channel_roster/graph.py
+++ b/src/osprey/channel_roster/graph.py
@@ -182,10 +182,7 @@ def read_graph_roster(source: RosterSource) -> RosterResult:
             )
         )
 
-    records = tuple(
-        _record(address, binding, source, writes, reads, readbacks)
-        for address, binding in sorted(bindings, key=lambda binding: binding[0])
-    )
+    records = _records(bindings, source, writes, reads, readbacks)
     if not records:
         logger.warning(
             f"The knowledge-graph corpus at {source.path} parsed cleanly and declares no "
@@ -201,18 +198,52 @@ def read_graph_roster(source: RosterSource) -> RosterResult:
     return RosterResult(records=records, source=source)
 
 
-def _record(
-    address: str,
-    binding: object,
+def _records(
+    bindings: list[tuple[str, object]],
     source: RosterSource,
     writes: set,
     reads: set,
     readbacks: dict[str, str],
-) -> ChannelRecord:
-    """One record for a binding, carrying the corpus-stated readback when it is a setpoint."""
-    direction = _direction(binding, writes, reads)
-    readback = readbacks.get(address) if direction == "write" else None
-    return ChannelRecord(address=address, source=source, direction=direction, readback=readback)
+) -> tuple[ChannelRecord, ...]:
+    """One record per address, in address order.
+
+    The roster is a namespace: two bindings carrying one ``fullPv`` are one
+    channel, however many devices the corpus hangs it under (a timing
+    system's delay generator is bound once per device it serves; a facility
+    corpus can carry a fifth of its bindings this way). Every consumer keys
+    on the address -- the plan-device document names each device for it and
+    the build refuses a name claimed twice, the manifest serves it once -- so
+    the collapse happens here, once, rather than in each of them.
+
+    Direction is the one the address's bindings agree on. A binding that
+    states none abstains; bindings that disagree leave the address with no
+    direction, the same honest unknown a single binding claiming both ways
+    gets. A settable address carries the readback the corpus stated for it,
+    provided the readback ADDRESS resolves readable too -- a pair is stated
+    between bindings, and the binding it names as the monitor may share its
+    address with a write binding elsewhere in the corpus.
+    """
+    votes: dict[str, set[ChannelDirection]] = {}
+    for address, binding in bindings:
+        directions = votes.setdefault(address, set())
+        direction = _direction(binding, writes, reads)
+        if direction is not None:
+            directions.add(direction)
+    resolved: dict[str, ChannelDirection | None] = {
+        address: next(iter(directions)) if len(directions) == 1 else None
+        for address, directions in votes.items()
+    }
+
+    records: list[ChannelRecord] = []
+    for address in sorted(resolved):
+        direction = resolved[address]
+        readback = readbacks.get(address) if direction == "write" else None
+        if readback is not None and resolved.get(readback) != "read":
+            readback = None
+        records.append(
+            ChannelRecord(address=address, source=source, direction=direction, readback=readback)
+        )
+    return tuple(records)
 
 
 def _binding_field(binding_id: str) -> str | None:

--- a/src/osprey/channel_roster/pairing.py
+++ b/src/osprey/channel_roster/pairing.py
@@ -60,8 +60,14 @@ def assign_readbacks(records: Sequence[ChannelRecord]) -> tuple[ChannelRecord, .
 
 
 def _paired(record: ChannelRecord, readable: frozenset[str] | set[str]) -> ChannelRecord:
-    """Return ``record`` with its readback, or unchanged when it has none."""
-    if record.direction != "write":
+    """Return ``record`` with its readback, or unchanged when it has none.
+
+    A readback the source itself stated (the graph reader's device grouping,
+    :func:`osprey.channel_roster.graph._corpus_readbacks`) is kept as it is:
+    the corpus is the authority on what reports a setpoint, and the grammar
+    here is only for the records it paired nothing with.
+    """
+    if record.direction != "write" or record.readback is not None:
         return record
     candidate = _readback_address(record.address)
     if candidate is None or candidate not in readable:

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1522,6 +1522,14 @@ def _report_va_manifest_outcome(
         # that exist nowhere else.
         line += f", plus {len(novel)} address(es) seeded only by simulation/machine.json"
     line += "."
+    if corpus is not None and metadata["setpoint_count"]:
+        # What the corpus's device grouping bought: the pairs it states are
+        # the only channels a graph-sourced accelerator can echo a write on,
+        # and the operator driving one should know which count that is.
+        line += (
+            f" The corpus pairs {metadata['setpoint_count']} setpoint(s) with a readback; "
+            "those are served as setpoint-echo channels, every other channel as static-noisy."
+        )
     if absent:
         line += f" Not staged at that tier: {_named_in_prose(absent)}."
     corrupt = metadata["corrupt_paradigms"]

--- a/src/osprey/services/virtual_accelerator/manifest/build.py
+++ b/src/osprey/services/virtual_accelerator/manifest/build.py
@@ -492,6 +492,93 @@ def _graph_missing_sources(paths: ManifestPaths) -> list[Path]:
     return missing
 
 
+#: The subfield tokens the container pairs a setpoint with its readback on
+#: (``serving/pvdb.py`` spells the same two; not imported from there because
+#: this module is imported on the build host, where the IOC's dependencies
+#: are not installed).
+SETPOINT_SUBFIELD = "SP"
+READBACK_SUBFIELD = "RB"
+
+
+def _echo_entry(address: str, *, pair_key: str, subfield: str) -> ManifestEntry:
+    """One half of a setpoint-echo pair the roster states.
+
+    The container pairs a setpoint with its readback on the five identity keys
+    ``(ring, system, family, device, field)``, differing only in subfield
+    (``serving/pvdb._channel_key``). The graph states no hierarchy path, so
+    the pair is keyed on the one thing that identifies it -- the setpoint's
+    own address, carried in ``device`` -- and the other four keys stay empty,
+    exactly as on a pathless entry. That is enough for the IOC to echo a write
+    to the setpoint onto the readback, which is all the partition promises.
+    """
+    return ManifestEntry(
+        address=address,
+        ring="",
+        system="",
+        family="",
+        device=pair_key,
+        field="",
+        subfield=subfield,
+        partition=classify.PARTITION_SP_ECHO,
+        record_type=classify.RECORD_TYPE_ANALOG,
+        noise=False,
+    )
+
+
+def _graph_entries(records) -> list[ManifestEntry]:
+    """Manifest entries for a knowledge-graph roster.
+
+    The graph states each channel's address, direction and -- where the
+    corpus groups a setpoint with the readback reporting it -- its readback.
+    Every stated pair becomes a setpoint-echo pair (:func:`_echo_entry`): a
+    write to the setpoint echoes onto the readback, physics-free, which is
+    what a plan driving that setpoint against the accelerator needs to observe
+    its own write. Everything else is pathless and static-noisy: the graph
+    carries no hierarchy path, the identity keys are read from nowhere else,
+    and nothing is invented to classify better than the source can say; the
+    build's fact states the cost.
+
+    The manifest is a namespace, so two records sharing one address are one
+    channel, and a readback is emitted once, beside its setpoint. A pair is
+    dropped -- both halves served static-noisy instead -- when the corpus
+    states it ambiguously: a readback claimed by two setpoints, a setpoint that
+    is itself another pair's readback, or a readback that is itself a
+    setpoint.
+
+    Args:
+        records: The roster's records, in source order.
+    """
+    stated: dict[str, str] = {}
+    for record in records:
+        if record.readback is not None:
+            stated.setdefault(record.address, record.readback)
+    addresses = {record.address for record in records}
+    claimed = {}
+    for setpoint, readback in stated.items():
+        claimed.setdefault(readback, []).append(setpoint)
+    pairs = {
+        setpoint: readback
+        for setpoint, readback in stated.items()
+        if readback in addresses
+        and len(claimed[readback]) == 1
+        and setpoint not in claimed
+        and readback not in stated
+    }
+    readbacks = set(pairs.values())
+
+    entries: list[ManifestEntry] = []
+    for address in sorted(addresses):
+        if address in readbacks:
+            continue
+        readback = pairs.get(address)
+        if readback is None:
+            entries.append(_pathless_entry(address, noise=False))
+            continue
+        entries.append(_echo_entry(address, pair_key=address, subfield=SETPOINT_SUBFIELD))
+        entries.append(_echo_entry(readback, pair_key=address, subfield=READBACK_SUBFIELD))
+    return entries
+
+
 def _prepare_graph_manifest(roster, paths: ManifestPaths) -> PreparedManifest | None:
     """Build the manifest from the knowledge-graph roster, or say no.
 
@@ -529,18 +616,7 @@ def _prepare_graph_manifest(roster, paths: ManifestPaths) -> PreparedManifest | 
         )
         return None
 
-    # The graph states each channel's address, direction and readback pairing
-    # -- membership -- but no hierarchy path, and the identity keys are read
-    # from nowhere else. So every entry is pathless: empty identity keys,
-    # static-noisy partition, exactly what a tree without a hierarchical
-    # database already gets. Nothing is invented to classify better than the
-    # source can say; the build's fact states the cost. The manifest is a
-    # namespace, so two bindings sharing one address are one channel: entries
-    # are built from the unique address set, never once per record.
-    entries = [
-        _pathless_entry(address, noise=False)
-        for address in sorted({record.address for record in roster.records})
-    ]
+    entries = _graph_entries(roster.records)
 
     try:
         manifest = _finish_manifest(

--- a/tests/channel_roster/test_graph.py
+++ b/tests/channel_roster/test_graph.py
@@ -156,6 +156,58 @@ class TestTheShippedDemoCorpus:
         assert all(record.readback is None for record in result.records)
 
 
+class TestOneRecordPerAddress:
+    """The roster is a namespace: bindings sharing a ``fullPv`` are one channel."""
+
+    def test_two_bindings_on_one_address_are_one_record(self, tmp_path) -> None:
+        # A delay generator's channel, bound once per device it serves.
+        body = _binding("evr_a", "B0215:EVR1-DlyGen:3:Delay-SP", "writesSignal") + _binding(
+            "evr_b", "B0215:EVR1-DlyGen:3:Delay-SP", "writesSignal"
+        )
+        source = _corpus(tmp_path, body)
+
+        result = read_graph_roster(source)
+
+        assert result.addresses == ("B0215:EVR1-DlyGen:3:Delay-SP",)
+        assert result.records[0].direction == "write"
+
+    def test_bindings_disagreeing_on_direction_leave_an_honest_unknown(self, tmp_path) -> None:
+        body = _binding("sp", "SR04C___BSC_P__AC01", "writesSignal") + _binding(
+            "rb", "SR04C___BSC_P__AC01", "readsSignal"
+        )
+        source = _corpus(tmp_path, body)
+
+        (record,) = read_graph_roster(source).records
+
+        assert record.direction is None
+        assert record.readback is None
+
+    def test_a_directionless_binding_abstains(self, tmp_path) -> None:
+        body = _binding("sp", "SR01C___B______AC00", "writesSignal") + _binding(
+            "bare", "SR01C___B______AC00", None
+        )
+        source = _corpus(tmp_path, body)
+
+        (record,) = read_graph_roster(source).records
+
+        assert record.direction == "write"
+
+    def test_a_stated_readback_survives_the_collapse(self, tmp_path) -> None:
+        # The same setpoint address bound a second time, off any device.
+        body = _magnet() + _binding("again", "SR01C___B______AC00", "writesSignal")
+        source = _corpus(tmp_path, body)
+
+        assert _readbacks(source) == {
+            "SR01C___B______AC00": "SR01C___B______AM00",
+            "SR01C___B______AM00": None,
+        }
+
+    def test_the_demo_corpus_is_already_a_namespace(self, demo_source) -> None:
+        addresses = read_graph_roster(demo_source).addresses
+
+        assert len(addresses) == DEMO_CHANNELS == len(set(addresses))
+
+
 class TestCorpusStatedReadbacks:
     """A device carrying ``<stem>Setpoint`` and ``<stem>Monitor`` states a pair."""
 

--- a/tests/channel_roster/test_graph.py
+++ b/tests/channel_roster/test_graph.py
@@ -71,10 +71,53 @@ def _corpus(tmp_path: Path, body: str, name: str = "corpus.ttl") -> RosterSource
     return RosterSource(kind=RosterSourceKind.GRAPH, path=path)
 
 
-def _binding(name: str, address: str, predicate: str | None) -> str:
-    """Render one ``ChannelBinding`` with the given direction predicate."""
+def _binding(name: str, address: str, predicate: str | None, binding_id: str | None = None) -> str:
+    """Render one ``ChannelBinding`` with the given direction predicate.
+
+    ``binding_id`` is the corpus's ``narad_p:bindingId`` literal, whose field
+    token is what the device grouping pairs setpoints with readbacks on.
+    """
     direction = f" ;\n    narad_p:{predicate} narad_sem:{name}_signal" if predicate else ""
-    return f'<https://narad.example.org/binding/{name}> narad_p:fullPv "{address}"{direction} .\n'
+    identity = f' ;\n    narad_p:bindingId "{binding_id}"' if binding_id else ""
+    return (
+        f'<https://narad.example.org/binding/{name}> narad_p:fullPv "{address}"'
+        f"{direction}{identity} .\n"
+    )
+
+
+def _device(name: str, *bindings: str) -> str:
+    """Render one device grouping the named bindings under ``narad_p:hasBinding``."""
+    objects = ",\n        ".join(f"<https://narad.example.org/binding/{b}>" for b in bindings)
+    return f"<https://narad.example.org/device/{name}> narad_p:hasBinding {objects} .\n"
+
+
+def _magnet(
+    device: str = "bend",
+    *,
+    setpoint: str = "SR01C___B______AC00",
+    monitor: str = "SR01C___B______AM00",
+    setpoint_predicate: str | None = "writesSignal",
+    monitor_predicate: str | None = "readsSignal",
+    stem: str = "",
+    grouped: bool = True,
+) -> str:
+    """An ALS-shaped device: a ``<stem>Setpoint`` and a ``<stem>Monitor`` binding.
+
+    The addresses are the facility's own (no ``:SP``/``:RB`` grammar to fall
+    back on), so a readback here can only have come from the grouping.
+    """
+    sp, mon = f"{device}_sp", f"{device}_mon"
+    body = _binding(
+        sp, setpoint, setpoint_predicate, f"narad:binding:als:SR:BEND:0:{stem}Setpoint:val"
+    ) + _binding(mon, monitor, monitor_predicate, f"narad:binding:als:SR:BEND:0:{stem}Monitor:val")
+    if grouped:
+        body += _device(device, sp, mon)
+    return body
+
+
+def _readbacks(source: RosterSource) -> dict[str, str | None]:
+    """``address -> readback`` for every record the source yields."""
+    return {record.address: record.readback for record in read_graph_roster(source).records}
 
 
 class TestTheShippedDemoCorpus:
@@ -103,10 +146,190 @@ class TestTheShippedDemoCorpus:
         assert list(addresses) == sorted(addresses)
         assert len(set(addresses)) == len(addresses)
 
-    def test_records_come_back_unpaired(self, demo_source) -> None:
+    def test_a_corpus_stating_no_pairs_yields_unpaired_records(self, demo_source) -> None:
+        """The demo corpus groups bindings under devices, but its field names
+        (``GOLDEN_X``, ``POSITION_X``, ...) are not the ``Setpoint``/``Monitor``
+        vocabulary, so it states no pair and every readback is left to the
+        address-grammar pass."""
         result = read_graph_roster(demo_source)
 
         assert all(record.readback is None for record in result.records)
+
+
+class TestCorpusStatedReadbacks:
+    """A device carrying ``<stem>Setpoint`` and ``<stem>Monitor`` states a pair."""
+
+    def test_a_setpoint_and_monitor_on_one_device_pair_on_facility_addresses(
+        self, tmp_path
+    ) -> None:
+        source = _corpus(tmp_path, _magnet())
+
+        readbacks = _readbacks(source)
+
+        assert readbacks == {
+            "SR01C___B______AC00": "SR01C___B______AM00",
+            "SR01C___B______AM00": None,
+        }
+
+    def test_the_readback_rides_the_write_record_only(self, tmp_path) -> None:
+        source = _corpus(tmp_path, _magnet())
+
+        result = read_graph_roster(source)
+
+        (setpoint,) = result.write_records
+        assert setpoint.readback == "SR01C___B______AM00"
+        assert all(record.readback is None for record in result.read_records)
+
+    def test_a_stemmed_field_pair_is_recognised(self, tmp_path) -> None:
+        """``GapSetpoint``/``GapMonitor`` is an insertion device's pair."""
+        source = _corpus(
+            tmp_path,
+            _magnet(
+                "id", setpoint="SR04U___GDS1PS_AC00", monitor="SR04U___GDS1PS_AM00", stem="Gap"
+            ),
+        )
+
+        assert _readbacks(source)["SR04U___GDS1PS_AC00"] == "SR04U___GDS1PS_AM00"
+
+    def test_a_setpoint_without_a_monitor_on_its_device_stays_unpaired(self, tmp_path) -> None:
+        body = (
+            _binding(
+                "sp",
+                "SR01C___B______AC00",
+                "writesSignal",
+                "narad:binding:als:SR:BEND:0:Setpoint:val",
+            )
+            + _binding(
+                "golden",
+                "SR01C:BEND:Setpoint:Golden",
+                "writesSignal",
+                "narad:binding:als:SR:BEND:0:SetpointGolden:val",
+            )
+            + _device("bend", "sp", "golden")
+        )
+        source = _corpus(tmp_path, body)
+
+        assert _readbacks(source)["SR01C___B______AC00"] is None
+
+    def test_a_monitor_the_corpus_calls_settable_is_not_a_readback(self, tmp_path) -> None:
+        # A corpus asserting the Monitor is driven has drifted; reading it
+        # back would report a demand, not the machine.
+        source = _corpus(tmp_path, _magnet(monitor_predicate="writesSignal"))
+
+        assert _readbacks(source)["SR01C___B______AC00"] is None
+
+    def test_a_directionless_monitor_is_not_a_readback(self, tmp_path) -> None:
+        source = _corpus(tmp_path, _magnet(monitor_predicate=None))
+
+        assert _readbacks(source)["SR01C___B______AC00"] is None
+
+    def test_a_setpoint_claiming_both_directions_states_no_pair(self, tmp_path) -> None:
+        body = (
+            (
+                "<https://narad.example.org/binding/both> "
+                'narad_p:fullPv "SR01C___B______AC00" ;\n'
+                "    narad_p:writesSignal narad_sem:bend_sp ;\n"
+                "    narad_p:readsSignal narad_sem:bend_sp_rb ;\n"
+                '    narad_p:bindingId "narad:binding:als:SR:BEND:0:Setpoint:val" .\n'
+            )
+            + _binding(
+                "mon",
+                "SR01C___B______AM00",
+                "readsSignal",
+                "narad:binding:als:SR:BEND:0:Monitor:val",
+            )
+            + _device("bend", "both", "mon")
+        )
+        source = _corpus(tmp_path, body)
+
+        assert _readbacks(source) == {"SR01C___B______AC00": None, "SR01C___B______AM00": None}
+
+    def test_bindings_no_device_groups_state_no_pair(self, tmp_path) -> None:
+        """Matching field names alone are not a pair: the device is the grouping."""
+        source = _corpus(tmp_path, _magnet(grouped=False))
+
+        assert _readbacks(source)["SR01C___B______AC00"] is None
+
+    def test_bindings_on_different_devices_do_not_pair(self, tmp_path) -> None:
+        body = (
+            _binding(
+                "sp",
+                "SR01C___B______AC00",
+                "writesSignal",
+                "narad:binding:als:SR:BEND:0:Setpoint:val",
+            )
+            + _binding(
+                "mon",
+                "SR02C___B______AM00",
+                "readsSignal",
+                "narad:binding:als:SR:BEND:1:Monitor:val",
+            )
+            + _device("bend0", "sp")
+            + _device("bend1", "mon")
+        )
+        source = _corpus(tmp_path, body)
+
+        assert _readbacks(source)["SR01C___B______AC00"] is None
+
+    def test_a_binding_without_an_id_states_no_field(self, tmp_path) -> None:
+        body = (
+            _binding("sp", "SR01C___B______AC00", "writesSignal")
+            + _binding("mon", "SR01C___B______AM00", "readsSignal")
+            + _device("bend", "sp", "mon")
+        )
+        source = _corpus(tmp_path, body)
+
+        assert _readbacks(source)["SR01C___B______AC00"] is None
+
+    def test_a_binding_id_without_the_value_slot_still_names_its_field(self, tmp_path) -> None:
+        """The demo corpus spells ids without the trailing ``val`` token."""
+        body = (
+            _binding(
+                "sp", "SR01C___B______AC00", "writesSignal", "narad:binding:demo:SR:B:Setpoint"
+            )
+            + _binding(
+                "mon", "SR01C___B______AM00", "readsSignal", "narad:binding:demo:SR:B:Monitor"
+            )
+            + _device("bend", "sp", "mon")
+        )
+        source = _corpus(tmp_path, body)
+
+        assert _readbacks(source)["SR01C___B______AC00"] == "SR01C___B______AM00"
+
+    def test_a_setpoint_and_monitor_sharing_one_address_state_no_pair(self, tmp_path) -> None:
+        source = _corpus(tmp_path, _magnet(monitor="SR01C___B______AC00"))
+
+        assert _readbacks(source) == {"SR01C___B______AC00": None}
+
+    def test_two_devices_stating_different_readbacks_resolve_in_device_order(
+        self, tmp_path
+    ) -> None:
+        """A corpus that says two things picks one deterministically, not by parse order."""
+        body = (
+            _binding(
+                "sp",
+                "SR01C___B______AC00",
+                "writesSignal",
+                "narad:binding:als:SR:BEND:0:Setpoint:val",
+            )
+            + _binding(
+                "mon_z",
+                "SR01C___B______AM99",
+                "readsSignal",
+                "narad:binding:als:SR:BEND:9:Monitor:val",
+            )
+            + _binding(
+                "mon_a",
+                "SR01C___B______AM00",
+                "readsSignal",
+                "narad:binding:als:SR:BEND:0:Monitor:val",
+            )
+            + _device("z_bend", "sp", "mon_z")
+            + _device("a_bend", "sp", "mon_a")
+        )
+        source = _corpus(tmp_path, body)
+
+        assert _readbacks(source)["SR01C___B______AC00"] == "SR01C___B______AM00"
 
 
 class TestDirection:

--- a/tests/channel_roster/test_pairing.py
+++ b/tests/channel_roster/test_pairing.py
@@ -162,3 +162,64 @@ class TestBothSourcesArePairedAlike:
 
     def test_an_empty_roster_pairs_to_an_empty_roster(self) -> None:
         assert assign_readbacks(()) == ()
+
+
+class TestAStatedReadbackSurvives:
+    """The source is the authority; the grammar only fills what it left unpaired."""
+
+    def test_a_readback_the_source_stated_is_kept_over_the_grammar_candidate(
+        self, source: RosterSource
+    ) -> None:
+        # ``X:RB`` is enumerated and readable -- grammar would choose it -- but
+        # the source itself said ``X:MON`` reports this setpoint.
+        stated = ChannelRecord(address="X:SP", source=source, direction="write", readback="X:MON")
+        records = (stated,) + _records(source, ("X:MON", "read"), ("X:RB", "read"))
+
+        assert assign_readbacks(records)[0].readback == "X:MON"
+
+    def test_a_stated_readback_needs_no_grammar_at_all(self, source: RosterSource) -> None:
+        stated = ChannelRecord(
+            address="SR01C___B______AC00",
+            source=source,
+            direction="write",
+            readback="SR01C___B______AM00",
+        )
+        records = (stated,) + _records(source, ("SR01C___B______AM00", "read"))
+
+        assert assign_readbacks(records)[0].readback == "SR01C___B______AM00"
+
+    def test_the_grammar_still_fills_the_records_the_source_left_unpaired(
+        self, source: RosterSource
+    ) -> None:
+        stated = ChannelRecord(address="A:SP", source=source, direction="write", readback="A:MON")
+        records = (stated,) + _records(
+            source, ("A:MON", "read"), ("B:SP", "write"), ("B:RB", "read")
+        )
+
+        paired = assign_readbacks(records)
+
+        assert [record.readback for record in paired] == ["A:MON", None, "B:RB", None]
+
+    def test_a_graph_corpus_pair_survives_the_pass_end_to_end(self, tmp_path: Path) -> None:
+        """What the roster resolver does: read the corpus, then pair the rest."""
+        corpus = tmp_path / "corpus.ttl"
+        corpus.write_text(
+            "@prefix narad_p: <https://narad.example.org/property/> .\n"
+            "@prefix narad_sem: <https://narad.example.org/schema/shared_semantics/> .\n"
+            "<https://narad.example.org/binding/sp> "
+            'narad_p:fullPv "SR01C___B______AC00" ;\n'
+            "    narad_p:writesSignal narad_sem:bend_sp ;\n"
+            '    narad_p:bindingId "narad:binding:als:SR:BEND:0:Setpoint:val" .\n'
+            "<https://narad.example.org/binding/mon> "
+            'narad_p:fullPv "SR01C___B______AM00" ;\n'
+            "    narad_p:readsSignal narad_sem:bend_mon ;\n"
+            '    narad_p:bindingId "narad:binding:als:SR:BEND:0:Monitor:val" .\n'
+            "<https://narad.example.org/device/bend> narad_p:hasBinding "
+            "<https://narad.example.org/binding/sp>, <https://narad.example.org/binding/mon> .\n",
+            encoding="utf-8",
+        )
+        records = read_graph_roster(RosterSource(kind=RosterSourceKind.GRAPH, path=corpus)).records
+
+        paired = {record.address: record.readback for record in assign_readbacks(records)}
+
+        assert paired == {"SR01C___B______AC00": "SR01C___B______AM00", "SR01C___B______AM00": None}

--- a/tests/cli/test_build_va_manifest_honesty.py
+++ b/tests/cli/test_build_va_manifest_honesty.py
@@ -715,8 +715,12 @@ def test_a_graph_mode_repo_deploys_a_va_and_the_fact_names_the_corpus(tmp_path_f
     printed = " ".join(result.output.split())
     assert "knowledge-graph corpus (./data/facility.ttl)" in printed
     assert "3 channel(s)" in printed
-    # The honest cost: no identity keys, so no setpoints and no lattice.
-    assert "serves 0 setpoints" in printed
+    # The honest gain and cost: the one pair the roster vouches for is served
+    # as a setpoint echo, and everything else is static-noisy -- no identity
+    # keys and no lattice.
+    assert "The corpus pairs 1 setpoint(s) with a readback" in printed
+    assert "served as setpoint-echo channels, every other channel as static-noisy" in printed
+    assert "serves 0 setpoints" not in printed
     assert _DEAD_FALLBACK_SENTENCE not in printed
 
     manifest = json.loads((repo / "build" / "data" / "simulation" / MANIFEST_FILENAME).read_text())
@@ -746,8 +750,39 @@ def test_a_graph_manifests_fact_names_the_corpus_not_databases(tmp_path, capsys)
     assert "knowledge-graph corpus (./data/facility.ttl)" in printed
     assert "channel database(s)" not in printed
     assert "Not staged" not in printed
+    assert "The corpus pairs 1 setpoint(s) with a readback" in printed
+    # The pair is a real setpoint, so the all-static-noisy degradation
+    # sentence would be false here and is not printed over it.
+    assert "carries no hierarchy identity keys" not in printed
+    assert "serves 0 setpoints" not in printed
+
+
+def test_a_graph_corpus_pairing_nothing_still_states_the_cost(tmp_path, capsys):
+    """A corpus whose device grouping states no pair gets the degradation sentence.
+
+    The claim is read off the manifest's census, not the source: with no
+    setpoint served, saying so is the honest fact, and the pairing sentence
+    (which would read ``pairs 0 setpoint(s)``) is not printed at all.
+    """
+    corpus = (
+        "@prefix narad_p: <https://narad.example.org/property/> .\n"
+        "@prefix narad_sem: <https://narad.example.org/schema/shared_semantics/> .\n"
+        '<https://narad.example.org/binding/dcct> narad_p:fullPv "SR01C___T______AM00" ;\n'
+        "    narad_p:readsSignal narad_sem:dcct_signal .\n"
+        '<https://narad.example.org/binding/bend_sp> narad_p:fullPv "SR01C___B______AC00" ;\n'
+        "    narad_p:writesSignal narad_sem:bend_signal .\n"
+    )
+    root = _graph_repo(tmp_path / "repo", corpus=corpus)
+    prepared = prepare_project_manifest(root / "data", DEFAULT_TIER, config=_graph_config(root))
+
+    _report(_shared(tmp_path), _profile(data="data"), root / "data", prepared)
+
+    printed = _printed(capsys)
+    assert "2 channel(s)" in printed
     assert "The knowledge graph carries no hierarchy identity keys" in printed
     assert "serves 0 setpoints" in printed
+    assert "The corpus pairs" not in printed
+    assert prepared.manifest["_metadata"]["setpoint_count"] == 0
 
 
 def test_a_graph_repo_with_an_unreadable_corpus_refuses_naming_it(tmp_path):

--- a/tests/va/test_build_time_manifest.py
+++ b/tests/va/test_build_time_manifest.py
@@ -568,23 +568,33 @@ class TestGraphSourcedManifest:
     def test_census_is_honest_about_what_the_graph_cannot_say(self, tmp_path):
         """No hierarchy identity keys are invented, so nothing is pyat-coupled.
 
-        The corpus states membership and direction, not the hierarchy path the
-        identity keys are read from. Every entry lands pathless in the
-        static-noisy partition -- exactly what a database tree without its
-        hierarchical paradigm gets -- and the setpoint census says 0 rather
-        than guessing from address grammar.
+        The corpus states membership, direction and -- for the one pair the
+        roster vouches for, ``HCM:01:CURRENT:SP``/``:RB`` -- a readback, but
+        not the hierarchy path the identity keys are read from. The pair is
+        served as setpoint-echo, keyed on nothing but itself; every other
+        entry lands pathless in the static-noisy partition -- exactly what a
+        database tree without its hierarchical paradigm gets -- and the
+        setpoint census counts the pair rather than guessing further.
         """
         root, config = _graph_tree(tmp_path / "data")
 
         prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
 
         metadata = prepared.manifest["_metadata"]
-        assert metadata["by_partition"] == {classify.PARTITION_STATIC_NOISY: 5}
-        assert metadata["setpoint_count"] == 0
+        assert metadata["by_partition"] == {
+            classify.PARTITION_SP_ECHO: 2,
+            classify.PARTITION_STATIC_NOISY: 3,
+        }
+        assert metadata["setpoint_count"] == 1
         for channel in prepared.manifest["channels"]:
-            assert channel["partition"] == classify.PARTITION_STATIC_NOISY
-            for key in ("ring", "system", "family", "device", "field", "subfield"):
+            for key in ("ring", "system", "family", "field"):
                 assert channel[key] == ""
+            if channel["partition"] == classify.PARTITION_STATIC_NOISY:
+                assert channel["device"] == "" and channel["subfield"] == ""
+            else:
+                assert channel["partition"] == classify.PARTITION_SP_ECHO
+                assert channel["device"] == "SR:MAG:HCM:01:CURRENT:SP"
+                assert channel["subfield"] == ("SP" if channel["address"].endswith(":SP") else "RB")
 
     def test_duplicate_addresses_in_the_corpus_collapse_to_one_channel(self, tmp_path):
         """The manifest is a namespace: two bindings sharing one fullPv are one channel."""
@@ -640,6 +650,161 @@ class TestGraphSourcedManifest:
         assert prepare_project_manifest(root, DEFAULT_TIER, config=config) is None
         reason = manifest_gap_reason(root, DEFAULT_TIER, config=config)
         assert "no channel database is staged" in reason
+
+
+def _device(name: str, *bindings: str) -> str:
+    """Render one corpus device grouping the named bindings."""
+    objects = ", ".join(f"<https://narad.example.org/binding/{b}>" for b in bindings)
+    return f"<https://narad.example.org/device/{name}> narad_p:hasBinding {objects} .\n"
+
+
+def _bound(name: str, address: str, predicate: str, field: str, device: str = "BEND:0") -> str:
+    """A binding carrying the ``bindingId`` whose field token the device grouping pairs on."""
+    return (
+        f'<https://narad.example.org/binding/{name}> narad_p:fullPv "{address}" ;\n'
+        f"    narad_p:{predicate} narad_sem:{name}_signal ;\n"
+        f'    narad_p:bindingId "narad:binding:als:SR:{device}:{field}:val" .\n'
+    )
+
+
+#: A facility whose addresses carry no ``:SP``/``:RB`` grammar at all: the one
+#: pair here is stated by the corpus's device grouping, and the two leftover
+#: channels (a golden setpoint nobody reports, a beam-current monitor) are not.
+_STATED_PAIR_CORPUS = _TTL_PREAMBLE + "".join(
+    (
+        _bound("bend_sp", "SR01C___B______AC00", "writesSignal", "Setpoint"),
+        _bound("bend_mon", "SR01C___B______AM00", "readsSignal", "Monitor"),
+        _bound("bend_golden", "SR01C:BEND:Setpoint:Golden", "writesSignal", "SetpointGolden"),
+        _device("bend", "bend_sp", "bend_mon", "bend_golden"),
+        _bound("dcct", "SR01C___T______AM00", "readsSignal", "Monitor", device="DCCT:0"),
+        _device("dcct", "dcct"),
+    )
+)
+
+
+class TestGraphStatedPairs:
+    """A pair the corpus states is served as a setpoint-echo pair, nothing more invented."""
+
+    def test_a_stated_pair_becomes_an_sp_echo_pair_keyed_on_the_setpoint(self, tmp_path):
+        root, config = _graph_tree(tmp_path / "data", corpus=_STATED_PAIR_CORPUS)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        by_address = {c["address"]: c for c in prepared.manifest["channels"]}
+        setpoint = by_address["SR01C___B______AC00"]
+        readback = by_address["SR01C___B______AM00"]
+        assert setpoint["partition"] == readback["partition"] == classify.PARTITION_SP_ECHO
+        assert setpoint["subfield"] == "SP"
+        assert readback["subfield"] == "RB"
+        # The pair shares exactly one identity key -- the setpoint's own
+        # address -- and the other four stay as empty as on a pathless entry:
+        # the graph states no hierarchy path, and none is invented.
+        for channel in (setpoint, readback):
+            assert channel["device"] == "SR01C___B______AC00"
+            assert [channel[key] for key in ("ring", "system", "family", "field")] == [
+                "",
+                "",
+                "",
+                "",
+            ]
+        assert setpoint["record_type"] == readback["record_type"] == classify.RECORD_TYPE_ANALOG
+        assert setpoint["noise"] is False and readback["noise"] is False
+
+    def test_everything_the_corpus_leaves_unpaired_stays_pathless_static_noisy(self, tmp_path):
+        root, config = _graph_tree(tmp_path / "data", corpus=_STATED_PAIR_CORPUS)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        by_address = {c["address"]: c for c in prepared.manifest["channels"]}
+        for address in ("SR01C:BEND:Setpoint:Golden", "SR01C___T______AM00"):
+            channel = by_address[address]
+            assert channel["partition"] == classify.PARTITION_STATIC_NOISY
+            for key in ("ring", "system", "family", "device", "field", "subfield"):
+                assert channel[key] == ""
+        metadata = prepared.manifest["_metadata"]
+        assert metadata["by_partition"] == {
+            classify.PARTITION_SP_ECHO: 2,
+            classify.PARTITION_STATIC_NOISY: 2,
+        }
+        assert metadata["setpoint_count"] == 1
+        assert metadata["total_channels"] == 4
+
+    def test_the_written_manifest_loads_and_the_container_pairs_the_echo(self, tmp_path):
+        """The shape the IOC reads: through the file loader, then the pvdb pairing.
+
+        ``build_serving_pvdb`` is what pairs the two halves on their identity
+        keys, and it is the one consumer that refuses an echo setpoint with
+        nothing to echo into -- so it is the contract this manifest has to
+        satisfy, proven here on the build host rather than at container boot.
+        """
+        from osprey.services.virtual_accelerator.serving.pvdb import build_serving_pvdb
+
+        root, config = _graph_tree(tmp_path / "data", corpus=_STATED_PAIR_CORPUS)
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+        project_data = tmp_path / "project" / "data"
+        project_data.mkdir(parents=True)
+
+        manifest_path = write_project_manifest(prepared, project_data)
+
+        channels = loaders.load_manifest_file(manifest_path)
+        assert len(channels) == 4
+        records = build_serving_pvdb(channels)
+        assert records.setpoint_readbacks == {"SR01C___B______AC00": "SR01C___B______AM00"}
+        assert set(records.static_noisy) == {"SR01C:BEND:Setpoint:Golden", "SR01C___T______AM00"}
+
+    def test_a_readback_two_setpoints_claim_pairs_with_neither(self, tmp_path):
+        """An ambiguous pair is served static-noisy on both sides, never half an echo."""
+        from osprey.services.virtual_accelerator.serving.pvdb import build_serving_pvdb
+
+        corpus = _TTL_PREAMBLE + "".join(
+            (
+                _bound("sp_a", "SR01C___B______AC00", "writesSignal", "Setpoint"),
+                _bound("sp_b", "SR01C___B______AC01", "writesSignal", "Setpoint", device="BEND:1"),
+                _bound("mon", "SR01C___B______AM00", "readsSignal", "Monitor"),
+                _device("bend0", "sp_a", "mon"),
+                _bound("mon_dup", "SR01C___B______AM00", "readsSignal", "Monitor", device="BEND:1"),
+                _device("bend1", "sp_b", "mon_dup"),
+            )
+        )
+        root, config = _graph_tree(tmp_path / "data", corpus=corpus)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        metadata = prepared.manifest["_metadata"]
+        assert metadata["by_partition"] == {classify.PARTITION_STATIC_NOISY: 3}
+        assert metadata["setpoint_count"] == 0
+        # And the IOC's contract holds on it: no echo setpoint left without a readback.
+        assert build_serving_pvdb(prepared.manifest["channels"]).setpoint_readbacks == {}
+
+    def test_a_readback_that_is_itself_a_setpoint_pairs_with_nothing(self, tmp_path):
+        """A chain ``A -> B -> C`` states no clean pair; both links are dropped."""
+        corpus = _TTL_PREAMBLE + "".join(
+            (
+                _bound("a", "SR:A", "writesSignal", "Setpoint"),
+                _bound("b_mon", "SR:B", "readsSignal", "Monitor"),
+                _device("dev_ab", "a", "b_mon"),
+                _bound("b_sp", "SR:B", "writesSignal", "Setpoint", device="BEND:1"),
+                _bound("c", "SR:C", "readsSignal", "Monitor", device="BEND:1"),
+                _device("dev_bc", "b_sp", "c"),
+            )
+        )
+        root, config = _graph_tree(tmp_path / "data", corpus=corpus)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        metadata = prepared.manifest["_metadata"]
+        assert metadata["by_partition"] == {classify.PARTITION_STATIC_NOISY: 3}
+        assert metadata["setpoint_count"] == 0
+
+    def test_a_readback_is_emitted_once_beside_its_setpoint(self, tmp_path):
+        """The manifest is a namespace: the readback half is one channel, not two."""
+        root, config = _graph_tree(tmp_path / "data", corpus=_STATED_PAIR_CORPUS)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        addresses = [c["address"] for c in prepared.manifest["channels"]]
+        assert addresses == sorted(addresses)
+        assert len(set(addresses)) == len(addresses) == 4
 
 
 class TestStagedDatabasesWinOverTheGraph:


### PR DESCRIPTION
## What

A graph-mode facility whose addresses carry no `:SP`/`:RB` grammar (ALS: `SR01C___B______AC00` / `AM00`) had every settable channel come out of the roster unpaired, and #814's graph-sourced VA manifest served all of them static-noisy, so a plan driving a setpoint on the VA could never observe its own write.

- **`channel_roster/graph.py`** — the reader states each setpoint's readback from the corpus's own device grouping: a device (`narad_p:hasBinding`) carrying a write binding whose `bindingId` field is `<stem>Setpoint` and a read binding whose field is `<stem>Monitor` (the NARAD vocabulary the seeder already reads). Both halves are checked against the corpus's declared directions; a binding without a device, an id or an address states no pair; two devices disagreeing resolve in sorted device order.
- **`channel_roster/pairing.py`** — the grammar pass keeps a readback the source stated and only fills the rest.
- **`virtual_accelerator/manifest/build.py`** — every stated pair becomes a **setpoint-echo pair** keyed on the setpoint's own address in `device`, other identity keys empty (what `serving/pvdb._channel_key` pairs on). Everything else stays pathless static-noisy; an ambiguous pair (readback claimed twice, a chain of setpoints) is dropped to static-noisy on both sides rather than served as half an echo.
- **`cli/build_cmd.py`** — the manifest fact adds "The corpus pairs N setpoint(s) with a readback; those are served as setpoint-echo channels, every other channel as static-noisy." A corpus pairing nothing still gets the "serves 0 setpoints" sentence.

Against the ALS corpus: 857 write `…Setpoint` bindings, 810 paired with a read `…Monitor` on the same device (insertion-device gaps included); the 47 unpaired stems are Voltage/Phase/plain setpoints the corpus reports nothing for.

## Tests

- `tests/channel_roster/test_graph.py` — the device grouping on facility-shaped addresses, stemmed fields (`GapSetpoint`/`GapMonitor`), and every way a corpus fails to state a pair (no Monitor, a Monitor called settable, directionless, both-directions setpoint, no device, different devices, no id, shared address, disagreeing devices). The demo corpus still yields unpaired records.
- `tests/channel_roster/test_pairing.py` — a stated readback survives the grammar pass, the grammar still fills the rest, end to end through `read_graph_roster`.
- `tests/va/test_build_time_manifest.py` — a stated pair renders as an sp-echo pair sharing one `device` key, loads through `loaders.load_manifest_file`, and `build_serving_pvdb` pairs it; ambiguous pairs and chains fall back to static-noisy and satisfy the pvdb contract.
- `tests/cli/test_build_va_manifest_honesty.py` — the new fact sentence, and the degradation sentence for a corpus that pairs nothing.

Changelog: `graph-va-setpoint-echo.added.md`, `graph-roster-readbacks.changed.md`.
