### PR TITLE
fix(va): authored data/simulation/channel_manifest.json outranks graph derivation

### DIFF
--- a/changelog.d/834.fixed.md
+++ b/changelog.d/834.fixed.md
@@ -1,0 +1,8 @@
+A project that stages its own `data/simulation/channel_manifest.json` — a path
+the profile conventions reserve for it — now has that manifest served as
+staged, instead of being ignored in favour of a manifest derived from the
+knowledge-graph corpus. The `channel_limits.json` beside it is what lands in the
+render, where before the project's live `data/channel_limits.json` was copied
+over it. The source precedence is staged paradigm databases, then the authored
+manifest, then graph derivation, and a build refusing on a tree that stages none
+of them now names the reserved path as one of the ways out.

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1424,6 +1424,30 @@ def _named_in_prose(names: Sequence[str]) -> str:
     return f"{', '.join(names[:-1])} and {names[-1]}"
 
 
+def _authored_manifest_fact(prepared: Any, data_root: Path) -> str:
+    """The fact for a channel set the project staged rather than derived.
+
+    Same register as the corpus-derivation fact -- what the accelerator will
+    serve, and the file it came from, named as an operator would retype it --
+    with the one thing that differs said outright: nothing here was derived, so
+    none of the derivation's degradations apply and none of its census can be
+    quoted. An authored manifest's ``_metadata`` is the facility's own, so only
+    what every manifest must carry is read off it.
+
+    The limits are named because they are the second half of what an authored
+    manifest changes: they come from beside it, not from the project's live
+    ``channel_limits.json``.
+    """
+    manifest_name = prepared.manifest_path.relative_to(data_root)
+    limits_name = prepared.limits_source.relative_to(data_root)
+    return (
+        f"Virtual-accelerator channel set taken from the manifest this project stages "
+        f"({manifest_name}): {prepared.channel_count} channel(s), served exactly as "
+        f"staged. Nothing is derived from the rest of the data tree, and the drive "
+        f"limits beside it ({limits_name}) are what the accelerator enforces."
+    )
+
+
 def _report_va_manifest_outcome(
     shared: _SharedRenderInputs,
     build_profile: Any,
@@ -1449,6 +1473,10 @@ def _report_va_manifest_outcome(
     (which the tree did not stage, and which it staged but could not read), and
     how the machine-state list reconciled against it.
 
+    A manifest the project STAGED gets one fact instead, naming the file (see
+    :func:`_authored_manifest_fact`): nothing was derived from the tree, so
+    there is no source census to publish and nothing was reconciled against it.
+
     Args:
         shared: The build's shared render inputs, holding what has been said.
         build_profile: The profile this render came from.
@@ -1464,7 +1492,10 @@ def _report_va_manifest_outcome(
         BuildProfileError: when a deployed virtual accelerator has no channels
             of the project's to serve.
     """
-    from osprey.services.virtual_accelerator.manifest.build import manifest_gap_reason
+    from osprey.services.virtual_accelerator.manifest.build import (
+        ManifestSource,
+        manifest_gap_reason,
+    )
 
     if not build_profile.deploy_services or build_profile.virtual_accelerator is None:
         return
@@ -1494,6 +1525,9 @@ def _report_va_manifest_outcome(
         )
 
     shared.va_reported.add(key)
+    if prepared.source is ManifestSource.AUTHORED:
+        _report_fact(_authored_manifest_fact(prepared, data_root))
+        return
     metadata = prepared.manifest["_metadata"]
     corpus = metadata.get("source_corpus")
     absent = metadata["absent_paradigms"]
@@ -1640,6 +1674,7 @@ def _render_project(
     from osprey.build.claude_code_resolver import load_provider_spec
     from osprey.deployment.reach import reach_errors
     from osprey.services.virtual_accelerator.manifest.build import (
+        ManifestSource,
         prepare_project_manifest,
         write_project_manifest,
     )
@@ -1910,9 +1945,13 @@ def _render_project(
 
     if prepared_va_manifest is not None:
         write_project_manifest(prepared_va_manifest, render_dir / "data")
+        # An authored manifest is copied, not generated, and the step says which
+        # it did: a facility reading "generated" over its own file would have
+        # every reason to think the build had replaced it.
         progress(
-            "  ✓ Generated virtual-accelerator channel manifest (%d channels)",
-            prepared_va_manifest.manifest["_metadata"]["total_channels"],
+            "  ✓ %s virtual-accelerator channel manifest (%d channels)",
+            "Staged" if prepared_va_manifest.source is ManifestSource.AUTHORED else "Generated",
+            prepared_va_manifest.channel_count,
         )
 
     # The limits database is read here and not in the `unrunnable` gate above,

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2607,30 +2607,36 @@ _VA_LATTICE_NONE = "none"
 
 
 def _manifest_has_lattice_channels(manifest_path: Path) -> bool:
-    """Whether a generated manifest carries channels the built-in lattice moves.
+    """Whether the written manifest carries channels the built-in lattice moves.
 
     The PyAT model behind ``VA_LATTICE=builtin`` acts on the ``pyat-coupled``
-    partition and nothing else, so its presence in the manifest's own partition
-    census is the whole question. Read from the written file rather than passed
-    down from the render: this runs after the swap, on the tree that was
-    actually published, which is the manifest the container will mount.
+    partition and nothing else, so whether any channel sits in it is the whole
+    question. Answered off the channel list itself -- the one part of the
+    schema every manifest has, authored or generated -- rather than off a
+    ``_metadata`` census a facility-authored file need not carry. Read from
+    the written file rather than passed down from the render: this runs after
+    the swap, on the tree that was actually published, which is the manifest
+    the container will mount.
 
     Args:
-        manifest_path: The generated ``channel_manifest.json`` in the output zone.
+        manifest_path: The ``channel_manifest.json`` in the output zone.
 
     Returns:
         True when the manifest declares at least one pyat-coupled channel. False
         when it declares none, and also when the file cannot be read as the
         expected shape: a lattice is the claim that needs evidence, so an
-        unreadable census answers no rather than guessing yes.
+        unreadable manifest answers no rather than guessing yes.
     """
     from osprey.services.virtual_accelerator.manifest.classify import PARTITION_PYAT_COUPLED
 
     try:
-        census = json.loads(manifest_path.read_text())["_metadata"]["by_partition"]
+        channels = json.loads(manifest_path.read_text())["channels"]
+        return any(
+            isinstance(channel, dict) and channel.get("partition") == PARTITION_PYAT_COUPLED
+            for channel in channels
+        )
     except (json.JSONDecodeError, KeyError, OSError, TypeError):
         return False
-    return bool(census.get(PARTITION_PYAT_COUPLED))
 
 
 def _wire_build_derived_env(repo_root: Path, build_dir: Path) -> None:

--- a/src/osprey/services/virtual_accelerator/manifest/build.py
+++ b/src/osprey/services/virtual_accelerator/manifest/build.py
@@ -18,8 +18,15 @@ A graph-mode project stages no paradigm database at all -- its channels live in
 the knowledge-graph corpus the deploy seeds the graph store from. For such a
 tree the manifest's channel set is derived from the channel roster's graph
 reader (:func:`osprey.channel_roster.registered_channels`, the one membership
-authority), and ``_metadata`` names the corpus as the source. Staged paradigm
-databases always win: the graph is consulted only when the tree stages none.
+authority), and ``_metadata`` names the corpus as the source.
+
+A project may also AUTHOR its manifest outright, at the
+``data/simulation/channel_manifest.json`` the framework reserves for it, and
+then no derivation happens at all: the file is the answer, and the
+``channel_limits.json`` beside it is what bounds the accelerator. So the source
+precedence is staged paradigm databases, then the authored manifest, then the
+graph -- most specific first, and each one only consulted when nothing above it
+is staged.
 
 Run as a script to (re)generate ``channel_manifest.json``::
 
@@ -32,21 +39,39 @@ import json
 import logging
 import shutil
 from dataclasses import asdict, dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from osprey.errors import BuildProfileError
 
 from . import classify, loaders
-from .paths import MANIFEST_OUTPUT, PACKAGE_PATHS, ManifestPaths
+from .paths import (
+    LIMITS_FILENAME,
+    MANIFEST_FILENAME,
+    MANIFEST_OUTPUT,
+    PACKAGE_PATHS,
+    ManifestPaths,
+)
 
 logger = logging.getLogger(__name__)
 
-# Filenames the virtual-accelerator container looks for under its
-# ``/data/simulation`` mount: ``VA_CHANNELS_FILE`` resolves relative names
-# against the data dir, and drive limits are read from ``channel_limits.json``
-# beside it (see services/virtual_accelerator/entrypoint.py).
-MANIFEST_FILENAME = "channel_manifest.json"
-LIMITS_FILENAME = "channel_limits.json"
+
+class ManifestSource(StrEnum):
+    """Where a prepared manifest came from.
+
+    Carried on the prepared manifest rather than re-derived from its
+    ``_metadata``, because the two consumers that branch on it -- the writer
+    and the build's fact -- must agree with the selection that actually
+    happened, and an AUTHORED manifest's metadata is the facility's to write
+    (it may say anything, or nothing at all).
+    """
+
+    #: Expanded from the paradigm channel databases the tree stages.
+    PARADIGM = "paradigm"
+    #: Read verbatim from the profile's own ``data/simulation/`` manifest.
+    AUTHORED = "authored"
+    #: Derived from the project's knowledge-graph corpus.
+    GRAPH = "graph"
 
 
 @dataclass(frozen=True)
@@ -563,7 +588,9 @@ def _prepare_graph_manifest(roster, paths: ManifestPaths) -> PreparedManifest | 
             f"data tree {paths.data_root}: {detail}. Repair the file."
         ) from exc
 
-    return PreparedManifest(manifest=manifest, limits_source=paths.channel_limits)
+    return PreparedManifest(
+        manifest=manifest, limits_source=paths.channel_limits, source=ManifestSource.GRAPH
+    )
 
 
 @dataclass(frozen=True)
@@ -572,13 +599,159 @@ class PreparedManifest:
 
     Holding the built manifest (rather than re-deriving it at write time) is
     what makes the build step atomic: every way generation can fail -- absent
-    sources, disagreeing paradigm DBs -- has already happened by the time a
-    caller holds one of these, so the decision to wire ``VA_CHANNELS_FILE``
-    into the project's ``.env`` can be made before anything is written.
+    sources, disagreeing paradigm DBs, an unreadable authored file -- has
+    already happened by the time a caller holds one of these, so the decision
+    to wire ``VA_CHANNELS_FILE`` into the project's ``.env`` can be made before
+    anything is written.
+
+    Attributes:
+        manifest: The manifest document, parsed.
+        limits_source: The drive limits that ship beside it.
+        source: Which of the three sources answered. The writer and the build's
+            fact branch on this rather than on the manifest's ``_metadata``,
+            which an authored manifest owns.
+        manifest_path: The staged file the manifest was read from, for an
+            authored one; ``None`` for a derived manifest, which exists only in
+            memory until it is written.
     """
 
     manifest: dict
     limits_source: Path
+    source: ManifestSource = ManifestSource.PARADIGM
+    manifest_path: Path | None = None
+
+    @property
+    def channel_count(self) -> int:
+        """How many channels the accelerator will serve.
+
+        Read from ``_metadata`` when it states a count and from the channel
+        list otherwise: a derived manifest always carries the census this
+        package writes, while an authored one carries whatever its facility's
+        generator wrote -- possibly no ``_metadata`` at all. The channels
+        themselves are the one part every manifest must have.
+        """
+        metadata = self.manifest.get("_metadata") or {}
+        total = metadata.get("total_channels")
+        if isinstance(total, int):
+            return total
+        return len(self.manifest.get("channels", []))
+
+
+def _authored_limits_source(paths: ManifestPaths) -> Path | None:
+    """The drive limits an authored manifest is served under, or ``None``.
+
+    Beside the manifest first -- a facility that writes its own simulation
+    channel set writes the bounds for it in the same directory, and those are
+    the ones the accelerator has to enforce. The tree-wide
+    ``channel_limits.json`` is the fallback, so authoring a manifest without a
+    limits file beside it still lands the project's limits in the render rather
+    than none at all. ``None`` means the tree has neither, which is the silent
+    unbounded-setpoint state every source path here refuses.
+    """
+    if paths.authored_limits.is_file():
+        return paths.authored_limits
+    if paths.channel_limits.is_file():
+        return paths.channel_limits
+    return None
+
+
+def _read_authored_manifest(path: Path, data_root: Path) -> dict:
+    """Read and check the manifest a profile staged, or refuse by name.
+
+    Checked through :func:`loaders.load_manifest_file` -- the exact reader the
+    container boots on -- so a file that would kill the accelerator at start is
+    caught at build time instead, and by the same rules rather than by a second
+    opinion written here. That reader takes a path and returns the channel
+    list, so the document itself is read a second time; one extra parse of a
+    file this build is about to copy anyway is cheaper than keeping a private
+    copy of the schema in sync with the one the container enforces.
+
+    A staged file that cannot be served is a REFUSAL, never a fall-through to
+    derivation: deriving past it would quietly replace the facility's own
+    channel set with one this package reconstructed, which is precisely what
+    staging the file said not to do.
+
+    Raises:
+        BuildProfileError: if the file is not readable as a manifest, or reads
+            as one that declares no channels.
+    """
+    relative = path.relative_to(data_root)
+    remedy = (
+        "Repair the file, or remove it so the manifest is derived from the rest of the data tree."
+    )
+    try:
+        channels = loaders.load_manifest_file(path)
+    except loaders.ManifestFileError as exc:
+        raise BuildProfileError(
+            f"the virtual-accelerator channel manifest this project stages at "
+            f"{relative} could not be read: {exc}. {remedy}"
+        ) from exc
+    if not channels:
+        raise BuildProfileError(
+            f"the virtual-accelerator channel manifest this project stages at "
+            f"{relative} declares no channels, so the accelerator has nothing of "
+            f"the project's to serve. {remedy}"
+        )
+    document: dict = json.loads(path.read_text())
+    return document
+
+
+def _prepare_authored_manifest(paths: ManifestPaths) -> PreparedManifest | None:
+    """Take the manifest the project staged, as staged.
+
+    ``data/simulation/channel_manifest.json`` is a path the framework reserves
+    for the profile, so a tree carrying one has already answered the question
+    this module otherwise derives an answer to -- and it can answer it with
+    things no derivation here can reconstruct: identity keys, setpoint/readback
+    pairing, partitions a facility's own lattice knowledge assigned. Nothing is
+    merged into it and nothing is recomputed from it: the file is the manifest.
+
+    Returns:
+        The prepared manifest, or ``None`` when the tree stages no authored
+        manifest at all, or stages one with no drive limits anywhere to serve it
+        under. :func:`manifest_gap_reason` renders which.
+
+    Raises:
+        BuildProfileError: if the staged manifest is present and cannot be read
+            as one.
+    """
+    manifest_path = paths.authored_manifest
+    if not manifest_path.is_file():
+        return None
+
+    manifest = _read_authored_manifest(manifest_path, paths.data_root)
+
+    limits_source = _authored_limits_source(paths)
+    if limits_source is None:
+        logger.debug(
+            "Virtual-accelerator manifest staged at %s not used: neither %s nor %s "
+            "is present, and drive limits ship beside a manifest or the accelerator "
+            "enforces none",
+            manifest_path,
+            paths.authored_limits,
+            paths.channel_limits,
+        )
+        return None
+
+    return PreparedManifest(
+        manifest=manifest,
+        limits_source=limits_source,
+        source=ManifestSource.AUTHORED,
+        manifest_path=manifest_path,
+    )
+
+
+def _authored_alternative(paths: ManifestPaths) -> str:
+    """The clause naming the reserved path a tree could satisfy the build with.
+
+    Appended to every refusal raised by a tree that stages no paradigm
+    database, because for such a tree an authored manifest is the second way
+    out and an operator reading only the first would never learn it exists.
+    """
+    return (
+        f"; no manifest is staged at {paths.authored_manifest.relative_to(paths.data_root)} "
+        f"either, which is the other way to give this accelerator a channel set"
+    )
 
 
 def prepare_project_manifest(
@@ -594,12 +767,20 @@ def prepare_project_manifest(
     the framework's built-in demo namespace.
 
     A tree that stages no paradigm database is not always a tree with no
-    channels: a graph-mode project's channels live in its knowledge-graph
-    corpus. When *config* is given and resolves the project's roster source to
-    the graph, such a tree gets its manifest from the roster's graph reader
-    instead (see :func:`_prepare_graph_manifest`). Staged paradigm databases
-    always win over the graph, exactly as before; a ``config`` of ``None``
-    keeps every existing caller on the paradigm-database rules alone.
+    channels, so two more sources are consulted in order, most specific first:
+
+    1. an AUTHORED ``data/simulation/channel_manifest.json`` -- a path the
+       framework reserves for the profile -- taken as-is, with the
+       ``channel_limits.json`` beside it as its limits (see
+       :func:`_prepare_authored_manifest`);
+    2. a graph-mode project's knowledge-graph corpus, when *config* is given
+       and resolves the project's roster source to the graph (see
+       :func:`_prepare_graph_manifest`).
+
+    Staged paradigm databases always win over both, exactly as before. A
+    ``config`` of ``None`` keeps every existing caller off the graph source; it
+    does NOT hide an authored manifest, which is read off the tree and depends
+    on no rendered configuration to be found.
 
     Args:
         data_root: The ``data/`` tree this build is sourcing from -- the
@@ -611,12 +792,12 @@ def prepare_project_manifest(
 
     Returns:
         The prepared manifest, or ``None`` when this tree cannot back one: it
-        stages no paradigm database at this tier, the databases it stages name
-        no channel, every one of them is present and unreadable, it is missing
-        the scenario seed, the machine-state list or the drive limits, or the
-        databases it does stage disagree. :func:`manifest_gap_reason` says
-        which, in the words the refusal is written in. A caller deploying a
-        virtual accelerator MUST refuse on ``None`` rather than continue.
+        stages no channel source at all at this tier, the databases it stages
+        name no channel, every one of them is present and unreadable, it is
+        missing the scenario seed, the machine-state list or the drive limits,
+        or the databases it does stage disagree. :func:`manifest_gap_reason`
+        says which, in the words the refusal is written in. A caller deploying
+        a virtual accelerator MUST refuse on ``None`` rather than continue.
 
         SOME of the staged databases being corrupt is not one of those cases:
         the manifest is built from the ones that are left, and ``_metadata``
@@ -626,21 +807,26 @@ def prepare_project_manifest(
     Raises:
         BuildProfileError: if the scenario seed or the machine-state list --
             the sources a tree carries one of, rather than one per paradigm --
-            cannot be read. There is nothing left to build from when either is
-            broken, and reading past it would quietly serve a different channel
-            set than the operator believes they are driving.
+            cannot be read, or if an authored manifest is staged and cannot be
+            read as one. There is nothing left to build from when any of them
+            is broken, and reading past it would quietly serve a different
+            channel set than the operator believes they are driving.
     """
     paths = ManifestPaths(data_root=data_root, tier=tier)
     if not paths.staged_paradigms:
+        authored = _prepare_authored_manifest(paths)
+        if authored is not None:
+            return authored
         if config is not None:
             roster = _graph_roster(config)
             if roster is not None:
                 return _prepare_graph_manifest(roster, paths)
         logger.debug(
             "Virtual-accelerator manifest not generated from %s: %s stages no "
-            "paradigm channel database",
+            "paradigm channel database and no manifest is staged at %s",
             data_root,
             paths.tier_dir,
+            paths.authored_manifest,
         )
         return None
 
@@ -709,7 +895,9 @@ def prepare_project_manifest(
         )
         return None
 
-    return PreparedManifest(manifest=manifest, limits_source=paths.channel_limits)
+    return PreparedManifest(
+        manifest=manifest, limits_source=paths.channel_limits, source=ManifestSource.PARADIGM
+    )
 
 
 def _staged_expansion_is_empty(paths: ManifestPaths, expansion: ParadigmExpansion) -> bool:
@@ -754,23 +942,33 @@ def manifest_gap_reason(data_root: Path, tier: int, *, config: dict | None = Non
         different work. A graph-mode tree gets the roster's own absence
         sentence -- the corpus named, with why it yielded nothing -- never the
         absent-paradigms wording, which would send its operator staging
-        database files graph mode does not use.
+        database files graph mode does not use. Every reason a tree staging no
+        database gets also names the reserved manifest path, because staging
+        one there is the other way to satisfy the build.
     """
     paths = ManifestPaths(data_root=data_root, tier=tier)
     if not paths.staged_paradigms:
+        if paths.authored_manifest.is_file():
+            # It is staged and readable -- otherwise the preparation raised
+            # rather than answering None -- so the drive limits are what is
+            # left to be missing.
+            return "missing " + str(paths.authored_limits.relative_to(data_root))
         if config is not None:
             roster = _graph_roster(config)
             if roster is not None:
                 if roster.absence is not None:
-                    return roster.absence.message().rstrip(".")
+                    return roster.absence.message().rstrip(".") + _authored_alternative(paths)
                 missing = _graph_missing_sources(paths)
                 if missing:
-                    return "missing " + ", ".join(
-                        str(path.relative_to(data_root)) for path in missing
+                    return (
+                        "missing "
+                        + ", ".join(str(path.relative_to(data_root)) for path in missing)
+                        + _authored_alternative(paths)
                     )
         return (
             f"no channel database is staged at tier {tier} "
             f"({', '.join(sorted(paths.absent_paradigms))} are all absent)"
+            + _authored_alternative(paths)
         )
     missing = paths.missing_sources()
     if not paths.channel_limits.is_file():
@@ -825,6 +1023,19 @@ def _first_unreadable_source(paths: ManifestPaths) -> Path | None:
     return None
 
 
+def _copy_unless_same_file(source: Path, destination: Path) -> None:
+    """Copy *source* onto *destination*, unless they are already one file.
+
+    A build whose output zone IS the tree the manifest was read from -- the
+    project's own ``data/`` -- would otherwise hand :func:`shutil.copy2` a file
+    and itself, which raises. Nothing to do is the right answer there: the
+    bytes are already where they are wanted.
+    """
+    if destination.exists() and destination.samefile(source):
+        return
+    shutil.copy2(source, destination)
+
+
 def write_project_manifest(prepared: PreparedManifest, project_data_dir: Path) -> Path:
     """Write a prepared manifest and its drive limits into ``data/simulation/``.
 
@@ -834,23 +1045,37 @@ def write_project_manifest(prepared: PreparedManifest, project_data_dir: Path) -
     from beside it. The limits file is copied rather than bind-mounted
     single-file, which fails at container init.
 
-    The limits copy is taken from the built project when it has one (so any
-    facility overlay applied to ``data/channel_limits.json`` is what the VA
-    enforces), falling back to the source tree the manifest was prepared
-    from.
+    For a DERIVED manifest the limits copy is taken from the built project when
+    it has one (so any facility overlay applied to ``data/channel_limits.json``
+    is what the VA enforces), falling back to the source tree the manifest was
+    prepared from.
+
+    An AUTHORED manifest is exempt from that rule, in both halves. Its bytes
+    are copied rather than re-serialized, so what the accelerator serves is the
+    file the facility staged and reviewed; and its limits are the ones prepared
+    with it -- the ``channel_limits.json`` staged beside it -- because the
+    project's live limits file bounds the real machine, and a facility that
+    authors a simulation channel set authors the bounds for it in the same
+    place. Copying the live file over those would leave the accelerator
+    enforcing limits its channel set was never written against.
 
     Returns:
         The path the manifest was written to.
     """
     simulation_dir = project_data_dir / "simulation"
     simulation_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = simulation_dir / MANIFEST_FILENAME
+
+    if prepared.source is ManifestSource.AUTHORED and prepared.manifest_path is not None:
+        _copy_unless_same_file(prepared.limits_source, simulation_dir / LIMITS_FILENAME)
+        _copy_unless_same_file(prepared.manifest_path, manifest_path)
+        return manifest_path
 
     limits_source = project_data_dir / LIMITS_FILENAME
     if not limits_source.is_file():
         limits_source = prepared.limits_source
-    shutil.copy2(limits_source, simulation_dir / LIMITS_FILENAME)
+    _copy_unless_same_file(limits_source, simulation_dir / LIMITS_FILENAME)
 
-    manifest_path = simulation_dir / MANIFEST_FILENAME
     manifest_path.write_text(json.dumps(prepared.manifest, indent=2) + "\n")
     return manifest_path
 

--- a/src/osprey/services/virtual_accelerator/manifest/paths.py
+++ b/src/osprey/services/virtual_accelerator/manifest/paths.py
@@ -24,6 +24,17 @@ _TEMPLATES_ROOT = Path(osprey.templates.__file__).parent
 
 _CONTROL_ASSISTANT_DATA = _TEMPLATES_ROOT / "apps" / "control_assistant" / "data"
 
+# Filenames the virtual-accelerator container looks for under its
+# ``/data/simulation`` mount: ``VA_CHANNELS_FILE`` resolves relative names
+# against the data dir, and drive limits are read from ``channel_limits.json``
+# beside it (see services/virtual_accelerator/entrypoint.py). They live here
+# rather than in ``build`` because the same two names are also the pair a
+# profile may AUTHOR under its ``data/simulation/`` tree -- the paths reserved
+# for it by ``osprey.cli.profile_conventions.RESERVED_PROJECT_PATHS`` -- so the
+# path object that resolves every manifest source has to know them.
+MANIFEST_FILENAME = "channel_manifest.json"
+LIMITS_FILENAME = "channel_limits.json"
+
 # Build-resolved default tier for the control-assistant preset. The preset's
 # `channel_finder_mode` defaults to "hierarchical"
 # (src/osprey/profiles/presets/control-assistant.yml), and
@@ -76,7 +87,35 @@ class ManifestPaths:
 
     @property
     def channel_limits(self) -> Path:
-        return self.data_root / "channel_limits.json"
+        return self.data_root / LIMITS_FILENAME
+
+    @property
+    def authored_manifest(self) -> Path:
+        """The manifest a profile may stage itself, instead of one being derived.
+
+        ``data/simulation/channel_manifest.json`` is a path the framework
+        RESERVES for the profile (see
+        ``osprey.cli.profile_conventions.RESERVED_PROJECT_PATHS``), so a tree
+        carrying one is stating its accelerator's channel set outright: a
+        facility whose channels come from a generator of its own -- lattice
+        coupling, setpoint/readback pairing and partitions included -- rather
+        than from anything this package can reconstruct from the tree.
+        ``build.prepare_project_manifest`` takes it as-is when the tree stages
+        no paradigm database.
+        """
+        return self.data_root / "simulation" / MANIFEST_FILENAME
+
+    @property
+    def authored_limits(self) -> Path:
+        """The drive limits an authored manifest ships beside itself.
+
+        Reserved for the profile by the same table, and read from the same
+        directory the container mounts. It is the limits source for an authored
+        manifest; :attr:`channel_limits` -- the tree-wide file a derived
+        manifest is bounded by -- is the fallback when a profile authors a
+        manifest without one beside it.
+        """
+        return self.data_root / "simulation" / LIMITS_FILENAME
 
     @property
     def paradigm_databases(self) -> dict[str, Path]:

--- a/tests/cli/test_build_derived_env.py
+++ b/tests/cli/test_build_derived_env.py
@@ -30,15 +30,33 @@ from osprey.utils.dotenv import (
 def repo(tmp_path: Path) -> Path:
     """A deployment repo whose build produced a channel manifest.
 
-    The manifest carries a partition census because ``VA_LATTICE`` is DERIVED
-    from it: the built-in lattice moves pyat-coupled channels and nothing else,
-    so a manifest declaring some is what earns ``builtin`` here. A censusless
-    stub would be a manifest claiming no lattice, which is a different case and
-    is covered on its own in ``tests/cli/test_build_va_manifest_honesty.py``.
+    The manifest carries a pyat-coupled channel because ``VA_LATTICE`` is
+    DERIVED from it: the built-in lattice moves pyat-coupled channels and
+    nothing else, so a manifest declaring one is what earns ``builtin`` here.
+    A manifest with no such channel would claim no lattice, which is a
+    different case and is covered on its own in
+    ``tests/cli/test_build_va_manifest_honesty.py``.
     """
     (tmp_path / "build" / "data" / "simulation").mkdir(parents=True)
     (tmp_path / "build" / "data" / "simulation" / MANIFEST_FILENAME).write_text(
-        json.dumps({"_metadata": {"by_partition": {"pyat-coupled": 1}}, "channels": []})
+        json.dumps(
+            {
+                "channels": [
+                    {
+                        "address": "SR:MAG:HCM:01:CURRENT:SP",
+                        "ring": "SR",
+                        "system": "MAG",
+                        "family": "HCM",
+                        "device": "01",
+                        "field": "CURRENT",
+                        "subfield": "SP",
+                        "partition": "pyat-coupled",
+                        "record_type": "analog",
+                        "noise": False,
+                    }
+                ]
+            }
+        )
     )
     return tmp_path
 

--- a/tests/cli/test_build_va_manifest_honesty.py
+++ b/tests/cli/test_build_va_manifest_honesty.py
@@ -950,3 +950,19 @@ def test_a_graph_repo_with_an_unreadable_corpus_fails_a_real_build(tmp_path_fact
     env = parse_dotenv_file(env_path) if env_path.is_file() else {}
     assert "VA_CHANNELS_FILE" not in env
     assert "VA_LATTICE" not in env
+
+
+def test_an_authored_manifest_without_a_census_keeps_the_builtin_lattice(tmp_path):
+    """The lattice question is answered off the channels, which every manifest has.
+
+    A facility's own generator need not write the ``_metadata`` block the
+    framework's writer does; the channel list is the schema the container
+    reads, so it is what earns ``builtin`` here.
+    """
+    from osprey.utils.dotenv import VA_LATTICE_DEFAULT
+
+    manifest = {"channels": _AUTHORED_MANIFEST["channels"]}
+
+    env = _wired_env(tmp_path, manifest)
+
+    assert env["VA_LATTICE"] == VA_LATTICE_DEFAULT

--- a/tests/cli/test_build_va_manifest_honesty.py
+++ b/tests/cli/test_build_va_manifest_honesty.py
@@ -796,6 +796,128 @@ def test_a_graph_repo_with_an_empty_corpus_refuses_naming_it(tmp_path):
     assert "declares no channels" in message
 
 
+# --- a tree that AUTHORS its manifest ---------------------------------------
+
+#: A manifest a facility's own generator wrote: identity keys, a setpoint
+#: paired with its readback, and a partition census -- none of which the corpus
+#: can state, so the two sources are told apart by what the render carries.
+_AUTHORED_MANIFEST: dict[str, Any] = {
+    "_metadata": {
+        "generator": "facility.scripts.va_channels",
+        "total_channels": 2,
+        "setpoint_count": 1,
+        "by_partition": {"pyat-coupled": 2},
+    },
+    "channels": [
+        {
+            "address": "SR:MAG:HCM:01:CURRENT:RB",
+            "ring": "SR",
+            "system": "MAG",
+            "family": "HCM",
+            "device": "01",
+            "field": "CURRENT",
+            "subfield": "RB",
+            "partition": "pyat-coupled",
+            "record_type": "ai",
+            "noise": False,
+        },
+        {
+            "address": "SR:MAG:HCM:01:CURRENT:SP",
+            "ring": "SR",
+            "system": "MAG",
+            "family": "HCM",
+            "device": "01",
+            "field": "CURRENT",
+            "subfield": "SP",
+            "partition": "pyat-coupled",
+            "record_type": "ai",
+            "noise": False,
+        },
+    ],
+}
+
+#: The bounds the facility wrote for its simulated channel set.
+_AUTHORED_LIMITS = '{"SR:MAG:HCM:01:CURRENT:SP": {"min_value": -1, "max_value": 1}}\n'
+
+
+def _authored_repo(root: Path) -> Path:
+    """A graph-mode repo that stages its own simulation manifest and limits.
+
+    The shape a facility with its own channel generator ships: a corpus for the
+    graph store, no machine-state list (nothing derives a manifest here), and
+    the two reserved ``data/simulation/`` files stating what the accelerator
+    serves.
+    """
+    from osprey.services.virtual_accelerator.manifest.build import MANIFEST_FILENAME
+
+    repo = _graph_repo(root)
+    data = repo / "data"
+    (data / "machine_state_channels.json").unlink()
+    (data / "simulation" / MANIFEST_FILENAME).write_text(json.dumps(_AUTHORED_MANIFEST, indent=2))
+    (data / "simulation" / LIMITS_FILENAME).write_text(_AUTHORED_LIMITS)
+    # The live limits the machine is driven under: a different, narrower set of
+    # bounds, and never what the simulation enforces.
+    (data / LIMITS_FILENAME).write_text(
+        '{"SR:MAG:HCM:01:CURRENT:SP": {"min_value": -0.1, "max_value": 0.1}}\n'
+    )
+    return repo
+
+
+def test_an_authored_manifests_fact_names_the_staged_file(tmp_path, capsys):
+    """The reporting step: the source is named, as the corpus is on a derivation."""
+    from osprey.services.virtual_accelerator.manifest.build import MANIFEST_FILENAME
+
+    root = _authored_repo(tmp_path / "repo")
+    prepared = prepare_project_manifest(root / "data", DEFAULT_TIER, config=_graph_config(root))
+
+    _report(_shared(tmp_path), _profile(data="data"), root / "data", prepared)
+
+    printed = _printed(capsys)
+    assert f"simulation/{MANIFEST_FILENAME}" in printed
+    assert "2 channel(s)" in printed
+    # It is not a derivation, so none of the derivation's wordings apply.
+    assert "knowledge-graph corpus" not in printed
+    assert "channel database(s)" not in printed
+    assert "serves 0 setpoints" not in printed
+    assert _DEAD_FALLBACK_SENTENCE not in printed
+
+
+def test_an_authored_manifest_repo_builds_and_reaches_the_render_unchanged(
+    tmp_path_factory, capsys
+):
+    """The whole build: staged bytes in, the same bytes out, limits included.
+
+    A facility that authors its channel set gets it served. Nothing is derived
+    from the corpus over it, and the live ``channel_limits.json`` -- the bounds
+    of the real machine -- does not replace the simulation limits staged beside
+    the manifest.
+    """
+    from click.testing import CliRunner
+
+    from osprey.cli.build_cmd import build as build_command
+    from osprey.services.virtual_accelerator.manifest.build import MANIFEST_FILENAME
+
+    repo = _authored_repo(tmp_path_factory.mktemp("authored") / "repo")
+
+    previous = Path.cwd()
+    os.chdir(repo)
+    try:
+        result = CliRunner().invoke(build_command, ["--skip-deps", "--skip-lifecycle"])
+    finally:
+        os.chdir(previous)
+
+    assert result.exit_code == 0, result.output
+    printed = " ".join(result.output.split())
+    assert f"simulation/{MANIFEST_FILENAME}" in printed
+    assert "knowledge-graph corpus" not in printed
+
+    rendered = repo / "build" / "data" / "simulation"
+    assert (rendered / MANIFEST_FILENAME).read_bytes() == (
+        repo / "data" / "simulation" / MANIFEST_FILENAME
+    ).read_bytes()
+    assert (rendered / LIMITS_FILENAME).read_text() == _AUTHORED_LIMITS
+
+
 def test_a_graph_repo_with_an_unreadable_corpus_fails_a_real_build(tmp_path_factory, caplog):
     """The refusing path through the CLI itself, not just the reporting helper.
 

--- a/tests/va/test_build_time_manifest.py
+++ b/tests/va/test_build_time_manifest.py
@@ -29,6 +29,7 @@ from osprey.services.virtual_accelerator.manifest.build import (
     LIMITS_FILENAME,
     MANIFEST_FILENAME,
     CorruptChannelSourcesError,
+    ManifestSource,
     NoChannelSourcesError,
     build_manifest,
     manifest_gap_reason,
@@ -744,3 +745,272 @@ class TestGraphYieldsNothing:
             prepare_project_manifest(root, DEFAULT_TIER, config=config)
 
         assert "machine.json" in str(excinfo.value)
+
+
+# --- an authored simulation manifest ----------------------------------------
+
+
+def _authored_channel(address: str, *, subfield: str = "RB", partition: str | None = None) -> dict:
+    """One channel entry in the schema a file-backed manifest must supply."""
+    return {
+        "address": address,
+        "ring": "SR",
+        "system": "MAG",
+        "family": "HCM",
+        "device": "01",
+        "field": "CURRENT",
+        "subfield": subfield,
+        "partition": partition or classify.PARTITION_PYAT_COUPLED,
+        "record_type": classify.RECORD_TYPE_ANALOG,
+        "noise": False,
+    }
+
+
+#: What a facility's own generator writes: identity keys, a setpoint paired
+#: with its readback, and a partition census -- everything the derivation
+#: paths in this module cannot reconstruct from a tree that stages no
+#: hierarchical database.
+_AUTHORED_MANIFEST: dict = {
+    "_metadata": {
+        "generator": "facility.scripts.va_channels",
+        "total_channels": 2,
+        "setpoint_count": 1,
+        "by_partition": {classify.PARTITION_PYAT_COUPLED: 2},
+    },
+    "channels": [
+        _authored_channel("SR:MAG:HCM:01:CURRENT:RB"),
+        _authored_channel("SR:MAG:HCM:01:CURRENT:SP", subfield="SP"),
+    ],
+}
+
+#: The drive limits a facility authors beside that manifest -- distinguishable
+#: from the tree-wide ``channel_limits.json`` a derived manifest is bounded by,
+#: so a test can see WHICH file reached the render.
+_AUTHORED_LIMITS = '{"SR:MAG:HCM:01:CURRENT:SP": {"min_value": -1, "max_value": 1}}\n'
+
+
+def _author_manifest(root: Path, *, manifest: dict | str = _AUTHORED_MANIFEST, limits=True) -> Path:
+    """Stage an authored manifest (and optionally its limits) under ``simulation/``."""
+    simulation = root / "simulation"
+    simulation.mkdir(parents=True, exist_ok=True)
+    path = simulation / MANIFEST_FILENAME
+    path.write_text(manifest if isinstance(manifest, str) else json.dumps(manifest, indent=2))
+    if limits:
+        (simulation / LIMITS_FILENAME).write_text(_AUTHORED_LIMITS)
+    return path
+
+
+class TestAuthoredManifestOutranksDerivation:
+    """A manifest the profile STAGED is the answer, not an input to a derivation.
+
+    ``data/simulation/channel_manifest.json`` is reserved for the profile, so a
+    tree that carries one has already said what its accelerator serves. It is
+    taken as-is: nothing is re-derived from the corpus, and the limits beside it
+    are the limits that land in the render.
+    """
+
+    def test_authored_manifest_wins_over_the_graph_corpus(self, tmp_path):
+        root, config = _graph_tree(tmp_path / "data")
+        # The file the derivation demands and a facility with an authored
+        # manifest has no reason to write: the tree is complete without it.
+        (root / "machine_state_channels.json").unlink()
+        authored = _author_manifest(root)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        assert prepared is not None
+        assert prepared.source is ManifestSource.AUTHORED
+        assert prepared.manifest == json.loads(authored.read_text())
+        assert prepared.limits_source == root / "simulation" / LIMITS_FILENAME
+        # Nothing from the corpus leaked into it.
+        assert [c["address"] for c in prepared.manifest["channels"]] == [
+            "SR:MAG:HCM:01:CURRENT:RB",
+            "SR:MAG:HCM:01:CURRENT:SP",
+        ]
+
+    def test_without_an_authored_manifest_the_graph_derivation_is_unchanged(self, tmp_path):
+        """The same tree, minus the authored file: today's answer, untouched."""
+        root, config = _graph_tree(tmp_path / "data")
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        assert prepared.source is ManifestSource.GRAPH
+        assert prepared.manifest["_metadata"]["source_paradigms"] == ["graph"]
+        assert prepared.manifest["_metadata"]["total_channels"] == 5
+
+    def test_without_an_authored_manifest_the_graph_refusal_is_unchanged(self, tmp_path):
+        """And a tree that can back neither still refuses, naming both ways out."""
+        root, config = _graph_tree(tmp_path / "data")
+        (root / "machine_state_channels.json").unlink()
+
+        assert prepare_project_manifest(root, DEFAULT_TIER, config=config) is None
+        reason = manifest_gap_reason(root, DEFAULT_TIER, config=config)
+        assert "missing machine_state_channels.json" in reason
+        # The reserved path is one of the ways to satisfy the build, so the
+        # refusal names it rather than leaving it to be discovered.
+        assert f"simulation/{MANIFEST_FILENAME}" in reason
+
+    def test_a_staged_paradigm_database_still_wins(self, tmp_path, facility_tree):
+        """Precedence is databases, then the authored manifest, then the graph."""
+        root, config = _graph_tree(tmp_path / "data")
+        db = root / f"channel_databases/tiers/tier{DEFAULT_TIER}/hierarchical.json"
+        db.parent.mkdir(parents=True)
+        shutil.copy2(
+            facility_tree / f"channel_databases/tiers/tier{DEFAULT_TIER}/hierarchical.json", db
+        )
+        _author_manifest(root)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        assert prepared.source is ManifestSource.PARADIGM
+        assert prepared.manifest["_metadata"]["source_paradigms"] == ["hierarchical"]
+        assert prepared.limits_source == root / LIMITS_FILENAME
+
+    def test_an_authored_manifest_needs_no_config(self, tmp_path):
+        """It is not graph-derived, so nothing about it depends on the rendered config.
+
+        A ``config=None`` caller keeps the paradigm-database rules for every
+        DERIVATION, as before -- the graph is still never consulted without one
+        -- but an authored manifest is not a derivation. It is read off the
+        tree, so it answers the same for every caller.
+        """
+        root, _ = _graph_tree(tmp_path / "data")
+        (root / "machine_state_channels.json").unlink()
+        _author_manifest(root)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER)
+
+        assert prepared is not None
+        assert prepared.source is ManifestSource.AUTHORED
+
+    def test_limits_fall_back_to_the_tree_wide_file(self, tmp_path):
+        """A manifest authored without limits beside it is bounded by the tree's."""
+        root, config = _graph_tree(tmp_path / "data")
+        _author_manifest(root, limits=False)
+
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        assert prepared.limits_source == root / LIMITS_FILENAME
+
+    def test_an_authored_manifest_with_no_limits_at_all_backs_nothing(self, tmp_path):
+        """Limits and manifest ship together on this path too, or neither does."""
+        root, config = _graph_tree(tmp_path / "data")
+        (root / LIMITS_FILENAME).unlink()
+        _author_manifest(root, limits=False)
+
+        assert prepare_project_manifest(root, DEFAULT_TIER, config=config) is None
+        reason = manifest_gap_reason(root, DEFAULT_TIER, config=config)
+        assert f"missing simulation/{LIMITS_FILENAME}" in reason
+
+
+class TestAuthoredManifestValidation:
+    """A staged file that cannot be served is refused, never derived past.
+
+    Silently falling through to the corpus would replace the facility's own
+    channel set with a derived one -- which is the failure this precedence
+    exists to prevent, arriving by a different door.
+    """
+
+    def test_an_unparseable_authored_manifest_raises_naming_the_file(self, tmp_path):
+        from osprey.errors import BuildProfileError
+
+        root, config = _graph_tree(tmp_path / "data")
+        _author_manifest(root, manifest="{not json\n")
+
+        with pytest.raises(BuildProfileError) as excinfo:
+            prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        assert f"simulation/{MANIFEST_FILENAME}" in str(excinfo.value)
+
+    def test_a_wrongly_shaped_authored_manifest_raises_naming_the_file(self, tmp_path):
+        from osprey.errors import BuildProfileError
+
+        root, config = _graph_tree(tmp_path / "data")
+        _author_manifest(root, manifest={"channels": {"SR:MAG:HCM:01:CURRENT:RB": {}}})
+
+        with pytest.raises(BuildProfileError) as excinfo:
+            prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        assert f"simulation/{MANIFEST_FILENAME}" in str(excinfo.value)
+
+    def test_an_authored_manifest_missing_schema_keys_raises(self, tmp_path):
+        """The container reads every key of every channel; a build says so first."""
+        from osprey.errors import BuildProfileError
+
+        root, config = _graph_tree(tmp_path / "data")
+        _author_manifest(root, manifest={"channels": [{"address": "SR:MAG:HCM:01:CURRENT:RB"}]})
+
+        with pytest.raises(BuildProfileError) as excinfo:
+            prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        assert f"simulation/{MANIFEST_FILENAME}" in str(excinfo.value)
+
+    def test_an_empty_authored_manifest_raises(self, tmp_path):
+        from osprey.errors import BuildProfileError
+
+        root, config = _graph_tree(tmp_path / "data")
+        _author_manifest(root, manifest={"channels": []})
+
+        with pytest.raises(BuildProfileError) as excinfo:
+            prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        assert "no channels" in str(excinfo.value)
+
+
+class TestWriteAuthoredManifest:
+    """What the render gets: the authored bytes, and the authored limits."""
+
+    def test_the_authored_bytes_reach_the_render_unchanged(self, tmp_path):
+        root, config = _graph_tree(tmp_path / "data")
+        authored = _author_manifest(root)
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+        project_data = tmp_path / "project" / "data"
+        project_data.mkdir(parents=True)
+
+        manifest_path = write_project_manifest(prepared, project_data)
+
+        assert manifest_path.read_bytes() == authored.read_bytes()
+
+    def test_the_live_limits_never_overwrite_the_authored_ones(self, tmp_path):
+        """The copy-from-the-project rule is for DERIVED manifests only.
+
+        A built project carries the facility's live ``channel_limits.json`` --
+        the bounds the real machine is driven under, which for a facility that
+        authors its simulation limits is a different, much shorter file. Copying
+        it over the authored one leaves the accelerator enforcing limits its
+        channel set was never written against.
+        """
+        root, config = _graph_tree(tmp_path / "data")
+        _author_manifest(root)
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+        project_data = tmp_path / "project" / "data"
+        project_data.mkdir(parents=True)
+        (project_data / LIMITS_FILENAME).write_text('{"channels": {}}\n')
+
+        write_project_manifest(prepared, project_data)
+
+        assert (project_data / "simulation" / LIMITS_FILENAME).read_text() == _AUTHORED_LIMITS
+
+    def test_the_written_pair_loads_through_the_container_reader(self, tmp_path):
+        root, config = _graph_tree(tmp_path / "data")
+        _author_manifest(root)
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+        project_data = tmp_path / "project" / "data"
+        project_data.mkdir(parents=True)
+
+        manifest_path = write_project_manifest(prepared, project_data)
+
+        channels = loaders.load_manifest_file(manifest_path)
+        assert len(channels) == 2
+        assert (project_data / "simulation" / LIMITS_FILENAME).is_file()
+
+    def test_writing_in_place_is_a_no_op_rather_than_a_failure(self, tmp_path):
+        """A build whose render zone IS the data tree must not copy a file onto itself."""
+        root, config = _graph_tree(tmp_path / "data")
+        authored = _author_manifest(root)
+        prepared = prepare_project_manifest(root, DEFAULT_TIER, config=config)
+
+        manifest_path = write_project_manifest(prepared, root)
+
+        assert manifest_path.read_bytes() == authored.read_bytes()
+        assert (root / "simulation" / LIMITS_FILENAME).read_text() == _AUTHORED_LIMITS


### PR DESCRIPTION
Since #814 gave graph mode a manifest source, a `channel_finder_mode: graph`
deployment that stages an **authored** `data/simulation/channel_manifest.json`
could no longer build — and the one-line change that made it build silently
replaced that manifest with a graph-derived one (every setpoint gone, every
channel static-noisy) and copied the project's live `data/channel_limits.json`
over the authored simulation limits. The profile conventions reserve both of
those paths *for the profile*
(`src/osprey/cli/profile_conventions.py:330-331`), so the framework was
reserving two files for the facility and then ignoring them.

The VA manifest's source precedence is now:

1. staged paradigm databases — unchanged;
2. an authored `data/simulation/channel_manifest.json`, taken as-is, with the
   `channel_limits.json` beside it as its limits source (the tree-wide
   `channel_limits.json` is the fallback when a profile authors no limits);
3. graph derivation (#814), only when neither of the above is staged;
4. refusal — and a refusal from a tree that stages no database now names the
   reserved path as the other way to satisfy the build.

`PreparedManifest` carries which source answered (`source`, plus the staged
file's path), so `write_project_manifest` copies an authored manifest's bytes
and its limits verbatim instead of re-serializing and applying the
copy-the-project's-limits rule — that rule stays exactly as it was for derived
manifests. The build's fact names the staged file the way it already names a
corpus, and the render step says "Staged" rather than "Generated" over a file
it did not write. An authored manifest is validated through
`loaders.load_manifest_file`, the same reader the container boots on, and an
unreadable or empty one is refused by name rather than silently derived past.
`config=None` callers keep the paradigm-only rules for every *derivation*; an
authored manifest is not graph-dependent, so it answers the same with or
without a config.

### Acceptance, against the ALS profile

`osprey -v build --skip-deps` at this branch, on the real ALS deployment repo,
with no `machine_state_channels.json` staged:

```
EXIT=0
cmp data/simulation/channel_manifest.json build/data/simulation/channel_manifest.json  -> 0
cmp data/simulation/channel_limits.json   build/data/simulation/channel_limits.json    -> 0

· Virtual-accelerator channel set taken from the manifest this project stages
  (simulation/channel_manifest.json): 2964 channel(s), served exactly as staged.
  Nothing is derived from the rest of the data tree, and the drive limits beside
  it (simulation/channel_limits.json) are what the accelerator enforces.
· bluesky plan devices: 684 settable / 986 readable from data/bluesky_devices.yml
```

Only the deployment's own by-design warnings remain (the `Edit`/`Bash`
PreToolUse-matcher pair per render, two profile-hygiene lines, and the
pre-existing `openobserve.password` `UserWarning`).

The second commit follows from the first: `VA_LATTICE` was derived from the
manifest's `_metadata.by_partition` census, which an authored file need not
carry, so a facility manifest full of pyat-coupled channels still wired
`VA_LATTICE=none`. It is now answered off the channel list — the one part of
the schema every manifest has. Deployments adopting this should expect the
derived value to move from `none` to `builtin`; the `.env` write stays
append-only, so a value already on file is kept and the disagreement is
reported rather than overwritten, but the line may want revisiting.

### Tests

New coverage in `tests/va/test_build_time_manifest.py`
(`TestAuthoredManifestOutranksDerivation`, `TestAuthoredManifestValidation`,
`TestWriteAuthoredManifest`) and `tests/cli/test_build_va_manifest_honesty.py`
(the fact line, and a whole build whose render carries the staged bytes and the
staged limits). They fail at `origin/main` and pass here; the graph-derivation
path and its refusals are asserted unchanged.

Closes #834
