### PR TITLE
A settable with a distinct readback reports its demand beside its readback

### DIFF
--- a/changelog.d/settable-demand.changed.md
+++ b/changelog.d/settable-demand.changed.md
@@ -1,0 +1,10 @@
+A bluesky plan device with a distinct readback now reports its demand as
+well as its readback: `ConnectorSettable.read()` and `describe()` carry
+`<name>_setpoint` (the setpoint channel, read live through the connector)
+beside `<name>` (the readback), the same convention as ophyd's positioners.
+Only the readback stays hinted, so `bps.rd` and live tables keep answering
+where the device is. A plan that settle-checks a slow device (an
+insertion-device gap, a ramping magnet) reads both facts off the one device
+it drives instead of needing a second device that aliases the setpoint
+channel under another name. A device whose readback aliases its setpoint
+reports one key, as before.

--- a/src/osprey/services/bluesky_bridge/devices/connector.py
+++ b/src/osprey/services/bluesky_bridge/devices/connector.py
@@ -61,6 +61,15 @@ class."""
 _READBACK_POLL_INTERVAL_S = 0.05
 """Sleep between readback polls in ``ConnectorSettable.set()``."""
 
+SETPOINT_KEY_SUFFIX = "_setpoint"
+"""Suffix of the data key a :class:`ConnectorSettable` with a *distinct*
+readback reports its demand under: ``<name>_setpoint`` beside ``<name>``.
+The same convention as ophyd's positioners (``<name>_setpoint`` beside the
+``<name>`` readback), so a plan that settle-checks a slow device -- an
+insertion-device gap, a ramping magnet -- reads where the device is and where
+it was told to go off one device, without a second device aliasing the
+setpoint channel."""
+
 
 class ConnectorSettable(StandardReadable):
     """A settable/readable PV pair mediated entirely by the OSPREY connector.
@@ -86,6 +95,17 @@ class ConnectorSettable(StandardReadable):
     ``confirm: false``, so nothing was checked). With a separate
     ``readback_pv`` the write's outcome is about the *setpoint*, not the
     readback channel, so it never stands in for a settle sample there.
+
+    A device with a separate ``readback_pv`` reports BOTH channels: the
+    readback under ``<name>`` (the hinted field, what ``bps.rd`` returns) and
+    the demand under ``<name>_setpoint`` (:data:`SETPOINT_KEY_SUFFIX`), each
+    read live through the connector. Where the device is and where it was
+    told to go are two different facts about a device that takes time to
+    move, and a plan that decides when to advance on the difference between
+    them needs both off the one device it drives -- the alternative is a
+    second device aliasing the setpoint channel, which puts the same address
+    in the worker's namespace twice. An aliased device reports one key: its
+    readback IS its demand.
 
     The OSPREY connector instance is stored as ``self._osprey_connector``,
     not ``self._connector``: ophyd-async's own ``Device.__init__`` already
@@ -164,37 +184,69 @@ class ConnectorSettable(StandardReadable):
                 )
             await asyncio.sleep(_READBACK_POLL_INTERVAL_S)
 
+    @property
+    def has_distinct_readback(self) -> bool:
+        """Whether this device reads back a channel other than the one it writes."""
+        return self._readback_pv != self._setpoint_pv
+
+    @property
+    def setpoint_key(self) -> str:
+        """The data key the demand is reported under, ``<name>_setpoint``.
+
+        Only present in ``read()``/``describe()`` when
+        :attr:`has_distinct_readback` -- an aliased device's demand IS its
+        readback, and the key would restate ``<name>``.
+        """
+        return f"{self.name}{SETPOINT_KEY_SUFFIX}"
+
     async def read(self) -> dict[str, dict[str, Any]]:
         """Return the live readback value, read fresh through the connector.
 
         Never returns a cached/soft value: every call issues a new
         ``connector.read_channel`` so the document a plan records reflects
-        the current mediated state of the readback channel.
+        the current mediated state of the readback channel. A device with a
+        distinct readback also reads its setpoint channel and reports the
+        demand under :attr:`setpoint_key`.
         """
         reading = await self._osprey_connector.read_channel(self._readback_pv)
-        return {self.name: {"value": reading.value, "timestamp": time.time()}}
+        document = {self.name: {"value": reading.value, "timestamp": time.time()}}
+        if self.has_distinct_readback:
+            demand = await self._osprey_connector.read_channel(self._setpoint_pv)
+            document[self.setpoint_key] = {"value": demand.value, "timestamp": time.time()}
+        return document
 
     async def describe(self) -> dict[str, dict[str, Any]]:
-        """Describe the live readback channel as a scalar numeric data key."""
-        return {
+        """Describe the live readback channel as a scalar numeric data key,
+        and the setpoint channel beside it when the two differ."""
+        described = {
             self.name: {
                 "source": f"connector:{self._readback_pv}",
                 "dtype": "number",
                 "shape": [],
             }
         }
+        if self.has_distinct_readback:
+            described[self.setpoint_key] = {
+                "source": f"connector:{self._setpoint_pv}",
+                "dtype": "number",
+                "shape": [],
+            }
+        return described
 
     @property
     def hints(self) -> Hints:
-        """Declare this movable's single readback field as the hinted one.
+        """Declare this movable's readback field as the one hinted field.
 
         ``StandardReadable`` builds its hints by aggregating over the
         ophyd-async signals declared on the device; this class declares
         none (every read goes through the connector instead), so the
         inherited property would report no fields at all and consumers of
         the run — live table, plot axes, ``PeakStats`` — would have nothing
-        to key on. ``read()``/``describe()`` emit exactly one data key,
-        named for the device, so that is the field named here.
+        to key on. The readback key, named for the device, is the field
+        named here; the ``<name>_setpoint`` key a distinct-readback device
+        also emits is deliberately NOT hinted, so ``bps.rd`` keeps returning
+        where the device is and a live table plots the machine, not the
+        demand.
 
         Overriding as a property is required, not stylistic: the base class
         declares ``hints`` read-only, so assigning an instance attribute in

--- a/tests/services/bluesky_bridge/test_connector_devices.py
+++ b/tests/services/bluesky_bridge/test_connector_devices.py
@@ -297,6 +297,66 @@ async def test_connector_readable_describe_shape() -> None:
     assert described == {"bpm1": {"source": "connector:BPM:1", "dtype": "number", "shape": []}}
 
 
+async def test_a_settable_with_a_distinct_readback_reports_its_demand_too() -> None:
+    """``<name>`` is where the device is, ``<name>_setpoint`` where it was told to go.
+
+    A plan that decides when to advance on the difference between the two --
+    an insertion-device gap that takes ten seconds to arrive -- needs both off
+    the one device it drives, without a second device aliasing the setpoint
+    channel under a second name.
+    """
+    fake = FakeConnector(readbacks={"SR04U___GDS1PS_AC00": 25.0, "SR04U___GDS1PS_AM00": 17.3})
+    device = ConnectorSettable(
+        fake, "SR04U___GDS1PS_AC00", readback_pv="SR04U___GDS1PS_AM00", name="gap"
+    )
+
+    reading = await device.read()
+
+    assert device.has_distinct_readback
+    assert device.setpoint_key == "gap_setpoint"
+    assert reading["gap"]["value"] == 17.3
+    assert reading["gap_setpoint"]["value"] == 25.0
+    assert set(reading) == {"gap", "gap_setpoint"}
+    # Both halves are LIVE reads through the connector, never cached.
+    assert set(fake.read_calls) == {"SR04U___GDS1PS_AC00", "SR04U___GDS1PS_AM00"}
+    fake.readbacks["SR04U___GDS1PS_AM00"] = 25.0
+    assert (await device.read())["gap"]["value"] == 25.0
+
+
+async def test_a_settable_with_a_distinct_readback_describes_both_channels() -> None:
+    fake = FakeConnector(readbacks={"SP": 0.0, "RB": 0.0})
+    device = ConnectorSettable(fake, "SP", readback_pv="RB", name="motor")
+
+    assert await device.describe() == {
+        "motor": {"source": "connector:RB", "dtype": "number", "shape": []},
+        "motor_setpoint": {"source": "connector:SP", "dtype": "number", "shape": []},
+    }
+
+
+async def test_an_aliased_settable_reports_one_key() -> None:
+    """Its readback IS its demand: a second key would restate ``<name>``."""
+    fake = FakeConnector(readbacks={"SP": 4.0})
+    device = ConnectorSettable(fake, "SP", name="motor")
+
+    assert not device.has_distinct_readback
+    assert await device.read() == {
+        "motor": {"value": 4.0, "timestamp": pytest.approx(time.time(), abs=5)}
+    }
+    assert set(await device.describe()) == {"motor"}
+
+
+async def test_the_demand_key_is_not_hinted_so_rd_returns_the_readback() -> None:
+    """``bps.rd`` reads the one hinted field; a second hint would make it raise."""
+    from bluesky.utils import get_hinted_fields
+
+    fake = FakeConnector(readbacks={"SP": 25.0, "RB": 17.3})
+    device = ConnectorSettable(fake, "SP", readback_pv="RB", name="gap")
+
+    assert device.hints == {"fields": ["gap"]}
+    assert get_hinted_fields(device) == ["gap"]
+    assert set(await device.read()) == {"gap", "gap_setpoint"}
+
+
 def test_connector_settable_hints_declare_the_device_field() -> None:
     """The movable declares its one data key as the hinted field."""
     device = ConnectorSettable(FakeConnector(readbacks={"SP": 0.0}), "SP", name="motor")

--- a/tests/services/bluesky_bridge/test_device_no_raw_ca_attr.py
+++ b/tests/services/bluesky_bridge/test_device_no_raw_ca_attr.py
@@ -117,6 +117,7 @@ _EXPECTED_SETTABLE_PUBLIC_ATTRS = [
     "connect",
     "describe",
     "describe_configuration",
+    "has_distinct_readback",
     "hints",
     "log",
     "name",
@@ -125,6 +126,7 @@ _EXPECTED_SETTABLE_PUBLIC_ATTRS = [
     "read_configuration",
     "set",
     "set_name",
+    "setpoint_key",
     "stage",
     "unstage",
 ]


### PR DESCRIPTION
## What

`ConnectorSettable.read()` / `describe()` now report `<name>_setpoint` (the setpoint channel, read live through the connector) beside `<name>` (the readback) whenever the two channels differ. Only the readback stays hinted, so `bps.rd` and live tables keep answering where the device *is*. An aliased device (readback == setpoint) reports one key, as before. Two small public properties carry the shape: `has_distinct_readback`, `setpoint_key`.

## Why

A plan that decides when to advance on the difference between where a device is and where it was told to go (an insertion-device gap that takes ~10 s to arrive, a ramping magnet) previously needed a *second* device aliasing the setpoint channel under another name, because reading the paired device returned only the readback. With the roster now pairing every setpoint it can (#835), a derived device set (#814) has no such alias to offer, and the demand has to be readable off the one device the plan drives. This is ophyd's positioner convention (`<name>_setpoint` beside `<name>`).

## Tests

`tests/services/bluesky_bridge/test_connector_devices.py`: a distinct-readback device reports both keys, both read live; `describe()` names both channels; an aliased device reports one key; the demand key is not hinted so `get_hinted_fields` (what `bps.rd` uses) still returns the readback. `test_device_no_raw_ca_attr.py`'s public-surface pin gains the two properties.

Changelog: `settable-demand.changed.md`.
