### PR TITLE
feat(models): attribute spend to the acting identity on LiteLLM gateways

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,21 @@ jobs:
     # Without a bound, a single wedged xdist worker holds the lane at 99% for
     # the 6-hour default.
     #
-    # 45 rather than 30, and the cells are no longer close to it. A healthy run
-    # is ~15-18 min on all four cells, coverage cell included: it measures
-    # through PEP 669 (see COVERAGE_CORE below), which costs near enough
-    # nothing, so no cell is an outlier any more. What forces the headroom is a known
-    # intermittent tail worth ~12 minutes: a worker wedges mid-test and its
-    # share has to be redistributed to a replacement, or the session hangs
-    # after the last test on non-daemon threads that outlive it. Both are
-    # visible in this lane's uploaded diagnostics, and neither is bounded by
-    # anything the suite controls, so a cap tight enough to catch them also
-    # reds the runs where they merely cost time.
-    timeout-minutes: 45
+    # 60 rather than 45, because the healthy run grew. Through August a cell
+    # finished in ~15-18 min; by 2026-09-01 the suite had grown to the point
+    # where every cell needs ~35-41 min (ubuntu and macOS alike, coverage cell
+    # included: it measures through PEP 669, see COVERAGE_CORE below, which
+    # costs near enough nothing, so no cell is an outlier). What forces the
+    # headroom on top of that is a known intermittent tail worth ~12 minutes:
+    # a worker wedges mid-test and its share has to be redistributed to a
+    # replacement, or the session hangs after the last test on non-daemon
+    # threads that outlive it. Both are visible in this lane's uploaded
+    # diagnostics, and neither is bounded by anything the suite controls, so
+    # a cap tight enough to catch them also reds the runs where they merely
+    # cost time. The 40-minute step cap below sat at the healthy runtime for
+    # a day and did exactly that: main timed out on the macOS cell at 99%
+    # three times on 2026-09-01 with zero test failures.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -174,8 +178,10 @@ jobs:
       # minute intermittent tail described on the job cap above. A cap set just
       # above the healthy runtime kills the runs that hit that tail and would
       # have passed anyway; the value is deliberately loose for that reason, and
-      # tightening it is how this lane starts flaking.
-      timeout-minutes: 40
+      # tightening it is how this lane starts flaking. 55 = the ~41 min the
+      # slowest healthy cell now takes + the ~12 min tail; the previous 40 was
+      # sized for a ~18 min cell and became the healthy runtime itself.
+      timeout-minutes: 55
       env:
         # Switches on tests/ci_diagnostics.py: a continuously flushed event log
         # and stack-dump file per xdist worker, written here and uploaded below.

--- a/changelog.d/spend-attribution.added.md
+++ b/changelog.d/spend-attribution.added.md
@@ -1,0 +1,10 @@
+Requests to a LiteLLM-fronted provider (`als-apg`, `cborg`, or a custom
+provider with `gateway: litellm`) now carry the acting identity for spend
+attribution: the agent sends `x-litellm-end-user-id` (the terminal's roster
+user, the dispatch worker, or the local account) and `x-litellm-tags`
+(`osprey,surface:<terminal|dispatch|service|local>`) via
+`ANTHROPIC_CUSTOM_HEADERS`, merged into any operator headers already there,
+and the LiteLLM SDK path sets the same identity as the OpenAI `user` field.
+The gateway's spend logs then book each call to a person and a surface instead
+of to the deployment's shared key. The translation proxy forwards `x-litellm-*`
+headers to an OpenAI-protocol gateway so both protocol paths attribute alike.

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -267,6 +267,43 @@ translation proxy:
 (The unmapped ``opus`` tier here falls back to the default model at build
 time, with a warning — map it to silence the substitution.)
 
+Spend Attribution on a LiteLLM Gateway
+--------------------------------------
+
+A deployment authenticates to its gateway with one key, so without help the
+gateway's spend logs book every terminal, the dispatch worker and every
+headless run to that single key. When the provider is a `LiteLLM proxy
+<https://docs.litellm.ai/docs/proxy/cost_tracking>`_, OSPREY stamps the acting
+identity onto every request instead:
+
+* ``x-litellm-end-user-id`` — who asked: the terminal's roster user
+  (``OSPREY_TERMINAL_USER``), a service container's framework identity such as
+  ``dispatch-worker-0``, or the local account of an ``osprey chat`` session.
+* ``x-litellm-tags`` — ``osprey,surface:<terminal|dispatch|service|local>``.
+
+The agent carries them through Claude Code's ``ANTHROPIC_CUSTOM_HEADERS``
+(merged into any corporate-proxy headers you already set there), and the
+LiteLLM SDK path used by MCP servers sets the same identity as the OpenAI
+``user`` field. Nothing is sent to a direct vendor.
+
+The built-in ``als-apg`` and ``cborg`` providers are LiteLLM proxies and get
+this automatically. A custom gateway declares it:
+
+.. code-block:: yaml
+
+   api:
+     providers:
+       my-litellm-gateway:
+         api_key: ${MY_GATEWAY_KEY}
+         base_url: https://my-gateway.example.com/v1
+         api_protocol: anthropic   # or omit it for the OpenAI route
+         gateway: litellm
+
+On the gateway, read the result per person with ``/customer/info?end_user_id=``
+or from the ``end_user`` and ``request_tags`` columns of ``/spend/logs``. Both
+need the gateway to run with a database (virtual keys enabled); a stateless
+LiteLLM ignores the headers.
+
 Verifying Connectivity
 ----------------------
 

--- a/src/osprey/agent_runner/primitives.py
+++ b/src/osprey/agent_runner/primitives.py
@@ -250,6 +250,11 @@ def provider_env_for_project(project_dir: Path, *, provider: str | None = None) 
                 env[spec.auth_env_var] = secret
             # Raw secret for the MCP-subprocess ${SECRET} expansion (see Notes).
             env[spec.auth_secret_env] = secret
+
+    # Spend attribution on a LiteLLM-fronted provider (mirrors inject_provider_env).
+    from osprey.models.spend_attribution import apply_attribution_env
+
+    apply_attribution_env(env, spec.gateway)
     return env
 
 

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -31,6 +31,7 @@ from osprey.build.claude_code_telemetry import (
     _running_in_container,
     resolve_openobserve_port,
 )
+from osprey.models.spend_attribution import apply_attribution_env, gateway_for
 from osprey.models.tiers import VALID_TIERS
 from osprey.utils.dotenv import chain_files
 
@@ -437,6 +438,13 @@ def inject_provider_env(
         if spec.auth_secret_env != spec.auth_env_var:
             environ[spec.auth_secret_env] = secret
 
+    # On a LiteLLM-fronted provider, stamp the acting identity onto every
+    # request the agent makes (ANTHROPIC_CUSTOM_HEADERS), merged into any
+    # corporate-proxy headers the operator already carries there. Resolved
+    # here, at launch, because the identity is a property of the running
+    # container (OSPREY_TERMINAL_USER), not of the render.
+    apply_attribution_env(environ, spec.gateway)
+
     return sorted(spec.env_block.keys())
 
 
@@ -536,6 +544,9 @@ class ClaudeCodeModelSpec:
             model read ``default_model_id or tier_to_model[default_model_tier]``.
         shell_exports: Shell export lines the user must add to their profile
             (e.g. ``export ANTHROPIC_AUTH_TOKEN="$CBORG_API_KEY"``).
+        gateway: ``"litellm"`` when a LiteLLM proxy fronts the provider, else
+            ``None``; the built-ins ``als-apg`` and ``cborg`` are, and a custom
+            provider declares it with ``gateway: litellm``.
     """
 
     provider: str
@@ -549,6 +560,10 @@ class ClaudeCodeModelSpec:
     auth_secret_env: str = ""
     needs_proxy: bool = False
     upstream_base_url: str | None = None
+    #: The gateway kind fronting the provider (``"litellm"``), or ``None`` for a
+    #: direct vendor. Decides whether the launch paths stamp the acting identity
+    #: onto the agent's requests — see :mod:`osprey.models.spend_attribution`.
+    gateway: str | None = None
 
     def agent_tier(self, name: str) -> str:
         """Resolve the tier alias for a named agent (for Claude Code model: frontmatter).
@@ -961,6 +976,7 @@ class ClaudeCodeModelResolver:
             auth_secret_env=auth_secret_env,
             needs_proxy=_needs_proxy,
             upstream_base_url=_upstream_url,
+            gateway=gateway_for(provider_name, api_providers),
         )
 
     @staticmethod

--- a/src/osprey/infrastructure/proxy/app.py
+++ b/src/osprey/infrastructure/proxy/app.py
@@ -92,6 +92,11 @@ def create_proxy_app(
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
+        # Carry the gateway's attribution headers (x-litellm-end-user-id,
+        # x-litellm-tags — set via ANTHROPIC_CUSTOM_HEADERS) through to the
+        # upstream, so an OpenAI-protocol LiteLLM gateway books the spend to
+        # the acting identity exactly as the Anthropic-native path does.
+        headers.update(_attribution_headers(request.headers))
 
         if is_stream:
             return StreamingResponse(
@@ -248,6 +253,18 @@ async def _stream_proxy(
                 "error": {"type": "api_error", "message": str(exc)},
             },
         )
+
+
+_ATTRIBUTION_HEADER_PREFIX = "x-litellm-"
+
+
+def _attribution_headers(incoming) -> dict[str, str]:
+    """The ``x-litellm-*`` headers of an incoming request, to forward verbatim."""
+    return {
+        name: value
+        for name, value in incoming.items()
+        if name.lower().startswith(_ATTRIBUTION_HEADER_PREFIX)
+    }
 
 
 def _translate_error(response: httpx.Response) -> JSONResponse:

--- a/src/osprey/models/providers/als_apg.py
+++ b/src/osprey/models/providers/als_apg.py
@@ -47,6 +47,9 @@ class ALSAPGProviderAdapter(LiteLLMDelegatingProvider):
 
     # LiteLLM integration - ALS-APG is an OpenAI-compatible proxy
     is_openai_compatible = True
+    # A LiteLLM proxy: requests carry the acting identity so the gateway's
+    # spend logs book each call to a person, not to the deployment's key.
+    gateway = "litellm"
     # Note: intentionally leaves supports_native_structured_output at the None default
     # so structured-output support is auto-detected via litellm.supports_response_schema()
     # on the resolved openai/<model> id, which is what the proxy actually serves.

--- a/src/osprey/models/providers/base.py
+++ b/src/osprey/models/providers/base.py
@@ -85,6 +85,10 @@ class BaseProvider(ABC):
     # eliminating hardcoded provider checks in the adapter layer.
     litellm_prefix: str | None = None  # LiteLLM prefix (e.g., "anthropic", "gemini")
     is_openai_compatible: bool = False  # True for OpenAI-compatible endpoints (CBORG, etc.)
+    # The gateway kind fronting this provider, when it is a proxy rather than a
+    # model vendor. "litellm" makes every request carry the acting identity for
+    # spend attribution (see models/spend_attribution.py); None sends nothing.
+    gateway: str | None = None
     # Structured output routing:
     #   True  -> send response_format json_schema (native constrained decoding)
     #   False -> use OSPREY's prompt-based JSON fallback

--- a/src/osprey/models/providers/cborg.py
+++ b/src/osprey/models/providers/cborg.py
@@ -43,6 +43,7 @@ class CBorgProviderAdapter(LiteLLMDelegatingProvider):
 
     # LiteLLM integration - CBORG is an OpenAI-compatible proxy
     is_openai_compatible = True
+    gateway = "litellm"  # a LiteLLM proxy — requests carry the acting identity
     supports_native_structured_output = True  # proxies to models with native json_schema support
 
     # execute_completion / check_health inherited from LiteLLMDelegatingProvider.

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -39,6 +39,12 @@ os.environ.setdefault("LITELLM_MODE", "PRODUCTION")
 import litellm  # noqa: E402  (must follow the LITELLM_MODE setdefault above)
 from pydantic import BaseModel  # noqa: E402
 
+from osprey.models.spend_attribution import (  # noqa: E402
+    LITELLM_GATEWAY,
+    TAGS_HEADER,
+    attribution_tags,
+)
+from osprey.utils.identity import acting_identity  # noqa: E402
 from osprey.utils.logger import get_logger  # noqa: E402
 
 if TYPE_CHECKING:
@@ -134,6 +140,22 @@ def get_litellm_model_name(
     return f"{provider}/{model_id}"
 
 
+def _provider_gateway(provider: str) -> str | None:
+    """The gateway kind the provider adapter declares, or ``None``.
+
+    Read from the registered adapter class (``gateway`` attribute) so the SDK
+    path and the agent's launch paths agree on which providers are LiteLLM
+    proxies. An unregistered name is a direct provider for this purpose.
+    """
+    from osprey.models.provider_registry import get_provider_registry
+
+    try:
+        provider_class = get_provider_registry().get_provider(provider)
+    except Exception:  # noqa: BLE001 — unknown provider: attribute nothing
+        return None
+    return getattr(provider_class, "gateway", None)
+
+
 def execute_litellm_completion(
     provider: str,
     message: str,
@@ -195,6 +217,13 @@ def execute_litellm_completion(
 
     # HTTP proxy needs no handling here: LiteLLM honors the standard
     # HTTP_PROXY / HTTPS_PROXY environment variables automatically.
+
+    # Spend attribution: on a LiteLLM-fronted provider, book this call to the
+    # acting identity (OpenAI `user` field) and tag it like the agent's own
+    # requests, so the gateway's spend logs see one caller on both paths.
+    if _provider_gateway(provider) == LITELLM_GATEWAY:
+        completion_kwargs["user"] = acting_identity()
+        completion_kwargs["extra_headers"] = {TAGS_HEADER: attribution_tags()}
 
     # Handle extended thinking
     enable_thinking = kwargs.get("enable_thinking", False)

--- a/src/osprey/models/spend_attribution.py
+++ b/src/osprey/models/spend_attribution.py
@@ -1,0 +1,151 @@
+"""Spend attribution: the identity every request to a LiteLLM gateway carries.
+
+A deployment authenticates to its LLM gateway with ONE credential, so at the
+gateway every terminal, the dispatch worker and every headless run look like
+the same caller. The gateway prices each call and can attribute it — but only
+if the request says who asked. LiteLLM reads two headers for that:
+
+* ``x-litellm-end-user-id`` — the end user the spend is booked to
+  (``/customer/info``, ``end_user`` in the spend logs);
+* ``x-litellm-tags`` — free-form tags on the spend-log row (``request_tags``).
+
+OSPREY already knows who is asking: :func:`osprey.utils.identity.acting_identity`
+resolves the roster user of a terminal container, the framework identity of a
+service container, or the local account. This module turns that answer into
+those two headers and delivers them on both LLM call paths:
+
+* **The agent.** Claude Code adds ``ANTHROPIC_CUSTOM_HEADERS`` (newline-
+  separated ``Name: Value`` pairs) to every request it makes, so the launch
+  paths set that variable through :func:`apply_attribution_env`. It merges into
+  an operator's own value rather than replacing it — that variable is also the
+  one way to carry corporate-proxy headers, which is why the resolver never
+  scrubs it.
+* **The LiteLLM SDK path** (structured completions from MCP servers and
+  services) sets the same identity as the OpenAI ``user`` field plus
+  ``extra_headers``; see ``providers/litellm_adapter.py``.
+
+Only providers fronted by a LiteLLM gateway get the headers (:func:`gateway_for`).
+A direct provider would ignore them at best, so it gets none.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, MutableMapping
+
+from osprey.utils.identity import AUDIT_IDENTITY_ENV, TERMINAL_USER_ENV, acting_identity
+
+#: The one gateway kind OSPREY knows how to attribute spend on.
+LITELLM_GATEWAY = "litellm"
+
+#: LiteLLM's end-user header — the spend is booked to this id.
+END_USER_HEADER = "x-litellm-end-user-id"
+
+#: LiteLLM's request-tags header — a comma-separated list on the spend-log row.
+TAGS_HEADER = "x-litellm-tags"
+
+#: Claude Code's extra-request-headers variable: ``Name: Value`` per line.
+CUSTOM_HEADERS_ENV = "ANTHROPIC_CUSTOM_HEADERS"
+
+#: The tag every OSPREY request carries, so a gateway shared with other
+#: consumers can pick OSPREY's spend out of the rest.
+_PRODUCT_TAG = "osprey"
+
+#: The ``surface:<name>`` tag values, keyed by how the process is identified.
+SURFACE_TERMINAL = "terminal"
+SURFACE_DISPATCH = "dispatch"
+SURFACE_SERVICE = "service"
+SURFACE_LOCAL = "local"
+
+#: Built-in providers that are LiteLLM proxies. A custom ``api.providers``
+#: entry declares the same with ``gateway: litellm``.
+_BUILTIN_GATEWAYS: Mapping[str, str] = {
+    "als-apg": LITELLM_GATEWAY,
+    "cborg": LITELLM_GATEWAY,
+}
+
+
+def gateway_for(
+    provider_name: str, api_providers: Mapping[str, Mapping] | None = None
+) -> str | None:
+    """Return the gateway kind fronting *provider_name*, or ``None`` for a direct provider.
+
+    A custom provider's ``gateway`` key wins over nothing: the built-in table
+    only names providers that have no ``api.providers`` entry of their own.
+    """
+    if provider_name in _BUILTIN_GATEWAYS:
+        return _BUILTIN_GATEWAYS[provider_name]
+    if api_providers:
+        declared = api_providers.get(provider_name, {}).get("gateway")
+        if isinstance(declared, str) and declared.strip():
+            return declared.strip()
+    return None
+
+
+def acting_surface() -> str:
+    """Which kind of process is asking — the ``surface:`` tag value.
+
+    Follows the same ladder as :func:`osprey.utils.identity.acting_identity`:
+    a terminal container names a person; a service container names a
+    framework identity, and the dispatch worker is the one whose runs a
+    facility wants to see apart from the rest; everything else is a local
+    session on somebody's own machine.
+    """
+    if (os.environ.get(TERMINAL_USER_ENV) or "").strip():
+        return SURFACE_TERMINAL
+    audit_identity = (os.environ.get(AUDIT_IDENTITY_ENV) or "").strip()
+    if audit_identity:
+        return SURFACE_DISPATCH if audit_identity.startswith("dispatch-worker") else SURFACE_SERVICE
+    return SURFACE_LOCAL
+
+
+def attribution_tags() -> str:
+    """The comma-separated ``x-litellm-tags`` value for this process."""
+    return f"{_PRODUCT_TAG},surface:{acting_surface()}"
+
+
+def attribution_headers() -> dict[str, str]:
+    """The two headers a request from this process should carry."""
+    return {
+        END_USER_HEADER: acting_identity(),
+        TAGS_HEADER: attribution_tags(),
+    }
+
+
+def render_custom_headers(headers: Mapping[str, str]) -> str:
+    """Render *headers* in Claude Code's ``ANTHROPIC_CUSTOM_HEADERS`` format."""
+    return "\n".join(f"{name}: {value}" for name, value in headers.items())
+
+
+def merge_custom_headers(existing: str | None, headers: Mapping[str, str]) -> str:
+    """Add *headers* to an ``ANTHROPIC_CUSTOM_HEADERS`` value, keeping the operator's own.
+
+    A line already naming one of *headers* (case-insensitively) is replaced —
+    a stale attribution must not ride beside a fresh one — and every other
+    line is kept in its place. Blank lines are dropped.
+    """
+    ours = {name.lower() for name in headers}
+    kept: list[str] = []
+    for line in (existing or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        name = line.split(":", 1)[0].strip().lower()
+        if name in ours:
+            continue
+        kept.append(line)
+    kept.append(render_custom_headers(headers))
+    return "\n".join(kept)
+
+
+def apply_attribution_env(environ: MutableMapping[str, str], gateway: str | None) -> None:
+    """Set ``ANTHROPIC_CUSTOM_HEADERS`` in *environ* when *gateway* attributes spend.
+
+    Mutates *environ* in place. A ``None`` or unknown gateway leaves it
+    untouched — including any operator value already there.
+    """
+    if gateway != LITELLM_GATEWAY:
+        return
+    environ[CUSTOM_HEADERS_ENV] = merge_custom_headers(
+        environ.get(CUSTOM_HEADERS_ENV), attribution_headers()
+    )

--- a/tests/cli/test_provider_isolation.py
+++ b/tests/cli/test_provider_isolation.py
@@ -652,3 +652,64 @@ class TestProxyEnvWarning:
 
         assert environ["HTTPS_PROXY"] == "socks5://127.0.0.1:1080"  # load ran
         assert self._records(caplog) == []
+
+
+# ── Spend attribution through a LiteLLM gateway ──────────────────
+
+
+class TestSpendAttributionEnv:
+    """``inject_provider_env`` stamps the acting identity onto the agent's
+    requests when the provider is fronted by a LiteLLM gateway, and leaves
+    ``ANTHROPIC_CUSTOM_HEADERS`` alone otherwise."""
+
+    def test_builtin_litellm_providers_carry_gateway(self):
+        assert ClaudeCodeModelResolver.resolve({"provider": "als-apg"}).gateway == "litellm"
+        assert ClaudeCodeModelResolver.resolve({"provider": "cborg"}).gateway == "litellm"
+
+    def test_direct_provider_has_no_gateway(self):
+        assert ClaudeCodeModelResolver.resolve({"provider": "anthropic"}).gateway is None
+
+    def test_custom_provider_declares_gateway(self):
+        providers = {
+            "my-gw": {
+                "base_url": "https://gw.example/v1",
+                "gateway": "litellm",
+                "models": {"haiku": "h", "sonnet": "s", "opus": "o"},
+            }
+        }
+        spec = ClaudeCodeModelResolver.resolve({"provider": "my-gw"}, providers)
+        assert spec.gateway == "litellm"
+
+    def test_inject_sets_identity_headers_for_gateway(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
+        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        environ = {"ALS_APG_API_KEY": "sk-secret"}
+
+        inject_provider_env(environ, spec)
+
+        assert environ["ANTHROPIC_CUSTOM_HEADERS"] == (
+            "x-litellm-end-user-id: thellert\nx-litellm-tags: osprey,surface:terminal"
+        )
+
+    def test_inject_keeps_operator_headers(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
+        spec = ClaudeCodeModelResolver.resolve({"provider": "cborg"})
+        environ = {
+            "CBORG_API_KEY": "sk-secret",
+            "ANTHROPIC_CUSTOM_HEADERS": "X-Corp-Trace: abc123",
+        }
+
+        inject_provider_env(environ, spec)
+
+        lines = environ["ANTHROPIC_CUSTOM_HEADERS"].splitlines()
+        assert lines[0] == "X-Corp-Trace: abc123"
+        assert "x-litellm-end-user-id: thellert" in lines
+
+    def test_inject_leaves_direct_provider_alone(self, monkeypatch):
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
+        spec = ClaudeCodeModelResolver.resolve({"provider": "anthropic"})
+        environ = {"ANTHROPIC_API_KEY": "secret-123"}
+
+        inject_provider_env(environ, spec)
+
+        assert "ANTHROPIC_CUSTOM_HEADERS" not in environ

--- a/tests/infrastructure/proxy/test_proxy_app_mock.py
+++ b/tests/infrastructure/proxy/test_proxy_app_mock.py
@@ -202,3 +202,40 @@ def test_health_endpoint_reports_upstream():
     resp = client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok", "upstream": "https://api.cborg.lbl.gov/v1"}
+
+
+def test_proxy_forwards_litellm_attribution_headers(monkeypatch):
+    """The x-litellm-* headers Claude Code adds (ANTHROPIC_CUSTOM_HEADERS) reach
+    the upstream gateway; unrelated client headers do not."""
+    captured = _install_fake_upstream(
+        monkeypatch,
+        {
+            "choices": [
+                {"message": {"role": "assistant", "content": "PONG"}, "finish_reason": "stop"}
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+        },
+    )
+    app = create_proxy_app("https://gw.example/v1", upstream_api_key="secret-key")
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 16,
+        },
+        headers={
+            "X-LiteLLM-End-User-Id": "thellert",
+            "x-litellm-tags": "osprey,surface:terminal",
+            "X-Corp-Trace": "abc123",
+        },
+    )
+    assert resp.status_code == 200
+
+    sent = {k.lower(): v for k, v in captured["headers"].items()}
+    assert sent["x-litellm-end-user-id"] == "thellert"
+    assert sent["x-litellm-tags"] == "osprey,surface:terminal"
+    assert "x-corp-trace" not in sent
+    assert sent["authorization"] == "Bearer secret-key"

--- a/tests/models/test_litellm_adapter.py
+++ b/tests/models/test_litellm_adapter.py
@@ -866,3 +866,43 @@ class TestCheckLitellmHealth:
         )
         assert ok is False
         assert msg.startswith("API error")
+
+
+class TestSpendAttribution:
+    """The SDK path books its spend to the acting identity on a LiteLLM gateway."""
+
+    @patch("osprey.models.providers.litellm_adapter.litellm")
+    def test_gateway_provider_sends_user_and_tags(self, mock_litellm, monkeypatch):
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
+        mock_litellm.completion.return_value.choices[0].message.content = "ok"
+        mock_litellm.completion.return_value.choices[0].message.tool_calls = None
+
+        execute_litellm_completion(
+            provider="als-apg",
+            message="hi",
+            model_id="claude-haiku-4-5-20251001",
+            api_key="sk-x",
+            base_url="https://gw.example/v1",
+        )
+
+        kwargs = mock_litellm.completion.call_args.kwargs
+        assert kwargs["user"] == "thellert"
+        assert kwargs["extra_headers"] == {"x-litellm-tags": "osprey,surface:terminal"}
+
+    @patch("osprey.models.providers.litellm_adapter.litellm")
+    def test_direct_provider_sends_nothing(self, mock_litellm, monkeypatch):
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
+        mock_litellm.completion.return_value.choices[0].message.content = "ok"
+        mock_litellm.completion.return_value.choices[0].message.tool_calls = None
+
+        execute_litellm_completion(
+            provider="openai",
+            message="hi",
+            model_id="gpt-4o-mini",
+            api_key="sk-x",
+            base_url=None,
+        )
+
+        kwargs = mock_litellm.completion.call_args.kwargs
+        assert "user" not in kwargs
+        assert "extra_headers" not in kwargs

--- a/tests/models/test_spend_attribution.py
+++ b/tests/models/test_spend_attribution.py
@@ -1,0 +1,168 @@
+"""Spend attribution through a LiteLLM gateway — the identity every request carries.
+
+Covers the pure helpers in :mod:`osprey.models.spend_attribution`: which
+providers are LiteLLM-fronted, what surface a process is, the headers a
+request carries, and how they merge into an operator's own
+``ANTHROPIC_CUSTOM_HEADERS`` without clobbering it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.models.spend_attribution import (
+    CUSTOM_HEADERS_ENV,
+    END_USER_HEADER,
+    LITELLM_GATEWAY,
+    TAGS_HEADER,
+    acting_surface,
+    apply_attribution_env,
+    attribution_headers,
+    gateway_for,
+    merge_custom_headers,
+    render_custom_headers,
+)
+from osprey.utils.identity import AUDIT_IDENTITY_ENV, TERMINAL_USER_ENV
+
+
+@pytest.fixture
+def no_identity(monkeypatch):
+    """Neither identity rung is set — the single-user laptop case."""
+    monkeypatch.delenv(TERMINAL_USER_ENV, raising=False)
+    monkeypatch.delenv(AUDIT_IDENTITY_ENV, raising=False)
+
+
+class TestGatewayFor:
+    def test_builtin_litellm_providers(self):
+        assert gateway_for("als-apg") == LITELLM_GATEWAY
+        assert gateway_for("cborg") == LITELLM_GATEWAY
+
+    def test_direct_providers_have_no_gateway(self):
+        assert gateway_for("anthropic") is None
+        assert gateway_for("openai") is None
+
+    def test_custom_provider_declares_gateway_in_config(self):
+        providers = {"my-gw": {"base_url": "https://gw.example/v1", "gateway": "litellm"}}
+        assert gateway_for("my-gw", providers) == LITELLM_GATEWAY
+
+    def test_custom_provider_without_key_is_unattributed(self):
+        providers = {"my-gw": {"base_url": "https://gw.example/v1"}}
+        assert gateway_for("my-gw", providers) is None
+
+    def test_unknown_provider_is_unattributed(self):
+        assert gateway_for("no-such-provider") is None
+
+
+class TestActingSurface:
+    def test_terminal_user_wins(self, monkeypatch):
+        monkeypatch.setenv(TERMINAL_USER_ENV, "thellert")
+        monkeypatch.setenv(AUDIT_IDENTITY_ENV, "dispatch-worker-0")
+        assert acting_surface() == "terminal"
+
+    def test_dispatch_worker(self, monkeypatch):
+        monkeypatch.delenv(TERMINAL_USER_ENV, raising=False)
+        monkeypatch.setenv(AUDIT_IDENTITY_ENV, "dispatch-worker-0")
+        assert acting_surface() == "dispatch"
+
+    def test_other_service_container(self, monkeypatch):
+        monkeypatch.delenv(TERMINAL_USER_ENV, raising=False)
+        monkeypatch.setenv(AUDIT_IDENTITY_ENV, "sidecar")
+        assert acting_surface() == "service"
+
+    def test_local(self, no_identity):
+        assert acting_surface() == "local"
+
+
+class TestAttributionHeaders:
+    def test_terminal_user_is_the_end_user(self, monkeypatch):
+        monkeypatch.setenv(TERMINAL_USER_ENV, "thellert")
+        headers = attribution_headers()
+        assert headers[END_USER_HEADER] == "thellert"
+        assert headers[TAGS_HEADER] == "osprey,surface:terminal"
+
+    def test_dispatch_worker_identity(self, monkeypatch):
+        monkeypatch.delenv(TERMINAL_USER_ENV, raising=False)
+        monkeypatch.setenv(AUDIT_IDENTITY_ENV, "dispatch-worker-1")
+        headers = attribution_headers()
+        assert headers[END_USER_HEADER] == "dispatch-worker-1"
+        assert headers[TAGS_HEADER] == "osprey,surface:dispatch"
+
+    def test_exactly_two_headers(self, no_identity):
+        assert set(attribution_headers()) == {END_USER_HEADER, TAGS_HEADER}
+
+
+class TestCustomHeadersRendering:
+    def test_render_is_newline_separated_name_colon_value(self):
+        text = render_custom_headers({"A": "1", "B": "two"})
+        assert text == "A: 1\nB: two"
+
+    def test_merge_keeps_operator_headers(self):
+        merged = merge_custom_headers("X-Corp-Trace: abc123", {"x-litellm-tags": "osprey"})
+        assert merged == "X-Corp-Trace: abc123\nx-litellm-tags: osprey"
+
+    def test_merge_replaces_same_name_case_insensitively(self):
+        merged = merge_custom_headers(
+            "X-LiteLLM-Tags: stale\nX-Corp-Trace: abc",
+            {"x-litellm-tags": "osprey"},
+        )
+        assert merged == "X-Corp-Trace: abc\nx-litellm-tags: osprey"
+
+    def test_merge_from_empty(self):
+        assert merge_custom_headers(None, {"a": "1"}) == "a: 1"
+        assert merge_custom_headers("", {"a": "1"}) == "a: 1"
+
+    def test_merge_drops_blank_lines(self):
+        merged = merge_custom_headers("X-A: 1\n\n  \n", {"b": "2"})
+        assert merged == "X-A: 1\nb: 2"
+
+
+class TestApplyAttributionEnv:
+    def test_litellm_gateway_sets_custom_headers(self, monkeypatch):
+        monkeypatch.setenv(TERMINAL_USER_ENV, "thellert")
+        environ: dict[str, str] = {}
+        apply_attribution_env(environ, LITELLM_GATEWAY)
+        assert environ[CUSTOM_HEADERS_ENV] == (
+            f"{END_USER_HEADER}: thellert\n{TAGS_HEADER}: osprey,surface:terminal"
+        )
+
+    def test_merges_into_existing_operator_headers(self, monkeypatch):
+        monkeypatch.setenv(TERMINAL_USER_ENV, "thellert")
+        environ = {CUSTOM_HEADERS_ENV: "X-Corp-Trace: abc123"}
+        apply_attribution_env(environ, LITELLM_GATEWAY)
+        assert environ[CUSTOM_HEADERS_ENV].startswith("X-Corp-Trace: abc123\n")
+        assert f"{END_USER_HEADER}: thellert" in environ[CUSTOM_HEADERS_ENV]
+
+    def test_no_gateway_leaves_environ_untouched(self, no_identity):
+        environ = {CUSTOM_HEADERS_ENV: "X-Corp-Trace: abc123"}
+        apply_attribution_env(environ, None)
+        assert environ == {CUSTOM_HEADERS_ENV: "X-Corp-Trace: abc123"}
+
+        environ2: dict[str, str] = {}
+        apply_attribution_env(environ2, None)
+        assert environ2 == {}
+
+
+class TestBuiltinTableAgreesWithAdapters:
+    """The resolver-side built-in table and the adapters' ``gateway`` attribute
+    are two spellings of one fact; the table exists so the launch paths need not
+    import litellm. Pin them together."""
+
+    def test_every_table_entry_matches_its_adapter(self):
+        from osprey.models.provider_registry import get_provider_registry
+        from osprey.models.spend_attribution import _BUILTIN_GATEWAYS
+
+        registry = get_provider_registry()
+        for name, gateway in _BUILTIN_GATEWAYS.items():
+            assert registry.get_provider(name).gateway == gateway, name
+
+    def test_every_adapter_gateway_is_in_the_table(self):
+        from osprey.models.provider_registry import get_provider_registry
+        from osprey.models.spend_attribution import _BUILTIN_GATEWAYS
+
+        registry = get_provider_registry()
+        declared = {
+            name: registry.get_provider(name).gateway
+            for name in registry.list_providers()
+            if getattr(registry.get_provider(name), "gateway", None)
+        }
+        assert declared == dict(_BUILTIN_GATEWAYS)


### PR DESCRIPTION
## Why

A deployment authenticates to its LLM gateway with one key, so the gateway's spend logs book every terminal, the dispatch worker and every headless run to that single key. There is no way to say what a person, or the dispatch surface, cost.

OSPREY already knows who is asking (`osprey.utils.identity.acting_identity` — the audit log's ladder: `OSPREY_TERMINAL_USER` → `OSPREY_AUDIT_IDENTITY` → local account). The join key just never left the process.

## What

On a **LiteLLM-fronted provider** (built-in `als-apg`, `cborg`; custom providers opt in with `gateway: litellm`), every request now carries the acting identity:

| Header | Value |
|---|---|
| `x-litellm-end-user-id` | the terminal's roster user, `dispatch-worker-N`, or the local account |
| `x-litellm-tags` | `osprey,surface:<terminal\|dispatch\|service\|local>` |

- **Agent path** — `inject_provider_env` (the seam every launch path shares: web terminal, dispatch worker, `osprey chat`) sets `ANTHROPIC_CUSTOM_HEADERS`, *merged into* any corporate-proxy headers the operator already has there (the variable is deliberately not scrubbed, and stays that way). `provider_env_for_project` mirrors it for the SDK/benchmark runner.
- **LiteLLM SDK path** — `execute_litellm_completion` sets the same identity as the OpenAI `user` field plus `extra_headers`, so MCP-server completions book to the same caller.
- **Translation proxy** — forwards incoming `x-litellm-*` headers upstream, so an OpenAI-protocol LiteLLM gateway attributes exactly like the Anthropic-native path.
- Direct vendors (`anthropic`, `openai`, …) get nothing.

`ClaudeCodeModelSpec` gains a `gateway` field; `BaseProvider` gains a `gateway` attribute; a test pins the resolver-side built-in table to the adapters' attribute so the two cannot drift.

## Verified

- New: `tests/models/test_spend_attribution.py` (22), plus cases in `test_provider_isolation.py`, `test_litellm_adapter.py`, `test_proxy_app_mock.py`.
- `./scripts/quick_check.sh` green; mypy error count on the touched files unchanged from `main`.
- The ALS terminal image's Claude Code (2.1.146) reads `ANTHROPIC_CUSTOM_HEADERS` (checked against the installed binary).

## Docs

`how-to/llm-providers/configure-providers.rst` — new *Spend Attribution on a LiteLLM Gateway* section, including the `gateway: litellm` key and how to read the result back on the gateway. Changelog fragment `spend-attribution.added.md`.
