### PR TITLE
web_terminals lint: access: any carried by a passive base is silent; warn on access: any beside oidc_subject

### DIFF
--- a/changelog.d/831.fixed.md
+++ b/changelog.d/831.fixed.md
@@ -5,3 +5,9 @@ a passive base that a host variant arms with `password` or `oidc` has to
 carry the key on the base entry — the same place `oidc_subject` already sits
 silently. The warning for `access: any` beside `login: false` under a login
 wall is unchanged.
+
+Under `oidc`, a roster entry that sets `access: any` and also carries an
+`oidc_subject` now draws a warning naming the entry. A shared card is opened
+with the opener's identity, so the subject is not the card's own login; the
+warning catches `access: any` landing on a personal card, which would open
+that terminal to every roster identity.

--- a/changelog.d/831.fixed.md
+++ b/changelog.d/831.fixed.md
@@ -1,0 +1,7 @@
+`access: any` on a web-terminal roster entry no longer draws a warning on
+every validate and build of a deployment whose `auth.method` is `none` or
+`token`. Profile overlays append to the roster rather than merging entries, so
+a passive base that a host variant arms with `password` or `oidc` has to
+carry the key on the base entry — the same place `oidc_subject` already sits
+silently. The warning for `access: any` beside `login: false` under a login
+wall is unchanged.

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -253,6 +253,7 @@ def lint_web_terminals(
     findings.extend(_check_auth_oidc(root, web_terminals))
     findings.extend(_check_auth_credential_collisions(web_terminals, users))
     findings.extend(_check_shared_card_duplicate_subject(web_terminals, users))
+    findings.extend(_check_shared_card_subject(web_terminals, users))
     findings.extend(_check_authorization(web_terminals))
     findings.extend(_check_claims_without_oidc(web_terminals))
     findings.extend(_check_role_charset(web_terminals))
@@ -3364,6 +3365,59 @@ def _check_shared_card_duplicate_subject(
         for colliding in by_subject.values()
         if len(colliding) > 1
     ]
+
+
+def _check_shared_card_subject(web_terminals: dict[str, Any], users: list[Any]) -> list[Finding]:
+    """OIDC: a shared card that also carries a non-empty ``oidc_subject`` — a WARN.
+
+    A shared card is opened with the OPENER's identity: the sidecar's callback
+    reverse-matches the asserted subject over every roster entry's mapping,
+    and the card's own subject participates like any other entry's. So a
+    subject on the shared card itself maps one more identity that may open
+    the card as itself — a documented shape (a service identity on its own
+    shared card), which is why this is a WARN and not a refusal.
+
+    The hazard is the other reading of the same two keys: ``access: any``
+    typo'd onto a *personal* card — the admin login, say — which hands that
+    terminal to every mapped roster identity the moment ``oidc`` is in force,
+    with a green build. Nothing else in this module says so, and the entry
+    alone cannot tell the two readings apart, so the message names the entry
+    and both ways out.
+
+    Scoped to ``method: oidc`` like the two subject checks above: no other
+    method reads the mapping, and on a passive ``none``/``token`` base that an
+    ``oidc`` variant arms both keys are carried base-entry state
+    (:func:`_check_user_access`); the finding belongs to the merged render
+    where the wall stands. The message names the user, never the subject —
+    same reasoning as the ``$`` scan.
+    """
+    context = _auth_context(web_terminals)
+    if context is None or context["auth_method"] != "oidc":
+        return []
+    findings: list[Finding] = []
+    for user in users:
+        if not isinstance(user, dict) or not entry_is_shared(user):
+            continue
+        subject = user.get("oidc_subject")
+        if not isinstance(subject, str) or not subject.strip():
+            continue
+        name = user.get("name", user)
+        findings.append(
+            Finding(
+                severity="warn",
+                code="web_terminals.shared_card_subject",
+                message=(
+                    f"modules.web_terminals.users entry {name!r} sets access: any and "
+                    "also carries an oidc_subject. A shared card is opened with the "
+                    "opener's identity, so this subject only lets that one identity "
+                    "open the card as itself — it is not the card's own login. If "
+                    f"{name!r} is a personal card, drop access: any: as written, every "
+                    "roster identity can open it. If it is a shared card, its own "
+                    "oidc_subject is usually unneeded"
+                ),
+            )
+        )
+    return findings
 
 
 def _check_notice_docs(root: dict[str, Any], web_terminals: dict[str, Any]) -> list[Finding]:

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -628,13 +628,21 @@ def _check_user_access(web_terminals: dict[str, Any], users: list[Any]) -> list[
       deliberately fail-closed to ``own`` — so ``access: ANY`` (or ``true``, or
       a number) never widens an entry's reach, but the author who wrote it
       believes the opposite of what deploys.
-    * ``access: any`` is a WARN when it cannot change anything: either the
-      deployment stands no wall at all (``sidecar_active`` is false — under
-      ``token`` and ``none`` alike no login gates the roster, so every entry is
-      as reachable as the key promises to make this one), or the same entry
-      also carries ``login: false`` (nginx proxies it with no ``auth_request``,
-      so there is no authenticated identity for ``access`` to widen). One code
-      for both; the message names the cause.
+    * ``access: any`` is a WARN on an entry that also carries ``login: false``
+      under a walled deployment: nginx proxies a login-exempt entry with no
+      ``auth_request``, so there is no authenticated identity for ``access`` to
+      widen, and the key claims a distinction the entry does not have.
+
+    Where the deployment stands no wall at all (``sidecar_active`` is false —
+    under ``token`` and ``none`` alike no login gates the roster) the key is
+    inert too, and deliberately NOT reported. Profile overlays concatenate the
+    roster list rather than merging entries by name, so a passive base that a
+    host variant arms with ``password``/``oidc`` has to carry ``access: any``
+    on the base entry — the same position ``oidc_subject`` already sits in
+    silently (:func:`_check_auth_oidc` reads it only under ``oidc``). A finding
+    there would recur on every validate/build of the base and train operators
+    to skip the WARN block; the key arms the moment the variant is selected,
+    and the merged view is what both commands lint.
 
     ``access: own`` explicit is silent — a valid spelling of the default, even
     though the normalizer drops it.
@@ -646,7 +654,6 @@ def _check_user_access(web_terminals: dict[str, Any], users: list[Any]) -> list[
     context = _auth_context(web_terminals)
     inert = context is None or not context["sidecar_active"]
 
-    any_declared = False
     for user in users:
         if not isinstance(user, dict) or "access" not in user:
             continue
@@ -654,10 +661,9 @@ def _check_user_access(web_terminals: dict[str, Any], users: list[Any]) -> list[
         if isinstance(access, str) and access == "own":
             continue
         if isinstance(access, str) and access == "any":
-            any_declared = True
-            # Only where the wall stands: with no sidecar the deployment-level
-            # warning below already covers this entry, and reporting both
-            # causes for one key would double-count a single inertness.
+            # Only where the wall stands: with no sidecar both keys are carried
+            # base-entry state, and the pair becomes this finding on the
+            # variant render that arms the wall.
             if not inert and user.get("login") is False:
                 name = user.get("name", user)
                 findings.append(
@@ -684,22 +690,6 @@ def _check_user_access(web_terminals: dict[str, Any], users: list[Any]) -> list[
                     f"access {access!r}; access must be the string 'own' (default: "
                     f"this entry reaches only its own terminal) or 'any' (may reach "
                     f"every roster entry's terminal). Anything else deploys as 'own'"
-                ),
-            )
-        )
-
-    if any_declared and inert:
-        method = "unset" if context is None else repr(context["auth_method"])
-        findings.append(
-            Finding(
-                severity="warn",
-                code="web_terminals.user_access_inert",
-                message=(
-                    "a modules.web_terminals.users entry sets access: any, but "
-                    f"auth.method is {method} so no login wall stands between "
-                    "entries — every terminal is already as reachable as the key "
-                    "promises to make this one; the key changes nothing until "
-                    "auth.method is password or oidc"
                 ),
             )
         )
@@ -1739,8 +1729,9 @@ def _check_privileged_persona_exposure(
 
     # A shared card is judged on the same ABSOLUTE answer, and only reported
     # where a wall stands: with no sidecar there is no authenticated identity
-    # for `access: any` to widen (`user_access_inert` says so), and the
-    # deployment-wide arm above already names every privileged entry once.
+    # for `access: any` to widen (see `_check_user_access` on why that is a
+    # carried key rather than a finding), and the deployment-wide arm above
+    # already names every privileged entry once.
     for problem in shared_card_privileged_problems(resolved, absolute):
         findings.append(
             Finding(

--- a/tests/cli/test_variant_selection.py
+++ b/tests/cli/test_variant_selection.py
@@ -668,6 +668,47 @@ class TestValidateHonorsTheVariant:
 
         assert result.exit_code != 0
 
+    def test_the_merged_roster_is_what_is_linted(
+        self, runner: CliRunner, lifecycle_repo: Path
+    ) -> None:
+        """Roster keys that only mean something under the variant's auth method
+        are judged on the merged document. The exemplar's tracked roster is
+        under ``password``; the overlay arms ``oidc``, which is the one method
+        that reads ``oidc_subject`` — so a card carrying both ``access: any``
+        and a subject draws its advisory only once the variant is selected."""
+        profile = lifecycle_repo / PROFILE_FILENAME
+        text = profile.read_text(encoding="utf-8")
+        marker = '        display_name: "Control Room (Alice)"\n'
+        assert text.count(marker) == 1
+        profile.write_text(
+            text.replace(
+                marker,
+                marker + "        access: any\n        oidc_subject: alice@example.org\n",
+            ),
+            encoding="utf-8",
+        )
+        _write_variant(
+            lifecycle_repo,
+            "sso",
+            "config:\n"
+            "  modules.web_terminals:\n"
+            "    auth:\n"
+            "      method: oidc\n"
+            "      allow_insecure_http: true\n"
+            "      oidc:\n"
+            "        issuer: https://idp.example.org\n",
+        )
+
+        tracked = _run_validate(runner, lifecycle_repo)
+        write_setting(lifecycle_repo, f"{VARIANT_SETTING_KEY}=sso\n")
+        merged = _run_validate(runner, lifecycle_repo)
+
+        assert tracked.exit_code == 0, tracked.output
+        assert merged.exit_code == 0, merged.output
+        assert "'alice'" not in tracked.output
+        assert "access: any" in merged.output
+        assert "'alice'" in merged.output
+
     def test_a_persona_delta_has_no_variant(self, runner: CliRunner, lifecycle_repo: Path) -> None:
         """A delta named directly is a file, not a deployment — nothing overlays it."""
         personas = sorted((lifecycle_repo / "personas").glob("*.yml"))

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -693,10 +693,12 @@ def test_lint_user_access_skips_non_dict_entries() -> None:
     assert not any(f.code == "web_terminals.user_access_inert" for f in findings)
 
 
-def test_lint_access_any_without_sidecar_is_an_inert_key_warning() -> None:
+def test_lint_access_any_without_sidecar_is_silent() -> None:
     """`access: any` under the default `auth.method: token` changes nothing —
-    no sidecar stands a login wall, so every terminal is already as reachable
-    as the key promises to make this one."""
+    no sidecar stands a login wall — but it is a carried roster key, not a
+    mistake: overlays concatenate the roster list, so a passive base that a
+    host variant arms with `password`/`oidc` has to carry the key on the base
+    entry, exactly where `oidc_subject` already sits silently."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
@@ -707,13 +709,12 @@ def test_lint_access_any_without_sidecar_is_an_inert_key_warning() -> None:
     findings = lint_web_terminals(config)
 
     # Assert
-    assert any(f.code == "web_terminals.user_access_inert" for f in _warnings(findings))
+    assert not any(f.code == "web_terminals.user_access_inert" for f in findings)
 
 
-def test_lint_access_any_under_auth_none_is_an_inert_key_warning() -> None:
-    """Under `auth.method: none` the key is inert too: `login: false` still
-    means something there (it withholds the injected secret), but `access`
-    reads the sidecar-established identity, and there is none."""
+def test_lint_access_any_under_auth_none_is_silent() -> None:
+    """Under `auth.method: none` the same carried-key reading holds: the open,
+    tunnel-only posture is the usual passive base an `sso` variant arms."""
     # Arrange
     config = _auth_config({"method": "none"}, tls=False, fqdn=None)
     config["modules"]["web_terminals"]["users"] = [
@@ -724,7 +725,7 @@ def test_lint_access_any_under_auth_none_is_an_inert_key_warning() -> None:
     findings = lint_web_terminals(config)
 
     # Assert
-    assert any(f.code == "web_terminals.user_access_inert" for f in _warnings(findings))
+    assert not any(f.code == "web_terminals.user_access_inert" for f in findings)
 
 
 def test_lint_access_any_on_a_login_exempt_entry_is_an_inert_key_warning() -> None:

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -3231,7 +3231,7 @@ def test_lint_duplicate_subject_with_a_shared_card_is_an_error() -> None:
     config["modules"]["web_terminals"]["users"] = [
         {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
         {"name": "thellert-admin", "index": 1, "oidc_subject": " thorsten@example.org "},
-        {"name": "control", "index": 2, "access": "any", "oidc_subject": "svc@example.org"},
+        {"name": "control", "index": 2, "access": "any"},
     ]
 
     # Act
@@ -3283,6 +3283,68 @@ def test_lint_distinct_subjects_with_a_shared_card_report_nothing() -> None:
 
     # Assert
     assert not any(f.code == "web_terminals.shared_card_duplicate_subject" for f in findings)
+
+
+def test_lint_shared_card_with_a_subject_is_a_warning() -> None:
+    """`access: any` beside a non-empty `oidc_subject`, under `oidc`: a shared
+    card is opened with the OPENER's identity, so the card's own subject only
+    lets that one identity open it as itself. The hazard is the other
+    reading — `access: any` typo'd onto a personal card, which hands the
+    terminal to every mapped roster identity the moment `oidc` is in force —
+    so the finding names the entry and both ways out."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "access": "any", "oidc_subject": "thorsten@example.org"},
+        {"name": "gmartino", "index": 1, "oidc_subject": "gmartino@example.org"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    offenders = [f for f in _warnings(findings) if f.code == "web_terminals.shared_card_subject"]
+    assert len(offenders) == 1
+    assert "'thellert'" in offenders[0].message
+    assert "'gmartino'" not in offenders[0].message
+    assert "thorsten@example.org" not in offenders[0].message
+    assert "access: any" in offenders[0].message
+    assert "oidc_subject" in offenders[0].message
+
+
+def test_lint_shared_card_with_a_blank_subject_reports_nothing() -> None:
+    """An empty or whitespace-only `oidc_subject` maps no identity — there is
+    nothing on the card for the finding to be about."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "control", "index": 0, "access": "any", "oidc_subject": "  "},
+        {"name": "gmartino", "index": 1, "oidc_subject": "gmartino@example.org"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.shared_card_subject" for f in findings)
+
+
+def test_lint_shared_card_subject_check_is_mode_gated() -> None:
+    """Only `oidc` reads the subject mapping. On a passive `none` base that an
+    `oidc` variant arms, both keys are carried base-entry state (see the
+    `access: any` carried-key tests above); the finding belongs to the merged
+    render where the wall stands, not to every build of the base."""
+    # Arrange
+    config = _auth_config({"method": "none"}, tls=False, fqdn=None)
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "access": "any", "oidc_subject": "thorsten@example.org"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.shared_card_subject" for f in findings)
 
 
 def test_lint_duplicate_subject_check_is_mode_gated() -> None:


### PR DESCRIPTION
Fixes #831 — two follow-ups to the `access: own|any` roster rule (#808), both in `_check_user_access`'s neighbourhood of `web_terminals/lint.py`, one commit each.

## 1. `access: any` on a passive base that an overlay arms — no longer a warning

Overlays concatenate the roster list (`_merge_lists`), so a deployment whose tracked base is the `none`/`token` posture and whose host variant arms `password`/`oidc` has to carry `access: any` on the base entry — the same position `oidc_subject` already sits in silently. The deployment-level `user_access_inert` WARN fired on every validate/build of that base.

**Shape chosen: silence, like `oidc_subject` — not an INFO-level finding.** The issue offered both. `Finding`'s docstring rules that out on purpose ("There is deliberately no third, purely informational level … a level that meant neither would be a way to report a problem without owning whether it is one"), and an INFO line here would be exactly that. The key is inert where no sidecar stands a wall, and it arms on the merged render the moment the variant is selected, which is what both `osprey validate` and `osprey build` lint. The per-entry `user_access_inert` for `access: any` beside `login: false` under a walled deployment is unchanged.

**The parenthetical (WARN missing when a non-auth variant is selected):** not reproducible. Reproduced the shape on the exemplar repo — `auth.method: none` base, `access: any` on a card, a variant that only sets `facility.name` — and the WARN printed identically with and without `.env.variant` selecting it; it disappeared only when the overlay armed auth. The variant path lints the merged roster. The new CLI test in `test_variant_selection.py` pins that from the other side (a roster finding that exists only under the overlay's method appears once the variant is selected).

## 2. `access: any` beside a non-empty `oidc_subject` — a warning naming the entry

New code `web_terminals.shared_card_subject`, gated to `oidc` like the other subject checks. The message names the entry (never the subject) and both ways out.

**WARN, not the recommended ERROR, because the pair is a documented shape.** The login guide says a shared card under `oidc` can be opened by "every entry that carries an `oidc_subject:` … and the shared card itself when it carries one", and the sidecar's callback implements it: the reverse match over configured subjects includes the card's own ("The card's own subject, when it carries one, participates like every other entry's", `routes/oidc.py`). So a service identity on its own shared card is legitimate, and the entry alone cannot tell that reading from the hazardous one (`access: any` landing on a personal card). The existing duplicate-subject test fixture carried this shape on its shared card; it now carries no subject there so that test stays about its own code.

Not touched: the login guide's "Two rosters are refused" list is about ERRORs; the new advisory is not listed there. Happy to add a sentence if wanted.

## Tests

- `test_lint.py`: two carried-key tests flipped to silence; three new tests for the subject warning (positive, blank subject, mode gate).
- `test_variant_selection.py::TestValidateHonorsTheVariant::test_the_merged_roster_is_what_is_linted`: exemplar roster given `access: any` + `oidc_subject` on a card, an `sso` variant arming `oidc`; the advisory appears only with the variant selected.
- `scripts/quick_check.sh` after commit 1: 35912 passed, one failure in `test_file_watcher.py::test_detects_file_creation` (watchdog FSEvents, 3 s deadline) that fails identically in isolation on this machine and is untouched by the branch. Commit 2's changed modules were run in full afterwards.
