### PR TITLE
fix(templates): version pins reaching generated projects, plus two CI-shape guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,6 +955,7 @@ jobs:
             - 'tests/interfaces/design_system/**'
             - 'tests/interfaces/web_terminal/**'
             - 'tests/interfaces/bluesky_web/**'
+            - 'tests/interfaces/lattice_dashboard/**'
             - 'tests/interfaces/ariel/**'
             - 'tests/interfaces/conftest.py'
             - 'tests/interfaces/_browser.py'
@@ -993,6 +994,7 @@ jobs:
         uv run pytest tests/interfaces/design_system/test_behavioral.py \
           tests/interfaces/design_system/test_theme_lab.py \
           tests/interfaces/design_system/test_dispatch_dashboard_unauthorized.py \
+          tests/interfaces/design_system/test_panel_browser.py \
           tests/interfaces/artifacts/test_gallery_interactions.py \
           tests/interfaces/artifacts/test_plot_theme_browser.py \
           tests/interfaces/web_terminal/test_panels_browser.py \
@@ -1006,9 +1008,14 @@ jobs:
           tests/interfaces/web_terminal/test_posture_toggle_browser.py \
           tests/interfaces/web_terminal/test_bar_items_browser.py \
           tests/interfaces/web_terminal/test_ui_mode_browser.py \
+          tests/interfaces/web_terminal/test_chat_browser.py \
+          tests/interfaces/web_terminal/test_rail_position_browser.py \
+          tests/interfaces/web_terminal/test_session_persistence_browser.py \
           tests/interfaces/web_terminal/test_osprey_drawer.py \
           tests/interfaces/web_terminal/test_scaffold_detail.py \
           tests/interfaces/bluesky_web/test_channel_combobox_browser.py \
+          tests/interfaces/bluesky_web/test_lane_picker_browser.py \
+          tests/interfaces/lattice_dashboard/test_retheme_browser.py \
           tests/interfaces/ariel/test_embedded_nav.py \
           tests/interfaces/ariel/test_display_menu.py \
           tests/interfaces/ariel/test_vocabulary_banner.py \

--- a/changelog.d/housekeeping-pins.fixed.md
+++ b/changelog.d/housekeeping-pins.fixed.md
@@ -1,0 +1,5 @@
+Generated projects and the dispatch-worker image now pin Claude Code CLI
+`2.1.258` (was `2.1.146`), and the generated GitLab CI pipeline builds on
+`docker:29` / `docker:29-dind`, deploys from `alpine:3.23`, and validates the
+profile on `python:3.12-slim` — the project image's own Python — instead of
+the end-of-life `docker:27`, `alpine:3.20` and `python:3.11-slim`.

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -65,7 +65,7 @@ Step 2: Install Claude Code
 
 .. code-block:: bash
 
-   npm install -g @anthropic-ai/claude-code@2.1.146
+   npm install -g @anthropic-ai/claude-code@2.1.258
 
 The pinned version is the one OSPREY's generated projects run. Installing it
 exactly — rather than whatever was published most recently — means a brand-new
@@ -91,7 +91,7 @@ globally — set a version under ``config:`` in ``profile.yml`` and run
 
    config:
      claude_code:
-       cli_version: "2.1.146"   # exact version, no semver ranges
+       cli_version: "2.1.258"   # exact version, no semver ranges
 
 When set, ``osprey chat`` and the web terminal launch the pinned
 version via ``npx -y @anthropic-ai/claude-code@<version>`` instead of the
@@ -327,7 +327,7 @@ Troubleshooting
    :icon: alert
 
    **"claude: command not found"**
-      Install Claude Code: ``npm install -g @anthropic-ai/claude-code@2.1.146``
+      Install Claude Code: ``npm install -g @anthropic-ai/claude-code@2.1.258``
 
    **"osprey: command not found"**
       If you installed via ``uv tool install osprey-framework``, make sure uv's

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -395,7 +395,7 @@ def _ci_extra_text(name: str, seeded: tuple[str, ...] = ()) -> str:
 #
 #   ioc-smoke-test:
 #     stage: validate
-#     image: python:3.11-slim
+#     image: python:3.12-slim
 #     script:
 #       - ./ci/ioc_smoke_test.sh
 

--- a/src/osprey/cli/templates/scaffolding.py
+++ b/src/osprey/cli/templates/scaffolding.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("osprey.cli.templates")
 # than silently tracking whatever `npm install -g @anthropic-ai/claude-code`
 # resolves to at build time. Bump deliberately, alongside the dispatch-worker
 # pin.
-_DEFAULT_CLAUDE_CLI_VERSION = "2.1.146"
+_DEFAULT_CLAUDE_CLI_VERSION = "2.1.258"
 
 CONFIG_TEMPLATE = "config.yml.j2"
 """The project-file template that renders ``config.yml``."""

--- a/src/osprey/templates/deploy/gitlab-ci.yml.j2
+++ b/src/osprey/templates/deploy/gitlab-ci.yml.j2
@@ -81,7 +81,7 @@ variables:
 # -----------------------------------------------------------------------------
 render-build:
   stage: validate
-  image: python:3.11-slim
+  image: python:3.12-slim
   before_script:
     # The floor the profile itself declares (requires_osprey_version), so the
     # pipeline can never run an OSPREY that does not understand it.
@@ -106,9 +106,9 @@ render-build:
 # -----------------------------------------------------------------------------
 .service-image:
   stage: images
-  image: docker:27
+  image: docker:29
   services:
-    - docker:27-dind
+    - docker:29-dind
   before_script:
     - docker login -u "$CI_REGISTRY_USER" -p "${{ ctx.registry_token_var }}" "$REGISTRY_HOST"
   script:
@@ -143,9 +143,9 @@ image:{{ service }}:
 
 external:{{ project.name }}:
   stage: images
-  image: docker:27
+  image: docker:29
   services:
-    - docker:27-dind
+    - docker:29-dind
   script:
 {% if project.token_env_var %}
     - docker login -u "$CI_REGISTRY_USER" -p "${{ project.token_env_var }}" "{{ project.url.split('/')[0] }}"
@@ -191,7 +191,7 @@ external:{{ project.name }}:
 # -----------------------------------------------------------------------------
 deploy:
   stage: deploy
-  image: alpine:3.20
+  image: alpine:3.23
   needs:
     - render-build
   before_script:

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -404,7 +404,7 @@ claude_code:
   # via `npx -y @anthropic-ai/claude-code@<version>` instead of bare `claude`.
   # First run downloads the package; subsequent runs hit the npx cache.
   # Verify with `osprey health` after setting.
-  # cli_version: "2.1.146"
+  # cli_version: "2.1.258"
   #
   # ── Server / Agent Overrides ──────────────────────────────
   # Disable framework servers or add custom MCP servers:

--- a/src/osprey/templates/services/event_dispatcher/Dockerfile
+++ b/src/osprey/templates/services/event_dispatcher/Dockerfile
@@ -52,7 +52,7 @@ RUN export http_proxy="${http_proxy:-${HTTP_PROXY:-}}" https_proxy="${https_prox
     # Pin the Claude Code CLI so an upstream release cannot silently change the
     # headless agent's behavior between image builds (matches the cli_version
     # OSPREY documents in config.yml). Bump deliberately.
-    && npm install -g @anthropic-ai/claude-code@2.1.146 \
+    && npm install -g @anthropic-ai/claude-code@2.1.258 \
     && rm -rf /var/lib/apt/lists/*
 # The pin is the point, so the CLI's background self-updater is off: a
 # successful update would silently replace the pinned version. Same rationale

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -694,6 +694,24 @@ def _has_any_provider_api_key() -> bool:
     )
 
 
+def _has_openai_api_key() -> bool:
+    import os as _os
+
+    return bool(_os.environ.get("OPENAI_API_KEY"))
+
+
+def _has_google_api_key() -> bool:
+    import os as _os
+
+    return bool(_os.environ.get("GOOGLE_API_KEY"))
+
+
+def _has_cborg_api_key() -> bool:
+    import os as _os
+
+    return bool(_os.environ.get("CBORG_API_KEY"))
+
+
 def _is_ollama_available() -> bool:
     """True if a local Ollama server responds at localhost:11434."""
     try:
@@ -713,6 +731,9 @@ _RESOURCE_CHECKS: dict[str, tuple[callable, str]] = {
         "AMSC_I2_API_KEY / ANTHROPIC_API_KEY)",
     ),
     "requires_ollama": (_is_ollama_available, "Ollama not reachable at localhost:11434"),
+    "requires_openai": (_has_openai_api_key, "OPENAI_API_KEY not set"),
+    "requires_google": (_has_google_api_key, "GOOGLE_API_KEY not set"),
+    "requires_cborg": (_has_cborg_api_key, "CBORG_API_KEY not set"),
 }
 
 

--- a/tests/deployment/goldens/ci-extra.yml
+++ b/tests/deployment/goldens/ci-extra.yml
@@ -10,7 +10,7 @@
 #
 #   ioc-smoke-test:
 #     stage: validate
-#     image: python:3.11-slim
+#     image: python:3.12-slim
 #     script:
 #       - ./ci/ioc_smoke_test.sh
 

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import ast
 import copy
+import fnmatch
 import importlib.util
 import json
 import re
@@ -2275,6 +2276,88 @@ def test_browser_lane_is_triggered_by_the_bluesky_web_tests(workflow: dict[str, 
     ``src/osprey/interfaces/**`` already, but a PR that only edits the tests
     (fixtures, assertions) would otherwise green-skip the job."""
     assert COMBOBOX_TESTS_FILTER_PATH in _browser_lane_filter_paths(workflow)
+
+
+# ---------------------------------------------------------------------------
+# (h3) every browser suite on disk: (h) and (h2) each pin one file by name,
+# which is exactly how the next one gets forgotten. The lane's explicit file
+# list is checked against a glob over the tree instead, so a ``*_browser.py``
+# that nobody registers is red here rather than silently never collected.
+# ---------------------------------------------------------------------------
+
+TESTS_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = TESTS_ROOT.parent
+
+
+def _browser_suites_on_disk() -> list[str]:
+    """Every ``tests/**/test_*_browser.py``, repo-relative, POSIX-spelled."""
+    return sorted(
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in TESTS_ROOT.rglob("test_*_browser.py")
+        if "__pycache__" not in path.parts
+    )
+
+
+def _browser_lane_named_files(wf: dict[str, Any]) -> set[str]:
+    """The pytest file arguments of the lane's run step, one token at a time —
+    not a substring search, so ``test_panel_browser.py`` is never satisfied by
+    ``test_panels_browser.py``."""
+    return {tok for tok in _browser_lane_files(wf).split() if tok.endswith(".py")}
+
+
+def _armed_by_filter(path: str, filter_paths: list[str]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in filter_paths)
+
+
+def test_browser_suite_discovery_has_a_floor() -> None:
+    """A glob that finds nothing would make the guards below vacuous."""
+    found = _browser_suites_on_disk()
+    assert AUTH_BROWSER_TEST_FILE in found
+    assert COMBOBOX_BROWSER_TEST_FILE in found
+
+
+def test_every_browser_suite_on_disk_is_named_in_the_browser_lane(
+    workflow: dict[str, Any],
+) -> None:
+    named = _browser_lane_named_files(workflow)
+    missing = [suite for suite in _browser_suites_on_disk() if suite not in named]
+    assert missing == [], (
+        f"browser suites on disk that the '{BROWSER_JOB}' lane never runs (the unit lane "
+        f"skips them without chromium, so nothing collects them anywhere): {missing}"
+    )
+
+
+def test_every_browser_suite_on_disk_is_named__mutation_drops_one_suite() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, BROWSER_JOB, BROWSER_RUN_STEP)
+    step["run"] = step["run"].replace(f"{AUTH_BROWSER_TEST_FILE} \\\n", "")
+    named = _browser_lane_named_files(mutated)
+    assert [s for s in _browser_suites_on_disk() if s not in named] == [AUTH_BROWSER_TEST_FILE]
+
+
+def test_every_browser_suite_on_disk_arms_the_browser_lane(workflow: dict[str, Any]) -> None:
+    """Being named in the run step is not enough: the paths filter must also
+    fire for the suite's own file, or a PR that only edits the suite reports
+    the lane green without running it."""
+    filter_paths = _browser_lane_filter_paths(workflow)
+    unarmed = [s for s in _browser_suites_on_disk() if not _armed_by_filter(s, filter_paths)]
+    assert unarmed == [], (
+        f"browser suites whose own path does not trigger the '{BROWSER_JOB}' lane: {unarmed}"
+    )
+
+
+def test_every_browser_suite_on_disk_arms_the_lane__mutation_drops_a_directory() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, BROWSER_JOB, BROWSER_FILTER_STEP)
+    filters = yaml.safe_load(step["with"]["filters"])
+    filters["theming"] = [p for p in filters["theming"] if p != COMBOBOX_TESTS_FILTER_PATH]
+    step["with"]["filters"] = yaml.safe_dump(filters)
+    filter_paths = _browser_lane_filter_paths(mutated)
+    unarmed = [s for s in _browser_suites_on_disk() if not _armed_by_filter(s, filter_paths)]
+    # Every suite under the dropped directory, and only those, comes back unarmed.
+    assert COMBOBOX_BROWSER_TEST_FILE in unarmed, unarmed
+    dropped_dir = COMBOBOX_TESTS_FILTER_PATH.removesuffix("**")
+    assert all(s.startswith(dropped_dir) for s in unarmed), unarmed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_service_dockerfiles.py
+++ b/tests/deployment/test_service_dockerfiles.py
@@ -491,5 +491,64 @@ def test_proxy_guard_accepts_the_declared_arg_idiom():
     assert carries_proxy_idiom(run_instructions(from_arg)[0])
 
 
+# ── Claude Code CLI pin parity ───────────────────────────────────────────────
+#
+# The framework's default CLI pin is spelled once in code
+# (``_DEFAULT_CLAUDE_CLI_VERSION``, which the project Dockerfile.j2 renders
+# from) and hand-copied into three places that cannot read it: the
+# dispatch-worker Dockerfile (a literal file, not a template), the commented
+# ``cli_version:`` example in the generated config.yml, and the installation
+# page (three times; RST substitutions do not expand inside code blocks or
+# inline literals). Each copy is asserted equal to the constant so a bump that
+# misses one fails here instead of shipping two different CLIs.
+
+DOCS_DIR = pathlib.Path(osprey.__file__).parents[2] / "docs" / "source"
+INSTALLATION_PAGE = DOCS_DIR / "getting-started" / "installation.rst"
+CONFIG_TEMPLATE = TEMPLATES_DIR / "project" / "config.yml.j2"
+_CLI_PIN_RE = re.compile(r'@anthropic-ai/claude-code@([0-9][\w.\-]*)|cli_version: "([^"]+)"')
+
+
+def _cli_pins(text: str) -> list[str]:
+    """Every spelled-out CLI version in *text*, in order of appearance."""
+    return [a or b for a, b in _CLI_PIN_RE.findall(text)]
+
+
+def _default_cli_pin() -> str:
+    from osprey.cli.templates.scaffolding import _DEFAULT_CLAUDE_CLI_VERSION
+
+    return _DEFAULT_CLAUDE_CLI_VERSION
+
+
+def test_event_dispatcher_pins_the_default_cli_version():
+    pins = _cli_pins(_dockerfile("event_dispatcher"))
+    assert pins == [_default_cli_pin()], (
+        f"event_dispatcher/Dockerfile pins {pins}, _DEFAULT_CLAUDE_CLI_VERSION is "
+        f"{_default_cli_pin()!r} — bump both together"
+    )
+
+
+def test_config_template_example_pins_the_default_cli_version():
+    pins = _cli_pins(CONFIG_TEMPLATE.read_text())
+    assert pins == [_default_cli_pin()], (
+        f"config.yml.j2's cli_version example says {pins}, _DEFAULT_CLAUDE_CLI_VERSION is "
+        f"{_default_cli_pin()!r}"
+    )
+
+
+def test_installation_page_pins_the_default_cli_version():
+    pins = _cli_pins(INSTALLATION_PAGE.read_text())
+    assert len(pins) >= 3, f"expected the install command and the pin example, found {pins}"
+    assert set(pins) == {_default_cli_pin()}, (
+        f"{INSTALLATION_PAGE.relative_to(DOCS_DIR)} spells the CLI pin as {sorted(set(pins))}, "
+        f"_DEFAULT_CLAUDE_CLI_VERSION is {_default_cli_pin()!r}"
+    )
+
+
+def test_cli_pin_regex_reads_both_spellings():
+    """Meta-test: the matcher sees the npm spec and the YAML key, and nothing else."""
+    sample = 'npm install -g @anthropic-ai/claude-code@1.2.3 \\\n  cli_version: "4.5.6"  # x.y.z\n'
+    assert _cli_pins(sample) == ["1.2.3", "4.5.6"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -1648,7 +1648,7 @@ CI_EXTRA_YML = """\
 #
 #   ioc-smoke-test:
 #     stage: validate
-#     image: python:3.11-slim
+#     image: python:3.12-slim
 #     script:
 #       - ./ci/ioc_smoke_test.sh
 
@@ -1712,7 +1712,7 @@ variables:
 # -----------------------------------------------------------------------------
 render-build:
   stage: validate
-  image: python:3.11-slim
+  image: python:3.12-slim
   before_script:
     # The floor the profile itself declares (requires_osprey_version), so the
     # pipeline can never run an OSPREY that does not understand it.
@@ -1755,7 +1755,7 @@ render-build:
 # -----------------------------------------------------------------------------
 deploy:
   stage: deploy
-  image: alpine:3.20
+  image: alpine:3.23
   needs:
     - render-build
   before_script:

--- a/tests/infrastructure/test_resource_marker_checks.py
+++ b/tests/infrastructure/test_resource_marker_checks.py
@@ -1,0 +1,51 @@
+"""Every ``requires_<resource>`` marker has a skip-gate behind it.
+
+``tests/conftest.py`` turns ``@pytest.mark.requires_<resource>`` into a real
+skip when the resource is missing, but only for markers listed in its
+``_RESOURCE_CHECKS`` table. A marker registered in ``pyproject.toml`` and
+absent from that table passes ``--strict-markers`` and then fails *open*: the
+test runs with no credential and dies on the provider call instead of
+skipping. This pins the two lists to each other in both directions.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from tests.conftest import _RESOURCE_CHECKS
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _declared_requires_markers() -> set[str]:
+    markers = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["tool"]["pytest"]["ini_options"][
+        "markers"
+    ]
+    names = {entry.split(":", 1)[0].strip() for entry in markers}
+    return {name for name in names if name.startswith("requires_")}
+
+
+def test_declared_markers_have_a_floor() -> None:
+    declared = _declared_requires_markers()
+    assert {"requires_api", "requires_anthropic", "requires_ollama"} <= declared, declared
+
+
+def test_every_requires_marker_has_a_resource_check() -> None:
+    missing = sorted(_declared_requires_markers() - set(_RESOURCE_CHECKS))
+    assert missing == [], (
+        f"requires_* markers registered in pyproject.toml with no entry in "
+        f"tests/conftest.py's _RESOURCE_CHECKS — they fail open instead of skipping: {missing}"
+    )
+
+
+def test_every_resource_check_is_a_declared_marker() -> None:
+    unknown = sorted(set(_RESOURCE_CHECKS) - _declared_requires_markers())
+    assert unknown == [], f"_RESOURCE_CHECKS entries with no registered marker: {unknown}"
+
+
+def test_resource_checks_are_predicate_reason_pairs() -> None:
+    for name, entry in _RESOURCE_CHECKS.items():
+        predicate, reason = entry
+        assert callable(predicate), name
+        assert isinstance(reason, str) and reason, name


### PR DESCRIPTION
Housekeeping 2026-09-02, items D1, D5, D6 and two CI guards. Lands via the staging branch.

## Keys

- `pin:src/osprey/cli/templates/scaffolding.py:claude-cli-version`
- `pin:src/osprey/templates/deploy/gitlab-ci.yml.j2:docker-and-alpine-images`
- `pin:src/osprey/templates/deploy/gitlab-ci.yml.j2:python-runtime-skew`

## What changed

- **Claude Code CLI pin** `2.1.146` → `2.1.258` (npm latest today) in the scaffolding constant, the dispatch-worker Dockerfile, the `cli_version` example in the generated config, and the three copies on the installation page. A parity test in `tests/deployment/test_service_dockerfiles.py` asserts every hand-kept copy equals the constant; RST substitutions do not expand inside code blocks, so the docs page is covered by the test rather than rendered.
- **Generated GitLab pipeline**: `docker:27` / `docker:27-dind` → `docker:29` / `docker:29-dind`, `alpine:3.20` → `alpine:3.23` (tags verified on Docker Hub). The `render-build` job and the `ci-extra.yml` example move `python:3.11-slim` → `python:3.12-slim`, matching the project image. Exemplar goldens regenerated.
- **Guard 1**: every `tests/**/test_*_browser.py` must be named in the `visual-theming` lane's run step and armed by its paths filter. Six suites were absent (`test_lane_picker_browser`, `test_panel_browser`, `test_retheme_browser`, `test_chat_browser`, `test_rail_position_browser`, `test_session_persistence_browser`); all 22 tests across them pass locally under chromium, so all six are added. The filter check also caught that `tests/interfaces/lattice_dashboard/**` did not trigger the lane; added.
- **Guard 2**: `requires_*` markers in `pyproject.toml` and `_RESOURCE_CHECKS` in `tests/conftest.py` are pinned to each other in both directions. `requires_openai`, `requires_google`, `requires_cborg` gained env-var presence checks.

## Verification

- `./scripts/quick_check.sh` green (38170 passed).
- Targeted: service Dockerfile tests, CI-wiring tests, resource-marker guard, template render and golden tests, the six browser suites.
