### PR TITLE
feat(web-terminal): tighten the onboarding tour copy and add a bars step

### DIFF
--- a/changelog.d/tour-copy.changed.md
+++ b/changelog.d/tour-copy.changed.md
@@ -1,0 +1,6 @@
+The onboarding tour gains a step for arranging the header and status bar, and
+its copy is tighter throughout: the terminal step drops the "no commands to
+learn" line, the display step names the expert **Settings** on the same card,
+the workspace step drops the rail-glow and shipped-example sentences, and the
+feedback step suggests saving a report as Local and pasting its record id into
+a coding-agent session. The new step appears only where bar editing does.

--- a/src/osprey/interfaces/web_terminal/static/js/tour.js
+++ b/src/osprey/interfaces/web_terminal/static/js/tour.js
@@ -160,23 +160,6 @@ const visible = (node) => {
   return r.width > 0 && r.height > 0;
 };
 
-/**
- * Whether the gallery currently lists a shipped example (its tree renders an
- * "Examples" section). The gallery is a same-origin iframe, so its document
- * is readable; any failure (not loaded yet, cross-origin embed) reads as "no".
- * @returns {boolean}
- */
-function workspaceHasExample() {
-  try {
-    const frame = /** @type {HTMLIFrameElement | null} */ (
-      document.querySelector('iframe[data-panel-id="artifacts"]')
-    );
-    return !!frame?.contentDocument?.querySelector('.tree-section[data-type="examples"]');
-  } catch {
-    return false;
-  }
-}
-
 /* ---- Copy ---- */
 
 /**
@@ -211,7 +194,9 @@ const listPhrase = (items) =>
  * A step's anchor, but only when it is somewhere the operator can see.
  *
  * Four anchors are now bar ITEMS — the control-target chip, the display menu,
- * the command-palette button and (through the rail) the feedback control — and
+ * the command-palette button and (through the rail) the feedback control — a
+ * fifth rides INSIDE one of them (the display menu's Customize row, which is
+ * why removing that item drops two steps, not one) — and
  * a bar item the layout does not name is MOVED into the hidden
  * `#bar-item-pool`, never removed. So `querySelector` keeps answering for
  * chrome that is off screen, and a presence check alone would spotlight a
@@ -240,11 +225,7 @@ const STEPS = [
     anchor: () => document.querySelector('.terminal-card'),
     title: 'Ask in plain language',
     body: () => {
-      const parts = [
-        'This terminal talks to the ',
-        strong('OSPREY agent'),
-        '. Type what you want — no commands to learn.',
-      ];
+      const parts = ['This terminal lets you talk to the ', strong('OSPREY agent'), '.'];
       if (facts.capabilities.length > 0) {
         parts.push(` Here it can ${listPhrase(facts.capabilities)}.`);
       }
@@ -285,7 +266,20 @@ const STEPS = [
     body: () => [
       'Light or dark theme, and a ',
       strong('simple or expert view'),
-      ' of the terminal — switch both here, any time.',
+      ' of the terminal. Expert ',
+      strong('Settings'),
+      ' open from here too.',
+    ],
+  },
+  {
+    anchor: () => document.querySelector('.bar-customize-entry'),
+    activate: () => toggleOpen('.display-menu-trigger'),
+    place: 'left',
+    title: 'Arrange the bars',
+    body: () => [
+      'The header and status bar are yours to arrange. Open ',
+      strong('Customize bars'),
+      ' here, or right-click either bar, to add, move and remove items.',
     ],
   },
   {
@@ -294,7 +288,7 @@ const STEPS = [
     body: () => [
       'Press ',
       strong('⌘K'),
-      ' to search settings, panels, and actions — the fastest way to find anything in this terminal.',
+      ' to search settings, panels, and actions. The fastest way to find anything in this terminal.',
     ],
   },
   {
@@ -305,10 +299,7 @@ const STEPS = [
     body: () => [
       'Everything the agent produces — plots, data files, reports — lands in ',
       strong('WORKSPACE'),
-      ', ready to open or download. Its rail entry glows when something new arrives.',
-      ...(workspaceHasExample()
-        ? [' The entry under Examples is a shipped sample; your own work lands above it.']
-        : []),
+      ', ready to open or download.',
     ],
     foot: '＋ on the rail adds more panels.',
   },
@@ -319,7 +310,7 @@ const STEPS = [
     title: 'Facility knowledge',
     body: () => [
       strong('KNOWLEDGE'),
-      ' holds this facility’s curated documentation — the same material the agent consults when you ask about the machine. Browse it directly here.',
+      ' holds this facility’s curated documentation, the same material the agent consults when you ask about the machine. Browse it directly here.',
     ],
   },
   {
@@ -336,13 +327,14 @@ const STEPS = [
   {
     anchor: () => document.querySelector('#panel-feedback-btn'),
     title: 'Something wrong? Tell us',
-    body: () => ['If the agent — or this terminal — gets something wrong, report it here.'],
+    body: () => ['If something is not working as you expect, please let us know.'],
+    foot: 'Tip: save it as Local, then paste the record id into your coding-agent session to have it looked at.',
   },
   {
     anchor: () => document.querySelector('.terminal-card'),
     title: 'Try it',
     body: () => [
-      'Pick a question to start — it’s typed into the terminal for you; press Enter to send.',
+      'Pick a question to start.',
     ],
     chips: ['What can you see on this machine?', 'What are you allowed to do in this session?'],
     foot: 'Retake this tour any time from the rail.',

--- a/tests/interfaces/web_terminal/js/tour.test.js
+++ b/tests/interfaces/web_terminal/js/tour.test.js
@@ -31,6 +31,7 @@ const ALL_TITLES = [
   'Ask in plain language',
   'Your control target',
   'Make it yours',
+  'Arrange the bars',
   'Search everything',
   'Your workspace',
   'Facility knowledge',
@@ -53,6 +54,9 @@ const BAR_ITEMS = {
   display:
     '<osprey-display-menu id="display-menu">' +
     '<button class="display-menu-trigger" aria-expanded="false"></button>' +
+    '<div class="display-menu-card">' +
+    '<button class="display-menu-settings bar-customize-entry">Customize bars</button>' +
+    '</div>' +
     '</osprey-display-menu>',
 };
 
@@ -185,11 +189,12 @@ describe('anchors the operator removed', () => {
     expect(kicker()).toBe(`Step 1 of ${ALL_TITLES.length - 1}`);
   });
 
-  test('every pooled bar item drops its own step and no other', () => {
+  test('every pooled bar item drops its own steps and no others', () => {
     poolItem('search');
     poolItem('display');
     poolItem('control-target');
 
+    // The display item owns two: its own step and the Customize row inside it.
     expect(walkTour()).toEqual([
       'Ask in plain language',
       'Your workspace',
@@ -198,6 +203,17 @@ describe('anchors the operator removed', () => {
       'Something wrong? Tell us',
       'Try it',
     ]);
+  });
+
+  test('pooling the display item drops BOTH steps it carries', () => {
+    poolItem('display');
+
+    const seen = walkTour();
+    expect(seen).not.toContain('Make it yours');
+    expect(seen).not.toContain('Arrange the bars');
+    expect(seen).toEqual(
+      ALL_TITLES.filter((t) => t !== 'Make it yours' && t !== 'Arrange the bars')
+    );
   });
 
   test('putting the item back brings its step back', () => {
@@ -215,6 +231,16 @@ describe('anchors that are not bar items', () => {
 
     const seen = walkTour();
     expect(seen).toEqual(ALL_TITLES.filter((t) => t !== 'Something wrong? Tell us'));
+  });
+
+  test('a missing Customize row drops only its own step', () => {
+    // The row is projected into the display menu at runtime; when it is not
+    // there the anchor is gone while the display menu around it stays put.
+    find('.bar-customize-entry').remove();
+
+    const seen = walkTour();
+    expect(seen).toContain('Make it yours');
+    expect(seen).toEqual(ALL_TITLES.filter((t) => t !== 'Arrange the bars'));
   });
 
   test('the terminal card and the rail are unaffected by the pool', () => {
@@ -237,7 +263,8 @@ describe('an anchor parked mid-tour', () => {
     expect(cardTitle()).toBe('Your control target');
 
     // The ladder folds the display item away while the operator is reading —
-    // narrowing the window is enough. The next step must not land on it.
+    // narrowing the window is enough. Neither the display step nor the
+    // Customize row riding inside it may be landed on.
     poolItem('display');
     find('.tour-nav .tour-btn.primary').click();
 

--- a/tests/interfaces/web_terminal/tour.test.mjs
+++ b/tests/interfaces/web_terminal/tour.test.mjs
@@ -38,6 +38,9 @@ function mountFullShell() {
     </button>
     <osprey-display-menu id="display-menu">
       <button class="display-menu-trigger" aria-expanded="false"></button>
+      <div class="display-menu-card">
+        <button class="display-menu-settings bar-customize-entry">Customize bars</button>
+      </div>
     </osprey-display-menu>
     <button id="command-palette-btn"></button>
     <nav class="panel-rail">
@@ -160,13 +163,13 @@ describe('invite policy', () => {
 });
 
 describe('steps', () => {
-  test('all nine steps run with the full shell mounted, in order', () => {
+  test('all ten steps run with the full shell mounted, in order', () => {
     mountFullShell();
     applyTourConfig({ tour: { policy: 'never', capabilities: [] } });
     startTour();
 
     const titles = [];
-    for (let i = 0; i < 9; i++) {
+    for (let i = 0; i < 10; i++) {
       titles.push(cardTitle());
       click(nextBtn());
       vi.advanceTimersByTime(200); // settle re-render
@@ -175,6 +178,7 @@ describe('steps', () => {
       'Ask in plain language',
       'Your control target',
       'Make it yours',
+      'Arrange the bars',
       'Search everything',
       'Your workspace',
       'Facility knowledge',
@@ -183,33 +187,6 @@ describe('steps', () => {
       'Try it',
     ]);
     expect(document.querySelector('.tour-card')).toBe(null);
-  });
-
-  test('the workspace step mentions the shipped example only when the gallery lists one', () => {
-    /** Advance to "Your workspace" (step 5) and return the card body text. */
-    const workspaceBody = () => {
-      applyTourConfig({ tour: { policy: 'never', capabilities: [] } });
-      startTour();
-      for (let i = 0; i < 4; i++) {
-        click(nextBtn());
-        vi.advanceTimersByTime(200);
-      }
-      expect(cardTitle()).toBe('Your workspace');
-      return document.querySelector('.tour-body')?.textContent ?? '';
-    };
-
-    mountFullShell();
-    expect(workspaceBody()).not.toContain('shipped sample');
-
-    mountFullShell();
-    const frame = document.createElement('iframe');
-    frame.setAttribute('data-panel-id', 'artifacts');
-    document.body.appendChild(frame);
-    const doc = /** @type {Document} */ (frame.contentDocument);
-    doc.body.innerHTML = '<div class="tree-section" data-type="examples"></div>';
-    expect(workspaceBody()).toContain(
-      'The entry under Examples is a shipped sample; your own work lands above it.'
-    );
   });
 
   test('steps with absent anchors drop out and the count adjusts', () => {
@@ -274,8 +251,10 @@ describe('activation', () => {
     workspace.addEventListener('click', clicks);
 
     startTour();
-    for (let i = 0; i < 4; i++) {
-      click(nextBtn()); // → Your workspace
+    // Walked by title rather than by count, so inserting a step ahead of this
+    // one cannot silently retarget the assertion at a different card.
+    for (let guard = 0; guard < 20 && cardTitle() !== 'Your workspace'; guard += 1) {
+      click(nextBtn());
       vi.advanceTimersByTime(200);
     }
     expect(cardTitle()).toBe('Your workspace');


### PR DESCRIPTION
## What

A copy pass over the onboarding tour, plus one new step.

- **Ask in plain language** — drops the "Type what you want — no commands to learn" line; the server-derived capability sentence stays.
- **Make it yours** — "…switch both here, any time" replaced by naming the expert **Settings** that open from the same card.
- **Search everything**, **Facility knowledge** — dashes removed.
- **Your workspace** — drops the rail-glow and shipped-example sentences, and the gallery-iframe probe (`workspaceHasExample`) that existed only for the latter.
- **Something wrong? Tell us** — body is now "If something is not working as you expect, please let us know." with a tip to save the report as Local and paste its record id into a coding-agent session (the Local channel really does show `Recorded on this deployment (fb-…)`).
- **Try it** — drops "it's typed into the terminal for you; press Enter to send."
- **New step 4 — Arrange the bars** — "The header and status bar are yours to arrange. Open **Customize bars** here, or right-click either bar, to add, move and remove items." Anchors on the display menu's Customize row and drops out wherever that row is absent.

The new anchor is the first that lives *inside* another bar item, so pooling the display item now drops two steps; `tour.js`'s module comment and both tour suites pin that. The "never presses the ACTIVE rail entry" test walked by a hardcoded click count and silently retargeted when a step was inserted ahead of it — it now walks by title.

## Tests

- `tour.test.mjs` + `js/tour.test.js`: 25 / 25; full JS suite 3161 / 3161; `tsc` + `eslint` clean.
- `test_tour.py`: 13 / 13.

Changelog fragment: `changelog.d/tour-copy.changed.md`.
