### PR TITLE
fix(auth): compare the OIDC email claim case-insensitively

### DIFF
--- a/changelog.d/857.fixed.md
+++ b/changelog.d/857.fixed.md
@@ -1,0 +1,6 @@
+The web-terminal login service now compares an OIDC ``email`` claim
+case-insensitively against the roster's ``oidc_subject:`` values. An identity
+provider that releases the directory's spelling (``THellert@lbl.gov``) no
+longer refuses every login for a roster written in lowercase; ``sub`` and every
+other claim keep the exact match, and the ``shared_card_duplicate_subject``
+lint groups ``email`` subjects the same way.

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -115,6 +115,13 @@ user's terminal:
            index: 0
            oidc_subject: "8f4c1e02-..."     # alice's value of that claim
 
+A login matches when the asserted claim equals the card's ``oidc_subject``.
+The comparison is exact for every claim except ``email``, which is compared
+case-insensitively: an address is the same mailbox in any case, and an
+identity provider is free to release the directory's spelling
+(``THellert@lbl.gov``) where the roster says ``thellert@lbl.gov``. ``sub`` is
+an opaque, case-sensitive identifier by specification and stays exact.
+
 Under ``password`` or ``oidc`` a small authentication service joins the stack
 and nginx asks it about every request under ``/u/<name>/`` before proxying
 anything. Optional keys: ``auth.port`` (the port layout's ``10001`` unless you
@@ -294,7 +301,8 @@ build verbs that run it:
   changes the question: the login service must resolve each identity to a
   single roster entry to know who opened it, so once any card is shared, such
   a person keeps ``oidc_subject:`` on one card only — a login by that
-  identity would otherwise be ambiguous, and is refused.
+  identity would otherwise be ambiguous, and is refused. Under
+  ``claim: email`` two subjects that differ only in case count as the same.
 
 
 .. _multi-user-https:

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -69,6 +69,7 @@ from osprey.deployment.web_terminals.render import (
 )
 from osprey.interfaces.web_auth import DEFAULT_SESSION_LIFETIME
 from osprey.port_layout import _MAX_PORT, default_port, resolve_port_base
+from osprey.services.auth_sidecar.identity_headers import CASE_INSENSITIVE_CLAIMS
 from osprey_connectors.types import TYPE_WRITES_ENABLED_LEAF, WRITES_ENABLED_KEY
 
 # Both listeners in the gated auth/TLS seam are config-driven: nginx's TLS
@@ -3207,13 +3208,22 @@ def _check_shared_card_duplicate_subject(
     Scoped to ``method: oidc`` — no other method reads the subject mapping —
     and grouped like :func:`_check_auth_credential_collisions`: exact strings
     (stripped of surrounding whitespace) across the raw roster, one finding
-    per colliding subject. The message names the entries, never the subject —
-    same reasoning as the ``$`` scan above: echoing a value invites pasting
-    it, and the names are what the operator edits.
+    per colliding subject. Under an ``email`` claim the grouping is
+    case-insensitive as well, because that is how the sidecar matches such a
+    claim (:data:`~osprey.services.auth_sidecar.identity_headers.CASE_INSENSITIVE_CLAIMS`):
+    two entries spelling one mailbox in two cases ARE the ambiguity it would
+    refuse, and lint has to see the collision the callback would. The message
+    names the entries, never the subject — same reasoning as the ``$`` scan
+    above: echoing a value invites pasting it, and the names are what the
+    operator edits.
     """
     context = _auth_context(web_terminals)
     if context is None or context["auth_method"] != "oidc":
         return []
+    # `None` is render's "unset" — the sidecar's own default (`sub`) applies,
+    # which is not on the case-insensitive list, so the exact grouping holds.
+    claim = context.get("auth_oidc_claim") or ""
+    fold = claim in CASE_INSENSITIVE_CLAIMS
     # Only the literal `access: "any"` survives normalization, so reading it
     # off the raw entry through the shared predicate cannot disagree with
     # what deploys.
@@ -3227,7 +3237,8 @@ def _check_shared_card_duplicate_subject(
         subject = user.get("oidc_subject")
         if name is None or not isinstance(subject, str) or not subject.strip():
             continue
-        by_subject.setdefault(subject.strip(), []).append(name)
+        key = subject.strip()
+        by_subject.setdefault(key.casefold() if fold else key, []).append(name)
     return [
         Finding(
             severity="error",

--- a/src/osprey/services/auth_sidecar/identity_headers.py
+++ b/src/osprey/services/auth_sidecar/identity_headers.py
@@ -32,7 +32,9 @@ than the deployment thinks it forwarded, which is exactly the failure this
 module exists to prevent.
 
 The module also owns :func:`same_value`, the constant-time comparator every
-check of an identity value uses.
+check of an identity value uses, and :func:`same_identity`, the one rule for
+when a *mapped identity* may match under a different spelling — an ``email``
+claim is a mailbox, and a mailbox does not change with its case.
 """
 
 from __future__ import annotations
@@ -44,7 +46,9 @@ __all__ = [
     "ROLE_HEADER",
     "ROLE_SOURCE_HEADER",
     "SUBJECT_HEADER",
+    "CASE_INSENSITIVE_CLAIMS",
     "is_header_safe",
+    "same_identity",
     "same_value",
 ]
 
@@ -129,3 +133,46 @@ def same_value(left: str, right: str) -> bool:
     comparison that was about to *succeed*, locking that operator out for good.
     """
     return secrets.compare_digest(left.encode("utf-8"), right.encode("utf-8"))
+
+
+CASE_INSENSITIVE_CLAIMS: frozenset[str] = frozenset({"email"})
+"""The ID-token claims whose values name a mailbox, matched without regard to case.
+
+``email`` is the one claim OpenID Connect defines as an RFC 5322 address, and
+an address is the same mailbox in any case: the domain by RFC 5321, the local
+part by every mail provider in practice — the same person is
+``THellert@lbl.gov`` in a directory and ``thellert@lbl.gov`` in daily use, and
+a provider releases whichever spelling it stores. A byte-exact match would
+couple a roster to that cosmetic choice, refusing every login with a 403 that
+names nothing an operator can see in the config.
+
+Nothing else is on the list, and that is deliberate. ``sub`` is a
+case-sensitive opaque identifier by specification, so two subjects differing
+only in case are two accounts, and ``preferred_username`` is a display value
+the specification tells a relying party not to lean on at all — a deployment
+that maps on it gets the exact compare and can move to ``email`` when its
+provider spells that one unpredictably.
+"""
+
+
+def same_identity(asserted: str, configured: str, *, claim: str) -> bool:
+    """Whether an asserted identity matches a roster mapping, under ``claim``'s rule.
+
+    The one comparator for a mapped identity: the callback's own-card and
+    shared-card branches and ``/verify``'s opener re-validation all go through
+    it, so the three cannot disagree about what "the same identity" means.
+
+    Args:
+        asserted: The value the identity provider asserted (or, on
+            re-validation, the value a session recorded).
+        configured: The roster entry's mapped value.
+        claim: The ID-token claim the deployment maps on.
+
+    Returns:
+        For a claim in :data:`CASE_INSENSITIVE_CLAIMS`, whether the two are the
+        same mailbox — both sides casefolded, then compared in constant time.
+        For every other claim, exactly :func:`same_value`.
+    """
+    if claim in CASE_INSENSITIVE_CLAIMS:
+        return same_value(asserted.casefold(), configured.casefold())
+    return same_value(asserted, configured)

--- a/src/osprey/services/auth_sidecar/routes/oidc.py
+++ b/src/osprey/services/auth_sidecar/routes/oidc.py
@@ -88,7 +88,7 @@ from ..app import (
     get_settings,
 )
 from ..exceptions import InvalidSessionError
-from ..identity_headers import is_header_safe, same_value
+from ..identity_headers import is_header_safe, same_identity, same_value
 from ..return_to import safe_return_to
 from ..sessions import SESSION_COOKIE_NAME, SessionState
 from ..throttle import AttemptThrottle
@@ -984,7 +984,7 @@ async def oidc_callback(request: Request) -> Response:
         matches = [
             (name, configured)
             for name, configured in settings.oidc_subjects.items()
-            if same_value(asserted, configured)
+            if same_identity(asserted, configured, claim=settings.oidc_claim)
         ]
         if not matches:
             logger.warning(
@@ -1049,7 +1049,12 @@ async def oidc_callback(request: Request) -> Response:
             raise _refuse_login(user, reason=refused.reason, message=refused.message) from None
     else:
         opener_name = ""
-        if not same_value(asserted, expected_subject):
+        # `expected_subject is None` was refused before the exchange on this
+        # same (own-card) branch; the re-check here is for the type checker,
+        # which cannot carry that narrowing across the two `shared` branches.
+        if expected_subject is None or not same_identity(
+            asserted, expected_subject, claim=settings.oidc_claim
+        ):
             # No search of the roster for a user this identity *would* match:
             # on an own card, the clicked card is the only user this login can
             # unlock, so the asserted identity is compared against that user's
@@ -1097,11 +1102,12 @@ async def oidc_callback(request: Request) -> Response:
     # expiry and by logout alone. It carries the asserted subject instead — an
     # opaque account identifier, not a credential — so a later verify subrequest
     # can name which provider account is behind this unlocked user without
-    # re-contacting the IdP. `grant.subject` and `asserted` are byte-equal here
-    # (the constant-time check above just proved it, against the clicked card's
-    # own mapping or against the matched entry's on a shared card); the
-    # configured value is stored so the cookie carries the deployment's own
-    # canonical spelling.
+    # re-contacting the IdP. `grant.subject` and `asserted` name the same
+    # identity here (the constant-time check above just proved it, against the
+    # clicked card's own mapping or against the matched entry's on a shared
+    # card) — the same bytes, or under an `email` claim the same mailbox in
+    # whatever case the provider chose to spell it; the configured value is
+    # stored so the cookie carries the deployment's own canonical spelling.
     session = _current_session(request).with_user(
         user,
         expires_at=now + settings.session_lifetime,

--- a/src/osprey/services/auth_sidecar/routes/verify.py
+++ b/src/osprey/services/auth_sidecar/routes/verify.py
@@ -48,7 +48,7 @@ from ..identity_headers import (
     ROLE_SOURCE_HEADER,
     SUBJECT_HEADER,
     is_header_safe,
-    same_value,
+    same_identity,
 )
 from ..passwords import verify_generation_tag
 from ..revocation import RevocationStore
@@ -219,7 +219,10 @@ async def verify(
             # Checked explicitly, and first, so the comparison below can never
             # run against ``None``.
             return _deny(username, "the opener is no longer a mapped roster user")
-        if not same_value(expected, entry.oidc_subject):
+        # Under the claim's own rule, like the login that minted the entry: an
+        # operator re-spelling an `email` mapping in a different case has not
+        # remapped anyone, and must not log the whole roster out of the card.
+        if not same_identity(expected, entry.oidc_subject, claim=settings.oidc_claim):
             return _deny(username, "the opener's mapped subject has changed")
 
     if settings.method != "oidc":

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -3224,6 +3224,51 @@ def test_lint_duplicate_subject_with_a_shared_card_is_an_error() -> None:
     assert "one of them only" in offenders[0].message
 
 
+def test_lint_duplicate_email_subjects_differing_only_in_case_are_an_error() -> None:
+    """Under ``claim: email`` the sidecar matches a mailbox without regard to
+    case, so two entries spelling one address in two cases are the same
+    ambiguity a byte-identical pair is — and lint sees it the way the
+    callback would."""
+    # Arrange
+    config = _auth_config(
+        {"method": "oidc", "oidc": {"issuer": "https://idp.example.org", "claim": "email"}}
+    )
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "oidc_subject": "THellert@lbl.gov"},
+        {"name": "thellert-admin", "index": 1, "oidc_subject": "thellert@lbl.gov"},
+        {"name": "control", "index": 2, "access": "any"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    offenders = [
+        f for f in _errors(findings) if f.code == "web_terminals.shared_card_duplicate_subject"
+    ]
+    assert len(offenders) == 1
+    assert "thellert" in offenders[0].message
+    assert "thellert-admin" in offenders[0].message
+
+
+def test_lint_sub_subjects_differing_only_in_case_are_distinct() -> None:
+    """The default ``sub`` claim is case-sensitive at the sidecar, so the
+    same two spellings are two identities there — and two here."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+    config["modules"]["web_terminals"]["users"] = [
+        {"name": "thellert", "index": 0, "oidc_subject": "IDP|Thorsten"},
+        {"name": "thellert-admin", "index": 1, "oidc_subject": "idp|thorsten"},
+        {"name": "control", "index": 2, "access": "any"},
+    ]
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.shared_card_duplicate_subject" for f in findings)
+
+
 def test_lint_duplicate_subject_without_a_shared_card_reports_nothing() -> None:
     """The same two-cards-one-person roster with no shared entry is silent:
     every login still arrives through the card that was clicked, so nothing

--- a/tests/services/auth_sidecar/test_identity_headers.py
+++ b/tests/services/auth_sidecar/test_identity_headers.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 import pytest
 
-from osprey.services.auth_sidecar.identity_headers import same_value
+from osprey.services.auth_sidecar.identity_headers import (
+    CASE_INSENSITIVE_CLAIMS,
+    same_identity,
+    same_value,
+)
 
 
 def test_equal_values_match() -> None:
@@ -44,3 +48,44 @@ def test_public_name_is_importable() -> None:
     from osprey.services.auth_sidecar.identity_headers import same_value as imported
 
     assert imported is same_value
+
+
+# --- same_identity: the claim decides whether case matters -------------------
+
+
+def test_only_email_is_matched_without_regard_to_case() -> None:
+    """The list is exactly ``email``: the one claim that names a mailbox."""
+    assert CASE_INSENSITIVE_CLAIMS == frozenset({"email"})
+
+
+@pytest.mark.parametrize(
+    ("asserted", "configured"),
+    [
+        ("THellert@lbl.gov", "thellert@lbl.gov"),
+        ("thellert@lbl.gov", "THellert@lbl.gov"),
+        ("Tom_Scarvie@LBL.GOV", "tom_scarvie@lbl.gov"),
+        ("thellert@lbl.gov", "thellert@lbl.gov"),
+    ],
+)
+def test_an_email_claim_matches_the_same_mailbox_in_any_case(
+    asserted: str, configured: str
+) -> None:
+    assert same_identity(asserted, configured, claim="email") is True
+
+
+def test_an_email_claim_still_refuses_a_different_mailbox() -> None:
+    assert same_identity("thellert@lbl.gov", "thellert@lbl.org", claim="email") is False
+    assert same_identity("t.hellert@lbl.gov", "thellert@lbl.gov", claim="email") is False
+
+
+@pytest.mark.parametrize("claim", ["sub", "preferred_username", "uid"])
+def test_every_other_claim_stays_byte_exact(claim: str) -> None:
+    """``sub`` is a case-sensitive opaque identifier by specification, and no
+    other claim is on the list: a case difference is a different identity."""
+    assert same_identity("idp|Alice", "idp|alice", claim=claim) is False
+    assert same_identity("idp|alice", "idp|alice", claim=claim) is True
+
+
+def test_same_identity_compares_non_ascii_instead_of_raising() -> None:
+    assert same_identity("JÖRG@example.org", "jörg@example.org", claim="email") is True
+    assert same_identity("JÖRG@example.org", "jörg@example.org", claim="sub") is False

--- a/tests/services/auth_sidecar/test_oidc_flow.py
+++ b/tests/services/auth_sidecar/test_oidc_flow.py
@@ -621,7 +621,7 @@ def test_a_non_ascii_identity_is_refused_over_the_wire(idp: MockIdP) -> None:
     handshake completes against the IdP and the login is then refused with a
     category pointing at the configuration. The refusal is a clean 403 rather
     than the ``TypeError`` a ``str`` comparison would raise on this input, which
-    is why :func:`~osprey.services.auth_sidecar.routes.oidc._same_value`
+    is why :func:`~osprey.services.auth_sidecar.identity_headers.same_value`
     compares UTF-8 bytes.
     """
     idp.subject = "jörg@example.org"
@@ -647,6 +647,55 @@ def test_a_configured_claim_other_than_sub_is_honoured(idp: MockIdP) -> None:
 
     assert response.status_code == 303
     assert _session_from(response).unlocked_usernames(now=0.0) == ("alice",)
+
+
+def test_an_email_claim_is_matched_without_regard_to_case(idp: MockIdP) -> None:
+    """The provider spells the mailbox as its directory does; the roster spells
+    it lowercase. Same mailbox, so alice logs in — and the session carries the
+    roster's own spelling, not the provider's."""
+    idp.subject = "an-opaque-provider-id"
+    idp.extra_claims = {"email": "Alice.Example@Example.ORG"}
+    app = _sidecar(
+        idp,
+        OSPREY_AUTH_OIDC_CLAIM="email",
+        OSPREY_AUTH_OIDC_SUBJECT_ALICE="alice.example@example.org",
+    )
+    with _browser(app) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 303
+    session = _session_from(response)
+    assert session.unlocked_usernames(now=0.0) == ("alice",)
+    entry = session.entry("alice")
+    assert entry is not None
+    assert entry.oidc_subject == "alice.example@example.org"
+
+
+def test_an_email_claim_naming_another_mailbox_is_still_refused(idp: MockIdP) -> None:
+    """Case-insensitive is not lenient: a different address is a different person."""
+    idp.subject = "an-opaque-provider-id"
+    idp.extra_claims = {"email": "Alice.Example@example.net"}
+    app = _sidecar(
+        idp,
+        OSPREY_AUTH_OIDC_CLAIM="email",
+        OSPREY_AUTH_OIDC_SUBJECT_ALICE="alice.example@example.org",
+    )
+    with _browser(app) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_the_default_sub_claim_stays_case_sensitive(idp: MockIdP) -> None:
+    """``sub`` is an opaque, case-sensitive identifier by specification: a
+    subject differing from the mapping only in case is somebody else."""
+    idp.subject = ALICE_SUBJECT.upper()
+    with _browser(_sidecar(idp)) as client:
+        response = _log_in(client, "alice")
+
+    assert response.status_code == 403
+    assert SESSION_COOKIE_NAME not in response.cookies
 
 
 def test_the_session_cookie_carries_the_pinned_attributes(idp: MockIdP) -> None:
@@ -737,6 +786,29 @@ def test_a_shared_card_with_its_own_identity_admits_any_mapped_entry(
     assert entry is not None
     assert entry.oidc_subject == asserted
     assert entry.opener == opener
+
+
+def test_a_shared_card_reverse_match_honours_the_email_claim_rule(idp: MockIdP) -> None:
+    """The reverse match over the roster goes through the same comparator as
+    an own card: alice's directory-cased mailbox still resolves to alice, so
+    she opens bob's shared card as herself."""
+    idp.subject = "an-opaque-provider-id"
+    idp.extra_claims = {"email": "Alice.Example@Example.ORG"}
+    app = _sidecar(
+        idp,
+        OSPREY_AUTH_OIDC_CLAIM="email",
+        OSPREY_AUTH_OIDC_SUBJECT_ALICE="alice.example@example.org",
+        OSPREY_AUTH_OIDC_SUBJECT_CAROL="carol.example@example.org",
+        OSPREY_AUTH_ROSTER_ACCESS_BOB="any",
+    )
+    with _browser(app) as client:
+        response = _log_in(client, "bob")
+
+    assert response.status_code == 303
+    entry = _session_from(response).entry("bob")
+    assert entry is not None
+    assert entry.opener == "alice"
+    assert entry.oidc_subject == "alice.example@example.org"
 
 
 def test_an_entry_that_never_logs_into_its_own_card_can_open_a_shared_one(idp: MockIdP) -> None:

--- a/tests/services/auth_sidecar/test_verify.py
+++ b/tests/services/auth_sidecar/test_verify.py
@@ -490,6 +490,26 @@ class TestSharedCardOpener:
         with TestClient(_app(env)) as client:
             assert _verify(client, "alice", cookie).status_code == 401
 
+    def test_an_email_opener_re_spelled_in_another_case_is_still_the_opener(self) -> None:
+        """Under ``claim: email`` an operator changing only the case of the
+        opener's mapping has remapped nobody — the same comparator the login
+        went through keeps the card open; under ``sub`` the same edit is a new
+        identity and closes it."""
+        cookie = _mint(_unlocked("alice", stored=None, subject="bob@example.org", opener="bob"))
+        env = {
+            **self.SHARED_ENV,
+            "OSPREY_AUTH_OIDC_CLAIM": "email",
+            "OSPREY_AUTH_OIDC_SUBJECT_BOB": "Bob@Example.ORG",
+        }
+        with TestClient(_app(env)) as client:
+            response = _verify(client, "alice", cookie)
+        assert response.status_code == 200
+        assert response.headers[self.SUBJECT_HEADER] == "bob@example.org"
+
+        env_sub = {**self.SHARED_ENV, "OSPREY_AUTH_OIDC_SUBJECT_BOB": self.BOB_SUBJECT.upper()}
+        with TestClient(_app(env_sub)) as client:
+            assert _verify(client, "alice", cookie).status_code == 401
+
     def test_a_shared_card_session_naming_no_opener_is_denied(self) -> None:
         """Flipping a card to ``any`` must not widen sessions minted while it
         was an own card — they carry no opener to re-validate."""


### PR DESCRIPTION
## Summary

- With `auth.oidc.claim: email`, a roster whose `oidc_subject:` values are lowercase refuses a login whenever the IdP spells the same mailbox in another case. One real LBL token (the IT responder's own) carried `email: TASaif@lbl.gov`; no roster user's token has been seen and the form may differ per directory entry — which is exactly why a byte-exact compare is the wrong shape: it cannot be made safe by guessing each user's casing. An address names the same mailbox in any case.
- `sub` is a case-sensitive opaque identifier by specification and keeps the exact compare; only `email` is on the case-insensitive list, and the docstring says why `preferred_username` is not.

## Changes

- `identity_headers.py`: `CASE_INSENSITIVE_CLAIMS = {"email"}` and `same_identity(asserted, configured, *, claim)` — casefold both sides for a listed claim, then the existing constant-time `same_value`; exact otherwise.
- `routes/oidc.py`: both the own-card match and the shared-card reverse match use `same_identity` under `settings.oidc_claim`; the session still stores the roster's own spelling.
- `routes/verify.py`: the shared-card opener re-validation uses the same comparator, so re-spelling an `email` mapping in another case does not log the roster out of the card.
- `deployment/web_terminals/lint.py`: `shared_card_duplicate_subject` groups subjects case-insensitively under `claim: email`, reporting the ambiguity the sidecar would refuse.
- Docs (`how-to/web-terminal/multi-user/login.rst`) state the rule; changelog fragment `857.fixed.md`.

## Test plan

- [x] `tests/services/auth_sidecar/test_identity_headers.py`: the list is exactly `email`; same mailbox in any case matches; a different mailbox does not; `sub`/`preferred_username`/`uid` stay byte-exact; non-ASCII compares instead of raising.
- [x] `test_oidc_flow.py`: own card logs in on a display-cased `email` claim and stores the roster spelling; a different mailbox is still refused; the default `sub` claim stays case-sensitive; the shared-card reverse match resolves the opener under the same rule.
- [x] `test_verify.py`: an `email` opener mapping re-spelled in another case keeps the shared card open; the same edit under `sub` closes it.
- [x] `test_lint.py`: case-only duplicate `email` subjects with a shared card are an error; case-only `sub` duplicates are distinct.
- [x] `scripts/quick_check.sh`, `scripts/ci_check.sh`, `scripts/premerge_check.sh main`

## Related issues

Closes #857
