### PR TITLE
Pre-release polish: nine FOLLOWUPS items before the release tag

### DIFF
--- a/changelog.d/pre-release-polish.fixed.md
+++ b/changelog.d/pre-release-polish.fixed.md
@@ -1,0 +1,16 @@
+A batch of pre-release fixes. An EPICS put whose callback times out is now
+reported as `unconfirmed` and is not re-read; pyepics answers that timeout with
+`-1`, which the connector had taken as a success. The `unconfirmed` outcome now
+reads "sent, but not acknowledged in time or the re-read itself failed"
+everywhere it is described. A middle-layer channel database in the wrong shape
+(a non-mapping root, system or family) is refused as a corrupt source instead
+of loading as zero channels, so a build no longer falls back to scenario seeds
+while claiming the channels came from that file; `osprey channel-finder
+preview` and the spec generator raise on such a file rather than reporting no
+channels. The control-target popover reads whether the deployment is running
+read-only from the posture route's new `readonly_run` field instead of
+inferring it, so a posture store that fails to resolve is no longer reported as
+a read-only deployment, and a read-only run is named even when one target was
+never armed. The posture route answers instead of crashing when the config it
+falls back to does not load. In the two high-contrast themes a healthy status
+dot no longer shares its grey with muted text.

--- a/docs/source/_diagrams/write-sequence.html
+++ b/docs/source/_diagrams/write-sequence.html
@@ -85,7 +85,7 @@
   <text class="ta" x="1056" y="549" text-anchor="middle">write_channel()</text>
 
   <line class="e e-dash" x1="1156" y1="592" x2="956" y2="592" marker-end="url(#write-sequence-arr)"/>
-  <rect class="mask" x="1016" y="572" width="80" height="12" rx="2"/>
+  <rect class="mask" x="1024" y="572" width="64" height="12" rx="2"/>
   <text class="ta" x="1056" y="581" text-anchor="middle">confirmed</text>
 
   <line class="e e-dash" x1="948" y1="624" x2="332" y2="624" marker-end="url(#write-sequence-arr)"/>

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -228,7 +228,9 @@ row then reads ``✓ switched``, or ``✗`` with the phrase for the refusal ---
 the same refusal, for the same reason, the agent is given. While a request is
 out the chip reads ``switching…``, and one request is outstanding at a time.
 If nothing answers within 30 seconds the row reads ``request_expired``:
-nothing that could carry out the switch was alive to pick it up.
+nothing that could carry out the switch was alive to pick it up. The outcome
+line leaves the row after about a minute --- an outcome is news for as long as
+someone is watching for it.
 
 What the switch itself is gated on --- the approval prompt, the limits
 posture, the archive --- is :doc:`../control-systems/switch-control-target`.

--- a/docs/source/reference/contracts/connectors.rst
+++ b/docs/source/reference/contracts/connectors.rst
@@ -90,8 +90,8 @@ Every write ends in exactly one of six outcomes:
      - The re-read holds a different value. A setpoint the machine clamped or
        rounded is reported here, not smoothed over.
    * - ``unconfirmed``
-     - The value was sent, but the re-read itself failed, so what the channel
-       holds is unknown.
+     - The value was sent, but not acknowledged in time or the re-read itself
+       failed, so what the channel holds is unknown.
    * - ``unrequested``
      - Confirmation is switched off for this channel; nothing was checked.
 

--- a/packages/osprey-connectors/README.md
+++ b/packages/osprey-connectors/README.md
@@ -86,7 +86,8 @@ callers that branch on them.
 - `ChannelWriteFailedError` — the write was attempted but did not verifiably
   succeed. `reason` is one of `FAILED` (the control system did not take the
   value), `MISMATCH` (the channel holds a different value), or `UNCONFIRMED`
-  (the confirming re-read raised). The codes are the `WriteOutcome` words that
+  (sent, but not acknowledged in time or the confirming re-read itself
+  failed). The codes are the `WriteOutcome` words that
   raise; the exception also carries `outcome`, `value_written` and
   `observed_value`.
 - `ChannelLimitsViolationError` — a channel write violated configured safety

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/base.py
@@ -102,8 +102,8 @@ class WriteOutcome(StrEnum):
       alarm state. Alarm state is reported, never raised on.
     * ``MISMATCH`` — the re-read holds a different value (a clamped or rounded
       setpoint is reported here, not tolerated).
-    * ``UNCONFIRMED`` — the value was sent, but the re-read itself raised, so
-      what the channel holds is unknown.
+    * ``UNCONFIRMED`` — the value was sent, but not acknowledged in time or
+      the re-read itself failed, so what the channel holds is unknown.
     * ``UNREQUESTED`` — ``confirm=False``: nothing was checked.
     """
 
@@ -889,8 +889,9 @@ class ControlSystemConnector(ABC):
               state. Alarm state is reported with the write, never raised on.
             - ``mismatch`` — the re-read holds a different value. A clamped or
               rounded setpoint is reported here, not tolerated.
-            - ``unconfirmed`` — the value was sent but the re-read itself
-              raised, so what the channel holds is unknown.
+            - ``unconfirmed`` — the value was sent, but not acknowledged in
+              time or the re-read itself failed, so what the channel holds is
+              unknown.
             - ``unrequested`` — ``confirm=False``: nothing was checked.
 
             The comparison is :func:`values_match`, one rule shared by every

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -1003,6 +1003,26 @@ class EPICSConnector(ControlSystemConnector):
                 error_message=f"Write to '{channel_address}' refused: validation error: {payload}",
             )
 
+        # pyepics answers a put whose callback never arrived with -1, not with
+        # a falsy value: ``ca.put`` waits for the callback and, on timeout,
+        # negates its return (``ret = -ret``). -1 is truthy, so it must be
+        # caught before the falsy check below or it would sail on to the
+        # confirming read as a success. The value was sent; nothing has said
+        # the IOC took it, so the outcome is unknown and no re-read is made.
+        if payload == -1:
+            logger.warning(
+                f"EPICS put not acknowledged within {timeout}s: {channel_address} = {value}"
+            )
+            return ChannelWriteResult(
+                channel_address=channel_address,
+                value_written=value,
+                outcome=WriteOutcome.UNCONFIRMED,
+                error_message=(
+                    f"Write to '{channel_address}' could not be confirmed — the control "
+                    f"system did not acknowledge the put within {timeout}s"
+                ),
+            )
+
         if not payload:
             return ChannelWriteResult(
                 channel_address=channel_address,

--- a/packages/osprey-connectors/src/osprey_connectors/errors.py
+++ b/packages/osprey-connectors/src/osprey_connectors/errors.py
@@ -117,7 +117,8 @@ class ChannelWriteFailedError(Exception):
     """Raised when a channel write was attempted but was not confirmed.
 
     The control system was asked to write but the write failed, the channel now
-    holds a different value, or the confirming re-read could not be made.
+    holds a different value, or the write was sent but not acknowledged in time
+    or the confirming re-read itself failed.
     Distinct from ChannelWriteBlockedError (a refusal — no value was written).
     A scan consumer must abort on this.
 

--- a/src/osprey/interfaces/design_system/static/css/tokens.css
+++ b/src/osprey/interfaces/design_system/static/css/tokens.css
@@ -512,7 +512,7 @@
   --color-accent-secondary: #d9d9d9;
   --color-accent-secondary-light: #f2f2f2;
   --color-accent-secondary-hover: #b3b3b3;
-  --color-success: #999999;
+  --color-success: #b3b3b3;
   --color-warning: #cccccc;
   --color-error: #ffffff;
   --color-error-hover: #d9d9d9;
@@ -608,7 +608,7 @@
   --ariel-score-high-bg: rgba(255, 255, 255, 0.15);
   --ariel-score-medium: #cccccc;
   --ariel-score-medium-bg: rgba(255, 255, 255, 0.12);
-  --ariel-score-low: #999999;
+  --ariel-score-low: #b3b3b3;
   --ariel-score-low-bg: rgba(255, 255, 255, 0.08);
   --art-violet-base: #cccccc;
   --art-violet-light: #e6e6e6;
@@ -618,7 +618,7 @@
   --art-panel-gap: 8px;
   --art-browser-band-height: 210px;
   --cf-font-pv: 'Syne Mono', 'JetBrains Mono', monospace;
-  --lat-led-ready: #999999;
+  --lat-led-ready: #b3b3b3;
   --lat-led-computing: #d9d9d9;
   --lat-led-error: #ffffff;
   --lat-led-stale: #cccccc;
@@ -660,7 +660,7 @@
   --color-accent-secondary: #333333;
   --color-accent-secondary-light: #4d4d4d;
   --color-accent-secondary-hover: #000000;
-  --color-success: #666666;
+  --color-success: #4d4d4d;
   --color-warning: #333333;
   --color-error: #000000;
   --color-error-hover: #1a1a1a;
@@ -756,7 +756,7 @@
   --ariel-score-high-bg: rgba(0, 0, 0, 0.12);
   --ariel-score-medium: #333333;
   --ariel-score-medium-bg: rgba(0, 0, 0, 0.09);
-  --ariel-score-low: #666666;
+  --ariel-score-low: #4d4d4d;
   --ariel-score-low-bg: rgba(0, 0, 0, 0.06);
   --art-violet-base: #333333;
   --art-violet-light: #666666;
@@ -766,7 +766,7 @@
   --art-panel-gap: 8px;
   --art-browser-band-height: 210px;
   --cf-font-pv: 'Syne Mono', 'JetBrains Mono', monospace;
-  --lat-led-ready: #666666;
+  --lat-led-ready: #4d4d4d;
   --lat-led-computing: #262626;
   --lat-led-error: #000000;
   --lat-led-stale: #333333;

--- a/src/osprey/interfaces/design_system/tokens/interfaces/ariel.json
+++ b/src/osprey/interfaces/design_system/tokens/interfaces/ariel.json
@@ -27,7 +27,7 @@
       "high-bg": { "$value": "rgba(255, 255, 255, 0.15)", "$type": "color" },
       "medium": { "$value": "{color.mono.200}", "$type": "color", "$description": "13.08:1 vs high-contrast-dark's bg.primary." },
       "medium-bg": { "$value": "rgba(255, 255, 255, 0.12)", "$type": "color" },
-      "low": { "$value": "{color.mono.400}", "$type": "color", "$description": "7.37:1 vs high-contrast-dark's bg.primary — clears the AAA body-text floor even at the bottom of the ladder." },
+      "low": { "$value": "{color.mono.300}", "$type": "color", "$description": "10.02:1 vs high-contrast-dark's bg.primary — clears the AAA body-text floor even at the bottom of the ladder. Follows status.success (one step above text.muted), so a low score is never drawn in the inactive-label grey." },
       "low-bg": { "$value": "rgba(255, 255, 255, 0.08)", "$type": "color" }
     }
   },
@@ -37,7 +37,7 @@
       "high-bg": { "$value": "rgba(0, 0, 0, 0.12)", "$type": "color" },
       "medium": { "$value": "{color.mono.800}", "$type": "color", "$description": "11.29:1 vs high-contrast-light's bg.primary." },
       "medium-bg": { "$value": "rgba(0, 0, 0, 0.09)", "$type": "color" },
-      "low": { "$value": "{color.mono.600}", "$type": "color", "$description": "5.13:1 vs high-contrast-light's bg.primary." },
+      "low": { "$value": "{color.mono.700}", "$type": "color", "$description": "7.55:1 vs high-contrast-light's bg.primary. Follows status.success (one step above text.muted), so a low score is never drawn in the inactive-label grey." },
       "low-bg": { "$value": "rgba(0, 0, 0, 0.06)", "$type": "color" }
     }
   },

--- a/src/osprey/interfaces/design_system/tokens/interfaces/lattice_dashboard.json
+++ b/src/osprey/interfaces/design_system/tokens/interfaces/lattice_dashboard.json
@@ -21,7 +21,7 @@
   },
   "high-contrast-dark": {
     "lat-led": {
-      "ready": { "$value": "{color.mono.400}", "$type": "color" },
+      "ready": { "$value": "{color.mono.300}", "$type": "color", "$description": "Follows status.success: one step above text.muted, so a ready LED and a muted label never share a grey." },
       "computing": { "$value": "{color.mono.150}", "$type": "color" },
       "error": { "$value": "{color.mono.0}", "$type": "color" },
       "stale": { "$value": "{color.mono.200}", "$type": "color" },
@@ -30,7 +30,7 @@
   },
   "high-contrast-light": {
     "lat-led": {
-      "ready": { "$value": "{color.mono.600}", "$type": "color" },
+      "ready": { "$value": "{color.mono.700}", "$type": "color", "$description": "Follows status.success: one step above text.muted, so a ready LED and a muted label never share a grey." },
       "computing": { "$value": "{color.mono.850}", "$type": "color" },
       "error": { "$value": "{color.mono.1000}", "$type": "color" },
       "stale": { "$value": "{color.mono.800}", "$type": "color" },

--- a/src/osprey/interfaces/design_system/tokens/themes/high-contrast-dark.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/high-contrast-dark.json
@@ -25,8 +25,8 @@
     "hover": { "$value": "{color.mono.300}", "$type": "color" }
   },
   "status": {
-    "$description": "The monochrome emphasis ladder, brightest = most urgent: error (white) > warning > success (dim). Consuming surfaces carry the glyph and label that name the state; this only sets how loudly it is drawn.",
-    "success": { "$value": "{color.mono.400}", "$type": "color" },
+    "$description": "The monochrome emphasis ladder, brightest = most urgent: error (white) > warning > success (dim). Success sits one ramp step ABOVE text.muted (mono.300 vs mono.400), so a healthy dot and an inactive one never share a grey: on a monochrome canvas the lightness gap is the only thing telling them apart. mono.300 is also accent-secondary.hover and chart.series.4, neither of which is drawn beside a status dot. Consuming surfaces carry the glyph and label that name the state; this only sets how loudly it is drawn.",
+    "success": { "$value": "{color.mono.300}", "$type": "color", "$description": "10.02:1 vs bg.primary; one step above text.muted." },
     "warning": { "$value": "{color.mono.200}", "$type": "color" },
     "error": { "$value": "{color.mono.0}", "$type": "color" },
     "error-hover": { "$value": "{color.mono.150}", "$type": "color" }

--- a/src/osprey/interfaces/design_system/tokens/themes/high-contrast-light.json
+++ b/src/osprey/interfaces/design_system/tokens/themes/high-contrast-light.json
@@ -25,8 +25,8 @@
     "hover": { "$value": "{color.mono.1000}", "$type": "color" }
   },
   "status": {
-    "$description": "The monochrome emphasis ladder, darkest = most urgent on a light canvas: error (black) > warning > success (mid-gray). Consuming surfaces carry the glyph and label that name the state; this only sets how loudly it is drawn.",
-    "success": { "$value": "{color.mono.600}", "$type": "color" },
+    "$description": "The monochrome emphasis ladder, darkest = most urgent on a light canvas: error (black) > warning > success (mid-gray). Success sits one ramp step ABOVE text.muted (mono.700 vs mono.600), so a healthy dot and an inactive one never share a grey: on a monochrome canvas the lightness gap is the only thing telling them apart. mono.700 is also accent-secondary.light and diff.word-del-text, neither of which is drawn beside a status dot. Consuming surfaces carry the glyph and label that name the state; this only sets how loudly it is drawn.",
+    "success": { "$value": "{color.mono.700}", "$type": "color", "$description": "7.55:1 vs bg.primary; one step above text.muted." },
     "warning": { "$value": "{color.mono.800}", "$type": "color" },
     "error": { "$value": "{color.mono.1000}", "$type": "color" },
     "error-hover": { "$value": "{color.mono.900}", "$type": "color" }

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -258,9 +258,17 @@ def _posture_store_path() -> Path | None:
 
     Delegates to :func:`osprey_connectors.session_store.store_path` — the ONE
     path rule (env ``OSPREY_AGENT_DATA_ROOT``, else
-    ``resolve_shared_data_root()``) that `session_store` owns.
+    ``resolve_shared_data_root()``) that `session_store` owns. That rule can
+    raise as well as answer ``None``: the web server carries no stamp, so the
+    fallback loads the config, and a config that does not load is a store
+    with no location — the 503 on a gesture, ``store_available: false`` on the
+    GET — not a crash.
     """
-    return session_store.store_path()
+    try:
+        return session_store.store_path()
+    except Exception:  # noqa: BLE001 — an unresolvable root is a location-less store
+        logger.warning("The posture store's location does not resolve", exc_info=True)
+        return None
 
 
 #: Prefix of the ``/ws/operator`` session keys (``operator-<hex8>``, minted per
@@ -691,10 +699,16 @@ def _state_dir_names(target_state: Any) -> tuple[str, ...]:
     only watched its own file would go on happily naming a target while the
     live resolver had stopped being able to.
     """
+    # ``state_dir()`` is not only a filesystem call: the web server is never
+    # stamped with ``OSPREY_AGENT_DATA_ROOT`` (that goes into the CHILD's
+    # environment), so the resolver takes its config branch and raises whatever
+    # loading the config raises. Any failure is "cannot read", the same
+    # answer :func:`_target_request_facts` gives an unresolvable root.
     try:
         directory = target_state.state_dir()
         return tuple(sorted(p.name for p in directory.glob(target_state.STATE_FILE_GLOB)))
-    except OSError:
+    except Exception:  # noqa: BLE001 — an unreadable directory is an empty one, not a crash
+        logger.warning("The control-target state directory could not be read", exc_info=True)
         return ()
 
 
@@ -1622,16 +1636,12 @@ def _target_refusal(
     :func:`_posture_refusal` is split out of its own route, so the ladder
     reads as the ordered list of reasons it is and the handler as what it
     does once nothing refuses: mint an id, write the request, record, answer.
+    The rungs, in order and with their reasons, are documented on the route.
 
     Only the rungs decided BEFORE the write live here. The second
     ``request_pending`` — the one that answers a ``RequestSuperseded`` — is
     not a rung: it is what the write itself came back with, and moving it
     here would mean refusing before finding out.
-
-    The order differs from the posture route's and is load-bearing in its
-    own right: 400 for a target this render does not configure, then the 503
-    ahead of the 409, because the state directory is where a record would
-    have been found and "cannot look" is not "never started".
     """
     subject = AUDIT_SUBJECT_TARGET_SET
 
@@ -1758,6 +1768,10 @@ async def request_terminal_target(body: TargetRequest, request: Request):
     * **400** — an id outside the closed key grammar, or a target this render
       does not configure. Both are identifiers, checked before anything is read
       or written.
+    * **503** ``store_unavailable`` — the state directory does not resolve.
+      It comes before every 409 because it is where a record would have been
+      looked for: "cannot look" is not "never started", and a server that
+      cannot look must not tell the operator to send a prompt.
     * **409** ``agent_exited`` — the PTY registered for this session reports
       its process has exited. There is no server to address and no prompt that
       could start one; the message names the exit code when it is known.
@@ -1766,14 +1780,16 @@ async def request_terminal_target(body: TargetRequest, request: Request):
       is no PTY at all. There is nothing to address: the request file's whole
       addressing scheme is that pid. Only the live-agent case is told to send
       a prompt, because only there does a prompt start the server.
-    * **503** ``store_unavailable`` / ``store_write_failed`` — the state
-      directory does not resolve, or the write failed. The gesture did not
-      happen and the operator is told so, rather than being shown a request id
-      nothing will ever read.
     * **409** ``request_pending`` — a fresh request is already addressed to
       that server. One outstanding gesture at a time; the pending file is left
       exactly as it is, because overwriting it would strand the operator who is
       still watching for the first one's outcome.
+
+    After the ladder, the write itself can still answer **503**
+    ``store_write_failed`` (the request file could not be written) or **409**
+    ``request_pending`` (a concurrent gesture landed first). Both mean the
+    gesture did not happen, and the operator is told so rather than shown a
+    request id nothing will ever read.
     """
     session_id = body.session_id
     _require_session_uuid(session_id)
@@ -2053,10 +2069,8 @@ def _posture_refusal(
     around it: refuse, apply, persist, record, answer. Everything here is
     decided from :class:`_PostureRequestFacts`; the one refusal that fires
     BEFORE that threadpool hop stays in the handler, where it can be reached
-    without paying for the facts.
-
-    The order is load-bearing and is documented on the route: 400 before 503
-    before 403, because each rung answers a question the next one assumes.
+    without paying for the facts. The rungs, in order and with their reasons,
+    are documented on the route.
 
     Returns the exception rather than raising it, for the same reason
     :func:`_refuse_gesture` does: the audit record is filed here, and the

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -39,6 +39,7 @@ from osprey.interfaces.web_terminal.operator_session import (
 )
 from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
 from osprey_connectors import session_store
+from osprey_connectors.control_system.base import is_readonly_run
 
 logger = logging.getLogger(__name__)
 
@@ -2814,6 +2815,11 @@ def _posture_view(app: Any, session_key: str, config_path: Path | None) -> dict[
     return {
         "session_target": session_target,
         "store_available": _posture_store_path() is not None,
+        # Published rather than left for the client to infer from
+        # ``ceiling_writes ∧ posture ≠ sandbox ∧ ¬effective``: that signature
+        # is also what a store that fails to resolve leaves behind, and an
+        # operator must not be told the deployment is read-only when it is not.
+        "readonly_run": is_readonly_run(),
         "enforceable": enforceable,
         "enforceable_reason": None if enforceable else ENFORCEABLE_REASON_NO_RECORD,
         "execution_in_flight": _first_live_execution() is not None,
@@ -2865,6 +2871,10 @@ async def get_terminal_posture(session_id: str, request: Request):
       other roles named beside it (see :func:`_collapse_reachability`).
 
     And, once for the session: ``session_target``, ``store_available``,
+    ``readonly_run`` (the whole deployment was started read-only, which is
+    the one thing besides the ceiling and the narrowing that holds
+    ``effective`` down — stated outright, so a client never has to infer it
+    from a row whose ``effective`` a failed store read zeroed),
     ``enforceable`` (+``enforceable_reason``), ``execution_in_flight``,
     ``last_switch`` (the publisher's block — ``request_id``, ``target``,
     ``status``, ``reason``, ``detail``, ``at`` — passed through whole with

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
@@ -181,16 +181,19 @@ export function isChatSession(rows) {
 }
 
 /**
- * Whether nothing this session can do would turn this row's writes on.
+ * Whether the run, and nothing this session can do, is holding this row's
+ * writes off.
  *
- * The signature of a read-only run, read off the columns the route publishes:
- * the render's ceiling is up and this session has not narrowed the row, and
- * writes are STILL off. `effective` is `ceiling ∧ ¬readonly_run ∧ entry ≠
- * sandbox`, so with the other two terms true only the run can be holding it.
+ * Read from the route's own `readonly_run`, never inferred from the columns:
+ * "ceiling up, not narrowed, still off" is also what a posture store that
+ * failed to resolve leaves behind, and that must not be reported as the
+ * deployment running read-only. A row the deployment never armed is not held
+ * by the run either — the ceiling holds it, and {@link lockReason} says so.
  * @param {any} row
+ * @param {any} state
  */
-export function writesHeldByTheRun(row) {
-  return Boolean(row.ceiling_writes) && row.posture !== 'sandbox' && !row.effective;
+export function writesHeldByTheRun(row, state) {
+  return Boolean(state?.readonly_run) && Boolean(row.ceiling_writes);
 }
 
 /**
@@ -208,7 +211,7 @@ export function writesHeldByTheRun(row) {
 export function lockReason(row, state) {
   if (!state?.store_available) return 'changes cannot be recorded right now';
   if (!state.enforceable) return 'changes here would not reach the agent';
-  if (writesHeldByTheRun(row)) return 'the whole deployment is running read-only';
+  if (writesHeldByTheRun(row, state)) return 'the whole deployment is running read-only';
   if (!row.ceiling_writes) return 'kept read-only by the deployment';
   // Narrowing this row would select a gateway role the deployment has not
   // configured. The route only reports it for a row a narrowing would CHANGE,
@@ -222,17 +225,19 @@ export function lockReason(row, state) {
  * case: absence is the good news, and only a session that is not plain gets a
  * sentence. Same order as {@link lockReason} — the widest abnormal fact wins.
  * @param {any} state
- * @param {any[]} rows
  * @returns {{text: string, tone: string}|null}
  */
-export function bannerNote(state, rows) {
+export function bannerNote(state) {
   if (!state.store_available) {
     return { text: 'Changes cannot be recorded right now — the posture store is unavailable.', tone: 'error' };
   }
   if (!state.enforceable) {
     return { text: 'Changes here will not reach the agent yet.', tone: 'warn' };
   }
-  if (rows.length > 0 && rows.every(writesHeldByTheRun)) {
+  // The run alone decides this line. Keying it on every row would hide the
+  // banner from a readonly run with one unarmed row — that row is held by the
+  // ceiling, not the run, but the run is still the widest fact on the page.
+  if (state.readonly_run) {
     return { text: 'The whole deployment is running read-only.', tone: 'warn' };
   }
   return null;

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-popover.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-popover.js
@@ -354,7 +354,7 @@ function render() {
   if (!state) return;
   const rows = Array.isArray(state.targets) ? state.targets : [];
 
-  const banner = bannerNote(state, rows);
+  const banner = bannerNote(state);
   if (banner) {
     const note = el('div', 'ctc-banner', banner.text);
     note.dataset.tone = banner.tone;

--- a/src/osprey/mcp_server/control_system/tools/channel_write.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_write.py
@@ -445,8 +445,8 @@ async def channel_write(
       MAJOR alarm is worth telling the operator about.
     - `mismatch` — the re-read holds a different value. `observed_value` is what
       the channel actually holds; a clamped or rounded setpoint appears here.
-    - `unconfirmed` — sent, but the re-read itself failed, so what the channel
-      holds now is unknown.
+    - `unconfirmed` — sent, but not acknowledged in time or the re-read itself
+      failed, so what the channel holds now is unknown.
     - `unrequested` — confirmation is switched off for this channel; the value
       was sent and nothing was checked.
 

--- a/src/osprey/mcp_server/control_system/tools/channel_write.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_write.py
@@ -198,15 +198,14 @@ def _binding_from_record(record: object) -> tuple[str, int] | None:
 def _approval_stamp_key(operations: list[dict], confirm: bool | None) -> str | None:
     """The name the approval hook filed this write's stamp under, or ``None``.
 
-    A SHA-256 over the canonical JSON of the write's own arguments —
-    ``operations`` and ``confirm``, which are every parameter the tool accepts
-    and exactly what the hook finds in the ``tool_input`` it is handed. The hook
-    and this server share no call identifier — the hook is handed a tool-call
-    payload, the tool is handed its arguments — so the payload is the only thing
-    that provably crosses the gap between them, and it is what both sides key
-    on. The hook restates this derivation in stdlib-only Python (it runs outside
-    this venv and cannot import this module); a test pins the two spellings
-    against each other.
+    A SHA-256 over the canonical JSON of ``operations`` and ``confirm`` —
+    every parameter the tool accepts, and exactly what the hook finds in the
+    ``tool_input`` it is handed. The hook and this server share no call
+    identifier (the hook is handed a tool-call payload, the tool is handed its
+    arguments), so the payload is the only thing that provably crosses the gap
+    between them. Both sides key on it. The hook restates this derivation in
+    stdlib-only Python (it runs outside this venv and cannot import this
+    module); a test pins the two spellings against each other.
 
     ``None`` when no key can be formed, which the caller reads as "do not
     compare": no comparison is a better failure than a wrong one.

--- a/src/osprey/runtime/__init__.py
+++ b/src/osprey/runtime/__init__.py
@@ -417,7 +417,8 @@ def write_channel(channel_address: str, value: Any, **kwargs) -> None:
         ChannelWriteFailedError: If the write was attempted but did not come
             back confirmed — the control system did not take it (FAILED), a
             confirming re-read holds a different value (MISMATCH), or the
-            confirming re-read itself failed (UNCONFIRMED)
+            write was not acknowledged in time or the confirming re-read itself
+            failed (UNCONFIRMED)
         ControlTargetChangedError: If the session switched control target after
             this execution started; nothing was written
         TimeoutError: If operation times out

--- a/src/osprey/services/bluesky_bridge/devices/connector.py
+++ b/src/osprey/services/bluesky_bridge/devices/connector.py
@@ -140,7 +140,8 @@ class ConnectorSettable(StandardReadable):
                 not verifiably hold the value sent — ``FAILED`` (the control
                 system did not take it), ``MISMATCH`` (the channel holds a
                 different value, e.g. a clamped setpoint) or ``UNCONFIRMED``
-                (the confirming re-read itself raised). All three abort the
+                (sent, but not acknowledged in time or the confirming re-read
+                itself failed). All three abort the
                 plan: an unconfirmed or mismatched write is a false premise
                 for every step that follows it.
             ConnectionError: Propagated unchanged from the connector's

--- a/src/osprey/services/channel_finder/databases/middle_layer.py
+++ b/src/osprey/services/channel_finder/databases/middle_layer.py
@@ -95,9 +95,26 @@ class MiddleLayerDatabase(BaseDatabase):
         super().__init__(db_path)
 
     def load_database(self) -> None:
-        """Load middle layer database from JSON file."""
+        """Load middle layer database from JSON file.
+
+        Raises:
+            ValueError: The file is valid JSON in a shape this parser does not
+                read. Raised rather than read as an empty tree: every consumer
+                turns a loader exception into a corrupt-source verdict, while a
+                database that "loaded" zero channels is indistinguishable from
+                an empty facility.
+        """
         with open(self.db_path) as f:
             self.data = json.load(f)
+
+        if not isinstance(self.data, dict):
+            raise ValueError(
+                "Invalid database format: a middle-layer database is a dict of "
+                "systems -> families -> fields, keyed by name at every level; this "
+                f"file's root is a {type(self.data).__name__}. See "
+                "data/channel_databases/tiers/tier3/middle_layer.json for the "
+                "expected format."
+            )
 
         # Build flat channel map for validation and lookup
         self.channel_map = self._build_channel_map()
@@ -106,18 +123,42 @@ class MiddleLayerDatabase(BaseDatabase):
         """
         Flatten MML hierarchy into channel map for O(1) validation.
 
+        Keys starting with ``_`` are metadata (``_description``, ``_meta``) at
+        any level and are skipped. Any other value that is not a mapping is a
+        shape error, and is named rather than skipped: a system or family that
+        silently contributed nothing would read as a facility with fewer
+        channels, not as a broken file.
+
         Returns:
             Dict mapping channel names to metadata
+
+        Raises:
+            ValueError: A system or family whose value is not a mapping.
         """
         channels = {}
 
         for system, families in self.data.items():
-            if not isinstance(families, dict):
+            if system.startswith("_"):
                 continue
+            if not isinstance(families, dict):
+                raise ValueError(
+                    f"Invalid database format: system '{system}' must map family "
+                    f"names to their fields, got a {type(families).__name__}. See "
+                    "data/channel_databases/tiers/tier3/middle_layer.json for the "
+                    "expected format."
+                )
 
             for family, fields in families.items():
-                if not isinstance(fields, dict):
+                if family.startswith("_"):
                     continue
+                if not isinstance(fields, dict):
+                    raise ValueError(
+                        f"Invalid database format: family '{system}:{family}' must "
+                        f"map field names to their definitions, got a "
+                        f"{type(fields).__name__}. See "
+                        "data/channel_databases/tiers/tier3/middle_layer.json for the "
+                        "expected format."
+                    )
 
                 # Process each field in the family
                 self._extract_channels_from_field(channels, system, family, fields, path=[])

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -565,15 +565,14 @@ WRITE_APPROVAL_TTL_S = 3600.0
 def write_approval_key(tool_input) -> str | None:
     """Correlate a prompt with the tool call it will authorize, or ``None``.
 
-    The key is a SHA-256 over the canonical JSON of the two fields of the write
-    that both sides see — ``operations`` and ``confirm``, which are every
-    parameter the tool accepts — because the hook and the server share no
-    identifier at all: Claude Code gives the hook a session id and a tool-call
-    payload, and the MCP tool receives only its arguments. The payload is the
-    one thing that provably crosses the gap, and the tool's own parameter names
-    are the spelling of it, so the legacy single-channel shape
-    (``channel``/``value``, which the tool does not accept) is deliberately not
-    stamped.
+    The key is a SHA-256 over the canonical JSON of ``operations`` and
+    ``confirm`` — every parameter the tool accepts. The hook and the server
+    share no identifier at all (Claude Code gives the hook a session id and a
+    tool-call payload; the MCP tool receives only its arguments), so the
+    payload is the one thing that provably crosses the gap. The tool's own
+    parameter names are the spelling of that payload, which is why the legacy
+    single-channel shape (``channel``/``value``, which the tool does not
+    accept) is deliberately not stamped.
 
     ``None`` whenever no key can be formed, which the caller renders as "do not
     stamp": no comparison is a far better failure than a wrong comparison.

--- a/tests/cli/test_build_va_manifest_honesty.py
+++ b/tests/cli/test_build_va_manifest_honesty.py
@@ -265,10 +265,9 @@ def test_a_hierarchical_trees_fact_states_no_degradation(whole_tree, tmp_path, c
 #: build has every reason to believe it holds the facility's channels.
 _SCHEMA_INVALID_DB = '{"channels": {"FACILITY:TIER:SRC": {"description": "profile"}}}\n'
 
-#: A body no parser can get past at all: the schema-invalid one above reads as
-#: an empty tree to the middle-layer parser, which navigates any nesting it is
-#: given, so a test that needs EVERY staged database unreadable truncates the
-#: JSON instead.
+#: A body no parser can get past at all -- truncated JSON. Every paradigm
+#: parser rejects the schema-invalid one above too; this one makes the refusal
+#: come from the JSON decoder rather than from a parser's shape check.
 _UNPARSEABLE_DB = '{"channels": [\n'
 
 

--- a/tests/connectors/test_epics_connector.py
+++ b/tests/connectors/test_epics_connector.py
@@ -351,6 +351,24 @@ class TestWriteConfirmation:
         assert result.error_message is None
 
     @pytest.mark.asyncio
+    async def test_a_put_whose_callback_times_out_is_unconfirmed_and_not_re_read(self):
+        """pyepics answers a put-callback timeout with -1, which is truthy.
+
+        The value was sent and nothing has said the IOC took it: the outcome is
+        unknown, not a success to go and confirm. No confirming read is made,
+        because a read that raced the record's own processing would report
+        whatever the channel held a moment ago as the outcome of this write.
+        """
+        connector = _write_connector(caput=-1)
+
+        result = await connector.write_channel("SR:CH", 5.0, confirm=True)
+
+        assert result.outcome is WriteOutcome.UNCONFIRMED
+        assert result.observed_value is None
+        assert "did not acknowledge" in result.error_message
+        connector._epics.PV.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_a_confirming_read_that_raises_is_unconfirmed(self):
         """The value was sent; what the channel holds is unknown, not wrong."""
         connector = _write_connector(read_error=TimeoutError("ca timeout"))

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -7944,6 +7944,59 @@ def test_the_gate_lets_the_shipped_demo_posture_build(
     _gate(config)
 
 
+def test_the_gate_lets_the_shipped_stand_in_posture_build(
+    tmp_path: Path, cold_roster_cache: None
+) -> None:
+    """The stand-in the preset deploys keeps building, on the posture it inherits.
+
+    The control-assistant preset makes the stand-in its baseline
+    (``control_system.type: live_standin``), arms the deployment-wide limits
+    pair, and writes NO ``connector.live_standin.limits_checking`` block of
+    its own: the preset's comment promises that the hardware-shaped stand-in
+    inherits the strict pair the real machine gets. The sibling test above
+    pins the simulator's per-type block; this one pins the inheritance. Both
+    halves are READ OUT of the preset, so a preset edit that handed the
+    stand-in a block of its own, or turned the global pair off, fails here
+    rather than shipping a demo the gate refuses at build time.
+
+    The lane is bound to ``standin`` the way the real single-lane build is:
+    the injector writes ``services.bluesky.target`` for the stand-in baseline
+    because it runs two soft IOCs. Writes are armed on the deployment-wide
+    key, since no shipped preset writes the stand-in's own ``writes_enabled``
+    leaf and the gate reads no limits for a lane whose target is unarmed.
+    """
+    from osprey.cli.build_profile_presets import _presets_dir
+
+    preset = yaml.safe_load((_presets_dir() / "control-assistant.yml").read_text(encoding="utf-8"))[
+        "config"
+    ]
+    assert preset["control_system.type"] == "live_standin", (
+        "this test pins the stand-in baseline the preset ships; if the baseline moved "
+        "deliberately, pin the new one"
+    )
+    assert preset["control_system.limits_checking.enabled"] is True, (
+        "the deployment-wide pair is the stand-in's posture -- if this preset changed "
+        "deliberately, the gate now refuses the shipped demo"
+    )
+    standin_prefix = "control_system.connector.live_standin.limits_checking."
+    assert [key for key in preset if key.startswith(standin_prefix)] == [], (
+        "the preset promises the stand-in INHERITS the deployment-wide pair; a block of "
+        "its own replaces that pair rather than merging with it"
+    )
+
+    _corpus(tmp_path / "data" / "demo_machine.ttl", {"A:B:C:SP": "writesSignal"})
+    config = _graph_devices_config(tmp_path, control_system_type="live_standin")
+    config["services"]["bluesky"]["target"] = "standin"
+    config["control_system"]["writes_enabled"] = True
+    config["control_system"]["limits_checking"] = {
+        "database_path": "data/channel_limits.json",
+        "enabled": preset["control_system.limits_checking.enabled"],
+        "allow_unlisted_channels": preset["control_system.limits_checking.allow_unlisted_channels"],
+    }
+
+    _gate(config)
+
+
 def test_the_gate_lets_a_read_only_lane_derive_without_limits(
     tmp_path: Path, cold_roster_cache: None
 ) -> None:

--- a/tests/interfaces/design_system/test_validate.py
+++ b/tests/interfaces/design_system/test_validate.py
@@ -1111,3 +1111,26 @@ def test_real_tokens_tree_currently_validates_clean() -> None:
     errors = validate_token_tree(tree)
 
     assert errors == [], "\n".join(str(error) for error in errors)
+
+
+@pytest.mark.skipif(not REAL_TOKENS_DIR.is_dir(), reason="real tokens/ tree not present yet")
+def test_real_tokens_status_success_never_shares_a_colour_with_text_muted() -> None:
+    """A healthy status dot must not be drawn in the inactive-label grey.
+
+    The monochrome high-contrast themes carry state by lightness alone, so the
+    one way for ``status.success`` and ``text.muted`` to become
+    indistinguishable is to resolve to the same ramp step -- which they once
+    did. Pinned for every theme, because a chromatic theme that aliased the
+    two would lose the distinction just the same.
+    """
+    tree = load_token_tree(REAL_TOKENS_DIR)
+
+    collisions = {
+        stem: tokens["status.success"].value
+        for stem, tokens in tree.themes.items()
+        if tokens["status.success"].value == tokens["text.muted"].value
+    }
+
+    assert collisions == {}, (
+        f"status.success resolves to the same colour as text.muted in: {collisions}"
+    )

--- a/tests/interfaces/web_terminal/control-target-chip.test.mjs
+++ b/tests/interfaces/web_terminal/control-target-chip.test.mjs
@@ -143,6 +143,7 @@ const viewOf = (o = {}) => ({
   session_id: SESSION,
   session_target: 'standin',
   store_available: true,
+  readonly_run: false,
   enforceable: true,
   enforceable_reason: null,
   execution_in_flight: false,

--- a/tests/interfaces/web_terminal/control-target-popover.test.mjs
+++ b/tests/interfaces/web_terminal/control-target-popover.test.mjs
@@ -137,6 +137,7 @@ const viewOf = (o = {}) => ({
   session_id: SESSION,
   session_target: 'standin',
   store_available: true,
+  readonly_run: false,
   enforceable: true,
   enforceable_reason: null,
   execution_in_flight: false,
@@ -538,6 +539,7 @@ describe('the banner', () => {
     const readonly = { ceiling_writes: true, posture: 'writes', effective: false };
     await bootOpen(
       viewOf({
+        readonly_run: true,
         targets: [
           rowOf(KINDS.live, readonly),
           rowOf(KINDS.standin, {
@@ -552,6 +554,40 @@ describe('the banner', () => {
     );
     expect(bannerEl()?.textContent).toBe('The whole deployment is running read-only.');
     expect(bannerEl()?.dataset.tone).toBe('warn');
+  });
+
+  test('a readonly run with one unarmed row is still named: the run is the widest fact', async () => {
+    const readonly = { ceiling_writes: true, posture: 'writes', effective: false };
+    await bootOpen(
+      viewOf({
+        readonly_run: true,
+        targets: [
+          rowOf(KINDS.live, { ...STATES['read-only'] }),
+          rowOf(KINDS.standin, {
+            ...readonly,
+            active: true,
+            available_now: false,
+            reason: 'already_active',
+          }),
+          rowOf(KINDS.va, readonly),
+        ],
+      })
+    );
+    expect(bannerEl()?.textContent).toBe('The whole deployment is running read-only.');
+  });
+
+  test('a store that failed to resolve is not called a readonly run', async () => {
+    // Ceiling up, nothing narrowed, writes still off: the columns a failed
+    // store read leaves behind. Without the route saying `readonly_run`,
+    // that signature is not the deployment running read-only.
+    const unresolved = { ceiling_writes: true, posture: 'writes', effective: false };
+    await bootOpen(
+      viewOf({
+        readonly_run: false,
+        targets: [rowOf(KINDS.live, unresolved), rowOf(KINDS.va, unresolved)],
+      })
+    );
+    expect(bannerEl()).toBeNull();
   });
 });
 
@@ -582,13 +618,26 @@ describe('the verb locks, one reason at a time', () => {
     expect(reason).toBe('changes here would not reach the agent');
   });
 
-  test('a readonly run: the ceiling is up, nothing is narrowed, writes are still off', async () => {
+  test('a readonly run: the route says so, and every armed row is locked on it', async () => {
     const readonly = { ceiling_writes: true, posture: 'writes', effective: false };
     const { reason } = await lockOn(
-      viewOf({ targets: [rowOf(KINDS.live, readonly), rowOf(KINDS.va, readonly)] }),
+      viewOf({
+        readonly_run: true,
+        targets: [rowOf(KINDS.live, readonly), rowOf(KINDS.va, readonly)],
+      }),
       'va'
     );
     expect(reason).toBe('the whole deployment is running read-only');
+  });
+
+  test('a store that failed to resolve does not lock the row on the run', async () => {
+    const unresolved = { ceiling_writes: true, posture: 'writes', effective: false };
+    const { toggle, reason } = await lockOn(
+      viewOf({ readonly_run: false, targets: [rowOf(KINDS.va, unresolved)] }),
+      'va'
+    );
+    expect(toggle?.disabled).toBe(false);
+    expect(reason).not.toContain('read-only');
   });
 
   test('a ceiling that never armed the target reads as the deployment holding it', async () => {

--- a/tests/interfaces/web_terminal/test_posture_get_contract.py
+++ b/tests/interfaces/web_terminal/test_posture_get_contract.py
@@ -95,6 +95,7 @@ TOP_LEVEL_FIELDS = {
     "session_id",
     "session_target",
     "store_available",
+    "readonly_run",
     "enforceable",
     "enforceable_reason",
     "execution_in_flight",
@@ -1323,3 +1324,24 @@ class TestUnresolvableRoots:
         with patch.object(session_store, "store_path", side_effect=RuntimeError("no config")):
             payload = get_posture(client)
         assert payload["store_available"] is False
+
+
+class TestReadonlyRun:
+    """A read-only run is published, never left for the client to infer."""
+
+    def test_an_ordinary_run_says_so(self, client):
+        assert get_posture(client)["readonly_run"] is False
+
+    def test_a_readonly_run_is_published_and_holds_every_row(
+        self, make_client, tmp_path, agent_data_root, monkeypatch
+    ):
+        # After the fixture: it clears OSPREY_EXECUTION_MODE so no test
+        # inherits a read-only run from whatever ran before.
+        monkeypatch.setenv("OSPREY_EXECUTION_MODE", "readonly")
+        with make_client(render(tmp_path=tmp_path, global_writes=True)) as client:
+            payload = get_posture(client)
+
+        assert payload["readonly_run"] is True
+        for row in payload["targets"]:
+            assert row["ceiling_writes"] is True, row["target"]
+            assert row["effective"] is False, row["target"]

--- a/tests/interfaces/web_terminal/test_posture_get_contract.py
+++ b/tests/interfaces/web_terminal/test_posture_get_contract.py
@@ -1296,3 +1296,30 @@ class TestOneResolutionPerRequest:
             get_posture(client)
 
         assert resolve.call_count <= 1
+
+
+class TestUnresolvableRoots:
+    """Neither resolver is only a filesystem call, and neither may crash the GET.
+
+    The web server is never stamped with ``OSPREY_AGENT_DATA_ROOT`` — that
+    goes into the child's environment — so both ``target_state.state_dir()``
+    and ``session_store.store_path()`` fall back to loading the config, and
+    raise whatever loading it raises. A config that does not load is a
+    directory the server cannot read and a store with no location; the route
+    still answers, the way the gesture routes answer their 503.
+    """
+
+    def test_a_state_dir_that_raises_reads_as_no_record(self, client):
+        with (
+            attached_pty(client),
+            patch.object(target_state, "state_dir", side_effect=RuntimeError("no config")),
+        ):
+            payload = get_posture(client)
+        # No record could be read, so the session is one this server cannot
+        # reach — the toggles govern nothing — rather than an error page.
+        assert payload["enforceable"] is False
+
+    def test_a_store_path_that_raises_reads_as_store_unavailable(self, client):
+        with patch.object(session_store, "store_path", side_effect=RuntimeError("no config")):
+            payload = get_posture(client)
+        assert payload["store_available"] is False

--- a/tests/interfaces/web_terminal/test_posture_routes.py
+++ b/tests/interfaces/web_terminal/test_posture_routes.py
@@ -334,6 +334,11 @@ def only_alive(*pids):
         yield
 
 
+#: The 400's sentence for a target this render does not configure, spelled
+#: once in ``_unknown_target_message`` and pinned on both gesture routes.
+UNKNOWN_TARGET_SENTENCE = "This deployment configures no control target by that name."
+
+
 def post_posture(client, *, session_id=SESSION_A, target="standin", posture="sandbox"):
     return client.post(
         "/api/terminal/posture",
@@ -373,6 +378,7 @@ class TestGrammar:
             resp = post_posture(client, target="banana")
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "unknown_target"
+        assert resp.json()["detail"]["message"].startswith(UNKNOWN_TARGET_SENTENCE + " It has: ")
 
     def test_all_plus_writes_is_400(self, client, agent_data_root):
         """Widening is per target, always.
@@ -406,6 +412,7 @@ class TestGrammar:
             resp = post_posture(client, target=target, posture=posture)
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "unknown_target"
+        assert resp.json()["detail"]["message"] == UNKNOWN_TARGET_SENTENCE + " It has: none."
 
 
 class TestUnspokenSessions:

--- a/tests/interfaces/web_terminal/test_target_request_route.py
+++ b/tests/interfaces/web_terminal/test_target_request_route.py
@@ -270,6 +270,11 @@ def write_request_file(*, server_pid=SERVER_PID, target="va", age_s=0.0, request
     return path
 
 
+#: The 400's sentence for a target this render does not configure, spelled
+#: once in ``_unknown_target_message`` and pinned on both gesture routes.
+UNKNOWN_TARGET_SENTENCE = "This deployment configures no control target by that name."
+
+
 def post_target(client, session_id=SESSION_A, target="va"):
     return client.post(
         "/api/terminal/target",
@@ -297,6 +302,7 @@ class TestGrammar:
             resp = post_target(client, target="banana")
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "unknown_target"
+        assert resp.json()["detail"]["message"].startswith(UNKNOWN_TARGET_SENTENCE + " It has: ")
 
     def test_a_target_this_deployment_did_not_configure_is_400(self, client, tmp_path):
         """``va`` is a real target name; a render without its block has no such row.
@@ -316,6 +322,7 @@ class TestGrammar:
             resp = post_target(client, target="va")
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "unknown_target"
+        assert resp.json()["detail"]["message"] == UNKNOWN_TARGET_SENTENCE + " It has: live."
 
     def test_a_body_missing_a_field_is_422(self, client):
         assert client.post("/api/terminal/target", json={"target": "va"}).status_code == 422

--- a/tests/services/channel_finder/databases/test_middle_layer_loading.py
+++ b/tests/services/channel_finder/databases/test_middle_layer_loading.py
@@ -1,0 +1,60 @@
+"""Shape checks on loading a middle-layer database.
+
+A middle-layer file is a dict of systems -> families -> fields. The parser
+used to navigate any nesting it was given and read a wrong-shaped file as an
+empty tree, which every consumer then reported as a facility with zero
+channels. These pin that a wrong shape raises, and that metadata keys (the
+``_``-prefixed ones) stay tolerated at every level.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osprey.services.channel_finder.databases.middle_layer import MiddleLayerDatabase
+
+
+def _write(tmp_path: Path, body: object) -> str:
+    path = tmp_path / "ml.json"
+    path.write_text(json.dumps(body))
+    return str(path)
+
+
+_FIELDS = {"Monitor": {"ChannelNames": ["SR01:BPM:X"], "DataType": "double"}}
+
+
+def test_a_root_that_is_not_a_dict_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Invalid database format.*root is a list"):
+        MiddleLayerDatabase(_write(tmp_path, [{"SR": {"BPM": _FIELDS}}]))
+
+
+def test_a_system_that_is_not_a_dict_raises_and_names_it(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="system 'SR'.*got a list"):
+        MiddleLayerDatabase(_write(tmp_path, {"SR": ["BPM"]}))
+
+
+def test_a_family_that_is_not_a_dict_raises_and_names_it(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="family 'SR:BPM'.*got a str"):
+        MiddleLayerDatabase(_write(tmp_path, {"SR": {"BPM": "SR01:BPM:X"}}))
+
+
+def test_the_flat_paradigms_list_of_channels_is_refused_rather_than_read_as_empty(
+    tmp_path: Path,
+) -> None:
+    """The shape a half-migrated file most often has: a flat channel list."""
+    body = {"channels": [{"address": "FACILITY:TIER:SRC", "description": "profile"}]}
+    with pytest.raises(ValueError, match="system 'channels'.*got a list"):
+        MiddleLayerDatabase(_write(tmp_path, body))
+
+
+def test_metadata_keys_are_tolerated_at_every_level(tmp_path: Path) -> None:
+    body = {
+        "_meta": {"tier": 3, "generated": "today"},
+        "_description": "a facility",
+        "SR": {"_description": "Storage Ring", "BPM": {"_description": "BPMs", **_FIELDS}},
+    }
+    db = MiddleLayerDatabase(_write(tmp_path, body))
+    assert set(db.channel_map) == {"SR01:BPM:X"}

--- a/tests/va/test_build_time_manifest.py
+++ b/tests/va/test_build_time_manifest.py
@@ -320,11 +320,10 @@ class TestParadigmMismatchYieldsNoManifest:
 #: reading it raises from deep inside a parser.
 _SCHEMA_INVALID_DB = '{"channels": {"FACILITY:TIER:SRC": {"description": "profile"}}}\n'
 
-#: A body no parser can get past at all. The schema-invalid one above is
-#: rejected by the flat and hierarchical parsers but reads as an empty tree to
-#: the middle-layer one, which navigates any nesting it is given -- so a test
-#: that needs EVERY staged database to be unreadable truncates the JSON
-#: instead.
+#: A body no parser can get past at all -- truncated JSON. Every paradigm
+#: parser rejects the schema-invalid one above too; this one is for tests
+#: that want the refusal to come from the JSON decoder rather than from a
+#: parser's shape check, whichever parser reads it.
 _UNPARSEABLE_DB = '{"channels": [\n'
 
 
@@ -386,6 +385,27 @@ class TestCorruptDatabaseDegrades:
 
         assert "hierarchical" not in metadata["source_paradigms"]
         assert metadata["setpoint_count"] == 0
+
+    def test_a_shape_invalid_middle_layer_database_is_corrupt_not_seeds_only(self, editable_tree):
+        """Valid JSON in the wrong shape is a corrupt source, not an empty facility.
+
+        The middle-layer parser used to skip any system or family that was not
+        a mapping and read such a file as zero channels; on a tier that stages
+        only that database, the build then fell through to the scenario seeds
+        while the build fact said "N channels from its middle_layer database".
+        The body here is the flat paradigm's list of channels, which is what a
+        half-migrated file looks like.
+        """
+        paths = ManifestPaths(data_root=editable_tree, tier=DEFAULT_TIER)
+        paths.hierarchical_db.unlink()
+        paths.in_context_db.unlink()
+        _corrupt(paths.middle_layer_db, '{"channels": [{"address": "FACILITY:TIER:SRC"}]}\n')
+
+        assert prepare_project_manifest(editable_tree, DEFAULT_TIER) is None
+        with pytest.raises(CorruptChannelSourcesError) as excinfo:
+            build_manifest(paths)
+
+        assert "middle_layer" in str(excinfo.value)
 
     def test_every_database_corrupt_backs_no_manifest(self, editable_tree, caplog):
         paths = ManifestPaths(data_root=editable_tree, tier=DEFAULT_TIER)


### PR DESCRIPTION
Pre-release polish: nine FOLLOWUPS items ruled do-now in the 2026-09-02 release triage, one commit each, one changelog fragment. Merges after skills-curation lands and before the release PR.

Items: F03 F05 F10 F12 F13 F14 F15 F17 F18

- **F15** `fix(connectors)` — a pyepics put-callback timeout (`caput` returns `-1`, which is truthy) is reported as `unconfirmed` with no confirming re-read; the `unconfirmed` wording is widened in every place it is stated.
- **F03** `fix(channel-finder)` — a middle-layer database in the wrong shape raises `ValueError` (non-dict root, system or family, naming the key) instead of loading as zero channels, so a middle_layer-only tier becomes a corrupt source rather than a seeds-only manifest that claims otherwise. `_`-prefixed keys stay metadata.
- **F10** `fix(web-terminal)` — the posture GET publishes `readonly_run`; the popover reads it instead of inferring a read-only run from columns a failed store read leaves behind. The banner keys on it alone.
- **F12** `fix(web-terminal)` — target route docstring lists its ladder in code order (503 before the 409s); the four unknown-target tests pin the sentence the docstring says they pin; the state-directory scan and the posture-store path catch the config-load failures the web server can hit, so the posture GET answers instead of crashing.
- **F14** `style(design-system)` — high-contrast `status.success` sits one ramp step above `text.muted` (mono.300 dark, mono.700 light); `lat-led.ready` and `ariel-score-low` move with it; `tokens.css` regenerated; a validate test pins success ≠ muted for every theme. No high-contrast visual baselines exist.
- **F05** `test(deploy)` — pins that the shipped stand-in posture (live_standin baseline inheriting the global limits pair) builds through the lane-writes gate.
- **F18** `docs(approval)` — the two stamp-key derivation docstrings split into short sentences.
- **F13** `docs(web-terminal)` — operate.rst says the switch outcome leaves the row after about a minute.
- **F17** `docs(diagrams)` — the `confirmed` mask in the write sequence sized to its label.

Verification: `./scripts/quick_check.sh` green; targeted suites per item green; vitest (124 cases for the two control-target files), `tsc --noEmit` and eslint clean; changelog gate green.
