### PR TITLE
docs: fix five claims the code no longer honours

### DIFF
--- a/docs/source/_diagrams/otel-endpoint-context.html
+++ b/docs/source/_diagrams/otel-endpoint-context.html
@@ -1,7 +1,7 @@
 <div class="osprey-diagram">
 <svg viewBox="0 0 960 336" role="img" aria-labelledby="otel-endpoint-title otel-endpoint-desc">
   <title id="otel-endpoint-title">Where the OTLP endpoint points, by running context</title>
-  <desc id="otel-endpoint-desc">One OpenObserve store is reached under a different host name depending on where the emitter runs: localhost from a plain host run, the compose service name openobserve from a bridge-networked container, and localhost again from a host-networked container where the compose DNS name would not resolve. The port 5080 is fixed and does not follow a changed published port.</desc>
+  <desc id="otel-endpoint-desc">One OpenObserve store is reached under a different host name depending on where the emitter runs: localhost from a plain host run, the compose service name openobserve from a bridge-networked container, and localhost again from a host-networked container where the compose DNS name would not resolve. The port is the one the store publishes (services.openobserve.port); only a bridge-networked container reaches it on the image's fixed listen port, 5080.</desc>
   <defs>
     <marker id="otel-endpoint-arr" viewBox="0 0 8 6" refX="7" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
       <polygon points="0,0 8,3 0,6" fill="context-stroke"/>
@@ -23,7 +23,7 @@
   <rect class="nb" x="16" y="130" width="300" height="64" rx="6"/>
   <text class="tn" x="166" y="154" text-anchor="middle">bridge-networked container</text>
   <text class="ts" x="166" y="171" text-anchor="middle">the containerized dispatch worker</text>
-  <text class="ts" x="166" y="186" text-anchor="middle">host must be openobserve</text>
+  <text class="ts" x="166" y="186" text-anchor="middle">host must be openobserve, port must be 5080</text>
 
   <rect class="nb" x="16" y="220" width="300" height="64" rx="6"/>
   <text class="tn" x="166" y="244" text-anchor="middle">host-networked container</text>
@@ -39,10 +39,10 @@
 
   <rect class="nb-st" x="620" y="120" width="300" height="84" rx="6"/>
   <text class="tn" x="770" y="148" text-anchor="middle">OpenObserve</text>
-  <text class="ts" x="770" y="167" text-anchor="middle">http://&lt;host&gt;:5080/api/&lt;org&gt;</text>
+  <text class="ts" x="770" y="167" text-anchor="middle">http://&lt;host&gt;:&lt;port&gt;/api/&lt;org&gt;</text>
   <text class="ts" x="770" y="185" text-anchor="middle">one store, reached by three names</text>
 
-  <text class="ta ta-warn" x="480" y="308" text-anchor="middle">5080 is fixed — the derivation does not follow a changed services.openobserve.port; publish elsewhere and set endpoint: explicitly</text>
+  <text class="ta ta-warn" x="480" y="308" text-anchor="middle">the port follows services.openobserve.port — only the bridge case uses the image's fixed 5080; do not hardcode endpoint:</text>
   <text class="ta ta-warn" x="480" y="324" text-anchor="middle">hardcoding endpoint: points every context at one host and silently drops the records from the others</text>
 </svg>
 </div>

--- a/docs/source/getting-started/hello-world-tutorial.rst
+++ b/docs/source/getting-started/hello-world-tutorial.rst
@@ -331,7 +331,8 @@ containerized service, and this is the deployment lesson:
 
 This needs a container runtime (Docker or Podman) and starts **OpenObserve**, a
 local telemetry store bound to localhost, with its UI at
-http://localhost:5080. The agent already emits its logs and metrics there, so
+http://localhost:10050 (``deployment.port_base`` + 50). The agent already
+emits its logs and metrics there, so
 ``osprey up`` plus ``osprey web`` gives you a queryable record of every
 session out of the box — see :doc:`/how-to/health-and-monitoring/monitor-agent`. Stop the stack
 with ``osprey down``; the agent itself keeps working without it.

--- a/docs/source/how-to/agent-interfaces/cli-agent.rst
+++ b/docs/source/how-to/agent-interfaces/cli-agent.rst
@@ -73,18 +73,24 @@ global installation.
 Companion Services
 ------------------
 
-On startup, ``osprey chat`` launches the same companion servers as
-``osprey web``. Each server's URL is printed before the Osprey agent starts:
+On startup, ``osprey chat`` launches every framework companion server whose
+``auto_launch`` is on. Each server's URL is printed before the Osprey agent
+starts:
 
 .. code-block:: text
 
    Companion servers
-     Artifact gallery   http://127.0.0.1:10200
-     ARIEL server       http://127.0.0.1:10300
+     Artifact gallery   http://127.0.0.1:10200/?token=…
+     ARIEL server       http://127.0.0.1:10300/?token=…
 
-Open any of these URLs in a browser to access the service while the Osprey agent
-runs in your terminal. Which servers start depends on your ``config.yml`` —
-each server respects its own ``auto_launch`` setting.
+Each line is a login URL — the ``?token=`` carries this session's operator
+secret. Open it in a browser to reach the service while the Osprey agent runs
+in your terminal; the address without the token will not sign you in. Which
+servers start depends on your ``config.yml`` — each server respects its own
+``auto_launch`` setting. Unlike ``osprey web``, chat does not consult
+``web.panels``: a panel switched off there still gets its companion server
+here, because chat opens companions as browser tabs rather than as a panel
+rail.
 
 The servers run as background threads and stop automatically when you exit
 the Osprey agent.

--- a/docs/source/how-to/health-and-monitoring/monitor-agent.rst
+++ b/docs/source/how-to/health-and-monitoring/monitor-agent.rst
@@ -123,7 +123,7 @@ default. If your project removed it, restore it:
    services:
      openobserve:
        path: ./services/openobserve
-       port: 5080          # host port for the UI + OTLP ingest
+       port: 10050         # host port for the UI + OTLP ingest (deployment.port_base + 50)
 
    deployed_services:
      - openobserve
@@ -246,8 +246,10 @@ deploy warns with a named remedy and carries on — telemetry is the only thing
 affected, and every other service in the deployment comes up as usual. The
 remedy is almost always to run ``osprey up`` again once the store is running.
 
-The UI is then available at ``http://localhost:5080`` (log in with the **root**
-credentials). Verify the service is recognized with ``osprey health``.
+The UI is then available at ``http://localhost:10050`` — the layout's
+``openobserve`` slot, ``deployment.port_base`` + 50; ``services.openobserve.port``
+moves it. Log in with the **root** credentials. Verify the service is
+recognized with ``osprey health``.
 
 4. Point the agent at it
 ------------------------
@@ -414,5 +416,6 @@ Caveats
   if below OpenObserve's floor of 3 days), and the percentage-full of the disk
   the volume grows into.
 - **Local by design.** The service binds to localhost by default. Do not expose
-  port 5080 beyond the host without putting authentication and transport
-  security in front of it.
+  the store's published port (``services.openobserve.port``, 10050 by default)
+  beyond the host without putting authentication and transport security in
+  front of it.

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -109,17 +109,41 @@ Ollama and vLLM run locally and do not require an API key.
    secret store, and nothing else re-reads your shell. See
    :ref:`profile-secrets`.
 
+
+.. _provider-configuration:
+
 Provider Configuration
 ----------------------
 
-Providers are configured in two sections of ``config.yml``:
+Providers are configured in the deployment repository's ``profile.yml``. Its
+top-level ``provider:`` and ``model:`` keys select the provider the Osprey
+agent uses and its default model tier (``osprey set provider=… model=…``
+writes them for you), and a gateway that is not built in is described with
+dotted overrides in the profile's ``config:`` block:
+
+.. code-block:: yaml
+
+   provider: my-gateway
+   config:
+     api.providers.my-gateway.api_key: ${MY_GATEWAY_API_KEY}
+     api.providers.my-gateway.base_url: https://my-gateway.example.com/v1
+     api.providers.my-gateway.models:
+       haiku: claude-haiku-4-5
+       sonnet: claude-sonnet-4-6
+       opus: claude-opus-4-6
+
+``osprey build`` renders the profile into ``build/config.yml``, which every
+build wipes and re-renders; edit the profile, never the rendered file. The
+rendered file has two relevant sections:
 
 1. ``api.providers`` — declares available providers with their endpoints and
    model IDs.
 2. ``claude_code`` — selects which provider the Osprey agent uses and at which
    model tier.
 
-**Declare providers** under ``api.providers``:
+The YAML blocks below show that **rendered** ``build/config.yml``, so you can
+see what the profile's overrides become. **Declared providers** appear under
+``api.providers``:
 
 .. note::
 
@@ -316,8 +340,11 @@ After configuring a provider, check that the API key and endpoint work:
 Adding a New Provider
 ---------------------
 
-To add a new OpenAI-compatible provider, add an entry to ``api.providers``
-in ``config.yml`` — no code changes required:
+To add a new OpenAI-compatible provider, add the dotted ``api.providers``
+overrides to ``profile.yml``'s ``config:`` block (see
+:ref:`Provider Configuration <provider-configuration>` above) and run
+``osprey build`` — no code changes required. The rendered result in
+``build/config.yml``:
 
 .. code-block:: yaml
 

--- a/tests/docs/test_openobserve_host_port.py
+++ b/tests/docs/test_openobserve_host_port.py
@@ -1,0 +1,59 @@
+"""No doc page may send a reader to the telemetry store on its container port.
+
+OpenObserve listens on one fixed port inside its container. The port a reader
+reaches it on from the host is a different number: the ``openobserve`` slot of
+the port layout, ``deployment.port_base`` + 50, movable with
+``services.openobserve.port``. The two coincided in no shipped configuration
+since the layout landed, yet the docs kept telling readers to open
+``localhost:<container port>``, because that literal was copied into prose
+before the layout existed and nothing ever re-checked it.
+
+The layout table is the one producer of host ports. A page that names the
+container port as a host URL is a copy that has already drifted once, so this
+sweep fails on any ``localhost`` or ``127.0.0.1`` URL carrying that port in
+``docs/source``, including the inline SVG diagrams the pages embed. The
+container port itself is still allowed to appear where it is correct: the
+compose publish line, the bridge-networked ``OSPREY_OTEL_OPENOBSERVE_PORT``
+declaration, and prose that says "the container's 5080" without a host name.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from osprey.build.claude_code_telemetry import OPENOBSERVE_LISTEN_PORT
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCS_ROOT = _REPO_ROOT / "docs" / "source"
+_SUFFIXES = (".rst", ".md", ".html")
+
+#: A host URL on the container port: ``localhost:5080`` or ``127.0.0.1:5080``,
+#: optionally preceded by a scheme, not followed by another digit.
+_HOST_URL_ON_CONTAINER_PORT = re.compile(
+    rf"(?:https?://)?(?:localhost|127\.0\.0\.1):{OPENOBSERVE_LISTEN_PORT}(?!\d)"
+)
+
+
+def _doc_files() -> list[Path]:
+    return sorted(
+        path
+        for path in _DOCS_ROOT.rglob("*")
+        if path.is_file() and path.suffix in _SUFFIXES and "_build" not in path.parts
+    )
+
+
+@pytest.mark.parametrize("path", _doc_files(), ids=lambda p: str(p.relative_to(_DOCS_ROOT)))
+def test_no_host_url_on_the_container_port(path: Path) -> None:
+    offending = [
+        f"{path.relative_to(_REPO_ROOT)}:{lineno}: {line.strip()}"
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1)
+        if _HOST_URL_ON_CONTAINER_PORT.search(line)
+    ]
+    assert not offending, (
+        "a doc page names the telemetry store's container port as a host URL; the host "
+        "port is the layout's openobserve slot (deployment.port_base + 50):\n"
+        + "\n".join(offending)
+    )


### PR DESCRIPTION
## Summary

First supervised run of the `doc-sync` skill on three how-to pages (184 claims, 68 run, 15 candidate findings refuted before filing). Five drifts survived, all proven, all ruled doc-side:

1. **configure-providers** told readers to configure providers in `config.yml`. A fresh repository has no `config.yml` (`osprey init --preset hello-world` emits `profile.yml`), and every `osprey build` wipes and re-renders `build/config.yml`. The procedure now targets `profile.yml` with the dotted `config:` overrides, and the YAML blocks are labelled as the rendered result.
2. **cli-agent** showed companion URLs without the `?token=` login secret; the printed URLs carry it (`mint_and_announce`, added in eefe3f8c4) and the bare address stops at the login wall. The sample now shows the token form.
3. **cli-agent** claimed `osprey chat` launches the same companion set as `osprey web`. Chat gates on `auto_launch` only and never consults `web.panels`; with two panels disabled, web starts one companion and chat starts three. The page now says so.
4. **monitor-agent** and the **hello-world tutorial** pointed at `localhost:5080`, the container's listen port. The host port is the layout's `openobserve` slot, `deployment.port_base` + 50, so 10050 by default (`port_layout.py`, landed 3d73c4ff1 after the page was written).
5. The **endpoint diagram** embedded in monitor-agent said the port was fixed at 5080 and told readers to hardcode `endpoint:`, which the page's own prose forbids two paragraphs later. Since 8f6de9b2d the derived endpoint follows `services.openobserve.port`; the diagram now says that.

A new guard, `tests/docs/test_openobserve_host_port.py`, fails any doc page that names the store's container port as a `localhost` or `127.0.0.1` URL.

## Verification

- `tests/docs`: 224 passed (110 new parametrized cases from the guard).
- Sphinx build with `-W --keep-going`: clean, including the new `provider-configuration` label.