### PR TITLE
fix(epics): PVA address list gets no default port; warn when pva_channels has no pva_gateway

### DIFF
--- a/changelog.d/862.fixed.md
+++ b/changelog.d/862.fixed.md
@@ -1,0 +1,5 @@
+PVA reads through `pva_gateway` no longer time out when `port` is unset: the
+address list is passed to the client without a port (its UDP default applies)
+instead of the TCP port 5075, and `address` may list several hosts. The build
+now warns when `pva_channels` is set with no `pva_gateway`, since environment
+`EPICS_PVA_*` variables never reach the connector.

--- a/docs/source/how-to/control-systems/use-connectors.rst
+++ b/docs/source/how-to/control-systems/use-connectors.rst
@@ -109,8 +109,7 @@ Pick a control system
                  - "*:IMAGE*"
                  - "BL:CAM?:ARRAY"
                pva_gateway:
-                 address: pvagw.facility.edu
-                 port: 5075               # default
+                 address: pvagw.facility.edu   # or "cam1 cam2 cam3" for many servers
                  use_name_server: false
                gateways:
                  read_only: { address: cagw.facility.edu, port: 5064 }
@@ -126,10 +125,20 @@ Pick a control system
       ``pva_gateway`` is a single flat block, unlike the ``read_only`` /
       ``write_access`` pair on the Channel Access side, because pvAccess is
       read-only here. The block is only consulted when ``pva_channels`` is
-      non-empty, and it becomes ``EPICS_PVA_ADDR_LIST`` in the form
-      ``address:port`` -- or ``EPICS_PVA_NAME_SERVERS``, same form, when
-      ``use_name_server`` is true, which makes the client connect over TCP
-      instead of searching by UDP broadcast (that is what an SSH tunnel needs).
+      non-empty, and it is the **only** way to tell the connector where to
+      search: the connector runs in a child process that drops every inherited
+      ``EPICS_PVA_*`` variable, so an ``EPICS_PVA_ADDR_LIST`` set in ``.env``
+      never reaches it. The build warns when ``pva_channels`` is set and this
+      block is missing.
+
+      ``address`` is one host or a space-separated list of hosts -- what a
+      facility with many pvAccess servers and no gateway needs. It becomes
+      ``EPICS_PVA_ADDR_LIST``, a list of UDP search targets: leave ``port``
+      unset and the client's default (5076) applies; set it and it is appended
+      to every listed host. Do not set 5075 here -- that is the TCP port, and a
+      search sent to it times out. With ``use_name_server: true`` the entry
+      becomes ``EPICS_PVA_NAME_SERVERS`` instead, a TCP endpoint where ``port``
+      defaults to 5075; that is what an SSH tunnel needs.
       Whenever the block is present, ``EPICS_PVA_AUTO_ADDR_LIST`` is forced to
       ``"NO"`` -- the same containment the Channel Access side applies, so a
       deployment deliberately pinned to one gateway cannot also

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -332,9 +332,21 @@ class EPICSConnector(ControlSystemConnector):
                   matching any pattern are served over PVAccess (p4p) instead of
                   Channel Access. Absent or empty => pure Channel Access, exactly
                   as before: p4p is not imported and no PVA env var is touched.
-                - pva_gateway: (optional) {address, port, use_name_server} for the
-                  PVA gateway, mapping to EPICS_PVA_ADDR_LIST or
-                  EPICS_PVA_NAME_SERVERS. Only read when pva_channels is non-empty.
+                - pva_gateway: (optional) {address, port, use_name_server} naming
+                  where PVA searches go. Only read when pva_channels is non-empty,
+                  and the ONLY route: the connector host scrubs every inherited
+                  EPICS_PVA_* variable before connect() runs, so a value set in
+                  the deployment's environment never reaches p4p.
+                    - address: one host, or a space-separated list of hosts (what
+                      a facility with many PVA servers and no gateway needs).
+                    - port: (optional) With use_name_server false the entries go
+                      to EPICS_PVA_ADDR_LIST as UDP search targets, and no port
+                      is appended unless one is set here (p4p's default, 5076,
+                      applies). Set, it is appended to every listed host. With
+                      use_name_server true the entry is a TCP name server in
+                      EPICS_PVA_NAME_SERVERS, defaulting to 5075.
+                    - use_name_server: (optional) TCP instead of UDP search.
+                      Required for SSH tunnels. Default: False
 
         Raises:
             ImportError: If pyepics is not installed, or if PVA channels are
@@ -449,20 +461,29 @@ class EPICSConnector(ControlSystemConnector):
 
             pva_gateway = config.get("pva_gateway") or {}
             if pva_gateway:
-                pva_address = pva_gateway.get("address", "")
-                pva_port = pva_gateway.get("port", 5075)
+                pva_address = str(pva_gateway.get("address", ""))
+                pva_port = pva_gateway.get("port")
                 # Config system automatically converts "true"/"false" to booleans
                 pva_use_name_server = pva_gateway.get("use_name_server", False)
                 # PVA carries the port inside the address entry itself — there is
                 # no client-side "server port" variable to set, unlike CA.
-                pva_endpoint = f"{pva_address}:{pva_port}" if pva_port else pva_address
                 if pva_use_name_server:
                     # Name servers make the client connect by TCP instead of
-                    # UDP-searching — required for SSH tunnels.
+                    # UDP-searching — required for SSH tunnels. 5075 is the PVA
+                    # TCP port.
+                    pva_endpoint = f"{pva_address}:{pva_port or 5075}"
                     os.environ["EPICS_PVA_NAME_SERVERS"] = pva_endpoint
                     os.environ.pop("EPICS_PVA_ADDR_LIST", None)
                     logger.debug(f"Using EPICS_PVA_NAME_SERVERS: {pva_endpoint}")
                 else:
+                    # Address-list entries are UDP search targets, whose default
+                    # port is 5076, not the TCP 5075 — an appended 5075 makes
+                    # every search miss. So no port is appended unless one is
+                    # set explicitly, and then to every host of the list.
+                    hosts = pva_address.split()
+                    if pva_port:
+                        hosts = [f"{host}:{pva_port}" for host in hosts]
+                    pva_endpoint = " ".join(hosts)
                     os.environ["EPICS_PVA_ADDR_LIST"] = pva_endpoint
                     os.environ.pop("EPICS_PVA_NAME_SERVERS", None)
                     logger.debug(f"Using EPICS_PVA_ADDR_LIST: {pva_endpoint}")

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2961,15 +2961,23 @@ def _build_repo(
             # copy's — is told about the deployment's services from the render
             # just written (see _SharedRenderInputs.host_config). A profile
             # that is itself attached hosts nothing and projects nothing.
+            from .build_profile_reach import (
+                ariel_ingestion_advisories,
+                pva_address_source_advisories,
+            )
+
+            rendered = _rendered_config(host_render)
+            # Every render carries the same connector table, so PVA channels
+            # with no address source are named once, here. Advisory: the
+            # build is sound, the reads would time out.
+            for advisory in pva_address_source_advisories(rendered):
+                output.note(f"⚠ {advisory}")
             if build_profile.deploy_services:
-                host_config = _rendered_config(host_render)
-                shared = shared._replace(host_config=host_config)
+                shared = shared._replace(host_config=rendered)
                 # The one render that has `deployed_services` in hand, so the
                 # one place a remote logbook with nothing mirroring it can be
                 # named. Advisory: the build is sound, the mirror is missing.
-                from .build_profile_reach import ariel_ingestion_advisories
-
-                for advisory in ariel_ingestion_advisories(host_config):
+                for advisory in ariel_ingestion_advisories(rendered):
                     output.note(f"⚠ {advisory}")
             phase.step("project files, agent artifacts and services")
             if injected:

--- a/src/osprey/cli/build_profile_reach.py
+++ b/src/osprey/cli/build_profile_reach.py
@@ -95,6 +95,53 @@ def ariel_ingestion_advisories(rendered_config: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def pva_address_source_advisories(rendered_config: Mapping[str, Any]) -> list[str]:
+    """Say when a connector block routes PVA channels but names no address source.
+
+    The connector-host child scrubs every inherited ``EPICS_PVA_*`` variable
+    before the connector runs, so ``pva_gateway`` is the only route a PVA
+    address list has into p4p. A block that lists ``pva_channels`` and relies
+    on ``EPICS_PVA_ADDR_LIST`` from the deployment's environment gets subnet
+    auto-discovery instead, which from an off-subnet host is a bare timeout on
+    every read. Advisory only: on the servers' own subnet discovery works.
+
+    ``pva_channels`` and ``pva_gateway`` are read exactly as ``connect()`` reads
+    them — a single glob may be a string, and an empty gateway block configures
+    nothing.
+
+    Args:
+        rendered_config: A render's config, after its ``config:`` overlay.
+
+    Returns:
+        One message per connector block with routing globs and no gateway,
+        naming the key to add; empty otherwise.
+    """
+    control_system = rendered_config.get("control_system")
+    connector = control_system.get("connector") if isinstance(control_system, Mapping) else None
+    if not isinstance(connector, Mapping):
+        return []
+    advisories: list[str] = []
+    for connector_type, block in connector.items():
+        if not isinstance(block, Mapping):
+            continue
+        globs = block.get("pva_channels") or []
+        if isinstance(globs, str):
+            globs = [globs]
+        if not isinstance(globs, list | tuple) or not any(str(g).strip() for g in globs):
+            continue
+        gateway = block.get("pva_gateway")
+        if isinstance(gateway, Mapping) and gateway:
+            continue
+        advisories.append(
+            f"control_system.connector.{connector_type}.pva_channels routes channels "
+            f"over PVA with no address source: add control_system.connector."
+            f"{connector_type}.pva_gateway (address may list several hosts, "
+            f"space-separated). EPICS_PVA_* variables set in the environment do "
+            f"not reach the connector."
+        )
+    return advisories
+
+
 def spelled_values(config: Any, dotted_key: str) -> list[tuple[str, Any]]:
     """Every way *config* writes *dotted_key*, with the value each gives.
 

--- a/src/osprey/mcp_server/control_system/target_eligibility.py
+++ b/src/osprey/mcp_server/control_system/target_eligibility.py
@@ -153,7 +153,9 @@ MODE_ADDR_LIST = "addr_list"
 
 #: The ports ``EPICSConnector.connect()`` falls back to when a gateway names
 #: none. The virtual accelerator never reaches the CA default: its unset ports
-#: are filled from ``services.virtual_accelerator.port`` first.
+#: are filled from ``services.virtual_accelerator.port`` first. The PVA default
+#: applies to name servers only (TCP); an address-list entry that names no port
+#: is passed to p4p without one, so its row carries ``None``.
 DEFAULT_CA_PORT = 5064
 DEFAULT_PVA_PORT = 5075
 
@@ -369,7 +371,7 @@ def _mode(gateway: dict[str, Any]) -> str:
     return MODE_NAME_SERVER if gateway.get("use_name_server", False) else MODE_ADDR_LIST
 
 
-def _row(gateway: Any, default_port: int) -> Endpoint | None:
+def _row(gateway: Any, default_port: int | None) -> Endpoint | None:
     """One endpoint row, or ``None`` for a gateway ``connect()`` would ignore.
 
     ``connect()`` guards its environment derivation with ``if gateway_config:``,
@@ -478,7 +480,11 @@ def derive_endpoints(
     # globs AND a gateway. Globs without a gateway import p4p but touch no PVA
     # environment variable, so there is no endpoint to report.
     if _pva_globs(block):
-        pva_row = _row(block.get("pva_gateway"), DEFAULT_PVA_PORT)
+        pva_gateway = block.get("pva_gateway")
+        # connect() appends no port to an address list unless one is set; the
+        # TCP default applies to name servers only.
+        name_server = isinstance(pva_gateway, dict) and _mode(pva_gateway) == MODE_NAME_SERVER
+        pva_row = _row(pva_gateway, DEFAULT_PVA_PORT if name_server else None)
         if pva_row is not None:
             endpoints[ROLE_PVA] = pva_row
 

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -588,10 +588,15 @@ control_system:
     #
     # `pva_gateway` is ONE flat block, not the read_only/write_access pair the
     # CA `gateways` below uses, precisely because there is no PVA write path.
-    # It is read only when pva_channels is non-empty, and maps to
-    # EPICS_PVA_ADDR_LIST — or to EPICS_PVA_NAME_SERVERS when use_name_server is
-    # true (TCP instead of UDP search: what SSH tunnels need). Whenever the block
-    # is present, EPICS_PVA_AUTO_ADDR_LIST is forced to "NO", mirroring the
+    # It is read only when pva_channels is non-empty, and it is the ONLY route:
+    # the connector host drops every EPICS_PVA_* variable from its environment,
+    # so an EPICS_PVA_ADDR_LIST set in .env never reaches it. `address` is one
+    # host or a space-separated list of hosts and maps to EPICS_PVA_ADDR_LIST
+    # (UDP search; leave `port` unset and p4p's default 5076 applies — 5075 is
+    # the TCP port and breaks the search) — or to EPICS_PVA_NAME_SERVERS when
+    # use_name_server is true (TCP instead of UDP search: what SSH tunnels need;
+    # port defaults to 5075). Whenever the block is present,
+    # EPICS_PVA_AUTO_ADDR_LIST is forced to "NO", mirroring the
     # EPICS_CA_AUTO_ADDR_LIST containment the CA path applies: a deployment
     # deliberately pinned to a gateway must not also broadcast-discover servers
     # on its local subnet.
@@ -616,8 +621,8 @@ control_system:
       #   - "*:IMAGE*"
       #   - "*:ARRAY*"
       # pva_gateway:
-      #   address: your-pva-gateway.example.com  # Replace with your PVA gateway
-      #   port: 5075
+      #   address: your-pva-gateway.example.com  # Or "host1 host2 host3" for many servers
+      #   # port: 5076  # Only if your servers search on a non-default port
       #   use_name_server: false  # Set true for SSH tunnels
       # use_name_server: Set to true for SSH tunnels (uses EPICS_CA_NAME_SERVERS)
       #                  Set to false for direct gateway (uses EPICS_CA_ADDR_LIST)

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -321,17 +321,22 @@ control_system:
       # pva_channels:
       #   - "*:IMAGE*"
       #   - "*:ARRAY*"
-      # PVA gateway - one flat block, unlike the CA read_only/write_access pair
-      # below, because PVA is read-only in this deployment. Read only when
-      # pva_channels is non-empty. Maps to EPICS_PVA_ADDR_LIST, or to
-      # EPICS_PVA_NAME_SERVERS when use_name_server is true (SSH tunnels).
-      # Whenever this block is present, EPICS_PVA_AUTO_ADDR_LIST is forced to
-      # "NO" - the same containment the CA side applies with
-      # EPICS_CA_AUTO_ADDR_LIST, so a deployment pinned to a gateway cannot also
-      # broadcast-discover servers on the local subnet.
+      # Where PVA searches go - one flat block, unlike the CA
+      # read_only/write_access pair below, because PVA is read-only in this
+      # deployment. Read only when pva_channels is non-empty, and the ONLY
+      # route: the connector host drops every EPICS_PVA_* variable from its
+      # environment, so an EPICS_PVA_ADDR_LIST set in .env never reaches it.
+      # `address` is one host or a space-separated list of hosts and maps to
+      # EPICS_PVA_ADDR_LIST (UDP search; leave `port` unset and p4p's default
+      # 5076 applies - 5075 is the TCP port and breaks the search), or to
+      # EPICS_PVA_NAME_SERVERS when use_name_server is true (TCP, SSH tunnels;
+      # port defaults to 5075). Whenever this block is present,
+      # EPICS_PVA_AUTO_ADDR_LIST is forced to "NO" - the same containment the CA
+      # side applies with EPICS_CA_AUTO_ADDR_LIST, so a deployment pinned to a
+      # gateway cannot also broadcast-discover servers on the local subnet.
       # pva_gateway:
-      #   address: your-gateway.example.com  # Replace with your PVA gateway address
-      #   port: 5075
+      #   address: your-gateway.example.com  # Or "host1 host2 host3" for many servers
+      #   # port: 5076  # Only if your servers search on a non-default port
       #   use_name_server: false  # Set true for SSH tunnels
       gateways:
         read_only:

--- a/tests/cli/test_pva_address_source_advisory.py
+++ b/tests/cli/test_pva_address_source_advisory.py
@@ -1,0 +1,132 @@
+"""The build advisory for PVA channels that name no address source.
+
+The connector-host child scrubs every inherited ``EPICS_PVA_*`` variable
+before the connector runs, so a ``pva_gateway`` block is the only route a PVA
+address list has into p4p. A deployment that lists ``pva_channels`` and sets
+``EPICS_PVA_ADDR_LIST`` in its environment instead gets subnet auto-discovery,
+which from an off-subnet host is a bare timeout on every read. The build is
+where that is worth saying.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from osprey.cli.build_cmd import build
+from osprey.cli.build_profile_reach import pva_address_source_advisories
+
+
+def _config(**epics: Any) -> dict[str, Any]:
+    """A rendered config whose ``epics`` connector block carries *epics*."""
+    return {
+        "control_system": {
+            "type": "epics",
+            "connector": {"mock": {"response_delay_ms": 0}, "epics": {"timeout": 5.0, **epics}},
+        }
+    }
+
+
+def test_pva_channels_without_a_gateway_are_advised() -> None:
+    advisories = pva_address_source_advisories(_config(pva_channels=["*:image"]))
+
+    assert len(advisories) == 1
+    assert "control_system.connector.epics.pva_gateway" in advisories[0]
+    assert "EPICS_PVA_" in advisories[0]
+
+
+def test_a_string_glob_counts_as_configured() -> None:
+    """``connect()`` accepts a single glob as a string, so the advisory must too."""
+    assert len(pva_address_source_advisories(_config(pva_channels="*:image"))) == 1
+
+
+def test_an_empty_gateway_block_is_no_address_source() -> None:
+    """``connect()`` treats an empty ``pva_gateway`` exactly like an absent one."""
+    advisories = pva_address_source_advisories(_config(pva_channels=["*:image"], pva_gateway={}))
+
+    assert len(advisories) == 1
+
+
+def test_a_gateway_block_is_silent() -> None:
+    config = _config(pva_channels=["*:image"], pva_gateway={"address": "10.0.0.1 10.0.0.2"})
+
+    assert pva_address_source_advisories(config) == []
+
+
+def test_no_pva_channels_is_silent() -> None:
+    assert pva_address_source_advisories(_config()) == []
+    assert pva_address_source_advisories(_config(pva_channels=[])) == []
+    assert pva_address_source_advisories(_config(pva_channels=["  "])) == []
+
+
+def test_a_config_without_connector_blocks_is_silent() -> None:
+    assert pva_address_source_advisories({}) == []
+    assert pva_address_source_advisories({"control_system": {"connector": None}}) == []
+
+
+def test_every_connector_block_is_checked() -> None:
+    """The advisory names the block it found, whichever connector type owns it."""
+    config = {
+        "control_system": {
+            "connector": {
+                "epics": {"pva_channels": ["*:image"], "pva_gateway": {"address": "gw"}},
+                "virtual_accelerator": {"pva_channels": ["*:image"]},
+            }
+        }
+    }
+
+    advisories = pva_address_source_advisories(config)
+
+    assert len(advisories) == 1
+    assert "control_system.connector.virtual_accelerator.pva_gateway" in advisories[0]
+
+
+# ---------------------------------------------------------------------------
+# Build wiring — a real `osprey build` names the gap exactly once
+# ---------------------------------------------------------------------------
+
+_PROFILE = """\
+extends: hello-world
+name: PVA Advisory Fixture
+config:
+  control_system.connector.epics.pva_channels: ["*:image"]
+{gateway}"""
+
+_GATEWAY = """\
+  control_system.connector.epics.pva_gateway:
+    address: cam1.example.org cam2.example.org
+"""
+
+
+def _build(tmp_path: Path, profile: str) -> str:
+    """Run a real ``osprey build`` on *profile*; return its captured output.
+
+    ``--skip-deps --skip-lifecycle``: the virtualenv install and the profile's
+    shell phases render nothing this module reads and cost minutes.
+    """
+    repo = tmp_path / "pva-advisory-fixture"
+    repo.mkdir()
+    (repo / "profile.yml").write_text(profile, encoding="utf-8")
+
+    result = CliRunner().invoke(build, ["--repo", str(repo), "--skip-deps", "--skip-lifecycle"])
+
+    assert result.exit_code == 0, result.output
+    # Rich wraps to the console width; single-space the output before matching.
+    return re.sub(r"\s+", " ", result.output)
+
+
+def test_build_names_the_missing_gateway_once(tmp_path: Path) -> None:
+    """One line, not one per render pass. Advisory: the build still succeeds."""
+    output = _build(tmp_path, _PROFILE.format(gateway=""))
+
+    assert output.count("control_system.connector.epics.pva_gateway") == 1
+    assert "EPICS_PVA_" in output
+
+
+def test_build_with_a_gateway_is_silent(tmp_path: Path) -> None:
+    output = _build(tmp_path, _PROFILE.format(gateway=_GATEWAY))
+
+    assert "pva_gateway" not in output

--- a/tests/connectors/test_pva_routing.py
+++ b/tests/connectors/test_pva_routing.py
@@ -301,7 +301,13 @@ class TestPvaGatewayEnv:
         assert "EPICS_PVA_NAME_SERVERS" not in os.environ
 
     @pytest.mark.asyncio
-    async def test_port_defaults_to_5075(self, monkeypatch, clean_epics_env):
+    async def test_addr_list_branch_appends_no_port_unless_set(self, monkeypatch, clean_epics_env):
+        """EPICS_PVA_ADDR_LIST entries are UDP search targets (default 5076).
+
+        5075 is the PVA TCP port. Appending it here made p4p search on the
+        wrong port and every read time out, so an unset port appends nothing
+        and p4p's own default applies.
+        """
         _patch_writes_enabled(monkeypatch, False)
         _install_fake_p4p(monkeypatch)
 
@@ -313,7 +319,59 @@ class TestPvaGatewayEnv:
             }
         )
 
-        assert os.environ["EPICS_PVA_ADDR_LIST"] == "pvagw.example.com:5075"
+        assert os.environ["EPICS_PVA_ADDR_LIST"] == "pvagw.example.com"
+
+    @pytest.mark.asyncio
+    async def test_addr_list_accepts_a_space_separated_host_list(
+        self, monkeypatch, clean_epics_env
+    ):
+        """A many-server facility lists its hosts in ``address``; passed verbatim."""
+        _patch_writes_enabled(monkeypatch, False)
+        _install_fake_p4p(monkeypatch)
+
+        connector = EPICSConnector()
+        await connector.connect(
+            {
+                "pva_channels": ["*:image"],
+                "pva_gateway": {"address": "10.0.0.1 10.0.0.2 cam3.example.com"},
+            }
+        )
+
+        assert os.environ["EPICS_PVA_ADDR_LIST"] == "10.0.0.1 10.0.0.2 cam3.example.com"
+
+    @pytest.mark.asyncio
+    async def test_explicit_port_is_appended_to_every_listed_host(
+        self, monkeypatch, clean_epics_env
+    ):
+        """``port`` names the search port of each host, not a suffix on the string."""
+        _patch_writes_enabled(monkeypatch, False)
+        _install_fake_p4p(monkeypatch)
+
+        connector = EPICSConnector()
+        await connector.connect(
+            {
+                "pva_channels": ["*:image"],
+                "pva_gateway": {"address": "10.0.0.1 cam2.example.com", "port": 5086},
+            }
+        )
+
+        assert os.environ["EPICS_PVA_ADDR_LIST"] == "10.0.0.1:5086 cam2.example.com:5086"
+
+    @pytest.mark.asyncio
+    async def test_name_server_branch_still_defaults_to_5075(self, monkeypatch, clean_epics_env):
+        """Name servers are TCP endpoints, where 5075 is the right default."""
+        _patch_writes_enabled(monkeypatch, False)
+        _install_fake_p4p(monkeypatch)
+
+        connector = EPICSConnector()
+        await connector.connect(
+            {
+                "pva_channels": ["SR:CAM1:IMAGE"],
+                "pva_gateway": {"address": "pvagw.example.com", "use_name_server": True},
+            }
+        )
+
+        assert os.environ["EPICS_PVA_NAME_SERVERS"] == "pvagw.example.com:5075"
 
     @pytest.mark.asyncio
     async def test_name_server_branch_sets_and_clears_env(self, monkeypatch, clean_epics_env):

--- a/tests/mcp_server/test_target_eligibility.py
+++ b/tests/mcp_server/test_target_eligibility.py
@@ -853,6 +853,28 @@ def test_a_pva_row_appears_only_with_both_globs_and_a_gateway() -> None:
     )
 
 
+def test_a_pva_addr_list_row_without_a_port_carries_none() -> None:
+    """``connect()`` appends no port to an address list unless one is set.
+
+    Address-list entries are UDP search targets, and p4p's own default applies
+    when the entry names no port — so the row must not restate the TCP default.
+    """
+    config = _config(
+        connector={
+            EPICS_TYPE: _epics_block(
+                pva_channels=["*:IMAGE*"],
+                pva_gateway={"address": "cam1.example.org cam2.example.org"},
+            )
+        }
+    )
+
+    derivation = _derive(config, LIVE)
+
+    assert derivation.endpoints["pva"] == te.Endpoint(
+        "cam1.example.org cam2.example.org", None, "addr_list"
+    )
+
+
 def test_pva_globs_without_a_gateway_derive_no_pva_row() -> None:
     """``connect()`` touches no PVA environment variable without a gateway."""
     config = _config(connector={EPICS_TYPE: _epics_block(pva_channels=["*:IMAGE*"])})


### PR DESCRIPTION
`pva_gateway` with `port` unset appended the TCP port 5075 to `EPICS_PVA_ADDR_LIST`, whose entries are UDP search targets (default 5076), so every PVA read timed out. The address-list branch now appends no port unless one is set, and `address` may be a space-separated host list (an explicit port is appended to every host). The name-server branch keeps 5075. The target roster restates the same rule.

Since the connector host scrubs inherited `EPICS_PVA_*` variables, `pva_gateway` is the only address route; the build now warns once when `pva_channels` is set with no `pva_gateway`. Template comments, the connect() docstring and the connectors how-to say so.

Closes #862