### PR TITLE
fix: issue wave — preset-drift lint, renderable bar default, PVA address list, orphan terminal containers, faster builds

### DIFF
--- a/changelog.d/841.changed.md
+++ b/changelog.d/841.changed.md
@@ -1,0 +1,3 @@
+`osprey build` is faster: a deployment's YAML is parsed on the libyaml scanner
+when it is installed, and the rendered `config.yml` is parsed once per change
+instead of on every check.

--- a/changelog.d/850.fixed.md
+++ b/changelog.d/850.fixed.md
@@ -1,0 +1,4 @@
+`osprey up` now stops and removes a web-terminal container whose user was
+renamed or dropped from the roster, and its host-port preflight covers every
+per-user index port, so the old container can no longer keep serving the new
+user's ports. Volumes are left for `osprey users prune`.

--- a/changelog.d/862.fixed.md
+++ b/changelog.d/862.fixed.md
@@ -1,0 +1,5 @@
+PVA reads through `pva_gateway` no longer time out when `port` is unset: the
+address list is passed to the client without a port (its UDP default applies)
+instead of the TCP port 5075, and `address` may list several hosts. The build
+now warns when `pva_channels` is set with no `pva_gateway`, since environment
+`EPICS_PVA_*` variables never reach the connector.

--- a/changelog.d/863.fixed.md
+++ b/changelog.d/863.fixed.md
@@ -1,0 +1,6 @@
+Customize Bars is editable again on a deployment whose panels do not include
+`system-health`. The default bar layout served to a fresh operator now holds
+only items that deployment can show, and the browser no longer treats a gated
+item leaving the never-saved default as lost content, so tiles stay enabled and
+Default recovers a read-only layout. `osprey build` and `osprey validate` warn
+about a `web.bar_items` entry the deployment cannot show.

--- a/changelog.d/864.added.md
+++ b/changelog.d/864.added.md
@@ -1,0 +1,5 @@
+`osprey validate` compares a profile `osprey init` wrote with the preset it
+came from, personas included, and refuses every difference no
+`# DEVIATION: <why>` comment claims (tag set by `provenance.deviation_marker`;
+`--drift=warn` demotes to a warning). `osprey build` notes when the preset has
+moved on since materialization and lists the unmarked differences under `-v`.

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -825,6 +825,21 @@ Resolves the profile and runs the full consistency check — convention
 directories, the data tree, service templates, lifecycle steps, environment
 variables — reporting every problem found, not just the first.
 
+It also compares the profile with the preset it was materialized from, so a
+line the preset gained after ``osprey init`` (a panel, a hook, a permission)
+does not go missing silently. A difference you mean is claimed once, with a
+comment above the line:
+
+.. code-block:: yaml
+
+   config:
+     # DEVIATION: the control room is dark
+     web.theme: dark
+
+Unclaimed differences fail the check (``--drift=warn`` only reports them); a
+stale marker is reported too. The tag defaults to ``DEVIATION`` and is set by
+``provenance.deviation_marker``.
+
 
 What the build does
 ===================

--- a/docs/source/how-to/control-systems/use-connectors.rst
+++ b/docs/source/how-to/control-systems/use-connectors.rst
@@ -109,8 +109,7 @@ Pick a control system
                  - "*:IMAGE*"
                  - "BL:CAM?:ARRAY"
                pva_gateway:
-                 address: pvagw.facility.edu
-                 port: 5075               # default
+                 address: pvagw.facility.edu   # or "cam1 cam2 cam3" for many servers
                  use_name_server: false
                gateways:
                  read_only: { address: cagw.facility.edu, port: 5064 }
@@ -126,10 +125,20 @@ Pick a control system
       ``pva_gateway`` is a single flat block, unlike the ``read_only`` /
       ``write_access`` pair on the Channel Access side, because pvAccess is
       read-only here. The block is only consulted when ``pva_channels`` is
-      non-empty, and it becomes ``EPICS_PVA_ADDR_LIST`` in the form
-      ``address:port`` -- or ``EPICS_PVA_NAME_SERVERS``, same form, when
-      ``use_name_server`` is true, which makes the client connect over TCP
-      instead of searching by UDP broadcast (that is what an SSH tunnel needs).
+      non-empty, and it is the **only** way to tell the connector where to
+      search: the connector runs in a child process that drops every inherited
+      ``EPICS_PVA_*`` variable, so an ``EPICS_PVA_ADDR_LIST`` set in ``.env``
+      never reaches it. The build warns when ``pva_channels`` is set and this
+      block is missing.
+
+      ``address`` is one host or a space-separated list of hosts -- what a
+      facility with many pvAccess servers and no gateway needs. It becomes
+      ``EPICS_PVA_ADDR_LIST``, a list of UDP search targets: leave ``port``
+      unset and the client's default (5076) applies; set it and it is appended
+      to every listed host. Do not set 5075 here -- that is the TCP port, and a
+      search sent to it times out. With ``use_name_server: true`` the entry
+      becomes ``EPICS_PVA_NAME_SERVERS`` instead, a TCP endpoint where ``port``
+      defaults to 5075; that is what an SSH tunnel needs.
       Whenever the block is present, ``EPICS_PVA_AUTO_ADDR_LIST`` is forced to
       ``"NO"`` -- the same containment the Channel Access side applies, so a
       deployment deliberately pinned to one gateway cannot also

--- a/docs/source/how-to/deploy-project/networking.rst
+++ b/docs/source/how-to/deploy-project/networking.rst
@@ -95,4 +95,7 @@ project its own ``deployment.port_base`` (:ref:`reference-ports`), which moves
 the pair along with everything else.
 A facility service you place on the host network is covered the same way,
 read from its ``services.<name>.port`` key; one without that key cannot be
-checked, and ``osprey up`` says so rather than skipping it silently.
+checked, and ``osprey up`` says so rather than skipping it silently. The
+multi-user web terminals are covered the same way: every port of every roster
+index — terminal and companion panels alike — is checked, and a conflict names
+the user whose ``index`` to move.

--- a/docs/source/how-to/web-terminal/multi-user/index.rst
+++ b/docs/source/how-to/web-terminal/multi-user/index.rst
@@ -288,6 +288,11 @@ The config block
                 ``osprey up``. The new container comes up with freshly
                 allocated ports and a seeded workspace; existing users are
                 untouched.
+            * - **Rename or drop a user**
+              - Edit the roster entry, then ``osprey up``. A container whose
+                user is no longer on the roster is stopped and removed, so it
+                cannot keep serving that index's ports; its volumes are
+                retained until ``osprey users prune``.
             * - **Reseed workspaces**
               - ``osprey users seed [USER]`` re-applies the seeded configuration
                 for one user, or for everyone when ``USER`` is omitted.

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -173,7 +173,7 @@ Check the deployment profile without building.
 
 .. code-block:: bash
 
-   osprey validate [TARGET] [--repo DIRECTORY]
+   osprey validate [TARGET] [--repo DIRECTORY] [--drift error|warn]
 
 With no argument, validates the deployment repository enclosing the working
 directory. ``TARGET`` names a different profile to check instead â€” a persona
@@ -184,6 +184,18 @@ directories, the ``data:`` tree, service templates, lifecycle steps, env vars â€
 then lints the declared web stack against the config a build would render. Every
 problem found is reported, not just the first. Exits 0 when the profile is
 valid, 2 with the accumulated errors when it is not, so a CI job can gate on it.
+
+A profile ``osprey init`` wrote is also compared with the preset it came from,
+persona deltas included: a value that differs, a key or list member the preset
+has and the profile lacks, one the profile adds that neither the preset nor the
+app template knows, or a persona ``exclude:`` of something the preset keeps.
+Each is refused with both ``file:line`` references unless a ``# DEVIATION:
+<why>`` comment within three lines above the profile line claims it (for a
+missing line, a comment anywhere naming the key or member). The tag is set by
+``provenance.deviation_marker``; a marker that no longer marks a difference is
+reported as stale. ``--drift=warn`` prints the differences and passes. ``osprey
+build`` prints the same list under ``-v`` and, whenever the bundled preset's hash
+differs from the recorded one, a one-line note that the preset has moved on.
 
 .. code-block:: bash
 

--- a/docs/source/reference/configuration/config.rst
+++ b/docs/source/reference/configuration/config.rst
@@ -587,6 +587,12 @@ Customize returns a user to.
 - ``header_visible`` and ``status_visible`` hide a bar without emptying it. A
   user can bring it back; the items you listed are still there when they do.
 
+An item this deployment cannot show leaves the arrangement before it is served:
+``system-health`` without the SYSTEM panel in ``web_panels``, ``bluesky-queue``
+without the Bluesky panel, ``identity`` with neither a terminal user nor an
+``app_name``. ``osprey build`` and ``osprey validate`` name each such entry you
+wrote, and the server logs the same line at start-up.
+
 An item that needs an option takes a mapping instead of a bare name, for
 example ``- {type: clock, options: {zone: utc, format: 12h}}`` or
 ``- {type: space, options: {width: 120}}`` (a ``space`` at width ``0``, the

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -142,7 +142,11 @@ Profile YAML reference
      - mapping
      - *written*
      - Which preset this profile was materialized from, and that preset's hash.
-       Written by the materialization; do not edit it.
+       Written by the materialization; ``osprey validate`` compares the profile
+       with that preset and refuses unmarked differences (see ``osprey
+       validate``). The one key you may add is ``deviation_marker``, the tag of
+       the ``# <TAG>: <why>`` comment that marks a difference as deliberate
+       (default ``DEVIATION``).
 
 
 Configuration overrides

--- a/packages/osprey-connectors/src/osprey_connectors/config.py
+++ b/packages/osprey-connectors/src/osprey_connectors/config.py
@@ -29,7 +29,9 @@ from typing import TYPE_CHECKING, Any, overload
 import yaml
 
 # Safe at module level despite this module's no-osprey-imports rule below:
-# ``workspace`` imports nothing from osprey itself, so there is no cycle.
+# ``workspace`` and ``yaml_loader`` import nothing from osprey itself, so
+# there is no cycle.
+from osprey_connectors import yaml_loader
 from osprey_connectors.workspace import (
     DEFAULT_AGENT_DATA_BASE_DIR,
     SIMULATION_STATE_DIR_CONFIG_KEY,
@@ -513,7 +515,7 @@ class ConfigBuilder:
         """Load and validate a YAML configuration file."""
         try:
             with open(file_path) as f:
-                config = yaml.safe_load(f)
+                config = yaml_loader.safe_load(f)
 
             if config is None:
                 logger.warning(f"Configuration file is empty: {file_path}")

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -332,9 +332,21 @@ class EPICSConnector(ControlSystemConnector):
                   matching any pattern are served over PVAccess (p4p) instead of
                   Channel Access. Absent or empty => pure Channel Access, exactly
                   as before: p4p is not imported and no PVA env var is touched.
-                - pva_gateway: (optional) {address, port, use_name_server} for the
-                  PVA gateway, mapping to EPICS_PVA_ADDR_LIST or
-                  EPICS_PVA_NAME_SERVERS. Only read when pva_channels is non-empty.
+                - pva_gateway: (optional) {address, port, use_name_server} naming
+                  where PVA searches go. Only read when pva_channels is non-empty,
+                  and the ONLY route: the connector host scrubs every inherited
+                  EPICS_PVA_* variable before connect() runs, so a value set in
+                  the deployment's environment never reaches p4p.
+                    - address: one host, or a space-separated list of hosts (what
+                      a facility with many PVA servers and no gateway needs).
+                    - port: (optional) With use_name_server false the entries go
+                      to EPICS_PVA_ADDR_LIST as UDP search targets, and no port
+                      is appended unless one is set here (p4p's default, 5076,
+                      applies). Set, it is appended to every listed host. With
+                      use_name_server true the entry is a TCP name server in
+                      EPICS_PVA_NAME_SERVERS, defaulting to 5075.
+                    - use_name_server: (optional) TCP instead of UDP search.
+                      Required for SSH tunnels. Default: False
 
         Raises:
             ImportError: If pyepics is not installed, or if PVA channels are
@@ -449,20 +461,29 @@ class EPICSConnector(ControlSystemConnector):
 
             pva_gateway = config.get("pva_gateway") or {}
             if pva_gateway:
-                pva_address = pva_gateway.get("address", "")
-                pva_port = pva_gateway.get("port", 5075)
+                pva_address = str(pva_gateway.get("address", ""))
+                pva_port = pva_gateway.get("port")
                 # Config system automatically converts "true"/"false" to booleans
                 pva_use_name_server = pva_gateway.get("use_name_server", False)
                 # PVA carries the port inside the address entry itself — there is
                 # no client-side "server port" variable to set, unlike CA.
-                pva_endpoint = f"{pva_address}:{pva_port}" if pva_port else pva_address
                 if pva_use_name_server:
                     # Name servers make the client connect by TCP instead of
-                    # UDP-searching — required for SSH tunnels.
+                    # UDP-searching — required for SSH tunnels. 5075 is the PVA
+                    # TCP port.
+                    pva_endpoint = f"{pva_address}:{pva_port or 5075}"
                     os.environ["EPICS_PVA_NAME_SERVERS"] = pva_endpoint
                     os.environ.pop("EPICS_PVA_ADDR_LIST", None)
                     logger.debug(f"Using EPICS_PVA_NAME_SERVERS: {pva_endpoint}")
                 else:
+                    # Address-list entries are UDP search targets, whose default
+                    # port is 5076, not the TCP 5075 — an appended 5075 makes
+                    # every search miss. So no port is appended unless one is
+                    # set explicitly, and then to every host of the list.
+                    hosts = pva_address.split()
+                    if pva_port:
+                        hosts = [f"{host}:{pva_port}" for host in hosts]
+                    pva_endpoint = " ".join(hosts)
                     os.environ["EPICS_PVA_ADDR_LIST"] = pva_endpoint
                     os.environ.pop("EPICS_PVA_NAME_SERVERS", None)
                     logger.debug(f"Using EPICS_PVA_ADDR_LIST: {pva_endpoint}")

--- a/packages/osprey-connectors/src/osprey_connectors/yaml_loader.py
+++ b/packages/osprey-connectors/src/osprey_connectors/yaml_loader.py
@@ -1,0 +1,42 @@
+"""PyYAML safe loading on the libyaml scanner when it is installed.
+
+``yaml.safe_load`` always runs PyYAML's pure-Python scanner, even when the
+``yaml`` wheel shipped the libyaml bindings — the C scanner is only reached by
+naming ``yaml.CSafeLoader`` explicitly. The two loaders share the constructor
+and the resolver, so a document parses to the same objects either way; only the
+scanning speed differs, by an order of magnitude. Every hot parse of a
+deployment's YAML (``osprey build`` re-reads its rendered ``config.yml`` many
+times per build) goes through :func:`safe_load` here rather than through
+``yaml.safe_load`` directly.
+"""
+
+from __future__ import annotations
+
+from typing import IO, Any
+
+import yaml
+
+
+def safe_loader() -> type[Any]:
+    """The safe loader class to parse with: libyaml's when present, else PyYAML's.
+
+    Resolved at call time rather than at import, so a build that runs without
+    the C bindings falls back on the same code path a test can exercise by
+    removing ``yaml.CSafeLoader``.
+    """
+    return getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+
+
+def safe_load(stream: str | bytes | IO[str] | IO[bytes]) -> Any:
+    """Parse one YAML document the way ``yaml.safe_load`` does, on the fastest loader.
+
+    Args:
+        stream: The document — a string, bytes, or an open file.
+
+    Returns:
+        The document as plain Python objects; ``None`` for an empty document.
+
+    Raises:
+        yaml.YAMLError: On a document that does not parse.
+    """
+    return yaml.load(stream, Loader=safe_loader())

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2093,7 +2093,7 @@ def _render_persona_projects(shared: _SharedRenderInputs, zones: _RenderZones) -
     The naming is the catalog's, not this function's invention:
     ``<repo>-<persona>`` is what ``osprey init`` writes into every catalog
     entry's ``project`` and ``project_path``
-    (:func:`~osprey.cli.profile_cmd._persona_catalog_layer`), which is how the
+    (:func:`~osprey.cli.build_profile_emit.persona_catalog_layer`), which is how the
     deploy finds the render this produced. Every delta is rendered whether the
     catalog names it or not — the catalog decides which personas are *deployed*,
     ``personas/`` decides which exist — so a delta added before its catalog entry
@@ -2888,6 +2888,26 @@ def _build_repo(
         # nobody has: every surface that gates on the errors discards these.
         for web_warning in web_warnings:
             output.note(f"⚠ {web_warning}")
+
+        # The comparison the `provenance:` stamp promises: a note whenever the
+        # preset has moved on since this profile was materialized, and — under
+        # `-v`, since a build is not the verb that refuses — the places the
+        # profile differs from it that no marker comment claims. `osprey
+        # validate` is where those become a refusal.
+        if build_profile.provenance is not None:
+            from .build_profile_drift import preset_drift_report
+            from .phase_reporter import is_verbose
+
+            drift = preset_drift_report(profile_path, build_profile.provenance)
+            if drift.note:
+                output.note(drift.note)
+            if is_verbose() and drift.unmarked:
+                output.warn(
+                    f"preset drift: {PROFILE_FILENAME} differs from preset {drift.preset} in "
+                    f"{len(drift.unmarked)} place(s) no marker claims (osprey validate refuses "
+                    f"these)",
+                    "\n".join(finding.render() for finding in drift.unmarked),
+                )
 
         # A fresh staging tree, and the output zone it will replace. Both are
         # created now: the venv below is written into `build/` directly, at the

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -1236,12 +1236,35 @@ class _SharedRenderInputs(NamedTuple):
     """
 
 
-def _rendered_config(render_dir: Path) -> dict[str, Any]:
-    """The ``config.yml`` a render wrote, as a plain mapping."""
-    import yaml
+#: Parsed ``config.yml`` documents by (path, content digest); see
+#: :func:`_rendered_config`. Cleared at the start of every ``osprey build``.
+_rendered_config_cache: dict[tuple[str, bytes], dict[str, Any]] = {}
 
-    with (render_dir / "config.yml").open("r", encoding="utf-8") as fh:
-        return yaml.safe_load(fh) or {}
+
+def _rendered_config(render_dir: Path) -> dict[str, Any]:
+    """The ``config.yml`` a render wrote, as a plain mapping.
+
+    Read a dozen times per render — every injector and every pre-publish check
+    asks for it — and rewritten in between by the resolvers that answer
+    ``auto`` values in place. The parse is what costs; the read is not. So the
+    file's bytes are read every time and the parse is cached under their
+    digest: a rewrite changes the digest and is parsed afresh, an unchanged
+    file is parsed once. Callers get their own copy, since some annotate the
+    mapping before handing it on.
+    """
+    import copy
+    import hashlib
+
+    from osprey_connectors import yaml_loader
+
+    path = render_dir / "config.yml"
+    data = path.read_bytes()
+    key = (str(path), hashlib.sha256(data).digest())
+    parsed = _rendered_config_cache.get(key)
+    if parsed is None:
+        parsed = yaml_loader.safe_load(data.decode("utf-8")) or {}
+        _rendered_config_cache[key] = parsed
+    return copy.deepcopy(parsed)
 
 
 def _resolve_rendered_execution_method(render_dir: Path) -> list[str]:
@@ -3494,6 +3517,8 @@ def build(
     """
     from .main import lifecycle_reporter
     from .summary_card import owns_summary_card, print_summary_card
+
+    _rendered_config_cache.clear()
 
     # Both decided here rather than in `_build_repo`, because a chained build —
     # `init --up`, `up --build` — reaches that function with the chaining verb's

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -732,6 +732,8 @@ def _index_rendered_services(
     """
     import yaml
 
+    from osprey_connectors import yaml_loader
+
     owners = {}
     build_dir = str(config.get("build_dir", "./build"))
     for name, block in _mapping(config.get("services")).items():
@@ -741,7 +743,7 @@ def _index_rendered_services(
     indexed: list[_RenderedService] = []
     for path in compose_files:
         try:
-            document = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+            document = yaml_loader.safe_load(Path(path).read_text(encoding="utf-8"))
         except (OSError, yaml.YAMLError) as exc:
             logger.debug("Network checks skipped %s: %s", path, exc)
             continue

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2961,15 +2961,23 @@ def _build_repo(
             # copy's — is told about the deployment's services from the render
             # just written (see _SharedRenderInputs.host_config). A profile
             # that is itself attached hosts nothing and projects nothing.
+            from .build_profile_reach import (
+                ariel_ingestion_advisories,
+                pva_address_source_advisories,
+            )
+
+            rendered = _rendered_config(host_render)
+            # Every render carries the same connector table, so PVA channels
+            # with no address source are named once, here. Advisory: the
+            # build is sound, the reads would time out.
+            for advisory in pva_address_source_advisories(rendered):
+                output.note(f"⚠ {advisory}")
             if build_profile.deploy_services:
-                host_config = _rendered_config(host_render)
-                shared = shared._replace(host_config=host_config)
+                shared = shared._replace(host_config=rendered)
                 # The one render that has `deployed_services` in hand, so the
                 # one place a remote logbook with nothing mirroring it can be
                 # named. Advisory: the build is sound, the mirror is missing.
-                from .build_profile_reach import ariel_ingestion_advisories
-
-                for advisory in ariel_ingestion_advisories(host_config):
+                for advisory in ariel_ingestion_advisories(rendered):
                     output.note(f"⚠ {advisory}")
             phase.step("project files, agent artifacts and services")
             if injected:

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2850,6 +2850,16 @@ def _build_repo(
         web_warnings = deploy_aware_config_warnings(
             build_profile.deploy, build_profile.config, profile_root=repo_root
         )
+        # An authored `web.bar_items` entry the served default will not carry:
+        # the server filters a panel-gated item whose panel this profile does
+        # not select, so the operator who wrote it is told here, not by an
+        # item that never appears.
+        from .build_profile_panels import bar_items_selection_warnings
+
+        web_warnings = [
+            *web_warnings,
+            *bar_items_selection_warnings(build_profile.config, build_profile.web_panels),
+        ]
         if not build_profile.provider:
             raise click.UsageError(
                 f"{PROFILE_FILENAME} names no provider. Add `provider: "

--- a/src/osprey/cli/build_limits_check.py
+++ b/src/osprey/cli/build_limits_check.py
@@ -30,10 +30,10 @@ LIMITS_DATABASE_KEY = "control_system.limits_checking.database_path"
 
 
 def _rendered_config(render_dir: Path) -> dict[str, Any]:
-    import yaml
+    from osprey_connectors import yaml_loader
 
     with (render_dir / "config.yml").open("r", encoding="utf-8") as fh:
-        return yaml.safe_load(fh) or {}
+        return yaml_loader.safe_load(fh) or {}
 
 
 def limits_database_errors(render_dir: Path) -> list[str]:

--- a/src/osprey/cli/build_profile_document.py
+++ b/src/osprey/cli/build_profile_document.py
@@ -23,6 +23,7 @@ from typing import Any
 import yaml
 
 from osprey.errors import BuildProfileError
+from osprey_connectors import yaml_loader
 
 # YAML-surface spelling -> canonical BuildProfile field name. The rename is
 # confined to the YAML surface: the Python identifier, the manifest JSON keys,
@@ -65,8 +66,8 @@ def _normalize_profile_aliases(raw: dict[str, Any], source: str) -> dict[str, An
 def _read_profile_document(path: Path, source: str | None = None) -> Any:
     """Read one raw profile-YAML document, normalizing YAML-surface aliases.
 
-    The only ``yaml.safe_load`` of a profile document in the pipeline (pinned
-    by a guard test). Mapping-shape checks stay with the callers so each keeps
+    The only YAML parse of a profile document in the pipeline (pinned by a
+    guard test). Mapping-shape checks stay with the callers so each keeps
     naming its own layer ("Override must be a YAML mapping", ...); a
     non-mapping document is returned exactly as parsed.
 
@@ -83,7 +84,7 @@ def _read_profile_document(path: Path, source: str | None = None) -> Any:
     """
     label = str(path) if source is None else source
     try:
-        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        raw = yaml_loader.safe_load(path.read_text(encoding="utf-8"))
     except yaml.YAMLError as e:
         raise BuildProfileError(f"Invalid YAML in {label}: {e}") from e
     if isinstance(raw, dict):

--- a/src/osprey/cli/build_profile_document.py
+++ b/src/osprey/cli/build_profile_document.py
@@ -65,11 +65,6 @@ def _normalize_profile_aliases(raw: dict[str, Any], source: str) -> dict[str, An
 def _read_profile_document(path: Path, source: str | None = None) -> Any:
     """Read one raw profile-YAML document, normalizing YAML-surface aliases.
 
-    The only ``yaml.safe_load`` of a profile document in the pipeline (pinned
-    by a guard test). Mapping-shape checks stay with the callers so each keeps
-    naming its own layer ("Override must be a YAML mapping", ...); a
-    non-mapping document is returned exactly as parsed.
-
     Args:
         path: File to read.
         source: How to name the file in error messages (defaults to ``path``).
@@ -81,11 +76,36 @@ def _read_profile_document(path: Path, source: str | None = None) -> Any:
         BuildProfileError: On invalid YAML, or on a same-document double
             spelling with differing values.
     """
-    label = str(path) if source is None else source
+    return _parse_profile_document(
+        path.read_text(encoding="utf-8"), str(path) if source is None else source
+    )
+
+
+def _parse_profile_document(text: str, source: str) -> Any:
+    """Parse one raw profile-YAML document, normalizing YAML-surface aliases.
+
+    The only ``yaml.safe_load`` of a profile document in the pipeline (pinned
+    by a guard test), reached from files through :func:`_read_profile_document`
+    and directly for a document that exists only as text — the profile the
+    emitter would write. Mapping-shape checks stay with the callers so each
+    keeps naming its own layer ("Override must be a YAML mapping", ...); a
+    non-mapping document is returned exactly as parsed.
+
+    Args:
+        text: The document.
+        source: How to name it in error messages.
+
+    Returns:
+        The parsed document — normalized in place when it is a mapping.
+
+    Raises:
+        BuildProfileError: On invalid YAML, or on a same-document double
+            spelling with differing values.
+    """
     try:
-        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        raw = yaml.safe_load(text)
     except yaml.YAMLError as e:
-        raise BuildProfileError(f"Invalid YAML in {label}: {e}") from e
+        raise BuildProfileError(f"Invalid YAML in {source}: {e}") from e
     if isinstance(raw, dict):
-        _normalize_profile_aliases(raw, label)
+        _normalize_profile_aliases(raw, source)
     return raw

--- a/src/osprey/cli/build_profile_drift.py
+++ b/src/osprey/cli/build_profile_drift.py
@@ -67,7 +67,7 @@ class DriftFinding:
     Attributes:
         subject: What differs, as an operator would name it — a dotted key
             (``config.web.theme``, ``bluesky``) or a list member
-            (``web_panels: system-health``).
+            (``web_panels: lattice``).
         detail: Which way it differs.
         profile_ref: ``file:line`` in the profile, or the file alone when the
             profile has no line for it.

--- a/src/osprey/cli/build_profile_drift.py
+++ b/src/osprey/cli/build_profile_drift.py
@@ -1,0 +1,561 @@
+"""The preset-drift lint — what a materialized profile no longer shares with its preset.
+
+``osprey init`` writes a preset out as ``profile.yml`` and stamps
+``provenance:`` with the preset's name and content hash. From then on the
+profile is the source of truth, and the emitted header invites editing it. The
+cost of that copy is silence: when the preset later gains a line — a panel, a
+hook, a permission — no build says so, and a profile maintained as a delta over
+the preset drifts without anyone choosing to. This module is the comparison the
+stamp was written for.
+
+The reference is not the preset's raw layer, which no repo ever holds, but
+:func:`~osprey.cli.build_profile_emit.materialized_profile` — the document
+``osprey init`` would write from the installed preset for this repo today. The
+profile is compared with it key by key, and each persona delta with the persona
+preset the host preset's catalog names for it, both merged over the same
+resolved profile through :func:`~osprey.cli.build_profile_merge.merge_persona_delta`
+so a persona's ``exclude:`` is judged by the merge semantics the build uses.
+
+A difference is deliberate when a ``# <TAG>: <why>`` comment says so — within
+three lines above the profile line it describes, or, for a line the profile
+does not have, anywhere in the file naming what is absent. The tag is
+``provenance.deviation_marker`` (default ``DEVIATION``), so a facility's
+existing marker convention is the first consumer rather than a second one.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML, CommentedMap, CommentedSeq
+
+from osprey import __version__
+from osprey.errors import BuildProfileError
+
+from .build_profile_document import _read_profile_document
+from .build_profile_emit import materialized_profile, persona_catalog
+from .build_profile_merge import (
+    _resolve_extends,
+    compute_preset_hash,
+    merge_persona_delta,
+    resolve_profile_document,
+)
+from .build_profile_presets import _load_preset_raw, _normalize_preset_name, _preset_exists
+from .build_profile_schema import ProfileProvenance
+from .profile_root import ROOT_PROFILE_FILENAME, resolve_profile_root
+
+#: How far above a profile line a marker comment reaches.
+MARKER_REACH = 3
+
+# Top-level keys `osprey init` writes for the repo rather than copies from the
+# preset: the display name, the materialized data tree, the schema floor, and
+# the provenance stamp itself — whose hash difference is the note, not a finding.
+_MATERIALIZATION_KEYS: frozenset[str] = frozenset(
+    {"name", "data", "provenance", "requires_osprey_version"}
+)
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    """One place the profile and its preset disagree.
+
+    Attributes:
+        subject: What differs, as an operator would name it — a dotted key
+            (``config.web.theme``, ``bluesky``) or a list member
+            (``web_panels: system-health``).
+        detail: Which way it differs.
+        profile_ref: ``file:line`` in the profile, or the file alone when the
+            profile has no line for it.
+        preset_ref: ``file:line`` in the preset, or the preset's name when the
+            value is one the emitter synthesizes.
+        token: What a marker comment must name to silence this finding.
+        line: The profile line the finding sits on, or ``None`` for an absence.
+        marked: Whether a marker comment claims it.
+    """
+
+    subject: str
+    detail: str
+    profile_ref: str
+    preset_ref: str
+    token: str
+    line: int | None
+    marked: bool = False
+
+    def render(self) -> str:
+        """The one-line form the verbs print."""
+        return f"{self.subject} — {self.detail} ({self.profile_ref}; {self.preset_ref})"
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Everything the lint has to say about one profile.
+
+    Attributes:
+        preset: The bundled preset the profile's provenance names.
+        note: The one-line advisory that does not depend on the diff — the
+            preset has moved on since materialization, or is not bundled here.
+        findings: Every difference found, marked or not.
+        stale_markers: Marker comments that silence nothing.
+    """
+
+    preset: str
+    note: str | None
+    findings: list[DriftFinding]
+    stale_markers: list[str]
+
+    @property
+    def unmarked(self) -> list[DriftFinding]:
+        """The differences nobody has claimed as deliberate."""
+        return [finding for finding in self.findings if not finding.marked]
+
+
+def preset_drift_report(profile_file: Path, provenance: ProfileProvenance) -> DriftReport:
+    """Compare the profile at *profile_file* with the preset its provenance names.
+
+    Reads the tracked documents — ``profile.yml`` and the persona deltas its
+    catalog points at — never a host-variant overlay: drift is a property of
+    what the repo tracks, and an overlay is one host's layer over it.
+
+    Args:
+        profile_file: A repo's ``profile.yml``, or one persona delta under its
+            ``personas/``. A delta is compared alone; the root compares itself
+            and every persona whose catalog entry the preset also has.
+        provenance: The root profile's parsed ``provenance:`` block.
+
+    Returns:
+        The report. Empty findings and a note when the preset is not bundled.
+
+    Raises:
+        BuildProfileError: When a document the lint has to read is not a YAML
+            mapping, or the preset will not emit.
+    """
+    root_dir, is_delta = resolve_profile_root(profile_file)
+    root_path = root_dir / ROOT_PROFILE_FILENAME
+    preset = _normalize_preset_name(provenance.preset)
+
+    installed_hash = compute_preset_hash(preset)
+    if installed_hash is None:
+        return DriftReport(
+            preset,
+            f"provenance names preset {preset!r}, which OSPREY {__version__} does not bundle "
+            f"— the profile cannot be compared with it",
+            [],
+            [],
+        )
+    note = None
+    if installed_hash != provenance.preset_hash:
+        emitted = _emitted_version(root_path)
+        by = f" by OSPREY {emitted}" if emitted else ""
+        note = (
+            f"{ROOT_PROFILE_FILENAME} was materialized from preset {preset} at "
+            f"{_short_hash(provenance.preset_hash)}{by}; the preset bundled with OSPREY "
+            f"{__version__} is {_short_hash(installed_hash)} — it has moved on since"
+        )
+
+    root_raw = _read_profile_document(root_path)
+    if not isinstance(root_raw, dict):
+        raise BuildProfileError(f"Profile must be a YAML mapping: {root_path}")
+    profile = resolve_profile_document(copy.deepcopy(root_raw), root_path, warn=False).raw
+
+    preset_raw, preset_path = _load_preset_raw(preset)
+    chain: list[Path] = []
+    preset_resolved = _resolve_extends(preset_raw, preset_path, chain)
+    expected = materialized_profile(
+        preset, repo_name=root_dir.name, profile_name=str(profile.get("name", ""))
+    )
+    template = _template_defaults(
+        str(profile.get("data_bundle", "control_assistant")), profile.get("channel_finder_mode")
+    )
+    tag = provenance.deviation_marker
+
+    findings: list[DriftFinding] = []
+    stale: list[str] = []
+    if not is_delta:
+        comparison = _Comparison(
+            ROOT_PROFILE_FILENAME,
+            _Lines(root_path),
+            preset,
+            [_Lines(path) for path in chain],
+            template,
+        )
+        comparison.compare(profile, expected)
+        claimed, unclaimed = _apply_markers(comparison.findings, root_path, root_dir, tag)
+        findings.extend(claimed)
+        stale.extend(unclaimed)
+
+    for delta_path, persona_preset in _persona_pairs(
+        profile, preset_resolved, preset, root_dir, profile_file if is_delta else None
+    ):
+        delta_raw = _read_profile_document(delta_path)
+        if not isinstance(delta_raw, dict):
+            continue
+        layer, layer_path = _load_preset_raw(persona_preset)
+        layer.pop("extends", None)
+        relative = delta_path.relative_to(root_dir).as_posix()
+        comparison = _Comparison(
+            relative, _Lines(delta_path), persona_preset, [_Lines(layer_path)], template
+        )
+        # The delta enters the merge as the build feeds it — unresolved, so its
+        # `exclude:` is consumed against the root rather than its own layer.
+        comparison.compare(
+            merge_persona_delta(copy.deepcopy(profile), delta_raw),
+            merge_persona_delta(copy.deepcopy(profile), layer),
+        )
+        claimed, unclaimed = _apply_markers(comparison.findings, delta_path, root_dir, tag)
+        findings.extend(claimed)
+        stale.extend(unclaimed)
+
+    return DriftReport(preset, note, findings, stale)
+
+
+def _persona_pairs(
+    profile: Mapping[str, Any],
+    preset_resolved: Mapping[str, Any],
+    preset: str,
+    root_dir: Path,
+    only: Path | None,
+) -> list[tuple[Path, str]]:
+    """Each persona delta with the bundled persona preset it was emitted from.
+
+    A persona is comparable when the profile's catalog points its
+    ``build_profile`` at a delta file that exists and the preset's own catalog
+    names, for the same persona, a bundled preset extending *preset* directly —
+    the condition ``osprey init`` enforces before emitting a delta. Personas the
+    facility added, or whose entry still names a preset, have no counterpart and
+    are left to the web-stack lint.
+
+    Args:
+        profile: The resolved root profile.
+        preset_resolved: The preset, ``extends`` resolved, catalog unrepointed.
+        preset: The normalized host preset name.
+        root_dir: The profile root the catalog's paths anchor at.
+        only: Restrict to the persona whose delta is this file, if any.
+    """
+    from osprey.deployment.web_terminals.persona_images import persona_build_profile_shape_problem
+
+    actual = persona_catalog(_mapping(profile.get("config")))
+    reference = persona_catalog(_mapping(preset_resolved.get("config")))
+    pairs: list[tuple[Path, str]] = []
+    for name in sorted(actual):
+        ref = actual[name].get("build_profile")
+        if not isinstance(ref, str) or persona_build_profile_shape_problem(ref) is not None:
+            continue
+        delta_path = (root_dir / ref).resolve()
+        if not delta_path.is_file() or (only is not None and delta_path != only.resolve()):
+            continue
+        persona_preset = reference.get(name, {}).get("build_profile")
+        if not isinstance(persona_preset, str) or _preset_exists(persona_preset) is None:
+            continue
+        persona_preset = _normalize_preset_name(persona_preset)
+        parent = _load_preset_raw(persona_preset)[0].get("extends")
+        if not isinstance(parent, str) or _normalize_preset_name(parent) != preset:
+            continue
+        pairs.append((delta_path, persona_preset))
+    return pairs
+
+
+class _Comparison:
+    """Key-level diff of one document against its reference, collecting findings."""
+
+    def __init__(
+        self,
+        label: str,
+        lines: _Lines,
+        preset: str,
+        preset_lines: list[_Lines],
+        template: Mapping[str, Any],
+    ) -> None:
+        self.label = label
+        self.lines = lines
+        self.preset = preset
+        self.preset_lines = preset_lines
+        self.template = template
+        self.findings: list[DriftFinding] = []
+
+    def compare(self, actual: Mapping[str, Any], expected: Mapping[str, Any]) -> None:
+        """Diff two resolved profile documents from the top."""
+        from osprey.deployment.web_terminals.lint import _nest_dotted
+
+        for key in sorted(set(actual) | set(expected), key=str):
+            if key in _MATERIALIZATION_KEYS:
+                continue
+            path = (str(key),)
+            if key not in expected:
+                self._extra(path, actual[key])
+            elif key not in actual:
+                self._missing(path)
+            elif key == "config":
+                # Dotted keys, nested mappings and any mix of the two address
+                # the same rendered leaves; both sides are read the way the
+                # renderer reads them before a single leaf is compared.
+                self._compare(
+                    _nest_dotted(_mapping(actual[key])), _nest_dotted(_mapping(expected[key])), path
+                )
+            else:
+                self._compare(actual[key], expected[key], path)
+
+    def _compare(self, actual: Any, expected: Any, path: tuple[str, ...]) -> None:
+        if isinstance(actual, Mapping) and isinstance(expected, Mapping):
+            for key in sorted(set(actual) | set(expected), key=str):
+                sub = (*path, str(key))
+                if key not in expected:
+                    self._extra(sub, actual[key])
+                elif key not in actual:
+                    self._missing(sub)
+                else:
+                    self._compare(actual[key], expected[key], sub)
+        elif _is_name_list(actual) and _is_name_list(expected):
+            for member in expected:
+                if member not in actual:
+                    self._missing_member(path, member)
+            for member in actual:
+                if member not in expected:
+                    self._extra_member(path, member)
+        elif actual != expected:
+            self.findings.append(
+                DriftFinding(
+                    _dotted(path),
+                    f"{self.label} has {_short_repr(actual)}, the preset has "
+                    f"{_short_repr(expected)}",
+                    self._profile_ref(path),
+                    self._preset_ref(path),
+                    _token(path),
+                    self.lines.line(path),
+                )
+            )
+
+    def _extra(self, path: tuple[str, ...], value: Any) -> None:
+        """A key the profile sets and the preset does not.
+
+        Under ``config:`` a key the app template renders a default for is a
+        facility tuning a knob the preset left alone, not a departure from the
+        preset, and is not reported.
+        """
+        in_config = path[0] == "config" and len(path) > 1
+        if in_config and _template_knows(self.template, path[1:]):
+            return
+        unknown_to = "the preset and the app template" if in_config else "the preset"
+        self.findings.append(
+            DriftFinding(
+                _dotted(path),
+                f"set by {self.label}, unknown to {unknown_to}",
+                self._profile_ref(path),
+                f"preset {self.preset}",
+                _token(path),
+                self.lines.line(path),
+            )
+        )
+
+    def _missing(self, path: tuple[str, ...]) -> None:
+        self.findings.append(
+            DriftFinding(
+                _dotted(path),
+                f"set by the preset, absent from {self.label}",
+                self.label,
+                self._preset_ref(path),
+                _token(path),
+                None,
+            )
+        )
+
+    def _missing_member(self, path: tuple[str, ...], member: str) -> None:
+        # A persona subtracts a member with `exclude:`; that line, when it
+        # exists, is where the operator would write the marker.
+        line = self.lines.line(("exclude", *path, member))
+        self.findings.append(
+            DriftFinding(
+                f"{_dotted(path)}: {member}",
+                f"selected by the preset, not by {self.label}",
+                self._profile_ref(("exclude", *path, member)) if line else self.label,
+                self._preset_ref((*path, member)),
+                member,
+                line,
+            )
+        )
+
+    def _extra_member(self, path: tuple[str, ...], member: str) -> None:
+        self.findings.append(
+            DriftFinding(
+                f"{_dotted(path)}: {member}",
+                f"selected by {self.label}, not by the preset",
+                self._profile_ref((*path, member)),
+                f"preset {self.preset}",
+                member,
+                self.lines.line((*path, member)),
+            )
+        )
+
+    def _profile_ref(self, path: tuple[str, ...]) -> str:
+        line = self.lines.line(path)
+        return f"{self.label}:{line}" if line else self.label
+
+    def _preset_ref(self, path: tuple[str, ...]) -> str:
+        for lines in self.preset_lines:
+            line = lines.line(path)
+            if line:
+                return f"{lines.path.name}:{line}"
+        return f"preset {self.preset}"
+
+
+class _Lines:
+    """The 1-based line of every key and list member in one YAML file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        try:
+            self.root: Any = YAML(typ="rt").load(path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — an unreadable file simply has no lines to cite
+            self.root = None
+
+    def line(self, path: tuple[str, ...]) -> int | None:
+        """Where *path* is written, whichever legal spelling it uses.
+
+        A ``config:`` leaf may be one dotted key, a nested mapping, or any
+        split between the two, so every cut of the segments is tried in turn.
+        """
+        return _locate(self.root, list(path))
+
+
+def _locate(node: Any, segments: list[str]) -> int | None:
+    if not segments:
+        return None
+    if isinstance(node, CommentedMap):
+        for cut in range(1, len(segments) + 1):
+            head = ".".join(segments[:cut])
+            if head not in node:
+                continue
+            rest = segments[cut:]
+            if not rest:
+                return int(node.lc.key(head)[0]) + 1
+            found = _locate(node[head], rest)
+            if found is not None:
+                return found
+        return None
+    if isinstance(node, CommentedSeq) and len(segments) == 1:
+        for index, item in enumerate(node):
+            if isinstance(item, str) and item == segments[0]:
+                return int(node.lc.item(index)[0]) + 1
+    return None
+
+
+def _apply_markers(
+    findings: list[DriftFinding], path: Path, root_dir: Path, tag: str
+) -> tuple[list[DriftFinding], list[str]]:
+    """Claim findings with the ``# <tag>:`` comments in *path*; name the rest.
+
+    A marker reaches a finding that sits within :data:`MARKER_REACH` lines
+    below it, and any finding whose token it names. A marker reaching nothing
+    is stale: the line it described has come back into step with the preset,
+    or it has drifted too far from that line.
+    """
+    pattern = re.compile(rf"^\s*#\s*{re.escape(tag)}:\s*(?P<text>.*)$")
+    markers: list[tuple[int, str]] = []
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        match = pattern.match(line)
+        if match:
+            markers.append((number, match.group("text")))
+
+    used: set[int] = set()
+    claimed: list[DriftFinding] = []
+    for finding in findings:
+        covering = [number for number, text in markers if _covers(number, text, finding)]
+        used.update(covering)
+        claimed.append(replace(finding, marked=bool(covering)))
+
+    relative = path.relative_to(root_dir).as_posix()
+    stale = [
+        f"{relative}:{number}: `# {tag}:` marks no difference from the preset — the line it "
+        f"describes matches again, or sits more than {MARKER_REACH} lines below it"
+        for number, _text in markers
+        if number not in used
+    ]
+    return claimed, stale
+
+
+def _covers(marker_line: int, text: str, finding: DriftFinding) -> bool:
+    if finding.line is not None and 1 <= finding.line - marker_line <= MARKER_REACH:
+        return True
+    return re.search(rf"(?<![\w.-]){re.escape(finding.token)}(?![\w.-])", text) is not None
+
+
+def _template_defaults(data_bundle: str, channel_finder_mode: Any) -> dict[str, Any]:
+    """The config the app template renders at its defaults, or ``{}`` if it will not."""
+    import tempfile
+
+    import yaml
+
+    from .templates.manager import TemplateManager
+
+    context: dict[str, Any] = {"deploy_services": True}
+    artifacts: dict[str, list[str]] | None = {}
+    if isinstance(channel_finder_mode, str) and channel_finder_mode:
+        # With a mode in hand the template's own artifact selection renders in
+        # full; without one the channel-finder sections are the only loss.
+        context["channel_finder_mode"] = channel_finder_mode
+        artifacts = None
+    with tempfile.TemporaryDirectory() as scratch:
+        output = Path(scratch) / "config.yml"
+        try:
+            TemplateManager().render_config(
+                "example",
+                Path(scratch),
+                output,
+                data_bundle=data_bundle,
+                context=context,
+                artifacts=artifacts,
+            )
+            rendered = yaml.safe_load(output.read_text(encoding="utf-8"))
+        except (ValueError, OSError, BuildProfileError, yaml.YAMLError):
+            return {}
+    return rendered if isinstance(rendered, dict) else {}
+
+
+def _template_knows(template: Mapping[str, Any], path: tuple[str, ...]) -> bool:
+    node: Any = template
+    for part in path:
+        if not isinstance(node, Mapping) or part not in node:
+            return False
+        node = node[part]
+    return True
+
+
+def _emitted_version(profile_path: Path) -> str | None:
+    """The OSPREY version the emitted header names, if the header is still there."""
+    for line in profile_path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("#"):
+            break
+        match = re.search(r"emitted by OSPREY (\S+)", line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _is_name_list(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _dotted(path: tuple[str, ...]) -> str:
+    return ".".join(path)
+
+
+def _token(path: tuple[str, ...]) -> str:
+    """What a marker names for a key finding: the key as the profile spells it."""
+    return _dotted(path[1:]) if path[0] == "config" and len(path) > 1 else _dotted(path)
+
+
+def _short_repr(value: Any) -> str:
+    text = repr(value)
+    return text if len(text) <= 60 else text[:57] + "..."
+
+
+def _short_hash(digest: str) -> str:
+    return digest if len(digest) <= 19 else digest[:19] + "…"

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import copy
 import io
 import re
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -42,7 +42,8 @@ from .build_profile_load import _PROFILE_SCHEMA_MIN_OSPREY
 from .build_profile_merge import _deep_merge, _resolve_extends, compute_preset_hash
 from .build_profile_presets import _load_preset_raw
 from .build_profile_resolve import merge_cli_overrides
-from .profile_conventions import BUILD_OUTPUT_DIR
+from .profile_conventions import BUILD_OUTPUT_DIR, PROFILE_TRIGGERS_FILENAME
+from .profile_root import PERSONA_DIRNAME
 
 # YAML-surface spellings that differ from the canonical resolved-content field
 # name (D2: the rename is confined to the profile-YAML surface, so the
@@ -216,7 +217,9 @@ _REQUIRES_VERSION_COMMENT = (
 _PROVENANCE_COMMENT = [
     "# What this profile was materialized from. Emitted, not hand-written: a",
     "# build compares it against the installed preset and mentions it when the",
-    "# preset has moved on. Advisory only — this profile is the source of truth.",
+    "# preset has moved on; `osprey validate` refuses every difference from the",
+    "# preset that no `# DEVIATION: <why>` comment above the line claims (tag set",
+    "# by `deviation_marker:`). This profile is the source of truth either way.",
 ]
 
 # Round-trip mode preserves comments, key order, and quoting style (same
@@ -1148,6 +1151,94 @@ _ZONE_MAP = """\
 #   SECRETS  .env, your API keys. Not in git. Rebuilds never touch it
 #   OUTPUT   build/, generated. Never edit it; deleting it is safe
 #   STATE    var/, the agent's memory and audit log. Not in git. Kept"""
+
+
+def persona_catalog_layer(persona_names: Iterable[str], *, repo_name: str) -> dict[str, Any]:
+    """A raw profile fragment repointing each persona's ``build_profile`` at its
+    emitted sibling profile.
+
+    Written at the DEEPEST spelling on purpose. ``_collapse_config_prefixes``
+    resolves a prefix pair deeper-key-wins, so these keys survive whatever
+    shallower spelling the preset used for the module subtree
+    (``modules.web_terminals:``, or even a nested ``modules:``) and land inside
+    it — while a shallower fragment of ours would instead be overwritten
+    wholesale by the preset's own subtree.
+
+    Args:
+        persona_names: Personas the profile's catalog declares.
+        repo_name: Directory name of the deployment repo. A persona render is
+            build output like every other render, so its ``project_path`` lands
+            under the repo's ``build/`` zone and its ``project`` is keyed off
+            the deployment's own name rather than the preset's. This is why a
+            shipped preset cannot spell either value correctly on its own —
+            neither is knowable until a repo has a name.
+    """
+    layer: dict[str, str] = {}
+    for name in persona_names:
+        prefix = f"modules.web_terminals.personas.{name}"
+        layer[f"{prefix}.build_profile"] = f"{PERSONA_DIRNAME}/{name}.yml"
+        # `project` must equal `project_path`'s basename. Both are derived from
+        # the repo name here, and `osprey build` derives the render's own name
+        # the same way, which is how the render lands exactly where the catalog
+        # mounts it.
+        layer[f"{prefix}.project"] = f"{repo_name}-{name}"
+        layer[f"{prefix}.project_path"] = f"{BUILD_OUTPUT_DIR}/{repo_name}-{name}"
+    return {"config": layer}
+
+
+def triggers_layer() -> dict[str, Any]:
+    """A raw profile fragment repointing ``dispatch.triggers`` at the profile's own file.
+
+    The materialized ``triggers.yml`` is what the build must read (FR-3), so the
+    emitted key names it rather than the bundled trigger set it was copied from.
+    Merged through the same channel as every other emitted value, so nothing
+    here is a second path into the resolved content.
+    """
+    return {"dispatch": {"triggers": PROFILE_TRIGGERS_FILENAME}}
+
+
+def materialized_profile(preset_name: str, *, repo_name: str, profile_name: str) -> dict[str, Any]:
+    """The profile ``osprey init`` writes for *preset_name* today, as data.
+
+    The reference a materialized profile is compared with
+    (:func:`~osprey.cli.build_profile_drift.preset_drift_report`): not the
+    preset's raw layer, which no repo ever holds, but the document the emitter
+    makes of it — ``extends`` resolved, defaults synthesized, ``config:``
+    prefixes collapsed, the persona catalog and ``dispatch.triggers`` repointed
+    at the files a repo of this name owns. Produced by the emitter itself, so a
+    difference between this and the profile on disk is either an operator's
+    edit or a change in the preset, never an artifact of how ``osprey init``
+    spells things.
+
+    Args:
+        preset_name: Bundled preset, any CLI spelling.
+        repo_name: Directory name of the deployment repo, which the persona
+            catalog's ``project`` and ``project_path`` derive from.
+        profile_name: The profile's display ``name:``, copied in so it never
+            reads as a difference.
+
+    Returns:
+        The emitted profile, parsed.
+
+    Raises:
+        BuildProfileError: When the preset is unknown or will not emit.
+    """
+    from .build_profile_document import _parse_profile_document
+
+    raw, anchor = _load_preset_raw(preset_name)
+    resolved = _resolve_extends(dict(raw), anchor)
+    config = resolved.get("config")
+    personas = persona_catalog(config if isinstance(config, Mapping) else {})
+    layers: tuple[Mapping[str, Any], ...] = (
+        *((persona_catalog_layer(personas, repo_name=repo_name),) if personas else ()),
+        *((triggers_layer(),) if isinstance(resolved.get("dispatch"), Mapping) else ()),
+    )
+    text = emit_standalone_profile_yaml(preset_name, (), (), profile_name, extra_layers=layers)
+    # Parsed the way the profile on disk is, aliases canonicalized, so the
+    # emitted ``app_template`` is never compared with the loader's ``data_bundle``
+    # spelling as if they were two keys.
+    document = _parse_profile_document(text, f"materialized preset {preset_name!r}")
+    return document if isinstance(document, dict) else {}
 
 
 def emit_standalone_profile_yaml(

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -33,6 +33,7 @@ from .build_profile_document import _normalize_profile_aliases, _read_profile_do
 from .build_profile_merge import resolve_profile_document
 from .build_profile_model import BuildProfile
 from .build_profile_schema import (
+    DEFAULT_DEVIATION_MARKER,
     BlueskyConfig,
     BlueskyExternalConfig,
     BlueskyWebConfig,
@@ -196,6 +197,12 @@ _KNOWN_PROFILE_KEYS = frozenset(
         "provenance",
     }
 )
+
+
+# Keys recognized inside the ``provenance:`` block. Closed like the others: a
+# misspelled `deviation_marker:` would silently leave the default tag in force
+# and every `# ALS-DEVIATION:` comment unread.
+_KNOWN_PROVENANCE_KEYS = frozenset({"preset", "preset_hash", "deviation_marker"})
 
 
 # Keys recognized inside the ``environment:`` block. Rejected outright like the
@@ -1026,9 +1033,18 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
                 f"`osprey init` and records what the profile was materialized from; "
                 f"drop the block rather than half-filling it."
             )
+        _reject_unknown_block_keys(provenance_raw, _KNOWN_PROVENANCE_KEYS, "provenance")
+        marker = provenance_raw.get("deviation_marker", DEFAULT_DEVIATION_MARKER)
+        if not isinstance(marker, str) or not marker.strip():
+            raise BuildProfileError(
+                f"Profile 'provenance.deviation_marker' must be a non-empty string — the "
+                f"tag of the `# <TAG>:` comment that marks a deliberate difference from "
+                f"the preset (got {marker!r})."
+            )
         provenance = ProfileProvenance(
             preset=str(provenance_raw["preset"]),
             preset_hash=str(provenance_raw["preset_hash"]),
+            deviation_marker=marker.strip(),
         )
 
     # A `config:` key present but empty — every entry commented out, say —

--- a/src/osprey/cli/build_profile_panels.py
+++ b/src/osprey/cli/build_profile_panels.py
@@ -28,24 +28,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from osprey.profiles.web_panels import UNIVERSAL_PANELS
+from osprey.profiles.web_panels import BAR_ITEM_PANEL_GATES, UNIVERSAL_PANELS
 
 from .build_profile_reach import spelled_values
 
 __all__ = ["bar_items_selection_warnings", "panel_selection_errors", "panel_selection_overrides"]
-
-#: The bar items whose availability is a panel's presence, and the panel each
-#: needs. The build-time half of ``BAR_ITEM_AVAILABILITY`` in
-#: ``interfaces/web_terminal/app.py``: the server drops such an item from the
-#: default it serves when the panel is absent, and this is what lets the build
-#: say so first. ``identity`` is gated too, but on a runtime fact (a terminal
-#: user or a deployment name) a build cannot judge, so it is deliberately not
-#: here; ``tests/interfaces/web_terminal/test_bar_items_ssr.py`` pins the two
-#: tables together.
-BAR_ITEM_PANEL_GATES: dict[str, str] = {
-    "bluesky-queue": "bluesky",
-    "system-health": "system-health",
-}
 
 #: The two bars a ``web.bar_items`` block arranges, as ``BAR_HOSTS`` names them.
 _BAR_HOSTS: tuple[str, ...] = ("header", "status")
@@ -138,8 +125,8 @@ def _spelled_panel_ids(config: Any) -> set[str]:
 def bar_items_selection_warnings(config: Any, selected_panels: Iterable[str]) -> list[str]:
     """Name each authored ``web.bar_items`` entry this deployment cannot show.
 
-    ``system-health`` renders only where the SYSTEM panel is selected and
-    ``bluesky-queue`` only where the Bluesky panel is; an authored default that
+    The SYSTEM panel's status item renders only where that panel is selected
+    and ``bluesky-queue`` only where the Bluesky panel is; an authored default that
     places either on a deployment without the panel is filtered by the server
     before it is served, so the item never appears and nothing on screen says
     why. A warning, not an error — the deployment still builds and renders,

--- a/src/osprey/cli/build_profile_panels.py
+++ b/src/osprey/cli/build_profile_panels.py
@@ -32,7 +32,23 @@ from osprey.profiles.web_panels import UNIVERSAL_PANELS
 
 from .build_profile_reach import spelled_values
 
-__all__ = ["panel_selection_errors", "panel_selection_overrides"]
+__all__ = ["bar_items_selection_warnings", "panel_selection_errors", "panel_selection_overrides"]
+
+#: The bar items whose availability is a panel's presence, and the panel each
+#: needs. The build-time half of ``BAR_ITEM_AVAILABILITY`` in
+#: ``interfaces/web_terminal/app.py``: the server drops such an item from the
+#: default it serves when the panel is absent, and this is what lets the build
+#: say so first. ``identity`` is gated too, but on a runtime fact (a terminal
+#: user or a deployment name) a build cannot judge, so it is deliberately not
+#: here; ``tests/interfaces/web_terminal/test_bar_items_ssr.py`` pins the two
+#: tables together.
+BAR_ITEM_PANEL_GATES: dict[str, str] = {
+    "bluesky-queue": "bluesky",
+    "system-health": "system-health",
+}
+
+#: The two bars a ``web.bar_items`` block arranges, as ``BAR_HOSTS`` names them.
+_BAR_HOSTS: tuple[str, ...] = ("header", "status")
 
 
 def panel_selection_overrides(
@@ -117,3 +133,44 @@ def _spelled_panel_ids(config: Any) -> set[str]:
                 elif isinstance(sub_value, Mapping):
                     ids.update(str(leaf).split(".")[0] for leaf in sub_value)
     return ids
+
+
+def bar_items_selection_warnings(config: Any, selected_panels: Iterable[str]) -> list[str]:
+    """Name each authored ``web.bar_items`` entry this deployment cannot show.
+
+    ``system-health`` renders only where the SYSTEM panel is selected and
+    ``bluesky-queue`` only where the Bluesky panel is; an authored default that
+    places either on a deployment without the panel is filtered by the server
+    before it is served, so the item never appears and nothing on screen says
+    why. A warning, not an error — the deployment still builds and renders,
+    minus that one item — but the operator wrote the entry and will look for it,
+    so the build says which one it was and what it needs.
+
+    Every spelling of the list is found (dotted, prefix-over-mapping, nested),
+    and each entry is reported by position, the way the server's own log line
+    reports it.
+
+    Args:
+        config: The profile's ``config:`` block, whatever shape it parsed as.
+        selected_panels: The profile's resolved ``web_panels`` selection.
+
+    Returns:
+        One warning per unrenderable entry, in bar order then list order.
+    """
+    shown = set(selected_panels) | UNIVERSAL_PANELS
+    warnings: list[str] = []
+    for host in _BAR_HOSTS:
+        for spelling, entries in spelled_values(config, f"web.bar_items.{host}"):
+            if not isinstance(entries, list):
+                continue
+            for index, entry in enumerate(entries):
+                item_type = entry.get("type") if isinstance(entry, Mapping) else entry
+                panel = BAR_ITEM_PANEL_GATES.get(str(item_type))
+                if panel is None or panel in shown:
+                    continue
+                warnings.append(
+                    f"{spelling}[{index}] places {item_type!r}, which needs the {panel!r} panel "
+                    f"and {panel!r} is not in web_panels — the item leaves the default this "
+                    f"deployment serves. Add {panel!r} to web_panels, or drop the entry."
+                )
+    return warnings

--- a/src/osprey/cli/build_profile_reach.py
+++ b/src/osprey/cli/build_profile_reach.py
@@ -95,6 +95,53 @@ def ariel_ingestion_advisories(rendered_config: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def pva_address_source_advisories(rendered_config: Mapping[str, Any]) -> list[str]:
+    """Say when a connector block routes PVA channels but names no address source.
+
+    The connector-host child scrubs every inherited ``EPICS_PVA_*`` variable
+    before the connector runs, so ``pva_gateway`` is the only route a PVA
+    address list has into p4p. A block that lists ``pva_channels`` and relies
+    on ``EPICS_PVA_ADDR_LIST`` from the deployment's environment gets subnet
+    auto-discovery instead, which from an off-subnet host is a bare timeout on
+    every read. Advisory only: on the servers' own subnet discovery works.
+
+    ``pva_channels`` and ``pva_gateway`` are read exactly as ``connect()`` reads
+    them — a single glob may be a string, and an empty gateway block configures
+    nothing.
+
+    Args:
+        rendered_config: A render's config, after its ``config:`` overlay.
+
+    Returns:
+        One message per connector block with routing globs and no gateway,
+        naming the key to add; empty otherwise.
+    """
+    control_system = rendered_config.get("control_system")
+    connector = control_system.get("connector") if isinstance(control_system, Mapping) else None
+    if not isinstance(connector, Mapping):
+        return []
+    advisories: list[str] = []
+    for connector_type, block in connector.items():
+        if not isinstance(block, Mapping):
+            continue
+        globs = block.get("pva_channels") or []
+        if isinstance(globs, str):
+            globs = [globs]
+        if not isinstance(globs, list | tuple) or not any(str(g).strip() for g in globs):
+            continue
+        gateway = block.get("pva_gateway")
+        if isinstance(gateway, Mapping) and gateway:
+            continue
+        advisories.append(
+            f"control_system.connector.{connector_type}.pva_channels routes channels "
+            f"over PVA with no address source: add control_system.connector."
+            f"{connector_type}.pva_gateway (address may list several hosts, "
+            f"space-separated). EPICS_PVA_* variables set in the environment do "
+            f"not reach the connector."
+        )
+    return advisories
+
+
 def spelled_values(config: Any, dotted_key: str) -> list[tuple[str, Any]]:
     """Every way *config* writes *dotted_key*, with the value each gives.
 

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -118,22 +118,32 @@ def env_names_errors(value: Any, key: str) -> list[str]:
     return errors
 
 
+#: Tag of the comment that marks a deliberate difference from the preset —
+#: ``# DEVIATION: <why>`` — when the profile's ``provenance:`` block names none.
+DEFAULT_DEVIATION_MARKER = "DEVIATION"
+
+
 @dataclass
 class ProfileProvenance:
     """What a materialized profile was emitted from (``provenance:``).
 
-    Written by ``osprey init`` and never by hand. It is the
-    MACHINE-READABLE record of the profile's source — the emitted header says
-    the same thing in prose, for people — and it is what a later build compares
-    against the installed preset to notice that the preset has moved on since
-    the profile was materialized (FR-6). That comparison is advisory: a profile
-    is the source of truth once it exists, so drift is reported, never enforced.
+    Written by ``osprey init`` and never by hand, except for the marker tag. It
+    is the MACHINE-READABLE record of the profile's source — the emitted header
+    says the same thing in prose, for people — and it is what
+    :func:`~osprey.cli.build_profile_drift.preset_drift_report` compares against
+    the installed preset to notice that the preset has moved on since the
+    profile was materialized (FR-6). A profile is the source of truth once it
+    exists, so a difference is never overwritten: ``osprey validate`` refuses
+    the ones nobody has marked as deliberate, and ``osprey build`` only names
+    them.
     """
 
     preset: str
     """Bundled preset name the profile was materialized from."""
     preset_hash: str
     """Content hash of that preset as resolved at materialization time."""
+    deviation_marker: str = DEFAULT_DEVIATION_MARKER
+    """Tag of the ``# <TAG>:`` comment that marks a difference as deliberate."""
 
 
 @dataclass

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -24,7 +24,7 @@ Usage:
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection, Iterable, Mapping
+from collections.abc import Callable, Collection, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -35,9 +35,9 @@ from osprey.utils.logger import get_logger
 
 from .output import report, section
 from .profile_conventions import (
-    BUILD_OUTPUT_DIR,
     CONTEXT_BASELINE_FILENAME,
     PER_USER_CONTEXT_DIRNAME,
+    PROFILE_TRIGGERS_FILENAME,
     context_baseline_slot,
 )
 
@@ -132,10 +132,6 @@ _PROFILE_DATA_DIRNAME = "data"
 # `<profile>/` once and every persona render sees it.
 _PERSONA_PROFILE_DIRNAME = "personas"
 
-# File name the resolved trigger config gets at the profile root, and the value
-# written to the emitted `dispatch.triggers` key (FR-3). One constant so the
-# copy target and the emitted key cannot drift apart.
-_PROFILE_TRIGGERS_FILENAME = "triggers.yml"
 
 # Convention directory holding one subdirectory of per-user web-terminal context
 # per roster user. Named from the convention table rather than spelled again, so
@@ -179,7 +175,7 @@ MATERIALIZED_SOURCE_ENTRIES: tuple[str, ...] = (
     "profile.yml",
     _PROFILE_DATA_DIRNAME,
     _PERSONA_PROFILE_DIRNAME,
-    _PROFILE_TRIGGERS_FILENAME,
+    PROFILE_TRIGGERS_FILENAME,
     _CONTEXT_CONVENTION_DIRNAME,
     _PROFILE_ENV_EXAMPLE_FILENAME,
 )
@@ -225,39 +221,6 @@ def _data_copy_ignore(source_root: Path) -> Callable[[str, list[str]], set[str]]
         }
 
     return ignore
-
-
-def _persona_catalog_layer(persona_names: Iterable[str], *, repo_name: str) -> dict[str, Any]:
-    """A raw profile fragment repointing each persona's ``build_profile`` at its
-    emitted sibling profile.
-
-    Written at the DEEPEST spelling on purpose. ``_collapse_config_prefixes``
-    resolves a prefix pair deeper-key-wins, so these keys survive whatever
-    shallower spelling the preset used for the module subtree
-    (``modules.web_terminals:``, or even a nested ``modules:``) and land inside
-    it — while a shallower fragment of ours would instead be overwritten
-    wholesale by the preset's own subtree.
-
-    Args:
-        persona_names: Personas the profile's catalog declares.
-        repo_name: Directory name of the deployment repo. A persona render is
-            build output like every other render, so its ``project_path`` lands
-            under the repo's ``build/`` zone and its ``project`` is keyed off
-            the deployment's own name rather than the preset's. This is why a
-            shipped preset cannot spell either value correctly on its own —
-            neither is knowable until a repo has a name.
-    """
-    layer: dict[str, str] = {}
-    for name in persona_names:
-        prefix = f"modules.web_terminals.personas.{name}"
-        layer[f"{prefix}.build_profile"] = f"{_PERSONA_PROFILE_DIRNAME}/{name}.yml"
-        # `project` must equal `project_path`'s basename. Both are derived from
-        # the repo name here, and `osprey build` derives the render's own name
-        # the same way, which is how the render lands exactly where the catalog
-        # mounts it.
-        layer[f"{prefix}.project"] = f"{repo_name}-{name}"
-        layer[f"{prefix}.project_path"] = f"{BUILD_OUTPUT_DIR}/{repo_name}-{name}"
-    return {"config": layer}
 
 
 def _triggers_source(resolved: BuildProfile, preset_dir: Path) -> Path | None:
@@ -626,17 +589,6 @@ def _write_secret_channel(
             written.append(_PROFILE_ENV_FILENAME)
 
     return written
-
-
-def _triggers_layer() -> dict[str, Any]:
-    """A raw profile fragment repointing ``dispatch.triggers`` at the profile's own file.
-
-    The materialized ``triggers.yml`` is what the build must read (FR-3), so the
-    emitted key names it rather than the bundled trigger set it was copied from.
-    Merged through the same channel as every other emitted value, so nothing
-    here is a second path into the resolved content.
-    """
-    return {"dispatch": {"triggers": _PROFILE_TRIGGERS_FILENAME}}
 
 
 def _off_chain_problem(persona_name: str, persona_preset: str, host_preset: str) -> str | None:
@@ -1062,7 +1014,11 @@ def _materialize_profile_directory(
         merge_cli_overrides,
         resolve_build_profile,
     )
-    from .build_profile_emit import emit_standalone_profile_yaml
+    from .build_profile_emit import (
+        emit_standalone_profile_yaml,
+        persona_catalog_layer,
+        triggers_layer,
+    )
     from .templates.manager import TemplateManager
 
     # Resolving through the public path validates the preset AND its -O/--set
@@ -1120,8 +1076,8 @@ def _materialize_profile_directory(
     persona_deltas = _parsed_persona_deltas(persona_texts)
 
     extra_layers: tuple[dict[str, Any], ...] = (
-        *((_persona_catalog_layer(persona_texts, repo_name=target.name),) if persona_texts else ()),
-        *((_triggers_layer(),) if triggers_src is not None else ()),
+        *((persona_catalog_layer(persona_texts, repo_name=target.name),) if persona_texts else ()),
+        *((triggers_layer(),) if triggers_src is not None else ()),
     )
 
     # Read once, before anything is written: the README rendered below tells the
@@ -1170,8 +1126,8 @@ def _materialize_profile_directory(
         (target / "profile.yml").write_text(profile_text, encoding="utf-8")
 
         if triggers_src is not None:
-            shutil.copy2(triggers_src, target / _PROFILE_TRIGGERS_FILENAME)
-            logger.debug("  Trigger config: %s", _PROFILE_TRIGGERS_FILENAME)
+            shutil.copy2(triggers_src, target / PROFILE_TRIGGERS_FILENAME)
+            logger.debug("  Trigger config: %s", PROFILE_TRIGGERS_FILENAME)
 
         # The profile owns its secrets from the first minute (FR-1) — the
         # documented variable list, whatever the shell already exports, and the

--- a/src/osprey/cli/profile_conventions.py
+++ b/src/osprey/cli/profile_conventions.py
@@ -229,6 +229,11 @@ PROJECT_MIRROR_DIR = "project"
 #: one literal and two names for it.
 BUILD_OUTPUT_DIR = BUILD_DIR_NAME
 
+# File name the resolved trigger config gets at the profile root, and the value
+# `osprey init` writes to the emitted `dispatch.triggers` key (FR-3). One
+# constant so the copy target and the emitted key cannot drift apart.
+PROFILE_TRIGGERS_FILENAME = "triggers.yml"
+
 #: The durable state zone (``var/agent_data``, ``var/audit``) — git-ignored,
 #: never rendered, and never wiped by a build. Aliased for the same reason.
 STATE_DIR = STATE_DIR_NAME

--- a/src/osprey/cli/validate_cmd.py
+++ b/src/osprey/cli/validate_cmd.py
@@ -56,13 +56,13 @@ def profile_file_at(target: Path) -> Path:
     return target.resolve()
 
 
-def check_profile_file(profile_file: Path) -> None:
+def check_profile_file(profile_file: Path, *, drift: str = "error") -> None:
     """Validate the profile at *profile_file* and print the verdict.
 
     The whole of what both spellings of the verb do once a profile file has been
     named: resolve the ``extends:`` chain, run the profile's own consistency
     check, lint the declared web stack against the config a build would render,
-    and report.
+    compare a materialized profile with the preset it came from, and report.
 
     The host-variant overlay is applied first, exactly as ``osprey build``
     applies it. Without that, this verb would judge a document no host builds:
@@ -74,6 +74,9 @@ def check_profile_file(profile_file: Path) -> None:
     Args:
         profile_file: An existing profile file — a repo's ``profile.yml`` or a
             persona delta.
+        drift: ``error`` refuses a profile that differs from its preset in a
+            place no marker comment claims; ``warn`` prints those places and
+            passes.
 
     Raises:
         click.UsageError: With every accumulated problem, so the caller exits 2.
@@ -84,6 +87,7 @@ def check_profile_file(profile_file: Path) -> None:
         deploy_aware_config_warnings,
         limits_block_errors,
     )
+    from .build_profile_drift import MARKER_REACH, preset_drift_report
     from .variant_selection import VARIANT_DIRNAME, VariantSelection, resolve_variant_selection
 
     variant = VariantSelection(name=None, path=None)
@@ -140,6 +144,37 @@ def check_profile_file(profile_file: Path) -> None:
     ):
         note(f"⚠ {warning}")
 
+    # A materialized profile against the preset it was written from. Only a
+    # profile `osprey init` stamped has a preset to be compared with; a
+    # hand-written one has nothing to drift from. The findings refuse by
+    # default because the failure they name is the silent kind — a line the
+    # preset gained and this copy never did builds green forever — while a
+    # facility fact is claimed once, with a marker comment, and never asked
+    # about again.
+    if build_profile.provenance is not None:
+        try:
+            report_card = preset_drift_report(profile_file, build_profile.provenance)
+        except BuildProfileError as e:
+            raise click.UsageError(str(e)) from e
+        if report_card.note:
+            note(report_card.note)
+        for stale in report_card.stale_markers:
+            note(f"⚠ {stale}")
+        unmarked = report_card.unmarked
+        if unmarked and drift == "error":
+            tag = build_profile.provenance.deviation_marker
+            raise click.UsageError(
+                f"Profile differs from preset {report_card.preset} in {len(unmarked)} "
+                f"place(s) no marker claims:\n  - "
+                + "\n  - ".join(finding.render() for finding in unmarked)
+                + f"\nA deliberate difference is marked with a `# {tag}: <why>` comment "
+                f"within {MARKER_REACH} lines above its line, or one naming the key or "
+                f"member when the profile has no line for it. `--drift=warn` reports "
+                f"without refusing."
+            )
+        for finding in unmarked:
+            note(f"⚠ preset drift: {finding.render()}")
+
     # Before the verdict, and worded as `osprey build` words it: the reader has
     # to know WHICH document was judged before being told it is fine.
     if variant.selected:
@@ -167,8 +202,15 @@ def check_profile_file(profile_file: Path) -> None:
 
 @click.command()
 @click.argument("target", required=False, type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--drift",
+    type=click.Choice(["error", "warn"]),
+    default="error",
+    show_default=True,
+    help="What an unmarked difference from the profile's preset does: refuse, or warn.",
+)
 @repo_option
-def validate(target: Path | None, repo: Path | None) -> None:
+def validate(target: Path | None, drift: str, repo: Path | None) -> None:
     """Check the deployment profile without building.
 
     With no argument, validates the deployment repo enclosing the working
@@ -179,6 +221,11 @@ def validate(target: Path | None, repo: Path | None) -> None:
     directories, the data: tree, service templates, lifecycle steps, env vars —
     then lints the declared web stack against the config a build would render.
     Every problem found is reported, not just the first.
+
+    A profile `osprey init` wrote is also compared with the preset it came from,
+    persona deltas included. Every difference is refused unless a marker comment
+    (`# DEVIATION: <why>`, tag set by provenance.deviation_marker) claims it;
+    --drift=warn reports them and passes.
 
     Judges what this host builds: when .env.variant selects an overlay under
     profiles/, that overlay is merged in first, and named in the output.
@@ -206,4 +253,4 @@ def validate(target: Path | None, repo: Path | None) -> None:
         # so there is no second existence check to make here.
         profile_file = find_repo_root(repo) / PROFILE_FILENAME
 
-    check_profile_file(profile_file)
+    check_profile_file(profile_file, drift=drift)

--- a/src/osprey/cli/validate_cmd.py
+++ b/src/osprey/cli/validate_cmd.py
@@ -84,6 +84,7 @@ def check_profile_file(profile_file: Path) -> None:
         deploy_aware_config_warnings,
         limits_block_errors,
     )
+    from .build_profile_panels import bar_items_selection_warnings
     from .variant_selection import VARIANT_DIRNAME, VariantSelection, resolve_variant_selection
 
     variant = VariantSelection(name=None, path=None)
@@ -135,8 +136,13 @@ def check_profile_file(profile_file: Path) -> None:
     # (a privileged terminal with no login wall — `auth.method: token` or `none`) that are not
     # mistakes every deployment has made, so they must not fail a CI gate — but
     # a finding nobody prints is a finding nobody has.
-    for warning in deploy_aware_config_warnings(
-        build_profile.deploy, build_profile.config, profile_root=profile_root
+    for warning in (
+        *deploy_aware_config_warnings(
+            build_profile.deploy, build_profile.config, profile_root=profile_root
+        ),
+        # The same line `osprey build` prints for a `web.bar_items` entry the
+        # served default drops because its panel is not selected.
+        *bar_items_selection_warnings(build_profile.config, build_profile.web_panels),
     ):
         note(f"⚠ {warning}")
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -86,6 +86,7 @@ from osprey.deployment.service_tokens import (
 from osprey.deployment.staleness import BUILD_DIRNAME, warn_if_project_stale
 from osprey.deployment.subprocess_capture import run_captured
 from osprey.deployment.web_terminals.env_production import migrate_users_env
+from osprey.deployment.web_terminals.lifecycle import remove_orphan_terminals
 from osprey.deployment.web_terminals.provision import (
     deploy_down_web_terminals,
     deploy_up_web_terminals,
@@ -4038,12 +4039,33 @@ def _report_port_conflicts(conflicts):
     logger.key_info(report)
 
 
+def _reconcile_orphan_terminals(config):
+    """Remove this deployment's terminal containers whose user left the roster.
+
+    The web slice's ``--remove-orphans`` (see
+    :func:`osprey.deployment.web_terminals.lifecycle.remove_orphan_terminals`
+    for why compose's own flag cannot do it here). One line per container
+    removed, so the deploy log says what happened to the old terminal; nothing
+    printed when the roster owns every terminal it finds. Volumes are never
+    touched — that stays ``osprey users prune``'s decision.
+
+    :param config: Loaded configuration dictionary
+    :type config: dict
+    """
+    for user, container in sorted(remove_orphan_terminals(config).items()):
+        _report_fact(
+            f"removed web terminal container '{container}': "
+            f"user '{user}' is no longer on the roster"
+        )
+
+
 def _preflight_host_ports(config, compose_files):
     """Abort the deploy if a published host port is already taken.
 
     Parses the published bindings out of the rendered compose files and checks
-    them for intra-deploy duplicates and external listeners (see
-    :mod:`osprey.deployment.host_ports`). On any conflict the report is printed
+    them, together with the ports derived for host-network services and for
+    every web-terminal roster index, for intra-deploy duplicates and external
+    listeners (see :mod:`osprey.deployment.host_ports`). On any conflict the report is printed
     in the CLI's one failure shape and a :class:`RuntimeError` is raised so the
     caller aborts before running a single container-touching command.
 
@@ -5626,7 +5648,10 @@ def _start_stack(
     from an aborted deploy holds its published host ports on Docker Desktop,
     blocking the next ``up``), and the plain path's ``up`` carries
     ``--remove-orphans`` to reconcile away services dropped from the config.
-    Running containers and volumes are never touched by either measure.
+    The web path gets the same reconcile by hand (:func:`_reconcile_orphan_terminals`):
+    a terminal container whose user left the roster is removed ahead of the
+    host-port preflight. Volumes are never touched by any of these measures,
+    and running containers only by that last one.
 
     Args:
         config: Loaded deploy config.
@@ -5698,12 +5723,27 @@ def _start_stack(
     # leaves the host untouched.
     _preflight_bluesky_network_backend(config)
 
+    # Reconcile the web slice's orphans FIRST: a terminal whose user was renamed
+    # or dropped from the roster keeps running on the host network, holding
+    # every port of the index it used to serve, and the plain path's
+    # `--remove-orphans` cannot reach it (see remove_orphan_terminals). This is
+    # the one container-touching step ahead of the port preflight, and it has
+    # to be: the preflight would otherwise refuse the very redeploy that
+    # reconciles the orphan away, and the operator would be back to removing it
+    # by hand. It acts only on THIS project's own containers, by project label
+    # and roster name, so it is a reconcile of this deployment's state rather
+    # than a mutation of anything the preflight below guards.
+    if web_terminals_enabled:
+        _reconcile_orphan_terminals(config)
+
     # Fail fast on a host-port collision (a foreign stack, or a second project
     # on the same host) with an actionable diagnosis, rather than letting
     # `compose up` collapse mid-start on a bare "address already in use". Runs
-    # before any container-touching command below, so an abort here leaves the
-    # host untouched. A port held by this project's own container is not a
-    # conflict, so an idempotent redeploy stays green.
+    # before any other container-touching command below, so an abort here
+    # leaves the host untouched. A port held by this project's own container is
+    # not a conflict, so an idempotent redeploy stays green; the web-terminal
+    # roster's per-index ports are covered too, so a port a foreign process
+    # holds is named here rather than inside the new container's panel logs.
     _preflight_host_ports(config, compose_files)
 
     # Refuse a pin the deploy itself would write over. Ahead of the override

--- a/src/osprey/deployment/host_ports.py
+++ b/src/osprey/deployment/host_ports.py
@@ -21,7 +21,11 @@ A service placed on the host's network namespace renders no ``ports:`` block at
 all — it binds its port on the host directly — so parsing compose files alone
 would leave exactly the ports two projects are most likely to fight over out of
 the check. Those bindings are therefore *derived* from the rendered config (see
-:func:`derive_host_network_bindings`) and join the same two checks.
+:func:`derive_host_network_bindings`) and join the same two checks. The web
+terminals are the largest such family: every per-user container runs on the host
+network and binds one port per panel family at its roster index, so those are
+derived too (:func:`derive_web_terminal_bindings`) — a renamed or removed user
+whose old container still holds an index is a collision this check has to name.
 
 Everything here is framed by the deployment's **port block**: ``port_base`` is
 the first of a thousand ports (:mod:`osprey.port_layout`), and the base is
@@ -51,6 +55,8 @@ from osprey.deployment.graphdb_service import (
 )
 from osprey.deployment.qmd_service import PORT_CONFIG_KEY as QMD_PORT_CONFIG_KEY
 from osprey.deployment.runtime_helper import get_ps_command, runtime_env
+from osprey.deployment.web_terminals.personas import normalize_users
+from osprey.deployment.web_terminals.ports import allocate_ports, base_ports_from_config
 from osprey.port_layout import (
     CA_DEFAULT_PORT,
     PORT_BASE_CONFIG_KEY,
@@ -225,6 +231,9 @@ class HostPortBinding:
         :data:`_DERIVED_SOURCE` for a binding derived from the rendered config
     :param host_network: ``True`` when the service runs in the host's network
         namespace and binds this port directly instead of publishing it
+    :param remedy: The config key that moves this port, when the deriving code
+        knows it better than :func:`_remedy_for_service` can work it out from
+        the service name. ``None`` leaves the resolution to that function
     """
 
     service: str
@@ -233,6 +242,7 @@ class HostPortBinding:
     container_port: int | None
     compose_file: str
     host_network: bool = False
+    remedy: str | None = None
 
 
 @dataclass
@@ -682,6 +692,86 @@ def derive_host_network_bindings(config):
     return bindings
 
 
+def _web_terminal_service(user):
+    """Return the binding label of one user's terminal.
+
+    ``web-<user>`` is the container name (``<facility_prefix>-web-<user>``,
+    see :mod:`osprey.deployment.web_terminals.naming`) with the facility prefix
+    dropped, which is exactly the suffix :func:`_runs_service` matches a running
+    container's name against — so this deployment's own terminal, still up from
+    the previous deploy, is read as the idempotent redeploy it is.
+    """
+    return f"web-{user}"
+
+
+def derive_web_terminal_bindings(config):
+    """Derive the per-user index ports of the web-terminal stack.
+
+    Every terminal container runs on the host network (``docker-compose.web.yml``
+    has no ``ports:`` block to parse), and each one binds a port in every panel
+    family at its roster index: ``<family base> + index`` for the terminal
+    itself and for each companion server (artifact gallery, ARIEL, lattice, …).
+    The index band is allocated whole — a user holds a slot in every family
+    whether or not the persona starts that panel — so the whole band is checked,
+    the same way the allocator reserves it.
+
+    The ports are derived the same way the render derives them, from the same
+    keys (:func:`~osprey.deployment.web_terminals.ports.base_ports_from_config`
+    and :func:`~osprey.deployment.web_terminals.ports.allocate_ports` at the
+    base THIS config resolved), so a deployment that moved a family by its
+    ``<family>_base_port`` key is checked where it actually binds.
+
+    Each binding carries its own remedy, because the generic resolution keys on
+    a compose service name and these have none: the contested port belongs to
+    one roster entry, and the surgical fix is that user's ``index``. The family
+    key is named beside it for the operator who would rather move the band.
+
+    A roster entry whose index the allocator refuses derives nothing here; the
+    web-terminal lint that follows this preflight refuses the whole deploy with
+    the message that names the entry.
+
+    :param config: Loaded (rendered) configuration dictionary
+    :type config: dict
+    :return: One :class:`HostPortBinding` per family per roster user, all
+        labeled ``web-<user>`` and marked host-network
+    :rtype: list[HostPortBinding]
+    """
+    if not isinstance(config, dict):
+        return []
+    modules = config.get("modules") or {}
+    web_terminals = modules.get("web_terminals") or {}
+    if not isinstance(web_terminals, dict) or not web_terminals.get("enabled"):
+        return []
+
+    base_ports = base_ports_from_config(web_terminals, base=resolve_port_base(config))
+    bindings = []
+    for entry in normalize_users(web_terminals.get("users")):
+        user = entry["name"]
+        try:
+            ports = allocate_ports(base_ports, entry["index"])
+        except ValueError as exc:
+            logger.debug(f"Web terminal {user!r} derives no ports for the preflight: {exc}")
+            continue
+        for family, port in ports.items():
+            slot = SLOTS_BY_NAME.get(family)
+            family_key = slot.config_key if slot is not None else None
+            remedy = f"index for user {user!r} in modules.web_terminals.users"
+            if family_key:
+                remedy = f"{remedy} (or {family_key})"
+            bindings.append(
+                HostPortBinding(
+                    service=_web_terminal_service(user),
+                    host_ip=_HOST_NETWORK_BIND,
+                    host_port=port,
+                    container_port=port,
+                    compose_file=_DERIVED_SOURCE,
+                    host_network=True,
+                    remedy=remedy,
+                )
+            )
+    return bindings
+
+
 def _probe_host(host_ip):
     """Return the address a published port is reachable on for probing."""
     return "127.0.0.1" if host_ip in _WILDCARD_HOSTS else host_ip
@@ -1011,8 +1101,9 @@ def find_port_conflicts(bindings, project_name, config=None, repo_id=None):
     :type project_name: str
     :param config: Configuration dictionary, used for runtime detection, for the
         port base every remedy and the report's framing are derived from, and to
-        derive the ports of services on the host network namespace, which
-        publish nothing for :func:`parse_host_port_bindings` to find
+        derive the ports of services on the host network namespace — the
+        web-terminal roster's index ports included — which publish nothing for
+        :func:`parse_host_port_bindings` to find
     :type config: dict, optional
     :param repo_id: This checkout's ``com.osprey.repo-id`` value. Defaults to
         deriving it from the repo root ``config`` resolves, which is what every
@@ -1028,7 +1119,9 @@ def find_port_conflicts(bindings, project_name, config=None, repo_id=None):
     # Published bindings claim first: a host-network service whose port a
     # published one already took is the one that has to move, and its remedy is
     # the key that moves it.
-    bindings = list(bindings) + derive_host_network_bindings(config)
+    bindings = (
+        list(bindings) + derive_host_network_bindings(config) + derive_web_terminal_bindings(config)
+    )
 
     def _conflict(binding, kind, holder):
         """Build one conflict, resolving its remedy against this base."""
@@ -1038,7 +1131,8 @@ def find_port_conflicts(bindings, project_name, config=None, repo_id=None):
             service=binding.service,
             kind=kind,
             holder=holder,
-            remedy=_remedy_for_service(
+            remedy=binding.remedy
+            or _remedy_for_service(
                 binding.service, binding.container_port, binding.host_port, base
             ),
             host_network=binding.host_network,

--- a/src/osprey/deployment/web_terminals/lifecycle.py
+++ b/src/osprey/deployment/web_terminals/lifecycle.py
@@ -20,9 +20,10 @@ the one non-destructive verb here: it changes a credential rather than removing
 a resource, but it belongs with the others because it is reached the same way
 (``osprey users <verb> <user>``) and needs the same roster/runtime gating.
 
-Volume-scoping boundary (applies to :func:`prune_users`'s discovery and to
-:func:`nuke_stack`'s per-user volume teardown alike): orphan discovery
-(:func:`_discover_orphan_containers`, :func:`_discover_orphan_volumes`) filters
+Volume-scoping boundary (applies to :func:`prune_users`'s discovery, to
+:func:`nuke_stack`'s per-user volume teardown and to the off-roster container
+sweep ``osprey up`` runs through :func:`remove_orphan_terminals` alike): orphan
+discovery (:func:`_discover_orphan_containers`, :func:`_discover_orphan_volumes`) filters
 the runtime listing by the compose-assigned owning-project label
 (``com.docker.compose.project=<project>``, matching exactly what
 :func:`osprey.deployment.runtime_helper.runtime_env`'s ``COMPOSE_PROJECT_NAME``
@@ -409,6 +410,65 @@ def prune_users(
     # the artifacts first, so the fresh sidecar's digest label matches the
     # purged file it bakes.
     _reconcile_auth_after_user_removal(config, orphan_users, rerendered=False, repo_root=repo_root)
+
+
+# =============================================================================
+# osprey up: reconcile off-roster terminal containers
+# =============================================================================
+
+
+def remove_orphan_terminals(config: dict[str, Any]) -> dict[str, str]:
+    """Remove this project's terminal containers whose user left the roster.
+
+    The web slice's ``--remove-orphans``. The plain services path reconciles a
+    dropped service away with compose's own flag, but the web stack cannot use
+    it (both of ``osprey up``'s invocations share one compose project, so
+    either would destroy the other's containers as "orphans"), and a container
+    compose is never told about is one compose never touches. Renaming a roster
+    entry therefore used to leave the old terminal running on the reused
+    index's ports, with the new one failing to bind beside it.
+
+    Discovery is the read-only, project-label-scoped listing ``prune`` uses
+    (:func:`_discover_orphan_containers`); removal is one exact-named ``rm -f``
+    per orphan (:func:`remove_container`). Volumes are never touched — retaining,
+    archiving or purging a departed user's workspace stays ``osprey users
+    prune``'s decision, taken with a typed confirmation this deploy step has no
+    business skipping.
+
+    A removal the runtime refuses is logged and left out of the result rather
+    than aborting the deploy: the container then still holds its ports, and the
+    host-port preflight that follows names the port it holds.
+
+    Args:
+        config: Raw deploy config — the roster, the facility prefix, the runtime
+            and the compose project name are all read off it.
+
+    Returns:
+        ``{user: container_name}`` for every container removed, in no
+        particular order. Empty when the roster owns every terminal it finds.
+    """
+    web_terminals = as_dict(as_dict(config.get("modules")).get("web_terminals"))
+    roster_names = {entry["name"] for entry in normalize_users(web_terminals.get("users"))}
+
+    runtime = get_runtime_command(config)[0]
+    env = runtime_env(config, ignore_orphans=True)
+    facility_prefix = as_dict(config.get("facility")).get("prefix") or ""
+    project = resolve_project_name(config)
+
+    orphans = _discover_orphan_containers(runtime, project, facility_prefix, roster_names, env=env)
+
+    removed: dict[str, str] = {}
+    for user in sorted(orphans):
+        container = orphans[user]
+        result = remove_container(runtime, container, env=env)
+        if result.returncode != 0:
+            logger.warning(
+                f"Could not remove off-roster web terminal container {container!r} "
+                f"(user {user!r}): {(result.stderr or result.stdout).strip()}"
+            )
+            continue
+        removed[user] = container
+    return removed
 
 
 # =============================================================================

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -345,9 +345,16 @@ BAR_HOSTS: tuple[str, ...] = ("header", "status")
 #: show — the documentation link, the stopwatch — stays in the catalog and is one drag away in Customize; a screen an
 #: operator watches all day should start with what they read, not with what
 #: the terminal knows about itself. ``system-health`` renders only where this
-#: deployment enables the SYSTEM panel — :func:`bar_render_plan` drops it
-#: otherwise rather than painting an empty shell — so a deployment without
-#: that panel gets ``space · clock``.
+#: deployment enables the SYSTEM panel, and ``identity`` only where there is a
+#: user or a deployment name to show — so a deployment without that panel gets
+#: ``space · clock``. That degrade happens ONCE, at the lifespan:
+#: :func:`_load_bar_items` filters this document through
+#: :func:`renderable_bar_layout` with the same context the page stamps, so the
+#: rev-0 answer of ``GET /api/bar-items`` never names an item the deployment
+#: cannot paint. :func:`bar_render_plan` drops the same items again on paint,
+#: but only as a backstop — a served default that still carried them read, to
+#: the browser's normalizer, as content lost, and latched Customize read-only
+#: on every deployment without the SYSTEM panel (#863).
 #:
 #: ``web.bar_items`` overrides this per deployment, and the sheet's one preset,
 #: "Default", returns a user to whichever of the two applies.
@@ -487,6 +494,75 @@ BAR_ITEM_AVAILABILITY: dict[str, Callable[[dict], bool]] = {
     "system-health": lambda ctx: ctx.get("systemHealthAvailable") is True,
 }
 
+#: What each gated item needs, in the words a ``web.bar_items`` warning uses to
+#: tell an operator why the item they authored will not show. Keyed exactly as
+#: :data:`BAR_ITEM_AVAILABILITY`; ``tests/interfaces/web_terminal/
+#: test_bar_items_ssr.py`` pins the two key sets together.
+BAR_ITEM_GATES: dict[str, str] = {
+    "identity": "a terminal user or a deployment name",
+    "bluesky-queue": "the Bluesky panel",
+    "system-health": "the SYSTEM panel",
+}
+
+
+def bar_item_available(item_type: str, context: dict) -> bool:
+    """Whether this deployment can show *item_type*.
+
+    The one place :data:`BAR_ITEM_AVAILABILITY` is consulted, so the paint,
+    the lifespan's filtering of the deployment default and the config loader's
+    warnings all answer from the same predicate.
+
+    Args:
+        item_type: A type from :data:`BAR_ITEM_TYPES`.
+        context: The deployment facts from :func:`bar_availability_context`.
+
+    Returns:
+        True for a type the table does not gate, else the predicate's answer.
+    """
+    predicate = BAR_ITEM_AVAILABILITY.get(item_type)
+    return True if predicate is None else predicate(context)
+
+
+def renderable_bar_layout(layout: dict, *, context: dict) -> dict:
+    """*layout* with every item this deployment cannot show removed.
+
+    The deployment default must be renderable by construction on the deployment
+    that serves it: ``bar_render_plan`` already drops a gated item on paint,
+    but the document behind the paint — the rev-0 answer of
+    ``GET /api/bar-items``, and what a reset returns to — has to agree with it,
+    or the browser's normalizer reads the difference as lost content and
+    latches the whole layout read-only (#863). This is that agreement, applied
+    once at the lifespan where the facts are known.
+
+    Only the deployment default goes through here. An operator's stored
+    document is deliberately NOT filtered: an item they placed that this
+    deployment can no longer show is their content, and the client's latch
+    exists to keep it from being written back without them.
+
+    Args:
+        layout: A layout document — the shipped default or an authored one.
+        context: The deployment facts from :func:`bar_availability_context`.
+
+    Returns:
+        *layout* itself when it drops nothing, so a caller can tell the
+        shipped constant from a copy of it; otherwise a new document sharing
+        every key but the filtered host lists. Never mutates *layout*.
+    """
+    filtered: dict = {}
+    for host in BAR_HOSTS:
+        items = layout.get(host) or []
+        kept = [
+            item
+            for item in items
+            if not isinstance(item, dict)
+            or bar_item_available(str(item.get("type") or ""), context)
+        ]
+        if len(kept) != len(items):
+            filtered[host] = kept
+    if not filtered:
+        return layout
+    return {**layout, **filtered}
+
 
 def bar_availability_context(
     *,
@@ -546,6 +622,34 @@ def bluesky_panel_declared(custom_panels: list[dict] | None) -> bool:
     from osprey.deployment.web_terminals.personas import BLUESKY_PANEL_ID
 
     return any(panel.get("id") == BLUESKY_PANEL_ID for panel in custom_panels or ())
+
+
+def deployment_bar_context(app: FastAPI) -> dict:
+    """This deployment's availability facts, read off ``app.state``.
+
+    One function, two call sites, so they cannot disagree: the lifespan filters
+    the deployment default through it, and ``root()`` renders from it and
+    stamps it on ``<html>``. ``identityAvailable`` is the same condition the
+    identity block itself renders under — a user to name, or a deployment name
+    to show — stated once so the item and its body can never disagree.
+
+    Args:
+        app: The application, its lifespan far enough along to have resolved
+            the panel set, the Bluesky declaration, the terminal user and the
+            deployment name. Anything not yet on state reads as absent.
+
+    Returns:
+        The context :func:`bar_availability_context` builds.
+    """
+    state = app.state
+    enabled_panels = getattr(state, "enabled_panels", None) or set()
+    return bar_availability_context(
+        identity_available=bool(
+            getattr(state, "terminal_user", "") or getattr(state, "app_name", "")
+        ),
+        bluesky_available=bool(getattr(state, "bluesky_available", False)),
+        system_health_available=SYSTEM_HEALTH_PANEL_ID in enabled_panels,
+    )
 
 
 class BarRenderPlan(NamedTuple):
@@ -709,8 +813,7 @@ def bar_render_plan(layout: dict, *, context: dict) -> BarRenderPlan:
     """
 
     def _is_available(item_type: str) -> bool:
-        predicate = BAR_ITEM_AVAILABILITY.get(item_type)
-        return True if predicate is None else predicate(context)
+        return bar_item_available(item_type, context)
 
     seen: set[str] = set()
     runs: dict[str, list[dict]] = {}
@@ -1382,7 +1485,7 @@ def _coerce_bar_item(host: str, index: int, raw: object) -> dict | None:
     return item
 
 
-def _load_bar_items(config_path: str | Path | None = None) -> dict:
+def _load_bar_items(config_path: str | Path | None = None, *, context: dict | None = None) -> dict:
     """Read ``web.bar_items`` into this deployment's default bar layout.
 
     The deployment's half of the bar-items contract: an operator's saved
@@ -1390,6 +1493,15 @@ def _load_bar_items(config_path: str | Path | None = None) -> dict:
     the same fail-open coercion :func:`_load_panel_presets` performs for
     ``web.presets``, and for the same reason — there is no config schema
     anywhere, so a typo must cost the operator one item and never the boot.
+
+    With a *context* the result is also renderable by construction: an item
+    this deployment cannot show leaves the document here, so the rev-0 answer
+    of ``GET /api/bar-items`` never names one and the browser has nothing to
+    drop (#863). An AUTHORED item that goes is warned about by position and
+    gate, because an operator wrote it and will look for it; an item the
+    shipped order supplied is dropped quietly, because nobody did. Without a
+    *context* nothing is filtered — that is the coercion alone, which is what
+    the config tests exercise.
 
     Four keys, each degrading on its own:
 
@@ -1406,22 +1518,35 @@ def _load_bar_items(config_path: str | Path | None = None) -> dict:
     Args:
         config_path: Explicit ``config.yml`` to read; falls back to the
             ``CONFIG_FILE`` environment variable and then ``./config.yml``.
+        context: The deployment facts from :func:`bar_availability_context`,
+            or None to skip the availability filter.
 
     Returns:
         The resolved layout document. Falls open to :data:`DEFAULT_BAR_LAYOUT`
-        on any read error or when the key is absent.
+        on any read error or when the key is absent — filtered through
+        :func:`renderable_bar_layout` when a *context* is given, and the
+        constant itself when nothing needs to leave it.
     """
+
+    def _default() -> dict:
+        if context is None:
+            return DEFAULT_BAR_LAYOUT
+        return renderable_bar_layout(DEFAULT_BAR_LAYOUT, context=context)
+
+    def _shipped_host(host: str) -> list[dict]:
+        return list(_default()[host])
+
     try:
         raw = _load_web_ui_config(config_path).get("bar_items")
     except Exception:  # noqa: BLE001 — an unreadable config renders the shipped bars
         logger.warning("web.bar_items could not be read; using the default layout.")
-        return DEFAULT_BAR_LAYOUT
+        return _default()
 
     if raw is None:
-        return DEFAULT_BAR_LAYOUT
+        return _default()
     if not isinstance(raw, dict):
         logger.warning("web.bar_items is not a mapping; using the default layout.")
-        return DEFAULT_BAR_LAYOUT
+        return _default()
 
     layout: dict = {"version": BAR_LAYOUT_VERSION, "rev": 0}
     # Single-node types are counted across both bars, header first, exactly as
@@ -1430,20 +1555,30 @@ def _load_bar_items(config_path: str | Path | None = None) -> dict:
     for host in BAR_HOSTS:
         configured = raw.get(host)
         if configured is None:
-            layout[host] = list(DEFAULT_BAR_LAYOUT[host])
+            layout[host] = _shipped_host(host)
             placed.update(item["type"] for item in layout[host])
             continue
         if not isinstance(configured, list):
             logger.warning(
                 "web.bar_items.%s is not a list of item types; using the default order.", host
             )
-            layout[host] = list(DEFAULT_BAR_LAYOUT[host])
+            layout[host] = _shipped_host(host)
             placed.update(item["type"] for item in layout[host])
             continue
         items: list[dict] = []
         for index, entry in enumerate(configured):
             item = _coerce_bar_item(host, index, entry)
             if item is None:
+                continue
+            if context is not None and not bar_item_available(item["type"], context):
+                logger.warning(
+                    "web.bar_items.%s[%d] places %r, which this deployment cannot show "
+                    "(it needs %s); dropping it.",
+                    host,
+                    index,
+                    item["type"],
+                    BAR_ITEM_GATES.get(item["type"], "a deployment fact that is absent"),
+                )
                 continue
             if item["type"] not in BAR_ITEM_MULTI:
                 if item["type"] in placed:
@@ -2065,10 +2200,21 @@ def _create_lifespan(
         # (the default) → the "+" menu renders no presets section.
         app.state.panel_presets = _load_panel_presets(enabled_panels, custom_panels)
 
+        # Whether this deployment declares the Bluesky panel: the plan-queue
+        # item reads the queue through that panel's proxy, so the panel's
+        # presence is what makes the item offerable. It says nothing about
+        # whether the sidecar is answering; the item says that itself. Resolved
+        # before the bar layout because the layout is filtered by it.
+        app.state.bluesky_available = bluesky_panel_declared(custom_panels)
+
         # The deployment's default bar arrangement (web.bar_items), resolved
-        # once at boot. This is the document effective_bar_layout() renders
-        # until a user's saved layout is loaded ahead of it.
-        app.state.bar_layout = _load_bar_items(resolved_config_path)
+        # once at boot and filtered to what THIS deployment can show — the same
+        # facts root() stamps on the page, evaluated here first. This is the
+        # document effective_bar_layout() renders until a user's saved layout
+        # is loaded ahead of it, and the rev-0 answer of GET /api/bar-items.
+        app.state.bar_layout = _load_bar_items(
+            resolved_config_path, context=deployment_bar_context(app)
+        )
 
         # The per-user layer on top of that default, read from the store beside
         # the feedback records. Three pieces of state, and the layout routes
@@ -2090,12 +2236,6 @@ def _create_lifespan(
         app.state.bar_items_effective = _load_stored_bar_layout(
             bar_items_dir, app.state.bar_items_vocabulary, app.state.bar_layout
         )
-
-        # Whether this deployment declares the Bluesky panel: the plan-queue
-        # item reads the queue through that panel's proxy, so the panel's
-        # presence is what makes the item offerable. It says nothing about
-        # whether the sidecar is answering; the item says that itself.
-        app.state.bluesky_available = bluesky_panel_declared(custom_panels)
 
         # ── Tour capabilities ──
         # The "Ask in plain language" tour card lists what THIS deployment's
@@ -2324,20 +2464,15 @@ def create_app(
         # The two bars, rendered from the effective layout. Server-rendered
         # rather than fetched: the order is chrome, and chrome that arrives a
         # frame late is chrome the operator watches rearrange itself on every
-        # load. `identityAvailable` is the same condition the identity block
-        # itself renders under (a user to name, or a deployment name to show),
-        # stated once so the item and its body can never disagree.
+        # load.
         #
-        # The context is evaluated once and used twice: this render drops what
-        # the deployment cannot show, and the template stamps the same facts on
-        # <html> so bar-sync.js hands the browser's normalizer the server's
-        # answer instead of inferring one from the page it just received.
-        enabled_panels = getattr(request.app.state, "enabled_panels", None) or set()
-        bar_context = bar_availability_context(
-            identity_available=bool(terminal_user or app_name),
-            bluesky_available=bool(getattr(request.app.state, "bluesky_available", False)),
-            system_health_available=SYSTEM_HEALTH_PANEL_ID in enabled_panels,
-        )
+        # The context is the lifespan's own — the facts the deployment default
+        # was filtered by — read again off app.state and used twice: this
+        # render drops what the deployment cannot show, and the template stamps
+        # the same facts on <html> so bar-sync.js hands the browser's
+        # normalizer the server's answer instead of inferring one from the page
+        # it just received.
+        bar_context = deployment_bar_context(request.app)
         plan = bar_render_plan(effective_bar_layout(request.app), context=bar_context)
         return templates.TemplateResponse(
             request,

--- a/src/osprey/interfaces/web_terminal/static/js/bar-layout.js
+++ b/src/osprey/interfaces/web_terminal/static/js/bar-layout.js
@@ -22,9 +22,19 @@
  * client must render what it got, offer no Customize entry, and issue ZERO
  * PUTs until the user explicitly resets. `changed` answers the weaker question
  * — is this document byte-identical to the input — and is true for lossless
- * completions too, such as an option arriving with its declared default. A
- * dropped DUPLICATE is on the lossless side: a second copy of a single-node
- * item never rendered anything, so removing it takes nothing away.
+ * completions too, such as an option arriving with its declared default.
+ *
+ * Two drops are on the lossless side. A DUPLICATE: a second copy of a
+ * single-node item never rendered anything, so removing it takes nothing
+ * away. And an UNAVAILABLE item in a document at `rev` 0: that revision is the
+ * deployment default, which no operator authored and which the server already
+ * declined to paint, so dropping it takes nothing from anyone — whereas the
+ * same drop from a stored document (`rev` ≥ 1) is content the operator placed
+ * going missing, and latches. Without that distinction a default naming an
+ * item the deployment cannot show — the shipped one places `system-health`,
+ * which needs the SYSTEM panel — latched every deployment without that panel
+ * read-only, and a reset could not recover because it adopted the same
+ * default again.
  *
  * Pure: no DOM, no storage, no network, and no runtime dependency on the
  * catalog either. The catalog is a PARAMETER, so this module can be exercised
@@ -97,6 +107,17 @@ export const BAR_LAYOUT_VERSION = 1;
  */
 export const MAX_ITEMS_PER_HOST = 20;
 
+/**
+ * The drop reasons that are NOT a loss, for a stored document and for one at
+ * `rev` 0. See the module comment for why `unavailable` is on the second list.
+ * @type {ReadonlySet<BarLayoutDrop['reason']>}
+ */
+const LOSSLESS_STORED = new Set(/** @type {BarLayoutDrop['reason'][]} */ (['duplicate']));
+/** @type {ReadonlySet<BarLayoutDrop['reason']>} */
+const LOSSLESS_UNSAVED = new Set(
+  /** @type {BarLayoutDrop['reason'][]} */ (['duplicate', 'unavailable'])
+);
+
 /** Internal per-host outcome, before the two hosts are folded into a result. */
 /**
  * @typedef {object} HostResult
@@ -162,15 +183,18 @@ function fallback(catalog, ctx) {
  * @returns {BarLayoutResult}
  */
 function normalizeDocument(doc, catalog, ctx, isDefault) {
+  const rev = isDefault ? 0 : asRev(doc.rev);
+  const revChanged = !isDefault && rev !== doc.rev;
+  // rev 0 is nobody's saved content: an item this deployment cannot show can
+  // leave it without anything being lost. Anything unknown still latches.
+  const lossless = rev === 0 ? LOSSLESS_UNSAVED : LOSSLESS_STORED;
   // Single-node types are counted across the WHOLE document, header first:
   // a second `docs` in the status bar is a duplicate of the one in the header.
   /** @type {Set<string>} */
   const seen = new Set();
-  const header = normalizeHost(doc.header, 'header', catalog, ctx, seen);
-  const status = normalizeHost(doc.status, 'status', catalog, ctx, seen);
+  const header = normalizeHost(doc.header, 'header', catalog, ctx, seen, lossless);
+  const status = normalizeHost(doc.status, 'status', catalog, ctx, seen, lossless);
 
-  const rev = isDefault ? 0 : asRev(doc.rev);
-  const revChanged = !isDefault && rev !== doc.rev;
   const headerVisible = typeof doc.header_visible === 'boolean' ? doc.header_visible : true;
   const statusVisible = typeof doc.status_visible === 'boolean' ? doc.status_visible : true;
   const visibleChanged =
@@ -200,9 +224,11 @@ function normalizeDocument(doc, catalog, ctx, isDefault) {
  * @param {BarCatalog} catalog
  * @param {BarLayoutContext} ctx
  * @param {Set<string>} seen - single-node types already placed in this document
+ * @param {ReadonlySet<BarLayoutDrop['reason']>} lossless - drop reasons that
+ *   do not make the document read-only
  * @returns {HostResult}
  */
-function normalizeHost(rawList, host, catalog, ctx, seen) {
+function normalizeHost(rawList, host, catalog, ctx, seen, lossless) {
   /** @type {BarLayoutItem[]} */
   const items = [];
   /** @type {BarLayoutDrop[]} */
@@ -233,7 +259,7 @@ function normalizeHost(rawList, host, catalog, ctx, seen) {
   return {
     items,
     changed: changed || dropped.length > 0,
-    lossy: lossy || dropped.some((drop) => drop.reason !== 'duplicate'),
+    lossy: lossy || dropped.some((drop) => !lossless.has(drop.reason)),
     dropped,
   };
 }

--- a/src/osprey/interfaces/web_terminal/static/js/bar-sync.js
+++ b/src/osprey/interfaces/web_terminal/static/js/bar-sync.js
@@ -32,13 +32,21 @@
  * points at.
  *
  * A DOCUMENT WE HAD TO DROP CONTENT FROM IS READ-ONLY (FR5). `normalize()`
- * reports `readonly` when an entry was lost — an unknown item type, a host this
- * build will not render it in, an unreadable schema version. Rendering what
- * survived is right; writing it back is not, because the write would DELETE
- * whatever this build could not understand. So `readonly` latches and every
- * later save is refused before it reaches the network. A document that
- * salvaged nothing at all is not even reconciled: blanking the bars over a
- * version we cannot read is strictly worse than leaving the server's paint up.
+ * reports `readonly` when an entry was lost — an unknown item type, an
+ * unreadable schema version, an item the deployment cannot show that an
+ * operator had STORED. Rendering what survived is right; writing it back is
+ * not, because the write would DELETE whatever this build could not
+ * understand. So `readonly` latches and every later save is refused before it
+ * reaches the network. A document that salvaged nothing at all is not even
+ * reconciled: blanking the bars over a version we cannot read is strictly
+ * worse than leaving the server's paint up.
+ *
+ * The deployment default is the exception, and `normalize()` draws it: a
+ * document at `rev` 0 is nobody's saved content, so a gated item leaving it
+ * because this deployment lacks the panel behind it is not a loss and does not
+ * latch. The server serves the default already filtered by the same facts it
+ * stamps below; this is the belt to that brace, for a stale client against a
+ * newer server or a stamp that flips between loads.
  *
  * TWO TABS. There is no broadcast — the protection is arithmetic. Every PUT
  * carries the revision this client is holding; the server answers 409 with the
@@ -427,7 +435,9 @@ function refuse(reason) {
  * it here would leave an operator whose stored layout this build cannot fully
  * read with no way back at all. The latch is cleared only once the server has
  * confirmed the removal, and what comes back is judged on its own merits — a
- * deployment default this build cannot fully render latches again.
+ * deployment default naming a type this build does not know latches again,
+ * while one naming an item this deployment cannot show does not (it arrives at
+ * `rev` 0, and `normalize()` reads that drop as no loss).
  *
  * There is no revision and so no conflict ladder: a reset is unconditional by
  * construction, which is why it is its own verb rather than a `rev`-less PUT.

--- a/src/osprey/mcp_server/control_system/target_eligibility.py
+++ b/src/osprey/mcp_server/control_system/target_eligibility.py
@@ -153,7 +153,9 @@ MODE_ADDR_LIST = "addr_list"
 
 #: The ports ``EPICSConnector.connect()`` falls back to when a gateway names
 #: none. The virtual accelerator never reaches the CA default: its unset ports
-#: are filled from ``services.virtual_accelerator.port`` first.
+#: are filled from ``services.virtual_accelerator.port`` first. The PVA default
+#: applies to name servers only (TCP); an address-list entry that names no port
+#: is passed to p4p without one, so its row carries ``None``.
 DEFAULT_CA_PORT = 5064
 DEFAULT_PVA_PORT = 5075
 
@@ -369,7 +371,7 @@ def _mode(gateway: dict[str, Any]) -> str:
     return MODE_NAME_SERVER if gateway.get("use_name_server", False) else MODE_ADDR_LIST
 
 
-def _row(gateway: Any, default_port: int) -> Endpoint | None:
+def _row(gateway: Any, default_port: int | None) -> Endpoint | None:
     """One endpoint row, or ``None`` for a gateway ``connect()`` would ignore.
 
     ``connect()`` guards its environment derivation with ``if gateway_config:``,
@@ -478,7 +480,11 @@ def derive_endpoints(
     # globs AND a gateway. Globs without a gateway import p4p but touch no PVA
     # environment variable, so there is no endpoint to report.
     if _pva_globs(block):
-        pva_row = _row(block.get("pva_gateway"), DEFAULT_PVA_PORT)
+        pva_gateway = block.get("pva_gateway")
+        # connect() appends no port to an address list unless one is set; the
+        # TCP default applies to name servers only.
+        name_server = isinstance(pva_gateway, dict) and _mode(pva_gateway) == MODE_NAME_SERVER
+        pva_row = _row(pva_gateway, DEFAULT_PVA_PORT if name_server else None)
         if pva_row is not None:
             endpoints[ROLE_PVA] = pva_row
 

--- a/src/osprey/profiles/web_panels.py
+++ b/src/osprey/profiles/web_panels.py
@@ -48,6 +48,19 @@ BUILTIN_PANEL_LABELS: dict[str, str] = {
     "system-health": "SYSTEM",
 }
 
+#: The bar items whose availability is a panel's presence, and the panel each
+#: needs. The build-time half of ``BAR_ITEM_AVAILABILITY`` in
+#: ``interfaces/web_terminal/app.py``: the server drops such an item from the
+#: default it serves when the panel is absent, and this is what lets the build
+#: say so first. ``identity`` is gated too, but on a runtime fact (a terminal
+#: user or a deployment name) a build cannot judge, so it is deliberately not
+#: here; ``tests/interfaces/web_terminal/test_bar_items_ssr.py`` pins the two
+#: tables together.
+BAR_ITEM_PANEL_GATES: dict[str, str] = {
+    "bluesky-queue": "bluesky",
+    "system-health": "system-health",
+}
+
 # Frontend fallback when a profile/config doesn't pin a default tab.
 # The web terminal opens this tab first on cold load.
 DEFAULT_PANEL_FALLBACK: str = "artifacts"

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -588,10 +588,15 @@ control_system:
     #
     # `pva_gateway` is ONE flat block, not the read_only/write_access pair the
     # CA `gateways` below uses, precisely because there is no PVA write path.
-    # It is read only when pva_channels is non-empty, and maps to
-    # EPICS_PVA_ADDR_LIST — or to EPICS_PVA_NAME_SERVERS when use_name_server is
-    # true (TCP instead of UDP search: what SSH tunnels need). Whenever the block
-    # is present, EPICS_PVA_AUTO_ADDR_LIST is forced to "NO", mirroring the
+    # It is read only when pva_channels is non-empty, and it is the ONLY route:
+    # the connector host drops every EPICS_PVA_* variable from its environment,
+    # so an EPICS_PVA_ADDR_LIST set in .env never reaches it. `address` is one
+    # host or a space-separated list of hosts and maps to EPICS_PVA_ADDR_LIST
+    # (UDP search; leave `port` unset and p4p's default 5076 applies — 5075 is
+    # the TCP port and breaks the search) — or to EPICS_PVA_NAME_SERVERS when
+    # use_name_server is true (TCP instead of UDP search: what SSH tunnels need;
+    # port defaults to 5075). Whenever the block is present,
+    # EPICS_PVA_AUTO_ADDR_LIST is forced to "NO", mirroring the
     # EPICS_CA_AUTO_ADDR_LIST containment the CA path applies: a deployment
     # deliberately pinned to a gateway must not also broadcast-discover servers
     # on its local subnet.
@@ -616,8 +621,8 @@ control_system:
       #   - "*:IMAGE*"
       #   - "*:ARRAY*"
       # pva_gateway:
-      #   address: your-pva-gateway.example.com  # Replace with your PVA gateway
-      #   port: 5075
+      #   address: your-pva-gateway.example.com  # Or "host1 host2 host3" for many servers
+      #   # port: 5076  # Only if your servers search on a non-default port
       #   use_name_server: false  # Set true for SSH tunnels
       # use_name_server: Set to true for SSH tunnels (uses EPICS_CA_NAME_SERVERS)
       #                  Set to false for direct gateway (uses EPICS_CA_ADDR_LIST)

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -321,17 +321,22 @@ control_system:
       # pva_channels:
       #   - "*:IMAGE*"
       #   - "*:ARRAY*"
-      # PVA gateway - one flat block, unlike the CA read_only/write_access pair
-      # below, because PVA is read-only in this deployment. Read only when
-      # pva_channels is non-empty. Maps to EPICS_PVA_ADDR_LIST, or to
-      # EPICS_PVA_NAME_SERVERS when use_name_server is true (SSH tunnels).
-      # Whenever this block is present, EPICS_PVA_AUTO_ADDR_LIST is forced to
-      # "NO" - the same containment the CA side applies with
-      # EPICS_CA_AUTO_ADDR_LIST, so a deployment pinned to a gateway cannot also
-      # broadcast-discover servers on the local subnet.
+      # Where PVA searches go - one flat block, unlike the CA
+      # read_only/write_access pair below, because PVA is read-only in this
+      # deployment. Read only when pva_channels is non-empty, and the ONLY
+      # route: the connector host drops every EPICS_PVA_* variable from its
+      # environment, so an EPICS_PVA_ADDR_LIST set in .env never reaches it.
+      # `address` is one host or a space-separated list of hosts and maps to
+      # EPICS_PVA_ADDR_LIST (UDP search; leave `port` unset and p4p's default
+      # 5076 applies - 5075 is the TCP port and breaks the search), or to
+      # EPICS_PVA_NAME_SERVERS when use_name_server is true (TCP, SSH tunnels;
+      # port defaults to 5075). Whenever this block is present,
+      # EPICS_PVA_AUTO_ADDR_LIST is forced to "NO" - the same containment the CA
+      # side applies with EPICS_CA_AUTO_ADDR_LIST, so a deployment pinned to a
+      # gateway cannot also broadcast-discover servers on the local subnet.
       # pva_gateway:
-      #   address: your-gateway.example.com  # Replace with your PVA gateway address
-      #   port: 5075
+      #   address: your-gateway.example.com  # Or "host1 host2 host3" for many servers
+      #   # port: 5076  # Only if your servers search on a non-default port
       #   use_name_server: false  # Set true for SSH tunnels
       gateways:
         read_only:

--- a/tests/cli/test_build_profile_panels.py
+++ b/tests/cli/test_build_profile_panels.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import pytest
 
 from osprey.cli.build_profile_panels import (
+    bar_items_selection_warnings,
     panel_selection_errors,
     panel_selection_overrides,
 )
@@ -156,3 +157,83 @@ def test_an_agreeing_or_absent_enabled_is_allowed() -> None:
 
 def test_universal_panels_are_never_a_contradiction() -> None:
     assert panel_selection_errors({"web.panels.artifacts.enabled": True}, []) == []
+
+
+# ---------------------------------------------------------------------------
+# bar_items_selection_warnings — an authored bar item the render cannot show
+# ---------------------------------------------------------------------------
+
+
+def test_a_panel_gated_item_without_its_panel_is_warned_about_by_position() -> None:
+    """The server drops ``system-health`` from the default it serves when the
+    SYSTEM panel is not selected (#863); the build says so first, naming the
+    entry the operator wrote and the panel it needs."""
+    config = {"web": {"bar_items": {"status": ["space", "system-health", "clock"]}}}
+
+    warnings = bar_items_selection_warnings(config, ["ariel", "artifacts"])
+
+    assert len(warnings) == 1
+    assert warnings[0].startswith("web: bar_items: status[1] places 'system-health'")
+    assert "'system-health' is not in web_panels" in warnings[0]
+
+
+def test_a_selected_panel_keeps_its_item_quiet() -> None:
+    config = {"web.bar_items": {"status": ["space", "system-health", "clock"]}}
+    assert bar_items_selection_warnings(config, ["system-health"]) == []
+
+
+def test_a_mapping_entry_is_judged_by_its_type() -> None:
+    config = {
+        "web.bar_items.header": [
+            "logo",
+            {"type": "bluesky-queue", "options": {"controls": "full"}},
+        ]
+    }
+
+    warnings = bar_items_selection_warnings(config, ["ariel"])
+
+    assert len(warnings) == 1
+    assert warnings[0].startswith("web.bar_items.header[1] places 'bluesky-queue'")
+    assert "needs the 'bluesky' panel" in warnings[0]
+
+
+def test_both_bars_and_both_gated_items_in_bar_then_list_order() -> None:
+    config = {
+        "web": {
+            "bar_items": {
+                "header": ["logo", "bluesky-queue"],
+                "status": ["system-health", "clock", "bluesky-queue"],
+            }
+        }
+    }
+
+    warnings = bar_items_selection_warnings(config, [])
+
+    assert [w.split(" places ")[0] for w in warnings] == [
+        "web: bar_items: header[1]",
+        "web: bar_items: status[0]",
+        "web: bar_items: status[2]",
+    ]
+
+
+def test_identity_is_not_a_build_time_judgment() -> None:
+    """``identity`` is gated on a runtime fact (a terminal user or a deployment
+    name) the build cannot see, so an authored ``identity`` never warns here."""
+    config = {"web": {"bar_items": {"header": ["logo", "identity"]}}}
+    assert bar_items_selection_warnings(config, []) == []
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({}, id="no_config"),
+        pytest.param({"web": {"bar_items": None}}, id="bar_items_null"),
+        pytest.param({"web": {"bar_items": {"status": "system-health"}}}, id="not_a_list"),
+        pytest.param({"web": {"bar_items": {"status": [None, 3, {}]}}}, id="unreadable_entries"),
+        pytest.param({"web": {"bar_items": {"status": ["space", "clock"]}}}, id="ungated_items"),
+    ],
+)
+def test_nothing_to_judge_warns_nothing(config) -> None:
+    """Shape problems are the server loader's to report; this only speaks to a
+    readable entry naming a gated item."""
+    assert bar_items_selection_warnings(config, []) == []

--- a/tests/cli/test_build_rendered_config_cache.py
+++ b/tests/cli/test_build_rendered_config_cache.py
@@ -1,0 +1,83 @@
+"""``_rendered_config`` parses a render's ``config.yml`` once per content, never stale."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from osprey.cli import build_cmd
+from osprey_connectors import yaml_loader
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache() -> None:
+    build_cmd._rendered_config_cache.clear()
+
+
+@pytest.fixture
+def parse_calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    calls: list[str] = []
+    real = yaml_loader.safe_load
+
+    def counting(stream):  # type: ignore[no-untyped-def]
+        calls.append(stream if isinstance(stream, str) else "<stream>")
+        return real(stream)
+
+    monkeypatch.setattr(yaml_loader, "safe_load", counting)
+    return calls
+
+
+def _render(tmp_path: Path, text: str) -> Path:
+    render_dir = tmp_path / "render"
+    render_dir.mkdir(parents=True, exist_ok=True)
+    (render_dir / "config.yml").write_text(text, encoding="utf-8")
+    return render_dir
+
+
+def test_repeated_reads_parse_once(tmp_path: Path, parse_calls: list[str]) -> None:
+    render_dir = _render(tmp_path, "control_system:\n  type: mock\nports: [1, 2]\n")
+
+    first = build_cmd._rendered_config(render_dir)
+    second = build_cmd._rendered_config(render_dir)
+    third = build_cmd._rendered_config(render_dir)
+
+    assert first == second == third == {"control_system": {"type": "mock"}, "ports": [1, 2]}
+    assert len(parse_calls) == 1
+
+
+def test_callers_get_their_own_copy(tmp_path: Path) -> None:
+    render_dir = _render(tmp_path, "control_system:\n  type: mock\n")
+
+    annotated = build_cmd._rendered_config(render_dir)
+    annotated["config_dir"] = str(render_dir)
+    annotated["control_system"]["type"] = "epics"
+
+    assert build_cmd._rendered_config(render_dir) == {"control_system": {"type": "mock"}}
+
+
+def test_a_rewrite_is_parsed_afresh(tmp_path: Path, parse_calls: list[str]) -> None:
+    render_dir = _render(tmp_path, "container_runtime: auto\n")
+    assert build_cmd._rendered_config(render_dir) == {"container_runtime": "auto"}
+
+    # The resolvers rewrite config.yml in place mid-build; same path, new bytes.
+    (render_dir / "config.yml").write_text("container_runtime: docker\n", encoding="utf-8")
+
+    assert build_cmd._rendered_config(render_dir) == {"container_runtime": "docker"}
+    assert build_cmd._rendered_config(render_dir) == {"container_runtime": "docker"}
+    assert len(parse_calls) == 2
+
+
+def test_an_empty_document_is_an_empty_mapping(tmp_path: Path) -> None:
+    render_dir = _render(tmp_path, "")
+    assert build_cmd._rendered_config(render_dir) == {}
+
+
+def test_two_renders_do_not_share_an_entry(tmp_path: Path, parse_calls: list[str]) -> None:
+    a = _render(tmp_path / "a", "name: a\n")
+    b = _render(tmp_path / "b", "name: b\n")
+
+    assert build_cmd._rendered_config(a) == {"name": "a"}
+    assert build_cmd._rendered_config(b) == {"name": "b"}
+    assert build_cmd._rendered_config(a) == {"name": "a"}
+    assert len(parse_calls) == 2

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -322,6 +322,9 @@ class TestBuildPhases:
             # No live stand-in: _build_repo reads the block after the swap to
             # decide whether to run the stand-in's lattice gate.
             virtual_accelerator = None
+            # Hand-written, not materialized: nothing for the preset-drift lint
+            # to compare with.
+            provenance = None
 
             def resolved_tier(self) -> int:
                 return 1

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -325,6 +325,8 @@ class TestBuildPhases:
             # Hand-written, not materialized: nothing for the preset-drift lint
             # to compare with.
             provenance = None
+            # No panel selection: nothing for the bar-items warning to check.
+            web_panels: list[str] = []
 
             def resolved_tier(self) -> int:
                 return 1

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -167,7 +167,7 @@ def _render_deployable_config(tmp_path: Path, preset: str = "control-assistant")
     preset author wrote. No build renders a project from that layer: every build
     materializes a profile first, and materialization emits one
     ``personas/<name>.yml`` delta per catalog entry and repoints the catalog at
-    it (``_persona_catalog_layer``). A config linted before that rewrite is a
+    it (``persona_catalog_layer``). A config linted before that rewrite is a
     shape the pipeline never emits.
 
     So this applies the same rewrite, through the same function the
@@ -180,8 +180,7 @@ def _render_deployable_config(tmp_path: Path, preset: str = "control-assistant")
     ``tests/cli/test_persona_profile_emission.py``, which drives ``osprey
     init`` → ``osprey build`` for every persona-bearing preset.)
     """
-    from osprey.cli.build_profile_emit import persona_catalog
-    from osprey.cli.profile_cmd import _persona_catalog_layer
+    from osprey.cli.build_profile_emit import persona_catalog, persona_catalog_layer
 
     config_path = tmp_path / "config.yml"
     resolved = resolve_preset(preset)
@@ -190,7 +189,7 @@ def _render_deployable_config(tmp_path: Path, preset: str = "control-assistant")
     config_update_fields(config_path, resolved.config)
     config_update_fields(
         config_path,
-        _persona_catalog_layer(persona_catalog(resolved.config), repo_name=preset)["config"],
+        persona_catalog_layer(persona_catalog(resolved.config), repo_name=preset)["config"],
     )
     with config_path.open("r", encoding="utf-8") as fh:
         return yaml.safe_load(fh)

--- a/tests/cli/test_preset_drift.py
+++ b/tests/cli/test_preset_drift.py
@@ -1,0 +1,448 @@
+"""The preset-drift lint — a materialized profile compared with its preset.
+
+``osprey init`` stamps ``provenance:`` into the profile it writes and nothing
+read it back: a profile could lack a line the preset gained, and every build
+stayed green. These tests pin the comparison
+(:func:`~osprey.cli.build_profile_drift.preset_drift_report`) and the two
+surfaces that print it — ``osprey validate`` refuses unmarked differences,
+``osprey build`` names them under ``-v``.
+
+The fixture is a real ``osprey init`` of the ``control-assistant`` preset,
+made once per module and copied per test: the first assertion of the suite is
+that a fresh materialization reports nothing, and every other test edits that
+repo the way an operator would.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.build_profile import resolve_build_profile
+from osprey.cli.build_profile_drift import DriftReport, preset_drift_report
+from osprey.cli.build_profile_merge import compute_preset_hash
+from osprey.cli.build_profile_presets import _presets_dir
+from osprey.cli.init_cmd import init
+from osprey.cli.main import cli
+from osprey.cli.validate_cmd import validate
+
+PROFILE = "profile.yml"
+READONLY = Path("personas") / "readonly.yml"
+
+
+@pytest.fixture(scope="module")
+def materialized(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """One real materialization of the control-assistant preset."""
+    root = tmp_path_factory.mktemp("materialized") / "demo"
+    result = CliRunner().invoke(init, [str(root), "--preset", "control-assistant", "--no-git"])
+    assert result.exit_code == 0, result.output
+    return root
+
+
+@pytest.fixture
+def repo(materialized: Path, tmp_path: Path) -> Path:
+    """A private copy of the materialization for this test to edit."""
+    target = tmp_path / "demo"
+    shutil.copytree(materialized, target)
+    return target
+
+
+def _report(profile_file: Path) -> DriftReport:
+    """Run the lint the way the verbs do: the provenance the loader parsed."""
+    root = profile_file if profile_file.name == PROFILE else profile_file.parent.parent / PROFILE
+    profile, _ = resolve_build_profile(root, None)
+    assert profile.provenance is not None
+    return preset_drift_report(profile_file, profile.provenance)
+
+
+def _edit(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    assert text.count(old) == 1, f"{old!r} must occur exactly once in {path}"
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def _line_of(path: Path, needle: str) -> int:
+    """1-based line number of the one line containing *needle*."""
+    hits = [
+        i
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if needle in line
+    ]
+    assert len(hits) == 1, f"{needle!r} must occur exactly once in {path}"
+    return hits[0]
+
+
+# ---------------------------------------------------------------------------
+# The baseline: what init writes today does not drift
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_materialization_reports_nothing(repo: Path) -> None:
+    report = _report(repo / PROFILE)
+
+    assert report.unmarked == []
+    assert report.stale_markers == []
+    assert report.note is None
+
+
+def test_header_stamp_and_lint_share_one_hash(repo: Path) -> None:
+    """The header comment, the `provenance:` key and the lint all read
+    :func:`compute_preset_hash`, which is why a fresh materialization cannot
+    report the preset as moved."""
+    profile = repo / PROFILE
+    header_hash = _header_hash(profile)
+
+    assert header_hash == compute_preset_hash("control-assistant")
+    assert f"preset_hash: {header_hash}" in profile.read_text(encoding="utf-8")
+    assert _header_hash(repo / READONLY) == compute_preset_hash("control-assistant-readonly")
+
+
+def _header_hash(path: Path) -> str:
+    """The hash the emitted header comment names."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("#   preset content hash: "):
+            return line.removeprefix("#   preset content hash: ").strip()
+    raise AssertionError(f"{path} has no emitted header")
+
+
+def test_fresh_hello_world_reports_nothing(tmp_path: Path) -> None:
+    root = tmp_path / "hello"
+    result = CliRunner().invoke(init, [str(root), "--preset", "hello-world", "--no-git"])
+    assert result.exit_code == 0, result.output
+
+    report = _report(root / PROFILE)
+
+    assert report.unmarked == []
+    assert report.note is None
+
+
+# ---------------------------------------------------------------------------
+# What is reported
+# ---------------------------------------------------------------------------
+
+
+def test_member_the_preset_selects_and_the_profile_lacks(repo: Path) -> None:
+    """The failure that motivated the lint: a `web_panels` entry the preset
+    gained and the materialized copy never picked up."""
+    profile = repo / PROFILE
+    _edit(profile, "  - system-health", "  # - system-health")
+
+    report = _report(profile)
+
+    assert [f.subject for f in report.unmarked] == ["web_panels: system-health"]
+    rendered = report.unmarked[0].render()
+    assert "profile.yml" in rendered
+    preset_line = _line_of(_presets_dir() / "control-assistant.yml", "- system-health")
+    assert f"control-assistant.yml:{preset_line}" in rendered
+
+
+def test_scalar_that_differs_names_both_values_and_both_lines(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(profile, "  web.theme: light", "  web.theme: dark")
+
+    report = _report(profile)
+
+    assert [f.subject for f in report.unmarked] == ["config.web.theme"]
+    rendered = report.unmarked[0].render()
+    assert "'dark'" in rendered and "'light'" in rendered
+    assert f"profile.yml:{_line_of(profile, 'web.theme: dark')}" in rendered
+    preset_line = _line_of(_presets_dir() / "control-assistant.yml", "web.theme: light")
+    assert f"control-assistant.yml:{preset_line}" in rendered
+
+
+def test_member_the_profile_adds(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(profile, "  - system-health", "  - system-health\n  - artifacts")
+
+    report = _report(profile)
+
+    assert [f.subject for f in report.unmarked] == ["web_panels: artifacts"]
+
+
+def test_config_key_the_app_template_knows_is_not_drift(repo: Path) -> None:
+    """A facility tuning a template knob the preset leaves alone is ordinary
+    business, not a deviation from the preset."""
+    profile = repo / PROFILE
+    _edit(
+        profile,
+        "  web.theme: light",
+        "  web.theme: light\n  web.docs_url: https://docs.facility.example",
+    )
+
+    assert _report(profile).unmarked == []
+
+
+def test_config_key_nothing_knows_is_reported_once_at_its_root(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(
+        profile,
+        "  web.theme: light",
+        "  web.theme: light\n  web.no_such_block:\n    depth: 1\n    other: 2",
+    )
+
+    report = _report(profile)
+
+    assert [f.subject for f in report.unmarked] == ["config.web.no_such_block"]
+
+
+def test_top_level_block_the_profile_dropped(repo: Path) -> None:
+    profile = repo / PROFILE
+    text = profile.read_text(encoding="utf-8")
+    start = text.index("\nbluesky:\n")
+    end = text.index("\n", text.index("tiled_enabled", start))
+    profile.write_text(text[:start] + text[end:], encoding="utf-8")
+
+    report = _report(profile)
+
+    assert [f.subject for f in report.unmarked] == ["bluesky"]
+
+
+# ---------------------------------------------------------------------------
+# Markers
+# ---------------------------------------------------------------------------
+
+
+def test_marker_within_three_lines_above_silences_the_line(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(
+        profile,
+        "  web.theme: light",
+        "  # DEVIATION: facility — the control room is dark\n  #\n  #\n  web.theme: dark",
+    )
+
+    report = _report(profile)
+
+    assert report.unmarked == []
+    assert [f.subject for f in report.findings] == ["config.web.theme"]
+    assert report.stale_markers == []
+
+
+def test_marker_four_lines_above_does_not_reach(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(
+        profile,
+        "  web.theme: light",
+        "  # DEVIATION: facility — too far up\n  #\n  #\n  #\n  web.theme: dark",
+    )
+
+    report = _report(profile)
+
+    assert [f.subject for f in report.unmarked] == ["config.web.theme"]
+    assert len(report.stale_markers) == 1
+
+
+def test_absence_is_silenced_by_a_marker_that_names_it(repo: Path) -> None:
+    """A line the profile lacks has nothing to write a marker above, so the
+    marker names what is missing instead — anywhere in the file."""
+    profile = repo / PROFILE
+    _edit(profile, "  - system-health   # SYSTEM tab, a framework health dashboard\n", "")
+    with profile.open("a", encoding="utf-8") as fh:
+        fh.write("\n# DEVIATION: facility — no system-health tab; the SYSTEM view is elsewhere\n")
+
+    report = _report(profile)
+
+    assert report.unmarked == []
+    assert report.stale_markers == []
+
+
+def test_dropped_block_is_silenced_by_naming_it(repo: Path) -> None:
+    profile = repo / PROFILE
+    text = profile.read_text(encoding="utf-8")
+    start = text.index("\nbluesky:\n")
+    end = text.index("\n", text.index("tiled_enabled", start))
+    text = text[:start] + "\n# DEVIATION: facility — bluesky is not run here" + text[end:]
+    profile.write_text(text, encoding="utf-8")
+
+    assert _report(profile).unmarked == []
+
+
+def test_marker_tag_is_configurable(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(
+        profile,
+        "  preset: control-assistant\n",
+        "  preset: control-assistant\n  deviation_marker: ALS-DEVIATION\n",
+    )
+    _edit(
+        profile,
+        "  web.theme: light",
+        "  # DEVIATION: facility — wrong tag\n  web.theme: dark",
+    )
+
+    assert [f.subject for f in _report(profile).unmarked] == ["config.web.theme"]
+
+    _edit(profile, "  # DEVIATION: facility — wrong tag", "  # ALS-DEVIATION: facility — right tag")
+
+    assert _report(profile).unmarked == []
+
+
+def test_stale_marker_is_reported(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(
+        profile,
+        "  web.theme: light",
+        "  # DEVIATION: facility — nothing differs here\n  web.theme: light",
+    )
+
+    report = _report(profile)
+
+    assert report.unmarked == []
+    assert len(report.stale_markers) == 1
+    assert f"profile.yml:{_line_of(profile, 'nothing differs here')}" in report.stale_markers[0]
+
+
+# ---------------------------------------------------------------------------
+# The hash note
+# ---------------------------------------------------------------------------
+
+
+def test_moved_preset_hash_is_noted_with_both_versions(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(profile, "  preset_hash: sha256:", "  preset_hash: sha256:0000dead")
+
+    report = _report(profile)
+
+    assert report.note is not None
+    assert "sha256:0000dead" in report.note
+    assert "control-assistant" in report.note
+    assert "OSPREY" in report.note
+    assert report.unmarked == []
+
+
+def test_unbundled_preset_cannot_be_compared(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(profile, "  preset: control-assistant\n", "  preset: retired-preset\n")
+
+    report = _report(profile)
+
+    assert report.findings == []
+    assert report.note is not None and "retired-preset" in report.note
+
+
+# ---------------------------------------------------------------------------
+# Personas
+# ---------------------------------------------------------------------------
+
+
+def test_persona_delta_is_compared_with_its_own_preset(repo: Path) -> None:
+    delta = repo / READONLY
+    _edit(delta, "  web.ui_mode: simple\n", "")
+
+    report = _report(repo / PROFILE)
+
+    assert [f.subject for f in report.unmarked] == ["config.web.ui_mode"]
+    rendered = report.unmarked[0].render()
+    assert "personas/readonly.yml" in rendered
+    preset_line = _line_of(_presets_dir() / "control-assistant-readonly.yml", "web.ui_mode: simple")
+    assert f"control-assistant-readonly.yml:{preset_line}" in rendered
+
+
+def test_validating_a_delta_reports_that_persona_only(repo: Path) -> None:
+    _edit(repo / PROFILE, "  - system-health", "  # - system-health")
+    _edit(repo / READONLY, "  web.ui_mode: simple\n", "")
+
+    report = _report(repo / READONLY)
+
+    assert [f.subject for f in report.unmarked] == ["config.web.ui_mode"]
+
+
+def test_persona_exclude_of_something_the_preset_keeps(repo: Path) -> None:
+    delta = repo / READONLY
+    with delta.open("a", encoding="utf-8") as fh:
+        fh.write("\nexclude:\n  skills:\n    - diagnose\n")
+
+    report = _report(repo / PROFILE)
+
+    assert [f.subject for f in report.unmarked] == ["skills: diagnose"]
+    assert f"personas/readonly.yml:{_line_of(delta, '- diagnose')}" in report.unmarked[0].render()
+
+    _edit(
+        delta,
+        "    - diagnose",
+        "    # DEVIATION: facility — read-only logins do not diagnose\n    - diagnose",
+    )
+
+    assert _report(repo / PROFILE).unmarked == []
+
+
+def test_persona_the_preset_does_not_know_is_reported_once(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(
+        profile,
+        "      readonly:\n",
+        "      operator:\n        project: demo-operator\n        project_path: build/demo-operator\n"
+        "        build_profile: personas/operator.yml\n      readonly:\n",
+    )
+    (repo / "personas" / "operator.yml").write_text(
+        "name: Operator\ndeploy_services: false\n", encoding="utf-8"
+    )
+
+    report = _report(profile)
+
+    assert [f.subject for f in report.unmarked] == [
+        "config.modules.web_terminals.personas.operator"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The verbs
+# ---------------------------------------------------------------------------
+
+
+def test_validate_refuses_unmarked_drift(repo: Path) -> None:
+    _edit(repo / PROFILE, "  - system-health", "  # - system-health")
+
+    result = CliRunner().invoke(validate, ["--repo", str(repo)])
+
+    assert result.exit_code == 2, result.output
+    assert "web_panels: system-health" in result.output
+    assert "# DEVIATION:" in result.output
+
+
+def test_validate_drift_warn_demotes_to_a_warning(repo: Path) -> None:
+    _edit(repo / PROFILE, "  - system-health", "  # - system-health")
+
+    result = CliRunner().invoke(validate, ["--repo", str(repo), "--drift=warn"])
+
+    assert result.exit_code == 0, result.output
+    assert "web_panels: system-health" in result.output
+    assert "Profile is valid" in result.output
+
+
+def test_validate_passes_a_fresh_materialization(repo: Path) -> None:
+    result = CliRunner().invoke(validate, ["--repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "drift" not in result.output.lower()
+
+
+def test_validate_prints_stale_markers_and_the_hash_note(repo: Path) -> None:
+    profile = repo / PROFILE
+    _edit(
+        profile,
+        "  web.theme: light",
+        "  # DEVIATION: facility — nothing differs here\n  web.theme: light",
+    )
+    _edit(profile, "  preset_hash: sha256:", "  preset_hash: sha256:0000dead")
+
+    result = CliRunner().invoke(validate, ["--repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "marks no difference" in result.output
+    assert "sha256:0000dead" in result.output
+
+
+def test_build_names_drift_under_verbose_only(repo: Path) -> None:
+    _edit(repo / PROFILE, "  - system-health", "  # - system-health")
+    args = ["build", "--repo", str(repo), "--skip-deps", "--skip-lifecycle"]
+
+    quiet = CliRunner().invoke(cli, args)
+    assert quiet.exit_code == 0, quiet.output
+    assert "system-health" not in quiet.output
+
+    verbose = CliRunner().invoke(cli, ["-v", *args])
+    assert verbose.exit_code == 0, verbose.output
+    assert "web_panels: system-health" in verbose.output

--- a/tests/cli/test_profile_alias_normalization.py
+++ b/tests/cli/test_profile_alias_normalization.py
@@ -2,8 +2,8 @@
 
 ``app_template:`` is the profile-YAML spelling of the app-template selector;
 ``data_bundle:`` remains an accepted alias (and stays the canonical Python
-field name). Every raw profile document is read through
-``_read_profile_document``, which normalizes the spelling once per document —
+field name). Every raw profile document is parsed through
+``_parse_profile_document``, which normalizes the spelling once per document —
 so only one spelling survives a layer and mixed-spelling ``extends:`` /
 override chains merge child-wins through the ordinary deep merge.
 """
@@ -202,10 +202,13 @@ def test_profile_hash_is_blind_to_the_spelling(tmp_path: Path) -> None:
 
 
 # (module, enclosing function, call) triples allowed to deserialize YAML in the
-# profile pipeline. Everything else must route through _read_profile_document,
-# or a new read would silently skip alias normalization.
+# profile pipeline. Everything else must route through _parse_profile_document
+# (or _read_profile_document, its file-reading front), or a new read would
+# silently skip alias normalization.
 _ALLOWED_YAML_READS = {
-    ("build_profile_document.py", "_read_profile_document", "yaml.safe_load"),
+    ("build_profile_document.py", "_parse_profile_document", "yaml.safe_load"),
+    # The app template's rendered config.yml — not a profile document.
+    ("build_profile_drift.py", "_template_defaults", "yaml.safe_load"),
     # Scalar `--set` values, not documents — normalized as a layer instead.
     ("build_profile_resolve.py", "_parse_set_pairs", "yaml.safe_load"),
     # The emitter's ruamel round-trip is a comment source; it must keep the
@@ -240,7 +243,7 @@ def _yaml_read_sites(source_path: Path) -> set[tuple[str, str, str]]:
 
 
 def test_yaml_document_reads_happen_only_in_the_helper() -> None:
-    """Every profile-document parse routes through ``_read_profile_document``."""
+    """Every profile-document parse routes through ``_parse_profile_document``."""
     pipeline_dir = Path(build_profile_presets.__file__).parent
     modules = sorted(pipeline_dir.glob("build_profile_*.py"))
     assert modules, f"no build_profile_*.py modules found under {pipeline_dir}"
@@ -252,4 +255,4 @@ def test_yaml_document_reads_happen_only_in_the_helper() -> None:
     assert found - _ALLOWED_YAML_READS == set()
     # The helper itself must still be the read point — an empty result would
     # otherwise pass vacuously.
-    assert ("build_profile_document.py", "_read_profile_document", "yaml.safe_load") in found
+    assert ("build_profile_document.py", "_parse_profile_document", "yaml.safe_load") in found

--- a/tests/cli/test_profile_alias_normalization.py
+++ b/tests/cli/test_profile_alias_normalization.py
@@ -205,7 +205,7 @@ def test_profile_hash_is_blind_to_the_spelling(tmp_path: Path) -> None:
 # profile pipeline. Everything else must route through _read_profile_document,
 # or a new read would silently skip alias normalization.
 _ALLOWED_YAML_READS = {
-    ("build_profile_document.py", "_read_profile_document", "yaml.safe_load"),
+    ("build_profile_document.py", "_read_profile_document", "yaml_loader.safe_load"),
     # Scalar `--set` values, not documents — normalized as a layer instead.
     ("build_profile_resolve.py", "_parse_set_pairs", "yaml.safe_load"),
     # The emitter's ruamel round-trip is a comment source; it must keep the
@@ -252,4 +252,8 @@ def test_yaml_document_reads_happen_only_in_the_helper() -> None:
     assert found - _ALLOWED_YAML_READS == set()
     # The helper itself must still be the read point — an empty result would
     # otherwise pass vacuously.
-    assert ("build_profile_document.py", "_read_profile_document", "yaml.safe_load") in found
+    assert (
+        "build_profile_document.py",
+        "_read_profile_document",
+        "yaml_loader.safe_load",
+    ) in found

--- a/tests/cli/test_pva_address_source_advisory.py
+++ b/tests/cli/test_pva_address_source_advisory.py
@@ -1,0 +1,132 @@
+"""The build advisory for PVA channels that name no address source.
+
+The connector-host child scrubs every inherited ``EPICS_PVA_*`` variable
+before the connector runs, so a ``pva_gateway`` block is the only route a PVA
+address list has into p4p. A deployment that lists ``pva_channels`` and sets
+``EPICS_PVA_ADDR_LIST`` in its environment instead gets subnet auto-discovery,
+which from an off-subnet host is a bare timeout on every read. The build is
+where that is worth saying.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from osprey.cli.build_cmd import build
+from osprey.cli.build_profile_reach import pva_address_source_advisories
+
+
+def _config(**epics: Any) -> dict[str, Any]:
+    """A rendered config whose ``epics`` connector block carries *epics*."""
+    return {
+        "control_system": {
+            "type": "epics",
+            "connector": {"mock": {"response_delay_ms": 0}, "epics": {"timeout": 5.0, **epics}},
+        }
+    }
+
+
+def test_pva_channels_without_a_gateway_are_advised() -> None:
+    advisories = pva_address_source_advisories(_config(pva_channels=["*:image"]))
+
+    assert len(advisories) == 1
+    assert "control_system.connector.epics.pva_gateway" in advisories[0]
+    assert "EPICS_PVA_" in advisories[0]
+
+
+def test_a_string_glob_counts_as_configured() -> None:
+    """``connect()`` accepts a single glob as a string, so the advisory must too."""
+    assert len(pva_address_source_advisories(_config(pva_channels="*:image"))) == 1
+
+
+def test_an_empty_gateway_block_is_no_address_source() -> None:
+    """``connect()`` treats an empty ``pva_gateway`` exactly like an absent one."""
+    advisories = pva_address_source_advisories(_config(pva_channels=["*:image"], pva_gateway={}))
+
+    assert len(advisories) == 1
+
+
+def test_a_gateway_block_is_silent() -> None:
+    config = _config(pva_channels=["*:image"], pva_gateway={"address": "10.0.0.1 10.0.0.2"})
+
+    assert pva_address_source_advisories(config) == []
+
+
+def test_no_pva_channels_is_silent() -> None:
+    assert pva_address_source_advisories(_config()) == []
+    assert pva_address_source_advisories(_config(pva_channels=[])) == []
+    assert pva_address_source_advisories(_config(pva_channels=["  "])) == []
+
+
+def test_a_config_without_connector_blocks_is_silent() -> None:
+    assert pva_address_source_advisories({}) == []
+    assert pva_address_source_advisories({"control_system": {"connector": None}}) == []
+
+
+def test_every_connector_block_is_checked() -> None:
+    """The advisory names the block it found, whichever connector type owns it."""
+    config = {
+        "control_system": {
+            "connector": {
+                "epics": {"pva_channels": ["*:image"], "pva_gateway": {"address": "gw"}},
+                "virtual_accelerator": {"pva_channels": ["*:image"]},
+            }
+        }
+    }
+
+    advisories = pva_address_source_advisories(config)
+
+    assert len(advisories) == 1
+    assert "control_system.connector.virtual_accelerator.pva_gateway" in advisories[0]
+
+
+# ---------------------------------------------------------------------------
+# Build wiring — a real `osprey build` names the gap exactly once
+# ---------------------------------------------------------------------------
+
+_PROFILE = """\
+extends: hello-world
+name: PVA Advisory Fixture
+config:
+  control_system.connector.epics.pva_channels: ["*:image"]
+{gateway}"""
+
+_GATEWAY = """\
+  control_system.connector.epics.pva_gateway:
+    address: cam1.example.org cam2.example.org
+"""
+
+
+def _build(tmp_path: Path, profile: str) -> str:
+    """Run a real ``osprey build`` on *profile*; return its captured output.
+
+    ``--skip-deps --skip-lifecycle``: the virtualenv install and the profile's
+    shell phases render nothing this module reads and cost minutes.
+    """
+    repo = tmp_path / "pva-advisory-fixture"
+    repo.mkdir()
+    (repo / "profile.yml").write_text(profile, encoding="utf-8")
+
+    result = CliRunner().invoke(build, ["--repo", str(repo), "--skip-deps", "--skip-lifecycle"])
+
+    assert result.exit_code == 0, result.output
+    # Rich wraps to the console width; single-space the output before matching.
+    return re.sub(r"\s+", " ", result.output)
+
+
+def test_build_names_the_missing_gateway_once(tmp_path: Path) -> None:
+    """One line, not one per render pass. Advisory: the build still succeeds."""
+    output = _build(tmp_path, _PROFILE.format(gateway=""))
+
+    assert output.count("control_system.connector.epics.pva_gateway") == 1
+    assert "EPICS_PVA_" in output
+
+
+def test_build_with_a_gateway_is_silent(tmp_path: Path) -> None:
+    output = _build(tmp_path, _PROFILE.format(gateway=_GATEWAY))
+
+    assert "pva_gateway" not in output

--- a/tests/cli/test_source_zone_materialization.py
+++ b/tests/cli/test_source_zone_materialization.py
@@ -1334,6 +1334,7 @@ def test_resolves_identical_to_the_preset(runner: CliRunner, tmp_path: Path, pre
 
     from osprey.cli.build_profile_emit import emits_persona_profiles
     from osprey.cli.build_profile_merge import compute_preset_hash
+    from osprey.cli.build_profile_schema import DEFAULT_DEVIATION_MARKER
 
     target = tmp_path / "facility"
     assert _new(runner, target, preset).exit_code == 0
@@ -1348,6 +1349,7 @@ def test_resolves_identical_to_the_preset(runner: CliRunner, tmp_path: Path, pre
     assert d_new.pop("provenance") == {
         "preset": preset,
         "preset_hash": compute_preset_hash(preset),
+        "deviation_marker": DEFAULT_DEVIATION_MARKER,
     }
     for stamped in ("name", "requires_osprey_version", "data"):
         d_preset.pop(stamped)

--- a/tests/cli/test_variant_selection.py
+++ b/tests/cli/test_variant_selection.py
@@ -680,13 +680,16 @@ class TestValidateHonorsTheVariant:
         text = profile.read_text(encoding="utf-8")
         marker = '        display_name: "Control Room (Alice)"\n'
         assert text.count(marker) == 1
-        profile.write_text(
-            text.replace(
-                marker,
-                marker + "        access: any\n        oidc_subject: alice@example.org\n",
-            ),
-            encoding="utf-8",
+        text = text.replace(
+            marker, marker + "        access: any\n        oidc_subject: alice@example.org\n"
         )
+        # The roster now differs from the preset's; claimed as a facility fact so
+        # the preset-drift lint has nothing to refuse and the run stays about the
+        # variant.
+        roster = "    users:\n"
+        assert text.count(roster) == 1
+        text = text.replace(roster, "    # DEVIATION: the roster is this facility's\n" + roster)
+        profile.write_text(text, encoding="utf-8")
         _write_variant(
             lifecycle_repo,
             "sso",

--- a/tests/connectors/test_pva_routing.py
+++ b/tests/connectors/test_pva_routing.py
@@ -301,7 +301,13 @@ class TestPvaGatewayEnv:
         assert "EPICS_PVA_NAME_SERVERS" not in os.environ
 
     @pytest.mark.asyncio
-    async def test_port_defaults_to_5075(self, monkeypatch, clean_epics_env):
+    async def test_addr_list_branch_appends_no_port_unless_set(self, monkeypatch, clean_epics_env):
+        """EPICS_PVA_ADDR_LIST entries are UDP search targets (default 5076).
+
+        5075 is the PVA TCP port. Appending it here made p4p search on the
+        wrong port and every read time out, so an unset port appends nothing
+        and p4p's own default applies.
+        """
         _patch_writes_enabled(monkeypatch, False)
         _install_fake_p4p(monkeypatch)
 
@@ -313,7 +319,59 @@ class TestPvaGatewayEnv:
             }
         )
 
-        assert os.environ["EPICS_PVA_ADDR_LIST"] == "pvagw.example.com:5075"
+        assert os.environ["EPICS_PVA_ADDR_LIST"] == "pvagw.example.com"
+
+    @pytest.mark.asyncio
+    async def test_addr_list_accepts_a_space_separated_host_list(
+        self, monkeypatch, clean_epics_env
+    ):
+        """A many-server facility lists its hosts in ``address``; passed verbatim."""
+        _patch_writes_enabled(monkeypatch, False)
+        _install_fake_p4p(monkeypatch)
+
+        connector = EPICSConnector()
+        await connector.connect(
+            {
+                "pva_channels": ["*:image"],
+                "pva_gateway": {"address": "10.0.0.1 10.0.0.2 cam3.example.com"},
+            }
+        )
+
+        assert os.environ["EPICS_PVA_ADDR_LIST"] == "10.0.0.1 10.0.0.2 cam3.example.com"
+
+    @pytest.mark.asyncio
+    async def test_explicit_port_is_appended_to_every_listed_host(
+        self, monkeypatch, clean_epics_env
+    ):
+        """``port`` names the search port of each host, not a suffix on the string."""
+        _patch_writes_enabled(monkeypatch, False)
+        _install_fake_p4p(monkeypatch)
+
+        connector = EPICSConnector()
+        await connector.connect(
+            {
+                "pva_channels": ["*:image"],
+                "pva_gateway": {"address": "10.0.0.1 cam2.example.com", "port": 5086},
+            }
+        )
+
+        assert os.environ["EPICS_PVA_ADDR_LIST"] == "10.0.0.1:5086 cam2.example.com:5086"
+
+    @pytest.mark.asyncio
+    async def test_name_server_branch_still_defaults_to_5075(self, monkeypatch, clean_epics_env):
+        """Name servers are TCP endpoints, where 5075 is the right default."""
+        _patch_writes_enabled(monkeypatch, False)
+        _install_fake_p4p(monkeypatch)
+
+        connector = EPICSConnector()
+        await connector.connect(
+            {
+                "pva_channels": ["SR:CAM1:IMAGE"],
+                "pva_gateway": {"address": "pvagw.example.com", "use_name_server": True},
+            }
+        )
+
+        assert os.environ["EPICS_PVA_NAME_SERVERS"] == "pvagw.example.com:5075"
 
     @pytest.mark.asyncio
     async def test_name_server_branch_sets_and_clears_env(self, monkeypatch, clean_epics_env):

--- a/tests/connectors/test_yaml_loader.py
+++ b/tests/connectors/test_yaml_loader.py
@@ -1,0 +1,53 @@
+"""The shared YAML loader parses on libyaml when it is there and on PyYAML otherwise."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+import yaml
+
+from osprey_connectors import yaml_loader
+
+_DOCUMENT = """\
+# a comment
+name: demo
+count: 3
+ratio: 0.5
+flags: [yes, no, ~]
+nested:
+  when: 2026-09-02
+  text: "quoted: colon"
+  multi: |
+    line one
+    line two
+"""
+
+
+@pytest.mark.skipif(not yaml.__with_libyaml__, reason="libyaml bindings not installed")
+def test_picks_the_c_loader_when_libyaml_is_present() -> None:
+    assert yaml_loader.safe_loader() is yaml.CSafeLoader
+
+
+def test_falls_back_to_the_pure_python_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(yaml, "CSafeLoader", raising=False)
+    assert yaml_loader.safe_loader() is yaml.SafeLoader
+    assert yaml_loader.safe_load(_DOCUMENT) == yaml.safe_load(_DOCUMENT)
+
+
+def test_parses_like_safe_load_from_str_bytes_and_file() -> None:
+    expected = yaml.safe_load(_DOCUMENT)
+    assert yaml_loader.safe_load(_DOCUMENT) == expected
+    assert yaml_loader.safe_load(_DOCUMENT.encode("utf-8")) == expected
+    assert yaml_loader.safe_load(io.StringIO(_DOCUMENT)) == expected
+    assert yaml_loader.safe_load("") is None
+
+
+def test_rejects_python_object_tags_like_safe_load() -> None:
+    with pytest.raises(yaml.YAMLError):
+        yaml_loader.safe_load("!!python/object/apply:os.system ['true']")
+
+
+def test_invalid_yaml_raises_yaml_error() -> None:
+    with pytest.raises(yaml.YAMLError):
+        yaml_loader.safe_load("key: [unclosed")

--- a/tests/deployment/goldens/README.md
+++ b/tests/deployment/goldens/README.md
@@ -32,6 +32,8 @@ says.
 
 `exemplar-profile/` is a trimmed materialization of the bundled
 `control-assistant` preset — `data/` is empty on purpose (the fixture is
-validated and parsed, never built). The exact commands and edits that produced
+validated and parsed, never built). It carries no `provenance:` block: trimmed
+by hand, it is not the preset's materialization, so `osprey validate` has no
+preset to compare it with. The exact commands and edits that produced
 it are recorded outside the test tree, with the walkthrough this exemplar
 became.

--- a/tests/deployment/goldens/exemplar-profile/profile.yml
+++ b/tests/deployment/goldens/exemplar-profile/profile.yml
@@ -324,12 +324,6 @@ deploy:
 data: data
 # Minimum OSPREY release that understands this profile's keys. Builds below it abort.
 requires_osprey_version: '>=2026.8.0'
-# What this profile was materialized from. Emitted, not hand-written: a
-# build compares it against the installed preset and mentions it when the
-# preset has moved on. Advisory only — this profile is the source of truth.
-provenance:
-  preset: control-assistant
-  preset_hash: sha256:807a488a6d709eb2caec040fcbee659dbf7521bd3033e43c8fb50b35c8f3af27
 # true builds its own services stack; false attaches to another project's.
 deploy_services: true
 # Named web-terminal layouts, as label -> list of panel ids.

--- a/tests/deployment/test_collect_all_preflight.py
+++ b/tests/deployment/test_collect_all_preflight.py
@@ -688,6 +688,9 @@ def stubbed_start(monkeypatch):
         "log_endpoint_summary",
     ):
         monkeypatch.setattr(container_lifecycle, name, lambda *a, **k: None)
+    # The off-roster terminal sweep answers "nothing removed"; it lists the
+    # runtime's containers, which nothing here has.
+    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", lambda config: {})
     monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
     monkeypatch.setattr(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]

--- a/tests/deployment/test_compose_invocation.py
+++ b/tests/deployment/test_compose_invocation.py
@@ -744,6 +744,10 @@ def _podman_web_host(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
     runs = _podman_host(monkeypatch)
     monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["podman", "compose"])
     monkeypatch.setattr(container_lifecycle, "preflight_web_terminals", lambda *a, **k: None)
+    # The off-roster terminal sweep lists the runtime's containers with a bare
+    # `podman ps -a`, which is not a compose invocation and not what this
+    # module asserts; it has its own tests under web_terminals/.
+    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", lambda config: {})
     for name in (
         "ensure_env_production",
         "build_persona_images",

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -26,6 +26,21 @@ from osprey.deployment.errors import (
 from osprey.deployment.web_terminals import postup_hooks, provision
 
 
+@pytest.fixture(autouse=True)
+def _inert_orphan_reconcile(monkeypatch):
+    """Keep the off-roster container sweep out of every argv test by default.
+
+    ``_start_stack`` reconciles the roster before the host-port preflight, and
+    that sweep asks the runtime for a container listing -- through the real
+    runtime detection, which the runtime-less macOS unit cell answers with
+    ``RuntimeError``. The sweep is a collaborator with its own tests
+    (tests/deployment/web_terminals/test_lifecycle.py); the tests here are
+    about the compose argv around it, and the two that are about the sweep's
+    place in the sequence install their own recording stand-in on top.
+    """
+    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", lambda config: {})
+
+
 def _fake_popen(record):
     """A ``subprocess.Popen`` stand-in for the watched capture path.
 
@@ -304,10 +319,6 @@ def captured_web_runs(monkeypatch, tmp_path):
     monkeypatch.setattr(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
-    # The off-roster container sweep is a collaborator with its own tests
-    # (tests/deployment/web_terminals/test_lifecycle.py); inert here so the
-    # captured argv is exactly the compose sequence these tests are about.
-    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", lambda config: {})
 
     def _fake_write_artifacts(config, dest_dir="."):
         written.append(config)
@@ -749,12 +760,10 @@ def _mode_wiring_collab(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
     monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest_dir=".": [])
-    # Two roster-scoped steps ahead of the mode branch, each with its own tests:
-    # the off-roster container sweep would add its listing to `calls`, and the
-    # host-port preflight would probe this roster's real index ports on the
-    # machine running the suite. Inert here so the mode-wiring tests exercise
-    # only the local/registry step ordering.
-    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", lambda config: {})
+    # The host-port preflight ahead of the mode branch has its own tests and
+    # would probe this roster's real index ports on the machine running the
+    # suite. Inert here so the mode-wiring tests exercise only the
+    # local/registry step ordering.
     monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda *a, **k: None)
     # The persona-render check is a separate concern with its own dedicated
     # tests below; keep it inert here so the mode-wiring tests exercise only the

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -304,6 +304,10 @@ def captured_web_runs(monkeypatch, tmp_path):
     monkeypatch.setattr(
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
+    # The off-roster container sweep is a collaborator with its own tests
+    # (tests/deployment/web_terminals/test_lifecycle.py); inert here so the
+    # captured argv is exactly the compose sequence these tests are about.
+    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", lambda config: {})
 
     def _fake_write_artifacts(config, dest_dir="."):
         written.append(config)
@@ -745,6 +749,13 @@ def _mode_wiring_collab(monkeypatch, tmp_path):
         container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
     )
     monkeypatch.setattr(provision, "write_web_terminal_artifacts", lambda config, dest_dir=".": [])
+    # Two roster-scoped steps ahead of the mode branch, each with its own tests:
+    # the off-roster container sweep would add its listing to `calls`, and the
+    # host-port preflight would probe this roster's real index ports on the
+    # machine running the suite. Inert here so the mode-wiring tests exercise
+    # only the local/registry step ordering.
+    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", lambda config: {})
+    monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda *a, **k: None)
     # The persona-render check is a separate concern with its own dedicated
     # tests below; keep it inert here so the mode-wiring tests exercise only the
     # local/registry step ordering rather than any repo's rendered state.
@@ -3617,3 +3628,86 @@ def test_a_repo_with_no_chain_files_is_silent(tmp_path):
     repo = _chain_repo(tmp_path)
 
     assert container_lifecycle._warn_lowercase_proxy_names(repo, _oidc_web_config()) == []
+
+
+# ---------------------------------------------------------------------------
+# deploy_up ordering: off-roster terminal containers are removed BEFORE the
+# host-port preflight. The orphan holds every port of the index it used to
+# serve, so a preflight that ran first would refuse the redeploy that is about
+# to reconcile it away.
+# ---------------------------------------------------------------------------
+
+
+def _record_web_deploy(monkeypatch, tmp_path, order, web_terminals):
+    """Wire deploy_up for a web-terminal config, recording the two steps under test."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: (
+            {"deployed_services": [], "modules": {"web_terminals": web_terminals}},
+            ["docker-compose.yml"],
+        ),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "_preflight_host_ports", lambda *a, **k: order.append("ports")
+    )
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_collect_unmet_preconditions", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "preflight_web_terminals", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_build_project_image", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle, "deploy_up_web_terminals", lambda *a, **k: order.append("web_up")
+    )
+    monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
+
+
+def test_deploy_up_removes_orphan_terminals_before_the_host_port_preflight(
+    monkeypatch, tmp_path, capsys
+):
+    order: list[str] = []
+    _record_web_deploy(monkeypatch, tmp_path, order, {"enabled": True, "image_source": "local"})
+
+    def _fake_remove(config):
+        order.append("orphans")
+        return {"ariel": "als-web-ariel"}
+
+    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", _fake_remove)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert order == ["orphans", "ports", "web_up"]
+    out = capsys.readouterr().out
+    assert "als-web-ariel" in out
+    assert "ariel" in out
+
+
+def test_deploy_up_without_web_terminals_reconciles_no_orphans(monkeypatch, tmp_path):
+    order: list[str] = []
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "prepare_compose_files",
+        lambda *a, **k: ({"deployed_services": ["event_dispatcher"]}, ["docker-compose.yml"]),
+    )
+    monkeypatch.setattr(container_lifecycle, "verify_runtime_is_running", lambda config: (True, ""))
+    monkeypatch.setattr(
+        container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+    )
+    monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_ensure_service_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(container_lifecycle, "_build_project_image", lambda *a, **k: None)
+    monkeypatch.setattr(
+        container_lifecycle,
+        "remove_orphan_terminals",
+        lambda config: order.append("orphans"),
+    )
+    monkeypatch.setattr(
+        container_lifecycle.subprocess, "run", lambda *a, **k: _FakeCompletedProcess()
+    )
+    monkeypatch.setattr(container_lifecycle, "log_endpoint_summary", lambda *a, **k: None)
+
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+    assert order == []

--- a/tests/deployment/test_host_ports.py
+++ b/tests/deployment/test_host_ports.py
@@ -20,10 +20,12 @@ from osprey.deployment.host_ports import (
     HostPortBinding,
     PortConflict,
     derive_host_network_bindings,
+    derive_web_terminal_bindings,
     find_port_conflicts,
     format_conflict_report,
     parse_host_port_bindings,
 )
+from osprey.deployment.web_terminals.ports import FAMILY_BASE_FIELDS
 from osprey.port_layout import (
     CA_DEFAULT_PORT,
     DEFAULT_PORT_BASE,
@@ -1484,3 +1486,164 @@ class TestTwoDeploymentsOnOneHost:
         # Every in-block one names the single knob that moves them together.
         in_block = [c for c in conflicts if not c.channel_access]
         assert {c.remedy for c in in_block} == {PORT_BASE_CONFIG_KEY}
+
+
+def _web_config(users, *, base=None, prefix="dls", **web_terminals):
+    """A rendered-config stand-in for a web-terminal roster."""
+    config = {
+        "facility": {"prefix": prefix},
+        "modules": {"web_terminals": {"enabled": True, "users": users, **web_terminals}},
+    }
+    if base is not None:
+        config["deployment"] = {"port_base": base}
+    return config
+
+
+class TestWebTerminalDerivation:
+    """Per-user index ports of the web-terminal stack, which publishes nothing.
+
+    Every terminal runs on the host network, so the ports of a roster index
+    appear in no compose file; a foreign holder of one used to surface only as
+    the companion panel's own "port is already in use" inside the container.
+    """
+
+    families = tuple(FAMILY_BASE_FIELDS.values())
+
+    def test_no_web_terminals_derives_nothing(self):
+        assert derive_web_terminal_bindings(None) == []
+        assert derive_web_terminal_bindings({}) == []
+        assert derive_web_terminal_bindings({"modules": {"web_terminals": None}}) == []
+        disabled = _web_config(["alice"])
+        disabled["modules"]["web_terminals"]["enabled"] = False
+        assert derive_web_terminal_bindings(disabled) == []
+
+    def test_one_binding_per_family_per_roster_index(self):
+        config = _web_config([{"name": "alice", "index": 0}, {"name": "logbook", "index": 6}])
+
+        bindings = derive_web_terminal_bindings(config)
+
+        expected = {
+            (f"web-{user}", default_port(family, index, base=DEFAULT_PORT_BASE))
+            for user, index in (("alice", 0), ("logbook", 6))
+            for family in self.families
+        }
+        assert {(b.service, b.host_port) for b in bindings} == expected
+        assert all(b.host_network for b in bindings)
+        assert all(b.host_ip == "127.0.0.1" for b in bindings)
+        assert all(b.container_port == b.host_port for b in bindings)
+        assert all(b.compose_file == host_ports._DERIVED_SOURCE for b in bindings)
+
+    def test_bare_string_roster_entries_take_their_position(self):
+        bindings = derive_web_terminal_bindings(_web_config(["alice", "bob"]))
+        web = {
+            b.service: b.host_port
+            for b in bindings
+            if b.host_port in {default_port("web", i, base=DEFAULT_PORT_BASE) for i in (0, 1)}
+        }
+        assert web == {
+            "web-alice": default_port("web", 0, base=DEFAULT_PORT_BASE),
+            "web-bob": default_port("web", 1, base=DEFAULT_PORT_BASE),
+        }
+
+    def test_the_bands_follow_this_deployments_base(self):
+        bindings = derive_web_terminal_bindings(
+            _web_config([{"name": "alice", "index": 3}], base=SECOND_BASE)
+        )
+        assert {b.host_port for b in bindings} == {
+            default_port(family, 3, base=SECOND_BASE) for family in self.families
+        }
+
+    def test_a_family_moved_by_its_base_port_key_is_checked_where_it_binds(self):
+        config = _web_config([{"name": "alice", "index": 2}], web_base_port=30000)
+        ports = {b.host_port for b in derive_web_terminal_bindings(config)}
+        assert 30002 in ports
+        assert default_port("web", 2, base=DEFAULT_PORT_BASE) not in ports
+
+    def test_the_remedy_names_the_users_index_and_the_family_key(self):
+        config = _web_config([{"name": "logbook", "index": 6}])
+        web_port = default_port("web", 6, base=DEFAULT_PORT_BASE)
+        (binding,) = [b for b in derive_web_terminal_bindings(config) if b.host_port == web_port]
+        assert binding.remedy is not None
+        assert "logbook" in binding.remedy
+        assert "modules.web_terminals.web_base_port" in binding.remedy
+
+
+class TestWebTerminalConflicts:
+    """The derived index ports join the same two checks every other port gets."""
+
+    @staticmethod
+    def _only_busy(monkeypatch, busy):
+        monkeypatch.setattr(
+            host_ports, "_port_is_free", lambda host_ip, host_port: host_port != busy
+        )
+
+    def test_a_clear_roster_has_no_conflicts(self, monkeypatch):
+        monkeypatch.setattr(host_ports, "_port_is_free", lambda host_ip, host_port: True)
+        config = _web_config([{"name": "alice", "index": 0}])
+        assert find_port_conflicts([], project_name="proj", config=config) == []
+
+    def test_own_running_terminal_is_an_idempotent_redeploy(self, monkeypatch):
+        # Host network: `ps` maps no port, so the terminal is recognised by name.
+        busy = default_port("web", 0, base=DEFAULT_PORT_BASE)
+        self._only_busy(monkeypatch, busy)
+        ps_json = json.dumps(_ps_row("dls-web-alice", "proj"))
+        monkeypatch.setattr(host_ports, "_run_runtime_ps", lambda config=None: ps_json)
+        config = _web_config([{"name": "alice", "index": 0}])
+
+        assert find_port_conflicts([], project_name="proj", config=config) == []
+
+    def test_a_foreign_holder_of_an_index_port_fails_fast(self, monkeypatch):
+        """The reported shape after a rename: the roster says ``logbook`` on
+        index 6, but something else already answers on that index's web port."""
+        busy = default_port("web", 6, base=DEFAULT_PORT_BASE)
+        self._only_busy(monkeypatch, busy)
+        monkeypatch.setattr(host_ports, "_run_runtime_ps", lambda config=None: "")
+        config = _web_config([{"name": "logbook", "index": 6}])
+
+        conflicts = find_port_conflicts([], project_name="proj", config=config)
+
+        assert len(conflicts) == 1
+        (conflict,) = conflicts
+        assert conflict.host_port == busy
+        assert conflict.service == "web-logbook"
+        assert conflict.kind == "external"
+        assert conflict.host_network
+        assert conflict.holder == "an unknown host process"
+        assert "logbook" in conflict.remedy
+        report = format_conflict_report(conflicts)
+        assert f"port {busy}" in report
+        assert "web-logbook" in report
+
+    def test_a_foreign_container_holding_an_index_port_is_named(self, monkeypatch):
+        busy = default_port("artifact", 1, base=DEFAULT_PORT_BASE)
+        self._only_busy(monkeypatch, busy)
+        ps_json = json.dumps(_ps_row("other-thing", "other", port=busy))
+        monkeypatch.setattr(host_ports, "_run_runtime_ps", lambda config=None: ps_json)
+        config = _web_config([{"name": "bob", "index": 1}])
+
+        (conflict,) = find_port_conflicts([], project_name="proj", config=config)
+        assert conflict.holder == "container 'other-thing' (compose project 'other')"
+
+    def test_another_terminal_of_this_project_does_not_vouch_for_the_port(self, monkeypatch):
+        """An off-roster terminal of this very project still running is not the
+        roster's container: it cannot be told apart from a foreign process by
+        port, so the port is reported rather than waved through."""
+        busy = default_port("web", 6, base=DEFAULT_PORT_BASE)
+        self._only_busy(monkeypatch, busy)
+        ps_json = json.dumps(_ps_row("dls-web-ariel", "proj"))
+        monkeypatch.setattr(host_ports, "_run_runtime_ps", lambda config=None: ps_json)
+        config = _web_config([{"name": "logbook", "index": 6}])
+
+        conflicts = find_port_conflicts([], project_name="proj", config=config)
+        assert [c.service for c in conflicts] == ["web-logbook"]
+
+    def test_a_service_on_a_terminals_port_is_a_duplicate(self, monkeypatch):
+        monkeypatch.setattr(host_ports, "_port_is_free", lambda host_ip, host_port: True)
+        web_port = default_port("web", 0, base=DEFAULT_PORT_BASE)
+        config = _web_config([{"name": "alice", "index": 0}])
+        published = HostPortBinding("facility-api", "127.0.0.1", web_port, 80, "x.yml")
+
+        (conflict,) = find_port_conflicts([published], project_name="proj", config=config)
+        assert conflict.kind == "duplicate"
+        assert conflict.service == "web-alice"
+        assert conflict.holder == "service 'facility-api'"

--- a/tests/deployment/test_up_as_built.py
+++ b/tests/deployment/test_up_as_built.py
@@ -155,6 +155,9 @@ def started(monkeypatch):
     # must not depend on which ports happen to be free here. Exposure is read
     # from the rendered bindings by a different function, which stays live.
     monkeypatch.setattr(container_lifecycle, "_preflight_host_ports", lambda config, files: None)
+    # The off-roster terminal sweep lists this project's containers on the real
+    # runtime; nothing here has one. Its own tests live under web_terminals/.
+    monkeypatch.setattr(container_lifecycle, "remove_orphan_terminals", lambda config: {})
 
     def _fake_run(cmd, env=None, check=False, **kwargs):
         record.setdefault("cmds", []).append(list(cmd))

--- a/tests/deployment/web_terminals/test_env_users_rename.py
+++ b/tests/deployment/web_terminals/test_env_users_rename.py
@@ -279,6 +279,7 @@ def stubbed_start_stack(monkeypatch):
     """
     for name in (
         "_check_shared_disk_preflight",
+        "_reconcile_orphan_terminals",
         "_preflight_host_ports",
         "_ensure_service_tokens",
         "_preflight_archiver_pymongo",

--- a/tests/deployment/web_terminals/test_lifecycle.py
+++ b/tests/deployment/web_terminals/test_lifecycle.py
@@ -2485,3 +2485,115 @@ def test_decommission_of_the_conflicted_personas_own_user_still_succeeds(
 
     assert [entry["name"] for entry in _reload_users(config_path)] == ["bob"]
     assert [c for c in fake_runtime if c[1] == "rm"] == [["docker", "rm", "-f", "dls-web-alice"]]
+
+
+# =============================================================================
+# osprey up: off-roster terminal containers are reconciled away
+# =============================================================================
+
+
+def test_up_reconcile_removes_only_off_roster_terminal_containers(
+    tmp_path, monkeypatch, fake_runtime_prune
+):
+    """The web-slice equivalent of ``--remove-orphans``: a container named for a
+    user no longer on the roster is removed; on-roster terminals, nginx and every
+    volume are left alone."""
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    config = _config(["alice"])
+    listing["containers"] = ["dls-web-alice", "dls-web-eve", "dls-nginx", "dls-auth"]
+
+    removed = lifecycle.remove_orphan_terminals(config)
+
+    assert removed == {"eve": "dls-web-eve"}
+    assert [c for c in calls if c[1] == "rm"] == [["docker", "rm", "-f", "dls-web-eve"]]
+    assert [c for c in calls if c[1] == "volume"] == []
+
+
+def test_up_reconcile_with_no_orphans_removes_nothing(tmp_path, monkeypatch, fake_runtime_prune):
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    config = _config(["alice", "bob"])
+    listing["containers"] = ["dls-web-alice", "dls-web-bob", "dls-nginx"]
+
+    assert lifecycle.remove_orphan_terminals(config) == {}
+    assert [c for c in calls if c[1] == "rm"] == []
+
+
+def test_up_reconcile_treats_a_renamed_user_as_an_orphan(tmp_path, monkeypatch, fake_runtime_prune):
+    """The reported shape: ``ariel`` renamed to ``logbook`` on the same index. The
+    old container still holds every port of that index, so it has to go."""
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    config = _config([{"name": "logbook", "index": 6}])
+    listing["containers"] = ["dls-web-ariel"]
+
+    assert lifecycle.remove_orphan_terminals(config) == {"ariel": "dls-web-ariel"}
+    assert [c for c in calls if c[1] == "rm"] == [["docker", "rm", "-f", "dls-web-ariel"]]
+
+
+def test_up_reconcile_discovery_is_scoped_by_compose_project_label(
+    tmp_path, monkeypatch, fake_runtime_prune
+):
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    config = _config(["alice"], project_name="demo-project")
+    listing["containers"] = []
+
+    lifecycle.remove_orphan_terminals(config)
+
+    assert [c for c in calls if c[1:3] == ["ps", "-a"]] == [
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            "label=com.docker.compose.project=demo-project",
+            "--format",
+            "{{.Names}}",
+        ]
+    ]
+
+
+def test_up_reconcile_reports_a_failed_removal_instead_of_raising(
+    tmp_path, monkeypatch, fake_runtime_prune, caplog
+):
+    """A removal the runtime refuses is not this step's to diagnose: the
+    container keeps its ports, and the host-port preflight that follows names
+    the port. So: warn, leave it out of the removed set, never raise."""
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    config = _config(["alice"])
+    listing["containers"] = ["dls-web-eve"]
+
+    def _refusing_run(argv, capture_output=True, text=True, env=None, check=False, **kwargs):
+        calls.append(list(argv))
+        if argv[1] == "rm":
+            return subprocess.CompletedProcess(argv, returncode=1, stdout="", stderr="busy")
+        if argv[1:3] == ["ps", "-a"]:
+            return subprocess.CompletedProcess(
+                argv, returncode=0, stdout="\n".join(listing["containers"]), stderr=""
+            )
+        return subprocess.CompletedProcess(argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(lifecycle.subprocess, "run", _refusing_run)
+
+    assert lifecycle.remove_orphan_terminals(config) == {}
+    assert "dls-web-eve" in caplog.text
+    assert "busy" in caplog.text
+
+
+def test_up_reconcile_argv_safety_removal_is_exact_named(tmp_path, monkeypatch, fake_runtime_prune):
+    calls, listing = fake_runtime_prune
+    monkeypatch.chdir(tmp_path)
+    config = _config(["alice"])
+    listing["containers"] = ["dls-web-eve", "dls-web-mallory"]
+
+    lifecycle.remove_orphan_terminals(config)
+
+    removal_calls = [c for c in calls if c[1] == "rm"]
+    assert len(removal_calls) == 2
+    for argv in removal_calls:
+        assert not (_FORBIDDEN_ARGV_TOKENS & set(argv)), argv
+        assert not any(_GLOB_METACHARACTERS & set(token) for token in argv), argv
+        assert argv[:3] == ["docker", "rm", "-f"] and len(argv) == 4

--- a/tests/e2e/test_deploy_lifecycle.py
+++ b/tests/e2e/test_deploy_lifecycle.py
@@ -84,6 +84,7 @@ from osprey.deployment.compose_generator import (
 from osprey.deployment.qmd_service import QMDServiceConfig
 from osprey.deployment.staleness import BUILD_DIRNAME
 from osprey.deployment.web_terminals.personas import normalize_users
+from osprey.deployment.web_terminals.ports import FAMILY_BASE_FIELDS
 from osprey.services.qmd.client import QMDClient
 from osprey.utils import config_writer
 
@@ -712,8 +713,33 @@ PREFIX_B = "e2eb"
 USERS_A = ("keeper", "keeper2", "second", "orphan")
 USERS_B = ("main", "orphan")
 
-PORTS_A = {"nginx": 19180, "web": 19500, "artifact": 19600, "ariel": 19700, "lattice": 19800}
-PORTS_B = {"nginx": 19181, "web": 19900, "artifact": 20000, "ariel": 20100, "lattice": 20200}
+# Every port family gets its own band in each project. The fixture config pins
+# its three panel families at 19500/19600/19700, which is exactly where A's
+# web/artifact/ariel bands sit, and a family left at the fixture value would
+# make one user's terminal claim the same host port twice -- the intra-deploy
+# duplicate `osprey up`'s host-port preflight refuses. The panel families sit at
+# the half-hundreds so the whole table stays inside the 19180-20201 range the
+# sibling e2e modules document as this test's.
+PORTS_A = {
+    "nginx": 19180,
+    "web": 19500,
+    "artifact": 19600,
+    "ariel": 19700,
+    "lattice": 19800,
+    "channel_finder": 19550,
+    "okf": 19650,
+    "system_health": 19750,
+}
+PORTS_B = {
+    "nginx": 19181,
+    "web": 19900,
+    "artifact": 20000,
+    "ariel": 20100,
+    "lattice": 20200,
+    "channel_finder": 19950,
+    "okf": 20050,
+    "system_health": 20150,
+}
 
 # Persona catalog "project" values chosen so that A's own roster reference
 # ("mainp") produces a tag distinct from B, while the "borrowed" persona
@@ -754,6 +780,9 @@ def _make_isolation_repo(
             "modules.web_terminals.artifact_base_port": ports["artifact"],
             "modules.web_terminals.ariel_base_port": ports["ariel"],
             "modules.web_terminals.lattice_base_port": ports["lattice"],
+            "modules.web_terminals.channel_finder_base_port": ports["channel_finder"],
+            "modules.web_terminals.okf_base_port": ports["okf"],
+            "modules.web_terminals.system_health_base_port": ports["system_health"],
         },
     )
     config_writer.config_replace_list(
@@ -1008,7 +1037,16 @@ HETERO_USERS = ("alice", "bob", "carol")
 
 # Disjoint from every other range in this file, including the two-project
 # isolation test's 19180-20201.
-HETERO_PORTS = {"nginx": 20280, "web": 20300, "artifact": 20400, "ariel": 20500, "lattice": 20600}
+HETERO_PORTS = {
+    "nginx": 20280,
+    "web": 20300,
+    "artifact": 20400,
+    "ariel": 20500,
+    "lattice": 20600,
+    "channel_finder": 20350,
+    "okf": 20450,
+    "system_health": 20550,
+}
 
 HETERO_DEFAULT_PERSONA = "assistant"
 HETERO_ALT_PERSONA = "alt"
@@ -1136,6 +1174,9 @@ def _hetero_config_dict(default_persona_path: Path, alt_persona_path: Path) -> d
                 "artifact_base_port": HETERO_PORTS["artifact"],
                 "ariel_base_port": HETERO_PORTS["ariel"],
                 "lattice_base_port": HETERO_PORTS["lattice"],
+                "channel_finder_base_port": HETERO_PORTS["channel_finder"],
+                "okf_base_port": HETERO_PORTS["okf"],
+                "system_health_base_port": HETERO_PORTS["system_health"],
                 "users": [
                     "alice",
                     "bob",
@@ -1217,6 +1258,31 @@ def _mount_destination(name: str, volume_name: str) -> str | None:
         if mount.get("Name") == volume_name:
             return mount.get("Destination")
     return None
+
+
+def test_deploy_lifecycle_port_tables_bind_every_family_once() -> None:
+    """Each throwaway project's port table gives every family its own band.
+
+    ``_make_isolation_repo`` and the heterogeneous configs overwrite the fixture
+    config's port keys from these tables, so a family the table leaves out keeps
+    the fixture's value -- and the fixture pins its panel families exactly where
+    A's older bands sit. One user's terminal would then claim the same host port
+    for two families, which ``osprey up``'s host-port preflight refuses as an
+    intra-deploy duplicate before it touches a container. Checked over the
+    roster each table is deployed with, the way the web-terminal lint checks a
+    real config.
+    """
+    families = {"nginx", *FAMILY_BASE_FIELDS.values()}
+    for label, table, users in (
+        ("PORTS_A", PORTS_A, USERS_A),
+        ("PORTS_B", PORTS_B, USERS_B),
+        ("HETERO_PORTS", HETERO_PORTS, HETERO_USERS),
+    ):
+        assert set(table) == families, f"{label} must name every port family"
+        bound = [table["nginx"]]
+        for family in FAMILY_BASE_FIELDS.values():
+            bound.extend(table[family] + index for index in range(len(users)))
+        assert len(set(bound)) == len(bound), f"{label} binds a host port twice: {sorted(bound)}"
 
 
 def test_deploy_lifecycle_heterogeneous_local_mode_up(tmp_path: Path, stub_image: str) -> None:

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -594,7 +594,9 @@ data: data
 requires_osprey_version: '>=2026.9.0'
 # What this profile was materialized from. Emitted, not hand-written: a
 # build compares it against the installed preset and mentions it when the
-# preset has moved on. Advisory only — this profile is the source of truth.
+# preset has moved on; `osprey validate` refuses every difference from the
+# preset that no `# DEVIATION: <why>` comment above the line claims (tag set
+# by `deviation_marker:`). This profile is the source of truth either way.
 provenance:
   preset: control-assistant
   preset_hash: @PRESET_HASH:control-assistant@

--- a/tests/interfaces/web_terminal/js/bar-customize-fixture.mjs
+++ b/tests/interfaces/web_terminal/js/bar-customize-fixture.mjs
@@ -104,8 +104,12 @@ export function putBodies() {
  * projected children and no card at all, which is the DOM every real page has
  * until `osprey-display-menu.js` is evaluated. Use it to test what happens when
  * that module has not run yet.
+ *
+ * `context` is what the server stamped on `<html>` as `data-bar-context`;
+ * omitting it stamps nothing, which is a page this build did not render and
+ * where every gated item reads as unavailable.
  * @param {{fetch?: any, uiMode?: string, statusHidden?: boolean,
- *          menu?: boolean | 'cold'}} [options]
+ *          menu?: boolean | 'cold', context?: Record<string, unknown>}} [options]
  * @returns {Promise<{customize: any, sync: any}>}
  */
 export async function boot({
@@ -113,9 +117,11 @@ export async function boot({
   uiMode = 'expert',
   statusHidden = false,
   menu = false,
+  context,
 } = {}) {
   vi.resetModules();
   document.documentElement.setAttribute('data-ui-mode', uiMode);
+  if (context) document.documentElement.setAttribute('data-bar-context', JSON.stringify(context));
   if (statusHidden) document.documentElement.setAttribute('data-status-bar', 'hidden');
   const COLD_MENU = `<osprey-display-menu id="display-menu">
          <button class="display-menu-settings" id="display-menu-settings" type="button"
@@ -156,6 +162,7 @@ export function teardown({ customize, sync } = {}) {
   document.documentElement.removeAttribute('data-ui-mode');
   document.documentElement.removeAttribute('data-header-bar');
   document.documentElement.removeAttribute('data-status-bar');
+  document.documentElement.removeAttribute('data-bar-context');
   globalThis.fetch = realFetch;
   fetchSpy = null;
   vi.restoreAllMocks();

--- a/tests/interfaces/web_terminal/js/bar-default-renderable.test.js
+++ b/tests/interfaces/web_terminal/js/bar-default-renderable.test.js
@@ -1,0 +1,155 @@
+/**
+ * Customize Bars on a deployment that cannot render everything the shipped
+ * default names, happy-dom environment:
+ *   npx vitest run tests/interfaces/web_terminal/js/bar-default-renderable.test.js
+ *
+ * The regression this pins (#863): `DEFAULT_BAR_LAYOUT` places `system-health`,
+ * which renders only where the SYSTEM panel is enabled. Served unfiltered at
+ * rev 0 to a deployment without that panel, the normalizer dropped it as
+ * `unavailable`, read the drop as lost content, and latched the whole sheet
+ * read-only — every tile disabled, "Layout not editable", and Default could not
+ * recover because it adopted the same document again. The server now filters
+ * the default; the client must ALSO not latch on a rev-0 `unavailable` drop, so
+ * a stale client or a flipped stamp still gets an editable sheet.
+ *
+ * The document here is the shipped default spelled out, not a hand-built one
+ * that happens to avoid the item: the point is the arrangement a fresh
+ * deployment actually serves.
+ */
+
+import { test, expect, describe, afterEach } from 'vitest';
+import {
+  boot,
+  doc,
+  endpoint,
+  noticeText,
+  pointer,
+  putBodies,
+  rendered,
+  settle,
+  shell,
+  teardown,
+  tile,
+  withRect,
+} from './bar-customize-fixture.mjs';
+
+/** @type {any} */
+let customize;
+/** @type {any} */
+let sync;
+
+/** The shipped default, as `DEFAULT_BAR_LAYOUT` in `app.py` spells it. */
+const SHIPPED_DEFAULT = doc(
+  ['logo', 'identity', 'space', 'control-target', 'search', 'display'],
+  ['space', 'system-health', 'clock']
+);
+
+/** A multi-user deployment whose `web_panels` does not select `system-health`. */
+const NO_SYSTEM_PANEL = {
+  identityAvailable: true,
+  blueskyAvailable: false,
+  systemHealthAvailable: false,
+};
+
+const HEADER_BOX = { left: 0, right: 300, top: 0, bottom: 40 };
+const STATUS_BOX = { left: 0, right: 300, top: 100, bottom: 126 };
+const IN_HEADER = { x: 150, y: 20 };
+const IN_STATUS = { x: 150, y: 112 };
+
+/** Every catalog type the sheet offers a tile for. @returns {string[]} */
+function tileTypes() {
+  return Array.from(document.querySelectorAll('.bar-tile[data-bar-tile]')).map(
+    (/** @type {any} */ node) => node.dataset.barTile
+  );
+}
+
+async function editing() {
+  ({ customize, sync } = await boot({
+    fetch: endpoint({ get: SHIPPED_DEFAULT }),
+    context: NO_SYSTEM_PANEL,
+  }));
+  withRect(document.querySelector('[data-bar-host="header"]'), HEADER_BOX);
+  withRect(document.querySelector('[data-bar-host="status"]'), STATUS_BOX);
+  customize.enterEditMode();
+}
+
+afterEach(() => {
+  teardown({ customize, sync });
+  customize = null;
+  sync = null;
+});
+
+describe('the shipped default on a deployment without the SYSTEM panel', () => {
+  test('renders the degraded default and is not read-only', async () => {
+    await editing();
+
+    expect(rendered('status')).toEqual(['space', 'clock']);
+    expect(sync.isLayoutReadonly()).toBe(false);
+    expect(noticeText()).not.toContain('Layout not editable');
+  });
+
+  test('no tile is refused by the latch, and every unplaced offerable one is enabled', async () => {
+    await editing();
+
+    // The two gated items this deployment lacks are refused on their own
+    // merits ("Not in this deployment"), and a placed single-node item dims
+    // itself; neither is the latch's sentence.
+    expect(tileTypes().length).toBeGreaterThan(5);
+    for (const type of tileTypes()) {
+      expect(tile(type).querySelector('.bar-tile-reason')?.textContent ?? '').not.toBe(
+        'Layout not editable'
+      );
+    }
+    for (const type of ['clock', 'stopwatch', 'space', 'separator', 'docs', 'feedback']) {
+      expect(tile(type).disabled, `${type} tile`).toBe(false);
+    }
+  });
+
+  test('the one tile that is refused says why, and it is not the latch', async () => {
+    await editing();
+
+    const unavailable = tile('system-health');
+    expect(unavailable.disabled).toBe(true);
+    expect(unavailable.querySelector('.bar-tile-reason')?.textContent).toBe(
+      'Not in this deployment'
+    );
+    expect(customize.refusalFor('system-health', 'status')).not.toBe('Layout not editable');
+  });
+
+  test('a drag saves', async () => {
+    await editing();
+
+    pointer('pointerdown', shell('search'), IN_HEADER);
+    pointer('pointermove', shell('search'), IN_STATUS);
+    pointer('pointerup', shell('search'), IN_STATUS);
+    await settle();
+
+    const bodies = putBodies();
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].rev).toBe(0);
+    expect(bodies[0].status.map((/** @type {any} */ i) => i.type)).toEqual([
+      'space',
+      'clock',
+      'search',
+    ]);
+    expect(bodies[0].status.map((/** @type {any} */ i) => i.type)).not.toContain(
+      'system-health'
+    );
+    expect(rendered('status')).toEqual(['space', 'clock', 'search']);
+  });
+
+  test('a tile click saves', async () => {
+    await editing();
+
+    await expect(customize.addItem('stopwatch', 'status')).resolves.toBe(true);
+    expect(putBodies()).toHaveLength(1);
+  });
+
+  test('the status bar can be hidden', async () => {
+    await editing();
+
+    await expect(customize.setBarVisible('status', false)).resolves.toBe(true);
+    expect(putBodies()).toHaveLength(1);
+    expect(putBodies()[0].status_visible).toBe(false);
+  });
+});

--- a/tests/interfaces/web_terminal/js/bar-layout.test.js
+++ b/tests/interfaces/web_terminal/js/bar-layout.test.js
@@ -184,8 +184,12 @@ describe('dropping', () => {
     expect(result.readonly).toBe(false);
   });
 
-  test('an item this deployment cannot render is dropped', () => {
-    const layout = doc({ header: [item('identity'), item('system-health'), item('docs')] });
+  test('an item this deployment cannot render is dropped from a stored document', () => {
+    // rev 3: an operator saved this, so the drop is THEIR content going missing.
+    const layout = doc({
+      rev: 3,
+      header: [item('identity'), item('system-health'), item('docs')],
+    });
 
     const bare = normalize(layout, BAR_CATALOG, {});
     expect(types(bare.layout.header)).toEqual(['docs']);
@@ -198,6 +202,46 @@ describe('dropping', () => {
     });
     expect(types(equipped.layout.header)).toEqual(['identity', 'system-health', 'docs']);
     expect(equipped.readonly).toBe(false);
+  });
+
+  test('the same drop from a rev-0 document is not a loss', () => {
+    // rev 0 is the deployment default: nobody authored it and the server
+    // already declined to paint the item, so dropping it here takes nothing
+    // away from anyone. The drop is still reported, and the document is still
+    // `changed`; it just does not latch (#863).
+    const layout = doc({ header: [item('identity'), item('system-health'), item('docs')] });
+
+    const result = normalize(layout, BAR_CATALOG, {});
+    expect(types(result.layout.header)).toEqual(['docs']);
+    expect(result.dropped.map((drop) => drop.reason)).toEqual(['unavailable', 'unavailable']);
+    expect(result.changed).toBe(true);
+    expect(result.readonly).toBe(false);
+  });
+
+  test('a rev-0 document still latches on an unknown type', () => {
+    const result = normalize(
+      doc({ header: [item('identity'), item('quantum-flux'), item('docs')] }),
+      BAR_CATALOG,
+      {}
+    );
+    expect(result.dropped.map((drop) => drop.reason)).toEqual(['unavailable', 'unknown-type']);
+    expect(result.readonly).toBe(true);
+  });
+
+  test('a rev-0 document still latches on an unreadable version', () => {
+    const result = normalize(doc({ version: 99, header: [item('logo')] }), BAR_CATALOG, {});
+    expect(result.readonly).toBe(true);
+  });
+
+  test('a rev that is not a number reads as unsaved, and its unavailable drops do not latch', () => {
+    const result = normalize(
+      doc({ rev: 'seven', header: [item('identity'), item('docs')] }),
+      BAR_CATALOG,
+      {}
+    );
+    expect(result.layout.rev).toBe(0);
+    expect(result.dropped.map((drop) => drop.reason)).toEqual(['unavailable']);
+    expect(result.readonly).toBe(false);
   });
 
   test('a second copy of a single-node type is dropped, and that is NOT a loss', () => {

--- a/tests/interfaces/web_terminal/js/bar-sync.test.js
+++ b/tests/interfaces/web_terminal/js/bar-sync.test.js
@@ -527,9 +527,10 @@ describe('the deployment context is served, not inferred', () => {
     expect(sync.isLayoutReadonly()).toBe(false);
   });
 
-  test('an item the deployment does not offer is dropped and latches read-only', async () => {
+  test('an item the deployment does not offer is dropped from a stored document and latches read-only', async () => {
+    // rev 4: an operator saved this document, so the drop is their content.
     await boot({
-      fetch: endpoint({ get: doc([], ['bluesky-queue', 'clock']) }),
+      fetch: endpoint({ get: doc([], ['bluesky-queue', 'clock'], { rev: 4 }) }),
       context: { identityAvailable: false, blueskyAvailable: false, systemHealthAvailable: false },
     });
     await settle();
@@ -559,9 +560,10 @@ describe('the deployment context is served, not inferred', () => {
 
   test('system health follows the stamp, not a guess from the page', async () => {
     // Nothing on the page says whether the SYSTEM panel is enabled; only the
-    // stamp does, and without it the item is refused.
+    // stamp does, and without it the item is refused. rev 2: a stored
+    // document, so the refusal is a loss and latches.
     await boot({
-      fetch: endpoint({ get: doc([], ['system-health', 'clock']) }),
+      fetch: endpoint({ get: doc([], ['system-health', 'clock'], { rev: 2 }) }),
       context: { identityAvailable: false, blueskyAvailable: false, systemHealthAvailable: false },
     });
     await settle();
@@ -590,7 +592,7 @@ describe('the deployment context is served, not inferred', () => {
     // would let the client re-add an item the deployment cannot render; the
     // read-only latch says instead that we could not read the document fully.
     await boot({
-      fetch: endpoint({ get: doc(['logo', 'identity'], []) }),
+      fetch: endpoint({ get: doc(['logo', 'identity'], [], { rev: 5 }) }),
       headerShells: LOGO_SHELL,
       context: null,
     });
@@ -598,6 +600,84 @@ describe('the deployment context is served, not inferred', () => {
 
     expect(typesIn('header')).toEqual(['logo']);
     expect(sync.isLayoutReadonly()).toBe(true);
+  });
+});
+
+describe('the deployment default is never latched for what it cannot show (#863)', () => {
+  // The shipped default places `system-health`, which only a deployment with
+  // the SYSTEM panel renders. The server now serves the default already
+  // filtered; this is the belt to that brace — a stale client against a newer
+  // server, or a stamp that flips between loads, must still get an editable
+  // sheet. A rev-0 document is nobody's saved content, so an `unavailable`
+  // drop from it is not a loss.
+
+  /** The shipped default, as `DEFAULT_BAR_LAYOUT` spells it. */
+  const SHIPPED_DEFAULT = doc(
+    ['logo', 'identity', 'space', 'control-target', 'search', 'display'],
+    ['space', 'system-health', 'clock']
+  );
+
+  /** A deployment with a user but without the SYSTEM panel. */
+  const NO_SYSTEM_PANEL = {
+    identityAvailable: true,
+    blueskyAvailable: false,
+    systemHealthAvailable: false,
+  };
+
+  test('a rev-0 document missing a gated item renders the rest and stays writable', async () => {
+    await boot({
+      fetch: endpoint({
+        get: SHIPPED_DEFAULT,
+        puts: [jsonResponse(200, doc(['logo'], ['space', 'clock', 'stopwatch'], { rev: 1 }))],
+      }),
+      context: NO_SYSTEM_PANEL,
+    });
+    await settle();
+
+    expect(typesIn('status')).toEqual(['space', 'clock']);
+    expect(sync.isLayoutReadonly()).toBe(false);
+
+    await sync.saveLayout(doc(['logo'], ['space', 'clock', 'stopwatch']), { edit: true });
+    expect(putBodies()).toHaveLength(1);
+    expect(putBodies()[0].status.map((/** @type {any} */ i) => i.type)).toEqual([
+      'space',
+      'clock',
+      'stopwatch',
+    ]);
+  });
+
+  test('a rev-0 document with an unknown type still latches', async () => {
+    await boot({
+      fetch: endpoint({ get: doc(['logo', 'not-a-type'], ['space', 'system-health', 'clock']) }),
+      context: NO_SYSTEM_PANEL,
+    });
+    await settle();
+
+    expect(sync.isLayoutReadonly()).toBe(true);
+    expect(putBodies()).toEqual([]);
+  });
+
+  test('a reset onto a default the deployment cannot fully render leaves the sheet editable', async () => {
+    // The route answers a DELETE with the deployment default. Before #863 that
+    // answer re-latched the client on the next line, so "Default" — the
+    // documented way out of read-only — could not get out.
+    await boot({
+      fetch: endpoint({
+        get: doc(['logo', 'not-a-type'], ['clock'], { rev: 3 }),
+        deletes: [jsonResponse(200, SHIPPED_DEFAULT)],
+        puts: [jsonResponse(200, doc(['logo'], ['space', 'clock', 'stopwatch'], { rev: 1 }))],
+      }),
+      context: NO_SYSTEM_PANEL,
+    });
+    await settle();
+    expect(sync.isLayoutReadonly()).toBe(true);
+
+    await sync.resetLayout({ edit: true });
+
+    expect(typesIn('status')).toEqual(['space', 'clock']);
+    expect(sync.isLayoutReadonly()).toBe(false);
+    await sync.saveLayout(doc(['logo'], ['space', 'clock', 'stopwatch']), { edit: true });
+    expect(putBodies()).toHaveLength(1);
   });
 });
 

--- a/tests/interfaces/web_terminal/test_bar_items_config.py
+++ b/tests/interfaces/web_terminal/test_bar_items_config.py
@@ -27,8 +27,21 @@ from osprey.interfaces.web_terminal.app import (
     DEFAULT_BAR_LAYOUT,
     MAX_BAR_ITEMS_PER_HOST,
     _load_bar_items,
+    bar_availability_context,
     create_app,
     effective_bar_layout,
+    renderable_bar_layout,
+)
+
+#: A deployment that can show every gated item.
+_OFFERS_EVERYTHING = bar_availability_context(
+    identity_available=True, bluesky_available=True, system_health_available=True
+)
+
+#: A single-user deployment without the SYSTEM panel or the Bluesky bridge: the
+#: shape the shipped default degrades on.
+_BARE = bar_availability_context(
+    identity_available=False, bluesky_available=False, system_health_available=False
 )
 
 
@@ -212,9 +225,26 @@ class TestLifespanWiring:
         web_section: dict = {} if bar_items is None else {"bar_items": bar_items}
         project_dir = tmp_path / "project"
         project_dir.mkdir(exist_ok=True)
-        with patch(
-            "osprey.interfaces.web_terminal.app._load_web_ui_config",
-            return_value=web_section,
+        # Both places the lifespan reaches for an agent-data root are pointed
+        # at tmp, the way ``test_bar_items_routes.py`` does it: the watched
+        # tree through ``watch_dir``, and the stores through the resolver. Left
+        # alone, either lands under the repository's own ``var/agent_data``,
+        # which the session guard in ``tests/conftest.py`` rightly refuses.
+        watch_dir = tmp_path / "_watch"
+        watch_dir.mkdir(exist_ok=True)
+        with (
+            patch(
+                "osprey.interfaces.web_terminal.app._load_web_config",
+                return_value={"watch_dir": str(watch_dir)},
+            ),
+            patch(
+                "osprey.interfaces.web_terminal.app._load_web_ui_config",
+                return_value=web_section,
+            ),
+            patch(
+                "osprey.utils.workspace.resolve_shared_data_root",
+                return_value=tmp_path / "agent_data",
+            ),
         ):
             app = create_app(shell_command="echo", project_dir=project_dir)
             with TestClient(app):
@@ -226,5 +256,132 @@ class TestLifespanWiring:
             assert effective_bar_layout(app) is app.state.bar_layout
 
     def test_no_config_leaves_the_shipped_default_in_place(self, tmp_path):
+        """The shipped arrangement, less whatever this deployment cannot
+        render — the same document the constant's docstring promises."""
         with self._app(tmp_path, None) as app:
-            assert effective_bar_layout(app) == DEFAULT_BAR_LAYOUT
+            layout = effective_bar_layout(app)
+            assert layout["rev"] == 0
+            assert layout["header_visible"] is True and layout["status_visible"] is True
+            assert _types(layout["status"]) in (
+                ["space", "clock"],
+                ["space", "system-health", "clock"],
+            )
+            assert [t for t in _types(layout["header"]) if t != "identity"] == [
+                t for t in _types(DEFAULT_BAR_LAYOUT["header"]) if t != "identity"
+            ]
+
+    def test_the_default_is_filtered_by_what_the_deployment_renders(self, tmp_path):
+        """No SYSTEM panel and no user: the rev-0 document the lifespan leaves
+        on state names neither ``system-health`` nor ``identity``, so the
+        browser's normalizer has nothing to drop and nothing to latch on."""
+        with (
+            patch(
+                "osprey.interfaces.web_terminal.app._load_panel_config",
+                return_value=({"artifacts"}, [], None),
+            ),
+            patch.dict("os.environ", {"OSPREY_TERMINAL_USER": "", "OSPREY_WEB_APP_NAME": ""}),
+            self._app(tmp_path, None) as app,
+        ):
+            layout = app.state.bar_layout
+            assert _types(layout["status"]) == ["space", "clock"]
+            assert "identity" not in _types(layout["header"])
+            assert effective_bar_layout(app) is layout
+
+    def test_an_authored_default_is_filtered_the_same_way(self, tmp_path, caplog):
+        with (
+            patch(
+                "osprey.interfaces.web_terminal.app._load_panel_config",
+                return_value=({"artifacts"}, [], None),
+            ),
+            patch.dict("os.environ", {"OSPREY_TERMINAL_USER": "", "OSPREY_WEB_APP_NAME": ""}),
+            caplog.at_level(logging.WARNING),
+            self._app(tmp_path, {"status": ["system-health", "clock"]}) as app,
+        ):
+            assert _types(app.state.bar_layout["status"]) == ["clock"]
+        assert "web.bar_items.status[0]" in caplog.text
+        assert "system-health" in caplog.text
+
+
+class TestUnrenderableItemsLeaveTheDefault:
+    """The deployment default is renderable by construction.
+
+    ``bar_render_plan`` already drops a gated item the deployment cannot show;
+    the document behind the paint must drop it too, or the browser reads the
+    difference as lost content and latches Customize read-only (#863). An
+    authored item is warned about by position, because an operator wrote it;
+    an item the shipped order supplied is dropped quietly, because nobody did.
+    """
+
+    def test_without_a_context_the_shipped_default_is_returned_as_is(self, tmp_path):
+        assert _load_bar_items(tmp_path / "nope.yml") is DEFAULT_BAR_LAYOUT
+
+    def test_a_deployment_that_renders_everything_gets_the_shipped_default_itself(self, tmp_path):
+        assert _load_bar_items(tmp_path / "nope.yml", context=_OFFERS_EVERYTHING) is (
+            DEFAULT_BAR_LAYOUT
+        )
+
+    def test_a_bare_deployment_gets_the_default_less_the_gated_items(self, tmp_path):
+        layout = _load_bar_items(tmp_path / "nope.yml", context=_BARE)
+        assert _types(layout["status"]) == ["space", "clock"]
+        assert _types(layout["header"]) == ["logo", "space", "control-target", "search", "display"]
+        assert layout["rev"] == 0 and layout["version"] == BAR_LAYOUT_VERSION
+        assert layout["header_visible"] is True and layout["status_visible"] is True
+
+    def test_the_shipped_constant_is_not_mutated_by_the_filter(self, tmp_path):
+        before = {host: list(DEFAULT_BAR_LAYOUT[host]) for host in ("header", "status")}
+        _load_bar_items(tmp_path / "nope.yml", context=_BARE)
+        assert {host: list(DEFAULT_BAR_LAYOUT[host]) for host in ("header", "status")} == before
+
+    def test_an_authored_unrenderable_item_is_dropped_with_a_warning_by_position(
+        self, tmp_path, caplog
+    ):
+        path = _write_config(tmp_path, {"status": ["space", "system-health", "clock"]})
+        with caplog.at_level(logging.WARNING):
+            layout = _load_bar_items(path, context=_BARE)
+        assert _types(layout["status"]) == ["space", "clock"]
+        assert "web.bar_items.status[1]" in caplog.text
+        assert "system-health" in caplog.text
+
+    def test_the_same_authored_item_survives_where_the_deployment_renders_it(
+        self, tmp_path, caplog
+    ):
+        path = _write_config(tmp_path, {"status": ["space", "system-health", "clock"]})
+        with caplog.at_level(logging.WARNING):
+            layout = _load_bar_items(path, context=_OFFERS_EVERYTHING)
+        assert _types(layout["status"]) == ["space", "system-health", "clock"]
+        assert caplog.text == ""
+
+    def test_an_unconfigured_host_is_filtered_without_a_warning(self, tmp_path, caplog):
+        """The status bar came from the shipped order, not from the operator:
+        ``system-health`` leaves it, and no line blames ``web.bar_items`` for
+        an item the operator never wrote."""
+        path = _write_config(tmp_path, {"header": ["logo", "display"]})
+        with caplog.at_level(logging.WARNING):
+            layout = _load_bar_items(path, context=_BARE)
+        assert _types(layout["status"]) == ["space", "clock"]
+        assert _types(layout["header"]) == ["logo", "display"]
+        assert caplog.text == ""
+
+    def test_the_warning_names_the_gate_the_item_depends_on(self, tmp_path, caplog):
+        path = _write_config(tmp_path, {"header": ["logo", "identity", "bluesky-queue"]})
+        with caplog.at_level(logging.WARNING):
+            layout = _load_bar_items(path, context=_BARE)
+        assert _types(layout["header"]) == ["logo"]
+        assert "web.bar_items.header[1]" in caplog.text
+        assert "web.bar_items.header[2]" in caplog.text
+        assert "identity" in caplog.text and "bluesky-queue" in caplog.text
+
+    def test_renderable_bar_layout_returns_the_same_object_when_nothing_is_dropped(self):
+        assert renderable_bar_layout(DEFAULT_BAR_LAYOUT, context=_OFFERS_EVERYTHING) is (
+            DEFAULT_BAR_LAYOUT
+        )
+
+    def test_renderable_bar_layout_copies_and_keeps_the_envelope(self):
+        source = {**DEFAULT_BAR_LAYOUT, "rev": 0, "status_visible": False}
+        layout = renderable_bar_layout(source, context=_BARE)
+        assert layout is not source
+        assert _types(layout["status"]) == ["space", "clock"]
+        assert layout["status_visible"] is False
+        assert layout["rev"] == 0
+        assert layout["version"] == BAR_LAYOUT_VERSION
+        assert _types(source["status"]) == ["space", "system-health", "clock"]

--- a/tests/interfaces/web_terminal/test_bar_items_routes.py
+++ b/tests/interfaces/web_terminal/test_bar_items_routes.py
@@ -50,7 +50,6 @@ from fastapi.testclient import TestClient
 from osprey.interfaces.web_terminal import bar_items_store
 from osprey.interfaces.web_terminal.app import (
     BAR_LAYOUT_VERSION,
-    DEFAULT_BAR_LAYOUT,
     MAX_BAR_ITEMS_PER_HOST,
     create_app,
 )
@@ -625,8 +624,14 @@ class TestAStoredDocumentThisBuildCannotRead:
         assert response.status_code == 200
         layout = response.json()
         assert layout["rev"] == 0, "nothing readable is stored, so nothing has been saved"
-        assert types(layout, "status") == types(DEFAULT_BAR_LAYOUT, "status")
-        assert types(layout, "header") == types(DEFAULT_BAR_LAYOUT, "header")
+        # The deployment default as the lifespan resolved it — the shipped
+        # arrangement minus whatever this deployment cannot render — rather
+        # than the raw constant, which names items no single-user deployment
+        # without the SYSTEM panel can show.
+        deployment_default = unreadable_client.app.state.bar_layout
+        assert types(layout, "status") == types(deployment_default, "status")
+        assert types(layout, "header") == types(deployment_default, "header")
+        assert types(layout, "status") == ["space", "clock"]
 
     def test_the_first_paint_is_the_deployment_default(self, unreadable_client):
         page = unreadable_client.get("/").text

--- a/tests/interfaces/web_terminal/test_bar_items_ssr.py
+++ b/tests/interfaces/web_terminal/test_bar_items_ssr.py
@@ -35,11 +35,15 @@ from fastapi.testclient import TestClient
 from osprey.interfaces.web_terminal.app import (
     ADOPTED_BAR_ITEM_TYPES,
     BAR_ITEM_AVAILABILITY,
+    BAR_ITEM_GATES,
     BAR_ITEM_OPTIONS,
     BAR_ITEM_TYPES,
     BAR_LAYOUT_VERSION,
     DEFAULT_BAR_LAYOUT,
     STATIC_DIR,
+    SYSTEM_HEALTH_PANEL_ID,
+    bar_item_available,
+    bar_render_plan,
     create_app,
 )
 
@@ -891,6 +895,16 @@ class TestDeploymentContextIsServerSupplied:
             "system-health": {"systemHealthAvailable"},
         }
         assert set(expected) == set(BAR_ITEM_AVAILABILITY), "a gated type grew or vanished"
+        assert set(BAR_ITEM_GATES) == set(BAR_ITEM_AVAILABILITY), (
+            "every gated type names what it needs, for the web.bar_items warning"
+        )
+        # The build-time half: every panel-gated type is judged by `osprey
+        # build` too, and the one runtime-gated type (identity) is the only one
+        # it leaves to the server.
+        from osprey.cli.build_profile_panels import BAR_ITEM_PANEL_GATES
+
+        assert set(BAR_ITEM_AVAILABILITY) - set(BAR_ITEM_PANEL_GATES) == {"identity"}
+        assert BAR_ITEM_PANEL_GATES["system-health"] == SYSTEM_HEALTH_PANEL_ID
         for item_type, keys in expected.items():
             entry = _catalog_entry(source, item_type)
             predicate = entry[entry.index("available:") :]
@@ -908,3 +922,56 @@ class TestAssetsGoThroughThePrefix:
                 body = _body(client)
         assert 'href="/u/alice/static/css/bars.css"' in body
         assert 'href="/static/css/bars.css"' not in body
+
+
+class TestTheDefaultIsRenderableByConstruction:
+    """The rev-0 answer never names an item the stamp says is unavailable.
+
+    The shipped default places ``identity`` and ``system-health``, both gated.
+    ``bar_render_plan`` always dropped them on paint, but the document behind
+    the paint — the one ``GET /api/bar-items`` answers at ``rev`` 0 and the one
+    a reset returns to — still carried them, and the browser's normalizer read
+    that as lost content and latched Customize read-only on every deployment
+    without the SYSTEM panel. The default is therefore filtered once, at the
+    lifespan, by the same context the page stamps, so the served document and
+    the paint agree.
+    """
+
+    def test_the_rev_0_answer_names_no_item_the_stamp_says_is_unavailable(self, plain_app):
+        _, client = plain_app
+        context = _context(_body(client))
+        layout = client.get("/api/bar-items").json()
+
+        assert layout["rev"] == 0
+        for host in ("header", "status"):
+            for item in layout[host]:
+                assert bar_item_available(item["type"], context), (host, item["type"])
+
+    def test_the_plain_default_degrades_exactly_as_its_docstring_promises(self, plain_app):
+        """No SYSTEM panel and no identity: ``space · clock`` and a header
+        without the identity block — the served document, not just the paint."""
+        _, client = plain_app
+        layout = client.get("/api/bar-items").json()
+
+        assert [item["type"] for item in layout["status"]] == ["space", "clock"]
+        assert "identity" not in [item["type"] for item in layout["header"]]
+
+    def test_a_configured_deployment_keeps_the_gated_items(self, configured_app):
+        _, client = configured_app
+        layout = client.get("/api/bar-items").json()
+
+        assert [item["type"] for item in layout["status"]] == ["space", "system-health", "clock"]
+        assert "identity" in [item["type"] for item in layout["header"]]
+
+    def test_the_paint_drops_nothing_further_from_the_served_default(self, plain_app):
+        """The render plan and the document describe the same bars: every item
+        the deployment default holds is a shell on the page."""
+        app, client = plain_app
+        body = _body(client)
+        plan = bar_render_plan(app.state.bar_layout, context=_context(body))
+
+        for host in ("header", "status"):
+            assert [shell["type"] for shell in getattr(plan, host)] == [
+                item["type"] for item in app.state.bar_layout[host]
+            ]
+            assert _shell_types(body, host) == [item["type"] for item in app.state.bar_layout[host]]

--- a/tests/interfaces/web_terminal/test_bar_items_ssr.py
+++ b/tests/interfaces/web_terminal/test_bar_items_ssr.py
@@ -901,7 +901,7 @@ class TestDeploymentContextIsServerSupplied:
         # The build-time half: every panel-gated type is judged by `osprey
         # build` too, and the one runtime-gated type (identity) is the only one
         # it leaves to the server.
-        from osprey.cli.build_profile_panels import BAR_ITEM_PANEL_GATES
+        from osprey.profiles.web_panels import BAR_ITEM_PANEL_GATES
 
         assert set(BAR_ITEM_AVAILABILITY) - set(BAR_ITEM_PANEL_GATES) == {"identity"}
         assert BAR_ITEM_PANEL_GATES["system-health"] == SYSTEM_HEALTH_PANEL_ID

--- a/tests/mcp_server/test_target_eligibility.py
+++ b/tests/mcp_server/test_target_eligibility.py
@@ -853,6 +853,28 @@ def test_a_pva_row_appears_only_with_both_globs_and_a_gateway() -> None:
     )
 
 
+def test_a_pva_addr_list_row_without_a_port_carries_none() -> None:
+    """``connect()`` appends no port to an address list unless one is set.
+
+    Address-list entries are UDP search targets, and p4p's own default applies
+    when the entry names no port — so the row must not restate the TCP default.
+    """
+    config = _config(
+        connector={
+            EPICS_TYPE: _epics_block(
+                pva_channels=["*:IMAGE*"],
+                pva_gateway={"address": "cam1.example.org cam2.example.org"},
+            )
+        }
+    )
+
+    derivation = _derive(config, LIVE)
+
+    assert derivation.endpoints["pva"] == te.Endpoint(
+        "cam1.example.org cam2.example.org", None, "addr_list"
+    )
+
+
 def test_pva_globs_without_a_gateway_derive_no_pva_row() -> None:
     """``connect()`` touches no PVA environment variable without a gateway."""
     config = _config(connector={EPICS_TYPE: _epics_block(pva_channels=["*:IMAGE*"])})


### PR DESCRIPTION
Four independent fixes and one build speed-up, integrated on one branch so they share a single CI run. Each was developed test-first on its own branch and merged here; the only overlaps were in `validate_cmd.py` imports and the profile-document parse helper, resolved so the helper runs on the C loader.

### `osprey validate` preset-drift lint (#864)
`provenance.preset_hash` was written and never read. `osprey validate` now loads the named preset (and each persona's `<preset>-<persona>` preset) through `_resolve_extends`, diffs profile vs preset at key level (scalars, missing keys, selection-list membership incl. persona `exclude:`), and reports each difference with both file:line references. A `# DEVIATION: <why>` comment within three lines silences one; the tag is set by `provenance.deviation_marker`; stale markers are reported. `validate` refuses unmarked drift by default, `--drift=warn` demotes; `osprey build` prints the one-line "preset has moved on" note the emitted header promised and lists differences under `-v`. A fresh `osprey init` is drift-free by construction (pinned by test).

### Customize Bars editable without the SYSTEM panel (#863)
The deployment default placed `system-health` on the status bar; on a deployment whose `web_panels` lacks that panel the client normalizer counted the drop as lost content and latched the sheet read-only, and Default could not recover. The rev-0 answer of `GET /api/bar-items` and `effective_bar_layout` are now filtered by `bar_availability_context` once at lifespan, so the served default never names an unavailable item; authored `web.bar_items` gets the same filter with a build/validate warning per unshowable entry. The client no longer latches on an `unavailable` drop leaving a rev-0 document (unknown-type/version/host drops still latch). Tests boot the sheet with `systemHealthAvailable: false` against the shipped default and assert every tile is enabled and a drag saves; the SSR test pins that rev-0 names no unavailable item.

### PVA address list default port (#862)
`pva_gateway` with `port` unset appended the TCP port 5075 to `EPICS_PVA_ADDR_LIST`, whose entries are UDP search targets, so every PVA read timed out. The address-list branch appends no port unless one is set (then to every host of a space-separated list); the name-server branch keeps 5075; the target roster restates the rule. Because the connector host scrubs inherited `EPICS_PVA_*`, `pva_gateway` is the only route: the build warns once when `pva_channels` is set with no `pva_gateway`. Templates, docstring and the connectors how-to say so.

### `osprey up` removes off-roster terminal containers (#850)
A renamed or removed roster user left its old `network_mode: host` container running on the reused index ports. `osprey up` now reconciles the web slice: containers of this deployment whose user is no longer on the roster are stopped and removed (one line each; volumes untouched, that stays with `osprey users prune --purge`), and the host-port preflight covers every per-user index port (web/artifact/ariel/lattice/okf) and fails fast naming the port and holder.

### Faster builds (refs #841)
Unit-test cells are ~57% `osprey build` invocations, and one build had grown to ~700 pure-Python YAML parses across 12 sub-project renders. The build path now parses on the libyaml scanner when it is installed (identical semantics, `SafeLoader` fallback) and parses a render's `config.yml` once per change instead of on every check. The ruamel round-trip share of #841 remains open and is not touched here.

Closes #850
Closes #862
Closes #863
Closes #864
Refs #841
