### PR TITLE
fix: deploy-path and channel-roster honesty (roster-deploy-honesty)

### DIFF
--- a/changelog.d/roster-deploy-honesty.fixed.md
+++ b/changelog.d/roster-deploy-honesty.fixed.md
@@ -5,3 +5,7 @@ either is a lost key, and the virtual accelerator would exit on the empty
 value. The preflight names the key and how the build writes it back. The
 archiver seed no longer falls back to the framework's bundled channel set
 when nothing names a manifest.
+
+A malformed `services.graphdb` block is reported as its own reason. The
+channel roster used to file it under "names no corpus"; it now names the
+config keys and the parser's complaint, and stays fail-soft.

--- a/changelog.d/roster-deploy-honesty.fixed.md
+++ b/changelog.d/roster-deploy-honesty.fixed.md
@@ -1,0 +1,7 @@
+`osprey up` refuses a deployment whose `.env` has lost a key the build wrote.
+The build writes `VA_CHANNELS_FILE` and `VA_LATTICE` together whenever it
+generates a channel manifest, so a manifest on disk beside a chain missing
+either is a lost key, and the virtual accelerator would exit on the empty
+value. The preflight names the key and how the build writes it back. The
+archiver seed no longer falls back to the framework's bundled channel set
+when nothing names a manifest.

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,49 @@ METADATA_FIELDS = {"_comment", "_version", "_last_updated", "_description"}
 
 # Special functional field (not metadata)
 DEFAULTS_FIELD = "defaults"
+
+#: The one config key naming the channel-limits database. One value, one file,
+#: everywhere it is spoken about: the connector's own lookup, the compose bind
+#: mount, the build's parse, the bridge's startup gate, the roster's direction
+#: source, the knowledge graph's direction assignment, and every refusal that
+#: names the key back to the operator. Spelled here and imported everywhere
+#: else, because a key spelled six times is a key that drifts.
+LIMITS_DATABASE_CONFIG_KEY = "control_system.limits_checking.database_path"
+
+#: The config key the last-resort path anchor is read from.
+_PROJECT_ROOT_CONFIG_KEY = "project_root"
+
+#: The signature every ``config_lookup`` here has: that of
+#: :func:`osprey_connectors.config.get_config_value`.
+ConfigLookup = Callable[[str, Any], Any]
+
+
+def mapping_config_lookup(config: Mapping[str, Any]) -> ConfigLookup:
+    """A ``get_config_value``-shaped lookup over an already-loaded config.
+
+    For the callers that hold the config as a dict rather than through the
+    live configurable -- the build reading a render's ``config.yml``, the
+    roster reading the project config it was handed -- so they resolve the
+    limits database through the same path as the runtime instead of walking
+    the segments themselves.
+
+    Args:
+        config: The loaded configuration mapping.
+
+    Returns:
+        A callable ``(dotted_key, default) -> value`` that walks nested
+        mappings and answers *default* for any segment that is not there.
+    """
+
+    def lookup(path: str, default: Any = None) -> Any:
+        value: Any = config
+        for key in path.split("."):
+            if not isinstance(value, Mapping) or key not in value:
+                return default
+            value = value[key]
+        return value
+
+    return lookup
 
 
 @dataclass
@@ -99,8 +143,62 @@ class LimitsValidator:
         return db_path
 
     @classmethod
-    def _load_configured_database(
+    def configured_database_path(
         cls,
+        *,
+        config_lookup: ConfigLookup | None = None,
+        config_path: str | None = None,
+    ) -> str | None:
+        """The file :data:`LIMITS_DATABASE_CONFIG_KEY` names, resolved; or ``None``.
+
+        The one reading of that key. Every caller that used to walk the config
+        segments and call :meth:`resolve_database_path` itself asks here, so
+        the build, the bridge, the roster and the knowledge graph cannot resolve
+        the same relative path to different files.
+
+        ``None`` covers every way of naming nothing: key absent, not a string,
+        blank. Existence is not probed -- a configured file that is not there
+        is the loader's finding, with the loader's message.
+
+        Args:
+            config_lookup: Where the key is read from, with the signature of
+                :func:`osprey_connectors.config.get_config_value`. Defaults to
+                that function, which reads the live configurable; pass
+                :func:`mapping_config_lookup` for a config held as a dict.
+            config_path: The config file the lookup answers from, which is the
+                anchor a relative path resolves against (see
+                :meth:`resolve_database_path`). Defaults to
+                :func:`osprey_connectors.config.default_config_path` when the
+                lookup is the live one; a caller supplying its own lookup
+                names its own anchor, or leaves it to the fallbacks.
+
+        Returns:
+            The resolved path as a string, or ``None``.
+        """
+        if config_lookup is None:
+            from osprey_connectors.config import default_config_path, get_config_value
+
+            config_lookup = get_config_value
+            if config_path is None:
+                config_path = default_config_path()
+
+        raw = config_lookup(LIMITS_DATABASE_CONFIG_KEY, None)
+        if not isinstance(raw, str) or not raw.strip():
+            return None
+
+        project_root = config_lookup(_PROJECT_ROOT_CONFIG_KEY, None)
+        return cls.resolve_database_path(
+            str(Path(raw.strip()).expanduser()),
+            project_root if isinstance(project_root, str) else None,
+            config_path=config_path,
+        )
+
+    @classmethod
+    def load_configured_database(
+        cls,
+        *,
+        config_lookup: ConfigLookup | None = None,
+        config_path: str | None = None,
     ) -> tuple[tuple[dict[str, ChannelLimitsConfig], dict] | None, str | None]:
         """Resolve and load the deployment-wide limits database.
 
@@ -108,58 +206,66 @@ class LimitsValidator:
         deployment mounts one limits file (``compose_generator.py`` binds a
         single path), so a per-type block changes policy and never the data.
         This is the half of validator construction that is the same for every
-        posture, kept in one place so that the deployment-wide and per-type
-        entry points cannot drift in how they resolve a relative path or in
-        which load failures they treat as fatal.
+        posture, and the same read the build's pre-deploy parse and the bridge's
+        startup gate make -- kept in one place so that none of them can drift
+        in how they resolve a relative path or in which load failures they
+        report.
 
-        Failure is reported rather than raised because both entry points answer
-        it the same way — with a fail-safe validator that blocks every write.
-        Returning ``None`` instead would leave writes unchecked, and raising
-        would crash a connector on a deployment that never writes at all.
+        Failure is reported rather than raised because every caller answers it
+        its own way: the connector with a fail-safe validator that blocks every
+        write, the build with a refusal line, the bridge with a startup
+        refusal. Returning ``None`` alone would leave a connector's writes
+        unchecked, and raising would crash one on a deployment that never
+        writes at all.
+
+        Args:
+            config_lookup: As for :meth:`configured_database_path`.
+            config_path: As for :meth:`configured_database_path`.
 
         Returns:
-            A ``(loaded, failsafe_reason)`` pair with exactly one half set:
-            either the ``(limits_database, raw_database)`` tuple, or a reason
-            string naming what could not be read, ready to hand to
-            ``failsafe_reason``.
+            A ``(loaded, reason)`` pair with exactly one half set: either the
+            ``(limits_database, raw_database)`` tuple, or a sentence naming
+            what could not be read, complete enough to be quoted by any caller.
         """
-        from osprey_connectors.config import default_config_path, get_config_value
-
-        db_path = get_config_value("control_system.limits_checking.database_path", None)
-        # Validate db_path is actually a string path (not None, False, or other types)
-        if not db_path or not isinstance(db_path, str):
-            logger.warning(
-                "Limits checking enabled but no database path configured - blocking all writes"
-            )
-            return None, (
-                "limits checking is enabled but "
-                "control_system.limits_checking.database_path is not configured"
-            )
-
-        project_root = get_config_value("project_root", None)
-        resolved_path = cls.resolve_database_path(
-            db_path, project_root, config_path=default_config_path()
-        )
-        if resolved_path != db_path:
-            logger.debug(f"Resolved limits database path: {resolved_path}")
-        db_path = resolved_path
+        db_path = cls.configured_database_path(config_lookup=config_lookup, config_path=config_path)
+        if db_path is None:
+            return None, f"{LIMITS_DATABASE_CONFIG_KEY} is not configured"
 
         try:
             limits_db, raw_db = cls._load_limits_database(db_path)
         except ValueError as e:
-            # Same failsafe as the missing-database-path case above: a
-            # missing/unparseable database must never crash the connector
-            # (a read-only deployment needs no limits) nor silently disable
-            # checking (returning None would leave writes unchecked) — an
-            # empty DB blocks every write with a clear refusal instead.
-            logger.warning(
-                f"Limits checking enabled but the database at {db_path} could not "
-                f"be read or parsed - blocking all writes. {e}"
+            return None, (
+                f"the limits database at {db_path} ({LIMITS_DATABASE_CONFIG_KEY}) could not "
+                f"be read or parsed: {e}"
             )
-            return None, (f"the limits database at {db_path} could not be read or parsed: {e}")
 
-        logger.debug(f"Loaded limits database with {len(limits_db)} channels")
+        logger.debug(f"Loaded limits database with {len(limits_db)} channels from {db_path}")
         return (limits_db, raw_db), None
+
+    @staticmethod
+    def writable_addresses(db_path: str | Path) -> frozenset[str]:
+        """The addresses a limits database declares writable, defaults-merged.
+
+        Read through :meth:`_load_limits_database` rather than from the raw
+        JSON, so the ``defaults`` block, the metadata keys and the per-entry
+        validation are applied by the same code the write path applies them
+        with. That matters: the demo file grants writability by *omitting*
+        ``writable`` so entries inherit ``defaults.writable: true``, and a
+        reader that looked only for an explicit ``writable: true`` would find
+        none at all.
+
+        Args:
+            db_path: Path to a ``channel_limits.json``-shaped file.
+
+        Returns:
+            The writable addresses.
+
+        Raises:
+            ValueError: If the file is missing, is not JSON, is not a JSON
+                object, or carries an entry the validator refuses.
+        """
+        limits_db, _raw = LimitsValidator._load_limits_database(str(db_path))
+        return frozenset(address for address, entry in limits_db.items() if entry.writable)
 
     @classmethod
     def from_config(
@@ -314,10 +420,15 @@ class LimitsValidator:
             if posture.enabled is not True:
                 return None
 
-            loaded, failsafe_reason = cls._load_configured_database()
+            loaded, reason = cls.load_configured_database()
             if loaded is None:
-                # Empty DB = blocks all (failsafe)
-                return cls({}, {}, {}, failsafe_reason=failsafe_reason)
+                # Same failsafe as the incomplete-block case above: a missing
+                # or unparseable database must never crash the connector (a
+                # read-only deployment needs no limits) nor silently disable
+                # checking (returning None would leave writes unchecked) -- an
+                # empty DB blocks every write with a clear refusal instead.
+                logger.warning(f"Limits checking enabled but {reason} - blocking all writes")
+                return cls({}, {}, {}, failsafe_reason=f"limits checking is enabled but {reason}")
             limits_db, raw_db = loaded
 
             # Both entries are JSON-serialisable: the python executor embeds

--- a/packages/osprey-connectors/src/osprey_connectors/dotenv.py
+++ b/packages/osprey-connectors/src/osprey_connectors/dotenv.py
@@ -141,6 +141,16 @@ VA_LATTICE_KEY = "VA_LATTICE"
 
 #: What :func:`resolved_va_lattice` answers when no chain file pins the key —
 #: the value the build itself appends whenever it generates a channel manifest.
+#:
+#: The container reads an EMPTY ``VA_LATTICE`` the other way: the virtual
+#: accelerator's entrypoint (``entrypoint.LATTICE_NONE``) boots no lattice
+#: rather than the framework's tutorial ring. The two are never asked the same
+#: question. This one speaks for the render-side readers of a chain the build
+#: has not written yet; the entrypoint's speaks for a hand-run container. A
+#: deployed container only ever starts on a chain carrying the key, because the
+#: deploy preflight (``container_lifecycle._preflight_build_derived_env``)
+#: refuses to start a stack whose manifest is on disk and whose derived keys
+#: are not.
 VA_LATTICE_DEFAULT = "builtin"
 
 

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -567,14 +567,16 @@ keys:
       leaf, `_from_posture` returns the blocking failsafe and `osprey build`
       refuses it via `incomplete_limits_blocks`.
   control_system.limits_checking.database_path:
-    evidence: 'get_config_value\("control_system\.limits_checking\.database_path", None\)'
+    evidence: 'config_lookup\(LIMITS_DATABASE_CONFIG_KEY, None\)'
     note: >-
       Deliberately NOT per connector type: a deployment mounts one limits
       database (`compose_generator.py`), so the path stays deployment-wide and
       a per-type block that omits it is complete rather than half-written. The
-      one reader is `LimitsValidator._load_configured_database`, which is where
-      this call now lives; the dotted spelling is the anchor because it is the
-      only place the key is named.
+      one reader is `LimitsValidator.configured_database_path`, which every
+      other consumer (the compose mount, the build's parse, the bridge's
+      startup gate, the roster, the knowledge graph) resolves through; the key
+      is spelled once, as `LIMITS_DATABASE_CONFIG_KEY` beside it in
+      `limits_validator.py`, and that call is the anchor.
   control_system.limits_checking.allow_unlisted_channels:
     evidence: '_limits_leaf\(block\.get\(allow_unlisted_leaf\)\)'
     note: >-

--- a/src/osprey/audit/posture.py
+++ b/src/osprey/audit/posture.py
@@ -206,55 +206,6 @@ def _state_signature(path: Path) -> tuple[str, int, int, int] | None:
     return (str(path), st.st_mtime_ns, st.st_size, st.st_ino)
 
 
-def _match_session_record(target_state: Any, entries: list[Path], owner_ppid: int) -> str | None:
-    """The target named by the one live record this session owns, or ``None``.
-
-    Selection is *exact parent equality*: the controls MCP server that writes
-    these files and the server this code is running in are both spawned by the
-    same Claude Code process, so the record whose ``owner_ppid`` is our parent
-    is the one describing our session. That is the rule
-    ``executor._session_target_record`` and ``target_banner.resolve_session_target``
-    already use, and it is deliberately narrower than the ancestor-chain walk
-    the stdlib-only hooks do: a deployment that interposes a process breaks the
-    equality and gets "no answer", never another session's target.
-
-    Zero matches (no controls server, or a directory this deployment never
-    created) and more than one (an ``owner_ppid`` collision after PID reuse)
-    both answer ``None``, as does a record naming a target no reader knows. A
-    record whose ``server_pid`` is gone is residue — its target describes a
-    server nobody is talking to any more — and is skipped.
-
-    That liveness skip is evaluated when the *signature* moves, not on every
-    lookup: the caller caches this answer against the state files' signature,
-    and a server dying does not touch its file. Deliberately so — a ``kill(pid,
-    0)`` per tool call buys very little, because the record of a server that
-    died is rewritten or swept by the next server to start, which moves the
-    signature and re-runs this. Nothing rests on the freshness of the answer
-    either: the guarantee that a write cannot land on a machine nobody selected
-    is the runtime's generation pin, not this lookup.
-    """
-    matches: list[str] = []
-    for entry in entries:
-        record = target_state.read_file(entry)
-        if not isinstance(record, dict) or record.get("owner_ppid") != owner_ppid:
-            continue
-        server_pid = record.get("server_pid")
-        if not isinstance(server_pid, int) or not target_state.is_process_alive(server_pid):
-            continue
-        target = record.get("target")
-        if target in target_state.TARGET_NAMES:
-            matches.append(str(target))
-    if len(matches) != 1:
-        if matches:
-            logger.debug(
-                "%d control-target records share owner_ppid %s; the session target is unknown",
-                len(matches),
-                owner_ppid,
-            )
-        return None
-    return matches[0]
-
-
 def session_control_target() -> str | None:
     """The control target this process's writes are about, or ``None``.
 
@@ -274,9 +225,20 @@ def session_control_target() -> str | None:
        record's is — a stamp naming something no reader knows can only index
        the store to a key nothing writes, so it is dropped in favour of the
        state record rather than answered with.
-    2. Otherwise the controls server's state record for this session — see
-       :func:`_match_session_record`. This is the reader for the MCP servers,
-       which is where :func:`posture` is called from on every tool call.
+    2. Otherwise the controls server's state record for this session, matched
+       by :func:`osprey.mcp_server.control_system.target_state.session_record`
+       — exact parent equality, the one rule every child of the same Claude
+       Code process reads by. This is the reader for the MCP servers, which is
+       where :func:`posture` is called from on every tool call.
+
+    The liveness skip inside that match is evaluated when the state files'
+    *signature* moves, not on every lookup: the answer is cached against the
+    signature, and a server dying does not touch its file. Deliberately so — a
+    ``kill(pid, 0)`` per tool call buys very little, because the record of a
+    server that died is rewritten or swept by the next server to start, which
+    moves the signature and re-runs the match. Nothing rests on the freshness
+    of the answer either: the guarantee that a write cannot land on a machine
+    nobody selected is the runtime's generation pin, not this lookup.
 
     ``None`` is an honest "not knowable here", and :func:`posture` answers the
     environment for it rather than clamping: this gate refuses EVERY write tool
@@ -321,7 +283,8 @@ def session_control_target() -> str | None:
     if cached is not None and cached[0] == signature:
         return cached[1]
 
-    target = _match_session_record(target_state, entries, owner_ppid)
+    record = target_state.session_record(entries, owner_ppid)
+    target = None if record is None else str(record["target"])
     with _TARGET_CACHE_LOCK:
         _TARGET_CACHE = (signature, target)
     return target

--- a/src/osprey/channel_roster/database.py
+++ b/src/osprey/channel_roster/database.py
@@ -41,6 +41,11 @@ from pathlib import Path
 from typing import Any
 
 from osprey.utils.logger import get_logger
+from osprey_connectors.control_system.limits_validator import (
+    LIMITS_DATABASE_CONFIG_KEY,
+    LimitsValidator,
+    mapping_config_lookup,
+)
 
 from .records import (
     ChannelDirection,
@@ -53,9 +58,6 @@ from .records import (
 
 logger = get_logger("channel_roster.database")
 
-#: Config key naming the channel limits database, shared with the runtime write
-#: path and with the knowledge graph's direction assignment.
-LIMITS_DATABASE_CONFIG_KEY = "control_system.limits_checking.database_path"
 
 #: Final address token the grammar fallback reads as a setpoint.
 WRITE_SUBFIELD = "SP"
@@ -84,36 +86,24 @@ def resolve_limits_path(config: Mapping[str, Any]) -> Path | None:
         is not probed here: an unreadable file is a direction-source question,
         answered in :func:`_load_writable_addresses`.
     """
-    control_system = config.get("control_system") or {}
-    if not isinstance(control_system, dict):
-        return None
-    limits_checking = control_system.get("limits_checking") or {}
-    if not isinstance(limits_checking, dict):
-        return None
-
-    raw = limits_checking.get("database_path")
-    if not isinstance(raw, str) or not raw.strip():
-        return None
-
-    path = Path(raw).expanduser()
-    if path.is_absolute():
-        return path
-
     config_dir = config.get("config_dir")
     anchor = Path(config_dir) if isinstance(config_dir, str) and config_dir.strip() else Path.cwd()
-    return anchor / path
+    # The validator anchors a relative path on the directory of the config it
+    # is told about, so the anchor is spelled as that config.
+    resolved = LimitsValidator.configured_database_path(
+        config_lookup=mapping_config_lookup(config), config_path=str(anchor / "config.yml")
+    )
+    return None if resolved is None else Path(resolved)
 
 
 def _load_writable_addresses(limits_path: Path) -> frozenset[str] | None:
     """Read the addresses a limits file declares writable, defaults-merged.
 
     Delegates to
-    :meth:`~osprey_connectors.control_system.limits_validator.LimitsValidator._load_limits_database`
+    :meth:`~osprey_connectors.control_system.limits_validator.LimitsValidator.writable_addresses`
     rather than re-reading the JSON, so the ``defaults`` block, the metadata
     keys and the per-entry validation are applied by the same code the write
-    path applies them with. The demo file grants writability by *omitting*
-    ``writable`` so entries inherit ``defaults.writable: true``; a reader that
-    looked only for explicit ``writable: true`` would find none at all.
+    path applies them with.
 
     Args:
         limits_path: Path to a ``channel_limits.json``-shaped file.
@@ -123,8 +113,6 @@ def _load_writable_addresses(limits_path: Path) -> frozenset[str] | None:
         parsed -- direction then falls through to the address grammar, which is
         a degraded answer rather than a wrong one.
     """
-    from osprey_connectors.control_system.limits_validator import LimitsValidator
-
     if not limits_path.is_file():
         # Probed here rather than left to the validator: a deployment that
         # enforces no limits is an ordinary one, and the validator answers an
@@ -136,7 +124,7 @@ def _load_writable_addresses(limits_path: Path) -> frozenset[str] | None:
         return None
 
     try:
-        limits, _raw = LimitsValidator._load_limits_database(str(limits_path))
+        return LimitsValidator.writable_addresses(limits_path)
     except ValueError as exc:
         # Named by its config key rather than by the file it resolved to: a
         # build resolves a relative path into its own staging tree, so the
@@ -147,7 +135,6 @@ def _load_writable_addresses(limits_path: Path) -> frozenset[str] | None:
             f"read ({exc}); deriving channel directions from the address grammar instead."
         )
         return None
-    return frozenset(address for address, entry in limits.items() if entry.writable)
 
 
 def _database_class(pipeline_type: str, db_config: Mapping[str, Any]) -> Any:

--- a/src/osprey/channel_roster/records.py
+++ b/src/osprey/channel_roster/records.py
@@ -73,8 +73,9 @@ class RosterAbsenceReason(Enum):
     Named rather than left to each caller's prose because these are different
     situations with different remedies, and every surface that reports one has
     to tell them apart: nothing was configured, graph mode was configured but
-    points at no readable corpus, a source was read but cannot say which
-    channels are settable, or a configured source is there and unreadable.
+    points at no readable corpus, graph mode was configured but its block
+    cannot be read, a source was read but cannot say which channels are
+    settable, or a configured source is there and unreadable.
     """
 
     #: No roster source is configured at all -- ``detect_pipeline_config``
@@ -84,6 +85,15 @@ class RosterAbsenceReason(Enum):
     #: Graph mode is configured but no corpus resolves. The store is never
     #: dialed to find out; the config keys are named instead.
     GRAPH_NO_TTL = "graph-no-ttl"
+
+    #: Graph mode is configured but the ``services.graphdb`` block itself
+    #: cannot be read -- a blank ``ttl_path``, a value of the wrong shape. Kept
+    #: apart from :attr:`GRAPH_NO_TTL` because the remedy is different: not
+    #: "declare a corpus" but "fix the line you declared it with", so the
+    #: message carries the parser's own complaint. Fail-soft like its sibling,
+    #: and deliberately NOT :attr:`CORRUPT_SOURCE`: no source was named, so
+    #: none is there to be broken.
+    GRAPH_MALFORMED = "graph-malformed"
 
     #: A database source enumerated its channels, but carries neither a
     #: write-limits database nor ``:SP`` addresses, so no direction can be
@@ -124,6 +134,11 @@ ABSENCE_TEMPLATES: Mapping[RosterAbsenceReason, str] = {
         "Graph mode is configured but names no readable knowledge-graph corpus, "
         "so the set of channels this facility has is unknown; the corpus is "
         "declared by {config_keys}."
+    ),
+    RosterAbsenceReason.GRAPH_MALFORMED: (
+        "Graph mode is configured but its services.graphdb block cannot be read "
+        "({detail}), so the set of channels this facility has is unknown; the "
+        "corpus is declared by {config_keys}."
     ),
     RosterAbsenceReason.DIRECTION_UNDERIVABLE: (
         "The channels in {path} are known, but which of them are settable is "
@@ -212,7 +227,8 @@ class RosterAbsence:
         config_keys: The configuration keys that would have declared a source,
             when naming them is the remedy.
         detail: The underlying failure, for
-            :attr:`RosterAbsenceReason.CORRUPT_SOURCE`.
+            :attr:`RosterAbsenceReason.CORRUPT_SOURCE` and
+            :attr:`RosterAbsenceReason.GRAPH_MALFORMED`.
 
     Raises:
         ValueError: If the reason's phrasing names a subject this absence did

--- a/src/osprey/channel_roster/sources.py
+++ b/src/osprey/channel_roster/sources.py
@@ -170,12 +170,20 @@ def _graph_source(config: dict) -> RosterSourceResolution:
     operator has to edit, rather than a connection attempt whose failure would
     be reported as an empty facility.
 
+    A block the service resolver cannot read is its own absence
+    (:attr:`~osprey.channel_roster.records.RosterAbsenceReason.GRAPH_MALFORMED`),
+    carrying the resolver's complaint: "you declared no corpus" and "the line
+    you declared it with cannot be read" send an operator to different edits.
+    Fail-soft either way -- the build stays browse-only and the web body says
+    why -- because no source was named, so none is there to be corrupt.
+
     Args:
         config: Full project configuration dictionary.
 
     Returns:
         The corpus source, or a
         :attr:`~osprey.channel_roster.records.RosterAbsenceReason.GRAPH_NO_TTL`
+        / :attr:`~osprey.channel_roster.records.RosterAbsenceReason.GRAPH_MALFORMED`
         absence.
     """
     from osprey.deployment.graphdb_service import resolve_graphdb_service_config
@@ -187,7 +195,13 @@ def _graph_source(config: dict) -> RosterSourceResolution:
             f"The services.graphdb block is malformed ({e}), so it names no readable "
             "knowledge-graph corpus to enumerate channels from."
         )
-        settings = None
+        return RosterSourceResolution(
+            absence=RosterAbsence(
+                reason=RosterAbsenceReason.GRAPH_MALFORMED,
+                config_keys=GRAPH_CORPUS_CONFIG_KEYS,
+                detail=str(e),
+            )
+        )
 
     if settings is None or settings.ttl_path is None:
         return RosterSourceResolution(

--- a/src/osprey/cli/build_limits_check.py
+++ b/src/osprey/cli/build_limits_check.py
@@ -8,13 +8,15 @@ a superseded schema passed ``osprey build`` and surfaced twenty minutes into
 validator's message is the actionable one, and it was being produced in the
 one place nobody could read it.
 
-This is the same gate, run where the file is cheap to fix. It mirrors
-``_assert_limits_readable_if_writable`` in the bridge exactly — same posture
-readers, same resolution anchor (the render's own ``config.yml``), same loader
-— so a file the build accepts is a file the bridge starts on, and a file the
-bridge refuses is refused here first. A missing file is the bridge's refusal
-too, and stays one here: the compose renderer's mount-time check already says
-so for a deployment that arms writes, and this adds the parse.
+This is the same gate, run where the file is cheap to fix. It IS the bridge's
+read, not a mirror of it: the same posture readers, and the one resolver and
+loader every reader of the key shares
+(:meth:`~osprey_connectors.control_system.limits_validator.LimitsValidator.load_configured_database`),
+anchored on the render's own ``config.yml`` — so a file the build accepts is
+a file the bridge starts on, and a file the bridge refuses is refused here
+first. A missing file is the bridge's refusal too, and stays one here: the
+compose renderer's mount-time check already says so for a deployment that
+arms writes, and this adds the parse.
 
 Writes-gated for the same reason the bridge and the mount are. A deployment
 that leaves every target read-only may name a database it stages later, and
@@ -25,8 +27,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-
-LIMITS_DATABASE_KEY = "control_system.limits_checking.database_path"
 
 
 def _rendered_config(render_dir: Path) -> dict[str, Any]:
@@ -80,21 +80,20 @@ def limits_database_errors(render_dir: Path) -> list[str]:
         return []
     target, writes_key, limits_key = armed
 
-    limits_checking = section.get("limits_checking")
-    raw = limits_checking.get("database_path") if isinstance(limits_checking, dict) else None
-    if not isinstance(raw, str) or not raw.strip():
+    from osprey_connectors.control_system.limits_validator import (
+        LimitsValidator,
+        mapping_config_lookup,
+    )
+
+    lookup = mapping_config_lookup(config)
+    anchor = str(render_dir / "config.yml")
+    if LimitsValidator.configured_database_path(config_lookup=lookup, config_path=anchor) is None:
         return []
 
-    from osprey.connectors.control_system.limits_validator import LimitsValidator
-
-    db_path = LimitsValidator.resolve_database_path(
-        raw, config.get("project_root"), config_path=str(render_dir / "config.yml")
+    loaded, reason = LimitsValidator.load_configured_database(
+        config_lookup=lookup, config_path=anchor
     )
-    try:
-        LimitsValidator._load_limits_database(db_path)
-    except Exception as exc:  # noqa: BLE001 - the validator's message is the report
-        return [
-            f"{writes_key} and {limits_key} are both set for target {target}, but "
-            f"{LIMITS_DATABASE_KEY} ({raw}) could not be read or parsed: {exc}"
-        ]
+    if loaded is None:
+        # The loader's wording, not a paraphrase: it names the field that moved.
+        return [f"{writes_key} and {limits_key} are both set for target {target}, but {reason}"]
     return []

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -899,11 +899,11 @@ def _assign_directions(graph_model: Any, limits: Path | None) -> tuple[Any, Any]
             disagrees with itself about a signal.
     """
     from osprey.services.facility_knowledge.ttl_generator.direction import (
-        LIMITS_DATABASE_CONFIG_KEY,
         DirectionConflictError,
         LimitsFileMissing,
         resolve_and_assign,
     )
+    from osprey_connectors.control_system.limits_validator import LIMITS_DATABASE_CONFIG_KEY
 
     try:
         return resolve_and_assign(graph_model, limits)

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -51,6 +51,12 @@ from osprey.utils.config import ConfigBuilder, load_project_config
 from osprey.utils.log_filter import quiet_logger
 from osprey.utils.logger import get_logger
 
+# The single config key naming the channel-limits database, spelled once in the
+# validator that enforces it: the bind source on the host, the mount target in
+# the container and every refusal that names the key back to the operator all
+# read it from there.
+from osprey_connectors.control_system.limits_validator import LIMITS_DATABASE_CONFIG_KEY
+
 logger = get_logger("deployment.compose")
 
 
@@ -136,12 +142,6 @@ QMD_ARIEL_COLLECTION = "ariel"
 #: host-side has to agree with the directory the container's own config lookup
 #: resolves relative paths against.
 _CONTAINER_PROJECT_ROOT = "/app/project"
-
-#: The single config key naming the channel-limits database. One value, one
-#: file, everywhere it is spoken about — the bind source on the host, the mount
-#: target in the container, the connector's own lookup, and every refusal that
-#: names the key back to the operator.
-LIMITS_DATABASE_CONFIG_KEY = "control_system.limits_checking.database_path"
 
 
 def resolve_repo_root(config=None, config_path=None):

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -2574,6 +2574,24 @@ def _value_digest(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _interpolated_vars_across(compose_files: list[str], root: Path) -> set[str]:
+    """Every name some rendered compose file interpolates from the environment.
+
+    The union over the files a deploy will start, in ``-f`` order. Relative
+    entries resolve against *root*; unreadable ones are skipped, because a
+    missing render is the start's own error to raise, not a preflight's.
+    """
+    referenced: set[str] = set()
+    for compose_file in compose_files:
+        path = Path(compose_file)
+        path = path if path.is_absolute() else root / path
+        try:
+            referenced |= _compose_interpolated_vars(path.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+    return referenced
+
+
 def _read_chain_state(repo_root: Path) -> dict[str, str]:
     """The shared-file key digests recorded by the previous deploy.
 
@@ -3431,6 +3449,101 @@ def _preflight_env_chain_drift(compose_files: list[str], repo_root: Path | str) 
     )
 
 
+def _preflight_build_derived_env(
+    compose_files: list[str],
+    repo_root: Path | str,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Refuse the deploy when the build's own env keys are gone from the chain.
+
+    ``osprey build`` writes BOTH :data:`~osprey.utils.dotenv.BUILD_DERIVED_KEYS`
+    (``VA_CHANNELS_FILE``, ``VA_LATTICE``) into ``.env`` whenever it generates
+    ``build/data/simulation/channel_manifest.json``, and nothing else ever
+    writes them. So a manifest on disk beside a chain that carries only one of
+    them, or neither, is a key that was LOST — a line deleted by hand, a
+    ``.env`` restored from an older copy — and not a choice anybody made.
+
+    Left alone, the loss surfaces in the worst place: the compose templates
+    hand the container ``${VA_CHANNELS_FILE:-}``, the entrypoint refuses an
+    empty pointer rather than serving the framework's bundled demo namespace,
+    and the operator gets an unhealthy container whose compose log says only
+    that it exited. Named here instead, ahead of anything that costs time.
+
+    A refusal rather than a warning, for the reason
+    :func:`_preflight_env_chain_drift` gives: a stack started without the key
+    has no outcome anybody asked for.
+
+    Keyed on the names the rendered compose files actually interpolate, so a
+    stack that deploys no reader of the key (no virtual accelerator, no
+    recorder) is not refused over a manifest nothing reads. Existence is the
+    union of the chain and the process environment, as
+    :func:`_preflight_declared_env_unset` takes it, and an empty value counts
+    as no value: ``KEY=`` puts the same empty string in the container as no
+    line at all — and it is the shape that survives a rebuild, because the
+    build appends and never rewrites a key already on file.
+
+    :param compose_files: The compose files this deploy will start, in ``-f``
+        order. Relative entries resolve against *repo_root*.
+    :param repo_root: The deployment repo root, holding the chain and the
+        render.
+    :param environ: The environment to check against. ``None`` reads the live
+        one overlaid with the shell values the CLI's entry-time ``.env`` load
+        replaced, matching what the stack is actually started with.
+    :raises RuntimeError: The manifest exists, some compose file interpolates
+        a build-derived key, and neither the chain nor the environment gives
+        it a value.
+    """
+    from osprey.services.virtual_accelerator.manifest.build import MANIFEST_FILENAME
+    from osprey.utils.dotenv import BUILD_DERIVED_KEYS
+
+    root = Path(repo_root).expanduser().absolute()
+    manifest = Path(BUILD_DIRNAME) / "data" / "simulation" / MANIFEST_FILENAME
+    if not (root / manifest).is_file():
+        return
+
+    wanted = sorted(BUILD_DERIVED_KEYS & _interpolated_vars_across(compose_files, root))
+    if not wanted:
+        return
+
+    if environ is None:
+        from osprey.utils.config import dotenv_shell_overrides
+
+        process_env: Mapping[str, str] = {**os.environ, **dotenv_shell_overrides()}
+    else:
+        process_env = environ
+
+    chain = merge_chain(root)
+    missing = [
+        name
+        for name in wanted
+        if not (chain.get(name) or "").strip() and not (process_env.get(name) or "").strip()
+    ]
+    if not missing:
+        return
+
+    names = ", ".join(missing)
+    logger.error(
+        "Build-derived env lost: %s is on disk, but %s is unset in the env chain and the "
+        "environment.\n"
+        "  `osprey build` writes %s into %s whenever it generates that manifest, and the "
+        "container it points at refuses to start on an empty value rather than serve the "
+        "framework's bundled demo namespace. A manifest on disk beside a chain missing the "
+        "key is a key that was lost, not a choice.\n"
+        "  Run `osprey build` to write it back, then `osprey up`. Delete an empty `%s=` line "
+        "first: the build appends and never rewrites a key already on file.",
+        manifest,
+        names,
+        " and ".join(sorted(BUILD_DERIVED_KEYS)),
+        ENV_LOCAL_FILENAME,
+        names,
+    )
+    raise RuntimeError(
+        f"build-derived env preflight failed: {names} is unset while {manifest} exists "
+        "(see report above). Run `osprey build`, then `osprey up`."
+    )
+
+
 def _preflight_env_shadowing(
     compose_files: list[str],
     repo_root: Path | str,
@@ -3552,14 +3665,7 @@ def _preflight_env_shadowing(
     else:
         process_env = environ
 
-    referenced: set[str] = set()
-    for compose_file in compose_files:
-        path = Path(compose_file)
-        path = path if path.is_absolute() else root / path
-        try:
-            referenced |= _compose_interpolated_vars(path.read_text(encoding="utf-8"))
-        except OSError:
-            continue
+    referenced = _interpolated_vars_across(compose_files, root)
 
     shadowed = sorted(
         name
@@ -3756,14 +3862,7 @@ def _preflight_declared_env_unset(
         return []
 
     root = Path(repo_root).expanduser().absolute()
-    referenced: set[str] = set()
-    for compose_file in compose_files:
-        path = Path(compose_file)
-        path = path if path.is_absolute() else root / path
-        try:
-            referenced |= _compose_interpolated_vars(path.read_text(encoding="utf-8"))
-        except OSError:
-            continue
+    referenced = _interpolated_vars_across(compose_files, root)
     if not referenced:
         return []
 
@@ -4352,7 +4451,9 @@ def _archiver_seed_inputs(config: dict, project_dir: Path):
     seeded history covers precisely the channels the live half serves. It is read
     from the project's own ``.env`` first, because that is where the build wrote
     it; the ambient value is the fallback for a deploy whose environment carries
-    it instead.
+    it instead. Neither naming a manifest is a refusal, never the framework's
+    bundled channel set: a seed of another facility's namespace under this
+    deployment's name is indistinguishable, in the archive, from history.
 
     The value transform rides along because it is decided from the same two
     things this already has in hand — the config and the project's env chain —
@@ -4364,8 +4465,8 @@ def _archiver_seed_inputs(config: dict, project_dir: Path):
         empty for a project with no machine model — every channel is then
         procedural, which is a valid configuration, not a fault. The last two
         are ``None`` unless this deployment's archive is its stand-in's.
+    :raises RuntimeError: Nothing names a manifest to seed from.
     """
-    from osprey.services.virtual_accelerator.manifest.build import build_manifest
     from osprey.services.virtual_accelerator.manifest.loaders import (
         load_machine_json_channels,
         load_manifest_file,
@@ -4386,7 +4487,12 @@ def _archiver_seed_inputs(config: dict, project_dir: Path):
             manifest_path = project_dir / BUILD_DIRNAME / "data" / "simulation" / manifest_path
         channels = load_manifest_file(manifest_path)
     else:
-        channels = build_manifest()["channels"]
+        raise RuntimeError(
+            "The archiver seed has no channel set to build from: VA_CHANNELS_FILE is unset "
+            f"in {project_dir / '.env'} and in the environment. `osprey build` writes it "
+            "whenever it generates the channel manifest; the seed never falls back to the "
+            "framework's bundled channel set."
+        )
 
     transform, transform_fingerprint = _standin_seed_transform(
         config, project_dir, [str(channel["address"]) for channel in channels]
@@ -5817,6 +5923,13 @@ def _start_stack(
     # changes nothing about what the stack reads. Ahead of the advisory below
     # because there is no point reporting on a chain the render does not match.
     _preflight_env_chain_drift(compose_files, repo_root)
+
+    # Refuse a chain the build's own keys have gone missing from: the build
+    # writes VA_CHANNELS_FILE and VA_LATTICE together whenever it generates a
+    # channel manifest, so a manifest on disk beside a chain without them is a
+    # lost key, and the container would exit on the empty value. Reads only
+    # this deployment's own files, so it sits with the other refusals that do.
+    _preflight_build_derived_env(compose_files, repo_root)
 
     # Which compose implementation is behind the resolved runtime, answered once
     # for every invocation this start makes: the env-file fragment, the argv,

--- a/src/osprey/mcp_server/control_system/target_banner.py
+++ b/src/osprey/mcp_server/control_system/target_banner.py
@@ -79,6 +79,7 @@ import os
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from osprey.mcp_server.control_system import target_state
@@ -163,30 +164,30 @@ def resolve_baseline_target() -> str:
 
 
 def _int_or_none(value: object) -> int | None:
-    """Coerce a record field to ``int``, or ``None`` when it is not a number."""
+    """Coerce a caller-supplied pid to ``int``, or ``None`` when it is not a number.
+
+    For the pid a web client names, which arrives as whatever the transport
+    made of it. Record fields are never coerced: they are read strictly through
+    :func:`~osprey.mcp_server.control_system.target_state.record_pid`, because
+    the one writer emits ``int`` and anything else is a record nothing wrote.
+    """
     try:
         return int(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return None
 
 
-def _live_records() -> list[dict]:
-    """Every state record whose owning server process is still running."""
+def _state_entries() -> list[Path]:
+    """The state files on disk, sorted; empty when the directory cannot be listed."""
     try:
-        entries = sorted(target_state.state_dir().glob(target_state.STATE_FILE_GLOB))
+        return sorted(target_state.state_dir().glob(target_state.STATE_FILE_GLOB))
     except OSError:
         return []
 
-    records: list[dict] = []
-    for entry in entries:
-        record = target_state.read_file(entry)
-        if record is None:
-            continue
-        server_pid = _int_or_none(record.get("server_pid"))
-        if server_pid is None or not target_state.is_process_alive(server_pid):
-            continue
-        records.append(record)
-    return records
+
+def _live_records() -> list[dict]:
+    """Every state record whose owning server process is still running."""
+    return target_state.live_records(_state_entries())
 
 
 def resolve_session_target(baseline_target: str) -> str:
@@ -201,19 +202,12 @@ def resolve_session_target(baseline_target: str) -> str:
     Zero matches (no session has switched, or the switch happened under a
     different parent) and more than one match (ambiguous ownership) both mean
     the same thing: no answer. Both fall back to the baseline, so an unknown
-    state produces no refusal and no label rather than a guess.
+    state produces no refusal and no label rather than a guess. The match is
+    :func:`~osprey.mcp_server.control_system.target_state.session_record`, the
+    one rule every child of the same Claude Code process reads by.
     """
-    own_parent = os.getppid()
-    matches = [r for r in _live_records() if _int_or_none(r.get("owner_ppid")) == own_parent]
-    if len(matches) != 1:
-        if matches:
-            logger.debug("Ambiguous target state: %d records own ppid %s", len(matches), own_parent)
-        return baseline_target
-    target = matches[0].get("target")
-    if target not in target_state.TARGET_NAMES:
-        logger.debug("Target state names an unknown target %r; using baseline", target)
-        return baseline_target
-    return str(target)
+    record = target_state.session_record(_state_entries(), os.getppid())
+    return baseline_target if record is None else str(record["target"])
 
 
 # -- resolution for a process we are NOT inside ----------------------------
@@ -368,8 +362,8 @@ def _matched_record(pty_pid: object) -> dict | None:
 
     matches: list[dict] = []
     for record in records:
-        owner_ppid = _int_or_none(record.get("owner_ppid"))
-        if owner_ppid is None or owner_ppid <= 0:
+        owner_ppid = target_state.record_pid(record, "owner_ppid")
+        if owner_ppid is None:
             continue
         try:
             chain = _ancestor_pids(owner_ppid, stop_at=pid, parent_of=parent_of)

--- a/src/osprey/mcp_server/control_system/target_state.py
+++ b/src/osprey/mcp_server/control_system/target_state.py
@@ -138,6 +138,7 @@ import json
 import logging
 import os
 import tempfile
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -218,6 +219,7 @@ __all__ = [
     "in_flight_executions",
     "is_process_alive",
     "is_request_fresh",
+    "live_records",
     "publish_last_switch",
     "publish_posture_realign",
     "publish_reachability",
@@ -226,8 +228,10 @@ __all__ = [
     "read_file",
     "read_request",
     "record_child_pids",
+    "record_pid",
     "remove_request",
     "request_file_path",
+    "session_record",
     "state_dir",
     "state_file_path",
     "sweep_stale",
@@ -313,7 +317,7 @@ def _now_iso() -> str:
 # -- liveness --------------------------------------------------------------
 
 
-def is_process_alive(pid: int) -> bool:
+def is_process_alive(pid: object) -> bool:
     """Whether *pid* names a running process.
 
     ``os.kill(pid, 0)`` sends no signal and only asks the kernel whether the
@@ -322,8 +326,14 @@ def is_process_alive(pid: int) -> bool:
     it counts as ALIVE: sweeping a file whose owner is merely unreachable would
     delete live state. Non-positive PIDs are rejected without calling
     ``os.kill`` at all, because 0 and negatives address process *groups*.
+
+    Anything that is not an ``int`` names no process and is ``False`` without
+    a call either, so a record field can be handed over unconverted. That
+    includes ``bool``: ``True`` is ``1`` to ``os.kill``, and PID 1 is always
+    alive, so a record carrying ``"server_pid": true`` would otherwise read as
+    a running server forever.
     """
-    if pid <= 0:
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
         return False
     try:
         os.kill(pid, 0)
@@ -334,6 +344,118 @@ def is_process_alive(pid: int) -> bool:
     except OSError:  # pragma: no cover - platform oddity; assume alive
         return True
     return True
+
+
+# -- the records that describe a session -----------------------------------
+
+
+def record_pid(record: Mapping[str, Any], field: str) -> int | None:
+    """The PID a record's *field* carries, or ``None`` when it carries no PID.
+
+    Strict: the one writer of these files (:func:`write_on_start`) emits an
+    ``int``, so anything else — a string, a float, a ``bool`` (which IS an
+    ``int`` to ``isinstance`` and ``1`` to ``os.kill``) — is a record nothing
+    here wrote, and coercing it would let such a record match a real parent.
+    """
+    value = record.get(field)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def live_records(entries: Iterable[Path]) -> list[dict[str, Any]]:
+    """Every readable record among *entries* whose owning server still runs.
+
+    A record whose ``server_pid`` is gone is residue: its target describes a
+    server nobody is talking to any more, and the next server to start sweeps
+    it (:func:`sweep_stale`). Unreadable entries are skipped, not raised — a
+    half-written file is the documented "state unavailable" outcome.
+
+    Args:
+        entries: State-file paths, typically ``state_dir().glob(STATE_FILE_GLOB)``.
+            Taken rather than globbed here because one caller keys a cache on
+            the same listing and must not glob twice.
+    """
+    live: list[dict[str, Any]] = []
+    for entry in entries:
+        record = read_file(entry)
+        if record is None:
+            continue
+        server_pid = record_pid(record, "server_pid")
+        if server_pid is None or not is_process_alive(server_pid):
+            continue
+        live.append(record)
+    return live
+
+
+def session_record(
+    entries: Sequence[Path],
+    owner_ppid: int,
+    *,
+    require_generation: bool = False,
+) -> dict[str, Any] | None:
+    """The one live record this session owns, or ``None``.
+
+    THE matcher for every process that is a child of the same Claude Code
+    process as the controls server — the audit posture, the python executor,
+    the banner — so that no two of them can disagree about which session they
+    are in.
+
+    Selection is *exact parent equality*: the controls MCP server that writes
+    these files and the server this code runs in are both spawned by the same
+    Claude Code process, so the record whose ``owner_ppid`` equals our parent
+    is the one describing our session. Deliberately narrower than the
+    ancestor-chain walk the stdlib-only hooks do (and keep, by design: a hook
+    cannot import this module): a deployment that interposes a process breaks
+    the equality and gets "no answer", never another session's target. Strict
+    ``int`` on both sides, per :func:`record_pid`.
+
+    Zero matches (no controls server, or a directory this deployment never
+    created) and more than one (an ``owner_ppid`` collision after PID reuse)
+    both answer ``None``, as does a record naming a target no reader knows. A
+    record whose ``server_pid`` is gone is residue and is skipped
+    (:func:`live_records`).
+
+    Args:
+        entries: State-file paths, as for :func:`live_records`.
+        owner_ppid: This process's parent, ``os.getppid()``.
+        require_generation: Also require an ``int`` ``generation`` — the
+            executor stamps its sandbox with it, and a record without one
+            cannot pin a run.
+
+    Returns:
+        The matching record, or ``None``.
+    """
+    matches: list[dict[str, Any]] = []
+    for record in live_records(entries):
+        if record_pid(record, "owner_ppid") != owner_ppid:
+            continue
+        if record.get("target") not in TARGET_NAMES:
+            continue
+        if require_generation:
+            generation = record.get("generation")
+            if isinstance(generation, bool) or not isinstance(generation, int):
+                continue
+        matches.append(record)
+
+    if len(matches) != 1:
+        if matches:
+            logger.warning(
+                "%d control-target records share owner_ppid %s; the session target is unknown",
+                len(matches),
+                owner_ppid,
+            )
+        elif entries:
+            # Records exist but none is ours — another session's, or a parent
+            # this process does not have. Worth seeing when a switch appears to
+            # have had no effect.
+            logger.debug(
+                "%d control-target record(s) present, none owned by ppid %s",
+                len(entries),
+                owner_ppid,
+            )
+        return None
+    return matches[0]
 
 
 # -- record normalization --------------------------------------------------

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -402,22 +402,19 @@ def _session_target_record() -> dict[str, Any] | None:
     server's PID, which this process — a different MCP server — cannot know. It
     can know its own parent: both servers are spawned by the same Claude Code
     process, so the record whose ``owner_ppid`` equals ``os.getppid()`` here is
-    the one describing the session the execute call belongs to.
+    the one describing the session the execute call belongs to. That match is
+    :func:`osprey.mcp_server.control_system.target_state.session_record`, the
+    one rule every child of that process reads by; this asks it with
+    ``require_generation`` because a record without an ``int`` generation
+    cannot pin a run.
 
-    That is *exact parent equality*, deliberately narrower than the ancestor-
-    chain walk the prompt hook does. It holds for the servers Claude Code spawns
-    directly, which is how OSPREY's MCP servers are launched. A deployment that
-    interposes a process between Claude Code and this server would break the
-    equality, and the outcome of breaking it is an unstamped run on the
-    deployment baseline — the same fail-closed outcome as having no state at all,
-    never a wrong target.
-
-    Zero matches (no controls server, or a state directory this deployment never
-    created) and more than one match (an ``owner_ppid`` collision after a PID
-    was reused) both resolve to ``None``. The caller then stamps nothing, and
-    the sandbox routes off the deployment baseline: a run that is honestly
-    unstamped is recoverable, while a run stamped with a guessed target is a
-    tool call arriving somewhere nobody selected.
+    A deployment that interposes a process between Claude Code and this server
+    breaks the equality, and the outcome is an unstamped run on the deployment
+    baseline — the same fail-closed outcome as having no state at all, never a
+    wrong target. Zero matches and an ``owner_ppid`` collision both resolve to
+    ``None`` for the same reason: a run that is honestly unstamped is
+    recoverable, while a run stamped with a guessed target is a tool call
+    arriving somewhere nobody selected.
 
     Never raises — a missing, corrupt, or unreadable state directory is the
     documented "state unavailable" outcome, not an execution failure.
@@ -430,41 +427,7 @@ def _session_target_record() -> dict[str, Any] | None:
         logger.debug("Target state unavailable; execution runs unstamped", exc_info=True)
         return None
 
-    owner_ppid = os.getppid()
-    matches: list[dict[str, Any]] = []
-    for entry in entries:
-        record = target_state.read_file(entry)
-        if record is None or record.get("owner_ppid") != owner_ppid:
-            continue
-        server_pid = record.get("server_pid")
-        # A record whose owner died is residue: its target describes a server
-        # nobody is talking to any more.
-        if not isinstance(server_pid, int) or not target_state.is_process_alive(server_pid):
-            continue
-        if record.get("target") in target_state.TARGET_NAMES and isinstance(
-            record.get("generation"), int
-        ):
-            matches.append(record)
-
-    if len(matches) != 1:
-        if matches:
-            logger.warning(
-                "%d control-target records share owner_ppid %s; execution runs unstamped",
-                len(matches),
-                owner_ppid,
-            )
-        elif entries:
-            # Records exist but none is ours — another session's, or a parent
-            # this process does not have. Worth seeing when a switch appears to
-            # have had no effect on execute().
-            logger.debug(
-                "%d control-target record(s) present, none owned by ppid %s; "
-                "execution runs unstamped",
-                len(entries),
-                owner_ppid,
-            )
-        return None
-    return matches[0]
+    return target_state.session_record(entries, os.getppid(), require_generation=True)
 
 
 def _target_is_resolvable(target: str) -> bool:

--- a/src/osprey/services/bluesky_bridge/validation.py
+++ b/src/osprey/services/bluesky_bridge/validation.py
@@ -101,16 +101,16 @@ def _assert_limits_readable_if_writable() -> None:
     unsafe posture this guard exists to catch before any connector/CA work
     begins.
 
-    Mirrors `LimitsValidator.from_config`'s ``database_path`` resolution
-    (a relative path anchors on the directory of the config actually loaded,
-    falling back to the ``CONFIG_FILE`` env var's directory and then
-    ``project_root`` — container-correct, since the deploy flattens
-    ``project_root`` in as the HOST build path while the loaded config is the
-    one mounted in-container), but probes readability via
-    `LimitsValidator._load_limits_database`
-    directly rather than calling `from_config` — `from_config` swallows every
-    load failure to `None`, which would hide the exact failure this guard
-    must detect and raise on.
+    Resolves and loads the database through
+    `LimitsValidator.load_configured_database`, the same call
+    `LimitsValidator.from_config` makes (a relative path anchors on the
+    directory of the config actually loaded, falling back to the
+    ``CONFIG_FILE`` env var's directory and then ``project_root`` —
+    container-correct, since the deploy flattens ``project_root`` in as the
+    HOST build path while the loaded config is the one mounted in-container),
+    rather than calling `from_config` itself — `from_config` swallows every
+    load failure into a fail-safe validator, which would hide the exact
+    failure this guard must detect and raise on.
 
     No project config context at all (e.g. running outside a configured
     OSPREY project — most unit-test environments) is treated the same way
@@ -139,8 +139,6 @@ def _assert_limits_readable_if_writable() -> None:
 
     try:
         section = get_config_value("control_system", {})
-        db_path = get_config_value("control_system.limits_checking.database_path", None)
-        project_root = get_config_value("project_root", None)
     except (FileNotFoundError, KeyError, RuntimeError):
         return
 
@@ -163,31 +161,29 @@ def _assert_limits_readable_if_writable() -> None:
 
     limits_key = posture.key("enabled")
 
-    if not db_path or not isinstance(db_path, str):
-        raise RuntimeError(
-            f"refusing to start writable: lane {lane} serves target {lane_target}, "
-            f"where {writes_key} and {limits_key} are both set, but "
-            "control_system.limits_checking.database_path is not configured"
-        )
-
-    from osprey.connectors.control_system.limits_validator import LimitsValidator
-
-    # Same relative-path resolution as `LimitsValidator.from_config`.
-    from osprey.utils.config import default_config_path
-
-    db_path = LimitsValidator.resolve_database_path(
-        db_path, project_root, config_path=default_config_path()
+    from osprey_connectors.control_system.limits_validator import (
+        LIMITS_DATABASE_CONFIG_KEY,
+        LimitsValidator,
     )
 
     try:
-        LimitsValidator._load_limits_database(db_path)
-    except Exception as exc:
+        configured = LimitsValidator.configured_database_path()
+    except (FileNotFoundError, KeyError, RuntimeError):
+        return
+    if configured is None:
+        raise RuntimeError(
+            f"refusing to start writable: lane {lane} serves target {lane_target}, "
+            f"where {writes_key} and {limits_key} are both set, but "
+            f"{LIMITS_DATABASE_CONFIG_KEY} is not configured"
+        )
+
+    loaded, reason = LimitsValidator.load_configured_database()
+    if loaded is None:
         raise RuntimeError(
             f"refusing to start writable: lane {lane} serves target {lane_target}, "
             f"where {writes_key} and {limits_key} are both set, but the configured "
-            "control_system.limits_checking.database_path could not be read or "
-            "parsed"
-        ) from exc
+            f"{LIMITS_DATABASE_CONFIG_KEY} could not be read or parsed: {reason}"
+        )
 
 
 def _validate_launchable_request(request: Any) -> None:

--- a/src/osprey/services/facility_knowledge/ttl_generator/direction.py
+++ b/src/osprey/services/facility_knowledge/ttl_generator/direction.py
@@ -32,7 +32,6 @@ This module is standard-library plus in-repo imports only: no ``rdflib``, no
 
 from __future__ import annotations
 
-import json
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
@@ -43,7 +42,10 @@ from typing import Any
 # ``osprey_connectors.config``; importing from the real module keeps the two
 # connector-side helpers below spelled from one place.
 from osprey_connectors.config import default_config_path, get_config_value
-from osprey_connectors.control_system.limits_validator import LimitsValidator
+from osprey_connectors.control_system.limits_validator import (
+    LIMITS_DATABASE_CONFIG_KEY,
+    LimitsValidator,
+)
 
 from .model import GraphModel
 
@@ -55,15 +57,6 @@ DIRECTION_READ = "read"
 
 #: Subfield token the PV grammar treats as a setpoint.
 WRITE_SUBFIELD = "SP"
-
-#: Config key naming the channel limits database, shared with the write path.
-LIMITS_DATABASE_CONFIG_KEY = "control_system.limits_checking.database_path"
-
-#: Config key naming the project root, the last-resort path anchor.
-PROJECT_ROOT_CONFIG_KEY = "project_root"
-
-#: Keys in the limits file that name no channel.
-_LIMITS_DEFAULTS_KEY = "defaults"
 
 #: How many dissenting addresses a conflict message spells out before eliding.
 _MAX_NAMED_DISSENTERS = 10
@@ -201,59 +194,16 @@ def resolve_limits_path(
         return path, f"limits file given explicitly: {path}"
 
     lookup = get_config_value if config_lookup is None else config_lookup
-    configured = lookup(LIMITS_DATABASE_CONFIG_KEY, None)
-    if not configured or not isinstance(configured, str):
+    configured = LimitsValidator.configured_database_path(
+        config_lookup=lookup, config_path=default_config_path()
+    )
+    if configured is None:
         return None, f"{LIMITS_DATABASE_CONFIG_KEY} is not set in the OSPREY config"
 
-    project_root = lookup(PROJECT_ROOT_CONFIG_KEY, None)
-    resolved = Path(
-        LimitsValidator.resolve_database_path(
-            configured,
-            project_root if isinstance(project_root, str) else None,
-            config_path=default_config_path(),
-        )
-    )
+    resolved = Path(configured)
     if not resolved.is_file():
         return None, f"no limits file found at {resolved} (from {LIMITS_DATABASE_CONFIG_KEY})"
     return resolved, f"limits file from {LIMITS_DATABASE_CONFIG_KEY}: {resolved}"
-
-
-def load_writable_set(limits_path: Path) -> frozenset[str]:
-    """Read the addresses a channel limits file declares writable.
-
-    Writability is defaults-aware: the demo file grants it by *omitting* the
-    ``writable`` key so the entry inherits ``defaults.writable: true``.  Reading
-    only explicit ``writable: true`` entries would find none at all.
-
-    Args:
-        limits_path: Path to a ``channel_limits.json``-shaped file.
-
-    Returns:
-        The writable addresses.
-
-    Raises:
-        ValueError: If the file is not JSON, or is not a JSON object.
-    """
-    try:
-        raw = json.loads(Path(limits_path).read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"Channel limits file {limits_path} is not valid JSON: {exc}") from exc
-    if not isinstance(raw, dict):
-        raise ValueError(
-            f"Channel limits file {limits_path} must contain a JSON object keyed by "
-            f"channel address, got {type(raw).__name__}"
-        )
-
-    defaults = raw.get(_LIMITS_DEFAULTS_KEY)
-    defaults = defaults if isinstance(defaults, dict) else {}
-    writable = {
-        address
-        for address, entry in raw.items()
-        if not address.startswith("_")
-        and address != _LIMITS_DEFAULTS_KEY
-        and {**defaults, **(entry if isinstance(entry, dict) else {})}.get("writable", True)
-    }
-    return frozenset(writable)
 
 
 def assign_directions(
@@ -279,7 +229,7 @@ def assign_directions(
         DirectionConflictError: If a signal group's members do not share one
             limits-derived direction.
         ValueError: If the limits file is unreadable (see
-            :func:`load_writable_set`).
+            :meth:`~osprey_connectors.control_system.limits_validator.LimitsValidator.writable_addresses`).
     """
     if limits_path is None:
         directions = {
@@ -294,7 +244,7 @@ def assign_directions(
         )
 
     path = Path(limits_path)
-    writable = load_writable_set(path)
+    writable = LimitsValidator.writable_addresses(path)
     directions: dict[tuple[str, str, str], str] = {}
     for group in model.signal_groups:
         by_direction: dict[str, list[str]] = {}

--- a/src/osprey/services/virtual_accelerator/manifest/build.py
+++ b/src/osprey/services/virtual_accelerator/manifest/build.py
@@ -458,11 +458,14 @@ def _graph_roster(config: dict):
     )
 
     resolution = resolve_roster_source(config)
+    # Graph mode with no readable corpus is still graph mode: both absences
+    # come back so the refusal can name the corpus keys, or the broken line.
     graph_configured = (
         resolution.source is not None and resolution.source.kind is RosterSourceKind.GRAPH
     ) or (
         resolution.absence is not None
-        and resolution.absence.reason is RosterAbsenceReason.GRAPH_NO_TTL
+        and resolution.absence.reason
+        in (RosterAbsenceReason.GRAPH_NO_TTL, RosterAbsenceReason.GRAPH_MALFORMED)
     )
     if not graph_configured:
         return None

--- a/tests/channel_roster/test_records.py
+++ b/tests/channel_roster/test_records.py
@@ -207,6 +207,8 @@ class TestRosterAbsence:
         ("reason", "kwargs", "missing"),
         [
             (RosterAbsenceReason.GRAPH_NO_TTL, {}, "config_keys"),
+            (RosterAbsenceReason.GRAPH_MALFORMED, {"detail": "boom"}, "config_keys"),
+            (RosterAbsenceReason.GRAPH_MALFORMED, {"config_keys": ("k",)}, "detail"),
             (RosterAbsenceReason.DIRECTION_UNDERIVABLE, {}, "path"),
             (RosterAbsenceReason.CORRUPT_SOURCE, {"detail": "boom"}, "path"),
             (RosterAbsenceReason.CORRUPT_SOURCE, {"path": Path("/x")}, "detail"),

--- a/tests/channel_roster/test_sources.py
+++ b/tests/channel_roster/test_sources.py
@@ -92,7 +92,7 @@ class TestGraphMode:
         assert resolution.absence is not None
         assert resolution.absence.reason is RosterAbsenceReason.GRAPH_NO_TTL
 
-    def test_malformed_graphdb_block_degrades_to_the_same_absence(self, caplog) -> None:
+    def test_malformed_graphdb_block_is_its_own_absence_naming_the_why(self, caplog) -> None:
         config = {
             "channel_finder": {"pipeline_mode": "graph"},
             "services": {"graphdb": {"ttl_path": "   "}},
@@ -101,10 +101,17 @@ class TestGraphMode:
         with caplog.at_level("WARNING"):
             resolution = resolve_roster_source(config)
 
+        assert resolution.source is None
         assert resolution.absence is not None
-        assert resolution.absence.reason is RosterAbsenceReason.GRAPH_NO_TTL
         # A blank value is a config mistake rather than a deliberate "no local
-        # corpus", so unlike the absent block it is warned about by name.
+        # corpus": a different remedy, so a different reason, still fail-soft.
+        assert resolution.absence.reason is RosterAbsenceReason.GRAPH_MALFORMED
+        assert resolution.absence.config_keys == GRAPH_CORPUS_CONFIG_KEYS
+        assert resolution.absence.detail
+        message = resolution.absence.message()
+        assert resolution.absence.detail in message
+        assert "services.graphdb.ttl_path" in message
+        assert "services.graphdb.uri" in message
         assert "services.graphdb" in caplog.text
 
     def test_absolute_ttl_path_is_taken_as_written(self, tmp_path: Path) -> None:

--- a/tests/connectors/test_limits_validator.py
+++ b/tests/connectors/test_limits_validator.py
@@ -18,8 +18,10 @@ import pytest
 
 from osprey.connectors.control_system.limits_validator import (
     DEFAULTS_FIELD,
+    LIMITS_DATABASE_CONFIG_KEY,
     ChannelLimitsConfig,
     LimitsValidator,
+    mapping_config_lookup,
 )
 from osprey.errors import ChannelLimitsViolationError
 from osprey_connectors.types import EPICS, VIRTUAL_ACCELERATOR, LimitsPosture
@@ -1437,3 +1439,244 @@ class TestUnlistedRefusalNamesKey:
             validator.validate("NOT:IN:DB", 5.0)
 
         assert exc.value.violation_type == "UNLISTED_CHANNEL"
+
+
+# ---------------------------------------------------------------------------
+# The one home of the limits-database key and loader
+# ---------------------------------------------------------------------------
+
+
+def _write_limits(path: Path, entries: dict[str, dict], defaults: dict | None = None) -> Path:
+    """Write a synthetic channel_limits.json-shaped file."""
+    payload: dict[str, object] = {
+        "_comment": "synthetic fixture",
+        "_version": "4.0",
+        "defaults": {"writable": True} if defaults is None else defaults,
+    }
+    payload.update(entries)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class TestConfiguredDatabasePath:
+    """One reading of the key, for every caller that used to walk it itself."""
+
+    def test_the_key_is_spelled_once(self):
+        assert LIMITS_DATABASE_CONFIG_KEY == "control_system.limits_checking.database_path"
+
+    def test_a_mapping_lookup_walks_dotted_keys(self):
+        lookup = mapping_config_lookup({"control_system": {"limits_checking": {"enabled": True}}})
+
+        assert lookup("control_system.limits_checking.enabled", None) is True
+        assert lookup("control_system.limits_checking", None) == {"enabled": True}
+        assert lookup("control_system.missing.leaf", "dflt") == "dflt"
+        assert lookup("control_system.limits_checking.enabled.deeper", None) is None
+
+    @pytest.mark.parametrize("config", [{}, {"control_system": {}}, {"control_system": "x"}])
+    def test_an_absent_key_is_none(self, config):
+        assert (
+            LimitsValidator.configured_database_path(config_lookup=mapping_config_lookup(config))
+            is None
+        )
+
+    @pytest.mark.parametrize("value", ["", "   ", None, False, 3])
+    def test_a_key_naming_nothing_usable_is_none(self, value):
+        config = {"control_system": {"limits_checking": {"database_path": value}}}
+
+        assert (
+            LimitsValidator.configured_database_path(config_lookup=mapping_config_lookup(config))
+            is None
+        )
+
+    def test_a_relative_path_anchors_on_the_config_it_was_read_from(self, tmp_path):
+        config = {"control_system": {"limits_checking": {"database_path": "data/limits.json"}}}
+
+        resolved = LimitsValidator.configured_database_path(
+            config_lookup=mapping_config_lookup(config),
+            config_path=str(tmp_path / "render" / "config.yml"),
+        )
+
+        assert resolved == str(tmp_path / "render" / "data" / "limits.json")
+
+    def test_an_absolute_path_is_taken_as_written(self, tmp_path):
+        absolute = tmp_path / "elsewhere" / "limits.json"
+        config = {"control_system": {"limits_checking": {"database_path": str(absolute)}}}
+
+        resolved = LimitsValidator.configured_database_path(
+            config_lookup=mapping_config_lookup(config), config_path=str(tmp_path / "config.yml")
+        )
+
+        assert resolved == str(absolute)
+
+    def test_existence_is_not_probed_here(self, tmp_path):
+        config = {"control_system": {"limits_checking": {"database_path": "gone.json"}}}
+
+        resolved = LimitsValidator.configured_database_path(
+            config_lookup=mapping_config_lookup(config), config_path=str(tmp_path / "config.yml")
+        )
+
+        assert resolved is not None
+        assert not Path(resolved).exists()
+
+    def test_the_live_lookup_is_the_default(self, monkeypatch, tmp_path):
+        _patch_config(
+            monkeypatch,
+            {"control_system.limits_checking.database_path": str(tmp_path / "limits.json")},
+        )
+
+        assert LimitsValidator.configured_database_path() == str(tmp_path / "limits.json")
+
+
+class TestLoadConfiguredDatabase:
+    """Resolve and load, reporting rather than raising — for every caller."""
+
+    def _config(self, path) -> dict:
+        return {"control_system": {"limits_checking": {"database_path": str(path)}}}
+
+    def test_an_unconfigured_key_is_named(self):
+        loaded, reason = LimitsValidator.load_configured_database(
+            config_lookup=mapping_config_lookup({})
+        )
+
+        assert loaded is None
+        assert reason == f"{LIMITS_DATABASE_CONFIG_KEY} is not configured"
+
+    def test_a_missing_file_names_the_key_and_the_path(self, tmp_path):
+        missing = tmp_path / "limits.json"
+
+        loaded, reason = LimitsValidator.load_configured_database(
+            config_lookup=mapping_config_lookup(self._config(missing))
+        )
+
+        assert loaded is None
+        assert reason is not None
+        assert LIMITS_DATABASE_CONFIG_KEY in reason
+        assert str(missing) in reason
+        assert "could not be read or parsed" in reason
+        assert "not found" in reason
+
+    def test_a_broken_file_carries_the_validators_own_message(self, tmp_path):
+        broken = tmp_path / "limits.json"
+        broken.write_text("{not json", encoding="utf-8")
+
+        loaded, reason = LimitsValidator.load_configured_database(
+            config_lookup=mapping_config_lookup(self._config(broken))
+        )
+
+        assert loaded is None
+        assert reason is not None
+        assert "could not be read or parsed" in reason
+        assert "JSON" in reason
+
+    def test_a_readable_file_loads_with_no_reason(self, tmp_path):
+        limits = _write_limits(tmp_path / "limits.json", {"FOO": {"max_value": 1.0}})
+
+        loaded, reason = LimitsValidator.load_configured_database(
+            config_lookup=mapping_config_lookup(self._config(limits))
+        )
+
+        assert reason is None
+        assert loaded is not None
+        limits_db, raw_db = loaded
+        assert set(limits_db) == {"FOO"}
+        assert raw_db["FOO"] == {"max_value": 1.0}
+
+    def test_from_config_blocks_every_write_on_the_loaders_reason(self, monkeypatch, tmp_path):
+        """The connector's failsafe quotes the same sentence every other caller gets."""
+        _patch_config(
+            monkeypatch,
+            {
+                "control_system.limits_checking.enabled": True,
+                "control_system.limits_checking.allow_unlisted_channels": False,
+                "control_system.limits_checking.database_path": str(tmp_path / "gone.json"),
+            },
+        )
+
+        validator = LimitsValidator.from_config()
+
+        assert isinstance(validator, LimitsValidator)
+        assert validator.limits == {}
+        assert validator.failsafe_reason is not None
+        assert validator.failsafe_reason.startswith("limits checking is enabled but ")
+        assert "could not be read or parsed" in validator.failsafe_reason
+        with pytest.raises(ChannelLimitsViolationError) as exc:
+            validator.validate("FOO", 1.0)
+        assert exc.value.violation_type == "LIMITS_DATABASE_UNAVAILABLE"
+
+
+class TestWritableAddresses:
+    """Defaults-aware writability, the rule the runtime write path uses."""
+
+    """Defaults-aware writability, the rule the runtime write path uses."""
+
+    def test_entry_without_writable_inherits_the_default(self, tmp_path):
+        """The demo file grants writability by omission — that must be honored."""
+        limits = _write_limits(
+            tmp_path / "limits.json",
+            {"SR:MAG:DIPOLE:01:CURRENT:SP": {"min_value": 0.0, "max_value": 1.0}},
+            defaults={"writable": True},
+        )
+
+        assert LimitsValidator.writable_addresses(limits) == frozenset(
+            {"SR:MAG:DIPOLE:01:CURRENT:SP"}
+        )
+
+    def test_explicit_false_overrides_a_true_default(self, tmp_path):
+        """An explicit writable:false wins over defaults.writable:true."""
+        limits = _write_limits(
+            tmp_path / "limits.json",
+            {
+                "SR:MAG:DIPOLE:01:CURRENT:SP": {},
+                "SR:VAC:VALVE:01:CONTROL:OPEN": {"writable": False},
+            },
+            defaults={"writable": True},
+        )
+
+        assert LimitsValidator.writable_addresses(limits) == frozenset(
+            {"SR:MAG:DIPOLE:01:CURRENT:SP"}
+        )
+
+    def test_explicit_true_overrides_a_false_default(self, tmp_path):
+        """The merge runs both ways: an entry can opt in under a false default."""
+        limits = _write_limits(
+            tmp_path / "limits.json",
+            {
+                "SR:MAG:DIPOLE:01:CURRENT:SP": {"writable": True},
+                "SR:MAG:DIPOLE:01:CURRENT:RB": {},
+            },
+            defaults={"writable": False},
+        )
+
+        assert LimitsValidator.writable_addresses(limits) == frozenset(
+            {"SR:MAG:DIPOLE:01:CURRENT:SP"}
+        )
+
+    def test_metadata_and_defaults_keys_are_not_channels(self, tmp_path):
+        """Underscore keys and 'defaults' never become addresses."""
+        limits = _write_limits(
+            tmp_path / "limits.json",
+            {"SR:MAG:DIPOLE:01:CURRENT:SP": {}},
+            defaults={"writable": True},
+        )
+
+        writable = LimitsValidator.writable_addresses(limits)
+
+        assert writable == frozenset({"SR:MAG:DIPOLE:01:CURRENT:SP"})
+        assert not any(key.startswith("_") or key == "defaults" for key in writable)
+
+    def test_missing_defaults_block_falls_back_to_writable_true(self, tmp_path):
+        """No defaults block at all still matches the validator's ``get(..., True)``."""
+        path = tmp_path / "limits.json"
+        path.write_text(json.dumps({"SR:MAG:DIPOLE:01:CURRENT:SP": {}}), encoding="utf-8")
+
+        assert LimitsValidator.writable_addresses(path) == frozenset(
+            {"SR:MAG:DIPOLE:01:CURRENT:SP"}
+        )
+
+    def test_non_object_payload_is_a_legible_error(self, tmp_path):
+        """A JSON list is refused by name rather than raising AttributeError later."""
+        path = tmp_path / "limits.json"
+        path.write_text(json.dumps(["nope"]), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="JSON object"):
+            LimitsValidator.writable_addresses(path)

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -2990,6 +2990,21 @@ def test_seed_inputs_read_the_manifest_the_project_env_names(tmp_path):
     assert boot_values == {}
 
 
+def test_seed_inputs_refuse_when_nothing_names_a_manifest(tmp_path, monkeypatch):
+    """No pointer, no seed — never the framework's bundled channel set.
+
+    The bundled manifest is the demo namespace, and an archive seeded with it
+    under a facility's name is indistinguishable from that facility's history.
+    Every other reader of the channel roster dropped this fallback; the seed is
+    the last one, and it goes the same way.
+    """
+    monkeypatch.delenv("VA_CHANNELS_FILE", raising=False)
+    (tmp_path / ".env").write_text("OTHER=x\n")
+
+    with pytest.raises(RuntimeError, match="VA_CHANNELS_FILE"):
+        container_lifecycle._archiver_seed_inputs({}, tmp_path)
+
+
 def test_reapply_without_a_machine_model_is_a_no_op(tmp_path):
     """A store-only project has no scenarios to restore onto the rebuilt base."""
     container_lifecycle._reapply_active_scenarios({}, tmp_path, None)

--- a/tests/deployment/test_env_shadow_preflight.py
+++ b/tests/deployment/test_env_shadow_preflight.py
@@ -66,6 +66,7 @@ from osprey.deployment.compose_generator import (
 from osprey.deployment.container_lifecycle import (
     ENV_CHAIN_STATE_RELPATH,
     _compose_interpolated_vars,
+    _preflight_build_derived_env,
     _preflight_env_chain_drift,
     _preflight_env_shadowing,
     _report_chain_overrides,
@@ -2095,3 +2096,192 @@ def test_the_advisory_runs_before_the_image_build(tmp_path, monkeypatch):
     )
 
     assert order == ["declared", "image"]
+
+
+# ---------------------------------------------------------------------------
+# A build-derived key lost from the chain: a refusal, because the build wrote it
+# ---------------------------------------------------------------------------
+
+
+_VA_COMPOSE = (
+    "services:\n"
+    "  virtual-accelerator:\n"
+    "    image: va:local\n"
+    "    environment:\n"
+    '      VA_CHANNELS_FILE: "${VA_CHANNELS_FILE:-}"\n'
+    '      VA_LATTICE: "${VA_LATTICE:-}"\n'
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_inherited_build_derived_exports(monkeypatch):
+    for var in ("VA_CHANNELS_FILE", "VA_LATTICE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _manifest(root: Path) -> Path:
+    """The channel manifest a build generates into the render's data dir."""
+    simulation = root / "build" / "data" / "simulation"
+    simulation.mkdir(parents=True, exist_ok=True)
+    path = simulation / "channel_manifest.json"
+    path.write_text('{"channels": []}', encoding="utf-8")
+    return path
+
+
+def test_a_lost_channels_pointer_refuses_and_names_the_key(tmp_path, caplog):
+    """The build writes BOTH keys whenever it generates a manifest.
+
+    So a manifest on disk beside a chain missing one of them is a key that was
+    lost, not a choice anybody made — and the container it would start refuses
+    to boot on an empty pointer, which is a worse place to learn it.
+    """
+    repo = _repo(tmp_path, "VA_LATTICE=builtin\n", _VA_COMPOSE)
+    _manifest(repo)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError) as excinfo:
+        _preflight_build_derived_env(_files(), repo)
+
+    assert "VA_CHANNELS_FILE" in str(excinfo.value)
+    assert "VA_LATTICE" not in str(excinfo.value)
+    assert "osprey build" in caplog.text
+    assert "channel_manifest.json" in caplog.text
+
+
+def test_a_lost_lattice_key_refuses_and_names_the_key(tmp_path, caplog):
+    repo = _repo(tmp_path, "VA_CHANNELS_FILE=channel_manifest.json\n", _VA_COMPOSE)
+    _manifest(repo)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError) as excinfo:
+        _preflight_build_derived_env(_files(), repo)
+
+    assert "VA_LATTICE" in str(excinfo.value)
+    assert "VA_CHANNELS_FILE" not in str(excinfo.value)
+
+
+def test_both_lost_keys_are_named(tmp_path):
+    repo = _repo(tmp_path, "OTHER=x\n", _VA_COMPOSE)
+    _manifest(repo)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _preflight_build_derived_env(_files(), repo)
+
+    assert "VA_CHANNELS_FILE" in str(excinfo.value)
+    assert "VA_LATTICE" in str(excinfo.value)
+
+
+def test_an_empty_value_is_a_lost_key(tmp_path, caplog):
+    """``KEY=`` puts the same empty string in the container as no line at all.
+
+    And it is the shape that survives a rebuild: the build appends and never
+    rewrites a key already on file, so the empty line has to be named.
+    """
+    repo = _repo(tmp_path, "VA_CHANNELS_FILE=\nVA_LATTICE=builtin\n", _VA_COMPOSE)
+    _manifest(repo)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError) as excinfo:
+        _preflight_build_derived_env(_files(), repo)
+
+    assert "VA_CHANNELS_FILE" in str(excinfo.value)
+    assert "never rewrites" in caplog.text
+
+
+def test_both_keys_on_file_is_silent(tmp_path, caplog):
+    repo = _repo(tmp_path, "VA_CHANNELS_FILE=channel_manifest.json\nVA_LATTICE=none\n", _VA_COMPOSE)
+    _manifest(repo)
+
+    with caplog.at_level(logging.INFO):
+        _preflight_build_derived_env(_files(), repo)
+
+    assert caplog.text == ""
+
+
+def test_no_manifest_is_not_this_checks_business(tmp_path, caplog):
+    """No manifest, no pointer to lose.
+
+    A build that generated none already warned about a stale pointer left on
+    file, and a chain with neither key names nothing a virtual accelerator
+    could boot from — that refusal is the container's own, by name.
+    """
+    repo = _repo(tmp_path, "OTHER=x\n", _VA_COMPOSE)
+
+    with caplog.at_level(logging.INFO):
+        _preflight_build_derived_env(_files(), repo)
+
+    assert caplog.text == ""
+
+
+def test_a_key_no_compose_file_interpolates_is_not_reported(tmp_path, caplog):
+    """A manifest beside a stack that deploys no reader of it is not a lost key."""
+    repo = _repo(tmp_path, "OTHER=x\n", _worker_compose("./.env"))
+    _manifest(repo)
+
+    with caplog.at_level(logging.INFO):
+        _preflight_build_derived_env(_files(), repo)
+
+    assert caplog.text == ""
+
+
+def test_the_recorder_compose_counts_as_a_reader(tmp_path):
+    """Any compose file that interpolates the key is a reader, not just the VA's."""
+    recorder = (
+        "services:\n  archiver-recorder:\n    image: rec:local\n    environment:\n"
+        '      VA_CHANNELS_FILE: "${VA_CHANNELS_FILE:-}"\n'
+    )
+    repo = _repo(tmp_path, "VA_LATTICE=none\n", recorder)
+    _manifest(repo)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _preflight_build_derived_env(_files(), repo)
+
+    assert "VA_CHANNELS_FILE" in str(excinfo.value)
+
+
+def test_a_key_pinned_in_the_shared_file_counts(tmp_path, caplog):
+    repo = _repo(tmp_path, "VA_LATTICE=none\n", _VA_COMPOSE)
+    _shared(repo, "VA_CHANNELS_FILE=channel_manifest.json\n")
+    _manifest(repo)
+
+    with caplog.at_level(logging.INFO):
+        _preflight_build_derived_env(_files(), repo)
+
+    assert caplog.text == ""
+
+
+def test_an_exported_value_counts(tmp_path, caplog, monkeypatch):
+    """A shell export reaches compose too, so it is a value, not a lost key."""
+    repo = _repo(tmp_path, "VA_LATTICE=none\n", _VA_COMPOSE)
+    _manifest(repo)
+    monkeypatch.setenv("VA_CHANNELS_FILE", "channel_manifest.json")
+
+    with caplog.at_level(logging.INFO):
+        _preflight_build_derived_env(_files(), repo)
+
+    assert caplog.text == ""
+
+
+def test_a_missing_compose_file_is_skipped_not_raised_here_too(tmp_path):
+    repo = _repo(tmp_path, "OTHER=x\n")
+    _manifest(repo)
+
+    _preflight_build_derived_env(["build/services/docker-compose.gone.yml"], repo)
+
+
+def test_a_lost_key_refuses_the_deploy_before_the_image_build(tmp_path, monkeypatch):
+    """On the deploy path, and ahead of the build: the whole point is to be told early."""
+    repo = _repo(tmp_path, "VA_LATTICE=builtin\n", _VA_COMPOSE)
+    _manifest(repo)
+
+    order: list[str] = []
+    ran = _stub_runtime(monkeypatch, order)
+
+    with pytest.raises(RuntimeError):
+        container_lifecycle._start_stack(
+            {"project_name": "proj", "deployed_services": ["virtual_accelerator"]},
+            _files(),
+            repo,
+            detached=True,
+            env_path=repo / ".env",
+        )
+
+    assert order == []
+    assert not any("up" in cmd for cmd in ran)

--- a/tests/mcp_server/test_target_state.py
+++ b/tests/mcp_server/test_target_state.py
@@ -408,6 +408,145 @@ class TestIsProcessAlive:
         assert target_state.is_process_alive(0) is False
         assert target_state.is_process_alive(-1) is False
 
+    @pytest.mark.parametrize("value", [True, False, "4321", 4321.0, None, [4321]])
+    def test_anything_but_an_int_names_no_process(self, monkeypatch, value):
+        """``True`` is ``1`` to ``os.kill``, and PID 1 is always alive."""
+
+        def explode(pid, sig):  # pragma: no cover - must not be called
+            raise AssertionError(f"os.kill called with {pid!r}")
+
+        monkeypatch.setattr(os, "kill", explode)
+        assert target_state.is_process_alive(value) is False
+
+
+# ---------------------------------------------------------------------------
+# The records that describe a session: one matcher for every child process
+# ---------------------------------------------------------------------------
+
+
+def _record(pid, *, owner_ppid=None, target="va", generation=3, **extra) -> dict:
+    payload = {
+        "target": target,
+        "generation": generation,
+        "server_pid": pid,
+        "owner_ppid": os.getppid() if owner_ppid is None else owner_ppid,
+        **extra,
+    }
+    path = target_state.state_file_path(pid if isinstance(pid, int) else 99999)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
+def _entries():
+    return sorted(target_state.state_dir().glob(target_state.STATE_FILE_GLOB))
+
+
+class TestRecordPid:
+    @pytest.mark.parametrize("value", [True, False, "4321", 4321.0, None, 0, -1])
+    def test_only_a_positive_int_is_a_pid(self, value):
+        assert target_state.record_pid({"server_pid": value}, "server_pid") is None
+
+    def test_a_positive_int_is_returned_as_is(self):
+        assert target_state.record_pid({"server_pid": 4321}, "server_pid") == 4321
+
+    def test_a_missing_field_is_none(self):
+        assert target_state.record_pid({}, "server_pid") is None
+
+
+class TestLiveRecords:
+    def test_a_running_owner_keeps_its_record(self, state_root):
+        _record(os.getpid())
+
+        assert [r["server_pid"] for r in target_state.live_records(_entries())] == [os.getpid()]
+
+    def test_a_dead_owner_is_residue(self, state_root, monkeypatch):
+        _record(4321)
+        monkeypatch.setattr(os, "kill", TestSweep._kill_with_dead({4321}))
+
+        assert target_state.live_records(_entries()) == []
+
+    def test_a_bool_server_pid_is_not_a_live_server(self, state_root, monkeypatch):
+        """``True`` would reach ``os.kill(1, 0)`` and read as alive forever."""
+        _record(True)
+
+        def explode(pid, sig):  # pragma: no cover - must not be called
+            raise AssertionError(f"os.kill called with {pid!r}")
+
+        monkeypatch.setattr(os, "kill", explode)
+        assert target_state.live_records(_entries()) == []
+
+    def test_an_unreadable_entry_is_skipped(self, state_root):
+        _record(os.getpid())
+        target_state.state_file_path(4321).write_text("{not json", encoding="utf-8")
+
+        assert len(target_state.live_records(_entries())) == 1
+
+
+class TestSessionRecord:
+    def test_the_record_our_parent_owns_is_ours(self, state_root):
+        _record(os.getpid())
+
+        record = target_state.session_record(_entries(), os.getppid())
+
+        assert record is not None
+        assert record["target"] == "va"
+
+    def test_another_parents_record_is_not_ours(self, state_root):
+        _record(os.getpid(), owner_ppid=os.getppid() + 100000)
+
+        assert target_state.session_record(_entries(), os.getppid()) is None
+
+    def test_equality_is_strict_int(self, state_root):
+        """A record spelling the parent as a string or a bool matches nothing."""
+        _record(os.getpid(), owner_ppid=str(os.getppid()))
+
+        assert target_state.session_record(_entries(), os.getppid()) is None
+        assert target_state.session_record(_entries(), 1) is None
+
+    def test_a_bool_owner_never_matches_pid_one(self, state_root):
+        _record(os.getpid(), owner_ppid=True)
+
+        assert target_state.session_record(_entries(), 1) is None
+
+    def test_a_dead_server_record_is_residue(self, state_root, monkeypatch):
+        _record(4321)
+        monkeypatch.setattr(os, "kill", TestSweep._kill_with_dead({4321}))
+
+        assert target_state.session_record(_entries(), os.getppid()) is None
+
+    def test_an_unknown_target_is_no_answer(self, state_root):
+        _record(os.getpid(), target="production")
+
+        assert target_state.session_record(_entries(), os.getppid()) is None
+
+    def test_two_records_sharing_the_parent_are_ambiguous(self, state_root, caplog):
+        _record(os.getpid())
+        _record(os.getppid(), target="live")
+
+        with caplog.at_level("WARNING"):
+            assert target_state.session_record(_entries(), os.getppid()) is None
+
+        assert "share owner_ppid" in caplog.text
+
+    def test_generation_is_only_required_when_asked(self, state_root):
+        _record(os.getpid(), generation="3")
+
+        assert target_state.session_record(_entries(), os.getppid()) is not None
+        assert (
+            target_state.session_record(_entries(), os.getppid(), require_generation=True) is None
+        )
+
+    def test_a_bool_generation_does_not_pin_a_run(self, state_root):
+        _record(os.getpid(), generation=True)
+
+        assert (
+            target_state.session_record(_entries(), os.getppid(), require_generation=True) is None
+        )
+
+    def test_no_entries_is_none(self, state_root):
+        assert target_state.session_record([], os.getppid()) is None
+
 
 # ---------------------------------------------------------------------------
 # Shutdown + durability

--- a/tests/services/facility_knowledge/test_demo_ttl_consistency.py
+++ b/tests/services/facility_knowledge/test_demo_ttl_consistency.py
@@ -393,14 +393,15 @@ def test_demo_ttl_devices_match_the_pv_grammar(committed_graph: Any, directed_mo
 def test_demo_ttl_writes_exactly_the_limits_writable_set(committed_graph: Any) -> None:
     """``writesSignal`` bindings are exactly the limits file's writable set.
 
-    ``load_writable_set`` reads the file the way the runtime does — merging the
-    ``defaults`` block, where the demo machine grants write access by *omitting*
-    the key. Re-deriving it here from raw JSON would risk agreeing with the
-    corpus about the wrong thing.
+    ``LimitsValidator.writable_addresses`` reads the file the way the runtime
+    does — it IS the runtime's loader — merging the ``defaults`` block, where
+    the demo machine grants write access by *omitting* the key. Re-deriving it
+    here from raw JSON would risk agreeing with the corpus about the wrong
+    thing.
     """
-    from osprey.services.facility_knowledge.ttl_generator.direction import load_writable_set
+    from osprey_connectors.control_system.limits_validator import LimitsValidator
 
-    writable = set(load_writable_set(LIMITS_PATH))
+    writable = set(LimitsValidator.writable_addresses(LIMITS_PATH))
     written = _pvs_of_bindings_with(committed_graph, "writesSignal")
 
     assert len(writable) == EXPECTED_WRITABLE, (
@@ -422,9 +423,9 @@ def test_demo_ttl_reads_everything_the_limits_file_withholds(
     committed_graph: Any, corpus_pvs: set[str]
 ) -> None:
     """The read set is the complement — no channel is both, and none is neither."""
-    from osprey.services.facility_knowledge.ttl_generator.direction import load_writable_set
+    from osprey_connectors.control_system.limits_validator import LimitsValidator
 
-    writable = set(load_writable_set(LIMITS_PATH))
+    writable = set(LimitsValidator.writable_addresses(LIMITS_PATH))
     read = _pvs_of_bindings_with(committed_graph, "readsSignal")
     written = _pvs_of_bindings_with(committed_graph, "writesSignal")
 

--- a/tests/services/facility_knowledge/test_ttl_generator_direction.py
+++ b/tests/services/facility_knowledge/test_ttl_generator_direction.py
@@ -1,8 +1,9 @@
 """Tests for the TTL generator's read/write direction resolution.
 
 Two halves: the path-resolution branches (which limits file, if any, do we
-read?) and the direction rules themselves (defaults-aware writability, the
-group-constant invariant, and the PV-grammar fallback).
+read?) and the direction rules themselves (the group-constant invariant and
+the PV-grammar fallback). Defaults-aware writability is the validator's own
+rule and is tested with it (``tests/connectors/test_limits_validator.py``).
 
 The last test is the one that matters most — it runs both rules over the real
 shipped demo data and asserts they agree, which is what turns "writable iff
@@ -21,16 +22,18 @@ from osprey.services.facility_knowledge.ttl_generator import direction as direct
 from osprey.services.facility_knowledge.ttl_generator.direction import (
     DIRECTION_READ,
     DIRECTION_WRITE,
-    LIMITS_DATABASE_CONFIG_KEY,
     DirectionConflictError,
     DirectionSource,
     LimitsFileMissing,
     assign_directions,
-    load_writable_set,
     resolve_and_assign,
     resolve_limits_path,
 )
 from osprey.services.facility_knowledge.ttl_generator.model import build_model
+from osprey_connectors.control_system.limits_validator import (
+    LIMITS_DATABASE_CONFIG_KEY,
+    LimitsValidator,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CONTROL_ASSISTANT_DATA = _REPO_ROOT / "src/osprey/templates/apps/control_assistant/data"
@@ -206,79 +209,6 @@ class TestResolveLimitsPath:
 
         assert path is None
         assert str(missing) in message
-
-
-# ---------------------------------------------------------------------------
-# load_writable_set
-# ---------------------------------------------------------------------------
-
-
-class TestLoadWritableSet:
-    """Defaults-aware writability, the rule the runtime write path uses."""
-
-    def test_entry_without_writable_inherits_the_default(self, tmp_path):
-        """The demo file grants writability by omission — that must be honored."""
-        limits = _write_limits(
-            tmp_path / "limits.json",
-            {"SR:MAG:DIPOLE:01:CURRENT:SP": {"min_value": 0.0, "max_value": 1.0}},
-            defaults={"writable": True},
-        )
-
-        assert load_writable_set(limits) == frozenset({"SR:MAG:DIPOLE:01:CURRENT:SP"})
-
-    def test_explicit_false_overrides_a_true_default(self, tmp_path):
-        """An explicit writable:false wins over defaults.writable:true."""
-        limits = _write_limits(
-            tmp_path / "limits.json",
-            {
-                "SR:MAG:DIPOLE:01:CURRENT:SP": {},
-                "SR:VAC:VALVE:01:CONTROL:OPEN": {"writable": False},
-            },
-            defaults={"writable": True},
-        )
-
-        assert load_writable_set(limits) == frozenset({"SR:MAG:DIPOLE:01:CURRENT:SP"})
-
-    def test_explicit_true_overrides_a_false_default(self, tmp_path):
-        """The merge runs both ways: an entry can opt in under a false default."""
-        limits = _write_limits(
-            tmp_path / "limits.json",
-            {
-                "SR:MAG:DIPOLE:01:CURRENT:SP": {"writable": True},
-                "SR:MAG:DIPOLE:01:CURRENT:RB": {},
-            },
-            defaults={"writable": False},
-        )
-
-        assert load_writable_set(limits) == frozenset({"SR:MAG:DIPOLE:01:CURRENT:SP"})
-
-    def test_metadata_and_defaults_keys_are_not_channels(self, tmp_path):
-        """Underscore keys and 'defaults' never become addresses."""
-        limits = _write_limits(
-            tmp_path / "limits.json",
-            {"SR:MAG:DIPOLE:01:CURRENT:SP": {}},
-            defaults={"writable": True},
-        )
-
-        writable = load_writable_set(limits)
-
-        assert writable == frozenset({"SR:MAG:DIPOLE:01:CURRENT:SP"})
-        assert not any(key.startswith("_") or key == "defaults" for key in writable)
-
-    def test_missing_defaults_block_falls_back_to_writable_true(self, tmp_path):
-        """No defaults block at all still matches the validator's ``get(..., True)``."""
-        path = tmp_path / "limits.json"
-        path.write_text(json.dumps({"SR:MAG:DIPOLE:01:CURRENT:SP": {}}), encoding="utf-8")
-
-        assert load_writable_set(path) == frozenset({"SR:MAG:DIPOLE:01:CURRENT:SP"})
-
-    def test_non_object_payload_is_a_legible_error(self, tmp_path):
-        """A JSON list is refused by name rather than raising AttributeError later."""
-        path = tmp_path / "limits.json"
-        path.write_text(json.dumps(["nope"]), encoding="utf-8")
-
-        with pytest.raises(ValueError, match="JSON object"):
-            load_writable_set(path)
 
 
 # ---------------------------------------------------------------------------
@@ -502,7 +432,7 @@ class TestShippedDemoData:
 
     def test_shipped_limits_file_declares_the_expected_writable_count(self):
         """The 396 is a property of the committed file, pinned here directly."""
-        writable = load_writable_set(_CHANNEL_LIMITS)
+        writable = LimitsValidator.writable_addresses(_CHANNEL_LIMITS)
 
         assert len(writable) == _EXPECTED_WRITABLE
         assert all(address.endswith(":SP") for address in writable)

--- a/tests/services/facility_knowledge/test_ttl_generator_emitter.py
+++ b/tests/services/facility_knowledge/test_ttl_generator_emitter.py
@@ -35,6 +35,7 @@ from osprey.services.facility_knowledge.ttl_generator.ontology_map import (
     OntologyMap,
     load_demo_ontology,
 )
+from osprey_connectors.control_system.limits_validator import LimitsValidator
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CONTROL_ASSISTANT_DATA = _REPO_ROOT / "src/osprey/templates/apps/control_assistant/data"
@@ -533,7 +534,7 @@ class TestShippedDemoMachine:
         assert all(pv.endswith(":SP") for pv in written)
 
     def test_limits_file_and_corpus_agree_on_the_writable_set(self, real_graph: Graph) -> None:
-        writable = direction.load_writable_set(_CHANNEL_LIMITS)
+        writable = LimitsValidator.writable_addresses(_CHANNEL_LIMITS)
         written = {
             str(next(real_graph.objects(subject, _prop("fullPv"))))
             for subject in real_graph.subjects(_prop("writesSignal"), None)


### PR DESCRIPTION
Deploy-path and channel-roster honesty, plus two consolidations in the same neighbourhood. Four commits, one per item.

## Operator-visible

**`osprey up` refuses a chain the build's own keys are gone from** — `fix(deploy)`. `osprey build` writes `VA_CHANNELS_FILE` and `VA_LATTICE` together whenever it generates `build/data/simulation/channel_manifest.json`, so a manifest on disk beside a chain missing either is a lost key, not a choice. Until now the compose templates handed the container `${VA_CHANNELS_FILE:-}` and the entrypoint exited on the empty value: an unhealthy container whose log says nothing useful. A new preflight (`_preflight_build_derived_env`) refuses ahead of the image build, keyed on the names the rendered compose files actually interpolate (the recorder compose reads the key too), and names the key and how the build writes it back. Two faces of the same fallback go with it: the archiver seed no longer falls back to the bundled manifest when nothing names one, and the render-side `VA_LATTICE_DEFAULT` docstring cross-references the container's opposite reading of an empty value. The VA template is untouched.

**A malformed `services.graphdb` block names its why** — `fix(channel-roster)`. A new `GRAPH_MALFORMED` absence reason carries the config keys and the resolver's own complaint, instead of being filed under `GRAPH_NO_TTL`. Still fail-soft (503 + reason, not `CORRUPT_SOURCE`); the manifest build treats it as graph mode like its sibling.

## Consolidations (not user news)

**One home for the limits-database key and loader** — `refactor(limits)`. `control_system.limits_checking.database_path` was spelled in six modules and resolved three separate ways. It now lives once in `osprey_connectors.control_system.limits_validator` as `LIMITS_DATABASE_CONFIG_KEY`, beside a public `configured_database_path` / `load_configured_database` pair and a `mapping_config_lookup` for callers holding the config as a dict. The defaults-aware writable set is the validator's `writable_addresses`. The TTL generator, the roster's database reader, the compose renderer, the build's pre-deploy parse, the bridge's startup gate and `knowledge_cmd` all point at it; the tests that imported the `direction.py` copies import the home instead (re-pointed, not shimmed). The roster cache fingerprint still keys on `resolve_limits_path`, whose anchoring rule is unchanged. The config-key guard's evidence for the key now anchors on the constant read (`config_lookup(LIMITS_DATABASE_CONFIG_KEY, None)`) instead of the literal it used to grep for.

**One matcher for the record this session owns** — `refactor(target-state)`. `target_state` now owns `record_pid` (strict int, no bool), `live_records` and `session_record` (exact-parent equality, known target, and the executor-only int-generation check with its second log branch). The audit posture, the python executor and the target banner call it; the banner's `int()` coercion of record fields is gone. `is_process_alive` itself now answers `False` for anything that is not an `int`, so a `True` can never reach `os.kill(1, 0)` and read as alive. The hooks' stdlib copy stays, by design.

## Notes

- One changelog fragment, `changelog.d/roster-deploy-honesty.fixed.md`, covering the two operator-visible fixes.
- Merge order per the release triage: after target-display-posture, before the release PR.
